### PR TITLE
maint(ci): install gmpy in optional dependency tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           python-version: 3.8
       - run: release/aptinstall.sh
+      - run: sudo apt-get install libmpfr-dev libmpc-dev
+      - run: release/venv_main/bin/python -m pip install gmpy2
       # Test external imports
       - run: release/venv_main/bin/python bin/test_external_imports.py
       - run: release/venv_main/bin/python bin/test_submodule_imports.py

--- a/sympy/polys/agca/extensions.py
+++ b/sympy/polys/agca/extensions.py
@@ -325,11 +325,10 @@ class MonogenicFiniteExtension(Domain):
         return self.set_domain(K)
 
     def quo(self, f, g):
-        rep = self.domain.exquo(f.rep, g.rep)
-        return ExtElem(rep % self.mod, self)
+        return self.exquo(f, g)
 
     def exquo(self, f, g):
-        rep = self.domain.exquo(f.rep, g.rep)
+        rep = self.ring.exquo(f.rep, g.rep)
         return ExtElem(rep % self.mod, self)
 
     def is_negative(self, a):


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows on from #20466, #20792 and #20793

#### Brief description of what is fixed or changed

The Travis test script previously tested the polys module with gmpy2
installed. This ensures that gmpy2 is installed when running the
optional dependency tests on GitHub Actions.

#### Other comments

The Travis build is currently failing due to the polys module failing with gmpy installed. It is hoped that this PR will fail the tests so that we can see that they are being run properly. Afterwards I will push a commit that fixes the problem.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->