### PR TITLE
maint(ci): skip failing doctest in sympy/physics/vector/frame.py

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -835,7 +835,7 @@ class ReferenceFrame:
         >>> B1.orient_axis(N, N.z, q1)
         >>> B2.orient_axis(B1, N.x, q2)
         >>> B.orient_axis(B2, N.y, q3)
-        >>> B.dcm(N).simplify()
+        >>> B.dcm(N).simplify() # doctest: +SKIP
         Matrix([
         [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2),                                                                                sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
         [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(-q1 + q2 + q3)/4 - sin(q1 - q2 + q3)/4 + sin(q1 + q2 - q3)/4 + sin(q1 + q2 + q3)/4 + cos(q1 - q3)/2 - cos(q1 + q3)/2],


### PR DESCRIPTION
The test passes sometimes and fails at other times. It was causing
failures in CI so for now this commit disables the test.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/pull/20946#issuecomment-778467372


#### Brief description of what is fixed or changed

Disables a test that fails intermittently

#### Other comments

If this is merged then an issue should be opened pointing to the previous discussion - this does not fix the issue but it does unblock CI by disabling the test.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->