### PR TITLE
feat(assump) : modify ClassFactRegistry so that facts and handlers can be viewed

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -109,11 +109,13 @@ class ClassFactRegistry:
     ===========
 
     ``register`` method registers the handler function for a class. Here,
-    handler function should return a single fact. ``multiregister`` method
-    registers the handler function for multiple classes. Here, handler function
-    should return a container of multiple facts.
+    handler function should return a single fact.
 
-    ``registry(expr)`` returns a set of facts for *expr*.
+    ``multiregister`` method registers the handler function for multiple
+    classes. Here, handler function should return a container of multiple facts.
+
+    ``registry(expr)`` returns a dictionary of computed facts and their handler
+    functions for *expr*.
 
     Examples
     ========
@@ -132,12 +134,13 @@ class ClassFactRegistry:
     ...     arg = expr.args[0]
     ...     return Equivalent(~Q.zero(arg), ~Q.zero(expr))
 
-    Calling the registry with expression returns the defined facts for the
-    expression.
+    Calling the registry with expression returns a dictionary of computed
+    facts and their handler functions for the expression.
 
     >>> from sympy.abc import x
-    >>> reg(Abs(x))
-    {Q.nonnegative(Abs(x)), Equivalent(~Q.zero(x), ~Q.zero(Abs(x)))}
+    >>> reg(Abs(x)) # doctest: +SKIP
+    {Q.nonnegative(Abs(x)): <function __main__.f1(expr)>,
+     Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function __main__.f2(expr)>}
 
     Multiple facts can be registered at once by ``multiregister`` method.
 
@@ -181,14 +184,17 @@ class ClassFactRegistry:
         return ret1, ret2
 
     def __call__(self, expr):
-        ret = set()
+        ret = {}
 
         handlers1, handlers2 = self[expr.func]
 
         for h in handlers1:
-            ret.add(h(expr))
+            fact = h(expr)
+            ret[fact] = h
         for h in handlers2:
-            ret.update(h(expr))
+            facts = h(expr)
+            for fact in facts:
+                ret[fact] = h
         return ret
 
 class_fact_registry = ClassFactRegistry()

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -109,11 +109,15 @@ class ClassFactRegistry(MutableMapping):
     Explanation
     ===========
 
-    ``register`` method registers the handler function for a class. Here,
+    ``register()`` method registers the handler function for a class. Here,
     handler function should return a single fact.
 
-    ``registry(expr)`` returns a dictionary of computed facts and their handler
-    functions for *expr*.
+    ``registry(expr)`` method returns a dictionary of computed facts and their
+    handler functions for *expr*.
+
+    ``remove_handler()`` method removes a handler function from every class.
+    This can be useful when you want to extract a compact registry from the
+    pre-built one.
 
     Examples
     ========
@@ -139,6 +143,13 @@ class ClassFactRegistry(MutableMapping):
     >>> reg(Abs(x)) # doctest: +SKIP
     {Q.nonnegative(Abs(x)): <function __main__.f1(expr)>,
      Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function __main__.f2(expr)>}
