### PR TITLE
printing: term reversal and powers with negative exponents

### DIFF
--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -77,7 +77,7 @@ TR11's behavior is similar. It rewrites double angles as smaller angles but
 doesn't do any simplification of the result.
 
     >>> TR11(sin(2)**a*cos(1)**(-a), 1)
-    (2*sin(1)*cos(1))**a*cos(1)**(-a)
+    (2*sin(1)*cos(1))**a/cos(1)**a
     >>> powsimp(_)
     (2*sin(1))**a
 

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -98,7 +98,7 @@ class Product(ExprWithIntLimits):
     Product(4*i**2/((2*i - 1)*(2*i + 1)), (i, 1, n))
     >>> W2e = W2.doit()
     >>> W2e
-    2**(-2*n)*4**n*factorial(n)**2/(RisingFactorial(1/2, n)*RisingFactorial(3/2, n))
+    4**n*factorial(n)**2/(2**(2*n)*RisingFactorial(1/2, n)*RisingFactorial(3/2, n))
     >>> limit(W2e, n, oo)
     pi/2
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -743,8 +743,7 @@ class harmonic(Function):
     >>> H = harmonic(25/S(7))
     >>> He = simplify(expand_func(H).doit())
     >>> He
-    log(sin(pi/7)**(-2*cos(pi/7))*sin(2*pi/7)**(2*cos(16*pi/7))*cos(pi/14)**(-2*sin(pi/14))/14)
-    + pi*tan(pi/14)/2 + 30247/9900
+    log(sin(2*pi/7)**(2*cos(16*pi/7))/(14*sin(pi/7)**(2*cos(pi/7))*cos(pi/14)**(2*sin(pi/14)))) + pi*tan(pi/14)/2 + 30247/9900
     >>> He.n(40)
     1.983697455232980674869851942390639915940
     >>> harmonic(25/S(7)).n(40)

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -95,7 +95,7 @@ class jacobi(OrthogonalPolynomial):
     (-1)**n*jacobi(n, b, a, x)
 
     >>> jacobi(n, a, b, 0)
-    2**(-n)*gamma(a + n + 1)*hyper((-b - n, -n), (a + 1,), -1)/(factorial(n)*gamma(a + 1))
+    gamma(a + n + 1)*hyper((-b - n, -n), (a + 1,), -1)/(2**n*factorial(n)*gamma(a + 1))
     >>> jacobi(n, a, b, 1)
     RisingFactorial(a + 1, n)/factorial(n)
 

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -76,7 +76,7 @@ class lerchphi(Function):
     reduces to a sum of Hurwitz zeta functions:
 
     >>> expand_func(lerchphi(-1, s, a))
-    2**(-s)*zeta(s, a/2) - 2**(-s)*zeta(s, a/2 + 1/2)
+    zeta(s, a/2)/2**s - zeta(s, a/2 + 1/2)/2**s
 
     If $a=1$, the Lerch transcendent reduces to the polylogarithm:
 
@@ -595,7 +595,7 @@ class riemann_xi(Function):
     >>> from sympy import riemann_xi, zeta
     >>> from sympy.abc import s
     >>> riemann_xi(s).rewrite(zeta)
-    pi**(-s/2)*s*(s - 1)*gamma(s/2)*zeta(s)/2
+    s*(s - 1)*gamma(s/2)*zeta(s)/(2*pi**(s/2))
 
     References
     ==========

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -47,7 +47,7 @@ def test_as_integral():
     assert laplace_transform(f(x), x, s).rewrite('Integral') == \
         Integral(f(x)*exp(-s*x), (x, 0, oo))
     assert str(2*pi*I*inverse_mellin_transform(f(s), s, x, (a, b)).rewrite('Integral')) \
