### PR TITLE
fix(core): fix pickling of Basic to use __getnewargs__

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,7 +7,6 @@ from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import iterable, ordered
-from .singleton import S
 from .kind import UndefinedKind
 from ._print_helpers import Printable
 
@@ -121,19 +120,11 @@ class Basic(Printable, metaclass=ManagedProperties):
     def copy(self):
         return self.func(*self.args)
 
-    def __reduce_ex__(self, proto):
-        """ Pickling support."""
-        return type(self), self.__getnewargs__(), self.__getstate__()
-
     def __getnewargs__(self):
         return self.args
 
     def __getstate__(self):
-        return {}
-
-    def __setstate__(self, state):
-        for k, v in state.items():
-            setattr(self, k, v)
+        return None
 
     def __hash__(self):
         # hash cannot be cached using cache_it because infinite recurrence
@@ -2060,3 +2051,7 @@ def _make_find_query(query):
     elif isinstance(query, Basic):
         return lambda expr: expr.match(query) is not None
     return query
+
+
+# Delayed to avoid cyclic import
+from .singleton import S

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -126,6 +126,12 @@ class Basic(Printable, metaclass=ManagedProperties):
     def __getstate__(self):
         return None
 
+    def __reduce_ex__(self, protocol):
+        if protocol < 2:
+            msg = "Only pickle protocol 2 or higher is supported by sympy"
+            raise NotImplementedError(msg)
+        return super().__reduce_ex__(protocol)
+
     def __hash__(self):
         # hash cannot be cached using cache_it because infinite recurrence
         # occurs as hash is needed for setting cache dictionary keys

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1206,11 +1206,8 @@ class Float(Number):
         return obj
 
     # mpz can't be pickled
-    def __getnewargs__(self):
-        return (mlib.to_pickable(self._mpf_),)
-
-    def __getstate__(self):
-        return {'_prec': self._prec}
+    def __getnewargs_ex__(self):
+        return ((mlib.to_pickable(self._mpf_),), {'precision': self._prec})
 
     def _hashable_content(self):
         return (self._mpf_, self._prec)
@@ -2665,6 +2662,7 @@ class One(IntegerConstant, metaclass=Singleton):
     .. [1] https://en.wikipedia.org/wiki/1_%28number%29
     """
     is_number = True
+    is_positive = True
 
     p = 1
     q = 1

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -171,26 +171,14 @@ class Singleton(ManagedProperties):
     subclasses to have a different metaclass than the superclass, except the
     subclass may use a subclassed metaclass).
     """
+    def __init__(cls, *args, **kwargs):
+        super().__init__(cls, *args, **kwargs)
+        cls._instance = obj = Basic.__new__(cls)
+        cls.__new__ = lambda cls: obj
+        cls.__getnewargs__ = lambda obj: ()
+        cls.__getstate__ = lambda obj: None
+        S.register(cls)
 
-    _instances = {}  # type: Dict[Type[Any], Any]
-    "Maps singleton classes to their instances."
 
-    def __new__(cls, *args, **kwargs):
-        result = super().__new__(cls, *args, **kwargs)
-        S.register(result)
-        return result
-
-    def __call__(self, *args, **kwargs):
-        # Called when application code says SomeClass(), where SomeClass is a
-        # class of which Singleton is the metaclas.
-        # __call__ is invoked first, before __new__() and __init__().
-        if self not in Singleton._instances:
-            Singleton._instances[self] = \
-                super().__call__(*args, **kwargs)
-                # Invokes the standard constructor of SomeClass.
-        return Singleton._instances[self]
-
-        # Inject pickling support.
-        def __getnewargs__(self):
-            return ()
-        self.__getnewargs__ = __getnewargs__
+# Delayed to avoid cyclic import
+from .basic import Basic

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -1,8 +1,6 @@
 """Singleton mechanism"""
 
 
-from typing import Any, Dict, Type
-
 from .core import Registry
 from .assumptions import ManagedProperties
 from .sympify import sympify

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -300,11 +300,8 @@ class Symbol(AtomicExpr, Boolean):
     __xnew_cached_ = staticmethod(
         cacheit(__new_stage2__))   # symbols are always cached
 
-    def __getnewargs__(self):
-        return (self.name,)
-
-    def __getstate__(self):
-        return {'_assumptions': self._assumptions}
+    def __getnewargs_ex__(self):
+        return ((self.name,), self.assumptions0)
 
     def _hashable_content(self):
         # Note: user-specified assumptions not hashed, just derived ones
@@ -414,8 +411,8 @@ class Dummy(Symbol):
 
         return obj
 
-    def __getstate__(self):
-        return {'_assumptions': self._assumptions, 'dummy_index': self.dummy_index}
+    def __getnewargs_ex__(self):
+        return ((self.name, self.dummy_index), self.assumptions0)
 
     @cacheit
     def sort_key(self, order=None):

--- a/sympy/core/tests/test_singleton.py
+++ b/sympy/core/tests/test_singleton.py
@@ -3,28 +3,19 @@ from sympy.core.numbers import Rational
 from sympy.core.singleton import S, Singleton
 
 def test_Singleton():
-    global instantiated
-    instantiated = 0
 
     class MySingleton(Basic, metaclass=Singleton):
-        def __new__(cls):
-            global instantiated
-            instantiated += 1
-            return Basic.__new__(cls)
+        pass
 
-    assert instantiated == 0
     MySingleton() # force instantiation
