### PR TITLE
perf(printing): make print_seq O(n) rather than quadratic

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2234,26 +2234,25 @@ class PrettyPrinter(Printer):
 
     def _print_seq(self, seq, left=None, right=None, delimiter=', ',
             parenthesize=lambda x: False, ifascii_nougly=True):
-        s = None
         try:
+            pforms = []
             for item in seq:
                 pform = self._print(item)
-
                 if parenthesize(item):
                     pform = prettyForm(*pform.parens())
-                if s is None:
-                    # first element
-                    s = pform
-                else:
-                    # XXX: Under the tests from #15686 this raises:
-                    # AttributeError: 'Fake' object has no attribute 'baseline'
-                    # This is caught below but that is not the right way to
-                    # fix it.
-                    s = prettyForm(*stringPict.next(s, delimiter))
-                    s = prettyForm(*stringPict.next(s, pform))
+                if pforms:
+                    pforms.append(delimiter)
+                pforms.append(pform)
 
-            if s is None:
+            if not pforms:
                 s = stringPict('')
+            else:
+                s = prettyForm(*stringPict.next(*pforms))
+
+                # XXX: Under the tests from #15686 the above raises:
+                # AttributeError: 'Fake' object has no attribute 'baseline'
+                # This is caught below but that is not the right way to
+                # fix it.
 
         except AttributeError:
             s = None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * The pretty printer was made faster when printing large sequences (e.g. tuples, sets etc). 
<!-- END RELEASE NOTES -->
