### PR TITLE
Don't try to parse methods as implicit multiplications in parse_expr

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -208,8 +208,16 @@ def _implicit_multiplication(tokens, local_dict, global_dict):
 
     """
     result = []
+    skip = False
     for tok, nextTok in zip(tokens, tokens[1:]):
         result.append(tok)
+        if skip:
+            skip = False
+            continue
+        if tok[0] == OP and tok[1] == '.' and nextTok[0] == NAME:
+            # Dotted name. Do not do implicit multiplication
+            skip = True
+            continue
         if (isinstance(tok, AppliedFunction) and
               isinstance(nextTok, AppliedFunction)):
             result.append((OP, '*'))

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -908,7 +908,6 @@ def eval_expr(code, local_dict, global_dict):
     """
     expr = eval(
         code, global_dict, local_dict)  # take local objects in preference
-
     return expr
 
 
@@ -1012,7 +1011,10 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     if not evaluate:
         code = compile(evaluateFalse(code), '<string>', 'eval')
 
-    return eval_expr(code, local_dict, global_dict)
+    try:
+        return eval_expr(code, local_dict, global_dict)
+    except Exception as e:
+        raise e from ValueError(f"Error from parse_expr with transformed code: {code!r}")
 
 
 def evaluateFalse(s):

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -183,3 +183,15 @@ def test_all_implicit_steps():
         implicit = parse_expr(case, transformations=transformations2)
         normal = parse_expr(cases[case], transformations=transformations)
         assert(implicit == normal)
+
+
+def test_no_methods_implicit_multiplication():
+    # Issue 21020
+    u = sympy.Symbol('u')
+    transformations = standard_transformations + \
+                      (implicit_multiplication,)
+    expr = parse_expr('x.is_polynomial(x)', transformations=transformations)
+    assert expr == True
+    expr = parse_expr('(exp(x) / (1 + exp(2x))).subs(exp(x), u)',
+                      transformations=transformations)
+    assert expr == u/(u**2 + 1)


### PR DESCRIPTION
For example x.y(z) should not be parsed as x.y*z.

Attributes of an object are almost never expressions that would be multiplied.
Methods are far more likely. Unlike for top-level names, we can't easily guess
what methods an object will have since we don't know its type, so we just
disable all implicit multiplications if the first name is a method.

Fixes #21020.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Fix `parse_expr` parsing of expressions with methods when using the `implicit_multiplications` transformation.
  - Include the transformed code in the error message when the evaluation in `parse_expr` fails. 
<!-- END RELEASE NOTES -->
