### PR TITLE
feat(assumptions) : remove Q.is_true wrapping over relational classes

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -389,18 +389,8 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     """
     from sympy.assumptions.satask import satask
 
-    def relcls_to_relpred(expr):
-        # recursively replace relational class to relational predicate
-        if not expr.args:
-            return expr
-        binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}
-        func = binrelpreds.get(expr.func, expr.func)
-        args = (relcls_to_relpred(i) for i in expr.args)
-        return func(*args)
-
-    proposition = relcls_to_relpred(sympify(proposition))
-    assumptions = relcls_to_relpred(sympify(assumptions))
-    context = {relcls_to_relpred(a) for a in context}
+    proposition = sympify(proposition)
+    assumptions = sympify(assumptions)
 
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
@@ -408,8 +398,11 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if isinstance(assumptions, Predicate) or assumptions.kind is not BooleanKind:
         raise TypeError("assumptions must be a valid logical expression")
 
+    binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}
     if isinstance(proposition, AppliedPredicate):
         key, args = proposition.function, proposition.arguments
+    elif proposition.func in binrelpreds:
+        key, args = binrelpreds[proposition.func], proposition.args
     else:
         key, args = Q.is_true, (proposition,)
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -66,7 +66,7 @@ class AssumptionsContext(set):
     """
 
     def add(self, *assumptions):
-        """Add an assumption."""
+        """Add assumptions."""
         for a in assumptions:
             super().add(a)
 
@@ -168,11 +168,10 @@ class AppliedPredicate(Boolean):
 
     @property
     def binary_symbols(self):
-        from sympy.core.relational import Eq, Ne
         from .ask import Q
         if self.function == Q.is_true:
             i = self.arguments[0]
-            if i.is_Boolean or i.is_Symbol or isinstance(i, (Eq, Ne)):
+            if i.is_Boolean or i.is_Symbol:
                 return i.binary_symbols
         if self.function in (Q.eq, Q.ne):
             if true in self.arguments or false in self.arguments:
@@ -271,7 +270,6 @@ class Predicate(Boolean, metaclass=PredicateMeta):
     Applying and evaluating to boolean value:
 
     >>> from sympy import Q, ask
-    >>> from sympy.abc import x
     >>> ask(Q.prime(7))
     True
 
@@ -304,11 +302,6 @@ class Predicate(Boolean, metaclass=PredicateMeta):
     Traceback (most recent call last):
       ...
     TypeError: <class 'sympy.assumptions.assume.UndefinedPredicate'> cannot be dispatched.
-
-    The tautological predicate ``Q.is_true`` can be used to wrap other objects.
-
-    >>> Q.is_true(x > 1)
-    Q.is_true(x > 1)
 
     References
     ==========

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -22,14 +22,14 @@ def test_pretty():
 
 def test_global():
     """Test for global assumptions"""
-    global_assumptions.add(Q.is_true(x > 0))
-    assert Q.is_true(x > 0) in global_assumptions
-    global_assumptions.remove(Q.is_true(x > 0))
-    assert not Q.is_true(x > 0) in global_assumptions
+    global_assumptions.add(x > 0)
+    assert (x > 0) in global_assumptions
+    global_assumptions.remove(x > 0)
+    assert not (x > 0) in global_assumptions
     # same with multiple of assumptions
-    global_assumptions.add(Q.is_true(x > 0), Q.is_true(y > 0))
-    assert Q.is_true(x > 0) in global_assumptions
-    assert Q.is_true(y > 0) in global_assumptions
+    global_assumptions.add(x > 0, y > 0)
+    assert (x > 0) in global_assumptions
+    assert (y > 0) in global_assumptions
     global_assumptions.clear()
-    assert not Q.is_true(x > 0) in global_assumptions
-    assert not Q.is_true(y > 0) in global_assumptions
+    assert not (x > 0) in global_assumptions
+    assert not (y > 0) in global_assumptions

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -66,37 +66,37 @@ def test_exp():
 
 
 def test_Piecewise():
-    assert refine(Piecewise((1, x < 0), (3, True)), Q.is_true(x < 0)) == 1
-    assert refine(Piecewise((1, x < 0), (3, True)), ~Q.is_true(x < 0)) == 3
-    assert refine(Piecewise((1, x < 0), (3, True)), Q.is_true(y < 0)) == \
+    assert refine(Piecewise((1, x < 0), (3, True)), (x < 0)) == 1
+    assert refine(Piecewise((1, x < 0), (3, True)), ~(x < 0)) == 3
+    assert refine(Piecewise((1, x < 0), (3, True)), (y < 0)) == \
         Piecewise((1, x < 0), (3, True))
