### PR TITLE
Revert "Lambert and _is_lambert modifications"

### DIFF
--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -4,7 +4,6 @@ from sympy.core.function import expand_log
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
-from sympy.core.numbers import I
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.miscellaneous import root
 from sympy.polys.polyroots import roots
@@ -119,7 +118,7 @@ def _linab(arg, symbol):
     return a, b, x
 
 
-def _lambert(eq, x, domain=S.Complexes):
+def _lambert(eq, x):
     """
     Given an expression assumed to be in the form
         ``F(X, a..f) = a*log(b*X + c) + d*X + f = 0``
@@ -177,26 +176,8 @@ def _lambert(eq, x, domain=S.Complexes):
     p, den = den.as_coeff_Mul()
     e = exp(num/den)
     t = Dummy('t')
+    args = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
 
-    if p == 1:
-        t = e
-        args = [d/(a*b)*t]
-    elif domain.is_subset(S.Reals):
-        # print(l090)
-        ind_ls = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
-        args = []
-        j = -1
-        for i in ind_ls:
-            j += 1
-            if not isinstance(i,int):
-                if not i.has(I):
-                    args.append(ind_ls[j])
-            elif isinstance(i,int):
-                args.append(ind_ls[j])
-    else:
-        args = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
-    if len(args) == 0:
-        return S.EmptySet
     # calculating solutions from args
     for arg in args:
         for k in lambert_real_branches:
@@ -210,11 +191,7 @@ def _lambert(eq, x, domain=S.Complexes):
     return sol
 
 
-def _lambert_real(eq, x):
-    return _lambert(eq, x, domain=S.Reals)
-
-
-def _solve_lambert(f, symbol, gens, domain=S.Complexes):
+def _solve_lambert(f, symbol, gens):
     """Return solution to ``f`` if it is a Lambert-type expression
     else raise NotImplementedError.
 
@@ -248,7 +225,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
       X = B, a = -1, d = a*log(p), f = -log(d) - g*log(p)
     """
 
-    def _solve_even_degree_expr(expr, t, symbol, domain=S.Complexes):
+    def _solve_even_degree_expr(expr, t, symbol):
         """Return the unique solutions of equations derived from
         ``expr`` by replacing ``t`` with ``+/- symbol``.
 
