### PR TITLE
Added Replacer class to simplify the creation of replacement expressions with MatchPy

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -807,13 +807,13 @@ class StrPrinter(Printer):
         return expr.name + '_'
 
     def _print_WildDot(self, expr):
-        return expr.name + '_'
+        return expr.name
 
     def _print_WildPlus(self, expr):
-        return expr.name + '__'
+        return expr.name
 
     def _print_WildStar(self, expr):
-        return expr.name + '___'
+        return expr.name
 
     def _print_Zero(self, expr):
         if self._settings.get("sympy_integers", False):

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -726,9 +726,9 @@ def test_wild_matchpy():
     if matchpy is None:
         return
 
-    wd = WildDot('w')
-    wp = WildPlus('w')
-    ws = WildStar('w')
+    wd = WildDot('w_')
+    wp = WildPlus('w__')
+    ws = WildStar('w___')
 
     assert str(wd) == 'w_'
     assert str(wp) == 'w__'

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -169,6 +169,7 @@ def _get_srepr(expr):
     return s
 
 
+@doctest_depends_on(modules=('matchpy',))
 class Replacer:
     """
     Replacer object to perform multiple pattern matching and subexpression

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -2,13 +2,16 @@
 The objects in this module allow the usage of the MatchPy pattern matching
 library on SymPy expressions.
 """
+import re
+from typing import List, Callable
+
 from sympy.core.sympify import _sympify
 from sympy.external import import_module
 from sympy.functions import (log, sin, cos, tan, cot, csc, sec, erf, gamma, uppergamma)
 from sympy.functions.elementary.hyperbolic import acosh, asinh, atanh, acoth, acsch, asech, cosh, sinh, tanh, coth, sech, csch
 from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei
-from sympy import (Basic, Mul, Add, Pow, Integral, exp, Symbol)
+from sympy import (Basic, Mul, Add, Pow, Integral, exp, Symbol, Expr, srepr, Equality, Unequality)
 from sympy.utilities.decorator import doctest_depends_on
 
 matchpy = import_module("matchpy")
@@ -30,6 +33,11 @@ if matchpy:
     OneIdentityOperation.register(Mul)
     CommutativeOperation.register(Mul)
     AssociativeOperation.register(Mul)
+
+    Operation.register(Equality)
+    CommutativeOperation.register(Equality)
+    Operation.register(Unequality)
+    CommutativeOperation.register(Unequality)
 
     Operation.register(exp)
     Operation.register(log)
@@ -131,6 +139,9 @@ class _WildAbstract(Wildcard, Symbol):
     def __repr__(self):
         return str(self)
 
+    def __str__(self):
+        return self.name
+
 
 @doctest_depends_on(modules=('matchpy',))
 class WildDot(_WildAbstract):
@@ -148,3 +159,109 @@ class WildPlus(_WildAbstract):
 class WildStar(_WildAbstract):
     min_length = 0
     fixed_size = False
