### PR TITLE
feat(polys): Add sparse implementation of DomainMatrix

### DIFF
--- a/sympy/polys/agca/extensions.py
+++ b/sympy/polys/agca/extensions.py
@@ -332,7 +332,7 @@ class MonogenicFiniteExtension(Domain):
         return ExtElem(rep % self.mod, self)
 
     def exquo(self, f, g):
-        rep = self.domain.exquo(f.rep, g.rep)
+        rep = self.ring.exquo(f.rep, g.rep)
         return ExtElem(rep % self.mod, self)
 
     def is_negative(self, a):

--- a/sympy/polys/agca/extensions.py
+++ b/sympy/polys/agca/extensions.py
@@ -31,6 +31,9 @@ class ExtensionElement(DomainElement, DefaultPrinting):
     def __bool__(f):
         return bool(f.rep)
 
+    def __pos__(f):
+        return f
+
     def __neg__(f):
         return ExtElem(-f.rep, f.ext)
 

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -45,6 +45,9 @@ class GaussianElement(DomainElement):
             return NotImplemented
         return [self.y, self.x] < [other.y, other.x]
 
+    def __pos__(self):
+        return self
+
     def __neg__(self):
         return self.new(-self.x, -self.y)
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -143,6 +143,12 @@ class DDM(list):
         else:
             return NotImplemented
 
+    def __rmul__(a, b):
+        if b in a.domain:
+            return a.mul(b)
+        else:
+            return NotImplemented
+
     def __matmul__(a, b):
         if isinstance(b, DDM):
             return a.matmul(b)

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -87,6 +87,10 @@ class DomainMatrix:
         rowstr = '[%s]' % ', '.join(rows_str)
         return 'DomainMatrix(%s, %r, %r)' % (rowstr, self.shape, self.domain)
 
+    def hstack(A, B):
+        A, B = A.unify(B)
+        return A.from_rep(A.rep.hstack(B.rep))
+
     def __add__(A, B):
         if not isinstance(B, DomainMatrix):
             return NotImplemented
@@ -168,7 +172,7 @@ class DomainMatrix:
         return self.from_rep(rref_ddm), tuple(pivots)
 
     def nullspace(self):
-        return self.from_rep(self.rep.nullspace())
+        return self.from_rep(self.rep.nullspace()[0])
 
     def inv(self):
         if not self.domain.is_Field:

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -17,16 +17,21 @@ from .exceptions import NonSquareMatrixError, ShapeError
 
 from .ddm import DDM
 
+from .sdm import SDM
+
 
 class DomainMatrix:
 
     def __init__(self, rows, shape, domain):
-        self.rep = DDM(rows, shape, domain)
+        if isinstance(rows, list):
+            self.rep = SDM.from_list(rows, shape, domain)
+        else:
+            self.rep = SDM(rows, shape, domain)
         self.shape = shape
         self.domain = domain
 
     @classmethod
-    def from_ddm(cls, ddm):
+    def from_rep(cls, ddm):
         return cls(ddm, ddm.shape, ddm.domain)
 
     @classmethod
@@ -52,11 +57,7 @@ class DomainMatrix:
         return K, items_K
 
     def convert_to(self, K):
-        Kold = self.domain
-        if K == Kold:
-            return self.from_ddm(self.rep.copy())
-        new_rows = [[K.convert_from(e, Kold) for e in row] for row in self.rep]
-        return DomainMatrix(new_rows, self.shape, K)
+        return self.from_rep(self.rep.convert_to(K))
 
     def to_field(self):
         K = self.domain.get_field()
@@ -76,11 +77,13 @@ class DomainMatrix:
 
     def to_Matrix(self):
         from sympy.matrices.dense import MutableDenseMatrix
-        rows_sympy = [[self.domain.to_sympy(e) for e in row] for row in self.rep]
+        elemlist = self.rep.to_list()
+        rows_sympy = [[self.domain.to_sympy(e) for e in row] for row in elemlist]
         return MutableDenseMatrix(rows_sympy)
 
     def __repr__(self):
-        rows_str = ['[%s]' % (', '.join(map(str, row))) for row in self.rep]
+        elemlist = self.rep.to_list()
+        rows_str = ['[%s]' % (', '.join(map(str, row))) for row in elemlist]
         rowstr = '[%s]' % ', '.join(rows_str)
         return 'DomainMatrix(%s, %r, %r)' % (rowstr, self.shape, self.domain)
 
@@ -102,13 +105,13 @@ class DomainMatrix:
         if isinstance(B, DomainMatrix):
             return A.matmul(B)
         elif B in A.domain:
-            return A.from_ddm(A.rep * B)
+            return A.from_rep(A.rep * B)
         else:
             return NotImplemented
 
     def __rmul__(A, B):
         if B in A.domain:
-            return A.from_ddm(A.rep * B)
+            return A.from_rep(A.rep * B)
         else:
             return NotImplemented
 
@@ -123,23 +126,23 @@ class DomainMatrix:
             raise ShapeError("shape")
         if A.domain != B.domain:
             raise ValueError("domain")
-        return A.from_ddm(A.rep.add(B.rep))
+        return A.from_rep(A.rep.add(B.rep))
 
     def sub(A, B):
         if A.shape != B.shape:
             raise ShapeError("shape")
         if A.domain != B.domain:
             raise ValueError("domain")
-        return A.from_ddm(A.rep.sub(B.rep))
+        return A.from_rep(A.rep.sub(B.rep))
 
     def neg(A):
-        return A.from_ddm(A.rep.neg())
+        return A.from_rep(A.rep.neg())
 
     def mul(A, b):
-        return A.from_ddm(A.rep.mul(b))
+        return A.from_rep(A.rep.mul(b))
 
     def matmul(A, B):
-        return A.from_ddm(A.rep.matmul(B.rep))
+        return A.from_rep(A.rep.matmul(B.rep))
 
     def pow(A, n):
         if n < 0:
@@ -162,10 +165,10 @@ class DomainMatrix:
         if not self.domain.is_Field:
             raise ValueError('Not a field')
         rref_ddm, pivots = self.rep.rref()
-        return self.from_ddm(rref_ddm), tuple(pivots)
+        return self.from_rep(rref_ddm), tuple(pivots)
 
     def nullspace(self):
-        return self.from_ddm(self.rep.nullspace())
+        return self.from_rep(self.rep.nullspace())
 
     def inv(self):
         if not self.domain.is_Field:
@@ -174,7 +177,7 @@ class DomainMatrix:
         if m != n:
             raise NonSquareMatrixError
         inv = self.rep.inv()
