### PR TITLE
Enhancing `latex` printing

### DIFF
--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2709,5 +2709,5 @@ def test_printing_latex_array_expressions():
 def test_issue_21204():
     e1 = "6-(-8)"
     e2 = "5-(-2)"
-    assert latex(sympify(e, evaluate = False)) == 6-(-8)
-    assert latex(sympify(e, evaluate = False)) == 5-(-2)
+    assert latex(sympify(e1, evaluate = False)) == 6-(-8)
+    assert latex(sympify(e2, evaluate = False)) == 5-(-2)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -52,6 +52,7 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Lap
 from sympy.sets.setexpr import SetExpr
 from sympy.sets.sets import \
     Union, Intersection, Complement, SymmetricDifference, ProductSet
+from sympy.core.sympify import sympify
 
 import sympy as sym
 
@@ -2704,3 +2705,9 @@ def test_pickleable():
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+
+def test_issue_21204():
+    e1 = "6-(-8)"
+    e2 = "5-(-2)"
+    assert latex(sympify(e, evaluate = False)) == 6-(-8)
+    assert latex(sympify(e, evaluate = False)) == 5-(-2)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2709,5 +2709,5 @@ def test_printing_latex_array_expressions():
 def test_issue_21204():
     e1 = "6-(-8)"
     e2 = "5-(-2)"
-    assert latex(sympify(e1, evaluate = False)) == 6-(-8)
-    assert latex(sympify(e2, evaluate = False)) == 5-(-2)
+    assert latex(sympify(e1, evaluate = False)) == "6-(-8)"
+    assert latex(sympify(e2, evaluate = False)) == "5-(-2)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#21204
#### Brief description of what is fixed or changed
Improved printing of `exp = "4-(-8)"`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