-    assert refine(Piecewise((1, x > 0), (3, True)), Q.is_true(x > 0)) == 1
-    assert refine(Piecewise((1, x > 0), (3, True)), ~Q.is_true(x > 0)) == 3
-    assert refine(Piecewise((1, x > 0), (3, True)), Q.is_true(y > 0)) == \
+    assert refine(Piecewise((1, x > 0), (3, True)), (x > 0)) == 1
+    assert refine(Piecewise((1, x > 0), (3, True)), ~(x > 0)) == 3
+    assert refine(Piecewise((1, x > 0), (3, True)), (y > 0)) == \
         Piecewise((1, x > 0), (3, True))
-    assert refine(Piecewise((1, x <= 0), (3, True)), Q.is_true(x <= 0)) == 1
-    assert refine(Piecewise((1, x <= 0), (3, True)), ~Q.is_true(x <= 0)) == 3
-    assert refine(Piecewise((1, x <= 0), (3, True)), Q.is_true(y <= 0)) == \
+    assert refine(Piecewise((1, x <= 0), (3, True)), (x <= 0)) == 1
+    assert refine(Piecewise((1, x <= 0), (3, True)), ~(x <= 0)) == 3
+    assert refine(Piecewise((1, x <= 0), (3, True)), (y <= 0)) == \
         Piecewise((1, x <= 0), (3, True))
-    assert refine(Piecewise((1, x >= 0), (3, True)), Q.is_true(x >= 0)) == 1
-    assert refine(Piecewise((1, x >= 0), (3, True)), ~Q.is_true(x >= 0)) == 3
-    assert refine(Piecewise((1, x >= 0), (3, True)), Q.is_true(y >= 0)) == \
+    assert refine(Piecewise((1, x >= 0), (3, True)), (x >= 0)) == 1
+    assert refine(Piecewise((1, x >= 0), (3, True)), ~(x >= 0)) == 3
+    assert refine(Piecewise((1, x >= 0), (3, True)), (y >= 0)) == \
         Piecewise((1, x >= 0), (3, True))
-    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), Q.is_true(Eq(x, 0)))\
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), (Eq(x, 0)))\
         == 1
-    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), Q.is_true(Eq(0, x)))\
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), (Eq(0, x)))\
         == 1
-    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~Q.is_true(Eq(x, 0)))\
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~(Eq(x, 0)))\
         == 3
-    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~Q.is_true(Eq(0, x)))\
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~(Eq(0, x)))\
         == 3
-    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), Q.is_true(Eq(y, 0)))\
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), (Eq(y, 0)))\
         == Piecewise((1, Eq(x, 0)), (3, True))
-    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), Q.is_true(Ne(x, 0)))\
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), (Ne(x, 0)))\
         == 1
-    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), ~Q.is_true(Ne(x, 0)))\
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), ~(Ne(x, 0)))\
         == 3
-    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), Q.is_true(Ne(y, 0)))\
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), (Ne(y, 0)))\
         == Piecewise((1, Ne(x, 0)), (3, True))
 
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -991,9 +991,9 @@ def test_binary_symbols():
     assert x.binary_symbols == {x}
     assert And(x, Eq(y, False), Eq(z, 1)).binary_symbols == {x, y}
     assert Q.prime(x).binary_symbols == set()
-    assert Q.is_true(x < 1).binary_symbols == set()
+    assert Q.lt(x, 1).binary_symbols == set()
     assert Q.is_true(x).binary_symbols == {x}
-    assert Q.is_true(Eq(x, True)).binary_symbols == {x}
+    assert Q.eq(x, True).binary_symbols == {x}
     assert Q.prime(x).binary_symbols == set()
 
 
@@ -1212,36 +1212,36 @@ def test_convert_to_varsPOS():
 
 def test_refine():
     # relational
