### PR TITLE
Return KroneckerDelta when alpha,beta,gamma are 0 in WignerD Function

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -856,39 +856,42 @@ class WignerD(Expr):
         alpha = sympify(self.alpha)
         beta = sympify(self.beta)
         gamma = sympify(self.gamma)
-        if not j.is_number:
-            raise ValueError(
-                'j parameter must be numerical to evaluate, got %s' % j)
-        r = 0
-        if beta == pi/2:
-            # Varshalovich Equation (5), Section 4.16, page 113, setting
-            # alpha=gamma=0.
-            for k in range(2*j + 1):
-                if k > j + mp or k > j - m or k < mp - m:
-                    continue
-                r += (S.NegativeOne)**k*binomial(j + mp, k)*binomial(j - mp, k + m - mp)
-            r *= (S.NegativeOne)**(m - mp) / 2**j*sqrt(factorial(j + m) *
-                    factorial(j - m) / (factorial(j + mp)*factorial(j - mp)))
+        if alpha==0 and beta==0 and gamma==0:
+            return KroneckerDelta(m,mp)
         else:
-            # Varshalovich Equation(5), Section 4.7.2, page 87, where we set
-            # beta1=beta2=pi/2, and we get alpha=gamma=pi/2 and beta=phi+pi,
-            # then we use the Eq. (1), Section 4.4. page 79, to simplify:
-            # d(j, m, mp, beta+pi) = (-1)**(j-mp)*d(j, m, -mp, beta)
-            # This happens to be almost the same as in Eq.(10), Section 4.16,
-            # except that we need to substitute -mp for mp.
-            size, mvals = m_values(j)
-            for mpp in mvals:
-                r += Rotation.d(j, m, mpp, pi/2).doit()*(cos(-mpp*beta) + I*sin(-mpp*beta))*\
-                    Rotation.d(j, mpp, -mp, pi/2).doit()
-            # Empirical normalization factor so results match Varshalovich
-            # Tables 4.3-4.12
-            # Note that this exact normalization does not follow from the
-            # above equations
-            r = r*I**(2*j - m - mp)*(-1)**(2*m)
-            # Finally, simplify the whole expression
-            r = simplify(r)
-        r *= exp(-I*m*alpha)*exp(-I*mp*gamma)
-        return r
+            if not j.is_number:
+                raise ValueError(
+                    'j parameter must be numerical to evaluate, got %s' % j)
+            r = 0
+            if beta == pi/2:
+                # Varshalovich Equation (5), Section 4.16, page 113, setting
+                # alpha=gamma=0.
+                for k in range(2*j + 1):
+                    if k > j + mp or k > j - m or k < mp - m:
+                        continue
+                    r += (S.NegativeOne)**k*binomial(j + mp, k)*binomial(j - mp, k + m - mp)
+                r *= (S.NegativeOne)**(m - mp) / 2**j*sqrt(factorial(j + m) *
+                        factorial(j - m) / (factorial(j + mp)*factorial(j - mp)))
+            else:
+                # Varshalovich Equation(5), Section 4.7.2, page 87, where we set
+                # beta1=beta2=pi/2, and we get alpha=gamma=pi/2 and beta=phi+pi,
+                # then we use the Eq. (1), Section 4.4. page 79, to simplify:
+                # d(j, m, mp, beta+pi) = (-1)**(j-mp)*d(j, m, -mp, beta)
+                # This happens to be almost the same as in Eq.(10), Section 4.16,
+                # except that we need to substitute -mp for mp.
+                size, mvals = m_values(j)
+                for mpp in mvals:
+                    r += Rotation.d(j, m, mpp, pi/2).doit()*(cos(-mpp*beta) + I*sin(-mpp*beta))*\
+                        Rotation.d(j, mpp, -mp, pi/2).doit()
+                # Empirical normalization factor so results match Varshalovich
+                # Tables 4.3-4.12
+                # Note that this exact normalization does not follow from the
+                # above equations
+                r = r*I**(2*j - m - mp)*(-1)**(2*m)
+                # Finally, simplify the whole expression
+                r = simplify(r)
+            r *= exp(-I*m*alpha)*exp(-I*mp*gamma)
+            return r
 
 
 Jx = JxOp('J')

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3677,11 +3677,8 @@ def test_wignerd():
 
 def test_wignerD():
     i,j=symbols('i j')
-    k=Symbol('k',nonzero=True)
     assert Rotation.D(1,1,1,0,0,0) == 1
     assert Rotation.D(1,1,2,0,0,0) == 0
-    assert Rotation.D(1,k,0,0,0,0) == 0
-    assert Rotation.D(1,x,x,0,0,0) == 1
     assert Rotation.D(1,i**2 - j**2, i**2 - j**2,0,0,0) == 1
     assert Rotation.D(1,i,i,0,0,0) == 1
     assert Rotation.D(1,i,i + 1,0,0,0) == 0

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3677,12 +3677,12 @@ def test_wignerd():
 
 def test_wignerD():
     i,j=symbols('i j')
