### PR TITLE
Subs.doit: Added Conditional statement by checking argument

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2276,9 +2276,13 @@ class Subs(Expr):
                 # do Subs that aren't related to differentiation
                 undone2 = []
                 D = Dummy()
+                arg = e.args[0]
+                arg = repr(arg)
                 for vi, pi in undone:
                     if D not in e.xreplace({vi: D}).free_symbols:
-                        e = e.subs(vi, pi)
+                        vrbl = repr(vi)
+                        if arg.find(vrbl)!=-1:
+                            e = e.subs(vi, pi)
                     else:
                         undone2.append((vi, pi))
                 undone = undone2

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2279,7 +2279,7 @@ class Subs(Expr):
                 arg = e.args[0]
                 for vi, pi in undone:
                     if D not in e.xreplace({vi: D}).free_symbols:
-                        if arg.has(vi) == True:
+                        if arg.has(vi):
                             e = e.subs(vi, pi)
                     else:
                         undone2.append((vi, pi))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2277,11 +2277,9 @@ class Subs(Expr):
                 undone2 = []
                 D = Dummy()
                 arg = e.args[0]
-                arg = repr(arg)
                 for vi, pi in undone:
                     if D not in e.xreplace({vi: D}).free_symbols:
-                        vrbl = repr(vi)
-                        if arg.find(vrbl)!=-1:
+                        if arg.has(vi) == True:
                             e = e.subs(vi, pi)
                     else:
                         undone2.append((vi, pi))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1366,15 +1366,16 @@ def test_Derivative_free_symbols():
     assert diff(f(x), (x, n)).free_symbols == {n, x}
 
 
-def test_issue_10503():
-    f = exp(x**3)*cos(x**6)
-    assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)
-
 def test_issue_20683():
     x = Symbol('x')
     y = Symbol('y')
     z = Symbol('z')
-    y=Derivative(z,x).subs(x,0)
+    y = Derivative(z, x).subs(x,0)
     assert y.doit() == 0
-    y=Derivative(8,x).subs(x,0)
+    y = Derivative(8, x).subs(x,0)
     assert y.doit() == 0
+
+
+def test_issue_10503():
+    f = exp(x**3)*cos(x**6)
+    assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1369,3 +1369,12 @@ def test_Derivative_free_symbols():
 def test_issue_10503():
     f = exp(x**3)*cos(x**6)
     assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)
+
+def test_issue_20683():
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
+    y=Derivative(z,x).subs(x,0)
+    assert y.doit() == 0
+    y=Derivative(8,x).subs(x,0)
+    assert y.doit() == 0


### PR DESCRIPTION
Checked for the presence of the variable w.r.t which differentiation occurs, accordingly added conditional statement for it to avoid subs method.

Originally, this issue arose while debugging #18118 
Fixes #20683 

In addition to the above, if there was no presence of variable w.r.t which differentiation will occur(vi in code) found, simply added if condition to not use subs method w.r.t. the variable then.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->