### PR TITLE
Plotting - Simplified the keyword arguments to set the number of discretization points

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1704,7 +1704,7 @@ def plot(*args, show=True, **kwargs):
 
     adaptive : bool, optional
         The default value is set to ``True``. Set adaptive to ``False``
-        and specify ``n1`` if uniform sampling is required.
+        and specify ``n`` if uniform sampling is required.
 
         The plotting uses an adaptive algorithm which samples
         recursively to accurately plot. The adaptive algorithm uses a
@@ -1719,9 +1719,9 @@ def plot(*args, show=True, **kwargs):
         If the ``adaptive`` flag is set to ``False``, this will be
         ignored.
 
-    n1 : int, optional
+    n : int, optional
         Used when the ``adaptive`` is set to ``False``. The function
-        is uniformly sampled at ``n1`` number of points.
+        is uniformly sampled at ``n`` number of points.
 
         If the ``adaptive`` flag is set to ``True``, this will be
         ignored.
@@ -1786,7 +1786,7 @@ def plot(*args, show=True, **kwargs):
        :format: doctest
        :include-source: True
 
-       >>> plot(x**2, adaptive=False, n1=400)
+       >>> plot(x**2, adaptive=False, n=400)
        Plot object containing:
        [0]: cartesian line: x**2 for x over (-10.0, 10.0)
 
@@ -1859,13 +1859,13 @@ def plot_parametric(*args, show=True, **kwargs):
         Specifies whether to use the adaptive sampling or not.
 
         The default value is set to ``True``. Set adaptive to ``False``
-        and specify ``n1`` if uniform sampling is required.
+        and specify ``n`` if uniform sampling is required.
 
     depth :  int, optional
         The recursion depth of the adaptive algorithm. A depth of
         value $n$ samples a maximum of $2^n$ points.
 
-    n1 : int, optional
+    n : int, optional
         Used when the ``adaptive`` flag is set to ``False``.
 
         Specifies the number of the points used for the uniform
@@ -2051,7 +2051,7 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
 
     Arguments for ``Parametric3DLineSeries`` class.
 
-    ``n1``: The range is uniformly sampled at ``n1`` number of points.
+    ``n``: The range is uniformly sampled at ``n`` number of points.
 
     Aesthetics:
 
@@ -2183,6 +2183,9 @@ def plot3d(*args, show=True, **kwargs):
     ``n1``: int. The x range is sampled uniformly at ``n1`` of points.
 
     ``n2``: int. The y range is sampled uniformly at ``n2`` of points.
+
+    ``n``: int. The x and y ranges are sampled uniformly at ``n`` of points.
+    It overrides ``n1`` and ``n2``.
 
     Aesthetics:
 
@@ -2321,6 +2324,9 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
 
     ``n2``: int. The ``v`` range is sampled uniformly at ``n2`` of points
 
+    ``n``: int. The u and v ranges are sampled uniformly at ``n`` of points.
+    It overrides ``n1`` and ``n2``.
+
     Aesthetics:
 
     ``surface_color``: Function which returns a float. Specifies the color for
@@ -2431,6 +2437,9 @@ def plot_contour(*args, show=True, **kwargs):
     ``n1``: int. The x range is sampled uniformly at ``n1`` of points.
 
     ``n2``: int. The y range is sampled uniformly at ``n2`` of points.
+
+    ``n``: int. The x and y ranges are sampled uniformly at ``n`` of points.
+    It overrides ``n1`` and ``n2``.
 
     Aesthetics:
 
@@ -2573,7 +2582,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
         return args
 
 def _set_discretization_points(kwargs, pt):
-    """ This function allows the user two use the keyword arguments n1 and n2
+    """ This function allows the user two use the keyword arguments n, n1 and n2
     to specify the number of discretization points in two directions.
 
     Parameters
