### PR TITLE
Improve frame caching

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -535,20 +535,21 @@ class ReferenceFrame:
         frames = self._dcm_cache.keys()
         dcm_dict_del = []
         dcm_cache_del = []
-        for frame in frames:
-            if frame in self._dcm_dict:
-                dcm_dict_del += [frame]
-            dcm_cache_del += [frame]
-        for frame in dcm_dict_del:
-            del frame._dcm_dict[self]
-        for frame in dcm_cache_del:
-            del frame._dcm_cache[self]
+        if parent in frames:
+            for frame in frames:
+                if frame in self._dcm_dict:
+                    dcm_dict_del += [frame]
+                dcm_cache_del += [frame]
+            for frame in dcm_dict_del:
+                del frame._dcm_dict[self]
+            for frame in dcm_cache_del:
+                del frame._dcm_cache[self]
         # Add the dcm relationship to _dcm_dict
-        self._dcm_dict = self._dlist[0] = {}
+            self._dcm_dict = self._dlist[0] = {}
+            self._dcm_cache = {}
         self._dcm_dict.update({parent: parent_orient.T})
         parent._dcm_dict.update({self: parent_orient})
         # Also update the dcm cache after resetting it
-        self._dcm_cache = {}
         self._dcm_cache.update({parent: parent_orient.T})
         parent._dcm_cache.update({self: parent_orient})
 
@@ -887,7 +888,7 @@ class ReferenceFrame:
         >>> B1.orient_axis(N, N.z, q1)
         >>> B2.orient_axis(B1, N.x, q2)
         >>> B.orient_axis(B2, N.y, q3)
-        >>> B.dcm(N).simplify() # doctest: +SKIP
+        >>> B.dcm(N).simplify()
         Matrix([
         [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
         [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -190,9 +190,9 @@ class ReferenceFrame:
             self.latex_vecs = latexs
         self.name = name
         self._var_dict = {}
-        #The _dcm_dict dictionary will only store the dcms of parent-child
-        #relationships. The _dcm_cache dictionary will work as the dcm
-        #cache.
+        #The _dcm_dict dictionary will only store the dcms of immediate parent-child
+        #relationships. The _dcm_cache dictionary will store calculated dcm along with
+        #all content of _dcm_dict for faster retrieval of dcms.
         self._dcm_dict = {}
         self._dcm_cache = {}
         self._ang_vel_dict = {}
@@ -529,9 +529,12 @@ class ReferenceFrame:
         return outdcm
 
     def _dcm(self, parent, parent_orient):
-        # Reset the _dcm_cache of this frame, and remove it from the
-        # _dcm_caches of the frames it is linked to. Also remove it from the
-        # _dcm_dict of its parent
+        # If parent.oreint(self) is already defined,then
+        # update the _dcm_dict of parent while over write
+        # all content of self._dcm_dict and self._dcm_cache
+        # with new dcm relation.
+        # else update _dcm_cache and _dcm_dict of both
+        # self and parent.
         frames = self._dcm_cache.keys()
         dcm_dict_del = []
         dcm_cache_del = []
@@ -540,16 +543,21 @@ class ReferenceFrame:
                 if frame in self._dcm_dict:
                     dcm_dict_del += [frame]
                 dcm_cache_del += [frame]
+            # Reset the _dcm_cache of this frame, and remove it from the
+            # _dcm_caches of the frames it is linked to. Also remove it from the
+            # _dcm_dict of its parent
             for frame in dcm_dict_del:
                 del frame._dcm_dict[self]
             for frame in dcm_cache_del:
                 del frame._dcm_cache[self]
-        # Add the dcm relationship to _dcm_dict
+        # Reset the _dcm_dict
             self._dcm_dict = self._dlist[0] = {}
+        # Reset the _dcm_cache
             self._dcm_cache = {}
+        # Add the dcm relationship to _dcm_dict
         self._dcm_dict.update({parent: parent_orient.T})
         parent._dcm_dict.update({self: parent_orient})
-        # Also update the dcm cache after resetting it
+        # Update the dcm cache
         self._dcm_cache.update({parent: parent_orient.T})
         parent._dcm_cache.update({self: parent_orient})
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -190,7 +190,7 @@ class ReferenceFrame:
             self.latex_vecs = latexs
         self.name = name
         self._var_dict = {}
-        #The _dcm_dict dictionary will only store the dcms of immediate parent-child
+        #The _dcm_dict dictionary will only store the dcms of adjacent parent-child
         #relationships. The _dcm_cache dictionary will store calculated dcm along with
         #all content of _dcm_dict for faster retrieval of dcms.
         self._dcm_dict = {}
@@ -533,7 +533,7 @@ class ReferenceFrame:
         # update the _dcm_dict of parent while over write
         # all content of self._dcm_dict and self._dcm_cache
         # with new dcm relation.
-        # else update _dcm_cache and _dcm_dict of both
+        # Else update _dcm_cache and _dcm_dict of both
         # self and parent.
         frames = self._dcm_cache.keys()
         dcm_dict_del = []

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -479,19 +479,19 @@ def test_vector_cache():
 
     a, b, c = symbols('a b c')
 
-    B.orient(A, 'Axis', (a, A.x))
+    B.orient_axis(A, A.x, a)
     assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(a), -sin(a)],[0, sin(a),  cos(a)]])}
     assert B._dcm_dict == {A: Matrix([[1, 0, 0],[0,  cos(a), sin(a)],[0, -sin(a), cos(a)]])}
     assert C._dcm_dict == {}
 
