### PR TITLE
Remove redundant `.doit()` in `_matrix_derivative()`

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -653,7 +653,7 @@ def _matrix_derivative(expr, x):
 
     from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
 
-    parts = [[convert_array_to_matrix(j).doit() for j in i] for i in parts]
+    parts = [[convert_array_to_matrix(j) for j in i] for i in parts]
 
     def _get_shape(elem):
         if isinstance(elem, MatrixExpr):
@@ -897,7 +897,7 @@ class _LeftRightArgs:
         data = [self._build(i) for i in self._lines]
         if self.higher != 1:
             data += [self._build(self.higher)]
-        data = [i.doit() for i in data]
+        data = [i for i in data]
         return data
 
     def matrix_form(self):

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -1,8 +1,9 @@
 from sympy import (KroneckerDelta, diff, Sum, Dummy, factor,
                    expand, zeros, gcd_terms, Eq, Symbol)
 
-from sympy.core import S, symbols, Add, Mul, SympifyError, Rational
-from sympy.functions import sin, cos, sqrt, cbrt, exp
+from sympy.core import (S, symbols, Add, Mul, SympifyError, Rational,
+                    Function)
+from sympy.functions import sin, cos, tan, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError,
@@ -338,6 +339,18 @@ def test_issue_7842():
     A = ZeroMatrix(2, 3)
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True
+
+
+def test_issue_21208():
+    t = symbols('t')
+    x = Function('x')(t)
+    dx = x.diff(t)
+    exp1 = cos(x) + cos(x)*dx
+    exp2 = sin(x) + tan(x)*(dx.diff(t))
+    exp3 = sin(x)*sin(t)*(dx.diff(t)).diff(t)
+    A = Matrix([[exp1], [exp2], [exp3]])
+    B = Matrix([[exp1.diff(x)], [exp2.diff(x)], [exp3.diff(x)]])
+    assert A.diff(x) == B
 
 
 def test_MatMul_postprocessor():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -341,7 +341,7 @@ def test_issue_7842():
     assert Eq(A, B) == True
 
 
-def test_issue_21208():
+def test_issue_21195():
     t = symbols('t')
     x = Function('x')(t)
     dx = x.diff(t)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21195 

#### Brief description of what is fixed or changed

In the derivative calculation of Matrix expressions, `doit()` in _matrix_derivative() made some of the terms vanish when carried out with respect to a variable belonging to `sympy.core.function.Function` class. Moreover, there was no significance of `doit()` in computing the derivative so I removed it.

#### Other comments

I have given a detailed explanation in the issue thread. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed a bug that led to the wrong derivative result in matrix expressions.
<!-- END RELEASE NOTES -->
