### PR TITLE
refactor(assump) : redesign sathandlers.py

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from collections.abc import MutableMapping
 
 from sympy.assumptions.ask import Q
-from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol,)
+from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol, Symbol)
 from sympy.core.numbers import ImaginaryUnit
 from sympy.functions.elementary.complexes import Abs
 from sympy.logic.boolalg import (Equivalent, Implies, And, Or)
@@ -17,12 +17,24 @@ class ArgFactHandler:
     """
     Class to help apply boolean function to the arguments of expression.
 
+    Parameters
+    ==========
+
+    args : tuple of Symbols.
+        Placeholder symbols representing the arguments of *f*.
+
+    f : Any Boolean expression.
+
     """
-    def __init__(self, func):
-        if not callable(func):
-            raise ValueError(
-                "Argument of ArgFactHandler must be callable, but %s is not." % func)
-        self.func = func
+    def __init__(self, args, f):
+        self.args = args
+        self.f = f
+
+    def __repr__(self):
+        return "%s(%s, %s)" % (type(self).__name__, str(self.args), str(self.f))
+
+    def apply(self, args):
+        return self.f.subs(zip(self.args, args))
 
 
 class AllArgs(ArgFactHandler):
@@ -35,13 +47,17 @@ class AllArgs(ArgFactHandler):
     >>> from sympy import Q
     >>> from sympy.assumptions.sathandlers import AllArgs
     >>> from sympy.abc import x, y
-    >>> allargs = AllArgs(lambda x: Q.negative(x) | Q.positive(x))
+    >>> allargs = AllArgs(x, Q.negative(x) | Q.positive(x))
     >>> allargs(x*y)
     (Q.negative(x) | Q.positive(x)) & (Q.negative(y) | Q.positive(y))
 
     """
+    def __init__(self, x, f):
+        args = (x,)
+        super().__init__(args, f)
+
     def __call__(self, expr):
-        return And(*[self.func(arg) for arg in expr.args])
+        return And(*[self.apply((arg,)) for arg in expr.args])
 
 
 class AnyArgs(ArgFactHandler):
@@ -54,13 +70,17 @@ class AnyArgs(ArgFactHandler):
     >>> from sympy import Q
     >>> from sympy.assumptions.sathandlers import AnyArgs
     >>> from sympy.abc import x, y
-    >>> anyargs = AnyArgs(lambda x: Q.negative(x) & Q.positive(x))
+    >>> anyargs = AnyArgs(x, Q.negative(x) & Q.positive(x))
     >>> anyargs(x*y)
     (Q.negative(x) & Q.positive(x)) | (Q.negative(y) & Q.positive(y))
 
     """
+    def __init__(self, x, f):
+        args = (x,)
+        super().__init__(args, f)
+
     def __call__(self, expr):
-        return Or(*[self.func(arg) for arg in expr.args])
+        return Or(*[self.apply((arg,)) for arg in expr.args])
 
 
 class ExactlyOneArg(ArgFactHandler):
@@ -73,13 +93,17 @@ class ExactlyOneArg(ArgFactHandler):
     >>> from sympy import Q
     >>> from sympy.assumptions.sathandlers import ExactlyOneArg
     >>> from sympy.abc import x, y
