### PR TITLE
Added nseries for lerchpi and zeta functions

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -71,6 +71,12 @@ def test_zeta_eval():
 def test_zeta_series():
     assert zeta(x, a).series(a, 0, 2) == \
         zeta(x, 0) - x*a*zeta(x + 1, 0) + O(a**2)
+    assert zeta(x).series(x, n=3) == (Rational(3, 8) - 2**(-x)/4)/(-2**(1 - x) + 1)
+
+
+def test_lerchphi_series():
+    assert lerchphi(z, s, a).series(z, 0, 3) == \
+            z**2*(-2*(a + 1)**(-s) + a**(-s))/(-z + 1)**2 - a**(-s)*z/(-z + 1)
 
 
 def test_dirichlet_eta_eval():

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -71,12 +71,12 @@ def test_zeta_eval():
 def test_zeta_series():
     assert zeta(x, a).series(a, 0, 2) == \
         zeta(x, 0) - x*a*zeta(x + 1, 0) + O(a**2)
-    assert zeta(x).series(x, n=3) == (Rational(3, 8) - 2**(-x)/4)/(-2**(1 - x) + 1)
+    assert zeta(x).series(x, n=3) == (Rational(3, 8) - 2**(-x)/4)/(-2**(1 - x) + 1) + O(x**3)
 
 
 def test_lerchphi_series():
     assert lerchphi(z, s, a).series(z, 0, 3) == \
-            z**2*(-2*(a + 1)**(-s) + a**(-s))/(-z + 1)**2 - a**(-s)*z/(-z + 1)
+            z**2*(-2*(a + 1)**(-s) + a**(-s))/(-z + 1)**2 - a**(-s)*z/(-z + 1) + O(z**3)
 
 
 def test_dirichlet_eta_eval():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -1,6 +1,6 @@
 """ Riemann zeta and related function. """
 
-from sympy.core import Function, S, sympify, pi, I
+from sympy.core import Add, Function, S, sympify, pi, I, Symbol
 from sympy.core.function import ArgumentIndexError
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
 from sympy.functions.elementary.exponential import log, exp_polar
@@ -201,16 +201,18 @@ class lerchphi(Function):
         return self._eval_rewrite_helper(z, s, a, polylog)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        from sympy.core import Add
         from sympy.functions.combinatorial.factorials import binomial
+        from sympy.series.order import Order
         z, s, a = self.args
 
         p = []
         for k in range(0, n):
-            q = [(-1)**i * binomial(k, i) * (a + i)**(-s) for i in range(0, k)]
-            t = (-z/(1-z))**k * Add(*q)
+            i = Symbol('i')
+            q_terms = (-1)**i * binomial(k, i) * (a + i)**(-s)
+            q = [q_terms.subs(i, j) for j in range(0, k)]
+            t = (-z/(1 - z))**k * Add(*q)
             p.append(t)
-        return Add(*p)
+        return Add(*p) + Order(z**n, x)
 
 ###############################################################################
 ###################### POLYLOGARITHM ##########################################
@@ -545,19 +547,22 @@ class zeta(Function):
             raise ArgumentIndexError
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        from sympy.core import Add
         from sympy.functions.combinatorial.factorials import binomial
+        from sympy.series.order import Order
 
         if len(self.args) == 2:
             s, a = self.args
-            if a != 1:
+            if a != S.One:
                 return super(zeta, self)._eval_nseries(x, n, logx)
+
         p = []
         for k in range(0, n):
-            q = [(-1)**i * binomial(k, i) / (i+1)**(x) for i in range(0, k)]
-            t = S.Half**(k+1) * Add(*q)
+            i = Symbol('i')
+            q_terms = (-1)**i * binomial(k, i) / (i + 1)**(x)
+            q = [q_terms.subs(i, j) for j in range(0, k)]
+            t = S.Half**(k + 1) * Add(*q)
             p.append(t)
-        return 1/(1 - 2**(1-x)) * Add(*p)
+        return 1/(1 - 2**(1 - x)) * Add(*p) + Order(x**n, x)
 
 
 class dirichlet_eta(Function):

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -200,6 +200,18 @@ class lerchphi(Function):
     def _eval_rewrite_as_polylog(self, z, s, a, **kwargs):
         return self._eval_rewrite_helper(z, s, a, polylog)
 
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.core import Add
+        from sympy.functions.combinatorial.factorials import binomial
+        z, s, a = self.args
+
+        p = []
+        for k in range(0, n):
+            q = [(-1)**i * binomial(k, i) * (a + i)**(-s) for i in range(0, k)]
+            t = (-z/(1-z))**k * Add(*q)
+            p.append(t)
+        return Add(*p)
+
 ###############################################################################
 ###################### POLYLOGARITHM ##########################################
 ###############################################################################
@@ -531,6 +543,21 @@ class zeta(Function):
             return -s*zeta(s + 1, a)
         else:
             raise ArgumentIndexError
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.core import Add
+        from sympy.functions.combinatorial.factorials import binomial
+
+        if len(self.args) == 2:
+            s, a = self.args
+            if a != 1:
+                return super(zeta, self)._eval_nseries(x, n, logx)
+        p = []
+        for k in range(0, n):
+            q = [(-1)**i * binomial(k, i) / (i+1)**(x) for i in range(0, k)]
+            t = S.Half**(k+1) * Add(*q)
+            p.append(t)
+        return 1/(1 - 2**(1-x)) * Add(*p)
 
 
 class dirichlet_eta(Function):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Continuing #17303

#### Brief description of what is fixed or changed
Added `nseries` expansion for `zeta` and `lerchpi` functions
```py
In [2]: zeta(x).series(x)
Out[2]: 
        -x      -x       -x       -x
31   5⋅5     9⋅4     17⋅3     41⋅2  
── + ───── - ───── + ────── - ──────
64     64      32      32       64  
────────────────────────────────────
                  1 - x             
             1 - 2                  
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Added `nseries` expansion for lerchpi and zeta
<!-- END RELEASE NOTES -->