### PR TITLE
Assert Error for vertical tangent in ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1307,9 +1307,11 @@ class Ellipse(GeometrySet):
 
             # handle horizontal and vertical tangent lines
             if len(tangent_points) == 1:
-                assert tangent_points[0][
-                           0] == p.x or tangent_points[0][1] == p.y
-                return [Line(p, p + Point(1, 0)), Line(p, p + Point(0, 1))]
+                if tangent_points[0][
+                           0] == p.x or tangent_points[0][1] == p.y:
+                    return [Line(p, p + Point(1, 0)), Line(p, p + Point(0, 1))]
+                else:
+                    return [Line(p, p + Point(0, 1)), Line(p, tangent_points[0])]
 
             # others
             return [Line(p, tangent_points[0]), Line(p, tangent_points[1])]

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -157,6 +157,12 @@ def test_ellipse_geom():
     assert Circle(Point(5, 5), 2).tangent_lines(Point(5 - 2*sqrt(2), 5)) == \
         [Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 - sqrt(2))),
      Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 + sqrt(2))), ]
+    assert Circle(Point(5, 5), 5).tangent_lines(Point(4, 0)) == \
+        [Line(Point(4, 0), Point(Rational(40, 13), Rational(5, 13))),
+     Line(Point(4, 0), Point(5, 0))]
+    assert Circle(Point(5, 5), 5).tangent_lines(Point(0, 6)) == \
+        [Line(Point(0, 6), Point(0, 7)),
+        Line(Point(0, 6), Point(Rational(5, 13), Rational(90, 13)))]
 
     # for numerical calculations, we shouldn't demand exact equality,
     # so only test up to the desired precision


### PR DESCRIPTION
#### Brief description of what is fixed or changed
```
c = Circle(Point(5, 5), 5)
p = Point(0, 6)
t = c.tangent_lines(p)
```
Above code generates error Assert Error
https://github.com/sympy/sympy/blob/4875c64ff6249da145133f16e6b733a462139bff/sympy/geometry/ellipse.py#L1310

Above condition checks for tangents which are perpendicular (horizontal and vertical), but it does not take care of scenario where first tangent is vertical and second is non-horizontal


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* geometry
  * Fix `AssertError` for vertical tangent

<!-- END RELEASE NOTES -->

