### PR TITLE
maint(ci): remove coverage test jobs from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,32 +68,6 @@ jobs:
     # stage.
     - stage: test
 
-      # Code coverage tests. These are slow so put them first.
-      python: 3.7
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="1/4"
-        - TEST_COVERAGE="true"
-    - python: 3.7
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="2/4"
-        - TEST_COVERAGE="true"
-    - python: 3.7
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="3/4"
-        - TEST_COVERAGE="true"
-    - python: 3.7
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="4/4"
-        - TEST_COVERAGE="true"
-
     # PyPy tests are slow so put them first
     - python: "pypy"
       env:


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See also #20466, #20792, #20793, #20797, #20800

#### Brief description of what is fixed or changed

This commit removes the coverage testing jobs from the Travis config. At
the time of this commit sympy is migrating from Travis to Actions and
Travis is still running just to see if it picks up on anything that
isn't picked up by Actions. The coverage jobs are failing on Travis due
to timeouts that are actually caused by Travis itself slowing down. This
commit removes the coverage tests so that the build will pass.

#### Other comments

It would be good to add coverage testing in Actions but it's not critical right now.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->