### PR TITLE
ExprWithLimits `(free|bound)_symbols` updated

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -318,12 +318,9 @@ class ExprWithLimits(Expr):
 
         A new dummy was not needed for variable z so the ``_0``
         was re-used.
-
-        >>> Integral(x, (x, y), (y, z), z).as_dummy()
-        Integral(_0, (_0, _1), (_1, _0), (_0, z))
         """
         reps = super().canonical_variables
-        if len(self.limits) <= 2:
+        if len(reps) <= 2:
             return reps
         _0 = reps[self.limits[0][0]]
         free = self.function.free_symbols

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -326,8 +326,9 @@ class ExprWithLimits(Expr):
         if len(self.limits) <= 2:
             return reps
         _0 = reps[self.limits[0][0]]
+        free = self.function.free_symbols
         for i, ui in enumerate(uniq(i[0] for i in self.limits)):
-            if i > 1:
+            if i > 1 and ui not in free:
                 reps[ui] = _0
         return reps
 

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -340,7 +340,7 @@ class ExprWithLimits(Expr):
         ========
 
         >>> from sympy import Integral, Function
-        >>> from sympy.abc import x, y, z
+        >>> from sympy.abc import x, y
         >>> eq = Integral(x, y)
         >>> eq.as_dummy()
         Integral(x, (_0, y))

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -292,15 +292,16 @@ class ExprWithLimits(Expr):
         function, limits = self.function, self.limits
         isyms = function.free_symbols
         for xab in limits:
+            free0 = xab[0].free_symbols
             if len(xab) == 1:
-                isyms.add(xab[0])
-                continue
-            # take out the target symbol
-            if xab[0] in isyms:
-                isyms.remove(xab[0])
-            # add in the new symbols
-            for i in xab[1:]:
-                isyms.update(i.free_symbols)
+                # these are all free
+                isyms.update(free0)
+            else:
+                # take out the target symbol
+                isyms -= free0
+                # add in the new symbols
+                for i in xab[1:]:
+                    isyms.update(i.free_symbols)
         return isyms
 
     @property

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -323,7 +323,6 @@ class ExprWithLimits(Expr):
         if len(reps) <= 2:
             return reps
         _0 = reps[self.limits[0][0]]
-        free = self.function.free_symbols
         for i, ui in enumerate(uniq(i[0] for i in self.limits)):
             if i > 1 and ui in reps:
                 reps[ui] = _0

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -252,7 +252,7 @@ class ExprWithLimits(Expr):
         >>> from sympy import Integral, Function
         >>> from sympy.abc import x, i, j, k
         >>> Integral(x**i, (i, 1, 3), (j, 2), k).bound_symbols
-        [i, j]
+        [i, j, k]
         >>> f = Function('f')
         >>> Integral(x, (f(x), i)).bound_symbols
         [f(x), x]
@@ -266,10 +266,9 @@ class ExprWithLimits(Expr):
         """
         rv = []
         for l in self.limits:
-            if len(l) != 1:
-                rv.append(l[0])
-                if not l[0].is_Symbol:
-                    rv.extend(ordered(l[0].free_symbols))
+            rv.append(l[0])
+            if not l[0].is_Symbol:
+                rv.extend(ordered(l[0].free_symbols))
         return list(uniq(rv))
 
     @property
@@ -303,6 +302,15 @@ class ExprWithLimits(Expr):
                 for i in xab[1:]:
                     isyms.update(i.free_symbols)
         return isyms
+
+    def as_dummy(self):
+        from sympy.core.basic import Basic
+        self2 = self.func(*([self.function] + [
+            i if len(i) > 1 else i*2 for i in self.limits]))
+        rv = Basic.as_dummy(self2)
+        if rv == self2:
+             rv = self
+        return rv
 
     @property
     def is_number(self):

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -325,7 +325,7 @@ class ExprWithLimits(Expr):
         _0 = reps[self.limits[0][0]]
         free = self.function.free_symbols
         for i, ui in enumerate(uniq(i[0] for i in self.limits)):
-            if i > 1 and ui not in free:
+            if i > 1 and ui in reps:
                 reps[ui] = _0
         return reps
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -582,9 +582,8 @@ class Basic(Printable, metaclass=ManagedProperties):
         names = {i.name for i in self.free_symbols - set(bound)}
         for b in bound:
             d = next(dums)
-            if b.is_Symbol:
-                while d.name in names:
-                    d = next(dums)
+            while d.name in names:
+                d = next(dums)
             reps[b] = d
         return reps
 

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -327,6 +327,25 @@ def test_as_dummy():
         _0, (_0, x), (_1, _0), _0, (_0, z, y)), I1.as_dummy()
     assert Integral(x, y, y, x).as_dummy(
         ) == Integral(_1, _0, (_0, y), (_1, x))
