### PR TITLE
Dimensional Analysis Improvements

### DIFF
--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -18,7 +18,7 @@ from functools import reduce
 from sympy import (Integer, Matrix, S, Symbol, sympify, Basic, Tuple, Dict,
     default_sort_key)
 from sympy import (sin, cos, tan, cot, sec, csc, asin,
-                  acos, atan, acot, asec, acsc)
+                  acos, atan, acot, asec, acsc, log, exp)
 from sympy import pi, E
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
@@ -459,13 +459,13 @@ class DimensionSystem(Basic, _QuantityMapper):
                         return {}
                     else:
                         raise TypeError("The input argument for the function {} must be dimensionless or have dimensions of angle".format(name.func))
-                elif name.func in (asin, acos, atan, acot, asec, acsc):
+                elif name.func in (asin, acos, atan, acot, asec, acsc, log, exp):
                     if dicts[0] == {}:
                         return {}
                     else:
                         raise TypeError("The input argument for the function {} must be dimensionless".format(name.func))
                 else:
-                    raise TypeError("get_dimensional_dependencies not implement for function {}".format(name.func))
+                    raise TypeError("get_dimensional_dependencies not implement for function {}".format(name.func))                
             else:
                 return get_for_name(result)
 

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -454,7 +454,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             if isinstance(result, Dimension):
                 return self.get_dimensional_dependencies(result)
             elif result.func == name.func:
-                if name.func in (sin, cos, tan, cot, sec, csc):
+                if isinstance(name, (sin, cos, tan, cot, sec, csc)):
                     if dicts[0] == {} or dicts[0] == {Symbol('angle'): 1}:
                         return {}
                     else:

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -441,7 +441,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             dim_base = get_for_name(name.base)
             dim_exp = get_for_name(name.exp)
             if dim_exp != {}:
-                raise TypeError("The exponent for the power operator must be unitless.")
+                raise TypeError("The exponent for the power operator must be dimensionless.")
             return {k: v*name.exp for (k, v) in dim_base.items()}
 
         if name.is_Function:

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -439,10 +439,10 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         if name.is_Pow:
             dim_base = get_for_name(name.base)
