### PR TITLE
Fix "TODO: Check if x*log(a)+x*log(a)*log(b) -> x*log(a)*(1+log(b))" in logcombine() sympy/simplify/simplify.py

### DIFF
--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -178,7 +178,8 @@ class Ynm(Function):
 
     def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
-        # TODO: Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+            return 0
         return self.expand(func=True)
 
     def _eval_rewrite_as_sin(self, n, m, theta, phi, **kwargs):
@@ -188,7 +189,8 @@ class Ynm(Function):
         # This method can be expensive due to extensive use of simplification!
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N
-        # TODO: Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+            return 0
         term = simplify(self.expand(func=True))
         # We can do this because of the range of theta
         term = term.xreplace({Abs(sin(theta)):sin(theta)})

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -178,7 +178,7 @@ class Ynm(Function):
 
     def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
-        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
             return 0
         return self.expand(func=True)
 
@@ -189,7 +189,7 @@ class Ynm(Function):
         # This method can be expensive due to extensive use of simplification!
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N
-        if Abs(m) > n:  # Assert |m| <= n ortherwise we should return 0
+        if Abs(m) > n:  # Assert |m| <= n otherwise we should return 0
             return 0
         term = simplify(self.expand(func=True))
         # We can do this because of the range of theta

--- a/sympy/functions/special/tests/test_spherical_harmonics.py
+++ b/sympy/functions/special/tests/test_spherical_harmonics.py
@@ -7,6 +7,13 @@ def test_Ynm():
     th, ph = Symbol("theta", real=True), Symbol("phi", real=True)
     from sympy.abc import n,m
 
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(2, -3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(2, 3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_polynomial(-2, -1, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(2, -3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(2, 3, th, ph) == 0
+    assert Ynm(n, m, th, ph)._eval_rewrite_as_cos(-2, 1, th, ph) == 0
+
     assert Ynm(0, 0, th, ph).expand(func=True) == 1/(2*sqrt(pi))
     assert Ynm(1, -1, th, ph) == -exp(-2*I*ph)*Ynm(1, 1, th, ph)
     assert Ynm(1, -1, th, ph).expand(func=True) == sqrt(6)*sin(th)*exp(-I*ph)/(4*sqrt(pi))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1075,7 +1075,10 @@ def logcombine(expr, force=False):
             return rv
 
         # collapse multi-logs as far as possible in a canonical way
-        # TODO: see if x*log(a)+x*log(a)*log(b) -> x*log(a)*(1+log(b))?
+        # Check if x*log(a)+x*log(a)*log(b) -> x*log(a)*(1+log(b)): False
+        # x*log(a)+x*log(a)*log(b) -> x*(log(b)+1)*log(a) only when we call
+        # simplify(logcombine(x*log(a)+x*log(a)*log(b))). Simply calling
+        # logcombine() is not enough to get the above expected result
         # -- in this case, it's unambiguous, but if it were were a log(c) in
         # each term then it's arbitrary whether they are grouped by log(a) or
         # by log(c). So for now, just leave this alone; it's probably better to

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -452,6 +452,7 @@ def test_logcombine_1():
     a = Symbol("a")
     z, w = symbols("z,w", positive=True)
     b = Symbol("b", real=True)
+    assert logcombine(x*log(a)+x*log(a)*log(b)) == x*log(a)*log(b) + x*log(a)
     assert logcombine(log(x) + 2*log(y)) == log(x) + 2*log(y)
     assert logcombine(log(x) + 2*log(y), force=True) == log(x*y**2)
     assert logcombine(a*log(w) + log(z)) == a*log(w) + log(z)


### PR DESCRIPTION
#### Check if `logcombine(x\*log(a)+x\*log(a)\*log(b)) == x\*log(a)\*(1+log(b))`


#### Add testcases to check if `logcombine(x\*log(a)+x\*log(a)\*log(b)) == x\*log(a)\*(1+log(b))` in sympy/simplify/tests/test_simplify.py and it turns out to be false. `logcombine(x*log(a)+x*log(a)*log(b))` turns out to be equal `x\*log(a)\*log(b) + x\*log(a)`

#### `x\*log(a)+x\*log(a)\*log(b) -> x\*(log(b)+1)\*log(a)` only when we call `simplify(logcombine(x\*log(a)+x\*log(a)\*log(b)))`. Simply calling logcombine() is not enough to get the expected result

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
