### PR TITLE
Add residue formula for summation

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -11,16 +11,21 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Wild, Symbol
 from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.trigonometric import cot, csc
 from sympy.logic.boolalg import And
-from sympy.polys import apart, PolynomialError, together
+from sympy.polys import apart, together
+from sympy.polys.polyerrors import PolynomialError, PolificationFailed
+from sympy.polys.polytools import parallel_poly_from_expr
 from sympy.series.limitseq import limit_seq
 from sympy.series.order import O
+from sympy.series.residues import residue
 from sympy.sets.sets import FiniteSet
 from sympy.simplify import denom
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.powsimp import powsimp
 from sympy.solvers import solve
 from sympy.solvers.solveset import solveset
+from sympy.utilities.iterables import sift
 import itertools
 
 class Sum(AddWithLimits, ExprWithIntLimits):
@@ -1218,6 +1223,10 @@ def eval_sum_symbolic(f, limits):
     if h is not None:
         return h
 
+    r = eval_sum_residue(f_orig, (i, a, b))
+    if r is not None:
+        return r
+
     factored = f_orig.factor()
     if factored != f_orig:
         return eval_sum_symbolic(factored, (i, a, b))
@@ -1329,6 +1338,134 @@ def eval_sum_hyper(f, i_a_b):
                     return S.NegativeInfinity
             return None
         return Piecewise(res, (old_sum, True))
+
+
+def eval_sum_residue(f, i_a_b):
+    r"""Compute the infinite summation with residues
+
+    Notes
+    =====
+
+    If $f(n), g(n)$ are polynomials with $\deg(g(n)) - \deg(f(n)) >= 2$,
+    some infinite summations can be computed by the following residue
+    evaluations.
+
+    .. math::
+        \sum_{n=-\infty, g(n) \ne 0}^{\infty} \frac{f(n)}{g(n)} =
+        -\pi \sum_{\alpha|g(\alpha)=0}
+        \text{Res}(\cot(\pi x) \frac{f(x)}{g(x)}, \alpha)
+
+    .. math::
+        \sum_{n=-\infty, g(n) \ne 0}^{\infty} (-1)^n \frac{f(n)}{g(n)} =
+        -\pi \sum_{\alpha|g(\alpha)=0}
+        \text{Res}(\csc(\pi x) \frac{f(x)}{g(x)}, \alpha)
+    """
+    i, a, b = i_a_b
+
+    def is_even_function(numer, denom):
+        """Test if the rational function is an even function"""
+        numer_even = all([i % 2 == 0 for (i,) in numer.monoms()])
+        denom_even = all([i % 2 == 0 for (i,) in denom.monoms()])
+        numer_odd = all([i % 2 == 1 for (i,) in numer.monoms()])
+        denom_odd = all([i % 2 == 1 for (i,) in denom.monoms()])
+        return (numer_even and denom_even) or (numer_odd and denom_odd)
+
+    def match_rational(f, i):
+        numer, denom = f.as_numer_denom()
+        try:
+            (numer, denom), opt = parallel_poly_from_expr((numer, denom), i)
+        except (PolificationFailed, PolynomialError):
+            return None
+        return numer, denom
+
+    # We don't know how to deal with symbolic constants in summand
+    if f.free_symbols - set([i]):
+        return None
+
+    if not (a.is_Integer or a in (S.Infinity, S.NegativeInfinity)):
+        return None
+    if not (b.is_Integer or b in (S.Infinity, S.NegativeInfinity)):
+        return None
+
+    # Quick exit heuristic for the sums which doesn't have infinite range
+    if a != S.NegativeInfinity and b != S.Infinity:
+        return None
+
+    match = match_rational(f, i)
+    if match:
+        alternating = False
+        numer, denom = match
+    else:
+        match = match_rational(f / (-1)**i, i)
+        if match:
+            alternating = True
+            numer, denom = match
+        else:
+            return None
+
+    if denom.degree(i) - numer.degree(i) < 2:
+        return None
+
+    roots = denom.sqf_part().all_roots()
+    roots = sift(roots, lambda x: x.is_integer)
+    if None in roots:
+        return None
+    int_roots, nonint_roots = roots[True], roots[False]
+
+    if not alternating:
+        residue_expr = (numer.as_expr() / denom.as_expr()) * cot(S.Pi * i)
+    else:
+        residue_expr = (numer.as_expr() / denom.as_expr()) * csc(S.Pi * i)
+
+    if (a, b) == (S.NegativeInfinity, S.Infinity):
+        if int_roots:
+            return None
+
+        residues = [residue(residue_expr, i, root) for root in nonint_roots]
+        return -S.Pi * sum(residues)
+
+    if is_even_function(numer, denom):
+        if not (a.is_finite and b is S.Infinity):
+            return None
+
+        if int_roots:
+            int_roots = [int(root) for root in int_roots]
+            int_roots_max = max(int_roots)
+            int_roots_min = min(int_roots)
+            # Integer valued poles must be next to each other
+            # and also symmetric from origin (Because the function is even)
+            if not len(int_roots) == int_roots_max - int_roots_min + 1:
+                return None
+
+            # Check whether the summation indices contain poles
+            if a <= max(int_roots):
+                return None
+
+        residues = [residue(residue_expr, i, root) for root in int_roots + nonint_roots]
+        full_sum = -S.Pi * sum(residues)
+
+        if not int_roots:
+            # Compute Sum(f, (i, 0, oo)) by adding a extraneous evaluation
+            # at the origin.
+            half_sum = (full_sum + f.xreplace({i: 0})) / 2
+
+            # Add and subtract extraneous evaluations
+            extraneous_neg = [f.xreplace({i: i0}) for i0 in range(int(a), 0)]
+            extraneous_pos = [f.xreplace({i: i0}) for i0 in range(0, int(a))]
+            result = half_sum + sum(extraneous_neg) - sum(extraneous_pos)
+
+            return result
+
+        else:
+            # Compute Sum(f, (i, min(poles) + 1, oo))
+            half_sum = full_sum / 2
+
+            # Subtract extraneous evaluations
+            extraneous = [f.xreplace({i: i0}) for i0 in range(max(int_roots) + 1, int(a))]
+            result = half_sum - sum(extraneous)
+
+            return result
+    return None
 
 
 def _eval_matrix_sum(expression):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1360,6 +1360,45 @@ def eval_sum_residue(f, i_a_b):
         -\pi \sum_{\alpha|g(\alpha)=0}
         \text{Res}(\csc(\pi x) \frac{f(x)}{g(x)}, \alpha)
 
