### PR TITLE
Changed "stop" to "step" in the documentation for Range

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -494,7 +494,7 @@ class ImageSet(Set):
 class Range(Set):
     """
     Represents a range of integers. Can be called as Range(stop),
-    Range(start, stop), or Range(start, stop, step); when stop is
+    Range(start, stop), or Range(start, stop, step); when step is
     not given it defaults to 1.
 
     `Range(stop)` is the same as `Range(0, stop, 1)` and the stop value


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed what I believe is a typo in the documentation for the Range class.

The documentation originally said "when stop is not given it defaults 
to 1," however this doesn't make sense because stop must always be
given when creating a Range (see quote below from documentation). 

> Can be called as Range(stop), Range(start, stop), 
> or Range(start, stop, step)

The statement, "when *step* is not given it defaults to 1," makes more 
sense because step is an optional parameter. Moreover, this
statement is verified by simple tests:
```
>>> from sympy import Range
>>> list(Range(3))
[0, 1, 2]
>>> list(Range(2,6))
[2, 3, 4, 5]
```
In the example above, we did not specify a step, and the step was set 
to 1 by default, as expected.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
