### PR TITLE
Validate assumptions passed to Symbol

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2284,6 +2284,9 @@ def test_check_old_assumption():
     assert ask(Q.irrational(x)) is True
     assert ask(Q.rational(x)) is False
 
+    with raises(ValueError):
+        symbols('x', foo=True)
+
 
 def test_issue_9636():
     assert ask(Q.integer(1.0)) is False

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -227,8 +227,19 @@ class Symbol(AtomicExpr, Boolean):
         return True
 
     @staticmethod
+    def _validate_assumptions(assumptions):
+        """Validate assumption strings.
+        """
+        valid_assumptions = set(_assume_defined)
+        diff = set(assumptions) - valid_assumptions
+        if diff:
+            raise ValueError(
+                "invalid assumptions: %s " % ", ".join(diff) +
+                "(allowed: %s)" % ", ".join(valid_assumptions))
+
+    @staticmethod
     def _sanitize(assumptions, obj=None):
-        """Remove None, covert values to bool, check commutativity *in place*.
+        """Validate names, remove None, convert to bool, check commutativity *in place*.
         """
 
         # be strict about commutativity: cannot be None
@@ -268,6 +279,7 @@ class Symbol(AtomicExpr, Boolean):
         False
 
         """
+        cls._validate_assumptions(assumptions)
         cls._sanitize(assumptions, cls)
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 
@@ -404,6 +416,7 @@ class Dummy(Symbol):
             dummy_index = Dummy._base_dummy_index + Dummy._count
             Dummy._count += 1
 
+        cls._validate_assumptions(assumptions)
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)
 
@@ -519,6 +532,7 @@ class Wild(Symbol):
     def __new__(cls, name, exclude=(), properties=(), **assumptions):
         exclude = tuple([sympify(x) for x in exclude])
         properties = tuple(properties)
+        cls._validate_assumptions(assumptions)
         cls._sanitize(assumptions, cls)
         return Wild.__xnew__(cls, name, exclude, properties, **assumptions)
 


### PR DESCRIPTION
#### References to other Issues or PRs

This partially fixes #21416 (only the validation part, not the documentation issue).

#### Brief description of what is fixed or changed

`Symbol` now validates the assumptions passed to it and produces a nice error message when invalid assumptions are passed to the constructor. `ValueError` is raised in that case.

```sh
python -c 'from sympy import symbols; symbols("x", is_real=True)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/hdembinski/Extern/sympy/sympy/core/symbol.py", line 724, in symbols
    symbol = cls(literal(name), **args)
  File "/Users/hdembinski/Extern/sympy/sympy/core/symbol.py", line 282, in __new__
    cls._validate_assumptions(assumptions)
  File "/Users/hdembinski/Extern/sympy/sympy/core/symbol.py", line 236, in _validate_assumptions
    raise ValueError(
ValueError: invalid assumptions: is_real (allowed: real, extended_nonpositive, finite, imaginary, zero, extended_nonnegative, noninteger, extended_nonzero, nonnegative, rational, polar, infinite, extended_negative, commutative, negative, antihermitian, positive, prime, integer, algebraic, extended_real, transcendental, irrational, extended_positive, composite, hermitian, nonzero, complex, nonpositive, even, odd)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

<!-- BEGIN RELEASE NOTES -->

* core
  * Symbol now validates the assumptions and raises a ValueError on invalid assumptions.

<!-- END RELEASE NOTES -->