-        == "Integral(x**(-s)*f(s), (s, _c - oo*I, _c + oo*I))"
+        == "Integral(f(s)/x**s, (s, _c - oo*I, _c + oo*I))"
     assert str(2*pi*I*inverse_laplace_transform(f(s), s, x).rewrite('Integral')) == \
         "Integral(f(s)*exp(s*x), (s, _c - oo*I, _c + oo*I))"
     assert inverse_fourier_transform(f(s), s, x).rewrite('Integral') == \

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1173,7 +1173,7 @@ def laplace_transform(f, t, s, **hints):
     >>> from sympy.integrals import laplace_transform
     >>> from sympy.abc import t, s, a
     >>> laplace_transform(t**a, t, s)
-    (s**(-a)*gamma(a + 1)/s, 0, re(a) > -1)
+    (gamma(a + 1)/(s*s**a), 0, re(a) > -1)
 
     See Also
     ========
@@ -1911,7 +1911,7 @@ def hankel_transform(f, r, k, nu, **hints):
 
     >>> ht = hankel_transform(1/r**m, r, k, nu)
     >>> ht
-    2*2**(-m)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
+    2*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/(2**m*gamma(m/2 + nu/2))
 
     >>> inverse_hankel_transform(ht, k, r, nu)
     r**(-m)
@@ -1973,7 +1973,7 @@ def inverse_hankel_transform(F, k, r, nu, **hints):
 
     >>> ht = hankel_transform(1/r**m, r, k, nu)
     >>> ht
-    2*2**(-m)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
+    2*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/(2**m*gamma(m/2 + nu/2))
 
     >>> inverse_hankel_transform(ht, k, r, nu)
     r**(-m)

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -522,7 +522,7 @@ def test_factorrat():
     assert str(factorrat(Rational(1, 1), visual=True)) == '1'
     assert str(factorrat(S(25)/14, visual=True)) == '5**2/(2*7)'
     assert str(factorrat(Rational(25, 14), visual=True)) == '5**2/(2*7)'
-    assert str(factorrat(S(-25)/14/9, visual=True)) == '(-1)*5**2/(2*3**2*7)'
+    assert str(factorrat(S(-25)/14/9, visual=True)) == '-1*5**2/(2*3**2*7)'
 
     assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
     assert factorrat(Rational(1, 1), multiple=True) == []

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -522,7 +522,7 @@ def test_factorrat():
     assert str(factorrat(Rational(1, 1), visual=True)) == '1'
     assert str(factorrat(S(25)/14, visual=True)) == '5**2/(2*7)'
     assert str(factorrat(Rational(25, 14), visual=True)) == '5**2/(2*7)'
-    assert str(factorrat(S(-25)/14/9, visual=True)) == '-5**2/(2*3**2*7)'
+    assert str(factorrat(S(-25)/14/9, visual=True)) == '(-1)*5**2/(2*3**2*7)'
 
     assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
     assert factorrat(Rational(1, 1), multiple=True) == []

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1062,8 +1062,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             sympy_class = self.operators[node.op.__class__]
             right = self.visit(node.right)
             left = self.visit(node.left)
-            if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul',):
-                left, right = right, left
+
             if isinstance(node.op, ast.Sub):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1063,6 +1063,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             right = self.visit(node.right)
             left = self.visit(node.left)
 
+            rev = False
             if isinstance(node.op, ast.Sub):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
@@ -1071,10 +1072,10 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     starargs=None,
                     kwargs=None
                 )
-            if isinstance(node.op, ast.Div):
+            elif isinstance(node.op, ast.Div):
                 if isinstance(node.left, ast.UnaryOp):
-                    if isinstance(node.right,ast.UnaryOp):
-                        left, right = right, left
+                    left, right = right, left
+                    rev = True
                     left = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[left, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
@@ -1091,6 +1092,8 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     kwargs=None
                 )
 
+            if rev:  # undo reversal
+                left, right = right, left
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -158,10 +158,12 @@ def test_issue_7663():
     assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
     assert parse_expr(e, evaluate=0).equals(2*(x+1))
 