+
+    You can remove unnecessary handler with ``remove_handler()`` method.
+
+    >>> h = reg(Abs(x))[Q.nonnegative(Abs(x))]
+    >>> reg.remove_handler(h)
+    >>> reg(Abs(x)) # doctest: +SKIP
+    {Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function __main__.f2(expr)>}
 
     """
     def __init__(self, d=None):
@@ -177,6 +188,12 @@ class ClassFactRegistry(MutableMapping):
     def __call__(self, expr):
         handlers = self[expr.func]
         return {h(expr): h for h in handlers}
+
+    def remove_handler(self, handler):
+        for key in self.d.keys():
+            old_handlers = self.d[key]
+            new_handlers = old_handlers - {handler}
+            self.d[key] = new_handlers
 
 class_fact_registry = ClassFactRegistry()
 

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -13,13 +13,15 @@ def test_class_handler_registry():
     @my_handler_registry.register(Mul)
     def fact1(expr):
         pass
-    @my_handler_registry.multiregister(Expr)
+    @my_handler_registry.register(Expr)
     def fact2(expr):
         pass
 
-    assert my_handler_registry[Basic] == (frozenset(), frozenset())
-    assert my_handler_registry[Expr] == (frozenset(), frozenset({fact2}))
-    assert my_handler_registry[Mul] == (frozenset({fact1}), frozenset({fact2}))
+    assert my_handler_registry[Basic] == frozenset()
+    assert my_handler_registry[Expr] == frozenset({fact2})
+    assert my_handler_registry[Mul] == frozenset({fact1, fact2})
+
+    assert my_handler_registry(x*y) == {None: fact1}
 
 
 def test_allargs():

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -9,19 +9,18 @@ x, y, z = symbols('x y z')
 def test_class_handler_registry():
     my_handler_registry = ClassFactRegistry()
 
-    # The predicate doesn't matter here, so just pass
     @my_handler_registry.register(Mul)
     def fact1(expr):
-        pass
+        return Q.negative(expr)
     @my_handler_registry.register(Expr)
     def fact2(expr):
-        pass
+        return Q.positive(expr)
 
     assert my_handler_registry[Basic] == frozenset()
     assert my_handler_registry[Expr] == frozenset({fact2})
     assert my_handler_registry[Mul] == frozenset({fact1, fact2})
 
-    assert my_handler_registry(x*y) == {None: fact1}
+    assert my_handler_registry(x*y) == {Q.positive(x*y): fact2, Q.negative(x*y): fact1}
 
 
 def test_allargs():

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -22,6 +22,9 @@ def test_class_handler_registry():
 
     assert my_handler_registry(x*y) == {Q.positive(x*y): fact2, Q.negative(x*y): fact1}
 
+    my_handler_registry.remove_handler(fact2)
+    assert my_handler_registry[Mul] == frozenset({fact1})
+
 
 def test_allargs():
     assert allargs(x, Q.zero(x), x*y) == And(Q.zero(x), Q.zero(y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is inspired by @asmeurer 's [comment](https://github.com/sympy/sympy/pull/21367#issuecomment-826044819).

Now, passing an expression to `ClassFactRegistry` instance returns a dictionary which contains the facts and their handlers.

```python
>>> from sympy.assumptions.sathandlers import class_fact_registry
>>> class_fact_registry(Abs(x))
{Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function sympy.assumptions.sathandlers.<lambda>(expr)>,
 Implies(Q.odd(x), Q.odd(Abs(x))): <function sympy.assumptions.sathandlers.<lambda>(expr)>,
 Q.nonnegative(Abs(x)): <function sympy.assumptions.sathandlers.<lambda>(expr)>,
 Implies(Q.even(x), Q.even(Abs(x))): <function sympy.assumptions.sathandlers.<lambda>(expr)>,
 Implies(Q.integer(x), Q.integer(Abs(x))): <function sympy.assumptions.sathandlers.<lambda>(expr)>}
```

With this, you can print and see the facts for specific expression, and pick the handlers which return unsatisfiable facts. Or you can extract the handlers you want and build more compact fact registry.

For example,
```python

    # Build the fact registry

    >>> from sympy import Abs, Q
    >>> from sympy.logic.boolalg import Equivalent
    >>> from sympy.assumptions.sathandlers import ClassFactRegistry
    >>> reg = ClassFactRegistry()
    >>> @reg.register(Abs)
    ... def f1(expr):
    ...     return Q.nonnegative(expr)
    >>> @reg.register(Abs)
    ... def f2(expr):
    ...     arg = expr.args[0]
    ...     return Equivalent(~Q.zero(arg), ~Q.zero(expr))

    # Check the facts

    >>> from sympy.abc import x
    >>> reg(Abs(x)) # doctest: +SKIP
    {Q.nonnegative(Abs(x)): <function __main__.f1(expr)>,
     Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function __main__.f2(expr)>}

    # Remove unnecessary fact

    >>> h = reg(Abs(x))[Q.nonnegative(Abs(x))]
    >>> reg.remove_handler(h)
    >>> reg(Abs(x)) # doctest: +SKIP
    {Equivalent(~Q.zero(x), ~Q.zero(Abs(x))): <function __main__.f2(expr)>}
```

I expect this feature to be very useful for implementing heuristic approach to evaluate complicated propositions.

`multiregister` method is removed since this change expects one-to-one relation between the handlers and the facts.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
