### PR TITLE
gcd: Fix expansion of unevaluated Muls

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -937,9 +937,9 @@ class Mul(Expr, AssocOp):
         if d.is_Mul:
             n, d = [i._eval_expand_mul(**hints) if i.is_Mul else i
                 for i in (n, d)]
-            expr = n/d
-            if not expr.is_Mul:
-                return expr
+        expr = n/d
+        if not expr.is_Mul:
+            return expr
 
         plain, sums, rewrite = [], [], False
         for factor in expr.args:

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -230,6 +230,15 @@ def test_expand_arit():
     W = W.expand()
     assert W.has(-1672280820*x**15)
 
+def test_expand_mul():
+    # part of issue 20597
+    e = Mul(2, 3, evaluate=False)
+    assert e.expand() == 6
+
+    e = Mul(2, 3, 1/x, evaluate = False)
+    assert e.expand() == 6/x
+    e = Mul(2, R(1, 3), evaluate=False)
+    assert e.expand() == R(2, 3)
 
 def test_power_expand():
     """Test for Pow.expand()"""

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2077,6 +2077,9 @@ def test_gcd_numbers_vs_polys():
     assert gcd(3.0, 9.0) == 1.0
     assert gcd(3.0*x, 9.0) == 1.0
 
+    # partial fix of 20597
+    assert gcd(Mul(2, 3, evaluate=False), 2) == 2
+
 
 def test_terms_gcd():
     assert terms_gcd(1) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #20597

#### Brief description of what is fixed or changed
`gcd` was not functioning correctly when given an unevaluated `Mul`. Added a check within `expand` which simplifies `expr` using `fraction` prior to expansion if doing so results in a non-`Mul`, (and thus expands correctly).

#### Other comments
Similar behavior was observed with an unevaluated `Add` containing only Integers, but unlike `Mul`, there is no `_eval_expand_[hint]` to modify. Perhaps this would have to be added?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * gcd correctly handles unevaluated Mul
<!-- END RELEASE NOTES -->