### PR TITLE
core: fixed _eval_is_zero() and added test

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -604,7 +604,7 @@ class Add(Expr, AssocOp):
         nz = []
         z = 0
         im_or_z = False
-        im = False
+        im = 0
         for a in self.args:
             if a.is_extended_real:
                 if a.is_zero:
@@ -614,7 +614,7 @@ class Add(Expr, AssocOp):
                 else:
                     return
             elif a.is_imaginary:
-                im = True
+                im += 1
             elif (S.ImaginaryUnit*a).is_extended_real:
                 im_or_z = True
             else:
@@ -625,10 +625,12 @@ class Add(Expr, AssocOp):
             return None
         b = self.func(*nz)
         if b.is_zero:
-            if not im_or_z and not im:
-                return True
-            if im and not im_or_z:
-                return False
+            if not im_or_z:
+                if im == 0:
+                    return True
+                elif im == 1:
+                    return False
+            return True
         if b.is_zero is False:
             return False
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -630,7 +630,6 @@ class Add(Expr, AssocOp):
                     return True
                 elif im == 1:
                     return False
-            return True
         if b.is_zero is False:
             return False
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2307,3 +2307,8 @@ def test__neg__():
 
 def test_issue_18507():
     assert Mul(zoo, zoo, 0) is nan
+
+
+def test_issue_17130():
+    e = Add(b, -b, I, -I, evaluate=False)
+    assert e._eval_is_zero() == True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2311,4 +2311,4 @@ def test_issue_18507():
 
 def test_issue_17130():
     e = Add(b, -b, I, -I, evaluate=False)
-    assert e._eval_is_zero() == True
+    assert e._eval_is_zero() is None # ideally this would be True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2311,4 +2311,4 @@ def test_issue_18507():
 
 def test_issue_17130():
     e = Add(b, -b, I, -I, evaluate=False)
-    assert e._eval_is_zero() is None # ideally this would be True
+    assert e.is_zero is None # ideally this would be True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17130
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
_eval_is_zero() would give wrong result with imaginary numbers,
resolved as directed by @oscarbenjamin, and added
appropriate test.

#### Other comments
Please suggest any extra tests I should add to it.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `_eval_is_zero()` functionality when imaginary numbers are involved.
<!-- END RELEASE NOTES -->