### PR TITLE
refactor(polys): move smith_normal_form to DomainMatrix

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -263,13 +263,11 @@ class FpGroup(DefaultPrinting):
             return True
         # Abelianisation test: check is the abelianisation is infinite
         abelian_rels = []
-        from sympy.polys.solvers import RawMatrix as Matrix
-        from sympy.polys.domains import ZZ
         from sympy.matrices.normalforms import invariant_factors
+        from sympy.matrices import Matrix
         for rel in self.relators:
             abelian_rels.append([rel.exponent_sum(g) for g in self.generators])
-        m = Matrix(abelian_rels)
-        setattr(m, "ring", ZZ)
+        m = Matrix(Matrix(abelian_rels))
         if 0 in invariant_factors(m):
             return True
         else:

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -1,9 +1,24 @@
 '''Functions returning normal forms of matrices'''
 
-from sympy.matrices.dense import diag, zeros
+from sympy.polys.polytools import Poly
+from sympy.polys.matrices import DomainMatrix
+from sympy.polys.matrices.normalforms import (
+        smith_normal_form as _snf,
+        invariant_factors as _invf,
+    )
 
 
-def smith_normal_form(m, domain = None):
+def _to_domain(m, domain=None):
+    """Convert Matrix to DomainMatrix"""
+    m = m.applyfunc(lambda e: e.as_expr() if isinstance(e, Poly) else e)
+    dM = DomainMatrix.from_Matrix(m)
+    domain = domain or getattr(m, 'domain', None)
+    if domain is not None:
+        dM = dM.convert_to(domain)
+    return dM
+
+
+def smith_normal_form(m, domain=None):
     '''
     Return the Smith Normal Form of a matrix `m` over the ring `domain`.
     This will only work if the ring is a principal ideal domain.
@@ -11,25 +26,18 @@ def smith_normal_form(m, domain = None):
     Examples
     ========
 
-    >>> from sympy.polys.solvers import RawMatrix as Matrix
-    >>> from sympy.polys.domains import ZZ
+    >>> from sympy import Matrix, ZZ
     >>> from sympy.matrices.normalforms import smith_normal_form
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
-    >>> setattr(m, "ring", ZZ)
-    >>> print(smith_normal_form(m))
+    >>> print(smith_normal_form(m, domain=ZZ))
     Matrix([[1, 0, 0], [0, 10, 0], [0, 0, -30]])
 
     '''
-    invs = invariant_factors(m, domain=domain)
-    smf = diag(*invs)
-    n = len(invs)
-    if m.rows > n:
-        smf = smf.row_insert(m.rows, zeros(m.rows-n, m.cols))
-    elif m.cols > n:
-        smf = smf.col_insert(m.cols, zeros(m.rows, m.cols-n))
-    return smf
+    dM = _to_domain(m, domain)
+    return _snf(dM).to_Matrix()
 
-def invariant_factors(m, domain = None):
+
+def invariant_factors(m, domain=None):
     '''
     Return the tuple of abelian invariants for a matrix `m`
     (as in the Smith-Normal form)
@@ -41,103 +49,6 @@ def invariant_factors(m, domain = None):
     [2] http://sierra.nmsu.edu/morandi/notes/SmithNormalForm.pdf
 
     '''
