### PR TITLE
Uncommenting tests in test_setexpr.py 

### DIFF
--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -2,7 +2,7 @@ from sympy.sets.setexpr import SetExpr
 from sympy.sets import Interval, FiniteSet, Intersection, ImageSet, Union
 
 from sympy import (Expr, Set, exp, log, cos, Symbol, Min, Max, S, oo, I,
-        symbols, Lambda, Dummy, Rational)
+        symbols, Lambda, Dummy, Rational, sqrt)
 
 
 a, x = symbols("a, x")
@@ -216,7 +216,7 @@ def test_SetExpr_Interval_div():
 
     assert 1/SetExpr(Interval(0, 2)) == SetExpr(Interval(S.Half, oo))
     assert (-1)/SetExpr(Interval(0, 2)) == SetExpr(Interval(-oo, Rational(-1, 2)))
-    # assert 1/SetExpr(Interval(-oo, 0)) == SetExpr(Interval.open(-oo, 0))
+    assert 1/SetExpr(Interval(-oo, 0)) == SetExpr(Interval.open(-oo, 0))
     assert 1/SetExpr(Interval(-1, 0)) == SetExpr(Interval(-oo, -1))
     # assert (-2)/SetExpr(Interval(-oo, 0)) == SetExpr(Interval(0, oo))
     # assert 1/SetExpr(Interval(-oo, -1)) == SetExpr(Interval(-1, 0))
@@ -244,7 +244,7 @@ def test_SetExpr_Interval_pow():
     assert SetExpr(Interval(-1, 1))**0 == SetExpr(FiniteSet(1))
 
 
-    #assert SetExpr(Interval(1, 2))**Rational(5, 2) == SetExpr(Interval(1, 4*sqrt(2)))
+    assert SetExpr(Interval(1, 2))**Rational(5, 2) == SetExpr(Interval(1, 4*sqrt(2)))
     #assert SetExpr(Interval(-1, 2))**Rational(1, 3) == SetExpr(Interval(-1, 2**Rational(1, 3)))
     #assert SetExpr(Interval(0, 2))**S.Half == SetExpr(Interval(0, sqrt(2)))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None

#### Brief description of what is fixed or changed
Some tests in `test_setexpr.py` were commented because they weren't passing due to bugs. However, two of them, are passing right now and I've uncommented them. 

The two tests are:-
`assert SetExpr(Interval(1, 2))**Rational(5, 2) == SetExpr(Interval(1, 4*sqrt(2)))`
and 
`assert 1/SetExpr(Interval(-oo, 0)) == SetExpr(Interval.open(-oo, 0))`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->