+
+
+def _get_srepr(expr):
+    s = srepr(expr)
+    s = re.sub(r"WildDot\('(\w+)'\)", r"\1", s)
+    s = re.sub(r"WildPlus\('(\w+)'\)", r"*\1", s)
+    s = re.sub(r"WildStar\('(\w+)'\)", r"*\1", s)
+    return s
+
+
+class Replacer:
+    """
+    Replacer object to perform multiple pattern matching and subexpression
+    replacements in SymPy expressions.
+
+    Examples
+    ========
+
+    Example to construct a simple first degree equation solver:
+
+    >>> from sympy.utilities.matchpy_connector import WildDot, Replacer
+    >>> from sympy import Equality, Symbol
+    >>> x = Symbol("x")
+    >>> a_ = WildDot("a_", optional=1)
+    >>> b_ = WildDot("b_", optional=0)
+
+    The lines above have defined two wildcards, ``a_`` and ``b_``, the
+    coefficients of the equation `a x + b = 0`. The optional values specified
+    indicate which expression to return in case no match is found, they are
+    necessary in equations like `a x = 0` and `x + b = 0`.
+
+    Create two constraints to make sure that ``a_`` and ``b_`` will not match
+    any expression containing ``x``:
+
+    >>> from matchpy import CustomConstraint
+    >>> free_x_a = CustomConstraint(lambda a_: not a_.has(x))
+    >>> free_x_b = CustomConstraint(lambda b_: not b_.has(x))
+
+    Now create the rule replacer with the constraints:
+
+    >>> replacer = Replacer(common_constraints=[free_x_a, free_x_b])
+
+    Add the matching rule:
+
+    >>> replacer.add(Equality(a_*x + b_, 0), -b_/a_)
+
+    Let's try it:
+
+    >>> replacer.replace(Equality(3*x + 4, 0))
+    -4/3
+
+    Notice that it won't match equations expressed with other patterns:
+
+    >>> eq = Equality(3*x, 4)
+    >>> replacer.replace(eq)
+    Eq(3*x, 4)
+
+    In order to extend the matching patterns, define another one (we also need
+    to clear the cache, because the previous result has already been memorized
+    and the pattern matcher won't iterate again if given the same expression)
+
+    >>> replacer.add(Equality(a_*x, b_), b_/a_)
+    >>> replacer._replacer.matcher.clear()
+    >>> replacer.replace(eq)
+    4/3
+    """
+
+    def __init__(self, common_constraints: list = []):
+        self._replacer = matchpy.ManyToOneReplacer()
+        self._common_constraint = common_constraints
+
+    def _get_lambda(self, lambda_str: str) -> Callable[..., Expr]:
+        exec("from sympy import *")
+        return eval(lambda_str, locals())
+
+    def _get_custom_constraint(self, constraint_expr: Expr, condition_template: str) -> Callable[..., Expr]:
+        wilds = list(map(lambda x: x.name, constraint_expr.atoms(_WildAbstract)))
+        lambdaargs = ', '.join(wilds)
+        fullexpr = _get_srepr(constraint_expr)
+        condition = condition_template.format(fullexpr)
+        return matchpy.CustomConstraint(
+            self._get_lambda(f"lambda {lambdaargs}: ({condition})"))
+
+    def _get_custom_constraint_nonfalse(self, constraint_expr: Expr) -> Callable[..., Expr]:
+        return self._get_custom_constraint(constraint_expr, "({}) != False")
+
+    def _get_custom_constraint_true(self, constraint_expr: Expr) -> Callable[..., Expr]:
+        return self._get_custom_constraint(constraint_expr, "({}) == True")
+
+    def add(self, expr: Expr, result: Expr, conditions_true: List[Expr] = [], conditions_nonfalse: List[Expr] = []) -> None:
+        expr = _sympify(expr)
+        result = _sympify(result)
+        lambda_str = f"lambda {', '.join(map(lambda x: x.name, expr.atoms(_WildAbstract)))}: {_get_srepr(result)}"
+        lambda_expr = self._get_lambda(lambda_str)
+        constraints = self._common_constraint[:]
+        constraint_conditions_true = [
+            self._get_custom_constraint_true(cond) for cond in conditions_true]
+        constraint_conditions_nonfalse = [
+            self._get_custom_constraint_nonfalse(cond) for cond in conditions_nonfalse]
+        constraints.extend(constraint_conditions_true)
+        constraints.extend(constraint_conditions_nonfalse)
+        self._replacer.add(
+            matchpy.ReplacementRule(matchpy.Pattern(expr, *constraints), lambda_expr))
+
+    def replace(self, expr: Expr) -> Expr:
+        return self._replacer.replace(expr)

--- a/sympy/utilities/tests/test_matchpy_connector.py
+++ b/sympy/utilities/tests/test_matchpy_connector.py
@@ -1,4 +1,4 @@
-from sympy import symbols, cos, sin, S, Eq, Equality, sqrt, Ne, Tuple
+from sympy import symbols, cos, sin, S, Eq, Equality, sqrt, Ne
 from sympy.external import import_module
 from sympy.testing.pytest import skip
 from sympy.utilities.matchpy_connector import WildDot, WildPlus, WildStar, Replacer