+    assert Integral(x, y, z, (x, x)).as_dummy(
+        ) == Integral(_2, (_0, y), (_1, z), (_2, x))
+    v = symbols('a:d')
+
+
+def test_stress():
+    from sympy.utilities.iterables import subsets
+    lim = list(subsets(v,repetition=True))
+    for i in subsets(v, repetition=True):
+     if not i:continue
+     i = Add(*i)
+     for j in subsets(lim, repetition=True):
+      j = [k for k in j if k]
+      if not j:continue
+      I = Integral(i,*j)
+      try:assert I.doit() == I.as_dummy().doit()
+      except:
+       a,b,c=(I,I.doit(),I.as_dummy())
+       assert None, a
 
 
 def test_canonical_variables():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -332,6 +332,7 @@ def test_as_dummy():
 
 
 def test_stress():
+    from sympy import Add
     from sympy.utilities.iterables import subsets
     v = symbols('a:d')
     lim = list(subsets(v,repetition=True))

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -325,6 +325,8 @@ def test_as_dummy():
         x, x, (y, z), (z, z), (z, z, y))
     assert I1.as_dummy() == Integral(
         _0, (_0, x), (_1, _0), _0, (_0, z, y)), I1.as_dummy()
+    assert Integral(x, y, y, x).as_dummy(
+        ) == Integral(_1, _0, (_0, y), (_1, x))
 
 
 def test_canonical_variables():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -299,6 +299,12 @@ def test_as_dummy():
         assert D != d and D.func == Dummy and D.is_real is None
     assert Dummy().as_dummy().is_commutative
     assert Dummy(commutative=False).as_dummy().is_commutative is False
+    f = Function('f')
+    assert Integral(1, f(x)).free_symbols == {x}
+    assert Integral(x + f(x), (f(x), 0, f(x))).as_dummy() == Integral(
+        _0 + _1, (_0, 0, f(x)))
+    assert Integral(_0 + f(x), (f(x), 0, f(x))).as_dummy() == Integral(
+        _0 + _1, (_1, 0, f(x)))
 
 
 def test_canonical_variables():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -303,10 +303,12 @@ def test_as_dummy():
 
 def test_canonical_variables():
     x, i0, i1 = symbols('x _:2')
+    f = Function('f')
     assert Integral(x, (x, x + 1)).canonical_variables == {x: i0}
     assert Integral(x, (x, x + 1), (i0, 1, 2)).canonical_variables == {
         x: i0, i0: i1}
     assert Integral(x, (x, x + i0)).canonical_variables == {x: i1}
+    assert Integral(x, (f(x), 0, 1)).canonical_variables == {f(x): i0, x: i1}
 
 
 def test_replace_exceptions():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -282,7 +282,7 @@ def test_atomic():
 
 
 def test_as_dummy():
-    u, v, x, y, z, _0, _1 = symbols('u v x y z _0 _1')
+    u, v, x, y, z, _0, _1, _2 = symbols('u v x y z _0 _1 _2')
     assert Lambda(x, x + 1).as_dummy() == Lambda(_0, _0 + 1)
     assert Lambda(x, x + _0).as_dummy() == Lambda(_1, _0 + _1)
     eq = (1 + Sum(x, (x, 1, x)))
@@ -308,6 +308,24 @@ def test_as_dummy():
     # need to use explicit form of evaluate-at integral
     assert Integral(f(x) + x, f(x)).as_dummy() == Integral(
         _0 + _1, (_0, f(x)))
+    assert Integral(x, y, z).as_dummy(
+        )  == Integral(x, (_0, y), (_1, z))
+    # if a.doit() == b.doit() then a.as_dummy() == b.as_dummy()
+    # and a.as_dummy().doit() == a.doit()
+    I1 = Integral(x, (x, y), (y, x), (x, y))
+    I2 = Integral(x, (x, y), (y, z), (z, y))
+    assert I1.as_dummy() == I2.as_dummy() and I1.doit() == I2.doit()
+    assert I1.as_dummy().doit() == I2.as_dummy().doit() == I1.doit()
+    I1 = Integral(x, (x, y + 1), (y, z - 1), (z, x))
+    assert I1.as_dummy(
+        ) == Integral(_0, (_0, _1 + 1), (_1, _0 - 1), (_0, x))
+    I1 = Integral(x, x, (y, z), (z, z, v))
+    assert I1.doit() == I1.as_dummy().doit()
+    I1 = Integral(
+        x, x, (y, z), (z, z), (z, z, y))
+    assert I1.as_dummy() == Integral(
+        _0, (_0, x), (_1, _0), _0, (_0, z, y)), I1.as_dummy()
+
 
 def test_canonical_variables():
     x, i0, i1 = symbols('x _:2')

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -344,7 +344,7 @@ def test_stress():
       if not j:continue
       I = Integral(i,*j)
       if I.doit() != I.as_dummy().doit():
