### PR TITLE
refactor(assumptions): remove redundant lines

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -424,12 +424,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
                     # quick exit if proposition is directly satisfied by assumption
                     # e.g. proposition = Q.integer(x), assumptions = Q.odd(x)
                     return True
-                elif Not(key) in fdict:
-                    # quick exit if proposition is directly rejected by assumption
-                    # example might be proposition = Q.even(x), assumptions = Q.odd(x)
-                    # but known_facts_dict does not have such information yet and
-                    # such example is computed by satask.
-                    return False
 
     # direct resolution method, no logic
     res = key(*args)._eval_ask(assumptions)


### PR DESCRIPTION
Remove redundant lines in ask()

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The deleted lines checked negated predicates in `get_known_facts_dict()` in `ask_generated.py`. However negated predicates are dealt by `get_all_known_facts()` and `get_known_facts_cnf()`, and do not exist in `get_known_facts_dict()`. In fact, `compute_known_facts()` never adds negated predicate to `get_known_facts_dict()` so these lines are - and will be - never visited, and therefore we might as well remove these.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
