### PR TITLE
Routines to support deep copying expressions via Python ast module

### DIFF
--- a/sympy/core/ast_copy.py
+++ b/sympy/core/ast_copy.py
@@ -1,0 +1,115 @@
+import ast
+
+import sympy as sp
+
+
+class _Node:
+    """Used to store representation of expression graph
+    for conversion to AST."""
+
+    def __init__(self, expr, pos, parent_node):
+        self.expr = expr
+        self.pos = pos
+        self.parent_node = parent_node
+        self.child_nodes = []
+        self.ast = None
+
+    def __repr__(self):
+        return "Node%s %s: [%s]: n:%s, p:%s, c:%s" % (
+            "*" if self.ast is not None else "",
+            self.pos,
+            self.expr,
+            self.expr.func.__name__,
+            self.parent_node.pos if self.parent_node else None,
+            [c.pos for c in self.child_nodes],
+        )
+
+
+def _traverse_expression(e, depth, nodes, pos=(), parent_node=None):
+    """Recursive function to generate representation of expression graph."""
+    n = _Node(e, pos, parent_node)
+    if parent_node:
+        parent_node.child_nodes.append(n)
+    nodes.append(n)
+    for i, arg in enumerate(e.args):
+        if isinstance(arg, sp.Basic):
+            _traverse_expression(arg, depth + 1, nodes, pos + (i,), n)
+
+
+def _to_ast_call(func_name, args, kwds=[]):
+    """Creates an AST equivalent sympy call."""
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="sp", ctx=ast.Load()), attr=func_name, ctx=ast.Load()
+        ),
+        args=args,
+        keywords=kwds,
+    )
+
+
+def to_ast(expr):
+    """Return the AST for expr."""
+
+    # generate tree that mirrors expression
+    nodes = []
+    _traverse_expression(expr, 0, nodes)
+
+    # find leaf nodes and convert to ast.Num
+    for n in nodes:
+        if not n.child_nodes:
+            if isinstance(n.expr, (int, float)):
+                n.ast = ast.Num(n=n.expr)
+            elif isinstance(n.expr, sp.Integer):
+                n.ast = _to_ast_call(
+                    n.expr.func.__name__, [ast.Constant(value=int(n.expr))]
+                )
+            elif isinstance(n.expr, sp.Float):
+                n.ast = _to_ast_call(
+                    n.expr.func.__name__, [ast.Constant(value=float(n.expr))]
+                )
+            elif isinstance(n.expr, sp.Symbol):
+                n.ast = _to_ast_call(
+                    n.expr.func.__name__,
+                    [ast.Constant(value=str(n.expr))],
+                    [
+                        ast.keyword(arg=kw, value=ast.Constant(value=v))
+                        for kw, v in n.expr.assumptions0.items()
+                    ],
+                )
+            elif isinstance(n.expr, sp.Rational):
+                n.ast = _to_ast_call(
+                    n.expr.func.__name__,
+                    [
+                        ast.Constant(value=int(n.expr.numerator())),
+                        ast.Constant(value=int(n.expr.denominator())),
+                    ],
+                )
+            else:
+                raise RuntimeError("Unsupported type")
+
+    # find nodes where all children have ast generated
+    while True:
+        unchecked_nodes = [n for n in nodes if n.ast is None]
+        if not unchecked_nodes:
+            break
+        for n in unchecked_nodes:
+            if n.child_nodes and all([m.ast is not None for m in n.child_nodes]):
+                n.ast = _to_ast_call(
+                    n.expr.func.__name__,
+                    [m.ast for m in n.child_nodes],
+                    [ast.keyword(arg="evaluate", value=ast.Constant(value=False))],
+                )
+
+    # wrap in Expression and fix locations
+    ast_expr = ast.Expression(body=nodes[0].ast)
+    ast.fix_missing_locations(ast_expr)
+
+    return ast_expr
+
+
+def clone(expr):
+    """Clone the sympy expr using intermediate AST.
+    Preserves non-evaluation."""
+    ast_expr = to_ast(expr)
+    comp = compile(ast_expr, filename="<ast>", mode="eval")
+    return eval(comp)

--- a/sympy/core/tests/test_ast_copy.py
+++ b/sympy/core/tests/test_ast_copy.py
@@ -1,0 +1,53 @@
+import pickle
+
+import sympy as sp
+from sympy.core.ast_copy import clone
+
+x, y, z = sp.var("x y z")
+neg_x = sp.Symbol("x", negative=True)
+p = sp.Symbol("p", prime=True)
+
+
+def test_clone():
+    for expr in [
+        sp.Add(
+            sp.Pow(sp.Integer(2), 2, evaluate=False),
+            sp.Pow(sp.Float(3.1), 2, evaluate=False),
+            evaluate=False,
+        ),
+        # from Issue #5783
+        sp.Mul(sp.Float(-11.1), sp.Integer(19)),
+        # from PR #622
+        sp.Pow(3, 2, evaluate=False),
+        # symbols
+        x ** 2 + sp.sin(y) + x * y * z,
+        # rational
+        sp.Add(sp.Rational(2, 3), sp.Float(sp.pi), evaluate=False),
+        # assumptions
+        neg_x ** 3 + sp.sin(p),
+    ]:
+        assert clone(expr) == expr
+
+
+def test_pickle_unpickle_ast():
+    for expr in [
+        sp.Add(
+            sp.Pow(sp.Integer(2), 2, evaluate=False),
+            sp.Pow(sp.Float(3.1), 2, evaluate=False),
+            evaluate=False,
+        ),
+        # from Issue #5783
+        sp.Mul(sp.Float(-11.1), sp.Integer(19)),
+        # from PR #622
+        sp.Pow(3, 2, evaluate=False),
+        # symbols
+        x ** 2 + sp.sin(y) + x * y * z,
+        # rational
+        sp.Add(sp.Rational(2, 3), sp.Float(sp.pi), evaluate=False),
+        # assumptions
+        neg_x ** 3 + sp.sin(p),
+    ]:
+        ast_expr = to_ast(expr)
+        orig = compile(ast_expr, filename="<ast>", mode="eval")
+        unpickled_ast = pickle.loads(pickle.dumps(ast_expr))
+        assert eval(orig) == eval(comp)

