### PR TITLE
refactor(assump) : redesign get_relevant_facts()

### DIFF
--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,6 +1,8 @@
-from sympy.assumptions.satask import satask
+from sympy.assumptions.cnf import CNF, Literal
+from sympy.assumptions.satask import (satask, extract_predargs,
+    get_relevant_facts)
 
-from sympy import S, symbols, Q, assuming, Implies, MatrixSymbol, I, pi
+from sympy import S, symbols, Q, assuming, Implies, MatrixSymbol, I, pi, Abs
 
 from sympy.testing.pytest import raises, XFAIL
 
@@ -335,3 +337,31 @@ def test_prime_composite():
     assert satask(Q.prime(4)) is False
     assert satask(Q.prime(1)) is False
     assert satask(Q.composite(1)) is False
+
+
+def test_extract_predargs():
+    props = CNF.from_prop(Q.zero(Abs(x*y)) & Q.zero(x*y))
+    assump = CNF.from_prop(Q.zero(x))
+    context = CNF.from_prop(Q.zero(y))
+    assert extract_predargs(props) == {Abs(x*y), x*y}
+    assert extract_predargs(props, assump) == {Abs(x*y), x*y, x}
+    assert extract_predargs(props, assump, context) == {Abs(x*y), x*y, x, y}
+
+
+def test_get_relevant_facts():
+    exprs = {Abs(x*y)}
+    exprs, facts = get_relevant_facts(exprs)
+    assert exprs == {x*y}
+    assert facts.clauses == \
+        {frozenset({Literal(Q.odd(Abs(x*y)), False), Literal(Q.odd(x*y), True)}),
+        frozenset({Literal(Q.zero(Abs(x*y)), False), Literal(Q.zero(x*y), True)}),
+        frozenset({Literal(Q.even(Abs(x*y)), False), Literal(Q.even(x*y), True)}),
+        frozenset({Literal(Q.zero(Abs(x*y)), True), Literal(Q.zero(x*y), False)}),
+        frozenset({Literal(Q.even(Abs(x*y)), False),
+                    Literal(Q.odd(Abs(x*y)), False),
+                    Literal(Q.odd(x*y), True)}),
+        frozenset({Literal(Q.even(Abs(x*y)), False),
+                    Literal(Q.even(x*y), True),
+                    Literal(Q.odd(Abs(x*y)), False)}),
+        frozenset({Literal(Q.positive(Abs(x*y)), False),
+                    Literal(Q.zero(Abs(x*y)), False)})}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In master, `get_relevant_facts()` has completely different two functionalities.

1. If *exprs* is not passed, it extracts the symbolic expressions from *proposition*, *assumptions*, and *context*. *relevant_facts* is not used here.

2. If *exprs* is passed, facts relevant to *exprs* are found and returned. Here, *proposition*, *assumptions*, and *context* are not used.

This design is very confusing. In this change, I introduced a new function named `extract_predargs()` which does the first functionality. `get_relevant_facts()` now does only the second one.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