-    B.orient(C, 'Axis', (b, C.x))
+    B.orient_axis(C, C.x, b)
     # Previous relation is not wiped
     assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(a), -sin(a)],[0, sin(a),  cos(a)]])}
     assert B._dcm_dict == {A: Matrix([[1, 0, 0],[0,  cos(a), sin(a)],[0, -sin(a), cos(a)]]), \
         C: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]])}
     assert C._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}
 
-    A.orient(B, 'Axis', (c, B.x))
+    A.orient_axis(B, B.x, c)
     # Previous relation is updated
     assert B._dcm_dict == {C: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]]),\
         A: Matrix([[1, 0, 0],[0, cos(c), -sin(c)],[0, sin(c),  cos(c)]])}

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -480,20 +480,20 @@ def test_vector_cache():
     a, b, c = symbols('a b c')
 
     B.orient(A, 'Axis', (a, A.x))
-    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(a), -sin(a)], [0, sin(a), cos(a)]])
-    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(a), sin(a)], [0, -sin(a), cos(a)]])
+    assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(a), -sin(a)],[0, sin(a),  cos(a)]])}
+    assert B._dcm_dict == {A: Matrix([[1, 0, 0],[0,  cos(a), sin(a)],[0, -sin(a), cos(a)]])}
     assert C._dcm_dict == {}
 
     B.orient(C, 'Axis', (b, C.x))
     # Previous relation is not wiped
-    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(a), -sin(a)], [0, sin(a), cos(a)]])
-    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(a), sin(a)], [0, -sin(a), cos(a)]])
-    assert B._dcm_dict[C] == Matrix([[1, 0, 0], [0, cos(b), sin(b)], [0, -sin(b), cos(b)]])
-    assert C._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(b), -sin(b)], [0, sin(b), cos(b)]])
+    assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(a), -sin(a)],[0, sin(a),  cos(a)]])}
+    assert B._dcm_dict == {A: Matrix([[1, 0, 0],[0,  cos(a), sin(a)],[0, -sin(a), cos(a)]]), \
+        C: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]])}
+    assert C._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}
 
     A.orient(B, 'Axis', (c, B.x))
     # Previous relation is updated
-    assert B._dcm_dict[C] == Matrix([[1, 0, 0], [0, cos(b), sin(b)], [0, -sin(b), cos(b)]])
-    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(c), sin(c)], [0, -sin(c), cos(c)]])
-    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(c), -sin(c)], [0, sin(c), cos(c)]])
-    assert C._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(b), -sin(b)], [0, sin(b), cos(b)]])
+    assert B._dcm_dict == {C: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]]),\
+        A: Matrix([[1, 0, 0],[0, cos(c), -sin(c)],[0, sin(c),  cos(c)]])}
+    assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0,  cos(c), sin(c)],[0, -sin(c), cos(c)]])}
+    assert C._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -471,3 +471,29 @@ def test_orient_quaternion():
     B = ReferenceFrame('B')
     B.orient_quaternion(A, (0,0,0,0))
     assert B.dcm(A) == Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+def test_vector_cache():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
