### PR TITLE
Allows internal representation of DomainMatrix to be both sparse and dense

### DIFF
--- a/doc/src/modules/polys/domainmatrix.rst
+++ b/doc/src/modules/polys/domainmatrix.rst
@@ -46,3 +46,10 @@ DDM Class Reference
 
 .. autoclass:: DDM
    :members:
+
+SDM Class Reference
+===================
+.. currentmodule:: sympy.polys.matrices.sdm
+
+.. autoclass:: SDM
+   :members:

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -211,23 +211,19 @@ class DDM(list):
         ddm_imatmul(c, a, b)
         return c
 
-    def hstack(A, *B):
+    def hstack(A, B):
         Anew = list(A.copy())
         rows, cols = A.shape
         domain = A.domain
 
-        for Bk in B:
-            Bkrows, Bkcols = Bk.shape
-            assert Bkrows == rows
-            assert Bk.domain == domain
+        Brows, Bcols = B.shape
+        assert Brows == rows
+        assert B.domain == A.domain
 
-            for i, Bki in enumerate(Bk):
-                Ai = Anew[i]
-                if Ai is None:
-                    Anew[i] = Ai = []
-                for Bkij in (Bki):
-                    Ai.append(Bkij)
-            cols += Bkcols
+        cols += Bcols
+
+        for i, Bi in enumerate(B):
+            Anew[i].extend(Bi)
 
         return DDM(Anew, (rows, cols), A.domain)
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -211,6 +211,26 @@ class DDM(list):
         ddm_imatmul(c, a, b)
         return c
 
+    def hstack(A, *B):
+        Anew = list(A.copy())
+        rows, cols = A.shape
+        domain = A.domain
+
+        for Bk in B:
+            Bkrows, Bkcols = Bk.shape
+            assert Bkrows == rows
+            assert Bk.domain == domain
+
+            for i, Bki in enumerate(Bk):
+                Ai = Anew[i]
+                if Ai is None:
+                    Anew[i] = Ai = []
+                for Bkij in (Bki):
+                    Ai.append(Bkij)
+            cols += Bkcols
+
+        return DDM(Anew, (rows, cols), A.domain)
+
     def rref(a):
         """Reduced-row echelon form of a and list of pivots"""
         b = a.copy()

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -112,8 +112,11 @@ class DDM(list):
         return DDM(rows, self.shape, K)
 
     def __str__(self):
+        return list.__repr__(self)
+
+    def __repr__(self):
         cls = type(self).__name__
-        rows = list.__str__(self)
+        rows = list.__repr__(self)
         return '%s(%s, %s, %s)' % (cls, rows, self.shape, self.domain)
 
     def __eq__(self, other):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -112,7 +112,8 @@ class DDM(list):
         return DDM(rows, self.shape, K)
 
     def __str__(self):
-        return list.__repr__(self)
+        rowsstr = ['[%s]' % ', '.join(map(str, row)) for row in self]
+        return '[%s]' % ', '.join(rowsstr)
 
     def __repr__(self):
         cls = type(self).__name__

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -92,6 +92,19 @@ class DDM(list):
         if not (len(self) == m and all(len(row) == n for row in self)):
             raise DDMBadInputError("Inconsistent row-list/shape")
 
+    def to_list(self):
+        return list(self)
+
+    def to_ddm(self):
+        return self
+
+    def convert_to(self, K):
+        Kold = self.domain
+        if K == Kold:
+            return self.copy()
+        rows = ([K.convert_from(e, Kold) for e in row] for row in self)
+        return DDM(rows, self.shape, K)
+
     def __str__(self):
         cls = type(self).__name__
         rows = list.__str__(self)
@@ -210,15 +223,17 @@ class DDM(list):
         domain = a.domain
 
         basis = []
+        nonpivots = []
         for i in range(cols):
             if i in pivots:
                 continue
+            nonpivots.append(i)
             vec = [domain.one if i == j else domain.zero for j in range(cols)]
             for ii, jj in enumerate(pivots):
                 vec[jj] -= rref[ii][i]
             basis.append(vec)
 
-        return DDM(basis, (len(basis), cols), domain)
+        return DDM(basis, (len(basis), cols), domain), nonpivots
 
     def det(a):
         """Determinant of a"""

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -101,6 +101,9 @@ class DDM(list):
     def to_ddm(self):
         return self
 
+    def to_sdm(self):
+        return SDM.from_list(self, self.shape, self.domain)
+
     def convert_to(self, K):
         Kold = self.domain
         if K == Kold:
@@ -305,3 +308,6 @@ class DDM(list):
         vec = ddm_berk(a, K)
         coeffs = [vec[i][0] for i in range(n+1)]
         return coeffs
