### PR TITLE
Introduce KindDispatcher

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -28,6 +28,7 @@ from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc
 from .parameters import evaluate
+from .kind import UndefinedKind, NumberKind, BooleanKind
 
 # expose singletons
 Catalan = S.Catalan
@@ -88,4 +89,6 @@ __all__ = [
     'EulerGamma',
     'GoldenRatio',
     'TribonacciConstant',
+
+    'UndefinedKind', 'NumberKind', 'BooleanKind',
 ]

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -147,7 +147,6 @@ class Add(Expr, AssocOp):
     ========
 
     MatAdd
-    VectorAdd
 
     """
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -103,7 +103,7 @@ class Add(Expr, AssocOp):
 
     ``Add()`` also serves as a template for other classes.
 
-    >>> from sympy import symbols, MatrixSymbol
+    >>> from sympy import MatrixSymbol
     >>> A,B = MatrixSymbol('A', 2,2), MatrixSymbol('B', 2,2)
     >>> expr = Add(x,y).subs({x:A, y:B})
     >>> expr

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -143,8 +143,8 @@ class Add(Expr, AssocOp):
     See Also
     ========
 
-    sympy.matrices.MatAdd
-    sympy.vector.VectorAdd
+    sympy.matrices.expressions.matadd.MatAdd
+    sympy.vector.vector.VectorAdd
 
     """
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -70,6 +70,48 @@ def _unevaluated_Add(*args):
 
 
 class Add(Expr, AssocOp):
+    """
+    Addition operation for algebraic group.
+
+    This class mainly deals with the addition in the field of complex numbers.
+    Any abstract algebraic group can be dealt as well, but it is encouraged to
+    define specific class such as ``MatAdd`` or ``VectorAdd`` for other groups.
+    This class also serves as base class for these classes.
+
+    Another use of ``Add()`` is to behave as template for abstract addition so
+    that its arguments can be substituted to return different class. Refer to
+    examples section for this.
+
+    Since addition is group operation, every class should have the same kind.
+
+    Examples
+    ========
+
+    >>> from sympy import Add
+    >>> from sympy.abc import x, y
+    >>> Add(x, 1)
+    x + 1
+    >>> Add(x, x)
+    2*x
+
+    If ``evaluate=False`` is passed, result is not evaluated.
+
+    >>> Add(1, 2, evaluate=False)
+    1 + 2
+    >>> Add(x, x, evaluate=False)
+    x + x
+
+    ``Add()`` also serves as a template for other classes.
+
+    >>> from sympy import symbols, MatrixSymbol
+    >>> A,B = MatrixSymbol('A', 2,2), MatrixSymbol('B', 2,2)
+    >>> expr = Add(x,y).subs({x:A, y:B})
+    >>> expr
+    A + B
+    >>> expr.func
+    <class 'sympy.matrices.expressions.matadd.MatAdd'>
+
+    """
 
     __slots__ = ()
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -99,7 +99,10 @@ class Add(Expr, AssocOp):
     element is passed, that element is returned.
 
     Note that ``Add(*args)`` is more efficient than ``sum(args)`` because
