### PR TITLE
fix(polys): add conversion from ZZ_I and QQ_I to CC

### DIFF
--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -75,6 +75,9 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
     def from_ZZ(self, element, base):
         return self.dtype(element)
 
+    def from_QQ(self, element, base):
+        return self.dtype(int(element.numerator)) / int(element.denominator)
+
     def from_ZZ_python(self, element, base):
         return self.dtype(element)
 

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -87,6 +87,15 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
     def from_QQ_gmpy(self, element, base):
         return self.dtype(int(element.numerator)) / int(element.denominator)
 
+    def from_GaussianIntegerRing(self, element, base):
+        return self.dtype(int(element.x), int(element.y))
+
+    def from_GaussianRationalField(self, element, base):
+        x = element.x
+        y = element.y
+        return (self.dtype(int(x.numerator)) / int(x.denominator) +
+                self.dtype(0, int(y.numerator)) / int(y.denominator))
+
     def from_RealField(self, element, base):
         return self.dtype(element)
 

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -99,6 +99,9 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         return (self.dtype(int(x.numerator)) / int(x.denominator) +
                 self.dtype(0, int(y.numerator)) / int(y.denominator))
 
+    def from_AlgebraicField(self, element, base):
+        return self.from_sympy(base.to_sympy(element).evalf(self.dps))
+
     def from_RealField(self, element, base):
         return self.dtype(element)
 

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -728,7 +728,8 @@ class Domain:
 
             if ((K0.is_FractionField and K1.is_PolynomialRing or
                  K1.is_FractionField and K0.is_PolynomialRing) and
-                 (not K0_ground.is_Field or not K1_ground.is_Field) and domain.is_Field):
+                 (not K0_ground.is_Field or not K1_ground.is_Field) and domain.is_Field
+                 and domain.has_assoc_Ring):
                 domain = domain.get_ring()
 
             if K0.is_Composite and (not K1.is_Composite or K0.is_FractionField or K1.is_PolynomialRing):

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -118,15 +118,24 @@ class FractionField(Field, CompositeDomain):
 
     def from_AlgebraicField(K1, a, K0):
         """Convert an algebraic number to ``dtype``. """
-        if K1.domain == K0:
+        if K1.domain != K0:
+            a = K1.domain.convert_from(a, K0)
+        if a is not None:
             return K1.new(a)
 
     def from_PolynomialRing(K1, a, K0):
         """Convert a polynomial to ``dtype``. """
         try:
-            return K1.new(a)
+            return K1.new(a.set_ring(K1.field.ring))
         except (CoercionFailed, GeneratorsError):
-            return None
+            # XXX: We get here if K1=ZZ(x,y) and K0=QQ[x,y]
+            # and the poly a in K0 has non-integer coefficients.
+            # It seems that K1.new can handle this but K1.new doesn't work
+            # when K0.domain is an algebraic field...
+            try:
+                return K1.new(a)
+            except (CoercionFailed, GeneratorsError):
+                return None
 
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -112,6 +112,10 @@ class FractionField(Field, CompositeDomain):
         """Convert a mpmath ``mpf`` object to ``dtype``. """
         return K1(K1.domain.convert(a, K0))
 