+    Examples
+    ========
+
+    >>> from sympy import Sum, oo, Symbol
+    >>> x = Symbol('x')
+
+    Doubly infinite series of rational functions.
+
+    >>> Sum(1 / (x**2 + 1), (x, -oo, oo)).doit()
+    pi/tanh(pi)
+
+    Doubly infinite alternating series of rational functions.
+
+    >>> Sum((-1)**x / (x**2 + 1), (x, -oo, oo)).doit()
+    pi/sinh(pi)
+
+    Infinite series of even rational functions.
+
+    >>> Sum(1 / (x**2 + 1), (x, 0, oo)).doit()
+    1/2 + pi/(2*tanh(pi))
+
+    Infinite series of alternating even rational functions.
+
+    >>> Sum((-1)**x / (x**2 + 1), (x, 0, oo)).doit()
+    pi/(2*sinh(pi)) + 1/2
+
+    This also have heuristics to transform arbitrarily shifted summand or
+    arbitrarily shifted summation range to the canonical problem the
+    formula can handle.
+
+    >>> Sum(1 / (x**2 + 2*x + 2), (x, -1, oo)).doit()
+    1/2 + pi/(2*tanh(pi))
+    >>> Sum(1 / (x**2 + 4*x + 5), (x, -2, oo)).doit()
+    1/2 + pi/(2*tanh(pi))
+    >>> Sum(1 / (x**2 + 1), (x, 1, oo)).doit()
+    -1/2 + pi/(2*tanh(pi))
+    >>> Sum(1 / (x**2 + 1), (x, 2, oo)).doit()
+    -1 + pi/(2*tanh(pi))
+
     References
     ==========
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1359,6 +1359,16 @@ def eval_sum_residue(f, i_a_b):
         \sum_{n=-\infty, g(n) \ne 0}^{\infty} (-1)^n \frac{f(n)}{g(n)} =
         -\pi \sum_{\alpha|g(\alpha)=0}
         \text{Res}(\csc(\pi x) \frac{f(x)}{g(x)}, \alpha)
