### PR TITLE
maint(ci): scale back Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,10 @@ language: python
 os:
   - linux
 
-stages:
-  - quality
-  - baseline
-  - test
-  - allowed_failures
-
-env:
-  jobs:
-    - TEST_SYMPY="true" SPLIT="1/2"
-    - TEST_SYMPY="true" SPLIT="2/2"
-    - TEST_DOCTESTS="true" TEST_SETUP="true" TEST_EXAMPLES="true"
-dist: trusty
-
-python:
-  - 3.6
-
 jobs:
   fast_finish: true
   include:
-    - stage: quality
-      python: 3.8
+    - python: 3.8
       dist: xenial
       script: bin/test quality
       env:
@@ -32,8 +15,7 @@ jobs:
       env:
         - TEST_FLAKE8="true"
 
-    - stage: baseline
-      python: 3.8
+    - python: 3.8
       dist: xenial
       env:
         - TEST_DOCTESTS="true" TEST_SETUP="true" TEST_EXAMPLES="true"
@@ -63,10 +45,6 @@ jobs:
             - liblapack-dev
             - gfortran
             - python-scipy
-
-    # Full tests. Hopefully basic problems were picked up in the previous
-    # stage.
-    - stage: test
 
     # PyPy tests are slow so put them first
     - python: "pypy"
@@ -98,19 +76,6 @@ jobs:
             - pypy
           packages:
             - pypy3
-
-    - python: 3.9-dev
-      dist: xenial
-      env:
-        - SPLIT="1/2" TEST_SYMPY="true"
-    - python: 3.9-dev
-      dist: xenial
-      env:
-        - SPLIT="2/2" TEST_SYMPY="true"
-    - python: 3.9-dev
-      dist: xenial
-      env:
-        - TEST_DOCTESTS="true" TEST_SETUP="true" TEST_EXAMPLES="true"
 
     # Tensorflow 1 support
     - python: 3.6
@@ -159,10 +124,6 @@ jobs:
     - python: 3.6
       dist: xenial
       env:
-        - BENCHMARK="true"
-
-  allow_failures:
-    - env:
         - BENCHMARK="true"
 
 before_install:


### PR DESCRIPTION
Eliminate the less useful jobs from the Travis build script. It is hoped
that this will bring the Travis build time down to around 200 minutes
which would be enough to run a Travis build once per week under the new
1000 minutes per month free plan.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See also #20466, #20792, #20793, #20797, #20800, #20802

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->