-    >>> onearg = ExactlyOneArg(Q.positive)
+    >>> onearg = ExactlyOneArg(x, Q.positive(x))
     >>> onearg(x*y)
     (Q.positive(x) & ~Q.positive(y)) | (Q.positive(y) & ~Q.positive(x))
 
     """
+    def __init__(self, x, f):
+        args = (x,)
+        super().__init__(args, f)
+
     def __call__(self, expr):
-        pred_args = [self.func(arg) for arg in expr.args]
+        pred_args = [self.apply((arg,)) for arg in expr.args]
         res = Or(*[And(pred_args[i], *[~lit for lit in pred_args[:i] +
             pred_args[i+1:]]) for i in range(len(pred_args))])
         return res
@@ -192,6 +216,8 @@ class_fact_registry = ClassFactRegistry()
 
 ### Class fact registration ###
 
+x = Symbol('x')
+
 ## Abs ##
 
 @class_fact_registry.register(Abs)
@@ -223,38 +249,38 @@ def _(expr):
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_positive = AllArgs(Q.positive)(expr)
+    allargs_positive = AllArgs(x, Q.positive(x))(expr)
     return Implies(allargs_positive, Q.positive(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_negative = AllArgs(Q.negative)(expr)
+    allargs_negative = AllArgs(x, Q.negative(x))(expr)
     return Implies(allargs_negative, Q.negative(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_real = AllArgs(Q.real)(expr)
+    allargs_real = AllArgs(x, Q.real(x))(expr)
     return Implies(allargs_real, Q.real(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_rational = AllArgs(Q.rational)(expr)
+    allargs_rational = AllArgs(x, Q.rational(x))(expr)
     return Implies(allargs_rational, Q.rational(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_integer = AllArgs(Q.integer)(expr)
+    allargs_integer = AllArgs(x, Q.integer(x))(expr)
     return Implies(allargs_integer, Q.integer(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    onearg_notinteger = ExactlyOneArg(lambda x: ~Q.integer(x))(expr)
+    onearg_notinteger = ExactlyOneArg(x, ~Q.integer(x))(expr)
     return Implies(onearg_notinteger, ~Q.integer(expr))
 
 @class_fact_registry.register(Add)
 def _(expr):
-    allargs_real = AllArgs(Q.real)(expr)
-    onearg_irrational = ExactlyOneArg(Q.irrational)(expr)
+    allargs_real = AllArgs(x, Q.real(x))(expr)
+    onearg_irrational = ExactlyOneArg(x, Q.irrational(x))(expr)
     return Implies(allargs_real, Implies(onearg_irrational, Q.irrational(expr)))
 
 
@@ -262,59 +288,59 @@ def _(expr):
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    anyargs_zero = AnyArgs(Q.zero)(expr)
+    anyargs_zero = AnyArgs(x, Q.zero(x))(expr)
     return Equivalent(Q.zero(expr), anyargs_zero)
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_positive = AllArgs(Q.positive)(expr)
+    allargs_positive = AllArgs(x, Q.positive(x))(expr)
     return Implies(allargs_positive, Q.positive(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_real = AllArgs(Q.real)(expr)
+    allargs_real = AllArgs(x, Q.real(x))(expr)
     return Implies(allargs_real, Q.real(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_rational = AllArgs(Q.rational)(expr)
+    allargs_rational = AllArgs(x, Q.rational(x))(expr)
     return Implies(allargs_rational, Q.rational(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_integer = AllArgs(Q.integer)(expr)
+    allargs_integer = AllArgs(x, Q.integer(x))(expr)
     return Implies(allargs_integer, Q.integer(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    onearg_notrational = ExactlyOneArg(lambda x: ~Q.rational(x))(expr)
+    onearg_notrational = ExactlyOneArg(x, ~Q.rational(x))(expr)
     return Implies(onearg_notrational, ~Q.integer(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_commutative = AllArgs(Q.commutative)(expr)
+    allargs_commutative = AllArgs(x, Q.commutative(x))(expr)
     return Implies(allargs_commutative, Q.commutative(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
     # Implicitly assumes Mul has more than one arg
-    # Would be AllArgs(Q.prime | Q.composite) except 1 is composite
+    # Would be AllArgs(x, Q.prime(x) | Q.composite(x)) except 1 is composite
     # More advanced prime assumptions will require inequalities, as 1 provides
     # a corner case.
-    allargs_prime = AllArgs(Q.prime)(expr)
+    allargs_prime = AllArgs(x, Q.prime(x))(expr)
     return Implies(allargs_prime, ~Q.prime(expr))
 
 @class_fact_registry.register(Mul)
 def _(expr):
     # General Case: Odd number of imaginary args implies mul is imaginary(To be implemented)
-    allargs_imag_or_real = AllArgs(lambda x: Q.imaginary(x) | Q.real(x))(expr)
-    onearg_imaginary = ExactlyOneArg(Q.imaginary)(expr)
+    allargs_imag_or_real = AllArgs(x, Q.imaginary(x) | Q.real(x))(expr)
+    onearg_imaginary = ExactlyOneArg(x, Q.imaginary(x))(expr)
     return Implies(allargs_imag_or_real, Implies(onearg_imaginary, Q.imaginary(expr)))
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    allargs_real = AllArgs(Q.real)(expr)
-    onearg_irrational = ExactlyOneArg(Q.irrational)(expr)
+    allargs_real = AllArgs(x, Q.real(x))(expr)
+    onearg_irrational = ExactlyOneArg(x, Q.irrational(x))(expr)
     return Implies(allargs_real, Implies(onearg_irrational, Q.irrational(expr)))
 
 @class_fact_registry.register(Mul)
@@ -322,8 +348,8 @@ def _(expr):
     # Including the integer qualification means we don't need to add any facts
     # for odd, since the assumptions already know that every integer is
     # exactly one of even or odd.
-    allargs_integer = AllArgs(Q.integer)(expr)
-    anyargs_even = AnyArgs(Q.even)(expr)
+    allargs_integer = AllArgs(x, Q.integer(x))(expr)
+    anyargs_even = AnyArgs(x, Q.even(x))(expr)
     return Implies(allargs_integer, Equivalent(anyargs_even, Q.even(expr)))
 
 
@@ -331,8 +357,8 @@ def _(expr):
 
 @class_fact_registry.register(MatMul)
 def _(expr):
-    allargs_square = AllArgs(Q.square)(expr)
-    allargs_invertible = AllArgs(Q.invertible)(expr)
+    allargs_square = AllArgs(x, Q.square(x))(expr)
+    allargs_invertible = AllArgs(x, Q.invertible(x))(expr)
     return Implies(allargs_square, Equivalent(Q.invertible(expr), allargs_invertible))
 
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from sympy.assumptions.ask import Q
-from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol, Symbol)
+from sympy.core import (Add, Mul, Pow, Number, NumberSymbol, Symbol)
 from sympy.core.numbers import ImaginaryUnit
 from sympy.functions.elementary.complexes import Abs
 from sympy.logic.boolalg import (Equivalent, And, Or, Implies)
@@ -298,16 +298,6 @@ def _(expr):
     ]
 
 
-### Integer ###
-
-@class_fact_registry.multiregister(Integer)
-def _(expr):
-    from sympy import isprime
-    return [Equivalent(Q.prime(expr), isprime(expr)),
-            Equivalent(Q.composite(expr), expr.is_composite),
-    ]
-
-
 ### Numbers ###
 
 _old_assump_getters = {
@@ -319,6 +309,8 @@ _old_assump_getters = {
     Q.even: lambda o: o.is_even,
     Q.odd: lambda o: o.is_odd,
     Q.imaginary: lambda o: o.is_imaginary,
+    Q.prime: lambda o: o.is_prime,
+    Q.composite: lambda o: o.is_composite,
 }
 
 @class_fact_registry.multiregister(Number, NumberSymbol, ImaginaryUnit)

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -244,7 +244,7 @@ x = Symbol('x')
 @class_fact_registry.register(Abs)
 def _(expr):
     arg = expr.args[0]
-    return [Q.nonnegative(expr), 
+    return [Q.nonnegative(expr),
             Equivalent(~Q.zero(arg), ~Q.zero(expr)),
             Q.even(arg) >> Q.even(expr),
             Q.odd(arg) >> Q.odd(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -114,7 +114,14 @@ class ExactlyOneArg(ArgFactHandler):
 
 class FactRegistry(MutableMapping):
     """
