### PR TITLE
Refactor Exact ODE solver into a class

### DIFF
--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -77,7 +77,7 @@ factorable
 
 1st_exact
 ^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode::ode_1st_exact
+.. autoclass:: sympy.solvers.ode.single.FirstExact
 
 1st_homogeneous_coeff_best
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -2834,7 +2834,7 @@ def _handle_Integral(expr, func, hint):
     else:
         sol = expr
     return sol
-    
+
 
 def ode_1st_homogeneous_coeff_best(eq, func, order, match):
     r"""

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -943,6 +943,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
     >>> classify_ode(Eq(f(x).diff(x), 0), f(x))
     ('nth_algebraic',
     'separable',
+    '1st_exact',
     '1st_linear',
     'Bernoulli',
     '1st_homogeneous_coeff_best',
@@ -950,7 +951,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
     '1st_homogeneous_coeff_subs_dep_div_indep',
     '1st_power_series', 'lie_group', 'nth_linear_constant_coeff_homogeneous',
     'nth_linear_euler_eq_homogeneous',
-    'nth_algebraic_Integral', 'separable_Integral',
+    'nth_algebraic_Integral', 'separable_Integral', '1st_exact_Integral',
     '1st_linear_Integral', 'Bernoulli_Integral',
     '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
     '1st_homogeneous_coeff_subs_dep_div_indep_Integral')

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -677,12 +677,6 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
 
     if isinstance(match, SingleODESolver):
         solvefunc = match
-        # XXX: This global y hack should be removed
-        global y
-        if hint == "1st_exact":
-            y = match.y
-        elif hint == "1st_exact_Integral":
-            y = match.y
     elif hint.endswith('_Integral'):
         solvefunc = globals()['ode_' + hint[:-len('_Integral')]]
     else:
@@ -2817,17 +2811,10 @@ def _handle_Integral(expr, func, hint):
     For most hints, this simply runs ``expr.doit()``.
 
     """
-    # XXX: This global y hack should be removed
-    global y
     x = func.args[0]
     f = func.func
-    if hint == "1st_exact":
-        sol = (expr.doit()).subs(y, f(x))
-        del y
-    elif hint == "1st_exact_Integral":
-        sol = Eq(Subs(expr.lhs, y, f(x)), expr.rhs)
-        del y
-    elif hint == "nth_linear_constant_coeff_homogeneous":
+
+    if hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr
     elif not hint.endswith("_Integral"):
         sol = expr.doit()

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -6969,5 +6969,6 @@ def _nonlinear_3eq_order1_type5(x, y, z, t, eq):
 
 
 #This import is written at the bottom to avoid circular imports.
-from .single import (FirstExact,NthAlgebraic, Factorable, FirstLinear, AlmostLinear,
-        Bernoulli, SingleODEProblem, SingleODESolver, RiccatiSpecial)
+from .single import (NthAlgebraic, Factorable, FirstLinear, AlmostLinear,
+        Bernoulli, SingleODEProblem, SingleODESolver, RiccatiSpecial,
+        SecondNonlinearAutonomousConserved, FirstExact)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -677,6 +677,12 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
 
     if isinstance(match, SingleODESolver):
         solvefunc = match
+        # XXX: This global y hack should be removed
+        global y
+        if hint == "1st_exact":
+            y = match.y
+        elif hint == "1st_exact_Integral":
+            y = match.y
     elif hint.endswith('_Integral'):
         solvefunc = globals()['ode_' + hint[:-len('_Integral')]]
     else:
