### PR TITLE
Added sub, neg and scalar mul for TWave

### DIFF
--- a/sympy/physics/optics/__init__.py
+++ b/sympy/physics/optics/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     'jones_vector', 'stokes_vector', 'jones_2_stokes', 'linear_polarizer',
     'phase_retarder', 'half_wave_retarder', 'quarter_wave_retarder',
     'transmissive_filter', 'reflective_filter', 'mueller_matrix',
-    'polarizing_beam_splitte',
+    'polarizing_beam_splitter',
 ]
 from .waves import TWave
 
@@ -35,4 +35,4 @@ from .utils import (refraction_angle, deviation, fresnel_coefficients,
 from .polarization import (jones_vector, stokes_vector, jones_2_stokes,
         linear_polarizer, phase_retarder, half_wave_retarder,
         quarter_wave_retarder, transmissive_filter, reflective_filter,
-        mueller_matrix)
+        mueller_matrix, polarizing_beam_splitter)

--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -9,7 +9,6 @@ from sympy.testing.pytest import raises
 
 c = speed_of_light.convert_to(m/s)
 
-
 def test_twave():
     A1, phi1, A2, phi2, f = symbols('A1, phi1, A2, phi2, f')
     n = Symbol('n')  # Refractive index

--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -26,26 +26,54 @@ def test_twave():
     assert w1.angular_velocity == 2*pi*f
     assert w1.wavenumber == 2*pi*f*n/c
     assert w1.speed == c/n
+
     w3 = w1 + w2
     assert w3.amplitude == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2) + A2**2)
     assert w3.frequency == f
-    assert w3.phase == atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2))
+    assert w3.phase == atan2(A1*sin(phi1) + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2))
     assert w3.wavelength == c/(f*n)
     assert w3.time_period == 1/f
     assert w3.angular_velocity == 2*pi*f
     assert w3.wavenumber == 2*pi*f*n/c
     assert w3.speed == c/n
-    assert simplify(w3.rewrite(sin) - sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
-    + A2**2)*sin(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*cos(phi1)
-    + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2)) + pi/2)) == 0
+    assert simplify(w3.rewrite(sin) - w2.rewrite(sin) - w1.rewrite(sin)) == 0
     assert w3.rewrite('pde') == epsilon*mu*Derivative(E(x, t), t, t) + Derivative(E(x, t), x, x)
     assert w3.rewrite(cos) == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
-    + A2**2)*cos(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*cos(phi1)
-    + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2)))
+        + A2**2)*cos(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*sin(phi1)
+        + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2)))
     assert w3.rewrite(exp) == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
-    + A2**2)*exp(I*(pi*f*n*x*s/(149896229*m) - 2*pi*f*t
-    + atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2))))
+        + A2**2)*exp(I*(-2*pi*f*t + atan2(A1*sin(phi1) + A2*sin(phi2), A1*cos(phi1)
+        + A2*cos(phi2)) + pi*s*f*n*x/(149896229*m)))
+
     w4 = TWave(A1, None, 0, 1/f)
     assert w4.frequency == f
+
+    w5 = w1 - w2
+    assert w5.amplitude == sqrt(A1**2 - 2*A1*A2*cos(phi1 - phi2) + A2**2)
+    assert w5.frequency == f
+    assert w5.phase == atan2(A1*sin(phi1) - A2*sin(phi2), A1*cos(phi1) - A2*cos(phi2))
+    assert w5.wavelength == c/(f*n)
+    assert w5.time_period == 1/f
+    assert w5.angular_velocity == 2*pi*f
+    assert w5.wavenumber == 2*pi*f*n/c
+    assert w5.speed == c/n
+    assert simplify(w5.rewrite(sin) - w1.rewrite(sin) + w2.rewrite(sin)) == 0
+    assert w5.rewrite('pde') == epsilon*mu*Derivative(E(x, t), t, t) + Derivative(E(x, t), x, x)
+    assert w5.rewrite(cos) == sqrt(A1**2 - 2*A1*A2*cos(phi1 - phi2)
+        + A2**2)*cos(-2*pi*f*t + atan2(A1*sin(phi1) - A2*sin(phi2), A1*cos(phi1)
+        - A2*cos(phi2)) + pi*s*f*n*x/(149896229*m))
+    assert w5.rewrite(exp) == sqrt(A1**2 - 2*A1*A2*cos(phi1 - phi2)
+        + A2**2)*exp(I*(-2*pi*f*t + atan2(A1*sin(phi1) - A2*sin(phi2), A1*cos(phi1)
+        - A2*cos(phi2)) + pi*s*f*n*x/(149896229*m)))
+
+    w6 = 2*w1
+    assert w6.amplitude == 2*A1
+    assert w6.frequency == f
+    assert w6.phase == phi1
+    w7 = -w6
+    assert w7.amplitude == -2*A1
+    assert w7.frequency == f
+    assert w7.phase == phi1
+
     raises(ValueError, lambda:TWave(A1))
     raises(ValueError, lambda:TWave(A1, f, phi1, t))

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -8,7 +8,7 @@ This module has all the classes and functions related to waves in optics.
 
 __all__ = ['TWave']
 