-       assert None, (I, I.doit())
+       assert None, (I, I.as_dummy())
 
 
 def test_canonical_variables():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -305,7 +305,9 @@ def test_as_dummy():
         _0 + _1, (_0, 0, f(x)))
     assert Integral(_0 + f(x), (f(x), 0, f(x))).as_dummy() == Integral(
         _0 + _1, (_1, 0, f(x)))
-
+    # need to use explicit form of evaluate-at integral
+    assert Integral(f(x) + x, f(x)).as_dummy() == Integral(
+        _0 + _1, (_0, f(x)))
 
 def test_canonical_variables():
     x, i0, i1 = symbols('x _:2')

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -329,11 +329,11 @@ def test_as_dummy():
         ) == Integral(_1, _0, (_0, y), (_1, x))
     assert Integral(x, y, z, (x, x)).as_dummy(
         ) == Integral(_2, (_0, y), (_1, z), (_2, x))
-    v = symbols('a:d')
 
 
 def test_stress():
     from sympy.utilities.iterables import subsets
+    v = symbols('a:d')
     lim = list(subsets(v,repetition=True))
     for i in subsets(v, repetition=True):
      if not i:continue
@@ -342,10 +342,8 @@ def test_stress():
       j = [k for k in j if k]
       if not j:continue
       I = Integral(i,*j)
-      try:assert I.doit() == I.as_dummy().doit()
-      except:
-       a,b,c=(I,I.doit(),I.as_dummy())
-       assert None, a
+      if I.doit() != I.as_dummy().doit():
+       assert None, (I, I.doit())
 
 
 def test_canonical_variables():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1718,6 +1718,10 @@ def test_eval_interval():
 def test_eval_interval_zoo():
     # Test that limit is used when zoo is returned
     assert Si(1/x)._eval_interval(x, S.Zero, S.One) == -pi/2 + Si(1)
+    # test that if there is a None in the limit that the
+    # correct direction is used
+    assert Si(1/x)._eval_interval(x, 0, None) == -pi/2
+    assert Si(1/x)._eval_interval(x, None, 0) == 0
 
 
 def test_primitive():

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -530,7 +530,6 @@ class Abs(Function):
         from sympy.simplify.simplify import signsimp
         from sympy.core.function import expand_mul
         from sympy.core.power import Pow
-
         if hasattr(arg, '_eval_Abs'):
             obj = arg._eval_Abs()
             if obj is not None:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -401,8 +401,7 @@ class Integral(AddWithLimits):
         from sympy.concrete.summations import Sum
         if not hints.get('integrals', True):
             return self
-        bv = [f[0] for f in self.limits if
-            len(f) == 1 and not f[0].is_Symbol]
+        bv = [f[0] for f in self.limits if not f[0].is_Symbol]
         if bv:
             free = self.function.free_symbols - set(bv)
             if any(i.free_symbols & free for i in bv):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -70,9 +70,13 @@ class Integral(AddWithLimits):
         >>> i = Integral(x, x)
         >>> at = Integral(x, (x, x))
         >>> i.as_dummy()
-        Integral(x, x)
+        Integral(_0, (_0, x))
+        >>> i.subs(x, y)
+        Integral(y, y)
         >>> at.as_dummy()
         Integral(_0, (_0, x))
+        >>> at.subs(x, y)
+        Integral(x, (x, y))
 
         """
 
@@ -397,6 +401,12 @@ class Integral(AddWithLimits):
         from sympy.concrete.summations import Sum
         if not hints.get('integrals', True):
             return self
+        bv = [f[0] for f in self.limits if
+            len(f) == 1 and not f[0].is_Symbol]
+        if bv:
+            free = self.function.free_symbols - set(bv)
+            if any(i.free_symbols & free for i in bv):
+                return self
 
         deep = hints.get('deep', True)
         meijerg = hints.get('meijerg', None)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -259,7 +259,7 @@ class Integral(AddWithLimits):
         ========
 
         sympy.concrete.expr_with_limits.ExprWithLimits.variables : Lists the integration variables
-        as_dummy : Replace integration variables with dummy ones
+        sympy.concrete.expr_with_limits.ExprWithLimits.as_dummy : Replace integration variables with dummy ones
         """
         from sympy.solvers.solvers import solve, posify
         d = Dummy('d')

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -401,10 +401,13 @@ class Integral(AddWithLimits):
         from sympy.concrete.summations import Sum
         if not hints.get('integrals', True):
             return self