@@ -2586,17 +2595,30 @@ def _set_discretization_points(kwargs, pt):
             ["p", "pp", "p3d", "p3dl", "p3ds", "pc", "pi"]
             to indicate plot, plot_parametric, ..., respectively.
     """
-    if pt in ["p", "pp", "p3dpl", "pi"]:
+    if pt in ["p", "pp", "p3dpl"]:
         if "n1" in kwargs.keys():
             kwargs["nb_of_points"] = kwargs["n1"]
+        if "n" in kwargs.keys():
+            kwargs["nb_of_points"] = kwargs["n"]
     elif pt in ["p3d", "pc"]:
         if "n1" in kwargs.keys():
             kwargs["nb_of_points_x"] = kwargs["n1"]
         if "n2" in kwargs.keys():
             kwargs["nb_of_points_y"] = kwargs["n2"]
+        if "n" in kwargs.keys():
+            kwargs["nb_of_points_x"] = kwargs["n"]
+            kwargs["nb_of_points_y"] = kwargs["n"]
     elif pt in ["p3dps"]:
         if "n1" in kwargs.keys():
             kwargs["nb_of_points_u"] = kwargs["n1"]
         if "n2" in kwargs.keys():
             kwargs["nb_of_points_v"] = kwargs["n2"]
+        if "n" in kwargs.keys():
+            kwargs["nb_of_points_u"] = kwargs["n"]
+            kwargs["nb_of_points_v"] = kwargs["n"]
+    elif pt in ["pi"]:
+        if "n1" in kwargs.keys():
+            kwargs["points"] = kwargs["n1"]
+        if "n" in kwargs.keys():
+            kwargs["points"] = kwargs["n"]
     return kwargs

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1731,7 +1731,7 @@ def plot(*args, show=True, **kwargs):
 
     adaptive : bool, optional
         The default value is set to ``True``. Set adaptive to ``False``
-        and specify ``nb_of_points`` if uniform sampling is required.
+        and specify ``n1`` if uniform sampling is required.
 
         The plotting uses an adaptive algorithm which samples
         recursively to accurately plot. The adaptive algorithm uses a
@@ -1746,9 +1746,9 @@ def plot(*args, show=True, **kwargs):
         If the ``adaptive`` flag is set to ``False``, this will be
         ignored.
 
-    nb_of_points : int, optional
+    n1 : int, optional
         Used when the ``adaptive`` is set to ``False``. The function
-        is uniformly sampled at ``nb_of_points`` number of points.
+        is uniformly sampled at ``n1`` number of points.
 
         If the ``adaptive`` flag is set to ``True``, this will be
         ignored.
@@ -1813,7 +1813,7 @@ def plot(*args, show=True, **kwargs):
        :format: doctest
        :include-source: True
 
-       >>> plot(x**2, adaptive=False, nb_of_points=400)
+       >>> plot(x**2, adaptive=False, n1=400)
        Plot object containing:
        [0]: cartesian line: x**2 for x over (-10.0, 10.0)
 
@@ -1835,6 +1835,7 @@ def plot(*args, show=True, **kwargs):
     x = free.pop() if free else Symbol('x')
     kwargs.setdefault('xlabel', x.name)
     kwargs.setdefault('ylabel', 'f(%s)' % x.name)
+    kwargs = _set_discretization_points(kwargs, "p")
     series = []
     plot_expr = check_arguments(args, 1, 1)
     series = [LineOver1DRangeSeries(*arg, **kwargs) for arg in plot_expr]
@@ -1885,13 +1886,13 @@ def plot_parametric(*args, show=True, **kwargs):
         Specifies whether to use the adaptive sampling or not.
 
         The default value is set to ``True``. Set adaptive to ``False``
-        and specify ``nb_of_points`` if uniform sampling is required.
+        and specify ``n1`` if uniform sampling is required.
 
     depth :  int, optional
         The recursion depth of the adaptive algorithm. A depth of
         value $n$ samples a maximum of $2^n$ points.
 
-    nb_of_points : int, optional
+    n1 : int, optional
         Used when the ``adaptive`` flag is set to ``False``.
 
         Specifies the number of the points used for the uniform
@@ -2029,6 +2030,7 @@ def plot_parametric(*args, show=True, **kwargs):
     """
     args = list(map(sympify, args))
     series = []
+    kwargs = _set_discretization_points(kwargs, "pp")
     plot_expr = check_arguments(args, 2, 1)
     series = [Parametric2DLineSeries(*arg, **kwargs) for arg in plot_expr]
     plots = Plot(*series, **kwargs)
@@ -2076,8 +2078,7 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
 
     Arguments for ``Parametric3DLineSeries`` class.
 
-    ``nb_of_points``: The range is uniformly sampled at ``nb_of_points``
-    number of points.
+    ``n1``: The range is uniformly sampled at ``n1`` number of points.
 
     Aesthetics:
 
