### PR TITLE
Core: removed threshold on difference of approximation in get_integer_part

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -353,8 +353,7 @@ def get_integer_part(expr, no, options, return_ints=False):
     # positive or negative (which may fail if very close).
     def calc_part(re_im, nexpr):
         from sympy.core.add import Add
-        n, c, p, b = nexpr
-        is_int = (p == 0)
+        is_int = (nexpr[2] == 0)
         nint = int(to_int(nexpr, rnd))
         if is_int:
             # make sure that we had enough precision to distinguish
@@ -369,9 +368,8 @@ def get_integer_part(expr, no, options, return_ints=False):
                     re_im, size, options)
                 assert not iim
                 nexpr = ire
-                n, c, p, b = nexpr
-                is_int = (p == 0)
-                nint = int(to_int(nexpr, rnd))
+            nint = int(to_int(nexpr, rnd))
+            is_int = (ire[2] == 0)
         if not is_int:
             # if there are subs and they all contain integer re/im parts
             # then we can (hopefully) safely substitute them into the

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -370,7 +370,8 @@ def get_integer_part(expr, no, options, return_ints=False):
                 assert not iim
                 nexpr = ire
             nint = int(to_int(nexpr, rnd))
-            is_int = ire[2] == 0
+            _, _, new_exp, _ = ire
+            is_int = new_exp == 0
         if not is_int:
             # if there are subs and they all contain integer re/im parts
             # then we can (hopefully) safely substitute them into the

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -353,7 +353,8 @@ def get_integer_part(expr, no, options, return_ints=False):
     # positive or negative (which may fail if very close).
     def calc_part(re_im, nexpr):
         from sympy.core.add import Add
-        is_int = (nexpr[2] == 0)
+        _, _, exponent, _ = nexpr
+        is_int = exponent == 0
         nint = int(to_int(nexpr, rnd))
         if is_int:
             # make sure that we had enough precision to distinguish
@@ -369,7 +370,7 @@ def get_integer_part(expr, no, options, return_ints=False):
                 assert not iim
                 nexpr = ire
             nint = int(to_int(nexpr, rnd))
-            is_int = (ire[2] == 0)
+            is_int = ire[2] == 0
         if not is_int:
             # if there are subs and they all contain integer re/im parts
             # then we can (hopefully) safely substitute them into the

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
-    integrate, log, Mul, N, oo, pi, Pow, product, Product,
+    integrate, log, Mul, N, oo, pi, Pow, product, Product, tan,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
@@ -236,7 +236,6 @@ def test_evalf_bugs():
 
 
 def test_evalf_integer_parts():
-    from sympy.functions.elementary.trigonometric import tan
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)
     b = floor(log(8)/log(2), evaluate=False)
     assert a.evalf() == 3

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -236,6 +236,7 @@ def test_evalf_bugs():
 
 
 def test_evalf_integer_parts():
+    from sympy.functions.elementary.trigonometric import tan
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)
     b = floor(log(8)/log(2), evaluate=False)
     assert a.evalf() == 3
@@ -261,6 +262,16 @@ def test_evalf_integer_parts():
 
     assert float((floor(1.5, evaluate=False)+1/9).evalf()) == 1 + 1/9
     assert float((floor(0.5, evaluate=False)+20).evalf()) == 20
+
+    # issue 19991
+    n = 1169809367327212570704813632106852886389036911
+    r = 744723773141314414542111064094745678855643068
+
+    assert floor(n / (pi / 2)) == r
+    assert floor(80782 * sqrt(2)) == 114242
+
+    # issue 20076
+    assert 260515 - floor(260515/pi + 1/2) * pi == atan(tan(260515))
 
 
 def test_evalf_trig_zero_detection():

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -445,8 +445,6 @@ class frac(Function):
     def _eval_rewrite_as_ceiling(self, arg, **kwargs):
         return arg + ceiling(-arg)
 
-
-
     def _eval_is_finite(self):
         return True
 
@@ -464,6 +462,8 @@ class frac(Function):
 
     def _eval_is_negative(self):
         return False
+
+
 
     def __ge__(self, other):
         if self.is_extended_real:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -156,8 +156,6 @@ class floor(RoundFunction):
     def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg - frac(arg)
 
-
-
     def __le__(self, other):
         other = S(other)
         if self.args[0].is_real:
@@ -214,10 +212,12 @@ class floor(RoundFunction):
 
         return Lt(self, other, evaluate=False)
 
+
 @dispatch(floor, Expr)
 def _eval_is_eq(lhs, rhs): # noqa:F811
    return is_eq(lhs.rewrite(ceiling), rhs) or \
         is_eq(lhs.rewrite(frac),rhs)
+
 
 class ceiling(RoundFunction):
     """
@@ -292,8 +292,6 @@ class ceiling(RoundFunction):
     def _eval_is_nonpositive(self):
         return self.args[0].is_nonpositive
 
-
-
     def __lt__(self, other):
         other = S(other)
         if self.args[0].is_real:
@@ -350,9 +348,11 @@ class ceiling(RoundFunction):
 
         return Le(self, other, evaluate=False)
 
+
 @dispatch(ceiling, Basic)  # type:ignore
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(floor), rhs) or is_eq(lhs.rewrite(frac),rhs)
+
 
 class frac(Function):
     r"""Represents the fractional part of x
@@ -463,8 +463,6 @@ class frac(Function):
     def _eval_is_negative(self):
         return False
 
-
-
     def __ge__(self, other):
         if self.is_extended_real:
             other = _sympify(other)
@@ -521,6 +519,7 @@ class frac(Function):
                     return S.true
             if other.is_integer and other.is_positive:
                 return S.true
+
 
 @dispatch(frac, Basic)  # type:ignore
 def _eval_is_eq(lhs, rhs): # noqa:F811


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19991
Fixes #20076

#### Brief description of what is fixed or changed
If the difference between the nearest calculated integer and input of `get_integer_part` was small, `is_int` flag was recalculated. This has been changed to be recalculated regardless of the difference between the nearest integer and input. This allows `floor` to give a more accurate answer, even for smaller precision passed in `evalf`.

#### Other comments
Changes suggested and explained at https://github.com/sympy/sympy/issues/20076#issuecomment-693451747
Note: `frac(n / (pi / 2)).evalf()` gives `1.000000000` due to low default precision. If 50 precision is passed, then it gives `0.99999999999999999999999999999999999999999999986481`
A couple of lines in `frac` were also rearranged to match with the formatting of `floor` and ceiling`

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `get_integer_part` no longer has a threshold on the approximation to closest integer based on difference, allowing `floor` to give more accurate results for smaller `evalf` precisions also
<!-- END RELEASE NOTES -->