### PR TITLE
Updating autolev variable naming

### DIFF
--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -47,24 +47,24 @@ def parse_autolev(autolev_code, include_numeric=False):
     >>> my_al_text = '\\n'.join(my_al_text)
     >>> from sympy.parsing.autolev import parse_autolev
     >>> print(parse_autolev(my_al_text, include_numeric=True))
-    import sympy.physics.mechanics as me
-    import sympy as sm
+    import sympy.physics.mechanics as _me
+    import sympy as _sm
     import math as m
-    import numpy as np
+    import numpy as _np
     <BLANKLINE>
-    q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')
-    q1d, q2d, u1d, u2d = me.dynamicsymbols('q1 q2 u1 u2', 1)
-    l, m, g = sm.symbols('l m g', real=True)
-    frame_n = me.ReferenceFrame('n')
-    frame_a = me.ReferenceFrame('a')
-    frame_b = me.ReferenceFrame('b')
+    q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
+    q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)
+    l, m, g = _sm.symbols('l m g', real=True)
+    frame_n = _me.ReferenceFrame('n')
+    frame_a = _me.ReferenceFrame('a')
+    frame_b = _me.ReferenceFrame('b')
     frame_a.orient(frame_n, 'Axis', [q1, frame_n.z])
     frame_b.orient(frame_n, 'Axis', [q2, frame_n.z])
     frame_a.set_ang_vel(frame_n, u1*frame_n.z)
     frame_b.set_ang_vel(frame_n, u2*frame_n.z)
-    point_o = me.Point('o')
-    particle_p = me.Particle('p', me.Point('p_pt'), sm.Symbol('m'))
-    particle_r = me.Particle('r', me.Point('r_pt'), sm.Symbol('m'))
+    point_o = _me.Point('o')
+    particle_p = _me.Particle('p', _me.Point('p_pt'), _sm.Symbol('m'))
+    particle_r = _me.Particle('r', _me.Point('r_pt'), _sm.Symbol('m'))
     particle_p.point.set_pos(point_o, l*frame_a.x)
     particle_r.point.set_pos(particle_p.point, l*frame_b.x)
     point_o.set_vel(frame_n, 0)
@@ -74,16 +74,16 @@ def parse_autolev(autolev_code, include_numeric=False):
     particle_r.mass = m
     force_p = particle_p.mass*(g*frame_n.x)
     force_r = particle_r.mass*(g*frame_n.x)
-    kd_eqs = [q1d - u1, q2d - u2]
+    kd_eqs = [q1_d - u1, q2_d - u2]
     forceList = [(particle_p.point,particle_p.mass*(g*frame_n.x)), (particle_r.point,particle_r.mass*(g*frame_n.x))]
-    kane = me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u1, u2], kd_eqs = kd_eqs)
+    kane = _me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u1, u2], kd_eqs = kd_eqs)
     fr, frstar = kane.kanes_equations([particle_p, particle_r], forceList)
     zero = fr+frstar
     from pydy.system import System
     sys = System(kane, constants = {l:1, m:1, g:9.81},
     specifieds={},
     initial_conditions={q1:.1, q2:.2, u1:0, u2:0},
-    times = np.linspace(0.0, 10, 10/.01))
+    times = _np.linspace(0.0, 10, 10/.01))
     <BLANKLINE>
     y=sys.integrate()
     <BLANKLINE>

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -1475,7 +1475,7 @@ if AutolevListener:
                     except Exception:
                         l.append(self.getValue(ctx.index().getChild(2)) + "-1")
                     self.write(self.symbol_table[ctx.ID().getText().lower()] +
-                               "[" + "".join(l) + "]" + equals + self.getValue(ctx.expr()) + "\n")
+                               "[" + "".join(l) + "]" + " " + equals + " " + self.getValue(ctx.expr()) + "\n")
 
         def exitVecAssign(self, ctx):
             # Handle assignments of the type vec = expr
@@ -1562,11 +1562,11 @@ if AutolevListener:
                 else:
                     name = ch.ID().getText().lower()
                     self.symbol_table.update({vec_text: name})
-                    self.write(name + ctx.getChild(1).getText() + self.getValue(ctx.expr()) + "\n")
+                    self.write(name + " " + ctx.getChild(1).getText() + " " + self.getValue(ctx.expr()) + "\n")
             else:
                 name = ch.ID().getText().lower()
                 self.symbol_table.update({vec_text: name})
-                self.write(name + ctx.getChild(1).getText() + self.getValue(ctx.expr()) + "\n")
+                self.write(name + " " + ctx.getChild(1).getText() + " " + self.getValue(ctx.expr()) + "\n")
 
         def enterInputs2(self, ctx):
             self.in_inputs = True

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -19,9 +19,9 @@ def strfunc(z):
     if z == 0:
         return ""
     elif z == 1:
-        return "d"
+        return "_d"
     else:
-        return "d" + str(z)
+        return "_" + "d" * z
 
 def declare_phy_entities(self, ctx, phy_type, i, j=None):
     if phy_type in ("frame", "newtonian"):
@@ -52,7 +52,7 @@ def declare_frames(self, ctx, i, j=None):
     self.symbol_table.update({name1 + "3>": name2 + ".z"})
 
     self.type2.update({name1: "frame"})
