### PR TITLE
updates to `unrad`, `continuous_domain`, `roots_(cubic, quartic, quintic)`

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -71,6 +71,8 @@ def test_continuous_domain():
     domain = continuous_domain(log(tan(x)**2 + 1), x, S.Reals)
     assert not domain.contains(3*pi/2)
     assert domain.contains(5)
+    d = Symbol('d', even=True, zero=False)
+    assert continuous_domain(x**(1/d), x, S.Reals) == Interval(0, oo)
 
 
 def test_not_empty_in():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -300,6 +300,12 @@ def test_minimum():
     raises(ValueError, lambda : minimum(sin(x), S.One))
 
 
+def test_issue_19869():
+    t = symbols('t')
+    assert (maximum(sqrt(3)*(t - 1)/(3*sqrt(t**2 + 1)), t)
+        ) == sqrt(3)/3
+
+
 def test_AccumBounds():
     assert AccumBounds(1, 2).args == (1, 2)
     assert AccumBounds(1, 2).delta is S.One

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -64,14 +64,13 @@ def continuous_domain(f, symbol, domain):
 
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
-    from sympy.solvers.solveset import _has_rational_power
     from sympy.calculus.singularities import singularities
 
     if domain.is_subset(S.Reals):
         constrained_interval = domain
         for atom in f.atoms(Pow):