-            dim_exp = get_for_name(name.exp)
-            if dim_exp != {}:
-                raise TypeError("The exponent for the power operator must be dimensionless.")
-            return {k: v*name.exp for (k, v) in dim_base.items()}
+            if name.exp.is_number or name.exp.is_NumberSymbol or name.exp.is_Symbol:
+                return {k: v*name.exp for (k, v) in dim_base.items()}
+            else:
+                raise TypeError("The exponent for the power operator must be a Symbol or dimensionless.")
 
         if name.is_Function:
             args = (Dimension._from_dimensional_dependencies(

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -454,7 +454,6 @@ class DimensionSystem(Basic, _QuantityMapper):
             if isinstance(result, Dimension):
                 return self.get_dimensional_dependencies(result)
             elif result.func == name.func:
-                print(name.func)
                 if name.func in (sin, cos, tan, cot, sec, csc):
                     if dicts[0] == {} or dicts[0] == {Symbol('angle'): 1}:
                         return {}

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -439,7 +439,8 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         if name.is_Pow:
             dim_base = get_for_name(name.base)
-            if name.exp.is_number or name.exp.is_NumberSymbol or name.exp.is_Symbol:
+            dim_exp = get_for_name(name.exp)
+            if dim_exp == {} or name.exp.is_Symbol:
                 return {k: v*name.exp for (k, v) in dim_base.items()}
             else:
                 raise TypeError("The exponent for the power operator must be a Symbol or dimensionless.")

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -418,7 +418,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             # as base dimensions:
             return dict(self.dimensional_dependencies.get(name, {name: 1}))
 
-        if name.is_Number or name.is_NumberSymbol:
+        if name.is_number or name.is_NumberSymbol:
             return {}
 
         get_for_name = self._get_dimensional_dependencies_for_name

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -17,9 +17,7 @@ from functools import reduce
 
 from sympy import (Integer, Matrix, S, Symbol, sympify, Basic, Tuple, Dict,
     default_sort_key)
-from sympy import (sin, cos, tan, cot, sec, csc, asin,
-                  acos, atan, acot, asec, acsc, log, exp)
-from sympy import pi, E
+from sympy import sin, cos, tan, cot, sec, csc
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -440,8 +438,11 @@ class DimensionSystem(Basic, _QuantityMapper):
             raise TypeError("Only equivalent dimensions can be added or subtracted.")
 
         if name.is_Pow:
-            dim = get_for_name(name.base)
-            return {k: v*name.exp for (k, v) in dim.items()}
+            dim_base = get_for_name(name.base)
+            dim_exp = get_for_name(name.exp)
+            if dim_exp != {}:
+                raise TypeError("The exponent for the power operator must be unitless.")
+            return {k: v*name.exp for (k, v) in dim_base.items()}
 
         if name.is_Function:
             args = (Dimension._from_dimensional_dependencies(
@@ -458,14 +459,12 @@ class DimensionSystem(Basic, _QuantityMapper):
                     if dicts[0] == {} or dicts[0] == {Symbol('angle'): 1}:
                         return {}
                     else:
-                        raise TypeError("The input argument for the function {} must be dimensionless or have dimensions of angle".format(name.func))
-                elif name.func in (asin, acos, atan, acot, asec, acsc, log, exp):
-                    if dicts[0] == {}:
+                        raise TypeError("The input argument for the function {} must be dimensionless or have dimensions of angle.".format(name.func))
+                else:
+                    if all( (item == {} for item in dicts) ):
                         return {}
                     else:
-                        raise TypeError("The input argument for the function {} must be dimensionless".format(name.func))
-                else:
-                    raise TypeError("get_dimensional_dependencies not implement for function {}".format(name.func))                
+                        raise TypeError("The input arguments for the function {} must be dimensionless.".format(name.func))
             else:
                 return get_for_name(result)
 

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -17,7 +17,7 @@ from functools import reduce
 
 from sympy import (Integer, Matrix, S, Symbol, sympify, Basic, Tuple, Dict,
     default_sort_key)
-from sympy import sin, cos, tan, cot, sec, csc
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -454,7 +454,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             if isinstance(result, Dimension):
                 return self.get_dimensional_dependencies(result)
             elif result.func == name.func:
-                if isinstance(name, (sin, cos, tan, cot, sec, csc)):
+                if isinstance(name, TrigonometricFunction):
                     if dicts[0] == {} or dicts[0] == {Symbol('angle'): 1}:
                         return {}
                     else:

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -100,6 +100,12 @@ def test_Dimension_mul_div_exp():
     assert dimsys_SI.get_dimensional_dependencies(length ** -1) == {"length": -1}
     assert dimsys_SI.get_dimensional_dependencies(velo ** -1.5) == {"length": -1.5, "time": 1.5}
 
+
+    length_a = length**"a"
+    assert dimsys_SI.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
+
+    assert dimsys_SI.get_dimensional_dependencies(length**pi) == {"length": pi}
+
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(length**length))
 
     assert length != 1

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -129,3 +129,5 @@ def test_Dimension_functions():
 
     assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
     assert dimsys_SI.get_dimensional_dependencies(Abs(length/length)) == {}
+
+    assert dimsys_SI.get_dimensional_dependencies(sqrt(-1)) == {} 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -117,8 +117,10 @@ def test_Dimension_mul_div_exp():
 
 def test_Dimension_functions():
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(cos(length)))
-    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(atan2(length,time)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(atan2(length, time)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(length)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(100, length)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(length, 10)))
 
     assert dimsys_SI.get_dimensional_dependencies(pi) == {}
 
@@ -127,7 +129,9 @@ def test_Dimension_functions():
 
     assert dimsys_SI.get_dimensional_dependencies(atan2(length, length)) == {}
 
+    assert dimsys_SI.get_dimensional_dependencies(log(length / length, length / length)) == {}
+
     assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
-    assert dimsys_SI.get_dimensional_dependencies(Abs(length/length)) == {}
+    assert dimsys_SI.get_dimensional_dependencies(Abs(length / length)) == {}
 
     assert dimsys_SI.get_dimensional_dependencies(sqrt(-1)) == {}

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -129,4 +129,3 @@ def test_Dimension_functions():
 
     assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
     assert dimsys_SI.get_dimensional_dependencies(Abs(length/length)) == {}
-

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -130,4 +130,4 @@ def test_Dimension_functions():
     assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
     assert dimsys_SI.get_dimensional_dependencies(Abs(length/length)) == {}
 
-    assert dimsys_SI.get_dimensional_dependencies(sqrt(-1)) == {} 
+    assert dimsys_SI.get_dimensional_dependencies(sqrt(-1)) == {}

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -1,9 +1,9 @@
 from sympy.physics.units.systems.si import dimsys_SI
 
-from sympy import S, Symbol, sqrt
+from sympy import S, Symbol, sqrt, cos, log, atan2, pi, Abs
 from sympy.physics.units.dimensions import Dimension
 from sympy.physics.units.definitions.dimension_definitions import (
-    length, time, mass, force, pressure
+    length, time, mass, force, pressure, angle
 )
 from sympy.physics.units import foot
 from sympy.testing.pytest import raises
@@ -100,8 +100,7 @@ def test_Dimension_mul_div_exp():
     assert dimsys_SI.get_dimensional_dependencies(length ** -1) == {"length": -1}
     assert dimsys_SI.get_dimensional_dependencies(velo ** -1.5) == {"length": -1.5, "time": 1.5}
 
-    length_a = length**"a"
-    assert dimsys_SI.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(length**length))
 
     assert length != 1
     assert length / length != 1
@@ -115,3 +114,19 @@ def test_Dimension_mul_div_exp():
     c = sqrt(a**2 + b**2)
     c_dim = c.subs({a: length, b: length})
     assert dimsys_SI.equivalent_dims(c_dim, length)
+
+def test_Dimension_functions():
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(cos(length)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(atan2(length,time)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(length)))
+
+    assert dimsys_SI.get_dimensional_dependencies(pi) == {}
+
+    assert dimsys_SI.get_dimensional_dependencies(cos(1)) == {}
+    assert dimsys_SI.get_dimensional_dependencies(cos(angle)) == {}
+
+    assert dimsys_SI.get_dimensional_dependencies(atan2(length, length)) == {}
+
+    assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
+    assert dimsys_SI.get_dimensional_dependencies(Abs(length/length)) == {}
+

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -100,7 +100,6 @@ def test_Dimension_mul_div_exp():
     assert dimsys_SI.get_dimensional_dependencies(length ** -1) == {"length": -1}
     assert dimsys_SI.get_dimensional_dependencies(velo ** -1.5) == {"length": -1.5, "time": 1.5}
 
-
     length_a = length**"a"
     assert dimsys_SI.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -104,6 +104,7 @@ def test_Dimension_mul_div_exp():
     assert dimsys_SI.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
 
     assert dimsys_SI.get_dimensional_dependencies(length**pi) == {"length": pi}
+    assert dimsys_SI.get_dimensional_dependencies(length**(length/length)) == {"length": Dimension(1)}
 
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(length**length))
 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -1,6 +1,6 @@
 from sympy.physics.units.systems.si import dimsys_SI
 
