### PR TITLE
Rewrite ITE as Piecewise in numexpr printer

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -152,6 +152,10 @@ class NumExprPrinter(LambdaPrinter):
             ans.append('log(-1)')
         return ''.join(ans) + ')' * parenthesis_count
 
+    def _print_ITE(self, expr):
+        from sympy.functions.elementary.piecewise import Piecewise
+        return self._print(expr.rewrite(Piecewise))
+
     def blacklisted(self, expr):
         raise TypeError("numexpr cannot be used with %s" %
                         expr.__class__.__name__)

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -203,6 +203,14 @@ def test_settings():
     raises(TypeError, lambda: lambdarepr(sin(x), method="garbage"))
 
 
+def test_numexpr():
+    # test ITE rewrite as Piecewise
+    from sympy.logic.boolalg import ITE
+    expr = ITE(x > 0, True, False, evaluate=False)
+    assert NumExprPrinter().doprint(expr) == \
+           "evaluate('where((x > 0), True, False)', truediv=True)"
+
+
 class CustomPrintedObject(Expr):
     def _lambdacode(self, printer):
         return 'lambda'


### PR DESCRIPTION
Fix ITE printing for NumExprPrinter by rewriting as Piecewise (which is already done in numpy printer). Failing to do so results in printing of Python Booleans. MWE-

```python
In [1]: expr = ITE(x > 0, True, False, evaluate=False)

In [2]: expr
Out[2]: 
⎧True   for x > 0
⎨                
⎩False  otherwise

In [3]: printing.lambdarepr.NumExprPrinter().doprint(expr)  # this is incorrect (uses Python Booleans)
Out[3]: "evaluate('((True) if ((x > 0)) else (False))', truediv=True)"

In [4]: lambdify([x], expr, 'numexpr')(1)  # the current state of NumExprPrinter fails
TypeError: You can't use Python's standard boolean operators in NumExpr expressions. You should use their bitwise counterparts instead: '&' instead of 'and', '|' instead of 'or', and '~' instead of 'not'.

In [5]: printing.lambdarepr.NumExprPrinter().doprint(expr)  # this is with the patch applied
Out[5]: "evaluate('where((x > 0), True, False)', truediv=True)"

In [6]: lambdify([x], expr, modules='numexpr')(1)  # the expected result
Out[6]: array(True)
```


#### Brief description of what is fixed or changed
`NumExprPrinter` now rewrites `ITE` expressions as `Piecewise`

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * `NumExprPrinter` now properly supports expressions containing `ITE`
<!-- END RELEASE NOTES -->
