### PR TITLE
doc(polys): document ExpressionDomain.Expression

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -104,6 +104,8 @@ Concrete Domains
 .. autoclass:: ExpressionDomain
    :members:
 
+.. autoclass:: sympy.polys.domains.expressiondomain::ExpressionDomain.Expression
+
 Implementation Domains
 **********************
 


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Part of a series trying to get the Travis build to pass before Travis shuts down. See also #20466, #20792, #20793, #20797

#### Brief description of what is fixed or changed

This class needs to be explicitly shown in the docs so that building
the docs with sphinx 3.4.3 works without warning about a missing
reference to the nested class ExpressionDomain.Expression.

#### Other comments

There shouldn't be any noticeable difference with this on GH Actions but it should pass the docs build on Travis (Travis won't run until after this is merged)

Once the Travis build is working the next step will be to unpin the versions installed in GH Actions so it also runs with the latest version of Sphinx.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->