-            predicate, denomin = _has_rational_power(atom, symbol)
-            if predicate and denomin == 2:
+            den = atom.exp.as_numer_denom()[1]
+            if den.is_even and den.is_nonzero:
                 constraint = solve_univariate_inequality(atom.base >= 0,
                                                          symbol).as_set()
                 constrained_interval = Intersection(constraint,

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -512,6 +512,8 @@ def roots_quintic(f):
         if not all(coeff.is_Rational for coeff in l):
             return result
         f = Poly(f/coeff_5)
+    elif not all(coeff.is_Rational for coeff in (p, q, r, s)):
+        return result
     quintic = PolyQuintic(f)
 
     # Eqn standardized. Algo for solving starts here

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -341,6 +341,12 @@ def roots_quartic(f):
                         ans.append((s*w - t*root)/2 - aon4)
                 return ans
 
+            # whether a Piecewise is returned or not
+            # depends on knowing p, so try to put
+            # in a simple form
+            p = _mexpand(p)
+
+
             # p == 0 case
             y1 = e*Rational(-5, 6) - q**TH
             if p.is_zero:

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -131,12 +131,14 @@ def roots_cubic(f, trig=False):
                 rv.append(2*sqrt(-p/3)*cos(acos(q/p*sqrt(-3/p)*Rational(3, 2))/3 - k*pi*Rational(2, 3)))
             return [i - b/3/a for i in rv]
 
+    # a*x**3 + b*x**2 + c*x + d -> x**3 + a*x**2 + b*x + c
     _, a, b, c = f.monic().all_coeffs()
 
     if c is S.Zero:
         x1, x2 = roots([1, a, b], multiple=True)
         return [x1, S.Zero, x2]
 
+    # x**3 + a*x**2 + b*x + c -> u**3 + p*u + q
     p = b - a**2/3
     q = c - a*b/3 + 2*a**3/27
 
@@ -147,11 +149,7 @@ def roots_cubic(f, trig=False):
     if p is S.Zero:
         if q is S.Zero:
             return [-aon3]*3
-        if q.is_real:
-            if q.is_positive:
-                u1 = -root(q, 3)
-            elif q.is_negative:
-                u1 = root(-q, 3)
+        u1 = -root(q, 3) if q.is_positive else root(-q, 3)
     elif q is S.Zero:
         y1, y2 = roots([1, 0, p], multiple=True)
         return [tmp - aon3 for tmp in [y1, S.Zero, y2]]

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6118,7 +6118,7 @@ def to_rational_coeffs(f):
         f1 = f1 or f1.monic()
         coeffs = f1.all_coeffs()[1:]
         coeffs = [simplify(coeffx) for coeffx in coeffs]
-        if coeffs[-2]:
+        if len(coeffs) > 1 and coeffs[-2]:
             rescale1_x = simplify(coeffs[-2]/coeffs[-1])
             coeffs1 = []
             for i in range(len(coeffs)):
@@ -6145,22 +6145,16 @@ def to_rational_coeffs(f):
         ``alpha`` is the translating factor, and ``f`` is the shifted
         polynomial; else ``alpha`` is ``None``.
         """
-        from sympy.core.add import Add
         if not len(f.gens) == 1 or not (f.gens[0]).is_Atom:
             return None, f
         n = f.degree()
         f1 = f1 or f1.monic()
         coeffs = f1.all_coeffs()[1:]
         c = simplify(coeffs[0])
-        if c and not c.is_rational:
-            func = Add
-            if c.is_Add:
-                args = c.args
-                func = c.func
-            else:
-                args = [c]
-            c1, c2 = sift(args, lambda z: z.is_rational, binary=True)
-            alpha = -func(*c2)/n
+        if c.is_Add and not c.is_rational:
+            rat, nonrat = sift(c.args,
+                lambda z: z.is_rational is True, binary=True)
+            alpha = -c.func(*nonrat)/n
             f2 = f1.shift(alpha)
             return alpha, f2
         return None

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -153,6 +153,7 @@ def test_issue_16589():
     roots_eq = roots(eq)
     assert 0 in roots_eq
 
+
 def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]
     assert roots_cubic(Poly(x**3 - 3*x**2 + 3*x - 1, x)) == [1, 1, 1]
@@ -232,6 +233,11 @@ def test_roots_quartic():
     for rep in reps:
         sol = roots_quartic(Poly(eq.subs(rep), x))
         assert all([verify_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol)])
+
+
+def test_issue_21287():
+    assert not any(isinstance(i, Piecewise) for i in roots_quartic(
+        Poly(x**4 - x**2*(3 + 5*I) + 2*x*(-1 + I) - 1 + 3*I, x)))
 
 
 def test_roots_cyclotomic():

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -157,7 +157,13 @@ def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]
     assert roots_cubic(Poly(x**3 - 3*x**2 + 3*x - 1, x)) == [1, 1, 1]
 
-    assert roots_cubic(Poly(x**3 + 1, x)) == \
+    # valid for arbitrary y (issue 21263)
+    r = root(y, 3)
+    assert roots_cubic(Poly(x**3 - y, x)) == [r,
+        r*(-S.Half + sqrt(3)*I/2),
+        r*(-S.Half - sqrt(3)*I/2)]
+    # simpler form when y is negative
+    assert roots_cubic(Poly(x**3 - -1, x)) == \
         [-1, S.Half - I*sqrt(3)/2, S.Half + I*sqrt(3)/2]
     assert roots_cubic(Poly(2*x**3 - 3*x**2 - 3*x - 1, x))[0] == \
          S.Half + 3**Rational(1, 3)/2 + 3**Rational(2, 3)/2
@@ -537,8 +543,8 @@ def test_roots0():
     assert roots(eq) == {-2*sqrt(2) + 2: 1, -2*sqrt(2) + 1: 1, -2*sqrt(2) - 1: 1}
 
     assert roots(Poly((x + sqrt(2))**3 - 7, x, domain='EX')) == \
-        {-sqrt(2) - root(7, 3)/2 - sqrt(3)*root(7, 3)*I/2: 1,
-         -sqrt(2) - root(7, 3)/2 + sqrt(3)*root(7, 3)*I/2: 1,
+        {-sqrt(2) + root(7, 3)*(-S.Half - sqrt(3)*I/2): 1,
+         -sqrt(2) + root(7, 3)*(-S.Half + sqrt(3)*I/2): 1,
          -sqrt(2) + root(7, 3): 1}
 
 def test_roots_slow():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3349,6 +3349,12 @@ def test_noncommutative():
 def test_to_rational_coeffs():
     assert to_rational_coeffs(
         Poly(x**3 + y*x**2 + sqrt(y), x, domain='EX')) is None
+    # issue 21268
+    assert to_rational_coeffs(
+        Poly(y**3 + sqrt(2)*y**2*sin(x) + 1, y)) is None
+
+    assert to_rational_coeffs(Poly(x, y)) is None
+    assert to_rational_coeffs(Poly(sqrt(2)*y)) is None
 
 
 def test_factor_terms():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3283,8 +3283,7 @@ def unrad(eq, *syms, **flags):
     _take = flags.setdefault('_take', _take)
 
     if isinstance(eq, Eq):
-        eq = eq.rewrite(Add)
-        assert isinstance(eq, Expr)
+        eq = eq.lhs - eq.rhs  # XXX legacy Eq as Eqn support
     elif not isinstance(eq, Expr):
         return
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -42,7 +42,7 @@ from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1, TR2i
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
-from sympy.polys import roots, cancel, factor, Poly, degree
+from sympy.polys import roots, cancel, factor, Poly
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
@@ -3207,12 +3207,13 @@ def unrad(eq, *syms, **flags):
     >>> unrad(sqrt(x)*x**Rational(1, 3) + 2)
     (x**5 - 64, [])
     >>> unrad(sqrt(x) + root(x + 1, 3))
-    (x**3 - x**2 - 2*x - 1, [])
+    (-x**3 + x**2 + 2*x + 1, [])
     >>> eq = sqrt(x) + root(x, 3) - 2
     >>> unrad(eq)
     (_p**3 + _p**2 - 2, [_p, _p**6 - x])
 
     """
+    from sympy import Equality as Eq
 
     uflags = dict(check=False, simplify=False)
 
@@ -3243,19 +3244,21 @@ def unrad(eq, *syms, **flags):
             for f in eq.args:
                 if f.is_number:
                     continue
-                if f.is_Pow and _take(f, True):
+                if f.is_Pow:
                     args.append(f.base)
                 else:
                     args.append(f)
             eq = Mul(*args)  # leave as Mul for more efficient solving
 
         # make the sign canonical
-        free = eq.free_symbols
-        if len(free) == 1:
-            if eq.coeff(free.pop()**degree(eq)).could_extract_minus_sign():
-                eq = -eq
-        elif eq.could_extract_minus_sign():
-            eq = -eq
+        margs = list(Mul.make_args(eq))
+        changed = False
+        for i, m in enumerate(margs):
+            if m.could_extract_minus_sign():
+                margs[i] = -m
+                changed = True
+        if changed:
+            eq = Mul(*margs, evaluate=False)
 
         return eq, cov
 
@@ -3267,52 +3270,46 @@ def unrad(eq, *syms, **flags):
         return c.q
 
     # define the _take method that will determine whether a term is of interest
-    def _take(d, take_int_pow):
+    def _take(d):
         # return True if coefficient of any factor's exponent's den is not 1
         for pow in Mul.make_args(d):
-            if not (pow.is_Symbol or pow.is_Pow):
+            if not pow.is_Pow:
                 continue
-            b, e = pow.as_base_exp()
-            if not b.has(*syms):
+            if _Q(pow) == 1:
                 continue
-            if not take_int_pow and _Q(pow) == 1:
-                continue
-            free = pow.free_symbols
-            if free.intersection(syms):
+            if pow.free_symbols & syms:
                 return True
         return False
     _take = flags.setdefault('_take', _take)
+
+    if isinstance(eq, Eq):
+        eq = eq.rewrite(Add)
+        assert isinstance(eq, Expr)
+    elif not isinstance(eq, Expr):
+        return
 
     cov, nwas, rpt = [flags.setdefault(k, v) for k, v in
         sorted(dict(cov=[], n=None, rpt=0).items())]
 
     # preconditioning
     eq = powdenest(factor_terms(eq, radical=True, clear=True))
-
-    if isinstance(eq, Relational):
-        eq, d = eq, 1
-    else:
-        eq, d = eq.as_numer_denom()
-
+    eq = eq.as_numer_denom()[0]
     eq = _mexpand(eq, recursive=True)
     if eq.is_number:
-        return eq, []
+        return
 
-    syms = set(syms) or eq.free_symbols
+    # see if there are radicals in symbols of interest
+    syms = set(syms) or eq.free_symbols  # _take uses this
     poly = eq.as_poly()
-    gens = [g for g in poly.gens if _take(g, True)]
+    gens = [g for g in poly.gens if _take(g)]
     if not gens:
         return
 
-    # check for trivial case
-    # - already a polynomial in integer powers
-    if all(_Q(g) == 1 for g in gens):
-        if (len(gens) == len(poly.gens) and d!=1):
-            return eq, []
-        else:
-            return
+    # recast poly in terms of eigen-gens
+    poly = eq.as_poly(*gens)
+
     # - an exponent has a symbol of interest (don't handle)
-    if any(g.as_base_exp()[1].has(*syms) for g in gens):
+    if any(g.exp.has(*syms) for g in gens):
         return
 
     def _rads_bases_lcm(poly):
@@ -3323,8 +3320,6 @@ def unrad(eq, *syms, **flags):
         rads = set()
         bases = set()
         for g in poly.gens:
-            if not _take(g, False):
-                continue
             q = _Q(g)
             if q != 1:
                 rads.add(g)
@@ -3332,9 +3327,6 @@ def unrad(eq, *syms, **flags):
                 bases.add(g.base)
         return rads, bases, lcm
     rads, bases, lcm = _rads_bases_lcm(poly)
-
-    if not rads:
-        return
 
     covsym = Dummy('p', nonnegative=True)
 
@@ -3352,7 +3344,7 @@ def unrad(eq, *syms, **flags):
     rterms = {(): []}
     args = Add.make_args(poly.as_expr())
     for t in args:
-        if _take(t, False):
+        if _take(t):
             common = set(t.as_poly().gens).intersection(rads)
             key = tuple(sorted([drad[i] for i in common]))
         else:
@@ -3377,14 +3369,10 @@ def unrad(eq, *syms, **flags):
         if len(bases) == 1:
             b = bases.pop()
             if len(syms) > 1:
-                free = b.free_symbols
-                x = {g for g in gens if g.is_Symbol} & free
-                if not x:
-                    x = free
-                x = ordered(x)
+                x = b.free_symbols
             else:
                 x = syms
-            x = list(x)[0]
+            x = list(ordered(x))[0]
             try:
                 inv = _solve(covsym**lcm - b, x, **uflags)
                 if not inv:
@@ -3394,9 +3382,6 @@ def unrad(eq, *syms, **flags):
                 return _canonical(eq, cov)
             except NotImplementedError:
                 pass
-        else:
-            # no longer consider integer powers as generators
-            gens = [g for g in gens if _Q(g) != 1]
 
         if len(rterms) == 2:
             if not others:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -284,6 +284,11 @@ def test_quintics_2():
         CRootOf(x**5 - 6*x**3 - 6*x**2 + x - 6, 4)]
 
 
