### PR TITLE
fix(assumptions) : Fix wrong handler names

### DIFF
--- a/sympy/assumptions/predicates/common.py
+++ b/sympy/assumptions/predicates/common.py
@@ -15,7 +15,7 @@ class CommutativePredicate(Predicate):
     """
     # TODO: Add examples
     name = 'commutative'
-    handler = Dispatcher("FiniteHandler", doc="Handler for key 'commutative'.")
+    handler = Dispatcher("CommutativeHandler", doc="Handler for key 'commutative'.")
 
 
 class IsTruePredicate(Predicate):
@@ -39,6 +39,6 @@ class IsTruePredicate(Predicate):
     """
     name = 'is_true'
     handler = Dispatcher(
-        "FiniteHandler",
+        "IsTrueHandler",
         doc="Wrapper allowing to query the truth value of a boolean expression."
     )


### PR DESCRIPTION
Fix wrong handler names in predicates/common.py

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