+
+
+from .sdm import SDM

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -84,6 +84,9 @@ class DDM(list):
     This is a list subclass and is a wrapper for a list of lists that supports
     basic matrix arithmetic +, -, *, **.
     """
+
+    fmt = 'dense'
+
     def __init__(self, rowslist, shape, domain):
         super().__init__(rowslist)
         self.shape = self.rows, self.cols = m, n = shape

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -218,7 +218,7 @@ class DDM(list):
 
         Brows, Bcols = B.shape
         assert Brows == rows
-        assert B.domain == A.domain
+        assert B.domain == domain
 
         cols += Bcols
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -359,21 +359,52 @@ class DomainMatrix:
 
         return self.from_rep(SDM.to_ddm(self.rep))
 
+    def _unify_domain(self, other):
+        K1 = self.domain
+        K2 = other.domain
+        if K1 == K2:
+            return self, other
+        K = K1.unify(K2)
+        if K1 != K:
+            self = self.convert_to(K)
+        if K2 != K:
+            other = other.convert_to(K)
+        return self, other
 
-    def unify(self, other):
-        r"""
-        Unify the domains of self and other
+    def _unify_fmt(self, other, fmt):
+        if isinstance(self.rep, list) == isinstance(other.rep, list):
+            return self, other
+
+        if fmt is None:
+            return self.to_dense(), other.to_dense()
+        else:
+            if fmt == 'sparse':
+                return self.to_sparse(), other.to_sparse()
+            elif fmt == 'dense':
+                return self.to_dense(), other.to_dense()
+            else:
+                raise ValueError("fmt should be 'sparse' or 'dense'")
+
+    def unify(self, other, domain=True, fmt='dense'):
+        """
+        Unify the domains of self and other when domain=True,
+        otherwise unifies internal representation 'sparse'
+        and 'dense' of DomainMatrix
 
         Parameters
         ==========
 
         other : another DomainMatrix
+        domain: specifies whether unify domain or internal representation
+        fmt: if domain=False, fmt='dense'/'sparse' specifies which representation
+            to convert to
 
         Returns
         =======
 
         (dM1, dM2)
-            dM1, dM2 DomainMatrix matrices with unified Domain
+            dM1, dM2 DomainMatrix matrices with unified Domain, if domain=True
+            dM1, dM2 DomainMatrix with same internal representation, if domain=False
 
         Examples
         ========
@@ -391,19 +422,14 @@ class DomainMatrix:
         See Also
         ========
 
-        convert_to
+        convert_to, to_dense, to_sparse
 
         """
-        K1 = self.domain
-        K2 = other.domain
-        if K1 == K2:
-            return self, other
-        K = K1.unify(K2)
-        if K1 != K:
-            self = self.convert_to(K)
-        if K2 != K:
-            other = other.convert_to(K)
-        return self, other
+
+        if domain:
+            return self._unify_domain(other)
+        else:
+            return self._unify_fmt(other, fmt)
 
     def to_Matrix(self):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -121,12 +121,11 @@ class DomainMatrix:
 
         >>> from sympy.polys.domains import ZZ
         >>> from sympy.polys.matrices import DomainMatrix
-        >>> from sympy.polys.matrices.sdm import SDM
-        >>> drep = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> drep = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
         >>> dM = DomainMatrix.from_rep(drep)
         >>> dM
         DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
-
 
         Create a :py:class:`~.DomainMatrix` with a sparse internal
         representation as :py:class:`~.SDM`:
@@ -137,7 +136,7 @@ class DomainMatrix:
         >>> drep = SDM({0:{1:ZZ(1)},1:{0:ZZ(2)}}, (2, 2), ZZ)
         >>> dM = DomainMatrix.from_rep(drep)
         >>> dM
-        DomainMatrix([[0, 1], [2, 0]], (2, 2), ZZ)
+        DomainMatrix({0: {1: 1}, 1: {0: 2}}, (2, 2), ZZ)
 
         Parameters
         ==========
@@ -1111,7 +1110,7 @@ class DomainMatrix:
         >>> from sympy.polys.matrices import DomainMatrix
         >>> from sympy import QQ
         >>> DomainMatrix.eye(3, QQ)
-        DomainMatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]], (3, 3), QQ)
+        DomainMatrix({0: {0: 1}, 1: {1: 1}, 2: {2: 1}}, (3, 3), QQ)
 
         """
         return cls.from_rep(SDM.eye(n, domain))
@@ -1126,7 +1125,7 @@ class DomainMatrix:
         >>> from sympy.polys.matrices import DomainMatrix
         >>> from sympy import QQ
         >>> DomainMatrix.zeros((2, 3), QQ)
-        DomainMatrix([[0, 0, 0], [0, 0, 0]], (2, 3), QQ)
+        DomainMatrix({}, (2, 3), QQ)
 
         """
         return cls.from_rep(SDM.zeros(shape, domain))

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -385,26 +385,23 @@ class DomainMatrix:
             else:
                 raise ValueError("fmt should be 'sparse' or 'dense'")
 
