### PR TITLE
solvers: modify symbols ordering in _solve_system

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1743,6 +1743,7 @@ def _solve_system(exprs, symbols, **flags):
         symsset = set(symbols)
         exprsyms = {e: e.free_symbols & symsset for e in exprs}
         E = []
+        sym_indices = {sym: i for i, sym in enumerate(symbols)}
         for n, e1 in enumerate(exprs):
             for e2 in exprs[:n]:
                 # Equations are connected if they share a symbol
@@ -1756,7 +1757,7 @@ def _solve_system(exprs, symbols, **flags):
                 subsyms = set()
                 for e in subexpr:
                     subsyms |= exprsyms[e]
-                subsyms = list(ordered(subsyms))
+                subsyms = list(sorted(subsyms, key = lambda x: sym_indices[x]))
                 # use canonical subset to solve these equations
                 # since there may be redundant equations in the set:
                 # take the first equation of several that may have the

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -35,6 +35,7 @@ from sympy.testing.pytest import (XFAIL, raises, skip, slow, SKIP, _both_exp_pow
 from sympy.testing.randtest import verify_numerically as tn
 from sympy.physics.units import cm
 
+from sympy.solvers import solve
 from sympy.solvers.solveset import (
     solveset_real, domain_check, solveset_complex, linear_eq_to_matrix,
     linsolve, _is_function_class_equation, invert_real, invert_complex,
@@ -2490,6 +2491,88 @@ def test_issue_10426():
         Intersection(S.Complexes, ImageSet(Lambda(n, -I*(I*(2*n*pi + arg(-exp(-2*I*x))) + 2*im(x))),
         S.Integers)))).dummy_eq(Dummy('x,n'))
 
+def test_issue_18208():
+    vars = symbols('x0:16') + symbols('y0:12')
+    x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15,\
+    y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11 = vars
+
+    eqs = [x0 + x1 + x2 + x3 - 51,
+           x0 + x1 + x4 + x5 - 46,
+           x2 + x3 + x6 + x7 - 39,
+           x0 + x3 + x4 + x7 - 50,
+           x1 + x2 + x5 + x6 - 35,
+           x4 + x5 + x6 + x7 - 34,
+           x4 + x5 + x8 + x9 - 46,
+           x10 + x11 + x6 + x7 - 23,
+           x11 + x4 + x7 + x8 - 25,
+           x10 + x5 + x6 + x9 - 44,
+           x10 + x11 + x8 + x9 - 35,
+           x12 + x13 + x8 + x9 - 35,
+           x10 + x11 + x14 + x15 - 29,
+           x11 + x12 + x15 + x8 - 35,
+           x10 + x13 + x14 + x9 - 29,
+           x12 + x13 + x14 + x15 - 29,
+           y0 + y1 + y2 + y3 - 55,
+           y0 + y1 + y4 + y5 - 53,
+           y2 + y3 + y6 + y7 - 56,
+           y0 + y3 + y4 + y7 - 57,
+           y1 + y2 + y5 + y6 - 52,
+           y4 + y5 + y6 + y7 - 54,
+           y4 + y5 + y8 + y9 - 48,
+           y10 + y11 + y6 + y7 - 60,
+           y11 + y4 + y7 + y8 - 51,
+           y10 + y5 + y6 + y9 - 57,
+           y10 + y11 + y8 + y9 - 54,
+           x10 - 2,
+           x11 - 5,
+           x12 - 1,
+           x13 - 6,
+           x14 - 1,
+           x15 - 21,
+           y0 - 12,
+           y1 - 20]
+
+    # solve
+    solve_expected = {x0: 38 - x3, x1: x3 - 10, x2: 23 - x3, x4: 12 - x7, x5: x7 + 6,
+                x6: 16 - x7, x8: 8, x9: 20, x10: 2, x11: 5, x12: 1, x13: 6, x14: 1,
+                x15: 21, y0: 12, y1: 20, y2: -y11 + y9 + 2, y3: y11 - y9 + 21,
+                y4: -y11 - y7 + y9 + 24, y5: y11 + y7 - y9 - 3, y6: 33 - y7, y8: 27 - y9,
+                y10: 27 - y11}
+
+    assert solve(eqs, vars) == solve_expected
+
+    # linsolve
+    A, b = linear_eq_to_matrix(eqs, vars)
+    linsolve_expected = FiniteSet((38 - x3, x3 - 10, 23 - x3, x3, 12 - x7, x7 + 6, 16 - x7, x7,
+                          8, 20, 2, 5, 1, 6, 1, 21, 12, 20, -y11 + y9 + 2, y11 - y9 + 21,
+                          -y11 - y7 + y9 + 24, y11 + y7 - y9 - 3, 33 - y7, y7, 27 - y9, y9,
+                          27 - y11, y11))
+
+    assert linsolve(eqs, vars) == linsolve_expected
+    assert linsolve((A, b), vars) == linsolve_expected
+
+    # gauss_jordan_solve
+    gj_solve, new_vars = A.gauss_jordan_solve(b)
+    gj_solve = [i for i in gj_solve]
+    tau0, tau1, tau2, tau3, tau4 = symbols([str(v) for v in new_vars])
+
+    gj_expected = linsolve_expected.subs(zip([x3, x7, y7, y9, y11], new_vars))
+
+    assert FiniteSet(Tuple(*gj_solve)) == gj_expected
+
+    # nonlinsolve
+    # The solution set of nonlinsolve is currently equivalent to linsolve and is
+    # also correct. However, we would prefer to use the same symbols as parameters
+    # for the solution to the underdetermined system in all cases if possible.
+    # We want a solution that is not just equivalent but also given in the same form.
+    # This test may be changed should nonlinsolve be modified in this way.
+
+    nonlinsolve_expected = FiniteSet((38 - x3, x3 - 10, 23 - x3, x3, 12 - x7, x7 + 6,
+                                      16 - x7, x7, 8, 20, 2, 5, 1, 6, 1, 21, 12, 20,
+                                      -y5 + y7 - 1, y5 - y7 + 24, 21 - y5, y5, 33 - y7,
+                                      y7, 27 - y9, y9, -y5 + y7 - y9 + 24, y5 - y7 + y9 + 3))
+
+    assert nonlinsolve(eqs, vars) == nonlinsolve_expected
 
 @XFAIL
 def test_substitution_with_infeasible_solution():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2532,21 +2532,20 @@ def test_issue_18208():
            y0 - 12,
            y1 - 20]
 
