### PR TITLE
Added inverse method for conjugate

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -826,6 +826,9 @@ class conjugate(Function):
         if obj is not None:
             return obj
 
+    def inverse(self):
+        return conjugate
+
     def _eval_Abs(self):
         return Abs(self.args[0], evaluate=True)
 

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -667,6 +667,7 @@ def test_conjugate():
 
     x, y = symbols('x y')
     assert conjugate(conjugate(x)) == x
+    assert conjugate(x).inverse() == conjugate
     assert conjugate(x + y) == conjugate(x) + conjugate(y)
     assert conjugate(x - y) == conjugate(x) - conjugate(y)
     assert conjugate(x * y) == conjugate(x) * conjugate(y)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -5,7 +5,7 @@ from sympy import (
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
-    E, cbrt, denom, Add, Piecewise, GoldenRatio, TribonacciConstant)
+    E, cbrt, denom, Add, Piecewise, GoldenRatio, TribonacciConstant, conjugate)
 
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -294,6 +294,10 @@ def test_solve_rational():
     """Test solve for rational functions"""
     assert solve( ( x - y**3 )/( (y**2)*sqrt(1 - y**2) ), x) == [y**3]
 
+
+def test_solve_conjugate():
+    """Test solve for simple conjugate functions"""
+    assert solve(conjugate(x) -3 + I) == [3 + I]
 
 def test_solve_nonlinear():
     assert solve(x**2 - y**2, x, y, dict=True) == [{x: -y}, {x: y}]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -6,7 +6,7 @@ from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
-from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
+from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign, conjugate)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     sinh, tanh, cosh, sech, coth)
@@ -2487,6 +2487,9 @@ def test_issue_10426():
         Intersection(S.Complexes, ImageSet(Lambda(n, -I*(I*(2*n*pi + arg(-exp(-2*I*x))) + 2*im(x))),
         S.Integers)))).dummy_eq(Dummy('x,n'))
 
+def test_solveset_conjugate():
+    """Test solveset for simple conjugate functions"""
+    assert solveset(conjugate(x) -3 + I) == FiniteSet(3 + I)
 
 @XFAIL
 def test_substitution_with_infeasible_solution():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20305

#### Brief description of what is fixed or changed

Added an inverse method to `conjugate` class which return the class itself.  

Fix suggested by @oscarbenjamin [here](https://github.com/sympy/sympy/issues/20305#issuecomment-716203999)

#### Other comments

I also tried doing https://github.com/sympy/sympy/issues/20305#issuecomment-716202814 but it seems that direct substitution of `conjugate(x)` as `abs(x)*exp(-I*arg(x))` in `solve` won't work as further processing in solve fails to find solution of `abs(x)*exp(-I*arg(x))` even in the simplest of cases. So we'll probably need to rethink that approach if we are to make `solve` compatible with equations containing both `x` and `conjugate(x)`. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- functions
  - Conjugate class now has an inverse method so it should work better in the solvers.
<!-- END RELEASE NOTES -->