### PR TITLE
functions: Implemented an _eval_expand_trig method for tanh

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -7,6 +7,7 @@ from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
+from sympy.utilities.iterables import numbered_symbols
 
 from sympy.core.logic import fuzzy_or, fuzzy_and
 
@@ -623,6 +624,40 @@ class tanh(HyperbolicFunction):
             re, im = self.args[0].as_real_imag()
         denom = sinh(re)**2 + cos(im)**2
         return (sinh(re)*cosh(re)/denom, sin(im)*cos(im)/denom)
+
+    def _eval_expand_trig(self, **hints):
+        arg = self.args[0]
+        x = None
+        if arg.is_Add or arg.is_Mul:
+            from sympy import symmetric_poly
+            n = len(arg.args)
+            TX = []
+            if arg.is_Add:
+                for x in arg.args:
+                    tx = tanh(x, evaluate=False)._eval_expand_trig()
+                    TX.append(tx)
+            else:
+                coeff, terms = arg.as_coeff_Mul()
+                #double angle formula
+                if coeff.is_Integer and coeff == 2:
+                    tx = tanh(terms, evaluate=False)._eval_expand_trig()
+                    TX.append(tx)
+                    TX.append(tx)
+                #half angle formula
+                elif coeff == (1/2):
+                    cx = cosh(terms, evaluate=False)._eval_expand_trig()
+                    sx = sinh(terms, evaluate=False)._eval_expand_trig()
+                    return (cx-1)/sx
+                else:
+                    return coeff*tanh(terms)
+            Yg = numbered_symbols('Y')
+            Y = [ next(Yg) for i in range(n) ]
+
+            p = [0, 0]
+            for i in range(n + 1):
+                p[1 - i % 2] += symmetric_poly(i, Y)*(1)**((i % 4)//2)
+            return (p[0]/p[1]).subs(list(zip(Y, TX)))
+        return tanh(arg)
 
     def _eval_rewrite_as_tractable(self, arg, limitvar=None, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -649,7 +649,7 @@ class tanh(HyperbolicFunction):
                     sx = sinh(terms, evaluate=False)._eval_expand_trig()
                     return (cx-1)/sx
                 else:
-                    return coeff*tanh(terms)
+                    return tanh(coeff*terms)
             Yg = numbered_symbols('Y')
             Y = [ next(Yg) for i in range(n) ]
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -7,7 +7,6 @@ from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
-from sympy.utilities.iterables import numbered_symbols
 
 from sympy.core.logic import fuzzy_or, fuzzy_and
 
@@ -637,24 +636,22 @@ class tanh(HyperbolicFunction):
                     tx = tanh(x, evaluate=False)._eval_expand_trig()
                     TX.append(tx)
 
-                Yg = numbered_symbols('Y')
-                Y = [ next(Yg) for i in range(n) ]
-
-                p = [0, 0]
+                p = [0, 0]  # [den, num]
                 for i in range(n + 1):
-                    p[1 - i % 2] += symmetric_poly(i, Y)
-                return (p[0]/p[1]).subs(list(zip(Y, TX)))
+                    p[i % 2] += symmetric_poly(i, TX)
+                return p[1]/p[0]
         else:
             from sympy.functions.combinatorial.numbers import nC
             coeff, terms = arg.as_coeff_Mul()
             if coeff.is_Integer and coeff > 1:
-                numerator = 0
-                denominator = 0
-                for k in range(0,floor((coeff-1)/2)+1):
-                    numerator += nC(range(coeff),2*k+1) * tanh(terms)**(2*k+1)
-                for k in range(0,floor(coeff/2)+1):
-                    denominator += nC(range(coeff),(2*k)) * tanh(terms)**(2*k)
-                return numerator / denominator
+                n = []
+                d = []
+                T = tanh(terms)
+                for k in range(1, coeff + 1, 2):
+                    n.append(nC(range(coeff), k)*T**k)
+                for k in range(0, coeff + 1, 2):
+                    d.append(nC(range(coeff), k)*T**k)
+                return Add(*n)/Add(*d)
         return tanh(arg)
 
     def _eval_rewrite_as_tractable(self, arg, limitvar=None, **kwargs):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -637,7 +637,7 @@ class tanh(HyperbolicFunction):
                 for x in arg.args:
                     tx = tanh(x, evaluate=False)._eval_expand_trig()
                     TX.append(tx)
-                
+
                 Yg = numbered_symbols('Y')
                 Y = [ next(Yg) for i in range(n) ]
 
@@ -647,7 +647,7 @@ class tanh(HyperbolicFunction):
                 return (p[0]/p[1]).subs(list(zip(Y, TX)))
             else:
                 coeff, terms = arg.as_coeff_Mul()
-                #tanh(n*z) (general case)
+                #tanh(n*x) (general case)
                 if coeff.is_Integer and coeff > 1:
                     numerator = 0
                     denominator = 0
@@ -655,7 +655,7 @@ class tanh(HyperbolicFunction):
                         numerator += nC(range(coeff),2*k+1) * tanh(terms)**(2*k+1)
                     for k in range(0,floor(coeff/2)+1):
                         denominator += nC(range(coeff),(2*k)) * tanh(terms)**(2*k)
-                    return numerator / denominator 
+                    return numerator / denominator
                 #half angle formula
                 elif coeff == (1/2):
                     cx = cosh(terms, evaluate=False)._eval_expand_trig()

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -628,9 +628,8 @@ class tanh(HyperbolicFunction):
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
         x = None
-        if arg.is_Add or arg.is_Mul:
+        if arg.is_Add:
             from sympy import symmetric_poly
-            from sympy.functions.combinatorial.numbers import nC
             n = len(arg.args)
             TX = []
             if arg.is_Add:
@@ -645,24 +644,17 @@ class tanh(HyperbolicFunction):
                 for i in range(n + 1):
                     p[1 - i % 2] += symmetric_poly(i, Y)
                 return (p[0]/p[1]).subs(list(zip(Y, TX)))
-            else:
-                coeff, terms = arg.as_coeff_Mul()
-                #tanh(n*x) (general case)
-                if coeff.is_Integer and coeff > 1:
-                    numerator = 0
-                    denominator = 0
-                    for k in range(0,floor((coeff-1)/2)+1):
-                        numerator += nC(range(coeff),2*k+1) * tanh(terms)**(2*k+1)
-                    for k in range(0,floor(coeff/2)+1):
-                        denominator += nC(range(coeff),(2*k)) * tanh(terms)**(2*k)
-                    return numerator / denominator
-                #half angle formula
-                elif coeff == (1/2):
-                    cx = cosh(terms, evaluate=False)._eval_expand_trig()
-                    sx = sinh(terms, evaluate=False)._eval_expand_trig()
-                    return (cx-1)/sx
-                else:
-                    return tanh(coeff*terms)
+        else:
+            from sympy.functions.combinatorial.numbers import nC
+            coeff, terms = arg.as_coeff_Mul()
+            if coeff.is_Integer and coeff > 1:
+                numerator = 0
+                denominator = 0
+                for k in range(0,floor((coeff-1)/2)+1):
+                    numerator += nC(range(coeff),2*k+1) * tanh(terms)**(2*k+1)
+                for k in range(0,floor(coeff/2)+1):
+                    denominator += nC(range(coeff),(2*k)) * tanh(terms)**(2*k)
+                return numerator / denominator
         return tanh(arg)
 
     def _eval_rewrite_as_tractable(self, arg, limitvar=None, **kwargs):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -635,7 +635,7 @@ class tanh(HyperbolicFunction):
             for i in range(n + 1):
                 p[i % 2] += symmetric_poly(i, TX)
             return p[1]/p[0]
-        else:
+        elif arg.is_Mul:
             from sympy.functions.combinatorial.numbers import nC
             coeff, terms = arg.as_coeff_Mul()
             if coeff.is_Integer and coeff > 1:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -626,20 +626,15 @@ class tanh(HyperbolicFunction):
 
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
-        x = None
         if arg.is_Add:
             from sympy import symmetric_poly
             n = len(arg.args)
-            TX = []
-            if arg.is_Add:
-                for x in arg.args:
-                    tx = tanh(x, evaluate=False)._eval_expand_trig()
-                    TX.append(tx)
-
-                p = [0, 0]  # [den, num]
-                for i in range(n + 1):
-                    p[i % 2] += symmetric_poly(i, TX)
-                return p[1]/p[0]
+            TX = [tanh(x, evaluate=False)._eval_expand_trig()
+                for x in arg.args]
+            p = [0, 0]  # [den, num]
+            for i in range(n + 1):
+                p[i % 2] += symmetric_poly(i, TX)
+            return p[1]/p[0]
         else:
             from sympy.functions.combinatorial.numbers import nC
             coeff, terms = arg.as_coeff_Mul()


### PR DESCRIPTION
**References to other Issues or PRs**
Fixes #21365

**Brief description of what is fixed or changed**
- Implemented _eval_expand_trig  method for tanh funciton. expand_trig now works to expand tanh in a few different ways.
- tanh(coeff*x) will be expanded to coeff\*tanh(x).
- tanh now detects double and half angle formulas, so if coeff is 2 or .5, it will be expanded according to the following formulas:
    - tanh Half Angle Formula: **tanh(.5\*x) = (cosh(x)-1)/sinh(x)**
    - tanh Double Angle Formula: **tanh(2x) = 2\*tanh(x)/(1+tanh^2(x))**
- _eval_expand_trig also expands tanh(x+y) using the sum of arguments identity.
    - tanh Sum of Arguments Identity: **tanh(x+y) = (tanh(x)+tanh(y))/(1+tanh(x)\*tanh(y))**

**Release Notes**
<!-- BEGIN RELEASE NOTES -->
* functions
  * Add _eval_expand_trig method for tanh. 
<!-- END RELEASE NOTES -->

Example:
```
>>> from sympy import *
>>> x = Symbol('x')
>>> y = Symbol('y')

>>> expand_trig(tanh(x + y))
(tanh(x) + tanh(y))/(tanh(x)*tanh(y) + 1)

>>> expand_trig(tanh(2*x))
2*tanh(x)/(tanh(x)**2 + 1)

>>> expand_trig(tanh(3*x))
3*tanh(x)

>>> expand_trig(tanh(y*x))
tanh(x*y)

>>> expand_trig(tanh((1/2)*x))
(cosh(x) - 1)/sinh(x)
```