-    def unify(self, other, domain=True, fmt='dense'):
+    def unify(self, other, fmt='dense'):
         """
-        Unify the domains of self and other when domain=True,
-        otherwise unifies internal representation 'sparse'
-        and 'dense' of DomainMatrix
+        Unifies the domains and the format of self and other
+        matrices.
 
         Parameters
         ==========
 
         other : another DomainMatrix
-        domain: specifies whether unify domain or internal representation
-        fmt: if domain=False, fmt='dense'/'sparse' specifies which representation
+        fmt: fmt='dense'/'sparse' specifies which representation
             to convert to
 
         Returns
         =======
 
         (dM1, dM2)
-            dM1, dM2 DomainMatrix matrices with unified Domain, if domain=True
-            dM1, dM2 DomainMatrix with same internal representation, if domain=False
+            dM1, dM2 DomainMatrix matrices with unified Domain and format
 
         Examples
         ========
@@ -419,6 +416,15 @@ class DomainMatrix:
         >>> A.unify(B)
         (DomainMatrix([[1, 2, 3]], (1, 3), QQ), DomainMatrix([[1/2, 3/5]], (1, 2), QQ))
 
+        >>> A = DomainMatrix([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
+        >>> B = DomainMatrix({0:{0: ZZ(1)}}, (2, 2), ZZ)
+        >>> B.rep
+        {0: {0: 1}}
+
+        >>> C, D = A.unify(B)
+        >>> D.rep
+        [[1, 0], [0, 0]]
+
         See Also
         ========
 
@@ -426,10 +432,8 @@ class DomainMatrix:
 
         """
 
-        if domain:
-            return self._unify_domain(other)
-        else:
-            return self._unify_fmt(other, fmt)
+        dM1, dM2 = self._unify_domain(other)
+        return dM1._unify_fmt(dM2, fmt)
 
     def to_Matrix(self):
         r"""
@@ -597,8 +601,7 @@ class DomainMatrix:
         if A.domain != B.domain:
             raise ValueError("domain")
         if isinstance(A.rep, list) != isinstance(B.rep, list):
-            A = A.to_dense()
-            B = B.to_dense()
+            raise ValueError("format")
 
         return A.from_rep(A.rep.add(B.rep))
 
@@ -655,8 +658,7 @@ class DomainMatrix:
             raise ValueError("domain")
 
         if isinstance(A.rep, list) != isinstance(B.rep, list):
-            A = A.to_dense()
-            B = B.to_dense()
+            raise ValueError("format")
 
         return A.from_rep(A.rep.sub(B.rep))
 
@@ -773,8 +775,7 @@ class DomainMatrix:
         """
 
         if isinstance(A.rep, list) != isinstance(B.rep, list):
-            A = A.to_dense()
-            B = B.to_dense()
+            raise ValueError("format")
 
         return A.from_rep(A.rep.matmul(B.rep))
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -312,6 +312,56 @@ class DomainMatrix:
         K = self.domain.get_field()
         return self.convert_to(K)
 
+    def to_sparse(self):
+        """
+
+        Converts internal representation of DomainMatrix
+        from dense to sparse
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy import QQ
+        >>> A = DomainMatrix([[1, 0],[0, 2]], (2, 2), QQ, fmt='dense')
+        >>> A
+        DomainMatrix([[1, 0], [0, 2]], (2, 2), QQ)
+        >>> B = A.to_sparse()
+        >>> B
+        {0: {0: 1}, 1: {1: 2}}
+
+
+        """
+        if isinstance(self.rep, dict):
+            return self
+
+        return SDM.from_ddm(self.rep)
+
+    def to_dense(self):
+        """
+
+        Converts internal representation of
+        a DomainMatrix from sparse to dense
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy import QQ
+        >>> A = DomainMatrix({0: {0: 1}, 1: {1: 2}}, (2, 2), QQ)
+        >>> A.rep
+        {0: {0: 1}, 1: {1: 2}}
+        >>> B = A.to_dense()
+        >>> B
+        [[1, 0], [0, 2]]
+
+        """
+        if isinstance(self.rep, list):
+            return self
+
+        return SDM.to_ddm(self.rep)
+
+
     def unify(self, other):
         r"""
         Unify the domains of self and other

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -21,12 +21,6 @@ from .ddm import DDM
 from .sdm import SDM
 
 
-# Map from format string to class for internal representation
-# defaulting to either dense ot sparse
-_REPCLS_SPARSE = {'dense': DDM, 'sparse': SDM, None: SDM}
-_REPCLS_DENSE  = {'dense': DDM, 'sparse': SDM, None: DDM}
-
-
 class DomainMatrix:
     r"""
     Associate Matrix with :py:class:`~.Domain`
