### PR TITLE
Fixed a bug in primetest.py -> is_gaussian_prime

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -653,8 +653,8 @@ def is_gaussian_prime(num):
     from sympy import sympify
     num = sympify(num)
     a, b = num.as_real_imag()
-    a = as_int(a)
-    b = as_int(b)
+    a = as_int(a, strict=False)
+    b = as_int(b, strict=False)
     if a == 0:
         b = abs(b)
         return isprime(b) and b % 4 == 3


### PR DESCRIPTION
### Changes
Changed the invocation of `as_int` function to use the flag `strict=False` in the function `is_gaussian_prime` of `sympy.ntheory` module in order to fix the following bug.

#### The bug:
Using the standard python "complex" library to do 
`sympy.ntheory.is_gaussian_prime(1+1j)`
results in `ValueError` which is caused due to the usage of the default `strict=True` flag while invoking the `as_int` function.
#### Resolution:
Override the default `strict=True` flag to use `strict=False` while invoking the `as_int` function.

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed a bug in the `is_gaussian_prime` function for python complex numbers (e.g. `1+1j`).

<!-- END RELEASE NOTES -->





