### PR TITLE
Added aseries support for error functions

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3015,6 +3015,8 @@ class Expr(Basic, EvalfMixin):
                 o = s1.getO()
                 s1 = s1.removeO()
             else:
+                if s1.has(Order):
+                    return s1
                 o = Order(x**n, x)
                 s1done = s1.doit()
                 if (s1done + o).removeO() == s1done:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3014,9 +3014,10 @@ class Expr(Basic, EvalfMixin):
                     s1 += Order(x**n, x)
                 o = s1.getO()
                 s1 = s1.removeO()
+            elif s1.has(Order):
+                # asymptotic expansion
+                return s1
             else:
-                if s1.has(Order):
-                    return s1
                 o = Order(x**n, x)
                 s1done = s1.doit()
                 if (s1done + o).removeO() == s1done:

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -242,8 +242,9 @@ class erf(Function):
         from sympy.series.order import Order
         point = args0[0]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             z = self.args[0]
+
             s = [(-1)**k * factorial2(2*k - 1) / (z**(2*k + 1) * 2**k)
                     for k in range(0, n)] + [Order(1/z**n, x)]
             return S.One - (exp(-z**2)/sqrt(pi)) * Add(*s)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -4,7 +4,7 @@
 from sympy.core import Add, S, sympify, cacheit, pi, I, Rational
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.symbol import Symbol
-from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.combinatorial.factorials import factorial, factorial2, RisingFactorial
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt, root
 from sympy.functions.elementary.exponential import exp, log
@@ -238,6 +238,18 @@ class erf(Function):
         else:
             return self.func(arg)
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            s = [(-1)**k * factorial2(2*k - 1) / (z**(2*k + 1) * 2**k)
+                    for k in range(0, n)] + [Order(1/z**n, x)]
+            return S.One - (exp(-z**2)/sqrt(pi)) * Add(*s)
+
+        return super(erf, self)._eval_aseries(n, args0, x, logx)
+
     as_real_imag = real_to_real_as_real_imag
 
 
@@ -426,6 +438,9 @@ class erfc(Function):
 
     as_real_imag = real_to_real_as_real_imag
 
+    def _eval_aseries(self, n, args0, x, logx):
+        return S.One - erf(*self.args)._eval_aseries(n, args0, x, logx)
+
 
 class erfi(Function):
     r"""
@@ -596,6 +611,18 @@ class erfi(Function):
         return self.rewrite(erf)
 
     as_real_imag = real_to_real_as_real_imag
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            s = [factorial2(2*k - 1) / (2**k * z**(2*k + 1))
+                    for k in range(0, n)] + [Order(1/z**n, x)]
+            return -S.ImaginaryUnit + (exp(z**2)/sqrt(pi)) * Add(*s)
+
+        return super(erfi, self)._eval_aseries(n, args0, x, logx)
 
 
 class erf2(Function):
@@ -1164,6 +1191,18 @@ class Ei(Function):
             return f._eval_nseries(x, n, logx)
         return super()._eval_nseries(x, n, logx)
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            s = [factorial(k) / (z)**k for k in range(0, n)] + \
+                    [Order(1/z**n, x)]
+            return (exp(z)/z) * Add(*s)
+
+        return super(Ei, self)._eval_aseries(n, args0, x, logx)
+
 
 class expint(Function):
     r"""
@@ -1340,6 +1379,18 @@ class expint(Function):
                 f = self._eval_rewrite_as_Ei(*self.args)
                 return f._eval_nseries(x, n, logx)
         return super()._eval_nseries(x, n, logx)
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[1]
+        nu = self.args[0]
+
+        if point is S.Infinity:
+            z = self.args[1]
+            s = [(-1)**k * RisingFactorial(nu, k) / z**k for k in range(0, n)] + [Order(1/z**n, x)]
+            return (exp(-z)/z) * Add(*s)
+
+        return super(expint, self)._eval_aseries(n, args0, x, logx)
 
     def _sage_(self):
         import sage.all as sage
@@ -1538,6 +1589,11 @@ class li(Function):
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):
         return z * _eis(log(z))
 
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        z = self.args[0]
+        s = [(log(z))**k / (factorial(k) * k) for k in range(1, n)]
+        return S.EulerGamma + log(log(z)) + Add(*s)
+
     def _eval_is_zero(self):
         z = self.args[0]
         if z.is_zero:
@@ -1630,6 +1686,10 @@ class Li(Function):
 
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):
         return self.rewrite(li).rewrite("tractable", deep=True)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        f = self._eval_rewrite_as_li(*self.args)
+        return f._eval_nseries(x, n, logx)
 
 ###############################################################################
 #################### TRIGONOMETRIC INTEGRALS ##################################
@@ -1800,6 +1860,20 @@ class Si(TrigonometricIntegral):
         t = Symbol('t', Dummy=True)
         return Integral(sinc(t), (t, 0, z))
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            p = [(-1)**k * factorial(2*k) / z**(2*k) for k in range(0, n)] + \
+                    [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k+1) for k in range(0, n)] + \
+                    [Order(1/z**n, x)]
+            return pi/2 - (cos(z)/z)*Add(*p) - (sin(z)/z)*Add(*q)
+
+        return super(Si, self)._eval_aseries(n, args0, x, logx)
+
     def _eval_is_zero(self):
         z = self.args[0]
         if z.is_zero:
@@ -1911,6 +1985,20 @@ class Ci(TrigonometricIntegral):
 
     def _eval_rewrite_as_expint(self, z, **kwargs):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            p = [(-1)**k * factorial(2*k) / z**(2*k) for k in range(0, n)] + \
+                    [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k+1) for k in range(0, n)] + \
+                    [Order(1/z**n, x)]
+            return (sin(z)/z)*Add(*p) - (cos(z)/z)*Add(*q)
+
+        return super(Ci, self)._eval_aseries(n, args0, x, logx)
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1869,9 +1869,9 @@ class Si(TrigonometricIntegral):
         if point is S.Infinity:
             z = self.args[0]
             p = [(-1)**k * factorial(2*k) / z**(2*k)
-                    for k in range(0, int(n/2))] + [Order(1/z**n, x)]
-            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
                     for k in range(0, int((n - 1)/2))] + [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
+                    for k in range(0, int(n/2) - 1)] + [Order(1/z**n, x)]
             return pi/2 - (cos(z)/z)*Add(*p) - (sin(z)/z)*Add(*q)
 
         # All other points are not handled
@@ -1997,9 +1997,9 @@ class Ci(TrigonometricIntegral):
         if point is S.Infinity:
             z = self.args[0]
             p = [(-1)**k * factorial(2*k) / z**(2*k)
-                    for k in range(0, int(n/2))] + [Order(1/z**n, x)]
-            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
                     for k in range(0, int((n - 1)/2))] + [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
+                    for k in range(0, int(n/2) - 1)] + [Order(1/z**n, x)]
             return (sin(z)/z)*Add(*p) - (cos(z)/z)*Add(*q)
 
         # All other points are not handled

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1865,14 +1865,16 @@ class Si(TrigonometricIntegral):
         from sympy.series.order import Order
         point = args0[0]
 
+        # Expansion at oo
         if point is S.Infinity:
             z = self.args[0]
-            p = [(-1)**k * factorial(2*k) / z**(2*k) for k in range(0, n)] + \
-                    [Order(1/z**n, x)]
-            q = [(-1)**k * factorial(2*k + 1) / z**(2*k+1) for k in range(0, n)] + \
-                    [Order(1/z**n, x)]
+            p = [(-1)**k * factorial(2*k) / z**(2*k)
+                    for k in range(0, int(n/2))] + [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
+                    for k in range(0, int((n - 1)/2))] + [Order(1/z**n, x)]
             return pi/2 - (cos(z)/z)*Add(*p) - (sin(z)/z)*Add(*q)
 
+        # All other points are not handled
         return super(Si, self)._eval_aseries(n, args0, x, logx)
 
     def _eval_is_zero(self):
@@ -1991,14 +1993,16 @@ class Ci(TrigonometricIntegral):
         from sympy.series.order import Order
         point = args0[0]
 
+        # Expansion at oo
         if point is S.Infinity:
             z = self.args[0]