@@ -2811,88 +2817,24 @@ def _handle_Integral(expr, func, hint):
     For most hints, this simply runs ``expr.doit()``.
 
     """
-    if hint == "nth_linear_constant_coeff_homogeneous":
+    # XXX: This global y hack should be removed
+    global y
+    x = func.args[0]
+    f = func.func
+    if hint == "1st_exact":
+        sol = (expr.doit()).subs(y, f(x))
+        del y
+    elif hint == "1st_exact_Integral":
+        sol = Eq(Subs(expr.lhs, y, f(x)), expr.rhs)
+        del y
+    elif hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr
     elif not hint.endswith("_Integral"):
         sol = expr.doit()
     else:
         sol = expr
     return sol
-
-
-# FIXME: replace the general solution in the docstring with
-# dsolve(equation, hint='1st_exact_Integral').  You will need to be able
-# to have assumptions on P and Q that dP/dy = dQ/dx.
-def ode_1st_exact(eq, func, order, match):
-    r"""
-    Solves 1st order exact ordinary differential equations.
-
-    A 1st order differential equation is called exact if it is the total
-    differential of a function. That is, the differential equation
-
-    .. math:: P(x, y) \,\partial{}x + Q(x, y) \,\partial{}y = 0
-
-    is exact if there is some function `F(x, y)` such that `P(x, y) =
-    \partial{}F/\partial{}x` and `Q(x, y) = \partial{}F/\partial{}y`.  It can
-    be shown that a necessary and sufficient condition for a first order ODE
-    to be exact is that `\partial{}P/\partial{}y = \partial{}Q/\partial{}x`.
-    Then, the solution will be as given below::
-
-        >>> from sympy import Function, Eq, Integral, symbols, pprint
-        >>> x, y, t, x0, y0, C1= symbols('x,y,t,x0,y0,C1')
-        >>> P, Q, F= map(Function, ['P', 'Q', 'F'])
-        >>> pprint(Eq(Eq(F(x, y), Integral(P(t, y), (t, x0, x)) +
-        ... Integral(Q(x0, t), (t, y0, y))), C1))
-                    x                y
-                    /                /
-                   |                |
-        F(x, y) =  |  P(t, y) dt +  |  Q(x0, t) dt = C1
-                   |                |
-                  /                /
-                  x0               y0
-
-    Where the first partials of `P` and `Q` exist and are continuous in a
-    simply connected region.
-
-    A note: SymPy currently has no way to represent inert substitution on an
-    expression, so the hint ``1st_exact_Integral`` will return an integral
-    with `dy`.  This is supposed to represent the function that you are
-    solving for.
-
-    Examples
-    ========
-
-    >>> from sympy import Function, dsolve, cos, sin
-    >>> from sympy.abc import x
-    >>> f = Function('f')
-    >>> dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x),
-    ... f(x), hint='1st_exact')
-    Eq(x*cos(f(x)) + f(x)**3/3, C1)
-
-    References
-    ==========
-
-    - https://en.wikipedia.org/wiki/Exact_differential_equation
-    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
-      Dover 1963, pp. 73
-
-    # indirect doctest
-
-    """
-    x = func.args[0]
-    r = match  # d+e*diff(f(x),x)
-    e = r[r['e']]
-    d = r[r['d']]
-    # XXX: This global y hack should be removed
-    global y  # This is the only way to pass dummy y to _handle_Integral
-    y = r['y']
-    C1 = get_numbered_constants(eq, num=1)
-    # Refer Joel Moses, "Symbolic Integration - The Stormy Decade",
-    # Communications of the ACM, Volume 14, Number 8, August 1971, pp. 558
-    # which gives the method to solve an exact differential equation.
-    sol = Integral(d, x) + Integral((e - (Integral(d, x).diff(y))), y)
-    return Eq(sol, C1)
-
+    
 
 def ode_1st_homogeneous_coeff_best(eq, func, order, match):
     r"""

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -2811,9 +2811,6 @@ def _handle_Integral(expr, func, hint):
     For most hints, this simply runs ``expr.doit()``.
 
     """
-    x = func.args[0]
-    f = func.func
-
     if hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr
     elif not hint.endswith("_Integral"):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -457,8 +457,8 @@ class FirstExact(SinglePatternODESolver):
 
         m, n = self.wilds_match()
 
-        m = m.subs(fx,y)
-        n = n.subs(fx,y)
+        m = m.subs(fx, y)
+        n = n.subs(fx, y)
         numerator = cancel(m.diff(y) - n.diff(x))
         if numerator.is_zero:
             # Is exact
@@ -485,7 +485,7 @@ class FirstExact(SinglePatternODESolver):
                 # Couldn't convert to exact
                 return False
 
-            factor = exp(Integral(factor).doit())
+            factor = exp(Integral(factor))
             m *= factor
             n *= factor
             self._wilds_match[P] = m.subs(y, fx)

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -14,12 +14,13 @@ from sympy.core import S
 from sympy.core.exprtools import factor_terms
 from sympy.core.expr import Expr
 from sympy.core.function import AppliedUndef, Derivative, Function, expand, Subs
+from sympy.core.numbers import Float
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Dummy, Wild
 from sympy.core.mul import Mul
 from sympy.functions import exp, sqrt, tan, log
 from sympy.integrals import Integral
-from sympy.polys.polytools import cancel, factor, factor_list
+from sympy.polys.polytools import cancel, factor
 from sympy.simplify import simplify
 from sympy.simplify.radsimp import fraction
 from sympy.utilities import numbered_symbols
@@ -259,7 +260,7 @@ class SinglePatternODESolver(SingleODESolver):
 
         if not pattern.coeff(df).has(Wild):
             eq = expand(eq / eq.coeff(df))
-        eq = eq.collect([f(x).diff(x)], func = cancel)
+        eq = eq.collect([f(x).diff(x), f(x)], func = cancel)
 
         self._wilds_match = match = eq.match(pattern)
         if match is not None:
@@ -418,22 +419,20 @@ class FirstExact(SinglePatternODESolver):
 
     Examples
     ========
-    >>> from sympy import Symbol,Function
-    >>> from sympy import E,dsolve,Eq,log,sin,cos
-    >>> x=Symbol('x')
-    >>> f=Function('f')
-    >>> eq=Eq(0,(sin(x)*sin(f(x))-x*E**f(x))*f(x).diff(x)-(E**f(x)+cos(x)*cos(f(x))))
-    >>> dsolve(eq,hint='1st_exact')
-    Eq(x*exp(f(x)) + sin(x)*cos(f(x)), C1)
-    >>> dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x),f(x), hint='1st_exact')
+
+    >>> from sympy import Function, dsolve, cos, sin
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x),
+    ... f(x), hint='1st_exact')
     Eq(x*cos(f(x)) + f(x)**3/3, C1)
 
     References
     ==========
 
-    - "Differential Equations With Applications And Historical Notes",
-       Second Edition, George.F.Simmons
     - https://en.wikipedia.org/wiki/Exact_differential_equation
+    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
+      Dover 1963, pp. 73
 
     # indirect doctest
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -381,39 +381,55 @@ class NthAlgebraic(SingleODESolver):
         return diffcls
 
 
-class FirstExact(SingleODESolver):
-    r"""Solves 1st order exact ordinary differential equations.
+class FirstExact(SinglePatternODESolver):
+    r"""
+    Solves 1st order exact ordinary differential equations.
+
     A 1st order differential equation is called exact if it is the total
-    differential of a function. That is, the differential equation:
-    P(x,y)dx+Q(x,y)dy=0, is exact if:
-    dP(x,y)/dy = dQ(x,y)/dx
+    differential of a function. That is, the differential equation
+
+    .. math:: P(x, y) \,\partial{}x + Q(x, y) \,\partial{}y = 0
+
+    is exact if there is some function `F(x, y)` such that `P(x, y) =
+    \partial{}F/\partial{}x` and `Q(x, y) = \partial{}F/\partial{}y`.  It can
+    be shown that a necessary and sufficient condition for a first order ODE
+    to be exact is that `\partial{}P/\partial{}y = \partial{}Q/\partial{}x`.
+    Then, the solution will be as given below::
+
+        >>> from sympy import Function, Eq, Integral, symbols, pprint
+        >>> x, y, t, x0, y0, C1= symbols('x,y,t,x0,y0,C1')
+        >>> P, Q, F= map(Function, ['P', 'Q', 'F'])
+        >>> pprint(Eq(Eq(F(x, y), Integral(P(t, y), (t, x0, x)) +
+        ... Integral(Q(x0, t), (t, y0, y))), C1))
+                    x                y
+                    /                /
+                   |                |
+        F(x, y) =  |  P(t, y) dt +  |  Q(x0, t) dt = C1
+                   |                |
+                  /                /
+                  x0               y0
+
+    Where the first partials of `P` and `Q` exist and are continuous in a
+    simply connected region.
+
+    A note: SymPy currently has no way to represent inert substitution on an
+    expression, so the hint ``1st_exact_Integral`` will return an integral
+    with `dy`.  This is supposed to represent the function that you are
+    solving for.
 
     Examples
     ========
-    Following examples are problems:1,8 from SECTION.8 of
-    "Differential Equations With Applications And Historical Notes",
-     Second Edition, George.F.Simmons
-
-     >>> from sympy import Symbol,Function
-     >>> from sympy.solvers.ode.single import ExactODESolver,SingleODEProblem
-     >>> x=Symbol('x')
-     >>> f=Function('f')
-     >>> eq=(x+2/f(x))*f(x).diff(x)+f(x)
-     >>> prob=SingleODEProblem(eq,f(x),x)
-     >>> solver=ExactODESolver(prob)
-     >>> solver.matches()
-     True
-     >>> solver.get_general_solution()
-     [C1 + x*f(x) + 2*log(f(x))]
-     >>>
-     >>> from sympy import sin
-     >>> eq=(-sin(x/f(x))/f(x))+(x*sin(x/f(x))/f(x)**2)*f(x).diff(x)
-     >>> prob=SingleODEProblem(eq,f(x),x)
-     >>> solver=ExactODESolver(prob)
-     >>> solver.matches()
-     True
-     >>> solver.get_general_solution()
-     >>> [C1 + Integral(-sin(x/f(x))/f(x), x) + Integral(x*sin(x/f(x))/f(x)**2 - Integral(x*cos(x/f(x))/f(x)**3 + sin(x/f(x))/f(x)**2, x), f(x))]
+    >>> from sympy import Symbol,Function
+    >>> from sympy import E,dsolve,Eq,log,sin,cos
+    >>> x=Symbol('x')
+    >>> f=Function('f')
+    >>>>
+    >>> eq=Eq(0,(sin(x)*sin(f(x))-x*E**f(x))*f(x).diff(x)-(E**f(x)+cos(x)*cos(f(x))))
+    >>> dsolve(eq,hint='1st_exact')
+    Eq(x*exp(f(x)) + sin(x)*cos(f(x)), C1)
+    >>>
+    >>> dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x),f(x), hint='1st_exact')
+    Eq(x*cos(f(x)) + f(x)**3/3, C1)
 
     References
     ==========
@@ -421,31 +437,38 @@ class FirstExact(SingleODESolver):
     - "Differential Equations With Applications And Historical Notes",
        Second Edition, George.F.Simmons
     - https://en.wikipedia.org/wiki/Exact_differential_equation
-    """
 
