### PR TITLE
fix(assumptions) : Fix infinite query

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -228,7 +228,3 @@ def _(expr, assumptions):
 @InfinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity)
 def _(expr, assumptions):
     return True
-
-@InfinitePredicate.register(NaN)
-def _(expr, assumptions):
-    return None

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -10,8 +10,7 @@ from sympy.core.numbers import (ComplexInfinity, Exp1, GoldenRatio, ImaginaryUni
 from sympy.functions import cos, exp, log, sign, sin
 from sympy.logic.boolalg import conjuncts
 
-from ..predicates.calculus import (FinitePredicate, InfinitePredicate,
-    PositiveInfinitePredicate, NegativeInfinitePredicate)
+from ..predicates.calculus import FinitePredicate, InfinitePredicate
 
 
 # FinitePredicate
@@ -228,31 +227,5 @@ def _(expr, assumptions):
 
 
 @InfinitePredicate.register(NaN)
-def _(expr, assumptions):
-    return False
-
-
-# PositiveInfinitePredicate
-
-
-@PositiveInfinitePredicate.register(Infinity)
-def _(expr, assumptions):
-    return True
-
-
-@PositiveInfinitePredicate.register_many(NegativeInfinity, ComplexInfinity)
-def _(expr, assumptions):
-    return False
-
-
-# NegativeInfinitePredicate
-
-
-@NegativeInfinitePredicate.register(NegativeInfinity)
-def _(expr, assumptions):
-    return True
-
-
-@NegativeInfinitePredicate.register_many(Infinity, ComplexInfinity)
 def _(expr, assumptions):
     return False

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -213,9 +213,13 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@FinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity, NaN)
+@FinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity)
 def _(expr, assumptions):
     return False
+
+@FinitePredicate.register(NaN)
+def _(expr, assumptions):
+    return None
 
 
 # InfinitePredicate
@@ -225,7 +229,6 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-
 @InfinitePredicate.register(NaN)
 def _(expr, assumptions):
-    return False
+    return None

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -5,12 +5,13 @@ infinitesimal, finite, etc.
 
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Mul, Pow, Symbol
-from sympy.core.numbers import (Exp1, GoldenRatio, ImaginaryUnit, Infinity, NaN,
-    NegativeInfinity, Number, Pi, TribonacciConstant, E)
+from sympy.core.numbers import (ComplexInfinity, Exp1, GoldenRatio, ImaginaryUnit,
+    Infinity, NaN, NegativeInfinity, Number, Pi, TribonacciConstant, E)
 from sympy.functions import cos, exp, log, sign, sin
 from sympy.logic.boolalg import conjuncts
 
-from ..predicates.calculus import FinitePredicate
+from ..predicates.calculus import (FinitePredicate, InfinitePredicate,
+    PositiveInfinitePredicate, NegativeInfinitePredicate)
 
 
 # FinitePredicate
@@ -213,6 +214,45 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@FinitePredicate.register_many(Infinity, NegativeInfinity, NaN)
+@FinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity, NaN)
+def _(expr, assumptions):
+    return False
+
+
+# InfinitePredicate
+
+
+@InfinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity)
+def _(expr, assumptions):
+    return True
+
+
+@InfinitePredicate.register(NaN)
+def _(expr, assumptions):
+    return False
+
+
+# PositiveInfinitePredicate
+
+
+@PositiveInfinitePredicate.register(Infinity)
+def _(expr, assumptions):
+    return True
+
+
+@PositiveInfinitePredicate.register_many(NegativeInfinity, ComplexInfinity)
+def _(expr, assumptions):
+    return False
+
+
+# NegativeInfinitePredicate
+
+
+@NegativeInfinitePredicate.register(NegativeInfinity)
+def _(expr, assumptions):
+    return True
+
+
+@NegativeInfinitePredicate.register_many(Infinity, ComplexInfinity)
 def _(expr, assumptions):
     return False

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -69,7 +69,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return isprime(expr)
 
