### PR TITLE
Plotting - Improved custom labelling

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2469,7 +2469,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
     SymPyDeprecationWarning(
         feature = "check_arguments",
         useinstead = "_check_arguments",
-        issue = 21300,
+        issue = 21330,
         deprecated_since_version = "1.8.1").warn()
 
     if not args:

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2648,7 +2648,7 @@ def _check_arguments(args, nexpr, npar):
        >>> from sympy import cos, sin, symbols
        >>> from sympy.plotting.plot import _check_arguments
        >>> x = symbols('x')
-       >>> _check_arguments([cos(x), sin(x)], 1, 2)
+       >>> _check_arguments([cos(x), sin(x)], 2, 1)
            [(cos(x), sin(x), (x, -10, 10), '(cos(x), sin(x))')]
 
        >>> _check_arguments([x, x**2], 1, 1)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1558,8 +1558,7 @@ def plot(*args, show=True, **kwargs):
         - Plotting multiple expressions with multiple ranges.
             ``plot((expr1, range1), (expr2, range2), ..., **kwargs)``
         - Plotting multiple expressions with multiple ranges and custom labels.
-            ``plot((expr1, range1, label1), (expr2, range2, label2), ...,
-                legend=True, **kwargs)``
+            ``plot((expr1, range1, label1), (expr2, range2, label2), ..., legend=True, **kwargs)``
 
         It is best practice to specify range explicitly because default
         range may change in the future if a more advanced default range
@@ -1779,7 +1778,7 @@ def plot_parametric(*args, show=True, **kwargs):
         - Plotting multiple parametric curves with different ranges
             ``plot_parametric((expr_x, expr_y, range), ...)``
         - Plotting multiple parametric curves with different ranges and
-        custom labels
+            custom labels
             ``plot_parametric((expr_x, expr_y, range, label), ...)``
 
         ``expr_x`` is the expression representing $x$ component of the
@@ -1992,8 +1991,7 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
 
     Multiple plots.
 