@@ -292,11 +269,9 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
         """
         nlhs, plhs = [
             expr.xreplace({t: sgn*symbol}) for sgn in (-1, 1)]
-        sols = _solve_lambert(nlhs, symbol, gens, domain)
-        if sols == S.EmptySet:
-            return S.EmptySet
+        sols = _solve_lambert(nlhs, symbol, gens)
         if plhs != nlhs:
-            sols.extend(_solve_lambert(plhs, symbol, gens, domain))
+            sols.extend(_solve_lambert(plhs, symbol, gens))
         # uniq is needed for a case like
         # 2*log(t) - log(-z**2) + log(z + log(x) + log(z))
         # where subtituting t with +/-x gives all the same solution;
@@ -331,7 +306,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
             if not t_term.is_Add and _rhs and not (
                     t_term.has(S.ComplexInfinity, S.NaN)):
                 eq = expand_log(log(t_term) - log(_rhs))
-                return _solve_even_degree_expr(eq, t, symbol, domain)
+                return _solve_even_degree_expr(eq, t, symbol)
         elif lhs.is_Mul and rhs:
             # this needs to happen whether t is present or not
             lhs = expand_log(log(lhs), force=True)
@@ -339,7 +314,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
             if lhs.has(t) and lhs.is_Add:
                 # it expanded from Mul to Add
                 eq = lhs - rhs
-                return _solve_even_degree_expr(eq, t, symbol, domain)
+                return _solve_even_degree_expr(eq, t, symbol)
 
         # restore symbol in lhs
         lhs = lhs.xreplace({t: symbol})
@@ -368,10 +343,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
         mainlog = _mostfunc(lhs, log, symbol)
         if mainlog:
             if lhs.is_Mul and rhs != 0:
-                if domain.is_subset(S.Reals):
-                    soln = _lambert_real(log(lhs) - log(rhs), symbol)
-                else:
-                    soln = _lambert(log(lhs) - log(rhs), symbol)
+                soln = _lambert(log(lhs) - log(rhs), symbol)
             elif lhs.is_Add:
                 other = lhs.subs(mainlog, 0)
                 if other and not other.is_Add and [
@@ -381,18 +353,11 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
                         diff = log(other) - log(other - lhs)
                     else:
                         diff = log(lhs - other) - log(rhs - other)
-                    if domain.is_subset(S.Reals):
-                        soln = _lambert_real(expand_log(diff), symbol)
-                    else:
-                        soln = _lambert(expand_log(diff), symbol)
+                    soln = _lambert(expand_log(diff), symbol)
                 else:
                     #it's ready to go
-                    if domain.is_subset(S.Reals):
-                        soln = _lambert_real(lhs - rhs, symbol)
-                    else:
-                        soln = _lambert(lhs - rhs, symbol)
-                    if soln == S.EmptySet :
-                            return S.EmptySet
+                    soln = _lambert(lhs - rhs, symbol)
+
     # For the next forms,
     #
     #     collect on main exp
@@ -409,10 +374,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
         if mainexp:
             lhs = collect(lhs, mainexp)
             if lhs.is_Mul and rhs != 0:
-                if domain.is_subset(S.Reals):
-                    soln = _lambert_real(expand_log(log(lhs) - log(rhs)), symbol)
-                else:
-                    soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
+                soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
             elif lhs.is_Add:
                 # move all but mainexp-containing term to rhs
                 other = lhs.subs(mainexp, 0)
@@ -423,11 +385,7 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
                     mainterm *= -1
                     rhs *= -1
                 diff = log(mainterm) - log(rhs)
-                if domain.is_subset(S.Reals):
-                    soln = _lambert_real(expand_log(diff), symbol)
-                else:
-                    soln = _lambert(expand_log(diff), symbol)
-
+                soln = _lambert(expand_log(diff), symbol)
 
     # For the last form:
     #
@@ -441,20 +399,14 @@ def _solve_lambert(f, symbol, gens, domain=S.Complexes):
             lhs = collect(lhs, mainpow)
             if lhs.is_Mul and rhs != 0:
                 # b*B = 0
-                if domain.is_subset(S.Reals):
-                    soln = _lambert_real(expand_log(log(lhs) - log(rhs)), symbol)
-                else:
-                    soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
+                soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
             elif lhs.is_Add:
                 # move all but mainpow-containing term to rhs
                 other = lhs.subs(mainpow, 0)
                 mainterm = lhs - other
                 rhs = rhs - other
                 diff = log(mainterm) - log(rhs)
-                if domain.is_subset(S.Reals):
-                    soln = _lambert_real(expand_log(diff), symbol)
-                else:
-                    soln = _lambert(expand_log(diff), symbol)
+                soln = _lambert(expand_log(diff), symbol)
 
     if not soln:
         raise NotImplementedError('%s does not appear to have a solution in '

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -314,10 +314,6 @@ def linodesolve_type(A, t, b=None):
 
 
 def _first_order_type5_6_subs(A, t, b=None):
-    from sympy.solvers.solveset import _is_lambert
-    from sympy.sets.conditionset import ConditionSet
-    from sympy import symbols
-    x = symbols('x')
     match = {}
 
     factor_terms = _factor_matrix(A, t)
@@ -326,11 +322,8 @@ def _first_order_type5_6_subs(A, t, b=None):
     if factor_terms is not None:
         t_ = Symbol("{}_".format(t))
         F_t = integrate(factor_terms[0], t)
+        inverse = solveset(Eq(t_, F_t), t)
 
-        if _is_lambert(F_t,x):
-            inverse = ConditionSet(t_, Eq(F_t,0),S.Complexes)
-        else:
-            inverse = solveset(Eq(t_, F_t), t)
         # Note: A simple way to check if a function is invertible
         # or not.
         if isinstance(inverse, FiniteSet) and not inverse.has(Piecewise)\

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -14,10 +14,11 @@ from sympy.core.sympify import sympify
 from sympy.core import (S, Pow, Dummy, pi, Expr, Wild, Mul, Equality,
                         Add)
 from sympy.core.containers import Tuple
-from sympy.core.numbers import I, Number, Rational, oo, igcd
+from sympy.core.numbers import I, Number, Rational, oo
 from sympy.core.function import (Lambda, expand_complex, AppliedUndef,
                                 expand_log)
 from sympy.core.mod import Mod
+from sympy.core.numbers import igcd
 from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
@@ -25,7 +26,7 @@ from sympy.simplify.simplify import simplify, fraction, trigsimp
 from sympy.simplify import powdenest, logcombine
 from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
                              acos, asin, acsc, asec, arg,
-                             piecewise_fold, Piecewise, LambertW)
+                             piecewise_fold, Piecewise)
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.functions.elementary.miscellaneous import real_root
@@ -41,11 +42,10 @@ from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf, factor, lcm, gcd)
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polytools import invert
-from sympy.solvers.bivariate import _solve_lambert, _filtered_gens, bivariate_type
 from sympy.polys.solvers import (sympy_eqs_to_ring, solve_lin_sys,
     PolyNonlinearError)
 from sympy.solvers.solvers import (checksol, denoms, unrad,
-    _simple_dens, recast_to_symbols, solve, _tsolve)
+    _simple_dens, recast_to_symbols)
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
@@ -55,7 +55,6 @@ from sympy.core.compatibility import ordered, default_sort_key, is_sequence
 
 from types import GeneratorType
 from collections import defaultdict
-from sympy import sqrt
 
 
 class NonlinearError(ValueError):
@@ -278,8 +277,6 @@ def _invert_real(f, g_ys, symbol):
                 elif one == S.false:
                     return _invert_real(expo, S.EmptySet, symbol)
 
-        else:
-            return _invert_real(expo*log(base), imageset(Lambda(n, log(n)), g_ys), symbol)
 
     if isinstance(f, TrigonometricFunction):
         if isinstance(g_ys, FiniteSet):
@@ -301,8 +298,6 @@ def _invert_real(f, g_ys, symbol):
                 invs += Union(*[imageset(Lambda(n, L(g)), S.Integers) for g in g_ys])
             return _invert_real(f.args[0], invs, symbol)
 
-    if isinstance(f, LambertW):
-        return _invert_real(f.args[0], imageset(Lambda(n, n*exp(n)), g_ys), symbol)
     return (f, g_ys)
 
 
@@ -993,8 +988,6 @@ def _solveset(f, symbol, domain, _check=False):
     # _check controls whether the answer is checked or not
     from sympy.simplify.simplify import signsimp
     from sympy.logic.boolalg import BooleanTrue
-    from sympy.functions.elementary.complexes import re
-
 
     if isinstance(f, BooleanTrue):
         return domain
@@ -1091,17 +1084,7 @@ def _solveset(f, symbol, domain, _check=False):
                         result_rational = _solve_as_rational(equation, symbol, domain)
                         if isinstance(result_rational, ConditionSet):
                             # may be a transcendental type equation
-                            if isinstance(f, Pow):
-                                base_sym = list(f.base.free_symbols)[0]
-                                pow_sym = list(f.exp.free_symbols)[0]
-                                if base_sym == pow_sym:
-                                    result = Intersection(solveset(f.base, base_sym), \
-                                        ConditionSet(pow_sym, re(pow_sym)>0, domain))
-                                else:
-                                    result = ProductSet(solveset(f.base, base_sym), \
-                                        ConditionSet(pow_sym, re(pow_sym)>0, domain))
-                            else:
-                                result = _transolve(equation, symbol, domain)
+                            result += _transolve(equation, symbol, domain)
                         else:
                             result += result_rational
                 else:
@@ -1122,46 +1105,7 @@ def _solveset(f, symbol, domain, _check=False):
                 result = _result - singularities
 
     if _check:
-        if (isinstance(result,ConditionSet)) and \
-                (domain.is_subset(S.Reals) and \
-                    (not isinstance(result,list))):
-            x = Symbol('x')
-            f = f.subs({symbol: x})
-            if _is_lambert(f,x):
-                if result.has(cos,sin):
-                    if (result.has(exp)) or (f.has(sqrt(x))) or\
-                        f.has(Abs):
-                        return result
-                    elif not domain.is_subset(S.Integers) and \
-                        ((result.has(cos) and not result.has(sin)) or \
-                            (result.has(sin) and not result.has(cos))) :
-                        f = solve(f,x)
-                        f = FiniteSet(*f)
-                        return f
-                elif domain.is_subset(S.Reals):
-                    if not any(i for i in f.atoms(Pow) if i.exp is S.Half) and f.count_ops() < 120:
-                        indls = _tsolve(f,x)
-                        if indls is None or indls == []:
-                            return result
-                        elif indls is not None:
-                            if len(indls) == 1:
-                                if indls[0] == 0:
-                                    return result
-                        if indls is not None:
-                            args = []
-                            j = -1
-                            for i in indls:
-                                j += 1
-                                if not isinstance(i,int):
-                                    if not i.has(I):
-                                        args.append(indls[j])
-                                elif isinstance(i,int):
-                                    args.append(indls[j])
-                            f = FiniteSet(*args)
-                            return f
-            else:
-                return result
-        elif isinstance(result,ConditionSet):
+        if isinstance(result, ConditionSet):
             # it wasn't solved or has enumerated all conditions
             # -- leave it alone
             return result
@@ -1179,11 +1123,6 @@ def _solveset(f, symbol, domain, _check=False):
             result = FiniteSet(*[s for s in result
                       if isinstance(s, RootOf)
                       or domain_check(fx, symbol, s)])
-        elif isinstance(result,list):
-            for _ in range(len(result) - 1):
-                result = result[_] + result[_+1]
-            if len(result) == 1:
-                return result[0]
 
     return result
 
@@ -1809,122 +1748,6 @@ def _is_logarithmic(f, symbol):
     return rv
 
 
-def _is_bivariate(f, symbol):
-    r"""
-    Return True if the equation has two generators, else False.
-    """
-    poly = f.as_poly()
-    gens = _filtered_gens(poly, symbol)
-
-    return len(gens) == 2
-
-
-def _solve_as_bivariate(lhs, rhs, symbol, domain):
-    r"""
-    Helper solver to solve equations of bivariate form.
-    """
-    result = ConditionSet(symbol, Eq(lhs - rhs, 0), domain)
-
-    poly = lhs.as_poly()
-    gens = _filtered_gens(poly, symbol)
-    gpu = bivariate_type(lhs - rhs, *gens)
-    if gpu is not None:
-        g, p, u = gpu
-        if g != lhs:
-            usol = _solveset(p, u, domain)
-            if not isinstance(usol, ConditionSet):
-                result = [_solveset(g - us, symbol, domain) for us in usol]
-    return result
-
-
-def _is_lambert(f, symbol):
-    r"""
-    Return True if the equation is of Lambert type, else False.
-    Equations containing `Pow`, `log` or `exp` terms are currently
-    treated as Lambert types.
-    """
-    for arg1 in list(_term_factors(f.expand())):
-        if isinstance(arg1,(Pow,exp)):
-            base, exponent = arg1.as_base_exp()
-            if isinstance(arg1,(Pow,Mul)) and len(list(Add.make_args(f))) == 1:
-                for a in list(Mul.make_args(f)):
-                    if isinstance(a,exp):
-                        base, exponent = a.as_base_exp()
-            if not exponent.has(symbol,Dummy) and len(list(Add.make_args(f))) > 1:
-                continue
-            if exponent.has(symbol,Dummy, TrigonometricFunction, HyperbolicFunction): # exponent is variable
-                if len(list(Add.make_args(f))) <= 2:
-                    j=0
-                    for args in list(Add.make_args(f)):
-                        from sympy import symbols
-                        x= symbols('x')
-                        if isinstance(args,Mul) and args.atoms(exp(x)) and (args.atoms(symbol) or args.atoms(Dummy)):
-                            for ar in list(Mul.make_args(args)):
-                                return ar.is_real
-                        elif len(list(args.atoms(symbol,Dummy))) == 1 :
-                            if list(args.atoms(symbol))[0].has(symbol,Dummy):
-                                j+=1
-                        else:
-                            return True
-                    return j>1
-                elif len(list(Add.make_args(f))) > 2:
-                    j=0
-                    for args in list(Add.make_args(f)):
-                        if len(list(args.atoms(symbol))) == 1 :
-                            if list(args.atoms(symbol))[0].has(symbol): # to check it has more than 2 variables
-                                j+=1
-                        else:
-                            return True
-                    return j>1
-
-            else:
-                return False
-        elif isinstance(arg1,log):
-            i, j,k = 0,0,0
-            for arg2 in list(_term_factors(f)):
-                if arg2.atoms(log) :
-                    j += 1
-                    if arg2.has((symbol)):
-                        i += 1
-                elif arg2.has(symbol):
-                    k += 1
-
-            return (j>1 or k>0) and (i >0)
-
-def _compute_lambert_solutions(lhs, rhs, symbol,domain=S.Complexes):
-    """
-    Computes the Lambert solutions. Returns `None` if it
-    fails doing so.
-    """
-    try:
-        poly = lhs.as_poly()
-        gens = _filtered_gens(poly, symbol)
-        return _solve_lambert(lhs - rhs, symbol, gens,domain)
-    except NotImplementedError:
-        pass
-
-
-def _solve_as_lambert(lhs, rhs, symbol, domain):
-    r"""
-    Helper solver to handle equations having Lambert solutions.
-    First tries to solve equation directly. If unsuccessful
-    attempts to find the solutions by making the `symbol` positive.
-    """
-    result = ConditionSet(symbol, Eq(lhs - rhs, 0), domain)
-    soln = _compute_lambert_solutions(lhs, rhs, symbol,domain)
-    if soln is None:
-        # try with positive `symbol`
-        u = Dummy('u', positive=True)
-        pos_lhs = lhs.subs({symbol: u})
-        soln = _compute_lambert_solutions(pos_lhs, rhs, u)
-        if soln:
-            result = FiniteSet(*soln)
-    else:
-        result = FiniteSet(*soln)
-
-    return result
-
-
 def _transolve(f, symbol, domain):
     r"""
     Function to solve transcendental equations. It is a helper to
