### PR TITLE
Expanding documentation

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -37,6 +37,10 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode', 'sphinx_math_dollar',
 # with the -W flag in the Makefile.
 nitpicky = True
 
+nitpick_ignore = [
+    ('py:class', 'sympy.logic.boolalg.Boolean')
+]
+
 # To stop docstrings inheritance.
 autodoc_inherit_docstrings = False
 

--- a/doc/src/modules/assumptions/index.rst
+++ b/doc/src/modules/assumptions/index.rst
@@ -11,9 +11,11 @@ Predicate
 =========
 
 .. autoclass:: sympy.assumptions.assume::Predicate
+   :members:
    :noindex:
 
 .. autoclass:: sympy.assumptions.assume::AppliedPredicate
+   :members:
    :noindex:
 
 

--- a/doc/src/modules/assumptions/predicates.rst
+++ b/doc/src/modules/assumptions/predicates.rst
@@ -13,11 +13,13 @@ Tautological
 ------------
 
 .. autoclass:: sympy.assumptions.predicates.common.IsTruePredicate
+   :members:
 
 Commutative
 -----------
 
 .. autoclass:: sympy.assumptions.predicates.common.CommutativePredicate
+   :members:
 
 Calculus
 ========
@@ -26,11 +28,13 @@ Finite
 ------
 
 .. autoclass:: sympy.assumptions.predicates.calculus.FinitePredicate
+   :members:
 
 Infinite
 --------
 
 .. autoclass:: sympy.assumptions.predicates.calculus.InfinitePredicate
+   :members:
 
 Matrix
 ======
@@ -39,86 +43,103 @@ Symmetric
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.SymmetricPredicate
+   :members:
 
 Invertible
 ----------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.InvertiblePredicate
+   :members:
 
 Orthogonal
 ----------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.OrthogonalPredicate
+   :members:
 
 Unitary
 -------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.UnitaryPredicate
+   :members:
 
 Positive Definite
 -----------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.PositiveDefinitePredicate
+   :members:
 
 Upper triangular
 ----------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.UpperTriangularPredicate
+   :members:
 
 Lower triangular
 ----------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.LowerTriangularPredicate
+   :members:
 
 Diagonal
 --------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.DiagonalPredicate
+   :members:
 
 Full rank
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.FullRankPredicate
+   :members:
 
 Square
 ------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.SquarePredicate
+   :members:
 
 Integer elements
 ----------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.IntegerElementsPredicate
+   :members:
 
 Real elements
 -------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.RealElementsPredicate
+   :members:
 
 Complex elements
 ----------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.ComplexElementsPredicate
+   :members:
 
 Singular
 --------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.SingularPredicate
+   :members:
 
 Normal
 ------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.NormalPredicate
+   :members:
 
 Triangular
 ----------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.TriangularPredicate
+   :members:
 
 Unit triangular
 ---------------
 
 .. autoclass:: sympy.assumptions.predicates.matrices.UnitTriangularPredicate
+   :members:
 
 Number Theory
 =============
@@ -127,21 +148,25 @@ Even
 ----
 
 .. autoclass:: sympy.assumptions.predicates.ntheory.EvenPredicate
+   :members:
 
 Odd
 ---
 
 .. autoclass:: sympy.assumptions.predicates.ntheory.OddPredicate
+   :members:
 
 Prime
 -----
 
 .. autoclass:: sympy.assumptions.predicates.ntheory.PrimePredicate
+   :members:
 
 Composite
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.ntheory.CompositePredicate
+   :members:
 
 Order
 =====
@@ -150,31 +175,37 @@ Positive
 --------
 
 ... autoclass:: sympy.assumptions.predicates.order.PositivePredicate
+   :members:
 
 Negative
 --------
 
 .. autoclass:: sympy.assumptions.predicates.order.NegativePredicate
+   :members:
 
 Zero
 ----
 
 .. autoclass:: sympy.assumptions.predicates.order.ZeroPredicate
+   :members:
 
 Nonzero
 -------
 
 .. autoclass:: sympy.assumptions.predicates.order.NonZeroPredicate
+   :members:
 
 Nonpositive
 -----------
 
 .. autoclass:: sympy.assumptions.predicates.order.NonPositivePredicate
+   :members:
 
 Nonnegative
 -----------
 
 .. autoclass:: sympy.assumptions.predicates.order.NonNegativePredicate
+   :members:
 
 Sets
 ====
@@ -183,53 +214,64 @@ Integer
 -------
 
 .. autoclass:: sympy.assumptions.predicates.sets.IntegerPredicate
+   :members:
 
 Rational
 --------
 
 .. autoclass:: sympy.assumptions.predicates.sets.RationalPredicate
+   :members:
 
 Irrational
 ----------
 
 .. autoclass:: sympy.assumptions.predicates.sets.IrrationalPredicate
+   :members:
 
 Real
 ----
 
 .. autoclass:: sympy.assumptions.predicates.sets.RealPredicate
+   :members:
 
 Extended real
 -------------
 
 .. autoclass:: sympy.assumptions.predicates.sets.ExtendedRealPredicate
+   :members:
 
 Hermitian
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.sets.HermitianPredicate
+   :members:
 
 Complex
 -------
 
 .. autoclass:: sympy.assumptions.predicates.sets.ComplexPredicate