--- a/sympy/core/tests/test_ast_copy.py
+++ b/sympy/core/tests/test_ast_copy.py
@@ -59,12 +59,12 @@ def test_7672():
     # deepcopy interferes with original Issue #7672
     x, xx = sp.symbols("x"), sp.symbols("x", real=True)
     assert x != xx
-    xxx = deepcopy(xx)
+    xxx = deepcopy(xx)  # noqa
     assert x == xx
 
     # clone does not
     y, yy = sp.symbols("y"), sp.symbols("y", real=True)
     assert y != yy
     # deepcopy broken (should not be equal)
-    yyy = clone(yy)
+    yyy = clone(yy)  # noqa
     assert y != yy

--- a/sympy/core/tests/test_ast_copy.py
+++ b/sympy/core/tests/test_ast_copy.py
@@ -1,0 +1,70 @@
+import pickle
+from copy import deepcopy
+
+import sympy as sp
+from sympy.core.ast_copy import clone, to_ast
+
+x, y, z = sp.var("x y z")
+neg_x = sp.Symbol("x", negative=True)
+p = sp.Symbol("p", prime=True)
+
+
+def test_clone():
+    for expr in [
+        sp.Add(
+            sp.Pow(sp.Integer(2), 2, evaluate=False),
+            sp.Pow(sp.Float(3.1), 2, evaluate=False),
+            evaluate=False,
+        ),
+        # from Issue #5783
+        sp.Mul(sp.Float(-11.1), sp.Integer(19)),
+        # from PR #622
+        sp.Pow(3, 2, evaluate=False),
+        # symbols
+        x ** 2 + sp.sin(y) + x * y * z,
+        # rational
+        sp.Add(sp.Rational(2, 3), sp.Float(sp.pi), evaluate=False),
+        # assumptions
+        neg_x ** 3 + sp.sin(p),
+    ]:
+        assert clone(expr) == expr
+
+
+def test_pickle_unpickle_ast():
+    for expr in [
+        sp.Add(
+            sp.Pow(sp.Integer(2), 2, evaluate=False),
+            sp.Pow(sp.Float(3.1), 2, evaluate=False),
+            evaluate=False,
+        ),
+        # from Issue #5783
+        sp.Mul(sp.Float(-11.1), sp.Integer(19)),
+        # from PR #622
+        sp.Pow(3, 2, evaluate=False),
+        # symbols
+        x ** 2 + sp.sin(y) + x * y * z,
+        # rational
+        sp.Add(sp.Rational(2, 3), sp.Float(sp.pi), evaluate=False),
+        # assumptions
+        neg_x ** 3 + sp.sin(p),
+    ]:
+        ast_expr = to_ast(expr)
+        orig = compile(ast_expr, filename="<ast>", mode="eval")
+        unpickled_ast_expr = pickle.loads(pickle.dumps(ast_expr))
+        new = compile(unpickled_ast_expr, filename="<ast>", mode="eval")
+        assert eval(orig) == eval(new)
+
+
+def test_7672():
+    # deepcopy interferes with original Issue #7672
+    x, xx = sp.symbols("x"), sp.symbols("x", real=True)
+    assert x != xx
+    xxx = deepcopy(xx)
+    assert x == xx
+
+    # clone does not
+    y, yy = sp.symbols("y"), sp.symbols("y", real=True)
+    assert y != yy
+    # deepcopy broken (should not be equal)
+    yyy = clone(yy)
+    assert y != yy


### PR DESCRIPTION
#### References to other Issues or PRs

Potentially fixes #5783, #7672 with a little extra work (ie calling clone from \_\_deepcopy__). 

#### Brief description of what is fixed or changed

This introduces a function `clone` that deep-copies an expression honouring `evaluate=False`. It does this by mirroring the expression tree into a new graph then building an Python AST to match the original tree.

#### Other comments

I needed these routines for some investigations into number partitions and I felt they might be generally useful. I know this PR requires more work (ie integrate with \_\_deepcopy__ dunder). I am raising the PR to see if the Sympy maintainers feel this functionality is appropriate and of use. If so, then I am happy to further enhance so it may be merged into the master branch.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * introduce to_ast for converting expression into Python AST
  * introduce clone for deep copying expressions
  * deepcopy now honours evaluate=False (#TODO)

<!-- END RELEASE NOTES -->