-from sympy import (sympify, pi, sin, cos, sqrt, Symbol, S,
+from sympy import (sympify, pi, sin, cos, sqrt, Number, Symbol, S,
     symbols, Derivative, atan2)
 from sympy.core.expr import Expr
 from sympy.physics.units import speed_of_light, meter, second
@@ -28,7 +28,7 @@ class TWave(Expr):
     ===========
 
     It is represented as :math:`A \times cos(k*x - \omega \times t + \phi )`,
-    where :math:`A` is the amplitude, :math:`\omega` is the angular velocity,
+    where :math:`A` is the amplitude, :math:`\omega` is the angular frequency,
     :math:`k` is the wavenumber (spatial frequency), :math:`x` is a spatial variable
     to represent the position on the dimension on which the wave propagates,
     and :math:`\phi` is the phase angle of the wave.
@@ -67,11 +67,11 @@ class TWave(Expr):
     >>> w3 = w1 + w2  # Superposition of two waves
     >>> w3
     TWave(sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2) + A2**2), f,
-        atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2)))
+        atan2(A1*sin(phi1) + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2)))
     >>> w3.amplitude
     sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2) + A2**2)
     >>> w3.phase
-    atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2))
+    atan2(A1*sin(phi1) + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2))
     >>> w3.speed
     299792458*meter/(second*n)
     >>> w3.angular_velocity
@@ -266,19 +266,44 @@ class TWave(Expr):
         if isinstance(other, TWave):
             if self._frequency == other._frequency and self.wavelength == other.wavelength:
                 return TWave(sqrt(self._amplitude**2 + other._amplitude**2 + 2 *
-                                  self.amplitude*other.amplitude*cos(
+                                  self._amplitude*other._amplitude*cos(
                                       self._phase - other.phase)),
-                             self.frequency,
-                             atan2(self._amplitude*cos(self._phase)
-                             +other._amplitude*cos(other._phase),
-                             self._amplitude*sin(self._phase)
-                             +other._amplitude*sin(other._phase))
+                             self._frequency,
+                             atan2(self._amplitude*sin(self._phase)
+                             +other._amplitude*sin(other._phase),
+                             self._amplitude*cos(self._phase)
+                             +other._amplitude*cos(other._phase))
                              )
             else:
                 raise NotImplementedError("Interference of waves with different frequencies"
                     " has not been implemented.")
         else:
             raise TypeError(type(other).__name__ + " and TWave objects can't be added.")
+
+    def __mul__(self, other):
+        """
+        Multiplying a wave by a scalar rescales the amplitude of the wave.
+        """
+        other = sympify(other)
+        if isinstance(other, Number):
+            return TWave(self._amplitude*other, *self.args[1:])
+        else:
+            raise TypeError(type(other).__name__ + " and TWave objects can't be multiplied.")
+
+    def __sub__(self, other):
+            return self.__add__(-1*other)
+
+    def __neg__(self):
+            return self.__mul__(-1)
+
+    def __radd__(self, other):
+            return self.__add__(other)
+
+    def __rmul__(self, other):
+            return self.__mul__(other)
+
+    def __rsub__(self,other):
+            return (-self).__radd__(other)
 
     def _eval_rewrite_as_sin(self, *args, **kwargs):
         return self._amplitude*sin(self.wavenumber*Symbol('x')

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -270,9 +270,9 @@ class TWave(Expr):
                                       self._phase - other.phase)),
                              self._frequency,
                              atan2(self._amplitude*sin(self._phase)
-                             +other._amplitude*sin(other._phase),
+                             + other._amplitude*sin(other._phase),
                              self._amplitude*cos(self._phase)
-                             +other._amplitude*cos(other._phase))
+                             + other._amplitude*cos(other._phase))
                              )
             else:
                 raise NotImplementedError("Interference of waves with different frequencies"
@@ -291,19 +291,19 @@ class TWave(Expr):
             raise TypeError(type(other).__name__ + " and TWave objects can't be multiplied.")
 
     def __sub__(self, other):
-            return self.__add__(-1*other)
+        return self.__add__(-1*other)
 
     def __neg__(self):
-            return self.__mul__(-1)
+        return self.__mul__(-1)
 
     def __radd__(self, other):
-            return self.__add__(other)
+        return self.__add__(other)
 
     def __rmul__(self, other):
-            return self.__mul__(other)
+        return self.__mul__(other)
 
-    def __rsub__(self,other):
-            return (-self).__radd__(other)
+    def __rsub__(self, other):
+        return (-self).__radd__(other)
 
     def _eval_rewrite_as_sin(self, *args, **kwargs):
         return self._amplitude*sin(self.wavenumber*Symbol('x')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #8887 

#### Brief description of what is fixed or changed
TWave subtraction was returning an `Add` object and hence did not have required attributes. This has been fixed.
Neg, sub and scalar mul for `TWave` have been added, as scalar multiplication with `TWave` was also giving a `Mul`.
Some minor changes have been made to the documentation, tests and init.

#### Other comments
All credits for this work go to @kevinventullo but I do not know how to include his commits as his fork and branch have been deleted. Original work was https://github.com/sympy/sympy/pull/8908

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.optics
    * Fixed bugs related to basic operations on `TWave`
<!-- END RELEASE NOTES -->
