### PR TITLE
Don't try to evaluate a summation when not all Wild symbols are matched

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1183,6 +1183,8 @@ def eval_sum_symbolic(f, limits):
             e_exp = e.pop(wexp).expand().match(c2*i + c3)
             if e_exp is not None:
                 e.update(e_exp)
+            else:
+                e = None
 
         if e is not None:
             p = (c1**c3).subs(e)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1353,6 +1353,8 @@ def test_issue_17165():
 def test_issue_19379():
     assert Sum(factorial(n)/factorial(n + 2), (n, 1, oo)).is_convergent() is S.true
 
+def test_issue_20777():
+    assert Sum(exp(x*sin(n/m)), (n, 1, m)).doit() == Sum(exp(x*sin(n/m)), (n, 1, m))
 
 def test__dummy_with_inherited_properties_concrete():
     x = Symbol('x')


### PR DESCRIPTION
Otherwise the result will be a nonsense expression in terms of the internal
Wild symbols.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20777.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- concrete
  - Fix an issue where Sum would return a nonsense result in terms of internal dummy symbols. 
<!-- END RELEASE NOTES -->