-    Base class for fact registries
+    Base class for fact registries.
+
+    Explanation
+    ===========
+
+    This class provides regstration of several handlers to any type of
+    variable. Advanced behavior can be implemented by subclassing this
+    class.
 
     """
     def __init__(self, d=None):
@@ -128,6 +135,12 @@ class FactRegistry(MutableMapping):
     def __delitem__(self, key):
         del self.d[key]
 
+    def __getitem__(self, key):
+        return self.d[key]
+
+    def __call__(self, arg):
+        return {f(arg) for f in self[arg]}
+
     def __iter__(self):
         return self.d.__iter__()
 
@@ -137,20 +150,22 @@ class FactRegistry(MutableMapping):
     def __repr__(self):
         return repr(self.d)
 
-    def __call__(self, expr):
-        handlers = self[expr.func]
-        return {h(expr) for h in handlers}
-
     def register(self, item):
+        """
+        Register a function to *item*.
+        """
         def _(func):
             self[item] |= {func}
             return func
         return _
 
-    def register_many(self, *classes):
+    def register_many(self, *items):
+        """
+        Register a function to every element in *items*.
+        """
         def _(func):
-            for cls in classes:
-                self[cls] |= {func}
+            for itm in items:
+                self[itm] |= {func}
             return func
         return _
 

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,9 +1,8 @@
-
 from sympy import (S, symbols, Q, assuming, Implies, MatrixSymbol, I, pi, Abs,
     Eq, Gt)
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.satask import (satask, extract_predargs,
-    get_relevant_facts)
+    get_relevant_clsfacts)
 
 from sympy.testing.pytest import raises, XFAIL
 
@@ -353,9 +352,9 @@ def test_extract_predargs():
     assert extract_predargs(props, assump) == {x, y, z}
 
 
-def test_get_relevant_facts():
+def test_get_relevant_clsfacts():
     exprs = {Abs(x*y)}
-    exprs, facts = get_relevant_facts(exprs)
+    exprs, facts = get_relevant_clsfacts(exprs)
     assert exprs == {x*y}
     assert facts.clauses == \
         {frozenset({Literal(Q.odd(Abs(x*y)), False), Literal(Q.odd(x*y), True)}),

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -1,10 +1,7 @@
 from sympy import Mul, Basic, Q, Expr, And, symbols, Or
 
-from sympy.assumptions.sathandlers import (ClassFactRegistry, AllArgs,
-    AnyArgs, ExactlyOneArg, ArgFactHandler,)
-
-from sympy.testing.pytest import raises
-
+from sympy.assumptions.sathandlers import (ClassFactRegistry, allarg,
+    anyarg, exactlyonearg,)
 
 x, y, z = symbols('x y z')
 
@@ -25,41 +22,24 @@ def test_class_handler_registry():
     assert my_handler_registry[Mul] == (frozenset({fact1}), frozenset({fact2}))
 
 
-def test_ArgFactHandler():
-
-    class MyArgFactHandler(ArgFactHandler):
-        def __call__(self, expr):
-            return self.apply((expr,))
-
-    a = MyArgFactHandler((x,), Q.positive(x))
-    b = MyArgFactHandler((x,), Q.positive(x) | Q.negative(x))
-
-    assert a(x) == Q.positive(x)
-    assert b(x) == Q.positive(x) | Q.negative(x)
-
-    raises(TypeError, lambda: MyArgFactHandler(Q.positive))
+def test_allarg():
+    assert allarg(x, Q.zero(x), x*y) == And(Q.zero(x), Q.zero(y))
+    assert allarg(x, Q.positive(x) | Q.negative(x), x*y) == And(Q.positive(x) | Q.negative(x), Q.positive(y) | Q.negative(y))
 
 
-def test_AllArgs():
-    a = AllArgs(x, Q.zero(x))
-    b = AllArgs(x, Q.positive(x) | Q.negative(x))
-    assert a(x*y) == And(Q.zero(x), Q.zero(y))
-    assert b(x*y) == And(Q.positive(x) | Q.negative(x), Q.positive(y) | Q.negative(y))
+def test_anyarg():
+    assert anyarg(x, Q.zero(x), x*y) == Or(Q.zero(x), Q.zero(y))
+    assert anyarg(x, Q.positive(x) & Q.negative(x), x*y) == \
+        Or(Q.positive(x) & Q.negative(x), Q.positive(y) & Q.negative(y))
 
 
-def test_AnyArgs():
-    a = AnyArgs(x, Q.zero(x))
-    b = AnyArgs(x, Q.positive(x) & Q.negative(x))
-    assert a(x*y) == Or(Q.zero(x), Q.zero(y))
-    assert b(x*y) == Or(Q.positive(x) & Q.negative(x), Q.positive(y) & Q.negative(y))
-
-
-def test_ExactlyOneArg():
-    a = ExactlyOneArg(x, Q.zero(x))
-    b = ExactlyOneArg(x, Q.positive(x) | Q.negative(x))
-    assert a(x*y) == Or(Q.zero(x) & ~Q.zero(y), Q.zero(y) & ~Q.zero(x))
-    assert a(x*y*z) == Or(Q.zero(x) & ~Q.zero(y) & ~Q.zero(z), Q.zero(y)
+def test_exactlyonearg():
+    assert exactlyonearg(x, Q.zero(x), x*y) == \
+        Or(Q.zero(x) & ~Q.zero(y), Q.zero(y) & ~Q.zero(x))
+    assert exactlyonearg(x, Q.zero(x), x*y*z) == \
+        Or(Q.zero(x) & ~Q.zero(y) & ~Q.zero(z), Q.zero(y)
         & ~Q.zero(x) & ~Q.zero(z), Q.zero(z) & ~Q.zero(x) & ~Q.zero(y))
-    assert b(x*y) == Or((Q.positive(x) | Q.negative(x)) &
+    assert exactlyonearg(x, Q.positive(x) | Q.negative(x), x*y) == \
+        Or((Q.positive(x) | Q.negative(x)) &
         ~(Q.positive(y) | Q.negative(y)), (Q.positive(y) | Q.negative(y)) &
         ~(Q.positive(x) | Q.negative(x)))

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -1,8 +1,7 @@
-from sympy import Mul, Basic, Q, Expr, And, symbols, Equivalent, Or
-from sympy.assumptions.cnf import to_NNF
+from sympy import Mul, Basic, Q, Expr, And, symbols, Or
 
 from sympy.assumptions.sathandlers import (ClassFactRegistry, AllArgs,
-    UnevaluatedOnFree, AnyArgs, CheckOldAssump, ExactlyOneArg)
+    AnyArgs, ExactlyOneArg, ArgFactHandler,)
 
 from sympy.testing.pytest import raises
 
@@ -13,97 +12,54 @@ x, y, z = symbols('x y z')
 def test_class_handler_registry():
     my_handler_registry = ClassFactRegistry()
 
-    # The predicate doesn't matter here, so just use is_true
-    fact1 = Equivalent(Q.is_true, AllArgs(Q.is_true))
-    fact2 = Equivalent(Q.is_true, AnyArgs(Q.is_true))
-
-    my_handler_registry[Mul] = {fact1}
-    my_handler_registry[Expr] = {fact2}
+    # The predicate doesn't matter here, so just pass
+    @my_handler_registry.register(Mul)
+    def fact1(expr):
+        pass
+    @my_handler_registry.register(Expr)
+    def fact2(expr):
+        pass
 
     assert my_handler_registry[Basic] == set()
     assert my_handler_registry[Expr] == {fact2}
     assert my_handler_registry[Mul] == {fact1, fact2}
 
 
-def test_UnevaluatedOnFree():
-    a = UnevaluatedOnFree(Q.positive)
-    b = UnevaluatedOnFree(Q.positive | Q.negative)
-    c = UnevaluatedOnFree(Q.positive & ~Q.positive) # It shouldn't do any deduction
-    assert a.rcall(x) == UnevaluatedOnFree(Q.positive(x))
-    assert b.rcall(x) == UnevaluatedOnFree(Q.positive(x) | Q.negative(x))
-    assert c.rcall(x) == UnevaluatedOnFree(Q.positive(x) & ~Q.positive(x))
-    assert a.rcall(x).expr == x
-    assert a.rcall(x).pred == Q.positive
-    assert b.rcall(x).pred == Q.positive | Q.negative
-    raises(ValueError, lambda: UnevaluatedOnFree(Q.positive(x) | Q.negative))
-    raises(ValueError, lambda: UnevaluatedOnFree(Q.positive(x) |
-        Q.negative(y)))
+def test_ArgFactHandler():
 
-    class MyUnevaluatedOnFree(UnevaluatedOnFree):
-        def apply(self, expr=None):
-            return self.args[0]
+    class MyArgFactHandler(ArgFactHandler):
+        def __call__(self, expr):
+            return self.func(expr)
 
-    a = MyUnevaluatedOnFree(Q.positive)
-    b = MyUnevaluatedOnFree(Q.positive | Q.negative)
-    c = MyUnevaluatedOnFree(Q.positive(x))
-    d = MyUnevaluatedOnFree(Q.positive(x) | Q.negative(x))
+    a = MyArgFactHandler(Q.positive)
+    b = MyArgFactHandler(lambda x: Q.positive(x) | Q.negative(x))
 
-    assert a.rcall(x) == c == Q.positive(x)
-    assert b.rcall(x) == d == Q.positive(x) | Q.negative(x)
+    assert a(x) == Q.positive(x)
+    assert b(x) == Q.positive(x) | Q.negative(x)
 
-    raises(ValueError, lambda: MyUnevaluatedOnFree(Q.positive(x) | Q.negative(y)))
+    raises(ValueError, lambda: MyArgFactHandler(Q.positive(x)))
 
 
 def test_AllArgs():
     a = AllArgs(Q.zero)
-    b = AllArgs(Q.positive | Q.negative)
-    assert a.rcall(x*y) == to_NNF(And(Q.zero(x), Q.zero(y)))
-    assert b.rcall(x*y) == to_NNF(And(Q.positive(x) | Q.negative(x), Q.positive(y) | Q.negative(y)))
+    b = AllArgs(lambda x: Q.positive(x) | Q.negative(x))
+    assert a(x*y) == And(Q.zero(x), Q.zero(y))
+    assert b(x*y) == And(Q.positive(x) | Q.negative(x), Q.positive(y) | Q.negative(y))
 
 
 def test_AnyArgs():
     a = AnyArgs(Q.zero)
-    b = AnyArgs(Q.positive & Q.negative)
-    assert a.rcall(x*y) == to_NNF(Or(Q.zero(x), Q.zero(y)))
-    assert b.rcall(x*y) == to_NNF(Or(Q.positive(x) & Q.negative(x), Q.positive(y) & Q.negative(y)))
-
-
-def test_CheckOldAssump():
-    # TODO: Make these tests more complete
-
-    class Test1(Expr):
-        def _eval_is_extended_positive(self):
-            return True
-        def _eval_is_extended_negative(self):
-            return False
-
-    class Test2(Expr):
-        def _eval_is_finite(self):
-            return True
-        def _eval_is_extended_positive(self):
-            return True
-        def _eval_is_extended_negative(self):
-            return False
-
-    t1 = Test1()
-    t2 = Test2()
-
-    # We can't say if it's positive or negative in the old assumptions without
-    # bounded. Remember, True means "no new knowledge", and
-    # Q.positive(t2) means "t2 is positive."
-    assert CheckOldAssump(Q.positive(t1)) == to_NNF(True)
-    assert CheckOldAssump(Q.negative(t1)) == to_NNF(~Q.negative(t1))
-
-    assert CheckOldAssump(Q.positive(t2)) == to_NNF(Q.positive(t2))
-    assert CheckOldAssump(Q.negative(t2)) == to_NNF(~Q.negative(t2))
+    b = AnyArgs(lambda x: Q.positive(x) & Q.negative(x))
+    assert a(x*y) == Or(Q.zero(x), Q.zero(y))
+    assert b(x*y) == Or(Q.positive(x) & Q.negative(x), Q.positive(y) & Q.negative(y))
 
 
 def test_ExactlyOneArg():
     a = ExactlyOneArg(Q.zero)
-    b = ExactlyOneArg(Q.positive | Q.negative)
-    assert a.rcall(x*y) == to_NNF(Or(Q.zero(x) & ~Q.zero(y), Q.zero(y) & ~Q.zero(x)))
-    assert a.rcall(x*y*z) == to_NNF(Or(Q.zero(x) & ~Q.zero(y) & ~Q.zero(z), Q.zero(y)
-        & ~Q.zero(x) & ~Q.zero(z), Q.zero(z) & ~Q.zero(x) & ~Q.zero(y)))
-    assert b.rcall(x*y) == to_NNF(Or((Q.positive(x) | Q.negative(x)) &
+    b = ExactlyOneArg(lambda x: Q.positive(x) | Q.negative(x))
+    assert a(x*y) == Or(Q.zero(x) & ~Q.zero(y), Q.zero(y) & ~Q.zero(x))
+    assert a(x*y*z) == Or(Q.zero(x) & ~Q.zero(y) & ~Q.zero(z), Q.zero(y)
+        & ~Q.zero(x) & ~Q.zero(z), Q.zero(z) & ~Q.zero(x) & ~Q.zero(y))
+    assert b(x*y) == Or((Q.positive(x) | Q.negative(x)) &
         ~(Q.positive(y) | Q.negative(y)), (Q.positive(y) | Q.negative(y)) &
-        ~(Q.positive(x) | Q.negative(x))))
+        ~(Q.positive(x) | Q.negative(x)))

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -16,13 +16,13 @@ def test_class_handler_registry():
     @my_handler_registry.register(Mul)
     def fact1(expr):
         pass
-    @my_handler_registry.register(Expr)
+    @my_handler_registry.multiregister(Expr)
     def fact2(expr):
         pass
 
-    assert my_handler_registry[Basic] == set()
-    assert my_handler_registry[Expr] == {fact2}
-    assert my_handler_registry[Mul] == {fact1, fact2}
+    assert my_handler_registry[Basic] == (frozenset(), frozenset())
+    assert my_handler_registry[Expr] == (frozenset(), frozenset({fact2}))
+    assert my_handler_registry[Mul] == (frozenset({fact1}), frozenset({fact2}))
 
 
 def test_ArgFactHandler():

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -29,34 +29,34 @@ def test_ArgFactHandler():
 
     class MyArgFactHandler(ArgFactHandler):
         def __call__(self, expr):
-            return self.func(expr)
+            return self.apply((expr,))
 
-    a = MyArgFactHandler(Q.positive)
-    b = MyArgFactHandler(lambda x: Q.positive(x) | Q.negative(x))
+    a = MyArgFactHandler((x,), Q.positive(x))
+    b = MyArgFactHandler((x,), Q.positive(x) | Q.negative(x))
 
     assert a(x) == Q.positive(x)
     assert b(x) == Q.positive(x) | Q.negative(x)
 
-    raises(ValueError, lambda: MyArgFactHandler(Q.positive(x)))
+    raises(TypeError, lambda: MyArgFactHandler(Q.positive))
 
 
 def test_AllArgs():
-    a = AllArgs(Q.zero)
-    b = AllArgs(lambda x: Q.positive(x) | Q.negative(x))
+    a = AllArgs(x, Q.zero(x))
+    b = AllArgs(x, Q.positive(x) | Q.negative(x))
     assert a(x*y) == And(Q.zero(x), Q.zero(y))
     assert b(x*y) == And(Q.positive(x) | Q.negative(x), Q.positive(y) | Q.negative(y))
 
 
 def test_AnyArgs():
-    a = AnyArgs(Q.zero)
-    b = AnyArgs(lambda x: Q.positive(x) & Q.negative(x))
+    a = AnyArgs(x, Q.zero(x))
+    b = AnyArgs(x, Q.positive(x) & Q.negative(x))
     assert a(x*y) == Or(Q.zero(x), Q.zero(y))
     assert b(x*y) == Or(Q.positive(x) & Q.negative(x), Q.positive(y) & Q.negative(y))
 
 
 def test_ExactlyOneArg():
-    a = ExactlyOneArg(Q.zero)
-    b = ExactlyOneArg(lambda x: Q.positive(x) | Q.negative(x))
+    a = ExactlyOneArg(x, Q.zero(x))
+    b = ExactlyOneArg(x, Q.positive(x) | Q.negative(x))
     assert a(x*y) == Or(Q.zero(x) & ~Q.zero(y), Q.zero(y) & ~Q.zero(x))
     assert a(x*y*z) == Or(Q.zero(x) & ~Q.zero(y) & ~Q.zero(z), Q.zero(y)
         & ~Q.zero(x) & ~Q.zero(z), Q.zero(z) & ~Q.zero(x) & ~Q.zero(y))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -122,31 +122,6 @@ def test_sympy__assumptions__relation__binrel__BinaryRelation():
 def test_sympy__assumptions__relation__binrel__AppliedBinaryRelation():
     assert _test_args(Q.eq(1, 2))
 
-def test_sympy__assumptions__sathandlers__UnevaluatedOnFree():
-    from sympy.assumptions.sathandlers import UnevaluatedOnFree
-    assert _test_args(UnevaluatedOnFree(Q.positive))
-
-def test_sympy__assumptions__sathandlers__AllArgs():
-    from sympy.assumptions.sathandlers import AllArgs
-    assert _test_args(AllArgs(Q.positive))
-
-def test_sympy__assumptions__sathandlers__AnyArgs():
-    from sympy.assumptions.sathandlers import AnyArgs
-    assert _test_args(AnyArgs(Q.positive))
-
-def test_sympy__assumptions__sathandlers__ExactlyOneArg():
-    from sympy.assumptions.sathandlers import ExactlyOneArg
-    assert _test_args(ExactlyOneArg(Q.positive))
-
-def test_sympy__assumptions__sathandlers__CheckOldAssump():
-    from sympy.assumptions.sathandlers import CheckOldAssump
-    assert _test_args(CheckOldAssump(Q.positive))
-
-def test_sympy__assumptions__sathandlers__CheckIsPrime():
-    from sympy.assumptions.sathandlers import CheckIsPrime
-    # Input must be a number
-    assert _test_args(CheckIsPrime(Q.positive))
-
 def test_sympy__assumptions__wrapper__AssumptionsWrapper():
     from sympy.assumptions.wrapper import AssumptionsWrapper
     assert _test_args(AssumptionsWrapper(x, Q.positive(x)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In master, fact for classes are constructed and registered as `UnevaluatedOnFree` object, which tries to behave as a composite function using `rcall` method. The problem is that it requires `Predicate` class to be a subclass of `Boolean`, only to allow the composition between predicates like `(Q.positive & Q.even).rcall(x)` -> `Q.positive(x) & Q.even(x)`. This is mathematically incorrect since predicate is not a boolean but a function which returns boolean. Programmatically, it should be avoided because every type checking for `Boolean` should explicitly exclude `Predicate`.

This change allows handler functions to be registered as fact for classes. It provides more readability and allows first step to make `Predicate` not `Boolean`.

Previously, the registration has been done as
```python
register_fact(Mul, Implies(AllArgs(Q.imaginary | Q.real), Implies(ExactlyOneArg(Q.imaginary), Q.imaginary)))
```

Now, it can be done by 
```python
@class_fact_registry.register(Mul)
def _(expr):
    allargs_imag_or_real = allal
rg(x, Q.imaginary(x) | Q.real(x), expr)
    onearg_imaginary = exactlyonearg(x, Q.imaginary(x), expr)
    return Implies(allargs_imag_or_real, Implies(onearg_imaginary, Q.imaginary(expr)))
```

#### Other comments

`fact_registry` is renamed to `class_fact_registry` because I am planning to introduce another fact registry, `predicate_fact_registry` in next PR. This new registry will store the complicated facts for predicates such as `x > y` implying `x` and `y` being both extended real.

I already tried that change in my local to let `ask(Q.extended_real(x), x>y)` return `True`. However, to keep the diff small that feature is not included in this PR.

Benchmark showed no slowdown by this change.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