-@PrimePredicate.register_many(Rational, Infinity, NaN, NegativeInfinity, ImaginaryUnit)
+@PrimePredicate.register_many(Rational, Infinity, NegativeInfinity, ImaginaryUnit)
 def _(expr, assumptions):
     return False
 
@@ -80,6 +80,10 @@ def _(expr, assumptions):
 @PrimePredicate.register(NumberSymbol)
 def _(expr, assumptions):
     return _PrimePredicate_number(expr, assumptions)
+
+@PrimePredicate.register(NaN)
+def _(expr, assumptions):
+    return None
 
 
 # CompositePredicate
@@ -109,10 +113,6 @@ def _(expr, assumptions):
             return _integer
     else:
         return _positive
-
-@CompositePredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 
 # EvenPredicate
@@ -219,7 +219,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return not bool(expr.p & 1)
 
-@EvenPredicate.register_many(Rational, Infinity, NaN, NegativeInfinity, ImaginaryUnit)
+@EvenPredicate.register_many(Rational, Infinity, NegativeInfinity, ImaginaryUnit)
 def _(expr, assumptions):
     return False
 
@@ -242,6 +242,10 @@ def _(expr, assumptions):
     if ask(Q.real(expr.args[0]), assumptions):
         return True
 
+@EvenPredicate.register(NaN)
+def _(expr, assumptions):
+    return None
+
 
 # OddPredicate
 
@@ -261,7 +265,3 @@ def _(expr, assumptions):
             return None
         return not _even
     return _integer
-
-@OddPredicate.register(NaN)
-def _(expr, assumptions):
-    return False

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -5,7 +5,7 @@ Handlers related to order relations: positive, negative, etc.
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Basic, Expr, Mul, Pow
 from sympy.core.logic import fuzzy_not, fuzzy_and, fuzzy_or
-from sympy.core.numbers import ImaginaryUnit, NaN, E
+from sympy.core.numbers import E, ImaginaryUnit, NaN
 from sympy.functions import Abs, acos, acot, asin, atan, exp, factorial, log
 from sympy.matrices import Determinant, Trace
 from sympy.matrices.expressions.matexpr import MatrixElement
@@ -113,7 +113,7 @@ def _(expr, assumptions):
         if ask(Q.odd(expr.exp), assumptions):
             return ask(Q.negative(expr.base), assumptions)
 
-@NegativePredicate.register_many(Abs, ImaginaryUnit, NaN)
+@NegativePredicate.register_many(Abs, ImaginaryUnit)
 def _(expr, assumptions):
     return False
 
@@ -141,10 +141,6 @@ def _(expr, assumptions):
     if ret is None:
         raise MDNotImplementedError
     return ret
-
-@NonNegativePredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 
 # NonZeroPredicate
@@ -187,13 +183,13 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return ask(Q.nonzero(expr.base), assumptions)
 
-@NonZeroPredicate.register(NaN)
-def _(expr, assumptions):
-    return True
-
 @NonZeroPredicate.register(Abs)
 def _(expr, assumptions):
     return ask(Q.nonzero(expr.args[0]), assumptions)
+
+@NonZeroPredicate.register(NaN)
+def _(expr, assumptions):
+    return None
 
 
 # ZeroPredicate
@@ -215,10 +211,6 @@ def _(expr, assumptions):
     # TODO: This should be deducible from the nonzero handler
     return fuzzy_or(ask(Q.zero(arg), assumptions) for arg in expr.args)
 
-@ZeroPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
-
 
 # NonPositivePredicate
 
@@ -237,10 +229,6 @@ def _(expr, assumptions):
             return ask(Q.real(expr), assumptions)
         else:
             return notpositive
-
-@NonPositivePredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 
 # PositivePredicate
@@ -403,4 +391,4 @@ def _(expr, assumptions):
 
 @PositivePredicate.register(NaN)
 def _(expr, assumptions):
