### PR TITLE
Fix the printing of the vertical bar in ImageSet, ConditionSet, and ComplexRegion

### DIFF
--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -346,7 +346,7 @@ How do we manipulate and return an infinite solution?
    >>> from sympy import ImageSet, Lambda, pi, S, Dummy, pprint
    >>> n = Dummy('n')
    >>> pprint(ImageSet(Lambda(n, 2*pi*n), S.Integers), use_unicode=True)
-   {2⋅n⋅π | n ∊ ℤ}
+   {2⋅n⋅π │ n ∊ ℤ}
 
 
    Where ``n`` is a dummy variable. It is basically the image of the
@@ -361,7 +361,7 @@ How do we manipulate and return an infinite solution?
 
    >>> from sympy import ComplexRegion, FiniteSet, Interval, pi, pprint
    >>> pprint(ComplexRegion(FiniteSet(1)*Interval(0, 2*pi), polar=True), use_unicode=True)
-   {r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ {1} × [0, 2⋅π)}
+   {r⋅(ⅈ⋅sin(θ) + cos(θ)) │ r, θ ∊ {1} × [0, 2⋅π)}
 
 
    Where the ``FiniteSet`` in the ``ProductSet`` is the range of the value
@@ -376,7 +376,7 @@ How do we manipulate and return an infinite solution?
 
    >>> from sympy import ComplexRegion, Interval, pi, oo, pprint
    >>> pprint(ComplexRegion(Interval(-oo, oo)*Interval(0, oo)), use_unicode=True)
-   {x + y⋅ⅈ | x, y ∊ (-∞, ∞) × [0, ∞)}
+   {x + y⋅ⅈ │ x, y ∊ (-∞, ∞) × [0, ∞)}
 
 
    where the Intervals are the range of `x` and `y` for the set of complex
@@ -400,7 +400,7 @@ How does ``solveset`` ensure that it is not returning any wrong solution?
     >>> from sympy import symbols, S, pprint, solveset
     >>> x, n = symbols('x, n')
     >>> pprint(solveset(abs(x) - n, x, domain=S.Reals), use_unicode=True)
-    {x | x ∊ {-n, n} ∧ (n ∈ [0, ∞))}
+    {x │ x ∊ {-n, n} ∧ (n ∈ [0, ∞))}
 
  Though, there still a lot of work needs to be done in this regard.
 

--- a/doc/src/tutorial/solvers.rst
+++ b/doc/src/tutorial/solvers.rst
@@ -54,9 +54,9 @@ an ``Interval`` or ``ImageSet`` of the solutions.
     >>> solveset(x - x, x, domain=S.Reals)
     ℝ
     >>> solveset(sin(x) - 1, x, domain=S.Reals)
-    ⎧        π        ⎫
-    ⎨2⋅n⋅π + ─ | n ∊ ℤ⎬
-    ⎩        2        ⎭
+    ⎧        π │      ⎫
+    ⎨2⋅n⋅π + ─ │ n ∊ ℤ⎬
+    ⎩        2 │      ⎭
 
 
 If there are no solutions, an ``EmptySet`` is returned and if it
@@ -65,7 +65,7 @@ is not able to find solutions then a ``ConditionSet`` is returned.
     >>> solveset(exp(x), x)     # No solution exists
     ∅
     >>> solveset(cos(x) - x, x)  # Not able to find solution
-    {x | x ∊ ℂ ∧ (-x + cos(x) = 0)}
+    {x │ x ∊ ℂ ∧ (-x + cos(x) = 0)}
 
 
 In the ``solveset`` module, the linear system of equations is solved using ``linsolve``.
@@ -120,7 +120,7 @@ In the ``solveset`` module, the non linear system of equations is solved using
 
 	>>> system = [exp(x) - sin(y), 1/y - 3]
 	>>> nonlinsolve(system, vars)