-from sympy import S, Symbol, sqrt, cos, log, atan2, pi, Abs
+from sympy import S, Symbol, sqrt, cos, acos, log, atan2, pi, Abs
 from sympy.physics.units.dimensions import Dimension
 from sympy.physics.units.definitions.dimension_definitions import (
     length, time, mass, force, pressure, angle
@@ -117,6 +117,7 @@ def test_Dimension_mul_div_exp():
 
 def test_Dimension_functions():
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(cos(length)))
+    raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(acos(angle)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(atan2(length, time)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(length)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(log(100, length)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

In working on my [browser based app](https://github.com/mgreminger/EngineeringPaper) that does symbolic computations with dimensional analysis (powered by SymPy through Pyodide), I've come across several dimensional analysis edge cases that weren't working as expected. I've fixed those on my fork and would like to upstream these fixes.  

Summary of changes:
* The `reduce` call that gets triggered for function args didn't have an initial value of 1 so it failed for dimensionless arguments in cases like cos(1). 
* Numbers with a complex component or constants such as pi and E were not handled, they are now treated as dimensionless by default
* The default for functions previously was to allow any dimensions for the input args and then return dimensionless, the default behavior has been changed to enforce all function args to be dimensionless and to return dimensionless (this is a safer default, it didn't make sense for cos(length), cos(time), cos(angle) to all work and return dimensionless
* The functions sin, cos, tan, cot, sec, and csc are treated as a special case and are allowed to have a dimensionless or angle input argument (there may need to be other special case functions in the future but the above default should work for most cases included logarithmic functions)
* Exponents must now be dimensionless (cases such as length**length were allowed previously)


##### Old Behavior
```python
>>> import sympy
>>> sympy.__version__
'1.7.1'
>>> from sympy.physics.units.definitions.dimension_definitions import length, angle, time
>>> from sympy.physics.units.systems.si import dimsys_SI
>>> dimsys_SI.get_dimensional_dependencies(sympy.cos(1))
TypeError: reduce() of empty sequence with no initial value
>>> dimsys_SI.get_dimensional_dependencies(sympy.pi)
TypeError: Type <class 'sympy.core.numbers.Pi'> not implemented for get_dimensional_dependencies
>>> dimsys_SI.get_dimensional_dependencies(sympy.sqrt(-1))
TypeError: Type <class 'sympy.core.numbers.ImaginaryUnit'> not implemented for get_dimensional_dependencies
>>> dimsys_SI.get_dimensional_dependencies(sympy.cos(length))
{}
>>> dimsys_SI.get_dimensional_dependencies(length**length)
{'length': Dimension(length, L)}
```

##### New Behavior
```python
>>> import sympy
>>> from sympy.physics.units.definitions.dimension_definitions import length, angle, time
>>> from sympy.physics.units.systems.si import dimsys_SI
>>> dimsys_SI.get_dimensional_dependencies(sympy.cos(1))
{}
>>> dimsys_SI.get_dimensional_dependencies(sympy.pi)
{}
>>> dimsys_SI.get_dimensional_dependencies(sympy.sqrt(-1))
{}
>>> dimsys_SI.get_dimensional_dependencies(sympy.cos(length))
TypeError: The input argument for the function cos must be dimensionless or have dimensions of angle.
>>> dimsys_SI.get_dimensional_dependencies(length**length)
TypeError: The exponent for the power operator must be unitless.
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fix bug when input argument to a function is an integer
  * Change default behavior for functions (all function arguments must be dimensionless by default)
  * sin, cos, tan, cot, sec, and csc functions may have a dimensionless or angle input argument
  * Exponents must now be dimensionless
  * Constants such as pi and E are now treated as dimensionless (raised exception previously)
  * Numbers with an imaginary component are now treated as dimensionless (raised exception previously)
<!-- END RELEASE NOTES -->
