### PR TITLE
refactor(assumptions): fix test_query

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -438,6 +438,12 @@ class UndefinedPredicate(Predicate):
     def eval(self, args, assumptions=True):
         # Support for deprecated design
         # When old design is removed, this will always return None
+        SymPyDeprecationWarning(
+            feature="Evaluating UndefinedPredicate",
+            useinstead="multipledispatch handler of Predicate",
+            issue=20873,
+            deprecated_since_version="1.8"
+        ).warn()
         expr, = args
         res, _res = None, None
         mro = inspect.getmro(type(expr))

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2038,7 +2038,8 @@ def test_key_extensibility():
         with warns_deprecated_sympy():
             assert ask(Q.my_key(x + 1)) is None
     finally:
-        remove_handler('my_key', MyAskHandler)
+        with warns_deprecated_sympy():
+            remove_handler('my_key', MyAskHandler)
         del Q.my_key
     raises(AttributeError, lambda: ask(Q.my_key(x)))
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2026,19 +2026,21 @@ def test_key_extensibility():
     raises(AttributeError, lambda: ask(Q.my_key(x)))
 
     # Old handler system
-    with warns_deprecated_sympy():
-        class MyAskHandler(AskHandler):
-            @staticmethod
-            def Symbol(expr, assumptions):
-                return True
-        try:
+    class MyAskHandler(AskHandler):
+        @staticmethod
+        def Symbol(expr, assumptions):
+            return True
+    try:
+        with warns_deprecated_sympy():
             register_handler('my_key', MyAskHandler)
+        with warns_deprecated_sympy():
             assert ask(Q.my_key(x)) is True
+        with warns_deprecated_sympy():
             assert ask(Q.my_key(x + 1)) is None
-        finally:
-            remove_handler('my_key', MyAskHandler)
-            del Q.my_key
-        raises(AttributeError, lambda: ask(Q.my_key(x)))
+    finally:
+        remove_handler('my_key', MyAskHandler)
+        del Q.my_key
+    raises(AttributeError, lambda: ask(Q.my_key(x)))
 
     # New handler system
     class MyPredicate(Predicate):
@@ -2252,24 +2254,26 @@ def test_custom_AskHandler():
     from sympy.logic.boolalg import conjuncts
 
     # Old handler system
-    with warns_deprecated_sympy():
-        class MersenneHandler(AskHandler):
-            @staticmethod
-            def Integer(expr, assumptions):
-                from sympy import log
-                if ask(Q.integer(log(expr + 1, 2))):
-                    return True
-            @staticmethod
-            def Symbol(expr, assumptions):
-                if expr in conjuncts(assumptions):
-                    return True
-        try:
+    class MersenneHandler(AskHandler):
+        @staticmethod
+        def Integer(expr, assumptions):
+            from sympy import log
+            if ask(Q.integer(log(expr + 1, 2))):
+                return True
+        @staticmethod
+        def Symbol(expr, assumptions):
+            if expr in conjuncts(assumptions):
+                return True
+    try:
+        with warns_deprecated_sympy():
             register_handler('mersenne', MersenneHandler)
-            n = Symbol('n', integer=True)
+        n = Symbol('n', integer=True)
+        with warns_deprecated_sympy():
             assert ask(Q.mersenne(7))
+        with warns_deprecated_sympy():
             assert ask(Q.mersenne(n), Q.mersenne(n))
-        finally:
-            del Q.mersenne
+    finally:
+        del Q.mersenne
 
     # New handler system
     class MersennePredicate(Predicate):


### PR DESCRIPTION
Fix incorrect usage of `warns_deprecated_sympy`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #20835

#### Brief description of what is fixed or changed



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->