+    expected = [38 - x3, x3 - 10, 23 - x3, x3, 12 - x7, x7 + 6, 16 - x7, x7,
+                8, 20, 2, 5, 1, 6, 1, 21, 12, 20, -y11 + y9 + 2, y11 - y9 + 21,
+                -y11 - y7 + y9 + 24, y11 + y7 - y9 - 3, 33 - y7, y7, 27 - y9, y9,
+                27 - y11, y11]
+
+    A, b = linear_eq_to_matrix(eqs, vars)
+
     # solve
-    solve_expected = {x0: 38 - x3, x1: x3 - 10, x2: 23 - x3, x4: 12 - x7, x5: x7 + 6,
-                x6: 16 - x7, x8: 8, x9: 20, x10: 2, x11: 5, x12: 1, x13: 6, x14: 1,
-                x15: 21, y0: 12, y1: 20, y2: -y11 + y9 + 2, y3: y11 - y9 + 21,
-                y4: -y11 - y7 + y9 + 24, y5: y11 + y7 - y9 - 3, y6: 33 - y7, y8: 27 - y9,
-                y10: 27 - y11}
+    solve_expected = {v:eq for v, eq in zip(vars, expected) if v != eq}
 
     assert solve(eqs, vars) == solve_expected
 
     # linsolve
-    A, b = linear_eq_to_matrix(eqs, vars)
-    linsolve_expected = FiniteSet((38 - x3, x3 - 10, 23 - x3, x3, 12 - x7, x7 + 6, 16 - x7, x7,
-                          8, 20, 2, 5, 1, 6, 1, 21, 12, 20, -y11 + y9 + 2, y11 - y9 + 21,
-                          -y11 - y7 + y9 + 24, y11 + y7 - y9 - 3, 33 - y7, y7, 27 - y9, y9,
-                          27 - y11, y11))
+    linsolve_expected = FiniteSet(Tuple(*expected))
 
     assert linsolve(eqs, vars) == linsolve_expected
     assert linsolve((A, b), vars) == linsolve_expected


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18208 

#### Brief description of what is fixed or changed
`solve` was solving a system of equations in a different, albeit valid, way to `linsolve`. Modified the way `solvers._solve_system` sorts symbols to preserve order and keep `solve` and `linsolve` in sync.

#### Other comments
Will be adding tests for other solvers to test the same system of equations which caused the issue.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Modified symbols sorting in solvers._solve_system to ensure solve and linsolve solve the same way
<!-- END RELEASE NOTES -->