### PR TITLE
21303: do not canonicalize imageset with Floats

### DIFF
--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -192,8 +192,9 @@ def _set_function(f, self): # noqa:F811
     a = Wild('a', exclude=[n])
     b = Wild('b', exclude=[n])
     match = expr.match(a*n + b)
-    if match and match[a] and (not any(
-            i.atoms(Float) for i in (match[a], match[b]))):
+    if match and match[a] and (
+            not match[a].atoms(Float) and
+            not match[b].atoms(Float)):
         # canonical shift
         a, b = match[a], match[b]
         if a in [1, -1]:

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -1,4 +1,4 @@
-from sympy import Set, symbols, exp, log, S, Wild, Dummy, oo
+from sympy import Set, symbols, exp, log, S, Wild, Dummy, oo, Float
 from sympy.core import Expr, Add
 from sympy.core.function import Lambda, _coeff_isneg, FunctionClass
 from sympy.logic.boolalg import true
@@ -192,7 +192,8 @@ def _set_function(f, self): # noqa:F811
     a = Wild('a', exclude=[n])
     b = Wild('b', exclude=[n])
     match = expr.match(a*n + b)
-    if match and match[a]:
+    if match and match[a] and (not any(
+            i.atoms(Float) for i in (match[a], match[b]))):
         # canonical shift
         a, b = match[a], match[b]
         if a in [1, -1]:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -480,6 +480,9 @@ def test_Integers_eval_imageset():
     y = Symbol('y')
     L = imageset(x, 2*x + y, S.Integers)
     assert y + 4 in L
+    a, b, c = 0.092, 0.433, 0.341
+    assert a in imageset(x, a + c*x, S.Integers)
+    assert b in imageset(x, b + c*x, S.Integers)
 
     _x = symbols('x', negative=True)
     eq = _x**2 - _x + 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #21303

#### Brief description of what is fixed or changed

When imageset on integers has a linear expression, that expression is made canonical by shifting the origin. This should not be done so when there are Floats present as this may result in the constant term not appearing in the set as shown in #21303.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* sets
  * imageset involving Integers will not make linear expressions canonical when they contain Floats
<!-- END RELEASE NOTES -->