-def test_issue_10560():
+def test_recursive_evaluate_false_10560():
     inputs = {
-        '4*-3' : '(-3)*4',
+        '4*-3' : '4*-3',
         '-4*3' : '(-4)*3',
+        "-2*x*y": '(-2)*x*y',
+        "x*-4*x": "x*(-4)*x"
     }
     for text, result in inputs.items():
         assert parse_expr(text, evaluate=False) == parse_expr(result, evaluate=False)

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -77,7 +77,7 @@ def test_convert_to_tuples_of_quantities():
     assert convert_to(2 * speed_of_light, [meter, second, kilogram]) == 2 * 299792458 * meter / second
     assert convert_to(G, [G, speed_of_light, planck]) == 1.0*G
 
-    assert NS(convert_to(meter, [G, speed_of_light, hbar]), n=7) == '6.187142e+34*gravitational_constant**0.5000000*hbar**0.5000000*speed_of_light**(-1.500000)'
+    assert NS(convert_to(meter, [G, speed_of_light, hbar]), n=7) == '6.187142e+34*gravitational_constant**0.5000000*hbar**0.5000000/speed_of_light**1.500000'
     assert NS(convert_to(planck_mass, kilogram), n=7) == '2.176434e-8*kilogram'
     assert NS(convert_to(planck_length, meter), n=7) == '1.616255e-35*meter'
     assert NS(convert_to(planck_time, second), n=6) == '5.39125e-44*second'

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -82,7 +82,7 @@ def convert_to(expr, target_units, unit_system="SI"):
     Conversion to Planck units:
 
     >>> convert_to(atomic_mass_constant, [gravitational_constant, speed_of_light, hbar]).n()