-        bv = [f[0] for f in self.limits if not f[0].is_Symbol]
+        bv = [f[0] for f in self.limits if (
+            f[0].expr_free_symbols != {f[0]} and
+            f[0].free_symbols != {f[0]})]
         if bv:
-            free = self.function.free_symbols - set(bv)
-            if any(i.free_symbols & free for i in bv):
+            bv = set(bv)
+            free = self.function.expr_free_symbols - bv
+            if free and any(i.expr_free_symbols & free for i in bv):
                 return self
 
         deep = hints.get('deep', True)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -950,6 +950,7 @@ def test_symbols():
     assert Integral(2, (x, 1, 2), (y, x, 2), (y, 1, 2)).free_symbols == \
         {x}
     assert Integral(x, (f(y, x), z)).bound_symbols == [f(y, x), x, y]
+    assert Integral(x, (f(y, x), z)).free_symbols == {z}
 
 
 def test_is_zero():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -949,6 +949,7 @@ def test_symbols():
     assert Integral(2, (y, x, 2), (y, 1, x), (x, 1, 2)).free_symbols == set()
     assert Integral(2, (x, 1, 2), (y, x, 2), (y, 1, 2)).free_symbols == \
         {x}
+    assert Integral(x, (f(y, x), z)).bound_symbols == [f(y, x), x, y]
 
 
 def test_is_zero():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -104,6 +104,9 @@ def test_constructor():
 
 def test_basics():
 
+    assert Integral(x, (f(x), y)).doit() == Integral(x, (f(x), y))
+    assert Integral(f(x), (x, y)).doit() == Integral(f(x), (x, y))
+
     assert Integral(0, x) != 0
     assert Integral(x, (x, 1, 1)) != 0
     assert Integral(oo, x) != oo

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -720,10 +720,11 @@ def test_subs5():
     e = Integral(exp(-x**2), (x, -oo, oo))
     assert e.subs(x, 5) == e
     e = Integral(exp(-x**2 + y), x)
+    assert e.subs(x, 5) == Integral(exp(-x**2 + y), (x, 5))
     assert e.subs(y, 5) == Integral(exp(-x**2 + 5), x)
     e = Integral(exp(-x**2 + y), (x, x))
     assert e.subs(x, 5) == Integral(exp(y - x**2), (x, 5))
-    assert e.subs(y, 5) == Integral(exp(-x**2 + 5), x)
+    assert e.subs(y, 5) == Integral(exp(-x**2 + 5), (x, x))
     e = Integral(exp(-x**2 + y), (y, -oo, oo), (x, -oo, oo))
     assert e.subs(x, 5) == e
     assert e.subs(y, 5) == e
@@ -753,8 +754,9 @@ def test_subs7():
     e = Integral(sin(x) + sin(y), (x, sin(x), sin(y)),
                                   (y, 1, 2))
     assert e.subs(sin(y), 1) == e
-    assert e.subs(sin(x), 1) == Integral(sin(x) + sin(y), (x, 1, sin(y)),
-                                         (y, 1, 2))
+    assert e.subs(sin(x), 1) == Integral(
+        sin(x) + sin(y), (x, 1, sin(y)), (y, 1, 2))
+
 
 def test_expand():
     e = Integral(f(x)+f(x**2), (x, 1, y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

When a user-defined function is acting as a bound variable, it's arguments are implicitly bound and changes have been made to reflect this by modifying `bound_symbols` and `free_symbols` to account for those via change to `ExprWithLimits`.

`Basic.canonical_variables` will now include symbols contained within functions acting as bound symbols.

These changes are reflected in expressions returned for `as_dummy`:

```python
>>> f=Function('f')
>>> Integral(x,(f(x), y)).as_dummy()
Integral(_1, (_0, y))  <----- formerly Integral(x, (_0, y))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `canonical_variables` now includes free symbols from the arguments of bound functions
* concrete
  * symbols in functions appearing as bound functions are now considered bound, too
  * ExprWithLimits (like Integral) now reports arguments of functions as free symbols when appearing as singleton limit
  * Integrals like `Integral(x, f(x))` will not treat `x` and independent of `f(x)` and will not respond to `.doit()`
<!-- END RELEASE NOTES -->
