### PR TITLE
Fixes (solvers) : `isolve` ,`solveset` solves relational with integer domain

### DIFF
--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -625,11 +625,11 @@ def test_messy():
                        fourier_transform, sqrt)
     assert laplace_transform(Si(x), x, s) == ((-atan(s) + pi/2)/s, 0, True)
 
-    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, True)
+    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, s > 1)
 
     # where should the logs be simplified?
     assert laplace_transform(Chi(x), x, s) == \
-        ((log(s**(-2)) - log(1 - 1/s**2))/(2*s), 1, True)
+        ((log(s**(-2)) - log(1 - 1/s**2))/(2*s), 1, s > 1)
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -518,20 +518,20 @@ def test_laplace_transform():
 
     assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) ==\
         Matrix([
-            [(1/(s - 1), 1, True), ((s + 1)**(-2), 0, True)],
-            [((s + 1)**(-2), 0, True), (1/(s - 1), 1, True)]
+            [(1/(s - 1), 1, s > 1), ((s + 1)**(-2), 0, True)],
+            [((s + 1)**(-2), 0, True), (1/(s - 1), 1, s > 1)]
         ])
 
 
 def test_issue_8368_7173():
     LT = laplace_transform
     # hyperbolic
-    assert LT(sinh(x), x, s) == (1/(s**2 - 1), 1, True)
-    assert LT(cosh(x), x, s) == (s/(s**2 - 1), 1, True)
+    assert LT(sinh(x), x, s) == (1/(s**2 - 1), 1, s > 1)
+    assert LT(cosh(x), x, s) == (s/(s**2 - 1), 1, s > 1)
     assert LT(sinh(x + 3), x, s) == (
-        (-s + (s + 1)*exp(6) + 1)*exp(-3)/(s - 1)/(s + 1)/2, 1, True)
+        (-s + (s + 1)*exp(6) + 1)*exp(-3)/(s - 1)/(s + 1)/2, 1, s > 1)
     assert LT(sinh(x)*cosh(x), x, s) == (
-        1/(s**2 - 4), 2, Ne(s/2, 1))
+        1/(s**2 - 4), 2, s > 2)
     # trig (make sure they are not being rewritten in terms of exp)
     assert LT(cos(x + 3), x, s) == ((s*cos(3) - sin(3))/(s**2 + 1), 0, True)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -2,7 +2,7 @@
 from functools import reduce
 
 from sympy.core import S
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, ordered
 from sympy.core.function import Function
 from sympy.core.relational import _canonical, Ge, Gt
 from sympy.core.numbers import oo
@@ -1084,13 +1084,13 @@ def _laplace_transform(f, t, s_, simplify=True):
                 a = Max(a_, a)
             else:
                 aux = And(aux, Or(*aux_))
-        return a, aux
+        return a, aux.canonical if aux.is_Relational else aux
 
     conds = [process_conds(c) for c in disjuncts(cond)]
     conds2 = [x for x in conds if x[1] != False and x[0] != -oo]
     if not conds2:
         conds2 = [x for x in conds if x[1] != False]
-    conds = conds2
+    conds = list(ordered(conds2))
 
     def cnt(expr):
         if expr == True or expr == False:
@@ -1100,7 +1100,7 @@ def _laplace_transform(f, t, s_, simplify=True):
 
     if not conds:
         raise IntegralTransformError('Laplace', f, 'no convergence found')
-    a, aux = conds[0]
+    a, aux = conds[0]  # XXX is [0] always the right one?
 
     def sbs(expr):
         return expr.subs(s, s_)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -917,6 +917,10 @@ def test_Union_as_relational():
         Or(And(Le(0, x), Le(x, 1)), Eq(x, 2))
     assert (Interval(0, 1, True, True) + FiniteSet(1)).as_relational(x) == \
         And(Lt(0, x), Le(x, 1))
+    assert Or(x < 0, x > 0).as_set().as_relational(x) == \
+        And((x > -oo), (x < oo), Ne(x, 0))
+    assert (Interval.Ropen(1, 3) + Interval.Lopen(3, 5)
+        ).as_relational(x) == And((x > 1), (x < 5), Ne(x, 3))
 
 
 def test_Intersection_as_relational():

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -456,6 +456,20 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     from sympy.solvers.solvers import denoms
     from sympy.solvers.solveset import solvify, solveset
 
