### PR TITLE
Cancel before substituting in Pow._eval_nseries

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -7,7 +7,7 @@ from .singleton import S
 from .expr import Expr
 from .evalf import PrecisionExhausted
 from .function import (_coeff_isneg, expand_complex, expand_multinomial,
-    expand_mul)
+    expand_mul, _mexpand)
 from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .compatibility import as_int, HAS_GMPY, gmpy
 from .parameters import global_parameters
@@ -1693,10 +1693,9 @@ class Pow(Expr):
             ex = e1 + inex
             res += terms[e1]*inco*x**(ex)
 
-        for i in (1, 2, 3):
-            if (res - self).subs(x, i) is not S.Zero:
-                res += O(x**n, x)
-                break
+        if not (e.is_integer and e.is_positive and (e*d - n).is_nonpositive and
+                res == _mexpand(self)):
+            res += O(x**n, x)
         return res
 
     def _eval_as_leading_term(self, x, cdir=0):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1622,7 +1622,7 @@ class Pow(Expr):
         g = (b/f - S.One).cancel()
         maxpow = n - m*e
 
-        if maxpow < S.Zero:
+        if maxpow.is_negative:
             return O(x**(m*e), x)
 
         if g.is_zero:
@@ -1675,7 +1675,7 @@ class Pow(Expr):
         terms = {S.Zero: S.One}
         tk = gterms
 
-        while k*d < maxpow:
+        while (k*d - maxpow).is_negative:
             coeff = ff(e, k)/factorial(k)
             for ex in tk:
                 terms[ex] = terms.get(ex, S.Zero) + coeff*tk[ex]

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Rational, ln, exp, log, sqrt, E, O, pi, I, sinh,
     sin, cosh, cos, tanh, coth, asinh, acosh, atanh, acoth, tan, cot, Integer,
-    PoleError, floor, ceiling, asin, symbols, limit, sign,
+    PoleError, floor, ceiling, asin, symbols, limit, sign, cbrt,
     Derivative, S)
 from sympy.abc import x, y, z
 
@@ -36,6 +36,11 @@ def test_pow_0():
 
 def test_pow_1():
     assert ((1 + x)**2).nseries(x, n=5) == x**2 + 2*x + 1
+
+    # https://github.com/sympy/sympy/issues/21075
+    assert ((sqrt(x) + 1)**2).nseries(x) == 2*sqrt(x) + x + 1
+    assert ((sqrt(x) + cbrt(x))**2).nseries(x) == 2*x**Rational(5, 6)\
+        + x**Rational(2, 3) + x
 
 
 def test_geometric_1():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21075 

#### Brief description of what is fixed or changed
The original expression is now expanded and compared with the resultant expression obtain in the series expansion. Previously, values were substituted for zero checking on the difference of the expressions, which lead to corner cases and bugs.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in `Pow._eval_nseries` that added `Order` terms to exact expansions
<!-- END RELEASE NOTES -->
