### PR TITLE
Fix to CoercionFailed when integer poly multiplied with rational number

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1470,7 +1470,11 @@ class Poly(Basic):
         g = sympify(g)
 
         if not g.is_Poly:
-            return f.mul_ground(g)
+            try:
+                return f.mul_ground(g)
+            except CoercionFailed:
+                f = div(f,1,domain="QQ")[0]
+                return f.mul_ground(g)
 
         _, per, F, G = f._unify(g)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1473,7 +1473,7 @@ class Poly(Basic):
             try:
                 return f.mul_ground(g)
             except CoercionFailed:
-                f = div(f,1,domain="QQ")[0]
+                f = div(f, 1, domain = "QQ")[0]
                 return f.mul_ground(g)
 
         _, per, F, G = f._unify(g)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1470,11 +1470,7 @@ class Poly(Basic):
         g = sympify(g)
 
         if not g.is_Poly:
-            try:
-                return f.mul_ground(g)
-            except CoercionFailed:
-                f = div(f, 1, domain = "QQ")[0]
-                return f.mul_ground(g)
+            return f.mul_ground(g)
 
         _, per, F, G = f._unify(g)
 
@@ -7182,7 +7178,7 @@ def poly(expr, *gens, **args):
                     factor = Mul(*factors)
 
                     if factor.is_Number:
-                        product = product.mul(factor)
+                        product *= factor
                     else:
                         product = product.mul(Poly._from_expr(factor, opt))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19755 

#### Brief description of what is fixed or changed
Added try-catch to correct domain of 'ZZ' polynomial to 'QQ' when encountered with a rational scalar.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixes Coercion error when mixing integer polynomials with rationals 
<!-- END RELEASE NOTES -->