+   :members:
 
 Imaginary
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.sets.ImaginaryPredicate
+   :members:
 
 Antihermitian
 -------------
 
 .. autoclass:: sympy.assumptions.predicates.sets.AntihermitianPredicate
+   :members:
 
 Algebraic
 ---------
 
 .. autoclass:: sympy.assumptions.predicates.sets.AlgebraicPredicate
+   :members:
 
 Transcendental
 --------------
 
 .. autoclass:: sympy.assumptions.predicates.sets.TranscendentalPredicate
+   :members:

--- a/doc/src/modules/categories.rst
+++ b/doc/src/modules/categories.rst
@@ -62,6 +62,7 @@ diagrams.
    :members:
 
 .. autoclass:: ArrowStringDescription
+   :members:
 
 .. autoclass:: XypicDiagramDrawer
    :members:

--- a/doc/src/modules/functions/elementary.rst
+++ b/doc/src/modules/functions/elementary.rst
@@ -76,49 +76,42 @@ sin
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.sin
-
    :members:
 
 cos
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.cos
-
    :members:
 
 tan
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.tan
-
    :members:
 
 cot
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.cot
-
    :members:
 
 sec
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.sec
-
    :members:
 
 csc
 ---
 
 .. autoclass:: sympy.functions.elementary.trigonometric.csc
-
    :members:
 
 sinc
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.sinc
-
    :members:
 
 
@@ -129,49 +122,42 @@ asin
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.asin
-
    :members:
 
 acos
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.acos
-
    :members:
 
 atan
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.atan
-
    :members:
 
 acot
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.acot
-
    :members:
 
 asec
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.asec
-
    :members:
 
 acsc
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.acsc
-
    :members:
 
 atan2
 -----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.atan2
-
    :members:
 
 
@@ -186,49 +172,42 @@ HyperbolicFunction
 ------------------
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.HyperbolicFunction
-
    :members:
 
 sinh
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.sinh
-
    :members:
 
 cosh
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.cosh
-
    :members:
 
 tanh
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.tanh
-
    :members:
 
 coth
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.coth
-
    :members:
 
 sech
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.sech
-
    :members:
 
 csch
 ----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.csch
-
    :members:
 
 
@@ -239,42 +218,36 @@ asinh
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.asinh
-
    :members:
 
 acosh
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.acosh
-
    :members:
 
 atanh
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.atanh
-
    :members:
 
 acoth
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.acoth
-
    :members:
 
 asech
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.asech
-
    :members:
 
 acsch
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.acsch
-
    :members:
 
 sympy.functions.elementary.integers
@@ -284,7 +257,6 @@ ceiling
 -------
 
 .. autoclass:: sympy.functions.elementary.integers.ceiling
-
    :members:
 
 
@@ -292,7 +264,6 @@ floor
 -----
 
 .. autoclass:: sympy.functions.elementary.integers.floor
-
    :members:
 
 
@@ -300,12 +271,14 @@ RoundFunction
 -------------
 
 .. autoclass:: sympy.functions.elementary.integers.RoundFunction
+   :members:
 
 
 frac
 ----
 
 .. autoclass:: sympy.functions.elementary.integers.frac
+   :members:
 
 sympy.functions.elementary.exponential
 ======================================
@@ -314,21 +287,18 @@ exp
 ---
 
 .. autoclass:: sympy.functions.elementary.exponential.exp
-
    :members:
 
 LambertW
 --------
 
 .. autoclass:: sympy.functions.elementary.exponential.LambertW
-
    :members:
 
 log
 ---
 
 .. autoclass:: sympy.functions.elementary.exponential.log
-
    :members:
 
 
@@ -336,7 +306,6 @@ exp_polar
 ---------
 
 .. autoclass:: sympy.functions.elementary.exponential.exp_polar
-
    :members:
 
 
@@ -347,7 +316,6 @@ ExprCondPair
 ------------
 
 .. autoclass:: sympy.functions.elementary.piecewise.ExprCondPair
-
    :members:
 
 
@@ -355,8 +323,9 @@ Piecewise
 ---------
 
 .. autoclass:: sympy.functions.elementary.piecewise.Piecewise
-
    :members:
+
+   .. automethod:: sympy.functions.elementary.piecewise.Piecewise._eval_integral
 
 .. autofunction:: sympy.functions.elementary.piecewise.piecewise_fold
 
@@ -368,14 +337,12 @@ IdentityFunction
 ----------------
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.IdentityFunction
-
    :members:
 
 Min
 ---
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Min
-
    :members:
 
 
@@ -383,7 +350,6 @@ Max
 ---
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Max
-
    :members:
 
 root

--- a/doc/src/modules/functions/special.rst
+++ b/doc/src/modules/functions/special.rst
@@ -29,12 +29,15 @@ Gamma, Beta and related Functions
 .. autoclass:: sympy.functions.special.gamma_functions.polygamma
    :members:
 .. autoclass:: sympy.functions.special.gamma_functions.digamma
+   :members:
 .. autoclass:: sympy.functions.special.gamma_functions.trigamma
+   :members:
 .. autoclass:: sympy.functions.special.gamma_functions.uppergamma
    :members:
 .. autoclass:: sympy.functions.special.gamma_functions.lowergamma
    :members:
 .. autoclass:: sympy.functions.special.gamma_functions.multigamma
