### PR TITLE
stats:  Added function for self information

### DIFF
--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -106,7 +106,7 @@ __all__ = [
     'skewness', 'kurtosis', 'covariance', 'dependent', 'entropy', 'independent',
     'random_symbols', 'correlation', 'factorial_moment', 'moment', 'cmoment',
     'sampling_density', 'moment_generating_function', 'smoment', 'quantile',
-    'coskewness', 'sample_stochastic_process',
+    'coskewness', 'sample_stochastic_process', 'self_information',
 
     'FiniteRV', 'DiscreteUniform', 'Die', 'Bernoulli', 'Coin', 'Binomial',
     'BetaBinomial', 'Hypergeometric', 'Rademacher', 'IdealSoliton', 'RobustSoliton',
@@ -155,7 +155,7 @@ from .rv_interface import (P, E, H, density, where, given, sample, cdf, median,
         kurtosis, covariance, dependent, entropy, independent, random_symbols,
         correlation, factorial_moment, moment, cmoment, sampling_density,
         moment_generating_function, smoment, quantile, coskewness,
-        sample_stochastic_process)
+        sample_stochastic_process, self_information)
 
 from .frv_types import (FiniteRV, DiscreteUniform, Die, Bernoulli, Coin,
         Binomial, BetaBinomial, Hypergeometric, Rademacher,

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -495,7 +495,7 @@ def self_information(condition, base = 2, **kwargs):
     Parameters
     ==========
 
-    condition : Expression containing RandomSymbols 
+    condition : Expression containing RandomSymbols
     base : Base with respect to which the self-information is calculated
 
     Examples

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -489,7 +489,7 @@ def self_information(p):
     It represents the degree of surprise associated with a certain outcome.
     Mathematically it is defined as
 
-    .. math:: 
+    .. math::
         selfinformation(p)=-\log_2 (p)
 
     Parameters

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -501,7 +501,7 @@ def self_information(p):
     ========
     >>> from sympy.stats import self_information, P, Die
     >>> from sympy import Eq
-    >>> X, Y = Die('X', 6), Die('Y', 6)
+    >>> X = Die('X', 6)
     >>> self_information(P(X>3))
     1
     >>> self_information(P(Eq(X,4)))

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -12,7 +12,7 @@ __all__ = ['P', 'E', 'H', 'density', 'where', 'given', 'sample', 'cdf',
         'skewness', 'kurtosis', 'covariance', 'dependent', 'entropy', 'median',
         'independent', 'random_symbols', 'correlation', 'factorial_moment',
         'moment', 'cmoment', 'sampling_density', 'moment_generating_function',
-        'smoment', 'quantile', 'sample_stochastic_process']
+        'smoment', 'quantile', 'sample_stochastic_process', 'self_information']
 
 
 
@@ -483,6 +483,41 @@ def coskewness(X, Y, Z, condition=None, **kwargs):
          * std(Z, condition, **kwargs)
     return num/den
 
+def self_information(p):
+    """
+    Calculates the self-information of a particular outcome of an event.
+    It represents the degree of surprise associated with a certain outcome.
+    Mathematically it is defined as
+
+    .. math:: 
+        selfinformation(p)=-\log_2 (p)
+
+    Parameters
+    ==========
+
+    p : Probability of an event
+
+    Examples
+    ========
+    >>> from sympy.stats import self_information, P, Die
+    >>> from sympy import Eq
+    >>> X, Y = Die('X', 6), Die('Y', 6)
+    >>> self_information(P(X>3))
+    1
+    >>> self_information(P(Eq(X,4)))
+    1 + log(3)/log(2)
+
+    Returns
+    =======
+
+    self-information : The self-information of the probability of an event
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Information_content
+    """
+    return -log(p, 2)
 
 P = probability
 E = expectation

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -483,29 +483,32 @@ def coskewness(X, Y, Z, condition=None, **kwargs):
          * std(Z, condition, **kwargs)
     return num/den
 
-def self_information(p):
+def self_information(condition, base = 2, **kwargs):
     """
     Calculates the self-information of a particular outcome of an event.
     It represents the degree of surprise associated with a certain outcome.
     Mathematically it is defined as
 
     .. math::
-        selfinformation(p)=-\log_2 (p)
+        selfinformation(p, b)=-\log_b (p)
 
     Parameters
     ==========
 
-    p : Probability of an event
+    condition : Expression containing RandomSymbols 
+    base : Base with respect to which the self-information is calculated
 
     Examples
     ========
-    >>> from sympy.stats import self_information, P, Die
+    >>> from sympy.stats import self_information, Die
     >>> from sympy import Eq
     >>> X = Die('X', 6)
-    >>> self_information(P(X>3))
+    >>> self_information(X>3)
     1
-    >>> self_information(P(Eq(X,4)))
+    >>> self_information(Eq(X,4))
     1 + log(3)/log(2)
+    >>> self_information(X<2, 10)
+    log(6)/log(10)
 
     Returns
     =======
@@ -517,7 +520,8 @@ def self_information(p):
 
     .. [1] https://en.wikipedia.org/wiki/Information_content
     """
-    return -log(p, 2)
+    p = P(condition)
+    return -log(p, base)
 
 P = probability
 E = expectation

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -396,6 +396,6 @@ def test_issue_20286():
     assert eq.dummy_eq(H(B))
 
 def test_self_information():
-    X, Y = Die('X', 6), Die('Y', 6)
+    X = Die('X', 6)
     assert self_information(P(X>3)) == 1
     assert self_information(P(Eq(X,4))) == 1 + log(3)/log(2)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -5,7 +5,7 @@ from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
         density, given, independent, dependent, where, pspace, GaussianUnitaryEnsemble,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
         DiscreteUniform, Poisson, characteristic_function, moment_generating_function,
-        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance)
+        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance, self_information)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace, is_random, RandomIndexedSymbol, RandomMatrixSymbol)
 from sympy.testing.pytest import raises, skip, XFAIL, ignore_warnings
@@ -394,3 +394,8 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
+
+def test_self_information():
+    X, Y = Die('X', 6), Die('Y', 6)
+    assert self_information(P(X>3)) == 1
+    assert self_information(P(Eq(X,4))) == 1 + log(3)/log(2)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -397,5 +397,6 @@ def test_issue_20286():
 
 def test_self_information():
     X = Die('X', 6)
-    assert self_information(P(X>3)) == 1
-    assert self_information(P(Eq(X,4))) == 1 + log(3)/log(2)
+    assert self_information(X>3) == 1
+    assert self_information(Eq(X,4)) == 1 + log(3)/log(2)
+    assert self_information(X<2, 10) == log(6)/log(10)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Implements ideas from #20286, from the [link](https://colab.research.google.com/github/d2l-ai/d2l-en-colab/blob/master/chapter_appendix-mathematics-for-deep-learning/information-theory.ipynb) provided by OP. 

#### Brief description of what is fixed or changed
Implemented a function which calculates the self-information of a given outcome 
of an event using the probability.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Added a new method to calculate self-information.
<!-- END RELEASE NOTES -->