+def test_quintics_3():
+    y = x**5 + x**3 - 2**Rational(1, 3)
+    assert solve(y) == solve(-y) == []
+
+
 def test_highorder_poly():
     # just testing that the uniq generator is unpacked
     sol = solve(x**6 - 2*x + 2)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -973,6 +973,7 @@ def test_unrad1():
         return str(rv[0]) in [str(ans[0]), str(-ans[0])] and \
             str(rv[1]) == str(ans[1])
 
+    assert unrad(1) is None
     assert check(unrad(sqrt(x)),
         (x, []))
     assert check(unrad(sqrt(x) + 1),
@@ -1056,7 +1057,7 @@ def test_unrad1():
     assert solve(p + 6*I) == []
     # issue 8622
     assert unrad(root(x + 1, 5) - root(x, 3)) == (
-        x**5 - x**3 - 3*x**2 - 3*x - 1, [])
+        -(x**5 - x**3 - 3*x**2 - 3*x - 1), [])
     # issue #8679
     assert check(unrad(x + root(x, 3) + root(x, 3)**2 + sqrt(y), x),
         (s**3 + s**2 + s + sqrt(y), [s, s**3 - x]))
@@ -1129,14 +1130,21 @@ def test_unrad1():
         (s**12 - 2*s**8 - 8*s**7 - 8*s**6 + s**4 + 8*s**3 + 23*s**2 +
         32*s + 17, [s, s**6 - x]))
 