@@ -1933,7 +1756,6 @@ def _transolve(f, symbol, domain):
 
         - Exponential equations
         - Logarithmic equations
-        - Lambert type equations
 
     Parameters
     ==========
@@ -2120,12 +1942,6 @@ def _transolve(f, symbol, domain):
         # check if it is logarithmic type equation
         elif _is_logarithmic(lhs, symbol):
             result = _solve_logarithm(lhs, rhs, symbol, domain)
-        elif _is_lambert(lhs, symbol):
-            # try to get solutions in form of Lambert
-            result = _solve_as_lambert(lhs, rhs, symbol, domain)
-            if isinstance(result, ConditionSet):
-                if _is_bivariate(lhs, symbol):
-                    result = _solve_as_bivariate(lhs, rhs, symbol, domain)
 
         return result
 
@@ -2141,13 +1957,6 @@ def _transolve(f, symbol, domain):
 
         if lhs.is_Add:
             result = add_type(lhs, rhs, symbol, domain)
-        elif _is_lambert(lhs, symbol):
-            # try to get solutions in form of Lambert
-            result = _solve_as_lambert(lhs, rhs, symbol, domain)
-            if isinstance(result, ConditionSet):
-                if _is_bivariate(lhs, symbol):
-                    result = _solve_as_bivariate(lhs, rhs, symbol, domain)
-
     else:
         result = rhs_s
 
