### PR TITLE
Fix (solvers) : Fixed RuntimeError in nonlinsolve

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1527,7 +1527,9 @@ def _solve_exponential(lhs, rhs, symbol, domain):
     newlhs = powdenest(lhs)
     if lhs != newlhs:
         # it may also be advantageous to factor the new expr
-        return _solveset(factor(newlhs - rhs), symbol, domain)  # try again with _solveset
+        neweq = factor(newlhs - rhs)
+        if neweq != (lhs - rhs):
+            return _solveset(neweq, symbol, domain)  # try again with _solveset
 
     if not (isinstance(lhs, Add) and len(lhs.args) == 2):
         # solving for the sum of more than two powers is possible
@@ -3240,15 +3242,6 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         soln = solver(eq2, sym)
                         total_solvest_call += 1
                         soln_new = S.EmptySet
-                        if isinstance(soln, ConditionSet):
-                            if soln.base_set in (S.Reals, S.Complexes):
-                                soln = S.EmptySet
-                                # don't do `continue` we may get soln
-                                # in terms of other symbol(s)
-                                not_solvable = True
-                                total_conditionst += 1
-                            else:
-                                soln = soln.base_set
                         if isinstance(soln, Complement):
                             # separate solution and complement
                             complements[sym] = soln.args[1]
@@ -3272,6 +3265,15 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         # If sovleset is not able to solve equation `eq2`. Next
                         # time we may get soln using next equation `eq2`
                         continue
+                    if isinstance(soln, ConditionSet):
+                        if soln.base_set in (S.Reals, S.Complexes):
+                            soln = S.EmptySet
+                            # don't do `continue` we may get soln
+                            # in terms of other symbol(s)
+                            not_solvable = True
+                            total_conditionst += 1
+                        else:
+                            soln = soln.base_set
 
                     if soln is not S.EmptySet:
                         soln, soln_imageset = _extract_main_soln(

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1723,6 +1723,17 @@ def test_issue_16618():
     assert len(sol) == len(ans)
 
 
+def test_issue_17566():
+    assert nonlinsolve([32*(2**x)/2**(-y) - 4**y, 27*(3**x) - 1/3**y], x, y) ==\
+        FiniteSet((-log(81)/log(3), 1))
+
+
+def test_issue_19587():
+    n,m = symbols('n m')
+    assert nonlinsolve([32*2**m*2**n - 4**n, 27*3**m - 3**(-n)], m, n) ==\
+        FiniteSet((-log(81)/log(3), 1))
+
+
 def test_issue_5132_1():
     system = [sqrt(x**2 + y**2) - sqrt(10), x + y - 4]
     assert nonlinsolve(system, [x, y]) == FiniteSet((1, 3), (3, 1))


### PR DESCRIPTION
Fixed RuntimeError in `nonlinsolve` which was due to a lot of recursive calls between `solveset` and `_solve_exponential`!


Closes https://github.com/sympy/sympy/issues/18552
Closes https://github.com/sympy/sympy/issues/19587
Closes https://github.com/sympy/sympy/issues/20199
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->