### PR TITLE
Small fix for Lambda.evalf()

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2095,6 +2095,10 @@ class Lambda(Expr):
         """Return ``True`` if this ``Lambda`` is an identity function. """
         return self.signature == self.expr
 
+    def _eval_evalf(self, prec):
+        from sympy.core.evalf import prec_to_dps
+        return self.func(self.args[0], self.args[1].evalf(n=prec_to_dps(prec)))
+
 
 class Subs(Expr):
     """

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -2,7 +2,7 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
         Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise, Indexed,
-        Matrix, Basic, Dict, oo, zoo, nan, Pow)
+        Matrix, Basic, Dict, oo, zoo, nan, Pow, sstr)
 from sympy.core.basic import _aresame
 from sympy.core.cache import clear_cache
 from sympy.core.expr import unchanged
@@ -1379,3 +1379,16 @@ def test_issue_20683():
 def test_issue_10503():
     f = exp(x**3)*cos(x**6)
     assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)
+
+
+def test_issue_17382():
+    # copied from sympy/core/tests/test_evalf.py
+    def NS(e, n=15, **options):
+        return sstr(sympify(e).evalf(n, **options), full_prec=True)
+
+    x = Symbol('x')
+    expr = solveset(2 * cos(x) * cos(2 * x) - 1, x, S.Reals)
+    expected = "Union(" \
+               "ImageSet(Lambda(_n, 6.28318530717959*_n + 5.79812359592087), Integers), " \
+               "ImageSet(Lambda(_n, 6.28318530717959*_n + 0.485061711258717), Integers))"
+    assert NS(expr) == expected


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17382

#### Brief description of what is fixed or changed
`Lambda` did not have a valid `evalf` method. This PR adds it while #20479 is still in progress.

#### Other comments
Note that I explicitly evalf the first argument. This is because the first argument is a Python `tuple` and will throw an error. (It is also pointless to evalf the first argument since it will always be some kind of symbol).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->