+    def from_ComplexField(K1, a, K0):
+        """Convert a mpmath ``mpf`` object to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
     def from_AlgebraicField(K1, a, K0):
         """Convert an algebraic number to ``dtype``. """
         if K1.domain == K0:

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -122,6 +122,10 @@ class PolynomialRing(Ring, CompositeDomain):
         """Convert a mpmath `mpf` object to `dtype`. """
         return K1(K1.domain.convert(a, K0))
 
+    def from_ComplexField(K1, a, K0):
+        """Convert a mpmath `mpf` object to `dtype`. """
+        return K1(K1.domain.convert(a, K0))
+
     def from_AlgebraicField(K1, a, K0):
         """Convert an algebraic number to ``dtype``. """
         if K1.domain == K0:

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -128,7 +128,9 @@ class PolynomialRing(Ring, CompositeDomain):
 
     def from_AlgebraicField(K1, a, K0):
         """Convert an algebraic number to ``dtype``. """
-        if K1.domain == K0:
+        if K1.domain != K0:
+            a = K1.domain.convert_from(a, K0)
+        if a is not None:
             return K1.new(a)
 
     def from_PolynomialRing(K1, a, K0):

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -90,6 +90,9 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
     def from_QQ_gmpy(self, element, base):
         return self.dtype(int(element.numerator)) / int(element.denominator)
 
+    def from_AlgebraicField(self, element, base):
+        return self.from_sympy(base.to_sympy(element).evalf(self.dps))
+
     def from_RealField(self, element, base):
         if self == base:
             return element

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -575,6 +575,9 @@ def test_Domain_convert():
     assert ZZ.convert(x - x) == 0
     assert ZZ.convert(x - x, R.to_domain()) == 0
 
+    assert CC.convert(ZZ_I(1, 2)) == CC(1, 2)
+    assert CC.convert(QQ_I(1, 2)) == CC(1, 2)
+
 
 def test_GlobalPolynomialRing_convert():
     K1 = QQ.old_poly_ring(x)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -582,15 +582,15 @@ def test_Domain_convert():
         check_element(K3.convert_from(K2.zero, K2), K3.zero, K1, K2, K3)
 
     def composite_domains(K):
-        return [K1, K1[y], K1[z], K1[y, z], K1.frac_field(y),
-                K1.frac_field(z), K1.frac_field(y, z)]
+        return [K, K[y], K[z], K[y, z],
+                   K.frac_field(y), K.frac_field(z), K.frac_field(y, z)]
 
     QQ2 = QQ.algebraic_field(sqrt(2))
     QQ3 = QQ.algebraic_field(sqrt(3))
     doms = [ZZ, QQ, QQ2, QQ3, QQ_I, ZZ_I, RR, CC]
 
-    for K1 in doms:
-        for K2 in doms:
+    for i, K1 in enumerate(doms):
+        for K2 in doms[i:]:
             for K3 in composite_domains(K1):
                 for K4 in composite_domains(K2):
                     check_domains(K3, K4)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -569,6 +569,32 @@ def test_Domain_is_unit():
 
 
 def test_Domain_convert():
+
+    def check_element(e1, e2, K1, K2, K3):
+        assert type(e1) is type(e2), '%s, %s: %s %s -> %s' % (e1, e2, K1, K2, K3)
+        assert e1 == e2, '%s, %s: %s %s -> %s' % (e1, e2, K1, K2, K3)
+
+    def check_domains(K1, K2):
+        K3 = K1.unify(K2)
+        check_element(K3.convert_from(K1.one,  K1), K3.one , K1, K2, K3)
+        check_element(K3.convert_from(K2.one,  K2), K3.one , K1, K2, K3)
+        check_element(K3.convert_from(K1.zero, K1), K3.zero, K1, K2, K3)
+        check_element(K3.convert_from(K2.zero, K2), K3.zero, K1, K2, K3)
+
+    def composite_domains(K):
+        return [K1, K1[y], K1[z], K1[y, z], K1.frac_field(y),
+                K1.frac_field(z), K1.frac_field(y, z)]
+
+    QQ2 = QQ.algebraic_field(sqrt(2))
+    QQ3 = QQ.algebraic_field(sqrt(3))
+    doms = [ZZ, QQ, QQ2, QQ3, QQ_I, ZZ_I, RR, CC]
+
+    for K1 in doms:
+        for K2 in doms:
+            for K3 in composite_domains(K1):
+                for K4 in composite_domains(K2):
+                    check_domains(K3, K4)
+
     assert QQ.convert(10e-52) == QQ(1684996666696915, 1684996666696914987166688442938726917102321526408785780068975640576)
 
     R, x = ring("x", ZZ)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -351,19 +351,19 @@ class PolyRing(DefaultPrinting, IPolys):
 
     __call__ = ring_new
 
-    def from_dict(self, element):
+    def from_dict(self, element, orig_domain=None):
         domain_new = self.domain_new
         poly = self.zero
 
         for monom, coeff in element.items():
-            coeff = domain_new(coeff)
+            coeff = domain_new(coeff, orig_domain)
             if coeff:
                 poly[monom] = coeff
 
         return poly
 
-    def from_terms(self, element):
-        return self.from_dict(dict(element))
+    def from_terms(self, element, orig_domain=None):
+        return self.from_dict(dict(element), orig_domain)
 
     def from_list(self, element):
         return self.from_dict(dmp_to_dict(element, self.ngens-1, self.domain))
@@ -608,9 +608,9 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             return self
         elif self.ring.symbols != new_ring.symbols:
             terms = list(zip(*_dict_reorder(self, self.ring.symbols, new_ring.symbols)))
-            return new_ring.from_terms(terms)
+            return new_ring.from_terms(terms, self.ring.domain)
         else:
-            return new_ring.from_dict(self)
+            return new_ring.from_dict(self, self.ring.domain)
 
     def as_expr(self, *symbols):
         if symbols and len(symbols) != self.ring.ngens:


### PR DESCRIPTION
Fixes this bug:
```
In [1]: Poly(1.0*x)*I
---------------------------------------------------------------------------
AttributeError: 'ComplexField' object has no attribute 'from_GaussianIntegerRing'
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