-	{({2⋅n⋅ⅈ⋅π + log(sin(1/3)) | n ∊ ℤ}, 1/3)}
+	{({2⋅n⋅ⅈ⋅π + log(sin(1/3)) │ n ∊ ℤ}, 1/3)}
 
 4. When the system is positive-dimensional system (has infinitely many solutions):
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2179,15 +2179,15 @@ class LatexPrinter(Printer):
         sig = s.lamda.signature
         xys = ((self._print(x), self._print(y)) for x, y in zip(sig, s.base_sets))
         xinys = r" , ".join(r"%s \in %s" % xy for xy in xys)
-        return r"\left\{%s\; |\; %s\right\}" % (self._print(expr), xinys)
+        return r"\left\{%s\; \middle|\; %s\right\}" % (self._print(expr), xinys)
 
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
         if s.base_set is S.UniversalSet:
-            return r"\left\{%s \mid %s \right\}" % \
+            return r"\left\{%s\; \middle|\; %s \right\}" % \
                 (vars_print, self._print(s.condition))
 
-        return r"\left\{%s \mid %s \in %s \wedge %s \right\}" % (
+        return r"\left\{%s\; \middle|\; %s \in %s \wedge %s \right\}" % (
             vars_print,
             vars_print,
             self._print(s.base_set),
@@ -2195,7 +2195,7 @@ class LatexPrinter(Printer):
 
     def _print_ComplexRegion(self, s):
         vars_print = ', '.join([self._print(var) for var in s.variables])
-        return r"\left\{%s\; |\; %s \in %s \right\}" % (
+        return r"\left\{%s\; \middle|\; %s \in %s \right\}" % (
             self._print(s.expr),
             vars_print,
             self._print(s.sets))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1326,14 +1326,14 @@ class PrettyPrinter(Printer):
 
         return D
 
-    def _hprint_vseparator(self, p1, p2, left=None, right=None, ifascii_nougly=False):
+    def _hprint_vseparator(self, p1, p2, left=None, right=None, delimiter='', ifascii_nougly=False):
         if ifascii_nougly and not self._use_unicode:
             return self._print_seq((p1, '|', p2), left=left, right=right,
-                                   delimiter='', ifascii_nougly=True)
-        tmp = self._print_seq((p1, p2,), left=left, right=right, delimiter='')
+                                   delimiter=delimiter, ifascii_nougly=True)
+        tmp = self._print_seq((p1, p2,), left=left, right=right, delimiter=delimiter)
         sep = stringPict(vobj('|', tmp.height()), baseline=tmp.baseline)
         return self._print_seq((p1, sep, p2), left=left, right=right,
-                               delimiter='')
+                               delimiter=delimiter)
 
     def _print_hyper(self, e):
         # FIXME refactor Matrix, Piecewise, and this into a tabular environment
@@ -2114,19 +2114,18 @@ class PrettyPrinter(Printer):
         # centered on the right instead of aligned with the fraction bar on
         # the left. The same also applies to ConditionSet and ComplexRegion
         if len(signature) == 1:
-            E = self._print_seq((expr, ''),
+            S = self._print_seq((signature[0], inn, sets[0]),
                                 delimiter=' ')
-            S = self._print_seq(('', signature[0], inn, sets[0]),
-                                delimiter=' ')
-            return self._hprint_vseparator(E, S,
-                                           left='{', right='}', ifascii_nougly=True)
+            return self._hprint_vseparator(expr, S,
+                                           left='{', right='}',
+                                           ifascii_nougly=True, delimiter=' ')
         else:
             pargs = tuple(j for var, setv in zip(signature, sets) for j in
                           (var, ' ', inn, ' ', setv, ", "))
-            E = self._print_seq((expr, ''), delimiter=' ')
-            S = self._print_seq((' ',) + pargs[:-1], delimiter='')
-            return self._hprint_vseparator(E, S,
-                                           left='{', right='}', ifascii_nougly=True)
+            S = self._print_seq(pargs[:-1], delimiter='')
+            return self._hprint_vseparator(expr, S,
+                                           left='{', right='}',
+                                           ifascii_nougly=True, delimiter=' ')
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:
@@ -2149,15 +2148,15 @@ class PrettyPrinter(Printer):
                 cond = prettyForm(*cond.parens())
 
         if ts.base_set is S.UniversalSet:
-            V = self._print_seq((variables, ''), delimiter=' ')
-            C = self._print_seq(('', cond), delimiter=' ')
-            return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
+            return self._hprint_vseparator(variables, cond, left="{",
+                                           right="}", ifascii_nougly=True,
+                                           delimiter=' ')
 
         base = self._print(ts.base_set)
-        V = self._print_seq((variables, ''), delimiter=' ')
-        C = self._print_seq(('', variables, inn, base, _and, cond),
+        C = self._print_seq((variables, inn, base, _and, cond),
                             delimiter=' ')
-        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
+        return self._hprint_vseparator(variables, C, left="{", right="}",
+                                       ifascii_nougly=True, delimiter=' ')
 
     def _print_ComplexRegion(self, ts):
         if self._use_unicode:
@@ -2168,10 +2167,10 @@ class PrettyPrinter(Printer):
         expr = self._print(ts.expr)
         prodsets = self._print(ts.sets)
 
-        V = self._print_seq((expr, ''), delimiter=' ')
-        C = self._print_seq(('', variables, inn, prodsets),
+        C = self._print_seq((variables, inn, prodsets),
                             delimiter=' ')
-        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
+        return self._hprint_vseparator(expr, C, left="{", right="}",
+                                       ifascii_nougly=True, delimiter=' ')
 
     def _print_Contains(self, e):
         var, set = e.args

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1326,12 +1326,14 @@ class PrettyPrinter(Printer):
 
         return D
 
-    def _hprint_vseparator(self, p1, p2, left=None, right=None, **kwargs):
-        tmp = self._print_seq((p1, p2,), left=left, right=right, delimiter='',
-                              **kwargs)
+    def _hprint_vseparator(self, p1, p2, left=None, right=None, ifascii_nougly=False):
+        if ifascii_nougly and not self._use_unicode:
+            return self._print_seq((p1, '|', p2), left=left, right=right,
+                                   delimiter='', ifascii_nougly=True)
+        tmp = self._print_seq((p1, p2,), left=left, right=right, delimiter='')
         sep = stringPict(vobj('|', tmp.height()), baseline=tmp.baseline)
         return self._print_seq((p1, sep, p2), left=left, right=right,
-                               delimiter='', **kwargs)
+                               delimiter='')
 
     def _print_hyper(self, e):
         # FIXME refactor Matrix, Piecewise, and this into a tabular environment
@@ -1729,7 +1731,7 @@ class PrettyPrinter(Printer):
             pform = self._hprint_vseparator(pforma0, pforma1)
         else:
             pforma2 = self._print(e.args[2])
-            pforma = self._hprint_vseparator(pforma1, pforma2)
+            pforma = self._hprint_vseparator(pforma1, pforma2, ifascii_nougly=False)
             pforma = prettyForm(*pforma.left('; '))
             pform = prettyForm(*pforma.left(pforma0))
         pform = prettyForm(*pform.parens())
@@ -2117,14 +2119,14 @@ class PrettyPrinter(Printer):
             S = self._print_seq(('', signature[0], inn, sets[0]),
                                 delimiter=' ')
             return self._hprint_vseparator(E, S,
-                                           left='{', right='}', ifascii_nougly=False)
+                                           left='{', right='}', ifascii_nougly=True)
         else:
             pargs = tuple(j for var, setv in zip(signature, sets) for j in
                           (var, ' ', inn, ' ', setv, ", "))
             E = self._print_seq((expr, ''), delimiter=' ')
             S = self._print_seq((' ',) + pargs[:-1], delimiter='')
             return self._hprint_vseparator(E, S,
-                                           left='{', right='}', ifascii_nougly=False)
+                                           left='{', right='}', ifascii_nougly=True)
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:
@@ -2149,13 +2151,13 @@ class PrettyPrinter(Printer):
         if ts.base_set is S.UniversalSet:
             V = self._print_seq((variables, ''), delimiter=' ')
             C = self._print_seq(('', cond), delimiter=' ')
-            return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=False)
+            return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
 
         base = self._print(ts.base_set)
         V = self._print_seq((variables, ''), delimiter=' ')
         C = self._print_seq(('', variables, inn, base, _and, cond),
                             delimiter=' ')
