### PR TITLE
RecursionError in evaluate on Piecewise fixed

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -857,6 +857,7 @@ class Expr(Basic, EvalfMixin):
             return False
 
     def _eval_is_extended_positive_negative(self, positive):
+        from sympy.core.numbers import pure_complex
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
@@ -878,8 +879,15 @@ class Expr(Basic, EvalfMixin):
             if n2 is S.NaN:
                 return None
 
-            r, i = self.evalf(2).as_real_imag()
-            if not i.is_Number or not r.is_Number:
+            f = self.evalf(2)
+            if f.is_Float:
+                match = f, S.Zero
+            else:
+                match = pure_complex(f)
+            if match is None:
+                return False
+            r, i = match
+            if not (i.is_Number and r.is_Number):
                 return False
             if r._prec != 1 and i._prec != 1:
                 return bool(not i and ((r > 0) if positive else (r < 0)))

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -708,9 +708,6 @@ class Pow(Expr):
             if isodd is not None:
                 return isodd
 
-        if self.exp.is_negative:
-            return (1/self).is_imaginary
-
     def _eval_is_odd(self):
         if self.exp.is_integer:
             if self.exp.is_positive:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1104,6 +1104,15 @@ def test_Pow_is_real():
     assert (1/(i-1)).is_real is None
     assert (1/(i-1)).is_extended_real is None
 
+    # test issue 20715
+    from sympy.core.parameters import evaluate
+    x = S(-1)
+    with evaluate(False):
+        assert x.is_negative is True
+
+    f = Pow(x, -1)
+    with evaluate(False):
+        assert f.is_imaginary is False
 
 def test_real_Pow():
     k = Symbol('k', integer=True, nonzero=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#20715

#### Brief description of what is fixed or changed
Applies the diff mentioned by @oscarbenjamin [here](https://github.com/sympy/sympy/issues/20715#issuecomment-753521679). This partially fixes the issue, i.e. the `RecursionError` is gone, but the `AttributeError` (similar to #20597) still remains, which will require another fix.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Fixed a bug leading to infinite recursion in the old assumptions under `evaluate(False)`.
<!-- END RELEASE NOTES -->