-    the algoritm is linear in the number of terms.
+    it flattens the arguments. ``sum(a, b, c, ...)`` recursively adds the
+    arguments as ``a + (b + (c + ...))``, which has quadratic complexity.
+    On the other hand, ``Add(a, b, c, d)`` does not assume nested
+    structure, making the complexity linear.
 
     Since addition is group operation, every argument should have the
     same :obj:`sympy.core.kind.Kind()`.

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -71,18 +71,38 @@ def _unevaluated_Add(*args):
 
 class Add(Expr, AssocOp):
     """
-    Addition operation for algebraic group.
+    Expression representing addition operation for algebraic group.
+    Infix operator ``+`` on most ``Expr`` objects, except the one between
+    numbers, call this class.
 
-    This class mainly deals with the addition in the field of complex numbers.
-    Any abstract algebraic group can be dealt as well, but it is encouraged to
-    define specific class such as ``MatAdd`` or ``VectorAdd`` for other groups.
-    This class also serves as base class for these classes.
+    This class mainly deals with the addition over the field of complex
+    numbers. ``Add(*args)`` is more efficient than ``sum(args)`` because
+    the algoritm is linear in the number of terms.
 
-    Another use of ``Add()`` is to behave as template for abstract addition so
-    that its arguments can be substituted to return different class. Refer to
-    examples section for this.
+    Another use of ``Add()`` is to represent the structure of abstract
+    addition so that its arguments can be substituted to return different
+    class. Refer to examples section for this.
 
-    Since addition is group operation, every class should have the same kind.
+    ``Add()`` evaluates the argument unless ``evaluate=False`` is passed.
+    The evaluation logic includes:
+
+    1. Flattening
+        ``Add(x, Add(y, z))`` -> ``Add(x, y, z)``
+
+    2. Identity removing
+        ``Add(x, 0, y)`` -> ``Add(x, y)``
+
+    3. Coefficient collecting by ``.as_coeff_Mul()``
+        ``Add(x, 2*x)`` -> ``Mul(3, x)``
+
+    4. Term sorting
+        ``Add(y, x, 2)`` -> ``Add(2, x, y)``
+
+    If no argument is passed, identity element 0 is returned. If single
+    element is passed, that element is returned.
+
+    Since addition is group operation, every argument should have the
+    same kind.
 
     Examples
     ========
@@ -93,6 +113,8 @@ class Add(Expr, AssocOp):
     x + 1
     >>> Add(x, x)
     2*x
+    >>> 2*x**2 + 3*x + I*y + 2*y + 2*x/5 + 1.0*y + 1
+    2*x**2 + 17*x/5 + 3.0*y + I*y + 1
 
     If ``evaluate=False`` is passed, result is not evaluated.
 
@@ -101,7 +123,7 @@ class Add(Expr, AssocOp):
     >>> Add(x, x, evaluate=False)
     x + x
 
-    ``Add()`` also serves as a template for other classes.
+    ``Add()`` also represents the general structure of addition operation.
 
     >>> from sympy import MatrixSymbol
     >>> A,B = MatrixSymbol('A', 2,2), MatrixSymbol('B', 2,2)
@@ -110,6 +132,19 @@ class Add(Expr, AssocOp):
     A + B
     >>> expr.func
     <class 'sympy.matrices.expressions.matadd.MatAdd'>
+
+    Note that the printers don't display in args order.
+
+    >>> Add(x, 1)
+    x + 1
+    >>> Add(x, 1).args
+    (1, x)
+
+    See Also
+    ========
+
+    sympy.matrices.MatAdd
+    sympy.vector.VectorAdd
 
     """
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -143,8 +143,8 @@ class Add(Expr, AssocOp):
     See Also
     ========
 
-    sympy.matrices.expressions.matadd.MatAdd
-    sympy.vector.vector.VectorAdd
+    MatAdd
+    VectorAdd
 
     """
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -107,7 +107,7 @@ class Add(Expr, AssocOp):
     Examples
     ========
 
-    >>> from sympy import Add
+    >>> from sympy import Add, I
     >>> from sympy.abc import x, y
     >>> Add(x, 1)
     x + 1

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -72,12 +72,9 @@ def _unevaluated_Add(*args):
 class Add(Expr, AssocOp):
     """
     Expression representing addition operation for algebraic group.
-    Infix operator ``+`` on most ``Expr`` objects, except the one between
-    numbers, call this class.
 
-    This class mainly deals with the addition over the field of complex
-    numbers. ``Add(*args)`` is more efficient than ``sum(args)`` because
-    the algoritm is linear in the number of terms.
+    Every argument of ``Add()`` must be ``Expr``. Infix operator ``+``
+    on most scalar objects in SymPy calls this class.
 
     Another use of ``Add()`` is to represent the structure of abstract
     addition so that its arguments can be substituted to return different
@@ -101,8 +98,11 @@ class Add(Expr, AssocOp):
     If no argument is passed, identity element 0 is returned. If single
     element is passed, that element is returned.
 