-    assert not refine(x < 0, ~Q.is_true(x < 0))
-    assert refine(x < 0, Q.is_true(x < 0))
-    assert refine(x < 0, Q.is_true(0 > x)) == True
-    assert refine(x < 0, Q.is_true(y < 0)) == (x < 0)
-    assert not refine(x <= 0, ~Q.is_true(x <= 0))
-    assert refine(x <= 0,  Q.is_true(x <= 0))
-    assert refine(x <= 0,  Q.is_true(0 >= x)) == True
-    assert refine(x <= 0,  Q.is_true(y <= 0)) == (x <= 0)
-    assert not refine(x > 0, ~Q.is_true(x > 0))
-    assert refine(x > 0,  Q.is_true(x > 0))
-    assert refine(x > 0,  Q.is_true(0 < x)) == True
-    assert refine(x > 0,  Q.is_true(y > 0)) == (x > 0)
-    assert not refine(x >= 0, ~Q.is_true(x >= 0))
-    assert refine(x >= 0,  Q.is_true(x >= 0))
-    assert refine(x >= 0,  Q.is_true(0 <= x)) == True
-    assert refine(x >= 0,  Q.is_true(y >= 0)) == (x >= 0)
-    assert not refine(Eq(x, 0), ~Q.is_true(Eq(x, 0)))
-    assert refine(Eq(x, 0),  Q.is_true(Eq(x, 0)))
-    assert refine(Eq(x, 0),  Q.is_true(Eq(0, x))) == True
-    assert refine(Eq(x, 0),  Q.is_true(Eq(y, 0))) == Eq(x, 0)
-    assert not refine(Ne(x, 0), ~Q.is_true(Ne(x, 0)))
-    assert refine(Ne(x, 0), Q.is_true(Ne(0, x))) == True
-    assert refine(Ne(x, 0),  Q.is_true(Ne(x, 0)))
-    assert refine(Ne(x, 0),  Q.is_true(Ne(y, 0))) == (Ne(x, 0))
+    assert not refine(x < 0, ~(x < 0))
+    assert refine(x < 0, (x < 0))
+    assert refine(x < 0, (0 > x)) is S.true
+    assert refine(x < 0, (y < 0)) == (x < 0)
+    assert not refine(x <= 0, ~(x <= 0))
+    assert refine(x <= 0,  (x <= 0))
+    assert refine(x <= 0,  (0 >= x)) is S.true
+    assert refine(x <= 0,  (y <= 0)) == (x <= 0)
+    assert not refine(x > 0, ~(x > 0))
+    assert refine(x > 0,  (x > 0))
+    assert refine(x > 0,  (0 < x)) is S.true
+    assert refine(x > 0,  (y > 0)) == (x > 0)
+    assert not refine(x >= 0, ~(x >= 0))
+    assert refine(x >= 0,  (x >= 0))
+    assert refine(x >= 0,  (0 <= x)) is S.true
+    assert refine(x >= 0,  (y >= 0)) == (x >= 0)
+    assert not refine(Eq(x, 0), ~(Eq(x, 0)))
+    assert refine(Eq(x, 0),  (Eq(x, 0)))
+    assert refine(Eq(x, 0),  (Eq(0, x))) is S.true
+    assert refine(Eq(x, 0),  (Eq(y, 0))) == Eq(x, 0)
+    assert not refine(Ne(x, 0), ~(Ne(x, 0)))
+    assert refine(Ne(x, 0), (Ne(0, x))) is S.true
+    assert refine(Ne(x, 0),  (Ne(x, 0)))
+    assert refine(Ne(x, 0),  (Ne(y, 0))) == (Ne(x, 0))
 
     # boolean functions
-    assert refine(And(x > 0, y > 0), Q.is_true(x > 0)) == (y > 0)
-    assert refine(And(x > 0, y > 0), Q.is_true(x > 0) & Q.is_true(y > 0)) == True
+    assert refine(And(x > 0, y > 0), (x > 0)) == (y > 0)
+    assert refine(And(x > 0, y > 0), (x > 0) & (y > 0)) is S.true
 
     # predicates
-    assert refine(Q.positive(x), Q.positive(x)) == True
-    assert refine(Q.positive(x), Q.negative(x)) == False
+    assert refine(Q.positive(x), Q.positive(x)) is S.true
+    assert refine(Q.positive(x), Q.negative(x)) is S.false
     assert refine(Q.positive(x), Q.real(x)) == Q.positive(x)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -3,7 +3,7 @@
 
 import sys
 
-
+from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
 from sympy.functions import exp, factorial, factorial2, sin
 from sympy.logic import And