-    assert instantiated == 1
     assert MySingleton() is not Basic()
     assert MySingleton() is MySingleton()
     assert S.MySingleton is MySingleton()
-    assert instantiated == 1
 
     class MySingleton_sub(MySingleton):
         pass
-    assert instantiated == 1
+
     MySingleton_sub()
-    assert instantiated == 2
     assert MySingleton_sub() is not MySingleton()
     assert MySingleton_sub() is MySingleton_sub()
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -42,17 +42,16 @@ class IdentityFunction(Lambda, metaclass=Singleton):
 
     """
 
-    def __new__(cls):
-        x = Dummy('x')
-        #construct "by hand" to avoid infinite loop
-        return Expr.__new__(cls, Tuple(x), x)
+    _symbol = Dummy('x')
 
     @property
-    def args(self):
-        return ()
+    def signature(self):
+        return Tuple(self._symbol)
 
-    def __getnewargs__(self):
-        return ()
+    @property
+    def expr(self):
+        return self._symbol
+
 
 Id = S.IdentityFunction
 

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -131,8 +131,11 @@ class Pauli(Symbol):
         obj.label = label
         return obj
 
-    def __getnewargs__(self):
-        return (self.i,self.label,)
+    def __getnewargs_ex__(self):
+        return (self.i, self.label), {}
+
+    def _hashable_content(self):
+        return (self.i, self.label)
 
     # FIXME don't work for -I*Pauli(2)*Pauli(3)
     def __mul__(self, other):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -255,8 +255,21 @@ class Reals(Interval, metaclass=Singleton):
 
     ComplexRegion
     """
-    def __new__(cls):
-        return Interval.__new__(cls, S.NegativeInfinity, S.Infinity)
+    @property
+    def start(self):
+        return S.NegativeInfinity
+
+    @property
+    def end(self):
+        return S.Infinity
+
+    @property
+    def left_open(self):
+        return True
+
+    @property
+    def right_open(self):
+        return True
 
     def __eq__(self, other):
         return other == Interval(S.NegativeInfinity, S.Infinity)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -971,23 +971,6 @@ class Interval(Set):
         """
         return self._args[0]
 
-    _inf = left = start
-
-    @classmethod
-    def open(cls, a, b):
-        """Return an interval including neither boundary."""
-        return cls(a, b, True, True)
-
-    @classmethod
-    def Lopen(cls, a, b):
-        """Return an interval not including the left boundary."""
-        return cls(a, b, True, False)
-
-    @classmethod
-    def Ropen(cls, a, b):
-        """Return an interval not including the right boundary."""
-        return cls(a, b, False, True)
-
     @property
     def end(self):
         """
@@ -1004,8 +987,6 @@ class Interval(Set):
 
         """
         return self._args[1]
-
-    _sup = right = end
 
     @property
     def left_open(self):
@@ -1040,6 +1021,37 @@ class Interval(Set):
 
         """
         return self._args[3]
+
+    @classmethod
+    def open(cls, a, b):
+        """Return an interval including neither boundary."""
+        return cls(a, b, True, True)
+
+    @classmethod
+    def Lopen(cls, a, b):
+        """Return an interval not including the left boundary."""
+        return cls(a, b, True, False)
+
+    @classmethod
+    def Ropen(cls, a, b):
+        """Return an interval not including the right boundary."""
+        return cls(a, b, False, True)
+
+    @property
+    def _inf(self):
+        return self.start
+
+    @property
+    def _sup(self):
+        return self.end
+
+    @property
+    def left(self):
+        return self.start
+
+    @property
+    def right(self):
+        return self.end
 
     @property
     def is_empty(self):

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -4,7 +4,7 @@ import pickle
 
 from sympy.physics.units import meter
 
-from sympy.testing.pytest import XFAIL
+from sympy.testing.pytest import XFAIL, raises
 
 from sympy.core.basic import Atom, Basic
 from sympy.core.core import BasicMeta
@@ -40,6 +40,11 @@ excluded_attrs = {
 def check(a, exclude=[], check_attr=True):
     """ Check that pickling and copying round-trips.
     """
+    # Pickling with protocols 0 and 1 is disabled for Basic instances:
+    if isinstance(a, Basic):
+        for protocol in [0, 1]:
+            raises(NotImplementedError, lambda: pickle.dumps(a, protocol))
+
     protocols = [2, copy.copy, copy.deepcopy, 3, 4]
     if cloudpickle:
         protocols.extend([cloudpickle])

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -40,7 +40,7 @@ excluded_attrs = {
 def check(a, exclude=[], check_attr=True):
     """ Check that pickling and copying round-trips.
     """
-    protocols = [0, 1, 2, copy.copy, copy.deepcopy, 3, 4]
+    protocols = [2, copy.copy, copy.deepcopy, 3, 4]
     if cloudpickle:
         protocols.extend([cloudpickle])
 


### PR DESCRIPTION
This ensures that pickling of Basic subclasses is based on
`__getnewargs__` with the exception of Symbol that uses `__getnewargs_ex__`
for keyword argument support. The changes here fix pickling using
protocol 2 or higher but remove support for pickling using protocol 0
or 1. Protocol 2 was introduced in Python 2.3.

A number of classes needed to be rearranged or tidied up to accommodate for
this including Singleton and some of the Singleton class such as Reals.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21121 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Fixed pickling for a number of Basic subclasses (such as a Symbol with assumptions) for protocol 2 or higher. Removed support for pickling with protocol 0 or 1.
<!-- END RELEASE NOTES -->
