### PR TITLE
Customization of req. on base in 'create_expand_pow_optimization'

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -218,7 +218,7 @@ log1p_opt = ReplaceOptim(
     )).replace(log(_u+1), log1p(_u))
 )
 
-def create_expand_pow_optimization(limit):
+def create_expand_pow_optimization(limit, *, base_req=lambda b: b.is_symbol):
     """ Creates an instance of :class:`ReplaceOptim` for expanding ``Pow``.
 
     Explanation
@@ -233,6 +233,9 @@ def create_expand_pow_optimization(limit):
 
     limit : int
          The highest power which is expanded into multiplication.
+    base_req : function returning bool
+         Requirement on base for expansion to happen, default is to return
+         the ``is_symbol`` attribute of the base.
 
     Examples
     ========
@@ -245,10 +248,13 @@ def create_expand_pow_optimization(limit):
     x**5 + x*x*x
     >>> expand_opt(x**5 + x**3 + sin(x)**3)
     x**5 + sin(x)**3 + x*x*x
+    >>> opt2 = create_expand_pow_optimization(3 , base_req=lambda b: not b.is_Function)
+    >>> opt2((x+1)**2 + sin(x)**2)
+    sin(x)**2 + (x + 1)*(x + 1)
 
     """
     return ReplaceOptim(
-        lambda e: e.is_Pow and e.base.is_symbol and e.exp.is_Integer and abs(e.exp) <= limit,
+        lambda e: e.is_Pow and base_req(e.base) and e.exp.is_Integer and abs(e.exp) <= limit,
         lambda p: (
             UnevaluatedExpr(Mul(*([p.base]*+p.exp), evaluate=False)) if p.exp > 0 else
             1/UnevaluatedExpr(Mul(*([p.base]*-p.exp), evaluate=False))

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -218,7 +218,10 @@ def test_create_expand_pow_optimization():
     assert cc(x**4 - x**2) == '-x*x + x*x*x*x'
     i = Symbol('i', integer=True)
     assert cc(x**i - x**2) == 'pow(x, i) - x*x'
-
+    # gh issue 20753
+    cc2 = lambda x: ccode(optimize(x, [create_expand_pow_optimization(
+        4, base_req=lambda b: b.is_Function)]))
+    assert cc2(x**3 + sin(x)**3) == "pow(x, 3) + sin(x)*sin(x)*sin(x)"
 
 def test_matsolve():
     n = Symbol('n', integer=True)


### PR DESCRIPTION
 <!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
gh-20753
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a keyword only option in create_expand_pow_optimization, which allows the user to customize the requirement on the base for the expansion to happen.

#### Other comments
Requested by @Wrzlprmft in gh-20753

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * create_expand_pow_optimization is now customizable with respect to requirement on base.
<!-- END RELEASE NOTES -->