### PR TITLE
feat(polys): add indexing and slicing to DomainMatrix

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -95,6 +95,15 @@ class DDM(list):
         if not (len(self) == m and all(len(row) == n for row in self)):
             raise DDMBadInputError("Inconsistent row-list/shape")
 
+    def getitem(self, i, j):
+        return self[i][j]
+
+    def extract_slice(self, slice1, slice2):
+        ddm = [row[slice2] for row in self[slice1]]
+        rows = len(ddm)
+        cols = len(ddm[0]) if ddm else len(range(self.shape[1])[slice2])
+        return DDM(ddm, (rows, cols), self.domain)
+
     def to_list(self):
         return list(self)
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -112,6 +112,25 @@ class DomainMatrix:
 
         return cls.from_rep(rep)
 
+    def __getitem__(self, key):
+        i, j = key
+        m, n = self.shape
+        if not (isinstance(i, slice) or isinstance(j, slice)):
+            return DomainScalar(self.rep.getitem(i, j), self.domain)
+
+        if not isinstance(i, slice):
+            if not -m <= i < m:
+                raise IndexError("Row index out of range")
+            i = i % m
+            i = slice(i, i+1)
+        if not isinstance(j, slice):
+            if not -n <= j < n:
+                raise IndexError("Column index out of range")
+            j = j % n
+            j = slice(j, j+1)
+
+        return self.from_rep(self.rep.extract_slice(i, j))
+
     @classmethod
     def from_rep(cls, rep):
         """Create a new DomainMatrix efficiently from DDM/SDM.

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -31,6 +31,33 @@ class SDM(dict):
         if not all(0 <= c < n for row in self.values() for c in row):
             raise DDMBadInputError("Column out of range")
 
+    def getitem(self, i, j):
+        try:
+            return self[i][j]
+        except KeyError:
+            m, n = self.shape
+            if -m <= i < m and -n <= j < n:
+                try:
+                    return self[i % m][j % n]
+                except KeyError:
+                    return self.domain.zero
+            else:
+                raise IndexError("index out of range")
+
+    def extract_slice(self, slice1, slice2):
+        m, n = self.shape
+        ri = range(m)[slice1]
+        ci = range(n)[slice2]
+
+        sdm = {}
+        for i, row in self.items():
+            if i in ri:
+                row = {ci.index(j): e for j, e in row.items() if j in ci}
+                if row:
+                    sdm[ri.index(i)] = row
+
+        return self.new(sdm, (len(ri), len(ci)), self.domain)
+
     def __str__(self):
         rowsstr = []
         for i, row in self.items():

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -370,3 +370,34 @@ def test_DDM_charpoly():
 
     A = DDM([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
     raises(DDMShapeError, lambda: A.charpoly())
+
+
+def test_DDM_getitem():
+    dm = DDM([
+        [ZZ(1), ZZ(2), ZZ(3)],
+        [ZZ(4), ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)
+
+    assert dm.getitem(1, 1) == ZZ(5)
+    assert dm.getitem(1, -2) == ZZ(5)
+    assert dm.getitem(-1, -3) == ZZ(7)
+
+    raises(IndexError, lambda: dm.getitem(3, 3))
+
+
+def test_DDM_extract_slice():
+    dm = DDM([
+        [ZZ(1), ZZ(2), ZZ(3)],
+        [ZZ(4), ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)
+
+    assert dm.extract_slice(slice(0, 3), slice(0, 3)) == dm
+    assert dm.extract_slice(slice(1, 3), slice(-2)) == DDM([[4], [7]], (2, 1), ZZ)
+    assert dm.extract_slice(slice(1, 3), slice(-2)) == DDM([[4], [7]], (2, 1), ZZ)
+    assert dm.extract_slice(slice(2, 3), slice(-2)) == DDM([[ZZ(7)]], (1, 1), ZZ)
+    assert dm.extract_slice(slice(0, 2), slice(-2)) == DDM([[1], [4]], (2, 1), ZZ)
+    assert dm.extract_slice(slice(-1), slice(-1)) == DDM([[1, 2], [4, 5]], (2, 2), ZZ)
+
+    assert dm.extract_slice(slice(2), slice(3, 4)) == DDM([[], []], (2, 0), ZZ)
+    assert dm.extract_slice(slice(3, 4), slice(2)) == DDM([], (0, 2), ZZ)
+    assert dm.extract_slice(slice(3, 4), slice(3, 4)) == DDM([], (0, 0), ZZ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -8,12 +8,12 @@ from sympy.matrices.common import (NonInvertibleMatrixError,
 from sympy.matrices.dense import Matrix
 from sympy.polys import ZZ, QQ
 
-from sympy.polys.matrices.domainmatrix import DomainMatrix
+
+from sympy.polys.matrices.domainmatrix import DomainMatrix, DomainScalar
 from sympy.polys.matrices.exceptions import (DDMBadInputError, DDMDomainError,
         DDMShapeError, DDMFormatError)
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.sdm import SDM
-from sympy.polys.matrices.domainscalar import DomainScalar
 
 
 def test_DomainMatrix_init():
@@ -583,3 +583,47 @@ def test_DomainMatrix_truediv():
     raises(ZeroDivisionError, lambda: A / 0)
     raises(TypeError, lambda: A / 1.5)
     raises(ZeroDivisionError, lambda: A / DomainScalar(ZZ(0), ZZ))
+
+
+def test_DomainMatrix_getitem():
+    dM = DomainMatrix([
+        [ZZ(1), ZZ(2), ZZ(3)],
+        [ZZ(4), ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)
+
+    assert dM[1:,:-2] == DomainMatrix([[ZZ(4)], [ZZ(7)]], (2, 1), ZZ)
+    assert dM[2,:-2] == DomainMatrix([[ZZ(7)]], (1, 1), ZZ)
+    assert dM[:-2,:-2] == DomainMatrix([[ZZ(1)]], (1, 1), ZZ)
+    assert dM[:-1,0:2] == DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(4), ZZ(5)]], (2, 2), ZZ)
+    assert dM[:, -1] == DomainMatrix([[ZZ(3)], [ZZ(6)], [ZZ(9)]], (3, 1), ZZ)
+    assert dM[-1, :] == DomainMatrix([[ZZ(7), ZZ(8), ZZ(9)]], (1, 3), ZZ)
+    assert dM[::-1, :] == DomainMatrix([
+                            [ZZ(7), ZZ(8), ZZ(9)],
+                            [ZZ(4), ZZ(5), ZZ(6)],
+                            [ZZ(1), ZZ(2), ZZ(3)]], (3, 3), ZZ)
+
+    raises(IndexError, lambda: dM[4, :-2])
+    raises(IndexError, lambda: dM[:-2, 4])
+
+    assert dM[1, 2] == DomainScalar(ZZ(6), ZZ)
+    assert dM[-2, 2] == DomainScalar(ZZ(6), ZZ)
+    assert dM[1, -2] == DomainScalar(ZZ(5), ZZ)
+    assert dM[-1, -3] == DomainScalar(ZZ(7), ZZ)
+
+    raises(IndexError, lambda: dM[3, 3])
+    raises(IndexError, lambda: dM[1, 4])
+    raises(IndexError, lambda: dM[-1, -4])
+
+    dM = DomainMatrix({0: {0: ZZ(1)}}, (10, 10), ZZ)
+    assert dM[5, 5] == DomainScalar(ZZ(0), ZZ)
+    assert dM[0, 0] == DomainScalar(ZZ(1), ZZ)
+
+    dM = DomainMatrix({1: {0: 1}}, (2,1), ZZ)
+    assert dM[0:, 0] == DomainMatrix({1: {0: 1}}, (2, 1), ZZ)
+    raises(IndexError, lambda: dM[3, 0])
+
+    dM = DomainMatrix({2: {2: ZZ(1)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)
+    assert dM[:2,:2] == DomainMatrix({}, (2, 2), ZZ)
+    assert dM[2:,2:] == DomainMatrix({0: {0: 1}, 2: {2: 1}}, (3, 3), ZZ)
+    assert dM[3:,3:] == DomainMatrix({1: {1: 1}}, (2, 2), ZZ)
+    assert dM[2:, 6:] == DomainMatrix({}, (3, 0), ZZ)


### PR DESCRIPTION
This PR implements  `__getitem__` for indexing and slicing to `DomainMatrix`.

Reference to Task 7 in #20987

#### Brief description of what is fixed or changed
This PR adds `__getitem__` method for `DomainMatrix`. 
In the case of indexing, the element is returned as a `DomainScalar`, otherwise, it is returned as a `DomainMatrix`.

The implementation result as:
```py
In [1]: from sympy.polys.matrices import DomainMatrix

In [2]: dM = DomainMatrix([
   ...:         [ZZ(1), ZZ(2), ZZ(3)],
   ...:         [ZZ(4), ZZ(5), ZZ(6)],
   ...:         [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)

In [3]: dM[1:,:-2]
Out[3]: DomainMatrix([[4], [7]], (2, 1), ZZ)

In [4]: dM[::-1, :]
Out[4]: DomainMatrix([[7, 8, 9], [4, 5, 6], [1, 2, 3]], (3, 3), ZZ)

In [5]: dM[1, 2]
Out[5]: 6

In [6]: type(dM[1, 2])
Out[6]: sympy.polys.matrices.domainscalar.DomainScalar

In [7]: dM = DomainMatrix({2: {2: ZZ(1)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)

In [8]: dM[2:,2:]
Out[8]: DomainMatrix({0: {0: 1}, 2: {2: 1}}, (3, 3), ZZ)

In [9]: dM[2:, 6:]
Out[9]: DomainMatrix({}, (3, 0), ZZ)

In [10]: dM[2, 2]
Out[10]: 1

In [11]: type(dM[2, 2])
Out[11]: sympy.polys.matrices.domainscalar.DomainScalar

```

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