+    """
     hint="1st_exact"
     has_integral=True
-    p=None
-    q=None
+    y = Dummy('y') # This is the only way to pass dummy y to _handle_Integral
 
-    def _matches(self) -> bool:
-        if self.ode_problem.order!=1:
-            self._matched=False
-            return False
+    def _wilds(self, f, x, order):
+        P = Wild('P')
+        Q = Wild('Q', exclude=[f(x).diff(x)])
+        return P, Q
 
-        eq= self.ode_problem.eq
-        f = self.ode_problem.func
+    def _equation(self, fx, x, order):
+        P, Q = self.wilds()
+        return P + Q*fx.diff(x)
+
+    def _verify(self, fx) -> bool:
+        P, Q = self.wilds()
+        eq = self.ode_problem.eq
         x = self.ode_problem.sym
-        y=Dummy('y')
+        y = self.y
 
-        self.q=collect(eq,f.diff(x)).coeff(f.diff(x))
-        self.p=eq-self.q*f.diff(x)
+        #This checks if Derivative present in wild P
+        if fx.diff(x) in self._wilds_match[P].atoms(Derivative):
+            eq = collect(eq,fx.diff(x))
+            pattern = self._equation(fx, x, 1)
+            self._wilds_match = eq.match(pattern)
 
+        m, n = self.wilds_match()
         try:
-            if simplify(self.p)!=0:
-                m=self.p.subs(f,y)
-                n=self.q.subs(f,y)
-
+            if simplify(m) != 0:
+                m = m.subs(fx,y)
+                n = n.subs(fx,y)
                 numerator= simplify(m.diff(y)-n.diff(x))
                 # The following few conditions try to convert a non-exact
                 # differential equation into an exact one.
@@ -458,14 +481,12 @@ class FirstExact(SingleODESolver):
                     # then exp(integral(f(x))*equation becomes exact
                     factor = simplify(numerator/n)
                     variables = factor.free_symbols
-
                     if len(variables) == 1 and x == variables.pop():
                         factor = exp(Integral(factor).doit())
                         m*= factor
                         n*= factor
-                        self.p=m.subs(y,f)
-                        self.q=n.subs(y,f)
-                        self._matched=True
+                        self._wilds_match[P] = m.subs(y,fx)
+                        self._wilds_match[Q] = n.subs(y,fx)
                         return True
                     else:
                         # If (dP/dy - dQ/dx) / -P = f(y)
@@ -476,39 +497,31 @@ class FirstExact(SingleODESolver):
                             factor = exp(Integral(factor).doit())
                             m*= factor
                             n*= factor
-                            self.p=m.subs(y,f)
-                            self.q=n.subs(y,f)
-                            self._matched=True
+                            self._wilds_match[P] = m.subs(y,fx)
+                            self._wilds_match[Q] = n.subs(y,fx)
                             return True
                 else:
-                    self._matched=True
                     return True
         except NotImplementedError:
             # Differentiating the coefficients might fail because of things
             # like f(2*x).diff(x).  See issue 4624 and issue 4719.
             pass
 
-        self._matched=False
         return False
 
-    def _get_general_solution(self, *, simplify: bool = True) -> List[Equality]:
-        y=Dummy('y')
-        f=self.ode_problem.func
-        x=self.ode_problem.sym
+    def _get_general_solution(self, *, simplify: bool = True):
+        m, n = self.wilds_match()
+        f = self.ode_problem.func
+        x = self.ode_problem.sym
         (C1,) = self.ode_problem.get_numbered_constants(num=1)
+        # XXX: This global y hack should be removed
+        # This is the only way to pass dummy y to _handle_Integral
+        y = self.y
 
-        m=self.p.subs(f,y)
-        n=self.q.subs(f,y)
+        m = m.subs(f,y)
+        n = n.subs(f,y)
 
-        sol= Integral(m,x)+Integral(n-Integral(m,x).diff(y),y)
-
-        try:
-            sol=sol.doit()
-            gen_sol=Eq(sol.subs(y,f),C1)
-        except:
-            # For case Integration or differentiation fails
-            gen_sol=Eq(sol.subs(y,f),C1)
-
+        gen_sol = Eq(Integral(m,x)+Integral(n-Integral(m,x).diff(y),y), C1)
         return gen_sol
 
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -263,7 +263,6 @@ class SinglePatternODESolver(SingleODESolver):
         eq = eq.collect(f(x), func = cancel)
 
         self._wilds_match = match = eq.match(pattern)
-
         if match is not None:
             return self._verify(f(x))
         return False
@@ -380,6 +379,138 @@ class NthAlgebraic(SingleODESolver):
             diffcls = NthAlgebraic._diffx_stored.setdefault(var, diffx)
 
         return diffcls
+
+
+class FirstExact(SingleODESolver):
+    r"""Solves 1st order exact ordinary differential equations.
+    A 1st order differential equation is called exact if it is the total
+    differential of a function. That is, the differential equation:
+    P(x,y)dx+Q(x,y)dy=0, is exact if:
+    dP(x,y)/dy = dQ(x,y)/dx
+
+    Examples
+    ========
+    Following examples are problems:1,8 from SECTION.8 of
+    "Differential Equations With Applications And Historical Notes",
+     Second Edition, George.F.Simmons
+
+     >>> from sympy import Symbol,Function
+     >>> from sympy.solvers.ode.single import ExactODESolver,SingleODEProblem
+     >>> x=Symbol('x')
+     >>> f=Function('f')
+     >>> eq=(x+2/f(x))*f(x).diff(x)+f(x)
+     >>> prob=SingleODEProblem(eq,f(x),x)
+     >>> solver=ExactODESolver(prob)
+     >>> solver.matches()
+     True
+     >>> solver.get_general_solution()
+     [C1 + x*f(x) + 2*log(f(x))]
+     >>>
+     >>> from sympy import sin
+     >>> eq=(-sin(x/f(x))/f(x))+(x*sin(x/f(x))/f(x)**2)*f(x).diff(x)
+     >>> prob=SingleODEProblem(eq,f(x),x)
+     >>> solver=ExactODESolver(prob)
+     >>> solver.matches()
+     True
+     >>> solver.get_general_solution()
+     >>> [C1 + Integral(-sin(x/f(x))/f(x), x) + Integral(x*sin(x/f(x))/f(x)**2 - Integral(x*cos(x/f(x))/f(x)**3 + sin(x/f(x))/f(x)**2, x), f(x))]
+
+    References
+    ==========
+
+    - "Differential Equations With Applications And Historical Notes",
+       Second Edition, George.F.Simmons
+    - https://en.wikipedia.org/wiki/Exact_differential_equation
+    """
+
+    hint="1st_exact"
+    has_integral=True
+    p=None
+    q=None
+
+    def _matches(self) -> bool:
+        if self.ode_problem.order!=1:
+            self._matched=False
+            return False
+
+        eq= self.ode_problem.eq
+        f = self.ode_problem.func
+        x = self.ode_problem.sym
+        y=Dummy('y')
+
+        self.q=eq.coeff(f.diff(x))
+        self.p=eq-self.q*f.diff(x)
+
+        try:
+            if simplify(self.p)!=0:
+                m=self.p.subs(f,y)
+                n=self.q.subs(f,y)
+
+                numerator= simplify(m.diff(y)-n.diff(x))
+                # The following few conditions try to convert a non-exact
+                # differential equation into an exact one.
+                # References :
+                #1. Differential equations with applications
+                # and historical notes - George E. Simmons
+                #2. https://math.okstate.edu/people/binegar/2233-S99/2233-l12.pdf
+
+                if numerator:
+                    # If (dP/dy - dQ/dx) / Q = f(x)
+                    # then exp(integral(f(x))*equation becomes exact
+                    factor = simplify(numerator/n)
+                    variables = factor.free_symbols
+
+                    if len(variables) == 1 and x == variables.pop():
+                        factor = exp(Integral(factor).doit())
+                        m*= factor
+                        n*= factor
+                        self.p=m.subs(y,f)
+                        self.q=m.subs(y,f)
+                        self._matched=True
+                        return True
+                    else:
+                        # If (dP/dy - dQ/dx) / -P = f(y)
+                        # then exp(integral(f(y))*equation becomes exact
+                        factor = simplify(-numerator/m)
+                        variables = factor.free_symbols
+                        if len(variables) == 1 and y == variables.pop():
+                            factor = exp(Integral(factor).doit())
+                            m*= factor
+                            n*= factor
+                            self.p=m.subs(y,f)
+                            self.q=m.subs(y,f)
+                            self._matched=True
+                            return True
+                else:
+                    self._matched=True
+                    return True
+        except NotImplementedError:
+            # Differentiating the coefficients might fail because of things
+            # like f(2*x).diff(x).  See issue 4624 and issue 4719.
+            pass
+
+        self._matched=False
+        return False
+
+    def _get_general_solution(self, *, simplify: bool = True) -> List[Equality]:
+        y=Dummy('y')
+        f=self.ode_problem.func
+        x=self.ode_problem.sym
+        (C1,) = self.ode_problem.get_numbered_constants(num=1)
+
+        m=self.p.subs(f,y)
+        n=self.q.subs(f,y)
+
+        sol= Integral(m,x)+Integral(n-Integral(m,x).diff(y),y)
+
+        try:
+            sol=sol.doit()
+            gen_sol=Eq(sol.subs(y,f),C1)
+        except:
+            # For case Integration or differentiation fails
+            gen_sol=Eq(sol.subs(y,f),C1)
+
+        return gen_sol
 
 
 class FirstLinear(SinglePatternODESolver):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -460,6 +460,7 @@ class FirstExact(SinglePatternODESolver):
         m = m.subs(fx, y)
         n = n.subs(fx, y)
         numerator = cancel(m.diff(y) - n.diff(x))
+
         if numerator.is_zero:
             # Is exact
             return True
@@ -473,19 +474,21 @@ class FirstExact(SinglePatternODESolver):
 
             factor_n = cancel(numerator/n)
             factor_m = cancel(-numerator/m)
-            if factor_n.free_symbols == {x}:
+            if y not in factor_n.free_symbols:
                 # If (dP/dy - dQ/dx) / Q = f(x)
                 # then exp(integral(f(x))*equation becomes exact
                 factor = factor_n
-            elif factor_m.free_symbols == {y}:
+                integration_variable = x
+            elif x not in factor_m.free_symbols:
                 # If (dP/dy - dQ/dx) / -P = f(y)
                 # then exp(integral(f(y))*equation becomes exact
                 factor = factor_m
+                integration_variable = y
             else:
                 # Couldn't convert to exact
                 return False
 
-            factor = exp(Integral(factor))
+            factor = exp(Integral(factor, integration_variable))
             m *= factor
             n *= factor
             self._wilds_match[P] = m.subs(y, fx)

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -13,8 +13,7 @@ from typing import Iterator, List, Optional
 from sympy.core import S
 from sympy.core.exprtools import factor_terms
 from sympy.core.expr import Expr
-from sympy.core.function import AppliedUndef, Derivative, Function, expand
-from sympy.core.numbers import Float
+from sympy.core.function import AppliedUndef, Derivative, Function, expand, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Dummy, Wild
 from sympy.core.mul import Mul
@@ -464,7 +463,11 @@ class FirstExact(SinglePatternODESolver):
             pattern = self._equation(fx, x, 1)
             self._wilds_match = eq.match(pattern)
 
+        if fx.diff(x) in self._wilds_match[P].atoms(Derivative):
+            return False
+
         m, n = self.wilds_match()
+
         try:
             if simplify(m) != 0:
                 m = m.subs(fx,y)
@@ -483,22 +486,22 @@ class FirstExact(SinglePatternODESolver):
                     variables = factor.free_symbols
                     if len(variables) == 1 and x == variables.pop():
                         factor = exp(Integral(factor).doit())
-                        m*= factor
-                        n*= factor
-                        self._wilds_match[P] = m.subs(y,fx)
-                        self._wilds_match[Q] = n.subs(y,fx)
+                        m *= factor
+                        n *= factor
+                        self._wilds_match[P] = m.subs(y, fx)
+                        self._wilds_match[Q] = n.subs(y, fx)
                         return True
                     else:
                         # If (dP/dy - dQ/dx) / -P = f(y)
                         # then exp(integral(f(y))*equation becomes exact
-                        factor = simplify(-numerator/m)
+                        factor = simplify(-numerator / m)
                         variables = factor.free_symbols
                         if len(variables) == 1 and y == variables.pop():
                             factor = exp(Integral(factor).doit())
-                            m*= factor
-                            n*= factor
-                            self._wilds_match[P] = m.subs(y,fx)
-                            self._wilds_match[Q] = n.subs(y,fx)
+                            m *= factor
+                            n *= factor
+                            self._wilds_match[P] = m.subs(y, fx)
+                            self._wilds_match[Q] = n.subs(y, fx)
                             return True
                 else:
                     return True
@@ -514,14 +517,13 @@ class FirstExact(SinglePatternODESolver):
         f = self.ode_problem.func
         x = self.ode_problem.sym
         (C1,) = self.ode_problem.get_numbered_constants(num=1)
-        # XXX: This global y hack should be removed
-        # This is the only way to pass dummy y to _handle_Integral
-        y = self.y
+        y = Dummy('y')
 
-        m = m.subs(f,y)
-        n = n.subs(f,y)
+        m = m.subs(f, y)
+        n = n.subs(f, y)
 
-        gen_sol = Eq(Integral(m,x)+Integral(n-Integral(m,x).diff(y),y), C1)
+        gen_sol = Eq(Subs(Integral(m, x)
+                          + Integral(n - Integral(m, x).diff(y), y), y, f), C1)
         return gen_sol
 
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -507,7 +507,7 @@ class FirstExact(SinglePatternODESolver):
 
         gen_sol = Eq(Subs(Integral(m, x)
                           + Integral(n - Integral(m, x).diff(y), y), y, fx), C1)
-        return gen_sol
+        return [gen_sol]
 
 
 class FirstLinear(SinglePatternODESolver):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -20,8 +20,8 @@ from sympy.core.symbol import Symbol, Dummy, Wild
 from sympy.core.mul import Mul
 from sympy.functions import exp, sqrt, tan, log
 from sympy.integrals import Integral
-from sympy.polys.polytools import cancel, factor
-from sympy.simplify.simplify import simplify
+from sympy.polys.polytools import cancel, factor, factor_list
+from sympy.simplify import simplify,collect
 from sympy.simplify.radsimp import fraction
 from sympy.utilities import numbered_symbols
 
@@ -438,7 +438,7 @@ class FirstExact(SingleODESolver):
         x = self.ode_problem.sym
         y=Dummy('y')
 
-        self.q=eq.coeff(f.diff(x))
+        self.q=collect(eq,f.diff(x)).coeff(f.diff(x))
         self.p=eq-self.q*f.diff(x)
 
         try:
@@ -453,7 +453,6 @@ class FirstExact(SingleODESolver):
                 #1. Differential equations with applications
                 # and historical notes - George E. Simmons
                 #2. https://math.okstate.edu/people/binegar/2233-S99/2233-l12.pdf
-
                 if numerator:
                     # If (dP/dy - dQ/dx) / Q = f(x)
                     # then exp(integral(f(x))*equation becomes exact
@@ -465,7 +464,7 @@ class FirstExact(SingleODESolver):
                         m*= factor
                         n*= factor
                         self.p=m.subs(y,f)
-                        self.q=m.subs(y,f)
+                        self.q=n.subs(y,f)
                         self._matched=True
                         return True
                     else:
@@ -478,7 +477,7 @@ class FirstExact(SingleODESolver):
                             m*= factor
                             n*= factor
                             self.p=m.subs(y,f)
-                            self.q=m.subs(y,f)
+                            self.q=n.subs(y,f)
                             self._matched=True
                             return True
                 else:
@@ -503,7 +502,14 @@ class FirstExact(SingleODESolver):
 
         sol= Integral(m,x)+Integral(n-Integral(m,x).diff(y),y)
 
-        return Eq(sol,C1)
+        try:
+            sol=sol.doit()
+            gen_sol=Eq(sol.subs(y,f),C1)
+        except:
+            # For case Integration or differentiation fails
+            gen_sol=Eq(sol.subs(y,f),C1)
+
+        return gen_sol
 
 
 class FirstLinear(SinglePatternODESolver):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -20,7 +20,7 @@ from sympy.core.mul import Mul
 from sympy.functions import exp, sqrt, tan, log
 from sympy.integrals import Integral
 from sympy.polys.polytools import cancel, factor, factor_list
-from sympy.simplify import simplify,collect
+from sympy.simplify import simplify
 from sympy.simplify.radsimp import fraction
 from sympy.utilities import numbered_symbols
 
@@ -259,7 +259,7 @@ class SinglePatternODESolver(SingleODESolver):
 
         if not pattern.coeff(df).has(Wild):
             eq = expand(eq / eq.coeff(df))
-        eq = eq.collect(f(x), func = cancel)
+        eq = eq.collect([f(x).diff(x)], func = cancel)
 
         self._wilds_match = match = eq.match(pattern)
         if match is not None:
@@ -438,11 +438,12 @@ class FirstExact(SinglePatternODESolver):
     # indirect doctest
 
     """
