### PR TITLE
adds DomainMatrix to Matrix.det

### DIFF
--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -24,6 +24,7 @@ def test_determinant():
     M = Matrix(( (-3,  2),
                  ( 8, -5) ))
 
+    assert M.det(method="domain-ge") == -1
     assert M.det(method="bareiss") == -1
     assert M.det(method="berkowitz") == -1
     assert M.det(method="lu") == -1
@@ -31,6 +32,7 @@ def test_determinant():
     M = Matrix(( (x,   1),
                  (y, 2*y) ))
 
+    assert M.det(method="domain-ge") == 2*x*y - y
     assert M.det(method="bareiss") == 2*x*y - y
     assert M.det(method="berkowitz") == 2*x*y - y
     assert M.det(method="lu") == 2*x*y - y
@@ -39,6 +41,7 @@ def test_determinant():
                  (1, 2, 3),
                  (1, 3, 6) ))
 
+    assert M.det(method="domain-ge") == 1
     assert M.det(method="bareiss") == 1
     assert M.det(method="berkowitz") == 1
     assert M.det(method="lu") == 1
@@ -48,6 +51,7 @@ def test_determinant():
                  ( 0, -2,  5, 0),
                  ( 5,  0,  3, 4) ))
 
+    assert M.det(method="domain-ge") == -289
     assert M.det(method="bareiss") == -289
     assert M.det(method="berkowitz") == -289
     assert M.det(method="lu") == -289
@@ -57,6 +61,7 @@ def test_determinant():
                  ( 9, 10, 11, 12),
                  (13, 14, 15, 16) ))
 
+    assert M.det(method="domain-ge") == 0
     assert M.det(method="bareiss") == 0
     assert M.det(method="berkowitz") == 0
     assert M.det(method="lu") == 0
@@ -67,6 +72,7 @@ def test_determinant():
                  (0, 0, 0, 3, 2),
                  (2, 0, 0, 0, 3) ))
 
+    assert M.det(method="domain-ge") == 275
     assert M.det(method="bareiss") == 275
     assert M.det(method="berkowitz") == 275
     assert M.det(method="lu") == 275
@@ -76,6 +82,7 @@ def test_determinant():
                  ( 0, -2,  5, 0),
                  ( 5,  0,  3, 4) ))
 
+    assert M.det(method="domain-ge") == 60
     assert M.det(method="bareiss") == 60
     assert M.det(method="berkowitz") == 60
     assert M.det(method="lu") == 60
@@ -85,6 +92,7 @@ def test_determinant():
                  ( 9, 10, 11, 0),
                  (13, 14, 15, 16) ))
 
+    assert M.det(method="domain-ge") == 0
     assert M.det(method="bareiss") == 0
     assert M.det(method="berkowitz") == 0
     assert M.det(method="lu") == 0
@@ -95,6 +103,7 @@ def test_determinant():
                  (0, 0, 0, 3, 2),
                  (0, 0, 0, 0, 3) ))
 
+    assert M.det(method="domain-ge") == 243
     assert M.det(method="bareiss") == 243
     assert M.det(method="berkowitz") == 243
     assert M.det(method="lu") == 243
@@ -105,6 +114,7 @@ def test_determinant():
                  (3, 2, -1,  1,  8),
                  (1, 1,  1,  0,  6) ))
 
+    assert M.det(method="domain-ge") == -55
     assert M.det(method="bareiss") == -55
     assert M.det(method="berkowitz") == -55
     assert M.det(method="lu") == -55
@@ -115,6 +125,7 @@ def test_determinant():
                  ( 1,  2,  3, -2,  5),
                  ( 1,  2,  3,  4, -1) ))
 
+    assert M.det(method="domain-ge") == 11664
     assert M.det(method="bareiss") == 11664
     assert M.det(method="berkowitz") == 11664
     assert M.det(method="lu") == 11664
@@ -125,6 +136,7 @@ def test_determinant():
                  (-3, -2,  4, 5, 3),
                  ( 1,  0,  0, 0, 1) ))
 
+    assert M.det(method="domain-ge") == 123
     assert M.det(method="bareiss") == 123
     assert M.det(method="berkowitz") == 123
     assert M.det(method="lu") == 123
@@ -133,6 +145,7 @@ def test_determinant():
                  (1, 0, 0),
                  (y, z, x) ))
 
+    assert M.det(method="domain-ge") == z**2 - x*y
     assert M.det(method="bareiss") == z**2 - x*y
     assert M.det(method="berkowitz") == z**2 - x*y
     assert M.det(method="lu") == z**2 - x*y
@@ -271,6 +284,7 @@ def test_det():
     assert c.det() == -2
     assert d.det() == 3
     assert e.det() == 4*x - 24
+    assert e.det(method="domain-ge") == 4*x - 24
     assert e.det(method='bareiss') == 4*x - 24
     assert e.det(method='berkowitz') == 4*x - 24
     assert f.det() == i*j*k


### PR DESCRIPTION
This PR implements `DomainMatrix` to slow Matrix Method `det`

Reference to Task 6 in #20987

#### Brief description of what is fixed or changed
This PR implements `DomainMatrix` for `det` which speeds up the method by a large factor of time.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
