### PR TITLE
21024 fix coercion fail

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -404,95 +404,98 @@ def test_issue_18133():
 
 def test_issue_21024():
     x = Symbol('x', real=True, nonzero=True)
-
+    cnt=0
     f = log(x)*log(4*x) + log(3*x + exp(2))
     F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
         (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
+
 
     f = (x + exp(3))/x**2
     F = log(x) - exp(3)/x
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = (x**2 + exp(5))/x
     F = x**2/2 + exp(5)*log(x)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
-    #This test case fails as sinh is express in terms of E
     f = x/(2*x + tanh(1))
-    F = x/2 - log(2*x + tanh(1))*tanh(1)/4
-    assert F == integrate(f, x)
+    F = x/2 - (-1 + E)*(1 + E)*log(2*x + tanh(1))/(4*(1 + exp(2)))
+    assert simplify(F - integrate(f,x)).cancel() ==0
+
 
     f = x - sinh(4)/x
-    F = x**2/2 - log(x)*sinh(4)
-    assert F == integrate(f, x)
+    F = x**2/2 - (-1 + E)*(1 + E)*(1 + exp(2))*(1 + exp(4))*exp(-4)*log(x)/2
+    assert simplify(F - integrate(f,x)) == 0
 
     f = log(x + exp(5)/x)
     F = x*log(x + exp(5)/x) - x + 2*exp(5/2)*atan(x*exp(-5/2))
-    assert F == integrate(f, x)
+    assert simplify(f - integrate(f,x).diff(x)).cancel() == 0
 
     f = x**5/(x + E)
     F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = 4*x/(x + sinh(5))
-    F = 4*x - 4*log(x + sinh(5))*sinh(5)
-    assert F == integrate(f, x)
+    F = 4*x - 2*(-1 + E)*(1 + E)*(1 + E + exp(2) + \
+        exp(3) + exp(4))*(-exp(3) - E + 1 + exp(2) + exp(4))*exp(-5)*log(x + sinh(5))
+    assert simplify(F - integrate(f,x)) == 0
 
     f = x**2/(2*x + sinh(2))
     F = x**2/4 - x*sinh(2)/4 + (-1 + E)**2*(1 + E)**2*(1 + exp(2))**2*exp(-4)*log(2*x + sinh(2))/32
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = -x**2/(x + E)
     F = -x**2/2 + E*x - exp(2)*log(x + E)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = (2*x + 3)*exp(5)/x
     F = 2*x*exp(5) + 3*exp(5)*log(x)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = x + 2 + cosh(3)/x
-    F = x**2/2 + 2*x + log(x)*cosh(3)
-    assert F == integrate(f, x)
+    F = x**2/2 + 2*x + (1 + exp(2))*(-exp(2) + 1 + exp(4))*exp(-3)*log(x)/2
+    assert simplify(F - integrate(f,x)) == 0
 
     f = x - tanh(1)/x**3
-    F = x**2/2 + tanh(1)/(2*x**2)
-    assert F == integrate(f, x)
+    F = x**2/2 + (-1 + exp(2))/(x**2*(2 + 2*exp(2)))
+    assert simplify(F - integrate(f,x)) == 0
 
     f = (3*x - exp(6))/x
     F = 3*x - exp(6)*log(x)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f =  x**4/(x + exp(5))**2 + x
     F =  x**3/3 + x**2*(1/2 - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = x*(x + exp(10)/x**2) + x
     F =  x**3/3 + x**2/2 + exp(10)*log(x)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = x + x/(5*x + sinh(3))
     F = x**2/2 + x/5 - (-1 + E)*(1 + E)*(1 + E + exp(2))*(-E + 1 + exp(2))*exp(-3)*log(5*x + sinh(3))/50
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = (x + exp(3))/(2*x**2 + 2*x)
     F = exp(3)*log(x)/2 - (-1 + E)*(1 + E + exp(2))*log(x + ((-1 + E)*(1 + E + exp(2)) \
         + exp(3))/(-1 + 2*exp(3)))/2
-
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
     f = log(x + 4*sinh(4))
-    F = x*log(x + 4*sinh(4)) - x + 4*log(x + 4*sinh(4))*sinh(4)
-    assert F == integrate(f, x)
+    F = x*log(x + 4*sinh(4)) - x + 2*(-1 + E)*(1 + E)*(1 + \
+         exp(2))*(1 + exp(4))*exp(-4)*log(x + 4*sinh(4))
+    assert simplify(F - integrate(f,x)) == 0
 
     f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
     F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) + (180*x**2*exp(5)*sin(4)*atan(4) - \
         90*x*exp(10)*sin(4)*atan(4)**2 + 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
+
 
     f =  2*x**2*exp(-4) + 6/x
     F = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
-    assert F == integrate(f, x)
+    assert simplify(F - integrate(f,x)) == 0
 
 
 def test_matrices():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -417,8 +417,8 @@ def test_issue_21024():
     f = (x**2 + exp(5))/x
     F = x**2/2 + exp(5)*log(x)
     assert F == integrate(f, x)
-    
-    #This test case fails as sinh is express in terms of E 
+
+    #This test case fails as sinh is express in terms of E
     f = x/(2*x + tanh(1))
     F = x/2 - log(2*x + tanh(1))*tanh(1)/4
     assert F == integrate(f, x)
@@ -470,7 +470,7 @@ def test_issue_21024():
     f = x*(x + exp(10)/x**2) + x
     F =  x**3/3 + x**2/2 + exp(10)*log(x)
     assert F == integrate(f, x)
-    
+
     f = x + x/(5*x + sinh(3))
     F = x**2/2 + x/5 - (-1 + E)*(1 + E)*(1 + E + exp(2))*(-E + 1 + exp(2))*exp(-3)*log(5*x + sinh(3))/50
     assert F == integrate(f, x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -404,7 +404,7 @@ def test_issue_18133():
 
 def test_issue_21024():
     x = Symbol('x', real=True, nonzero=True)
-    cnt=0
+    
     f = log(x)*log(4*x) + log(3*x + exp(2))
     F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
         (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -402,6 +402,98 @@ def test_issue_13749():
 def test_issue_18133():
     assert integrate(exp(x)/(1 + x)**2, x) == NonElementaryIntegral(exp(x)/(x + 1)**2, x)
 
+def test_issue_21024():
+    x = Symbol('x', real=True, nonzero=True)
+
+    f = log(x)*log(4*x) + log(3*x + exp(2))
+    F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
+        (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
+    assert F == integrate(f, x)
+
+    f = (x + exp(3))/x**2
+    F = log(x) - exp(3)/x
+    assert F == integrate(f, x)
+
+    f = (x**2 + exp(5))/x
+    F = x**2/2 + exp(5)*log(x)
+    assert F == integrate(f, x)
+    
+    #This test case fails as sinh is express in terms of E 
+    f = x/(2*x + tanh(1))
+    F = x/2 - log(2*x + tanh(1))*tanh(1)/4
+    assert F == integrate(f, x)
+
+    f = x - sinh(4)/x
+    F = x**2/2 - log(x)*sinh(4)
+    assert F == integrate(f, x)
+
+    f = log(x + exp(5)/x)
+    F = x*log(x + exp(5)/x) - x + 2*exp(5/2)*atan(x*exp(-5/2))
+    assert F == integrate(f, x)
+
+    f = x**5/(x + E)
+    F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
+    assert F == integrate(f, x)
+
+    f = 4*x/(x + sinh(5))
+    F = 4*x - 4*log(x + sinh(5))*sinh(5)
+    assert F == integrate(f, x)
+
+    f = x**2/(2*x + sinh(2))
+    F = x**2/4 - x*sinh(2)/4 + (-1 + E)**2*(1 + E)**2*(1 + exp(2))**2*exp(-4)*log(2*x + sinh(2))/32
+    assert F == integrate(f, x)
+
+    f = -x**2/(x + E)
+    F = -x**2/2 + E*x - exp(2)*log(x + E)
+    assert F == integrate(f, x)
+
+    f = (2*x + 3)*exp(5)/x
+    F = 2*x*exp(5) + 3*exp(5)*log(x)
+    assert F == integrate(f, x)
+
+    f = x + 2 + cosh(3)/x
+    F = x**2/2 + 2*x + log(x)*cosh(3)
+    assert F == integrate(f, x)
+
+    f = x - tanh(1)/x**3
+    F = x**2/2 + tanh(1)/(2*x**2)
+    assert F == integrate(f, x)
+
+    f = (3*x - exp(6))/x
+    F = 3*x - exp(6)*log(x)
+    assert F == integrate(f, x)
+
+    f =  x**4/(x + exp(5))**2 + x
+    F =  x**3/3 + x**2*(1/2 - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
+    assert F == integrate(f, x)
+
+    f = x*(x + exp(10)/x**2) + x
+    F =  x**3/3 + x**2/2 + exp(10)*log(x)
+    assert F == integrate(f, x)
+    
+    f = x + x/(5*x + sinh(3))
+    F = x**2/2 + x/5 - (-1 + E)*(1 + E)*(1 + E + exp(2))*(-E + 1 + exp(2))*exp(-3)*log(5*x + sinh(3))/50
+    assert F == integrate(f, x)
+
+    f = (x + exp(3))/(2*x**2 + 2*x)
+    F = exp(3)*log(x)/2 - (-1 + E)*(1 + E + exp(2))*log(x + ((-1 + E)*(1 + E + exp(2)) \
+        + exp(3))/(-1 + 2*exp(3)))/2
+
+    assert F == integrate(f, x)
+
+    f = log(x + 4*sinh(4))
+    F = x*log(x + 4*sinh(4)) - x + 4*log(x + 4*sinh(4))*sinh(4)
+    assert F == integrate(f, x)
+
+    f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
+    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) + (180*x**2*exp(5)*sin(4)*atan(4) - \
+        90*x*exp(10)*sin(4)*atan(4)**2 + 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
+    assert F == integrate(f, x)
+
+    f =  2*x**2*exp(-4) + 6/x
+    F = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
+    assert F == integrate(f, x)
+
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -406,96 +406,113 @@ def test_issue_21024():
     x = Symbol('x', real=True, nonzero=True)
 
     f = log(x)*log(4*x) + log(3*x + exp(2))
-    F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
+    F1 = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
         (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
-    assert simplify(F - integrate(f,x)) == 0
-
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = (x + exp(3))/x**2
-    F = log(x) - exp(3)/x
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = log(x) - exp(3)/x
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = (x**2 + exp(5))/x
-    F = x**2/2 + exp(5)*log(x)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/2 + exp(5)*log(x)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x/(2*x + tanh(1))
-    F = x/2 - (-1 + E)*(1 + E)*log(2*x + tanh(1))/(4*(1 + exp(2)))
-    assert simplify(F - integrate(f,x)).cancel() ==0
-
+    F1 = x/2 - (-1 + E)*(1 + E)*log(2*x + tanh(1))/(4*(1 + exp(2)))
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x - sinh(4)/x
-    F = x**2/2 - (-1 + E)*(1 + E)*(1 + exp(2))*(1 + exp(4))*exp(-4)*log(x)/2
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/2 - (-1 + E)*(1 + E)*(1 + exp(2))*(1 + exp(4))*exp(-4)*log(x)/2
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = log(x + exp(5)/x)
-    F = x*log(x + exp(5)/x) - x + 2*exp(5/2)*atan(x*exp(-5/2))
-    assert simplify(f - integrate(f,x).diff(x)).cancel() == 0
+    F1 = integrate(f,x).diff(x)
+    assert simplify(f - F1) == 0
 
     f = x**5/(x + E)
-    F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = 4*x/(x + sinh(5))
-    F = 4*x - 2*(-1 + E)*(1 + E)*(1 + E + exp(2) + \
+    F1 = 4*x - 2*(-1 + E)*(1 + E)*(1 + E + exp(2) + \
         exp(3) + exp(4))*(-exp(3) - E + 1 + exp(2) + exp(4))*exp(-5)*log(x + sinh(5))
-    assert simplify(F - integrate(f,x)) == 0
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x**2/(2*x + sinh(2))
-    F = x**2/4 - x*sinh(2)/4 + (-1 + E)**2*(1 + E)**2*(1 + exp(2))**2*exp(-4)*log(2*x + sinh(2))/32
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/4 - x*sinh(2)/4 + (-1 + E)**2*(1 + E)**2*(1 + exp(2))**2*exp(-4)*log(2*x + sinh(2))/32
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = -x**2/(x + E)
-    F = -x**2/2 + E*x - exp(2)*log(x + E)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = -x**2/2 + E*x - exp(2)*log(x + E)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = (2*x + 3)*exp(5)/x
-    F = 2*x*exp(5) + 3*exp(5)*log(x)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = 2*x*exp(5) + 3*exp(5)*log(x)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x + 2 + cosh(3)/x
-    F = x**2/2 + 2*x + (1 + exp(2))*(-exp(2) + 1 + exp(4))*exp(-3)*log(x)/2
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/2 + 2*x + (1 + exp(2))*(-exp(2) + 1 + exp(4))*exp(-3)*log(x)/2
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x - tanh(1)/x**3
-    F = x**2/2 + (-1 + exp(2))/(x**2*(2 + 2*exp(2)))
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/2 + (-1 + exp(2))/(x**2*(2 + 2*exp(2)))
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = (3*x - exp(6))/x
-    F = 3*x - exp(6)*log(x)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = 3*x - exp(6)*log(x)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f =  x**4/(x + exp(5))**2 + x
-    F =  x**3/3 + x**2*(1/2 - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
-    assert simplify(F - integrate(f,x)) == 0
+    F1 =  x**3/3 + x**2*(1/2 - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x*(x + exp(10)/x**2) + x
-    F =  x**3/3 + x**2/2 + exp(10)*log(x)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 =  x**3/3 + x**2/2 + exp(10)*log(x)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = x + x/(5*x + sinh(3))
-    F = x**2/2 + x/5 - (-1 + E)*(1 + E)*(1 + E + exp(2))*(-E + 1 + exp(2))*exp(-3)*log(5*x + sinh(3))/50
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = x**2/2 + x/5 - (-1 + E)*(1 + E)*(1 + E + exp(2))*(-E + 1 + exp(2))*exp(-3)*log(5*x + sinh(3))/50
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = (x + exp(3))/(2*x**2 + 2*x)
-    F = exp(3)*log(x)/2 - (-1 + E)*(1 + E + exp(2))*log(x + ((-1 + E)*(1 + E + exp(2)) \
+    F1 = exp(3)*log(x)/2 - (-1 + E)*(1 + E + exp(2))*log(x + ((-1 + E)*(1 + E + exp(2)) \
         + exp(3))/(-1 + 2*exp(3)))/2
-    assert simplify(F - integrate(f,x)) == 0
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = log(x + 4*sinh(4))
-    F = x*log(x + 4*sinh(4)) - x + 2*(-1 + E)*(1 + E)*(1 + \
+    F1 = x*log(x + 4*sinh(4)) - x + 2*(-1 + E)*(1 + E)*(1 + \
          exp(2))*(1 + exp(4))*exp(-4)*log(x + 4*sinh(4))
-    assert simplify(F - integrate(f,x)) == 0
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
-    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) + (180*x**2*exp(5)*sin(4)*atan(4) - \
+    F1 = (-x**2*exp(15)/2 + 20*log(x)*sin(4) + (180*x**2*exp(5)*sin(4)*atan(4) - \
         90*x*exp(10)*sin(4)*atan(4)**2 + 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
-    assert simplify(F - integrate(f,x)) == 0
-
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
     f =  2*x**2*exp(-4) + 6/x
-    F = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
-    assert simplify(F - integrate(f,x)) == 0
+    F1 = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
+    F2 = integrate(f,x)
+    assert simplify(F1 - F2) == 0
 
 
 def test_matrices():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -404,7 +404,7 @@ def test_issue_18133():
 
 def test_issue_21024():
     x = Symbol('x', real=True, nonzero=True)
-    
+
     f = log(x)*log(4*x) + log(3*x + exp(2))
     F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
         (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -574,8 +574,13 @@ def test_Domain_convert():
     R, x = ring("x", ZZ)
     assert ZZ.convert(x - x) == 0
     assert ZZ.convert(x - x, R.to_domain()) == 0
-
-    assert ZZ[E].convert(exp(3))
+   
+    
+def test_exponential_domain():
+    K = ZZ[E]
+    eK = K.from_sympy(E)
+    assert K.from_sympy(exp(3)) == eK ** 3
+    assert K.convert(exp(3)) == eK ** 3
 
 
 def test_GlobalPolynomialRing_convert():

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1,6 +1,6 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
-from sympy import I, S, sqrt, sin, oo, Poly, Float, Rational, pi
+from sympy import I, S, sqrt, sin, oo, Poly, Float, Rational, pi, exp, E
 from sympy.abc import x, y, z
 
 from sympy.core.compatibility import HAS_GMPY
@@ -574,6 +574,8 @@ def test_Domain_convert():
     R, x = ring("x", ZZ)
     assert ZZ.convert(x - x) == 0
     assert ZZ.convert(x - x, R.to_domain()) == 0
+
+    assert ZZ[E].convert(exp(3))
 
 
 def test_GlobalPolynomialRing_convert():

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -574,8 +574,8 @@ def test_Domain_convert():
     R, x = ring("x", ZZ)
     assert ZZ.convert(x - x) == 0
     assert ZZ.convert(x - x, R.to_domain()) == 0
-   
-    
+
+
 def test_exponential_domain():
     K = ZZ[E]
     eK = K.from_sympy(E)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -372,6 +372,7 @@ class PolyRing(DefaultPrinting, IPolys):
         domain = self.domain
 
         def _rebuild(expr):
+            
             generator = mapping.get(expr)
 
             if generator is not None:
@@ -380,10 +381,12 @@ class PolyRing(DefaultPrinting, IPolys):
                 return reduce(add, list(map(_rebuild, expr.args)))
             elif expr.is_Mul:
                 return reduce(mul, list(map(_rebuild, expr.args)))
-            elif expr.is_Pow and expr.exp.is_Integer and expr.exp >= 0:
-                return _rebuild(expr.base)**int(expr.exp)
             else:
-                return self.ground_new(domain.convert(expr))
+                base, exp = expr.as_base_exp()
+                if exp.is_Integer and exp > 1:
+                    return _rebuild(base)**int(exp)
+                else:
+                    return self.ground_new(domain.convert(expr))
 
         return _rebuild(sympify(expr))
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -372,7 +372,7 @@ class PolyRing(DefaultPrinting, IPolys):
         domain = self.domain
 
         def _rebuild(expr):
-            
+
             generator = mapping.get(expr)
 
             if generator is not None:

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -13,7 +13,7 @@ from sympy.polys.polyerrors import GeneratorsError, \
 from sympy.testing.pytest import raises
 from sympy.core import Symbol, symbols
 
-from sympy import sqrt, pi, oo
+from sympy import sqrt, pi, oo, exp
 
 def test_PolyRing___init__():
     x, y, z, t = map(Symbol, "xyzt")
@@ -275,6 +275,10 @@ def test_PolyElement_from_expr():
 
     f = R.from_expr(x**3*y*z + x**2*y**7 + 1)
     assert f == X**3*Y*Z + X**2*Y**7 + 1 and isinstance(f, R.dtype)
+
+    r,F=sring([exp(2)])
+    f=r.from_expr(exp(2))
+    assert f==F[0] and isinstance(f, r.dtype)
 
     raises(ValueError, lambda: R.from_expr(1/x))
     raises(ValueError, lambda: R.from_expr(2**x))

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -276,9 +276,9 @@ def test_PolyElement_from_expr():
     f = R.from_expr(x**3*y*z + x**2*y**7 + 1)
     assert f == X**3*Y*Z + X**2*Y**7 + 1 and isinstance(f, R.dtype)
 
-    r,F=sring([exp(2)])
-    f=r.from_expr(exp(2))
-    assert f==F[0] and isinstance(f, r.dtype)
+    r, F = sring([exp(2)])
+    f = r.from_expr(exp(2))
+    assert f == F[0] and isinstance(f, r.dtype)
 
     raises(ValueError, lambda: R.from_expr(1/x))
     raises(ValueError, lambda: R.from_expr(2**x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix for #21024

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Applies the diff mentions by @oscarbenjamin as well as creates test cases for bug fix as mentioned [here](https://github.com/sympy/sympy/issues/21024#issuecomment-789900540). This fixes problem `CoercionFailed("can't convert %s of type %s to %s" % (element, type(element), self))` in `sympy/polys/rings.py` becaused `PolynomialRing.convert` does not recognise the function `exp(3)` as being the power `E**3`. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


* functions
  * 

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug in `_rebuild_expr` of `rings.py` by using `_base_exp()` to handle `Pow(x, n)` and `exp(n)`
<!-- END RELEASE NOTES -->
