### PR TITLE
added _eval_derivative for products

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -5,6 +5,8 @@ from sympy.core.exprtools import factor_terms
 from sympy.functions.elementary.exponential import exp, log
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
+from sympy.core.function import Derivative
+from sympy.core.symbol import Dummy, Symbol
 
 
 class Product(ExprWithIntLimits):
@@ -400,18 +402,18 @@ class Product(ExprWithIntLimits):
         return Mul(*[term.subs(k, a + i) for i in range(n - a + 1)])
 
     def _eval_derivative(self, x):
-        from sympy.concrete.summations import Sum, Dummy, Symbol, Derivative
+        from sympy.concrete.summations import Sum
         if isinstance(x, Symbol) and x not in self.free_symbols:
             return S.Zero
         f, limits = self.function, list(self.limits)
         limit = limits.pop(-1)
         if limits:
             f = self.func(f, *limits)
-        _, a, b = limit
+        i, a, b = limit
         if x in a.free_symbols or x in b.free_symbols:
             return None
         h = Dummy()
-        rv = Sum( Product(f, (_, a, h - 1)) * Product(f, (_, h + 1, b)) * Derivative(f, x, evaluate=True).subs(_, h), (h, a, b))
+        rv = Sum( Product(f, (i, a, h - 1)) * Product(f, (i, h + 1, b)) * Derivative(f, x, evaluate=True).subs(i, h), (h, a, b))
         return rv
 
     def is_convergent(self):

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -400,11 +400,16 @@ class Product(ExprWithIntLimits):
         return Mul(*[term.subs(k, a + i) for i in range(n - a + 1)])
 
     def _eval_derivative(self, x):
-        from sympy import Sum
+        if self.is_zero:
+            return S.Zero
+        from sympy.concrete.summations import Sum, Dummy
+        i = Dummy('i')
+        f = self.function
         limits = list(self.limits)
-        if any(x in limit[1:].free_symbols for limit in reversed(limits)):
+        _, a, b = limits[0]
+        if any(x in limit[1:].free_symbols for limit in limits):
             return None
-        return self * Sum(self.function.diff(x) / self.function, self._args[1:], **self.assumptions0)
+        return Sum(f.subs(_, i).diff(x) * Product(f, (_, a, i - 1)) * Product(f, (_, i + 1, b)), (i, a, b), **self.assumptions0)
 
     def is_convergent(self):
         r"""

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -399,6 +399,13 @@ class Product(ExprWithIntLimits):
         (k, a, n) = limits
         return Mul(*[term.subs(k, a + i) for i in range(n - a + 1)])
 
+    def _eval_derivative(self, x):
+        from sympy import Sum
+        limits = list(self.limits)
+        if any(x in limit[1:].free_symbols for limit in reversed(limits)):
+            return None
+        return self * Sum(self.function.diff(x) / self.function, self._args[1:], **self.assumptions0)
+
     def is_convergent(self):
         r"""
         See docs of :obj:`.Sum.is_convergent()` for explanation of convergence

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, Symbol, product, combsimp, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S, pi,
-                   KroneckerDelta, Derivative, diff, sin, polygamma, gamma, Dummy)
+                   KroneckerDelta, Derivative, diff, sin, Dummy)
 from sympy.testing.pytest import raises
 from sympy import simplify
 
@@ -384,11 +384,10 @@ def test_KroneckerDelta_Product():
     assert Product(x*KroneckerDelta(x, y), (x, 0, 1)).doit() == 0
 
 def test_issue_20848():
-    _i = Dummy('_i')
+    _i = Dummy('i')
     t, y, z = symbols('t y z')
     assert diff(Product(x, (y, 1, z)), x).as_dummy() == Sum(Product(x, (y, 1, _i - 1))*Product(x, (y, _i + 1, z)), (_i, 1, z)).as_dummy()
     assert diff(Product(x, (y, 1, z)), x).doit() == x**z*z/x
     assert diff(Product(x, (y, x, z)), x) == Derivative(Product(x, (y, x, z)), x)
     assert diff(Product(t, (x, 1, z)), x) == S(0)
     assert Product(sin(n*x), (n, -1, 1)).diff(x).doit() == S(0)
