### PR TITLE
RecursionError in integrate fixed

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3767,7 +3767,7 @@ class Expr(Basic, EvalfMixin):
                     'Expected a number but got %s:' % func_name(x))
         elif x in (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
             return x
-        if not x.is_extended_real:
+        if x.is_extended_real is False:
             r, i = x.as_real_imag()
             return r.round(n) + S.ImaginaryUnit*i.round(n)
         if not x:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -8,6 +8,8 @@ from sympy.core.expr import unchanged
 from sympy.utilities.iterables import cartes
 from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy.testing.randtest import verify_numerically
+from sympy.functions.elementary.trigonometric import asin, sinh, cosh
+from sympy.integrals import integrate
 
 
 a, c, x, y, z = symbols('a,c,x,y,z')
@@ -2321,3 +2323,16 @@ def test_issue_18507():
 def test_issue_17130():
     e = Add(b, -b, I, -I, evaluate=False)
     assert e.is_zero is None # ideally this would be True
+
+
+def test_issue_21034():
+    x = Symbol('x', real=True, nonzero=True)
+    f1 = x*(-x**4/asin(5)**4 - x*sinh(x + log(asin(5))) + 5)
+    e = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))
+    e2 = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))/pi
+    assert integrate(f1, x) == \
+        -x**6/(6*asin(5)**4) - x**2*cosh(x + log(asin(5))) + 5*x**2/2 + 2*x*sinh(x + log(asin(5))) - 2*cosh(x + log(asin(5)))
+    assert f1.is_zero is None
+    assert sinh(x + log(asin(5))).is_extended_positive is None
+    assert e % pi
+    assert e2.round(2)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -8,8 +8,7 @@ from sympy.core.expr import unchanged
 from sympy.utilities.iterables import cartes
 from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy.testing.randtest import verify_numerically
-from sympy.functions.elementary.trigonometric import asin, sinh, cosh
-from sympy.integrals import integrate
+from sympy.functions.elementary.trigonometric import asin
 
 
 a, c, x, y, z = symbols('a,c,x,y,z')
@@ -2326,13 +2325,5 @@ def test_issue_17130():
 
 
 def test_issue_21034():
-    x = Symbol('x', real=True, nonzero=True)
-    f1 = x*(-x**4/asin(5)**4 - x*sinh(x + log(asin(5))) + 5)
-    e = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))
-    e2 = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))/pi
-    assert integrate(f1, x) == \
-        -x**6/(6*asin(5)**4) - x**2*cosh(x + log(asin(5))) + 5*x**2/2 + 2*x*sinh(x + log(asin(5))) - 2*cosh(x + log(asin(5)))
-    assert f1.is_zero is None
-    assert sinh(x + log(asin(5))).is_extended_positive is None
-    assert e % pi
-    assert e2.round(2)
+    e = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))/pi
+    assert e.round(2)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -16,6 +16,7 @@ from sympy.physics import units
 from sympy.testing.pytest import (raises, slow, skip, ON_TRAVIS,
     warns_deprecated_sympy)
 from sympy.testing.randtest import verify_numerically
+from sympy.functions.elementary.trigonometric import asin, sinh, cosh
 
 
 x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')
@@ -1704,3 +1705,10 @@ def test_issue_4231():
 def test_issue_17841():
     f = diff(1/(x**2+x+I), x)
     assert integrate(f, x) == 1/(x**2 + x + I)
+
+
+def test_issue_21034():
+    x = Symbol('x', real=True, nonzero=True)
+    f = x*(-x**4/asin(5)**4 - x*sinh(x + log(asin(5))) + 5)
+    assert integrate(f, x) == \
+        -x**6/(6*asin(5)**4) - x**2*cosh(x + log(asin(5))) + 5*x**2/2 + 2*x*sinh(x + log(asin(5))) - 2*cosh(x + log(asin(5)))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -16,7 +16,6 @@ from sympy.physics import units
 from sympy.testing.pytest import (raises, slow, skip, ON_TRAVIS,
     warns_deprecated_sympy)
 from sympy.testing.randtest import verify_numerically
-from sympy.functions.elementary.trigonometric import asin, sinh, cosh
 
 
 x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #21034 

#### Brief description of what is fixed or changed
Applies the diff mentions by @oscarbenjamin [here](https://github.com/sympy/sympy/issues/21034#issuecomment-790178650). This fixes one of the problems in the issue, i.e. `RecurstionError` caused due to `not x.is_extended_real` in `sympy/core/expr.py`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in `Expr.round` that could lead to infinite recursion in `integrate`.
<!-- END RELEASE NOTES -->
