### PR TITLE
single arg ok for primerange

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -105,7 +105,7 @@ class Sieve:
         newsieve = _arange(begin, n + 1)
 
         # Now eliminate all multiples of primes in [2, sqrt(n)]
-        for p in self.primerange(2, maxbase):
+        for p in self.primerange(maxbase):
             # Start counting at a multiple of p, offsetting
             # the index to account for the new sieve's base index
             startindex = (-begin) % p
@@ -149,13 +149,22 @@ class Sieve:
         ========
 
         >>> from sympy import sieve, prime
-        >>> print([i for i in sieve.primerange(7, 19)])
-        [7, 11, 13, 17]
-        >>> list(sieve.primerange(prime(10) + 1))  # first 10 primes
-        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+        All primes less than 19:
 
         >>> print([i for i in sieve.primerange(19)])
         [2, 3, 5, 7, 11, 13, 17]
+
+        All primes greater than or equal to 7 and less than 19:
+
+        >>> print([i for i in sieve.primerange(7, 19)])
+        [7, 11, 13, 17]
+
+        All primes through the 10th prime
+
+        >>> list(sieve.primerange(prime(10) + 1))
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
         """
         from sympy.functions.elementary.integers import ceiling
 
@@ -471,9 +480,20 @@ class primepi(Function):
         Examples
         ========
 
-        >>> from sympy import primepi
+        >>> from sympy import primepi, prime, prevprime, isprime
         >>> primepi(25)
         9
+
+        So there are 9 primes less than or equal to 25. Is 25 prime?
+
+        >>> isprime(25)
+        False
+
+        It isn't. So the first prime less than 25 must be the
+        9th prime:
+
+        >>> prevprime(25) == prime(9)
+        True
 
         See Also
         ========
@@ -659,16 +679,28 @@ def primerange(a, b=None):
         Examples
         ========
 
-        >>> from sympy import primerange, sieve, prime
-        >>> print([i for i in primerange(1, 30)])
+        >>> from sympy import primerange, prime
+
+        All primes less than 19:
+
+        >>> list(primerange(19))
+        [2, 3, 5, 7, 11, 13, 17]
+
+        All primes greater than or equal to 7 and less than 19:
+
+        >>> list(primerange(7, 19))
+        [7, 11, 13, 17]
+
+        All primes through the 10th prime
+
+        >>> list(primerange(prime(10) + 1))
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
-        >>> list(primerange(prime(5) + 1))  # first 5 primes
-        [2, 3, 5, 7, 11]
 
         The Sieve method, primerange, is generally faster but it will
         occupy more memory as the sieve stores values. The default
         instance of Sieve, named sieve, can be used:
 
+        >>> from sympy import sieve
         >>> list(sieve.primerange(1, 30))
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -143,15 +143,16 @@ class Sieve:
             self.extend(int(self._list[-1] * 1.5))
 
     def primerange(self, a, b=None):
-        """Generate all prime numbers in the range [a, b) when both a and b are
-           provided and generates all prime numbers till a when only a is provided.
+        """Generate all prime numbers in the range [2, a) or [a, b).
 
         Examples
         ========
 
-        >>> from sympy import sieve
+        >>> from sympy import sieve, prime
         >>> print([i for i in sieve.primerange(7, 19)])
         [7, 11, 13, 17]
+        >>> list(sieve.primerange(prime(10) + 1))  # first 10 primes
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
         >>> print([i for i in sieve.primerange(19)])
         [2, 3, 5, 7, 11, 13, 17]
@@ -647,8 +648,9 @@ def prevprime(n):
         n -= 4
 
 
-def primerange(a, b):
-    """ Generate a list of all prime numbers in the range [a, b).
+def primerange(a, b=None):
+    """ Generate a list of all prime numbers in the range [2, a),
+        or [a, b).
 
         If the range exists in the default sieve, the values will
         be returned from there; otherwise values will be returned
@@ -657,9 +659,11 @@ def primerange(a, b):
         Examples
         ========
 
-        >>> from sympy import primerange, sieve
+        >>> from sympy import primerange, sieve, prime
         >>> print([i for i in primerange(1, 30)])
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+        >>> list(primerange(prime(5) + 1))  # first 5 primes
+        [2, 3, 5, 7, 11]
 
         The Sieve method, primerange, is generally faster but it will
         occupy more memory as the sieve stores values. The default
@@ -692,6 +696,7 @@ def primerange(a, b):
         See Also
         ========
 
+        prime : Return the ith prime
         nextprime : Return the ith prime greater than n
         prevprime : Return the largest prime smaller than n
         randprime : Returns a random prime in a given range
@@ -708,6 +713,8 @@ def primerange(a, b):
     """
     from sympy.functions.elementary.integers import ceiling
 
+    if b is None:
+        a, b = 2, a
     if a >= b:
         return
     # if we already have the range, return it

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -728,7 +728,7 @@ def primerange(a, b=None):
         See Also
         ========
 
-        prime : Return the ith prime
+        prime : Return the nth prime
         nextprime : Return the ith prime greater than n
         prevprime : Return the largest prime smaller than n
         randprime : Returns a random prime in a given range


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

close #19118 

#### Brief description of what is fixed or changed

give `primerange` a single-arg option and document the use of `prime` to reference by index the desired number of primes to generate
```python
>>> primerange(prime(10))  # up to 10th
[2, 3, 5, 7, 11, 13, 17, 19, 23]
>>> primerange(prime(10)+1)  # including the 10th
[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `primerange` now accepts a single argument, a,  which gives the range [2, a)
<!-- END RELEASE NOTES -->
