### PR TITLE
core: Make S(0.0) == S.false return False

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1386,8 +1386,6 @@ class Float(Number):
             other = _sympify(other)
         except SympifyError:
             return NotImplemented
-        if not self:
-            return not other
         if isinstance(other, Boolean):
             return False
         if other.is_NumberSymbol:
@@ -1408,6 +1406,8 @@ class Float(Number):
             # the mpf tuples
             ompf = other._as_mpf_val(self._prec)
             return bool(mlib.mpf_eq(self._mpf_, ompf))
+        if not self:
+            return not other
         return False    # Float != non-Number
 
     def __ne__(self, other):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -436,6 +436,7 @@ def test_Float():
     a = Float(2) ** Float(4)
     assert eq(a.evalf(), Float(16))
     assert (S(.3) == S(.5)) is False
+
     mpf = (0, 5404319552844595, -52, 53)
     x_str =  Float((0, '13333333333333', -52, 53))
     x2_str = Float((0, '26666666666666', -53, 54))
@@ -582,7 +583,12 @@ def test_Float():
     for i, a in zip(u, v):
         assert Float(i) is a
 
-
+def test_zero_not_false():
+    # https://github.com/sympy/sympy/issues/20796
+    assert (S(0.0) == S.false) is False
+    assert (S.false == S(0.0)) is False
+    assert (S(0) == S.false) is False
+    assert (S.false == S(0)) is False
 
 @conserve_mpmath_dps
 def test_float_mpf():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #20796 


#### Brief description of what is fixed or changed
Moved the `not self` check to the end of other checks in `Float.__eq__` so that `S(0.0) == S.false` will be correctly evaluated by an earlier check.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Make S(0.0) == S.false return False
<!-- END RELEASE NOTES -->