### PR TITLE
primerange accepts single arugment for computing prime numbers less than n

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -150,7 +150,6 @@ class Sieve:
         ========
 
         >>> from sympy import sieve
-        # Note the endpoint 19 is not included even though it is prime
         >>> print([i for i in sieve.primerange(7, 19)])
         [7, 11, 13, 17]
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -142,7 +142,7 @@ class Sieve:
         while len(self._list) < i:
             self.extend(int(self._list[-1] * 1.5))
 
-    def primerange(self, a, b):
+    def primerange(self, a, b = None):
         """Generate all prime numbers in the range [a, b).
 
         Examples
@@ -156,8 +156,12 @@ class Sieve:
 
         # wrapping ceiling in as_int will raise an error if there was a problem
         # determining whether the expression was exactly an integer or not
-        a = max(2, as_int(ceiling(a)))
-        b = as_int(ceiling(b))
+        if b == None:
+            b = as_int(ceiling(a))
+            a = 2
+        else:
+            a = max(2, as_int(ceiling(a)))
+            b = as_int(ceiling(b))
         if a >= b:
             return
         self.extend(b)

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -142,8 +142,9 @@ class Sieve:
         while len(self._list) < i:
             self.extend(int(self._list[-1] * 1.5))
 
-    def primerange(self, a, b = None):
-        """Generate all prime numbers in the range [a, b).
+    def primerange(self, a, b=None):
+        """Generate all prime numbers in the range [a, b) when both a and b are
+           provided and generates all prime numbers till a when only a is provided.
 
         Examples
         ========
@@ -151,12 +152,15 @@ class Sieve:
         >>> from sympy import sieve
         >>> print([i for i in sieve.primerange(7, 18)])
         [7, 11, 13, 17]
+
+        >>> print([i for i in sieve.primerange(18)])
+        [2, 3, 5, 7, 11, 13, 17]
         """
         from sympy.functions.elementary.integers import ceiling
 
         # wrapping ceiling in as_int will raise an error if there was a problem
         # determining whether the expression was exactly an integer or not
-        if b == None:
+        if b is None:
             b = as_int(ceiling(a))
             a = 2
         else:

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -150,10 +150,11 @@ class Sieve:
         ========
 
         >>> from sympy import sieve
-        >>> print([i for i in sieve.primerange(7, 18)])
+        # Note the endpoint 19 is not included even though it is prime
+        >>> print([i for i in sieve.primerange(7, 19)])
         [7, 11, 13, 17]
 
-        >>> print([i for i in sieve.primerange(18)])
+        >>> print([i for i in sieve.primerange(19)])
         [2, 3, 5, 7, 11, 13, 17]
         """
         from sympy.functions.elementary.integers import ceiling

--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -128,10 +128,12 @@ def test_generate():
     assert list(sieve.primerange(10, 1)) == []
     assert list(sieve.primerange(5, 9)) == [5, 7]
     sieve._reset(prime=True)
-    assert list(sieve.primerange(2, 12)) == [2, 3, 5, 7, 11]
+    assert list(sieve.primerange(2, 13)) == [2, 3, 5, 7, 11]
+    assert list(sieve.primerange(13)) == [2, 3, 5, 7, 11]
     assert list(sieve.primerange(8)) == [2, 3, 5, 7]
     assert list(sieve.primerange(-2)) == []
-    assert list(sieve.primerange(30)) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+    assert list(sieve.primerange(29)) == [2, 3, 5, 7, 11, 13, 17, 19, 23]
+    assert list(sieve.primerange(34)) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
 
     assert list(sieve.totientrange(5, 15)) == [4, 2, 6, 4, 6, 4, 10, 4, 12, 6]
     sieve._reset(totient=True)

--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -129,6 +129,9 @@ def test_generate():
     assert list(sieve.primerange(5, 9)) == [5, 7]
     sieve._reset(prime=True)
     assert list(sieve.primerange(2, 12)) == [2, 3, 5, 7, 11]
+    assert list(sieve.primerange(8)) == [2, 3, 5, 7]
+    assert list(sieve.primerange(-2)) == []
+    assert list(sieve.primerange(30)) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
     assert list(sieve.totientrange(5, 15)) == [4, 2, 6, 4, 6, 4, 10, 4, 12, 6]
     sieve._reset(totient=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19118

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `primerange` now accepts a single argument i.e., `primerange(input_arg)` is valid and is same as `primerange(2, input_arg)`.
<!-- END RELEASE NOTES -->