-    assert Product(x*y, (x, 1, z), (y, 1, m)).diff(z).doit() == m*factorial(m)**z*factorial(z)**m*gamma(z + 1)*polygamma(0, z + 1)/factorial(z) + log(factorial(m))*factorial(m)**z*factorial(z)**m

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, Symbol, product, combsimp, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S, pi,
-                   KroneckerDelta, Derivative, diff, sin, polygamma, gamma)
+                   KroneckerDelta, Derivative, diff, sin, polygamma, gamma, Dummy)
 from sympy.testing.pytest import raises
 from sympy import simplify
 
@@ -384,8 +384,10 @@ def test_KroneckerDelta_Product():
     assert Product(x*KroneckerDelta(x, y), (x, 0, 1)).doit() == 0
 
 def test_issue_20848():
+    _i = Dummy('_i')
     t, y, z = symbols('t y z')
-    assert diff(Product(x, (y, 1, z)), x) == Product(x, (y, 1, z))*Sum(1/x, (y, 1, z))
+    assert diff(Product(x, (y, 1, z)), x).as_dummy() == Sum(Product(x, (y, 1, _i - 1))*Product(x, (y, _i + 1, z)), (_i, 1, z)).as_dummy()
+    assert diff(Product(x, (y, 1, z)), x).doit() == x**z*z/x
     assert diff(Product(x, (y, x, z)), x) == Derivative(Product(x, (y, x, z)), x)
     assert diff(Product(t, (x, 1, z)), x) == S(0)
     assert Product(sin(n*x), (n, -1, 1)).diff(x).doit() == S(0)

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, Symbol, product, combsimp, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S, pi,
-                   KroneckerDelta, Derivative, diff)
+                   KroneckerDelta, Derivative, diff, sin, polygamma, gamma)
 from sympy.testing.pytest import raises
 from sympy import simplify
 
@@ -384,7 +384,9 @@ def test_KroneckerDelta_Product():
     assert Product(x*KroneckerDelta(x, y), (x, 0, 1)).doit() == 0
 
 def test_issue_20848():
-    w, y, z = symbols('w y z')
+    t, y, z = symbols('t y z')
     assert diff(Product(x, (y, 1, z)), x) == Product(x, (y, 1, z))*Sum(1/x, (y, 1, z))
     assert diff(Product(x, (y, x, z)), x) == Derivative(Product(x, (y, x, z)), x)
-    assert diff(Product(w, (x, 1, z)), x) == S(0)
+    assert diff(Product(t, (x, 1, z)), x) == S(0)
+    assert Product(sin(n*x), (n, -1, 1)).diff(x).doit() == S(0)
+    assert Product(x*y, (x, 1, z), (y, 1, m)).diff(z).doit() == m*factorial(m)**z*factorial(z)**m*gamma(z + 1)*polygamma(0, z + 1)/factorial(z) + log(factorial(m))*factorial(m)**z*factorial(z)**m

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, Symbol, product, combsimp, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S, pi,
-                   KroneckerDelta)
+                   KroneckerDelta, Derivative, diff)
 from sympy.testing.pytest import raises
 from sympy import simplify
 
@@ -382,3 +382,9 @@ def test_rewrite_Sum():
 def test_KroneckerDelta_Product():
     y = Symbol('y')
     assert Product(x*KroneckerDelta(x, y), (x, 0, 1)).doit() == 0
+
+def test_issue_20848():
+    w, y, z = symbols('w y z')
+    assert diff(Product(x, (y, 1, z)), x) == Product(x, (y, 1, z))*Sum(1/x, (y, 1, z))
+    assert diff(Product(x, (y, x, z)), x) == Derivative(Product(x, (y, x, z)), x)
+    assert diff(Product(w, (x, 1, z)), x) == S(0)


### PR DESCRIPTION
This PR adds the `_eval_derivative` method based on the `Leibniz rule`.

Fixes #20848

Added `_eval_derivative` method based on the `Leibniz rule`.
Also added test cases for the same.

Credits to @Maelstrom6 and @asmeurer 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->