-        return self.from_ddm(inv)
+        return self.from_rep(inv)
 
     def det(self):
         m, n = self.shape
@@ -186,7 +189,7 @@ class DomainMatrix:
         if not self.domain.is_Field:
             raise ValueError('Not a field')
         L, U, swaps = self.rep.lu()
-        return self.from_ddm(L), self.from_ddm(U), swaps
+        return self.from_rep(L), self.from_rep(U), swaps
 
     def lu_solve(self, rhs):
         if self.shape[0] != rhs.shape[0]:
@@ -194,7 +197,7 @@ class DomainMatrix:
         if not self.domain.is_Field:
             raise ValueError('Not a field')
         sol = self.rep.lu_solve(rhs.rep)
-        return self.from_ddm(sol)
+        return self.from_rep(sol)
 
     def charpoly(self):
         m, n = self.shape
@@ -204,7 +207,7 @@ class DomainMatrix:
 
     @classmethod
     def eye(cls, n, domain):
-        return cls.from_ddm(DDM.eye(n, domain))
+        return cls.from_rep(DDM.eye(n, domain))
 
     def __eq__(A, B):
         """A == B"""

--- a/sympy/polys/matrices/eigen.py
+++ b/sympy/polys/matrices/eigen.py
@@ -41,7 +41,7 @@ def dom_eigenvects(A, l=Dummy('lambda')):
 
             AA_items = [
                 [Poly.from_list([item], l, domain=domain).rep for item in row]
-                for row in A.rep]
+                for row in A.rep.to_ddm()]
             AA_items = [[field(item) for item in row] for row in AA_items]
             AA = DomainMatrix(AA_items, (rows, cols), field)
             EE_items = [
@@ -70,7 +70,7 @@ def dom_eigenvects_to_sympy(
         result.append((eigenvalue, multiplicity, new_eigenvects))
 
     for field, minpoly, multiplicity, eigenvects in algebraic_eigenvects:
-        eigenvects = eigenvects.rep
+        eigenvects = eigenvects.rep.to_ddm()
         l = minpoly.gens[0]
 
         eigenvects = [[field.to_sympy(x) for x in vect] for vect in eigenvects]

--- a/sympy/polys/matrices/eigen.py
+++ b/sympy/polys/matrices/eigen.py
@@ -62,7 +62,7 @@ def dom_eigenvects_to_sympy(
     result = []
 
     for field, eigenvalue, multiplicity, eigenvects in rational_eigenvects:
-        eigenvects = eigenvects.rep
+        eigenvects = eigenvects.rep.to_ddm()
         eigenvalue = field.to_sympy(eigenvalue)
         new_eigenvects = [
             Matrix([field.to_sympy(x) for x in vect])

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -1,0 +1,178 @@
+#
+# sympy.polys.matrices.linsolve module
+#
+# This module defines the _linsolve function which is the internal workhorse
+# used by linsolve. This computes the solution of a system of linear equations
+# using the SDM sparse matrix implementation in sympy.polys.matrices.sdm. This
+# is a replacement for solve_lin_sys in sympy.polys.solvers which is
+# inefficient for large sparse systems due to the use of a PolyRing with many
+# generators:
+#
+#     https://github.com/sympy/sympy/issues/20857
+#
+# The implementation of _linsolve here handles:
+#
+# - Extracting the coefficients from the Expr/Eq input equations.
+# - Constructing a domain and converting the coefficients to
+#   that domain.
+# - Using the SDM.rref, SDM.nullspace etc methods to generate the full
+#   solution working with arithmetic only in the domain of the coefficients.
+#
+# The routines here are particularly designed to be efficient for large sparse
+# systems of linear equations although as well as dense systems. It is
+# possible that for some small dense systems solve_lin_sys which uses the
+# dense matrix implementation DDM will be more efficient. With smaller systems
+# though the bulk of the time is spent just preprocessing the inputs and the
+# relative time spent in rref is too small to be noticeable.
+#
+
+from collections import defaultdict
+
+from sympy.core.add import Add
+from sympy.core.mul import Mul
+from sympy.core.function import expand_mul
+from sympy.core.singleton import S
+
+from sympy.polys.constructor import construct_domain
+
+from .sdm import (
+    SDM,
+    sdm_irref,
+    sdm_particular_from_rref,
+    sdm_nullspace_from_rref
+)
+
+
+def _linsolve(eqs, syms):
+    """Solve a linear system of equations.
+
+    Examples
+    ========
+
+    Solve a linear system with a unique solution:
+
+    >>> from sympy import symbols, Eq
+    >>> from sympy.polys.matrices.linsolve import _linsolve
+    >>> x, y = symbols('x, y')
+    >>> eqs = [Eq(x + y, 1), Eq(x - y, 2)]
+    >>> _linsolve(eqs, [x, y])
+    {x: 3/2, y: -1/2}
+
+    In the case of underdetermined systems the solution will be expressed in
+    terms of the unknown symbols that are unconstrained:
+
+    >>> _linsolve([Eq(x + y, 0)], [x, y])
+    {x: -y, y: y}
+
+    """
+    # Number of unknowns (columns in the non-augmented matrix)
+    nsyms = len(syms)
+
+    # Convert to sparse augmented matrix (len(eqs) x (nsyms+1))
+    eqsdict, rhs = _linear_eq_to_dict(eqs, syms)
+    Aaug = sympy_dict_to_dm(eqsdict, rhs, syms)
+    K = Aaug.domain
+
+    # Compute reduced-row echelon form (RREF)
+    Arref, pivots, nzcols = sdm_irref(Aaug)
+
+    # No solution:
+    if pivots[-1] == nsyms:
+        return None
+
+    # Particular solution for non-homogeneous system:
+    P = sdm_particular_from_rref(Arref, nsyms+1, pivots)
+
+    # Nullspace - general solution to homogeneous system
+    # Note: using nsyms not nsyms+1 to ignore last column
+    V, nonpivots = sdm_nullspace_from_rref(Arref, K.one, nsyms, pivots, nzcols)
+
+    # Collect together terms from particular and nullspace:
+    sol = defaultdict(list)
+    for i, v in P.items():
+        sol[syms[i]].append(K.to_sympy(v))
+    for npi, Vi in zip(nonpivots, V):
+        sym = syms[npi]
+        for i, v in Vi.items():
+            sol[syms[i]].append(sym * K.to_sympy(v))
+
+    # Use a single call to Add for each term:
+    sol = {s: Add(*terms) for s, terms in sol.items()}
+
+    # Fill in the zeros:
+    zero = S.Zero
+    for s in set(syms) - set(sol):
+        sol[s] = zero
+
+    # All done!
+    return sol
+
+
+def sympy_dict_to_dm(eqs_coeffs, eqs_rhs, syms):
+    """Convert a system of dict equations to a sparse augmented matrix"""
+    elems = set(eqs_rhs).union(*(e.values() for e in eqs_coeffs))
+    K, elems_K = construct_domain(elems, field=True, extension=True)
+    elem_map = dict(zip(elems, elems_K))
+    neqs = len(eqs_coeffs)
+    nsyms = len(syms)
+    sym2index = dict(zip(syms, range(nsyms)))
+    eqsdict = []
+    for eq, rhs in zip(eqs_coeffs, eqs_rhs):
+        eqdict = {sym2index[s]: elem_map[c] for s, c in eq.items()}
+        if rhs:
+            eqdict[nsyms] = - elem_map[rhs]
+        eqsdict.append(eqdict)
+    sdm_aug = SDM(enumerate(eqsdict), (neqs, nsyms+1), K)
+    return sdm_aug
+
+
+def _linear_eq_to_dict(eqs, syms):
+    """Convert a system Expr/Eq equations into dict form"""
+    syms = set(syms)
+    eqsdict, eqs_rhs = [], []
+    for eq in eqs:
+        rhs, eqdict = _lin_eq2dict(eq, syms)
+        eqsdict.append(eqdict)
+        eqs_rhs.append(rhs)
+    return eqsdict, eqs_rhs
+
+
+def _lin_eq2dict(a, symset):
+    """Efficiently convert a linear equation to a dict of coefficients"""
+    if a in symset:
+        return S.Zero, {a: S.One}
+    elif a.is_Add:
+        terms_list = defaultdict(list)
+        coeff_list = []
+        for ai in a.args:
+            ci, ti = _lin_eq2dict(ai, symset)
+            coeff_list.append(ci)
+            for mij, cij in ti.items():
+                terms_list[mij].append(cij)
+        coeff = Add(*coeff_list)
+        terms = {sym: Add(*coeffs) for sym, coeffs in terms_list.items()}
+        return coeff, terms
+    elif a.is_Mul:
+        terms = terms_coeff = None
+        coeff_list = []
+        for ai in a.args:
+            ci, ti = _lin_eq2dict(ai, symset)
+            if not ti:
+                coeff_list.append(ci)
+            elif terms is None:
+                terms = ti
+                terms_coeff = ci
+            else:
+                raise PolyNonlinearError
+        coeff = Mul(*coeff_list)
+        if terms is None:
+            return coeff, {}
+        else:
+            terms = {sym: coeff * c for sym, c in terms.items()}
+            return  coeff * terms_coeff, terms
+    elif a.is_Equality:
+        return _lin_eq2dict(expand_mul(a.lhs - a.rhs), symset)
+    elif not a.free_symbols & symset:
+        return a, {}
+    else:
+        raise PolyNonlinearError

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1,0 +1,358 @@
+"""
+
+Module for the SDM class.
+
+"""
+
+from operator import add, neg, pos, sub
+from collections import defaultdict
+
+from .exceptions import DDMBadInputError, DDMDomainError
+
+from .ddm import DDM
+
+
+class SDM(dict):
+    """Sparse matrix based on polys domain elements
+
+    This is a dict subclass and is a wrapper for a dict of dicts that supports
+    basic matrix arithmetic +, -, *, **.
+    """
+    def __init__(self, elemsdict, shape, domain):
+        super().__init__(elemsdict)
+        self.shape = self.rows, self.cols = m, n = shape
+        self.domain = domain
+
+        if not all(0 <= r < m for r in self):
+            raise DDMBadInputError("Row out of range")
+        if not all(0 <= c < n for row in self.values() for c in row):
+            raise DDMBadInputError("Column out of range")
+
+    @classmethod
+    def new(cls, sdm, shape, domain):
+        return cls(sdm, shape, domain)
+
+    def copy(A):
+        Ac = {i: Ai.copy() for i, Ai in A.items()}
+        return A.new(Ac, A.shape, A.domain)
+
+    @classmethod
+    def from_list(cls, ddm, shape, domain):
+        m, n = shape
+        if not (len(ddm) == m and all(len(row) == n for row in ddm)):
+            raise DDMBadInputError("Inconsistent row-list/shape")
+        getrow = lambda i: {j:ddm[i][j] for j in range(n) if ddm[i][j]}
+        irows = ((i, getrow(i)) for i in range(m))
+        sdm = {i: row for i, row in irows if row}
+        return cls(sdm, shape, domain)
+
+    @classmethod
+    def from_ddm(cls, ddm):
+        return cls.from_list(ddm, ddm.shape, ddm.domain)
+
+    def to_list(M):
+        m, n = M.shape
+        zero = M.domain.zero
+        ddm = [[zero] * n for _ in range(m)]
+        for i, row in M.items():
+            for j, e in row.items():
+                ddm[i][j] = e
+        return ddm
+
+    def to_ddm(M):
+        return DDM(M.to_list(), M.shape, M.domain)
+
+    @classmethod
+    def zeros(cls, shape, domain):
+        return cls({}, shape, domain)
+
+    @classmethod
+    def eye(cls, size, domain):
+        one = domain.one
+        sdm = {i: {i: one} for i in range(size)}
+        return cls(sdm, (size, size), domain)
+
+    def transpose(M):
+        MT = {}
+        for i, Mi in M.items():
+            for j, Mij in Mi.items():
+                try:
+                    MT[j][i] = Mij
+                except KeyError:
+                    MT[j] = {i: Mij}
+        return M.new(MT, M.shape, M.domain)
+
+    def __mul__(a, b):
+        if b in a.domain:
+            return a.mul(b)
+        else:
+            return NotImplemented
+
+    def matmul(A, B):
+        if A.domain != B.domain:
+            raise DDMDomainError
+        C = {}
+        BT = B.transpose()
+        for i, Ai in A.items():
+            Ai_ks = set(Ai)
+            Ci = {}
+            for j, BTj in BT.items():
+                BTj_ks = set(BTj)
+                knonzero = Ai_ks & BTj_ks
+                if knonzero:
+                    Cij = sum(Ai[k] * BTj[k] for k in knonzero)
+                    if Cij:
+                        Ci[j] = Cij
+            if Ci:
+                C[i] = Ci
+        return A.new(C, A.shape, A.domain)
+
+    def mul(A, b):
+        Csdm = unop_dict(A, lambda aij: aij*b)
+        return A.new(Csdm, A.shape, A.domain)
+
+    def add(A, B):
+        Csdm = binop_dict(A, B, add, pos, pos)
+        return A.new(Csdm, A.shape, A.domain)
+
+    def sub(A, B):
+        Csdm = binop_dict(A, B, sub, pos, neg)
+        return A.new(Csdm, A.shape, A.domain)
+
+    def neg(A):
+        Csdm = unop_dict(A, neg)
+        return A.new(Csdm, A.shape, A.domain)
+
+    def convert_to(A, K):
+        Kold = A.domain
+        if K == Kold:
+            return A.copy()
+        Ak = unop_dict(A, lambda e: K.convert_from(e, Kold))
+        return A.new(Ak, A.shape, K)
+
+    def rref(A):
+        B, pivots = sdm_irref(A)
+        return A.new(B, A.shape, A.domain), pivots
+
+    def inv(A):
+        return A.from_ddm(A.to_ddm().inv())
+
+    def det(A):
+        return A.to_ddm().det()
+
+    def lu(A):
+        L, U, swaps = A.to_ddm().lu()
+        return A.from_ddm(L), A.from_ddm(U), swaps
+
+    def lu_solve(A, b):
+        return A.from_ddm(A.to_ddm().lu_solve(b.to_ddm()))
+
+    def charpoly(A):
+        return A.to_ddm().charpoly()
+
+
+def binop_dict(A, B, fab, fa, fb):
+    Anz, Bnz = set(A), set(B)
+    C = {}
+    for i in Anz & Bnz:
+        Ai, Bi = A[i], B[i]
+        Ci = {}
+        Anzi, Bnzi = set(Ai), set(Bi)
+        for j in Anzi & Bnzi:
+            elem = fab(Ai[j], Bi[j])
+            if elem:
+                Ci[j] = elem
+        for j in Anzi - Bnzi:
+            Ci[j] = fa(Anzi[j])
+        for j in Bnzi - Anzi:
+            Ci[j] = fb(Bnzi[j])
+        if Ci:
+            C[i] = Ci
+    return C
+
+
+def unop_dict(A, f):
+    B = {}
+    for i, Ai in A.items():
+        Bi = {}
+        for j, Aij in Ai.items():
+            Bij = f(Aij)
+            if Bij:
+                Bi[j] = Bij
+        if Bi:
+            B[i] = Bi
+    return B
+
+
+def sdm_irref(A):
+    """RREF and pivots of a sparse matrix *A*.
+
+    Compute the reduced row echelon form (RREF) of the matrix *A* and return a
+    list of the pivot columns. This routine does not work in place and leaves
+    the original matrix *A* unmodified.
+
+    Examples
+    ========
+
+    This routine works with a dict of dicts sparse representation of a matrix:
+
+    >>> from sympy import QQ
+    >>> from sympy.polys.matrices.sdm import sdm_irref
+    >>> A = {0: {0: QQ(1), 1: QQ(2)}, 1: {0: QQ(3), 1: QQ(4)}}
+    >>> Arref, pivots = sdm_irref(A)
+    >>> Arref
+    {0: {0: 1}, 1: {1: 1}}
+    >>> pivots
+    [0, 1]
+
+    The analogous calculation with :py:class:`~.Matrix` would be
+
+    >>> from sympy import Matrix
+    >>> M = Matrix([[1, 2], [3, 4]])
+    >>> Mrref, pivots = M.rref()
+    >>> Mrref
+    Matrix([
+    [1, 0],
+    [0, 1]])
+    >>> pivots
+    (0, 1)
+
+    Notes
+    =====
+
+    The cost of this algorithm is determined purely by the nonzero elements of
+    the matrix. No part of the cost of any step in this algorithm depends on
+    the number of rows or columns in the matrix. No step depends even on the
+    number of nonzero rows apart from the primary loop over those rows. The
+    implementation is much faster than ddm_rref for sparse matrices. In fact
+    at the time of writing it is also (slightly) faster than the dense
+    implementation even if the input is a fully dense matrix so it seems to be
+    faster in all cases.
+
+    The elements of the matrix should support exact division with ``/``. For
+    example elements of any domain that is a field (e.g. ``QQ``) should be
+    fine. No attempt is made to handle inexact arithmetic.
+
+    """
+    #
+    # Any zeros in the matrix are not stored at all so an element is zero if
+    # its the row dict has no index at that key. A row is entirely zero if its
+    # row index is not in the outer dict. Since rref reorders the rows and
+    # removes zero rows we can completely discard the row indices. The first
+    # step then copys the row dicts into a list sorted by the index of the
+    # first nonzero column in each row.
+    #
+    # The algorithm then processes each row ai one at a time. Previously seen
+    # rows are used to cancel their pivot columns from Ai. Then a pivot from
+    # Ai is chosen and is cancelled from all previously seen rows. At this
+    # point Ai joins the previously seen rows. Once all rows are seen all
+    # elimination has occurred and the rows are sorted by pivot column index.
+    #
+    # The previously seen rows are stored in two separate groups. The reduced
+    # group consists of all rows that have been reduced to a single nonzero
+    # element (the pivot). There is no need to attempt any further reduction
+    # with these. Rows that still have other nonzeros need to be considered
+    # when ai is cancelled from the previously seen rows.
+    #
+    # A dict nonzerocolumns is used to map from a column index to a set of
+    # previously seen rows that still have a nonzero element in that column.
+    # This means that we can cancel the pivot from ai into the previously seen
+    # rows without needing to loop over each row that might have a zero in
+    # that column.
+    #
+
+    # Row dicts sorted by index of first nonzero column
+    # (Maybe sorting is not needed/useful.)
+    Arows = sorted((Ai.copy() for Ai in A.values()), key=min)
+
+    # Each processed row has an associated pivot column.
+    # pivot_row_map maps from the pivot column index to the row dict.
+    # This means that we can represent a set of rows purely as a set of their
+    # pivot indices.
+    pivot_row_map = {}
+
+    # Set of pivot indices for rows that are fuly reduced to a single nonzero.
+    reduced_pivots = set()
+
+    # Set of pivot indices for rows not fully reduced
+    nonreduced_pivots = set()
+
+    # Map from column index to a set of pivot indices representing the rows
+    # that have a nonzero at that column.
+    nonzero_columns = defaultdict(set)
+
+    while Arows:
+        # Select pivot element and row
+        Ai = Arows.pop()
+
+        # Nonzero columns from fully reduced pivot rows can be removed
+        Ai = {j: Aij for j, Aij in Ai.items() if j not in reduced_pivots}
+
+        # Others require full row cancellation
+        for j in nonreduced_pivots & set(Ai):
+            Aj = pivot_row_map[j]
+            Aij = Ai[j]
+            Ainz = set(Ai)
+            Ajnz = set(Aj)
+            for k in Ajnz - Ainz:
+                Ai[k] = - Aij * Aj[k]
+            for k in Ajnz & Ainz:
+                Aik = Ai[k] - Aij * Aj[k]
+                if Aik:
+                    Ai[k] = Aik
+                else:
+                    Ai.pop(k)
+
+        # We have now cancelled previously seen pivots from Ai.
+        # If it is zero then discard it.
+        if not Ai:
+            continue
+
+        # Choose a pivot from Ai:
+        j = min(Ai)
+        Aij = Ai[j]
+        pivot_row_map[j] = Ai
+        Ainz = set(Ai)
+
+        # Normalise the pivot row to make the pivot 1.
+        #
+        # This approach is slow for some domains. Cross cancellation might be
+        # better for e.g. QQ(x) with division delayed to the final steps.
+        Aijinv = Aij**-1
+        for l in Ai:
+            Ai[l] *= Aijinv
+
+        # Use Aij to cancel column j from all previously seen rows
+        for k in nonzero_columns.pop(j, ()):
+            Ak = pivot_row_map[k]
+            Akj = Ak[j]
+            Aknz = set(Ak)
+            for l in Ainz - Aknz:
+                Ak[l] = - Akj * Ai[l]
+                nonzero_columns[l].add(k)
+            for l in Ainz & Aknz:
+                Akl = Ak[l] - Akj * Ai[l]
+                if Akl:
+                    Ak[l] = Akl
+                else:
+                    # Drop nonzero elements
+                    Ak.pop(l)
+                    if l != j:
+                        nonzero_columns[l].remove(k)
+            if len(Ak) == 1:
+                reduced_pivots.add(k)
+                nonreduced_pivots.remove(k)
+
+        if len(Ai) == 1:
+            reduced_pivots.add(j)
+        else:
+            nonreduced_pivots.add(j)
+            for l in Ai:
+                if l != j:
+                    nonzero_columns[l].add(j)
+
+    # All done!
+    pivots = sorted(reduced_pivots | nonreduced_pivots)
+    rows = [pivot_row_map[i] for i in pivots]
+    rref = dict(enumerate(rows))
+    return rref, pivots

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -171,6 +171,12 @@ def binop_dict(A, B, fab, fa, fb):
             Ci[j] = fb(Bi[j])
         if Ci:
             C[i] = Ci
+    for i in Anz - Bnz:
+        Ai = A[i]
+        C[i] = {j: fa(Aij) for j, Aij in Ai.items()}
+    for i in Bnz - Anz:
+        Bi = B[i]
+        C[i] = {j: fb(Bij) for j, Bij in Bi.items()}
     return C
 
 

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -147,6 +147,9 @@ class SDM(dict):
     def lu_solve(A, b):
         return A.from_ddm(A.to_ddm().lu_solve(b.to_ddm()))
 
+    def nullspace(A):
+        return A.to_ddm().nullspace()
+
     def charpoly(A):
         return A.to_ddm().charpoly()
 
@@ -163,9 +166,9 @@ def binop_dict(A, B, fab, fa, fb):
             if elem:
                 Ci[j] = elem
         for j in Anzi - Bnzi:
-            Ci[j] = fa(Anzi[j])
+            Ci[j] = fa(Ai[j])
         for j in Bnzi - Anzi:
-            Ci[j] = fb(Bnzi[j])
+            Ci[j] = fb(Bi[j])
         if Ci:
             C[i] = Ci
     return C

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -39,9 +39,9 @@ def test_DDM_getsetitem():
 
 def test_DDM_str():
     ddm = DDM([[ZZ(0), ZZ(1)], [ZZ(2), ZZ(3)]], (2, 2), ZZ)
-    if HAS_GMPY:
+    if HAS_GMPY: # pragma: no cover
         assert str(ddm) == 'DDM([[mpz(0), mpz(1)], [mpz(2), mpz(3)]], (2, 2), ZZ)'
-    else:
+    else:        # pragma: no cover
         assert str(ddm) == 'DDM([[0, 1], [2, 3]], (2, 2), ZZ)'
 
 
@@ -139,6 +139,9 @@ def test_DDM_neg():
 
 def test_DDM_mul():
     A = DDM([[ZZ(1)]], (1, 1), ZZ)
+    A2 = DDM([[ZZ(2)]], (1, 1), ZZ)
+    assert A * ZZ(2) == A2
+    assert ZZ(2) * A == A2
     raises(TypeError, lambda: [[1]] * A)
     raises(TypeError, lambda: A * [[1]])
 
@@ -215,6 +218,12 @@ def test_DDM_rref():
     Ar = DDM([[QQ(1), QQ(0), QQ(0)], [QQ(0), QQ(0), QQ(1)]], (2, 3), QQ)
     pivots = [0, 2]
     assert A.rref() == (Ar, pivots)
+
+
+def test_DDM_nullspace():
+     A = DDM([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), QQ)
+     Anull = DDM([[QQ(-1), QQ(1)]], (1, 2), QQ)
+     assert A.nullspace() == Anull
 
 
 def test_DDM_det():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -16,10 +16,8 @@ from sympy.polys.matrices.sdm import SDM
 
 def test_DomainMatrix_init():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    if isinstance(A.rep, DDM):
-        assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    else:
-        assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    # assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -259,6 +257,12 @@ def test_DomainMatrix_rref():
 
     Az = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     raises(ValueError, lambda: Az.rref())
+
+
+def test_DomainMatrix_nullspace():
+    A = DomainMatrix([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), ZZ)
+    Anull = DomainMatrix([[QQ(-1), QQ(1)]], (1, 2), ZZ)
+    assert A.nullspace() == Anull
 
 
 def test_DomainMatrix_inv():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -11,27 +11,33 @@ from sympy.polys import ZZ, QQ
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.matrices.exceptions import DDMBadInputError, DDMDomainError
 from sympy.polys.matrices.ddm import DDM
+from sympy.polys.matrices.sdm import SDM
 
 
 def test_DomainMatrix_init():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    if isinstance(A.rep, DDM):
+        assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    else:
+        assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
     raises(DDMBadInputError, lambda: DomainMatrix([[ZZ(1), ZZ(2)]], (2, 2), ZZ))
 
 
-def test_DomainMatrix_from_ddm():
-    ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    A = DomainMatrix.from_ddm(ddm)
+def test_DomainMatrix_from_rep():
+    # ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    A = DomainMatrix.from_rep(ddm)
     assert A.rep == ddm
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
 
 def test_DomainMatrix_from_list_sympy():
-    ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    # ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     A = DomainMatrix.from_list_sympy(2, 2, [[1, 2], [3, 4]])
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -44,6 +50,7 @@ def test_DomainMatrix_from_list_sympy():
         (2, 2),
         K
     )
+    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_list_sympy(
         2, 2, [[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]],
         extension=True)
@@ -54,6 +61,7 @@ def test_DomainMatrix_from_list_sympy():
 
 def test_DomainMatrix_from_Matrix():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(Matrix([[1, 2], [3, 4]]))
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -66,6 +74,7 @@ def test_DomainMatrix_from_Matrix():
         (2, 2),
         K
     )
+    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(
         Matrix([[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]]),
         extension=True)
@@ -417,6 +426,7 @@ def test_DomainMatrix_charpoly():
 
 def test_DomainMatrix_eye():
     A = DomainMatrix.eye(3, QQ)
-    assert A.rep == DDM.eye(3, QQ)
+    #assert A.rep == DDM.eye(3, QQ)
+    assert A.rep == SDM.eye(3, QQ)
     assert A.shape == (3, 3)
     assert A.domain == QQ

--- a/sympy/polys/matrices/tests/test_eigen.py
+++ b/sympy/polys/matrices/tests/test_eigen.py
@@ -1,0 +1,88 @@
+"""
+Tests for the sympy.polys.matrices.eigen module
+"""
+
+from sympy import S, Matrix, sqrt
+
+from sympy.polys.agca.extensions import FiniteExtension
+from sympy.polys.domains import QQ
+from sympy.polys.polytools import Poly
+from sympy.polys.rootoftools import CRootOf
+from sympy.polys.matrices.domainmatrix import DomainMatrix
+
+from sympy.polys.matrices.eigen import dom_eigenvects, dom_eigenvects_to_sympy
+
+
+def test_dom_eigenvects_rational():
+    # Rational eigenvalues
+    A = DomainMatrix([[QQ(1), QQ(2)], [QQ(1), QQ(2)]], (2, 2), QQ)
+    rational_eigenvects = [
+        (QQ, QQ(3), 1, DomainMatrix([[QQ(1), QQ(1)]], (1, 2), QQ)),
+        (QQ, QQ(0), 1, DomainMatrix([[QQ(-2), QQ(1)]], (1, 2), QQ)),
+    ]
+    assert dom_eigenvects(A) == (rational_eigenvects, [])
+
+    # Test converting to Expr:
+    sympy_eigenvects = [
+        (S(3), 1, [Matrix([1, 1])]),
+        (S(0), 1, [Matrix([-2, 1])]),
+    ]
+    assert dom_eigenvects_to_sympy(rational_eigenvects, [], Matrix) == sympy_eigenvects
+
+
+def test_dom_eigenvects_algebraic():
+    # Algebraic eigenvalues
+    A = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
+    Avects = dom_eigenvects(A)
+
+    # Extract the dummy to build the expected result:
+    lamda = Avects[1][0][1].gens[0]
+    irreducible = Poly(lamda**2 - 5*lamda - 2, lamda, domain=QQ)
+    K = FiniteExtension(irreducible)
+    KK = K.from_sympy
+    algebraic_eigenvects = [
+        (K, irreducible, 1, DomainMatrix([[KK((lamda-4)/3), KK(1)]], (1, 2), K)),
+    ]
+    assert Avects == ([], algebraic_eigenvects)
+
+    # Test converting to Expr:
+    sympy_eigenvects = [
+        (S(5)/2 - sqrt(33)/2, 1, [Matrix([[-sqrt(33)/6 - S(1)/2], [1]])]),
+        (S(5)/2 + sqrt(33)/2, 1, [Matrix([[-S(1)/2 + sqrt(33)/6], [1]])]),
+    ]
+    assert dom_eigenvects_to_sympy([], algebraic_eigenvects, Matrix) == sympy_eigenvects
+
+
+def test_dom_eigenvects_rootof():
+    # Algebraic eigenvalues
+    A = DomainMatrix([
+        [0, 0, 0, 0, -1],
+        [1, 0, 0, 0, 1],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0]], (5, 5), QQ)
+    Avects = dom_eigenvects(A)
+
+    # Extract the dummy to build the expected result:
+    lamda = Avects[1][0][1].gens[0]
+    irreducible = Poly(lamda**5 - lamda + 1, lamda, domain=QQ)
+    K = FiniteExtension(irreducible)
+    KK = K.from_sympy
+    algebraic_eigenvects = [
+        (K, irreducible, 1,
+            DomainMatrix([
+                [KK(lamda**4-1), KK(lamda**3), KK(lamda**2), KK(lamda), KK(1)]
+            ], (1, 5), K)),
+    ]
+    assert Avects == ([], algebraic_eigenvects)
+
+    # Test converting to Expr (slow):
+    l0, l1, l2, l3, l4 = [CRootOf(lamda**5 - lamda + 1, i) for i in range(5)]
+    sympy_eigenvects = [
+        (l0, 1, [Matrix([-1 + l0**4, l0**3, l0**2, l0, 1])]),
+        (l1, 1, [Matrix([-1 + l1**4, l1**3, l1**2, l1, 1])]),
+        (l2, 1, [Matrix([-1 + l2**4, l2**3, l2**2, l2, 1])]),
+        (l3, 1, [Matrix([-1 + l3**4, l3**3, l3**2, l3, 1])]),
+        (l4, 1, [Matrix([-1 + l4**4, l4**3, l4**2, l4, 1])]),
+    ]
+    assert dom_eigenvects_to_sympy([], algebraic_eigenvects, Matrix) == sympy_eigenvects

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -1,0 +1,228 @@
+"""
+Tests for the basic functionality of the SDM class.
+"""
+
+
+from sympy.testing.pytest import raises
+
+from sympy import QQ, ZZ
+from sympy.polys.matrices.sdm import SDM
+from sympy.polys.matrices.ddm import DDM
+from sympy.polys.matrices.exceptions import DDMBadInputError, DDMDomainError
+
+
+def test_SDM():
+    A = SDM({0:{0:ZZ(1)}}, (2, 2), ZZ)
+    assert A.domain == ZZ
+    assert A.shape == (2, 2)
+    assert dict(A) == {0:{0:ZZ(1)}}
+
+    raises(DDMBadInputError, lambda: SDM({5:{1:ZZ(0)}}, (2, 2), ZZ))
+    raises(DDMBadInputError, lambda: SDM({0:{5:ZZ(0)}}, (2, 2), ZZ))
+
+
+def test_SDM_new():
+    A = SDM({0:{0:ZZ(1)}}, (2, 2), ZZ)
+    B = A.new({}, (2, 2), ZZ)
+    assert B == SDM({}, (2, 2), ZZ)
+
+
+def test_SDM_copy():
+    A = SDM({0:{0:ZZ(1)}}, (2, 2), ZZ)
+    B = A.copy()
+    assert A == B
+    A[0][0] = ZZ(2)
+    assert A != B
+
+
+def test_SDM_from_list():
+    A = SDM.from_list([[ZZ(0), ZZ(1)], [ZZ(1), ZZ(0)]], (2, 2), ZZ)
+    assert A == SDM({0:{1:ZZ(1)}, 1:{0:ZZ(1)}}, (2, 2), ZZ)
+
+    raises(DDMBadInputError, lambda: SDM.from_list([[ZZ(0)], [ZZ(0), ZZ(1)]], (2, 2), ZZ))
+    raises(DDMBadInputError, lambda: SDM.from_list([[ZZ(0), ZZ(1)]], (2, 2), ZZ))
+
+
+def test_SDM_to_list():
+    A = SDM({0:{1: ZZ(1)}}, (2, 2), ZZ)
+    assert A.to_list() == [[ZZ(0), ZZ(1)], [ZZ(0), ZZ(0)]]
+
+    A = SDM({}, (0, 2), ZZ)
+    assert A.to_list() == []
+
+    A = SDM({}, (2, 0), ZZ)
+    assert A.to_list() == [[], []]
+
+
+def test_SDM_from_ddm():
+    A = DDM([[ZZ(1), ZZ(0)], [ZZ(1), ZZ(0)]], (2, 2), ZZ)
+    B = SDM.from_ddm(A)
+    assert B.domain == ZZ
+    assert B.shape == (2, 2)
+    assert dict(B) == {0:{0:ZZ(1)}, 1:{0:ZZ(1)}}
+
+
+def test_SDM_to_ddm():
+    A = SDM({0:{1: ZZ(1)}}, (2, 2), ZZ)
+    B = DDM([[ZZ(0), ZZ(1)], [ZZ(0), ZZ(0)]], (2, 2), ZZ)
+    assert A.to_ddm() == B
+
+
+def test_SDM_zeros():
+    A = SDM.zeros((2, 2), ZZ)
+    assert A.domain == ZZ
+    assert A.shape == (2, 2)
+    assert dict(A) == {}
+
+
+def test_SDM_eye():
+    A = SDM.eye(2, ZZ)
+    assert A.domain == ZZ
+    assert A.shape == (2, 2)
+    assert dict(A) == {0:{0:ZZ(1)}, 1:{1:ZZ(1)}}
+
+
+def test_SDM_transpose():
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(1), 1:ZZ(3)}, 1:{0:ZZ(2), 1:ZZ(4)}}, (2, 2), ZZ)
+    assert A.transpose() == B
+
+    A = SDM({0:{1:ZZ(2)}}, (2, 2), ZZ)
+    B = SDM({1:{0:ZZ(2)}}, (2, 2), ZZ)
+    assert A.transpose() == B
+
+    A = SDM({0:{1:ZZ(2)}}, (1, 2), ZZ)
+    B = SDM({1:{0:ZZ(2)}}, (2, 1), ZZ)
+    assert A.transpose() == B
+
+
+def test_SDM_mul():
+    A = SDM({0:{0:ZZ(2)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(4)}}, (2, 2), ZZ)
+    assert A*ZZ(2) == B
+    assert ZZ(2)*A == B
+
+    raises(TypeError, lambda: A*QQ(1, 2))
+    raises(TypeError, lambda: QQ(1, 2)*A)
+
+
+def test_SDM_matmul():
+    A = SDM({0:{0:ZZ(2)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(4)}}, (2, 2), ZZ)
+    assert A.matmul(A) == B
+
+    C = SDM({0:{0:ZZ(2)}}, (2, 2), QQ)
+    raises(DDMDomainError, lambda: A.matmul(C))
+
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(7), 1:ZZ(10)}, 1:{0:ZZ(15), 1:ZZ(22)}}, (2, 2), ZZ)
+    assert A.matmul(A) == B
+
+
+def test_SDM_add():
+    A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
+    C = SDM({0:{0:ZZ(1), 1:ZZ(1)}, 1:{1:ZZ(6)}}, (2, 2), ZZ)
+    assert A.add(B) == C
+
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
+    C = SDM({0:{0:ZZ(1), 1:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
+    assert A.add(B) == C
+    assert B.add(A) == C
+
+
+def test_SDM_sub():
+    A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
+    B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
+    C = SDM({0:{0:ZZ(-1), 1:ZZ(1)}, 1:{0:ZZ(4)}}, (2, 2), ZZ)
+    assert A.sub(B) == C
+
+
+def test_SDM_neg():
+    A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
+    B = SDM({0:{1:ZZ(-1)}, 1:{0:ZZ(-2), 1:ZZ(-3)}}, (2, 2), ZZ)
+    assert A.neg() == B
+
+
+def test_SDM_convert_to():
+    A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
+    B = SDM({0:{1:QQ(1)}, 1:{0:QQ(2), 1:QQ(3)}}, (2, 2), QQ)
+    C = A.convert_to(QQ)
+    assert C == B
+    assert C.domain == QQ
+
+    D = A.convert_to(ZZ)
+    assert D == A
+    assert D.domain == ZZ
+
+
+def test_SDM_inv():
+    A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    B = SDM({0:{0:QQ(-2), 1:QQ(1)}, 1:{0:QQ(3, 2), 1:QQ(-1, 2)}}, (2, 2), QQ)
+    assert A.inv() == B
+
+
+def test_SDM_det():
+    A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    assert A.det() == QQ(-2)
+
+
+def test_SDM_lu():
+    A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    L = SDM({0:{0:QQ(1)}, 1:{0:QQ(3), 1:QQ(1)}}, (2, 2), QQ)
+    #U = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(-2)}}, (2, 2), QQ)
+    #swaps = []
+    # This doesn't quite work. U has some nonzero elements in the lower part.
+    #assert A.lu() == (L, U, swaps)
+    assert A.lu()[0] == L
+
+
+def test_SDM_lu_solve():
+    A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    b = SDM({0:{0:QQ(1)}, 1:{0:QQ(2)}}, (2, 1), QQ)
+    x = SDM({1:{0:QQ(1, 2)}}, (2, 1), QQ)
+    assert A.matmul(x) == b
+    assert A.lu_solve(b) == x
+
+
+def test_SDM_charpoly():
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    assert A.charpoly() == [ZZ(1), ZZ(-5), ZZ(-2)]
+
+
+def test_SDM_nullspace():
+    A = SDM({0:{0:QQ(1), 1:QQ(1)}}, (2, 2), QQ)
+    assert A.nullspace()[0] == SDM({0:{0:QQ(-1), 1:QQ(1)}}, (1, 2), QQ)
+
+
+def test_SDM_rref():
+    eye2 = SDM({0:{0:QQ(1)}, 1:{1:QQ(1)}}, (2, 2), QQ)
+
+    A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    assert A.rref() == (eye2, [0, 1])
+
+    A = SDM({0:{0:QQ(1)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    assert A.rref() == (eye2, [0, 1])
+
+    A = SDM({0:{1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
+    assert A.rref() == (eye2, [0, 1])
+
+    A = SDM({0:{0:QQ(1), 1:QQ(2), 2:QQ(3)},
+             1:{0:QQ(4), 1:QQ(5), 2:QQ(6)},
+             2:{0:QQ(7), 1:QQ(8), 2:QQ(9)} }, (3, 3), QQ)
+    Arref = SDM({0:{0:QQ(1), 2:QQ(-1)}, 1:{1:QQ(1), 2:QQ(2)}}, (3, 3), QQ)
+    assert A.rref() == (Arref, [0, 1])
+
+    A = SDM({0:{0:QQ(1), 1:QQ(2), 3:QQ(1)},
+             1:{0:QQ(1), 1:QQ(1), 2:QQ(9)}}, (2, 4), QQ)
+    Arref = SDM({0:{0:QQ(1), 2:QQ(18), 3:QQ(-1)},
+                 1:{1:QQ(1), 2:QQ(-9), 3:QQ(1)}}, (2, 4), QQ)
+    assert A.rref() == (Arref, [0, 1])
+
+    A = SDM({0:{0:QQ(1), 1:QQ(1), 2:QQ(1)},
+             1:{0:QQ(1), 1:QQ(2), 2:QQ(2)}}, (2, 3), QQ)
+    Arref = SDM(
+            {0: {0: QQ(1,1)}, 1: {1: QQ(1,1), 2: QQ(1,1)}},
+            (2, 3), QQ)
+    assert A.rref() == (Arref, [0, 1])

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1670,6 +1670,9 @@ class ANP(PicklableWithSlots, CantSympify):
         """Returns ``True`` if ``f`` is an element of the ground domain. """
         return not f.rep or len(f.rep) == 1
 
+    def __pos__(f):
+        return f
+
     def __neg__(f):
         return f.neg()
 

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -360,7 +360,7 @@ def _solve_lin_sys_component(eqs_coeffs, eqs_rhs, ring):
 
     if len(pivots) == len(keys):
         sol = []
-        for s in [row[-1] for row in echelon.rep]:
+        for s in [row[-1] for row in echelon.rep.to_ddm()]:
             a = s
             sol.append(a)
         sols = dict(zip(keys, sol))
@@ -372,7 +372,7 @@ def _solve_lin_sys_component(eqs_coeffs, eqs_rhs, ring):
             convert = ring.ring.ground_new
         else:
             convert = ring.ground_new
-        echelon = [[convert(eij) for eij in ei] for ei in echelon.rep]
+        echelon = [[convert(eij) for eij in ei] for ei in echelon.rep.to_ddm()]
         for i, p in enumerate(pivots):
             v = echelon[i][-1] - sum(echelon[i][j]*g[j] for j in range(p+1, len(g)) if echelon[i][j])
             sols[keys[p]] = v

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2844,19 +2844,17 @@ def linsolve(system, *symbols):
                     be given as a sequence, too.
                 '''))
             eqs = system
-            try:
-                eqs, ring = sympy_eqs_to_ring(eqs, symbols)
-            except PolynomialError as exc:
-                # e.g. cos(x) contains an element of the set of generators
-                raise NonlinearError(str(exc))
 
+            from sympy.polys.matrices.linsolve import _linsolve
             try:
-                sol = solve_lin_sys(eqs, ring, _raw=False)
+                sol = _linsolve(eqs, symbols)
             except PolyNonlinearError as exc:
+                # e.g. cos(x) contains an element of the set of generators
                 raise NonlinearError(str(exc))
 
             if sol is None:
                 return S.EmptySet
+
             sol = FiniteSet(Tuple(*(sol.get(sym, sym) for sym in symbols)))
             return sol
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows up from #20759, #20621, #19882, #18844

#### Brief description of what is fixed or changed

Add a sparse implementation of DomainMatrix along with an optimised sparse RREF algorithm. Make the new RREF algorithm used by in `solve_lin_sys` when inputs are Expr/Eq rather than a Matrix.

#### Other comments

This is a work in progress so some details will change.

The sparse RREF algorithm here is faster than the dense algorithm even for dense matrices. I have only timed with QQ but it seems to be faster in all cases. When the matrix is sparse then it's *much* faster. I expect that for other domains the arithmetic will be more expensive and so I think that it will probably make sense to use sparse matrices always except for small matrices of very simple domains like QQ and ZZ.

As an example of what you can do in this PR:
```python
In [1]: syms = symbols('x:1000')

In [2]: eqs = [x1 + x2 - 1 for x1, x2 in zip(syms[:-1], syms[1:])]

In [3]: eqs.append(syms[-1])

In [4]: %time ok = linsolve(eqs, syms) 
CPU times: user 700 ms, sys: 24.2 ms, total: 725 ms
Wall time: 724 ms
```
That's solving a sparse system of 1000 equations in 1000 unknowns. Actually the call to `sdm_rref` only takes 8 milliseconds in this example. The other 99% of the time in linsolve is consumed with other overheads that could be mostly optimised away.

On master it takes much longer:
```python
In [4]: %time ok = linsolve(eqs, syms)
CPU times: user 50.1 s, sys: 371 ms, total: 50.5 s
Wall time: 51.2 s
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * The new sparse DomainMatrix implementation is used in linsolve to make it much faster when solving large sparse systems of linear equations.
* polys
    * A new sparse implementation of DomainMatrix is added.
<!-- END RELEASE NOTES -->