### PR TITLE
Fixed calculation of expectation in SingleContinousDistribution when expression is zero

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -420,6 +420,8 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
         if evaluate:
             try:
                 p = poly(expr, var)
+                if p.is_zero:
+                    return S.Zero
                 t = Dummy('t', real=True)
                 mgf = self._moment_generating_function(t)
                 if mgf is None:

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1558,6 +1558,13 @@ def test_issue_13324():
     assert E(X, X > S.Half) == Rational(3, 4)
     assert E(X, X > 0) == S.Half
 
+def test_issue_20756():
+    X = Uniform('X', -1, +1)
+    Y = Uniform('Y', -1, +1)
+    assert E(X * Y) == S.Zero
+    assert E(X * ((Y + 1) - 1)) == S.Zero
+    assert E(Y * (X*(X + 1) - X*X)) == S.Zero
+
 def test_FiniteSet_prob():
     E = Exponential('E', 3)
     N = Normal('N', 5, 7)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20756

#### Brief description of what is fixed or changed

The issue was arising due to `SingleContinuousDistribution` trying to calculate expectation using Taylor series. 

Since degree of `Poly(0)` is `-oo` It tries to calculate series of values the mgf over infinite points.

https://github.com/sympy/sympy/blob/ab39cbb48e23284889ca851c35845ec9b66a37c9/sympy/stats/crv.py#L427-L428

Rather, It'll be better for it to follow the simple integration path when expression is zero. The case in which it'll simply return zero for integrating over zero.   

https://github.com/sympy/sympy/blob/ab39cbb48e23284889ca851c35845ec9b66a37c9/sympy/stats/crv.py#L436

#### Other comments


#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- stats
  - Expectation can now be calculated across multiple Uniform RVs evaluating to zero

<!-- END RELEASE NOTES -->