### PR TITLE
doc: fixed a typo in Matrix.eigenvects()

### DIFF
--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -319,7 +319,7 @@ Eigenvalues, Eigenvectors, and Diagonalization
 ----------------------------------------------
 
 To find the eigenvalues of a matrix, use ``eigenvals``.  ``eigenvals``
-returns a dictionary of ``eigenvalue:algebraic multiplicity`` pairs (similar to the
+returns a dictionary of ``eigenvalue: algebraic_multiplicity`` pairs (similar to the
 output of :ref:`roots <tutorial-roots>`).
 
     >>> M = Matrix([[3, -2,  4, -2], [5,  3, -3, -2], [5, -2,  2, -2], [5, -2, -3,  3]])
@@ -339,7 +339,7 @@ eigenvalues -2 and 3 have algebraic multiplicity 1 and that the eigenvalue 5
 has algebraic multiplicity 2.
 
 To find the eigenvectors of a matrix, use ``eigenvects``.  ``eigenvects``
-returns a list of tuples of the form ``(eigenvalue:algebraic multiplicity,
+returns a list of tuples of the form ``(eigenvalue, algebraic_multiplicity,
 [eigenvectors])``.
 
     >>> M.eigenvects()


### PR DESCRIPTION
#### References to other Issues or PRs



#### Brief description of what is fixed or changed
The matrices method `eigenvects()` returns a list of _tuples_, but currently those tuples are [documented](https://docs.sympy.org/latest/tutorial/matrices.html#eigenvalues-eigenvectors-and-diagonalization) in the form of
```python
(eigenvalue:algebraic multiplicity, [eigenvectors])
```
in which the colon in `eigenvalue:algebraic multiplicity` is not a valid tuple syntax.

This PR replaced colon `:` with comma `,`, and replaced `algebraic multiplicity` with `algebraic_multiplicity`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->