+   :members:
 .. module:: sympy.functions.special.beta_functions
 .. autoclass:: sympy.functions.special.beta_functions.beta
    :members:
@@ -44,31 +47,48 @@ Error Functions and Fresnel Integrals
 .. module:: sympy.functions.special.error_functions
 
 .. autoclass:: sympy.functions.special.error_functions.erf
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erfc
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erfi
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erf2
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erfinv
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erfcinv
+   :members:
 .. autoclass:: sympy.functions.special.error_functions.erf2inv
+   :members:
 
 .. autoclass:: sympy.functions.special.error_functions.FresnelIntegral
    :members:
 
 .. autoclass:: fresnels
+   :members:
 .. autoclass:: fresnelc
+   :members:
 
 Exponential, Logarithmic and Trigonometric Integrals
 ----------------------------------------------------
 
 .. autoclass:: Ei
+   :members:
 .. autoclass:: expint
+   :members:
 .. autofunction:: E1
 .. autoclass:: li
+   :members:
 .. autoclass:: Li
+   :members:
 .. autoclass:: Si
+   :members:
 .. autoclass:: Ci
+   :members:
 .. autoclass:: Shi
+   :members:
 .. autoclass:: Chi
+   :members:
 
 Bessel Type Functions
 ---------------------
@@ -79,18 +99,27 @@ Bessel Type Functions
    :members:
 
 .. autoclass:: sympy.functions.special.bessel.besselj
+   :members:
 .. autoclass:: sympy.functions.special.bessel.bessely
+   :members:
 .. _besseli:
 .. autoclass:: sympy.functions.special.bessel.besseli
+   :members:
 .. autoclass:: sympy.functions.special.bessel.besselk
+   :members:
 .. autoclass:: sympy.functions.special.bessel.hankel1
+   :members:
 .. autoclass:: sympy.functions.special.bessel.hankel2
+   :members:
 .. autoclass:: sympy.functions.special.bessel.jn
+   :members:
 .. autoclass:: sympy.functions.special.bessel.yn
+   :members:
 
 .. autofunction:: sympy.functions.special.bessel.jn_zeros
 
 .. autoclass:: sympy.functions.special.bessel.marcumq
+   :members:
 
 Airy Functions
 --------------
@@ -99,9 +128,13 @@ Airy Functions
    :members:
 
 .. autoclass:: sympy.functions.special.bessel.airyai
+   :members:
 .. autoclass:: sympy.functions.special.bessel.airybi
+   :members:
 .. autoclass:: sympy.functions.special.bessel.airyaiprime
+   :members:
 .. autoclass:: sympy.functions.special.bessel.airybiprime
+   :members:
 
 B-Splines
 ---------
@@ -115,10 +148,15 @@ Riemann Zeta and Related Functions
 .. module:: sympy.functions.special.zeta_functions
 
 .. autoclass:: zeta
+   :members:
 .. autoclass:: dirichlet_eta
+   :members:
 .. autoclass:: polylog
+   :members:
 .. autoclass:: lerchphi
+   :members:
 .. autoclass:: stieltjes
+   :members:
 
 Hypergeometric Functions
 ------------------------
@@ -136,9 +174,13 @@ Elliptic integrals
 .. module:: sympy.functions.special.elliptic_integrals
 
 .. autoclass:: elliptic_k
+   :members:
 .. autoclass:: elliptic_f
+   :members:
 .. autoclass:: elliptic_e
+   :members:
 .. autoclass:: elliptic_pi
+   :members:
 
 Mathieu Functions
 -----------------
@@ -148,9 +190,13 @@ Mathieu Functions
    :members:
 
 .. autoclass:: sympy.functions.special.mathieu_functions.mathieus
+   :members:
 .. autoclass:: sympy.functions.special.mathieu_functions.mathieuc
+   :members:
 .. autoclass:: sympy.functions.special.mathieu_functions.mathieusprime
+   :members:
 .. autoclass:: sympy.functions.special.mathieu_functions.mathieucprime
+   :members:
 
 Orthogonal Polynomials
 ----------------------
@@ -213,10 +259,12 @@ Spherical Harmonics
 -------------------
 
 .. autoclass:: sympy.functions.special.spherical_harmonics.Ynm
+   :members:
 
 .. autofunction:: sympy.functions.special.spherical_harmonics.Ynm_c
 
 .. autoclass:: sympy.functions.special.spherical_harmonics.Znm
+   :members:
 
 Tensor Functions
 ----------------

--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -62,29 +62,41 @@ SymPy has special support for definite integrals, and integral transforms.
 
 .. autofunction:: mellin_transform
 .. autoclass:: MellinTransform
+   :members:
 .. autofunction:: inverse_mellin_transform
 .. autoclass:: InverseMellinTransform
+   :members:
 .. autofunction:: laplace_transform
 .. autoclass:: LaplaceTransform
+   :members:
 .. autofunction:: inverse_laplace_transform
 .. autoclass:: InverseLaplaceTransform
+   :members:
 .. autofunction:: fourier_transform
 .. autofunction:: _fourier_transform
 .. autoclass:: FourierTransform
+   :members:
 .. autofunction:: inverse_fourier_transform
 .. autoclass:: InverseFourierTransform
+   :members:
 .. autofunction:: sine_transform
 .. autoclass:: SineTransform