-        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=False)
+        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
 
     def _print_ComplexRegion(self, ts):
         if self._use_unicode:
@@ -2169,7 +2171,7 @@ class PrettyPrinter(Printer):
         V = self._print_seq((expr, ''), delimiter=' ')
         C = self._print_seq(('', variables, inn, prodsets),
                             delimiter=' ')
-        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=False)
+        return self._hprint_vseparator(V, C, left="{", right="}", ifascii_nougly=True)
 
     def _print_Contains(self, e):
         var, set = e.args

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4081,33 +4081,67 @@ def test_pretty_SetExpr():
 
 def test_pretty_ImageSet():
     imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
-    ascii_str = '{x + y | x in {1, 2, 3} , y in {3, 4}}'
-    ucode_str = '{x + y | x ∊ {1, 2, 3} , y ∊ {3, 4}}'
+    ascii_str = '{x + y | x in {1, 2, 3}, y in {3, 4}}'
+    ucode_str = '{x + y │ x ∊ {1, 2, 3}, y ∊ {3, 4}}'
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
     imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     ascii_str = '{x + y | (x, y) in {1, 2, 3} x {3, 4}}'
-    ucode_str = '{x + y | (x, y) ∊ {1, 2, 3} × {3, 4}}'
+    ucode_str = '{x + y │ (x, y) ∊ {1, 2, 3} × {3, 4}}'
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
     imgset = ImageSet(Lambda(x, x**2), S.Naturals)
