### PR TITLE
Replace Theano with Aesara

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -88,7 +88,7 @@ jobs:
           python-version: 3.8
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath gmpy2 matplotlib numpy scipy theano ipython \
+      - run: pip install mpmath gmpy2 matplotlib numpy scipy aesara ipython \
                          symengine cython llvmlite wurlitzer \
                          autowrap numexpr 'antlr4-python3-runtime==4.7.*'
       # Test external imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ jobs:
       # all of the dependencies are supported on 3.8.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.5.1 tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang lxml"
+        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib aesara llvmlite autowrap cython wurlitzer python-symengine=0.5.1 tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang lxml"
         - TEST_SAGE="true"
         - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:
         apt:
           packages:
-            # for theano
+            # for aesara
             - libatlas-dev
             - libatlas-base-dev
             - liblapack-dev

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -31,8 +31,8 @@ test_list = [
     # llvmlite
     '*llvm*',
 
-    # theano
-    '*theano*',
+    # aesara
+    '*aesara*',
 
     # gmpy
     'polys',
@@ -81,8 +81,8 @@ doctest_list = [
     # llvmlite
     '*llvm*',
 
-    # theano
-    '*theano*',
+    # aesara
+    '*aesara*',
 
     # gmpy
     'polys',

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -157,8 +157,8 @@ test_list = [
     # llvmlite
     '*llvm*',
 
-    # theano
-    '*theano*',
+    # aesara
+    '*aesara*',
 
     # gmpy
     'polys',
@@ -207,8 +207,8 @@ doctest_list = [
     # llvmlite
     '*llvm*',
 
-    # theano
-    '*theano*',
+    # aesara
+    '*aesara*',
 
     # gmpy
     'polys',

--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -59,8 +59,8 @@ This is where the meat of code generation is; the translation of SymPy
 actually more like a lightweight version of codegen for Python, and
 Python (:py:func:`sympy.printing.pycode.pycode`), and
 :py:func:`sympy.printing.lambdarepr.lambdarepr`, which supports many libraries
-(like NumPy), and theano
-(:py:func:`sympy.printing.theanocode.theano_function`). The code printers are
+(like NumPy), and Aesara
+(:py:func:`sympy.printing.aesaracode.aesara_function`). The code printers are
 special cases of the other prints in SymPy (str printer, pretty printer, etc.).
 
 An important distinction is that the code printer has to deal with assignments

--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -14,7 +14,7 @@ systems, allowing you to create mathematical expressions in SymPy and then
 ship them off to the numeric system of your choice.  This page documents many
 of the options available including the ``math`` library, the popular array
 computing package ``numpy``, code generation in ``Fortran`` or ``C``, and the
-use of the array compiler ``Theano``.
+use of the array compiler ``Aesara``.
 
 Subs/evalf
 ----------
@@ -90,37 +90,37 @@ The ``autowrap`` module contains methods that help in efficient computation.
 
 The API reference of all the above is listed here: :py:func:`sympy.utilities.autowrap`.
 
-Theano
+Aesara
 ------
 
 SymPy has a strong connection with
-`Theano <http://deeplearning.net/software/theano/>`_, a mathematical array
-compiler.  SymPy expressions can be easily translated to Theano graphs and then
-compiled using the Theano compiler chain.
+`Aesara <https://aesara.readthedocs.io/en/latest/>`_, a mathematical array
+compiler.  SymPy expressions can be easily translated to Aesara graphs and then
+compiled using the Aesara compiler chain.
 
     >>> from sympy import *
     >>> from sympy.abc import x
     >>> expr = sin(x)/x
 
-    >>> from sympy.printing.theanocode import theano_function
-    >>> f = theano_function([x], [expr])
+    >>> from sympy.printing.aesaracode import aesara_function
+    >>> f = aesara_function([x], [expr])
 
-If array broadcasting or types are desired then Theano requires this extra
+If array broadcasting or types are desired then Aesara requires this extra
 information
 
-    >>> f = theano_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})
+    >>> f = aesara_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})
 
-Theano has a more sophisticated code generation system than SymPy's C/Fortran
+Aesara has a more sophisticated code generation system than SymPy's C/Fortran
 code printers.  Among other things it handles common sub-expressions and
-compilation onto the GPU.  Theano also supports SymPy Matrix and Matrix
+compilation onto the GPU.  Aesara also supports SymPy Matrix and Matrix
 Expression objects.
 
 So Which Should I Use?
 ----------------------
 
 The options here were listed in order from slowest and least dependencies to
-fastest and most dependencies.  For example, if you have Theano installed then
-that will often be the best choice.  If you don't have Theano but do have
+fastest and most dependencies.  For example, if you have Aesara installed then
+that will often be the best choice.  If you don't have Aesara but do have
 ``f2py`` then you should use ``ufuncify``.
 
 +-----------------+-------+-----------------------------+---------------+
@@ -134,5 +134,5 @@ that will often be the best choice.  If you don't have Theano but do have
 +-----------------+-------+-----------------------------+---------------+
 | ufuncify        | 10ns  | Complex vector expressions  | f2py, Cython  |
 +-----------------+-------+-----------------------------+---------------+
-| Theano          | 10ns  | Many outputs, CSE, GPUs     | Theano        |
+| Aesara          | 10ns  | Many outputs, CSE, GPUs     | Aesara        |
 +-----------------+-------+-----------------------------+---------------+

--- a/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
+++ b/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
@@ -680,10 +680,10 @@ The tools in the PyDy workflow are :
     offers introspection, rich media, shell syntax, tab completion,
     and history.
 
--  `Theano <http://deeplearning.net/software/theano/>`_: Theano is
-    a numerical computation library for Python. In Theano,
+-  `Aesara <https://aesara.readthedocs.io/en/latest/>`_: Aesara is
+    a numerical computation library for Python. In Aesara,
     computations are expressed using a NumPy-esque syntax and
-    compiled to run efficiently on either CPU or GPU architectures
+    compiled to run efficiently on either CPU or GPU architectures.
 
 -  `Cython <http://cython.org/>`_: Cython is a superset of the
     Python programming language, designed to give C-like performance

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -377,21 +377,21 @@ Rust code printing
 
 .. autofunction:: sympy.printing.rust.rust_code
 
-Theano Code printing
+Aesara Code printing
 --------------------
 
-.. module:: sympy.printing.theanocode
+.. module:: sympy.printing.aesaracode
 
-.. autoclass:: sympy.printing.theanocode.TheanoPrinter
+.. autoclass:: sympy.printing.aesaracode.AesaraPrinter
    :members:
 
-   .. autoattribute:: TheanoPrinter.printmethod
+   .. autoattribute:: AesaraPrinter.printmethod
 
-.. autofunction:: sympy.printing.theanocode.theano_code
+.. autofunction:: sympy.printing.aesaracode.aesara_code
 
-.. autofunction:: sympy.printing.theanocode.theano_function
+.. autofunction:: sympy.printing.aesaracode.aesara_function
 
-.. autofunction:: sympy.printing.theanocode.dim_handling
+.. autofunction:: sympy.printing.aesaracode.dim_handling
 
 Gtk
 ---

--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -72,7 +72,7 @@ def mailmap_update():
 
 @activity
 def test_sympy():
