### PR TITLE
Fix type annotation on FF, ZZ, QQ in polys.domains.

### DIFF
--- a/sympy/polys/domains/__init__.py
+++ b/sympy/polys/domains/__init__.py
@@ -51,7 +51,7 @@ _GROUND_TYPES_MAP = {
 }
 
 try:
-    FF, ZZ, QQ = _GROUND_TYPES_MAP[GROUND_TYPES]  # type: Tuple[Type[FiniteField], Domain, Domain]
+    FF, ZZ, QQ = _GROUND_TYPES_MAP[GROUND_TYPES]  # type: Type[FiniteField], Domain, Domain
 except KeyError:
     raise ValueError("invalid ground types: %s" % GROUND_TYPES)
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed
The type annotations in [sympy.polys.domains](sympy/polys/domains/__init__.py) which were:
```python3
FF, ZZ, QQ = _GROUND_TYPES_MAP[GROUND_TYPES]  # type: Tuple[Type[FiniteField], Domain, Domain]
```
were fixed to:
```python3
FF, ZZ, QQ = _GROUND_TYPES_MAP[GROUND_TYPES]  # type: Type[FiniteField], Domain, Domain
```
which seems to be the correct way to annotate such unpacked variables and stop mypy/PyCharm from complaining.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
