### PR TITLE
Fixes #21127,  latex printer fails on printing a singularity function raised to a power

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -3,7 +3,7 @@ from sympy import (
     Integer, Eq, symbols, Add, I, Float, log, Rational,
     Lambda, atan2, cse, cot, tan, S, Tuple, Basic, Dict,
     Piecewise, oo, Mul, factor, nsimplify, zoo, Subs, RootOf,
-    AccumBounds, Matrix, zeros, ZeroMatrix, nan)
+    AccumBounds, Matrix, zeros, ZeroMatrix)
 from sympy.core.basic import _aresame
 from sympy.testing.pytest import XFAIL
 from sympy.abc import a, x, y, z, t
@@ -862,13 +862,3 @@ def test_issue_19558():
 
     assert e.subs(x, oo) == AccumBounds(-oo, oo)
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
-
-def test_subs_undefined_result():
-    x, y = symbols("x, y")
-    expr = x/y
-    assert expr.subs([(x, 0), (y, 0)]) == 0
-    assert expr.subs([(x, 0), (y, 0)], simultaneous=True) == nan
-    assert expr.subs([(x, 2), (y, 0)], simultaneous=True) == zoo
-    expr2 = x**y
-    assert expr2.subs([(x, 0), (y, 0)]) == 1
-    assert expr2.subs([(x, 0), (y, 0)], simultaneous=True) == 1

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -3,7 +3,7 @@ from sympy import (
     Integer, Eq, symbols, Add, I, Float, log, Rational,
     Lambda, atan2, cse, cot, tan, S, Tuple, Basic, Dict,
     Piecewise, oo, Mul, factor, nsimplify, zoo, Subs, RootOf,
-    AccumBounds, Matrix, zeros, ZeroMatrix)
+    AccumBounds, Matrix, zeros, ZeroMatrix, nan)
 from sympy.core.basic import _aresame
 from sympy.testing.pytest import XFAIL
 from sympy.abc import a, x, y, z, t
@@ -862,3 +862,13 @@ def test_issue_19558():
 
     assert e.subs(x, oo) == AccumBounds(-oo, oo)
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
+
+def test_subs_undefined_result():
+    x, y = symbols("x, y")
+    expr = x/y
+    assert expr.subs([(x, 0), (y, 0)]) == 0
+    assert expr.subs([(x, 0), (y, 0)], simultaneous=True) == nan
+    assert expr.subs([(x, 2), (y, 0)], simultaneous=True) == zoo
+    expr2 = x**y
+    assert expr2.subs([(x, 0), (y, 0)]) == 1
+    assert expr2.subs([(x, 0), (y, 0)], simultaneous=True) == 1

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -326,7 +326,7 @@ class Printer:
             for cls in classes:
                 printmethod = '_print_' + cls.__name__
                 if hasattr(self, printmethod):
-                    return getattr(self, printmethod)(expr, **kwargs)
+                    return getattr(self, printmethod)(expr)
             # Unknown object, fall back to the emptyPrinter.
             return self.emptyPrinter(expr)
         finally:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -212,7 +212,7 @@ def test_latex_SingularityFunction():
     assert latex(SingularityFunction(x, 4, -2)) == \
         r"{\left\langle x - 4 \right\rangle}^{-2}"
     assert latex(SingularityFunction(x, 4, -1)) == \
-        r"{\left\langle x - 4 \right\rangle}^{-1}"    
+        r"{\left\langle x - 4 \right\rangle}^{-1}"
     assert latex(SingularityFunction(x, 0, 0)**2) == \
         r"{\\left\\langle x \\right\\rangle}^{0}"
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -52,6 +52,7 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Lap
 from sympy.sets.setexpr import SetExpr
 from sympy.sets.sets import \
     Union, Intersection, Complement, SymmetricDifference, ProductSet
+
 import sympy as sym
 
 
@@ -2704,4 +2705,5 @@ def test_pickleable():
 
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
-    assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"     
+    assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+    

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -25,7 +25,7 @@ from sympy import (
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
-from sympy.abc import mu, tau, d
+from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary, multiline_latex,
                                   latex_escape, LatexPrinter)
@@ -52,7 +52,6 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Lap
 from sympy.sets.setexpr import SetExpr
 from sympy.sets.sets import \
     Union, Intersection, Complement, SymmetricDifference, ProductSet
-from sympy.physics.continuum_mechanics import Beam
 import sympy as sym
 
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2706,4 +2706,3 @@ def test_pickleable():
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
-    

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -25,7 +25,7 @@ from sympy import (
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
-from sympy.abc import mu, tau
+from sympy.abc import mu, tau, d
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary, multiline_latex,
                                   latex_escape, LatexPrinter)
@@ -52,7 +52,7 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Lap
 from sympy.sets.setexpr import SetExpr
 from sympy.sets.sets import \
     Union, Intersection, Complement, SymmetricDifference, ProductSet
-
+from sympy.physics.continuum_mechanics import Beam
 import sympy as sym
 
 
@@ -70,10 +70,10 @@ def test_printmethod():
             return "foo(%s)" % printer._print(self.args[0])
     assert latex(R(x)) == r"foo(x)"
 
-    class R(Abs):
+    class B(Abs):
         def _latex(self, printer):
             return "foo"
-    assert latex(R(x)) == r"foo"
+    assert latex(B(x)) == r"foo"
 
 
 def test_latex_basic():
@@ -212,7 +212,9 @@ def test_latex_SingularityFunction():
     assert latex(SingularityFunction(x, 4, -2)) == \
         r"{\left\langle x - 4 \right\rangle}^{-2}"
     assert latex(SingularityFunction(x, 4, -1)) == \
-        r"{\left\langle x - 4 \right\rangle}^{-1}"
+        r"{\left\langle x - 4 \right\rangle}^{-1}"    
+    assert latex(SingularityFunction(x, 0, 0)**2) == \
+        r"{\\left\\langle x \\right\\rangle}^{0}"
 
 
 def test_latex_cycle():
@@ -2703,4 +2705,4 @@ def test_pickleable():
 
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
-    assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+    assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"     


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
I have tried to fix the issue #21127.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes  #21127

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
