### PR TITLE
improved _af_rmuln. Able to work for more than 8 arguments

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -50,7 +50,7 @@ def _af_rmul(a, b):
     return [a[i] for i in b]
 
 
-def _af_rmuln(*abc):
+def _af_rmuln(*permutations):
     """
     Given [a, b, c, ...] return the product of ...*c*b*a using array forms.
     The ith value is a[b[c[i]]].
@@ -79,36 +79,13 @@ def _af_rmuln(*abc):
 
     rmul, _af_rmul
     """
-    a = abc
-    m = len(a)
-    if m == 3:
-        p0, p1, p2 = a
-        return [p0[p1[i]] for i in p2]
-    if m == 4:
-        p0, p1, p2, p3 = a
-        return [p0[p1[p2[i]]] for i in p3]
-    if m == 5:
-        p0, p1, p2, p3, p4 = a
-        return [p0[p1[p2[p3[i]]]] for i in p4]
-    if m == 6:
-        p0, p1, p2, p3, p4, p5 = a
-        return [p0[p1[p2[p3[p4[i]]]]] for i in p5]
-    if m == 7:
-        p0, p1, p2, p3, p4, p5, p6 = a
-        return [p0[p1[p2[p3[p4[p5[i]]]]]] for i in p6]
-    if m == 8:
-        p0, p1, p2, p3, p4, p5, p6, p7 = a
-        return [p0[p1[p2[p3[p4[p5[p6[i]]]]]]] for i in p7]
-    if m == 1:
-        return a[0][:]
-    if m == 2:
-        a, b = a
-        return [a[i] for i in b]
     if m == 0:
         raise ValueError("String must not be empty")
-    p0 = _af_rmuln(*a[:m//2])
-    p1 = _af_rmuln(*a[m//2:])
-    return [p0[i] for i in p1]
+
+    result, perms = permutations[0], permutations[1:]
+    for p in perms:
+        result = [result[i] for i in p]
+    return result
 
 
 def _af_parity(pi):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20707 


#### Brief description of what is fixed or changed
Writes _af_rmuln more efficiently and allows it to work for any number of inputs. Was previously restricted to 8.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixes  _af_rmuln to work for more than 8 inputs for reverse multiplication of permutations.
<!-- END RELEASE NOTES -->