-    hint="1st_exact"
-    has_integral=True
+    hint = "1st_exact"
+    has_integral = True
+    order = [1]
 
     def _wilds(self, f, x, order):
-        P = Wild('P')
+        P = Wild('P', exclude=[f(x).diff(x)])
         Q = Wild('Q', exclude=[f(x).diff(x)])
         return P, Q
 
@@ -452,18 +453,8 @@ class FirstExact(SinglePatternODESolver):
 
     def _verify(self, fx) -> bool:
         P, Q = self.wilds()
-        eq = self.ode_problem.eq
         x = self.ode_problem.sym
         y = Dummy('y')
-
-        #This checks if Derivative present in wild P
-        if fx.diff(x) in self._wilds_match[P].atoms(Derivative):
-            eq = collect(eq,fx.diff(x))
-            pattern = self._equation(fx, x, 1)
-            self._wilds_match = eq.match(pattern)
-
-        if fx.diff(x) in self._wilds_match[P].atoms(Derivative):
-            return False
 
         m, n = self.wilds_match()
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -440,7 +440,6 @@ class FirstExact(SinglePatternODESolver):
     """
     hint="1st_exact"
     has_integral=True
-    y = Dummy('y') # This is the only way to pass dummy y to _handle_Integral
 
     def _wilds(self, f, x, order):
         P = Wild('P')
@@ -455,7 +454,7 @@ class FirstExact(SinglePatternODESolver):
         P, Q = self.wilds()
         eq = self.ode_problem.eq
         x = self.ode_problem.sym
-        y = self.y
+        y = Dummy('y')
 
         #This checks if Derivative present in wild P
         if fx.diff(x) in self._wilds_match[P].atoms(Derivative):
@@ -514,16 +513,16 @@ class FirstExact(SinglePatternODESolver):
 
     def _get_general_solution(self, *, simplify: bool = True):
         m, n = self.wilds_match()
-        f = self.ode_problem.func
+        fx = self.ode_problem.func
         x = self.ode_problem.sym
         (C1,) = self.ode_problem.get_numbered_constants(num=1)
         y = Dummy('y')
 
-        m = m.subs(f, y)
-        n = n.subs(f, y)
+        m = m.subs(fx, y)
+        n = n.subs(fx, y)
 
         gen_sol = Eq(Subs(Integral(m, x)
-                          + Integral(n - Integral(m, x).diff(y), y), y, f), C1)
+                          + Integral(n - Integral(m, x).diff(y), y), y, fx), C1)
         return gen_sol
 
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -471,31 +471,26 @@ class FirstExact(SinglePatternODESolver):
             # and historical notes - George E. Simmons
             # 2. https://math.okstate.edu/people/binegar/2233-S99/2233-l12.pdf
 
-            # If (dP/dy - dQ/dx) / Q = f(x)
-            # then exp(integral(f(x))*equation becomes exact
-            factor = cancel(numerator/n)
-            variables = factor.free_symbols
-            if len(variables) == 1 and x == variables.pop():
-                factor = exp(Integral(factor).doit())
-                m *= factor
-                n *= factor
-                self._wilds_match[P] = m.subs(y, fx)
-                self._wilds_match[Q] = n.subs(y, fx)
-                return True
-            else:
+            factor_n = cancel(numerator/n)
+            factor_m = cancel(-numerator/m)
+            if factor_n.free_symbols == {x}:
+                # If (dP/dy - dQ/dx) / Q = f(x)
+                # then exp(integral(f(x))*equation becomes exact
+                factor = factor_n
+            elif factor_m.free_symbols == {y}:
                 # If (dP/dy - dQ/dx) / -P = f(y)
                 # then exp(integral(f(y))*equation becomes exact
-                factor = cancel(-numerator/m)
-                variables = factor.free_symbols
-                if len(variables) == 1 and y == variables.pop():
-                    factor = exp(Integral(factor).doit())
-                    m *= factor
-                    n *= factor
-                    self._wilds_match[P] = m.subs(y, fx)
-                    self._wilds_match[Q] = n.subs(y, fx)
-                    return True
+                factor = factor_m
+            else:
+                # Couldn't convert to exact
+                return False
 
-        return False
+            factor = exp(Integral(factor).doit())
+            m *= factor
+            n *= factor
+            self._wilds_match[P] = m.subs(y, fx)
+            self._wilds_match[Q] = n.subs(y, fx)
+            return True
 
     def _get_general_solution(self, *, simplify: bool = True):
         m, n = self.wilds_match()

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -456,11 +456,10 @@ class FirstExact(SinglePatternODESolver):
         y = Dummy('y')
 
         m, n = self.wilds_match()
-
-        if simplify(m) != 0:
+        if expand(m) != 0:
             m = m.subs(fx,y)
             n = n.subs(fx,y)
-            numerator= simplify(m.diff(y)-n.diff(x))
+            numerator = cancel(m.diff(y) - n.diff(x))
             # The following few conditions try to convert a non-exact
             # differential equation into an exact one.
             # References :
@@ -470,7 +469,7 @@ class FirstExact(SinglePatternODESolver):
             if numerator:
                 # If (dP/dy - dQ/dx) / Q = f(x)
                 # then exp(integral(f(x))*equation becomes exact
-                factor = simplify(numerator/n)
+                factor = cancel(numerator/n)
                 variables = factor.free_symbols
                 if len(variables) == 1 and x == variables.pop():
                     factor = exp(Integral(factor).doit())
@@ -482,7 +481,7 @@ class FirstExact(SinglePatternODESolver):
                 else:
                     # If (dP/dy - dQ/dx) / -P = f(y)
                     # then exp(integral(f(y))*equation becomes exact
-                    factor = simplify(-numerator / m)
+                    factor = cancel(-numerator / m)
                     variables = factor.free_symbols
                     if len(variables) == 1 and y == variables.pop():
                         factor = exp(Integral(factor).doit())

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -503,14 +503,7 @@ class FirstExact(SingleODESolver):
 
         sol= Integral(m,x)+Integral(n-Integral(m,x).diff(y),y)
 
-        try:
-            sol=sol.doit()
-            gen_sol=Eq(sol.subs(y,f),C1)
-        except:
-            # For case Integration or differentiation fails
-            gen_sol=Eq(sol.subs(y,f),C1)
-
-        return gen_sol
+        return Eq(sol,C1)
 
 
 class FirstLinear(SinglePatternODESolver):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -423,11 +423,9 @@ class FirstExact(SinglePatternODESolver):
     >>> from sympy import E,dsolve,Eq,log,sin,cos
     >>> x=Symbol('x')
     >>> f=Function('f')
-    >>>>
     >>> eq=Eq(0,(sin(x)*sin(f(x))-x*E**f(x))*f(x).diff(x)-(E**f(x)+cos(x)*cos(f(x))))
     >>> dsolve(eq,hint='1st_exact')
     Eq(x*exp(f(x)) + sin(x)*cos(f(x)), C1)
-    >>>
     >>> dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x),f(x), hint='1st_exact')
     Eq(x*cos(f(x)) + f(x)**3/3, C1)
 
@@ -437,6 +435,8 @@ class FirstExact(SinglePatternODESolver):
     - "Differential Equations With Applications And Historical Notes",
        Second Edition, George.F.Simmons
     - https://en.wikipedia.org/wiki/Exact_differential_equation
+
+    # indirect doctest
 
     """
     hint="1st_exact"

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -60,6 +60,8 @@ def test_dsolve_all_hint():
         'nth_algebraic_Integral': Eq(f(x), C1),
         '1st_linear': Eq(f(x), C1),
         '1st_linear_Integral': Eq(f(x), C1 + Integral(0, x)),