@@ -49,6 +49,7 @@ def test_sympy_parser():
             Pow(3, 1, evaluate=False),
             evaluate=False),
         'Limit(sin(x), x, 0, dir="-")': Limit(sin(x), x, 0, dir='-'),
+        'Q.even(x)': Q.even(x),
 
 
     }

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -20,7 +20,7 @@ from sympy import (Rational, symbols, Dummy, factorial, sqrt, log, exp, oo, zoo,
     FiniteSet, elliptic_e, elliptic_f, powsimp, hessian, wronskian, fibonacci,
     sign, Lambda, Piecewise, Subs, residue, Derivative, logcombine, Symbol,
     Intersection, Union, EmptySet, Interval, idiff, ImageSet, acos, Max,
-    MatMul, conjugate)
+    MatMul, conjugate, Eq)
 
 import mpmath
 from sympy.functions.combinatorial.numbers import stirling
@@ -1006,7 +1006,7 @@ def test_M26():
 def test_M27():
     x = symbols('x', real=True)
     b = symbols('b', real=True)
-    with assuming(Q.is_true(sin(cos(1/E**2) + 1) + b > 0)):
+    with assuming(sin(cos(1/E**2) + 1) + b > 0):
         # TODO: Replace solve with solveset
         solve(log(acos(asin(x**R(2, 3) - b) - 1)) + 2, x) == [-b - sin(1 + cos(1/E**2))**R(3/2), b + sin(1 + cos(1/E**2))**R(3/2)]
 
@@ -1152,50 +1152,50 @@ def test_M39():
 
 
 def test_N1():
-    assert ask(Q.is_true(E**pi > pi**E))
+    assert ask(E**pi > pi**E)
 
 
 @XFAIL
 def test_N2():
     x = symbols('x', real=True)
-    assert ask(Q.is_true(x**4 - x + 1 > 0)) is True
-    assert ask(Q.is_true(x**4 - x + 1 > 1)) is False
+    assert ask(x**4 - x + 1 > 0) is True
+    assert ask(x**4 - x + 1 > 1) is False
 
 
 @XFAIL
 def test_N3():
     x = symbols('x', real=True)
-    assert ask(Q.is_true(And(Lt(-1, x), Lt(x, 1))), Q.is_true(abs(x) < 1 ))
+    assert ask(And(Lt(-1, x), Lt(x, 1)), abs(x) < 1 )
 
 @XFAIL
 def test_N4():
     x, y = symbols('x y', real=True)
-    assert ask(Q.is_true(2*x**2 > 2*y**2), Q.is_true((x > y) & (y > 0))) is True
+    assert ask(2*x**2 > 2*y**2, (x > y) & (y > 0)) is True
 
 
 @XFAIL
 def test_N5():
     x, y, k = symbols('x y k', real=True)
-    assert ask(Q.is_true(k*x**2 > k*y**2), Q.is_true((x > y) & (y > 0) & (k > 0))) is True
+    assert ask(k*x**2 > k*y**2, (x > y) & (y > 0) & (k > 0)) is True
 
 
 @XFAIL
 def test_N6():
     x, y, k, n = symbols('x y k n', real=True)
-    assert ask(Q.is_true(k*x**n > k*y**n), Q.is_true((x > y) & (y > 0) & (k > 0) & (n > 0))) is True
+    assert ask(k*x**n > k*y**n, (x > y) & (y > 0) & (k > 0) & (n > 0)) is True
 
 
 @XFAIL
 def test_N7():
     x, y = symbols('x y', real=True)
-    assert ask(Q.is_true(y > 0), Q.is_true((x > 1) & (y >= x - 1))) is True
+    assert ask(y > 0, (x > 1) & (y >= x - 1)) is True
 
 
 @XFAIL
 def test_N8():
     x, y, z = symbols('x y z', real=True)
-    assert ask(Q.is_true((x == y) & (y == z)),
-               Q.is_true((x >= y) & (y >= z) & (z >= x)))
+    assert ask(Eq(x, y) & Eq(y, z),
+               (x >= y) & (y >= z) & (z >= x))
 
 
 def test_N9():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Now, `ask()` automatically replaces relational objects such as `x>0` with relational predicates (e.g. `Q.gt(x, 0)`)
Therefore, `refine(x > 0, x > 0)` can be used instead of `refine(x > 0, Q.is_true(x > 0))`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Relational objects do not need to be wrapped by `Q.is_true` to be asked or refined anymore
<!-- END RELEASE NOTES -->