@@ -2300,16 +2109,15 @@ def solveset(f, symbol=None, domain=S.Complexes):
     # solveset should ignore assumptions on symbols
     if symbol not in _rc:
         x = _rc[0] if domain.is_subset(S.Reals) else _rc[1]
-        if not isinstance(f,list):
-            rv = solveset(f.xreplace({symbol: x}), x, domain)
-            # try to use the original symbol if possible
-            try:
-                _rv = rv.xreplace({x: symbol})
-            except TypeError:
-                _rv = rv
-            if rv.dummy_eq(_rv):
-                rv = _rv
-            return rv
+        rv = solveset(f.xreplace({symbol: x}), x, domain)
+        # try to use the original symbol if possible
+        try:
+            _rv = rv.xreplace({x: symbol})
+        except TypeError:
+            _rv = rv
+        if rv.dummy_eq(_rv):
+            rv = _rv
+        return rv
 
     # Abs has its own handling method which avoids the
     # rewriting property that the first piece of abs(x)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1047,6 +1047,100 @@ def test_solve_trig_simplified():
         imageset(Lambda(n, n*pi - pi/4), S.Integers))
 
 
+@XFAIL
+def test_solve_lambert():
+    assert solveset_real(x*exp(x) - 1, x) == FiniteSet(LambertW(1))
+    assert solveset_real(exp(x) + x, x) == FiniteSet(-LambertW(1))
+    assert solveset_real(x + 2**x, x) == \
+        FiniteSet(-LambertW(log(2))/log(2))
+
+    # issue 4739
+    ans = solveset_real(3*x + 5 + 2**(-5*x + 3), x)
+    assert ans == FiniteSet(Rational(-5, 3) +
+                            LambertW(-10240*2**Rational(1, 3)*log(2)/3)/(5*log(2)))
+
+    eq = 2*(3*x + 4)**5 - 6*7**(3*x + 9)
+    result = solveset_real(eq, x)
+    ans = FiniteSet((log(2401) +
+                     5*LambertW(-log(7**(7*3**Rational(1, 5)/5))))/(3*log(7))/-1)
+    assert result == ans
+    assert solveset_real(eq.expand(), x) == result
+
+    assert solveset_real(5*x - 1 + 3*exp(2 - 7*x), x) == \
+        FiniteSet(Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7)
+
+    assert solveset_real(2*x + 5 + log(3*x - 2), x) == \
+        FiniteSet(Rational(2, 3) + LambertW(2*exp(Rational(-19, 3))/3)/2)
+
+    assert solveset_real(3*x + log(4*x), x) == \
+        FiniteSet(LambertW(Rational(3, 4))/3)
+
+    assert solveset_real(x**x - 2) == FiniteSet(exp(LambertW(log(2))))
+
+    a = Symbol('a')
+    assert solveset_real(-a*x + 2*x*log(x), x) == FiniteSet(exp(a/2))
+    a = Symbol('a', real=True)
+    assert solveset_real(a/x + exp(x/2), x) == \
+        FiniteSet(2*LambertW(-a/2))
+    assert solveset_real((a/x + exp(x/2)).diff(x), x) == \
+        FiniteSet(4*LambertW(sqrt(2)*sqrt(a)/4))
+
+    # coverage test
+    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
+
+    assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*S.Exp1)/3)
+    assert solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x) == \
+        FiniteSet(LambertW(3*exp(-sqrt(2)))/3, LambertW(3*exp(sqrt(2)))/3)
+    assert solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(-sqrt(3) + 1))/3)
+    assert solveset_real(x*log(x) + 3*x + 1, x) == \
+        FiniteSet(exp(-3 + LambertW(-exp(3))))
+    eq = (x*exp(x) - 3).subs(x, x*exp(x))
+    assert solveset_real(eq, x) == \
+        FiniteSet(LambertW(3*exp(-LambertW(3))))
+
+    assert solveset_real(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == \
+        FiniteSet(-((log(a**5) + LambertW(Rational(1, 3)))/(3*log(a))))
+    p = symbols('p', positive=True)
+    assert solveset_real(3*log(p**(3*x + 5)) + p**(3*x + 5), x) == \
+        FiniteSet(
+        log((-3**Rational(1, 3) - 3**Rational(5, 6)*I)*LambertW(Rational(1, 3))**Rational(1, 3)/(2*p**Rational(5, 3)))/log(p),
+        log((-3**Rational(1, 3) + 3**Rational(5, 6)*I)*LambertW(Rational(1, 3))**Rational(1, 3)/(2*p**Rational(5, 3)))/log(p),
+        log((3*LambertW(Rational(1, 3))/p**5)**(1/(3*log(p)))),)  # checked numerically
+    # check collection
+    b = Symbol('b')
+    eq = 3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5)
+    assert solveset_real(eq, x) == FiniteSet(
+        -((log(a**5) + LambertW(1/(b + 3)))/(3*log(a))))
+
+    # issue 4271
+    assert solveset_real((a/x + exp(x/2)).diff(x, 2), x) == FiniteSet(
+        6*LambertW((-1)**Rational(1, 3)*a**Rational(1, 3)/3))
+
+    assert solveset_real(x**3 - 3**x, x) == \
+        FiniteSet(-3/log(3)*LambertW(-log(3)/3))
+    assert solveset_real(3**cos(x) - cos(x)**3) == FiniteSet(
+        acos(-3*LambertW(-log(3)/3)/log(3)))
+
+    assert solveset_real(x**2 - 2**x, x) == \
+        solveset_real(-x**2 + 2**x, x)
+
+    assert solveset_real(3*log(x) - x*log(3)) == FiniteSet(
+        -3*LambertW(-log(3)/3)/log(3),
+        -3*LambertW(-log(3)/3, -1)/log(3))
+
+    assert solveset_real(LambertW(2*x) - y) == FiniteSet(
+        y*exp(y)/2)
+
+
+@XFAIL
+def test_other_lambert():
+    a = Rational(6, 5)
+    assert solveset_real(x**a - a**x, x) == FiniteSet(
+        a, -a*LambertW(-log(a)/a)/log(a))
+
+
 def test_solveset():
     f = Function('f')
     raises(ValueError, lambda: solveset(x + y))