-    if not domain:
-        if not (hasattr(m, "ring") and m.ring.is_PID):
-            raise ValueError(
-                "The matrix entries must be over a principal ideal domain")
-        else:
-            domain = m.ring
-
-    if len(m) == 0:
-        return ()
-
-    m = m[:, :]
-
-    def add_rows(m, i, j, a, b, c, d):
-        # replace m[i, :] by a*m[i, :] + b*m[j, :]
-        # and m[j, :] by c*m[i, :] + d*m[j, :]
-        for k in range(m.cols):
-            e = m[i, k]
-            m[i, k] = a*e + b*m[j, k]
-            m[j, k] = c*e + d*m[j, k]
-
-    def add_columns(m, i, j, a, b, c, d):
-        # replace m[:, i] by a*m[:, i] + b*m[:, j]
-        # and m[:, j] by c*m[:, i] + d*m[:, j]
-        for k in range(m.rows):
-            e = m[k, i]
-            m[k, i] = a*e + b*m[k, j]
-            m[k, j] = c*e + d*m[k, j]
-
-    def clear_column(m):
-        # make m[1:, 0] zero by row and column operations
-        if m[0,0] == 0:
-            return m
-        pivot = m[0, 0]
-        for j in range(1, m.rows):
-            if m[j, 0] == 0:
-                continue
-            d, r = domain.div(m[j,0], pivot)
-            if r == 0:
-                add_rows(m, 0, j, 1, 0, -d, 1)
-            else:
-                a, b, g = domain.gcdex(pivot, m[j,0])
-                d_0 = domain.div(m[j, 0], g)[0]
-                d_j = domain.div(pivot, g)[0]
-                add_rows(m, 0, j, a, b, d_0, -d_j)
-                pivot = g
-        return m
-
-    def clear_row(m):
-        # make m[0, 1:] zero by row and column operations
-        if m[0] == 0:
-            return m
-        pivot = m[0, 0]
-        for j in range(1, m.cols):
-            if m[0, j] == 0:
-                continue
-            d, r = domain.div(m[0, j], pivot)
-            if r == 0:
-                add_columns(m, 0, j, 1, 0, -d, 1)
-            else:
-                a, b, g = domain.gcdex(pivot, m[0, j])
-                d_0 = domain.div(m[0, j], g)[0]
-                d_j = domain.div(pivot, g)[0]
-                add_columns(m, 0, j, a, b, d_0, -d_j)
-                pivot = g
-        return m
-
-    # permute the rows and columns until m[0,0] is non-zero if possible
-    ind = [i for i in range(m.rows) if m[i,0] != 0]
-    if ind and ind[0] != 0:
-        m = m.permute_rows([[0, ind[0]]])
-    else:
-        ind = [j for j in range(m.cols) if m[0,j] != 0]
-        if ind and ind[0] != 0:
-            m = m.permute_cols([[0, ind[0]]])
-
-    # make the first row and column except m[0,0] zero
-    while (any([m[0,i] != 0 for i in range(1,m.cols)]) or
-           any([m[i,0] != 0 for i in range(1,m.rows)])):
-        m = clear_column(m)
-        m = clear_row(m)
-
-    if 1 in m.shape:
-        invs = ()
-    else:
-        invs = invariant_factors(m[1:,1:], domain=domain)
-
-    if m[0,0]:
-        result = [m[0,0]]
-        result.extend(invs)
-        # in case m[0] doesn't divide the invariants of the rest of the matrix
-        for i in range(len(result)-1):
-            if result[i] and domain.div(result[i+1], result[i])[1] != 0:
-                g = domain.gcd(result[i+1], result[i])
-                result[i+1] = domain.div(result[i], g)[0]*result[i+1]
-                result[i] = g
-            else:
-                break
-    else:
-        result = invs + (m[0,0],)
-    return tuple(result)
+    dM = _to_domain(m, domain)
+    factors = _invf(dM)
+    return tuple(dM.domain.to_sympy(f) for f in factors)

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -1,7 +1,9 @@
+from sympy.testing.pytest import warns_deprecated_sympy
+
 from sympy import Symbol, Poly
 from sympy.matrices import Matrix
 from sympy.matrices.normalforms import invariant_factors, smith_normal_form
-from sympy.polys.domains import QQ
+from sympy.polys.domains import ZZ, QQ
 
 
 def test_smith_normal():
@@ -18,4 +20,31 @@ def test_smith_normal():
 
     m = Matrix([[2, 4]])
     smf = Matrix([[2, 0]])
