### PR TITLE
make FiniteSet not contain equal Elements

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1907,6 +1907,10 @@ class FiniteSet(Set, EvalfMixin):
     def _eval_evalf(self, prec):
         return FiniteSet(*[elem.evalf(n=prec_to_dps(prec)) for elem in self])
 
+    def _eval_simplify(self, **kwargs):
+        from sympy.simplify import simplify
+        return FiniteSet(*[simplify(elem, **kwargs) for elem in self])
+
     @property
     def _sorted_args(self):
         return self.args

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1612,3 +1612,7 @@ def test_issue_20379():
     #https://github.com/sympy/sympy/issues/20379
     x = pi - 3.14159265358979
     assert FiniteSet(x).evalf(2) == FiniteSet(Float('3.23108914886517e-15', 2))
+
+def test_finiteset_simplify():
+    S = FiniteSet(1, cos(1)**2 + sin(1)**2)
+    assert S.simplify() == {1}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20432

#### Brief description of what is fixed or changed
Added `.simplify` to `FiniteSet` to simplify elements .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * Add `.simplify` to `FiniteSet`.
<!-- END RELEASE NOTES -->