### PR TITLE
Fix expressions like `\log_2 x` in latex parser

### DIFF
--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -427,7 +427,10 @@ def convert_func(func):
 
         if (name == "log" or name == "ln"):
             if func.subexpr():
-                base = convert_expr(func.subexpr().expr())
+                if func.subexpr().expr():
+                    base = convert_expr(func.subexpr().expr())
+                else:
+                    base = convert_atom(func.subexpr().atom())
             elif name == "log":
                 base = 10
             elif name == "ln":

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -240,6 +240,8 @@ GOOD_PAIRS = [
     (r"a \negmedspace b", _Mul(a, b)),
     (r"a \negthickspace b", _Mul(a, b)),
     (r"\int x \, dx", Integral(x, x)),
+    (r"\log_2 x", _log(x, 2)),
+    (r"\log_a x", _log(x, a)),
 ]
 
 def test_parseable():
@@ -248,10 +250,7 @@ def test_parseable():
         assert parse_latex(latex_str) == sympy_expr
 
 # At time of migration from latex2sympy, should work but doesn't
-FAILING_PAIRS = [
-    (r"\log_2 x", _log(x, 2)),
-    (r"\log_a x", _log(x, a)),
-]
+FAILING_PAIRS = []
 
 def test_failing_parseable():
     from sympy.parsing.latex import parse_latex

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -249,15 +249,6 @@ def test_parseable():
     for latex_str, sympy_expr in GOOD_PAIRS:
         assert parse_latex(latex_str) == sympy_expr
 
-# At time of migration from latex2sympy, should work but doesn't
-FAILING_PAIRS = []
-
-def test_failing_parseable():
-    from sympy.parsing.latex import parse_latex
-    for latex_str, sympy_expr in FAILING_PAIRS:
-        with raises(Exception):
-            assert parse_latex(latex_str) == sympy_expr
-
 # These bad LaTeX strings should raise a LaTeXParsingError when parsed
 BAD_STRINGS = [
     r"(",


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Fixes the two failing pairs in `test_latex.py`:

https://github.com/sympy/sympy/blob/b564d9ba2705ee2978766e1ee2102750834df68b/sympy/parsing/tests/test_latex.py#L251-L254

Moves these to the list of `GOOD_PAIRS`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed issue with parsing logarithm bases without curly braces
<!-- END RELEASE NOTES -->