+    assert smith_normal_form(m) == smf
+
+
+def test_smith_normal_deprecated():
+    from sympy.polys.solvers import RawMatrix as Matrix
+
+    with warns_deprecated_sympy():
+        m = Matrix([[12, 6, 4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
+    setattr(m, 'ring', ZZ)
+    with warns_deprecated_sympy():
+        smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
+    assert smith_normal_form(m) == smf
+
+    x = Symbol('x')
+    with warns_deprecated_sympy():
+        m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
+                    [0, Poly(x), Poly(-1,x)],
+                    [Poly(0,x),Poly(-1,x),Poly(x)]])
+    setattr(m, 'ring', QQ[x])
+    invs = (Poly(1, x, domain='QQ'), Poly(x - 1, domain='QQ'), Poly(x**2 - 1, domain='QQ'))
+    assert invariant_factors(m) == invs
+
+    with warns_deprecated_sympy():
+        m = Matrix([[2, 4]])
+    setattr(m, 'ring', ZZ)
+    with warns_deprecated_sympy():
+        smf = Matrix([[2, 0]])
     assert smith_normal_form(m) == smf

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -1,11 +1,11 @@
 from sympy import Symbol, Poly
-from sympy.polys.solvers import RawMatrix as Matrix
+from sympy.matrices import Matrix
 from sympy.matrices.normalforms import invariant_factors, smith_normal_form
-from sympy.polys.domains import ZZ, QQ
+from sympy.polys.domains import QQ
+
 
 def test_smith_normal():
-    m = Matrix([[12, 6, 4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
-    setattr(m, 'ring', ZZ)
+    m = Matrix([[12,6,4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
     smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
     assert smith_normal_form(m) == smf
 
@@ -13,11 +13,9 @@ def test_smith_normal():
     m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
                 [0, Poly(x), Poly(-1,x)],
                 [Poly(0,x),Poly(-1,x),Poly(x)]])
-    setattr(m, 'ring', QQ[x])
-    invs = (Poly(1, x, domain='QQ'), Poly(x - 1, domain='QQ'), Poly(x**2 - 1, domain='QQ'))
-    assert invariant_factors(m) == invs
+    invs = 1, x - 1, x**2 - 1
+    assert invariant_factors(m, domain=QQ[x]) == invs
 
     m = Matrix([[2, 4]])
-    setattr(m, 'ring', ZZ)
     smf = Matrix([[2, 0]])
     assert smith_normal_form(m) == smf

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1240,7 +1240,7 @@ class DomainMatrix:
         >>> from sympy.polys.matrices import DomainMatrix
         >>> from sympy import ZZ
         >>> DomainMatrix.diag([ZZ(5), ZZ(6)], ZZ)
-        DomainMatrix({0: {0: 6}, 1: {1: 6}}, (3, 3), ZZ)
+        DomainMatrix({0: {0: 5}, 1: {1: 6}}, (2, 2), ZZ)
 
         """
         if shape is None:

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1230,6 +1230,25 @@ class DomainMatrix:
         return cls.from_rep(SDM.eye(n, domain))
 
     @classmethod
+    def diag(cls, diagonal, domain, shape=None):
+        r"""
+        Return diagonal matrix with entries from ``diagonal``.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy import ZZ
+        >>> DomainMatrix.diag([ZZ(5), ZZ(6)], ZZ)
+        DomainMatrix({0: {0: 6}, 1: {1: 6}}, (3, 3), ZZ)
+
+        """
+        if shape is None:
+            N = len(diagonal)
+            shape = (N, N)
+        return cls.from_rep(SDM.diag(diagonal, domain, shape))
+
+    @classmethod
     def zeros(cls, shape, domain, *, fmt='sparse'):
         """Returns a zero DomainMatrix of size shape, belonging to the specified domain
 

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -1,0 +1,141 @@
+'''Functions returning normal forms of matrices'''
+
+from .domainmatrix import DomainMatrix
+
+
+def smith_normal_form(m):
+    '''
+    Return the Smith Normal Form of a matrix `m` over the ring `domain`.
+    This will only work if the ring is a principal ideal domain.
+
+    Examples
+    ========
+
+    >>> from sympy import ZZ
+    >>> from sympy.polys.matrices import DomainMatrix
+    >>> from sympy.polys.matrices.normalforms import smith_normal_form
+    >>> m = DomainMatrix([[ZZ(12), ZZ(6), ZZ(4)],
+    ...                   [ZZ(3), ZZ(9), ZZ(6)],
+    ...                   [ZZ(2), ZZ(16), ZZ(14)]], (3, 3), ZZ)
+    >>> print(smith_normal_form(m).to_Matrix())
+    Matrix([[1, 0, 0], [0, 10, 0], [0, 0, -30]])
+
+    '''
+    invs = invariant_factors(m)
+    smf = DomainMatrix.diag(invs, m.domain, m.shape)
+    return smf
+
+
+def invariant_factors(m):
+    '''
+    Return the tuple of abelian invariants for a matrix `m`
+    (as in the Smith-Normal form)
+
+    References
+    ==========
+
+    [1] https://en.wikipedia.org/wiki/Smith_normal_form#Algorithm
+    [2] http://sierra.nmsu.edu/morandi/notes/SmithNormalForm.pdf
+
+    '''
+    domain = m.domain
+    if not domain.is_PID:
+        msg = "The matrix entries must be over a principal ideal domain"
+        raise ValueError(msg)
+
+    if 0 in m.shape:
+        return ()
+
+    rows, cols = shape = m.shape
+    m = list(m.to_dense().rep)
+
+    def add_rows(m, i, j, a, b, c, d):
+        # replace m[i, :] by a*m[i, :] + b*m[j, :]
+        # and m[j, :] by c*m[i, :] + d*m[j, :]
+        for k in range(cols):
+            e = m[i][k]
+            m[i][k] = a*e + b*m[j][k]
+            m[j][k] = c*e + d*m[j][k]
+
+    def add_columns(m, i, j, a, b, c, d):
+        # replace m[:, i] by a*m[:, i] + b*m[:, j]
+        # and m[:, j] by c*m[:, i] + d*m[:, j]
+        for k in range(rows):
+            e = m[k][i]
+            m[k][i] = a*e + b*m[k][j]
+            m[k][j] = c*e + d*m[k][j]
+
+    def clear_column(m):
+        # make m[1:, 0] zero by row and column operations
+        if m[0][0] == 0:
+            return m  # pragma: nocover
+        pivot = m[0][0]
+        for j in range(1, rows):
+            if m[j][0] == 0:
+                continue
+            d, r = domain.div(m[j][0], pivot)
+            if r == 0:
+                add_rows(m, 0, j, 1, 0, -d, 1)
+            else:
+                a, b, g = domain.gcdex(pivot, m[j][0])
+                d_0 = domain.div(m[j][0], g)[0]
+                d_j = domain.div(pivot, g)[0]
+                add_rows(m, 0, j, a, b, d_0, -d_j)
+                pivot = g
+        return m
+
+    def clear_row(m):
+        # make m[0, 1:] zero by row and column operations
+        if m[0][0] == 0:
+            return m  # pragma: nocover
+        pivot = m[0][0]
+        for j in range(1, cols):
+            if m[0][j] == 0:
+                continue
+            d, r = domain.div(m[0][j], pivot)
+            if r == 0:
+                add_columns(m, 0, j, 1, 0, -d, 1)
+            else:
+                a, b, g = domain.gcdex(pivot, m[0][j])
+                d_0 = domain.div(m[0][j], g)[0]
+                d_j = domain.div(pivot, g)[0]
+                add_columns(m, 0, j, a, b, d_0, -d_j)
+                pivot = g
+        return m
+
+    # permute the rows and columns until m[0,0] is non-zero if possible
+    ind = [i for i in range(rows) if m[i][0] != 0]
+    if ind and ind[0] != 0:
+        m[0], m[ind[0]] = m[ind[0]], m[0]
+    else:
+        ind = [j for j in range(cols) if m[0][j] != 0]
+        if ind and ind[0] != 0:
+            for row in m:
+                row[0], row[ind[0]] = row[ind[0]], row[0]
+
+    # make the first row and column except m[0,0] zero
+    while (any([m[0][i] != 0 for i in range(1,cols)]) or
+           any([m[i][0] != 0 for i in range(1,rows)])):
+        m = clear_column(m)
+        m = clear_row(m)
+
+    if 1 in shape:
+        invs = ()
+    else:
+        lower_right = DomainMatrix([r[1:] for r in m[1:]], (rows-1, cols-1), domain)
+        invs = invariant_factors(lower_right)
+
+    if m[0][0]:
+        result = [m[0][0]]
+        result.extend(invs)
+        # in case m[0] doesn't divide the invariants of the rest of the matrix
+        for i in range(len(result)-1):
+            if result[i] and domain.div(result[i+1], result[i])[1] != 0:
+                g = domain.gcd(result[i+1], result[i])
+                result[i+1] = domain.div(result[i], g)[0]*result[i+1]
+                result[i] = g
+            else:
+                break
+    else:
+        result = invs + (m[0][0],)
+    return tuple(result)

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -125,6 +125,11 @@ class SDM(dict):
         sdm = {i: {i: one} for i in range(size)}
         return cls(sdm, (size, size), domain)
 
+    @classmethod
+    def diag(cls, diagonal, domain, shape):
+        sdm = {i: {i: v} for i, v in enumerate(diagonal) if v}
+        return cls(sdm, shape, domain)
+
     def transpose(M):
         MT = sdm_transpose(M)
         return M.new(MT, M.shape[::-1], M.domain)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -85,12 +85,19 @@ def test_DomainMatrix_from_list_sympy():
     assert A.shape == (2, 2)
     assert A.domain == K
 
+
 def test_DomainMatrix_from_dict_sympy():
     sdm = SDM({0: {0: QQ(1, 2)}, 1: {1: QQ(2, 3)}}, (2, 2), QQ)
-    A = DomainMatrix.from_dict_sympy(2, 2, {0: {0: QQ(1, 2)}, 1: {1: QQ(2, 3)}})
+    sympy_dict = {0: {0: Rational(1, 2)}, 1: {1: Rational(2, 3)}}
+    A = DomainMatrix.from_dict_sympy(2, 2, sympy_dict)
     assert A.rep == sdm
     assert A.shape == (2, 2)
     assert A.domain == QQ
+
+    fds = DomainMatrix.from_dict_sympy
+    raises(DDMBadInputError, lambda: fds(2, 2, {3: {0: Rational(1, 2)}}))
+    raises(DDMBadInputError, lambda: fds(2, 2, {0: {3: Rational(1, 2)}}))
+
 
 def test_DomainMatrix_from_Matrix():
     sdm = SDM({0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(4)}}, (2, 2), ZZ)
@@ -119,6 +126,7 @@ def test_DomainMatrix_from_Matrix():
     assert A.rep == ddm
     assert A.shape == (2, 2)
     assert A.domain == QQ
+
 
 def test_DomainMatrix_eq():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
@@ -545,11 +553,20 @@ def test_DomainMatrix_zeros():
     assert A.shape == (1, 2)
     assert A.domain == QQ
 
+
 def test_DomainMatrix_ones():
     A = DomainMatrix.ones((2, 3), QQ)
     assert A.rep == DDM.ones((2, 3), QQ)
     assert A.shape == (2, 3)
     assert A.domain == QQ
+
+
+def test_DomainMatrix_diag():
+    A = DomainMatrix({0:{0:ZZ(2)}, 1:{1:ZZ(3)}}, (2, 2), ZZ)
+    assert DomainMatrix.diag([ZZ(2), ZZ(3)], ZZ) == A
+
+    A = DomainMatrix({0:{0:ZZ(2)}, 1:{1:ZZ(3)}}, (3, 4), ZZ)
+    assert DomainMatrix.diag([ZZ(2), ZZ(3)], ZZ, (3, 4)) == A
 
 
 def test_DomainMatrix_hstack():

--- a/sympy/polys/matrices/tests/test_linsolve.py
+++ b/sympy/polys/matrices/tests/test_linsolve.py
@@ -4,13 +4,26 @@
 #    Test the internal implementation of linsolve.
 #
 
+from sympy.testing.pytest import raises
 
-from sympy import S
-from sympy.abc import x
+from sympy import S, Eq, I
+from sympy.abc import x, y
 
 from sympy.polys.matrices.linsolve import _linsolve
+from sympy.polys.solvers import PolyNonlinearError
 
 
 def test__linsolve():
     assert _linsolve([], [x]) == {x:x}
     assert _linsolve([S.Zero], [x]) == {x:x}
+    assert _linsolve([x-1,x-2], [x]) is None
+    assert _linsolve([x-1], [x]) == {x:1}
+    assert _linsolve([x-1, y], [x, y]) == {x:1, y:S.Zero}
+    assert _linsolve([2*I], [x]) is None
+    raises(PolyNonlinearError, lambda: _linsolve([x*(1 + x)], [x]))
+
+
+def test__linsolve_deprecated():
+    assert _linsolve([Eq(x**2, x**2+y)], [x, y]) == {x:x, y:S.Zero}
+    assert _linsolve([(x+y)**2-x**2], [x]) == {x:-y/2}
+    assert _linsolve([Eq((x+y)**2, x**2)], [x]) == {x:-y/2}

--- a/sympy/polys/matrices/tests/test_normalforms.py
+++ b/sympy/polys/matrices/tests/test_normalforms.py
@@ -1,0 +1,40 @@
+from sympy.testing.pytest import raises
+
+from sympy import Symbol, sympify
+from sympy.polys.matrices.normalforms import invariant_factors, smith_normal_form
+from sympy.polys.domains import ZZ, QQ
+from sympy.polys.matrices import DomainMatrix
+
+
+def test_smith_normal():
+
+    def DM(elems, domain):
+        conv = lambda e: domain.from_sympy(sympify(e))
+        elems = [[conv(e) for e in row] for row in elems]
+        return DomainMatrix(elems, (len(elems), len(elems[0])), domain)
+
+    m = DM([[12, 6, 4, 8], [3, 9, 6, 12], [2, 16, 14, 28], [20, 10, 10, 20]], ZZ)
+    smf = DM([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]], ZZ)
+    assert smith_normal_form(m).to_dense() == smf
+
+    x = Symbol('x')
+    m = DM([[x-1,  1, -1],
+            [  0,  x, -1],
+            [  0, -1,  x]], QQ[x])
+    dx = m.domain.gens[0]
+    assert invariant_factors(m) == (1, dx-1, dx**2-1)
+
+    zr = DomainMatrix([], (0, 2), ZZ)
+    zc = DomainMatrix([[], []], (2, 0), ZZ)
+    assert smith_normal_form(zr).to_dense() == zr
+    assert smith_normal_form(zc).to_dense() == zc
+
+    assert smith_normal_form(DM([[2, 4]], ZZ)).to_dense() == DM([[2, 0]], ZZ)
+    assert smith_normal_form(DM([[0, -2]], ZZ)).to_dense() == DM([[-2, 0]], ZZ)
+    assert smith_normal_form(DM([[0], [-2]], ZZ)).to_dense() == DM([[-2], [0]], ZZ)
+
+    m =   DM([[3, 0, 0, 0], [0, 0, 0, 0], [0, 0, 2, 0]], ZZ)
+    snf = DM([[1, 0, 0, 0], [0, 6, 0, 0], [0, 0, 0, 0]], ZZ)
+    assert smith_normal_form(m).to_dense() == snf
+
+    raises(ValueError, lambda: smith_normal_form(DM([[1]], ZZ[x])))

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -146,6 +146,10 @@ def test_SDM_matmul():
     #raises(DDMShapeError, lambda: A23 @ A22)
     raises(DDMShapeError, lambda: A23.matmul(A22))
 
+    A = SDM({0: {0: ZZ(-1), 1: ZZ(1)}}, (1, 2), ZZ)
+    B = SDM({0: {0: ZZ(-1)}, 1: {0: ZZ(-1)}}, (2, 1), ZZ)
+    assert A.matmul(B) == SDM({}, (1, 1), ZZ)
+
 
 def test_SDM_add():
     A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
@@ -264,3 +268,9 @@ def test_SDM_rref():
             {0: {0: QQ(1,1)}, 1: {1: QQ(1,1), 2: QQ(1,1)}},
             (2, 3), QQ)
     assert A.rref() == (Arref, [0, 1])
+
+
+def test_SDM_particular():
+    A = SDM({0:{1:QQ(1)}}, (2, 2), QQ)
+    Apart = SDM({0:{1:QQ(1)}}, (1, 2), QQ)
+    assert A.particular() == Apart

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -3,7 +3,6 @@
 
 from sympy.utilities.iterables import connected_components
 
-from sympy.matrices import MutableDenseMatrix
 from sympy.polys.domains import EX
 from sympy.polys.rings import sring
 from sympy.polys.polyerrors import NotInvertible
@@ -13,10 +12,6 @@ from sympy.polys.domainmatrix import DomainMatrix
 class PolyNonlinearError(Exception):
     """Raised by solve_lin_sys for nonlinear equations"""
     pass
-
-
-class RawMatrix(MutableDenseMatrix):
-    _sympify = staticmethod(lambda x: x)
 
 
 def eqs_to_matrix(eqs_coeffs, eqs_rhs, gens, domain):

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -46,7 +46,7 @@ class RawMatrix(MutableDenseMatrix):
                     val_sympy = val.as_expr()
                 elif hasattr(val, 'parent'):
                     K = val.parent()
-                    val_sympy = other_domain.to_sympy(val)
+                    val_sympy = K.to_sympy(val)
                 elif isinstance(val, int):
                     K = ZZ
                     val_sympy = sympify(val)

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -1,7 +1,12 @@
 """Low-level linear systems solver. """
 
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import connected_components
+
+from sympy.core.sympify import sympify
+from sympy.matrices.dense import MutableDenseMatrix
+from sympy.polys.domains import ZZ, QQ
 
 from sympy.polys.domains import EX
 from sympy.polys.rings import sring
@@ -12,6 +17,49 @@ from sympy.polys.domainmatrix import DomainMatrix
 class PolyNonlinearError(Exception):
     """Raised by solve_lin_sys for nonlinear equations"""
     pass
+
+
+class RawMatrix(MutableDenseMatrix):
+    """
+    XXX: This class is broken by design. Use DomainMatrix if you want a matrix
+    over the polys domains or Matrix for a matrix with Expr elements. The
+    RawMatrix class will be removed/broken in future in order to reestablish
+    the invariant that the elements of a Matrix should be of type Expr.
+    """
+    _sympify = staticmethod(lambda x: x)
+
+    def __init__(self, *args, **kwargs):
+
+        SymPyDeprecationWarning(
+            feature="RawMatrix class",
+            useinstead="DomainMatrix or Matrix",
+            issue=21405,
+            deprecated_since_version="1.9"
+        ).warn()
+
+        domain = ZZ
+        for i in range(self.rows):
+            for j in range(self.cols):
+                val = self[i,j]
+                if getattr(val, 'is_Poly', False):
+                    K = val.domain[val.gens]
+                    val_sympy = val.as_expr()
+                elif hasattr(val, 'parent'):
+                    K = val.parent()
+                    val_sympy = other_domain.to_sympy(val)
+                elif isinstance(val, int):
+                    K = ZZ
+                    val_sympy = sympify(val)
+                else:
+                    for K in ZZ, QQ:
+                        if K.of_type(val):
+                            val_sympy = K.to_sympy(val)
+                            break
+                    else:
+                        raise TypeError
+                domain = domain.unify(K)
+                self[i,j] = val_sympy
+        self.ring = domain
 
 
 def eqs_to_matrix(eqs_coeffs, eqs_rhs, gens, domain):


### PR DESCRIPTION
This commit moves the Smith Normal Code routine from Matrix to
DomainMatrix and replaces the original function with one that can
convert to DomainMatrix for the calculation.

The SNF code was the last place in the codebase that used RawMatrix so
the RawMatrix class is also removed. The RawMatrix class was a bad idea
because it subclasses Matrix in order to insert non-Expr elements
breaking a key internal invariant of the Matrix class. The removal of
RawMatrix is a step towards being able to enforce that the elements of a
Matrix should always be Expr.

This also adds tests to improve coverage in sympy.polys.matrices.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * The `smith_normal_form` function now expects in ordinary `Matrix` as input rather than a `RawMatrix`
* polys
    * The `RawMatrix` class has been removed. Use `Matrix`, `DomainMatrix` or `PolyMatrix` instead depending on the application.
<!-- END RELEASE NOTES -->
