### PR TITLE
Fix irrational exponent case in solveset._invert_real

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -262,7 +262,7 @@ def _invert_real(f, g_ys, symbol):
                 res = imageset(Lambda(n, real_root(n, expo)), g_ys_pos)
                 return _invert_real(base, res, symbol)
             elif expo.is_Float:
-                return _invert_real(base, res, symbol)
+                return (f, g_ys)
 
         if not base_has_sym:
             rhs = g_ys.args[0]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -241,15 +241,15 @@ def _invert_real(f, g_ys, symbol):
         if not expo_has_sym:
 
             if expo.is_rational:
-                n, d = expo.as_numer_denom()
-                if d % 2 == 0 and n % 2 == 1 and d.is_zero is False:
+                num, den = expo.as_numer_denom()
+                if den % 2 == 0 and num % 2 == 1 and den.is_zero is False:
                     root = Lambda(n, real_root(n, expo))
                     g_ys_pos = g_ys & Interval(0, oo)
                     res = imageset(root, g_ys_pos)
                     base_positive = solveset(base >= 0, symbol, S.Reals)
                     _inv, _set = _invert_real(base, res, symbol)
                     return (_inv, _set.intersect(base_positive))
-                if n % 2 == 0 and d % 2 == 1:
+                if num % 2 == 0 and den % 2 == 1:
                     root = Lambda(n, real_root(n, expo))
                     res = imageset(root, g_ys)
                     n = Dummy("n")
@@ -263,7 +263,7 @@ def _invert_real(f, g_ys, symbol):
                 return _invert_real(base, res, symbol)
 
             # indeterminate exponent, e.g. Float or parity of
-            # numer, denom of rational could not be determined
+            # num, den of rational could not be determined
             return (f, g_ys)
 
         if not base_has_sym:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -239,30 +239,27 @@ def _invert_real(f, g_ys, symbol):
         expo_has_sym = expo.has(symbol)
 
         if not expo_has_sym:
-            res = imageset(Lambda(n, real_root(n, expo)), g_ys)
+            root = Lambda(n, real_root(n, expo))
             if expo.is_rational:
-                numer, denom = expo.as_numer_denom()
-                if denom % 2 == 0:
+                n, d = expo.as_numer_denom()
+                if d % 2 == 0 and n % 2 == 1 and d.is_zero is False:
+                    g_ys_pos = g_ys & Interval(0, oo)
+                    res = imageset(root, g_ys_pos)
                     base_positive = solveset(base >= 0, symbol, S.Reals)
-                    res = imageset(Lambda(n, real_root(n, expo)
-                        ), g_ys.intersect(
-                        Interval.Ropen(S.Zero, S.Infinity)))
                     _inv, _set = _invert_real(base, res, symbol)
                     return (_inv, _set.intersect(base_positive))
-
-                elif numer % 2 == 0:
-                        n = Dummy('n')
-                        neg_res = imageset(Lambda(n, -n), res)
-                        return _invert_real(base, res + neg_res, symbol)
-
-                else:
-                    return _invert_real(base, res, symbol)
-            elif expo.is_irrational:
+                if n % 2 == 0 and d % 2 == 1:
+                    res = imageset(root, g_ys)
+                    n = Dummy("n")
+                    neg_res = imageset(Lambda(n, -n), res)
+                    return _invert_real(base, res + neg_res, symbol)
+                return _invert_real(base, imageset(root, g_ys), symbol)
+            if expo.is_irrational:
                 g_ys_pos = g_ys & Interval(0, oo)
-                res = imageset(Lambda(n, real_root(n, expo)), g_ys_pos)
+                res = imageset(root, g_ys_pos)
                 return _invert_real(base, res, symbol)
-            elif expo.is_Float:
-                return (f, g_ys)
+            # indeterminate exponent, e.g. Float
+            return (f, g_ys)
 
         if not base_has_sym:
             rhs = g_ys.args[0]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -239,26 +239,31 @@ def _invert_real(f, g_ys, symbol):
         expo_has_sym = expo.has(symbol)
 
         if not expo_has_sym:
-            root = Lambda(n, real_root(n, expo))
+
             if expo.is_rational:
                 n, d = expo.as_numer_denom()
                 if d % 2 == 0 and n % 2 == 1 and d.is_zero is False:
+                    root = Lambda(n, real_root(n, expo))
                     g_ys_pos = g_ys & Interval(0, oo)
                     res = imageset(root, g_ys_pos)
                     base_positive = solveset(base >= 0, symbol, S.Reals)
                     _inv, _set = _invert_real(base, res, symbol)
                     return (_inv, _set.intersect(base_positive))
                 if n % 2 == 0 and d % 2 == 1:
+                    root = Lambda(n, real_root(n, expo))
                     res = imageset(root, g_ys)
                     n = Dummy("n")
                     neg_res = imageset(Lambda(n, -n), res)
                     return _invert_real(base, res + neg_res, symbol)
-                return _invert_real(base, imageset(root, g_ys), symbol)
+
             if expo.is_irrational:
+                root = Lambda(n, real_root(n, expo))
                 g_ys_pos = g_ys & Interval(0, oo)
                 res = imageset(root, g_ys_pos)
                 return _invert_real(base, res, symbol)
-            # indeterminate exponent, e.g. Float
+
+            # indeterminate exponent, e.g. Float or parity of
+            # numer, denom of rational could not be determined
             return (f, g_ys)
 
         if not base_has_sym:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -242,6 +242,7 @@ def _invert_real(f, g_ys, symbol):
 
             if expo.is_rational:
                 num, den = expo.as_numer_denom()
+
                 if den % 2 == 0 and num % 2 == 1 and den.is_zero is False:
                     root = Lambda(n, real_root(n, expo))
                     g_ys_pos = g_ys & Interval(0, oo)
@@ -249,22 +250,26 @@ def _invert_real(f, g_ys, symbol):
                     base_positive = solveset(base >= 0, symbol, S.Reals)
                     _inv, _set = _invert_real(base, res, symbol)
                     return (_inv, _set.intersect(base_positive))
-                if num % 2 == 0 and den % 2 == 1:
+
+                if den % 2 == 1:
                     root = Lambda(n, real_root(n, expo))
                     res = imageset(root, g_ys)
-                    n = Dummy("n")
-                    neg_res = imageset(Lambda(n, -n), res)
-                    return _invert_real(base, res + neg_res, symbol)
+                    if num % 2 == 0:
+                        neg_res = imageset(Lambda(n, -n), res)
+                        return _invert_real(base, res + neg_res, symbol)
+                    if num % 2 == 1:
+                        return _invert_real(base, res, symbol)
 
-            if expo.is_irrational:
+            elif expo.is_irrational:
                 root = Lambda(n, real_root(n, expo))
                 g_ys_pos = g_ys & Interval(0, oo)
                 res = imageset(root, g_ys_pos)
                 return _invert_real(base, res, symbol)
 
-            # indeterminate exponent, e.g. Float or parity of
-            # num, den of rational could not be determined
-            return (f, g_ys)
+            else:
+                # indeterminate exponent, e.g. Float or parity of
+                # num, den of rational could not be determined
+                pass  # use default return
 
         if not base_has_sym:
             rhs = g_ys.args[0]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -240,7 +240,7 @@ def _invert_real(f, g_ys, symbol):
 
         if not expo_has_sym:
             res = imageset(Lambda(n, real_root(n, expo)), g_ys)
-            if expo.is_rational:
+            if expo.is_rational or expo.is_Float:
                 numer, denom = expo.as_numer_denom()
                 if denom % 2 == 0:
                     base_positive = solveset(base >= 0, symbol, S.Reals)
@@ -257,10 +257,9 @@ def _invert_real(f, g_ys, symbol):
 
                 else:
                     return _invert_real(base, res, symbol)
-            else:
-                if not base.is_positive:
-                    raise ValueError("x**w where w is irrational is not "
-                                     "defined for negative x")
+            elif expo.is_irrational:
+                g_ys_pos = g_ys & Interval(0, oo)
+                res = imageset(Lambda(n, real_root(n, expo)), g_ys_pos)
                 return _invert_real(base, res, symbol)
 
         if not base_has_sym:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -240,7 +240,7 @@ def _invert_real(f, g_ys, symbol):
 
         if not expo_has_sym:
             res = imageset(Lambda(n, real_root(n, expo)), g_ys)