-    with run_in_conda_env(['mpmath', 'matplotlib>=2.2', 'numpy', 'scipy', 'theano',
+    with run_in_conda_env(['mpmath', 'matplotlib>=2.2', 'numpy', 'scipy', 'aesara',
         'ipython', 'gmpy2', 'symengine', 'libgfortran', 'cython',
         'tensorflow', 'llvmlite', 'wurlitzer', 'autowrap',
         'python-symengine=0.3.*', 'numexpr', 'antlr-python-runtime>=4.7,<4.8',

--- a/release/update_requirements.sh
+++ b/release/update_requirements.sh
@@ -34,7 +34,7 @@ pip install\
   'matplotlib>=2.2'\
   'numpy==1.18.5'\
   scipy\
-  theano\
+  aesara\
   ipython\
   symengine\
   tensorflow\

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-symengine.*]
 ignore_missing_imports = True
-[mypy-theano.*]
+[mypy-aesara.*]
 ignore_missing_imports = True
 [mypy-xml.*]
 ignore_missing_imports = True

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -6,69 +6,69 @@ from sympy.printing.printer import Printer
 import sympy
 from functools import partial
 
-from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-theano = import_module('theano')
+aesara = import_module('aesara')
 
-if theano:
-    ts = theano.scalar
-    tt = theano.tensor
-    from theano.sandbox import linalg as tlinalg
+if aesara:
+    aes = aesara.scalar
+    aet = aesara.tensor
+    from aesara.tensor import nlinalg
+    from aesara.tensor.elemwise import Elemwise
+    from aesara.tensor.elemwise import DimShuffle
 
     mapping = {
-            sympy.Add: tt.add,
-            sympy.Mul: tt.mul,
-            sympy.Abs: tt.abs_,
-            sympy.sign: tt.sgn,
-            sympy.ceiling: tt.ceil,
-            sympy.floor: tt.floor,
-            sympy.log: tt.log,
-            sympy.exp: tt.exp,
-            sympy.sqrt: tt.sqrt,
-            sympy.cos: tt.cos,
-            sympy.acos: tt.arccos,
-            sympy.sin: tt.sin,
-            sympy.asin: tt.arcsin,
-            sympy.tan: tt.tan,
-            sympy.atan: tt.arctan,
-            sympy.atan2: tt.arctan2,
-            sympy.cosh: tt.cosh,
-            sympy.acosh: tt.arccosh,
-            sympy.sinh: tt.sinh,
-            sympy.asinh: tt.arcsinh,
-            sympy.tanh: tt.tanh,
-            sympy.atanh: tt.arctanh,
-            sympy.re: tt.real,
-            sympy.im: tt.imag,
-            sympy.arg: tt.angle,
-            sympy.erf: tt.erf,
-            sympy.gamma: tt.gamma,
-            sympy.loggamma: tt.gammaln,
-            sympy.Pow: tt.pow,
-            sympy.Eq: tt.eq,
-            sympy.StrictGreaterThan: tt.gt,
-            sympy.StrictLessThan: tt.lt,
-            sympy.LessThan: tt.le,
-            sympy.GreaterThan: tt.ge,
-            sympy.And: tt.and_,
-            sympy.Or: tt.or_,
-            sympy.Max: tt.maximum,  # Sympy accept >2 inputs, Theano only 2
-            sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
-            sympy.conjugate: tt.conj,
-            sympy.core.numbers.ImaginaryUnit: lambda:tt.complex(0,1),
+            sympy.Add: aet.add,
+            sympy.Mul: aet.mul,
+            sympy.Abs: aet.abs_,
+            sympy.sign: aet.sgn,
+            sympy.ceiling: aet.ceil,
+            sympy.floor: aet.floor,
+            sympy.log: aet.log,
+            sympy.exp: aet.exp,
+            sympy.sqrt: aet.sqrt,
+            sympy.cos: aet.cos,
+            sympy.acos: aet.arccos,
+            sympy.sin: aet.sin,
+            sympy.asin: aet.arcsin,
+            sympy.tan: aet.tan,
+            sympy.atan: aet.arctan,
+            sympy.atan2: aet.arctan2,
+            sympy.cosh: aet.cosh,
+            sympy.acosh: aet.arccosh,
+            sympy.sinh: aet.sinh,
+            sympy.asinh: aet.arcsinh,
+            sympy.tanh: aet.tanh,
+            sympy.atanh: aet.arctanh,
+            sympy.re: aet.real,
+            sympy.im: aet.imag,
+            sympy.arg: aet.angle,
+            sympy.erf: aet.erf,
+            sympy.gamma: aet.gamma,
+            sympy.loggamma: aet.gammaln,
+            sympy.Pow: aet.pow,
+            sympy.Eq: aet.eq,
+            sympy.StrictGreaterThan: aet.gt,
+            sympy.StrictLessThan: aet.lt,
+            sympy.LessThan: aet.le,
+            sympy.GreaterThan: aet.ge,
+            sympy.And: aet.and_,
+            sympy.Or: aet.or_,
+            sympy.Max: aet.maximum,  # Sympy accept >2 inputs, Aesara only 2
+            sympy.Min: aet.minimum,  # Sympy accept >2 inputs, Aesara only 2
+            sympy.conjugate: aet.conj,
+            sympy.core.numbers.ImaginaryUnit: lambda:aet.complex(0,1),
             # Matrices
-            sympy.MatAdd: tt.Elemwise(ts.add),
-            sympy.HadamardProduct: tt.Elemwise(ts.mul),
-            sympy.Trace: tlinalg.trace,
-            sympy.Determinant : tlinalg.det,
-            sympy.Inverse: tlinalg.matrix_inverse,
-            sympy.Transpose: tt.DimShuffle((False, False), [1, 0]),
+            sympy.MatAdd: Elemwise(aes.add),
+            sympy.HadamardProduct: Elemwise(aes.mul),
+            sympy.Trace: nlinalg.trace,
+            sympy.Determinant : nlinalg.det,
+            sympy.Inverse: nlinalg.matrix_inverse,
+            sympy.Transpose: DimShuffle((False, False), [1, 0]),
     }
 
 
-class TheanoPrinter(Printer):
-    """ Code printer which creates Theano symbolic expression graphs.
+class AesaraPrinter(Printer):
+    """ Code printer which creates Aesara symbolic expression graphs.
 
     Parameters
     ==========
@@ -79,22 +79,22 @@ class TheanoPrinter(Printer):
         global state pass an empty dictionary. Note: the dictionary is not
         copied on initialization of the printer and will be updated in-place,
         so using the same dict object when creating multiple printers or making
-        multiple calls to :func:`.theano_code` or :func:`.theano_function` means
+        multiple calls to :func:`.aesara_code` or :func:`.aesara_function` means
         the cache is shared between all these applications.
 
     Attributes
     ==========
 
     cache : dict
-        A cache of Theano variables which have been created for Sympy
+        A cache of Aesara variables which have been created for Sympy
         symbol-like objects (e.g. :class:`sympy.core.symbol.Symbol` or
         :class:`sympy.matrices.expressions.MatrixSymbol`). This is used to
         ensure that all references to a given symbol in an expression (or
-        multiple expressions) are printed as the same Theano variable, which is
+        multiple expressions) are printed as the same Aesara variable, which is
         created only once. Symbols are differentiated only by name and type. The
         format of the cache's contents should be considered opaque to the user.
     """
-    printmethod = "_theano"
+    printmethod = "_aesara"
 
     def __init__(self, *args, **kwargs):
         self.cache = kwargs.pop('cache', dict())
@@ -120,7 +120,7 @@ class TheanoPrinter(Printer):
 
     def _get_or_create(self, s, name=None, dtype=None, broadcastable=None):
         """
-        Get the Theano variable for a Sympy symbol from the cache, or create it
+        Get the Aesara variable for a Sympy symbol from the cache, or create it
         if it does not exist.
         """
 
@@ -137,7 +137,7 @@ class TheanoPrinter(Printer):
         if key in self.cache:
             return self.cache[key]
 
-        value = tt.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
+        value = aet.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
         self.cache[key] = value
         return value
 
@@ -166,11 +166,11 @@ class TheanoPrinter(Printer):
         return self._get_or_create(X, dtype=dtype, broadcastable=(None, None))
 
     def _print_DenseMatrix(self, X, **kwargs):
-        if not hasattr(tt, 'stacklists'):
+        if not hasattr(aet, 'stacklists'):
             raise NotImplementedError(
-               "Matrix translation not yet supported in this version of Theano")
+               "Matrix translation not yet supported in this version of Aesara")
 
-        return tt.stacklists([
+        return aet.stacklists([
             [self._print(arg, **kwargs) for arg in L]
             for L in X.tolist()
         ])
@@ -181,7 +181,7 @@ class TheanoPrinter(Printer):
         children = [self._print(arg, **kwargs) for arg in expr.args]
         result = children[0]
         for child in children[1:]:
-            result = tt.dot(result, child)
+            result = aet.dot(result, child)
         return result
 
     def _print_MatPow(self, expr, **kwargs):
@@ -189,10 +189,10 @@ class TheanoPrinter(Printer):
         result = 1
         if isinstance(children[1], int) and children[1] > 0:
             for i in range(children[1]):
-                result = tt.dot(result, children[0])
+                result = aet.dot(result, children[0])
         else:
             raise NotImplementedError('''Only non-negative integer
-           powers of matrices can be handled by Theano at the moment''')
+           powers of matrices can be handled by Aesara at the moment''')
         return result
 
     def _print_MatrixSlice(self, expr, **kwargs):
@@ -206,7 +206,7 @@ class TheanoPrinter(Printer):
         blocks = [[self._print(expr.blocks[r, c], **kwargs)
                         for c in range(ncols)]
                         for r in range(nrows)]
-        return tt.join(0, *[tt.join(1, *row) for row in blocks])
+        return aet.join(0, *[aet.join(1, *row) for row in blocks])
 
 
     def _print_slice(self, expr, **kwargs):
@@ -228,15 +228,15 @@ class TheanoPrinter(Printer):
         # One condition only
         if len(expr.args) == 1:
             # Return value if condition else NaN
-            return tt.switch(p_cond, p_e, np.nan)
+            return aet.switch(p_cond, p_e, np.nan)
 
         # Return value_1 if condition_1 else evaluate remaining conditions
         p_remaining = self._print(sympy.Piecewise(*expr.args[1:]), **kwargs)
-        return tt.switch(p_cond, p_e, p_remaining)
+        return aet.switch(p_cond, p_e, p_remaining)
 
     def _print_Rational(self, expr, **kwargs):
-        return tt.true_div(self._print(expr.p, **kwargs),
-                           self._print(expr.q, **kwargs))
+        return aet.true_div(self._print(expr.p, **kwargs),
+                            self._print(expr.q, **kwargs))
 
     def _print_Integer(self, expr, **kwargs):
         return expr.p
@@ -245,28 +245,30 @@ class TheanoPrinter(Printer):
         return self._print(sympy.gamma(expr.args[0] + 1), **kwargs)
 
     def _print_Derivative(self, deriv, **kwargs):
+        from aesara.gradient import Rop
+
         rv = self._print(deriv.expr, **kwargs)
         for var in deriv.variables:
             var = self._print(var, **kwargs)
-            rv = tt.Rop(rv, var, tt.ones_like(var))
+            rv = Rop(rv, var, aet.ones_like(var))
         return rv
 
     def emptyPrinter(self, expr):
         return expr
 
     def doprint(self, expr, dtypes=None, broadcastables=None):
-        """ Convert a Sympy expression to a Theano graph variable.
+        """ Convert a Sympy expression to a Aesara graph variable.
 
         The ``dtypes`` and ``broadcastables`` arguments are used to specify the
-        data type, dimension, and broadcasting behavior of the Theano variables
+        data type, dimension, and broadcasting behavior of the Aesara variables
         corresponding to the free symbols in ``expr``. Each is a mapping from
         Sympy symbols to the value of the corresponding argument to
-        ``theano.tensor.Tensor``.
+        ``aesara.tensor.var.TensorVariable``.
 
         See the corresponding `documentation page`__ for more information on
-        broadcasting in Theano.
+        broadcasting in Aesara.
 
-        .. __: http://deeplearning.net/software/theano/tutorial/broadcasting.html
+        .. __: https://aesara.readthedocs.io/en/latest/tutorial/broadcasting.html
 
         Parameters
         ==========
@@ -275,22 +277,22 @@ class TheanoPrinter(Printer):
             Sympy expression to print.
 
         dtypes : dict
-            Mapping from Sympy symbols to Theano datatypes to use when creating
-            new Theano variables for those symbols. Corresponds to the ``dtype``
-            argument to ``theano.tensor.Tensor``. Defaults to ``'floatX'``
+            Mapping from Sympy symbols to Aesara datatypes to use when creating
+            new Aesara variables for those symbols. Corresponds to the ``dtype``
+            argument to ``aesara.tensor.var.TensorVariable``. Defaults to ``'floatX'``
             for symbols not included in the mapping.
 
         broadcastables : dict
             Mapping from Sympy symbols to the value of the ``broadcastable``
-            argument to ``theano.tensor.Tensor`` to use when creating Theano
+            argument to ``aesara.tensor.var.TensorVariable`` to use when creating Aesara
             variables for those symbols. Defaults to the empty tuple for symbols
             not included in the mapping (resulting in a scalar).
 
         Returns
         =======
 
-        theano.gof.graph.Variable
-            A variable corresponding to the expression's value in a Theano
+        aesara.graph.basic.Variable
+            A variable corresponding to the expression's value in a Aesara
             symbolic expression graph.
 
         """
@@ -305,9 +307,9 @@ class TheanoPrinter(Printer):
 global_cache = {}  # type: Dict[Any, Any]
 
 
-def theano_code(expr, cache=None, **kwargs):
+def aesara_code(expr, cache=None, **kwargs):
     """
-    Convert a Sympy expression into a Theano graph variable.
+    Convert a Sympy expression into a Aesara graph variable.
 
     Parameters
     ==========
@@ -316,42 +318,36 @@ def theano_code(expr, cache=None, **kwargs):
         Sympy expression object to convert.
 
     cache : dict
-        Cached Theano variables (see :class:`TheanoPrinter.cache
-        <TheanoPrinter>`). Defaults to the module-level global cache.
+        Cached Aesara variables (see :class:`AesaraPrinter.cache
+        <AesaraPrinter>`). Defaults to the module-level global cache.
 
     dtypes : dict
-        Passed to :meth:`.TheanoPrinter.doprint`.
+        Passed to :meth:`.AesaraPrinter.doprint`.
 
     broadcastables : dict
-        Passed to :meth:`.TheanoPrinter.doprint`.
+        Passed to :meth:`.AesaraPrinter.doprint`.
 
     Returns
     =======
 
-    theano.gof.graph.Variable
-        A variable corresponding to the expression's value in a Theano symbolic
+    aesara.graph.basic.Variable
+        A variable corresponding to the expression's value in a Aesara symbolic
         expression graph.
 
     """
-    SymPyDeprecationWarning(
-        feature="sympy.printing.theanocode",
-        useinstead="Theano is deprecated; use Aesara and sympy.printing.aesaracode",
-        issue=21150,
-        deprecated_since_version="1.8").warn()
-
-    if not theano:
-        raise ImportError("theano is required for theano_code")
+    if not aesara:
+        raise ImportError("aesara is required for aesara_code")
 
     if cache is None:
         cache = global_cache
 
-    return TheanoPrinter(cache=cache, settings={}).doprint(expr, **kwargs)
+    return AesaraPrinter(cache=cache, settings={}).doprint(expr, **kwargs)
 
 
 def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
     r"""
-    Get value of ``broadcastables`` argument to :func:`.theano_code` from
-    keyword arguments to :func:`.theano_function`.
+    Get value of ``broadcastables`` argument to :func:`.aesara_code` from
+    keyword arguments to :func:`.aesara_function`.
 
     Included for backwards compatibility.
 
@@ -371,7 +367,7 @@ def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
 
     broadcastables : dict
         Explicit value of ``broadcastables`` argument to
-        :meth:`.TheanoPrinter.doprint`. If not None function will return this value unchanged.
+        :meth:`.AesaraPrinter.doprint`. If not None function will return this value unchanged.
 
     Returns
     =======
@@ -395,14 +391,13 @@ def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
     return {}
 
 
-@doctest_depends_on(modules=('theano',))
-def theano_function(inputs, outputs, scalar=False, *,
+def aesara_function(inputs, outputs, scalar=False, *,
         dim=None, dims=None, broadcastables=None, **kwargs):
     """
-    Create a Theano function from SymPy expressions.
+    Create a Aesara function from SymPy expressions.
 
-    The inputs and outputs are converted to Theano variables using
-    :func:`.theano_code` and then passed to ``theano.function``.
+    The inputs and outputs are converted to Aesara variables using
+    :func:`.aesara_code` and then passed to ``aesara.function``.
 
     Parameters
     ==========
@@ -417,17 +412,17 @@ def theano_function(inputs, outputs, scalar=False, *,
 
     scalar : bool
         Convert 0-dimensional arrays in output to scalars. This will return a
-        Python wrapper function around the Theano function object.
+        Python wrapper function around the Aesara function object.
 
     cache : dict
-        Cached Theano variables (see :class:`TheanoPrinter.cache
-        <TheanoPrinter>`). Defaults to the module-level global cache.
+        Cached Aesara variables (see :class:`AesaraPrinter.cache
+        <AesaraPrinter>`). Defaults to the module-level global cache.
 
     dtypes : dict
-        Passed to :meth:`.TheanoPrinter.doprint`.
+        Passed to :meth:`.AesaraPrinter.doprint`.
 
     broadcastables : dict
-        Passed to :meth:`.TheanoPrinter.doprint`.
+        Passed to :meth:`.AesaraPrinter.doprint`.
 
     dims : dict
         Alternative to ``broadcastables`` argument. Mapping from elements of
@@ -437,7 +432,7 @@ def theano_function(inputs, outputs, scalar=False, *,
     dim : int
         Another alternative to the ``broadcastables`` argument. Common number of
         dimensions to use for all arrays/tensors.
-        ``theano_function([x, y], [...], dim=2)`` is equivalent to using
+        ``aesara_function([x, y], [...], dim=2)`` is equivalent to using
         ``broadcastables={x: (False, False), y: (False, False)}``.
 
     Returns
@@ -450,32 +445,32 @@ def theano_function(inputs, outputs, scalar=False, *,
         function will return a list of arrays. See description of the ``squeeze``
         argument above for the behavior when a single output is passed in a list.
         The returned object will either be an instance of
-        ``theano.compile.function_module.Function`` or a Python wrapper
+        ``aesara.compile.function.types.Function`` or a Python wrapper
         function around one. In both cases, the returned value will have a
-        ``theano_function`` attribute which points to the return value of
-        ``theano.function``.
+        ``aesara_function`` attribute which points to the return value of
+        ``aesara.function``.
 
     Examples
     ========
 
     >>> from sympy.abc import x, y, z
-    >>> from sympy.printing.theanocode import theano_function
+    >>> from sympy.printing.aesaracode import aesara_function
 
     A simple function with one input and one output:
 
-    >>> f1 = theano_function([x], [x**2 - 1], scalar=True)
+    >>> f1 = aesara_function([x], [x**2 - 1], scalar=True)
     >>> f1(3)
     8.0
 
     A function with multiple inputs and one output:
 
-    >>> f2 = theano_function([x, y, z], [(x**z + y**z)**(1/z)], scalar=True)
+    >>> f2 = aesara_function([x, y, z], [(x**z + y**z)**(1/z)], scalar=True)
     >>> f2(3, 4, 2)
     5.0
 
     A function with multiple inputs and multiple outputs:
 
-    >>> f3 = theano_function([x, y], [x**2 + y**2, x**2 - y**2], scalar=True)
+    >>> f3 = aesara_function([x, y], [x**2 + y**2, x**2 - y**2], scalar=True)
     >>> f3(2, 3)
     [13.0, -5.0]
 
@@ -485,16 +480,10 @@ def theano_function(inputs, outputs, scalar=False, *,
     dim_handling
 
     """
-    SymPyDeprecationWarning(
-        feature="sympy.printing.theanocode",
-        useinstead="Theano is deprecated; use Aesara and sympy.printing.aesaracode",
-        issue=21150,
-        deprecated_since_version="1.8").warn()
+    if not aesara:
+        raise ImportError("Aesara is required for aesara_function")
 
-    if not theano:
-        raise ImportError("theano is required for theano_function")
-
-    # Pop off non-theano keyword args
+    # Pop off non-aesara keyword args
     cache = kwargs.pop('cache', {})
     dtypes = kwargs.pop('dtypes', {})
 
@@ -503,25 +492,25 @@ def theano_function(inputs, outputs, scalar=False, *,
     )
 
     # Print inputs/outputs
-    code = partial(theano_code, cache=cache, dtypes=dtypes,
+    code = partial(aesara_code, cache=cache, dtypes=dtypes,
                    broadcastables=broadcastables)
     tinputs = list(map(code, inputs))
     toutputs = list(map(code, outputs))
 
     #fix constant expressions as variables
-    toutputs = [output if isinstance(output, theano.Variable) else tt.as_tensor_variable(output) for output in toutputs]
+    toutputs = [output if isinstance(output, aesara.graph.basic.Variable) else aet.as_tensor_variable(output) for output in toutputs]
 
     if len(toutputs) == 1:
         toutputs = toutputs[0]
 
-    # Compile theano func
-    func = theano.function(tinputs, toutputs, **kwargs)
+    # Compile aesara func
+    func = aesara.function(tinputs, toutputs, **kwargs)
 
     is_0d = [len(o.variable.broadcastable) == 0 for o in func.outputs]
 
     # No wrapper required
     if not scalar or not any(is_0d):
-        func.theano_function = func
+        func.aesara_function = func
         return func
 
     # Create wrapper to convert 0-dimensional outputs to scalars
@@ -536,5 +525,5 @@ def theano_function(inputs, outputs, scalar=False, *,
 
     wrapper.__wrapped__ = func
     wrapper.__doc__ = func.__doc__
-    wrapper.theano_function = func
+    wrapper.aesara_function = func
     return wrapper

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -1,0 +1,621 @@
+"""
+Important note on tests in this module - the Aesara printing functions use a
+global cache by default, which means that tests using it will modify global
+state and thus not be independent from each other. Instead of using the "cache"
+keyword argument each time, this module uses the aesara_code_ and
+aesara_function_ functions defined below which default to using a new, empty
+cache instead.
+"""
+
+import logging
+
+from sympy.external import import_module
+from sympy.testing.pytest import raises, SKIP
+
+aesaralogger = logging.getLogger('aesara.configdefaults')
+aesaralogger.setLevel(logging.CRITICAL)
+aesara = import_module('aesara')
+aesaralogger.setLevel(logging.WARNING)
+
+
+if aesara:
+    import numpy as np
+    aet = aesara.tensor
+    from aesara.scalar.basic import Scalar
+    from aesara.graph.basic import Variable
+    from aesara.tensor.var import TensorVariable
+    from aesara.tensor.elemwise import Elemwise, DimShuffle
+    from aesara.tensor.math import Dot
+
+    xt, yt, zt = [aet.scalar(name, 'floatX') for name in 'xyz']
+    Xt, Yt, Zt = [aet.tensor('floatX', (False, False), name=n) for n in 'XYZ']
+else:
+    #bin/test will not execute any tests now
+    disabled = True
+
+import sympy as sy
+from sympy import S
+from sympy.abc import x, y, z, t
+from sympy.printing.aesaracode import (aesara_code, dim_handling,
+        aesara_function)
+
+
+# Default set of matrix symbols for testing - make square so we can both
+# multiply and perform elementwise operations between them.
+X, Y, Z = [sy.MatrixSymbol(n, 4, 4) for n in 'XYZ']
+
+# For testing AppliedUndef
+f_t = sy.Function('f')(t)
+
+
+def aesara_code_(expr, **kwargs):
+    """ Wrapper for aesara_code that uses a new, empty cache by default. """
+    kwargs.setdefault('cache', {})
+    return aesara_code(expr, **kwargs)
+
+def aesara_function_(inputs, outputs, **kwargs):
+    """ Wrapper for aesara_function that uses a new, empty cache by default. """
+    kwargs.setdefault('cache', {})
+    return aesara_function(inputs, outputs, **kwargs)
+
+
+def fgraph_of(*exprs):
+    """ Transform SymPy expressions into Aesara Computation.
+
+    Parameters
+    ==========
+    exprs
+        Sympy expressions
+
+    Returns
+    =======
+    aesara.graph.fg.FunctionGraph
+    """
+    outs = list(map(aesara_code_, exprs))
+    ins = list(aesara.graph.basic.graph_inputs(outs))
+    ins, outs = aesara.graph.basic.clone(ins, outs)
+    return aesara.graph.fg.FunctionGraph(ins, outs)
+
+
+def aesara_simplify(fgraph):
+    """ Simplify a Aesara Computation.
+
+    Parameters
+    ==========
+    fgraph : aesara.graph.fg.FunctionGraph
+
+    Returns
+    =======
+    aesara.graph.fg.FunctionGraph
+    """
+    mode = aesara.compile.get_default_mode().excluding("fusion")
+    fgraph = fgraph.clone()
+    mode.optimizer.optimize(fgraph)
+    return fgraph
+
+
+def theq(a, b):
+    """ Test two Aesara objects for equality.
+
+    Also accepts numeric types and lists/tuples of supported types.
+
+    Note - debugprint() has a bug where it will accept numeric types but does
+    not respect the "file" argument and in this case and instead prints the number
+    to stdout and returns an empty string. This can lead to tests passing where
+    they should fail because any two numbers will always compare as equal. To
+    prevent this we treat numbers as a separate case.
+    """
+    numeric_types = (int, float, np.number)
+    a_is_num = isinstance(a, numeric_types)
+    b_is_num = isinstance(b, numeric_types)
+
+    # Compare numeric types using regular equality
+    if a_is_num or b_is_num:
+        if not (a_is_num and b_is_num):
+            return False
+
+        return a == b
+
+    # Compare sequences element-wise
+    a_is_seq = isinstance(a, (tuple, list))
+    b_is_seq = isinstance(b, (tuple, list))
+
+    if a_is_seq or b_is_seq:
+        if not (a_is_seq and b_is_seq) or type(a) != type(b):
+            return False
+
+        return list(map(theq, a)) == list(map(theq, b))
+
+    # Otherwise, assume debugprint() can handle it
+    astr = aesara.printing.debugprint(a, file='str')
+    bstr = aesara.printing.debugprint(b, file='str')
+
+    # Check for bug mentioned above
+    for argname, argval, argstr in [('a', a, astr), ('b', b, bstr)]:
+        if argstr == '':
+            raise TypeError(
+                'aesara.printing.debugprint(%s) returned empty string '
+                '(%s is instance of %r)'
+                % (argname, argname, type(argval))
+            )
+
+    return astr == bstr
+
+
+def test_example_symbols():
+    """
+    Check that the example symbols in this module print to their Aesara
+    equivalents, as many of the other tests depend on this.
+    """
+    assert theq(xt, aesara_code_(x))
+    assert theq(yt, aesara_code_(y))
+    assert theq(zt, aesara_code_(z))
+    assert theq(Xt, aesara_code_(X))
+    assert theq(Yt, aesara_code_(Y))
+    assert theq(Zt, aesara_code_(Z))
+
+
+def test_Symbol():
+    """ Test printing a Symbol to a aesara variable. """
+    xx = aesara_code_(x)
+    assert isinstance(xx, Variable)
+    assert xx.broadcastable == ()
+    assert xx.name == x.name
+
+    xx2 = aesara_code_(x, broadcastables={x: (False,)})
+    assert xx2.broadcastable == (False,)
+    assert xx2.name == x.name
+
+def test_MatrixSymbol():
+    """ Test printing a MatrixSymbol to a aesara variable. """
+    XX = aesara_code_(X)
+    assert isinstance(XX, TensorVariable)
+    assert XX.broadcastable == (False, False)
+
+@SKIP  # TODO - this is currently not checked but should be implemented
+def test_MatrixSymbol_wrong_dims():
+    """ Test MatrixSymbol with invalid broadcastable. """
+    bcs = [(), (False,), (True,), (True, False), (False, True,), (True, True)]
+    for bc in bcs:
+        with raises(ValueError):
+            aesara_code_(X, broadcastables={X: bc})
+
+def test_AppliedUndef():
+    """ Test printing AppliedUndef instance, which works similarly to Symbol. """
+    ftt = aesara_code_(f_t)
+    assert isinstance(ftt, TensorVariable)
+    assert ftt.broadcastable == ()
+    assert ftt.name == 'f_t'
+
+
+def test_add():
+    expr = x + y
+    comp = aesara_code_(expr)
+    assert comp.owner.op == aesara.tensor.add
+
+def test_trig():
+    assert theq(aesara_code_(sy.sin(x)), aet.sin(xt))
+    assert theq(aesara_code_(sy.tan(x)), aet.tan(xt))
+
+def test_many():
+    """ Test printing a complex expression with multiple symbols. """
+    expr = sy.exp(x**2 + sy.cos(y)) * sy.log(2*z)
+    comp = aesara_code_(expr)
+    expected = aet.exp(xt**2 + aet.cos(yt)) * aet.log(2*zt)
+    assert theq(comp, expected)
+
+
+def test_dtype():
+    """ Test specifying specific data types through the dtype argument. """
+    for dtype in ['float32', 'float64', 'int8', 'int16', 'int32', 'int64']:
+        assert aesara_code_(x, dtypes={x: dtype}).type.dtype == dtype
+
+    # "floatX" type
+    assert aesara_code_(x, dtypes={x: 'floatX'}).type.dtype in ('float32', 'float64')
+
+    # Type promotion
+    assert aesara_code_(x + 1, dtypes={x: 'float32'}).type.dtype == 'float32'
+    assert aesara_code_(x + y, dtypes={x: 'float64', y: 'float32'}).type.dtype == 'float64'
+
+
+def test_broadcastables():
+    """ Test the "broadcastables" argument when printing symbol-like objects. """
+
+    # No restrictions on shape
+    for s in [x, f_t]:
+        for bc in [(), (False,), (True,), (False, False), (True, False)]:
+            assert aesara_code_(s, broadcastables={s: bc}).broadcastable == bc
+
+    # TODO - matrix broadcasting?
+
+def test_broadcasting():
+    """ Test "broadcastable" attribute after applying element-wise binary op. """
+
+    expr = x + y
+
+    cases = [
+        [(), (), ()],
+        [(False,), (False,), (False,)],
+        [(True,), (False,), (False,)],
+        [(False, True), (False, False), (False, False)],
+        [(True, False), (False, False), (False, False)],
+    ]
+
+    for bc1, bc2, bc3 in cases:
+        comp = aesara_code_(expr, broadcastables={x: bc1, y: bc2})
+        assert comp.broadcastable == bc3
+
+
+def test_MatMul():
+    expr = X*Y*Z
+    expr_t = aesara_code_(expr)
+    assert isinstance(expr_t.owner.op, Dot)
+    assert theq(expr_t, Xt.dot(Yt).dot(Zt))
+
+def test_Transpose():
+    assert isinstance(aesara_code_(X.T).owner.op, DimShuffle)
+
+def test_MatAdd():
+    expr = X+Y+Z
+    assert isinstance(aesara_code_(expr).owner.op, Elemwise)
+
+
+def test_Rationals():
+    assert theq(aesara_code_(sy.Integer(2) / 3), aet.true_div(2, 3))
+    assert theq(aesara_code_(S.Half), aet.true_div(1, 2))
+
+def test_Integers():
+    assert aesara_code_(sy.Integer(3)) == 3
+
+def test_factorial():
+    n = sy.Symbol('n')
+    assert aesara_code_(sy.factorial(n))
+
+def test_Derivative():
+    simp = lambda expr: aesara_simplify(fgraph_of(expr))
+    assert theq(simp(aesara_code_(sy.Derivative(sy.sin(x), x, evaluate=False))),
+                simp(aesara.grad(aet.sin(xt), xt)))
+
+
+def test_aesara_function_simple():
+    """ Test aesara_function() with single output. """
+    f = aesara_function_([x, y], [x+y])
+    assert f(2, 3) == 5
+
+def test_aesara_function_multi():
+    """ Test aesara_function() with multiple outputs. """
+    f = aesara_function_([x, y], [x+y, x-y])
+    o1, o2 = f(2, 3)
+    assert o1 == 5
+    assert o2 == -1
+
+def test_aesara_function_numpy():
+    """ Test aesara_function() vs Numpy implementation. """
+    f = aesara_function_([x, y], [x+y], dim=1,
+                         dtypes={x: 'float64', y: 'float64'})
+    assert np.linalg.norm(f([1, 2], [3, 4]) - np.asarray([4, 6])) < 1e-9
+
+    f = aesara_function_([x, y], [x+y], dtypes={x: 'float64', y: 'float64'},
+                         dim=1)
+    xx = np.arange(3).astype('float64')
+    yy = 2*np.arange(3).astype('float64')
+    assert np.linalg.norm(f(xx, yy) - 3*np.arange(3)) < 1e-9
+
+
+def test_aesara_function_matrix():
+    m = sy.Matrix([[x, y], [z, x + y + z]])
+    expected = np.array([[1.0, 2.0], [3.0, 1.0 + 2.0 + 3.0]])
+    f = aesara_function_([x, y, z], [m])
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
+    f = aesara_function_([x, y, z], [m], scalar=True)
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
+    f = aesara_function_([x, y, z], [m, m])
+    assert isinstance(f(1.0, 2.0, 3.0), type([]))
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0)[0], expected)
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0)[1], expected)
+
+def test_dim_handling():
+    assert dim_handling([x], dim=2) == {x: (False, False)}
+    assert dim_handling([x, y], dims={x: 1, y: 2}) == {x: (False, True),
+                                                       y: (False, False)}
+    assert dim_handling([x], broadcastables={x: (False,)}) == {x: (False,)}
+
+def test_aesara_function_kwargs():
+    """
+    Test passing additional kwargs from aesara_function() to aesara.function().
+    """
+    import numpy as np
+    f = aesara_function_([x, y, z], [x+y], dim=1, on_unused_input='ignore',
+            dtypes={x: 'float64', y: 'float64', z: 'float64'})
+    assert np.linalg.norm(f([1, 2], [3, 4], [0, 0]) - np.asarray([4, 6])) < 1e-9
+
+    f = aesara_function_([x, y, z], [x+y],
+                        dtypes={x: 'float64', y: 'float64', z: 'float64'},
+                        dim=1, on_unused_input='ignore')
+    xx = np.arange(3).astype('float64')
+    yy = 2*np.arange(3).astype('float64')
+    zz = 2*np.arange(3).astype('float64')
+    assert np.linalg.norm(f(xx, yy, zz) - 3*np.arange(3)) < 1e-9
+
+def test_aesara_function_scalar():
+    """ Test the "scalar" argument to aesara_function(). """
+    from aesara.compile.function.types import Function
+
+    args = [
+        ([x, y], [x + y], None, [0]),  # Single 0d output
+        ([X, Y], [X + Y], None, [2]),  # Single 2d output
+        ([x, y], [x + y], {x: 0, y: 1}, [1]),  # Single 1d output
+        ([x, y], [x + y, x - y], None, [0, 0]),  # Two 0d outputs
+        ([x, y, X, Y], [x + y, X + Y], None, [0, 2]),  # One 0d output, one 2d
+    ]
+
+    # Create and test functions with and without the scalar setting
+    for inputs, outputs, in_dims, out_dims in args:
+        for scalar in [False, True]:
+
+            f = aesara_function_(inputs, outputs, dims=in_dims, scalar=scalar)
+
+            # Check the aesara_function attribute is set whether wrapped or not
+            assert isinstance(f.aesara_function, Function)
+
+            # Feed in inputs of the appropriate size and get outputs
+            in_values = [
+                np.ones([1 if bc else 5 for bc in i.type.broadcastable])
+                for i in f.aesara_function.input_storage
+            ]
+            out_values = f(*in_values)
+            if not isinstance(out_values, list):
+                out_values = [out_values]
+
+            # Check output types and shapes
+            assert len(out_dims) == len(out_values)
+            for d, value in zip(out_dims, out_values):
+
+                if scalar and d == 0:
+                    # Should have been converted to a scalar value
+                    assert isinstance(value, np.number)
+
+                else:
+                    # Otherwise should be an array
+                    assert isinstance(value, np.ndarray)
+                    assert value.ndim == d
+
+def test_aesara_function_bad_kwarg():
+    """
+    Passing an unknown keyword argument to aesara_function() should raise an
+    exception.
+    """
+    raises(Exception, lambda : aesara_function_([x], [x+1], foobar=3))
+
+
+def test_slice():
+    assert aesara_code_(slice(1, 2, 3)) == slice(1, 2, 3)
+
+    def theq_slice(s1, s2):
+        for attr in ['start', 'stop', 'step']:
+            a1 = getattr(s1, attr)
+            a2 = getattr(s2, attr)
+            if a1 is None or a2 is None:
+                if not (a1 is None or a2 is None):
+                    return False
+            elif not theq(a1, a2):
+                return False
+        return True
+
+    dtypes = {x: 'int32', y: 'int32'}
+    assert theq_slice(aesara_code_(slice(x, y), dtypes=dtypes), slice(xt, yt))
+    assert theq_slice(aesara_code_(slice(1, x, 3), dtypes=dtypes), slice(1, xt, 3))
+
+def test_MatrixSlice():
+    from aesara.graph.basic import Constant
+
+    cache = {}
+
+    n = sy.Symbol('n', integer=True)
+    X = sy.MatrixSymbol('X', n, n)
+
+    Y = X[1:2:3, 4:5:6]
+    Yt = aesara_code_(Y, cache=cache)
+
+    s = Scalar('int64')
+    assert tuple(Yt.owner.op.idx_list) == (slice(s, s, s), slice(s, s, s))
+    assert Yt.owner.inputs[0] == aesara_code_(X, cache=cache)
+    # == doesn't work in Aesara like it does in SymPy. You have to use
+    # equals.
+    assert all(Yt.owner.inputs[i].equals(Constant(s, i)) for i in range(1, 7))
+
+    k = sy.Symbol('k')
+    aesara_code_(k, dtypes={k: 'int32'})
+    start, stop, step = 4, k, 2
+    Y = X[start:stop:step]
+    Yt = aesara_code_(Y, dtypes={n: 'int32', k: 'int32'})
+    # assert Yt.owner.op.idx_list[0].stop == kt
+
+def test_BlockMatrix():
+    n = sy.Symbol('n', integer=True)
+    A, B, C, D = [sy.MatrixSymbol(name, n, n) for name in 'ABCD']
+    At, Bt, Ct, Dt = map(aesara_code_, (A, B, C, D))
+    Block = sy.BlockMatrix([[A, B], [C, D]])
+    Blockt = aesara_code_(Block)
+    solutions = [aet.join(0, aet.join(1, At, Bt), aet.join(1, Ct, Dt)),
+                 aet.join(1, aet.join(0, At, Ct), aet.join(0, Bt, Dt))]
+    assert any(theq(Blockt, solution) for solution in solutions)
+
+@SKIP
+def test_BlockMatrix_Inverse_execution():
+    k, n = 2, 4
+    dtype = 'float32'
+    A = sy.MatrixSymbol('A', n, k)
+    B = sy.MatrixSymbol('B', n, n)
+    inputs = A, B
+    output = B.I*A
+
+    cutsizes = {A: [(n//2, n//2), (k//2, k//2)],
+                B: [(n//2, n//2), (n//2, n//2)]}
+    cutinputs = [sy.blockcut(i, *cutsizes[i]) for i in inputs]
+    cutoutput = output.subs(dict(zip(inputs, cutinputs)))
+
+    dtypes = dict(zip(inputs, [dtype]*len(inputs)))
+    f = aesara_function_(inputs, [output], dtypes=dtypes, cache={})
+    fblocked = aesara_function_(inputs, [sy.block_collapse(cutoutput)],
+                                dtypes=dtypes, cache={})
+
+    ninputs = [np.random.rand(*x.shape).astype(dtype) for x in inputs]
+    ninputs = [np.arange(n*k).reshape(A.shape).astype(dtype),
+               np.eye(n).astype(dtype)]
+    ninputs[1] += np.ones(B.shape)*1e-5
+
+    assert np.allclose(f(*ninputs), fblocked(*ninputs), rtol=1e-5)
+
+def test_DenseMatrix():
+    from aesara.tensor.basic import Join
+
+    t = sy.Symbol('theta')
+    for MatrixType in [sy.Matrix, sy.ImmutableMatrix]:
+        X = MatrixType([[sy.cos(t), -sy.sin(t)], [sy.sin(t), sy.cos(t)]])
+        tX = aesara_code_(X)
+        assert isinstance(tX, TensorVariable)
+        assert isinstance(tX.owner.op, Join)
+
+
+def test_cache_basic():
+    """ Test single symbol-like objects are cached when printed by themselves. """
+
+    # Pairs of objects which should be considered equivalent with respect to caching
+    pairs = [
+        (x, sy.Symbol('x')),
+        (X, sy.MatrixSymbol('X', *X.shape)),
+        (f_t, sy.Function('f')(sy.Symbol('t'))),
+    ]
+
+    for s1, s2 in pairs:
+        cache = {}
+        st = aesara_code_(s1, cache=cache)
+
+        # Test hit with same instance
+        assert aesara_code_(s1, cache=cache) is st
+
+        # Test miss with same instance but new cache
+        assert aesara_code_(s1, cache={}) is not st
+
+        # Test hit with different but equivalent instance
+        assert aesara_code_(s2, cache=cache) is st
+
+def test_global_cache():
+    """ Test use of the global cache. """
+    from sympy.printing.aesaracode import global_cache
+
+    backup = dict(global_cache)
+    try:
+        # Temporarily empty global cache
+        global_cache.clear()
+
+        for s in [x, X, f_t]:
+            st = aesara_code(s)
+            assert aesara_code(s) is st
+
+    finally:
+        # Restore global cache
+        global_cache.update(backup)
+
+def test_cache_types_distinct():
+    """
+    Test that symbol-like objects of different types (Symbol, MatrixSymbol,
+    AppliedUndef) are distinguished by the cache even if they have the same
+    name.
+    """
+    symbols = [sy.Symbol('f_t'), sy.MatrixSymbol('f_t', 4, 4), f_t]
+
+    cache = {}  # Single shared cache
+    printed = {}
+
+    for s in symbols:
+        st = aesara_code_(s, cache=cache)
+        assert st not in printed.values()
+        printed[s] = st
+
+    # Check all printed objects are distinct
+    assert len(set(map(id, printed.values()))) == len(symbols)
+
+    # Check retrieving
+    for s, st in printed.items():
+        assert aesara_code(s, cache=cache) is st
+
+def test_symbols_are_created_once():
+    """
+    Test that a symbol is cached and reused when it appears in an expression
+    more than once.
+    """
+    expr = sy.Add(x, x, evaluate=False)
+    comp = aesara_code_(expr)
+
+    assert theq(comp, xt + xt)
+    assert not theq(comp, xt + aesara_code_(x))
+
+def test_cache_complex():
+    """
+    Test caching on a complicated expression with multiple symbols appearing
+    multiple times.
+    """
+    expr = x ** 2 + (y - sy.exp(x)) * sy.sin(z - x * y)
+    symbol_names = {s.name for s in expr.free_symbols}
+    expr_t = aesara_code_(expr)
+
+    # Iterate through variables in the Aesara computational graph that the
+    # printed expression depends on
+    seen = set()
+    for v in aesara.graph.basic.ancestors([expr_t]):
+        # Owner-less, non-constant variables should be our symbols
+        if v.owner is None and not isinstance(v, aesara.graph.basic.Constant):
+            # Check it corresponds to a symbol and appears only once
+            assert v.name in symbol_names
+            assert v.name not in seen
+            seen.add(v.name)
+
+    # Check all were present
+    assert seen == symbol_names
+
+
+def test_Piecewise():
+    # A piecewise linear
+    expr = sy.Piecewise((0, x<0), (x, x<2), (1, True))  # ___/III
+    result = aesara_code_(expr)
+    assert result.owner.op == aet.switch
+
+    expected = aet.switch(xt<0, 0, aet.switch(xt<2, xt, 1))
+    assert theq(result, expected)
+
+    expr = sy.Piecewise((x, x < 0))
+    result = aesara_code_(expr)
+    expected = aet.switch(xt < 0, xt, np.nan)
+    assert theq(result, expected)
+
+    expr = sy.Piecewise((0, sy.And(x>0, x<2)), \
+        (x, sy.Or(x>2, x<0)))
+    result = aesara_code_(expr)
+    expected = aet.switch(aet.and_(xt>0,xt<2), 0, \
+        aet.switch(aet.or_(xt>2, xt<0), xt, np.nan))
+    assert theq(result, expected)
+
+
+def test_Relationals():
+    assert theq(aesara_code_(sy.Eq(x, y)), aet.eq(xt, yt))
+    # assert theq(aesara_code_(sy.Ne(x, y)), aet.neq(xt, yt))  # TODO - implement
+    assert theq(aesara_code_(x > y), xt > yt)
+    assert theq(aesara_code_(x < y), xt < yt)
+    assert theq(aesara_code_(x >= y), xt >= yt)
+    assert theq(aesara_code_(x <= y), xt <= yt)
+
+
+def test_complexfunctions():
+    xt, yt = aesara_code(x, dtypes={x:'complex128'}), aesara_code(y, dtypes={y: 'complex128'})
+    from sympy import conjugate
+    from aesara.tensor import as_tensor_variable as atv
+    from aesara.tensor import complex as cplx
+    assert theq(aesara_code(y*conjugate(x)), yt*(xt.conj()))
+    assert theq(aesara_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
+
+
+def test_constantfunctions():
+    tf = aesara_function([],[1+1j])
+    assert(tf()==1+1j)

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -10,7 +10,7 @@ cache instead.
 import logging
 
 from sympy.external import import_module
-from sympy.testing.pytest import raises, SKIP
+from sympy.testing.pytest import raises, SKIP, warns_deprecated_sympy
 
 theanologger = logging.getLogger('theano.configdefaults')
 theanologger.setLevel(logging.CRITICAL)
@@ -46,12 +46,14 @@ f_t = sy.Function('f')(t)
 def theano_code_(expr, **kwargs):
     """ Wrapper for theano_code that uses a new, empty cache by default. """
     kwargs.setdefault('cache', {})
-    return theano_code(expr, **kwargs)
+    with warns_deprecated_sympy():
+        return theano_code(expr, **kwargs)
 
 def theano_function_(inputs, outputs, **kwargs):
     """ Wrapper for theano_function that uses a new, empty cache by default. """
     kwargs.setdefault('cache', {})
-    return theano_function(inputs, outputs, **kwargs)
+    with warns_deprecated_sympy():
+        return theano_function(inputs, outputs, **kwargs)
 
 
 def fgraph_of(*exprs):
@@ -135,6 +137,7 @@ def theq(a, b):
             )
 
     return astr == bstr
+
 
 
 def test_example_symbols():
@@ -503,8 +506,9 @@ def test_global_cache():
         global_cache.clear()
 
         for s in [x, X, f_t]:
-            st = theano_code(s)
-            assert theano_code(s) is st
+            with warns_deprecated_sympy():
+                st = theano_code(s)
+                assert theano_code(s) is st
 
     finally:
         # Restore global cache
@@ -531,7 +535,8 @@ def test_cache_types_distinct():
 
     # Check retrieving
     for s, st in printed.items():
-        assert theano_code(s, cache=cache) is st
+        with warns_deprecated_sympy():
+            assert theano_code(s, cache=cache) is st
 
 def test_symbols_are_created_once():
     """
@@ -600,14 +605,17 @@ def test_Relationals():
 
 
 def test_complexfunctions():
-    xt, yt = theano_code(x, dtypes={x:'complex128'}), theano_code(y, dtypes={y: 'complex128'})
+    with warns_deprecated_sympy():
+        xt, yt = theano_code(x, dtypes={x:'complex128'}), theano_code(y, dtypes={y: 'complex128'})
     from sympy import conjugate
     from theano.tensor import as_tensor_variable as atv
     from theano.tensor import complex as cplx
-    assert theq(theano_code(y*conjugate(x)), yt*(xt.conj()))
-    assert theq(theano_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
+    with warns_deprecated_sympy():
+        assert theq(theano_code(y*conjugate(x)), yt*(xt.conj()))
+        assert theq(theano_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
 
 
 def test_constantfunctions():
-    tf = theano_function([],[1+1j])
+    with warns_deprecated_sympy():
+        tf = theano_function([],[1+1j])
     assert(tf()==1+1j)

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -721,9 +721,9 @@ def _get_doctest_blacklist():
     if ON_TRAVIS or import_module('pyglet') is None:
         blacklist.extend(["sympy/plotting/pygletplot"])
 
-    if import_module('theano') is None:
+    if import_module('aesara') is None:
         blacklist.extend([
-            "sympy/printing/theanocode.py",
+            "sympy/printing/aesaracode.py",
             "doc/src/modules/numeric-computation.rst",
         ])
 


### PR DESCRIPTION
#### References to other Issues or PRs

This PR is a replacement for #21045.

#### Brief description of what is fixed or changed

Theano is no longer actively maintained, but its fork, [Aesara](https://github.com/pymc-devs/aesara), is, so this PR makes the changes necessary to replace Theano with Aesara. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Replaced the Theano printer with an Aesara printer
<!-- END RELEASE NOTES -->
