### PR TITLE
Add failing test for trigonometric integral

### DIFF
--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -280,3 +280,8 @@ def test_integrate_Piecewise_rational_over_reals():
 def test_issue_4311_slow():
     # Not slow when bypassing heurish
     assert not integrate(x*abs(9-x**2), x).has(Integral)
+
+@XFAIL
+def test_issue_20370():
+    a = symbols('a', positive=True)
+    assert integrate((1 + a * cos(x))**-1, (x, 0, 2 * pi)) == (2 * pi / sqrt(1 - a^2))

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -2,7 +2,8 @@
 
 from sympy import (
     integrate, I, Integral, exp, oo, pi, sign, sqrt, sin, cos, Piecewise,
-    tan, S, log, gamma, sinh, sec, acos, atan, sech, csch, DiracDelta, Rational
+    tan, S, log, gamma, sinh, sec, acos, atan, sech, csch, DiracDelta, Rational,
+    symbols
 )
 
 from sympy.testing.pytest import XFAIL, SKIP, slow, skip, ON_TRAVIS

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -284,4 +284,4 @@ def test_issue_4311_slow():
 @XFAIL
 def test_issue_20370():
     a = symbols('a', positive=True)
-    assert integrate((1 + a * cos(x))**-1, (x, 0, 2 * pi)) == (2 * pi / sqrt(1 - a^2))
+    assert integrate((1 + a * cos(x))**-1, (x, 0, 2 * pi)) == (2 * pi / sqrt(1 - a**2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Test for #20370

#### Brief description of what is fixed or changed

I added a simple test to `integrals/test_failing` that compares SymPy's output with the correct output.

#### Other comments

I'm not 100% sure I shouldn't add a `.doit()` to the integral.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->