-    7.62963085040767e-20*gravitational_constant**(-0.5)*hbar**0.5*speed_of_light**0.5
+    7.62963087839509e-20*hbar**0.5*speed_of_light**0.5/gravitational_constant**0.5
 
     """
     from sympy.physics.units import UnitSystem

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -254,7 +254,24 @@ class StrPrinter(Printer):
         # etc so we display in a straight-forward form that fully preserves all
         # args and their order.
         args = expr.args
-        if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]):
+        if args[0] is S.One or any(isinstance(arg, Number) or isinstance(1/arg, Number) for arg in args[1:]):
+            from sympy.utilities.iterables import sift
+            d, n  = sift(args, lambda x:
+                         isinstance(x,Pow) and x.exp == -1,
+                         binary=True
+                         )
+            d = [1/i for i in d]
+            nfactors = [self.parenthesize(arg, prec, strict=False) for arg in n]
+            dfactors = [self.parenthesize(arg, prec, strict=False) for arg in d]
+            numerator_string = '*'.join(nfactors)
+            denominator_string = '*'.join(dfactors)
+            if len(dfactors) > 1:
+                return '%s/(%s)' % (numerator_string, denominator_string)
+            elif dfactors:
+                return '%s/%s' % (numerator_string, denominator_string)
+            else:
+                return numerator_string
+
             factors = [self.parenthesize(a, prec, strict=False) for a in args]
             return '*'.join(factors)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
+from sympy.core.function import _coeff_isneg
 from .printer import Printer, print_function
 from sympy.printing.precedence import precedence, PRECEDENCE
 
@@ -269,10 +270,23 @@ class StrPrinter(Printer):
                     dargs[0] = -dargs[0]
                     e = Mul._from_args(dargs)
                 d[i] = Pow(di.base, e, evaluate=False) if e - 1 else di.base
-            nfactors = [self.parenthesize(a, prec, strict=False)
+
+            # don't parenthesize first factor if negative
+            if _coeff_isneg(n[0]):
+                pre = [str(n.pop(0))]
+            else:
+                pre = []
+            nfactors = pre + [self.parenthesize(a, prec, strict=False)
                 for a in n]
-            dfactors = [self.parenthesize(a, prec, strict=False)
+
+            # don't parenthesize first of denominator unless singleton
+            if len(d) > 1 and _coeff_isneg(d[0]):
+                pre = [str(d.pop(0))]
+            else:
+                pre = []
+            dfactors = pre + [self.parenthesize(a, prec, strict=False)
                 for a in d]
+
             n = '*'.join(nfactors)
             d = '*'.join(dfactors)
             if len(dfactors) > 1:

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1006,16 +1006,21 @@ def test_str_special_matrices():
     assert str(ZeroMatrix(2, 2)) == '0'
     assert str(OneMatrix(2, 2)) == '1'
 
+
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
 
+
 def test_issue_21119():
-    from sympy import sympify
-    assert str(sympify('4/2', evaluate=False)) == '4/2'
-    assert str(sympify('4/-2', evaluate=False)) == '4/(-2)'
-    assert str(sympify('-4/2', evaluate=False)) == '(-4)/2'
-    assert str(sympify('-4/-2', evaluate=False)) == '(-4)/(-2)'
-    assert str(sympify('4/2/1', evaluate=False)) == '4/(2*1)'
+    ss = lambda x: str(S(x, evaluate=False))
+    assert ss('4/2') == '4/2'
+    assert ss('4/-2') == '4/(-2)'
+    assert ss('-4/2') == '(-4)/2'
+    assert ss('-4/-2') == '(-4)/(-2)'
+    assert ss('4/2/1') == '4/(2*1)'
+    assert ss('2*3*4**(-2*3)') == '2*3/4**(2*3)'
+    assert ss('2*3*1*4**(-2*3)') == '2*3*1/4**(2*3)'
+
 
 def test_Str():
     from sympy.core.symbol import Str

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1009,6 +1009,14 @@ def test_str_special_matrices():
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
 
+def test_issue_21119():
+    from sympy import sympify
+    assert str(sympify('4/2', evaluate=False)) == '4/2'
+    assert str(sympify('4/-2', evaluate=False)) == '4/(-2)'
+    assert str(sympify('-4/2', evaluate=False)) == '(-4)/2'
+    assert str(sympify('-4/-2', evaluate=False)) == '(-4)/(-2)'
+    assert str(sympify('4/2/1', evaluate=False)) == '4/(2*1)'
+
 def test_Str():
     from sympy.core.symbol import Str
     assert str(Str('x')) == 'x'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -245,7 +245,7 @@ def test_Mul():
     assert str(Mul(1, 1, S.Half, evaluate=False)) == '1*1*(1/2)'
     assert str(Mul(1, 1, 2, 3, x, evaluate=False)) == '1*1*2*3*x'
     assert str(Mul(1, -1, evaluate=False)) == '1*(-1)'
-    assert str(Mul(-1, 1, evaluate=False)) == '(-1)*1'
+    assert str(Mul(-1, 1, evaluate=False)) == '-1*1'
     assert str(Mul(4, 3, 2, 1, 0, y, x, evaluate=False)) == '4*3*2*1*0*y*x'
     assert str(Mul(4, 3, 2, 1+z, 0, y, x, evaluate=False)) == '4*3*2*(z + 1)*0*y*x'
     assert str(Mul(Rational(2, 3), Rational(5, 7), evaluate=False)) == '(2/3)*(5/7)'
@@ -1011,13 +1011,16 @@ def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
 
 
-def test_issue_21119():
+def test_issue_21119_21460():
     ss = lambda x: str(S(x, evaluate=False))
     assert ss('4/2') == '4/2'
     assert ss('4/-2') == '4/(-2)'
-    assert ss('-4/2') == '(-4)/2'
-    assert ss('-4/-2') == '(-4)/(-2)'
+    assert ss('-4/2') == '-4/2'
+    assert ss('-4/-2') == '-4/(-2)'
+    assert ss('-2*3/-1') == '-2*3/(-1)'
+    assert ss('-2*3/-1/2') == '-2*3/(-1*2)'
     assert ss('4/2/1') == '4/(2*1)'
+    assert ss('-2/-1/2') == '-2/(-1*2)'
     assert ss('2*3*4**(-2*3)') == '2*3/4**(2*3)'
     assert ss('2*3*1*4**(-2*3)') == '2*3*1/4**(2*3)'
 
@@ -1026,6 +1029,7 @@ def test_Str():
     from sympy.core.symbol import Str
     assert str(Str('x')) == 'x'
     assert sstrrepr(Str('x')) == "Str('x')"
+
 
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -74,10 +74,10 @@ def rational_algorithm(f, x, k, order=4, full=False):
     >>> ra(1 / (1 - x), x, k)
     (1, 0, 0)
     >>> ra(log(1 + x), x, k)
-    (-(-1)**(-k)/k, 0, 1)
+    (-1/((-1)**k*k), 0, 1)
 
     >>> ra(atan(x), x, k, full=True)
-    ((-I*(-I)**(-k)/2 + I*I**(-k)/2)/k, 0, 1)
+    ((-I/(2*(-I)**k) + I/(2*I**k))/k, 0, 1)
 
     Notes
     =====

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -115,7 +115,7 @@ def TR2i(rv, half=False):
     for both numerator and denominator)
 
     >>> TR2i(sin(x)**a/(cos(x) + 1)**a)
-    (cos(x) + 1)**(-a)*sin(x)**a
+    sin(x)**a/(cos(x) + 1)**a
 
     """
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -903,7 +903,7 @@ def ChiNoncentral(name, k, l):
     >>> X = ChiNoncentral("x", k, l)
 
     >>> density(X)(z)