+   :members:
 .. autofunction:: inverse_sine_transform
 .. autoclass:: InverseSineTransform
+   :members:
 .. autofunction:: cosine_transform
 .. autoclass:: CosineTransform
+   :members:
 .. autofunction:: inverse_cosine_transform
 .. autoclass:: InverseCosineTransform
+   :members:
 .. autofunction:: hankel_transform
 .. autoclass:: HankelTransform
+   :members:
 .. autofunction:: inverse_hankel_transform
 .. autoclass:: InverseHankelTransform
+   :members:
 .. autoclass:: IntegralTransform
    :members:
 .. autoexception:: IntegralTransformError
@@ -136,6 +148,7 @@ SymPy first applies several heuristic algorithms, as these are the fastest:
 
    .. autofunction:: sympy.integrals.risch::risch_integrate
    .. autoclass:: sympy.integrals.risch::NonElementaryIntegral
+      :members:
 
 6. For non-elementary definite integrals, SymPy uses so-called Meijer G-functions.
    Details are described in :ref:`g-functions`.

--- a/doc/src/modules/liealgebras/index.rst
+++ b/doc/src/modules/liealgebras/index.rst
@@ -5,37 +5,37 @@ Lie Algebra
 .. automodule:: sympy.liealgebras
 
 .. autoclass:: sympy.liealgebras.root_system.RootSystem
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_a.TypeA
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_b.TypeB
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_c.TypeC
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_d.TypeD
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_e.TypeE
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_f.TypeF
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.type_g.TypeG
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.weyl_group.WeylGroup
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.cartan_type.CartanType_generator
-    :members:
+   :members:
 
 .. autoclass:: sympy.liealgebras.cartan_type.Standard_Cartan
-    :members:
+   :members:
 
 .. autofunction:: sympy.liealgebras.dynkin_diagram.DynkinDiagram
 

--- a/doc/src/modules/logic.rst
+++ b/doc/src/modules/logic.rst
@@ -50,26 +50,37 @@ Boolean functions
 -----------------
 
 .. autoclass:: sympy.logic.boolalg::BooleanTrue
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::BooleanFalse
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::And
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Or
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Not
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Xor
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Nand
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Nor
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Implies
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::Equivalent
+   :members:
 
 .. autoclass:: sympy.logic.boolalg::ITE
+   :members:
 
 The following functions can be used to handle Conjunctive and Disjunctive Normal
 forms-

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -531,7 +531,7 @@ MatrixDeterminant Class Reference
 MatrixReductions Class Reference
 --------------------------------
 .. autoclass:: MatrixReductions
-    :members:
+   :members:
 
 MatrixSubspaces Class Reference
 -------------------------------
@@ -557,10 +557,13 @@ Matrix Exceptions Reference
 ---------------------------
 
 .. autoclass:: MatrixError
+   :members:
 
 .. autoclass:: ShapeError
+   :members:
 
 .. autoclass:: NonSquareMatrixError
+   :members:
 
 
 Matrix Functions Reference

--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -71,26 +71,26 @@ Ntheory Functions Reference
 .. autofunction:: antidivisor_count
 
 .. autoclass:: totient
-    :members:
+   :members:
 
 .. autoclass:: reduced_totient
-    :members:
+   :members:
 
 .. autoclass:: divisor_sigma
-    :members:
+   :members:
 
 .. autoclass:: udivisor_sigma
-    :members:
+   :members:
 
 .. autofunction:: core
 
 .. autofunction:: digits
 
 .. autoclass:: primenu
-    :members:
+   :members:
 
 .. autoclass:: primeomega
-    :members:
+   :members:
 
 .. autofunction:: mersenne_prime_exponent
 
@@ -204,7 +204,7 @@ of `ecm` is dependent on the smallest proper factor of the number. So even if th
 number is really large but its factors are comparatively smaller then `ecm`
 can easily factor them. For example we take `N` with 15 digit factors
 `15154262241479`, `15423094826093`, `799333555511111`, `809709509409109`,
-`888888877777777`, `914148152112161`. Now N is a 87 digit number. `ECM` takes 
+`888888877777777`, `914148152112161`. Now N is a 87 digit number. `ECM` takes
 under around 47s to factorise this.
 
 .. autofunction:: ecm

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -92,7 +92,7 @@ change between releases, and become stricter, more relaxed, or some mix.
 ----------------------------------------------
 
 .. autoclass:: sympy.parsing.latex.LaTeXParsingError
-
+   :members:
 
 SymPy Expression Reference
 --------------------------
@@ -100,7 +100,7 @@ SymPy Expression Reference
 .. module:: sympy.parsing.sym_expr
 
 .. autoclass:: SymPyExpression
-  :members:
+   :members:
 
 Runtime Installation
 --------------------

--- a/doc/src/modules/physics/vector/api/classes.rst
+++ b/doc/src/modules/physics/vector/api/classes.rst
@@ -6,6 +6,7 @@ CoordinateSym
 =============
 
 .. autoclass:: sympy.physics.vector.frame.CoordinateSym
+   :members:
 
 
 ReferenceFrame

--- a/doc/src/modules/polys/agca.rst
+++ b/doc/src/modules/polys/agca.rst
@@ -188,6 +188,7 @@ and submodules:
    :members:
 
 .. autoclass:: FreeModuleElement
+   :members:
 
 .. autoclass:: SubModule
    :members:
@@ -231,6 +232,7 @@ subquotient modules:
    :members:
 
 .. autoclass:: QuotientModuleElement
+   :members:
 
 .. autoclass:: SubQuotientModule
    :members:

--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -128,7 +128,6 @@ when available.
    :members:
 
 .. autoclass:: PythonIntegerRing
-   :members:
 .. autoclass:: GMPYIntegerRing
    :members:
 

--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -64,8 +64,10 @@ GF(p)
    :members:
 
 .. autoclass:: PythonFiniteField
+   :members:
 
 .. autoclass:: GMPYFiniteField
+   :members:
 
 .. _ZZ:
 
@@ -126,7 +128,9 @@ when available.
    :members:
 
 .. autoclass:: PythonIntegerRing
+   :members:
 .. autoclass:: GMPYIntegerRing
+   :members:
 
 .. _QQ:
 
@@ -180,6 +184,7 @@ preferred because it is significantly faster.
 
 .. autoclass:: PythonRationalField
 .. autoclass:: GMPYRationalField
+   :members:
 
 .. autoclass:: PythonRational
 
@@ -192,7 +197,9 @@ The Gaussian domains :ref:`ZZ_I` and :ref:`QQ_I` share common superclasses
 :py:class:`~.GaussianDomain` for the domains themselves.
 
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianDomain
+   :members:
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianElement
+   :members:
 
 
 .. _ZZ_I:
@@ -202,7 +209,9 @@ ZZ_I
 ====
 
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianIntegerRing
+   :members:
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianInteger
+   :members:
 
 .. _QQ_I:
 
@@ -211,7 +220,9 @@ QQ_I
 ====
 
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianRationalField
+   :members:
 .. autoclass:: sympy.polys.domains.gaussiandomains.GaussianRational
+   :members:
 
 .. _QQ(a):
 
@@ -232,6 +243,7 @@ RR
    :members:
 
 .. autoclass:: sympy.polys.domains.mpelements.RealElement
+   :members:
 
 .. _CC:
 
@@ -243,6 +255,7 @@ CC
    :members:
 
 .. autoclass:: sympy.polys.domains.mpelements.ComplexElement
+   :members:
 
 .. _K[x]:
 
@@ -272,6 +285,7 @@ EX
    :members:
 
 .. autoclass:: sympy.polys.domains.expressiondomain::ExpressionDomain.Expression
+   :members:
 
 
 Quotient ring

--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -606,6 +606,7 @@ Options
 .. automodule:: sympy.polys.polyoptions
 
 .. autoclass:: sympy.polys.polyoptions.Options
+   :members:
 .. autofunction:: sympy.polys.polyoptions.build_options
 
 Configuration
@@ -625,30 +626,54 @@ TODO sort and explain
 .. currentmodule:: sympy.polys.polyerrors
 
 .. autoclass:: BasePolynomialError
+   :members:
 
 .. autoclass:: ExactQuotientFailed
+   :members:
 .. autoclass:: OperationNotSupported
+   :members:
 .. autoclass:: HeuristicGCDFailed
+   :members:
 .. autoclass:: HomomorphismFailed
+   :members:
 .. autoclass:: IsomorphismFailed
+   :members:
 .. autoclass:: ExtraneousFactors
+   :members:
 .. autoclass:: EvaluationFailed
+   :members:
 .. autoclass:: RefinementFailed
+   :members:
 .. autoclass:: CoercionFailed
+   :members:
 .. autoclass:: NotInvertible
+   :members:
 .. autoclass:: NotReversible
+   :members:
 .. autoclass:: NotAlgebraic
+   :members:
 .. autoclass:: DomainError
+   :members:
 .. autoclass:: PolynomialError
+   :members:
 .. autoclass:: UnificationFailed
+   :members:
 .. autoclass:: GeneratorsNeeded
+   :members:
 .. autoclass:: ComputationFailed
+   :members:
 .. autoclass:: GeneratorsError
+   :members:
 .. autoclass:: UnivariatePolynomialError
+   :members:
 .. autoclass:: MultivariatePolynomialError
+   :members:
 .. autoclass:: PolificationFailed
+   :members:
 .. autoclass:: OptionError
+   :members:
 .. autoclass:: FlagError
+   :members:
 
 Reference
 =========

--- a/doc/src/modules/polys/reference.rst
+++ b/doc/src/modules/polys/reference.rst
@@ -116,6 +116,7 @@ Monomials encoded as tuples
 .. currentmodule:: sympy.polys.monomials
 
 .. autoclass:: Monomial
+   :members:
 .. autofunction:: itermonomials
 .. autofunction:: monomial_count
 
@@ -125,9 +126,13 @@ Orderings of monomials
 .. currentmodule:: sympy.polys.orderings
 
 .. autoclass:: MonomialOrder
+   :members:
 .. autoclass:: LexOrder
+   :members:
 .. autoclass:: GradedLexOrder
+   :members:
 .. autoclass:: ReversedGradedLexOrder
+   :members:
 
 Formal manipulation of roots of polynomials
 ===========================================
@@ -141,6 +146,7 @@ Formal manipulation of roots of polynomials
    :members:
    :private-members:
 .. autoclass:: RootSum
