### PR TITLE
polys: make is_disjoint strict

### DIFF
--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1742,9 +1742,9 @@ class RealInterval:
     def is_disjoint(self, other):
         """Return ``True`` if two isolation intervals are disjoint. """
         if isinstance(other, RealInterval):
-            return (self.b <= other.a or other.b <= self.a)
+            return (self.b < other.a or other.b < self.a)
         assert isinstance(other, ComplexInterval)
-        return (self.b <= other.ax or other.bx <= self.a
+        return (self.b < other.ax or other.bx < self.a
             or other.ay*other.by > 0)
 
     def _inner_refine(self):
@@ -2008,10 +2008,10 @@ class ComplexInterval:
             return other.is_disjoint(self)
         if self.conj != other.conj:  # above and below real axis
             return True
-        re_distinct = (self.bx <= other.ax or other.bx <= self.ax)
+        re_distinct = (self.bx < other.ax or other.bx < self.ax)
         if re_distinct:
             return True
-        im_distinct = (self.by <= other.ay or other.by <= self.ay)
+        im_distinct = (self.by < other.ay or other.by < self.ay)
         return im_distinct
 
     def _inner_refine(self):

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -284,6 +284,10 @@ def test_CRootOf_real_roots():
     assert Poly(x**5 + x + 1).real_roots(radicals=False) == [rootof(
         x**3 - x**2 + 1, 0)]
 
+    # https://github.com/sympy/sympy/issues/20902
+    p = Poly(-3*x**4 - 10*x**3 - 12*x**2 - 6*x - 1, x, domain='ZZ')
+    assert CRootOf.real_roots(p) == [S(-1), S(-1), S(-1), S(-1)/3]
+
 
 def test_CRootOf_all_roots():
     assert Poly(x**5 + x + 1).all_roots() == [

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2300,3 +2300,10 @@ def test_issue_20747():
             / (1 - exp(c0/(DBH*c3 + THT*c4 + c2))))
     sol = [THT*term**(1/c1) - term**(1/c1) + 1]
     assert solve(eq, HT) == sol
+
+def test_issue_20902():
+    f = (t / ((1 + t) ** 2))
+    assert solve(f.subs({t: 3 * x + 2}).diff(x) > 0, x) == (S(-1) < x) & (x < S(-1)/3)
+    assert solve(f.subs({t: 3 * x + 3}).diff(x) > 0, x) == (S(-4)/3 < x) & (x < S(-2)/3)
+    assert solve(f.subs({t: 3 * x + 4}).diff(x) > 0, x) == (S(-5)/3 < x) & (x < S(-1))
+    assert solve(f.subs({t: 3 * x + 2}).diff(x) > 0, x) == (S(-1) < x) & (x < S(-1)/3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20902

#### Brief description of what is fixed or changed
Made inequalities of `is_disjoint` in both `rootisolation.RealInterval` and `rootisolation.ComplexInterval` strict so that intervals which share a boundary (e.g. `[1, 2]` and `[2, 3]`) are correctly evaluated as being not disjoint. In some cases (see linked issue), the original inequalities would cause `Poly.real_roots` to return roots in differing orders if computed at different times, thus leading to incorrect answers in `solve`.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * make is_disjoint strict so that inequalities evaluated with solve() return consistent results
<!-- END RELEASE NOTES -->