### PR TITLE
feat(polys): allow DomainMatrix to be dense or sparse

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -92,6 +92,19 @@ class DDM(list):
         if not (len(self) == m and all(len(row) == n for row in self)):
             raise DDMBadInputError("Inconsistent row-list/shape")
 
+    def to_list(self):
+        return list(self)
+
+    def to_ddm(self):
+        return self
+
+    def convert_to(self, K):
+        Kold = self.domain
+        if K == Kold:
+            return self.copy()
+        rows = ([K.convert_from(e, Kold) for e in row] for row in self)
+        return DDM(rows, self.shape, K)
+
     def __str__(self):
         cls = type(self).__name__
         rows = list.__str__(self)
@@ -210,15 +223,17 @@ class DDM(list):
         domain = a.domain
 
         basis = []
+        nonpivots = []
         for i in range(cols):
             if i in pivots:
                 continue
+            nonpivots.append(i)
             vec = [domain.one if i == j else domain.zero for j in range(cols)]
             for ii, jj in enumerate(pivots):
                 vec[jj] -= rref[ii][i]
             basis.append(vec)
 
-        return DDM(basis, (len(basis), cols), domain)
+        return DDM(basis, (len(basis), cols), domain), nonpivots
 
     def det(a):
         """Determinant of a"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -20,6 +20,12 @@ from .ddm import DDM
 from .sdm import SDM
 
 
+# Map from format string to class for internal representation
+# defaulting to either dense ot sparse
+_REPCLS_SPARSE = {'dense': DDM, 'sparse': SDM, None: SDM}
+_REPCLS_DENSE  = {'dense': DDM, 'sparse': SDM, None: DDM}
+
+
 class DomainMatrix:
     r"""
     Associate Matrix with :py:class:`~.Domain`
@@ -69,7 +75,7 @@ class DomainMatrix:
 
     """
 
-    def __init__(self, rows, shape, domain):
+    def __new__(cls, rows, shape, domain, *, fmt=None):
         """
         Creates a :py:class:`~.DomainMatrix`.
 
@@ -87,16 +93,80 @@ class DomainMatrix:
             If any of rows, shape and domain are not provided
 
         """
-        if isinstance(rows, list):
-            self.rep = SDM.from_list(rows, shape, domain)
+        if isinstance(rows, (DDM, SDM)):
+            raise TypeError("Use from_rep to initialise from SDM/DDM")
+        elif isinstance(rows, list):
+            rep = DDM(rows, shape, domain)
+        elif isinstance(rows, dict):
+            rep = SDM(rows, shape, domain)
         else:
-            self.rep = SDM(rows, shape, domain)
-        self.shape = shape
-        self.domain = domain
+            msg = "Input should be DDM, SDM, list-of-lists or dict-of-dicts"
+            raise TypeError(msg)
+
+        if fmt is not None:
+            if fmt == 'sparse':
+                rep = rep.to_sdm()
+            elif fmt == 'dense':
+                rep = rep.to_ddm()
+            else:
+                raise ValueError("fmt should be 'sparse' or 'dense'")
+
+        return cls.from_rep(rep)
 
     @classmethod
-    def from_rep(cls, ddm):
-        return cls(ddm, ddm.shape, ddm.domain)
+    def from_rep(cls, rep):
+        """Create a new DomainMatrix efficiently from DDM/SDM.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.domains import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+
+        Create a `~.DomainMatrix` with an dense internal representation as
+        `~.DDM`:
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> drep = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> dM = DomainMatrix.from_rep(drep)
+        >>> dM
+        DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
+
+        Create a `~.DomainMatrix` with a sparse internal representation as
+        `~.SDM`:
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> dM = DomainMatrix.from_rep(drep)
+        >>> dM
+        DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
+
+        Parameters
+        ==========
+
+        rep: `~.SDM` or `~.DDM`
+            The internal sparse or dense representation of the matrix.
+
+        Returns
+        =======
+
+        DomainMatrix
+            A `~.DomainMatrix` wrapping *rep*.
+
+        Notes
+        =====
+
+        This takes ownership of rep as its internal representation. If rep is
+        being mutated elsewhere then a copy should be provided to
+        ``from_rep``. Only minimal verification or checking is done on *rep*
+        as this is supposed to be an efficient internal routine.
+        """
+        if not isinstance(rep, (DDM, SDM)):
+            raise TypeError("rep should be of type DDM or SDM")
+        self = super().__new__(cls)
+        self.rep = rep
+        self.shape = rep.shape
+        self.domain = rep.domain
+        return self
 
     @classmethod
     def from_list_sympy(cls, nrows, ncols, rows, **kwargs):
@@ -955,10 +1025,10 @@ class DomainMatrix:
         DomainMatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]], (3, 3), QQ)
 
         """
-        return cls.from_rep(DDM.eye(n, domain))
+        return cls.from_rep(SDM.eye(n, domain))
 
     @classmethod
-    def zeros(cls, shape, domain):
+    def zeros(cls, shape, domain, *, fmt='sparse'):
         """Returns a zero DomainMatrix of size shape, belonging to the specified domain
 
         Examples
@@ -970,12 +1040,11 @@ class DomainMatrix:
         DomainMatrix([[0, 0, 0], [0, 0, 0]], (2, 3), QQ)
 
         """
-
-        return cls.from_rep(DDM.zeros(shape, domain))
+        return cls.from_rep(SDM.zeros(shape, domain))
 
     def __eq__(A, B):
         r"""
-        Checks for two DomainMatrix matrices two be equal or not
+        Checks for two DomainMatrix matrices to be equal or not
 
         Parameters
         ==========

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -223,7 +223,8 @@ def test_DDM_rref():
 def test_DDM_nullspace():
      A = DDM([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), QQ)
      Anull = DDM([[QQ(-1), QQ(1)]], (1, 2), QQ)
-     assert A.nullspace() == Anull
+     nonpivots = [1]
+     assert A.nullspace() == (Anull, [1])
 
 
 def test_DDM_det():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -16,8 +16,8 @@ from sympy.polys.matrices.sdm import SDM
 
 def test_DomainMatrix_init():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    # assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    # assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -34,8 +34,8 @@ def test_DomainMatrix_from_rep():
 
 
 def test_DomainMatrix_from_list_sympy():
-    # ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    # ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     A = DomainMatrix.from_list_sympy(2, 2, [[1, 2], [3, 4]])
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -48,7 +48,6 @@ def test_DomainMatrix_from_list_sympy():
         (2, 2),
         K
     )
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_list_sympy(
         2, 2, [[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]],
         extension=True)
@@ -59,7 +58,6 @@ def test_DomainMatrix_from_list_sympy():
 
 def test_DomainMatrix_from_Matrix():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(Matrix([[1, 2], [3, 4]]))
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -72,7 +70,6 @@ def test_DomainMatrix_from_Matrix():
         (2, 2),
         K
     )
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(
         Matrix([[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]]),
         extension=True)


### PR DESCRIPTION
The DomainMatrix class was originally introduces with DDM as its
internal representation representing a dense internal format. The SDM
sparse format was added later and made to be the internal format of DDM
always. This commit makes it possible DomainMatrix to use either SDM or
DDM as its internal format in the constructor by passing fmt="dense" or
fmt="sparse".

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
