### PR TITLE
printing: fix latex, pretty to properly render unevaluated Mul in Add

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -90,6 +90,7 @@ def _coeff_isneg(a):
         a = a.args[0]
     if a.is_Mul:
         a = a.args[0]
+
     return a.is_Number and a.is_extended_negative
 
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -375,6 +375,8 @@ class LatexPrinter(Printer):
         for i, term in enumerate(terms):
             if i == 0:
                 pass
+            elif term.is_Mul and not any([True for arg in term.args if not arg.is_Integer]):
+                tex += " + "
             elif _coeff_isneg(term):
                 tex += " - "
                 term = -term

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1779,7 +1779,7 @@ class PrettyPrinter(Printer):
             return prettyForm(binding=prettyForm.NEG, *p)
 
         for i, term in enumerate(terms):
-            if term.is_Mul and _coeff_isneg(term):
+            if term.is_Mul and _coeff_isneg(term) and any([True for arg in term.args if not arg.is_Integer]):
                 coeff, other = term.as_coeff_mul(rational=False)
                 if coeff == -1:
                     negterm = Mul(*other, evaluate=False)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6346,19 +6346,19 @@ def test_issue_8292():
     e = sympify('((x+x**4)/(x-1))-(2*(x-1)**4/(x-1)**4)', evaluate=False)
     ucode_str = \
 """\
-           4    4    \n\
-  2⋅(x - 1)    x  + x\n\
-- ────────── + ──────\n\
-          4    x - 1 \n\
-   (x - 1)           \
+              4     4     \n\
+  2⋅(x + -1⋅1)     x  + x \n\
+- ───────────── + ────────\n\
+             4    x + -1⋅1\n\
+   (x + -1⋅1)             \
 """
     ascii_str = \
 """\
-           4    4    \n\
-  2*(x - 1)    x  + x\n\
-- ---------- + ------\n\
-          4    x - 1 \n\
-   (x - 1)           \
+              4     4     \n\
+  2*(x + -1*1)     x  + x \n\
+- ------------- + --------\n\
+             4    x + -1*1\n\
+   (x + -1*1)             \
 """
     assert pretty(e) == ascii_str
     assert upretty(e) == ucode_str
@@ -6467,6 +6467,9 @@ def test_issue_13651():
     expr2 = c + Mul(-1, a - b + d, evaluate=False)
     assert pretty(expr2) == 'c - (a - b + d)'
 
+def test_issue_19889():
+    e = Add(-5, Mul(-1, -1, evaluate=False), evaluate=False)
+    assert pretty(e) == "-5 + -1*(-1)"
 
 def test_pretty_primenu():
     from sympy.ntheory.factor_ import primenu

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,7 +1,7 @@
 from sympy.tensor.toperators import PartialDerivative
 
 from sympy import (
-    Abs, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
+    Abs, Add, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
     FiniteSet, Float, FourierTransform, Function, Indexed, IndexedBase, Integral,
     Interval, InverseCosineTransform, InverseFourierTransform, Derivative,
     InverseLaplaceTransform, InverseMellinTransform, InverseSineTransform,
@@ -2205,6 +2205,9 @@ def test_issue_13651():
     expr = c + Mul(-1, a + b, evaluate=False)
     assert latex(expr) == r"c - \left(a + b\right)"
 
+def test_issue_19889():
+    e = Add(-5, Mul(-1, -1, evaluate=False), evaluate=False)
+    assert latex(e) == r"-5 + \left(-1\right) \left(-1\right)"
 
 def test_latex_UnevaluatedExpr():
     x = symbols("x")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19889

#### Brief description of what is fixed or changed
Updated `latex` and `pretty` so that they do not simplify unevaluated Muls with only Integers when a part of an Add. See linked issue for example.

#### Other comments
I've slightly modified the only test which failed as a result of this change. That test was originally intended to test whether or not `pretty` was automatically evaluating Muls (see pull request #8305). Ironically enough, this change causes it to more accurately preserve unevaluated Muls. However, I would still appreciate feedback on whether this is an acceptable modification.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fix both latex and pretty to properly render unevaluated Muls when inside an Add
<!-- END RELEASE NOTES -->