-    l*z**k*(l*z)**(-k/2)*exp(-l**2/2 - z**2/2)*besseli(k/2 - 1, l*z)
+    l*z**k*exp(-l**2/2 - z**2/2)*besseli(k/2 - 1, l*z)/(l*z)**(k/2)
 
     References
     ==========
@@ -983,7 +983,7 @@ def ChiSquared(name, k):
     >>> X = ChiSquared("x", k)
 
     >>> density(X)(z)
-    2**(-k/2)*z**(k/2 - 1)*exp(-z/2)/gamma(k/2)
+    z**(k/2 - 1)*exp(-z/2)/(2**(k/2)*gamma(k/2))
 
     >>> E(X)
     k
@@ -1710,10 +1710,10 @@ def Frechet(name, a, s=1, m=0):
     >>> X = Frechet("x", a, s, m)
 
     >>> density(X)(z)
-    a*((-m + z)/s)**(-a - 1)*exp(-((-m + z)/s)**(-a))/s
+    a*((-m + z)/s)**(-a - 1)*exp(-1/((-m + z)/s)**a)/s
 
     >>> cdf(X)(z)
-     Piecewise((exp(-((-m + z)/s)**(-a)), m <= z), (0, True))
+    Piecewise((exp(-1/((-m + z)/s)**a), m <= z), (0, True))
 
     References
     ==========
@@ -2832,7 +2832,7 @@ def Lomax(name, alpha, lamda):
     >>> density(X)(x)
     a*(1 + x/l)**(-a - 1)/l
     >>> cdf(X)(x)
-    Piecewise((1 - (1 + x/l)**(-a), x >= 0), (0, True))
+    Piecewise((1 - 1/(1 + x/l)**a, x >= 0), (0, True))
     >>> a = 2
     >>> X = Lomax('X', a, l)
     >>> E(X)

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -404,7 +404,7 @@ def Logarithmic(name, p):
     >>> X = Logarithmic("x", p)
 
     >>> density(X)(z)
-    -5**(-z)/(z*log(4/5))
+    -1/(5**z*z*log(4/5))
 
     >>> E(X)
     -1/(-4*log(5) + 8*log(2))
@@ -488,7 +488,7 @@ def NegativeBinomial(name, r, p):
     >>> X = NegativeBinomial("x", r, p)
 
     >>> density(X)(z)
