### PR TITLE
parsing: Add a shortcut for common transformations

### DIFF
--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -28,6 +28,8 @@ applied in the order given.
 
 .. autodata:: sympy.parsing.sympy_parser.standard_transformations
 
+.. autodata:: sympy.parsing.sympy_parser.all_transformations
+
 .. autofunction:: sympy.parsing.sympy_parser.split_symbols
 
 .. autofunction:: sympy.parsing.sympy_parser.split_symbols_custom


### PR DESCRIPTION
#### Brief description of what is fixed or changed
The `parse_expr` method now accepts `transformations="all"` as an argument, which as of now acts as a shortcut to passing

    transformations = (standard_transformations
        + (implicit_multiplication_application,))


This behavior can be modified using the new `all_transformations` variable.

#### Example

    In [1]: from sympy.parsing import parse_expr

    In [2]: parse_expr("7!x + sin**2 x", transformations="all")
    Out[2]: 5040*x + sin(x)**2

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added a shortcut for common parsing transformations.
<!-- END RELEASE NOTES -->

#### References to other Issues or PRs
Fixes #21226 