@@ -1150,7 +1244,7 @@ def test_conditionset():
         ).dummy_eq(ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals))
 
     assert solveset(y**x-z, x, S.Reals
-        ).dummy_eq(FiniteSet(log(z)/log(y)))
+        ).dummy_eq(ConditionSet(x, Eq(y**x - z, 0), S.Reals))
 
 
 @XFAIL
@@ -1520,8 +1614,14 @@ def test_nonlinsolve_using_substitution():
     assert nonlinsolve(system, [x, y]) == FiniteSet(soln)
 
     system = [z**2*x**2 - z**2*y**2/exp(x)]
+    soln_real_1 = (y, x, 0)
+    soln_real_2 = (-exp(x/2)*Abs(x), x, z)
+    soln_real_3 = (exp(x/2)*Abs(x), x, z)
+    soln_complex_1 = (-x*exp(x/2), x, z)
+    soln_complex_2 = (x*exp(x/2), x, z)
     syms = [y, x, z]
-    soln = FiniteSet((y, x, 0), (y, 2*LambertW(-y/2), z), (y, 2*LambertW(y/2), z), (x*exp(x/2), x, z), (-x*exp(x/2), x, z))
+    soln = FiniteSet(soln_real_1, soln_complex_1, soln_complex_2,\
+        soln_real_2, soln_real_3)
     assert nonlinsolve(system,syms) == soln
 
 