+   :members:
 
 Symbolic root-finding algorithms
 ================================

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -17,9 +17,9 @@ The main class responsible for printing is ``Printer`` (see also its
 `source code <https://github.com/sympy/sympy/blob/master/sympy/printing/printer.py>`_):
 
 .. autoclass:: Printer
-    :members: doprint, _print, set_global_settings, order
+   :members: doprint, _print, set_global_settings, order
 
-    .. autoattribute:: Printer.printmethod
+   .. autoattribute:: Printer.printmethod
 
 
 PrettyPrinter Class
@@ -421,6 +421,7 @@ This classes implements printing to strings that can be used by the
 :py:func:`sympy.utilities.lambdify.lambdify` function.
 
 .. autoclass:: LambdaPrinter
+   :members:
 
    .. autoattribute:: LambdaPrinter.printmethod
 
@@ -455,6 +456,7 @@ This class is responsible for MathML printing. See ``sympy.printing.mathml``.
 More info on mathml : http://www.w3.org/TR/MathML2
 
 .. autoclass:: MathMLPrinterBase
+   :members:
 
 .. autoclass:: MathMLContentPrinter
    :members:
@@ -581,6 +583,7 @@ functionality, and additionally lists a number of functions that cannot be
 easily translated to C or Fortran.
 
 .. autoclass:: sympy.printing.codeprinter.CodePrinter
+   :members:
 
    .. autoattribute:: CodePrinter.printmethod
 

--- a/doc/src/modules/series/formal.rst
+++ b/doc/src/modules/series/formal.rst
@@ -11,12 +11,16 @@ Methods for computing and manipulating Formal Power Series.
 .. autofunction:: sympy.series.formal::compute_fps
 
 .. autoclass:: sympy.series.formal::FormalPowerSeriesCompose
+   :members:
 
 .. autoclass:: sympy.series.formal::FormalPowerSeriesInverse
+   :members:
 
 .. autoclass:: sympy.series.formal::FormalPowerSeriesProduct
+   :members:
 
 .. autoclass:: sympy.series.formal::FiniteFormalPowerSeries
+   :members:
 
 
 Rational Algorithm

--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -167,4 +167,4 @@ ConditionSet
 ^^^^^^^^^^^^
 
 .. autoclass:: ConditionSet
-    :members:
+   :members:

--- a/doc/src/modules/solvers/diophantine.rst
+++ b/doc/src/modules/solvers/diophantine.rst
@@ -492,55 +492,69 @@ These classes are intended for internal use in the Diophantine module.
 DiophantineSolutionSet
 ^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.DiophantineSolutionSet
+   :members:
 
 DiophantineEquationType
 ^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.DiophantineEquationType
+   :members:
 
 Univariate
 ^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.Univariate
+   :members:
 
 Linear
 ^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.Linear
+   :members:
 
 BinaryQuadratic
 ^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.BinaryQuadratic
+   :members:
 
 InhomogeneousTernaryQuadratic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.InhomogeneousTernaryQuadratic
+   :members:
 
 HomogeneousTernaryQuadraticNormal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.HomogeneousTernaryQuadraticNormal
+   :members:
 
 HomogeneousTernaryQuadratic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.HomogeneousTernaryQuadratic
+   :members:
 
 InhomogeneousGeneralQuadratic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.InhomogeneousGeneralQuadratic
+   :members:
 
 HomogeneousGeneralQuadratic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.HomogeneousGeneralQuadratic
+   :members:
 
 GeneralSumOfSquares
 ^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.GeneralSumOfSquares
+   :members:
 
 GeneralPythagorean
 ^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.GeneralPythagorean
+   :members:
 
 CubicThue
 ^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.CubicThue
+   :members:
 
 GeneralSumOfEvenPowers
 ^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.diophantine.diophantine.GeneralSumOfEvenPowers
+   :members:

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -73,6 +73,7 @@ sol_simplicity
 factorable
 ^^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::Factorable
+   :members:
 
 1st_exact
 ^^^^^^^^^
@@ -93,6 +94,7 @@ factorable
 1st_linear
 ^^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::FirstLinear
+   :members:
 
 2nd_linear_airy
 ^^^^^^^^^^^^^^^
@@ -105,6 +107,7 @@ factorable
 Bernoulli
 ^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::Bernoulli
+   :members:
 
 Liouville
 ^^^^^^^^^
@@ -113,6 +116,7 @@ Liouville
 Riccati_special_minus2
 ^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::RiccatiSpecial
+   :members:
 
 nth_linear_constant_coeff_homogeneous
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,6 +133,7 @@ nth_linear_constant_coeff_variation_of_parameters
 nth_algebraic
 ^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::NthAlgebraic
+   :members:
 
 nth_order_reducible
 ^^^^^^^^^^^^^^^^^^^
@@ -141,6 +146,7 @@ separable
 almost_linear
 ^^^^^^^^^^^^^
 .. autoclass:: sympy.solvers.ode.single::AlmostLinear
+   :members:
 
 linear_coefficients
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -101,11 +101,17 @@ Joint Types
 Stochastic Processes
 --------------------
 .. autoclass:: DiscreteMarkovChain
+   :members:
 .. autoclass:: ContinuousMarkovChain
+   :members:
 .. autoclass:: BernoulliProcess
+   :members:
 .. autoclass:: PoissonProcess
+   :members:
 .. autoclass:: WienerProcess