@@ -2149,6 +2150,7 @@ def plot3d_parametric_line(*args, show=True, **kwargs):
 
     """
     args = list(map(sympify, args))
+    kwargs = _set_discretization_points(kwargs, "p3dpl")
     series = []
     plot_expr = check_arguments(args, 3, 1)
     series = [Parametric3DLineSeries(*arg, **kwargs) for arg in plot_expr]
@@ -2205,11 +2207,9 @@ def plot3d(*args, show=True, **kwargs):
 
     Arguments for ``SurfaceOver2DRangeSeries`` class:
 
-    ``nb_of_points_x``: int. The x range is sampled uniformly at
-    ``nb_of_points_x`` of points.
+    ``n1``: int. The x range is sampled uniformly at ``n1`` of points.
 
-    ``nb_of_points_y``: int. The y range is sampled uniformly at
-    ``nb_of_points_y`` of points.
+    ``n2``: int. The y range is sampled uniformly at ``n2`` of points.
 
     Aesthetics:
 
@@ -2287,6 +2287,7 @@ def plot3d(*args, show=True, **kwargs):
     """
 
     args = list(map(sympify, args))
+    kwargs = _set_discretization_points(kwargs, "p3d")
     series = []
     plot_expr = check_arguments(args, 1, 2)
     series = [SurfaceOver2DRangeSeries(*arg, **kwargs) for arg in plot_expr]
@@ -2343,11 +2344,9 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
 
     Arguments for ``ParametricSurfaceSeries`` class:
 
-    ``nb_of_points_u``: int. The ``u`` range is sampled uniformly at
-    ``nb_of_points_v`` of points
+    ``n1``: int. The ``u`` range is sampled uniformly at ``n1`` of points
 
-    ``nb_of_points_y``: int. The ``v`` range is sampled uniformly at
-    ``nb_of_points_y`` of points
+    ``n2``: int. The ``v`` range is sampled uniformly at ``n2`` of points
 
     Aesthetics:
 
@@ -2400,6 +2399,7 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
     """
 
     args = list(map(sympify, args))
+    kwargs = _set_discretization_points(kwargs, "p3dps")
     series = []
     plot_expr = check_arguments(args, 3, 2)
     series = [ParametricSurfaceSeries(*arg, **kwargs) for arg in plot_expr]
@@ -2455,11 +2455,9 @@ def plot_contour(*args, show=True, **kwargs):
 
     Arguments for ``ContourSeries`` class:
 
-    ``nb_of_points_x``: int. The x range is sampled uniformly at
-    ``nb_of_points_x`` of points.
+    ``n1``: int. The x range is sampled uniformly at ``n1`` of points.
 
-    ``nb_of_points_y``: int. The y range is sampled uniformly at
-    ``nb_of_points_y`` of points.
+    ``n2``: int. The y range is sampled uniformly at ``n2`` of points.
 
     Aesthetics:
 
@@ -2486,6 +2484,7 @@ def plot_contour(*args, show=True, **kwargs):
     """
 
     args = list(map(sympify, args))
+    kwargs = _set_discretization_points(kwargs, "pc")
     plot_expr = check_arguments(args, 1, 2)
     series = [ContourSeries(*arg) for arg in plot_expr]
     plot_contours = Plot(*series, **kwargs)
@@ -2599,3 +2598,32 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
                     raise ValueError("The ranges should be a tuple of "
                                      "length 3, got %s" % str(arg[i + expr_len]))
         return args
+
+def _set_discretization_points(kwargs, pt):
+    """ This function allows the user two use the keyword arguments n1 and n2
+    to specify the number of discretization points in two directions.
+
+    Parameters
+    ==========
+
+        kwargs : dict
+
+        pt : str
+            The calling plot function. Can be one of:
+            ["p", "pp", "p3d", "p3dl", "p3ds", "pc", "pi"]
+            to indicate plot, plot_parametric, ..., respectively.
+    """
+    if pt in ["p", "pp", "p3dpl", "pi"]:
+        if "n1" in kwargs.keys():
+            kwargs["nb_of_points"] = kwargs["n1"]
+    elif pt in ["p3d", "pc"]:
+        if "n1" in kwargs.keys():
+            kwargs["nb_of_points_x"] = kwargs["n1"]
+        if "n2" in kwargs.keys():
+            kwargs["nb_of_points_y"] = kwargs["n2"]
+    elif pt in ["p3dps"]:
+        if "n1" in kwargs.keys():
+            kwargs["nb_of_points_u"] = kwargs["n1"]
+        if "n2" in kwargs.keys():
+            kwargs["nb_of_points_v"] = kwargs["n2"]
+    return kwargs

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1139,29 +1139,11 @@ class ParametricSurfaceSeries(SurfaceBaseSeries):
 
 
 ### Contours
