### PR TITLE
Add missing new line in documentation style guide

### DIFF
--- a/doc/src/documentation-style-guide.rst
+++ b/doc/src/documentation-style-guide.rst
@@ -207,7 +207,8 @@ For Fedora (and maybe other RPM-based distributions), install the
 prerequisites::
 
    dnf install python3-sphinx librsvg2 ImageMagick docbook2X texlive-dvipng-bin
-   texlive-scheme-medium librsvg2-tools python -m pip install sphinx-math-dollar
+   texlive-scheme-medium librsvg2-tools
+   python -m pip install sphinx-math-dollar
 
 After that, run::
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Just add a new line between commands in the documentation.
This makes sure dnf won't give an incorrect argument error when copying and pasting the package list.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
