### PR TITLE
maint(ci): unpin versions of optional dependencies in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           python-version: 3.8
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
+      - run: python -m pip install --upgrade pip
       - run: pip install mpmath gmpy2 matplotlib numpy scipy theano ipython \
                          symengine tensorflow cython llvmlite wurlitzer \
                          autowrap numexpr 'antlr4-python3-runtime==4.7.*'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -86,15 +86,16 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: release/aptinstall.sh
-      - run: sudo apt-get install libmpfr-dev libmpc-dev
-      - run: release/venv_main/bin/python -m pip install gmpy2
+      - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
+      - run: pip install mpmath gmpy2 matplotlib numpy scipy theano ipython \
+                         symengine tensorflow cython llvmlite wurlitzer \
+                         autowrap numexpr 'antlr4-python3-runtime==4.7.*'
       # Test external imports
-      - run: release/venv_main/bin/python bin/test_external_imports.py
-      - run: release/venv_main/bin/python bin/test_submodule_imports.py
-      - run: release/venv_main/bin/python bin/test_executable.py
-      # Test modules for specific dependencies
-      - run: release/venv_main/bin/python bin/test_optional_dependencies.py
+      - run: bin/test_external_imports.py
+      - run: bin/test_submodule_imports.py
+      - run: bin/test_executable.py
+      # Test modules with specific dependencies
+      - run: bin/test_optional_dependencies.py
 
   # -------------------- Slow test split 1/2 ----------------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -89,7 +89,7 @@ jobs:
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip
       - run: pip install mpmath gmpy2 matplotlib numpy scipy theano ipython \
-                         symengine tensorflow cython llvmlite wurlitzer \
+                         symengine cython llvmlite wurlitzer \
                          autowrap numexpr 'antlr4-python3-runtime==4.7.*'
       # Test external imports
       - run: bin/test_external_imports.py

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+"""
+Run tests for specific packages that use optional dependencies.
+
+The optional dependencies need to be installed before running this.
+"""
+
 class TestsFailedError(Exception):
     pass
 

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -5,6 +5,12 @@ Run tests for specific packages that use optional dependencies.
 The optional dependencies need to be installed before running this.
 """
 
+
+# Add the local sympy to sys.path (needed for CI)
+from get_sympy import path_hack
+path_hack()
+
+
 class TestsFailedError(Exception):
     pass
 

--- a/sympy/physics/quantum/identitysearch.py
+++ b/sympy/physics/quantum/identitysearch.py
@@ -79,7 +79,7 @@ def is_scalar_sparse_matrix(circuit, nqubits, identity_only, eps=1e-11):
         corrected_real = np.where(bool_real, 0.0, dense_matrix.real)
         corrected_imag = np.where(bool_imag, 0.0, dense_matrix.imag)
         # Convert the matrix with real values into imaginary values
-        corrected_imag = corrected_imag * np.complex(1j)
+        corrected_imag = corrected_imag * complex(1j)
         # Recombine the real and imaginary components
         corrected_dense = corrected_real + corrected_imag
 

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -117,7 +117,7 @@ class vectorized_lambdify:
         self.lambda_func_2 = experimental_lambdify(
             args, expr, use_python_cmath=True)
         self.vector_func_2 = self.np.vectorize(
-            self.lambda_func_2, otypes=[self.np.complex])
+            self.lambda_func_2, otypes=[complex])
 
         self.vector_func = self.vector_func_1
         self.failure = False
@@ -126,7 +126,7 @@ class vectorized_lambdify:
         np = self.np
 
         try:
-            temp_args = (np.array(a, dtype=np.complex) for a in args)
+            temp_args = (np.array(a, dtype=complex) for a in args)
             results = self.vector_func(*temp_args)
             results = np.ma.masked_where(
                 np.abs(results.imag) > 1e-7 * np.abs(results),

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1493,8 +1493,8 @@ def flat(x, y, z, eps=1e-3):
     #   workaround for `lambdify` in `.experimental_lambdify` fails
     #   to return numerical values in some cases. Lower-level fix
     #   in `lambdify` is possible.
-    vector_a = (x - y).astype(np.float)
-    vector_b = (z - y).astype(np.float)
+    vector_a = (x - y).astype(np.float64)
+    vector_b = (z - y).astype(np.float64)
     dot_product = np.dot(vector_a, vector_b)
     vector_a_norm = np.linalg.norm(vector_a)
     vector_b_norm = np.linalg.norm(vector_b)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Unpin dependencies as in #20623 (partial fix because need to do the same for the docs build - also the way this is done does not yet run with the newest numpy version so it's not quite right...)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->