+        '1st_exact': Eq(f(x), C1),
+        '1st_exact_Integral': Eq(Subs(Integral(0, x) + Integral(1, _y), _y, f(x)), C1),
         'lie_group': Eq(f(x), C1),
         '1st_homogeneous_coeff_subs_dep_div_indep': Eq(f(x), C1),
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral': Eq(log(x), C1 + Integral(-1/_u1, (_u1, f(x)/x))),
@@ -168,6 +170,7 @@ def test_classify_ode():
     assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == (
         'nth_algebraic',
         'separable',
+        '1st_exact',
         '1st_linear',
         'Bernoulli',
         '1st_homogeneous_coeff_best',
@@ -178,6 +181,7 @@ def test_classify_ode():
         'nth_linear_euler_eq_homogeneous',
         'nth_algebraic_Integral',
         'separable_Integral',
+        '1st_exact_Integral',
         '1st_linear_Integral',
         'Bernoulli_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
@@ -185,6 +189,7 @@ def test_classify_ode():
     assert classify_ode(f(x).diff(x)**2, f(x)) == ('factorable',
          'nth_algebraic',
          'separable',
+         '1st_exact',
          '1st_linear',
          'Bernoulli',
          '1st_homogeneous_coeff_best',
@@ -196,6 +201,7 @@ def test_classify_ode():
          'nth_linear_euler_eq_homogeneous',
          'nth_algebraic_Integral',
          'separable_Integral',
+         '1st_exact_Integral',
          '1st_linear_Integral',
          'Bernoulli_Integral',
          '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
@@ -274,17 +280,18 @@ def test_classify_ode():
                         prep=True) == ans
 
     assert classify_ode(Eq(2*x**3*f(x).diff(x), 0), f(x)) == \
-        ('factorable', 'nth_algebraic', 'separable', '1st_linear',
-         'Bernoulli', '1st_power_series',
+        ('factorable', 'nth_algebraic', 'separable', '1st_exact',
+         '1st_linear', 'Bernoulli', '1st_power_series',
          'lie_group', 'nth_linear_euler_eq_homogeneous',
-         'nth_algebraic_Integral', 'separable_Integral',
+         'nth_algebraic_Integral', 'separable_Integral', '1st_exact_Integral',
          '1st_linear_Integral', 'Bernoulli_Integral')
 
 
     assert classify_ode(Eq(2*f(x)**3*f(x).diff(x), 0), f(x)) == \
-        ('factorable', 'nth_algebraic', 'separable', '1st_linear', 'Bernoulli',
-         '1st_power_series', 'lie_group', 'nth_algebraic_Integral',
-         'separable_Integral', '1st_linear_Integral', 'Bernoulli_Integral')
+        ('factorable', 'nth_algebraic', 'separable', '1st_exact', '1st_linear',
+         'Bernoulli', '1st_power_series', 'lie_group', 'nth_algebraic_Integral',
+         'separable_Integral', '1st_exact_Integral', '1st_linear_Integral',
+         'Bernoulli_Integral')
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -210,12 +210,14 @@ def test_classify_ode():
     a = classify_ode(Eq(f(x).diff(x) + f(x), x), f(x))
     b = classify_ode(f(x).diff(x)*f(x) + f(x)*f(x) - x*f(x), f(x))
     c = classify_ode(f(x).diff(x)/f(x) + f(x)/f(x) - x/f(x), f(x))
-    assert a == ('1st_linear',
+    assert a == ('1st_exact',
+        '1st_linear',
         'Bernoulli',
         'almost_linear',
         '1st_power_series', "lie_group",
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
+        '1st_exact_Integral',
         '1st_linear_Integral',
         'Bernoulli_Integral',
         'almost_linear_Integral',
@@ -242,8 +244,8 @@ def test_classify_ode():
 
     assert classify_ode(
         2*x*f(x)*f(x).diff(x) + (1 + x)*f(x)**2 - exp(x), f(x)
-    ) == ('Bernoulli', 'almost_linear', 'lie_group',
-        'Bernoulli_Integral', 'almost_linear_Integral')
+    ) == ('1st_exact', 'Bernoulli', 'almost_linear', 'lie_group',
+        '1st_exact_Integral', 'Bernoulli_Integral', 'almost_linear_Integral')
     assert 'Riccati_special_minus2' in \
         classify_ode(2*f(x).diff(x) + f(x)**2 - f(x)/x + 3*x**(-2), f(x))
     raises(ValueError, lambda: classify_ode(x + f(x, y).diff(x).diff(
@@ -717,11 +719,11 @@ def test_undetermined_coefficients_match():
 def test_issue_4785():
     from sympy.abc import A
     eq = x + A*(x + diff(f(x), x) + f(x)) + diff(f(x), x) + f(x) + 2
-    assert classify_ode(eq, f(x)) == ('1st_linear', 'almost_linear',
-        '1st_power_series', 'lie_group',
+    assert classify_ode(eq, f(x)) == ('1st_exact', '1st_linear',
+        'almost_linear', '1st_power_series', 'lie_group',
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
-        '1st_linear_Integral', 'almost_linear_Integral',
+        '1st_exact_Integral', '1st_linear_Integral', 'almost_linear_Integral',
         'nth_linear_constant_coeff_variation_of_parameters_Integral')
     # issue 4864
     eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)


### PR DESCRIPTION
#### References to other Issues or PRs
Continuing PR #18887 to refactor the exact ODE solver into a class, as suggested in #18348. 

#### Brief description of what is fixed or changed
The work done by @tnzl was was rebased to master. As suggested in the discussion of that PR, the calls to simplify were replaced by more specific functions. The try/except was also removed: the test case fixed by it passed even without this code block and none of the exact and inexact equations tested raised an error. The class docstring was replaced by the original docstring from the ode_1st_exact function.

#### Other comments
I'm in doubt about the `m != 0` conditional. If `m = 0` we can still have an exact equation (although it will be a trivial one): shouldn't `Eq(f(x).diff(x), 0)` (`m = 0, n = 1`) also be classified as `1st_exact`? If this is the case, we could simplify the verify function by removing this conditional and using just the numerator:
```
m, n = self.wilds_match()
m = m.subs(fx,y)
n = n.subs(fx,y)
numerator = cancel(m.diff(y) - n.diff(x))
if numerator.is_zero:
    # It's exact
    return True
else:
    # Try to convert to exact
```

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Refactor exact EDO solving into the FirstExact class.
<!-- END RELEASE NOTES -->