+
+    References
+    ==========
+
+    .. [#] http://www.supermath.info/InfiniteSeriesandtheResidueTheorem.pdf
+
+    .. [#] Asmar N.H., Grafakos L. (2018) Residue Theory.
+           In: Complex Analysis with Applications.
+           Undergraduate Texts in Mathematics. Springer, Cham.
+           https://doi.org/10.1007/978-3-319-94063-2_5
     """
     i, a, b = i_a_b
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -4,9 +4,10 @@ from sympy import (
     nan, oo, pi, Piecewise, Product, product, Rational, S, simplify, Identity,
     sin, sqrt, Sum, summation, Symbol, symbols, sympify, zeta, gamma,
     Indexed, Idx, IndexedBase, prod, Dummy, lowergamma, Range, floor,
-    rf, MatrixSymbol)
+    rf, MatrixSymbol, tanh, sinh)
 from sympy.abc import a, b, c, d, k, m, x, y, z
-from sympy.concrete.summations import telescopic, _dummy_with_inherited_properties_concrete
+from sympy.concrete.summations import (
+    telescopic, _dummy_with_inherited_properties_concrete, eval_sum_residue)
 from sympy.concrete.expr_with_intlimits import ReorderError
 from sympy.core.facts import InconsistentAssumptions
 from sympy.testing.pytest import XFAIL, raises, slow
@@ -1431,3 +1432,60 @@ def test_matrixsymbol_summation_symbolic_limits():
     n = Symbol('n', integer=True)
     assert Sum(A, (n, 0, N)).doit() == (N+1)*A
     assert Sum(n*A, (n, 0, N)).doit() == (N**2/2+N/2)*A
+
+
+def test_summation_by_residues():
+    x = Symbol('x')
+
+    # Examples from Nakhle H. Asmar, Loukas Grafakos,
+    # Complex Analysis with Applications
+    assert eval_sum_residue(1 / (x**2 + 1), (x, -oo, oo)) == pi/tanh(pi)
+    assert eval_sum_residue(1 / x**6, (x, S(1), oo)) == pi**6/945
+    assert eval_sum_residue(1 / (x**2 + 9), (x, -oo, oo)) == pi/(3*tanh(3*pi))
+    assert eval_sum_residue(1 / (x**2 + 1)**2, (x, -oo, oo)) == \
+        -pi*(-1/(2*tanh(pi)) - I*(-I*pi/tanh(pi) + \
+        I*pi*tanh(pi))/(4*tanh(pi)) + I*(-I*pi*tanh(pi) + \
+        I*pi/tanh(pi))/(4*tanh(pi)))
+    assert eval_sum_residue(x**2 / (x**2 + 1)**2, (x, -oo, oo)) == \
+        -pi*(-1/(2*tanh(pi)) - I*(-I*pi*tanh(pi) + \
+        I*pi/tanh(pi))/(4*tanh(pi)) + I*(-I*pi/tanh(pi) + \
+        I*pi*tanh(pi))/(4*tanh(pi)))
+    assert eval_sum_residue(1 / (4*x**2 - 1), (x, -oo, oo)) == 0
+    assert eval_sum_residue(x**2 / (x**2 - S(1)/4)**2, (x, -oo, oo)) == pi**2/2
+    assert eval_sum_residue(1 / (4*x**2 - 1)**2, (x, -oo, oo)) == pi**2/8
+    assert eval_sum_residue(1 / ((x - S(1)/2)**2 + 1), (x, -oo, oo)) == pi*tanh(pi)
+    assert eval_sum_residue(1 / x**2, (x, S(1), oo)) == pi**2/6
+    assert eval_sum_residue(1 / x**4, (x, S(1), oo)) == pi**4/90
+    assert eval_sum_residue(1 / x**2 / (x**2 + 4), (x, S(1), oo)) == \
+        -pi*(-pi/12 - 1/(16*pi) + 1/(8*tanh(2*pi)))/2
+
+    # Some examples made from 1 / (x**2 + 1)
+    assert eval_sum_residue(1 / (x**2 + 1), (x, S(0), oo)) == \
+        S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue(1 / (x**2 + 1), (x, S(1), oo)) == \
+        -S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue(1 / (x**2 + 1), (x, S(-1), oo)) == \
+        1 + pi/(2*tanh(pi))
+    assert eval_sum_residue((-1)**x / (x**2 + 1), (x, -oo, oo)) == \
+        pi/sinh(pi)
+    assert eval_sum_residue((-1)**x / (x**2 + 1), (x, S(0), oo)) == \
+        pi/(2*sinh(pi)) + S(1)/2
+    assert eval_sum_residue((-1)**x / (x**2 + 1), (x, S(1), oo)) == \
+        -S(1)/2 + pi/(2*sinh(pi))
+    assert eval_sum_residue((-1)**x / (x**2 + 1), (x, S(-1), oo)) == \
+        pi/(2*sinh(pi))
+
+    # Some examples made from 1 / x**2
+    assert eval_sum_residue(1 / x**2, (x, S(2), oo)) == -1 + pi**2/6
+    assert eval_sum_residue(1 / x**2, (x, S(3), oo)) == -S(5)/4 + pi**2/6
+    assert eval_sum_residue((-1)**x / x**2, (x, S(1), oo)) == -pi**2/12
+    assert eval_sum_residue((-1)**x / x**2, (x, S(2), oo)) == 1 - pi**2/12
+
+
+@XFAIL
+def test_summation_by_residues_failing():
+    x = Symbol('x')
+
+    # Failing because of the bug in residue computation
+    assert eval_sum_residue(x**2 / (x**4 + 1), (x, S(1), oo))
+    assert eval_sum_residue(1 / ((x - 1)*(x - 2) + 1), (x, -oo, oo)) != 0

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1475,6 +1475,14 @@ def test_summation_by_residues():
     assert eval_sum_residue((-1)**x / (x**2 + 1), (x, S(-1), oo)) == \
         pi/(2*sinh(pi))
 
+    # Some examples made from shifting of 1 / (x**2 + 1)
+    assert eval_sum_residue(1 / (x**2 + 2*x + 2), (x, S(-1), oo)) == S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue(1 / (x**2 + 4*x + 5), (x, S(-2), oo)) == S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue(1 / (x**2 - 2*x + 2), (x, S(1), oo)) == S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue(1 / (x**2 - 4*x + 5), (x, S(2), oo)) == S(1)/2 + pi/(2*tanh(pi))
+    assert eval_sum_residue((-1)**x * -1 / (x**2 + 2*x + 2), (x, S(-1), oo)) ==  S(1)/2 + pi/(2*sinh(pi))
+    assert eval_sum_residue((-1)**x * -1 / (x**2 -2*x + 2), (x, S(1), oo)) == S(1)/2 + pi/(2*sinh(pi))
+
     # Some examples made from 1 / x**2
     assert eval_sum_residue(1 / x**2, (x, S(2), oo)) == -1 + pi**2/6
     assert eval_sum_residue(1 / x**2, (x, S(3), oo)) == -S(5)/4 + pi**2/6


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21148

#### Brief description of what is fixed or changed

I have implemented the idea from #21148 which can solve some infinite summation problems that sympy can't solve.
Although I have limited for polynomial cases, I nontrivially extended it to handle summation over half interval for even functions, with taking account of extraneous evaluation for finite points.

However, there is still some more places left to improve the summation by residue formula to handle more generic classes of functions than polynomial, and also to handle shifted cases like `Sum(1 / (x**2 - 2*x + 2), (x, 1, oo))` which should be same as `Sum(1 / (x**2 + 1), (x, 0, oo))` but can't be recognized as an even function. (I tried using `decompose` but that doesn't work)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- concrete
  - Improved infinite summation capability by adding residue formula.
<!-- END RELEASE NOTES -->