+
+    a, b, c = symbols('a b c')
+
+    B.orient(A, 'Axis', (a, A.x))
+    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(a), -sin(a)], [0, sin(a), cos(a)]])
+    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(a), sin(a)], [0, -sin(a), cos(a)]])
+    assert C._dcm_dict == {}
+
+    B.orient(C, 'Axis', (b, C.x))
+    # Previous relation is not wiped
+    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(a), -sin(a)], [0, sin(a), cos(a)]])
+    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(a), sin(a)], [0, -sin(a), cos(a)]])
+    assert B._dcm_dict[C] == Matrix([[1, 0, 0], [0, cos(b), sin(b)], [0, -sin(b), cos(b)]])
+    assert C._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(b), -sin(b)], [0, sin(b), cos(b)]])
+
+    A.orient(B, 'Axis', (c, B.x))
+    # Previous relation is updated
+    assert B._dcm_dict[C] == Matrix([[1, 0, 0], [0, cos(b), sin(b)], [0, -sin(b), cos(b)]])
+    assert A._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(c), sin(c)], [0, -sin(c), cos(c)]])
+    assert B._dcm_dict[A] == Matrix([[1, 0, 0], [0, cos(c), -sin(c)], [0, sin(c), cos(c)]])
+    assert C._dcm_dict[B] == Matrix([[1, 0, 0], [0, cos(b), -sin(b)], [0, sin(b), cos(b)]])

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -497,3 +497,37 @@ def test_vector_cache():
         A: Matrix([[1, 0, 0],[0, cos(c), -sin(c)],[0, sin(c),  cos(c)]])}
     assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0,  cos(c), sin(c)],[0, -sin(c), cos(c)]])}
     assert C._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}
+
+def test_dcm_cache_dict():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
+    D = ReferenceFrame('D')
+
+    a, b, c = symbols('a b c')
+
+    B.orient_axis(A, A.x, a)
+    C.orient_axis(B, B.x, b)
+    D.orient_axis(C, C.x, c)
+
+    assert D._dcm_dict == {C: Matrix([[1, 0, 0],[0,  cos(c), sin(c)],[0, -sin(c), cos(c)]])}
+    assert C._dcm_dict == {B: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]]), \
+        D: Matrix([[1, 0, 0],[0, cos(c), -sin(c)],[0, sin(c),  cos(c)]])}
+    assert B._dcm_dict == {A: Matrix([[1, 0, 0],[0,  cos(a), sin(a)],[0, -sin(a), cos(a)]]), \
+        C: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}
+    assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0, cos(a), -sin(a)],[0, sin(a),  cos(a)]])}
+
+    assert D._dcm_dict == D._dcm_cache
+
+    D.dcm(A) # Check calculated dcm relation is stored in _dcm_cache and not in _dcm_dict
+    assert list(A._dcm_cache.keys()) == [A, B, D]
+    assert list(D._dcm_cache.keys()) == [C, A]
+    assert list(A._dcm_dict.keys()) == [B]
+    assert list(D._dcm_dict.keys()) == [C]
+    assert A._dcm_dict != A._dcm_cache
+
+    A.orient_axis(B, B.x, b) # _dcm_cache of A is wiped out and new relation is stored.
+    assert A._dcm_dict == {B: Matrix([[1, 0, 0],[0,  cos(b), sin(b)],[0, -sin(b), cos(b)]])}
+    assert A._dcm_dict == A._dcm_cache
+    assert B._dcm_dict == {C: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]]), \
+        A: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -472,7 +472,7 @@ def test_orient_quaternion():
     B.orient_quaternion(A, (0,0,0,0))
     assert B.dcm(A) == Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
 
-def test_vector_cache():
+def test_frame_dict():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
     C = ReferenceFrame('C')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20955
Partial #21036

#### Brief description of what is fixed or changed
Updated `frame._dcm()` to support orienting adjacent reference frame in arbitrary order. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * Reference frames can be oriented in arbitrary order.
<!-- END RELEASE NOTES -->