+    Note that ``Add(*args)`` is more efficient than ``sum(args)`` because
+    the algoritm is linear in the number of terms.
+
     Since addition is group operation, every argument should have the
-    same kind.
+    same :obj:`sympy.core.kind.Kind()`.
 
     Examples
     ========
@@ -130,7 +130,7 @@ class Add(Expr, AssocOp):
     >>> expr = Add(x,y).subs({x:A, y:B})
     >>> expr
     A + B
-    >>> expr.func
+    >>> type(expr)
     <class 'sympy.matrices.expressions.matadd.MatAdd'>
 
     Note that the printers don't display in args order.

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -25,6 +25,13 @@ This module defines basic kinds for core objects. Other kinds such as
        See https://github.com/sympy/sympy/pull/20549.
 """
 
+from collections import defaultdict
+
+from sympy.core.cache import cacheit
+from sympy.multipledispatch.dispatcher import (Dispatcher,
+    ambiguity_warn, ambiguity_register_error_ignore_dup,
+    str_signature, RaiseNotImplementedError)
+
 
 class KindMeta(type):
     """
@@ -178,3 +185,154 @@ class BooleanKind(Kind):
         return "BooleanKind"
 
 BooleanKind = BooleanKind()
+
+
+class KindDispatcher:
+    """
+    Dispatcher to select a kind from multiple kinds by binary dispatching.
+
+    .. notes::
+       This approach is experimental, and can be replaced or deleted in the future.
+
+    Explanation
+    ===========
+
+    SymPy object's kind vaguely represents the algebraic structure where the
+    object belongs to. Therefore, with given operation, we can always find a
+    dominating kind among the different kinds. This class selects the kind by
+    recursive binary dispatching. If the result cannot be determined, ``UndefinedKind``
+    is returned.
+
+    This class is designed for associative operator, where the number of arguments
+    is undefined. If the operator has fixed arity, multipledispatch will be enough.
+
+    Parameters
+    ==========
+
+    name : str
+
+    commutative : bool, optional
+        If True, binary dispatch will be automatically registered in
+        reversed order as well.
+
+    doc : str, optional
+
+    """
+    def __init__(self, name, commutative=False, doc=None):
+        self.name = name
+        self.doc = doc
+        self.commutative = commutative
+        self._dispatcher = Dispatcher(name)
+
+    def __repr__(self):
+        return "<dispatched %s>" % self.name
+
+    def register(self, *types, **kwargs):
+        """
+        Register the binary dispatcher for two kind classes.
+
+        If *self.commutative* is ``True``, signature in reversed order is
+        automatically registered as well.
+        """
+        on_ambiguity = kwargs.pop("on_ambiguity", None)
+        if not on_ambiguity:
+            if self.commutative:
+                on_ambiguity = ambiguity_register_error_ignore_dup
+            else:
+                on_ambiguity = ambiguity_warn
+        kwargs.update(on_ambiguity=on_ambiguity)
+
+        if not len(types) == 2:
+            raise RuntimeError(
+                "Only binary dispatch is supported, but got %s types: <%s>." % (
+                len(types), str_signature(types)
+            ))
+
+        def _(func):
+            self._dispatcher.add(types, func, **kwargs)
+            if self.commutative:
+                self._dispatcher.add(tuple(reversed(types)), func, **kwargs)
+        return _
+
+    @cacheit
+    def __call__(self, *args, **kwargs):
+        if self.commutative:
+            kinds = frozenset(args)
+        else:
+            kinds = []
+            prev = None
+            for a in args:
+                if prev is not a:
+                    kinds.append(a)
+                    prev = a
+
+        # Quick exit for the case where all kinds are same
+        if len(kinds) == 1:
+            result, = kinds
+            if not isinstance(result, Kind):
+                raise RuntimeError("%s is not a kind." % result)
+            return result
+
+        for i,kind in enumerate(kinds):
+            if not isinstance(kind, Kind):
+                raise RuntimeError("%s is not a kind." % kind)
+
+            if i == 0:
+                result = kind
+            else:
+                prev_kind = result
+                try:
+                    result = self._dispatcher(prev_kind, kind)
+                except NotImplementedError:
+                    result = UndefinedKind
+                if not isinstance(result, Kind):
+                    raise RuntimeError(
+                        "Dispatcher for {!r} and {!r} must return a Kind, but got {!r}".format(
+                        prev_kind, kind, result
+                    ))
+
+        return result
+
+    @property
+    def __doc__(self):
+        docs = [
+            "Associative kind dispatcher : %s" % self.name,
+            "Note that support for this is experimental. See the docs for :class:`KindDispatcher` for details"
+        ]
+
+        if self.doc:
+            docs.append(self.doc)
+
+        s = "Registered kind classes\n"
+        s += '=' * len(s)
+        docs.append(s)
+
+        amb_sigs = []
+
+        typ_sigs = defaultdict(list)
+        for sigs in self._dispatcher.ordering[::-1]:
+            key = self._dispatcher.funcs[sigs]
+            typ_sigs[key].append(sigs)
+
+        for typ, sigs in typ_sigs.items():
+
+            sigs_str = ', '.join('<%s>' % str_signature(sig) for sig in sigs)
+
+            if isinstance(typ, RaiseNotImplementedError):
+                amb_sigs.append(sigs_str)
+                continue
+
+            s = 'Inputs: %s\n' % sigs_str
+            s += '-' * len(s) + '\n'
+            s += typ.__name__
+            docs.append(s)
+
+        if amb_sigs:
+            s = "Ambiguous kind classes\n"
+            s += '=' * len(s)
+            docs.append(s)
+
+            s = '\n'.join(amb_sigs)
+            docs.append(s)
+
+        return '\n\n'.join(docs)

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -192,19 +192,18 @@ class KindDispatcher:
     Dispatcher to select a kind from multiple kinds by binary dispatching.
 
     .. notes::