@@ -2031,7 +2131,8 @@ def test_exponential_real():
     assert solveset_real(x**2 - y**2/exp(x), y) == Intersection(
         S.Reals, FiniteSet(-sqrt(x**2*exp(x)), sqrt(x**2*exp(x))))
     p = Symbol('p', positive=True)
-    assert solveset_real((1/p + 1)**(p + 1), p) == EmptySet()
+    assert solveset_real((1/p + 1)**(p + 1), p).dummy_eq(
+        ConditionSet(x, Eq((1 + 1/x)**(x + 1), 0), S.Reals))
 
 
 @XFAIL
@@ -2074,7 +2175,7 @@ def test_expo_conditionset():
     f5 = 2**x + 3**x - 5**x
 
     assert solveset(f1, x, S.Reals).dummy_eq(ConditionSet(
-        x,Eq(x*log(exp(x) + 1) - log(2), 0), S.Reals))
+        x, Eq((exp(x) + 1)**x - 2, 0), S.Reals))
     assert solveset(f2, x, S.Reals).dummy_eq(ConditionSet(
         x, Eq(x*(x + 2)**y - 3, 0), S.Reals))
     assert solveset(f3, x, S.Reals).dummy_eq(ConditionSet(
@@ -2098,13 +2199,14 @@ def test_exponential_symbols():
     assert solveset(f1, w, S.Reals) == sol1, solveset(f1, w, S.Reals)
     assert solveset(f2, w, S.Reals) == sol2, solveset(f2, w, S.Reals)
 
+    assert solveset(x**x, x, Interval.Lopen(0,oo)).dummy_eq(
+        ConditionSet(w, Eq(w**w, 0), Interval.open(0, oo)))
     assert solveset(x**y - 1, y, S.Reals) == FiniteSet(0)
     assert solveset(exp(x/y)*exp(-z/y) - 2, y, S.Reals) == FiniteSet(
         (x - z)/log(2)) - FiniteSet(0)
 
     assert solveset(a**x - b**x, x).dummy_eq(ConditionSet(
         w, Ne(a, 0) & Ne(b, 0), FiniteSet(0)))
-    assert solveset(x**x, x, Interval.Lopen(0,oo)) == EmptySet()
 
 
 def test_ignore_assumptions():
@@ -2120,9 +2222,10 @@ def test_issue_10864():
     assert solveset(x**(y*z) - x, x, S.Reals) == FiniteSet(1)
 
 
+@XFAIL
 def test_solve_only_exp_2():
     assert solveset_real(sqrt(exp(x)) + sqrt(exp(-x)) - 4, x) == \
-        FiniteSet(log(7 - 4*sqrt(3)), log(4*sqrt(3) + 7))
+        FiniteSet(2*log(-sqrt(3) + 2), 2*log(sqrt(3) + 2))
 
 
 def test_is_exponential():
@@ -2202,111 +2305,6 @@ def test_solve_logarithm():
     assert _solve_logarithm(log(x)*log(y), 0, x, S.Reals) == FiniteSet(1)
 
 # end of logarithmic tests
-
-
-# lambert tests
-
-def test_solve_lambert():
-    a = Symbol('a', real=True)
-    x = Symbol('x')
-    y = Symbol('y')
-    assert solveset_real(3*log(x) - x*log(3), x) == FiniteSet(
-        -3*LambertW(-log(3)/3)/log(3),
-        -3*LambertW(-log(3)/3, -1)/log(3))
-
-    assert solveset_real(3*log(a**(3*x + 5)) + a**(3*x + 5), x) ==FiniteSet(
-        (-log(a**5) - LambertW(S(1)/3))/(3*log(a)))
-    assert solveset_real(exp(x) + x, x) == FiniteSet(-LambertW(1))
-    assert solveset_real(x + 2**x, x) == \
-        FiniteSet(-LambertW(log(2))/log(2))
-
-    ans = solveset_real(3*x + 5 + 2**(-5*x + 3), x)
-    assert ans == FiniteSet(-Rational(5,3) +
-        LambertW(-10240*2**(S(1)/3)*log(2)/3)/(5*log(2)))
-
-    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
-    assert solveset_real(3**cos(x) - cos(x)**3,x) == FiniteSet(acos(3), acos(-3*LambertW(-log(3)/3)/log(3)))
-
-    assert solveset_real(LambertW(2*x) - y, x) == Intersection(FiniteSet(y*exp(y)/2), S.Reals)
-    # check collection
-    b = Symbol('b')
-    eq = 3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5)
-    assert solveset_real(eq, x) == FiniteSet(
-        (-log(a**5) - LambertW(S(1)/(b + 3)))/(3*log(a)))
-
-    p = symbols('p', positive=True)
-    eq = 3*log(p**(3*x + 5)) + p**(3*x + 5)
-    assert solveset(eq, x) == FiniteSet(-S(5)/3 - LambertW(S(1)/3)/(3*log(p)))
-    assert solveset_real(eq, x) == FiniteSet(-S(5)/3 - LambertW(S(1)/3)/(3*log(p)))
-
-    assert solveset_real(2*x + 5 + log(3*x - 2), x) == \
-        FiniteSet(Rational(2, 3) + LambertW(2*exp(-Rational(19, 3))/3)/2)
-
-    assert solveset_real(3*x + log(4*x), x) == \
-        FiniteSet(LambertW(Rational(3, 4))/3)
-
-    assert solveset_real(a/x + exp(x/2), x) == \
-        FiniteSet(2*LambertW(-a/2)) - FiniteSet(0)
-
-    assert solveset_real(x*exp(x) - 1, x) == FiniteSet(LambertW(1))
-    eq = (x*exp(x) - 3).subs(x, x*exp(x))
-    assert solveset_real(eq, x) == \
-        FiniteSet(LambertW(3*exp(-LambertW(3))))
-
-    assert solveset_real(x*log(x) + 3*x + 1, x) == \
-        FiniteSet(exp(-3 + LambertW(-exp(3))))
-    # issue 4271
-    assert solveset_real((a/x + exp(x/2)).diff(x, 2), x) == \
-        Complement(FiniteSet(6*LambertW((-a)**(S(1)/3)/3)), FiniteSet(0))
-    assert solveset_real(x**3 - 3**x, x) == FiniteSet(
-        -3*LambertW(-log(3)/3)/log(3), -3*LambertW(-log(3)/3, -1)/log(3))
-    assert solveset_real(x**2 - 2**x, x) == solveset_real(-x**2 + 2**x, x)
-
-    assert solveset_real((a/x + exp(x/2)).diff(x), x) == \
-        Complement(FiniteSet(4*LambertW(-sqrt(2)*sqrt(a)/4),
-         4*LambertW(sqrt(2)*sqrt(a)/4)), FiniteSet(0))
-    a = -1
-    assert solveset_real((a/x + exp(x/2)).diff(x), x) == S.EmptySet
-    a = 1
-    assert solveset_real((a/x + exp(x/2)).diff(x), x) == FiniteSet(
-        4*LambertW(sqrt(2)/4),4*LambertW(-sqrt(2)/4, -1),4*LambertW(-sqrt(2)/4))
-
-    assert solveset_real(x**x - 2, x) == FiniteSet(exp(LambertW(log(2))))
-
-    assert solveset_real(log(log(x - 3)) + log(x-3), x) == FiniteSet(
-        exp(LambertW(1)) + 3)
-
-    assert solveset_real(5*x - 1 + 3*exp(2 - 7*x), x) == \
-        FiniteSet(Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7)
-
-
-def test_solve_bivariate():
-
-    assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
-        FiniteSet(LambertW(3*S.Exp1)/3)
-
-    assert solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x) == \
-        FiniteSet(LambertW(3*exp(sqrt(2)))/3, LambertW(3*exp(-sqrt(2)))/3)
-
-    assert solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) == \
-        FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(1 - sqrt(3)))/3)
-
-    eq = 2*(3*x + 4)**5 - 6*7**(3*x + 9)
-    result = solveset_real(eq, x)
-    ans = FiniteSet((log(2401) +
-                     5*LambertW(-log(7**(7*3**Rational(1, 5)/5))))/(3*log(7))/-1)
-    assert result == ans
-    assert solveset_real(eq.expand(), x) == result
-    assert solveset_real(-a*x + 2*x*log(x), x) == FiniteSet(S.Zero, exp(a/2))
-
-
-@XFAIL
-def test_other_solve_lambert():
-    assert solveset_real(x**a - a**x, x) == \
-        FiniteSet(a, -a*LambertW(-log(a)/a)/log(a))
-
-
-# end of transolve's tests
 
 
 def test_linear_coeffs():


### PR DESCRIPTION
Reverts sympy/sympy#20613

See discussion in the PR. I think I merged it by accident somehow and there are problems with it.

@MaqOwais I think that #20613 had some good work in it but there are some basic problems with it as well. I have made some suggestions but it seems that you do not have a clear idea how to fix this because #20705 has gone off on a massive tangent with 500 lines changed and adding new arguments to `solve`. Changes to `solve` are not what is needed since this is about `solveset` and `solveset` should not use `solve`.

I think that the best thing now is to revert #20613 and then start again with this. Note that the `solveset` code should not use `solve`. Also if the basic functions for Lambert forms you are using are from `solve` and return incomplete solution sets then we do not want to use those as part of `solveset` either. It is very important that `solveset` only ever returns complete solutions or otherwise returns `ConditionSet`.

I think you now have a better idea what the full solution sets should look like for solutions involving LambertW but I think that we need to start from a clean implementation so it's best to revert #20613 for now and focus on getting a new implementation that is correct from the start even if it only handles e.g. the real case.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->