-    ascii_str = \
-    '  2                 \n'\
-    '{x  | x in Naturals}'
+    ascii_str = '''\
+/ 2 |              \\
+<x  | x in Naturals>
+\\   |              /'''
     ucode_str = '''\
-⎧ 2        ⎫\n\
-⎨x  | x ∊ ℕ⎬\n\
-⎩          ⎭'''
+⎧ 2 │      ⎫\n\
+⎨x  │ x ∊ ℕ⎬\n\
+⎩   │      ⎭'''
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
+    # TODO: The "x in N" parts below should be centered independently of the
+    # 1/x**2 fraction
+    imgset = ImageSet(Lambda(x, 1/x**2), S.Naturals)
+    ascii_str = '''\
+/1  |              \\
+|-- | x in Naturals|
+< 2 |              >
+|x  |              |
+\\   |              /'''
+    ucode_str = '''\
+⎧1  │      ⎫\n\
+⎪── │ x ∊ ℕ⎪\n\
+⎨ 2 │      ⎬\n\
+⎪x  │      ⎪\n\
+⎩   │      ⎭'''
+    assert pretty(imgset) == ascii_str
+    assert upretty(imgset) == ucode_str
+
+    imgset = ImageSet(Lambda((x, y), 1/(x + y)**2), S.Naturals, S.Naturals)
+    ascii_str = '''\
+/   1     |                             \\
+|-------- | x in Naturals, y in Naturals|
+<       2 |                             >
+|(x + y)  |                             |
+\\         |                             /'''
+    ucode_str = '''\
+⎧   1     │             ⎫
+⎪──────── │ x ∊ ℕ, y ∊ ℕ⎪
+⎨       2 │             ⎬
+⎪(x + y)  │             ⎪
+⎩         │             ⎭'''
+    assert pretty(imgset) == ascii_str
+    assert upretty(imgset) == ucode_str
 
 def test_pretty_ConditionSet():
     from sympy import ConditionSet
     ascii_str = '{x | x in (-oo, oo) and sin(x) = 0}'
-    ucode_str = '{x | x ∊ ℝ ∧ (sin(x) = 0)}'
+    ucode_str = '{x │ x ∊ ℝ ∧ (sin(x) = 0)}'
     assert pretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ascii_str
     assert upretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ucode_str
 
@@ -4120,14 +4154,83 @@ def test_pretty_ConditionSet():
     assert pretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == '{2}'
     assert upretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == '{2}'
 
+    condset = ConditionSet(x, 1/x**2 > 0)
+    ascii_str = '''\
+/  | 1     \\
+|x | -- > 0|
+<  |  2    >
+|  | x     |
+\\  |       /'''
+    ucode_str = '''\
+⎧  │ ⎛1     ⎞⎫
+⎪x │ ⎜── > 0⎟⎪
+⎨  │ ⎜ 2    ⎟⎬
+⎪  │ ⎝x     ⎠⎪
+⎩  │         ⎭'''
+    assert pretty(condset) == ascii_str
+    assert upretty(condset) == ucode_str
+
+    condset = ConditionSet(x, 1/x**2 > 0, S.Reals)
+    ascii_str = '''\
+/  |                    1     \\
+|x | x in (-oo, oo) and -- > 0|
+<  |                     2    >
+|  |                    x     |
+\\  |                          /'''
+    ucode_str = '''\
+⎧  │         ⎛1     ⎞⎫
+⎪x │ x ∊ ℝ ∧ ⎜── > 0⎟⎪
+⎨  │         ⎜ 2    ⎟⎬
+⎪  │         ⎝x     ⎠⎪
+⎩  │                 ⎭'''
+    assert pretty(condset) == ascii_str
+    assert upretty(condset) == ucode_str
 
 def test_pretty_ComplexRegion():
     from sympy import ComplexRegion
-    ucode_str = '{x + y⋅ⅈ | x, y ∊ [3, 5] × [4, 6]}'
-    assert upretty(ComplexRegion(Interval(3, 5)*Interval(4, 6))) == ucode_str
+    cregion = ComplexRegion(Interval(3, 5)*Interval(4, 6))
+    ascii_str = '{x + y*I | x, y in [3, 5] x [4, 6]}'
+    ucode_str = '{x + y⋅ⅈ │ x, y ∊ [3, 5] × [4, 6]}'
+    assert pretty(cregion) == ascii_str
+    assert upretty(cregion) == ucode_str
 
-    ucode_str = '{r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ [0, 1] × [0, 2⋅π)}'
-    assert upretty(ComplexRegion(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == ucode_str
+    cregion = ComplexRegion(Interval(0, 1)*Interval(0, 2*pi), polar=True)
+    ascii_str = '{r*(I*sin(theta) + cos(theta)) | r, theta in [0, 1] x [0, 2*pi)}'
+    ucode_str = '{r⋅(ⅈ⋅sin(θ) + cos(θ)) │ r, θ ∊ [0, 1] × [0, 2⋅π)}'
+    assert pretty(cregion) == ascii_str
+    assert upretty(cregion) == ucode_str
+
+    cregion = ComplexRegion(Interval(3, 1/a**2)*Interval(4, 6))
+    ascii_str = '''\
+/        |             1           \\
+|x + y*I | x, y in [3, --] x [4, 6]|
+<        |              2          >
+|        |             a           |
+\\        |                         /'''
+    ucode_str = '''\
+⎧        │        ⎡   1 ⎤         ⎫
+⎪x + y⋅ⅈ │ x, y ∊ ⎢3, ──⎥ × [4, 6]⎪
+⎨        │        ⎢    2⎥         ⎬
+⎪        │        ⎣   a ⎦         ⎪
+⎩        │                        ⎭'''
+    assert pretty(cregion) == ascii_str
+    assert upretty(cregion) == ucode_str
+
+    cregion = ComplexRegion(Interval(0, 1/a**2)*Interval(0, 2*pi), polar=True)
+    ascii_str = '''\
+/                              |                 1              \\
+|r*(I*sin(theta) + cos(theta)) | r, theta in [0, --] x [0, 2*pi)|
+<                              |                  2             >
+|                              |                 a              |
+\\                              |                                /'''
+    ucode_str = '''\
+⎧                      │        ⎡   1 ⎤           ⎫
+⎪r⋅(ⅈ⋅sin(θ) + cos(θ)) │ r, θ ∊ ⎢0, ──⎥ × [0, 2⋅π)⎪
+⎨                      │        ⎢    2⎥           ⎬
+⎪                      │        ⎣   a ⎦           ⎪
+⎩                      │                          ⎭'''
+    assert pretty(cregion) == ascii_str
+    assert upretty(cregion) == ucode_str
 
 def test_pretty_Union_issue_10414():
     a, b = Interval(2, 3), Interval(4, 7)
@@ -7263,26 +7366,26 @@ def test_issue_18272():
     n = Symbol('n')
 
     assert upretty(ConditionSet(x, Eq(-x + exp(x), 0), S.Complexes)) == \
-    '⎧            ⎛      x    ⎞⎫\n'\
-    '⎨x | x ∊ ℂ ∧ ⎝-x + ℯ  = 0⎠⎬\n'\
-    '⎩                         ⎭'
+    '⎧  │         ⎛      x    ⎞⎫\n'\
+    '⎨x │ x ∊ ℂ ∧ ⎝-x + ℯ  = 0⎠⎬\n'\
+    '⎩  │                      ⎭'
     assert upretty(ConditionSet(x, Contains(n/2, Interval(0, oo)), FiniteSet(-n/2, n/2))) == \
-    '⎧        ⎧-n   n⎫   ⎛n         ⎞⎫\n'\
-    '⎨x | x ∊ ⎨───, ─⎬ ∧ ⎜─ ∈ [0, ∞)⎟⎬\n'\
-    '⎩        ⎩ 2   2⎭   ⎝2         ⎠⎭'
+    '⎧  │     ⎧-n   n⎫   ⎛n         ⎞⎫\n'\
+    '⎨x │ x ∊ ⎨───, ─⎬ ∧ ⎜─ ∈ [0, ∞)⎟⎬\n'\
+    '⎩  │     ⎩ 2   2⎭   ⎝2         ⎠⎭'
     assert upretty(ConditionSet(x, Eq(Piecewise((1, x >= 3), (x/2 - 1/2, x >= 2), (1/2, x >= 1),
                 (x/2, True)) - 1/2, 0), Interval(0, 3))) == \
-    '⎧                 ⎛⎛⎧   1     for x ≥ 3⎞          ⎞⎫\n'\
-    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪x                 ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪─ - 0.5  for x ≥ 2⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪2                 ⎟          ⎟⎪\n'\
-    '⎨x | x ∊ [0, 3] ∧ ⎜⎜⎨                  ⎟ - 0.5 = 0⎟⎬\n'\
-    '⎪                 ⎜⎜⎪  0.5    for x ≥ 1⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
-    '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
+    '⎧  │              ⎛⎛⎧   1     for x ≥ 3⎞          ⎞⎫\n'\
+    '⎪  │              ⎜⎜⎪                  ⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪x                 ⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪─ - 0.5  for x ≥ 2⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪2                 ⎟          ⎟⎪\n'\
+    '⎨x │ x ∊ [0, 3] ∧ ⎜⎜⎨                  ⎟ - 0.5 = 0⎟⎬\n'\
+    '⎪  │              ⎜⎜⎪  0.5    for x ≥ 1⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪                  ⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
+    '⎪  │              ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
+    '⎩  │              ⎝⎝⎩   2              ⎠          ⎠⎭'
 
 def test_Str():
     from sympy.core.symbol import Str

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4094,9 +4094,8 @@ def test_pretty_ImageSet():
 
     imgset = ImageSet(Lambda(x, x**2), S.Naturals)
     ascii_str = '''\
