### PR TITLE
added methods and tests for CC

### DIFF
--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -101,6 +101,22 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         """Returns an exact domain associated with ``self``. """
         raise DomainError("there is no exact domain associated with %s" % self)
 
+    def is_negative(self, element):
+        """Returns ``False`` for any ``ComplexElement``. """
+        return False
+
+    def is_positive(self, element):
+        """Returns ``False`` for any ``ComplexElement``. """
+        return False
+
+    def is_nonnegative(self, element):
+        """Returns ``False`` for any ``ComplexElement``. """
+        return False
+
+    def is_nonpositive(self, element):
+        """Returns ``False`` for any ``ComplexElement``. """
+        return False
+
     def gcd(self, a, b):
         """Returns GCD of ``a`` and ``b``. """
         return self.one

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1044,3 +1044,31 @@ def test_gaussian_domains():
 def test_issue_18278():
     assert str(RR(2).parent()) == 'RR'
     assert str(CC(2).parent()) == 'CC'
+
+
+def test_Domain_is_negative():
+    I = S.ImaginaryUnit
+    a, b = [CC.convert(x) for x in (2 + I, 5)]
+    assert CC.is_negative(a) == False
+    assert CC.is_negative(b) == False
+
+
+def test_Domain_is_positive():
+    I = S.ImaginaryUnit
+    a, b = [CC.convert(x) for x in (2 + I, 5)]
+    assert CC.is_positive(a) == False
+    assert CC.is_positive(b) == False
+
+
+def test_Domain_is_nonnegative():
+    I = S.ImaginaryUnit
+    a, b = [CC.convert(x) for x in (2 + I, 5)]
+    assert CC.is_nonnegative(a) == False
+    assert CC.is_nonnegative(b) == False
+
+
+def test_Domain_is_nonpositive():
+    I = S.ImaginaryUnit
+    a, b = [CC.convert(x) for x in (2 + I, 5)]
+    assert CC.is_nonpositive(a) == False
+    assert CC.is_nonpositive(b) == False

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3463,3 +3463,10 @@ def test_deserialized_poly_equals_original():
 def test_issue_20389():
     result = degree(x * (x + 1) - x ** 2 - x, x)
     assert result == -oo
+
+
+def test_issue_20985():
+    from sympy import symbols
+    w, R = symbols('w R')
+    poly = Poly(1.0 + I*w/R, w, 1/R)
+    assert poly.degree() == S(1)


### PR DESCRIPTION
Added `is_negative`, `is_positive`, `is_nonnegative` and `is_nonpositive` methods for the complex field `CC`.

#### References to other Issues or PRs
Fixes #20985

#### Brief description of what is fixed or changed
We try to implement the same for `CC` as these methods are already implemented for `ZZ_I` and `QQ_I`.
Copied the codes provided in the [discussion](https://github.com/sympy/sympy/issues/20985#issuecomment-782668242)
Code Credits to @oscarbenjamin.

Tests are also added to the PR.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
