### PR TITLE
refactor(assump) : change function definition of get_all_relevant_facts

### DIFF
--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -142,6 +142,18 @@ def get_all_relevant_facts(proposition, assumptions, context,
 
     sympy.assumptions.cnf.EncodedCNF
 
+    Examples
+    ========
+
+    >>> from sympy.assumptions.cnf import CNF
+    >>> from sympy.assumptions.satask import get_all_relevant_facts
+    >>> from sympy.abc import x, y
+    >>> props = CNF.from_prop(Q.nonzero(x*y))
+    >>> assump = CNF.from_prop(Q.nonzero(x))
+    >>> context = CNF.from_prop(Q.nonzero(y))
+    >>> get_all_relevant_facts(props, assump, context) #doctest: +SKIP
+    <sympy.assumptions.cnf.EncodedCNF at 0x7f09faa6ccd0>
+
     """
     # The relevant facts might introduce new keys, e.g., Q.zero(x*y) will
     # introduce the keys Q.zero(x) and Q.zero(y), so we need to run it until

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -145,6 +145,7 @@ def get_all_relevant_facts(proposition, assumptions, context,
     Examples
     ========
 
+    >>> from sympy import Q
     >>> from sympy.assumptions.cnf import CNF
     >>> from sympy.assumptions.satask import get_all_relevant_facts
     >>> from sympy.abc import x, y

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -114,7 +114,7 @@ def get_all_relevant_facts(proposition, assumptions, context,
     Extract all relevant facts from *proposition* and *assumptions*.
 
     This function extracts the facts by recursively calling
-    ``get_all_relevant_facts()``. Extracted facts are converted to
+    ``get_relevant_facts()``. Extracted facts are converted to
     ``EncodedCNF`` and returned.
 
     Parameters


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

*proposition*, *assumptions* and *context* parameters of ``get_all_relevant_facts()`` must be ``CNF`` instance for the function to work. However, in master, default values for *assumptions* and *context* are not. Because of this, not passing these parameters raises error:

```python
In [1]: from sympy.assumptions.cnf import CNF 
   ...: from sympy.assumptions.satask import get_all_relevant_facts 
   ...: props = CNF.from_prop(Q.even(x)) 
   ...: get_all_relevant_facts(props)                                                                                                                                                                                                                                
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
...
AttributeError: 'bool' object has no attribute 'all_predicates'
```
Hence, these parameters must be passed and there is no reason that we should keep them optional.

This change makes *assumptions* and *context* parameters positional and specifies their types in docstring.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