@@ -71,6 +65,7 @@ class DomainMatrix:
     ========
 
     DDM
+    SDM
     Domain
     Poly
 
@@ -477,10 +472,7 @@ class DomainMatrix:
         return MutableDenseMatrix(rows_sympy)
 
     def __repr__(self):
-        elemlist = self.rep.to_list()
-        rows_str = ['[%s]' % (', '.join(map(str, row))) for row in elemlist]
-        rowstr = '[%s]' % ', '.join(rows_str)
-        return 'DomainMatrix(%s, %r, %r)' % (rowstr, self.shape, self.domain)
+        return 'DomainMatrix(%s, %r, %r)' % (str(self.rep), self.shape, self.domain)
 
     def hstack(A, B):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -101,7 +101,7 @@ class DomainMatrix:
         elif isinstance(rows, dict):
             rep = SDM(rows, shape, domain)
         else:
-            msg = "Input should be DDM, SDM, list-of-lists or dict-of-dicts"
+            msg = "Input should be list-of-lists or dict-of-dicts"
             raise TypeError(msg)
 
         if fmt is not None:

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -570,7 +570,12 @@ class DomainMatrix:
             raise ShapeError("shape")
         if A.domain != B.domain:
             raise ValueError("domain")
+        if isinstance(A.rep, list) != isinstance(B.rep, list):
+            A = A.to_dense()
+            B = B.to_dense()
+
         return A.from_rep(A.rep.add(B.rep))
+
 
     def sub(A, B):
         r"""
@@ -622,6 +627,11 @@ class DomainMatrix:
             raise ShapeError("shape")
         if A.domain != B.domain:
             raise ValueError("domain")
+
+        if isinstance(A.rep, list) != isinstance(B.rep, list):
+            A = A.to_dense()
+            B = B.to_dense()
+
         return A.from_rep(A.rep.sub(B.rep))
 
     def neg(A):
@@ -696,6 +706,10 @@ class DomainMatrix:
         matmul
 
         """
+        if isinstance(A.rep, list) != isinstance(B.rep, list):
+            A = A.to_dense()
+            B = B.to_dense()
+
         return A.from_rep(A.rep.mul(b))
 
     def matmul(A, B):
@@ -735,6 +749,11 @@ class DomainMatrix:
         mul, pow, add, sub
 
         """
+
+        if isinstance(A.rep, list) != isinstance(B.rep, list):
+            A = A.to_dense()
+            B = B.to_dense()
+
         return A.from_rep(A.rep.matmul(B.rep))
 
     def pow(A, n):

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -126,8 +126,6 @@ class DomainMatrix:
         Create a `~.DomainMatrix` with an dense internal representation as
         `~.DDM`:
 
-        >>> from sympy.polys.matrices import DomainMatrix
-        >>> from sympy.polys.matrices.ddm import DDM
         >>> drep = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
         >>> dM = DomainMatrix.from_rep(drep)
         >>> dM
@@ -706,10 +704,6 @@ class DomainMatrix:
         matmul
 
         """
-        if isinstance(A.rep, list) != isinstance(B.rep, list):
-            A = A.to_dense()
-            B = B.to_dense()
-
         return A.from_rep(A.rep.mul(b))
 
     def matmul(A, B):

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -120,12 +120,12 @@ class DomainMatrix:
         Examples
         ========
 
-        >>> from sympy.polys.domains import ZZ
-        >>> from sympy.polys.matrices import DomainMatrix
-
         Create a `~.DomainMatrix` with an dense internal representation as
         `~.DDM`:
 
+        >>> from sympy.polys.domains import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy.polys.matrices.sdm import SDM
         >>> drep = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
         >>> dM = DomainMatrix.from_rep(drep)
         >>> dM
@@ -467,11 +467,8 @@ class DomainMatrix:
 
         >>> from sympy import ZZ, QQ
         >>> from sympy.polys.matrices import DomainMatrix