-    assert Rotation.D(1,1,1,0,0,0) == WignerD(1,1,1,0,0,0)
-    assert Rotation.D(1,1,2,0,0,0) == WignerD(1,1,2,0,0,0)
-    assert Rotation.D(1,i**2 - j**2, i**2 - j**2,0,0,0) == WignerD(1,i**2 - j**2, i**2 - j**2,0,0,0)
-    assert Rotation.D(1,i,i,0,0,0) == WignerD(1,i,i,0,0,0)
-    assert Rotation.D(1,i,i+1,0,0,0) == WignerD(1,i,i+1,0,0,0)
-    assert Rotation.D(1,0,0,0,0,0) == WignerD(1,0,0,0,0,0)
+    assert Rotation.D(1, 1, 1, 0, 0, 0) == WignerD(1, 1, 1, 0, 0, 0)
+    assert Rotation.D(1, 1, 2, 0, 0, 0) == WignerD(1, 1, 2, 0, 0, 0)
+    assert Rotation.D(1, i**2 - j**2, i**2 - j**2, 0, 0, 0) == WignerD(1, i**2 - j**2, i**2 - j**2, 0, 0, 0)
+    assert Rotation.D(1, i, i, 0, 0, 0) == WignerD(1, i, i, 0, 0, 0)
+    assert Rotation.D(1, i, i+1, 0, 0, 0) == WignerD(1, i, i+1, 0, 0, 0)
+    assert Rotation.D(1, 0, 0, 0, 0, 0) == WignerD(1, 0, 0, 0, 0, 0)
 
 def test_jplus():
     assert Commutator(Jplus, Jminus).doit() == 2*hbar*Jz

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3677,12 +3677,12 @@ def test_wignerd():
 
 def test_wignerD():
     i,j=symbols('i j')
-    assert WignerD(1,1,1,0,0,0) == 1
-    assert WignerD(1,1,2,0,0,0) == 0
-    assert WignerD(1,i**2 - j**2, i**2 - j**2,0,0,0) == 1
-    assert WignerD(1,i,i,0,0,0) == 1
-    assert WignerD(1,i,i + 1,0,0,0) == 0
-    assert WignerD(1,0,0,0,0,0) == 1
+    assert Rotation.D(1,1,1,0,0,0) == WignerD(1,1,1,0,0,0)
+    assert Rotation.D(1,1,2,0,0,0) == WignerD(1,1,2,0,0,0)
+    assert Rotation.D(1,i**2 - j**2, i**2 - j**2,0,0,0) == WignerD(1,i**2 - j**2, i**2 - j**2,0,0,0)
+    assert Rotation.D(1,i,i,0,0,0) == WignerD(1,i,i,0,0,0)
+    assert Rotation.D(1,i,i+1,0,0,0) == WignerD(1,i,i+1,0,0,0)
+    assert Rotation.D(1,0,0,0,0,0) == WignerD(1,0,0,0,0,0)
 
 def test_jplus():
     assert Commutator(Jplus, Jminus).doit() == 2*hbar*Jz

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3675,6 +3675,17 @@ def test_wignerd():
         j, m, mp, alpha, beta, gamma) == WignerD(j, m, mp, alpha, beta, gamma)
     assert Rotation.d(j, m, mp, beta) == WignerD(j, m, mp, 0, beta, 0)
 
+def test_wignerD():
+    i,j=symbols('i j')
+    k=Symbol('k',nonzero=True)
+    assert Rotation.D(1,1,1,0,0,0) == 1
+    assert Rotation.D(1,1,2,0,0,0) == 0
+    assert Rotation.D(1,k,0,0,0,0) == 0
+    assert Rotation.D(1,x,x,0,0,0) == 1
+    assert Rotation.D(1,i**2 - j**2, i**2 - j**2,0,0,0) == 1
+    assert Rotation.D(1,i,i,0,0,0) == 1
+    assert Rotation.D(1,i,i + 1,0,0,0) == 0
+    assert Rotation.D(1,0,0,0,0,0) == 1
 
 def test_jplus():
     assert Commutator(Jplus, Jminus).doit() == 2*hbar*Jz

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3677,12 +3677,12 @@ def test_wignerd():
 
 def test_wignerD():
     i,j=symbols('i j')
-    assert Rotation.D(1,1,1,0,0,0) == 1
-    assert Rotation.D(1,1,2,0,0,0) == 0
-    assert Rotation.D(1,i**2 - j**2, i**2 - j**2,0,0,0) == 1
-    assert Rotation.D(1,i,i,0,0,0) == 1
-    assert Rotation.D(1,i,i + 1,0,0,0) == 0
-    assert Rotation.D(1,0,0,0,0,0) == 1
+    assert WignerD(1,1,1,0,0,0) == 1
+    assert WignerD(1,1,2,0,0,0) == 0
+    assert WignerD(1,i**2 - j**2, i**2 - j**2,0,0,0) == 1
+    assert WignerD(1,i,i,0,0,0) == 1
+    assert WignerD(1,i,i + 1,0,0,0) == 0
+    assert WignerD(1,0,0,0,0,0) == 1
 
 def test_jplus():
     assert Commutator(Jplus, Jminus).doit() == 2*hbar*Jz


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #6521 


#### Brief description of what is fixed or changed
Added conditional statement in _eval_wignerd of spin.py file to return KroneckerDelta when alpha,beta and gamme are 0.
Added new function named test_wignerD to test these cases in test_spin.py file.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * WignerD now evaluates to KroneckerDelta in some cases.  
<!-- END RELEASE NOTES -->