-    self.write(name2 + " = " + "me.ReferenceFrame('" + name1 + "')\n")
+    self.write(name2 + " = " + "_me.ReferenceFrame('" + name1 + "')\n")
 
 def declare_points(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -67,7 +67,7 @@ def declare_points(self, ctx, i, j=None):
 
     self.symbol_table2.update({name1: name2})
     self.type2.update({name1: "point"})
-    self.write(name2 + " = " + "me.Point('" + name1 + "')\n")
+    self.write(name2 + " = " + "_me.Point('" + name1 + "')\n")
 
 def declare_particles(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -83,8 +83,8 @@ def declare_particles(self, ctx, i, j=None):
     self.symbol_table2.update({name1: name2})
     self.type2.update({name1: "particle"})
     self.bodies.update({name1: name2})
-    self.write(name2 + " = " + "me.Particle('" + name1 + "', " + "me.Point('" +
-                name1 + "_pt" + "'), " + "sm.Symbol('m'))\n")
+    self.write(name2 + " = " + "_me.Particle('" + name1 + "', " + "_me.Point('" +
+                name1 + "_pt" + "'), " + "_sm.Symbol('m'))\n")
 
 def declare_bodies(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -109,20 +109,20 @@ def declare_bodies(self, ctx, i, j=None):
     self.type2.update({name1: "bodies"})
     self.type2.update({name1+"o": "point"})
 
-    self.write(masscenter + " = " + "me.Point('" + name1 + "_cm" + "')\n")
+    self.write(masscenter + " = " + "_me.Point('" + name1 + "_cm" + "')\n")
     if self.newtonian:
         self.write(masscenter + ".set_vel(" + self.newtonian + ", " + "0)\n")
-    self.write(refFrame + " = " + "me.ReferenceFrame('" + name1 + "_f" + "')\n")
+    self.write(refFrame + " = " + "_me.ReferenceFrame('" + name1 + "_f" + "')\n")
     # We set a dummy mass and inertia here.
     # They will be reset using the setters later in the code anyway.
-    self.write(name2 + " = " + "me.RigidBody('" + name1 + "', " + masscenter + ", " +
-                refFrame + ", " + "sm.symbols('m'), (me.outer(" + refFrame +
+    self.write(name2 + " = " + "_me.RigidBody('" + name1 + "', " + masscenter + ", " +
+                refFrame + ", " + "_sm.symbols('m'), (_me.outer(" + refFrame +
                 ".x," + refFrame + ".x)," + masscenter + "))\n")
 
 def inertia_func(self, v1, v2, l, frame):
 
     if self.type2[v1] == "particle":
-        l.append("me.inertia_of_point_mass(" + self.bodies[v1] + ".mass, " + self.bodies[v1] +
+        l.append("_me.inertia_of_point_mass(" + self.bodies[v1] + ".mass, " + self.bodies[v1] +
                  ".point.pos_from(" + self.symbol_table2[v2] + "), " + frame + ")")
 
     elif self.type2[v1] == "bodies":
@@ -135,7 +135,7 @@ def inertia_func(self, v1, v2, l, frame):
             # Asking point is not cm
             else:
                 l.append(self.bodies[v1] + ".inertia[0]" + " + " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[v2] +
                          "), " + frame + ")")
@@ -148,18 +148,18 @@ def inertia_func(self, v1, v2, l, frame):
             # Asking point is cm
             elif v2 == v1 + "o":
                 l.append(self.bodies[v1] + ".inertia[0]" + " - " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[self.inertia_point[v1]] +
                          "), " + frame + ")")
             # Asking point is some other point
             else:
                 l.append(self.bodies[v1] + ".inertia[0]" + " - " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[self.inertia_point[v1]] +
                          "), " + frame + ")" + " + " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[v2] +
                          "), " + frame + ")")
@@ -171,7 +171,7 @@ def processConstants(self, ctx):
     if "=" in ctx.getText():
         self.symbol_table.update({name: name})
         # self.inputs.update({self.symbol_table[name]: self.getValue(ctx.getChild(2))})
-        self.write(self.symbol_table[name] + " = " + "sm.S(" + self.getValue(ctx.getChild(2)) + ")\n")
+        self.write(self.symbol_table[name] + " = " + "_sm.S(" + self.getValue(ctx.getChild(2)) + ")\n")
         self.type.update({name: "constants"})
         return
 
@@ -250,15 +250,15 @@ def writeConstants(self, ctx):
         real = ", real=True"
 
     if l1:
-        a = ", ".join(l1) + " = " + "sm.symbols(" + "'" +\
+        a = ", ".join(l1) + " = " + "_sm.symbols(" + "'" +\
             " ".join(l1) + "'" + real + ")\n"
         self.write(a)
     if l2:
-        a = ", ".join(l2) + " = " + "sm.symbols(" + "'" +\
+        a = ", ".join(l2) + " = " + "_sm.symbols(" + "'" +\
             " ".join(l2) + "'" + real + ", nonnegative=True)\n"
         self.write(a)
     if l3:
-        a = ", ".join(l3) + " = " + "sm.symbols(" + "'" + \
+        a = ", ".join(l3) + " = " + "_sm.symbols(" + "'" + \
             " ".join(l3) + "'" + real + ", nonpositive=True)\n"
         self.write(a)
     self.var_list = []
@@ -377,7 +377,7 @@ def writeVariables(self, ctx):
                 if i > 1:
                     l.append(k[:-2])
             a = ", ".join(list(filter(lambda x: self.sign[x] == i, self.var_list))) + " = " +\
-                "me.dynamicsymbols(" + "'" + " ".join(l) + "'" + t + j + ")\n"
+                "_me.dynamicsymbols(" + "'" + " ".join(l) + "'" + t + j + ")\n"
             l = []
             self.write(a)
         self.maxDegree = 0
@@ -391,9 +391,9 @@ def processImaginary(self, ctx):
 
 
 def writeImaginary(self, ctx):
-    a = ", ".join(self.var_list) + " = " + "sm.symbols(" + "'" + \
+    a = ", ".join(self.var_list) + " = " + "_sm.symbols(" + "'" + \
         " ".join(self.var_list) + "')\n"
-    b = ", ".join(self.var_list) + " = " + "sm.I\n"
+    b = ", ".join(self.var_list) + " = " + "_sm.I\n"
     self.write(a)
     self.write(b)
     self.var_list = []
@@ -439,10 +439,10 @@ if AutolevListener:
             self.explicit = collections.OrderedDict()
 
             # Write code to import common dependencies.
-            self.output_code.append("import sympy.physics.mechanics as me\n")
-            self.output_code.append("import sympy as sm\n")
+            self.output_code.append("import sympy.physics.mechanics as _me\n")
+            self.output_code.append("import sympy as _sm\n")
             self.output_code.append("import math as m\n")
-            self.output_code.append("import numpy as np\n")
+            self.output_code.append("import numpy as _np\n")
             self.output_code.append("\n")
 
             # Just a store for the max degree variable in a line.
@@ -599,12 +599,12 @@ if AutolevListener:
             else:
                 # Reserved constant Pi
                 if ctx.ID().getText().lower() == "pi":
-                    self.setValue(ctx, "sm.pi")
+                    self.setValue(ctx, "_sm.pi")
                     self.numeric_expr.append(ctx)
 
                 # Reserved variable T (for time)
                 elif ctx.ID().getText().lower() == "t":
-                    self.setValue(ctx, "me.dynamicsymbols._t")
+                    self.setValue(ctx, "_me.dynamicsymbols._t")
                     if not self.in_inputs and not self.in_outputs:
                         self.t = True
 
@@ -652,7 +652,7 @@ if AutolevListener:
             # The subrule is expr = expr (*|/) expr
             try:
                 if ctx.expr(0) in self.vector_expr and ctx.expr(1) in self.vector_expr:
-                    self.setValue(ctx, "me.outer(" + self.getValue(ctx.expr(0)) + ", " +
+                    self.setValue(ctx, "_me.outer(" + self.getValue(ctx.expr(0)) + ", " +
                                   self.getValue(ctx.expr(1)) + ")")
                 else:
                     if ctx.expr(0) in self.matrix_expr or ctx.expr(1) in self.matrix_expr:
@@ -726,8 +726,8 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    # sm.Matrix([i.expand() for i in z]).reshape(z.shape[0], z.shape[1])
-                    self.setValue(ctx, "sm.Matrix([i.expand() for i in " + expr + "])" +
+                    # _sm.Matrix([i.expand() for i in z]).reshape(z.shape[0], z.shape[1])
+                    self.setValue(ctx, "_sm.Matrix([i.expand() for i in " + expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
                     self.setValue(ctx, "(" + expr + ")" + "." + "expand()")
@@ -737,10 +737,10 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([sm.factor(i, " + self.getValue(ch.expr(1)) + ") for i in " +
+                    self.setValue(ctx, "_sm.Matrix([_sm.factor(i, " + self.getValue(ch.expr(1)) + ") for i in " +
                                   expr + "])" + ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
-                    self.setValue(ctx, "sm.factor(" + "(" + expr + ")" +
+                    self.setValue(ctx, "_sm.factor(" + "(" + expr + ")" +
                                   ", " + self.getValue(ch.expr(1)) + ")")
 
             # D(y, x)
@@ -748,7 +748,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.diff(" + self.getValue(ch.expr(1)) + ") for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.diff(" + self.getValue(ch.expr(1)) + ") for i in " +
                                   expr + "])" + ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
                     if ch.getChildCount() == 8:
@@ -765,10 +765,10 @@ if AutolevListener:
                 if ch.expr(0) in self.vector_expr:
                     text = "dt("
                 else:
-                    text = "diff(sm.Symbol('t')"
+                    text = "diff(_sm.Symbol('t')"
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i." + text +
+                    self.setValue(ctx, "_sm.Matrix([i." + text +
                                   ") for i in " + expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -820,7 +820,7 @@ if AutolevListener:
 
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
                                   expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -835,7 +835,7 @@ if AutolevListener:
 
             # Polynomial([a, b, c], x)
             elif func_name == "polynomial":
-                self.setValue(ctx, "sm.Poly(" + self.getValue(ch.expr(0)) + ", " +
+                self.setValue(ctx, "_sm.Poly(" + self.getValue(ch.expr(0)) + ", " +
                               self.getValue(ch.expr(1)) + ")")
 
             # Roots(Poly, x, 2)
@@ -844,10 +844,10 @@ if AutolevListener:
                 self.matrix_expr.append(ctx)
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                    self.setValue(ctx, "[i.evalf() for i in " + "sm.solve(" +
-                                  "sm.Poly(" + expr + ", " + "x),x)]")
+                    self.setValue(ctx, "[i.evalf() for i in " + "_sm.solve(" +
+                                  "_sm.Poly(" + expr + ", " + "x),x)]")
                 else:
-                    self.setValue(ctx, "[i.evalf() for i in " + "sm.solve(" +
+                    self.setValue(ctx, "[i.evalf() for i in " + "_sm.solve(" +
                                   expr + ", " + self.getValue(ch.expr(1)) + ")]")
 
             # Transpose(A), Inv(A)
@@ -861,8 +861,8 @@ if AutolevListener:
 
             # Eig(A)
             elif func_name == "eig":
-                # "sm.Matrix([i.evalf() for i in " +
-                self.setValue(ctx, "sm.Matrix([i.evalf() for i in (" +
+                # "_sm.Matrix([i.evalf() for i in " +
+                self.setValue(ctx, "_sm.Matrix([i.evalf() for i in (" +
                               self.getValue(ch.expr(0)) + ").eigenvals().keys()])")
 
             # Diagmat(n, m, x)
@@ -874,14 +874,14 @@ if AutolevListener:
                     for i in range(int(self.getValue(ch.expr(0)))):
                         l.append(self.getValue(ch.expr(1)) + ",")
 
-                    self.setValue(ctx, "sm.diag(" + ("".join(l))[:-1] + ")")
+                    self.setValue(ctx, "_sm.diag(" + ("".join(l))[:-1] + ")")
 
                 elif ch.getChildCount() == 8:
-                    # sm.Matrix([x if i==j else 0 for i in range(n) for j in range(m)]).reshape(n, m)
+                    # _sm.Matrix([x if i==j else 0 for i in range(n) for j in range(m)]).reshape(n, m)
                     n = self.getValue(ch.expr(0))
                     m = self.getValue(ch.expr(1))
                     x = self.getValue(ch.expr(2))
-                    self.setValue(ctx, "sm.Matrix([" + x + " if i==j else 0 for i in range(" +
+                    self.setValue(ctx, "_sm.Matrix([" + x + " if i==j else 0 for i in range(" +
                                   n + ") for j in range(" + m + ")]).reshape(" + n + ", " + m + ")")
 
             # Cols(A)
@@ -914,7 +914,7 @@ if AutolevListener:
                                          "row(" + str(int(ch.getChild(i).getText())-1) + ")")
                         except Exception:
                             pass
-                    self.setValue(ctx, "sm.Matrix([" + ",".join(l) + "])")
+                    self.setValue(ctx, "_sm.Matrix([" + ",".join(l) + "])")
 
             # Det(A) Trace(A)
             elif func_name in ["det", "trace"]:
@@ -930,21 +930,21 @@ if AutolevListener:
             elif func_name in \
             ["cos", "sin", "tan", "cosh", "sinh", "tanh", "acos", "asin", "atan",
             "log", "exp", "sqrt", "factorial", "floor", "sign"]:
-                self.setValue(ctx, "sm." + func_name + "(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm." + func_name + "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "ceil":
-                self.setValue(ctx, "sm.ceiling" + "(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm.ceiling" + "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "sqr":
                 self.setValue(ctx, "(" + self.getValue(ch.expr(0)) +
                               ")" + "**2")
 
             elif func_name == "log10":
-                self.setValue(ctx, "sm.log" +
+                self.setValue(ctx, "_sm.log" +
                               "(" + self.getValue(ch.expr(0)) + ", 10)")
 
             elif func_name == "atan2":
-                self.setValue(ctx, "sm.atan2" + "(" + self.getValue(ch.expr(0)) + ", " +
+                self.setValue(ctx, "_sm.atan2" + "(" + self.getValue(ch.expr(0)) + ", " +
                               self.getValue(ch.expr(1)) + ")")
 
             elif func_name in ["int", "round"]:
@@ -952,7 +952,7 @@ if AutolevListener:
                               "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "abs":
-                self.setValue(ctx, "sm.Abs(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm.Abs(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name in ["max", "min"]:
                 # max(x, y, z)
@@ -962,7 +962,7 @@ if AutolevListener:
                         l.append(self.getValue(ch.getChild(i)))
                     elif ch.getChild(i).getText() in [",", "(", ")"]:
                         l.append(ch.getChild(i).getText())
-                self.setValue(ctx, "sm." + ch.getChild(0).getText().capitalize() + "".join(l))
+                self.setValue(ctx, "_sm." + ch.getChild(0).getText().capitalize() + "".join(l))
 
             # Coef(y, x)
             elif func_name == "coef":
@@ -987,7 +987,7 @@ if AutolevListener:
                             # a41_a53[i,j] = u4.expand().coeff(u1)
                             l.append(self.getValue(ch.expr(0).getChild(0).expr(i)) + ".expand().coeff("
                                      + self.getValue(ch.expr(1).getChild(0).expr(j)) + ")")
-                    self.setValue(ctx, "sm.Matrix([" + ", ".join(l) + "]).reshape(" + str(icount) + ", " + str(jcount) + ")")
+                    self.setValue(ctx, "_sm.Matrix([" + ", ".join(l) + "]).reshape(" + str(icount) + ", " + str(jcount) + ")")
                 else:
                     self.setValue(ctx, "(" + self.getValue(ch.expr(0)) +
                                   ")" + ".expand().coeff(" + self.getValue(ch.expr(1)) + ")")
@@ -1001,7 +1001,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.collect(" + self.getValue(ch.expr(1)) + "])" +
+                    self.setValue(ctx, "_sm.Matrix([i.collect(" + self.getValue(ch.expr(1)) + "])" +
                                   ".coeff(" + self.getValue(ch.expr(1)) + "," + e + ")" + "for i in " + expr + ")" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1018,7 +1018,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.collect(" + self.getValue(ch.expr(2)) +
+                    self.setValue(ctx, "_sm.Matrix([i.collect(" + self.getValue(ch.expr(2)) +
                                   ")" + "for i in " + expr + "])"+
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1038,7 +1038,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
                                   expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1051,14 +1051,14 @@ if AutolevListener:
                 num = (ch.expr(1).getChild(0).getChildCount()-1)//2
                 if ch.expr(1) in self.matrix_expr:
                     for i in range(num):
-                        l.append("me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1).getChild(0).expr(i)) + ")")
-                    self.setValue(ctx, "sm.Matrix([" + ",".join(l) + "]).reshape(" + str(num) + ", " + "1)")
+                        l.append("_me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1).getChild(0).expr(i)) + ")")
+                    self.setValue(ctx, "_sm.Matrix([" + ",".join(l) + "]).reshape(" + str(num) + ", " + "1)")
                 else:
-                    self.setValue(ctx, "me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
+                    self.setValue(ctx, "_me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
             # Cross(w_A_N>, P_NA_AB>)
             elif func_name == "cross":
                 self.vector_expr.append(ctx)
-                self.setValue(ctx, "me.cross(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
+                self.setValue(ctx, "_me.cross(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
 
             # Mag(P_O_Q>)
             elif func_name == "mag":
@@ -1094,7 +1094,7 @@ if AutolevListener:
                 else:
                     frame = self.symbol_table2[ch.expr(1).getText().lower()] + "_f"
                 if ch.expr(0).getText().lower() == "1>>":
-                    self.setValue(ctx, "me.inertia(" + frame + ", 1, 1, 1)")
+                    self.setValue(ctx, "_me.inertia(" + frame + ", 1, 1, 1)")
 
                 elif '_' in ch.expr(0).getText().lower() and ch.expr(0).getText().lower().count('_') == 2\
                 and ch.expr(0).getText().lower()[0] == "i" and ch.expr(0).getText().lower()[-2:] == ">>":
@@ -1132,13 +1132,13 @@ if AutolevListener:
                 else:
                     text = ".point"
                 if ch.getChildCount() == 4:
-                    self.setValue(ctx, "me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
+                    self.setValue(ctx, "_me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
                                   text + "," + ", ".join(self.bodies.values()) + ")")
                 else:
                     bodies = []
                     for i in range(1, (ch.getChildCount()-1)//2):
                         bodies.append(self.symbol_table2[ch.expr(i).getText().lower()])
-                    self.setValue(ctx, "me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
+                    self.setValue(ctx, "_me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
                                   text + "," + ", ".join(bodies) + ")")
 
             # PARTIALS(V_P1_E>,U1)
@@ -1182,7 +1182,7 @@ if AutolevListener:
                     self.setValue(ctx, "+".join(l))
 
             # Fr() FrStar()
-            # me.KanesMethod(n, q_ind, u_ind, kd, velocity_constraints).kanes_equations(pl, fl)[0]
+            # _me.KanesMethod(n, q_ind, u_ind, kd, velocity_constraints).kanes_equations(pl, fl)[0]
             elif func_name in ["fr", "frstar"]:
                 if not self.kane_parsed:
                     if self.kd_eqs:
@@ -1205,7 +1205,7 @@ if AutolevListener:
                                 elif self.sign[self.symbol_table[i.lower()]] == 1:
                                     name = "u_" + self.symbol_table[i.lower()]
                                     self.symbol_table.update({name: name})
-                                    self.write(name + " = " + "me.dynamicsymbols('" + name + "')\n")
+                                    self.write(name + " = " + "_me.dynamicsymbols('" + name + "')\n")
                                     if self.symbol_table[i.lower()] not in self.dependent_variables:
                                         self.u_ind.append(name)
                                         self.kd_equivalents.update({name: self.symbol_table[i.lower()]})
@@ -1244,7 +1244,7 @@ if AutolevListener:
                 if ctx.parentCtx not in self.fr_expr:
                     self.write("kd_eqs = [" + ", ".join(self.kd_eqs) + "]\n")
                     self.write("forceList = " + "[" + ", ".join(force_list) + "]\n")
-                    self.write("kane = me.KanesMethod(" + self.newtonian + ", " + "q_ind=[" +
+                    self.write("kane = _me.KanesMethod(" + self.newtonian + ", " + "q_ind=[" +
                             ",".join(self.q_ind) + "], " + "u_ind=[" +
                             ", ".join(self.u_ind) + "]" + u_dep_text + ", " +
                             "kd_eqs = kd_eqs" + velocity_constraints_text + ")\n")
@@ -1258,7 +1258,7 @@ if AutolevListener:
             # Tree annotation for Matrices which is a labeled subrule of the parser rule expr.
 
             # MO = [a, b; c, d]
-            # we generate sm.Matrix([a, b, c, d]).reshape(2, 2)
+            # we generate _sm.Matrix([a, b, c, d]).reshape(2, 2)
             # The reshape values are determined by counting the "," and ";" in the Autolev matrix
 
             # Eg:
@@ -1292,7 +1292,7 @@ if AutolevListener:
             num_of_rows = semicolon_count + 1
             num_of_cols = (comma_count//num_of_rows) + 1
 
-            self.setValue(ctx, "sm.Matrix(" + "".join(l) + ")" + ".reshape(" +
+            self.setValue(ctx, "_sm.Matrix(" + "".join(l) + ")" + ".reshape(" +
                           str(num_of_rows) + ", " + str(num_of_cols) + ")")
 
         def exitVectorOrDyadic(self, ctx):
@@ -1454,12 +1454,12 @@ if AutolevListener:
                     if ctx.index().getChild(0).getText() == "1":
                         self.type.update({text: "matrix"})
                         self.symbol_table.update({text: text})
-                        self.write(text + " = " + "sm.Matrix([[0]])\n")
+                        self.write(text + " = " + "_sm.Matrix([[0]])\n")
                         self.write(text + "[0] = " + self.getValue(ctx.expr()) + "\n")
                     else:
-                        # m = m.row_insert(m.shape[0], sm.Matrix([[0]]))
+                        # m = m.row_insert(m.shape[0], _sm.Matrix([[0]]))
                         self.write(text + " = " + text +
-                                   ".row_insert(" + text + ".shape[0]" + ", " + "sm.Matrix([[0]])" + ")\n")
+                                   ".row_insert(" + text + ".shape[0]" + ", " + "_sm.Matrix([[0]])" + ")\n")
                         self.write(text + "[" + text + ".shape[0]-1" + "] = " + self.getValue(ctx.expr()) + "\n")
 
                 # Handle assignments of type ID[2, 2] = expr
@@ -1624,7 +1624,7 @@ if AutolevListener:
                 self.write(matrix_name + "_list" + " = " + "[]\n")
                 self.write("for i in " + matrix_name + ":  " + matrix_name +
                            "_list" + ".append(i.subs({" + ", ".join(d) + "}))\n")
-                self.write("print(sm.linsolve(" + matrix_name + "_list" + ", " + ",".join(e) + "))\n")
+                self.write("print(_sm.linsolve(" + matrix_name + "_list" + ", " + ",".join(e) + "))\n")
 
             elif ctx.functionCall().getChild(0).getText().lower() == "nonlinear":
                 e = []
@@ -1643,19 +1643,19 @@ if AutolevListener:
                             z = ""
                         if i not in e:
                             if z == "deg":
-                                d.append(i + ":" + "np.deg2rad(" + j + ")")
+                                d.append(i + ":" + "_np.deg2rad(" + j + ")")
                             else:
                                 d.append(i + ":" + j)
                         else:
                             if z == "deg":
-                                guess.append("np.deg2rad(" + j + ")")
+                                guess.append("_np.deg2rad(" + j + ")")
                             else:
                                 guess.append(j)
 
                 self.write("matrix_list" + " = " + "[]\n")
                 self.write("for i in " + self.getValue(ctx.functionCall().expr(0)) + ":")
                 self.write("matrix_list" + ".append(i.subs({" + ", ".join(d) + "}))\n")
-                self.write("print(sm.nsolve(matrix_list," + "(" + ",".join(e) + ")" +
+                self.write("print(_sm.nsolve(matrix_list," + "(" + ",".join(e) + ")" +
                            ",(" + ",".join(guess) + ")" + "))\n")
 
             elif ctx.functionCall().getChild(0).getText().lower() in ["ode", "dynamics"] and self.include_numeric:
@@ -1673,7 +1673,7 @@ if AutolevListener:
                             if i in self.inputs.keys():
                                 if type(self.inputs[i]) is tuple:
                                     if self.inputs[i][1] == "deg":
-                                        x0.append(i + ":" + "np.deg2rad(" + self.inputs[i][0] + ")")
+                                        x0.append(i + ":" + "_np.deg2rad(" + self.inputs[i][0] + ")")
                                     else:
                                         x0.append(i + ":" + self.inputs[i][0])
                                 else:
@@ -1706,7 +1706,7 @@ if AutolevListener:
                             const_list.append(self.constants[i] + ":" + numerical_constants[i])
                     specifieds = []
                     if self.t:
-                        specifieds.append("me.dynamicsymbols('t')" + ":" + "lambda x, t: t")
+                        specifieds.append("_me.dynamicsymbols('t')" + ":" + "lambda x, t: t")
 
                     for i in self.inputs:
                         if i in self.symbol_table.keys() and self.symbol_table[i] not in\
@@ -1716,7 +1716,7 @@ if AutolevListener:
                     self.write("sys = System(kane, constants = {" + ", ".join(const_list) + "},\n" +
                                "specifieds={" + ", ".join(specifieds) + "},\n" +
                                "initial_conditions={" + ", ".join(x0) + "},\n" +
-                               "times = np.linspace(0.0, " + str(t_final) + ", " + str(t_final) +
+                               "times = _np.linspace(0.0, " + str(t_final) + ", " + str(t_final) +
                                "/" + str(integ_stp) + "))\n\ny=sys.integrate()\n")
 
                     # For outputs other than qs and us.
@@ -1754,7 +1754,7 @@ if AutolevListener:
                     expr = self.getValue(ctx.expr(0))
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([i.expand() for i in " + expr + "])" +
+                        self.write(symbol + " = " + "_sm.Matrix([i.expand() for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
                         self.write(symbol + " = " + symbol + "." + "expand()\n")
@@ -1764,11 +1764,11 @@ if AutolevListener:
                     expr = self.getValue(ctx.expr(0))
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([sm.factor(i," + self.getValue(ctx.expr(1)) +
+                        self.write(symbol + " = " + "_sm.Matrix([_sm.factor(i," + self.getValue(ctx.expr(1)) +
                                    ") for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
-                        self.write(expr + " = " + "sm.factor(" + expr + ", " +
+                        self.write(expr + " = " + "_sm.factor(" + expr + ", " +
                                    self.getValue(ctx.expr(1)) + ")\n")
 
                 # Solve(Zero, x, y)
@@ -1791,9 +1791,9 @@ if AutolevListener:
                                 pass
 
                     for i in l2:
-                        self.explicit.update({i: "sm.solve" + "".join(l) + "[" + i + "]"})
+                        self.explicit.update({i: "_sm.solve" + "".join(l) + "[" + i + "]"})
 
-                    self.write("print(sm.solve" + "".join(l) + ")\n")
+                    self.write("print(_sm.solve" + "".join(l) + ")\n")
 
                 # Arrange(y, n, x) *
                 elif func_name == "arrange":
@@ -1801,7 +1801,7 @@ if AutolevListener:
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
 
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([i.collect(" + self.getValue(ctx.expr(2)) +
+                        self.write(symbol + " = " + "_sm.Matrix([i.collect(" + self.getValue(ctx.expr(2)) +
                                    ")" + "for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
@@ -1812,13 +1812,13 @@ if AutolevListener:
                 elif func_name == "eig":
                     self.symbol_table.update({ctx.expr(1).getText().lower(): ctx.expr(1).getText().lower()})
                     self.symbol_table.update({ctx.expr(2).getText().lower(): ctx.expr(2).getText().lower()})
-                    # sm.Matrix([i.evalf() for i in (i_s_so).eigenvals().keys()])
+                    # _sm.Matrix([i.evalf() for i in (i_s_so).eigenvals().keys()])
                     self.write(ctx.expr(1).getText().lower() + " = " +
-                               "sm.Matrix([i.evalf() for i in " +
+                               "_sm.Matrix([i.evalf() for i in " +
                                "(" + self.getValue(ctx.expr(0)) + ")" + ".eigenvals().keys()])\n")
-                    # sm.Matrix([i[2][0].evalf() for i in (i_s_o).eigenvects()]).reshape(i_s_o.shape[0], i_s_o.shape[1])
+                    # _sm.Matrix([i[2][0].evalf() for i in (i_s_o).eigenvects()]).reshape(i_s_o.shape[0], i_s_o.shape[1])
                     self.write(ctx.expr(2).getText().lower() + " = " +
-                               "sm.Matrix([i[2][0].evalf() for i in " + "(" + self.getValue(ctx.expr(0)) + ")" +
+                               "_sm.Matrix([i[2][0].evalf() for i in " + "(" + self.getValue(ctx.expr(0)) + ")" +
                                ".eigenvects()]).reshape(" + self.getValue(ctx.expr(0)) + ".shape[0], " +
                                self.getValue(ctx.expr(0)) + ".shape[1])\n")
 
@@ -1850,7 +1850,7 @@ if AutolevListener:
                         value = self.getValue(ctx.expr(3))
                     else:
                         if ctx.expr(3) in self.numeric_expr:
-                            value = "np.deg2rad(" + self.getValue(ctx.expr(3)) + ")"
+                            value = "_np.deg2rad(" + self.getValue(ctx.expr(3)) + ")"
                         else:
                             value = self.getValue(ctx.expr(3))
                     self.write(frame2 + ".orient(" + frame1 +
@@ -2021,7 +2021,7 @@ if AutolevListener:
             particle = self.symbol_table2[ctx.getChild(0).getText().lower()]
             if ctx.getText().count("=") == 2:
                 if ctx.expr().expr(1) in self.numeric_expr:
-                    e = "sm.S(" + self.getValue(ctx.expr().expr(1)) + ")"
+                    e = "_sm.S(" + self.getValue(ctx.expr().expr(1)) + ")"
                 else:
                     e = self.getValue(ctx.expr().expr(1))
                 self.symbol_table.update({ctx.expr().expr(0).getText().lower(): ctx.expr().expr(0).getText().lower()})
@@ -2030,14 +2030,14 @@ if AutolevListener:
             else:
                 try:
                     if ctx.expr() in self.numeric_expr:
-                        mass = "sm.S(" + self.getValue(ctx.expr()) + ")"
+                        mass = "_sm.S(" + self.getValue(ctx.expr()) + ")"
                     else:
                         mass = self.getValue(ctx.expr())
                 except Exception:
                     a_text = ctx.expr().getText().lower()
                     self.symbol_table.update({a_text: a_text})
                     self.type.update({a_text: "constants"})
-                    self.write(a_text + " = " + "sm.symbols('" + a_text + "')\n")
+                    self.write(a_text + " = " + "_sm.symbols('" + a_text + "')\n")
                     mass = a_text
 
             self.write(particle + ".mass = " + mass + "\n")
@@ -2052,32 +2052,32 @@ if AutolevListener:
             for i in range((ctx.getChildCount()-num)//2):
                 try:
                     if ctx.expr(i) in self.numeric_expr:
-                        inertia_list.append("sm.S(" + self.getValue(ctx.expr(i)) + ")")
+                        inertia_list.append("_sm.S(" + self.getValue(ctx.expr(i)) + ")")
                     else:
                         inertia_list.append(self.getValue(ctx.expr(i)))
                 except Exception:
                     a_text = ctx.expr(i).getText().lower()
                     self.symbol_table.update({a_text: a_text})
                     self.type.update({a_text: "constants"})
-                    self.write(a_text + " = " + "sm.symbols('" + a_text + "')\n")
+                    self.write(a_text + " = " + "_sm.symbols('" + a_text + "')\n")
                     inertia_list.append(a_text)
 
             if len(inertia_list) < 6:
                 for i in range(6-len(inertia_list)):
                     inertia_list.append("0")
-            # body_a.inertia = (me.inertia(body_a, I1, I2, I3, 0, 0, 0), body_a_cm)
+            # body_a.inertia = (_me.inertia(body_a, I1, I2, I3, 0, 0, 0), body_a_cm)
             try:
                 frame = self.symbol_table2[ctx.ID(1).getText().lower()]
                 point = self.symbol_table2[ctx.ID(0).getText().lower().split('_')[1]]
                 body = self.symbol_table2[ctx.ID(0).getText().lower().split('_')[0]]
                 self.inertia_point.update({ctx.ID(0).getText().lower().split('_')[0]
                                           : ctx.ID(0).getText().lower().split('_')[1]})
-                self.write(body + ".inertia" + " = " + "(me.inertia(" + frame + ", " +
+                self.write(body + ".inertia" + " = " + "(_me.inertia(" + frame + ", " +
                            ", ".join(inertia_list) + "), " + point + ")\n")
 
             except Exception:
                 body_name = self.symbol_table2[ctx.ID(0).getText().lower()]
                 body_name_cm = body_name + "_cm"
                 self.inertia_point.update({ctx.ID(0).getText().lower(): ctx.ID(0).getText().lower() + "o"})
-                self.write(body_name + ".inertia" + " = " + "(me.inertia(" + body_name + "_f" + ", " +
+                self.write(body_name + ".inertia" + " = " + "(_me.inertia(" + body_name + "_f" + ", " +
                            ", ".join(inertia_list) + "), " + body_name_cm + ")\n")

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
@@ -1,24 +1,24 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-g, lb, w, h = sm.symbols('g lb w h', real=True)
-theta, phi, omega, alpha = me.dynamicsymbols('theta phi omega alpha')
-thetad, phid, omegad, alphad = me.dynamicsymbols('theta phi omega alpha', 1)
-thetad2, phid2 = me.dynamicsymbols('theta phi', 2)
-frame_n = me.ReferenceFrame('n')
-body_a_cm = me.Point('a_cm')
+g, lb, w, h = _sm.symbols('g lb w h', real=True)
+theta, phi, omega, alpha = _me.dynamicsymbols('theta phi omega alpha')
+theta_d, phi_d, omega_d, alpha_d = _me.dynamicsymbols('theta_ phi_ omega_ alpha_', 1)
+theta_dd, phi_dd = _me.dynamicsymbols('theta_ phi_', 2)
+frame_n = _me.ReferenceFrame('n')
+body_a_cm = _me.Point('a_cm')
 body_a_cm.set_vel(frame_n, 0)
-body_a_f = me.ReferenceFrame('a_f')
-body_a = me.RigidBody('a', body_a_cm, body_a_f, sm.symbols('m'), (me.outer(body_a_f.x,body_a_f.x),body_a_cm))
-body_b_cm = me.Point('b_cm')
+body_a_f = _me.ReferenceFrame('a_f')
+body_a = _me.RigidBody('a', body_a_cm, body_a_f, _sm.symbols('m'), (_me.outer(body_a_f.x,body_a_f.x),body_a_cm))
+body_b_cm = _me.Point('b_cm')
 body_b_cm.set_vel(frame_n, 0)
-body_b_f = me.ReferenceFrame('b_f')
-body_b = me.RigidBody('b', body_b_cm, body_b_f, sm.symbols('m'), (me.outer(body_b_f.x,body_b_f.x),body_b_cm))
+body_b_f = _me.ReferenceFrame('b_f')
+body_b = _me.RigidBody('b', body_b_cm, body_b_f, _sm.symbols('m'), (_me.outer(body_b_f.x,body_b_f.x),body_b_cm))
 body_a_f.orient(frame_n, 'Axis', [theta, frame_n.y])
 body_b_f.orient(body_a_f, 'Axis', [phi, body_a_f.z])
-point_o = me.Point('o')
+point_o = _me.Point('o')
 la = (lb-h/2)/2
 body_a_cm.set_pos(point_o, la*body_a_f.z)
 body_b_cm.set_pos(point_o, lb*body_a_f.z)
@@ -27,9 +27,9 @@ body_b_f.set_ang_vel(body_a_f, alpha*body_a_f.z)
 point_o.set_vel(frame_n, 0)
 body_a_cm.v2pt_theory(point_o,frame_n,body_a_f)
 body_b_cm.v2pt_theory(point_o,frame_n,body_a_f)
-ma = sm.symbols('ma')
+ma = _sm.symbols('ma')
 body_a.mass = ma
-mb = sm.symbols('mb')
+mb = _sm.symbols('mb')
 body_b.mass = mb
 iaxx = 1/12*ma*(2*la)**2
 iayy = iaxx
@@ -37,19 +37,19 @@ iazz = 0
 ibxx = 1/12*mb*h**2
 ibyy = 1/12*mb*(w**2+h**2)
 ibzz = 1/12*mb*w**2
-body_a.inertia = (me.inertia(body_a_f, iaxx, iayy, iazz, 0, 0, 0), body_a_cm)
-body_b.inertia = (me.inertia(body_b_f, ibxx, ibyy, ibzz, 0, 0, 0), body_b_cm)
+body_a.inertia = (_me.inertia(body_a_f, iaxx, iayy, iazz, 0, 0, 0), body_a_cm)
+body_b.inertia = (_me.inertia(body_b_f, ibxx, ibyy, ibzz, 0, 0, 0), body_b_cm)
 force_a = body_a.mass*(g*frame_n.z)
 force_b = body_b.mass*(g*frame_n.z)
-kd_eqs = [thetad - omega, phid - alpha]
+kd_eqs = [theta_d - omega, phi_d - alpha]
 forceList = [(body_a.masscenter,body_a.mass*(g*frame_n.z)), (body_b.masscenter,body_b.mass*(g*frame_n.z))]
-kane = me.KanesMethod(frame_n, q_ind=[theta,phi], u_ind=[omega, alpha], kd_eqs = kd_eqs)
+kane = _me.KanesMethod(frame_n, q_ind=[theta,phi], u_ind=[omega, alpha], kd_eqs = kd_eqs)
 fr, frstar = kane.kanes_equations([body_a, body_b], forceList)
 zero = fr+frstar
 from pydy.system import System
 sys = System(kane, constants = {g:9.81, lb:0.2, w:0.2, h:0.1, ma:0.01, mb:0.1},
 specifieds={},
-initial_conditions={theta:np.deg2rad(90), phi:np.deg2rad(0.5), omega:0, alpha:0},
-times = np.linspace(0.0, 10, 10/0.02))
+initial_conditions={theta:_np.deg2rad(90), phi:_np.deg2rad(0.5), omega:0, alpha:0},
+times = _np.linspace(0.0, 10, 10/0.02))
 
 y=sys.integrate()

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
@@ -1,21 +1,21 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')
-q1d, q2d, u1d, u2d = me.dynamicsymbols('q1 q2 u1 u2', 1)
-l, m, g = sm.symbols('l m g', real=True)
-frame_n = me.ReferenceFrame('n')
-frame_a = me.ReferenceFrame('a')
-frame_b = me.ReferenceFrame('b')
+q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
+q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)
+l, m, g = _sm.symbols('l m g', real=True)
+frame_n = _me.ReferenceFrame('n')
+frame_a = _me.ReferenceFrame('a')
+frame_b = _me.ReferenceFrame('b')
 frame_a.orient(frame_n, 'Axis', [q1, frame_n.z])
 frame_b.orient(frame_n, 'Axis', [q2, frame_n.z])
 frame_a.set_ang_vel(frame_n, u1*frame_n.z)
 frame_b.set_ang_vel(frame_n, u2*frame_n.z)
-point_o = me.Point('o')
-particle_p = me.Particle('p', me.Point('p_pt'), sm.Symbol('m'))
-particle_r = me.Particle('r', me.Point('r_pt'), sm.Symbol('m'))
+point_o = _me.Point('o')
+particle_p = _me.Particle('p', _me.Point('p_pt'), _sm.Symbol('m'))
+particle_r = _me.Particle('r', _me.Point('r_pt'), _sm.Symbol('m'))
 particle_p.point.set_pos(point_o, l*frame_a.x)
 particle_r.point.set_pos(particle_p.point, l*frame_b.x)
 point_o.set_vel(frame_n, 0)
@@ -25,15 +25,15 @@ particle_p.mass = m
 particle_r.mass = m
 force_p = particle_p.mass*(g*frame_n.x)
 force_r = particle_r.mass*(g*frame_n.x)
-kd_eqs = [q1d - u1, q2d - u2]
+kd_eqs = [q1_d - u1, q2_d - u2]
 forceList = [(particle_p.point,particle_p.mass*(g*frame_n.x)), (particle_r.point,particle_r.mass*(g*frame_n.x))]
-kane = me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u1, u2], kd_eqs = kd_eqs)
+kane = _me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u1, u2], kd_eqs = kd_eqs)
 fr, frstar = kane.kanes_equations([particle_p, particle_r], forceList)
 zero = fr+frstar
 from pydy.system import System
 sys = System(kane, constants = {l:1, m:1, g:9.81},
 specifieds={},
 initial_conditions={q1:.1, q2:.2, u1:0, u2:0},
-times = np.linspace(0.0, 10, 10/.01))
+times = _np.linspace(0.0, 10, 10/.01))
 
 y=sys.integrate()

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
@@ -1,31 +1,31 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-m, k, b, g = sm.symbols('m k b g', real=True)
-position, speed = me.dynamicsymbols('position speed')
-positiond, speedd = me.dynamicsymbols('position speed', 1)
-o = me.dynamicsymbols('o')
-force = o*sm.sin(me.dynamicsymbols._t)
-frame_ceiling = me.ReferenceFrame('ceiling')
-point_origin = me.Point('origin')
+m, k, b, g = _sm.symbols('m k b g', real=True)
+position, speed = _me.dynamicsymbols('position speed')
+position_d, speed_d = _me.dynamicsymbols('position_ speed_', 1)
+o = _me.dynamicsymbols('o')
+force = o*_sm.sin(_me.dynamicsymbols._t)
+frame_ceiling = _me.ReferenceFrame('ceiling')
+point_origin = _me.Point('origin')
 point_origin.set_vel(frame_ceiling, 0)
-particle_block = me.Particle('block', me.Point('block_pt'), sm.Symbol('m'))
+particle_block = _me.Particle('block', _me.Point('block_pt'), _sm.Symbol('m'))
 particle_block.point.set_pos(point_origin, position*frame_ceiling.x)
 particle_block.mass = m
 particle_block.point.set_vel(frame_ceiling, speed*frame_ceiling.x)
 force_magnitude = m*g-k*position-b*speed+force
-force_block = (force_magnitude*frame_ceiling.x).subs({positiond:speed})
-kd_eqs = [positiond - speed]
-forceList = [(particle_block.point,(force_magnitude*frame_ceiling.x).subs({positiond:speed}))]
-kane = me.KanesMethod(frame_ceiling, q_ind=[position], u_ind=[speed], kd_eqs = kd_eqs)
+force_block = (force_magnitude*frame_ceiling.x).subs({position_d:speed})
+kd_eqs = [position_d - speed]
+forceList = [(particle_block.point,(force_magnitude*frame_ceiling.x).subs({position_d:speed}))]
+kane = _me.KanesMethod(frame_ceiling, q_ind=[position], u_ind=[speed], kd_eqs = kd_eqs)
 fr, frstar = kane.kanes_equations([particle_block], forceList)
 zero = fr+frstar
 from pydy.system import System
 sys = System(kane, constants = {m:1.0, k:1.0, b:0.2, g:9.8},
-specifieds={me.dynamicsymbols('t'):lambda x, t: t, o:2},
+specifieds={_me.dynamicsymbols('t'):lambda x, t: t, o:2},
 initial_conditions={position:0.1, speed:-1*1.0},
-times = np.linspace(0.0, 10.0, 10.0/0.01))
+times = _np.linspace(0.0, 10.0, 10.0/0.01))
 
 y=sys.integrate()

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
@@ -1,36 +1,36 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-q1, q2 = me.dynamicsymbols('q1 q2')
-q1d, q2d = me.dynamicsymbols('q1 q2', 1)
-q1d2, q2d2 = me.dynamicsymbols('q1 q2', 2)
-l, m, g = sm.symbols('l m g', real=True)
-frame_n = me.ReferenceFrame('n')
-point_pn = me.Point('pn')
+q1, q2 = _me.dynamicsymbols('q1 q2')
+q1_d, q2_d = _me.dynamicsymbols('q1_ q2_', 1)
+q1_dd, q2_dd = _me.dynamicsymbols('q1_ q2_', 2)
+l, m, g = _sm.symbols('l m g', real=True)
+frame_n = _me.ReferenceFrame('n')
+point_pn = _me.Point('pn')
 point_pn.set_vel(frame_n, 0)
-theta1 = sm.atan(q2/q1)
-frame_a = me.ReferenceFrame('a')
+theta1 = _sm.atan(q2/q1)
+frame_a = _me.ReferenceFrame('a')
 frame_a.orient(frame_n, 'Axis', [theta1, frame_n.z])
-particle_p = me.Particle('p', me.Point('p_pt'), sm.Symbol('m'))
+particle_p = _me.Particle('p', _me.Point('p_pt'), _sm.Symbol('m'))
 particle_p.point.set_pos(point_pn, q1*frame_n.x+q2*frame_n.y)
 particle_p.mass = m
 particle_p.point.set_vel(frame_n, (point_pn.pos_from(particle_p.point)).dt(frame_n))
-f_v = me.dot((particle_p.point.vel(frame_n)).express(frame_a), frame_a.x)
+f_v = _me.dot((particle_p.point.vel(frame_n)).express(frame_a), frame_a.x)
 force_p = particle_p.mass*(g*frame_n.x)
-dependent = sm.Matrix([[0]])
+dependent = _sm.Matrix([[0]])
 dependent[0] = f_v
 velocity_constraints = [i for i in dependent]
-u_q1d = me.dynamicsymbols('u_q1d')
-u_q2d = me.dynamicsymbols('u_q2d')
-kd_eqs = [q1d-u_q1d, q2d-u_q2d]
+u_q1_d = _me.dynamicsymbols('u_q1_d')
+u_q2_d = _me.dynamicsymbols('u_q2_d')
+kd_eqs = [q1_d-u_q1_d, q2_d-u_q2_d]
 forceList = [(particle_p.point,particle_p.mass*(g*frame_n.x))]
-kane = me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u_q2d], u_dependent=[u_q1d], kd_eqs = kd_eqs, velocity_constraints = velocity_constraints)
+kane = _me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u_q2_d], u_dependent=[u_q1_d], kd_eqs = kd_eqs, velocity_constraints = velocity_constraints)
 fr, frstar = kane.kanes_equations([particle_p], forceList)
 zero = fr+frstar
 f_c = point_pn.pos_from(particle_p.point).magnitude()-l
-config = sm.Matrix([[0]])
+config = _sm.Matrix([[0]])
 config[0] = f_c
-zero = zero.row_insert(zero.shape[0], sm.Matrix([[0]]))
+zero = zero.row_insert(zero.shape[0], _sm.Matrix([[0]]))
 zero[zero.shape[0]-1] = config[0]

--- a/sympy/parsing/autolev/test-examples/ruletest1.py
+++ b/sympy/parsing/autolev/test-examples/ruletest1.py
@@ -1,15 +1,15 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-f = sm.S(3)
-g = sm.S(9.81)
-a, b = sm.symbols('a b', real=True)
-s, s1 = sm.symbols('s s1', real=True)
-s2, s3 = sm.symbols('s2 s3', real=True, nonnegative=True)
-s4 = sm.symbols('s4', real=True, nonpositive=True)
-k1, k2, k3, k4, l1, l2, l3, p11, p12, p13, p21, p22, p23 = sm.symbols('k1 k2 k3 k4 l1 l2 l3 p11 p12 p13 p21 p22 p23', real=True)
-c11, c12, c13, c21, c22, c23 = sm.symbols('c11 c12 c13 c21 c22 c23', real=True)
+f = _sm.S(3)
+g = _sm.S(9.81)
+a, b = _sm.symbols('a b', real=True)
+s, s1 = _sm.symbols('s s1', real=True)
+s2, s3 = _sm.symbols('s2 s3', real=True, nonnegative=True)
+s4 = _sm.symbols('s4', real=True, nonpositive=True)
+k1, k2, k3, k4, l1, l2, l3, p11, p12, p13, p21, p22, p23 = _sm.symbols('k1 k2 k3 k4 l1 l2 l3 p11 p12 p13 p21 p22 p23', real=True)
+c11, c12, c13, c21, c22, c23 = _sm.symbols('c11 c12 c13 c21 c22 c23', real=True)
 e1 = a*f+s2-g
 e2 = f**2+k3*k2*g

--- a/sympy/parsing/autolev/test-examples/ruletest10.py
+++ b/sympy/parsing/autolev/test-examples/ruletest10.py
@@ -1,62 +1,62 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x, y = me.dynamicsymbols('x y')
-a, b = sm.symbols('a b', real=True)
+x, y = _me.dynamicsymbols('x y')
+a, b = _sm.symbols('a b', real=True)
 e = a*(b*x+y)**2
-m = sm.Matrix([e,e]).reshape(2, 1)
+m = _sm.Matrix([e,e]).reshape(2, 1)
 e = e.expand()
-m = sm.Matrix([i.expand() for i in m]).reshape((m).shape[0], (m).shape[1])
-e = sm.factor(e, x)
-m = sm.Matrix([sm.factor(i,x) for i in m]).reshape((m).shape[0], (m).shape[1])
-eqn = sm.Matrix([[0]])
+m = _sm.Matrix([i.expand() for i in m]).reshape((m).shape[0], (m).shape[1])
+e = _sm.factor(e, x)
+m = _sm.Matrix([_sm.factor(i,x) for i in m]).reshape((m).shape[0], (m).shape[1])
+eqn = _sm.Matrix([[0]])
 eqn[0] = a*x+b*y
-eqn = eqn.row_insert(eqn.shape[0], sm.Matrix([[0]]))
+eqn = eqn.row_insert(eqn.shape[0], _sm.Matrix([[0]]))
 eqn[eqn.shape[0]-1] = 2*a*x-3*b*y
-print(sm.solve(eqn,x,y))
-rhs_y = sm.solve(eqn,x,y)[y]
+print(_sm.solve(eqn,x,y))
+rhs_y = _sm.solve(eqn,x,y)[y]
 e = (x+y)**2+2*x**2
 e.collect(x)
-a, b, c = sm.symbols('a b c', real=True)
-m = sm.Matrix([a,b,c,0]).reshape(2, 2)
-m2 = sm.Matrix([i.subs({a:1,b:2,c:3}) for i in m]).reshape((m).shape[0], (m).shape[1])
-eigvalue = sm.Matrix([i.evalf() for i in (m2).eigenvals().keys()])
-eigvec = sm.Matrix([i[2][0].evalf() for i in (m2).eigenvects()]).reshape(m2.shape[0], m2.shape[1])
-frame_n = me.ReferenceFrame('n')
-frame_a = me.ReferenceFrame('a')
+a, b, c = _sm.symbols('a b c', real=True)
+m = _sm.Matrix([a,b,c,0]).reshape(2, 2)
+m2 = _sm.Matrix([i.subs({a:1,b:2,c:3}) for i in m]).reshape((m).shape[0], (m).shape[1])
+eigvalue = _sm.Matrix([i.evalf() for i in (m2).eigenvals().keys()])
+eigvec = _sm.Matrix([i[2][0].evalf() for i in (m2).eigenvects()]).reshape(m2.shape[0], m2.shape[1])
+frame_n = _me.ReferenceFrame('n')
+frame_a = _me.ReferenceFrame('a')
 frame_a.orient(frame_n, 'Axis', [x, frame_n.x])
-frame_a.orient(frame_n, 'Axis', [sm.pi/2, frame_n.x])
-c1, c2, c3 = sm.symbols('c1 c2 c3', real=True)
-v=c1*frame_a.x+c2*frame_a.y+c3*frame_a.z
-point_o = me.Point('o')
-point_p = me.Point('p')
+frame_a.orient(frame_n, 'Axis', [_sm.pi/2, frame_n.x])
+c1, c2, c3 = _sm.symbols('c1 c2 c3', real=True)
+v = c1*frame_a.x+c2*frame_a.y+c3*frame_a.z
+point_o = _me.Point('o')
+point_p = _me.Point('p')
 point_o.set_pos(point_p, c1*frame_a.x)
 v = (v).express(frame_n)
 point_o.set_pos(point_p, (point_o.pos_from(point_p)).express(frame_n))
 frame_a.set_ang_vel(frame_n, c3*frame_a.z)
 print(frame_n.ang_vel_in(frame_a))
 point_p.v2pt_theory(point_o,frame_n,frame_a)
-particle_p1 = me.Particle('p1', me.Point('p1_pt'), sm.Symbol('m'))
-particle_p2 = me.Particle('p2', me.Point('p2_pt'), sm.Symbol('m'))
+particle_p1 = _me.Particle('p1', _me.Point('p1_pt'), _sm.Symbol('m'))
+particle_p2 = _me.Particle('p2', _me.Point('p2_pt'), _sm.Symbol('m'))
 particle_p2.point.v2pt_theory(particle_p1.point,frame_n,frame_a)
 point_p.a2pt_theory(particle_p1.point,frame_n,frame_a)
-body_b1_cm = me.Point('b1_cm')
+body_b1_cm = _me.Point('b1_cm')
 body_b1_cm.set_vel(frame_n, 0)
-body_b1_f = me.ReferenceFrame('b1_f')
-body_b1 = me.RigidBody('b1', body_b1_cm, body_b1_f, sm.symbols('m'), (me.outer(body_b1_f.x,body_b1_f.x),body_b1_cm))
-body_b2_cm = me.Point('b2_cm')
+body_b1_f = _me.ReferenceFrame('b1_f')
+body_b1 = _me.RigidBody('b1', body_b1_cm, body_b1_f, _sm.symbols('m'), (_me.outer(body_b1_f.x,body_b1_f.x),body_b1_cm))
+body_b2_cm = _me.Point('b2_cm')
 body_b2_cm.set_vel(frame_n, 0)
-body_b2_f = me.ReferenceFrame('b2_f')
-body_b2 = me.RigidBody('b2', body_b2_cm, body_b2_f, sm.symbols('m'), (me.outer(body_b2_f.x,body_b2_f.x),body_b2_cm))
-g = sm.symbols('g', real=True)
+body_b2_f = _me.ReferenceFrame('b2_f')
+body_b2 = _me.RigidBody('b2', body_b2_cm, body_b2_f, _sm.symbols('m'), (_me.outer(body_b2_f.x,body_b2_f.x),body_b2_cm))
+g = _sm.symbols('g', real=True)
 force_p1 = particle_p1.mass*(g*frame_n.x)
 force_p2 = particle_p2.mass*(g*frame_n.x)
 force_b1 = body_b1.mass*(g*frame_n.x)
 force_b2 = body_b2.mass*(g*frame_n.x)
-z = me.dynamicsymbols('z')
-v=x*frame_a.x+y*frame_a.z
+z = _me.dynamicsymbols('z')
+v = x*frame_a.x+y*frame_a.z
 point_o.set_pos(point_p, x*frame_a.x+y*frame_a.y)
 v = (v).subs({x:2*z, y:z})
 point_o.set_pos(point_p, (point_o.pos_from(point_p)).subs({x:2*z, y:z}))

--- a/sympy/parsing/autolev/test-examples/ruletest11.py
+++ b/sympy/parsing/autolev/test-examples/ruletest11.py
@@ -1,14 +1,14 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x, y = me.dynamicsymbols('x y')
-a11, a12, a21, a22, b1, b2 = sm.symbols('a11 a12 a21 a22 b1 b2', real=True)
-eqn = sm.Matrix([[0]])
+x, y = _me.dynamicsymbols('x y')
+a11, a12, a21, a22, b1, b2 = _sm.symbols('a11 a12 a21 a22 b1 b2', real=True)
+eqn = _sm.Matrix([[0]])
 eqn[0] = a11*x+a12*y-b1
-eqn = eqn.row_insert(eqn.shape[0], sm.Matrix([[0]]))
+eqn = eqn.row_insert(eqn.shape[0], _sm.Matrix([[0]]))
 eqn[eqn.shape[0]-1] = a21*x+a22*y-b2
 eqn_list = []
 for i in eqn:  eqn_list.append(i.subs({a11:2, a12:5, a21:3, a22:4, b1:7, b2:6}))
-print(sm.linsolve(eqn_list, x,y))
+print(_sm.linsolve(eqn_list, x,y))

--- a/sympy/parsing/autolev/test-examples/ruletest12.py
+++ b/sympy/parsing/autolev/test-examples/ruletest12.py
@@ -1,14 +1,14 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x, y = me.dynamicsymbols('x y')
-a, b, r = sm.symbols('a b r', real=True)
-eqn = sm.Matrix([[0]])
+x, y = _me.dynamicsymbols('x y')
+a, b, r = _sm.symbols('a b r', real=True)
+eqn = _sm.Matrix([[0]])
 eqn[0] = a*x**3+b*y**2-r
-eqn = eqn.row_insert(eqn.shape[0], sm.Matrix([[0]]))
-eqn[eqn.shape[0]-1] = a*sm.sin(x)**2+b*sm.cos(2*y)-r**2
+eqn = eqn.row_insert(eqn.shape[0], _sm.Matrix([[0]]))
+eqn[eqn.shape[0]-1] = a*_sm.sin(x)**2+b*_sm.cos(2*y)-r**2
 matrix_list = []
 for i in eqn:matrix_list.append(i.subs({a:2.0, b:3.0, r:1.0}))
-print(sm.nsolve(matrix_list,(x,y),(np.deg2rad(30),3.14)))
+print(_sm.nsolve(matrix_list,(x,y),(_np.deg2rad(30),3.14)))

--- a/sympy/parsing/autolev/test-examples/ruletest2.py
+++ b/sympy/parsing/autolev/test-examples/ruletest2.py
@@ -1,22 +1,22 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x1, x2 = me.dynamicsymbols('x1 x2')
+x1, x2 = _me.dynamicsymbols('x1 x2')
 f1 = x1*x2+3*x1**2
-f2 = x1*me.dynamicsymbols._t+x2*me.dynamicsymbols._t**2
-x, y = me.dynamicsymbols('x y')
-xd, yd = me.dynamicsymbols('x y', 1)
-yd2 = me.dynamicsymbols('y', 2)
-q1, q2, q3, u1, u2 = me.dynamicsymbols('q1 q2 q3 u1 u2')
-p1, p2 = me.dynamicsymbols('p1 p2')
-p1d, p2d = me.dynamicsymbols('p1 p2', 1)
-w1, w2, w3, r1, r2 = me.dynamicsymbols('w1 w2 w3 r1 r2')
-w1d, w2d, w3d, r1d, r2d = me.dynamicsymbols('w1 w2 w3 r1 r2', 1)
-r1d2, r2d2 = me.dynamicsymbols('r1 r2', 2)
-c11, c12, c21, c22 = me.dynamicsymbols('c11 c12 c21 c22')
-d11, d12, d13 = me.dynamicsymbols('d11 d12 d13')
-j1, j2 = me.dynamicsymbols('j1 j2')
-n = sm.symbols('n')
-n = sm.I
+f2 = x1*_me.dynamicsymbols._t+x2*_me.dynamicsymbols._t**2
+x, y = _me.dynamicsymbols('x y')
+x_d, y_d = _me.dynamicsymbols('x_ y_', 1)
+y_dd = _me.dynamicsymbols('y_', 2)
+q1, q2, q3, u1, u2 = _me.dynamicsymbols('q1 q2 q3 u1 u2')
+p1, p2 = _me.dynamicsymbols('p1 p2')
+p1_d, p2_d = _me.dynamicsymbols('p1_ p2_', 1)
+w1, w2, w3, r1, r2 = _me.dynamicsymbols('w1 w2 w3 r1 r2')
+w1_d, w2_d, w3_d, r1_d, r2_d = _me.dynamicsymbols('w1_ w2_ w3_ r1_ r2_', 1)
+r1_dd, r2_dd = _me.dynamicsymbols('r1_ r2_', 2)
+c11, c12, c21, c22 = _me.dynamicsymbols('c11 c12 c21 c22')
+d11, d12, d13 = _me.dynamicsymbols('d11 d12 d13')
+j1, j2 = _me.dynamicsymbols('j1 j2')
+n = _sm.symbols('n')
+n = _sm.I

--- a/sympy/parsing/autolev/test-examples/ruletest3.py
+++ b/sympy/parsing/autolev/test-examples/ruletest3.py
@@ -1,37 +1,37 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-frame_a = me.ReferenceFrame('a')
-frame_b = me.ReferenceFrame('b')
-frame_n = me.ReferenceFrame('n')
-x1, x2, x3 = me.dynamicsymbols('x1 x2 x3')
-l = sm.symbols('l', real=True)
-v1=x1*frame_a.x+x2*frame_a.y+x3*frame_a.z
-v2=x1*frame_b.x+x2*frame_b.y+x3*frame_b.z
-v3=x1*frame_n.x+x2*frame_n.y+x3*frame_n.z
-v=v1+v2+v3
-point_c = me.Point('c')
-point_d = me.Point('d')
-point_po1 = me.Point('po1')
-point_po2 = me.Point('po2')
-point_po3 = me.Point('po3')
-particle_l = me.Particle('l', me.Point('l_pt'), sm.Symbol('m'))
-particle_p1 = me.Particle('p1', me.Point('p1_pt'), sm.Symbol('m'))
-particle_p2 = me.Particle('p2', me.Point('p2_pt'), sm.Symbol('m'))
-particle_p3 = me.Particle('p3', me.Point('p3_pt'), sm.Symbol('m'))
-body_s_cm = me.Point('s_cm')
+frame_a = _me.ReferenceFrame('a')
+frame_b = _me.ReferenceFrame('b')
+frame_n = _me.ReferenceFrame('n')
+x1, x2, x3 = _me.dynamicsymbols('x1 x2 x3')
+l = _sm.symbols('l', real=True)
+v1 = x1*frame_a.x+x2*frame_a.y+x3*frame_a.z
+v2 = x1*frame_b.x+x2*frame_b.y+x3*frame_b.z
+v3 = x1*frame_n.x+x2*frame_n.y+x3*frame_n.z
+v = v1+v2+v3
+point_c = _me.Point('c')
+point_d = _me.Point('d')
+point_po1 = _me.Point('po1')
+point_po2 = _me.Point('po2')
+point_po3 = _me.Point('po3')
+particle_l = _me.Particle('l', _me.Point('l_pt'), _sm.Symbol('m'))
+particle_p1 = _me.Particle('p1', _me.Point('p1_pt'), _sm.Symbol('m'))
+particle_p2 = _me.Particle('p2', _me.Point('p2_pt'), _sm.Symbol('m'))
+particle_p3 = _me.Particle('p3', _me.Point('p3_pt'), _sm.Symbol('m'))
+body_s_cm = _me.Point('s_cm')
 body_s_cm.set_vel(frame_n, 0)
-body_s_f = me.ReferenceFrame('s_f')
-body_s = me.RigidBody('s', body_s_cm, body_s_f, sm.symbols('m'), (me.outer(body_s_f.x,body_s_f.x),body_s_cm))
-body_r1_cm = me.Point('r1_cm')
+body_s_f = _me.ReferenceFrame('s_f')
+body_s = _me.RigidBody('s', body_s_cm, body_s_f, _sm.symbols('m'), (_me.outer(body_s_f.x,body_s_f.x),body_s_cm))
+body_r1_cm = _me.Point('r1_cm')
 body_r1_cm.set_vel(frame_n, 0)
-body_r1_f = me.ReferenceFrame('r1_f')
-body_r1 = me.RigidBody('r1', body_r1_cm, body_r1_f, sm.symbols('m'), (me.outer(body_r1_f.x,body_r1_f.x),body_r1_cm))
-body_r2_cm = me.Point('r2_cm')
+body_r1_f = _me.ReferenceFrame('r1_f')
+body_r1 = _me.RigidBody('r1', body_r1_cm, body_r1_f, _sm.symbols('m'), (_me.outer(body_r1_f.x,body_r1_f.x),body_r1_cm))
+body_r2_cm = _me.Point('r2_cm')
 body_r2_cm.set_vel(frame_n, 0)
-body_r2_f = me.ReferenceFrame('r2_f')
-body_r2 = me.RigidBody('r2', body_r2_cm, body_r2_f, sm.symbols('m'), (me.outer(body_r2_f.x,body_r2_f.x),body_r2_cm))
-v4=x1*body_s_f.x+x2*body_s_f.y+x3*body_s_f.z
+body_r2_f = _me.ReferenceFrame('r2_f')
+body_r2 = _me.RigidBody('r2', body_r2_cm, body_r2_f, _sm.symbols('m'), (_me.outer(body_r2_f.x,body_r2_f.x),body_r2_cm))
+v4 = x1*body_s_f.x+x2*body_s_f.y+x3*body_s_f.z
 body_s_cm.set_pos(point_c, l*frame_n.x)

--- a/sympy/parsing/autolev/test-examples/ruletest4.py
+++ b/sympy/parsing/autolev/test-examples/ruletest4.py
@@ -1,20 +1,20 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-frame_a = me.ReferenceFrame('a')
-frame_b = me.ReferenceFrame('b')
-q1, q2, q3 = me.dynamicsymbols('q1 q2 q3')
+frame_a = _me.ReferenceFrame('a')
+frame_b = _me.ReferenceFrame('b')
+q1, q2, q3 = _me.dynamicsymbols('q1 q2 q3')
 frame_b.orient(frame_a, 'Axis', [q3, frame_a.x])
 dcm = frame_a.dcm(frame_b)
 m = dcm*3-frame_a.dcm(frame_b)
-r = me.dynamicsymbols('r')
-circle_area = sm.pi*r**2
-u, a = me.dynamicsymbols('u a')
-x, y = me.dynamicsymbols('x y')
-s = u*me.dynamicsymbols._t-1/2*a*me.dynamicsymbols._t**2
+r = _me.dynamicsymbols('r')
+circle_area = _sm.pi*r**2
+u, a = _me.dynamicsymbols('u a')
+x, y = _me.dynamicsymbols('x y')
+s = u*_me.dynamicsymbols._t-1/2*a*_me.dynamicsymbols._t**2
 expr1 = 2*a*0.5-1.25+0.25
 expr2 = -1*x**2+y**2+0.25*(x+y)**2
 expr3 = 0.5*10**(-10)
-dyadic=me.outer(frame_a.x, frame_a.x)+me.outer(frame_a.y, frame_a.y)+me.outer(frame_a.z, frame_a.z)
+dyadic = _me.outer(frame_a.x, frame_a.x)+_me.outer(frame_a.y, frame_a.y)+_me.outer(frame_a.z, frame_a.z)

--- a/sympy/parsing/autolev/test-examples/ruletest5.py
+++ b/sympy/parsing/autolev/test-examples/ruletest5.py
@@ -1,33 +1,33 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x, y = me.dynamicsymbols('x y')
-xd, yd = me.dynamicsymbols('x y', 1)
+x, y = _me.dynamicsymbols('x y')
+x_d, y_d = _me.dynamicsymbols('x_ y_', 1)
 e1 = (x+y)**2+(x-y)**3
 e2 = (x-y)**2
 e3 = x**2+y**2+2*x*y
-m1 = sm.Matrix([e1,e2]).reshape(2, 1)
-m2 = sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)
-m3 = m1+sm.Matrix([x,y]).reshape(2, 1)
-am = sm.Matrix([i.expand() for i in m1]).reshape((m1).shape[0], (m1).shape[1])
-cm = sm.Matrix([i.expand() for i in sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)]).reshape((sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[0], (sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[1])
-em = sm.Matrix([i.expand() for i in m1+sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+sm.Matrix([x,y]).reshape(2, 1)).shape[1])
+m1 = _sm.Matrix([e1,e2]).reshape(2, 1)
+m2 = _sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)
+m3 = m1+_sm.Matrix([x,y]).reshape(2, 1)
+am = _sm.Matrix([i.expand() for i in m1]).reshape((m1).shape[0], (m1).shape[1])
+cm = _sm.Matrix([i.expand() for i in _sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)]).reshape((_sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[0], (_sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[1])
+em = _sm.Matrix([i.expand() for i in m1+_sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[1])
 f = (e1).expand()
 g = (e2).expand()
-a = sm.factor((e3), x)
-bm = sm.Matrix([sm.factor(i, x) for i in m1]).reshape((m1).shape[0], (m1).shape[1])
-cm = sm.Matrix([sm.factor(i, x) for i in m1+sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+sm.Matrix([x,y]).reshape(2, 1)).shape[1])
+a = _sm.factor((e3), x)
+bm = _sm.Matrix([_sm.factor(i, x) for i in m1]).reshape((m1).shape[0], (m1).shape[1])
+cm = _sm.Matrix([_sm.factor(i, x) for i in m1+_sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[1])
 a = (e3).diff(x)
 b = (e3).diff(y)
-cm = sm.Matrix([i.diff(x) for i in m2]).reshape((m2).shape[0], (m2).shape[1])
-dm = sm.Matrix([i.diff(x) for i in m1+sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+sm.Matrix([x,y]).reshape(2, 1)).shape[1])
-frame_a = me.ReferenceFrame('a')
-frame_b = me.ReferenceFrame('b')
-frame_b.orient(frame_a, 'DCM', sm.Matrix([1,0,0,1,0,0,1,0,0]).reshape(3, 3))
-v1=x*frame_a.x+y*frame_a.y+x*y*frame_a.z
-e=(v1).diff(x, frame_b)
-fm = sm.Matrix([i.diff(sm.Symbol('t')) for i in m1]).reshape((m1).shape[0], (m1).shape[1])
-gm = sm.Matrix([i.diff(sm.Symbol('t')) for i in sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)]).reshape((sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[0], (sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[1])
-h=(v1).dt(frame_b)
+cm = _sm.Matrix([i.diff(x) for i in m2]).reshape((m2).shape[0], (m2).shape[1])
+dm = _sm.Matrix([i.diff(x) for i in m1+_sm.Matrix([x,y]).reshape(2, 1)]).reshape((m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[0], (m1+_sm.Matrix([x,y]).reshape(2, 1)).shape[1])
+frame_a = _me.ReferenceFrame('a')
+frame_b = _me.ReferenceFrame('b')
+frame_b.orient(frame_a, 'DCM', _sm.Matrix([1,0,0,1,0,0,1,0,0]).reshape(3, 3))
+v1 = x*frame_a.x+y*frame_a.y+x*y*frame_a.z
+e = (v1).diff(x, frame_b)
+fm = _sm.Matrix([i.diff(_sm.Symbol('t')) for i in m1]).reshape((m1).shape[0], (m1).shape[1])
+gm = _sm.Matrix([i.diff(_sm.Symbol('t')) for i in _sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)]).reshape((_sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[0], (_sm.Matrix([(x+y)**2,(x-y)**2]).reshape(1, 2)).shape[1])
+h = (v1).dt(frame_b)

--- a/sympy/parsing/autolev/test-examples/ruletest6.py
+++ b/sympy/parsing/autolev/test-examples/ruletest6.py
@@ -1,36 +1,36 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-q1, q2 = me.dynamicsymbols('q1 q2')
-x, y, z = me.dynamicsymbols('x y z')
+q1, q2 = _me.dynamicsymbols('q1 q2')
+x, y, z = _me.dynamicsymbols('x y z')
 e = q1+q2
 a = (e).subs({q1:x**2+y**2, q2:x-y})
-e2 = sm.cos(x)
-e3 = sm.cos(x*y)
+e2 = _sm.cos(x)
+e3 = _sm.cos(x*y)
 a = (e2).series(x, 0, 2).removeO()
 b = (e3).series(x, 0, 2).removeO().series(y, 0, 2).removeO()
 e = ((x+y)**2).expand()
 a = (e).subs({q1:x**2+y**2,q2:x-y}).subs({x:1,y:z})
-bm = sm.Matrix([i.subs({x:1,y:z}) for i in sm.Matrix([e,2*e]).reshape(2, 1)]).reshape((sm.Matrix([e,2*e]).reshape(2, 1)).shape[0], (sm.Matrix([e,2*e]).reshape(2, 1)).shape[1])
+bm = _sm.Matrix([i.subs({x:1,y:z}) for i in _sm.Matrix([e,2*e]).reshape(2, 1)]).reshape((_sm.Matrix([e,2*e]).reshape(2, 1)).shape[0], (_sm.Matrix([e,2*e]).reshape(2, 1)).shape[1])
 e = q1+q2
 a = (e).subs({q1:x**2+y**2,q2:x-y}).subs({x:2,y:z**2})
-j, k, l = sm.symbols('j k l', real=True)
-p1 = sm.Poly(sm.Matrix([j,k,l]).reshape(1, 3), x)
-p2 = sm.Poly(j*x+k, x)
-root1 = [i.evalf() for i in sm.solve(p1, x)]
-root2 = [i.evalf() for i in sm.solve(sm.Poly(sm.Matrix([1,2,3]).reshape(3, 1), x),x)]
-m = sm.Matrix([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).reshape(4, 4)
+j, k, l = _sm.symbols('j k l', real=True)
+p1 = _sm.Poly(_sm.Matrix([j,k,l]).reshape(1, 3), x)
+p2 = _sm.Poly(j*x+k, x)
+root1 = [i.evalf() for i in _sm.solve(p1, x)]
+root2 = [i.evalf() for i in _sm.solve(_sm.Poly(_sm.Matrix([1,2,3]).reshape(3, 1), x),x)]
+m = _sm.Matrix([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).reshape(4, 4)
 am = (m).T+m
-bm = sm.Matrix([i.evalf() for i in (m).eigenvals().keys()])
-c1 = sm.diag(1,1,1,1)
-c2 = sm.Matrix([2 if i==j else 0 for i in range(3) for j in range(4)]).reshape(3, 4)
+bm = _sm.Matrix([i.evalf() for i in (m).eigenvals().keys()])
+c1 = _sm.diag(1,1,1,1)
+c2 = _sm.Matrix([2 if i==j else 0 for i in range(3) for j in range(4)]).reshape(3, 4)
 dm = (m+c1)**(-1)
-e = (m+c1).det()+(sm.Matrix([1,0,0,1]).reshape(2, 2)).trace()
+e = (m+c1).det()+(_sm.Matrix([1,0,0,1]).reshape(2, 2)).trace()
 f = (m)[1,2]
 a = (m).cols
 bm = (m).col(0)
-cm = sm.Matrix([(m).T.row(0),(m).T.row(1),(m).T.row(2),(m).T.row(3),(m).T.row(2)])
+cm = _sm.Matrix([(m).T.row(0),(m).T.row(1),(m).T.row(2),(m).T.row(3),(m).T.row(2)])
 dm = (m).row(0)
-em = sm.Matrix([(m).row(0),(m).row(1),(m).row(2),(m).row(3),(m).row(2)])
+em = _sm.Matrix([(m).row(0),(m).row(1),(m).row(2),(m).row(3),(m).row(2)])

--- a/sympy/parsing/autolev/test-examples/ruletest7.py
+++ b/sympy/parsing/autolev/test-examples/ruletest7.py
@@ -1,35 +1,35 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-x, y = me.dynamicsymbols('x y')
-xd, yd = me.dynamicsymbols('x y', 1)
-e = sm.cos(x)+sm.sin(x)+sm.tan(x)+sm.cosh(x)+sm.sinh(x)+sm.tanh(x)+sm.acos(x)+sm.asin(x)+sm.atan(x)+sm.log(x)+sm.exp(x)+sm.sqrt(x)+sm.factorial(x)+sm.ceiling(x)+sm.floor(x)+sm.sign(x)
-e = (x)**2+sm.log(x, 10)
-a = sm.Abs(-1*1)+int(1.5)+round(1.9)
+x, y = _me.dynamicsymbols('x y')
+x_d, y_d = _me.dynamicsymbols('x_ y_', 1)
+e = _sm.cos(x)+_sm.sin(x)+_sm.tan(x)+_sm.cosh(x)+_sm.sinh(x)+_sm.tanh(x)+_sm.acos(x)+_sm.asin(x)+_sm.atan(x)+_sm.log(x)+_sm.exp(x)+_sm.sqrt(x)+_sm.factorial(x)+_sm.ceiling(x)+_sm.floor(x)+_sm.sign(x)
+e = (x)**2+_sm.log(x, 10)
+a = _sm.Abs(-1*1)+int(1.5)+round(1.9)
 e1 = 2*x+3*y
 e2 = x+y
-am = sm.Matrix([e1.expand().coeff(x), e1.expand().coeff(y), e2.expand().coeff(x), e2.expand().coeff(y)]).reshape(2, 2)
+am = _sm.Matrix([e1.expand().coeff(x), e1.expand().coeff(y), e2.expand().coeff(x), e2.expand().coeff(y)]).reshape(2, 2)
 b = (e1).expand().coeff(x)
 c = (e2).expand().coeff(y)
 d1 = (e1).collect(x).coeff(x,0)
 d2 = (e1).collect(x).coeff(x,1)
-fm = sm.Matrix([i.collect(x)for i in sm.Matrix([e1,e2]).reshape(1, 2)]).reshape((sm.Matrix([e1,e2]).reshape(1, 2)).shape[0], (sm.Matrix([e1,e2]).reshape(1, 2)).shape[1])
+fm = _sm.Matrix([i.collect(x)for i in _sm.Matrix([e1,e2]).reshape(1, 2)]).reshape((_sm.Matrix([e1,e2]).reshape(1, 2)).shape[0], (_sm.Matrix([e1,e2]).reshape(1, 2)).shape[1])
 f = (e1).collect(y)
 g = (e1).subs({x:2*x})
-gm = sm.Matrix([i.subs({x:3}) for i in sm.Matrix([e1,e2]).reshape(2, 1)]).reshape((sm.Matrix([e1,e2]).reshape(2, 1)).shape[0], (sm.Matrix([e1,e2]).reshape(2, 1)).shape[1])
-frame_a = me.ReferenceFrame('a')
-frame_b = me.ReferenceFrame('b')
-theta = me.dynamicsymbols('theta')
+gm = _sm.Matrix([i.subs({x:3}) for i in _sm.Matrix([e1,e2]).reshape(2, 1)]).reshape((_sm.Matrix([e1,e2]).reshape(2, 1)).shape[0], (_sm.Matrix([e1,e2]).reshape(2, 1)).shape[1])
+frame_a = _me.ReferenceFrame('a')
+frame_b = _me.ReferenceFrame('b')
+theta = _me.dynamicsymbols('theta')
 frame_b.orient(frame_a, 'Axis', [theta, frame_a.z])
-v1=2*frame_a.x-3*frame_a.y+frame_a.z
-v2=frame_b.x+frame_b.y+frame_b.z
-a = me.dot(v1, v2)
-bm = sm.Matrix([me.dot(v1, v2),me.dot(v1, 2*v2)]).reshape(2, 1)
-c=me.cross(v1, v2)
+v1 = 2*frame_a.x-3*frame_a.y+frame_a.z
+v2 = frame_b.x+frame_b.y+frame_b.z
+a = _me.dot(v1, v2)
+bm = _sm.Matrix([_me.dot(v1, v2),_me.dot(v1, 2*v2)]).reshape(2, 1)
+c = _me.cross(v1, v2)
 d = 2*v1.magnitude()+3*v1.magnitude()
-dyadic=me.outer(3*frame_a.x, frame_a.x)+me.outer(frame_a.y, frame_a.y)+me.outer(2*frame_a.z, frame_a.z)
+dyadic = _me.outer(3*frame_a.x, frame_a.x)+_me.outer(frame_a.y, frame_a.y)+_me.outer(2*frame_a.z, frame_a.z)
 am = (dyadic).to_matrix(frame_b)
-m = sm.Matrix([1,2,3]).reshape(3, 1)
-v=m[0]*frame_a.x +m[1]*frame_a.y +m[2]*frame_a.z
+m = _sm.Matrix([1,2,3]).reshape(3, 1)
+v = m[0]*frame_a.x +m[1]*frame_a.y +m[2]*frame_a.z

--- a/sympy/parsing/autolev/test-examples/ruletest8.py
+++ b/sympy/parsing/autolev/test-examples/ruletest8.py
@@ -1,49 +1,49 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-frame_a = me.ReferenceFrame('a')
-c1, c2, c3 = sm.symbols('c1 c2 c3', real=True)
-a=me.inertia(frame_a, 1, 1, 1)
-particle_p1 = me.Particle('p1', me.Point('p1_pt'), sm.Symbol('m'))
-particle_p2 = me.Particle('p2', me.Point('p2_pt'), sm.Symbol('m'))
-body_r_cm = me.Point('r_cm')
-body_r_f = me.ReferenceFrame('r_f')
-body_r = me.RigidBody('r', body_r_cm, body_r_f, sm.symbols('m'), (me.outer(body_r_f.x,body_r_f.x),body_r_cm))
-frame_a.orient(body_r_f, 'DCM', sm.Matrix([1,1,1,1,1,0,0,0,1]).reshape(3, 3))
-point_o = me.Point('o')
-m1 = sm.symbols('m1')
+frame_a = _me.ReferenceFrame('a')
+c1, c2, c3 = _sm.symbols('c1 c2 c3', real=True)
+a = _me.inertia(frame_a, 1, 1, 1)
+particle_p1 = _me.Particle('p1', _me.Point('p1_pt'), _sm.Symbol('m'))
+particle_p2 = _me.Particle('p2', _me.Point('p2_pt'), _sm.Symbol('m'))
+body_r_cm = _me.Point('r_cm')
+body_r_f = _me.ReferenceFrame('r_f')
+body_r = _me.RigidBody('r', body_r_cm, body_r_f, _sm.symbols('m'), (_me.outer(body_r_f.x,body_r_f.x),body_r_cm))
+frame_a.orient(body_r_f, 'DCM', _sm.Matrix([1,1,1,1,1,0,0,0,1]).reshape(3, 3))
+point_o = _me.Point('o')
+m1 = _sm.symbols('m1')
 particle_p1.mass = m1
-m2 = sm.symbols('m2')
+m2 = _sm.symbols('m2')
 particle_p2.mass = m2
-mr = sm.symbols('mr')
+mr = _sm.symbols('mr')
 body_r.mass = mr
-i1 = sm.symbols('i1')
-i2 = sm.symbols('i2')
-i3 = sm.symbols('i3')
-body_r.inertia = (me.inertia(body_r_f, i1, i2, i3, 0, 0, 0), body_r_cm)
+i1 = _sm.symbols('i1')
+i2 = _sm.symbols('i2')
+i3 = _sm.symbols('i3')
+body_r.inertia = (_me.inertia(body_r_f, i1, i2, i3, 0, 0, 0), body_r_cm)
 point_o.set_pos(particle_p1.point, c1*frame_a.x)
 point_o.set_pos(particle_p2.point, c2*frame_a.y)
 point_o.set_pos(body_r_cm, c3*frame_a.z)
-a=me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a)
-a=me.inertia_of_point_mass(particle_p2.mass, particle_p2.point.pos_from(point_o), frame_a)
-a=body_r.inertia[0] + me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
-a=me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a) + me.inertia_of_point_mass(particle_p2.mass, particle_p2.point.pos_from(point_o), frame_a) + body_r.inertia[0] + me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
-a=me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a) + body_r.inertia[0] + me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
-a=body_r.inertia[0] + me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
-a=body_r.inertia[0]
+a = _me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a)
+a = _me.inertia_of_point_mass(particle_p2.mass, particle_p2.point.pos_from(point_o), frame_a)
+a = body_r.inertia[0] + _me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
+a = _me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a) + _me.inertia_of_point_mass(particle_p2.mass, particle_p2.point.pos_from(point_o), frame_a) + body_r.inertia[0] + _me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
+a = _me.inertia_of_point_mass(particle_p1.mass, particle_p1.point.pos_from(point_o), frame_a) + body_r.inertia[0] + _me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
+a = body_r.inertia[0] + _me.inertia_of_point_mass(body_r.mass, body_r.masscenter.pos_from(point_o), frame_a)
+a = body_r.inertia[0]
 particle_p2.point.set_pos(particle_p1.point, c1*frame_a.x+c2*frame_a.y)
 body_r_cm.set_pos(particle_p1.point, c3*frame_a.x)
 body_r_cm.set_pos(particle_p2.point, c3*frame_a.y)
-b=me.functions.center_of_mass(point_o,particle_p1, particle_p2, body_r)
-b=me.functions.center_of_mass(point_o,particle_p1, body_r)
-b=me.functions.center_of_mass(particle_p1.point,particle_p1, particle_p2, body_r)
-u1, u2, u3 = me.dynamicsymbols('u1 u2 u3')
-v=u1*frame_a.x+u2*frame_a.y+u3*frame_a.z
-u=(v+c1*frame_a.x).normalize()
+b = _me.functions.center_of_mass(point_o,particle_p1, particle_p2, body_r)
+b = _me.functions.center_of_mass(point_o,particle_p1, body_r)
+b = _me.functions.center_of_mass(particle_p1.point,particle_p1, particle_p2, body_r)
+u1, u2, u3 = _me.dynamicsymbols('u1 u2 u3')
+v = u1*frame_a.x+u2*frame_a.y+u3*frame_a.z
+u = (v+c1*frame_a.x).normalize()
 particle_p1.point.set_vel(frame_a, u1*frame_a.x)
-a=particle_p1.point.partial_velocity(frame_a, u1)
+a = particle_p1.point.partial_velocity(frame_a, u1)
 m = particle_p1.mass+body_r.mass
 m = particle_p2.mass
 m = particle_p1.mass+particle_p2.mass+body_r.mass

--- a/sympy/parsing/autolev/test-examples/ruletest9.py
+++ b/sympy/parsing/autolev/test-examples/ruletest9.py
@@ -1,55 +1,55 @@
-import sympy.physics.mechanics as me
-import sympy as sm
+import sympy.physics.mechanics as _me
+import sympy as _sm
 import math as m
-import numpy as np
+import numpy as _np
 
-frame_n = me.ReferenceFrame('n')
-frame_a = me.ReferenceFrame('a')
-a=0
-d=me.inertia(frame_a, 1, 1, 1)
-point_po1 = me.Point('po1')
-point_po2 = me.Point('po2')
-particle_p1 = me.Particle('p1', me.Point('p1_pt'), sm.Symbol('m'))
-particle_p2 = me.Particle('p2', me.Point('p2_pt'), sm.Symbol('m'))
-c1, c2, c3 = me.dynamicsymbols('c1 c2 c3')
-c1d, c2d, c3d = me.dynamicsymbols('c1 c2 c3', 1)
-body_r_cm = me.Point('r_cm')
+frame_n = _me.ReferenceFrame('n')
+frame_a = _me.ReferenceFrame('a')
+a = 0
+d = _me.inertia(frame_a, 1, 1, 1)
+point_po1 = _me.Point('po1')
+point_po2 = _me.Point('po2')
+particle_p1 = _me.Particle('p1', _me.Point('p1_pt'), _sm.Symbol('m'))
+particle_p2 = _me.Particle('p2', _me.Point('p2_pt'), _sm.Symbol('m'))
+c1, c2, c3 = _me.dynamicsymbols('c1 c2 c3')
+c1_d, c2_d, c3_d = _me.dynamicsymbols('c1_ c2_ c3_', 1)
+body_r_cm = _me.Point('r_cm')
 body_r_cm.set_vel(frame_n, 0)
-body_r_f = me.ReferenceFrame('r_f')
-body_r = me.RigidBody('r', body_r_cm, body_r_f, sm.symbols('m'), (me.outer(body_r_f.x,body_r_f.x),body_r_cm))
+body_r_f = _me.ReferenceFrame('r_f')
+body_r = _me.RigidBody('r', body_r_cm, body_r_f, _sm.symbols('m'), (_me.outer(body_r_f.x,body_r_f.x),body_r_cm))
 point_po2.set_pos(particle_p1.point, c1*frame_a.x)
-v=2*point_po2.pos_from(particle_p1.point)+c2*frame_a.y
+v = 2*point_po2.pos_from(particle_p1.point)+c2*frame_a.y
 frame_a.set_ang_vel(frame_n, c3*frame_a.z)
-v=2*frame_a.ang_vel_in(frame_n)+c2*frame_a.y
+v = 2*frame_a.ang_vel_in(frame_n)+c2*frame_a.y
 body_r_f.set_ang_vel(frame_n, c3*frame_a.z)
-v=2*body_r_f.ang_vel_in(frame_n)+c2*frame_a.y
+v = 2*body_r_f.ang_vel_in(frame_n)+c2*frame_a.y
 frame_a.set_ang_acc(frame_n, (frame_a.ang_vel_in(frame_n)).dt(frame_a))
-v=2*frame_a.ang_acc_in(frame_n)+c2*frame_a.y
+v = 2*frame_a.ang_acc_in(frame_n)+c2*frame_a.y
 particle_p1.point.set_vel(frame_a, c1*frame_a.x+c3*frame_a.y)
 body_r_cm.set_acc(frame_n, c2*frame_a.y)
-v_a = me.cross(body_r_cm.acc(frame_n), particle_p1.point.vel(frame_a))
+v_a = _me.cross(body_r_cm.acc(frame_n), particle_p1.point.vel(frame_a))
 x_b_c = v_a
 x_b_d = 2*x_b_c
-a_b_c_d_e=x_b_d*2
+a_b_c_d_e = x_b_d*2
 a_b_c = 2*c1*c2*c3
 a_b_c += 2*c1
 a_b_c  =  3*c1
-q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')
-q1d, q2d, u1d, u2d = me.dynamicsymbols('q1 q2 u1 u2', 1)
-x, y = me.dynamicsymbols('x y')
-xd, yd = me.dynamicsymbols('x y', 1)
-xd2, yd2 = me.dynamicsymbols('x y', 2)
-yy = me.dynamicsymbols('yy')
-yy = x*xd**2+1
-m = sm.Matrix([[0]])
+q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
+q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)
+x, y = _me.dynamicsymbols('x y')
+x_d, y_d = _me.dynamicsymbols('x_ y_', 1)
+x_dd, y_dd = _me.dynamicsymbols('x_ y_', 2)
+yy = _me.dynamicsymbols('yy')
+yy = x*x_d**2+1
+m = _sm.Matrix([[0]])
 m[0] = 2*x
-m = m.row_insert(m.shape[0], sm.Matrix([[0]]))
+m = m.row_insert(m.shape[0], _sm.Matrix([[0]]))
 m[m.shape[0]-1] = 2*y
 a = 2*m[0]
-m = sm.Matrix([1,2,3,4,5,6,7,8,9]).reshape(3, 3)
-m[0,1]=5
+m = _sm.Matrix([1,2,3,4,5,6,7,8,9]).reshape(3, 3)
+m[0,1] = 5
 a = m[0, 1]*2
 force_ro = q1*frame_n.x
 torque_a = q2*frame_n.z
 force_ro = q1*frame_n.x + q2*frame_n.y
-f=force_ro*2
+f = force_ro*2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15187 

#### Brief description of what is fixed or changed

- `me`, `sm`, and `np` imports are renamed to `_me`, `_sm`, and `_np` to prevent these import names from clashing with user-created variables.
- naming of automatic declaration of time derivatives is updated from `var`, `vard`, `vard2` to `var`, `var_d`, `var_dd` respectively, given `var` is the name of the expected time derivative variable.
- spaces are added around `=` when dealing with vec variables, in compliance with PEP8 guidelines.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