-            if expo.is_rational or expo.is_Float:
+            if expo.is_rational:
                 numer, denom = expo.as_numer_denom()
                 if denom % 2 == 0:
                     base_positive = solveset(base >= 0, symbol, S.Reals)
@@ -260,6 +260,8 @@ def _invert_real(f, g_ys, symbol):
             elif expo.is_irrational:
                 g_ys_pos = g_ys & Interval(0, oo)
                 res = imageset(Lambda(n, real_root(n, expo)), g_ys_pos)
+                return _invert_real(base, res, symbol)
+            elif expo.is_Float:
                 return _invert_real(base, res, symbol)
 
         if not base_has_sym:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -96,7 +96,8 @@ def test_invert_real():
     # issue 21236
     assert invert_real(x**pi, y, x) == (x, FiniteSet(y**(1/pi)))
     assert invert_real(x**pi, -E, x) == (x, EmptySet())
-    assert invert_real(x**(3/2), 1000, x) == (x, FiniteSet(1000**(2/3)))
+    assert invert_real(x**Rational(3/2), 1000, x) == (x, FiniteSet(100))
+    assert invert_real(x**1.0, 1, x) == (x**1.0, FiniteSet(1))
 
     raises(ValueError, lambda: invert_real(S.One, y, x))
 
@@ -2816,3 +2817,7 @@ def test_substitution_with_infeasible_solution():
         (0, Complement(FiniteSet(p01), FiniteSet(0)), 0, p11, 0, 0, 0, 0, 0, 0, 0, -l2*p11/p01, -l3*p11/p01, l2, l3),
     )
     assert sol != nonlinsolve(system, solvefor)
+
+def test_issue_21236():
+    x, y, z = symbols("x y z")
+    assert solveset(x**y - z, x, S.Reals) == ConditionSet(x, Eq(x**y - z, 0), S.Reals)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -92,7 +92,12 @@ def test_invert_real():
     assert invert_real(x**S.Half, y, x) == (x, FiniteSet(y**2))
 
     raises(ValueError, lambda: invert_real(x, x, x))
-    raises(ValueError, lambda: invert_real(x**pi, y, x))
+
+    # issue 21236
+    assert invert_real(x**pi, y, x) == (x, FiniteSet(y**(1/pi)))
+    assert invert_real(x**pi, -E, x) == (x, EmptySet())
+    assert invert_real(x**(3/2), 1000, x) == (x, FiniteSet(1000**(2/3)))
+
     raises(ValueError, lambda: invert_real(S.One, y, x))
 
     assert invert_real(x**31 + x, y, x) == (x**31 + x, FiniteSet(y))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2819,5 +2819,9 @@ def test_substitution_with_infeasible_solution():
     assert sol != nonlinsolve(system, solvefor)
 
 def test_issue_21236():
-    x, y, z = symbols("x y z")
+    x, z = symbols("x z")
+    y = symbols('y', rational=True)
+    assert solveset(x**y - z, x, S.Reals) == ConditionSet(x, Eq(x**y - z, 0), S.Reals)
+    e1, e2 = symbols('e1 e2', even=True)
+    y = e1/e2  # don't know if num or den will be odd and the other even
     assert solveset(x**y - z, x, S.Reals) == ConditionSet(x, Eq(x**y - z, 0), S.Reals)


### PR DESCRIPTION
Fixes #21236

Original code would raise ValueError on 'not base.is_positive'
assuming that the only situation for this case is when the
exponent is irrational. Issue 21236 showed that this case is
reached even when exponent is a Float. Also, the 'not base.is_positive'
is invalid for three-valued logic. solveset removes assumptions before
calling invert causing 'not base.is_positive' to be True regardless.

- [x] change odd/even tests for numer and denom to be accurate for rational -- they are currently written for Rational cases. The `rational` case tests should be something like 
```
numer, denom = expo.as_numer_denom()
denom.is_odd and numer.is_even # for numer % 2 == 0 case
denom.is_even and numer.is_odd # for denom % 2 == 0 case
else:  # unknown
```
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed bug in solveset 
<!-- END RELEASE NOTES -->
