### PR TITLE
Fixes 21079 issue, periodicity, solvify for piecewise

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
                    cot, sec, csc, Abs, symbols, I, re, simplify,
-                   expint, Rational)
+                   expint, Rational, Piecewise)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex,
                                  stationary_points, minimum, maximum)
@@ -171,6 +171,9 @@ def test_periodicity():
     assert periodicity((E**x)%3, x) is None
 
     assert periodicity(sin(expint(1, x))/expint(1, x), x) is None
+    # returning `None` for any Piecewise
+    p = Piecewise((0, x < -1), (x**2, x <= 1), (log(x), True))
+    assert periodicity(p, x) is None
 
 
 def test_periodicity_check():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -512,9 +512,7 @@ def periodicity(f, symbol, check=False):
                 period = Abs(n / a.diff(symbol))
 
     elif isinstance(f, Piecewise):
-        # Returning None, as the return type, period of the `piecewise`
-        # also should be a piecewise. (i.e. the return type is not favorable)
-        return None
+        pass  # not handling Piecewise yet as the return type is not favorable
 
     elif period is None:
         from sympy.solvers.decompogen import compogen

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1,4 +1,4 @@
-from sympy import Order, S, log, limit, lcm_list, im, re, Dummy
+from sympy import Order, S, log, limit, lcm_list, im, re, Dummy, Piecewise
 from sympy.core import Add, Mul, Pow
 from sympy.core.basic import Basic
 from sympy.core.compatibility import iterable
@@ -510,6 +510,11 @@ def periodicity(f, symbol, check=False):
         elif (a.is_polynomial(symbol) and degree(a, symbol) == 1 and
             symbol not in n.free_symbols):
                 period = Abs(n / a.diff(symbol))
+
+    elif isinstance(f, Piecewise):
+        # Returning None, as the return type, period of the `piecewise`
+        # also should be a piecewise. (i.e. the return type is not favorable)
+        return None
 
     elif period is None:
         from sympy.solvers.decompogen import compogen

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2318,6 +2318,9 @@ def solvify(f, symbol, domain):
     ImageSet,   | list (if `f` is periodic)
     Union       |
 
+    Union       | list
+   (with FiniteSet)
+
     EmptySet    | empty list
 
     Others      | None
@@ -2377,7 +2380,16 @@ def solvify(f, symbol, domain):
 
         else:
             solution = solution_set.intersect(domain)
-            if isinstance(solution, FiniteSet):
+            if isinstance(solution, Union):
+                # concerned about only FiniteSet with Union but not about ImageSet
+                # if required could be extend
+                if any(isinstance(i, FiniteSet) for i in solution.args):
+                    result = [sol for soln in solution.args \
+                     for sol in soln.args if isinstance(soln,FiniteSet)]
+                else:
+                    return None
+
+            elif isinstance(solution, FiniteSet):
                 result += solution
 
     return result

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2318,8 +2318,7 @@ def solvify(f, symbol, domain):
     ImageSet,   | list (if `f` is periodic)
     Union       |
 
-    Union       | list
-   (with FiniteSet)
+    Union       | list (with FiniteSet)
 
     EmptySet    | empty list
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1320,7 +1320,24 @@ def test_solvify():
     raises(NotImplementedError, lambda: solvify(sin(exp(x)), x, S.Complexes))
 
 
+def test_solvify_piecewise():
+    p1 = Piecewise((0, x < -1), (x**2, x <= 1), (log(x), True))
+    p2 = Piecewise((0, x < -10), (x**2 + 5*x - 6, x >= -9))
+    p3 = Piecewise((0, Eq(x, 0)), (x**2/Abs(x), True))
+    p4 = Piecewise((0, Eq(x, pi)), ((x - pi)/sin(x), True))
+
+    # issue 21079
+    assert solvify(p1, x, S.Reals) == [0]
+    assert solvify(p2, x, S.Reals) == [-6, 1]
+    assert solvify(p3, x, S.Reals) == [0]
+    assert solvify(p4, x, S.Reals) == [pi]
+
+
 def test_abs_invert_solvify():
+
+    x = Symbol('x',positive=True)
+    assert solvify(sin(Abs(x)), x, S.Reals) == [0, pi]
+    x = Symbol('x')
     assert solvify(sin(Abs(x)), x, S.Reals) is None
 
 


### PR DESCRIPTION
`solvify` is now able to solve `piecewise` expressions.
Fixes  #21079 as it was giving an error due to a bug in `periodicity`.
Hence, periodicity for `piecewise` is fixed as `None` as the period of `piecewise` should also be `piecewise`.(which is an inconsistent return type)

```
>>> p = Piecewise((0, x < -10), (x**2 + 5*x - 6, x >= -9))
>>> solvify(p, x, S.Reals) 
        [-6, 1]

>>> periodicity(p, x) is None
        True
```
Closes & Fixes #21079
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->