### PR TITLE
Make Array differentiation work with non sympy expression

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,7 +1,8 @@
 import itertools
 from collections.abc import Iterable
 
-from sympy import S, Tuple, diff, Basic, sympify
+from sympy import S, Tuple, diff, Basic
+from sympy.core.sympify import _sympify
 
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.array.dense_ndim_array import DenseNDimArray, ImmutableDenseNDimArray
@@ -269,9 +270,6 @@ def derive_by_array(expr, dx):
     from sympy.tensor.array import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
 
-    expr = sympify(expr)
-    dx = sympify(dx)
-
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)
         for i in dx:
@@ -296,9 +294,11 @@ def derive_by_array(expr, dx):
         else:
             return expr.diff(dx)
     else:
+        expr = _sympify(expr)
         if isinstance(dx, array_types):
             return ImmutableDenseNDimArray([expr.diff(i) for i in Flatten(dx)], dx.shape)
         else:
+            dx = _sympify(dx)
             return diff(expr, dx)
 
 

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Iterable
 
-from sympy import S, Tuple, diff, Basic
+from sympy import S, Tuple, diff, Basic, sympify
 
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.array.dense_ndim_array import DenseNDimArray, ImmutableDenseNDimArray
@@ -268,6 +268,9 @@ def derive_by_array(expr, dx):
     from sympy.matrices import MatrixBase
     from sympy.tensor.array import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
+
+    expr = sympify(expr)
+    dx = sympify(dx)
 
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -101,6 +101,11 @@ def test_derivative_by_array():
         assert derive_by_array(b, i) == ImmutableSparseNDimArray({0: 1}, (10000, 20000))
         assert derive_by_array(b, (i, j)) == ImmutableSparseNDimArray({0: 1, 200000001: 1}, (2, 10000, 20000))
 
+    #https://github.com/sympy/sympy/issues/20655
+    U = Array([x, y, z])
+    E = 2
+    assert derive_by_array(E, U) ==  ImmutableDenseNDimArray([0, 0, 0])
+
 
 def test_issue_emerged_while_discussing_10972():
     ua = Array([-1,0])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20655 

#### Brief description of what is fixed or changed
Make derive_by_array sympify it's arguments first.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
    * Make Array differentiation(`derive_by_array`) work with non sympy expressions.
<!-- END RELEASE NOTES -->