-    ``plot3d_parametric_line((expr_x, expr_y, expr_z, range, label),
-        ..., **kwargs)``
+    ``plot3d_parametric_line((expr_x, expr_y, expr_z, range, label), ..., **kwargs)``
 
     Ranges have to be specified for every expression.
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2447,23 +2447,6 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
     """
     Checks the arguments and converts into tuples of the
     form (exprs, ranges).
-
-    Examples
-    ========
-
-    .. plot::
-       :context: reset
-       :format: doctest
-       :include-source: True
-
-       >>> from sympy import cos, sin, symbols
-       >>> from sympy.plotting.plot import check_arguments
-       >>> x = symbols('x')
-       >>> check_arguments([cos(x), sin(x)], 2, 1)
-           [(cos(x), sin(x), (x, -10, 10))]
-
-       >>> check_arguments([x, x**2], 1, 1)
-           [(x, (x, -10, 10)), (x**2, (x, -10, 10))]
     """
 
     SymPyDeprecationWarning(

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2437,8 +2437,6 @@ def plot_contour(*args, show=True, **kwargs):
     plot_expr = _check_arguments(args, 1, 2)
     series = [ContourSeries(*arg) for arg in plot_expr]
     plot_contours = Plot(*series, **kwargs)
-    # if len(plot_expr[0].free_symbols) > 2:
-    #     raise ValueError('Contour Plot cannot Plot for more than two variables.')
     if show:
         plot_contours.show()
     return plot_contours

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2724,7 +2724,7 @@ def _check_arguments(args, nexpr, npar):
 
 def _plot_sympify(args):
     """ By allowing the users to set custom labels to the expressions being
-    plotted, a critical issue is raised: whenever a special character like $, \,
+    plotted, a critical issue is raised: whenever a special character like $,
     {, }, ... is used in the label (type string), sympify will raise an error.
     This function recursively loop over the arguments passed to the plot
     functions: the sympify function will be applied to all arguments except

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2470,7 +2470,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
         feature = "check_arguments",
         useinstead = "_check_arguments",
         issue = 21330,
-        deprecated_since_version = "1.8.1").warn()
+        deprecated_since_version = "1.9").warn()
 
     if not args:
         return []

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1697,18 +1697,6 @@ def plot(*args, show=True, **kwargs):
        [1]: cartesian line: x**2 for x over (-5.0, 5.0)
        [2]: cartesian line: x**3 for x over (-5.0, 5.0)
 
-    Multiple plots with different ranges.
-
-    .. plot::
-       :context: close-figs
-       :format: doctest
-       :include-source: True
-
-       >>> plot((x**2, (x, -6, 6)), (x, (x, -5, 5)))
-       Plot object containing:
-       [0]: cartesian line: x**2 for x over (-6.0, 6.0)
-       [1]: cartesian line: x for x over (-5.0, 5.0)
-
     Multiple plots with different ranges and custom labels.
 
     .. plot::
@@ -1716,10 +1704,10 @@ def plot(*args, show=True, **kwargs):
        :format: doctest
        :include-source: True
 
-       >>> plot((x**2, (x, -6, 6), "$f_{1}$"), (x, "f2"), legend=True)
+       >>> plot((x**2, (x, -6, 6), "$f_{1}$"), (x, (x, -5, 5), "f2"), legend=True)
        Plot object containing:
        [0]: cartesian line: x**2 for x over (-6.0, 6.0)
-       [1]: cartesian line: x for x over (-10.0, 10.0)
+       [1]: cartesian line: x for x over (-5.0, 5.0)
 
     No adaptive sampling.
 
@@ -1894,20 +1882,6 @@ def plot_parametric(*args, show=True, **kwargs):
        [0]: parametric cartesian line: (cos(u), sin(u)) for u over (-10.0, 10.0)
        [1]: parametric cartesian line: (u, cos(u)) for u over (-10.0, 10.0)
 
-    A parametric plot with multiple expressions with different ranges
-    for each curve:
-
-    .. plot::
-       :context: close-figs
-       :format: doctest
-       :include-source: True
-
-       >>> plot_parametric((cos(u), sin(u), (u, -5, 5)),
-       ...     (cos(u), u, (u, -5, 5)))
-       Plot object containing:
-       [0]: parametric cartesian line: (cos(u), sin(u)) for u over (-5.0, 5.0)
-       [1]: parametric cartesian line: (cos(u), u) for u over (-5.0, 5.0)
-
     A parametric plot with multiple expressions with different ranges and
     custom labels for each curve:
 
@@ -2067,19 +2041,6 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
        Plot object containing:
        [0]: 3D parametric cartesian line: (cos(u), sin(u), u) for u over (-5.0, 5.0)
 
-
-    Multiple plots.
-
-    .. plot::
-       :context: close-figs
-       :format: doctest
-       :include-source: True
-
-       >>> plot3d_parametric_line((cos(u), sin(u), u, (u, -5, 5)),
-       ...     (sin(u), u**2, u, (u, -5, 5)))
-       Plot object containing:
-       [0]: 3D parametric cartesian line: (cos(u), sin(u), u) for u over (-5.0, 5.0)
-       [1]: 3D parametric cartesian line: (sin(u), u**2, u) for u over (-5.0, 5.0)
 
     Multiple plots with different ranges and custom labels.
 

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -3,7 +3,8 @@ from tempfile import TemporaryDirectory
 
 from sympy import (
     pi, sin, cos, Symbol, Integral, Sum, sqrt, log, exp, Ne, oo, LambertW, I,
-    meijerg, exp_polar, Piecewise, And, real_root)
+    meijerg, exp_polar, Piecewise, And, real_root, symbols, Tuple, Expr,
+    Integer)
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.external import import_module
@@ -13,6 +14,9 @@ from sympy.plotting.plot import (
 from sympy.plotting.plot import (
     unset_show, plot_contour, PlotGrid, DefaultBackend, MatplotlibBackend,
     TextBackend, BaseBackend)
+from sympy.plotting.plot import (
+    _plot_sympify, _check_arguments, _create_ranges
+)
 from sympy.testing.pytest import skip, raises, warns
 from sympy.utilities import lambdify as lambdify_
 
@@ -699,3 +703,454 @@ def test_issue_20113():
         p4.save("test/path")
     with raises(NotImplementedError):
         p4._backend.close()
+
+
+def test_plot_sympify():
+    x, y = symbols("x, y")
+
+    # argument is already sympified
+    args = x + y
+    r = _plot_sympify(args)
+    assert r == args
+
+    # one argument needs to be sympified
+    args = (x + y, 1)
+    r = _plot_sympify(args)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert isinstance(r[0], Expr)
+    assert isinstance(r[1], Integer)
+
+    # string should not be sympified
+    args = (x + y, (x, 0, 1), "str", 1)
+    r = _plot_sympify(args)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 4
+    assert isinstance(r[0], Expr)
+    assert isinstance(r[1], Tuple)
+    assert isinstance(r[2], str)
+    assert isinstance(r[3], Integer)
+
+    # nested arguments containing strings
+    args = ((x + y, (y, 0, 1), "a"), (x + 1, (x, 0, 1), "$f_{1}$"))
+    r = _plot_sympify(args)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert isinstance(r[0], Tuple)
+    assert isinstance(r[0][1], Tuple)
+    assert isinstance(r[0][1][1], Integer)
+    assert isinstance(r[0][2], str)
+    assert isinstance(r[1], Tuple)
+    assert isinstance(r[1][1], Tuple)
+    assert isinstance(r[1][1][1], Integer)
+    assert isinstance(r[1][2], str)
+
+def test_create_ranges():
+    x, y = symbols("x, y")
+
+    # user don't provide any range -> return a default range
+    r = _create_ranges({x}, [], 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert isinstance(r[0], (Tuple, tuple))
+    assert r[0] == (x, -10, 10)
+
+    r = _create_ranges({x, y}, [], 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert isinstance(r[0], (Tuple, tuple))
+    assert isinstance(r[1], (Tuple, tuple))
+    assert r[0] == (x, -10, 10) or (y, -10, 10)
+    assert r[1] == (y, -10, 10) or (x, -10, 10)
+    assert r[0] != r[1]
+
+    # not enough ranges provided by the user -> create default ranges
+    r = _create_ranges({x, y}, [(x, 0, 1), ], 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert isinstance(r[0], (Tuple, tuple))
+    assert isinstance(r[1], (Tuple, tuple))
+    assert r[0] == (x, 0, 1) or (y, -10, 10)
+    assert r[1] == (y, -10, 10) or (x, 0, 1)
+    assert r[0] != r[1]
+
+    # too many free symbols
+    raises(ValueError, lambda: _create_ranges({x, y}, [], 1))
+    raises(ValueError,
+        lambda: _create_ranges({x, y}, [(x, 0, 5), (y, 0, 1)], 1))
+    # too many ranges
+    raises(ValueError, lambda: _create_ranges({x}, [(x, 0, 5), (y, 0, 1)], 1))
+
+def test_check_arguments():
+    x, y = symbols("x, y")
+
+    ### Test arguments for plot()
+
+    # single expressions
+    args = _plot_sympify((x + 1, ))
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, -10, 10)
+    assert r[0][2] == "x + 1"
+
+    # single expressions with range
+    args = _plot_sympify((x + 1, (x, -2, 2)))
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, -2, 2)
+    assert r[0][2] == "x + 1"
+
+    # single expressions with range and label
+    args = _plot_sympify((x + 1, (x, -2, 2), "test"))
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, -2, 2)
+    assert r[0][2] == "test"
+
+    # multiple expressions
+    args = _plot_sympify((x + 1, x**2))
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 3
+    assert len(r[1]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, -10, 10)
+    assert r[0][2] == "x + 1"
+    assert r[1][0] == x**2
+    assert r[1][1] == (x, -10, 10)
+    assert r[1][2] == "x**2"
+
+    # multiple expressions over the same range
+    args = _plot_sympify((x + 1, x**2, (x, 0, 5)))
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 3
+    assert len(r[1]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, 0, 5)
+    assert r[0][2] == "x + 1"
+    assert r[1][0] == x**2
+    assert r[1][1] == (x, 0, 5)
+    assert r[1][2] == "x**2"
+
+    # multiple expressions with different ranges and labels
+    args = _plot_sympify([(x + 1, (x, 0, 5)), (x**2, (x, -2, 2), "test")])
+    r = _check_arguments(args, 1, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 3
+    assert len(r[1]) == 3
+    assert r[0][0] == x + 1
+    assert r[0][1] == (x, 0, 5)
+    assert r[0][2] == "x + 1"
+    assert r[1][0] == x**2
+    assert r[1][1] == (x, -2, 2)
+    assert r[1][2] == "test"
+
+
+    ### Test arguments for plot_parametric()
+
+    # single parametric expression
+    args = _plot_sympify((x + 1, x))
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -10, 10)
+    assert r[0][3] == "(x + 1, x)"
+
+    # single parametric expression with custom range and label
+    args = _plot_sympify((x + 1, x, (x, -2, 2), "test"))
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -2, 2)
+    assert r[0][3] == "test"
+
+    args = _plot_sympify(((x + 1, x), (x, -2, 2), "test"))
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -2, 2)
+    assert r[0][3] == "test"
+
+    # multiple parametric expressions
+    args = _plot_sympify([(x + 1, x), (x**2, x + 1)])
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -10, 10)
+    assert r[0][3] == "(x + 1, x)"
+    assert r[1][0] == x**2
+    assert r[1][1] == x + 1
+    assert r[1][2] == (x, -10, 10)
+    assert r[1][3] == "(x**2, x + 1)"
+
+    # multiple parametric expressions same range
+    args = _plot_sympify([(x + 1, x), (x**2, x + 1), (x, -2, 2)])
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -2, 2)
+    assert r[0][3] == "(x + 1, x)"
+    assert r[1][0] == x**2
+    assert r[1][1] == x + 1
+    assert r[1][2] == (x, -2, 2)
+    assert r[1][3] == "(x**2, x + 1)"
+
+    # multiple parametric expressions, custom ranges and labels
+    args = _plot_sympify([(x + 1, x, (x, -2, 2)),
+        (x**2, x + 1, (x, -3, 3), "test")])
+    r = _check_arguments(args, 2, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == (x, -2, 2)
+    assert r[0][3] == "(x + 1, x)"
+    assert r[1][0] == x**2
+    assert r[1][1] == x + 1
+    assert r[1][2] == (x, -3, 3)
+    assert r[1][3] == "test"
+
+
+    ### Test arguments for plot3d_parametric_line()
+
+    # single parametric expression
+    args = _plot_sympify((x + 1, x, sin(x)))
+    r = _check_arguments(args, 3, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 5
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == sin(x)
+    assert r[0][3] == (x, -10, 10)
+    assert r[0][4] == "(x + 1, x, sin(x))"
+
+    # single parametric expression with custom range and label
+    args = _plot_sympify((x + 1, x, sin(x), (x, -2, 2), "test"))
+    r = _check_arguments(args, 3, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 5
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == sin(x)
+    assert r[0][3] == (x, -2, 2)
+    assert r[0][4] == "test"
+
+    args = _plot_sympify(((x + 1, x, sin(x)), (x, -2, 2), "test"))
+    r = _check_arguments(args, 3, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 5
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == sin(x)
+    assert r[0][3] == (x, -2, 2)
+    assert r[0][4] == "test"
+
+    # multiple parametric expression
+    args = _plot_sympify([(x + 1, x, sin(x)), (x**2, 1, cos(x))])
+    r = _check_arguments(args, 3, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 5
+    assert len(r[1]) == 5
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == sin(x)
+    assert r[0][3] == (x, -10, 10)
+    assert r[0][4] == "(x + 1, x, sin(x))"
+    assert r[1][0] == x**2
+    assert r[1][1] == 1
+    assert r[1][2] == cos(x)
+    assert r[1][3] == (x, -10, 10)
+    assert r[1][4] == "(x**2, 1, cos(x))"
+
+    # multiple parametric expression, custom ranges and labels
+    args = _plot_sympify([(x + 1, x, sin(x)),
+            (x**2, 1, cos(x), (x, -2, 2), "test")])
+    r = _check_arguments(args, 3, 1)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 5
+    assert len(r[1]) == 5
+    assert r[0][0] == x + 1
+    assert r[0][1] == x
+    assert r[0][2] == sin(x)
+    assert r[0][3] == (x, -10, 10)
+    assert r[0][4] == "(x + 1, x, sin(x))"
+    assert r[1][0] == x**2
+    assert r[1][1] == 1
+    assert r[1][2] == cos(x)
+    assert r[1][3] == (x, -2, 2)
+    assert r[1][4] == "test"
+
+
+    ### Test arguments for plot3d() and plot_contour()
+
+    # single expression
+    args = _plot_sympify((x + y,))
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -10, 10) or (y, -10, 10)
+    assert r[0][2] == (y, -10, 10) or (x, -10, 10)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "x + y"
+
+    # single expression, custom range and label
+    args = _plot_sympify((x + y, (x, -2, 2), "test"))
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -2, 2) or (y, -10, 10)
+    assert r[0][2] == (y, -10, 10) or (x, -2, 2)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "test"
+
+    args = _plot_sympify((x + y, (x, -2, 2), (y, -4, 4), "test"))
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -2, 2)
+    assert r[0][2] == (y, -4, 4)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "test"
+
+    # multiple expressions
+    args = _plot_sympify((x + y, x * y))
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -10, 10) or (y, -10, 10)
+    assert r[0][2] == (y, -10, 10) or (x, -10, 10)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "x + y"
+    assert r[1][0] == x * y
+    assert r[1][1] == (x, -10, 10) or (y, -10, 10)
+    assert r[1][2] == (y, -10, 10) or (x, -10, 10)
+    assert r[1][1] != r[0][2]
+    assert r[1][3] == "x*y"
+
+    # multiple expressions, same custom ranges
+    args = _plot_sympify((x + y, x * y, (x, -2, 2), (y, -4, 4)))
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -2, 2)
+    assert r[0][2] == (y, -4, 4)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "x + y"
+    assert r[1][0] == x * y
+    assert r[1][1] == (x, -2, 2)
+    assert r[1][2] == (y, -4, 4)
+    assert r[1][1] != r[0][2]
+    assert r[1][3] == "x*y"
+
+    # multiple expressions, custom ranges and labels
+    args = _plot_sympify([(x + y, (x, -2, 2), (y, -4, 4)),
+                (x * y, (x, -3, 3), (y, -6, 6), "test")])
+    r = _check_arguments(args, 1, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 4
+    assert len(r[1]) == 4
+    assert r[0][0] == x + y
+    assert r[0][1] == (x, -2, 2)
+    assert r[0][2] == (y, -4, 4)
+    assert r[0][1] != r[0][2]
+    assert r[0][3] == "x + y"
+    assert r[1][0] == x * y
+    assert r[1][1] == (x, -3, 3)
+    assert r[1][2] == (y, -6, 6)
+    assert r[1][1] != r[0][2]
+    assert r[1][3] == "test"
+
+
+    ### Test arguments for plot3d_parametric_surface()
+
+    # single parametric expression
+    args = _plot_sympify((x + y, cos(x + y), sin(x + y)))
+    r = _check_arguments(args, 3, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 6
+    assert r[0][0] == x + y
+    assert r[0][1] == cos(x + y)
+    assert r[0][2] == sin(x + y)
+    assert r[0][3] == (x, -10, 10) or (y, -10, 10)
+    assert r[0][4] == (y, -10, 10) or (x, -10, 10)
+    assert r[0][3] != r[0][4]
+    assert r[0][5] == "(x + y, cos(x + y), sin(x + y))"
+
+    # single parametric expression, custom ranges and labels
+    args = _plot_sympify((x + y, cos(x + y), sin(x + y), (x, -2, 2),
+                (y, -4, 4), "test"))
+    r = _check_arguments(args, 3, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
+    assert len(r[0]) == 6
+    assert r[0][0] == x + y
+    assert r[0][1] == cos(x + y)
+    assert r[0][2] == sin(x + y)
+    assert r[0][3] == (x, -2, 2)
+    assert r[0][4] == (y, -4, 4)
+    assert r[0][3] != r[0][4]
+    assert r[0][5] == "test"
+
+    # multiple parametric expressions
+    args = _plot_sympify([(x + y, cos(x + y), sin(x + y)),
+                (x - y, cos(x - y), sin(x - y))])
+    r = _check_arguments(args, 3, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 6
+    assert len(r[1]) == 6
+    assert r[0][0] == x + y
+    assert r[0][1] == cos(x + y)
+    assert r[0][2] == sin(x + y)
+    assert r[0][3] == (x, -10, 10) or (y, -10, 10)
+    assert r[0][4] == (y, -10, 10) or (x, -10, 10)
+    assert r[0][3] != r[0][4]
+    assert r[0][5] == "(x + y, cos(x + y), sin(x + y))"
+    assert r[1][0] == x - y
+    assert r[1][1] == cos(x - y)
+    assert r[1][2] == sin(x - y)
+    assert r[1][3] == (x, -10, 10) or (y, -10, 10)
+    assert r[1][4] == (y, -10, 10) or (x, -10, 10)
+    assert r[1][3] != r[0][4]
+    assert r[1][5] == "(x - y, cos(x - y), sin(x - y))"
+
+    # multiple parametric expressions, custom ranges and labels
+    args = _plot_sympify([(x + y, cos(x + y), sin(x + y), (x, -2, 2), "test"),
+            (x - y, cos(x - y), sin(x - y), (x, -3, 3), (y, -4, 4), "test2")])
+    r = _check_arguments(args, 3, 2)
+    assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
+    assert len(r[0]) == 6
+    assert len(r[1]) == 6
+    assert r[0][0] == x + y
+    assert r[0][1] == cos(x + y)
+    assert r[0][2] == sin(x + y)
+    assert r[0][3] == (x, -2, 2) or (y, -10, 10)
+    assert r[0][4] == (y, -10, 10) or (x, -2, 2)
+    assert r[0][3] != r[0][4]
+    assert r[0][5] == "test"
+    assert r[1][0] == x - y
+    assert r[1][1] == cos(x - y)
+    assert r[1][2] == sin(x - y)
+    assert r[1][3] == (x, -3, 3)
+    assert r[1][4] == (y, -4, 4)
+    assert r[1][3] != r[0][4]
+    assert r[1][5] == "test2"

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -784,67 +784,40 @@ def test_check_arguments():
     args = _plot_sympify((x + 1, ))
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, -10, 10)
-    assert r[0][2] == "x + 1"
+    assert r[0] == (x + 1, (x, -10, 10), "x + 1")
 
     # single expressions with range
     args = _plot_sympify((x + 1, (x, -2, 2)))
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, -2, 2)
-    assert r[0][2] == "x + 1"
+    assert r[0] == (x + 1, (x, -2, 2), "x + 1")
 
     # single expressions with range and label
     args = _plot_sympify((x + 1, (x, -2, 2), "test"))
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, -2, 2)
-    assert r[0][2] == "test"
+    assert r[0] == (x + 1, (x, -2, 2), "test")
 
     # multiple expressions
     args = _plot_sympify((x + 1, x**2))
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 3
-    assert len(r[1]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, -10, 10)
-    assert r[0][2] == "x + 1"
-    assert r[1][0] == x**2
-    assert r[1][1] == (x, -10, 10)
-    assert r[1][2] == "x**2"
+    assert r[0] == (x + 1, (x, -10, 10), "x + 1")
+    assert r[1] == (x**2, (x, -10, 10), "x**2")
 
     # multiple expressions over the same range
     args = _plot_sympify((x + 1, x**2, (x, 0, 5)))
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 3
-    assert len(r[1]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, 0, 5)
-    assert r[0][2] == "x + 1"
-    assert r[1][0] == x**2
-    assert r[1][1] == (x, 0, 5)
-    assert r[1][2] == "x**2"
+    assert r[0] == (x + 1, (x, 0, 5), "x + 1")
+    assert r[1] == (x**2, (x, 0, 5), "x**2")
 
     # multiple expressions with different ranges and labels
     args = _plot_sympify([(x + 1, (x, 0, 5)), (x**2, (x, -2, 2), "test")])
     r = _check_arguments(args, 1, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 3
-    assert len(r[1]) == 3
-    assert r[0][0] == x + 1
-    assert r[0][1] == (x, 0, 5)
-    assert r[0][2] == "x + 1"
-    assert r[1][0] == x**2
-    assert r[1][1] == (x, -2, 2)
-    assert r[1][2] == "test"
+    assert r[0] == (x + 1, (x, 0, 5), "x + 1")
+    assert r[1] == (x**2, (x, -2, 2), "test")
 
 
     ### Test arguments for plot_parametric()
@@ -853,76 +826,40 @@ def test_check_arguments():
     args = _plot_sympify((x + 1, x))
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -10, 10)
-    assert r[0][3] == "(x + 1, x)"
+    assert r[0] == (x + 1, x, (x, -10, 10), "(x + 1, x)")
 
     # single parametric expression with custom range and label
     args = _plot_sympify((x + 1, x, (x, -2, 2), "test"))
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -2, 2)
-    assert r[0][3] == "test"
+    assert r[0] == (x + 1, x, (x, -2, 2), "test")
 
     args = _plot_sympify(((x + 1, x), (x, -2, 2), "test"))
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -2, 2)
-    assert r[0][3] == "test"
+    assert r[0] == (x + 1, x, (x, -2, 2), "test")
 
     # multiple parametric expressions
     args = _plot_sympify([(x + 1, x), (x**2, x + 1)])
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 4
-    assert len(r[1]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -10, 10)
-    assert r[0][3] == "(x + 1, x)"
-    assert r[1][0] == x**2
-    assert r[1][1] == x + 1
-    assert r[1][2] == (x, -10, 10)
-    assert r[1][3] == "(x**2, x + 1)"
+    assert r[0] == (x + 1, x, (x, -10, 10), "(x + 1, x)")
+    assert r[1] == (x**2, x + 1, (x, -10, 10), "(x**2, x + 1)")
 
     # multiple parametric expressions same range
     args = _plot_sympify([(x + 1, x), (x**2, x + 1), (x, -2, 2)])
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 4
-    assert len(r[1]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -2, 2)
-    assert r[0][3] == "(x + 1, x)"
-    assert r[1][0] == x**2
-    assert r[1][1] == x + 1
-    assert r[1][2] == (x, -2, 2)
-    assert r[1][3] == "(x**2, x + 1)"
+    assert r[0] == (x + 1, x, (x, -2, 2), "(x + 1, x)")
+    assert r[1] == (x**2, x + 1, (x, -2, 2), "(x**2, x + 1)")
 
     # multiple parametric expressions, custom ranges and labels
     args = _plot_sympify([(x + 1, x, (x, -2, 2)),
         (x**2, x + 1, (x, -3, 3), "test")])
     r = _check_arguments(args, 2, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 4
-    assert len(r[1]) == 4
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == (x, -2, 2)
-    assert r[0][3] == "(x + 1, x)"
-    assert r[1][0] == x**2
-    assert r[1][1] == x + 1
-    assert r[1][2] == (x, -3, 3)
-    assert r[1][3] == "test"
+    assert r[0] == (x + 1, x, (x, -2, 2), "(x + 1, x)")
+    assert r[1] == (x**2, x + 1, (x, -3, 3), "test")
 
 
     ### Test arguments for plot3d_parametric_line()
@@ -931,68 +868,33 @@ def test_check_arguments():
     args = _plot_sympify((x + 1, x, sin(x)))
     r = _check_arguments(args, 3, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 5
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == sin(x)
-    assert r[0][3] == (x, -10, 10)
-    assert r[0][4] == "(x + 1, x, sin(x))"
+    assert r[0] == (x + 1, x, sin(x), (x, -10, 10), "(x + 1, x, sin(x))")
 
     # single parametric expression with custom range and label
     args = _plot_sympify((x + 1, x, sin(x), (x, -2, 2), "test"))
     r = _check_arguments(args, 3, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 5
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == sin(x)
-    assert r[0][3] == (x, -2, 2)
-    assert r[0][4] == "test"
+    assert r[0] == (x + 1, x, sin(x), (x, -2, 2), "test")
 
     args = _plot_sympify(((x + 1, x, sin(x)), (x, -2, 2), "test"))
     r = _check_arguments(args, 3, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 5
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == sin(x)
-    assert r[0][3] == (x, -2, 2)
-    assert r[0][4] == "test"
+    assert r[0] == (x + 1, x, sin(x), (x, -2, 2), "test")
 
     # multiple parametric expression
     args = _plot_sympify([(x + 1, x, sin(x)), (x**2, 1, cos(x))])
     r = _check_arguments(args, 3, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 5
-    assert len(r[1]) == 5
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == sin(x)
-    assert r[0][3] == (x, -10, 10)
-    assert r[0][4] == "(x + 1, x, sin(x))"
-    assert r[1][0] == x**2
-    assert r[1][1] == 1
-    assert r[1][2] == cos(x)
-    assert r[1][3] == (x, -10, 10)
-    assert r[1][4] == "(x**2, 1, cos(x))"
+    assert r[0] == (x + 1, x, sin(x), (x, -10, 10), "(x + 1, x, sin(x))")
+    assert r[1] == (x**2, Integer(1), cos(x), (x, -10, 10), "(x**2, 1, cos(x))")
 
     # multiple parametric expression, custom ranges and labels
     args = _plot_sympify([(x + 1, x, sin(x)),
             (x**2, 1, cos(x), (x, -2, 2), "test")])
     r = _check_arguments(args, 3, 1)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 5
-    assert len(r[1]) == 5
-    assert r[0][0] == x + 1
-    assert r[0][1] == x
-    assert r[0][2] == sin(x)
-    assert r[0][3] == (x, -10, 10)
-    assert r[0][4] == "(x + 1, x, sin(x))"
-    assert r[1][0] == x**2
-    assert r[1][1] == 1
-    assert r[1][2] == cos(x)
-    assert r[1][3] == (x, -2, 2)
-    assert r[1][4] == "test"
+    assert r[0] == (x + 1, x, sin(x), (x, -10, 10), "(x + 1, x, sin(x))")
+    assert r[1] == (x**2, Integer(1), cos(x), (x, -2, 2), "test")
 
 
     ### Test arguments for plot3d() and plot_contour()
@@ -1022,12 +924,7 @@ def test_check_arguments():
     args = _plot_sympify((x + y, (x, -2, 2), (y, -4, 4), "test"))
     r = _check_arguments(args, 1, 2)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 4
-    assert r[0][0] == x + y
-    assert r[0][1] == (x, -2, 2)
-    assert r[0][2] == (y, -4, 4)
-    assert r[0][1] != r[0][2]
-    assert r[0][3] == "test"
+    assert r[0] == (x + y, (x, -2, 2), (y, -4, 4), "test")
 
     # multiple expressions
     args = _plot_sympify((x + y, x * y))
@@ -1050,36 +947,16 @@ def test_check_arguments():
     args = _plot_sympify((x + y, x * y, (x, -2, 2), (y, -4, 4)))
     r = _check_arguments(args, 1, 2)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 4
-    assert len(r[1]) == 4
-    assert r[0][0] == x + y
-    assert r[0][1] == (x, -2, 2)
-    assert r[0][2] == (y, -4, 4)
-    assert r[0][1] != r[0][2]
-    assert r[0][3] == "x + y"
-    assert r[1][0] == x * y
-    assert r[1][1] == (x, -2, 2)
-    assert r[1][2] == (y, -4, 4)
-    assert r[1][1] != r[0][2]
-    assert r[1][3] == "x*y"
+    assert r[0] == (x + y, (x, -2, 2), (y, -4, 4), "x + y")
+    assert r[1] == (x * y, (x, -2, 2), (y, -4, 4), "x*y")
 
     # multiple expressions, custom ranges and labels
     args = _plot_sympify([(x + y, (x, -2, 2), (y, -4, 4)),
                 (x * y, (x, -3, 3), (y, -6, 6), "test")])
     r = _check_arguments(args, 1, 2)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
-    assert len(r[0]) == 4
-    assert len(r[1]) == 4
-    assert r[0][0] == x + y
-    assert r[0][1] == (x, -2, 2)
-    assert r[0][2] == (y, -4, 4)
-    assert r[0][1] != r[0][2]
-    assert r[0][3] == "x + y"
-    assert r[1][0] == x * y
-    assert r[1][1] == (x, -3, 3)
-    assert r[1][2] == (y, -6, 6)
-    assert r[1][1] != r[0][2]
-    assert r[1][3] == "test"
+    assert r[0] == (x + y, (x, -2, 2), (y, -4, 4), "x + y")
+    assert r[1] == (x * y, (x, -3, 3), (y, -6, 6), "test")
 
 
     ### Test arguments for plot3d_parametric_surface()
@@ -1102,14 +979,8 @@ def test_check_arguments():
                 (y, -4, 4), "test"))
     r = _check_arguments(args, 3, 2)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 1
-    assert len(r[0]) == 6
-    assert r[0][0] == x + y
-    assert r[0][1] == cos(x + y)
-    assert r[0][2] == sin(x + y)
-    assert r[0][3] == (x, -2, 2)
-    assert r[0][4] == (y, -4, 4)
-    assert r[0][3] != r[0][4]
-    assert r[0][5] == "test"
+    assert r[0] == (x + y, cos(x + y), sin(x + y), (x, -2, 2), (y, -4, 4),
+                "test")
 
     # multiple parametric expressions
     args = _plot_sympify([(x + y, cos(x + y), sin(x + y)),
@@ -1139,7 +1010,6 @@ def test_check_arguments():
     r = _check_arguments(args, 3, 2)
     assert isinstance(r, (list, tuple, Tuple)) and len(r) == 2
     assert len(r[0]) == 6
-    assert len(r[1]) == 6
     assert r[0][0] == x + y
     assert r[0][1] == cos(x + y)
     assert r[0][2] == sin(x + y)
@@ -1147,10 +1017,5 @@ def test_check_arguments():
     assert r[0][4] == (y, -10, 10) or (x, -2, 2)
     assert r[0][3] != r[0][4]
     assert r[0][5] == "test"
-    assert r[1][0] == x - y
-    assert r[1][1] == cos(x - y)
-    assert r[1][2] == sin(x - y)
-    assert r[1][3] == (x, -3, 3)
-    assert r[1][4] == (y, -4, 4)
-    assert r[1][3] != r[0][4]
-    assert r[1][5] == "test2"
+    assert r[1] == (x - y, cos(x - y), sin(x - y), (x, -3, 3), (y, -4, 4),
+                "test2")


### PR DESCRIPTION
#### Brief description of what is fixed or changed

As mentioned in #21300 , the procedure to set custom labels to the expressions being plotted
is tedious. This commit add a new optional parameter to the plot interface, allowing to quickly
set custom labels to the expressions being plotted. For example, we can now write:

```
var("x, y")
plot((cos(x), "$f_{1}$"), (sin(x), (x, -2, 2), "f2"), (x / 10, (x, -6, 6)), legend=True)
```

Here, the first expression will be plotted over the default range `(x, -10, 10)` and will have a
label containing Latex code. The second expression will be plotted over the custom range
`(x, -2, 2)` having a string label. The last expression will be plotted over the custom range
`(x, -6, 6)` having the default label set to its string representation.

Back-compatibility has been important to maintain. However, a few adjustments had to be
done. For example, previously it was possible to set the label of a single expression with the
`label` keyword:

```
plot(sin(x), label="test", legend=True)
```

With this commit, that keyword has been phased out (it doesn't do anything anymore, look at the
`_remove_label_key` function), and the docstrings has been updated with all the necessary
information to correctly set custom labels.

From an implementation point of view, the old `check_arguments` function has been deprecated:
it was easier to come up with my own implementation in order to accommodate the new custom
label option, which can be found in the `_check_arguments` function. The latter has the same
signature of the former, and returns objects in the same format (with the added label string). 
Quite a few tests have been implemented to make sure the new function produces the expected
results.

All plot functions are going to sympify the provided arguments. However, when attempting to
sympify a string, it would either return an object of type Symbol, or it would raise an error
if any strange characters are present (/, {, }, $, ...). In order to solve this problem I had to
implement the `_plot_sympify` function, which is going to recursively sympify the provided
arguments, excluding the strings.

Finally, this PR together with PR #21256 should provide an adequate basic plotting
experience.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #21300 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->



#### Other comments


#### Release Notes



<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Added capability to quickly set custom labels when plotting multiple expressions
<!-- END RELEASE NOTES -->
