### PR TITLE
Added _eval_as_leading_term in floor and ceiling

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -132,12 +132,11 @@ class floor(RoundFunction):
             return arg.approximation_interval(Integer)[0]
 
     def _eval_as_leading_term(self, x, cdir=0):
-        arg = self.args[0].as_leading_term(x)
+        arg = self.args[0]
         arg0 = arg.subs(x, 0)
         if arg0.is_finite:
-            res = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-            return res.as_leading_term(x, cdir=cdir)
-        return arg
+            return self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        return arg.as_leading_term(x)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
@@ -282,12 +281,11 @@ class ceiling(RoundFunction):
             return arg.approximation_interval(Integer)[1]
 
     def _eval_as_leading_term(self, x, cdir=0):
-        arg = self.args[0].as_leading_term(x)
+        arg = self.args[0]
         arg0 = arg.subs(x, 0)
         if arg0.is_finite:
-            res = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-            return res.as_leading_term(x, cdir=cdir)
-        return arg
+            return self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        return arg.as_leading_term(x)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -131,6 +131,14 @@ class floor(RoundFunction):
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[0]
 
+    def _eval_as_leading_term(self, x, cdir=0):
+        arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
+        if arg0.is_finite:
+            res = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+            return res.as_leading_term(x, cdir=cdir)
+        return arg
+
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
@@ -138,7 +146,7 @@ class floor(RoundFunction):
             from sympy.calculus.util import AccumBounds
             from sympy.series.order import Order
             s = arg._eval_nseries(x, n, logx, cdir)
-            o = Order(1, (x, 0)) if n <= 1 else AccumBounds(-1, 0)
+            o = Order(1, (x, 0)) if n <= 0 else AccumBounds(-1, 0)
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:
@@ -273,6 +281,14 @@ class ceiling(RoundFunction):
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[1]
 
+    def _eval_as_leading_term(self, x, cdir=0):
+        arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
+        if arg0.is_finite:
+            res = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+            return res.as_leading_term(x, cdir=cdir)
+        return arg
+
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
@@ -280,7 +296,7 @@ class ceiling(RoundFunction):
             from sympy.calculus.util import AccumBounds
             from sympy.series.order import Order
             s = arg._eval_nseries(x, n, logx, cdir)
-            o = Order(1, (x, 0)) if n <= 1 else AccumBounds(0, 1)
+            o = Order(1, (x, 0)) if n <= 0  else AccumBounds(0, 1)
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -132,11 +132,17 @@ class floor(RoundFunction):
             return arg.approximation_interval(Integer)[0]
 
     def _eval_nseries(self, x, n, logx, cdir=0):
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+        if arg0.is_infinite:
+            from sympy.calculus.util import AccumBounds
+            from sympy.series.order import Order
+            s = arg._eval_nseries(x, n, logx, cdir)
+            o = Order(1, (x, 0)) if n <= 1 else AccumBounds(-1, 0)
+            return s + o
         r = self.subs(x, 0)
-        args = self.args[0]
-        args0 = args.subs(x, 0)
-        if args0 == r:
-            direction = (args - args0).leadterm(x)[0]
+        if arg0 == r:
+            direction = (arg - arg0).leadterm(x)[0]
             if direction.is_positive:
                 return r
             else:
@@ -268,11 +274,17 @@ class ceiling(RoundFunction):
             return arg.approximation_interval(Integer)[1]
 
     def _eval_nseries(self, x, n, logx, cdir=0):
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+        if arg0.is_infinite:
+            from sympy.calculus.util import AccumBounds
+            from sympy.series.order import Order
+            s = arg._eval_nseries(x, n, logx, cdir)
+            o = Order(1, (x, 0)) if n <= 1 else AccumBounds(0, 1)
+            return s + o
         r = self.subs(x, 0)
-        args = self.args[0]
-        args0 = args.subs(x, 0)
-        if args0 == r:
-            direction = (args - args0).leadterm(x)[0]
+        if arg0 == r:
+            direction = (arg - arg0).leadterm(x)[0]
             if direction.is_positive:
                 return r + 1
             else:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -136,7 +136,7 @@ def test_floor():
     assert limit(floor(x), x, 248, "-") == 247
 
     # https://github.com/sympy/sympy/issues/14478
-    assert limit(x/2*floor(3/x), x, 0, '+') == 3/2
+    assert limit(x*floor(3/x)/2, x, 0, '+') == Rational(3, 2)
     assert limit(floor(x + 1/2) - floor(x), x, oo) == AccumBounds(-0.5, 1.5)
 
 
@@ -166,7 +166,7 @@ def test_ceiling():
     assert limit(ceiling(x), x, 248, "-") == 248
 
     # https://github.com/sympy/sympy/issues/14478
-    assert limit(x/2*ceiling(3/x), x, 0, '+') == 3/2
+    assert limit(x*ceiling(3/x)/2, x, 0, '+') == Rational(3, 2)
     assert limit(ceiling(x + 1/2) - ceiling(x), x, oo) == AccumBounds(-0.5, 1.5)
 
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -135,6 +135,10 @@ def test_floor():
     assert limit(floor(x), x, 248, "+") == 248
     assert limit(floor(x), x, 248, "-") == 247
 
+    # https://github.com/sympy/sympy/issues/14478
+    assert limit(x/2*floor(3/x), x, 0, '+') == 3/2
+    assert limit(floor(x + 1/2) - floor(x), x, oo) == AccumBounds(-0.5, 1.5)
+
 
 def test_floor_requires_robust_assumptions():
     assert limit(floor(sin(x)), x, 0, "+") == 0
@@ -160,6 +164,10 @@ def test_ceiling():
     assert limit(ceiling(x), x, 2, "-") == 2
     assert limit(ceiling(x), x, 248, "+") == 249
     assert limit(ceiling(x), x, 248, "-") == 248
+
+    # https://github.com/sympy/sympy/issues/14478
+    assert limit(x/2*ceiling(3/x), x, 0, '+') == 3/2
+    assert limit(ceiling(x + 1/2) - ceiling(x), x, oo) == AccumBounds(-0.5, 1.5)
 
 
 def test_ceiling_requires_robust_assumptions():
@@ -724,7 +732,6 @@ def test_issue_10978():
     assert LambertW(x).limit(x, 0) == 0
 
 
-@XFAIL
 def test_issue_14313_comment():
     assert limit(floor(n/2), n, oo) is oo
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #14313
Fixes #14478 

#### Brief description of what is fixed or changed
There was no check being done for infinity in `_eval_nseries` of `floor` and `ceiling`. These checks have been added, and `floor(arg)`, when `arg` is infinity, returns `arg + Order(1)` if the expansion is expected to have order less than or equal to 1, and `arg + AccumBounds(-1, 0)` otherwise. This is because the value of `floor(x) - x` will lie between -1 and 0 always, but in the case that it is `floor(x + 1/2) - floor(x)`, we cannot determine the result, the best we can say is `AccumBounds(-0.5, 1.5)`

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Modified `_eval_nseries` to handle infinity and added `_eval_as_leading_term` in `floor` and `ceiling`
<!-- END RELEASE NOTES -->