-class ContourSeries(BaseSeries):
+class ContourSeries(SurfaceOver2DRangeSeries):
     """Representation for a contour plot."""
-    # The code is mostly repetition of SurfaceOver2DRange.
-    # Presently used in contour_plot function
 
+    is_3Dsurface = False
     is_contour = True
-
-    def __init__(self, expr, var_start_end_x, var_start_end_y):
-        super().__init__()
-        self.nb_of_points_x = 50
-        self.nb_of_points_y = 50
-        self.expr = sympify(expr)
-        self.var_x = sympify(var_start_end_x[0])
-        self.start_x = float(var_start_end_x[1])
-        self.end_x = float(var_start_end_x[2])
-        self.var_y = sympify(var_start_end_y[0])
-        self.start_y = float(var_start_end_y[1])
-        self.end_y = float(var_start_end_y[2])
-
-        self.get_points = self.get_meshes
-
-        self._xlim = (self.start_x, self.end_x)
-        self._ylim = (self.start_y, self.end_y)
 
     def __str__(self):
         return ('contour: %s for '
@@ -1171,15 +1153,6 @@ class ContourSeries(BaseSeries):
                     str((self.start_x, self.end_x)),
                     str(self.var_y),
                     str((self.start_y, self.end_y)))
-
-    def get_meshes(self):
-        np = import_module('numpy')
-        mesh_x, mesh_y = np.meshgrid(np.linspace(self.start_x, self.end_x,
-                                                 num=self.nb_of_points_x),
-                                     np.linspace(self.start_y, self.end_y,
-                                                 num=self.nb_of_points_y))
-        f = vectorized_lambdify((self.var_x, self.var_y), self.expr)
-        return (mesh_x, mesh_y, f(mesh_x, mesh_y))
 
 
 ##############################################################################
@@ -2486,7 +2459,7 @@ def plot_contour(*args, show=True, **kwargs):
     args = list(map(sympify, args))
     kwargs = _set_discretization_points(kwargs, "pc")
     plot_expr = check_arguments(args, 1, 2)