-       This approach is experimental, and can be replaced or deleted in the future.
+       This approach is experimental, and can be replaced or deleted in
+       the future.
 
     Explanation
     ===========
 
-    SymPy object's kind vaguely represents the algebraic structure where the
-    object belongs to. Therefore, with given operation, we can always find a
-    dominating kind among the different kinds. This class selects the kind by
-    recursive binary dispatching. If the result cannot be determined, ``UndefinedKind``
+    SymPy object's :obj:`sympy.core.kind.Kind()` vaguely represents the
+    algebraic structure where the object belongs to. Therefore, with
+    given operation, we can always find a dominating kind among the
+    different kinds. This class selects the kind by recursive binary
+    dispatching. If the result cannot be determined, ``UndefinedKind``
     is returned.
-
-    This class is designed for associative operator, where the number of arguments
-    is undefined. If the operator has fixed arity, multipledispatch will be enough.
 
     Examples
     ========

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -320,10 +320,17 @@ class KindDispatcher:
                 result = kind
             else:
                 prev_kind = result
-                try:
-                    result = self._dispatcher(prev_kind, kind)
-                except NotImplementedError:
+
+                t1, t2 = type(prev_kind), type(kind)
+                func = self._dispatcher.dispatch(t1, t2)
+                if func is None and self.commutative:
+                    # try reversed order
+                    func = self._dispatcher.dispatch(t2, t1)
+                if func is None:
+                    # unregistered kind relation
                     result = UndefinedKind
