### PR TITLE
simplify: Make Fu transformation _TR56 handle odd powers

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1344,7 +1344,7 @@ def TR14(rv, first=True):
 
 
 def TR15(rv, max=4, pow=False):
-    """Convert sin(x)*-2 to 1 + cot(x)**2.
+    """Convert sin(x)**-2 to 1 + cot(x)**2.
 
     See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
@@ -1365,7 +1365,7 @@ def TR15(rv, max=4, pow=False):
 
         e = rv.exp
         if e % 2 == 1:
-            return TR15(rv.base**(e+1))/rv.base
+            return TR15(rv.base**(e + 1))/rv.base
 
         ia = 1/rv
         a = _TR56(ia, sin, cot, lambda x: 1 + x, max=max, pow=pow)
@@ -1377,7 +1377,7 @@ def TR15(rv, max=4, pow=False):
 
 
 def TR16(rv, max=4, pow=False):
-    """Convert cos(x)*-2 to 1 + tan(x)**2.
+    """Convert cos(x)**-2 to 1 + tan(x)**2.
 
     See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
@@ -1398,7 +1398,7 @@ def TR16(rv, max=4, pow=False):
 
         e = rv.exp
         if e % 2 == 1:
-            return TR15(rv.base**(e+1))/rv.base
+            return TR15(rv.base**(e + 1))/rv.base
 
         ia = 1/rv
         a = _TR56(ia, cos, tan, lambda x: 1 + x, max=max, pow=pow)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1361,14 +1361,13 @@ def TR15(rv, max=4, pow=False):
         if not (isinstance(rv, Pow) and isinstance(rv.base, sin)):
             return rv
 
-        e = rv.exp
-        if e % 2 == 1:
-            return TR15(rv.base**(e+1))/rv.base
-
         ia = 1/rv
         a = _TR56(ia, sin, cot, lambda x: 1 + x, max=max, pow=pow)
         if a != ia:
-            rv = a
+            if rv.exp % 2 == 1:
+                rv = a*rv.base**-2
+            else:
+                rv = a
         return rv
 
     return bottom_up(rv, f)
@@ -1394,13 +1393,13 @@ def TR16(rv, max=4, pow=False):
         if not (isinstance(rv, Pow) and isinstance(rv.base, cos)):
             return rv
 
-        e = rv.exp
-        if e % 2 == 1:
-            return TR15(rv.base**(e+1))/rv.base
-
         ia = 1/rv
         a = _TR56(ia, cos, tan, lambda x: 1 + x, max=max, pow=pow)
         if a != ia:
+            if rv.exp % 2 == 1:
+                rv = a*rv.base**-2
+            else:
+                rv = a
             rv = a
         return rv
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1361,6 +1361,10 @@ def TR15(rv, max=4, pow=False):
         if not (isinstance(rv, Pow) and isinstance(rv.base, sin)):
             return rv
 
+        e = rv.exp
+        if e % 2 == 1:
+            return TR15(rv.base**(e+1))/rv.base
+
         ia = 1/rv
         a = _TR56(ia, sin, cot, lambda x: 1 + x, max=max, pow=pow)
         if a != ia:
@@ -1389,6 +1393,10 @@ def TR16(rv, max=4, pow=False):
     def f(rv):
         if not (isinstance(rv, Pow) and isinstance(rv.base, cos)):
             return rv
+
+        e = rv.exp
+        if e % 2 == 1:
+            return TR15(rv.base**(e+1))/rv.base
 
         ia = 1/rv
         a = _TR56(ia, cos, tan, lambda x: 1 + x, max=max, pow=pow)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1363,13 +1363,14 @@ def TR15(rv, max=4, pow=False):
         if not (isinstance(rv, Pow) and isinstance(rv.base, sin)):
             return rv
 
+        e = rv.exp
+        if e % 2 == 1:
+            return TR15(rv.base**(e+1))/rv.base
+
         ia = 1/rv
         a = _TR56(ia, sin, cot, lambda x: 1 + x, max=max, pow=pow)
         if a != ia:
-            if rv.exp % 2 == 1:
-                rv = a*rv.base**-2
-            else:
-                rv = a
+            rv = a
         return rv
 
     return bottom_up(rv, f)