-    return False
+    return None

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -39,7 +39,7 @@ def _IntegerPredicate_number(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@IntegerPredicate.register_many(Exp1, GoldenRatio, ImaginaryUnit, Infinity, NaN,
+@IntegerPredicate.register_many(Exp1, GoldenRatio, ImaginaryUnit, Infinity,
     NegativeInfinity, Pi, Rational, TribonacciConstant)
 def _(expr, assumptions):
     return False
@@ -110,7 +110,7 @@ def _(expr, assumptions):
     return None
 
 @RationalPredicate.register_many(Exp1, GoldenRatio, ImaginaryUnit, Infinity,
-    NaN, NegativeInfinity, Pi, TribonacciConstant)
+    NegativeInfinity, Pi, TribonacciConstant)
 def _(expr, assumptions):
     return False
 
@@ -179,10 +179,6 @@ def _(expr, assumptions):
 
 # IrrationalPredicate
 
-@IrrationalPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
-
 @IrrationalPredicate.register(Expr)
 def _(expr, assumptions):
     ret = expr.is_irrational
@@ -218,7 +214,7 @@ def _RealPredicate_number(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@RealPredicate.register_many(ImaginaryUnit, Infinity, NaN, NegativeInfinity)
+@RealPredicate.register_many(ImaginaryUnit, Infinity, NegativeInfinity)
 def _(expr, assumptions):
     return False
 
@@ -353,20 +349,12 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@ExtendedRealPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
-
 @ExtendedRealPredicate.register_many(Add, Mul, Pow)
 def _(expr, assumptions):
     return test_closed_group(expr, assumptions, Q.extended_real)
 
 
 # HermitianPredicate
-
-@HermitianPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 @HermitianPredicate.register(object)
 def _(expr, assumptions):
@@ -460,7 +448,7 @@ def _(mat, assumptions):
 def _(expr, assumptions):
     return True
 
-@ComplexPredicate.register_many(Infinity, NaN, NegativeInfinity)
+@ComplexPredicate.register_many(Infinity, NegativeInfinity)
 def _(expr, assumptions):
     return False
 
@@ -485,6 +473,10 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return ask(Q.complex_elements(expr.args[0]), assumptions)
 
+@ComplexPredicate.register(NaN)
+def _(expr, assumptions):
+    return None
+
 
 # ImaginaryPredicate
 
@@ -500,10 +492,6 @@ def _Imaginary_number(expr, assumptions):
 @ImaginaryPredicate.register(ImaginaryUnit)
 def _(expr, assumptions):
     return True
-
-@ImaginaryPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 @ImaginaryPredicate.register(Expr)
 def _(expr, assumptions):
@@ -639,12 +627,12 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return not (expr.as_real_imag()[1] == 0)
 
+@ImaginaryPredicate.register(NaN)
+def _(expr, assumptions):
+    return None
+
 
 # AntihermitianPredicate
-
-@AntihermitianPredicate.register(NaN)
-def _(expr, assumptions):
-    return False
 
 @AntihermitianPredicate.register(object)
 def _(expr, assumptions):
@@ -729,7 +717,7 @@ def _(mat, assumptions):
 def _(expr, assumptions):
     return True
 
-@AlgebraicPredicate.register_many(ComplexInfinity, Exp1, Infinity, NaN,
+@AlgebraicPredicate.register_many(ComplexInfinity, Exp1, Infinity,
     NegativeInfinity, Pi)
 def _(expr, assumptions):
     return False

--- a/sympy/assumptions/predicates/calculus.py
+++ b/sympy/assumptions/predicates/calculus.py
@@ -17,8 +17,6 @@ class FinitePredicate(Predicate):
 
     >>> from sympy import Q, ask, S, oo, I, zoo
     >>> from sympy.abc import x
-    >>> ask(Q.finite(S.NaN))
-    False
     >>> ask(Q.finite(oo))
     False
     >>> ask(Q.finite(-oo))
@@ -30,6 +28,8 @@ class FinitePredicate(Predicate):
     >>> ask(Q.finite(2 + 3*I))
     True
     >>> print(ask(Q.finite(x), Q.positive(x)))
+    None
+    >>> print(ask(Q.finite(S.NaN)))
     None
 
     References

--- a/sympy/assumptions/predicates/calculus.py
+++ b/sympy/assumptions/predicates/calculus.py
@@ -3,23 +3,27 @@ from sympy.multipledispatch import Dispatcher
 
 class FinitePredicate(Predicate):
     """
-    Finite predicate.
+    Finite number predicate.
 
     Explanation
     ===========
 
-    ``Q.finite(x)`` is true if ``x`` is neither an infinity
-    nor a ``NaN``. In other words, ``ask(Q.finite(x))`` is true for all ``x``
-    having a bounded absolute value.
+    ``Q.finite(x)`` is true if ``x`` is a number but neither an infinity
+    nor a ``NaN``. In other words, ``ask(Q.finite(x))`` is true for all
+    numerical ``x`` having a bounded absolute value.
 
     Examples
     ========
 
-    >>> from sympy import Q, ask, Symbol, S, oo, I
-    >>> x = Symbol('x')
+    >>> from sympy import Q, ask, S, oo, I, zoo
+    >>> from sympy.abc import x
     >>> ask(Q.finite(S.NaN))
     False
     >>> ask(Q.finite(oo))
+    False
+    >>> ask(Q.finite(-oo))
+    False
+    >>> ask(Q.finite(zoo))
     False
     >>> ask(Q.finite(1))
     True

--- a/sympy/assumptions/predicates/order.py
+++ b/sympy/assumptions/predicates/order.py
@@ -154,8 +154,8 @@ class ZeroPredicate(Predicate):
     True
     >>> ask(Q.zero(1/oo))
     True
-    >>> ask(Q.zero(0*oo))
-    False
+    >>> print(ask(Q.zero(0*oo)))
+    None
     >>> ask(Q.zero(1))
     False
     >>> ask(Q.zero(x*y), Q.zero(x) | Q.zero(y))

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -239,25 +239,25 @@ def test_complex_infinity():
 def test_nan():
     nan = S.NaN
     assert ask(Q.commutative(nan)) is True
-    assert ask(Q.integer(nan)) is False
-    assert ask(Q.rational(nan)) is False
-    assert ask(Q.algebraic(nan)) is False
-    assert ask(Q.real(nan)) is False
-    assert ask(Q.extended_real(nan)) is False
-    assert ask(Q.complex(nan)) is False
-    assert ask(Q.irrational(nan)) is False
-    assert ask(Q.imaginary(nan)) is False
-    assert ask(Q.positive(nan)) is False
-    assert ask(Q.nonzero(nan)) is True
-    assert ask(Q.zero(nan)) is False
-    assert ask(Q.even(nan)) is False
-    assert ask(Q.odd(nan)) is False
+    assert ask(Q.integer(nan)) is None
+    assert ask(Q.rational(nan)) is None
+    assert ask(Q.algebraic(nan)) is None
+    assert ask(Q.real(nan)) is None
+    assert ask(Q.extended_real(nan)) is None
+    assert ask(Q.complex(nan)) is None
+    assert ask(Q.irrational(nan)) is None
+    assert ask(Q.imaginary(nan)) is None
+    assert ask(Q.positive(nan)) is None
+    assert ask(Q.nonzero(nan)) is None
+    assert ask(Q.zero(nan)) is None
+    assert ask(Q.even(nan)) is None
+    assert ask(Q.odd(nan)) is None
     assert ask(Q.finite(nan)) is None
     assert ask(Q.infinite(nan)) is None
-    assert ask(Q.prime(nan)) is False
-    assert ask(Q.composite(nan)) is False
-    assert ask(Q.hermitian(nan)) is False
-    assert ask(Q.antihermitian(nan)) is False
+    assert ask(Q.prime(nan)) is None
+    assert ask(Q.composite(nan)) is None
+    assert ask(Q.hermitian(nan)) is None
+    assert ask(Q.antihermitian(nan)) is None
 
 
 def test_Rational_number():
@@ -2278,10 +2278,10 @@ def test_issue_9636():
 
 def test_autosimp_used_to_fail():
     # See issue #9807
-    assert ask(Q.imaginary(0**I)) is False
-    assert ask(Q.imaginary(0**(-I))) is False
-    assert ask(Q.real(0**I)) is False
-    assert ask(Q.real(0**(-I))) is False
+    assert ask(Q.imaginary(0**I)) is None
+    assert ask(Q.imaginary(0**(-I))) is None
+    assert ask(Q.real(0**I)) is None
+    assert ask(Q.real(0**(-I))) is None
 
 
 def test_custom_AskHandler():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -253,6 +253,7 @@ def test_nan():
     assert ask(Q.even(nan)) is False
     assert ask(Q.odd(nan)) is False
     assert ask(Q.finite(nan)) is None
+    assert ask(Q.infinite(nan)) is None
     assert ask(Q.prime(nan)) is False
     assert ask(Q.composite(nan)) is False
     assert ask(Q.hermitian(nan)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -252,7 +252,7 @@ def test_nan():
     assert ask(Q.zero(nan)) is False
     assert ask(Q.even(nan)) is False
     assert ask(Q.odd(nan)) is False
-    assert ask(Q.finite(nan)) is False
+    assert ask(Q.finite(nan)) is None
     assert ask(Q.prime(nan)) is False
     assert ask(Q.composite(nan)) is False
     assert ask(Q.hermitian(nan)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -5,7 +5,7 @@ from sympy.assumptions.assume import assuming, global_assumptions, Predicate
 from sympy.assumptions.ask import compute_known_facts, single_fact_lookup
 from sympy.assumptions.handlers import AskHandler
 from sympy.core.add import Add
-from sympy.core.numbers import (I, Integer, Rational, oo, pi)
+from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
 from sympy.core.symbol import symbols, Symbol
@@ -181,6 +181,7 @@ def test_infinity():
     assert ask(Q.even(oo)) is False
     assert ask(Q.odd(oo)) is False
     assert ask(Q.finite(oo)) is False
+    assert ask(Q.infinite(oo)) is True
     assert ask(Q.prime(oo)) is False
     assert ask(Q.composite(oo)) is False
     assert ask(Q.hermitian(oo)) is False
@@ -204,10 +205,35 @@ def test_neg_infinity():
     assert ask(Q.even(mm)) is False
     assert ask(Q.odd(mm)) is False
     assert ask(Q.finite(mm)) is False
+    assert ask(Q.infinite(oo)) is True
     assert ask(Q.prime(mm)) is False
     assert ask(Q.composite(mm)) is False
     assert ask(Q.hermitian(mm)) is False
     assert ask(Q.antihermitian(mm)) is False
+
+
+def test_complex_infinity():
+    assert ask(Q.commutative(zoo)) is True
+    assert ask(Q.integer(zoo)) is False
+    assert ask(Q.rational(zoo)) is False
+    assert ask(Q.algebraic(zoo)) is False
+    assert ask(Q.real(zoo)) is False
+    assert ask(Q.extended_real(zoo)) is False
+    assert ask(Q.complex(zoo)) is False
+    assert ask(Q.irrational(zoo)) is False
+    assert ask(Q.imaginary(zoo)) is False
+    assert ask(Q.positive(zoo)) is False
+    assert ask(Q.negative(zoo)) is False
+    assert ask(Q.zero(zoo)) is False
+    assert ask(Q.nonzero(zoo)) is False
+    assert ask(Q.even(zoo)) is False
+    assert ask(Q.odd(zoo)) is False
+    assert ask(Q.finite(zoo)) is False
+    assert ask(Q.infinite(zoo)) is True
+    assert ask(Q.prime(zoo)) is False
+    assert ask(Q.composite(zoo)) is False
+    assert ask(Q.hermitian(zoo)) is False
+    assert ask(Q.antihermitian(zoo)) is False
 
 
 def test_nan():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Make `ask(Q.infinite(oo))` return `True`
Make `ask(Q.infinite(-oo))` return `True`
Make `ask(Q.infinite(zoo))` return `True`

Make predicates evaluate to `None` for `NaN`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- assumptions
  - `Q.infinite` now correctly evaluates to `True` for `oo`, `-oo`, and `zoo`.
  - Assumption predicates now correctly evaluates to `None` for `S.NaN`.
<!-- END RELEASE NOTES -->
