### PR TITLE
perf(integrals): use xreplace instead of subs in heurisch

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -730,8 +730,8 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         if solution is None:
             return None
         else:
-            return candidate.subs(solution).subs(
-                list(zip(poly_coeffs, [S.Zero]*len(poly_coeffs))))
+            return candidate.xreplace(solution).xreplace(
+                dict(zip(poly_coeffs, [S.Zero]*len(poly_coeffs))))
 
     if not (F.free_symbols - set(V)):
         solution = _integrate('Q')


### PR DESCRIPTION
It should be safe to use xreplace here because the symbols involved are
all Dummys introduced by heurisch and are not used as bound symbols.
Using xreplace is generally faster than using subs.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Use xreplace instead of subs because it is faster.

On master we have:
```
In [1]: %time integrate(cos(x)*sin(x)*sin(2*x))
CPU times: user 3.86 s, sys: 34.5 ms, total: 3.9 s
Wall time: 3.93 s
Out[1]: 
       2                                               2                                     
  x⋅sin (x)⋅cos(2⋅x)   x⋅sin(x)⋅sin(2⋅x)⋅cos(x)   x⋅cos (x)⋅cos(2⋅x)   sin(x)⋅cos(x)⋅cos(2⋅x)
- ────────────────── + ──────────────────────── + ────────────────── - ──────────────────────
          4                       2                       4                      4           

```
With the PR that is:
```
In [1]: %time integrate(cos(x)*sin(x)*sin(2*x))
CPU times: user 1.21 s, sys: 16 ms, total: 1.22 s
Wall time: 1.22 s
Out[1]: 
       2                                               2                                     
  x⋅sin (x)⋅cos(2⋅x)   x⋅sin(x)⋅sin(2⋅x)⋅cos(x)   x⋅cos (x)⋅cos(2⋅x)   sin(x)⋅cos(x)⋅cos(2⋅x)
- ────────────────── + ──────────────────────── + ────────────────── - ──────────────────────
          4                       2                       4                      4           

```
So same result but 3x faster.

#### Other comments

This shows how slow subs is. Although this PR avoids using subs it shows how much potential speed benefit can be gained by making subs more efficient.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * The heurisch integration routine was made faster.
<!-- END RELEASE NOTES -->