-        >>> A = DomainMatrix([
-        ...    [ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
-        >>> B = DomainMatrix([
-        ...    [QQ(-1, 2), QQ(1, 2), QQ(1, 3)]],(1, 3), QQ)
-
+        >>> A = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
+        >>> B = DomainMatrix([[QQ(-1, 2), QQ(1, 2), QQ(1, 3)]],(1, 3), QQ)
         >>> A.hstack(B)
         DomainMatrix([[1, 2, 3, -1/2, 1/2, 1/3]], (1, 6), QQ)
 
@@ -481,6 +478,11 @@ class DomainMatrix:
         unify
 
         """
+
+        if isinstance(A.rep, list) != isinstance(B.rep, list):
+            A = A.to_dense()
+            B = B.to_dense()
+
         A, B = A.unify(B)
         return A.from_rep(A.rep.hstack(B.rep))
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -323,11 +323,11 @@ class DomainMatrix:
 
         >>> from sympy.polys.matrices import DomainMatrix
         >>> from sympy import QQ
-        >>> A = DomainMatrix([[1, 0],[0, 2]], (2, 2), QQ, fmt='dense')
+        >>> A = DomainMatrix([[1, 0],[0, 2]], (2, 2), QQ)
         >>> A
         DomainMatrix([[1, 0], [0, 2]], (2, 2), QQ)
         >>> B = A.to_sparse()
-        >>> B
+        >>> B.rep
         {0: {0: 1}, 1: {1: 2}}
 
 
@@ -335,7 +335,7 @@ class DomainMatrix:
         if isinstance(self.rep, dict):
             return self
 
-        return SDM.from_ddm(self.rep)
+        return self.from_rep(SDM.from_ddm(self.rep))
 
     def to_dense(self):
         """
@@ -352,14 +352,14 @@ class DomainMatrix:
         >>> A.rep
         {0: {0: 1}, 1: {1: 2}}
         >>> B = A.to_dense()
-        >>> B
+        >>> B.rep
         [[1, 0], [0, 2]]
 
         """
         if isinstance(self.rep, list):
             return self
 
-        return SDM.to_ddm(self.rep)
+        return self.from_rep(SDM.to_ddm(self.rep))
 
 
     def unify(self, other):

--- a/sympy/polys/matrices/exceptions.py
+++ b/sympy/polys/matrices/exceptions.py
@@ -33,8 +33,13 @@ class DDMShapeError(DDMError):
     pass
 
 
+class DDMFormatError(DDMError):
+    """mixed dense/sparse not supported"""
+    pass
+
+
 __all__ = [
-    'DDMError', 'DDMShapeError', 'DDMDomainError',
+    'DDMError', 'DDMShapeError', 'DDMDomainError', 'DDMFormatError',
 
     'NonSquareMatrixError', 'NonInvertibleMatrixError', 'ShapeError',
 ]

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -7,7 +7,7 @@ Module for the SDM class.
 from operator import add, neg, pos, sub
 from collections import defaultdict
 
-from .exceptions import DDMBadInputError, DDMDomainError
+from .exceptions import DDMBadInputError, DDMDomainError, DDMShapeError
 
 from .ddm import DDM
 
@@ -97,9 +97,12 @@ class SDM(dict):
     def matmul(A, B):
         if A.domain != B.domain:
             raise DDMDomainError
-        K = A.domain
+        m, n = A.shape
+        n2, o = B.shape
+        if n != n2:
+            raise DDMShapeError
         C = sdm_matmul(A, B)
-        return A.new(C, A.shape, A.domain)
+        return A.new(C, (m, o), A.domain)
 
     def mul(A, b):
         Csdm = unop_dict(A, lambda aij: aij*b)

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -18,6 +18,9 @@ class SDM(dict):
     This is a dict subclass and is a wrapper for a dict of dicts that supports
     basic matrix arithmetic +, -, *, **.
     """
+
+    fmt = 'sparse'
+
     def __init__(self, elemsdict, shape, domain):
         super().__init__(elemsdict)
         self.shape = self.rows, self.cols = m, n = shape

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -65,6 +65,9 @@ class SDM(dict):
     def to_ddm(M):
         return DDM(M.to_list(), M.shape, M.domain)
 
+    def to_sdm(M):
+        return M
+
     @classmethod
     def zeros(cls, shape, domain):
         return cls({}, shape, domain)

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -31,6 +31,18 @@ class SDM(dict):
         if not all(0 <= c < n for row in self.values() for c in row):
             raise DDMBadInputError("Column out of range")
 
+    def __str__(self):
+        rowsstr = []
+        for i, row in self.items():
+            elemsstr = ', '.join('%s: %s' % (j, elem) for j, elem in row.items())
+            rowsstr.append('%s: {%s}' % (i, elemsstr))
+        return '{%s}' % ', '.join(rowsstr)
+
+    def __repr__(self):
+        cls = type(self).__name__
+        rows = dict.__repr__(self)
+        return '%s(%s, %s, %s)' % (cls, rows, self.shape, self.domain)
+
     @classmethod
     def new(cls, sdm, shape, domain):
         return cls(sdm, shape, domain)

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -40,7 +40,7 @@ def test_DDM_getsetitem():
 def test_DDM_str():
     ddm = DDM([[ZZ(0), ZZ(1)], [ZZ(2), ZZ(3)]], (2, 2), ZZ)
     if HAS_GMPY: # pragma: no cover
-        assert str(ddm) == '[[mpz(0), mpz(1)], [mpz(2), mpz(3)]]'
+        assert str(ddm) == '[[0, 1], [2, 3]]'
         assert repr(ddm) == 'DDM([[mpz(0), mpz(1)], [mpz(2), mpz(3)]], (2, 2), ZZ)'
     else:        # pragma: no cover
         assert repr(ddm) == 'DDM([[0, 1], [2, 3]], (2, 2), ZZ)'

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -40,9 +40,11 @@ def test_DDM_getsetitem():
 def test_DDM_str():
     ddm = DDM([[ZZ(0), ZZ(1)], [ZZ(2), ZZ(3)]], (2, 2), ZZ)
     if HAS_GMPY: # pragma: no cover
-        assert str(ddm) == 'DDM([[mpz(0), mpz(1)], [mpz(2), mpz(3)]], (2, 2), ZZ)'
+        assert str(ddm) == '[[mpz(0), mpz(1)], [mpz(2), mpz(3)]]'
+        assert repr(ddm) == 'DDM([[mpz(0), mpz(1)], [mpz(2), mpz(3)]], (2, 2), ZZ)'
     else:        # pragma: no cover
-        assert str(ddm) == 'DDM([[0, 1], [2, 3]], (2, 2), ZZ)'
+        assert repr(ddm) == 'DDM([[0, 1], [2, 3]], (2, 2), ZZ)'
+        assert str(ddm) == '[[0, 1], [2, 3]]'
 
 
 def test_DDM_eq():

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -188,6 +188,15 @@ def test_DDM_matmul():
     raises(DDMShapeError, lambda: Z05 @ Z40)
     raises(DDMShapeError, lambda: Z05.matmul(Z40))
 
+def test_DDM_hstack():
+
+    A = DDM([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
+    B = DDM([[ZZ(4), ZZ(5)]], (1, 2), ZZ)
+    Ah = A.hstack(B)
+
+    assert Ah.shape == (1, 5)
+    assert Ah.domain == ZZ
+    assert Ah == DDM([[ZZ(1), ZZ(2), ZZ(3), ZZ(4), ZZ(5)]], (1, 5), ZZ)
 
 def test_DDM_rref():
 

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -71,6 +71,13 @@ def test_DDM_eq():
     assert (ddm3 != ddm1) is True
 
 
+def test_DDM_convert_to():
+    ddm = DDM([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
+    assert ddm.convert_to(ZZ) == ddm
+    ddmq = ddm.convert_to(QQ)
+    assert ddmq.domain == QQ
+
+
 def test_DDM_zeros():
     ddmz = DDM.zeros((3, 4), QQ)
     assert list(ddmz) == [[QQ(0)] * 4] * 3

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -223,7 +223,8 @@ def test_DDM_rref():
 def test_DDM_nullspace():
      A = DDM([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), QQ)
      Anull = DDM([[QQ(-1), QQ(1)]], (1, 2), QQ)
-     assert A.nullspace() == Anull
+     nonpivots = [1]
+     assert A.nullspace() == (Anull, nonpivots)
 
 
 def test_DDM_det():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -113,6 +113,17 @@ def test_DomainMatrix_to_field():
     Aq = A.to_field()
     assert Aq == DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
 
+def test_DomainMatrix_to_sparse():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    A_sparse = A.to_sparse()
+    assert A_sparse.rep == {0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}
+
+def test_DomainMatrix_to_dense():
+
+    A = DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
+    A_dense = A.to_dense()
+    assert A_dense.rep == DDM([[1, 2], [3, 4]], (2, 2), ZZ)
+
 
 def test_DomainMatrix_unify():
     Az = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -132,6 +132,20 @@ def test_DomainMatrix_unify():
     assert Aq.unify(Az) == (Aq, Aq)
     assert Aq.unify(Aq) == (Aq, Aq)
 
+    As = DomainMatrix({0: {1: ZZ(1)}, 1:{0:ZZ(2)}}, (2, 2), ZZ)
+    Ad = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+
+    assert As.unify(As, domain=False) == (As, As)
+    assert Ad.unify(Ad, domain=False) == (Ad, Ad)
+
+    Bs, Bd = As.unify(Ad, domain=False)
+    assert Bs.rep == DDM([[0, 1], [2, 0]], (2, 2), ZZ)
+    assert Bd.rep == DDM([[1, 2],[3, 4]], (2, 2), ZZ)
+
+    Bs, Bd = As.unify(Ad, domain=False, fmt='sparse')
+    assert Bs.rep == {0: {1: 1}, 1: {0: 2}}
+    assert Bd.rep == {0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}
+
 
 def test_DomainMatrix_to_Matrix():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
@@ -167,6 +181,12 @@ def test_DomainMatrix_add():
     raises(ValueError, lambda: Az.add(Aq))
     raises(ValueError, lambda: Aq.add(Az))
 
+    As = DomainMatrix({0: {1: ZZ(1)}, 1: {0: ZZ(2)}}, (2, 2), ZZ)
+    Ad = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+
+    assert As + Ad == DomainMatrix([[1, 3], [5, 4]], (2, 2), ZZ)
+    assert (As + Ad).rep == DDM([[1, 3], [5, 4]], (2, 2), ZZ)
+
 
 def test_DomainMatrix_sub():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
@@ -192,6 +212,13 @@ def test_DomainMatrix_sub():
     raises(ValueError, lambda: Az.sub(Aq))
     raises(ValueError, lambda: Aq.sub(Az))
 
+    As = DomainMatrix({0: {1: ZZ(1)}, 1: {0: ZZ(2)}}, (2, 2), ZZ)
+    Ad = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+
+    assert As - Ad == DomainMatrix([[-1, -1], [-1, -4]], (2, 2), ZZ)
+    assert (As - Ad).rep == DDM([[-1, -1], [-1, -4]], (2, 2), ZZ)
+    assert As - Ad == -(Ad - As)
+    assert (As - Ad).rep == -(Ad - As).rep
 
 def test_DomainMatrix_neg():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
@@ -226,6 +253,13 @@ def test_DomainMatrix_mul():
     x = ZZ(0)
     assert A * x == x * A == A.mul(x) == AA
 
+    As = DomainMatrix({0: {1: ZZ(1)}, 1: {0: ZZ(2)}}, (2, 2), ZZ)
+    Ad = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+
+    assert As*Ad == DomainMatrix([[3, 4], [2, 4]], (2, 2), ZZ)
+    assert (As*Ad).rep == DDM([[3, 4], [2, 4]], (2, 2), ZZ)
+    assert (Ad * As) == DomainMatrix([[4, 1], [8, 3]], (2, 2), ZZ)
+    assert (Ad*As).rep == DDM([[4, 1], [8, 3]], (2, 2), ZZ)
 
 def test_DomainMatrix_pow():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1,3 +1,5 @@
+from sympy.core.compatibility import HAS_GMPY
+
 from sympy.testing.pytest import raises
 
 from sympy.core.numbers import Rational
@@ -182,7 +184,10 @@ def test_DomainMatrix_to_Matrix():
 
 def test_DomainMatrix_repr():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert repr(A) == 'DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)'
+    if HAS_GMPY: # pragma: no cover
+        assert repr(A) == 'DomainMatrix([[mpz(1), mpz(2)], [mpz(3), mpz(4)]], (2, 2), ZZ)'
+    else:        # pragma: no cover
+        assert repr(A) == 'DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)'
 
 
 def test_DomainMatrix_add():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1,5 +1,3 @@
-from sympy.core.compatibility import HAS_GMPY
-
 from sympy.testing.pytest import raises
 
 from sympy.core.numbers import Rational
@@ -184,10 +182,7 @@ def test_DomainMatrix_to_Matrix():
 
 def test_DomainMatrix_repr():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    if HAS_GMPY: # pragma: no cover
-        assert repr(A) == 'DomainMatrix([[mpz(1), mpz(2)], [mpz(3), mpz(4)]], (2, 2), ZZ)'
-    else:        # pragma: no cover
-        assert repr(A) == 'DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)'
+    assert repr(A) == 'DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)'
 
 
 def test_DomainMatrix_add():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -16,8 +16,8 @@ from sympy.polys.matrices.sdm import SDM
 
 def test_DomainMatrix_init():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    # assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    assert A.rep == DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    # assert A.rep == SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -25,17 +25,22 @@ def test_DomainMatrix_init():
 
 
 def test_DomainMatrix_from_rep():
-    # ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     A = DomainMatrix.from_rep(ddm)
     assert A.rep == ddm
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
+    sdm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    A = DomainMatrix.from_rep(sdm)
+    assert A.rep == sdm
+    assert A.shape == (2, 2)
+    assert A.domain == ZZ
+
 
 def test_DomainMatrix_from_list_sympy():
-    # ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    # ddm = SDM({0: {0: ZZ(1), 1:ZZ(2)}, 1: {0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     A = DomainMatrix.from_list_sympy(2, 2, [[1, 2], [3, 4]])
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -48,7 +53,6 @@ def test_DomainMatrix_from_list_sympy():
         (2, 2),
         K
     )
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_list_sympy(
         2, 2, [[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]],
         extension=True)
@@ -59,7 +63,6 @@ def test_DomainMatrix_from_list_sympy():
 
 def test_DomainMatrix_from_Matrix():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(Matrix([[1, 2], [3, 4]]))
     assert A.rep == ddm
     assert A.shape == (2, 2)
@@ -72,7 +75,6 @@ def test_DomainMatrix_from_Matrix():
         (2, 2),
         K
     )
-    ddm = SDM.from_ddm(ddm)
     A = DomainMatrix.from_Matrix(
         Matrix([[1 + sqrt(2), 2 + sqrt(2)], [3 + sqrt(2), 4 + sqrt(2)]]),
         extension=True)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -119,7 +119,6 @@ def test_DomainMatrix_to_sparse():
     assert A_sparse.rep == {0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}
 
 def test_DomainMatrix_to_dense():
-
     A = DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
     A_dense = A.to_dense()
     assert A_dense.rep == DDM([[1, 2], [3, 4]], (2, 2), ZZ)

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -157,6 +157,16 @@ def test_SDM_convert_to():
     assert D.domain == ZZ
 
 
+def test_SDM_hstack():
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    B = SDM({1:{1:ZZ(1)}}, (2, 2), ZZ)
+    AA = SDM({0:{1:ZZ(1), 3:ZZ(1)}}, (2, 4), ZZ)
+    AB = SDM({0:{1:ZZ(1)}, 1:{3:ZZ(1)}}, (2, 4), ZZ)
+    assert SDM.hstack(A) == A
+    assert SDM.hstack(A, A) == AA
+    assert SDM.hstack(A, B) == AB
+
+
 def test_SDM_inv():
     A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
     B = SDM({0:{0:QQ(-2), 1:QQ(1)}, 1:{0:QQ(3, 2), 1:QQ(-1, 2)}}, (2, 2), QQ)

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -8,7 +8,8 @@ from sympy.testing.pytest import raises
 from sympy import QQ, ZZ
 from sympy.polys.matrices.sdm import SDM
 from sympy.polys.matrices.ddm import DDM
-from sympy.polys.matrices.exceptions import DDMBadInputError, DDMDomainError
+from sympy.polys.matrices.exceptions import (DDMBadInputError, DDMDomainError,
+        DDMShapeError)
 
 
 def test_SDM():
@@ -117,6 +118,19 @@ def test_SDM_matmul():
     A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(7), 1:ZZ(10)}, 1:{0:ZZ(15), 1:ZZ(22)}}, (2, 2), ZZ)
     assert A.matmul(A) == B
+
+    A22 = SDM({0:{0:ZZ(4)}}, (2, 2), ZZ)
+    A32 = SDM({0:{0:ZZ(2)}}, (3, 2), ZZ)
+    A23 = SDM({0:{0:ZZ(4)}}, (2, 3), ZZ)
+    A33 = SDM({0:{0:ZZ(8)}}, (3, 3), ZZ)
+    A22 = SDM({0:{0:ZZ(8)}}, (2, 2), ZZ)
+    assert A32.matmul(A23) == A33
+    assert A23.matmul(A32) == A22
+    # XXX: @ not supported by SDM...
+    #assert A32.matmul(A23) == A32 @ A23 == A33
+    #assert A23.matmul(A32) == A23 @ A32 == A22
+    #raises(DDMShapeError, lambda: A23 @ A22)
+    raises(DDMShapeError, lambda: A23.matmul(A22))
 
 
 def test_SDM_add():

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -2,7 +2,7 @@
 Tests for the basic functionality of the SDM class.
 """
 
-
+from sympy.core.compatibility import HAS_GMPY
 from sympy.testing.pytest import raises
 
 from sympy import QQ, ZZ
@@ -20,6 +20,15 @@ def test_SDM():
 
     raises(DDMBadInputError, lambda: SDM({5:{1:ZZ(0)}}, (2, 2), ZZ))
     raises(DDMBadInputError, lambda: SDM({0:{5:ZZ(0)}}, (2, 2), ZZ))
+
+
+def test_DDM_str():
+    sdm = SDM({0:{0:ZZ(1)}, 1:{1:ZZ(1)}}, (2, 2), ZZ)
+    assert str(sdm) == '{0: {0: 1}, 1: {1: 1}}'
+    if HAS_GMPY: # pragma: no cover
+        assert repr(sdm) == 'SDM({0: {0: mpz(1)}, 1: {1: mpz(1)}}, (2, 2), ZZ)'
+    else:        # pragma: no cover
+        assert repr(sdm) == 'SDM({0: {0: 1}, 1: {1: 1}}, (2, 2), ZZ)'
 
 
 def test_SDM_new():


### PR DESCRIPTION
#### References to other Issues or PRs
This completes #21140 


#### Brief description of what is fixed or changed
The DomainMatrix class was originally introduces with DDM as its
internal representation representing a dense internal format. The SDM
sparse format was added later and made to be the internal format of DDM
always. This commit makes it possible DomainMatrix to use either SDM or
DDM as its internal format in the constructor by passing fmt="dense" or
fmt="sparse".

#### Other comments
Also added functions `to_sparse` and `to_dense`
This PR also implements binary operations between sparse 
and dense matrices in DomainMatrix class

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added internal representation as both dense and sparse matrix
<!-- END RELEASE NOTES -->
