### PR TITLE
Fixed Liouville ODE failing to match

### DIFF
--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1295,7 +1295,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
         # Differential Equations", pg. 98
 
         s = d*f(x).diff(x, 2) + e*df**2 + k*df
-        r = reduced_eq.match(s)
+        r = reduced_eq.collect(f(x).diff(x)).match(s)
         if r and r[d] != 0:
             y = Dummy('y')
             g = simplify(r[e]/r[d]).subs(f(x), y)

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -37,7 +37,7 @@ from sympy import (acos, acosh, asin, asinh, atan, cos, Derivative, Dummy, diff,
     re, rootof, S, sin, sinh, cosh, tan, tanh, sec, sqrt, symbols, Ei, erfi)
 
 from sympy.core import Function, Symbol
-from sympy.functions import airyai, airybi, besselj, bessely
+from sympy.functions import airyai, airybi, besselj, bessely, lowergamma
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.solvers.ode import classify_ode, dsolve
 from sympy.solvers.ode.ode import allhints, _remove_redundant_solutions
@@ -988,6 +988,8 @@ def _get_examples_ode_sol_almost_linear():
 
 @_add_example_keys
 def _get_examples_ode_sol_liouville():
+    n = Symbol('n')
+    _y = Dummy('y')
     return {
             'hint': "Liouville",
             'func': f(x),
@@ -1026,6 +1028,11 @@ def _get_examples_ode_sol_liouville():
     'liouville_07': {
         'eq': (diff(f(x), x)/x + diff(f(x), x, x)/2 - diff(f(x), x)**2/2)*exp(-f(x))/exp(f(x)),
         'sol': [Eq(f(x), log(x/(C1 + C2*x)))],
+    },
+
+    'liouville_08': {
+        'eq': x**2*diff(f(x),x) + (n*f(x) + f(x)**2)*diff(f(x),x)**2 + diff(f(x), (x, 2)),
+        'sol': [Eq(C1 + C2*lowergamma(Rational(1,3), x**3/3) + NonElementaryIntegral(exp(_y**3/3)*exp(_y**2*n/2), (_y, f(x))), 0)],
     },
     }
     }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21290 


#### Brief description of what is fixed or changed
Issue #21290 showed an example where a Liouville ODE with multiple
terms fails to match:
```
In [0]: eq = f(x).diff(x, 2) + (f(x)**2 + n*f(x))*f(x).diff(x)**2 + x**2*f(x).diff(x)
In [1]: dsolve(eq, hint="Liouville")
ValueError: ODE x**2*Derivative(f(x), x) + (n*f(x) + f(x)**2)*Derivative(f(x), x)**2 + Derivative(f(x), (x, 2))
does not match hint Liouville
```

This change applies the diff suggested by the auther of the issue
@naveensaigit in ode.py which fixes the issue:
```
in ./sympy/solvers/ode/ode.py
-        r = reduced_eq.match(s)
+        r = reduced_eq.collect(f(x).diff(x)).match(s)
```
Example:
In [2]: dsolve(eq, hint="Liouville")
Out[2]:
```
                        f(x)
                        ⌠
                       ⎮     3   2
                       ⎮    y   y ⋅n
         ⎛      3⎞    ⎮    ──  ────
         ⎜     x ⎟    ⎮    3    2
C₁ + C₂⋅γ⎜1/3, ──⎟ +  ⎮   ℯ  ⋅ℯ     dy = 0
         ⎝     3 ⎠    ⌡
```

A regression test of the same example has been added in test_single.py
#### Other comments

A better way to solve this proposed by @oscarbenjamin is to refactorthe ode solvers into classes (Issue 18348)


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a bug where solving Liouville ODE with multiple terms fails.
<!-- END RELEASE NOTES -->