--- a/sympy/utilities/tests/test_matchpy_connector.py
+++ b/sympy/utilities/tests/test_matchpy_connector.py
@@ -1,6 +1,7 @@
-from sympy import symbols, cos, sin
+from sympy import symbols, cos, sin, S, Eq, Equality, sqrt, Ne, Tuple
 from sympy.external import import_module
-from sympy.utilities.matchpy_connector import WildDot, WildPlus, WildStar
+from sympy.testing.pytest import skip
+from sympy.utilities.matchpy_connector import WildDot, WildPlus, WildStar, Replacer
 
 matchpy = import_module("matchpy")
 
@@ -17,7 +18,7 @@ def _get_first_match(expr, pattern):
 
 def test_matchpy_connector():
     if matchpy is None:
-        return
+        skip("matchpy not installed")
 
     from multiset import Multiset
     from matchpy import Pattern, Substitution
@@ -47,7 +48,7 @@ def test_matchpy_connector():
 
 def test_matchpy_optional():
     if matchpy is None:
-        return
+        skip("matchpy not installed")
 
     from matchpy import Pattern, Substitution
     from matchpy import ManyToOneReplacer, ReplacementRule
@@ -83,3 +84,43 @@ def test_matchpy_optional():
     assert replacer.replace(expr2) == sin(1)*cos(3)
     assert replacer.replace(expr3) == sin(1)*cos(0)
     assert replacer.replace(expr4) == sin(y)*cos(z)
+
+
+def test_replacer():
+    if matchpy is None:
+        skip("matchpy not installed")
+
+    x1_ = WildDot("x1_")
+    x2_ = WildDot("x2_")
+
+    a_ = WildDot("a_", optional=S.One)
+    b_ = WildDot("b_", optional=S.One)
+    c_ = WildDot("c_", optional=S.Zero)
+
+    replacer = Replacer(common_constraints=[
+        matchpy.CustomConstraint(lambda a_: not a_.has(x)),
+        matchpy.CustomConstraint(lambda b_: not b_.has(x)),
+        matchpy.CustomConstraint(lambda c_: not c_.has(x)),
+    ])
+
+    # Rewrite the equation into implicit form, unless it's already solved:
+    replacer.add(Eq(x1_, x2_), Eq(x1_ - x2_, 0), conditions_nonfalse=[Ne(x2_, 0), Ne(x1_, 0), Ne(x1_, x), Ne(x2_, x)])
+
+    # Simple equation solver for real numbers:
+    replacer.add(Equality(a_*x + b_, 0), Equality(x, -b_/a_))
+    disc = b_**2 - 4*a_*c_
+    replacer.add(
+        Equality(a_*x**2 + b_*x + c_, 0),
+        Eq(x, (-b_ - sqrt(disc))/(2*a_)) | Eq(x, (-b_ + sqrt(disc))/(2*a_)),
+        conditions_nonfalse=[disc >= 0]
+    )
+    replacer.add(
+        Equality(a_*x**2 + c_, 0),
+        Eq(x, sqrt(-c_/a_)) | Eq(x, -sqrt(-c_/a_)),
+        conditions_nonfalse=[-c_*a_ > 0]
+    )
+
+    assert replacer.replace(Eq(3*x, y)) == Eq(x, y/3)
+    assert replacer.replace(Eq(x**2 + 1, 0)) == Eq(x**2 + 1, 0)
+    assert replacer.replace(Eq(x**2, 4)) == (Eq(x, 2) | Eq(x, -2))
+    assert replacer.replace(Eq(x**2 + 4*y*x + 4*y**2, 0)) == Eq(x, -2*y)


### PR DESCRIPTION
Replacer class is a wrapper around MatchPy's `ManyToOneReplacer` to simplify its usage in SymPy.

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added Replacer class to simplify the creation of replacement expressions with MatchPy.
<!-- END RELEASE NOTES -->