### PR TITLE
Plotting - Automatic line coloring when plotting multiple expressions

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -900,15 +900,6 @@ class Parametric2DLineSeries(Line2DBaseSeries):
 
         return x_coords, y_coords
 
-    def get_segments(self):
-        """ Return a Numpy masked array representing a list of segments having
-        the following form: [[[x0, y0], [x1, y1]], [[x1, y1], [x2, y2]], ...]
-        """
-        np = import_module('numpy')
-        points = self.get_data()
-        points = np.ma.array(points).T.reshape(-1, 1, self._dim)
-        return np.ma.concatenate([points[:-1], points[1:]], axis=1)
-
 
 ### 3D lines
 class Line3DBaseSeries(Line2DBaseSeries):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -23,7 +23,6 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 """
 
 
-import warnings
 from collections.abc import Callable
 
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
@@ -139,11 +138,13 @@ class Plot:
 
         For example, if ``MatplotlibBackend`` is being used, then
         Matplotlib string colors are acceptable ("red", "r", "cyan", "c", ...).
-        We can also specify grayscale colors by setting a float
-        value `0 < color < 1`. We can also specify a function returning a single
-        value: this will be used to apply a color-loop.
+        Alternatively, we can use a float number `0 < color < 1` wrapped in a
+        string (for example, `line_color="0.5"`) to specify grayscale colors.
+        Alternatively, We can specify a function returning a single
+        float value: this will be used to apply a color-loop (for example,
+        `line_color=lambda x: math.cos(x)`).
 
-        Note that by setting ``line_color``, it would be applied simultaneously
+        Note that by setting line_color, it would be applied simultaneously
         to all the series.
 
     options:
@@ -2106,9 +2107,9 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
     series = []
     plot_expr = check_arguments(args, 3, 1)
     series = [Parametric3DLineSeries(*arg, **kwargs) for arg in plot_expr]
-    kwargs.setdefault("xlabel", "x")
-    kwargs.setdefault("ylabel", "y")
-    kwargs.setdefault("zlabel", "f(x, y)")
+    xlabel = kwargs.setdefault("xlabel", "x")
+    ylabel = kwargs.setdefault("ylabel", "y")
+    kwargs.setdefault("zlabel", "f(%s, %s)" % (xlabel, ylabel))
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()
@@ -2357,10 +2358,8 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
     series = []
     plot_expr = check_arguments(args, 3, 2)
     series = [ParametricSurfaceSeries(*arg, **kwargs) for arg in plot_expr]
-    xlabel = "x"
-    ylabel = "y"
-    kwargs.setdefault("xlabel", xlabel)
-    kwargs.setdefault("ylabel", ylabel)
+    xlabel = kwargs.setdefault("xlabel", "x")
+    ylabel = kwargs.setdefault("ylabel", "y")
     kwargs.setdefault("zlabel", "f(%s, %s)" % (xlabel, ylabel))
     plots = Plot(*series, **kwargs)
     if show:

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -656,6 +656,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         =======
             x: list
                 List of x-coordinates
+
             y: list
                 List of y-coordinates
 
@@ -807,6 +808,7 @@ class Parametric2DLineSeries(Line2DBaseSeries):
         =======
             x: list
                 List of x-coordinates
+
             y: list
                 List of y-coordinates
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -586,7 +586,7 @@ class Line2DBaseSeries(BaseSeries):
         SymPyDeprecationWarning(
                 feature="get_segments",
                 issue=21329,
-                deprecated_since_version="1.8.1",
+                deprecated_since_version="1.9",
                 useinstead="MatplotlibBackend.get_segments").warn()
 
         np = import_module('numpy')

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1287,7 +1287,7 @@ class MatplotlibBackend(BaseBackend):
 
             y: list
                 List of y-coordinates
-            
+
             dim: int
                 Number of dimensions.
         """

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -940,8 +940,10 @@ class Line3DBaseSeries(Line2DBaseSeries):
 
 
 class Parametric3DLineSeries(Line3DBaseSeries):