-    # is this needed?
-    #assert unrad(root(cosh(x), 3)/x*root(x + 1, 5) - 1) == (
-    #    x**15 - x**3*cosh(x)**5 - 3*x**2*cosh(x)**5 - 3*x*cosh(x)**5 - cosh(x)**5, [])
-    raises(NotImplementedError, lambda:
-        unrad(sqrt(cosh(x)/x) + root(x + 1,3)*sqrt(x) - 1))
+    # why does this pass
+    assert unrad(root(cosh(x), 3)/x*root(x + 1, 5) - 1) == (
+        -(x**15 - x**3*cosh(x)**5 - 3*x**2*cosh(x)**5 - 3*x*cosh(x)**5
+        - cosh(x)**5), [])
+    # and this fail?
+    #assert unrad(sqrt(cosh(x)/x) + root(x + 1, 3)*sqrt(x) - 1) == (
+    #    -s**6 + 6*s**5 - 15*s**4 + 20*s**3 - 15*s**2 + 6*s + x**5 +
+    #    2*x**4 + x**3 - 1, [s, s**2 - cosh(x)/x])
+
+    # watch for symbols in exponents
     assert unrad(S('(x+y)**(2*y/3) + (x+y)**(1/3) + 1')) is None
     assert check(unrad(S('(x+y)**(2*y/3) + (x+y)**(1/3) + 1'), x),
         (s**(2*y) + s + 1, [s, s**3 - x - y]))