+                else:
+                    result = func(prev_kind, kind)
                 if not isinstance(result, Kind):
                     raise RuntimeError(
                         "Dispatcher for {!r} and {!r} must return a Kind, but got {!r}".format(

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -304,7 +304,7 @@ class KindDispatcher:
         return self.dispatch_kinds(self, kinds, **kwargs)
 
     @cacheit
-    def dispatch_kinds(self, kinds, **kwargs)
+    def dispatch_kinds(self, kinds, **kwargs):
         # Quick exit for the case where all kinds are same
         if len(kinds) == 1:
             result, = kinds

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -291,7 +291,6 @@ class KindDispatcher:
                 self._dispatcher.add(tuple(reversed(types)), func, **kwargs)
         return _
 
-    @cacheit
     def __call__(self, *args, **kwargs):
         if self.commutative:
             kinds = frozenset(args)
@@ -302,7 +301,10 @@ class KindDispatcher:
                 if prev is not a:
                     kinds.append(a)
                     prev = a
+        return self.dispatch_kinds(self, kinds, **kwargs)
 
+    @cacheit
+    def dispatch_kinds(self, kinds, **kwargs)
         # Quick exit for the case where all kinds are same
         if len(kinds) == 1:
             result, = kinds

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -342,7 +342,7 @@ class KindDispatcher:
     @property
     def __doc__(self):
         docs = [
-            "Associative kind dispatcher : %s" % self.name,
+            "Kind dispatcher : %s" % self.name,
             "Note that support for this is experimental. See the docs for :class:`KindDispatcher` for details"
         ]
 

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -301,7 +301,7 @@ class KindDispatcher:
                 if prev is not a:
                     kinds.append(a)
                     prev = a
-        return self.dispatch_kinds(self, kinds, **kwargs)
+        return self.dispatch_kinds(kinds, **kwargs)
 
     @cacheit
     def dispatch_kinds(self, kinds, **kwargs):

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -81,7 +81,7 @@ class Kind(object, metaclass=KindMeta):
         return inst
 
 
-class UndefinedKind(Kind):
+class _UndefinedKind(Kind):
     """
     Default kind for all SymPy object. If the kind is not defined for
     the object, or if the object cannot infer the kind from its
@@ -100,10 +100,10 @@ class UndefinedKind(Kind):
     def __repr__(self):
         return "UndefinedKind"
 
-UndefinedKind = UndefinedKind()
+UndefinedKind = _UndefinedKind()
 
 
-class NumberKind(Kind):
+class _NumberKind(Kind):
     """
     Kind for all numeric object.
 
@@ -159,10 +159,10 @@ class NumberKind(Kind):
     def __repr__(self):
         return "NumberKind"
 
-NumberKind = NumberKind()
+NumberKind = _NumberKind()
 
 
-class BooleanKind(Kind):
+class _BooleanKind(Kind):
     """
     Kind for boolean objects.
 
@@ -184,7 +184,7 @@ class BooleanKind(Kind):
     def __repr__(self):
         return "BooleanKind"
 
-BooleanKind = BooleanKind()
+BooleanKind = _BooleanKind()
 
 
 class KindDispatcher:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -87,19 +87,33 @@ def _unevaluated_Mul(*args):
 
 class Mul(Expr, AssocOp):
     """
-    Multiplication operation for algebraic group.
+    Expression representing multiplication operation for algebraic field.
 
-    This class mainly deals with the multiplication in the field of complex numbers.
-    Any abstract algebraic field can be dealt as well, but it is encouraged to
-    define specific class such as ``MatMul`` or ``VectorMul`` for other fields.
-    This class also serves as base class for these classes.
+    Every argument of ``Mul()`` must be ``Expr``. Infix operator ``*``
+    on most scalar objects in SymPy calls this class.
 
-    Another use of ``Mul()`` is to behave as template for abstract multiplication so
-    that its arguments can be substituted to return different class. Refer to
-    examples section for this.
+    Another use of ``Mul()`` is to represent the structure of abstract
+    multiplication so that its arguments can be substituted to return
+    different class. Refer to examples section for this.
 
-    Since multiplication can be vector space operation, arguments may have the different
-    kind. Kind of the resulting object is automatically inferred.
+    ``Mul()`` evaluates the argument unless ``evaluate=False`` is passed.
+    The evaluation logic includes:
+
+    1. Flattening
+        ``Mul(x, Mul(y, z))`` -> ``Mul(x, y, z)``
+
+    2. Identity removing
+        ``Mul(x, 1, y)`` -> ``Mul(x, y)``
+
+    3. Exponent collecting by ``.as_base_exp()``
+        ``Mul(x, x**2)`` -> ``Pow(x, 3)``
+
+    4. Term sorting
+        ``Mul(y, x, 2)`` -> ``Mul(2, x, y)``
+
+    Since multiplication can be vector space operation, arguments may\
+    have the different :obj:`sympy.core.kind.Kind()`. Kind of the
+    resulting object is automatically inferred.
 
     Examples
     ========
@@ -118,15 +132,22 @@ class Mul(Expr, AssocOp):
     >>> Mul(x, x, evaluate=False)
     x*x
 
-    ``Mul()`` also serves as a template for other classes.
+    ``Mul()`` also represents the general structure of multiplication
+    operation.
 
     >>> from sympy import MatrixSymbol
     >>> A = MatrixSymbol('A', 2,2)
     >>> expr = Mul(x,y).subs({y:A})
     >>> expr
     x*A
-    >>> expr.func
+    >>> type(expr)
     <class 'sympy.matrices.expressions.matmul.MatMul'>
+
+    See Also
+    ========
+
+    MatMul
+    VectorMul
 
     """
     __slots__ = ()

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -86,7 +86,49 @@ def _unevaluated_Mul(*args):
 
 
 class Mul(Expr, AssocOp):
+    """
+    Multiplication operation for algebraic group.
 
+    This class mainly deals with the multiplication in the field of complex numbers.
+    Any abstract algebraic field can be dealt as well, but it is encouraged to
+    define specific class such as ``MatMul`` or ``VectorMul`` for other fields.
+    This class also serves as base class for these classes.
+
+    Another use of ``Mul()`` is to behave as template for abstract multiplication so
+    that its arguments can be substituted to return different class. Refer to
+    examples section for this.
+
+    Since multiplication can be vector space operation, arguments may have the different
+    kind. Kind of the resulting object is automatically inferred.
+
+    Examples
+    ========
+
+    >>> from sympy import Mul
+    >>> from sympy.abc import x, y
+    >>> Mul(x, 1)
+    x
+    >>> Mul(x, x)
+    x**2
+
+    If ``evaluate=False`` is passed, result is not evaluated.
+
+    >>> Mul(1, 2, evaluate=False)
+    1*2
+    >>> Mul(x, x, evaluate=False)
+    x*x
+
+    ``Mul()`` also serves as a template for other classes.
+
+    >>> from sympy import symbols, MatrixSymbol
+    >>> A = MatrixSymbol('A', 2,2)
+    >>> expr = Mul(x,y).subs({y:A})
+    >>> expr
+    x*A
+    >>> expr.func
+    <class 'sympy.matrices.expressions.matmul.MatMul'>
+
+    """
     __slots__ = ()
 
     is_Mul = True

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -111,7 +111,7 @@ class Mul(Expr, AssocOp):
     4. Term sorting
         ``Mul(y, x, 2)`` -> ``Mul(2, x, y)``
 
-    Since multiplication can be vector space operation, arguments may\
+    Since multiplication can be vector space operation, arguments may
     have the different :obj:`sympy.core.kind.Kind()`. Kind of the
     resulting object is automatically inferred.
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -147,7 +147,6 @@ class Mul(Expr, AssocOp):
     ========
 
     MatMul
-    VectorMul
 
     """
     __slots__ = ()

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -10,7 +10,7 @@ from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .expr import Expr
 from .parameters import global_parameters
-
+from .kind import KindDispatcher
 
 
 # internal marker to indicate:
@@ -92,6 +92,12 @@ class Mul(Expr, AssocOp):
     is_Mul = True
 
     _args_type = Expr
+    _kind_dispatcher = KindDispatcher("Mul_kind_dispatcher", commutative=True)
+
+    @property
+    def kind(self):
+        arg_kinds = (a.kind for a in self.args)
+        return self._kind_dispatcher(*arg_kinds)
 
     def __neg__(self):
         c, args = self.as_coeff_mul()
@@ -1926,6 +1932,7 @@ class Mul(Expr, AssocOp):
         return tuple(self.as_ordered_factors())
 
 mul = AssocOpDispatcher('mul')
+
 
 def prod(a, start=1):
     """Return product of elements of a. Start with int 1 so if only

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -120,7 +120,7 @@ class Mul(Expr, AssocOp):
 
     ``Mul()`` also serves as a template for other classes.
 
-    >>> from sympy import symbols, MatrixSymbol
+    >>> from sympy import MatrixSymbol
     >>> A = MatrixSymbol('A', 2,2)
     >>> expr = Mul(x,y).subs({y:A})
     >>> expr

--- a/sympy/core/tests/test_kind.py
+++ b/sympy/core/tests/test_kind.py
@@ -1,11 +1,12 @@
 from sympy.core.add import Add
 from sympy.core.kind import NumberKind, UndefinedKind
+from sympy.core.mul import Mul
 from sympy.core.numbers import pi, zoo, I, AlgebraicNumber
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.integrals.integrals import Integral
 from sympy.matrices import (Matrix, SparseMatrix, ImmutableMatrix,
-    ImmutableSparseMatrix, MatrixSymbol, MatrixKind)
+    ImmutableSparseMatrix, MatrixSymbol, MatrixKind, MatMul)
 
 comm_x = Symbol('x')
 noncomm_x = Symbol('x', commutative=False)
@@ -23,6 +24,12 @@ def test_Add_kind():
     assert Add(2,comm_x).kind is NumberKind
     assert Add(2,noncomm_x).kind is UndefinedKind
 
+def test_mul_kind():
+    assert Mul(2,comm_x, evaluate=False).kind is NumberKind
+    assert Mul(2,3, evaluate=False).kind is NumberKind
+    assert Mul(noncomm_x,2, evaluate=False).kind is UndefinedKind
+    assert Mul(2,noncomm_x, evaluate=False).kind is UndefinedKind
+
 def test_Symbol_kind():
     assert comm_x.kind is NumberKind
     assert noncomm_x.kind is UndefinedKind
@@ -37,3 +44,8 @@ def test_Matrix_kind():
     for cls in classes:
         m = cls.zeros(3, 2)
         assert m.kind is MatrixKind(NumberKind)
+
+def test_MatMul_kind():
+    M = Matrix([[1,2],[3,4]])
+    assert MatMul(2, M).kind is MatrixKind(NumberKind)
+    assert MatMul(comm_x, M).kind is MatrixKind(NumberKind)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -19,7 +19,7 @@ from sympy.polys import cancel
 from sympy.printing import sstr
 from sympy.printing.defaults import Printable
 from sympy.simplify import simplify as _simplify
-from sympy.core.kind import Kind, NumberKind
+from sympy.core.kind import Kind, NumberKind, _NumberKind
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import filldedent
@@ -784,20 +784,23 @@ class MatrixKind(Kind):
         return "MatrixKind(%s)" % self.element_kind
 
 
-@Mul._kind_dispatcher.register(MatrixKind, type(NumberKind))
-def _(k1, k2):
-    """Return MatrixKind. Its element kind is selected by recursive dispatching."""
+@Mul._kind_dispatcher.register(MatrixKind, _NumberKind)
+def mat_num_mul(k1, k2):
+    """Return MatrixKind. The element kind is selected by recursive dispatching."""
     # Deal with Mul._kind_dispatcher's commutativity
-    if isinstance(k1, MatrixKind):
-        mk = k1
-    else:
-        mk = k2
-    elemk = Mul._kind_dispatcher(mk.element_kind, NumberKind)
+    elemk = Mul._kind_dispatcher(k1.element_kind, NumberKind)
+    return MatrixKind(elemk)
+
+@Mul._kind_dispatcher.register(_NumberKind, MatrixKind)
+def num_mat_mul(k1, k2):
+    """Return MatrixKind. The element kind is selected by recursive dispatching."""
+    # Deal with Mul._kind_dispatcher's commutativity
+    elemk = Mul._kind_dispatcher(k2.element_kind, NumberKind)
     return MatrixKind(elemk)
 
 @Mul._kind_dispatcher.register(MatrixKind, MatrixKind)
-def _(k1, k2):
-    """Return MatrixKind. Its element kind is selected by recursive dispatching."""
+def mat_mat_mul(k1, k2):
+    """Return MatrixKind. The element kind is selected by recursive dispatching."""
     elemk = Mul._kind_dispatcher(k1.element_kind, k2.element_kind)
     return MatrixKind(elemk)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -795,7 +795,7 @@ def mat_num_mul(k1, k2):
 def num_mat_mul(k1, k2):
     """Return MatrixKind. The element kind is selected by recursive dispatching."""
     # Deal with Mul._kind_dispatcher's commutativity
-    elemk = Mul._kind_dispatcher(k2.element_kind, NumberKind)
+    elemk = Mul._kind_dispatcher(NumberKind, k2.element_kind)
     return MatrixKind(elemk)
 
 @Mul._kind_dispatcher.register(MatrixKind, MatrixKind)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -784,23 +784,22 @@ class MatrixKind(Kind):
         return "MatrixKind(%s)" % self.element_kind
 
 
-@Mul._kind_dispatcher.register(MatrixKind, _NumberKind)
-def mat_num_mul(k1, k2):
-    """Return MatrixKind. The element kind is selected by recursive dispatching."""
-    # Deal with Mul._kind_dispatcher's commutativity
-    elemk = Mul._kind_dispatcher(k1.element_kind, NumberKind)
-    return MatrixKind(elemk)
-
 @Mul._kind_dispatcher.register(_NumberKind, MatrixKind)
 def num_mat_mul(k1, k2):
-    """Return MatrixKind. The element kind is selected by recursive dispatching."""
+    """
+    Return MatrixKind. The element kind is selected by recursive dispatching.
+    Do not need to dispatch in reversed order because KindDispatcher
+    searches for this automatically.
+    """
     # Deal with Mul._kind_dispatcher's commutativity
     elemk = Mul._kind_dispatcher(NumberKind, k2.element_kind)
     return MatrixKind(elemk)
 
 @Mul._kind_dispatcher.register(MatrixKind, MatrixKind)
 def mat_mat_mul(k1, k2):
-    """Return MatrixKind. The element kind is selected by recursive dispatching."""
+    """
+    Return MatrixKind. The element kind is selected by recursive dispatching.
+    """
     elemk = Mul._kind_dispatcher(k1.element_kind, k2.element_kind)
     return MatrixKind(elemk)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -6,6 +6,7 @@ from sympy.core.compatibility import (
     Callable, NotIterable, as_int, is_sequence)
 from sympy.core.decorators import deprecated
 from sympy.core.expr import Expr
+from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol, uniquely_named_symbol
@@ -782,6 +783,23 @@ class MatrixKind(Kind):
     def __repr__(self):
         return "MatrixKind(%s)" % self.element_kind
 
+
+@Mul._kind_dispatcher.register(MatrixKind, type(NumberKind))
+def _(k1, k2):
+    """Return MatrixKind. Its element kind is selected by recursive dispatching."""
+    # Deal with Mul._kind_dispatcher's commutativity
+    if isinstance(k1, MatrixKind):
+        mk = k1
+    else:
+        mk = k2
+    elemk = Mul._kind_dispatcher(mk.element_kind, NumberKind)
+    return MatrixKind(elemk)
+
+@Mul._kind_dispatcher.register(MatrixKind, MatrixKind)
+def _(k1, k2):
+    """Return MatrixKind. Its element kind is selected by recursive dispatching."""
+    elemk = Mul._kind_dispatcher(k1.element_kind, k2.element_kind)
+    return MatrixKind(elemk)
 
 class MatrixBase(MatrixDeprecated,
                  MatrixCalculus,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`KindDispatcher` is introduced to infer the kind of associative operation. This class selects a kind among multiple kinds, making associative operator able to infer its kind from arguments. The selection logic is based on multipledispatch and can be registered.
 
`Mul.kind` is introduced using this dispatcher.

Docstring is made on `Add` and `Mul`.

#### Other comments


Please see docstring of `KindDispatcher` for the examples.

Since `kind` system is introduced, multiply dispatched `add`, `mul` and `pow` functions need to work based on this. It will be done in succeeding PRs.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->