+    if domain.is_subset(S.Reals) is False:
+        raise NotImplementedError(filldedent('''
+        Inequalities in the complex domain are
+        not supported. Try the real domain by
+        setting domain=S.Reals'''))
+    elif domain is not S.Reals:
+        rv = solve_univariate_inequality(
+        expr, gen, relational=False, continuous=continuous).intersection(domain)
+        if relational:
+            rv = rv.as_relational(gen)
+        return rv
+    else:
+        pass  # continue with attempt to solve in Real domain
+
     # This keeps the function independent of the assumptions about `gen`.
     # `solveset` makes sure this function is called only when the domain is
     # real.

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1056,11 +1056,6 @@ def _solveset(f, symbol, domain, _check=False):
         result = solver(Add(f.lhs, - f.rhs, evaluate=False), symbol, domain)
 
     elif f.is_Relational:
-        if not domain.is_subset(S.Reals):
-            raise NotImplementedError(filldedent('''
-                Inequalities in the complex domain are
-                not supported. Try the real domain by
-                setting domain=S.Reals'''))
         try:
             result = solve_univariate_inequality(
             f, symbol, domain=domain, relational=False)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -24,7 +24,7 @@ from sympy.polys.polytools import Poly
 from sympy.polys.rootoftools import CRootOf
 from sympy.sets.contains import Contains
 from sympy.sets.conditionset import ConditionSet
-from sympy.sets.fancysets import ImageSet
+from sympy.sets.fancysets import ImageSet, Range
 from sympy.sets.sets import (Complement, EmptySet, FiniteSet,
     Intersection, Interval, Union, imageset, ProductSet)
 from sympy.simplify import simplify
@@ -1975,6 +1975,32 @@ def test_simplification():
     eq = x + (ap - bn)/(-2*ap + 2*bn)
     assert solveset(eq, x) == FiniteSet(S.Half)
     assert solveset(eq, x, S.Reals) == FiniteSet(S.Half)
+
+
+def test_integer_domain_relational():
+    eq1 = 2*x + 3 > 0
+    eq2 = x**2 + 3*x - 2 >= 0
+    eq3 = x + 1/x > -2 + 1/x
+    eq4 = x + sqrt(x**2 - 5) > 0
+    eq = x + 1/x > -2 + 1/x
+    eq5 = eq.subs(x,log(x))
+    eq6 = log(x)/x <= 0
+    eq7 = log(x)/x < 0
+    eq8 = x/(x-3) < 3
+    eq9 = x/(x**2-3) < 3
+
+    assert solveset(eq1, x, S.Integers) == Range(-1, oo, 1)
+    assert solveset(eq2, x, S.Integers) == Union(Range(-oo, -3, 1), Range(1, oo, 1))
+    assert solveset(eq3, x, S.Integers) == Union(Range(-1, 0, 1), Range(1, oo, 1))
+    assert solveset(eq4, x, S.Integers) == Range(3, oo, 1)
+    assert solveset(eq5, x, S.Integers) == Range(2, oo, 1)
+    assert solveset(eq6, x, S.Integers) == Range(1, 2, 1)
+    assert solveset(eq7, x, S.Integers) == S.EmptySet
+    assert solveset(eq8, x, domain=Range(0,5)) == Range(0, 3, 1)
+    assert solveset(eq9, x, domain=Range(0,5)) == Union(Range(0, 2, 1), Range(2, 5, 1))
+
+    # test_issue_19794
+    assert solveset(x + 2 < 0, x, S.Integers) == Range(-oo, -2, 1)
 
 
 def test_issue_10555():


### PR DESCRIPTION
`isolve` and `solveset` are now able to solve relational with Integer, Integer subsets domain (also any subset of Reals) up to a nice extent…

Fixes  #19794, as it was hanging.
```
>>> solveset( x**2 + 3*x - 2 >= 0, x, S.Integers)
     Union(Range(-oo, -3, 1), Range(1, oo, 1))

>>> assert isolve(2*x + 3 > 0, x, domain=S.Integers) ==\
     (x >= -1) & (x < oo) & Eq(x, floor(x))
```
Closes #19794
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->