### PR TITLE
Corrected latext for unevaluated Mul

### DIFF
--- a/doc/src/tutorial/manipulation.rst
+++ b/doc/src/tutorial/manipulation.rst
@@ -554,7 +554,7 @@ result in different output forms. For example
     >>> from sympy import latex
     >>> uexpr = UnevaluatedExpr(S.One*5/7)*UnevaluatedExpr(S.One*3/4)
     >>> print(latex(uexpr))
-    \frac{5}{7} \frac{3}{4}
+    \frac{5}{7} \cdot \frac{3}{4}
 
 In order to release the expression and get the evaluated LaTeX form,
 just use ``.doit()``:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -115,7 +115,7 @@ greek_letters_set = frozenset(greeks)
 
 _between_two_numbers_p = (
     re.compile(r'[0-9][} ]*$'),  # search
-    re.compile(r'[{ ]*[-+0-9]'),  # match
+    re.compile(r'[0-9]'),  # match
 )
 
 
@@ -529,7 +529,7 @@ class LatexPrinter(Printer):
                         term_tex = r"\left(%s\right)" % term_tex
 
                     if _between_two_numbers_p[0].search(last_term_tex) and \
-                            _between_two_numbers_p[1].match(term_tex):
+                            _between_two_numbers_p[1].match(str(term)):
                         # between two numbers
                         _tex += numbersep
                     elif _tex:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -93,9 +93,9 @@ def test_latex_basic():
     assert latex(Mul(-1, 1, evaluate=False)) == r'\left(-1\right) 1'
     assert latex(Mul(1, 1, 1, evaluate=False)) == r'1 \cdot 1 \cdot 1'
     assert latex(Mul(1, 2, evaluate=False)) == r'1 \cdot 2'
-    assert latex(Mul(1, S.Half, evaluate=False)) == r'1 \frac{1}{2}'
+    assert latex(Mul(1, S.Half, evaluate=False)) == r'1 \cdot \frac{1}{2}'
     assert latex(Mul(1, 1, S.Half, evaluate=False)) == \
-        r'1 \cdot 1 \frac{1}{2}'
+        r'1 \cdot 1 \cdot \frac{1}{2}'
     assert latex(Mul(1, 1, 2, 3, x, evaluate=False)) == \
         r'1 \cdot 1 \cdot 2 \cdot 3 x'
     assert latex(Mul(1, -1, evaluate=False)) == r'1 \left(-1\right)'
@@ -104,7 +104,7 @@ def test_latex_basic():
     assert latex(Mul(4, 3, 2, 1+z, 0, y, x, evaluate=False)) == \
         r'4 \cdot 3 \cdot 2 \left(z + 1\right) 0 y x'
     assert latex(Mul(Rational(2, 3), Rational(5, 7), evaluate=False)) == \
-        r'\frac{2}{3} \frac{5}{7}'
+        r'\frac{2}{3} \cdot \frac{5}{7}'
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == r"1 / x"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -87,6 +87,15 @@ def test_latex_basic():
     assert latex(3*x**2*y, mul_symbol='\\,') == r"3\,x^{2}\,y"
     assert latex(1.5*3**x, mul_symbol='\\,') == r"1.5 \cdot 3^{x}"
 
+    assert latex(x**S.Half**5) == r"\sqrt[32]{x}"
+    assert latex(Mul(S.Half, x**2, -5, evaluate=False)) == r"\frac{1}{2} x^{2} \left(-5\right)"
+    assert latex(Mul(S.Half, x**2, 5, evaluate=False)) == r"\frac{1}{2} x^{2} \cdot 5"
+    assert latex(Mul(-5, -5, evaluate=False)) == r"\left(-5\right) \left(-5\right)"
+    assert latex(Mul(5, -5, evaluate=False)) == r"5 \left(-5\right)"
+    assert latex(Mul(S.Half, -5, S.Half, evaluate=False)) == r"\frac{1}{2} \left(-5\right) \frac{1}{2}"
+    assert latex(Mul(5, I, 5, evaluate=False)) == r"5 i 5"
+    assert latex(Mul(5, I, -5, evaluate=False)) == r"5 i \left(-5\right)"
+
     assert latex(Mul(0, 1, evaluate=False)) == r'0 \cdot 1'
     assert latex(Mul(1, 0, evaluate=False)) == r'1 \cdot 0'
     assert latex(Mul(1, 1, evaluate=False)) == r'1 \cdot 1'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21094

#### Brief description of what is fixed or changed
Fixed incorrect latex output for unevaluated `Mul` while using fractions.  

Before
```python
>>> latex(Mul(1, S.Half, evaluate=False))
'1  \\frac{1}{2}'
```
Now
```python
>>> latex(Mul(1, S.Half, evaluate=False))
'1 \\cdot  \\frac{1}{2}'
```
Also updated the test cases for the same bug. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
   - Fixed issue with printing latex of unevaluated `Mul` with fractions
  

<!-- END RELEASE NOTES -->
