### PR TITLE
2-arg mul fix?

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -196,15 +196,15 @@ class Mul(Expr, AssocOp):
                 seq = [a, b]
             assert not a is S.One
             if not a.is_zero and a.is_Rational:
-                r, b = b.as_coeff_Mul()
+                r, b = a, b
                 if b.is_Add:
                     if r is not S.One:  # 2-arg hack
                         # leave the Mul as a Mul?
-                        ar = a*r
+                        ar = r
                         if ar is S.One:
                             arb = b
                         else:
-                            arb = cls(a*r, b, evaluate=False)
+                            arb = cls(r, b, evaluate=False)
                         rv = [arb], [], None
                     elif global_parameters.distribute and b.is_commutative:
                         r, b = b.as_coeff_Add()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I'm probably in over my head, but I found that this simple change fixed the distribution problem in the 2-arg mul. It did fail some tests, but I checked quite a few of them and this failure was simply due to the fact that the assertions were written to distribute the mul. Can someone tell me why this is wrong?

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * 2-arg mul fix
<!-- END RELEASE NOTES -->