+   :members:
 .. autoclass:: GammaProcess
+   :members:
 
 Matrix Distributions
 --------------------
@@ -116,22 +122,27 @@ Matrix Distributions
 Compound Distribution
 ---------------------
 .. autoclass:: sympy.stats.compound_rv.CompoundDistribution
+   :members:
 
 Interface
 ^^^^^^^^^
 
 .. autofunction:: P
 .. autoclass:: Probability
+   :members:
 .. autofunction:: E
 .. autoclass:: Expectation
+   :members:
 .. autofunction:: density
 .. autofunction:: entropy
 .. autofunction:: given
 .. autofunction:: where
 .. autofunction:: variance
 .. autoclass:: Variance
+   :members:
 .. autofunction:: covariance
 .. autoclass:: Covariance
+   :members:
 .. autofunction:: coskewness
 .. autofunction:: median
 .. autofunction:: std
@@ -145,12 +156,17 @@ Interface
 .. autofunction:: sympy.stats.rv.sampling_P
 .. autofunction:: sympy.stats.rv.sampling_E
 .. autoclass:: Moment
+   :members:
 .. autofunction:: moment
 .. autoclass:: CentralMoment
+   :members:
 .. autofunction:: cmoment
 .. autoclass:: ExpectationMatrix
+   :members:
 .. autoclass:: VarianceMatrix
+   :members:
 .. autoclass:: CrossCovarianceMatrix
+   :members:
 
 Mechanics
 ^^^^^^^^^

--- a/doc/src/modules/vector/api/classes.rst
+++ b/doc/src/modules/vector/api/classes.rst
@@ -30,7 +30,7 @@ Del
 
 .. autoclass:: sympy.vector.deloperator.Del
    :members:
-   
+
 
 ParametricRegion
 ================
@@ -44,7 +44,7 @@ ImplicitRegion
 
 .. autoclass:: sympy.vector.implicitregion.ImplicitRegion
    :members:
