### PR TITLE
Fix simplify('0.9-0.8-0.1', rational=True)

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -576,7 +576,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         rv = e.doit() if doit else e
         return shorter(rv, collect_abs(rv))
 
-    expr = sympify(expr)
+    expr = sympify(expr, rational=rational)
     kwargs = dict(
         ratio=kwargs.get('ratio', ratio),
         measure=kwargs.get('measure', measure),

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -201,6 +201,7 @@ def test_simplify_rational():
     assert simplify(expr, rational = True) == 2**(x+y)
     assert simplify(expr, rational = None) == 2.0**(x+y)
     assert simplify(expr, rational = False) == expr
+    assert simplify('0.9 - 0.8 - 0.1', rational = True) == 0
 
 
 def test_simplify_issue_1308():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
```py
>>> from sympy import *
>>> simplify('0.9-0.8-0.1', rational=True)
-2.77555756156289e-17
```
This is because simplify calls sympify without passing args.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fix simplify calls sympify without rational parameter
<!-- END RELEASE NOTES -->
