### PR TITLE
Make Predicate.eval() not search for next dispatched function when None is returned

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -370,11 +370,9 @@ class Predicate(Boolean, metaclass=PredicateMeta):
         for func in self.handler.dispatch_iter(*types):
             try:
                 result = func(*args, assumptions)
+                return result
             except MDNotImplementedError:
                 continue
-            else:
-                if result is not None:
-                    return result
         return result
 
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -365,14 +365,11 @@ class Predicate(Boolean, metaclass=PredicateMeta):
 
         This uses only direct resolution methods, not logical inference.
         """
-        types = tuple(type(a) for a in args)
         result = None
-        for func in self.handler.dispatch_iter(*types):
-            try:
-                result = func(*args, assumptions)
-                return result
-            except MDNotImplementedError:
-                continue
+        try:
+            result = self.handler(*args, assumptions=assumptions)
+        except NotImplementedError:
+            pass
         return result
 
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -6,9 +6,7 @@ from sympy.core.assumptions import ManagedProperties
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean, false, true
-from sympy.multipledispatch.dispatcher import (
-    Dispatcher, MDNotImplementedError, str_signature
-)
+from sympy.multipledispatch.dispatcher import Dispatcher, str_signature
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.source import get_class

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -4,10 +4,12 @@ Handlers for keys related to number theory: prime, even, odd, etc.
 
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Basic, Expr, Float, Mul, Pow, S
-from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NegativeInfinity,
-    NumberSymbol, Rational)
+from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NaN,
+    NegativeInfinity, NumberSymbol, Rational)
 from sympy.functions import Abs, im, re
 from sympy.ntheory import isprime
+
+from sympy.multipledispatch import MDNotImplementedError
 
 from ..predicates.ntheory import (PrimePredicate, CompositePredicate,
     EvenPredicate, OddPredicate)
@@ -31,7 +33,10 @@ def _PrimePredicate_number(expr, assumptions):
 
 @PrimePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_prime
+    ret = expr.is_prime
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @PrimePredicate.register(Basic)
 def _(expr, assumptions):
@@ -64,7 +69,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return isprime(expr)
 
-@PrimePredicate.register_many(Rational, Infinity, NegativeInfinity, ImaginaryUnit)
+@PrimePredicate.register_many(Rational, Infinity, NaN, NegativeInfinity, ImaginaryUnit)
 def _(expr, assumptions):
     return False
 
@@ -81,7 +86,10 @@ def _(expr, assumptions):
 
 @CompositePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_composite
+    ret = expr.is_composite
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @CompositePredicate.register(Basic)
 def _(expr, assumptions):
@@ -102,6 +110,10 @@ def _(expr, assumptions):
     else:
         return _positive
 
+@CompositePredicate.register(NaN)
+def _(expr, assumptions):
+    return False
+
 
 # EvenPredicate
 
@@ -119,7 +131,10 @@ def _EvenPredicate_number(expr, assumptions):
 
 @EvenPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_even
+    ret = expr.is_even
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @EvenPredicate.register(Basic)
 def _(expr, assumptions):
@@ -204,7 +219,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return not bool(expr.p & 1)
 
-@EvenPredicate.register_many(Rational, Infinity, NegativeInfinity, ImaginaryUnit)
+@EvenPredicate.register_many(Rational, Infinity, NaN, NegativeInfinity, ImaginaryUnit)
 def _(expr, assumptions):
     return False
 
@@ -232,7 +247,10 @@ def _(expr, assumptions):
 
 @OddPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_odd
+    ret = expr.is_odd
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @OddPredicate.register(Basic)
 def _(expr, assumptions):
@@ -243,3 +261,7 @@ def _(expr, assumptions):
             return None
         return not _even
     return _integer
+
+@OddPredicate.register(NaN)
+def _(expr, assumptions):
+    return False

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -10,6 +10,8 @@ from sympy.functions import Abs, acos, acot, asin, atan, exp, factorial, log
 from sympy.matrices import Determinant, Trace
 from sympy.matrices.expressions.matexpr import MatrixElement
 
+from sympy.multipledispatch import MDNotImplementedError
+
 from ..predicates.order import (NegativePredicate, NonNegativePredicate,
     NonZeroPredicate, ZeroPredicate, NonPositivePredicate, PositivePredicate)
 
@@ -42,7 +44,10 @@ def _(expr, assumptions):
 
 @NegativePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_negative
+    ret = expr.is_negative
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @NegativePredicate.register(Add)
 def _(expr, assumptions):
@@ -108,7 +113,7 @@ def _(expr, assumptions):
         if ask(Q.odd(expr.exp), assumptions):
             return ask(Q.negative(expr.base), assumptions)
 
-@NegativePredicate.register_many(Abs, ImaginaryUnit)
+@NegativePredicate.register_many(Abs, ImaginaryUnit, NaN)
 def _(expr, assumptions):
     return False
 
@@ -116,6 +121,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if ask(Q.real(expr.exp), assumptions):
         return False
+    raise MDNotImplementedError
 
 
 # NonNegativePredicate
@@ -131,14 +137,24 @@ def _(expr, assumptions):
 
 @NonNegativePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_nonnegative
+    ret = expr.is_nonnegative
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
+
+@NonNegativePredicate.register(NaN)
+def _(expr, assumptions):
+    return False
 
 
 # NonZeroPredicate
 
 @NonZeroPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_nonzero
+    ret = expr.is_nonzero
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @NonZeroPredicate.register(Basic)
 def _(expr, assumptions):
@@ -184,7 +200,10 @@ def _(expr, assumptions):
 
 @ZeroPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_zero
+    ret = expr.is_zero
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @ZeroPredicate.register(Basic)
 def _(expr, assumptions):
@@ -196,12 +215,19 @@ def _(expr, assumptions):
     # TODO: This should be deducible from the nonzero handler
     return fuzzy_or(ask(Q.zero(arg), assumptions) for arg in expr.args)
 
+@ZeroPredicate.register(NaN)
+def _(expr, assumptions):
+    return False
+
 
 # NonPositivePredicate
 
 @NonPositivePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_nonpositive
+    ret = expr.is_nonpositive
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @NonPositivePredicate.register(Basic)
 def _(expr, assumptions):
@@ -211,6 +237,10 @@ def _(expr, assumptions):
             return ask(Q.real(expr), assumptions)
         else:
             return notpositive
+
+@NonPositivePredicate.register(NaN)
+def _(expr, assumptions):
+    return False
 
 
 # PositivePredicate
@@ -236,7 +266,10 @@ def _PositivePredicate_number(expr, assumptions):
 
 @PositivePredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_positive
+    ret = expr.is_positive
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @PositivePredicate.register(Basic)
 def _(expr, assumptions):
@@ -367,3 +400,7 @@ def _(expr, assumptions):
 @PositivePredicate.register(acot)
 def _(expr, assumptions):
     return ask(Q.real(expr.args[0]), assumptions)
+
+@PositivePredicate.register(NaN)
+def _(expr, assumptions):
+    return False

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -14,6 +14,8 @@ from sympy import I, Eq, conjugate
 from sympy.matrices import Determinant, MatrixBase, Trace
 from sympy.matrices.expressions.matexpr import MatrixElement
 
+from sympy.multipledispatch import MDNotImplementedError
+
 from .common import test_closed_group
 from ..predicates.sets import (IntegerPredicate, RationalPredicate,
     IrrationalPredicate, RealPredicate, ExtendedRealPredicate,
@@ -44,7 +46,10 @@ def _(expr, assumptions):
 
 @IntegerPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_integer
+    ret = expr.is_integer
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @IntegerPredicate.register_many(Add, Pow)
 def _(expr, assumptions):
@@ -111,7 +116,10 @@ def _(expr, assumptions):
 
 @RationalPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_rational
+    ret = expr.is_rational
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @RationalPredicate.register_many(Add, Mul)
 def _(expr, assumptions):
@@ -177,7 +185,10 @@ def _(expr, assumptions):
 
 @IrrationalPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_irrational
+    ret = expr.is_irrational
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @IrrationalPredicate.register(Basic)
 def _(expr, assumptions):
@@ -213,7 +224,10 @@ def _(expr, assumptions):
 
 @RealPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_real
+    ret = expr.is_real
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @RealPredicate.register(Add)
 def _(expr, assumptions):
@@ -367,7 +381,7 @@ def _(expr, assumptions):
     * Hermitian + !Hermitian -> !Hermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     return test_closed_group(expr, assumptions, Q.hermitian)
 
 @HermitianPredicate.register(Mul)
@@ -380,7 +394,7 @@ def _(expr, assumptions):
     * Antihermitian*Antihermitian -> Hermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     nccount = 0
     result = True
     for arg in expr.args:
@@ -401,24 +415,27 @@ def _(expr, assumptions):
     * Hermitian**Integer -> Hermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     if expr.base == E:
         if ask(Q.hermitian(expr.exp), assumptions):
             return True
-        return
+        raise MDNotImplementedError
     if ask(Q.hermitian(expr.base), assumptions):
         if ask(Q.integer(expr.exp), assumptions):
             return True
+    raise MDNotImplementedError
 
 @HermitianPredicate.register_many(cos, sin)
 def _(expr, assumptions):
     if ask(Q.hermitian(expr.args[0]), assumptions):
         return True
+    raise MDNotImplementedError
 
 @HermitianPredicate.register(exp)
 def _(expr, assumptions):
     if ask(Q.hermitian(expr.exp), assumptions):
         return True
+    raise MDNotImplementedError
 
 @HermitianPredicate.register(MatrixBase)
 def _(mat, assumptions):
@@ -431,6 +448,8 @@ def _(mat, assumptions):
                 ret_val = None
             if cond == False:
                 return False
+    if ret_val is None:
+        raise MDNotImplementedError
     return ret_val
 
 
@@ -447,7 +466,10 @@ def _(expr, assumptions):
 
 @ComplexPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_complex
+    ret = expr.is_complex
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @ComplexPredicate.register_many(Add, Mul)
 def _(expr, assumptions):
@@ -485,7 +507,10 @@ def _(expr, assumptions):
 
 @ImaginaryPredicate.register(Expr)
 def _(expr, assumptions):
-    return expr.is_imaginary
+    ret = expr.is_imaginary
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
 
 @ImaginaryPredicate.register(Add)
 def _(expr, assumptions):
@@ -634,7 +659,7 @@ def _(expr, assumptions):
     * Antihermitian + !Antihermitian -> !Antihermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     return test_closed_group(expr, assumptions, Q.antihermitian)
 
 @AntihermitianPredicate.register(Mul)
@@ -647,7 +672,7 @@ def _(expr, assumptions):
     * Antihermitian*Antihermitian -> !Antihermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     nccount = 0
     result = False
     for arg in expr.args:
@@ -670,7 +695,7 @@ def _(expr, assumptions):
     * Antihermitian**Odd  -> Antihermitian
     """
     if expr.is_number:
