### PR TITLE
Removed unnecessary term swap while computing Mul in parse_expr.

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1062,8 +1062,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             sympy_class = self.operators[node.op.__class__]
             right = self.visit(node.right)
             left = self.visit(node.left)
-            if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul',):
-                left, right = right, left
+
             if isinstance(node.op, ast.Sub):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1063,6 +1063,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             right = self.visit(node.right)
             left = self.visit(node.left)
 
+            rev = False
             if isinstance(node.op, ast.Sub):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
@@ -1071,10 +1072,10 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     starargs=None,
                     kwargs=None
                 )
-            if isinstance(node.op, ast.Div):
+            elif isinstance(node.op, ast.Div):
                 if isinstance(node.left, ast.UnaryOp):
-                    if isinstance(node.right,ast.UnaryOp):
-                        left, right = right, left
+                    left, right = right, left
+                    rev = True
                     left = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[left, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
@@ -1091,6 +1092,8 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     kwargs=None
                 )
 
+            if rev:  # undo reversal
+                left, right = right, left
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -158,10 +158,12 @@ def test_issue_7663():
     assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
     assert parse_expr(e, evaluate=0).equals(2*(x+1))
 
-def test_issue_10560():
+def test_recursive_evaluate_false_10560():
     inputs = {
-        '4*-3' : '(-3)*4',
+        '4*-3' : '4*-3',
         '-4*3' : '(-4)*3',
+        "-2*x*y": '(-2)*x*y',
+        "x*-4*x": "x*(-4)*x"
     }
     for text, result in inputs.items():
         assert parse_expr(text, evaluate=False) == parse_expr(result, evaluate=False)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -254,7 +254,24 @@ class StrPrinter(Printer):
         # etc so we display in a straight-forward form that fully preserves all
         # args and their order.
         args = expr.args
-        if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]):
+        if args[0] is S.One or any(isinstance(arg, Number) or isinstance(1/arg, Number) for arg in args[1:]):
+            from sympy.utilities.iterables import sift
+            d, n  = sift(args, lambda x:
+                         isinstance(x,Pow) and x.exp == -1,
+                         binary=True
+                         )
+            d = [1/i for i in d]
+            nfactors = [self.parenthesize(arg, prec, strict=False) for arg in n]
+            dfactors = [self.parenthesize(arg, prec, strict=False) for arg in d]
+            numerator_string = '*'.join(nfactors)
+            denominator_string = '*'.join(dfactors)
+            if len(dfactors) > 1:
+                return '%s/(%s)' % (numerator_string, denominator_string)
+            elif dfactors:
+                return '%s/%s' % (numerator_string, denominator_string)
+            else:
+                return numerator_string
+
             factors = [self.parenthesize(a, prec, strict=False) for a in args]
             return '*'.join(factors)
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1009,6 +1009,14 @@ def test_str_special_matrices():
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
 
+def test_issue_21119():
+    from sympy import sympify
+    assert str(sympify('4/2', evaluate=False)) == '4/2'
+    assert str(sympify('4/-2', evaluate=False)) == '4/(-2)'
+    assert str(sympify('-4/2', evaluate=False)) == '(-4)/2'
+    assert str(sympify('-4/-2', evaluate=False)) == '(-4)/(-2)'
+    assert str(sympify('4/2/1', evaluate=False)) == '4/(2*1)'
+
 def test_Str():
     from sympy.core.symbol import Str
     assert str(Str('x')) == 'x'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes Mul issue of #21119


#### Brief description of what is fixed or changed
A swapping happens in `parse_expr`(evaluate=False) when operation is `Mul` that was changing the order, is removed since it is since unnecessary now.

#### Other comments
Note the #10560 for which the old swapping #10774 fix was done might be need to reopened since some of the nested terms `('9.2*(4.1+(-4)*3)')` aren't working, even with the old fix.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fix to maintain the order of Mul terms in parse_expr when evaluate=False
<!-- END RELEASE NOTES -->
