### PR TITLE
remove the `new_method` kwarg and deprecation warning.

### DIFF
--- a/doc/src/modules/physics/mechanics/linearize.rst
+++ b/doc/src/modules/physics/mechanics/linearize.rst
@@ -211,7 +211,7 @@ wrapper that calls ``to_linearizer`` internally, performs the linearization,
 and returns the result. Note that all the kwargs available in the
 ``linearize`` method described above are also available here: ::
 
-  >>> A, B, inp_vec = KM.linearize(A_and_B=True, op_point=op_point, new_method=True)
+  >>> A, B, inp_vec = KM.linearize(A_and_B=True, op_point=op_point)
   >>> A
   Matrix([
   [     0, 1],
@@ -225,14 +225,6 @@ the vector is empty: ::
 
   >>> inp_vec
   Matrix(0, 0, [])
-
-.. topic:: What's with the ``new_method`` kwarg?
-
-  Previous releases of SymPy contained a linearization method for
-  `KanesMethod`` objects. This method is deprecated, and will be removed
-  from future releases. Until then, you must set ``new_method=True`` in all
-  calls to ``KanesMethod.linearize``. After the old method is removed, this
-  kwarg will no longer be needed.
 
 Linearizing Lagrange's Equations
 ================================

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -473,7 +473,7 @@ class KanesMethod:
         return Linearizer(f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i,
                 q_d, u_i, u_d, r)
 
-    def linearize(self, *, **kwargs):
+    def linearize(self, **kwargs):
         """ Linearize the equations of motion about a symbolic operating point.
 
         Explanation

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -473,8 +473,7 @@ class KanesMethod:
         return Linearizer(f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i,
                 q_d, u_i, u_d, r)
 
-    # TODO : Remove `new_method` after 1.1 has been released.
-    def linearize(self, *, new_method=None, **kwargs):
+    def linearize(self, *, **kwargs):
         """ Linearize the equations of motion about a symbolic operating point.
 
         Explanation


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes (#7790), specifically the review left by @moorepants , at this link : [Click Here](https://github.com/sympy/sympy/pull/7790#discussion_r15885290)

#### Brief description of what is fixed or changed
This is a simple patch referring to the TODO given on line `476` in `sympy/sympy/physics/mechanics/kane.py` i.e. : https://github.com/sympy/sympy/blob/0f782091845fbb52b26c3d55fb50240c260054b4/sympy/physics/mechanics/kane.py#L476

The depreciated `new_method` parameter has been removed and the depreciation warning has also been removed.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * removed the new_method kwarg and deprecation warning
<!-- END RELEASE NOTES -->