### PR TITLE
perf(polys): make ZZ_I and QQ_I faster

### DIFF
--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -18,15 +18,17 @@ class GaussianElement(DomainElement):
 
     __slots__ = ('x', 'y')
 
-    def __init__(self, x, y=0):
-        conv = self.base.convert
-        self.x = conv(x)
-        self.y = conv(y)
+    def __new__(cls, x, y=0):
+        conv = cls.base.convert
+        return cls.new(conv(x), conv(y))
 
     @classmethod
     def new(cls, x, y):
         """Create a new GaussianElement of the same domain."""
-        return cls(x, y)
+        obj = super().__new__(cls)
+        obj.x = x
+        obj.y = y
+        return obj
 
     def parent(self):
         """The domain that this is an element of (ZZ_I or QQ_I)"""


### PR DESCRIPTION
Avoid calling convert during arithmetic operations between elements of
ZZ_I and QQ_I. This makes a+b and a*b etc faster for operations between
elements of the same Gaussian domain.

To time this try e.g.:
```python
In [1]: M = randMatrix(100) + randMatrix(100)*I

In [2]: from sympy.polys.matrices import DomainMatrix

In [3]: dM = DomainMatrix.from_Matrix(M)

In [4]: dM.domain
Out[4]: ZZ_I

In [5]: %time ok = dM**2
CPU times: user 3.55 s, sys: 11.9 ms, total: 3.57 s
Wall time: 3.57 s
```
On master that gives:
```python
In [4]: %time ok = dM**2
CPU times: user 9.95 s, sys: 49.7 ms, total: 10 s
Wall time: 10 s
```
So this is a roughly 3x speedup for this operation. Almost all calculations with `ZZ_I` and `QQ_I` will be faster from this change.

To test with `QQ_I` you can use
```python
M = randMatrix(100) + randMatrix(100)*I/3
```

Note that timings above are with gmpy2 installed.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
