### PR TITLE
refactor(assumptions): remove _extract_facts()

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -6,7 +6,7 @@ from sympy.core import sympify
 from sympy.core.cache import cacheit
 from sympy.core.relational import Relational
 from sympy.core.kind import BooleanKind
-from sympy.logic.boolalg import (to_cnf, And, Not, Or, Implies, Equivalent)
+from sympy.logic.boolalg import (to_cnf, And, Not, Implies, Equivalent)
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -241,42 +241,6 @@ class AssumptionKeys:
 
 
 Q = AssumptionKeys()
-
-def _extract_facts(expr, symbol, check_reversed_rel=True):
-    """
-    Helper for ask().
-
-    Explanation
-    ===========
-
-    Extracts the facts relevant to the symbol from an assumption.
-    Returns None if there is nothing to extract.
-    """
-    if isinstance(symbol, Relational):
-        if check_reversed_rel:
-            rev = _extract_facts(expr, symbol.reversed, False)
-            if rev is not None:
-                return rev
-    if isinstance(expr, bool):
-        return
-    if not expr.has(symbol):
-        return
-    if isinstance(expr, AppliedPredicate):
-        if expr.arg == symbol:
-            return expr.func
-        else:
-            return
-    if isinstance(expr, Not) and expr.args[0].func in (And, Or):
-        cls = Or if expr.args[0] == And else And
-        expr = cls(*[~arg for arg in expr.args[0].args])
-    args = [_extract_facts(arg, symbol) for arg in expr.args]
-    if isinstance(expr, And):
-        args = [x for x in args if x is not None]
-        if args:
-            return expr.func(*args)
-    if args and all(x is not None for x in args):
-        return expr.func(*args)
-
 
 def _extract_all_facts(expr, symbols):
     facts = set()

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -2,9 +2,8 @@
 rename this to test_assumptions.py when the old assumptions system is deleted
 """
 from sympy.abc import x, y
-from sympy.assumptions.assume import global_assumptions, Predicate
-from sympy.assumptions.ask import _extract_facts, Q
-from sympy.core import symbols
+from sympy.assumptions.assume import global_assumptions
+from sympy.assumptions.ask import Q
 from sympy.printing import pretty
 
 
@@ -19,20 +18,6 @@ def test_pretty():
     assert pretty(Q.positive(x)) == "Q.positive(x)"
     assert pretty(
         {Q.positive, Q.integer}) == "{Q.integer, Q.positive}"
-
-
-def test_extract_facts():
-    a, b = symbols('a b', cls=Predicate)
-    assert _extract_facts(a(x), x) == a
-    assert _extract_facts(a(x), y) is None
-    assert _extract_facts(~a(x), x) == ~a
-    assert _extract_facts(~a(x), y) is None
-    assert _extract_facts(a(x) | b(x), x) == a | b
-    assert _extract_facts(a(x) | ~b(x), x) == a | ~b
-    assert _extract_facts(a(x) & b(y), x) == a
-    assert _extract_facts(a(x) & b(y), y) == b
-    assert _extract_facts(a(x) | b(y), x) == None
-    assert _extract_facts(~(a(x) | b(y)), x) == ~a
 
 
 def test_global():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I found out that `_extract_facts()` function is used nowhere in SymPy codebase. Since this is private function, I believe this redundancy can be removed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->