### PR TITLE
Remove duplicate code wrt to `apply_load` and `remove_load` in `beam.py` of `physics.continuum_mechanics`

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -530,7 +530,7 @@ class Beam:
 
     def handle_end(self, x, value, start, order, end):
         """
-        This functions handles the optional `end` value in the 
+        This functions handles the optional `end` value in the
         `apply_load` and `remove_load` functions. When the value
         of end is not NULL, this function will be executed.
         """

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -462,18 +462,8 @@ class Beam:
         self._load += value*SingularityFunction(x, start, order)
 
         if end:
-            if order.is_negative:
-                msg = ("If 'end' is provided the 'order' of the load cannot "
-                       "be negative, i.e. 'end' is only valid for distributed "
-                       "loads.")
-                raise ValueError(msg)
-            # NOTE : A Taylor series can be used to define the summation of
-            # singularity functions that subtract from the load past the end
-            # point such that it evaluates to zero past 'end'.
-            f = value*x**order
-            for i in range(0, order + 1):
-                self._load -= (f.diff(x, i).subs(x, end - start) *
-                               SingularityFunction(x, end, i)/factorial(i))
+            # load has an end point within the length of the beam.
+            handle_end(x, value, start, order, end)
 
     def remove_load(self, value, start, order, end=None):
         """
@@ -535,21 +525,27 @@ class Beam:
             raise ValueError(msg)
 
         if end:
-            # TODO : This is essentially duplicate code wrt to apply_load,
-            # would be better to move it to one location and both methods use
-            # it.
-            if order.is_negative:
-                msg = ("If 'end' is provided the 'order' of the load cannot "
-                       "be negative, i.e. 'end' is only valid for distributed "
-                       "loads.")
-                raise ValueError(msg)
-            # NOTE : A Taylor series can be used to define the summation of
-            # singularity functions that subtract from the load past the end
-            # point such that it evaluates to zero past 'end'.
-            f = value*x**order
-            for i in range(0, order + 1):
-                self._load += (f.diff(x, i).subs(x, end - start) *
-                               SingularityFunction(x, end, i)/factorial(i))
+            # load has an end point within the length of the beam.
+            handle_end(x, value, start, order, end)
+
+    def handle_end(self, x, value, start, order, end):
+        """
+        This functions handles the optional `end` value in the 
+        `apply_load` and `remove_load` functions. When the value
+        of end is not NULL, this function will be executed.
+        """
+        if order.is_negative:
+            msg = ("If 'end' is provided the 'order' of the load cannot "
+                    "be negative, i.e. 'end' is only valid for distributed "
+                    "loads.")
+            raise ValueError(msg)
+        # NOTE : A Taylor series can be used to define the summation of
+        # singularity functions that subtract from the load past the end
+        # point such that it evaluates to zero past 'end'.
+        f = value*x**order
+        for i in range(0, order + 1):
+            self._load -= (f.diff(x, i).subs(x, end - start) *
+                            SingularityFunction(x, end, i)/factorial(i))
 
     @property
     def load(self):

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -463,7 +463,7 @@ class Beam:
 
         if end:
             # load has an end point within the length of the beam.
-            self.handle_end(x, value, start, order, end)
+            self._handle_end(x, value, start, order, end, type="apply")
 
     def remove_load(self, value, start, order, end=None):
         """
@@ -526,9 +526,9 @@ class Beam:
 
         if end:
             # load has an end point within the length of the beam.
-            self.handle_end(x, value, start, order, end)
+            self._handle_end(x, value, start, order, end, type="remove")
 
-    def handle_end(self, x, value, start, order, end):
+    def _handle_end(self, x, value, start, order, end, type):
         """
         This functions handles the optional `end` value in the
         `apply_load` and `remove_load` functions. When the value
@@ -543,9 +543,19 @@ class Beam:
         # singularity functions that subtract from the load past the end
         # point such that it evaluates to zero past 'end'.
         f = value*x**order
-        for i in range(0, order + 1):
-            self._load -= (f.diff(x, i).subs(x, end - start) *
-                            SingularityFunction(x, end, i)/factorial(i))
+
+        if type == "apply":
+            # iterating for "apply_load" method
+            for i in range(0, order + 1):
+                self._load -= (f.diff(x, i).subs(x, end - start) *
+                                SingularityFunction(x, end, i)/factorial(i))
+        elif type == "remove":
+            # iterating for "remove_load" method
+            for i in range(0, order + 1):
+                    self._load += (f.diff(x, i).subs(x, end - start) *
+                                    SingularityFunction(x, end, i)/factorial(i))
+
+        
 
     @property
     def load(self):

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -463,7 +463,7 @@ class Beam:
 
         if end:
             # load has an end point within the length of the beam.
-            handle_end(x, value, start, order, end)
+            self.handle_end(x, value, start, order, end)
 
     def remove_load(self, value, start, order, end=None):
         """
@@ -526,7 +526,7 @@ class Beam:
 
         if end:
             # load has an end point within the length of the beam.
-            handle_end(x, value, start, order, end)
+            self.handle_end(x, value, start, order, end)
 
     def handle_end(self, x, value, start, order, end):
         """

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -555,7 +555,6 @@ class Beam:
                     self._load += (f.diff(x, i).subs(x, end - start) *
                                     SingularityFunction(x, end, i)/factorial(i))
 
-        
 
     @property
     def load(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
I previously had another similar PR (#21209) which is closed now. I have simply changed the branch from `master` to `_handle_end` to avoid confusion when I am working on other issues.

#### Brief description of what is fixed or changed
This is a simple patch referring to the TODO given on line `538` in `sympy/sympy/physics/continuum_mechanics/beam.py` i.e. : https://github.com/sympy/sympy/blob/f9badb21b01f4f52ce4d545d071086ee650cd282/sympy/physics/continuum_mechanics/beam.py#L538

The duplicate code from `apply_load` and `remove_load` functions is defined in the new function of `handle_end` and has been  replaced with a call to this new function.

#### Other comments
Further optimization of code is required in the `physics` submodule.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Created the `handle_end` function to remove redundant duplicate code in the `apply_load` and `remove_load` functions.
<!-- END RELEASE NOTES -->