-/ 2 |              \\
-<x  | x in Naturals>
-\\   |              /'''
+  2                 \n\
+{x  | x in Naturals}'''
     ucode_str = '''\
 ⎧ 2 │      ⎫\n\
 ⎨x  │ x ∊ ℕ⎬\n\
@@ -4108,11 +4107,10 @@ def test_pretty_ImageSet():
     # 1/x**2 fraction
     imgset = ImageSet(Lambda(x, 1/x**2), S.Naturals)
     ascii_str = '''\
-/1  |              \\
-|-- | x in Naturals|
-< 2 |              >
-|x  |              |
-\\   |              /'''
+ 1                  \n\
+{-- | x in Naturals}
+  2                 \n\
+ x                  '''
     ucode_str = '''\
 ⎧1  │      ⎫\n\
 ⎪── │ x ∊ ℕ⎪\n\
@@ -4124,11 +4122,10 @@ def test_pretty_ImageSet():
 
     imgset = ImageSet(Lambda((x, y), 1/(x + y)**2), S.Naturals, S.Naturals)
     ascii_str = '''\
-/   1     |                             \\
-|-------- | x in Naturals, y in Naturals|
-<       2 |                             >
-|(x + y)  |                             |
-\\         |                             /'''
+    1                                    \n\
+{-------- | x in Naturals, y in Naturals}
+        2                                \n\
+ (x + y)                                 '''
     ucode_str = '''\
 ⎧   1     │             ⎫
 ⎪──────── │ x ∊ ℕ, y ∊ ℕ⎪
@@ -4156,11 +4153,10 @@ def test_pretty_ConditionSet():
 
     condset = ConditionSet(x, 1/x**2 > 0)
     ascii_str = '''\
