### PR TITLE
Add _eval_refine method to Boolean

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1035,6 +1035,11 @@ def ask(proposition, assumptions=True, context=global_assumptions):
             Evaluate the *proposition* with respect to *assumptions* in
             global assumption context.
 
+    This function evaluates the proposition to ``True`` or ``False`` if
+    the truth value can be determined. If not, it returns ``None``.
+    It should be discerned from :func:`~.refine()` which does not reduce
+    the expression to ``None``.
+
     Parameters
     ==========
 
@@ -1048,7 +1053,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     context : AssumptionsContext, optional
         Default assumptions to evaluate the *proposition*. By default,
         this is ``sympy.assumptions.global_assumptions`` variable.
-
 
     Examples
     ========
@@ -1076,6 +1080,12 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
         It is however a work in progress.
 
+    See Also
+    ========
+
+    sympy.assumptions.refine.refine : Simplification using assumptions.
+        Proposition is not reduced to ``None`` if the truth value cannot
+        be determined.
     """
     from sympy.assumptions.satask import satask
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -12,9 +12,14 @@ def refine(expr, assumptions=True):
     Explanation
     ===========
 
-    Gives the form of expr that would be obtained if symbols
-    in it were replaced by explicit numerical expressions satisfying
-    the assumptions.
+    Unlike :func:`~.simplify()` which performs structural simplification
+    without any assumption, this function transforms the expression into
+    the form which is only valid under certain assumptions. Note that
+    ``simplify()`` is generally not done in refining process.
+
+    Refining boolean expression involves reducing it to ``True`` or
+    ``False``. Unlike :func:~.`ask()`, the expression will not be reduced
+    if the truth value cannot be determined.
 
     Examples
     ========
@@ -26,6 +31,16 @@ def refine(expr, assumptions=True):
     >>> refine(sqrt(x**2), Q.positive(x))
     x
 
+    >>> refine(Q.real(x), Q.positive(x))
+    True
+    >>> refine(Q.positive(x), Q.real(x))
+    Q.positive(x)
+
+    See Also
+    ========
+
+    sympy.simplify.simplify.simplify : Structural simplification without assumptions.
+    sympy.assumptions.ask.ask : Query for boolean expressions using assumptions.
     """
     if not isinstance(expr, Basic):
         return expr
@@ -235,22 +250,6 @@ def refine_atan2(expr, assumptions):
         return expr
 
 