-        return None
+        raise MDNotImplementedError
     if ask(Q.hermitian(expr.base), assumptions):
         if ask(Q.integer(expr.exp), assumptions):
             return False
@@ -679,6 +704,7 @@ def _(expr, assumptions):
             return False
         elif ask(Q.odd(expr.exp), assumptions):
             return True
+    raise MDNotImplementedError
 
 @AntihermitianPredicate.register(MatrixBase)
 def _(mat, assumptions):
@@ -691,6 +717,8 @@ def _(mat, assumptions):
                 ret_val = None
             if cond == False:
                 return False
+    if ret_val is None:
+        raise MDNotImplementedError
     return ret_val
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In old predicate design where the handler class imitated multiple dispatching, the predicate searched for next handler when `None` is returned.

This behavior is unnecessary with new predicate design where multipledispatch handler is used, since multipledispatch already has `MDNotImplementedError` that makes the dispatcher call next function when raised. Also, this had made it difficult to deliberately return `None` for new type. Even if the handler were intentionally dispatched for `NewExpr` to return `None`, it automatically calls handler for `Expr` which may lead to undesired result.

This PR removes this tweak and makes `Predicate` follow standard multipledispatch behavior.

#### Other comments

Since new predicate is introduced in 1.8 dev, backwards compatibility need not be worried.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
