### PR TITLE
Array expressions: contraction indices with nested additions

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1623,7 +1623,8 @@ def _(expr: CodegenArrayContraction):
     subexpr = expr.expr
     contraction_indices: Tuple[Tuple[int]] = expr.contraction_indices
     if isinstance(subexpr, CodegenArrayTensorProduct):
-        newexpr = CodegenArrayContraction(*[array2matrix(arg) for arg in expr.args])
+        newexpr = CodegenArrayContraction(array2matrix(subexpr), *contraction_indices)
+        contraction_indices = newexpr.contraction_indices
         if any(i > 2 for i in newexpr.subranks):
             addends = CodegenArrayElementwiseAdd(*[_a2m_tensor_product(*j) for j in itertools.product(*[i.args if isinstance(i, CodegenArrayElementwiseAdd) else [i] for i in expr.expr.args])])
             newexpr = CodegenArrayContraction(addends, *contraction_indices)
@@ -1802,8 +1803,7 @@ def _suppress_trivial_dims_in_tensor_product(mat_list):
     # That is, add contractions over trivial dimensions:
     mat_11 = []
     mat_k1 = []
-    from sympy import Identity
-    mat_list = [i for i in mat_list if i != 1 and not isinstance(i, Identity)]
+    mat_list = [i for i in mat_list if i != 1 and not getattr(i, "is_Identity", False)]
     for mat in mat_list:
         if mat.shape == (1, 1):
             mat_11.append(mat)


### PR DESCRIPTION
Array expressions: contraction of tensor products with additions can have their contraction indices lowered to additions, if applicable

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->