-def refine_Relational(expr, assumptions):
-    """
-    Handler for Relational.
-
-    Examples
-    ========
-
-    >>> from sympy.assumptions.refine import refine_Relational
-    >>> from sympy.assumptions.ask import Q
-    >>> from sympy.abc import x
-    >>> refine_Relational(x<0, ~Q.is_true(x<0))
-    False
-    """
-    return ask(Q.is_true(expr), assumptions)
-
-
 def refine_re(expr, assumptions):
     """
     Handler for real part.
@@ -376,12 +375,6 @@ handlers_dict = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
     'atan2': refine_atan2,
-    'Equality': refine_Relational,
-    'Unequality': refine_Relational,
-    'GreaterThan': refine_Relational,
-    'LessThan': refine_Relational,
-    'StrictGreaterThan': refine_Relational,
-    'StrictLessThan': refine_Relational,
     're': refine_re,
     'im': refine_im,
     'sign': refine_sign,

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -65,33 +65,6 @@ def test_exp():
     assert refine(exp(pi*I*2*(x + Rational(3, 4)))) == -I
 
 
-def test_Relational():
-    assert not refine(x < 0, ~Q.is_true(x < 0))
-    assert refine(x < 0, Q.is_true(x < 0))
-    assert refine(x < 0, Q.is_true(0 > x)) == True
-    assert refine(x < 0, Q.is_true(y < 0)) == (x < 0)
-    assert not refine(x <= 0, ~Q.is_true(x <= 0))
-    assert refine(x <= 0,  Q.is_true(x <= 0))
-    assert refine(x <= 0,  Q.is_true(0 >= x)) == True
-    assert refine(x <= 0,  Q.is_true(y <= 0)) == (x <= 0)
-    assert not refine(x > 0, ~Q.is_true(x > 0))
-    assert refine(x > 0,  Q.is_true(x > 0))
-    assert refine(x > 0,  Q.is_true(0 < x)) == True
-    assert refine(x > 0,  Q.is_true(y > 0)) == (x > 0)
-    assert not refine(x >= 0, ~Q.is_true(x >= 0))
-    assert refine(x >= 0,  Q.is_true(x >= 0))
-    assert refine(x >= 0,  Q.is_true(0 <= x)) == True
-    assert refine(x >= 0,  Q.is_true(y >= 0)) == (x >= 0)
-    assert not refine(Eq(x, 0), ~Q.is_true(Eq(x, 0)))
-    assert refine(Eq(x, 0),  Q.is_true(Eq(x, 0)))
-    assert refine(Eq(x, 0),  Q.is_true(Eq(0, x))) == True
-    assert refine(Eq(x, 0),  Q.is_true(Eq(y, 0))) == Eq(x, 0)
-    assert not refine(Ne(x, 0), ~Q.is_true(Ne(x, 0)))
-    assert refine(Ne(x, 0), Q.is_true(Ne(0, x))) == True
-    assert refine(Ne(x, 0),  Q.is_true(Ne(x, 0)))
-    assert refine(Ne(x, 0),  Q.is_true(Ne(y, 0))) == (Ne(x, 0))
-
-
 def test_Piecewise():
     assert refine(Piecewise((1, x < 0), (3, True)), Q.is_true(x < 0)) == 1
     assert refine(Piecewise((1, x < 0), (3, True)), ~Q.is_true(x < 0)) == 3

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1674,6 +1674,11 @@ class Basic(Printable, metaclass=ManagedProperties):
         from sympy.simplify import simplify
         return simplify(self, **kwargs)
 
+    def refine(self, assumption=True):
+        """See the refine function in sympy.assumptions"""
+        from sympy.assumptions import refine
+        return refine(self, assumption)
+
     def _eval_rewrite(self, pattern, rule, **hints):
         if self.is_Atom:
             if hasattr(self, rule):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3683,11 +3683,6 @@ class Expr(Basic, EvalfMixin):
         from sympy.polys import factor
         return factor(self, *gens, **args)
 
-    def refine(self, assumption=True):
-        """See the refine function in sympy.assumptions"""
-        from sympy.assumptions import refine
-        return refine(self, assumption)
-
     def cancel(self, *gens, **args):
         """See the cancel function in sympy.polys"""
         from sympy.polys import cancel

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -315,6 +315,9 @@ class Symbol(AtomicExpr, Boolean):
         if old.is_Pow:
             return Pow(self, S.One, evaluate=False)._eval_subs(old, new)
 
+    def _eval_refine(self, assumptions):
+        return self
+
     @property
     def assumptions0(self):
         return {key: value for key, value

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -179,6 +179,10 @@ class Boolean(Basic):
                            if i.is_Boolean or i.is_Symbol
                            or isinstance(i, (Eq, Ne))])
 
+    def _eval_refine(self, assumptions):
+        from sympy.assumptions import ask
+        return ask(self, assumptions)
+
 
 class BooleanAtom(Boolean):
     """

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,4 +1,5 @@
 from sympy.assumptions.ask import Q
+from sympy.assumptions.refine import refine
 from sympy.core.numbers import oo
 from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
@@ -1191,3 +1192,40 @@ def test_bool_monomial():
     x, y = symbols('x,y')
     assert bool_monomial(1, [x, y]) == y
     assert bool_monomial([1, 1], [x, y]) == And(x, y)
