### PR TITLE
Fix TODO in sympy/functions/special/spherical_harmonics.py

### DIFF
--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -178,7 +178,8 @@ class Ynm(Function):
 
     def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
-        # TODO: Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+            return 0
         return self.expand(func=True)
 
     def _eval_rewrite_as_sin(self, n, m, theta, phi, **kwargs):
@@ -188,7 +189,8 @@ class Ynm(Function):
         # This method can be expensive due to extensive use of simplification!
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N
-        # TODO: Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+            return 0
         term = simplify(self.expand(func=True))
         # We can do this because of the range of theta
         term = term.xreplace({Abs(sin(theta)):sin(theta)})

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -179,7 +179,7 @@ class Ynm(Function):
     def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
         if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
-            return 0
+            return S.Zero
         return self.expand(func=True)
 
     def _eval_rewrite_as_sin(self, n, m, theta, phi, **kwargs):
@@ -190,7 +190,7 @@ class Ynm(Function):
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N
         if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
-            return 0
+            return S.Zero
         term = simplify(self.expand(func=True))
         # We can do this because of the range of theta
         term = term.xreplace({Abs(sin(theta)):sin(theta)})

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -178,7 +178,7 @@ class Ynm(Function):
 
     def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
-        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
             return 0
         return self.expand(func=True)
 
@@ -189,7 +189,7 @@ class Ynm(Function):
         # This method can be expensive due to extensive use of simplification!
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N
-        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
             return 0
         term = simplify(self.expand(func=True))
         # We can do this because of the range of theta

--- a/sympy/functions/special/tests/test_spherical_harmonics.py
+++ b/sympy/functions/special/tests/test_spherical_harmonics.py
@@ -7,6 +7,13 @@ def test_Ynm():
     th, ph = Symbol("theta", real=True), Symbol("phi", real=True)
     from sympy.abc import n,m
 
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(2, -3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(2, 3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(-2, -1, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(2, -3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(2, 3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(-2, 1, th, ph) == 0
+
     assert Ynm(0, 0, th, ph).expand(func=True) == 1/(2*sqrt(pi))
     assert Ynm(1, -1, th, ph) == -exp(-2*I*ph)*Ynm(1, 1, th, ph)
     assert Ynm(1, -1, th, ph).expand(func=True) == sqrt(6)*sin(th)*exp(-I*ph)/(4*sqrt(pi))


### PR DESCRIPTION
#### Fix 'TODO: Assert |m| <= n otherwise we should return 0' in sympy/functions/special/spherical_harmonics.py

#### Add the case |m| > n to return 0 in _eval_rewrite_as_polynomial() and _eval_rewrite_as_cos() of the class Ynm(Function)

#### Release Note

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
