### PR TITLE
Fixes, #21147 . evalf()  doesn't works properly with evaluate = False

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -25,7 +25,6 @@ from mpmath.libmp.gammazeta import mpf_bernoulli
 from .compatibility import SYMPY_INTS
 from .sympify import sympify
 from .singleton import S
-from .basic import doit
 from sympy.utilities.iterables import is_sequence
 
 LG10 = math.log(10, 2)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1498,7 +1498,7 @@ class EvalfMixin:
             rv = self.evalf(2, subs, maxn, chop, strict, quad, verbose)
             m = _mag(rv)
             rv = rv.round(1 - m)
-            return rv        
+            return rv
         if not evalf_table:
             _create_evalf_table()
         prec = dps_to_prec(n)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1499,9 +1499,7 @@ class EvalfMixin:
             rv = self.evalf(2, subs, maxn, chop, strict, quad, verbose)
             m = _mag(rv)
             rv = rv.round(1 - m)
-            return rv
-        if self.doit() is S.ComplexInfinity: # issue 21147
-            return self.doit()
+            return rv        
         if not evalf_table:
             _create_evalf_table()
         prec = dps_to_prec(n)
@@ -1529,6 +1527,8 @@ class EvalfMixin:
             except NotImplementedError:
                 # Probably contains symbols or unknown functions
                 return v
+        if self.doit() is S.ComplexInfinity: # issue 21147
+            return self.doit()
         re, im, re_acc, im_acc = result
         if re:
             p = max(min(prec, re_acc), 1)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -25,7 +25,7 @@ from mpmath.libmp.gammazeta import mpf_bernoulli
 from .compatibility import SYMPY_INTS
 from .sympify import sympify
 from .singleton import S
-
+from .basic import doit
 from sympy.utilities.iterables import is_sequence
 
 LG10 = math.log(10, 2)
@@ -1500,7 +1500,8 @@ class EvalfMixin:
             m = _mag(rv)
             rv = rv.round(1 - m)
             return rv
-
+        if self.doit() is S.ComplexInfinity: # issue 21147
+            return self.doit()
         if not evalf_table:
             _create_evalf_table()
         prec = dps_to_prec(n)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -612,4 +612,3 @@ def test_issue_21147():
     assert Mul(2, Pow(0,-1, evaluate=False), evaluate=False).evalf() == zoo
     expr = Pow(0, -1, evaluate=False)
     assert expr.evalf() == expr.doit()
-    

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
     integrate, log, Mul, N, oo, pi, Pow, product, Product, tan,
-    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos)
+    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos, zoo, doit)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath, evalf)
@@ -605,3 +605,10 @@ def test_issue_20291():
 
     sol = Complement(Intersection(FiniteSet(-b/2 - sqrt(b**2-4*pi)/2), Reals), FiniteSet(0))
     assert sol.evalf(subs={b: 1}) == EmptySet
+
+
+def test_issue_21147():
+    assert Pow(0, -1, evaluate=False).evalf() == zoo
+    assert Mul(2, Pow(0,-1, evaluate=False), evaluate=False).evalf() == zoo
+    expr = Pow(0, -1, evaluate=False)
+    assert expr.evalf() == expr.doit()

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
     integrate, log, Mul, N, oo, pi, Pow, product, Product, tan,
-    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos, zoo, doit)
+    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos, zoo)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath, evalf)
@@ -612,3 +612,4 @@ def test_issue_21147():
     assert Mul(2, Pow(0,-1, evaluate=False), evaluate=False).evalf() == zoo
     expr = Pow(0, -1, evaluate=False)
     assert expr.evalf() == expr.doit()
+    

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -3,7 +3,7 @@ from sympy import (
     Integer, Eq, symbols, Add, I, Float, log, Rational,
     Lambda, atan2, cse, cot, tan, S, Tuple, Basic, Dict,
     Piecewise, oo, Mul, factor, nsimplify, zoo, Subs, RootOf,
-    AccumBounds, Matrix, zeros, ZeroMatrix)
+    AccumBounds, Matrix, zeros, ZeroMatrix, nan)
 from sympy.core.basic import _aresame
 from sympy.testing.pytest import XFAIL
 from sympy.abc import a, x, y, z, t
@@ -856,9 +856,21 @@ def test_issue_19326():
     x, y = [i(t) for i in map(Function, 'xy')]
     assert (x*y).subs({x: 1 + x, y: x}) == (1 + x)*x
 
+
 def test_issue_19558():
     e = (7*x*cos(x) - 12*log(x)**3)*(-log(x)**4 + 2*sin(x) + 1)**2/ \
     (2*(x*cos(x) - 2*log(x)**3)*(3*log(x)**4 - 7*sin(x) + 3)**2)
 
     assert e.subs(x, oo) == AccumBounds(-oo, oo)
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
+
+
+def test_subs_undefined_result():
+    x, y = symbols("x, y")
+    expr = x/y
+    assert expr.subs([(x, 0), (y, 0)]) == 0
+    assert expr.subs([(x, 0), (y, 0)], simultaneous=True) == nan
+    assert expr.subs([(x, 2), (y, 0)], simultaneous=True) == zoo
+    expr2 = x**y
+    assert expr2.subs([(x, 0), (y, 0)]) == 1
+    assert expr2.subs([(x, 0), (y, 0)], simultaneous=True) == 1

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -3,7 +3,7 @@ from sympy import (
     Integer, Eq, symbols, Add, I, Float, log, Rational,
     Lambda, atan2, cse, cot, tan, S, Tuple, Basic, Dict,
     Piecewise, oo, Mul, factor, nsimplify, zoo, Subs, RootOf,
-    AccumBounds, Matrix, zeros, ZeroMatrix, nan)
+    AccumBounds, Matrix, zeros, ZeroMatrix)
 from sympy.core.basic import _aresame
 from sympy.testing.pytest import XFAIL
 from sympy.abc import a, x, y, z, t
@@ -856,21 +856,9 @@ def test_issue_19326():
     x, y = [i(t) for i in map(Function, 'xy')]
     assert (x*y).subs({x: 1 + x, y: x}) == (1 + x)*x
 
-
 def test_issue_19558():
     e = (7*x*cos(x) - 12*log(x)**3)*(-log(x)**4 + 2*sin(x) + 1)**2/ \
     (2*(x*cos(x) - 2*log(x)**3)*(3*log(x)**4 - 7*sin(x) + 3)**2)
 
     assert e.subs(x, oo) == AccumBounds(-oo, oo)
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
-
-
-def test_subs_undefined_result():
-    x, y = symbols("x, y")
-    expr = x/y
-    assert expr.subs([(x, 0), (y, 0)]) == 0
-    assert expr.subs([(x, 0), (y, 0)], simultaneous=True) == nan
-    assert expr.subs([(x, 2), (y, 0)], simultaneous=True) == zoo
-    expr2 = x**y
-    assert expr2.subs([(x, 0), (y, 0)]) == 1
-    assert expr2.subs([(x, 0), (y, 0)], simultaneous=True) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixed: #21147

#### Brief description of what is fixed or changed




#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