-    1024*5**(-z)*binomial(z + 4, z)/3125
+    1024*binomial(z + 4, z)/(3125*5**z)
 
     >>> E(X)
     5/4

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -580,7 +580,7 @@ def MultivariateEwens(syms, n, theta):
     >>> a2 = Symbol('a2', positive=True)
     >>> ed = MultivariateEwens('E', 2, 1)
     >>> density(ed)(a1, a2)
-    Piecewise((2**(-a2)/(factorial(a1)*factorial(a2)), Eq(a1 + 2*a2, 2)), (0, True))
+    Piecewise((1/(2**a2*factorial(a1)*factorial(a2)), Eq(a1 + 2*a2, 2)), (0, True))
     >>> marginal_distribution(ed, ed[0])(a1)
     Piecewise((1/factorial(a1), Eq(a1, 2)), (0, True))
 
@@ -662,8 +662,8 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
     >>> y = symbols('y_1:4', positive=True)
     >>> Gd = GeneralizedMultivariateLogGamma('G', d, v, l, mu)
     >>> density(Gd)(y[0], y[1], y[2])
-    Sum(2**(-n)*exp((n + 1)*(y_1 + y_2 + y_3) - exp(y_1) - exp(y_2) -
-    exp(y_3))/gamma(n + 1)**3, (n, 0, oo))/2
+    Sum(exp((n + 1)*(y_1 + y_2 + y_3) - exp(y_1) - exp(y_2) -
+    exp(y_3))/(2**n*gamma(n + 1)**3), (n, 0, oo))/2
 
     References
     ==========

--- a/sympy/stats/matrix_distributions.py
+++ b/sympy/stats/matrix_distributions.py
@@ -285,11 +285,11 @@ def MatrixGamma(symbol, alpha, beta, scale_matrix):
     >>> M = MatrixGamma('M', a, b, [[2, 1], [1, 2]])
     >>> X = MatrixSymbol('X', 2, 2)
     >>> density(M)(X).doit()
-    3**(-a)*b**(-2*a)*exp(Trace(Matrix([
+    exp(Trace(Matrix([
     [-2/3,  1/3],
-    [ 1/3, -2/3]])*X)/b)*Determinant(X)**(a - 3/2)/(sqrt(pi)*gamma(a)*gamma(a - 1/2))
+    [ 1/3, -2/3]])*X)/b)*Determinant(X)**(a - 3/2)/(3**a*sqrt(pi)*b**(2*a)*gamma(a)*gamma(a - 1/2))
     >>> density(M)([[1, 0], [0, 1]]).doit()
-    3**(-a)*b**(-2*a)*exp(-4/(3*b))/(sqrt(pi)*gamma(a)*gamma(a - 1/2))
+    exp(-4/(3*b))/(3**a*sqrt(pi)*b**(2*a)*gamma(a)*gamma(a - 1/2))
 
 
     References
@@ -369,11 +369,11 @@ def Wishart(symbol, n, scale_matrix):
     >>> W = Wishart('W', n, [[2, 1], [1, 2]])
     >>> X = MatrixSymbol('X', 2, 2)
     >>> density(W)(X).doit()
-    2**(-n)*3**(-n/2)*exp(Trace(Matrix([
+    exp(Trace(Matrix([
     [-1/3,  1/6],
-    [ 1/6, -1/3]])*X))*Determinant(X)**(n/2 - 3/2)/(sqrt(pi)*gamma(n/2)*gamma(n/2 - 1/2))
+    [ 1/6, -1/3]])*X))*Determinant(X)**(n/2 - 3/2)/(2**n*3**(n/2)*sqrt(pi)*gamma(n/2)*gamma(n/2 - 1/2))
     >>> density(W)([[1, 0], [0, 1]]).doit()
