### PR TITLE
Fixed is_palindromic function to return all negative integers as non-palindromic in ntheory module

### DIFF
--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -153,4 +153,3 @@ def is_palindromic(n, b=10):
         return False
     else:
         return _palindromic(digit_list, 1)
-    

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -140,4 +140,11 @@ def is_palindromic(n, b=10):
     ('0o171', True)
 
     """
-    return _palindromic(digits(n, b), 1)
+    #Get the list of its digits
+    digit_list=digits(n,b)  #b must be an integer > 1 else value error will be raised
+
+    #Check if the first element of the list is -ve then it isn't a palindrome
+    if(digit_list[0]<0):
+        return False
+    else:
+        return _palindromic(digit_list, 1)

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -153,3 +153,4 @@ def is_palindromic(n, b=10):
         return False
     else:
         return _palindromic(digit_list, 1)
+    

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -111,15 +111,20 @@ def count_digits(n, b=10):
 
 def is_palindromic(n, b=10):
     """return True if ``n`` is the same when read from left to right
-    or right to left in the given base, ``b``.
+    or right to left in the given base, ``b``.(b must be greater than 1)
 
     Examples
     ========
 
     >>> from sympy.ntheory import is_palindromic
 
-    >>> all(is_palindromic(i) for i in (-11, 1, 22, 121))
+    >>> all(is_palindromic(i) for i in (11, 1, 22, 121))
     True
+
+    Note:negative integers can't be palindromic by definition
+
+    >>> is_palindromic(-121)
+    False
 
     The second argument allows you to test numbers in other
     bases. For example, 88 is palindromic in base-10 but not

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -28,7 +28,7 @@ def test_count_digits():
 
 
 def test_is_palindromic():
-    assert is_palindromic(-11)
+    assert not is_palindromic(-11)
     assert is_palindromic(11)
     assert is_palindromic(0o121, 8)
     assert not is_palindromic(123)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None

#### Brief description of what is fixed or changed
The is_palindromic function in digits.py script in ntheory module returned True for negative integers whose absolute value is palindromic.
For example, -121 was regarded palindromic.
Fixed this bug i.e. now, the function returns False for all negative integers 
Theoretically, negative integers aren't considered palindromic owing to the - sign in front 

#### Other comments
None

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed a bug which in is_palindromic function 
<!-- END RELEASE NOTES -->