-/  | 1     \\
-|x | -- > 0|
-<  |  2    >
-|  | x     |
-\\  |       /'''
+     1      \n\
+{x | -- > 0}
+      2     \n\
+     x      '''
     ucode_str = '''\
 ⎧  │ ⎛1     ⎞⎫
 ⎪x │ ⎜── > 0⎟⎪
@@ -4172,11 +4168,10 @@ def test_pretty_ConditionSet():
 
     condset = ConditionSet(x, 1/x**2 > 0, S.Reals)
     ascii_str = '''\
-/  |                    1     \\
-|x | x in (-oo, oo) and -- > 0|
-<  |                     2    >
-|  |                    x     |
-\\  |                          /'''
+                        1      \n\
+{x | x in (-oo, oo) and -- > 0}
+                         2     \n\
+                        x      '''
     ucode_str = '''\
 ⎧  │         ⎛1     ⎞⎫
 ⎪x │ x ∊ ℝ ∧ ⎜── > 0⎟⎪
@@ -4202,11 +4197,10 @@ def test_pretty_ComplexRegion():
 
     cregion = ComplexRegion(Interval(3, 1/a**2)*Interval(4, 6))
     ascii_str = '''\
-/        |             1           \\
-|x + y*I | x, y in [3, --] x [4, 6]|
-<        |              2          >
-|        |             a           |
-\\        |                         /'''
+                       1            \n\
+{x + y*I | x, y in [3, --] x [4, 6]}
+                        2           \n\
+                       a            '''
     ucode_str = '''\
 ⎧        │        ⎡   1 ⎤         ⎫
 ⎪x + y⋅ⅈ │ x, y ∊ ⎢3, ──⎥ × [4, 6]⎪
@@ -4218,11 +4212,10 @@ def test_pretty_ComplexRegion():
 
     cregion = ComplexRegion(Interval(0, 1/a**2)*Interval(0, 2*pi), polar=True)
     ascii_str = '''\
