### PR TITLE
fix(assumptions) : make AppliedPredicate not Atom

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -109,8 +109,6 @@ class AppliedPredicate(Boolean):
     """
     __slots__ = ()
 
-    is_Atom = True  # do not attempt to decompose this
-
     def __new__(cls, predicate, *args):
         if not isinstance(predicate, Predicate):
             raise TypeError("%s is not a Predicate." % predicate)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1986,12 +1986,14 @@ def is_literal(expr):
     False
 
     """
+    from sympy.assumptions import AppliedPredicate
+
     if isinstance(expr, Not):
         return is_literal(expr.args[0])
-    elif expr in (True, False) or expr.is_Atom:
+    elif expr in (True, False) or isinstance(expr, AppliedPredicate) or expr.is_Atom:
         return True
     elif not isinstance(expr, BooleanFunction) and all(
-            a.is_Atom for a in expr.args):
+            (isinstance(expr, AppliedPredicate) or a.is_Atom) for a in expr.args):
         return True
     return False
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21017

#### Brief description of what is fixed or changed

AppliedPredicate has `is_Atom = True` by class attribute.
```python
>>> from sympy import Q
>>> from sympy.abc import x
>>> Q.positive(x).is_Atom
True
```
This is wrong design since applied predicate is a function applied to arguments and thus never should be atom. This change makes `AppliedPredicate.is_Atom` return `False`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