+    # should _Q be so lenient?
+    assert unrad(x**(S.Half/y) + y, x) == (x**(1/y) - y**2, [])
 
     # This tests two things: that if full unrad is attempted and fails
     # the solution should still be found; also it tests that the use of
@@ -1163,7 +1171,7 @@ def test_unrad1():
         (3*s**13 + 3*s**11 + 6*s**10 + s**9 + 12*s**8 + 6*s**6 + 12*s**5 +
         12*s**3 + 7, [s, s**15 - x]))
     assert check(unrad(root(x, 3) - root(x + 1, 4)/2 + root(x + 2, 3)),
-        (4096*s**13 + 960*s**12 + 48*s**11 - s**10 - 1728*s**4,
+        (s*(4096*s**9 + 960*s**8 + 48*s**7 - s**6 - 1728),
         [s, s**4 - x - 1]))  # orig expr has two real roots: -1, -.389
     assert check(unrad(root(x, 3) + root(x + 1, 4) - root(x + 2, 3)/2),
         (343*s**13 + 2904*s**12 + 1344*s**11 + 512*s**10 - 1323*s**9 -
@@ -1212,7 +1220,7 @@ def test_unrad1():
         sqrt(3)*I/2)*(3*x**3/2 - x*(3*x**2 - 34)/2 + sqrt((-3*x**3 + x*(3*x**2
         - 34) + 90)**2/4 - 39304/27) - 45)**(1/3))''')
     assert check(unrad(eq),
-        (-s*(-s**6 + sqrt(3)*s**6*I - 153*2**Rational(2, 3)*3**Rational(1, 3)*s**4 +
+        (s*-(-s**6 + sqrt(3)*s**6*I - 153*2**Rational(2, 3)*3**Rational(1, 3)*s**4 +
         51*12**Rational(1, 3)*s**4 - 102*2**Rational(2, 3)*3**Rational(5, 6)*s**4*I - 1620*s**3 +
         1620*sqrt(3)*s**3*I + 13872*18**Rational(1, 3)*s**2 - 471648 +
         471648*sqrt(3)*I), [s, s**3 - 306*x - sqrt(3)*sqrt(31212*x**2 -
@@ -1234,6 +1242,13 @@ def test_unrad1():
     eq = Eq(-x**(S(1)/5) + x**(S(1)/3), -3**(S(1)/3) - (-1)**(S(3)/5)*3**(S(1)/5))
     assert check(unrad(eq),
         (-s**5 + s**3 - 3**(S(1)/3) - (-1)**(S(3)/5)*3**(S(1)/5), [s, s**15 - x]))
+
+    # make sure buried radicals are exposed
+    s = sqrt(x) - 1
+    assert unrad(s**2 - s**3) == (x**3 - 6*x**2 + 9*x - 4, [])
+    # make sure numerators which are already polynomial are rejected
+    assert unrad((x/(x + 1) + 3)**(-2), x) is None
+
 
 @slow
 def test_unrad_slow():
@@ -2250,7 +2265,7 @@ def test_issue_17650():
 
 def test_issue_17882():
     eq = -8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3))
-    assert unrad(eq) == (4*x**2 - 12, [])
+    assert unrad(eq) is None
 
 
 def test_issue_17949():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1156,13 +1156,11 @@ def test_unrad1():
     # watch out for when the cov doesn't involve the symbol of interest
     eq = S('-x + (7*y/8 - (27*x/2 + 27*sqrt(x**2)/2)**(1/3)/3)**3 - 1')
     assert solve(eq, y) == [
-        4*2**Rational(2, 3)*(27*x + 27*sqrt(x**2))**Rational(1, 3)/21 - (Rational(-1, 2) -
-        sqrt(3)*I/2)*(x*Rational(-6912, 343) + sqrt((x*Rational(-13824, 343) - Rational(13824, 343))**2)/2 -
-        Rational(6912, 343))**Rational(1, 3)/3, 4*2**Rational(2, 3)*(27*x + 27*sqrt(x**2))**Rational(1, 3)/21 -
-        (Rational(-1, 2) + sqrt(3)*I/2)*(x*Rational(-6912, 343) + sqrt((x*Rational(-13824, 343) -
-        Rational(13824, 343))**2)/2 - Rational(6912, 343))**Rational(1, 3)/3, 4*2**Rational(2, 3)*(27*x +
-        27*sqrt(x**2))**Rational(1, 3)/21 - (x*Rational(-6912, 343) + sqrt((x*Rational(-13824, 343) -
-        Rational(13824, 343))**2)/2 - Rational(6912, 343))**Rational(1, 3)/3]
+        2**(S(2)/3)*(27*x + 27*sqrt(x**2))**(S(1)/3)*S(4)/21 + (512*x/343 +
+        S(512)/343)**(S(1)/3)*(-S(1)/2 - sqrt(3)*I/2), 2**(S(2)/3)*(27*x +
+        27*sqrt(x**2))**(S(1)/3)*S(4)/21 + (512*x/343 +
+        S(512)/343)**(S(1)/3)*(-S(1)/2 + sqrt(3)*I/2), 2**(S(2)/3)*(27*x +
+        27*sqrt(x**2))**(S(1)/3)*S(4)/21 + (512*x/343 + S(512)/343)**(S(1)/3)]
 
     eq = root(x + 1, 3) - (root(x, 3) + root(x, 5))
     assert check(unrad(eq),

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -213,6 +213,14 @@ def test_issue_18449():
     # TODO: Is the above solution set definitely complete?
 
 
+def test_issue_21047():
+    f = (2 - x)**2 + (sqrt(x - 1) - 1)**6
+    assert(solveset(f, x, S.Reals)) == FiniteSet(2)
+    f = (sqrt(x)-1)**2 + (sqrt(x)+1)**2 -2*x**2 + sqrt(2)
+    assert solveset(f, x, S.Reals) == FiniteSet(
+        S.Half - sqrt(2*sqrt(2) + 5)/2, S.Half + sqrt(2*sqrt(2) + 5)/2)
+
+
 def test_is_function_class_equation():
     from sympy.abc import x, a
     assert _is_function_class_equation(TrigonometricFunction,
@@ -387,16 +395,6 @@ def test_return_root_of():
                        CRootOf(x**6 - x + 1, 5))
 
 
-def test__has_rational_power():
-    from sympy.solvers.solveset import _has_rational_power
-    assert _has_rational_power(sqrt(2), x)[0] is False
-    assert _has_rational_power(x*sqrt(2), x)[0] is False
-
-    assert _has_rational_power(x**2*sqrt(x), x) == (True, 2)
-    assert _has_rational_power(sqrt(2)*x**Rational(1, 3), x) == (True, 3)
-    assert _has_rational_power(sqrt(x)*x**Rational(1, 3), x) == (True, 6)
-
-
 def test_solveset_sqrt_1():
     assert solveset_real(sqrt(5*x + 6) - 2 - x, x) == \
         FiniteSet(-S.One, S(2))
@@ -452,6 +450,9 @@ def test_solveset_sqrt_2():
 
     eq = sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))
     assert solveset_real(eq, x) == FiniteSet()
+
+    eq = (x - 4)**2 + (sqrt(x) - 2)**4
+    assert solveset_real(eq, x) == FiniteSet(-4, 4)
 
     eq = (sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
     ans = solveset_real(eq, x)
@@ -1294,13 +1295,9 @@ def test_solveset_domain():
 
 
 def test_improve_coverage():
-    from sympy.solvers.solveset import _has_rational_power
     solution = solveset(exp(x) + sin(x), x, S.Reals)
     unsolved_object = ConditionSet(x, Eq(exp(x) + sin(x), 0), S.Reals)
     assert solution.dummy_eq(unsolved_object)
-
-    assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)
-    assert _has_rational_power((sin(x)**2)*(exp(x) + 1)**3, x) == (False, S.One)
 
 
 def test_issue_9522():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2234,6 +2234,10 @@ def test_transolve():
     assert _transolve(3**x - 9**(x + 5), x, S.Reals) == FiniteSet(-10)
 
 
+def test_issue_21276():
+    eq = (2*x*(y - z) - y*erf(y - z) - y + z*erf(y - z) + z)**2
+    assert solveset(eq.expand(), y) == FiniteSet(z, z + erfinv(2*x - 1))
+
 # exponential tests
 def test_exponential_real():
     from sympy.abc import x, y, z

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1585,7 +1585,7 @@ def test_trig_system_fail():
     sys = [x + y - pi/2, sin(x) + sin(y) - 1]
     # solveset returns conditionset for sin(x) + sin(y) - 1
     soln_1 = (ImageSet(Lambda(n, n*pi + pi/2), S.Integers),
-        ImageSet(Lambda(n, n*pi)), S.Integers)
+        ImageSet(Lambda(n, n*pi), S.Integers))
     soln_1 = FiniteSet(soln_1)
     soln_2 = (ImageSet(Lambda(n, n*pi), S.Integers),
         ImageSet(Lambda(n, n*pi+ pi/2), S.Integers))

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,10 +4,11 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, atan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re, Lambda, asin,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, erfi, besselj, besselk)
+                   factorial, binomial, erfi, besselj, besselk, factor_terms)
 from sympy.functions.special.error_functions import erfinv
 from sympy.functions.special.hyper import meijerg
-from sympy.sets.sets import Intersection, FiniteSet
+from sympy.sets.sets import FiniteSet, Complement
+from sympy.sets.conditionset import ConditionSet
 from sympy.stats import (P, E, where, density, variance, covariance, skewness, kurtosis, median,
                          given, pspace, cdf, characteristic_function, moment_generating_function,
                          ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral, BetaPrime,
@@ -46,7 +47,13 @@ def test_single_normal():
             2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
 
     assert P(X**2 < 1) == erf(2**S.Half/2)
-    assert quantile(Y)(x) == Intersection(S.Reals, FiniteSet(sqrt(2)*sigma*(sqrt(2)*mu/(2*sigma) + erfinv(2*x - 1))))
+    ans = quantile(Y)(x)
+    eq = ans.atoms(Eq).pop()
+    ans = factor_terms(ans.xreplace({eq: Eq(eq.lhs.simplify().factor(), 0)}
+        ).xreplace({eq.atoms(Dummy).pop(): y}))
+    assert ans == Complement(ConditionSet(y, Eq((-mu +
+        y)*(2*x + erf(sqrt(2)*(mu - y)/(2*sigma)) - 1),
+        0), S.Reals), FiniteSet(mu))
     assert E(X, Eq(X, mu)) == mu
 
     assert median(X) == FiniteSet(0)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,11 +4,10 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, atan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re, Lambda, asin,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, erfi, besselj, besselk, factor_terms)
+                   factorial, binomial, erfi, besselj, besselk)
 from sympy.functions.special.error_functions import erfinv
 from sympy.functions.special.hyper import meijerg
-from sympy.sets.sets import FiniteSet, Complement
-from sympy.sets.conditionset import ConditionSet
+from sympy.sets.sets import FiniteSet, Complement, Intersection
 from sympy.stats import (P, E, where, density, variance, covariance, skewness, kurtosis, median,
                          given, pspace, cdf, characteristic_function, moment_generating_function,
                          ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral, BetaPrime,
@@ -48,12 +47,9 @@ def test_single_normal():
 
     assert P(X**2 < 1) == erf(2**S.Half/2)
     ans = quantile(Y)(x)
-    eq = ans.atoms(Eq).pop()
-    ans = factor_terms(ans.xreplace({eq: Eq(eq.lhs.simplify().factor(), 0)}
-        ).xreplace({eq.atoms(Dummy).pop(): y}))
-    assert ans == Complement(ConditionSet(y, Eq((-mu +
-        y)*(2*x + erf(sqrt(2)*(mu - y)/(2*sigma)) - 1),
-        0), S.Reals), FiniteSet(mu))
+    assert ans == Complement(Intersection(FiniteSet(
+        sqrt(2)*sigma*(sqrt(2)*mu/(2*sigma)+ erfinv(2*x - 1))),
+        Interval(-oo, oo)), FiniteSet(mu))
     assert E(X, Eq(X, mu)) == mu
 
     assert median(X) == FiniteSet(0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #19869 
fixes #21263 
fixes #21268
fixes #21287
closes #21049 and closes #21002 as an alternate
closes #21295
#### Brief description of what is fixed or changed

`unrad` was changed in #18324 and #21032 to return an expression even when the original expression didn't have persisting radicals; it should only return an expression when the expression is going to give a superset of the solutions to an expression, not when the expression can be simply expanded to remove radicals. Those changes have been reverted and the function modified to handle the case that prompted that change.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * `roots_quintic` better detects non-rational coefficients
  * `roots_cubic` results are simpler for cubics that can be written (or rewritten) as `x**3 + y = 0`
  * corner-case bugs fixed in `to_rational_coeffs`
* calculus
  * `continuous_domain` returns results for any power with even denominator, not just 2
* solvers
  * `unrad` better detects radicals to be removed even when they are hidden as bases of rational powers
  * `unrad` no longer makes the highest order term positive when making sign canonical
  * `_has_rational_power` (a private function) is no longer used and is removed
  * `_solve_as_rational` now fully expands the expression to be solved
  * the signature of `_solve_radical` was changed to accept the unrad form of f
  * `_solveset` will now use `unrad` to see if an equation needs to use `_solve_radical` before doing so
  * `solveset` now uses `factor` as a last-resort
<!-- END RELEASE NOTES -->