+
+
+def test_refine():
+    # relational
+    assert not refine(x < 0, ~Q.is_true(x < 0))
+    assert refine(x < 0, Q.is_true(x < 0))
+    assert refine(x < 0, Q.is_true(0 > x)) == True
+    assert refine(x < 0, Q.is_true(y < 0)) == (x < 0)
+    assert not refine(x <= 0, ~Q.is_true(x <= 0))
+    assert refine(x <= 0,  Q.is_true(x <= 0))
+    assert refine(x <= 0,  Q.is_true(0 >= x)) == True
+    assert refine(x <= 0,  Q.is_true(y <= 0)) == (x <= 0)
+    assert not refine(x > 0, ~Q.is_true(x > 0))
+    assert refine(x > 0,  Q.is_true(x > 0))
+    assert refine(x > 0,  Q.is_true(0 < x)) == True
+    assert refine(x > 0,  Q.is_true(y > 0)) == (x > 0)
+    assert not refine(x >= 0, ~Q.is_true(x >= 0))
+    assert refine(x >= 0,  Q.is_true(x >= 0))
+    assert refine(x >= 0,  Q.is_true(0 <= x)) == True
+    assert refine(x >= 0,  Q.is_true(y >= 0)) == (x >= 0)
+    assert not refine(Eq(x, 0), ~Q.is_true(Eq(x, 0)))
+    assert refine(Eq(x, 0),  Q.is_true(Eq(x, 0)))
+    assert refine(Eq(x, 0),  Q.is_true(Eq(0, x))) == True
+    assert refine(Eq(x, 0),  Q.is_true(Eq(y, 0))) == Eq(x, 0)
+    assert not refine(Ne(x, 0), ~Q.is_true(Ne(x, 0)))
+    assert refine(Ne(x, 0), Q.is_true(Ne(0, x))) == True
+    assert refine(Ne(x, 0),  Q.is_true(Ne(x, 0)))
+    assert refine(Ne(x, 0),  Q.is_true(Ne(y, 0))) == (Ne(x, 0))
+
+    # boolean functions
+    assert refine(And(x > 0, y > 0), Q.is_true(x > 0)) == (y > 0)
+    assert refine(And(x > 0, y > 0), Q.is_true(x > 0) & Q.is_true(y > 0)) == True
+
+    # predicates
+    assert refine(Q.positive(x), Q.positive(x)) == True
+    assert refine(Q.positive(x), Q.negative(x)) == False
+    assert refine(Q.positive(x), Q.real(x)) == Q.positive(x)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -547,6 +547,20 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     Note that ``simplify()`` automatically calls ``doit()`` on the final
     expression. You can avoid this behavior by passing ``doit=False`` as
     an argument.
+
+    Also, it should be noted that simplifying the boolian expression is not
+    well defined. If the expression prefers automatic evaluation (such as
+    :obj:`~.Eq()` or :obj:`~.Or()`), simplification will return ``True`` or
+    ``False`` if truth value can be determined. If the expression is not
+    evaluated by default (such as :obj:`~.Predicate()`), simplification will
+    not reduce it and you should use :func:`~.refine()` or :func:`~.ask()`
+    function. This inconsistency will be resolved in future version.
+
+    See Also
+    ========
+
+    sympy.assumptions.refine.refine : Simplification using assumptions.
+    sympy.assumptions.ask.ask : Query for boolean expressions using assumptions.
     """
 
     def shorter(*choices):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Derived from #20723

#### Brief description of what is fixed or changed

`refine` on relational object has returned boolean value if the truth value can be determined. This PR moves the logic to `Boolean._eval_refine` so that this can be applied to other boolean objects such as `Predicate`.

Before this PR:
```python
>>> refine(x > 0, Q.is_true(x > 0))
True
>>> refine(Q.positive(x), Q.positive(x)) # inconsistent
Q.positive(x)
```

With this PR:
```python
>>> refine(Q.positive(x), Q.positive(x))
True
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `.refine()` method is moved from `Expr` to `Basic`.
- logic
    - `Boolean._eval_refine()` method is defined. This makes every Boolean object, including `Predicate`, show consistent behavior.
<!-- END RELEASE NOTES -->