-      
+
 
 ParametricIntegral
 ==================

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -1,4 +1,4 @@
-"""Implementation of :class:``GMPYRationalField`` class. """
+"""Implementation of :class:`GMPYRationalField` class. """
 
 
 from sympy.polys.domains.groundtypes import (

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -1,4 +1,4 @@
-"""Implementation of :class:`GMPYRationalField` class. """
+"""Implementation of :class:``GMPYRationalField`` class. """
 
 
 from sympy.polys.domains.groundtypes import (
@@ -11,10 +11,10 @@ from sympy.utilities import public
 
 @public
 class GMPYRationalField(RationalField):
-    """Rational field based on GMPY's ``mpq`` type.
+    """Rational field based on GMPY's ````mpq```` type.
 
-    This will be the implementation of :ref:`QQ` if ``gmpy`` or ``gmpy2`` is
-    installed. Elements will be of type ``gmpy.mpq``.
+    This will be the implementation of :ref:``QQ`` if ````gmpy```` or ````gmpy2```` is
+    installed. Elements will be of type ````gmpy.mpq````.
     """
 
     dtype = GMPYRational
@@ -27,74 +27,74 @@ class GMPYRationalField(RationalField):
         pass
 
     def get_ring(self):
-        """Returns ring associated with ``self``. """
+        """Returns ring associated with ````self````. """
         from sympy.polys.domains import GMPYIntegerRing
         return GMPYIntegerRing()
 
     def to_sympy(self, a):
-        """Convert `a` to a SymPy object. """
+        """Convert ``a`` to a SymPy object. """
         return SymPyRational(int(gmpy_numer(a)),
                              int(gmpy_denom(a)))
 
     def from_sympy(self, a):
-        """Convert SymPy's Integer to `dtype`. """
+        """Convert SymPy's Integer to ``dtype``. """
         if a.is_Rational:
             return GMPYRational(a.p, a.q)
         elif a.is_Float:
             from sympy.polys.domains import RR
             return GMPYRational(*map(int, RR.to_rational(a)))
         else:
-            raise CoercionFailed("expected `Rational` object, got %s" % a)
+            raise CoercionFailed("expected ``Rational`` object, got %s" % a)
 
     def from_ZZ_python(K1, a, K0):
-        """Convert a Python `int` object to `dtype`. """
+        """Convert a Python ``int`` object to ``dtype``. """
         return GMPYRational(a)
 
     def from_QQ_python(K1, a, K0):
-        """Convert a Python `Fraction` object to `dtype`. """
+        """Convert a Python ``Fraction`` object to ``dtype``. """
         return GMPYRational(a.numerator, a.denominator)
 
     def from_ZZ_gmpy(K1, a, K0):
-        """Convert a GMPY `mpz` object to `dtype`. """
+        """Convert a GMPY ``mpz`` object to ``dtype``. """
         return GMPYRational(a)
 
     def from_QQ_gmpy(K1, a, K0):
-        """Convert a GMPY `mpq` object to `dtype`. """
+        """Convert a GMPY ``mpq`` object to ``dtype``. """
         return a
 
     def from_GaussianRationalField(K1, a, K0):
-        """Convert a `GaussianElement` object to `dtype`. """
+        """Convert a ``GaussianElement`` object to ``dtype``. """
         if a.y == 0:
             return GMPYRational(a.x)
 
     def from_RealField(K1, a, K0):
-        """Convert a mpmath `mpf` object to `dtype`. """
+        """Convert a mpmath ``mpf`` object to ``dtype``. """
         return GMPYRational(*map(int, K0.to_rational(a)))
 
     def exquo(self, a, b):
-        """Exact quotient of `a` and `b`, implies `__truediv__`.  """
+        """Exact quotient of ``a`` and ``b``, implies ``__truediv__``.  """
         return GMPYRational(a) / GMPYRational(b)
 
     def quo(self, a, b):
-        """Quotient of `a` and `b`, implies `__truediv__`. """
+        """Quotient of ``a`` and ``b``, implies ``__truediv__``. """
         return GMPYRational(a) / GMPYRational(b)
 
     def rem(self, a, b):
-        """Remainder of `a` and `b`, implies nothing.  """
+        """Remainder of ``a`` and ``b``, implies nothing.  """
         return self.zero
 
     def div(self, a, b):
-        """Division of `a` and `b`, implies `__truediv__`. """
+        """Division of ``a`` and ``b``, implies ``__truediv__``. """
         return GMPYRational(a) / GMPYRational(b), self.zero
 
     def numer(self, a):
-        """Returns numerator of `a`. """
+        """Returns numerator of ``a``. """
         return a.numerator
 
     def denom(self, a):
-        """Returns denominator of `a`. """
+        """Returns denominator of ``a``. """
         return a.denominator
 
     def factorial(self, a):
-        """Returns factorial of `a`. """
+        """Returns factorial of ``a``. """
         return GMPYRational(gmpy_factorial(int(a)))

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -13,7 +13,7 @@ from sympy.utilities import public
 class GMPYRationalField(RationalField):
     """Rational field based on GMPY's ``mpq`` type.
 
-    This will be the implementation of :ref:``QQ`` if ``gmpy`` or ``gmpy2`` is
+    This will be the implementation of :ref:`QQ` if ``gmpy`` or ``gmpy2`` is
     installed. Elements will be of type ``gmpy.mpq``.
     """
 

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -11,10 +11,10 @@ from sympy.utilities import public
 
 @public
 class GMPYRationalField(RationalField):
-    """Rational field based on GMPY's ````mpq```` type.
+    """Rational field based on GMPY's ``mpq`` type.
 
-    This will be the implementation of :ref:``QQ`` if ````gmpy```` or ````gmpy2```` is
-    installed. Elements will be of type ````gmpy.mpq````.
+    This will be the implementation of :ref:``QQ`` if ``gmpy`` or ``gmpy2`` is
+    installed. Elements will be of type ``gmpy.mpq``.
     """
 
     dtype = GMPYRational
@@ -27,7 +27,7 @@ class GMPYRationalField(RationalField):
         pass
 
     def get_ring(self):
-        """Returns ring associated with ````self````. """
+        """Returns ring associated with ``self``. """
         from sympy.polys.domains import GMPYIntegerRing
         return GMPYIntegerRing()
 

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -931,7 +931,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         return self.args[2]
 
-    def communication_classes(self) -> tList[tTuple[tList[Basic], bool, Integer]]:
+    def communication_classes(self) -> tList[tTuple[tList[Basic], Boolean, Integer]]:
         """
         Returns the list of communication classes that partition
         the states of the markov chain.

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -931,7 +931,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         return self.args[2]
 
-    def communication_classes(self) -> tList[tTuple[tList[Basic], Boolean, Integer]]:
+    def communication_classes(self) -> tList[tTuple[tList[Basic], bool, Integer]]:
         """
         Returns the list of communication classes that partition
         the states of the markov chain.
@@ -1203,7 +1203,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         See Also
         ========
 
-        sympy.stats.stochastic_process_types.DiscreteMarkovChain.limiting_distribution
+        sympy.stats.DiscreteMarkovChain.limiting_distribution
         """
         trans_probs = self.transition_probabilities
         n = self.number_of_states
@@ -1309,8 +1309,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         See Also
         ========
 
-        sympy.stats.stochastic_process_types.DiscreteMarkovChain.communication_classes
-        sympy.stats.stochastic_process_types.DiscreteMarkovChain.canonical_form
+        sympy.stats.DiscreteMarkovChain.communication_classes
+        sympy.stats.DiscreteMarkovChain.canonical_form
 
         References
         ==========
@@ -1428,8 +1428,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         See Also
         ========
 
-        sympy.stats.stochastic_process_types.DiscreteMarkovChain.communication_classes
-        sympy.stats.stochastic_process_types.DiscreteMarkovChain.decompose
+        sympy.stats.DiscreteMarkovChain.communication_classes
+        sympy.stats.DiscreteMarkovChain.decompose
 
         References
         ==========


### PR DESCRIPTION
Expanding documentation to include :members: for all autoclass declarations.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Many of the class methods with docstrings do not appear in the generated documentation due to a lack of :members: option declarations in the sphinx configuration files. For example, the online documentation for [`stats.DiscreteMarkovChain`](https://docs.sympy.org/latest/modules/stats.html?highlight=discretemarkovchain#sympy.stats.DiscreteMarkovChain) does not include the well-docstring'ed and very useful `DiscreteMarkovChain.stationary_distribution` method.

By adding the `:members:` option to each class, the published documentation will include much more useful information.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Expanding documentation to include all class members with docstrings
<!-- END RELEASE NOTES -->