@@ -1395,13 +1396,13 @@ def TR16(rv, max=4, pow=False):
         if not (isinstance(rv, Pow) and isinstance(rv.base, cos)):
             return rv
 
+        e = rv.exp
+        if e % 2 == 1:
+            return TR15(rv.base**(e+1))/rv.base
+
         ia = 1/rv
         a = _TR56(ia, cos, tan, lambda x: 1 + x, max=max, pow=pow)
         if a != ia:
-            if rv.exp % 2 == 1:
-                rv = a*rv.base**-2
-            else:
-                rv = a
             rv = a
         return rv
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -316,6 +316,8 @@ def _TR56(rv, f, g, h, max, pow):
             return rv
         if (rv.exp > max) == True:
             return rv
+        if rv.exp == 1:
+            return rv
         if rv.exp == 2:
             return h(g(rv.base.args[0])**2)
         else:

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -293,7 +293,7 @@ def _TR56(rv, f, g, h, max, pow):
     >>> from sympy import sin, cos
     >>> h = lambda x: 1 - x
     >>> T(sin(x)**3, sin, cos, h, 4, False)
-    sin(x)**3
+    sin(x)*(1- cos(x)**2)
     >>> T(sin(x)**6, sin, cos, h, 6, False)
     (1 - cos(x)**2)**3
     >>> T(sin(x)**6, sin, cos, h, 6, True)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -319,7 +319,10 @@ def _TR56(rv, f, g, h, max, pow):
         if rv.exp == 2:
             return h(g(rv.base.args[0])**2)
         else:
-            if rv.exp == 4:
+            if rv.exp % 2 == 1:
+                e = rv.exp//2
+                return f(rv.base.args[0])*h(g(rv.base.args[0])**2)**e
+            elif rv.exp == 4:
                 e = 2
             elif not pow:
                 if rv.exp % 2:

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -293,7 +293,7 @@ def _TR56(rv, f, g, h, max, pow):
     >>> from sympy import sin, cos
     >>> h = lambda x: 1 - x
     >>> T(sin(x)**3, sin, cos, h, 4, False)
-    sin(x)*(1- cos(x)**2)
+    (1 - cos(x)**2)*sin(x)
     >>> T(sin(x)**6, sin, cos, h, 6, False)
     (1 - cos(x)**2)**3
     >>> T(sin(x)**6, sin, cos, h, 6, True)

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -69,7 +69,7 @@ def test_TR3():
 
 def test__TR56():
     h = lambda x: 1 - x
-    assert T(sin(x)**3, sin, cos, h, 4, False) == sin(x)**3
+    assert T(sin(x)**3, sin, cos, h, 4, False) == sin(x)*(-cos(x)**2 + 1)
     assert T(sin(x)**10, sin, cos, h, 4, False) == sin(x)**10
     assert T(sin(x)**6, sin, cos, h, 6, False) == (-cos(x)**2 + 1)**3
     assert T(sin(x)**6, sin, cos, h, 6, True) == sin(x)**6
@@ -287,6 +287,9 @@ def test_fu():
 
     # issue #18059:
     assert fu(cos(x) + sqrt(sin(x)**2)) == cos(x) + sqrt(sin(x)**2)
+
+    assert fu((-14*sin(x)**3 + 35*sin(x) + 6*sqrt(3)*cos(x)**3 + 9*sqrt(3)*cos(x))/((cos(2*x) + 4))) == \
+        7*sin(x) + 3*sqrt(3)*cos(x)
 
 
 def test_objective():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently the Fu transformations `TR5`, `TR6`, `TR15`, `TR16`, and `TR22` only rewrites even powers of trig functions.  This modifies the helper function `_TR56` so these transformations can handle odd powers.

#### Other comments

Improves `fu` and `trigsimp` to now simplify the following complicated trig expression.

```python
>>> expr = (-14*sin(x)**3 + 35*sin(x) + 6*sqrt(3)*cos(x)**3 + 9*sqrt(3)*cos(x))/((cos(2*x) + 4))
>>> fu(expr)
7*sin(x) + 3*sqrt(3)*cos(x)
>>> trigsimp(expr)
7*sin(x) + 3*sqrt(3)*cos(x)
```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Modified the Fu transformation `_TR56` to handle odd powers
<!-- END RELEASE NOTES -->
