### PR TITLE
Generalized denominator rationalization

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1320,14 +1320,14 @@ def rationalize(denom):
             base, exp = origin.args
             s, t, d = gcdex(denom, dest ** exp.q - base ** exp.p, dest)
             if d != 1:
-                return S.One, S.Zero
+                raise ValueError("The denominator may be zero")
             new_numer, new_denom = s.as_numer_denom()
             numer *= new_numer
             denom = new_denom
         elif origin.is_algebraic:
             s, t, d = gcdex(denom, minpoly(origin, dest), dest)
             if d != 1:
-                return S.One, S.Zero
+                raise ValueError("The denominator may be zero")
             new_numer, new_denom = s.as_numer_denom()
             numer *= new_numer
             denom = new_denom

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -1,12 +1,12 @@
 from sympy import (
-    sqrt, Derivative, symbols, collect, Function, factor, Wild, S,
+    sqrt, cbrt, Derivative, symbols, collect, Function, factor, Wild, S,
     collect_const, log, fraction, I, cos, Add, O,sin, rcollect,
     Mul, Pow, radsimp, diff, root, Symbol, Rational, exp, Abs)
 
 from sympy.core.expr import unchanged
 from sympy.core.mul import _unevaluated_Mul as umul
 from sympy.simplify.radsimp import (_unevaluated_Add,
-    collect_sqrt, fraction_expand, collect_abs)
+    collect_sqrt, fraction_expand, collect_abs, rationalize)
 from sympy.testing.pytest import raises
 
 from sympy.abc import x, y, z, a, b, c, d
@@ -155,6 +155,34 @@ def test_radsimp_issue_3214():
     s = sqrt(c**2 - p**2)
     b = (c + I*p - s)/(c + I*p + s)
     assert radsimp(b) == -I*(c + I*p - sqrt(c**2 - p**2))**2/(2*c*p)
+
+
+def test_rationalize():
+    assert rationalize(sqrt(2) - 1) == (1 + sqrt(2), 1)
+    assert rationalize(sqrt(2) + sqrt(3) + sqrt(5)) == \
+        (2*sqrt(6)*(-sqrt(5) + sqrt(2) + sqrt(3)), 24)
+    assert rationalize(5**Rational(3, 2) - 5**Rational(4, 3)) == \
+        ((1 + sqrt(5))*(5**Rational(2, 3) + 5**Rational(5, 6) + 5), 100)
+    assert rationalize(2*sqrt(5) - 1) == (1 + 2*sqrt(5), 19)
+    assert rationalize(sqrt(3) - cbrt(2)) == \
+        ((2 + 3*sqrt(3))*(2**Rational(2, 3) + 2**Rational(1, 3)*sqrt(3) + 3),
+        23)
+    assert rationalize(
+        2*5**Rational(5, 2) - 2*5**Rational(7, 3)
+        - 10*5**Rational(3, 2) + 10*5**Rational(4, 3)
+    ) == (1, 0)
+
+    a, b, c = symbols('a b c')
+    assert rationalize(a + sqrt(b + sqrt(c))) == (
+        (a - sqrt(b + sqrt(c)))*(a**2 - b + sqrt(c)),
+        a**4 - 2*a**2*b + b**2 - c
+    )
+    assert rationalize(1 + sqrt(2 + sqrt(3))) == (
+        (-1 + sqrt(3))*(-1 + sqrt(sqrt(3) + 2)), 2)
+    assert rationalize(a + sqrt(b + cbrt(c))) == (
+        (a - sqrt(b + c**Rational(1, 3)))*(a**4 - 2*a**2*b + b**2 + c**Rational(2, 3) + c**Rational(1, 3)*(a**2 - b)),
+        a**6 - 3*a**4*b + 3*a**2*b**2 - b**3 - c
+    )
 
 
 def test_collect_1():

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -160,13 +160,12 @@ def test_radsimp_issue_3214():
 def test_rationalize():
     assert rationalize(sqrt(2) - 1) == (1 + sqrt(2), 1)
     assert rationalize(sqrt(2) + sqrt(3) + sqrt(5)) == \
-        (2*sqrt(6)*(-sqrt(5) + sqrt(2) + sqrt(3)), 24)
+        (-((6 - 2*sqrt(15))*(-sqrt(2) + sqrt(3) + sqrt(5))), 24)
     assert rationalize(5**Rational(3, 2) - 5**Rational(4, 3)) == \
         ((1 + sqrt(5))*(5**Rational(2, 3) + 5**Rational(5, 6) + 5), 100)
     assert rationalize(2*sqrt(5) - 1) == (1 + 2*sqrt(5), 19)
     assert rationalize(sqrt(3) - cbrt(2)) == \
-        ((2 + 3*sqrt(3))*(2**Rational(2, 3) + 2**Rational(1, 3)*sqrt(3) + 3),
-        23)
+        ((-sqrt(3) - 2**Rational(1, 3))*(-9 - 3*2**Rational(2, 3) - 2*2**Rational(1, 3)), 23)
     assert rationalize(
         2*5**Rational(5, 2) - 2*5**Rational(7, 3)
         - 10*5**Rational(3, 2) + 10*5**Rational(4, 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19757
Fixes #19731

#### Brief description of what is fixed or changed

This implements the idea of #19731 to extend the rationalization capability greatly, however, I have found better algorithm than #19731 that uses polynomial extended GCD computation.

Not only any complicated expression containing square roots and square root functions this can handle, It is also able to rationalize denominators containing algebraic numbers like `GoldenRatio`, `cos(pi/7)`, ... that are not in the form of explicit radicals.
It is even able to rationalize expressions containing `CRootOf`, but it needs some fix for `CRootOf.is_algebraic`.

This is still work in progress a bit, to decide how to handle conflicts or compatibility with `radsimp`,
I think that this should be able to replace `radsimp` completely, or at least partially (Because rationalizing complicated expression often leads to much more complicated numerators, which wouldn't make sense for 'simplify')
But I think that a dedicated function for rationalization can also be good. For this, I would use an alternative interface that accepts only the denominator than full rational `Expr`.

I also found that that this is often faster than computing `radsimp` or `minpoly`. 
I think that the speed can be improved further if sparse polynomials are used, but I couldn't implement that because of the lack of convenience utilities like `Poly.eject`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
