### PR TITLE
Make dynamicsymbols real by deafult

### DIFF
--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -211,9 +211,9 @@ def test_rolling_disc():
     BodyD.potential_energy = - m * g * r * cos(q2)
     Lag = Lagrangian(N, BodyD)
     q = [q1, q2, q3]
-    q1 = Function('q1')
-    q2 = Function('q2')
-    q3 = Function('q3')
+    q1 = Function('q1', real=True)
+    q2 = Function('q2', real=True)
+    q3 = Function('q3', real=True)
     l = LagrangesMethod(Lag, q)
     l.form_lagranges_equations()
     RHS = l.rhs()

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -626,6 +626,9 @@ def dynamicsymbols(names, level=0,**assumptions):
     Derivative(q1(t), t)
 
     """
+    if 'commutative' not in assumptions:
+        if 'real' not in assumptions:
+            assumptions['real'] = True
     esses = symbols(names, cls=Function,**assumptions)
     t = dynamicsymbols._t
     if iterable(esses):

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -496,7 +496,7 @@ def test_dynamicsymbols():
     f3 = dynamicsymbols('f3', positive=True)
     f4, f5 = dynamicsymbols('f4,f5', commutative=False)
     f6 = dynamicsymbols('f6', integer=True)
-    assert f1.is_real is None
+    assert f1.is_real is True
     assert f2.is_real
     assert f3.is_positive
     assert f4*f5 != f5*f4


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
dynamicsymbols have `real = True` unless `commutative` assumption is used.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * Make dynamicsymbols real by default unless commutative property is used.
<!-- END RELEASE NOTES -->