-            p = [(-1)**k * factorial(2*k) / z**(2*k) for k in range(0, n)] + \
-                    [Order(1/z**n, x)]
-            q = [(-1)**k * factorial(2*k + 1) / z**(2*k+1) for k in range(0, n)] + \
-                    [Order(1/z**n, x)]
+            p = [(-1)**k * factorial(2*k) / z**(2*k)
+                    for k in range(0, int(n/2))] + [Order(1/z**n, x)]
+            q = [(-1)**k * factorial(2*k + 1) / z**(2*k + 1)
+                    for k in range(0, int((n - 1)/2))] + [Order(1/z**n, x)]
             return (sin(z)/z)*Add(*p) - (cos(z)/z)*Add(*q)
 
+        # All other points are not handled
         return super(Ci, self)._eval_aseries(n, args0, x, logx)
 
     def _sage_(self):

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -91,8 +91,7 @@ def test_erf_series():
     assert erf(x).series(x, 0, 7) == 2*x/sqrt(pi) - \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
 
-    assert erf(x).series(x, oo) == \
-        -(3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(-x**2)/sqrt(pi) + 1
+    assert erf(x).series(x, oo) ==1 +  O(x**(-6), (x, oo))
 
 
 def test_erf_evalf():
@@ -167,8 +166,7 @@ def test_erfc_series():
     assert erfc(x).series(x, 0, 7) == 1 - 2*x/sqrt(pi) + \
         2*x**3/3/sqrt(pi) - x**5/5/sqrt(pi) + O(x**7)
 
-    assert erfc(x).series(x, oo) == \
-        (3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(-x**2)/sqrt(pi)
+    assert erfc(x).series(x, oo) == O(x**(-6), (x, oo))
 
 
 def test_erfc_evalf():
@@ -452,8 +450,7 @@ def test_expint():
         z**3*(log(z)/6 - Rational(11, 36) + EulerGamma/6 - I*pi/6) - z**4/24 + \
         z**5/240 + O(z**6)
 
-    assert expint(n, x).series(x, oo, n=3) == \
-        (n*(n + 1)/x**2 - n/x + 1 + O(x**(-3), (x, oo)))*exp(-x)/x
+    assert expint(n, x).series(x, oo, n=3) == O(x**(-3), (x, oo))
 
     assert expint(z, y).series(z, 0, 2) == exp(-y)/y - z*meijerg(((), (1, 1)),
                                   ((0, 0, 1), ()), y)/y + O(z**2)
@@ -599,7 +596,7 @@ def test_si():
     assert Si(x).nseries(x, 1, n=3) == \
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
-    assert Si(x).series(x, oo) == pi/2 + (-(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo)))*sin(x) -\
+    assert Si(x).series(x, oo) == pi/2 + (-sin(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) -\
                                 (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*cos(x))/x
 
     t = Symbol('t', Dummy=True)
@@ -647,7 +644,7 @@ def test_ci():
     assert Chi(x).nseries(x, n=4) == \
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
 
-    assert Ci(x).series(x, oo) == (-(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo)))*cos(x) +\
+    assert Ci(x).series(x, oo) == (-cos(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) +\
                                 (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*sin(x))/x
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
     assert Ci(x).rewrite(uppergamma) == -expint(1, x*exp_polar(-I*pi/2))/2 -\

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -597,7 +597,7 @@ def test_si():
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
     assert Si(x).series(x, oo) == pi/2 + (-sin(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) -\
-                                (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*cos(x))/x
+                                (24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*cos(x))/x
 
     t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc) == Integral(sinc(t), (t, 0, x))
@@ -645,7 +645,7 @@ def test_ci():
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
 
     assert Ci(x).series(x, oo) == (-cos(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) +\
-                                (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*sin(x))/x
+                                (24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*sin(x))/x
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
     assert Ci(x).rewrite(uppergamma) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
                                         expint(1, x*exp_polar(I*pi/2))/2

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -91,6 +91,9 @@ def test_erf_series():
     assert erf(x).series(x, 0, 7) == 2*x/sqrt(pi) - \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
 
+    assert erf(x).series(x, oo) == \
+        -(3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(-x**2)/sqrt(pi) + 1
+
 
 def test_erf_evalf():
     assert abs( erf(Float(2.0)) - 0.995322265 ) < 1E-8 # XXX
@@ -164,6 +167,9 @@ def test_erfc_series():
     assert erfc(x).series(x, 0, 7) == 1 - 2*x/sqrt(pi) + \
         2*x**3/3/sqrt(pi) - x**5/5/sqrt(pi) + O(x**7)
 
+    assert erfc(x).series(x, oo) == \
+        (3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(-x**2)/sqrt(pi)
+
 
 def test_erfc_evalf():
     assert abs( erfc(Float(2.0)) - 0.00467773 ) < 1E-8 # XXX
@@ -222,6 +228,9 @@ def test_erfi():
 def test_erfi_series():
     assert erfi(x).series(x, 0, 7) == 2*x/sqrt(pi) + \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
+
+    assert erfi(x).series(x, oo) == \
+        (3/(4*x**5) + 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(x**2)/sqrt(pi) - I
 
 
 def test_erfi_evalf():
@@ -386,6 +395,8 @@ def test_ei():
     assert Ei(x).series(x) == EulerGamma + log(x) + x + x**2/4 + \
         x**3/18 + x**4/96 + x**5/600 + O(x**6)
     assert Ei(x).series(x, 1, 3) == Ei(1) + E*(x - 1) + O((x - 1)**3, (x, 1))
+    assert Ei(x).series(x, oo) == \
+        (120/x**5 + 24/x**4 + 6/x**3 + 2/x**2 + 1/x + 1 + O(x**(-6), (x, oo)))*exp(x)/x
 
     assert str(Ei(cos(2)).evalf(n=10)) == '-0.6760647401'
     raises(ArgumentIndexError, lambda: Ei(x).fdiff(2))
@@ -440,6 +451,10 @@ def test_expint():
     assert expint(4, z).series(z) == Rational(1, 3) - z/2 + z**2/2 + \
         z**3*(log(z)/6 - Rational(11, 36) + EulerGamma/6 - I*pi/6) - z**4/24 + \
         z**5/240 + O(z**6)
+
+    assert expint(n, x).series(x, oo, n=3) == \
+        (n*(n + 1)/x**2 - n/x + 1 + O(x**(-3), (x, oo)))*exp(-x)/x
+
     assert expint(z, y).series(z, 0, 2) == exp(-y)/y - z*meijerg(((), (1, 1)),
                                   ((0, 0, 1), ()), y)/y + O(z**2)
     raises(ArgumentIndexError, lambda: expint(x, y).fdiff(3))
@@ -522,6 +537,8 @@ def test_li():
                                       meijerg(((), (1,)), ((0, 0), ()), -log(z)))
 
     assert gruntz(1/li(z), z, oo) == 0
+    assert li(z).series(z) == log(z)**5/600 + log(z)**4/96 + log(z)**3/18 + log(z)**2/4 + \
+            log(z) + log(log(z)) + EulerGamma
     raises(ArgumentIndexError, lambda: li(z).fdiff(2))
 
 
@@ -535,6 +552,8 @@ def test_Li():
 
     assert gruntz(1/Li(z), z, oo) == 0
     assert Li(z).rewrite(li) == li(z) - li(2)
+    assert Li(z).series(z) == \
+        log(z)**5/600 + log(z)**4/96 + log(z)**3/18 + log(z)**2/4 + log(z) + log(log(z)) - li(2) + EulerGamma
     raises(ArgumentIndexError, lambda: Li(z).fdiff(2))
 
 
@@ -580,6 +599,9 @@ def test_si():
     assert Si(x).nseries(x, 1, n=3) == \
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
+    assert Si(x).series(x, oo) == pi/2 + (-(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo)))*sin(x) -\
+                                (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*cos(x))/x
+
     t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc) == Integral(sinc(t), (t, 0, x))
 
@@ -624,6 +646,9 @@ def test_ci():
         EulerGamma + log(x) - x**2/4 + x**4/96 + O(x**5)
     assert Chi(x).nseries(x, n=4) == \
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
+
+    assert Ci(x).series(x, oo) == (-(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo)))*cos(x) +\
+                                (-720/x**6 + 24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*sin(x))/x
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
     assert Ci(x).rewrite(uppergamma) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
                                         expint(1, x*exp_polar(I*pi/2))/2

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -91,7 +91,8 @@ def test_erf_series():
     assert erf(x).series(x, 0, 7) == 2*x/sqrt(pi) - \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
 
-    assert erf(x).series(x, oo) ==1 +  O(x**(-6), (x, oo))
+    assert erf(x).series(x, oo) == \
+        -exp(-x**2)*(3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))/sqrt(pi) + 1
 
 
 def test_erf_evalf():
@@ -166,7 +167,8 @@ def test_erfc_series():
     assert erfc(x).series(x, 0, 7) == 1 - 2*x/sqrt(pi) + \
         2*x**3/3/sqrt(pi) - x**5/5/sqrt(pi) + O(x**7)
 
-    assert erfc(x).series(x, oo) == O(x**(-6), (x, oo))
+    assert erfc(x).series(x, oo) == \
+            (3/(4*x**5) - 1/(2*x**3) + 1/x + O(x**(-6), (x, oo)))*exp(-x**2)/sqrt(pi)
 
 
 def test_erfc_evalf():
@@ -352,7 +354,6 @@ def mytd(expr1, expr2, x):
 
 
 def tn_branch(func, s=None):
-    from sympy import I, pi, exp_polar
     from random import uniform
 
     def fn(x):
@@ -450,7 +451,8 @@ def test_expint():
         z**3*(log(z)/6 - Rational(11, 36) + EulerGamma/6 - I*pi/6) - z**4/24 + \
         z**5/240 + O(z**6)
 
-    assert expint(n, x).series(x, oo, n=3) == O(x**(-3), (x, oo))
+    assert expint(n, x).series(x, oo, n=3) == \
+        (n*(n + 1)/x**2 - n/x + 1 + O(x**(-3), (x, oo)))*exp(-x)/x
 
     assert expint(z, y).series(z, 0, 2) == exp(-y)/y - z*meijerg(((), (1, 1)),
                                   ((0, 0, 1), ()), y)/y + O(z**2)
@@ -596,8 +598,9 @@ def test_si():
     assert Si(x).nseries(x, 1, n=3) == \
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
-    assert Si(x).series(x, oo) == pi/2 + (-sin(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) -\
-                                (24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*cos(x))/x
+    assert Si(x).series(x, oo) == pi/2 - (- 6/x**3 + 1/x \
+        + O(x**(-7), (x, oo)))*sin(x)/x - (24/x**4 - 2/x**2 + 1 \
+        + O(x**(-7), (x, oo)))*cos(x)/x
 
     t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc) == Integral(sinc(t), (t, 0, x))
@@ -638,14 +641,14 @@ def test_ci():
     assert tn_arg(Ci)
     assert tn_arg(Chi)
 
-    from sympy import O, EulerGamma, log, limit
     assert Ci(x).nseries(x, n=4) == \
         EulerGamma + log(x) - x**2/4 + x**4/96 + O(x**5)
     assert Chi(x).nseries(x, n=4) == \
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
 
-    assert Ci(x).series(x, oo) == (-cos(x)*(120/x**5 - 6/x**3 + 1/x + O(x**(-7), (x, oo))) +\
-                                (24/x**4 - 2/x**2 + 1 + O(x**(-7), (x, oo)))*sin(x))/x
+    assert Ci(x).series(x, oo) == -cos(x)*(-6/x**3 + 1/x \
+        + O(x**(-7), (x, oo)))/x + (24/x**4 - 2/x**2 + 1 \
+        + O(x**(-7), (x, oo)))*sin(x)/x
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
     assert Ci(x).rewrite(uppergamma) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
                                         expint(1, x*exp_polar(I*pi/2))/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Continuing https://github.com/sympy/sympy/pull/17303

#### Brief description of what is fixed or changed
Added series support for error functions
```py
In [1]: Si(x).series(x, oo)
Out[1]: 
    ⎛  6    1    ⎛1        ⎞⎞          ⎛24   2         ⎛1        ⎞⎞       
    ⎜- ── + ─ + O⎜──; x → ∞⎟⎟⋅sin(x)   ⎜── - ── + 1 + O⎜──; x → ∞⎟⎟⋅cos(x)
    ⎜   3   x    ⎜ 5       ⎟⎟          ⎜ 4    2        ⎜ 5       ⎟⎟       
π   ⎝  x         ⎝x        ⎠⎠          ⎝x    x         ⎝x        ⎠⎠       
─ - ──────────────────────────────── - ───────────────────────────────────
2                  x                                    x                 

```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Added `aseries` expansion to error functions
<!-- END RELEASE NOTES -->