-    2**(-n)*3**(-n/2)*exp(-2/3)/(sqrt(pi)*gamma(n/2)*gamma(n/2 - 1/2))
+    exp(-2/3)/(2**n*3**(n/2)*sqrt(pi)*gamma(n/2)*gamma(n/2 - 1/2))
 
     References
     ==========
@@ -568,11 +568,11 @@ def MatrixStudentT(symbol, nu, location_matrix, scale_matrix_1, scale_matrix_2):
     >>> M = MatrixStudentT('M', v, [[1, 2]], [[1, 0], [0, 1]], [1])
     >>> X = MatrixSymbol('X', 1, 2)
     >>> density(M)(X)
-    pi**(-1.0)*gamma(v/2 + 1)*Determinant((Matrix([[-1, -2]]) + X)*(Matrix([
+    gamma(v/2 + 1)*Determinant((Matrix([[-1, -2]]) + X)*(Matrix([
     [-1],
-    [-2]]) + X.T) + Matrix([[1]]))**(-v/2 - 1)*Determinant(Matrix([[1]]))**(-1.0)*Determinant(Matrix([
+    [-2]]) + X.T) + Matrix([[1]]))**(-v/2 - 1)/(pi**1.0*gamma(v/2)*Determinant(Matrix([[1]]))**1.0*Determinant(Matrix([
     [1, 0],
-    [0, 1]]))**(-0.5)/gamma(v/2)
+    [0, 1]]))**0.5)
 
     References
     ==========

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -98,8 +98,8 @@ def test_GeneralizedMultivariateLogGammaDistribution():
     assert str(density(G)(y_1, y_2, y_3, y_4)) == den
     marg = ("5*2**(2/3)*5**(1/3)*exp(4*y_1)*exp(-exp(y_1))*Integral(exp(-exp(4*G[3])"
             "/4)*exp(16*G[3])*Integral(exp(-exp(3*G[2])/3)*exp(12*G[2])*Integral(exp("
-            "-exp(2*G[1])/2)*exp(8*G[1])*Sum((-1/4)**n*24**(-n)*(-4 + 2**(2/3)*5**(1/3"
-            "))**n*exp(n*y_1)*exp(2*n*G[1])*exp(3*n*G[2])*exp(4*n*G[3])/(gamma(n + 1)"
+            "-exp(2*G[1])/2)*exp(8*G[1])*Sum((-1/4)**n*(-4 + 2**(2/3)*5**(1/3"
+            "))**n*exp(n*y_1)*exp(2*n*G[1])*exp(3*n*G[2])*exp(4*n*G[3])/(24**n*gamma(n + 1)"
             "*gamma(n + 4)**3), (n, 0, oo)), (G[1], -oo, oo)), (G[2], -oo, oo)), (G[3]"
             ", -oo, oo))/5308416")
     assert str(marginal_distribution(G, G[0])(y_1)) == marg


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

close #21194 as extension with retention of original commits
fixes #21119 
fixes #21406

#### Brief description of what is fixed or changed

- term swap for unevaluated expression has been undone
- powers with a leading negative sign are now collected in the denominator when they appear as a factor

```python
>>> x**-y
x**(-y)
>>> 2*_
2/x**y
```

This doesn't always lead to a shorter expression but rather than optimize that, a consistent result was selected. This will help with requests as mentioned [here](https://stackoverflow.com/questions/67258281/how-to-make-a-fraction-instead-of-negative-power-for-unevaluatedexpression-divis) -- but there will always be requests for things to appear in non-standard ways, so there is no illusion that this is the best way of printing expressions.

- leading factor with a negative sign in an unevaluated Mul prints without parenthesis now
```python
>>> Mul(-x,2,evaluate=0)
(-x)*2 <--- now prints as -x*2
```
#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * fixed bug that caused factors in unevaluated expressions to be swapped
  * powers with negative signs in the exponent are now printed in the denominator
  * parentheses no longer appear on first factors in unevaluated Mul that have a negative sign 
<!-- END RELEASE NOTES -->
