### PR TITLE
Fixed `RecursionError` in integrals involving hyperbolic functions

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1708,6 +1708,11 @@ def test_issue_17841():
 
 def test_issue_21034():
     x = Symbol('x', real=True, nonzero=True)
-    f = x*(-x**4/asin(5)**4 - x*sinh(x + log(asin(5))) + 5)
-    assert integrate(f, x) == \
+    f1 = x*(-x**4/asin(5)**4 - x*sinh(x + log(asin(5))) + 5)
+    f2 = (x + cosh(cos(4)))/(x*(x + 1/(12*x)))
+
+    assert integrate(f1, x) == \
         -x**6/(6*asin(5)**4) - x**2*cosh(x + log(asin(5))) + 5*x**2/2 + 2*x*sinh(x + log(asin(5))) - 2*cosh(x + log(asin(5)))
+
+    assert integrate(f2, x) == \
+        log(x**2 + S(1)/12)/2 + 2*sqrt(3)*cosh(cos(4))*atan(2*sqrt(3)*x)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -912,7 +912,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi.as_expr()
 
         # rewrite hyperbolics in terms of exp
-        f[i] = f[i].replace(lambda w: isinstance(w, HyperbolicFunction),
+        f[i] = f[i].replace(lambda w: (w.free_symbols & set(symbols)) and isinstance(w, HyperbolicFunction),
                 lambda w: w.rewrite(exp))
 
         # if we have a Matrix, we need to iterate over its elements again
@@ -2296,7 +2296,7 @@ def solve_linear_system(system, *symbols, **flags):
     {}
 
     """
-    do_simplify = flags.get('simplify', True)
+    do_simplify = flags.get('simplify', False)
 
     assert system.shape[1] == len(symbols) + 1
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -912,8 +912,8 @@ def solve(f, *symbols, **flags):
             f[i] = fi.as_expr()
 
         # rewrite hyperbolics in terms of exp
-        f[i] = f[i].replace(lambda w: len(w.free_symbols & set(symbols)) and isinstance(w, HyperbolicFunction),
-                lambda w: w.rewrite(exp))
+        f[i] = f[i].replace(lambda w: isinstance(w, HyperbolicFunction) and \
+            (len(w.free_symbols & set(symbols)) > 0), lambda w: w.rewrite(exp))
 
         # if we have a Matrix, we need to iterate over its elements again
         if f[i].is_Matrix:
@@ -2300,7 +2300,7 @@ def solve_linear_system(system, *symbols, **flags):
 
     assert system.shape[1] == len(symbols) + 1
 
-    if(do_simplify):
+    if do_simplify:
         system = system.applyfunc(simplify)
 
     # This is just a wrapper for solve_lin_sys

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2296,12 +2296,7 @@ def solve_linear_system(system, *symbols, **flags):
     {}
 
     """
-    do_simplify = flags.get('simplify', False)
-
     assert system.shape[1] == len(symbols) + 1
-
-    if do_simplify:
-        system = system.applyfunc(simplify)
 
     # This is just a wrapper for solve_lin_sys
     eqs = list(system * Matrix(symbols + (-1,)))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -912,7 +912,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi.as_expr()
 
         # rewrite hyperbolics in terms of exp
-        f[i] = f[i].replace(lambda w: (w.free_symbols & set(symbols)) and isinstance(w, HyperbolicFunction),
+        f[i] = f[i].replace(lambda w: len(w.free_symbols & set(symbols)) and isinstance(w, HyperbolicFunction),
                 lambda w: w.rewrite(exp))
 
         # if we have a Matrix, we need to iterate over its elements again

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2296,7 +2296,12 @@ def solve_linear_system(system, *symbols, **flags):
     {}
 
     """
+    do_simplify = flags.get('simplify', True)
+
     assert system.shape[1] == len(symbols) + 1
+
+    if(do_simplify):
+        system = system.applyfunc(simplify)
 
     # This is just a wrapper for solve_lin_sys
     eqs = list(system * Matrix(symbols + (-1,)))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2319,7 +2319,7 @@ def test_issue_20902():
 def test_issue_21034():
     system = Matrix([[1, 0, 12],
         [0, 1, -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)]])
-    assert solve_linear_system(system, x, y) == {x: 12, y: 12*cosh(cos(4))}
+    assert solve_linear_system(system, x, y, simplify=True) == {x: 12, y: 12*cosh(cos(4))}
     #Do not change this test to any other form as some integrals might fail if expanded form
     #of hyperbolic cos is used, such as -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)
     #instead of simplified cosh(cos(4)). Refer to issue 21034

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2319,7 +2319,7 @@ def test_issue_20902():
 def test_issue_21034():
     a = symbols('a', real=True)
     system = [x - cosh(cos(4)), y - sinh(cos(a)), z - tanh(x)]
-    assert solve(system, x, y, z) == {x: cosh(cos(4)), z: tanh(cosh(cos(4))), 
+    assert solve(system, x, y, z) == {x: cosh(cos(4)), z: tanh(cosh(cos(4))),
         y: sinh(cos(a))}
     #Constants inside hyperbolic functions should not be rewritten in terms of exp
     newsystem = [(exp(x) - exp(-x)) - tanh(x)*(exp(x) + exp(-x)) + x - 5]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2317,9 +2317,15 @@ def test_issue_20902():
 
 
 def test_issue_21034():
-    system = Matrix([[1, 0, 12],
-        [0, 1, -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)]])
-    assert solve_linear_system(system, x, y, simplify=True) == {x: 12, y: 12*cosh(cos(4))}
+    a = symbols('a', real=True)
+    system = [x - cosh(cos(4)), y - sinh(cos(a)), z - tanh(x)]
+    assert solve(system, x, y, z) == {x: cosh(cos(4)), z: tanh(cosh(cos(4))), 
+        y: sinh(cos(a))}
+    #Constants inside hyperbolic functions should not be rewritten in terms of exp
+    newsystem = [(exp(x) - exp(-x)) - tanh(x)*(exp(x) + exp(-x)) + x - 5]
+    assert solve(newsystem, x) == {x: 5}
+    #If the variable of interest is present in hyperbolic function, only then
+    # it shouuld be rewritten in terms of exp and solved further
 
 
 def test_issue_4886():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2320,9 +2320,6 @@ def test_issue_21034():
     system = Matrix([[1, 0, 12],
         [0, 1, -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)]])
     assert solve_linear_system(system, x, y, simplify=True) == {x: 12, y: 12*cosh(cos(4))}
-    #Do not change this test to any other form as some integrals might fail if expanded form
-    #of hyperbolic cos is used, such as -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)
-    #instead of simplified cosh(cos(4)). Refer to issue 21034
 
 
 def test_issue_4886():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2316,6 +2316,15 @@ def test_issue_20902():
     assert solve(f.subs({t: 3 * x + 2}).diff(x) > 0, x) == (S(-1) < x) & (x < S(-1)/3)
 
 
+def test_issue_21034():
+    system = Matrix([[1, 0, 12],
+        [0, 1, -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)]])
+    assert solve_linear_system(system, x, y) == {x: 12, y: 12*cosh(cos(4))}
+    #Do not change this test to any other form as some integrals might fail if expanded form
+    #of hyperbolic cos is used, such as -(-6 - 6*exp(exp(-4*I))*exp(exp(4*I)))*exp(-exp(-4*I)/2)*exp(-exp(4*I)/2)
+    #instead of simplified cosh(cos(4)). Refer to issue 21034
+
+
 def test_issue_4886():
     z = a*sqrt(R**2*a**2 + R**2*b**2 - c**2)/(a**2 + b**2)
     t = b*c/(a**2 + b**2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21034 

#### Brief description of what is fixed or changed
`sympy.solvers.solvers.solve` used to expand any instance of `HyperbolicFunction` class in their `exp` form. This led to unnecessary computation time in cases having constants inside `HyperbolicFunctions`. I modified this behavior to expand only when the variable to be solved is present inside the function.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug that led to `RecursionError` in integrals involving hyperbolic functions.
* solvers
  * Fixed a bug in `solve` that expanded hyperbolic function constants to equivalent `exp` form.

<!-- END RELEASE NOTES -->
