### PR TITLE
improved _af_rmuln function in permutations

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -81,34 +81,19 @@ def _af_rmuln(*abc):
     """
     a = abc
     m = len(a)
-    if m == 3:
-        p0, p1, p2 = a
-        return [p0[p1[i]] for i in p2]
-    if m == 4:
-        p0, p1, p2, p3 = a
-        return [p0[p1[p2[i]]] for i in p3]
-    if m == 5:
-        p0, p1, p2, p3, p4 = a
-        return [p0[p1[p2[p3[i]]]] for i in p4]
-    if m == 6:
-        p0, p1, p2, p3, p4, p5 = a
-        return [p0[p1[p2[p3[p4[i]]]]] for i in p5]
-    if m == 7:
-        p0, p1, p2, p3, p4, p5, p6 = a
-        return [p0[p1[p2[p3[p4[p5[i]]]]]] for i in p6]
-    if m == 8:
-        p0, p1, p2, p3, p4, p5, p6, p7 = a
-        return [p0[p1[p2[p3[p4[p5[p6[i]]]]]]] for i in p7]
-    if m == 1:
-        return a[0][:]
-    if m == 2:
-        a, b = a
-        return [a[i] for i in b]
+
     if m == 0:
         raise ValueError("String must not be empty")
-    p0 = _af_rmuln(*a[:m//2])
-    p1 = _af_rmuln(*a[m//2:])
-    return [p0[i] for i in p1]
+
+    if m == 1:
+        return a[0][:]
+
+    if m > 2:
+        p = _af_rmuln(*a[1:])
+        return [a[0][i] for i in p]
+
+    elif m > 1:
+        return [a[-2][i] for i in a[-1]]
 
 
 def _af_parity(pi):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -55,9 +55,12 @@ def roots_quadratic(f):
     dom = f.get_domain()
 
     def _sqrt(d):
-        # remove squares from square root since both will be represented
-        # in the results; a similar thing is happening in roots() but
-        # must be duplicated here because not all quadratics are binomials
+        """
+        removes even powered variabes from the extression so that they aren't
+        represented twice in the results.
+        As roots() removes even powers for binomials, this duplication does
+        this for all binomial/non-binomial quadratics
+        """
         co = []
         other = []
         for di in Mul.make_args(d):


### PR DESCRIPTION
Change to reverse multiplication function for permutations to work more efficiently for any number of inputs.

#### References to other Issues or PRs
Fixes #20707 


#### Brief description of what is fixed or changed
Writes _af_rmuln more efficiently and allows it to work for any number of inputs. Was previously restricted to 8.
Added documentation to polyroots

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixes  _af_rmuln to work for more than 8 inputs for reverse multiplication of permutations.
* polys
  * adds documentation to polyroots

 
<!-- END RELEASE NOTES -->