### PR TITLE
Fixed OverflowError in plot

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -176,8 +176,8 @@ class lambdify:
             if abs(result.imag) > 1e-7 * abs(result):
                 return None
             return result.real
-        except (ZeroDivisionError, TypeError) as e:
-            if isinstance(e, ZeroDivisionError):
+        except (ZeroDivisionError, OverflowError, TypeError) as e:
+            if isinstance(e, ZeroDivisionError) or isinstance(e, OverflowError):
                 return None
 
             if self.failure:


### PR DESCRIPTION
#### Changes
Added handling for `OverflowError` caused while plotting expressions involving `exp(1/x)`.
#### The Bug
```python
>>> from sympy import *
>>> x = Symbol('x')
>>> plot(exp(1/x))
F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py:1486: RuntimeWarning: invalid value encountered in double_scalars
  cos_theta = dot_product / (vector_a_norm * vector_b_norm)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 1725, in plot
    plots.show()
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 219, in show
    self._backend.show()
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 1401, in show
    self.process_series()
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 1398, in process_series
    self._process_series(series, ax, parent)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 1226, in _process_series
    collection = self.LineCollection(s.get_segments())
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 697, in get_segments
    sample(np.array([self.start, f_start]),
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 668, in sample
    sample(p, new_point, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 669, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 669, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 669, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 668, in sample
    sample(p, new_point, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 669, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 691, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 691, in sample
    sample(new_point, q, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 691, in sample
    sample(new_point, q, depth + 1)
  [Previous line repeated 3 more times]
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 690, in sample
    sample(p, new_point, depth + 1)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\plot.py", line 658, in sample
    ynew = f(xnew)
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\experimental_lambdify.py", line 170, in __call__
    result = complex(self.lambda_func(args))
  File "F:\MyPrograms\Python\lib\site-packages\sympy\plotting\experimental_lambdify.py", line 267, in __call__
    return self.lambda_func(*args, **kwargs)
  File "<string>", line 1, in <lambda>
OverflowError: math range error
```


#### Resolution
During the sampling of the expression `exp(1/x)`, a very large value is encountered which causes it to crash in `OverflowError`. This error is (kind of) similar to the `ZeroDivisionError` because in both the cases, the resultant value is arbitrarily large (at least for the computer), and so we handle it just like the `ZeroDivisionError` (that has already been implemented).

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* plotting
  * Added handling for `OverflowError` (when plotting functions like `exp(1/x)`).
<!-- END RELEASE NOTES -->