### PR TITLE
added signsimp in _combine_inverse

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1197,6 +1197,7 @@ class Mul(Expr, AssocOp):
         like oo/oo return 1 (instead of a nan) and ``I`` behaves like
         a symbol instead of sqrt(-1).
         """
+        from sympy.simplify.simplify import signsimp
         from .symbol import Dummy
         if lhs == rhs:
             return S.One
@@ -1227,7 +1228,7 @@ class Mul(Expr, AssocOp):
             if len(b) != blen:
                 lhs = Mul(*[k**v for k, v in a.items()]).xreplace(i_)
                 rhs = Mul(*[k**v for k, v in b.items()]).xreplace(i_)
-        return lhs/rhs
+        return signsimp(lhs/rhs)
 
     def as_powers_dict(self):
         d = defaultdict(int)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -473,6 +473,7 @@ def test__combine_inverse():
     assert Mul._combine_inverse(oo*I*y, oo*I) == y
     assert Mul._combine_inverse(oo*y, -oo) == -y
     assert Mul._combine_inverse(-oo*y, oo) == -y
+    assert Mul._combine_inverse((1-exp(x/y)),(exp(x/y)-1)) == -1
     assert Add._combine_inverse(oo, oo) is S.Zero
     assert Add._combine_inverse(oo*I, oo*I) is S.Zero
     assert Add._combine_inverse(x*oo, x*oo) is S.Zero
@@ -714,6 +715,8 @@ def test_match_terms():
     assert (5*y - x).match(5*X - Y) == {X: y, Y: x}
     # 15907
     assert (x + (y - 1)*z).match(x + X*z) == {X: y - 1}
+    # 20747
+    assert (x - log(x/y)*(1-exp(x/y))).match(x - log(X/y)*(1-exp(x/y))) == {X: x}
 
 
 def test_match_bound():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2290,3 +2290,13 @@ def test_issue_19509():
         -d + a + sqrt(-b + c),
         d + a - sqrt(-b - c),
         d + a + sqrt(-b - c)]
+
+def test_issue_20747():
+    THT, HT, DBH, dib, c0, c1, c2, c3, c4  = symbols('THT HT DBH dib c0 c1 c2 c3 c4')
+    f = DBH*c3 + THT*c4 + c2
+    rhs = 1 - ((HT - 1)/(THT - 1))**c1*(1 - exp(c0/f))
+    eq = dib - DBH*(c0 - f*log(rhs))
+    term = ((1 - exp((DBH*c0 - dib)/(DBH*(DBH*c3 + THT*c4 + c2))))
+            / (1 - exp(c0/(DBH*c3 + THT*c4 + c2))))
+    sol = [THT*term**(1/c1) - term**(1/c1) + 1]
+    assert solve(eq, HT) == sol


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Sign-simplify returned expression of _combine_inverse

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
"Fixes #20747"

#### Brief description of what is fixed or changed
The expression returned by `_combine_inverse` in mul.py is sign simplified which allows cancellation of canonical equal subexpressions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * A bug causing `match` to fail for expressions with different signs was fixed. Previously this resulted in `solve` raising an exception for some inputs.
<!-- END RELEASE NOTES -->