-/                              |                 1              \\
-|r*(I*sin(theta) + cos(theta)) | r, theta in [0, --] x [0, 2*pi)|
-<                              |                  2             >
-|                              |                 a              |
-\\                              |                                /'''
+                                                 1               \n\
+{r*(I*sin(theta) + cos(theta)) | r, theta in [0, --] x [0, 2*pi)}
+                                                  2              \n\
+                                                 a               '''
     ucode_str = '''\
 ⎧                      │        ⎡   1 ⎤           ⎫
 ⎪r⋅(ⅈ⋅sin(θ) + cos(θ)) │ r, θ ∊ ⎢0, ──⎥ × [0, 2⋅π)⎪

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1079,32 +1079,32 @@ def test_latex_Integers():
 def test_latex_ImageSet():
     x = Symbol('x')
     assert latex(ImageSet(Lambda(x, x**2), S.Naturals)) == \
-        r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
+        r"\left\{x^{2}\; \middle|\; x \in \mathbb{N}\right\}"
     y = Symbol('y')
 
     imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
     assert latex(imgset) == \
-        r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\} , y \in \left\{3, 4\right\}\right\}"
+        r"\left\{x + y\; \middle|\; x \in \left\{1, 2, 3\right\} , y \in \left\{3, 4\right\}\right\}"
 
     imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     assert latex(imgset) == \
-        r"\left\{x + y\; |\; \left( x, \  y\right) \in \left\{1, 2, 3\right\} \times \left\{3, 4\right\}\right\}"
+        r"\left\{x + y\; \middle|\; \left( x, \  y\right) \in \left\{1, 2, 3\right\} \times \left\{3, 4\right\}\right\}"
 
 
 def test_latex_ConditionSet():
     x = Symbol('x')
     assert latex(ConditionSet(x, Eq(x**2, 1), S.Reals)) == \
-        r"\left\{x \mid x \in \mathbb{R} \wedge x^{2} = 1 \right\}"
+        r"\left\{x\; \middle|\; x \in \mathbb{R} \wedge x^{2} = 1 \right\}"
     assert latex(ConditionSet(x, Eq(x**2, 1), S.UniversalSet)) == \
-        r"\left\{x \mid x^{2} = 1 \right\}"
+        r"\left\{x\; \middle|\; x^{2} = 1 \right\}"
 
 
 def test_latex_ComplexRegion():
     assert latex(ComplexRegion(Interval(3, 5)*Interval(4, 6))) == \
-        r"\left\{x + y i\; |\; x, y \in \left[3, 5\right] \times \left[4, 6\right] \right\}"
+        r"\left\{x + y i\; \middle|\; x, y \in \left[3, 5\right] \times \left[4, 6\right] \right\}"
     assert latex(ComplexRegion(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == \
         r"\left\{r \left(i \sin{\left(\theta \right)} + \cos{\left(\theta "\
-        r"\right)}\right)\; |\; r, \theta \in \left[0, 1\right] \times \left[0, 2 \pi\right) \right\}"
+        r"\right)}\right)\; \middle|\; r, \theta \in \left[0, 1\right] \times \left[0, 2 \pi\right) \right\}"
 
 
 def test_latex_Contains():
@@ -2477,7 +2477,7 @@ def test_issue_15353():
     sol = ConditionSet(
         Tuple(x, a), Eq(sin(a*x), 0) & Eq(cos(a*x), 0), S.Complexes**2)
     assert latex(sol) == \
-        r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in ' \
+        r'\left\{\left( x, \  a\right)\; \middle|\; \left( x, \  a\right) \in ' \
         r'\mathbb{C}^{2} \wedge \sin{\left(a x \right)} = 0 \wedge ' \
         r'\cos{\left(a x \right)} = 0 \right\}'
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


**Before**

```
>>> pprint(ImageSet(Lambda((x, y), 1/(x + y)), S.Naturals, S.Naturals))
⎧  1                  ⎫
⎨───── | x ∊ ℕ , y ∊ ℕ⎬
⎩x + y                ⎭
```

**After**

```
>>> pprint(ImageSet(Lambda((x, y), 1/(x + y)), S.Naturals, S.Naturals))
⎧  1   │             ⎫
⎨───── │ x ∊ ℕ, y ∊ ℕ⎬
⎩x + y │             ⎭
```

(and similarly for `ConditionSet` and `ComplexRegion`). Same issue has also been fixed in the LaTeX printer.
#### Other comments

There is still an issue here which is that for the pretty printer, the baseline should be calculated separately for the parts to either side of the |, so that one side does not cause the other to be noncentered (see the example I added in the tests for ImageSet). However, I'm not sure how to fix this, so unless someone has an idea, I suggest making this a separate issue. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fix the printing of the vertical bar in `ImageSet`, `ConditionSet`, and `ComplexRegion` so that it is the full height in the pretty and LaTeX printers.
<!-- END RELEASE NOTES -->