### PR TITLE
`force=True` is more comprehensive for `powdenest`

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -530,7 +530,6 @@ class Abs(Function):
         from sympy.simplify.simplify import signsimp
         from sympy.core.function import expand_mul
         from sympy.core.power import Pow
-        from sympy.functions.elementary.exponential import exp_polar
 
         if hasattr(arg, '_eval_Abs'):
             obj = arg._eval_Abs()
@@ -544,12 +543,6 @@ class Abs(Function):
         n, d = arg.as_numer_denom()
         if d.free_symbols and not n.free_symbols:
             return cls(n)/cls(d)
-
-        if not arg.atoms(exp_polar):
-            if arg.is_extended_positive:
-                return arg
-            elif arg.is_extended_negative:
-                return -arg
 
         if arg.is_Mul:
             known = []
@@ -596,6 +589,10 @@ class Abs(Function):
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))
         if isinstance(arg, AppliedUndef):
+            if arg.is_positive:
+                return arg
+            elif arg.is_negative:
+                return -arg
             return
         if arg.is_Add and arg.has(S.Infinity, S.NegativeInfinity):
             if any(a.is_infinite for a in arg.as_real_imag()):

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -537,11 +537,16 @@ class Abs(Function):
                 return obj
         if not isinstance(arg, Expr):
             raise TypeError("Bad argument type for Abs(): %s" % type(arg))
+
         # handle what we can
         arg = signsimp(arg, evaluate=False)
         n, d = arg.as_numer_denom()
         if d.free_symbols and not n.free_symbols:
             return cls(n)/cls(d)
+        if arg.is_extended_positive:
+            return arg
+        elif arg.is_extended_negative:
+            return -arg
 
         if arg.is_Mul:
             known = []
@@ -751,7 +756,7 @@ class arg(Function):
             arg_ = sign(c)*arg_
         else:
             arg_ = arg
-        if arg_.atoms(AppliedUndef):
+        if any(i.is_extended_positive is None for i in arg_.atoms(AppliedUndef)):
             return
         x, y = arg_.as_real_imag()
         rv = atan2(y, x)

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -530,6 +530,7 @@ class Abs(Function):
         from sympy.simplify.simplify import signsimp
         from sympy.core.function import expand_mul
         from sympy.core.power import Pow
+        from sympy.functions.elementary.exponential import exp_polar
 
         if hasattr(arg, '_eval_Abs'):
             obj = arg._eval_Abs()
@@ -543,10 +544,12 @@ class Abs(Function):
         n, d = arg.as_numer_denom()
         if d.free_symbols and not n.free_symbols:
             return cls(n)/cls(d)
-        if arg.is_extended_positive:
-            return arg
-        elif arg.is_extended_negative:
-            return -arg
+
+        if not arg.atoms(exp_polar):
+            if arg.is_extended_positive:
+                return arg
+            elif arg.is_extended_negative:
+                return -arg
 
         if arg.is_Mul:
             known = []

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -461,6 +461,9 @@ def test_Abs():
 
     # coverage
     assert unchanged(Abs, Symbol('x', real=True)**y)
+    # issue 19627
+    f = Function('f', positive=True)
+    assert sqrt(f(x)**2) == f(x)
 
 
 def test_Abs_rewrite():
@@ -588,6 +591,11 @@ def test_arg():
     assert arg(exp_polar(5 - 3*pi*I/4)) == pi*Rational(-3, 4)
     f = Function('f')
     assert not arg(f(0) + I*f(1)).atoms(re)
+
+    x = Symbol('x')
+    p = Function('p', extended_positive=True)
+    assert arg(p(x)) == 0
+    assert arg((3 + I)*p(x)) == arg(3  + I)
 
     p = Symbol('p', positive=True)
     assert arg(p) == 0

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -329,3 +329,14 @@ def test_issue_17524():
     a = symbols("a", real=True)
     e = (-1 - a**2)*sqrt(1 + a**2)
     assert signsimp(powsimp(e)) == signsimp(e) == -(a**2 + 1)**(S(3)/2)
+
+
+def test_issue_19627():
+    # if you use force the user must verify
+    assert powdenest(sqrt(sin(x)**2), force=True) == sin(x)
+    assert powdenest((x**(S.Half/y))**(2*y), force=True) == x
+    from sympy import expand_power_base
+    e = 1 - a
+    expr = (exp(z/e)*x**(b/e)*y**((1 - b)/e))**e
+    assert powdenest(expand_power_base(expr, force=True), force=True
+        ) == x**b*y**(1 - b)*exp(z)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #19627

#### Brief description of what is fixed or changed

`powdenest` did not always denest exponents; now, except for when the base is negative, the denesting should occur.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * use of `force=True` with `powdenest` is more effective
<!-- END RELEASE NOTES -->