-    series = [ContourSeries(*arg) for arg in plot_expr]
+    series = [ContourSeries(*arg, **kwargs) for arg in plot_expr]
     plot_contours = Plot(*series, **kwargs)
     if len(plot_expr[0].free_symbols) > 2:
         raise ValueError('Contour Plot cannot Plot for more than two variables.')

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -29,7 +29,7 @@ Arithmetic. Master's thesis. University of Toronto, 1996
 """
 
 
-from .plot import BaseSeries, Plot
+from .plot import BaseSeries, Plot, _set_discretization_points
 from .experimental_lambdify import experimental_lambdify, vectorized_lambdify
 from .intervalmath import interval
 from sympy.core.relational import (Equality, GreaterThan, LessThan,
@@ -414,8 +414,9 @@ def plot_implicit(expr, x_var=None, y_var=None, adaptive=True, depth=0,
 
     # uniform experience between the different plot function when it comes to
     # set the number of discretization points
-    if "n1" in kwargs.keys():
-        points = kwargs["n1"]
+    kwargs["points"] = points
+    kwargs = _set_discretization_points(kwargs, "pi")
+    points = kwargs["points"]
 
     series_argument = ImplicitSeries(expr, var_start_end_x, var_start_end_y,
                                     has_equality, adaptive, depth,

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -412,6 +412,11 @@ def plot_implicit(expr, x_var=None, y_var=None, adaptive=True, depth=0,
     elif depth < 0:
         depth = 0
 
+    # uniform experience between the different plot function when it comes to
+    # set the number of discretization points
+    if "n1" in kwargs.keys():
+        points = kwargs["n1"]
+
     series_argument = ImplicitSeries(expr, var_start_end_x, var_start_end_y,
                                     has_equality, adaptive, depth,
                                     points, line_color)

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -735,14 +735,37 @@ def test_nb_discretization_points():
     assert p._series[0].nb_of_points == 50
     p = plot_parametric(cos(u), sin(u), n1=50)
     assert p._series[0].nb_of_points == 50
+    p = plot_parametric(cos(u), sin(u), n=50)
+    assert p._series[0].nb_of_points == 50
+    # n has the precedente over n1
+    p = plot_parametric(cos(u), sin(u), n=50, n1=60)
+    assert p._series[0].nb_of_points == 50
     p = plot3d_parametric_line(cos(u), sin(u), u, n1=50)
+    assert p._series[0].nb_of_points == 50
+    p = plot3d_parametric_line(cos(u), sin(u), u, n=50)
+    assert p._series[0].nb_of_points == 50
+    # n has the precedente over n1
+    p = plot3d_parametric_line(cos(u), sin(u), u, n=50, n1=60)
     assert p._series[0].nb_of_points == 50
     p = plot3d(x + y, n1=40, n2=30)
     assert p._series[0].nb_of_points_x == 40
     assert p._series[0].nb_of_points_y == 30
+    # n has the precedente over n1 and n2
+    p = plot3d(x + y, n1=40, n2=30, n=20)
+    assert p._series[0].nb_of_points_x == 20
+    assert p._series[0].nb_of_points_y == 20
     p = plot_contour(x + y, n1=40, n2=30)
     assert p._series[0].nb_of_points_x == 40
     assert p._series[0].nb_of_points_y == 30
+    # n has the precedente over n1 and n2
+    p = plot_contour(x + y, n1=40, n2=30, n=20)
+    assert p._series[0].nb_of_points_x == 20
+    assert p._series[0].nb_of_points_y == 20
     p = plot3d_parametric_surface(cos(u + v), sin(u - v), u - v, n1=40, n2=30)
     assert p._series[0].nb_of_points_u == 40
     assert p._series[0].nb_of_points_v == 30
+    # n has the precedente over n1 and n2
+    p = plot3d_parametric_surface(cos(u + v), sin(u - v), u - v,
+            n1=40, n2=30, n=10)
+    assert p._series[0].nb_of_points_u == 10
+    assert p._series[0].nb_of_points_v == 10

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -725,3 +725,24 @@ def test_custom_coloring():
             surface_color=lambda a, b: a**2 + b**2)
     plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color=1)
     plot3d(x*y, (x, -5, 5), (y, -5, 5), surface_color="r")
+
+def test_nb_discretization_points():
+    x = Symbol('x')
+    y = Symbol('y')
+    u = Symbol('u')
+    v = Symbol('v')
+    p = plot(cos(x), n1=50)
+    assert p._series[0].nb_of_points == 50
+    p = plot_parametric(cos(u), sin(u), n1=50)
+    assert p._series[0].nb_of_points == 50
+    p = plot3d_parametric_line(cos(u), sin(u), u, n1=50)
+    assert p._series[0].nb_of_points == 50
+    p = plot3d(x + y, n1=40, n2=30)
+    assert p._series[0].nb_of_points_x == 40
+    assert p._series[0].nb_of_points_y == 30
+    p = plot_contour(x + y, n1=40, n2=30)
+    assert p._series[0].nb_of_points_x == 40
+    assert p._series[0].nb_of_points_y == 30
+    p = plot3d_parametric_surface(cos(u + v), sin(u - v), u - v, n1=40, n2=30)
+    assert p._series[0].nb_of_points_u == 40
+    assert p._series[0].nb_of_points_v == 30

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -131,3 +131,8 @@ def test_nb_discretization_points():
     assert p._series[0].nb_of_points == 200
     p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), n1=100)
     assert p._series[0].nb_of_points == 100
+    p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), n=100)
+    assert p._series[0].nb_of_points == 100
+    # n has the precedente over n1
+    p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), n=50, n1=100)
+    assert p._series[0].nb_of_points == 50

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -122,3 +122,12 @@ def test_region_and():
         compare_images(cmp_filename, test_filename, 0.005)
     finally:
         TmpFileManager.cleanup()
+
+def test_nb_discretization_points():
+    x, y = symbols('x y')
+    p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2))
+    assert p._series[0].nb_of_points == 300
+    p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), points=200)
+    assert p._series[0].nb_of_points == 200
+    p = plot_implicit(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), n1=100)
+    assert p._series[0].nb_of_points == 100


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21282 

#### Brief description of what is fixed or changed

Previously a user has to remember to use `nb_of_points`, `nb_of_points_x`, `nb_of_points_y`, `nb_of_points_u`, `nb_of_points_v` depending on the plot function being used. This might be confusing and it is definitely longer to type.

This commit add the capability to use `n1` and `n2` as the keyword arguments to specify the number of discretization points for the first and second direction, respectively.

It also add the capability to use `n` as the sole argument to set the number of discretization points in the two direction simultaneously. 

Back-compatibility is maintained.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* plotting
  * Simplified the keyword arguments to set the number of discretization points

<!-- END RELEASE NOTES -->