-    """Representation for a 3D line consisting of two parametric sympy
+    """Representation for a 3D line consisting of three parametric sympy
     expressions and a range."""
+
+    is_parametric = True
 
     def __init__(self, expr_x, expr_y, expr_z, var_start_end, **kwargs):
         super().__init__()

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -896,6 +896,8 @@ class Parametric2DLineSeries(Line2DBaseSeries):
         f_end_x = f_x(self.end)
         f_end_y = f_y(self.end)
         end = [f_end_x, f_end_y]
+        x_coords.append(f_start_x)
+        y_coords.append(f_start_y)
         sample(self.start, self.end, start, end, 0)
 
         return x_coords, y_coords

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1009,7 +1009,7 @@ class SurfaceBaseSeries(BaseSeries):
             else:
                 return f(*variables)
         else:
-            return c*np.ones(self.nb_of_points)
+            return c*np.ones(min(self.nb_of_points_x, self.nb_of_points_y))
 
 
 class SurfaceOver2DRangeSeries(SurfaceBaseSeries):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2107,9 +2107,9 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
     series = []
     plot_expr = check_arguments(args, 3, 1)
     series = [Parametric3DLineSeries(*arg, **kwargs) for arg in plot_expr]
-    xlabel = kwargs.setdefault("xlabel", "x")
-    ylabel = kwargs.setdefault("ylabel", "y")
-    kwargs.setdefault("zlabel", "f(%s, %s)" % (xlabel, ylabel))
+    kwargs.setdefault("xlabel", "x")
+    kwargs.setdefault("ylabel", "y")
+    kwargs.setdefault("zlabel", "z")
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()
@@ -2358,9 +2358,9 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
     series = []
     plot_expr = check_arguments(args, 3, 2)
     series = [ParametricSurfaceSeries(*arg, **kwargs) for arg in plot_expr]
-    xlabel = kwargs.setdefault("xlabel", "x")
-    ylabel = kwargs.setdefault("ylabel", "y")
-    kwargs.setdefault("zlabel", "f(%s, %s)" % (xlabel, ylabel))
+    kwargs.setdefault("xlabel", "x")
+    kwargs.setdefault("ylabel", "y")
+    kwargs.setdefault("zlabel", "z")
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -517,7 +517,7 @@ def test_issue_17405():
     p = plot(f, (x, -10, 10), show=False)
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_logplot_PR_16796():
@@ -528,7 +528,7 @@ def test_logplot_PR_16796():
     p = plot(x, (x, .001, 100), xscale='log', show=False)
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
     assert p[0].end == 100.0
     assert p[0].start == .001
 
@@ -541,7 +541,7 @@ def test_issue_16572():
     p = plot(LambertW(x), show=False)
     # Random number of segments, probably more than 50, but we want to see
     # that there are segments generated, as opposed to when the bug was present
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_issue_11865():
@@ -554,7 +554,7 @@ def test_issue_11865():
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
     # and that there are no exceptions.
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_issue_11461():
@@ -566,7 +566,7 @@ def test_issue_11461():
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
     # and that there are no exceptions.
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_issue_11764():
@@ -578,7 +578,7 @@ def test_issue_11764():
     p.aspect_ratio == (1, 1)
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_issue_13516():
@@ -589,19 +589,19 @@ def test_issue_13516():
 
     pm = plot(sin(x), backend="matplotlib", show=False)
     assert pm.backend == MatplotlibBackend
-    assert len(pm[0].get_segments()) >= 30
+    assert len(pm[0].get_data()[0]) >= 30
 
     pt = plot(sin(x), backend="text", show=False)
     assert pt.backend == TextBackend
-    assert len(pt[0].get_segments()) >= 30
+    assert len(pt[0].get_data()[0]) >= 30
 
     pd = plot(sin(x), backend="default", show=False)
     assert pd.backend == DefaultBackend
-    assert len(pd[0].get_segments()) >= 30
+    assert len(pd[0].get_data()[0]) >= 30
 
     p = plot(sin(x), show=False)
     assert p.backend == DefaultBackend
-    assert len(p[0].get_segments()) >= 30
+    assert len(p[0].get_data()[0]) >= 30
 
 
 def test_plot_limits():
@@ -684,15 +684,15 @@ def test_issue_20113():
         plot(sin(x), backend=Plot, show=False)
     p2 = plot(sin(x), backend=MatplotlibBackend, show=False)
     assert p2.backend == MatplotlibBackend
-    assert len(p2[0].get_segments()) >= 30
+    assert len(p2[0].get_data()[0]) >= 30
     p3 = plot(sin(x), backend=DummyBackendOk, show=False)
     assert p3.backend == DummyBackendOk
-    assert len(p3[0].get_segments()) >= 30
+    assert len(p3[0].get_data()[0]) >= 30
 
     # test for an improper coded backend
     p4 = plot(sin(x), backend=DummyBackendNotOk, show=False)
     assert p4.backend == DummyBackendNotOk
-    assert len(p4[0].get_segments()) >= 30
+    assert len(p4[0].get_data()[0]) >= 30
     with raises(NotImplementedError):
         p4.show()
     with raises(NotImplementedError):

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -699,3 +699,29 @@ def test_issue_20113():
         p4.save("test/path")
     with raises(NotImplementedError):
         p4._backend.close()
+
+def test_custom_coloring():
+    x = Symbol('x')
+    y = Symbol('y')
+    p = plot(cos(x), line_color=lambda a: a)
+    p = plot(cos(x), line_color=1)
+    p = plot(cos(x), line_color="r")
+    p = plot_parametric(cos(x), sin(x), line_color=lambda a: a)
+    p = plot_parametric(cos(x), sin(x), line_color=1)
+    p = plot_parametric(cos(x), sin(x), line_color="r")
+    p = plot3d_parametric_line(cos(x), sin(x), x, line_color=lambda a: a)
+    p = plot3d_parametric_line(cos(x), sin(x), x, line_color=1)
+    p = plot3d_parametric_line(cos(x), sin(x), x, line_color="r")
+    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+            (x, -5, 5), (y, -5, 5),
+            surface_color=lambda a, b: a**2 + b**2)
+    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+            (x, -5, 5), (y, -5, 5),
+            surface_color=1)
+    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+            (x, -5, 5), (y, -5, 5),
+            surface_color="r")
+    p = plot3d(x*y, (x, -5, 5), (y, -5, 5),
+            surface_color=lambda a, b: a**2 + b**2)
+    p = plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color=1)
+    p = plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color="r")

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -703,25 +703,25 @@ def test_issue_20113():
 def test_custom_coloring():
     x = Symbol('x')
     y = Symbol('y')
-    p = plot(cos(x), line_color=lambda a: a)
-    p = plot(cos(x), line_color=1)
-    p = plot(cos(x), line_color="r")
-    p = plot_parametric(cos(x), sin(x), line_color=lambda a: a)
-    p = plot_parametric(cos(x), sin(x), line_color=1)
-    p = plot_parametric(cos(x), sin(x), line_color="r")
-    p = plot3d_parametric_line(cos(x), sin(x), x, line_color=lambda a: a)
-    p = plot3d_parametric_line(cos(x), sin(x), x, line_color=1)
-    p = plot3d_parametric_line(cos(x), sin(x), x, line_color="r")
-    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+    plot(cos(x), line_color=lambda a: a)
+    plot(cos(x), line_color=1)
+    plot(cos(x), line_color="r")
+    plot_parametric(cos(x), sin(x), line_color=lambda a: a)
+    plot_parametric(cos(x), sin(x), line_color=1)
+    plot_parametric(cos(x), sin(x), line_color="r")
+    plot3d_parametric_line(cos(x), sin(x), x, line_color=lambda a: a)
+    plot3d_parametric_line(cos(x), sin(x), x, line_color=1)
+    plot3d_parametric_line(cos(x), sin(x), x, line_color="r")
+    plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
             (x, -5, 5), (y, -5, 5),
             surface_color=lambda a, b: a**2 + b**2)
-    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+    plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
             (x, -5, 5), (y, -5, 5),
             surface_color=1)
-    p = plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
+    plot3d_parametric_surface(cos(x + y), sin(x - y), x - y,
             (x, -5, 5), (y, -5, 5),
             surface_color="r")
-    p = plot3d(x*y, (x, -5, 5), (y, -5, 5),
+    plot3d(x*y, (x, -5, 5), (y, -5, 5),
             surface_color=lambda a, b: a**2 + b**2)
-    p = plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color=1)
-    p = plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color="r")
+    plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color=1)
+    plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color="r")


### PR DESCRIPTION
#### Brief description of what is fixed or changed

1. Modified the Line series classes: now they return data which can
be used directly in matplotlib's plt.plot() method, which support
automatic line coloring. Previously, the format of the data was specific to
Matplotlib's `LineCollection`, which unfortunately doesn't support automatic
line coloring. The new format of the data makes it possible to easily create new
backends.
Back-compatibility has been maintained: it is still possible to apply a function to
the `line_color` attribute in order to create a color gradient.

2. Modified the `plot3d_parametric_line`, `plot3d`, `plot3d_parametric_surface`
methods in order to correctly set the axis labels in 3D plots.

3. Added the `zlabel` attribute to the `Plot` class, which will be rendered
by the backend. Similarly to a 2D plot where, for example, the x-label is set to
`"x"` and the y-label is set by default to `"f(x)"`, this edit will create a default
z-label `'"f(x, y)"` in 3D plots.

4. Modified the MatplotlibBackend class to:
	a. allow for automatic line coloring, while keeping back-compatibility
	with the `line_color` attribute.
	b. set the correct axis labels for 3D plots.

5. Updated the doc-strings associated to the `line_color` attribute.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #19384

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* plotting
  * Automatic line coloring

<!-- END RELEASE NOTES -->
