### PR TITLE
Fix Q.finite for log

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -5,6 +5,7 @@ infinitesimal, finite, etc.
 
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Mul, Pow, Symbol
+from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.core.numbers import (Exp1, GoldenRatio, ImaginaryUnit, Infinity, NaN,
     NegativeInfinity, Number, Pi, TribonacciConstant)
 from sympy.functions import cos, exp, log, sign, sin
@@ -193,9 +194,15 @@ def _(expr, assumptions):
         return False
     return None
 
-@FinitePredicate.register_many(exp, log)
+@FinitePredicate.register(exp)
 def _(expr, assumptions):
     return ask(Q.finite(expr.args[0]), assumptions)
+
+@FinitePredicate.register(log)
+def _(expr, assumptions):
+    arg_zero = ask(Q.zero(expr.args[0]), assumptions)
+    arg_bounded = ask(Q.finite(expr.args[0]), assumptions)
+    return fuzzy_and([fuzzy_not(arg_zero), arg_bounded])
 
 @FinitePredicate.register_many(cos, sin, Number, Pi, Exp1, GoldenRatio,
     TribonacciConstant, ImaginaryUnit, sign)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -5,7 +5,6 @@ infinitesimal, finite, etc.
 
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Mul, Pow, Symbol
-from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.core.numbers import (Exp1, GoldenRatio, ImaginaryUnit, Infinity, NaN,
     NegativeInfinity, Number, Pi, TribonacciConstant)
 from sympy.functions import cos, exp, log, sign, sin
@@ -200,9 +199,9 @@ def _(expr, assumptions):
 
 @FinitePredicate.register(log)
 def _(expr, assumptions):
-    arg_zero = ask(Q.zero(expr.args[0]), assumptions)
-    arg_bounded = ask(Q.finite(expr.args[0]), assumptions)
-    return fuzzy_and([fuzzy_not(arg_zero), arg_bounded])
+    if ask(Q.infinite(expr.args[0]), assumptions):
+        return False
+    return ask(Q.nonzero(expr.args[0]), assumptions)
 
 @FinitePredicate.register_many(cos, sin, Number, Pi, Exp1, GoldenRatio,
     TribonacciConstant, ImaginaryUnit, sign)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -199,6 +199,8 @@ def _(expr, assumptions):
 
 @FinitePredicate.register(log)
 def _(expr, assumptions):
+    # After complex -> finite fact is registered to new assumption system,
+    # querying Q.infinite may be removed.
     if ask(Q.infinite(expr.args[0]), assumptions):
         return False
     return ask(Q.nonzero(expr.args[0]), assumptions)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1047,10 +1047,9 @@ def test_bounded():
     # exponential functions
     assert ask(Q.finite(log(x))) is None
     assert ask(Q.finite(log(x)), Q.finite(x)) is None
-    assert ask(Q.finite(log(x)), Q.nonzero(x)) is None
+    assert ask(Q.finite(log(x)), Q.nonzero(x)) is True
     assert ask(Q.finite(log(x)), Q.infinite(x)) is False
     assert ask(Q.finite(log(x)), Q.zero(x)) is False
-    assert ask(Q.finite(log(x)), Q.nonzero(x) & Q.finite(x)) is True
     assert ask(Q.finite(exp(x))) is None
     assert ask(Q.finite(exp(x)), Q.finite(x)) is True
     assert ask(Q.finite(exp(2))) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1046,7 +1046,11 @@ def test_bounded():
 
     # exponential functions
     assert ask(Q.finite(log(x))) is None
-    assert ask(Q.finite(log(x)), Q.finite(x)) is True
+    assert ask(Q.finite(log(x)), Q.finite(x)) is None
+    assert ask(Q.finite(log(x)), Q.nonzero(x)) is None
+    assert ask(Q.finite(log(x)), Q.infinite(x)) is False
+    assert ask(Q.finite(log(x)), Q.zero(x)) is False
+    assert ask(Q.finite(log(x)), Q.nonzero(x) & Q.finite(x)) is True
     assert ask(Q.finite(exp(x))) is None
     assert ask(Q.finite(exp(x)), Q.finite(x)) is True
     assert ask(Q.finite(exp(2))) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This issue is found in #20783.
#### Brief description of what is fixed or changed
This PR changes the incorrect behavior on `Q.finite` and `Q.infinite` on `log`.

`log(0)` returns `zoo`, which is infinite. In `master`, old assumption system can catch this:
```python
>>> log(0, evaluate=False).is_finite
False
```

However `Q.finite` gave wrong result. In `master`:

```python
>>> ask(Q.finite(log(0, evaluate=False)))
True
```

This PR fixes this. In 97c75fd:

```python
>>> ask(Q.finite(log(0, evaluate=False)))
False
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->