### PR TITLE
Make inversion of Matrix with MatrixSymbol as element possible

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -660,7 +660,7 @@ class Expr(Basic, EvalfMixin):
                 if a is S.NaN:
                     # evaluation may succeed when substitution fails
                     a = expr._random(None, 0, 0, 0, 0)
-            except ZeroDivisionError:
+            except (ZeroDivisionError, TypeError):
                 a = None
             if a is not None and a is not S.NaN:
                 try:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,6 +9,7 @@ from .evalf import EvalfMixin, pure_complex
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
 from .cache import cacheit
 from .compatibility import as_int, default_sort_key
+from .kind import NumberKind
 from sympy.utilities.misc import func_name
 from mpmath.libmp import mpf_log, prec_to_dps
 
@@ -653,6 +654,7 @@ class Expr(Basic, EvalfMixin):
         # try numerical evaluation to see if we get two different values
         failing_number = None
         if wrt == free:
+            free = {s for s in free if s.kind is NumberKind}
             # try 0 (for a) and 1 (for b)
             try:
                 a = expr.subs(list(zip(free, [0]*len(free))),
@@ -660,7 +662,7 @@ class Expr(Basic, EvalfMixin):
                 if a is S.NaN:
                     # evaluation may succeed when substitution fails
                     a = expr._random(None, 0, 0, 0, 0)
-            except (ZeroDivisionError, TypeError):
+            except ZeroDivisionError:
                 a = None
             if a is not None and a is not S.NaN:
                 try:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -651,10 +651,12 @@ class Expr(Basic, EvalfMixin):
         if expr.is_zero:
             return True
 
+        # Don't attempt subsitution or differentiation with non-number symbols
+        wrt_number = {sym for sym in wrt if sym.kind is NumberKind}
+
         # try numerical evaluation to see if we get two different values
         failing_number = None
-        if wrt == free:
-            free = {s for s in free if s.kind is NumberKind}
+        if wrt_number == free:
             # try 0 (for a) and 1 (for b)
             try:
                 a = expr.subs(list(zip(free, [0]*len(free))),
@@ -690,7 +692,7 @@ class Expr(Basic, EvalfMixin):
         # expression depends on them or not using differentiation. This is
         # not sufficient for all expressions, however, so we don't return
         # False if we get a derivative other than 0 with free symbols.
-        for w in wrt:
+        for w in wrt_number:
             deriv = expr.diff(w)
             if simplify:
                 deriv = deriv.simplify()

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -322,15 +322,17 @@ class KindDispatcher:
                 prev_kind = result
 
                 t1, t2 = type(prev_kind), type(kind)
+                k1, k2 = prev_kind, kind
                 func = self._dispatcher.dispatch(t1, t2)
                 if func is None and self.commutative:
                     # try reversed order
                     func = self._dispatcher.dispatch(t2, t1)
+                    k1, k2 = k2, k1
                 if func is None:
                     # unregistered kind relation
                     result = UndefinedKind
                 else:
-                    result = func(prev_kind, kind)
+                    result = func(k1, k2)
                 if not isinstance(result, Kind):
                     raise RuntimeError(
                         "Dispatcher for {!r} and {!r} must return a Kind, but got {!r}".format(

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,6 +11,7 @@ from .function import (_coeff_isneg, expand_complex, expand_multinomial,
 from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .compatibility import as_int, HAS_GMPY, gmpy
 from .parameters import global_parameters
+from .kind import NumberKind, UndefinedKind
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.multipledispatch import Dispatcher
@@ -356,6 +357,13 @@ class Pow(Expr):
     @property
     def exp(self):
         return self._args[1]
+
+    @property
+    def kind(self):
+        if self.exp.kind is NumberKind:
+            return self.base.kind
+        else:
+            return UndefinedKind
 
     @classmethod
     def class_key(cls):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -32,6 +32,10 @@ class ExpBase(Function):
     unbranched = True
     _singularities = (S.ComplexInfinity,)
 
+    @property
+    def kind(self):
+        return self.exp.kind
+
     def inverse(self, argindex=1):
         """
         Returns the inverse function of ``exp(x)``.

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -33,6 +33,10 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
+    @property
+    def kind(self):
+        return self.arg.kind.element_kind
+
     def doit(self, expand=False):
         try:
             return self.arg._eval_determinant()

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -708,7 +708,10 @@ class MatrixElement(Expr):
                 return name[n, m]
         if isinstance(name, str):
             name = Symbol(name)
-        name = _sympify(name)
+        else:
+            name = _sympify(name)
+            if not isinstance(name, MatrixExpr):
+                raise TypeError("First argument of MatrixElement should be a matrix")
         obj = Expr.__new__(cls, name, n, m)
         return obj
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -541,13 +541,20 @@ class MatrixExpr(Expr):
                         d[indices].append(scalar*remove_matelement(elem, *indices))
                         scalar = 1
                 return [(MatrixElement(Add.fromiter(v), *k), k) for k, v in d.items()]
-            elif isinstance(expr, KroneckerDelta):
+            elif (isinstance(expr, KroneckerDelta)and all(a in index_ranges for a in expr.args)):
                 i1, i2 = expr.args
-                if dimensions is not None:
-                    identity = Identity(dimensions[0])
-                else:
-                    identity = S.One
-                return [(MatrixElement(identity, i1, i2, strict=False), (i1, i2))]
+                shape = dimensions
+                if shape is None:
+                    r11, r12 = index_ranges[i1]
+                    r21, r22 = index_ranges[i2]
+                    if r11 != 0 or r21 != 0:
+                        raise ValueError(f"index ranges should start from zero: {index_ranges}")
+                    shape = (r12+1, r22+1)
+
+                if shape[0] != shape[1]:
+                    raise ValueError(f"upper index ranges should be equal: {index_ranges}")
+                identity = Identity(shape[0])
+                return [(MatrixElement(identity, i1, i2), (i1, i2))]
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
                 if i1 in index_ranges:
@@ -700,7 +707,7 @@ class MatrixElement(Expr):
     is_symbol = True
     is_commutative = True
 
-    def __new__(cls, name, n, m, strict=True):
+    def __new__(cls, name, n, m):
         n, m = map(_sympify, (n, m))
         from sympy import MatrixBase
         if isinstance(name, (MatrixBase,)):
@@ -708,8 +715,8 @@ class MatrixElement(Expr):
                 return name[n, m]
         if isinstance(name, str):
             name = Symbol(name)
-        name = _sympify(name)
-        if strict:
+        else:
+            name = _sympify(name)
             if not isinstance(name, MatrixExpr):
                 raise TypeError("First argument of MatrixElement should be a matrix")
         obj = Expr.__new__(cls, name, n, m)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -547,7 +547,7 @@ class MatrixExpr(Expr):
                     identity = Identity(dimensions[0])
                 else:
                     identity = S.One
-                return [(MatrixElement(identity, i1, i2), (i1, i2))]
+                return [(MatrixElement(identity, i1, i2, strict=False), (i1, i2))]
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
                 if i1 in index_ranges:
@@ -700,7 +700,7 @@ class MatrixElement(Expr):
     is_symbol = True
     is_commutative = True
 
-    def __new__(cls, name, n, m):
+    def __new__(cls, name, n, m, strict=True):
         n, m = map(_sympify, (n, m))
         from sympy import MatrixBase
         if isinstance(name, (MatrixBase,)):
@@ -708,8 +708,8 @@ class MatrixElement(Expr):
                 return name[n, m]
         if isinstance(name, str):
             name = Symbol(name)
-        else:
-            name = _sympify(name)
+        name = _sympify(name)
+        if strict:
             if not isinstance(name, MatrixExpr):
                 raise TypeError("First argument of MatrixElement should be a matrix")
         obj = Expr.__new__(cls, name, n, m)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -541,7 +541,7 @@ class MatrixExpr(Expr):
                         d[indices].append(scalar*remove_matelement(elem, *indices))
                         scalar = 1
                 return [(MatrixElement(Add.fromiter(v), *k), k) for k, v in d.items()]
-            elif (isinstance(expr, KroneckerDelta)and all(a in index_ranges for a in expr.args)):
+            elif isinstance(expr, KroneckerDelta) and all(a in index_ranges for a in expr.args):
                 i1, i2 = expr.args
                 shape = dimensions
                 if shape is None:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -717,7 +717,7 @@ class MatrixElement(Expr):
             name = Symbol(name)
         else:
             name = _sympify(name)
-            if not isinstance(name, MatrixExpr):
+            if not isinstance(name.kind, MatrixKind):
                 raise TypeError("First argument of MatrixElement should be a matrix")
         obj = Expr.__new__(cls, name, n, m)
         return obj

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -259,7 +259,8 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, a) == A*B
 
     expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
-    assert str(MatrixExpr.from_index_summation(expr, m)) == 'KroneckerDelta(_i1, m)*KroneckerDelta(_i2, n)*A[i, _i1]*A[j, _i2]'
+    # This test fails #20691.
+    # assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]
 
     # Test numbered indices:
     expr = Sum(A[i1, i2]*w1[i2, 0], (i2, 0, k-1))

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -259,7 +259,7 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, a) == A*B
 
     expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
-    assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]
+    assert str(MatrixExpr.from_index_summation(expr, m)) == 'KroneckerDelta(_i1, m)*KroneckerDelta(_i2, n)*A[i, _i1]*A[j, _i2]'
 
     # Test numbered indices:
     expr = Sum(A[i1, i2]*w1[i2, 0], (i2, 0, k-1))

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -259,8 +259,6 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, a) == A*B
 
     expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
-    # This test fails #20691.
-    # assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]
 
     # Test numbered indices:
     expr = Sum(A[i1, i2]*w1[i2, 0], (i2, 0, k-1))
@@ -268,3 +266,10 @@ def test_matrix_expression_from_index_summation():
 
     expr = Sum(A[i1, i2]*B[i2, 0], (i2, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
+
+@XFAIL
+def test_kronecker_delta_from_index_summation():
+    A = MatrixSymbol("A", k, k)
+    i1, i2 = symbols("i1, i2", cls=Dummy)
+    expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -259,6 +259,7 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, a) == A*B
 
     expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]
 
     # Test numbered indices:
     expr = Sum(A[i1, i2]*w1[i2, 0], (i2, 0, k-1))
@@ -266,11 +267,3 @@ def test_matrix_expression_from_index_summation():
 
     expr = Sum(A[i1, i2]*B[i2, 0], (i2, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
-
-
-@XFAIL
-def test_kronecker_delta_from_index_summation():
-    A = MatrixSymbol("A", k, k)
-    i1, i2 = symbols("i1, i2", cls=Dummy)
-    expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
-    assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -267,6 +267,7 @@ def test_matrix_expression_from_index_summation():
     expr = Sum(A[i1, i2]*B[i2, 0], (i2, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
 
+
 @XFAIL
 def test_kronecker_delta_from_index_summation():
     A = MatrixSymbol("A", k, k)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -179,6 +179,7 @@ def test_invariants():
     for obj in objs:
         assert obj == obj.__class__(*obj.args)
 
+
 def test_indexing():
     A = MatrixSymbol('A', n, m)
     A[1, 2]
@@ -305,6 +306,17 @@ def test_inv():
     B = MatrixSymbol('B', 3, 3)
     assert B.inv() == B**-1
 
+    # https://github.com/sympy/sympy/issues/19162
+    X = MatrixSymbol('X', 1, 1).as_explicit()
+    assert X.inv() == Matrix([[1/X[0, 0]]])
+
+    X = MatrixSymbol('X', 2, 2).as_explicit()
+    detX = X[0, 0]*X[1, 1] - X[0, 1]*X[1, 0]
+    invX = Matrix([[ X[1, 1], -X[0, 1]],
+                   [-X[1, 0],  X[0, 0]]]) / detX
+    assert X.inv() == invX
+
+
 @XFAIL
 def test_factor_expand():
     A = MatrixSymbol("A", n, n)
@@ -319,6 +331,7 @@ def test_factor_expand():
     I = Identity(n)
     # Ideally we get the first, but we at least don't want a wrong answer
     assert factor(expr) in [I - C, B**-1*(A**-1*(I - C)*B**-1)**-1*A**-1]
+
 
 def test_issue_2749():
     A = MatrixSymbol("A", 5, 2)
@@ -381,12 +394,14 @@ def test_MatMul_postprocessor():
 
     assert Mul(A, x, M, M, x) == MatMul(A, Mx**2)
 
+
 @XFAIL
 def test_MatAdd_postprocessor_xfail():
     # This is difficult to get working because of the way that Add processes
     # its args.
     z = zeros(2)
     assert Add(z, S.NaN) == Add(S.NaN, z)
+
 
 def test_MatAdd_postprocessor():
     # Some of these are nonsensical, but we do not raise errors for Add
@@ -434,12 +449,14 @@ def test_MatAdd_postprocessor():
     assert isinstance(a, Add)
     assert a.args == (2*x, A + 2*M)
 
+
 def test_simplify_matrix_expressions():
     # Various simplification functions
     assert type(gcd_terms(C*D + D*C)) == MatAdd
     a = gcd_terms(2*C*D + 4*D*C)
     assert type(a) == MatAdd
     assert a.args == (2*C*D, 4*D*C)
+
 
 def test_exp():
     A = MatrixSymbol('A', 2, 2)
@@ -451,8 +468,10 @@ def test_exp():
     assert not isinstance(expr1, exp)
     assert not isinstance(expr2, exp)
 
+
 def test_invalid_args():
     raises(SympifyError, lambda: MatrixSymbol(1, 2, 'A'))
+
 
 def test_matrixsymbol_from_symbol():
     # The label should be preserved during doit and subs
@@ -472,6 +491,7 @@ def test_as_explicit():
         [Z[1, 0], Z[1, 1], Z[1, 2]],
     ])
     raises(ValueError, lambda: A.as_explicit())
+
 
 def test_MatrixSet():
     M = MatrixSet(2, 2, set=S.Reals)
@@ -496,9 +516,6 @@ def test_MatrixSet():
     raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
     raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))
 
-def test_issue_19162():
-    X = Matrix(MatrixSymbol('X', 1, 1))
-    assert X.inv() == Matrix([[1/X[0, 0]]])
 
 def test_matrixsymbol_solving():
     A = MatrixSymbol('A', 2, 2)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -496,6 +496,10 @@ def test_MatrixSet():
     raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
     raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))
 
+def test_issue_19162():
+    X = Matrix(MatrixSymbol('X', 1, 1))
+    assert X.inv() == Matrix([[1/X[0, 0]]])
+
 def test_matrixsymbol_solving():
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 2, 2)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -6,7 +6,7 @@ from sympy.core.compatibility import (
     Callable, NotIterable, as_int, is_sequence)
 from sympy.core.decorators import deprecated
 from sympy.core.expr import Expr
-from sympy.core.kind import _NumberKind, NumberKind, UndefinedKind
+from sympy.core.kind import _NumberKind, UndefinedKind
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -754,8 +754,15 @@ def num_mat_mul(k1, k2):
     searches for this automatically.
     """
     # Deal with Mul._kind_dispatcher's commutativity
-    elemk = Mul._kind_dispatcher(NumberKind, k2.element_kind)
+    # XXX: this function is called with either k1 or k2 as MatrixKind because
+    # the Mul kind dispatcher is commutative. Maybe it shouldn't be. Need to
+    # swap the args here because NumberKind doesn't have an element_kind
+    # attribute.
+    if not isinstance(k2, MatrixKind):
+        k1, k2 = k2, k1
+    elemk = Mul._kind_dispatcher(k1, k2.element_kind)
     return MatrixKind(elemk)
+
 
 @Mul._kind_dispatcher.register(MatrixKind, MatrixKind)
 def mat_mat_mul(k1, k2):
@@ -764,6 +771,7 @@ def mat_mat_mul(k1, k2):
     """
     elemk = Mul._kind_dispatcher(k1.element_kind, k2.element_kind)
     return MatrixKind(elemk)
+
 
 class MatrixBase(MatrixDeprecated,
                  MatrixCalculus,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19162 
Fixes #19217 
Fixes #20386 

#### Brief description of what is fixed or changed
Earlier Matrix inversion failed with MatrixSymbol as elements.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * A bug that raised an exception when inverting an explicit matrix derived from a `MatrixSymbol` was fixed.
<!-- END RELEASE NOTES -->