### PR TITLE
fixed many imports for transformation in parse_expr

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -979,6 +979,7 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     stringify_expr, eval_expr, standard_transformations,
     implicit_multiplication_application
+    
     """
     if type(transformations) is str:
         from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -984,7 +984,6 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     if type(transformations) is str:
         from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application
         transformations = (standard_transformations + (implicit_multiplication_application,))
-        
     if local_dict is None:
         local_dict = {}
     elif not isinstance(local_dict, dict):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -979,7 +979,6 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     stringify_expr, eval_expr, standard_transformations,
     implicit_multiplication_application
-
     """
     if type(transformations) is str:
         from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -981,7 +981,10 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     implicit_multiplication_application
 
     """
-
+    if type(transformations) is str:
+        from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application
+        transformations = (standard_transformations + (implicit_multiplication_application,))
+        
     if local_dict is None:
         local_dict = {}
     elif not isinstance(local_dict, dict):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -979,7 +979,6 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     stringify_expr, eval_expr, standard_transformations,
     implicit_multiplication_application
-    
     """
     if type(transformations) is str:
         from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* parsing
  * "Reduced the number of files imported before using parse_expr()"

<!-- END RELEASE NOTES -->

* ## Changes

 I worked on the parse_expr() making the end-user import less files.

Using parse_expr is now shorter.

Inline with this issue
"Make parse_expr with transformations easier to type #21226", I decided to help by making the parse_expr much more fun to use.

Before...(This was before i made the change)

>>>from sympy.parsing.sympy_parser import standard_transformations, implicit_multiplication_application
>>> transformations = (standard_transformations + (implicit_multiplication_application,))
>>> parse_expr("2x + 1", transformations=transformations)
2*x + 1

After...(The code base right now)

>>> parse_expr("2x + 1", transformations="all")
2*x + 1

I hope to improve it again based on more feedbacks.

I am here for Google Summer of code but I just felt "in-love" with sympy.