### PR TITLE
Raise warning if relation of frames is looped.

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -4,6 +4,8 @@ from sympy import (trigsimp, solve, Symbol, Dummy)
 from sympy.physics.vector.vector import Vector, _check_vector
 from sympy.utilities.misc import translate
 
+from warnings import warn
+
 __all__ = ['CoordinateSym', 'ReferenceFrame']
 
 
@@ -567,8 +569,8 @@ class ReferenceFrame:
                     neighbors = node._dcm_dict.keys()
                     for neighbor in neighbors:
                         if neighbor == parent:
-                            warn('Loops are defined among the orientation of frames. \
-                                This is likely not desired and may cause errors in your calculations.')
+                            warn('Loops are defined among the orientation of frames.' + \
+                                ' This is likely not desired and may cause errors in your calculations.')
                             cont = False
                             break
                         queue.append(neighbor)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -600,6 +600,12 @@ class ReferenceFrame:
         angle : sympifiable
             Angle in radians by which it the frame is to be rotated.
 
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
+
         Examples
         ========
 
@@ -677,6 +683,12 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
+
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
 
         Examples
         ========
@@ -781,6 +793,12 @@ class ReferenceFrame:
             ``131``. There are 12 unique valid rotation orders (6 Euler and 6
             Tait-Bryan): zxz, xyx, yzy, zyz, xzx, yxy, xyz, yzx, zxy, xzy, zyx,
             and yxz.
+
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
 
         Examples
         ========
@@ -892,6 +910,12 @@ class ReferenceFrame:
             vectors. The order can be specified by the strings ``'XZX'``,
             ``'131'``, or the integer ``131``. There are 12 unique valid
             rotation orders.
+
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
 
         Examples
         ========
@@ -1015,6 +1039,12 @@ class ReferenceFrame:
             The four quaternion scalar numbers as defined above: ``q0``,
             ``q1``, ``q2``, ``q3``.
 
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
+
         Examples
         ========
 
@@ -1120,6 +1150,12 @@ class ReferenceFrame:
             If applicable, the order of the successive of rotations. The string
             ``'123'`` and integer ``123`` are equivalent, for example. Required
             for ``'Body'`` and ``'Space'``.
+
+        Warns
+        ======
+
+        UserWarning
+            If frames are looped.
 
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -794,6 +794,7 @@ class ReferenceFrame:
         >>> B = ReferenceFrame('B')
         >>> B1 = ReferenceFrame('B1')
         >>> B2 = ReferenceFrame('B2')
+        >>> B3 = ReferenceFrame('B3')
 
         For example, a classic Euler Angle rotation can be done by:
 
@@ -811,8 +812,8 @@ class ReferenceFrame:
 
         >>> B1.orient_axis(N, N.x, q1)
         >>> B2.orient_axis(B1, B1.y, q2)
-        >>> B.orient_axis(B2, B2.x, q3)
-        >>> B.dcm(N)
+        >>> B3.orient_axis(B2, B2.x, q3)
+        >>> B3.dcm(N)
         Matrix([
         [        cos(q2),                            sin(q1)*sin(q2),                           -sin(q2)*cos(q1)],
         [sin(q2)*sin(q3), -sin(q1)*sin(q3)*cos(q2) + cos(q1)*cos(q3),  sin(q1)*cos(q3) + sin(q3)*cos(q1)*cos(q2)],
@@ -904,6 +905,7 @@ class ReferenceFrame:
         >>> B = ReferenceFrame('B')
         >>> B1 = ReferenceFrame('B1')
         >>> B2 = ReferenceFrame('B2')
+        >>> B3 = ReferenceFrame('B3')
 
         >>> B.orient_space_fixed(N, (q1, q2, q3), '312')
         >>> B.dcm(N)
@@ -916,8 +918,8 @@ class ReferenceFrame:
 
         >>> B1.orient_axis(N, N.z, q1)
         >>> B2.orient_axis(B1, N.x, q2)
-        >>> B.orient_axis(B2, N.y, q3)
-        >>> B.dcm(N).simplify()
+        >>> B3.orient_axis(B2, N.y, q3)
+        >>> B3.dcm(N).simplify()
         Matrix([
         [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
         [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -604,7 +604,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         Examples
         ========
@@ -688,7 +688,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         Examples
         ========
@@ -798,7 +798,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         Examples
         ========
@@ -915,7 +915,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         Examples
         ========
@@ -1043,7 +1043,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         Examples
         ========
@@ -1155,7 +1155,7 @@ class ReferenceFrame:
         ======
 
         UserWarning
-            If frames are looped.
+            If the orientation creates a kinematic loop.
 
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -554,6 +554,21 @@ class ReferenceFrame:
             self._dcm_dict = self._dlist[0] = {}
         # Reset the _dcm_cache
             self._dcm_cache = {}
+
+        else:
+        #Check for loops and raise warning accordingly.
+            visited = []
+            queue = list(frames)
+            while queue:
+                node = queue.pop(0)
+                if node not in visited:
+                    visited.append(node)
+                    neighbors = node._dcm_dict.keys()
+                    for neighbor in neighbors:
+                        if neighbor == parent:
+                            pass
+                        queue.append(neighbor)
+
         # Add the dcm relationship to _dcm_dict
         self._dcm_dict.update({parent: parent_orient.T})
         parent._dcm_dict.update({self: parent_orient})

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -559,14 +559,18 @@ class ReferenceFrame:
         #Check for loops and raise warning accordingly.
             visited = []
             queue = list(frames)
-            while queue:
+            cont = True #Flag to control queue loop.
+            while queue and cont:
                 node = queue.pop(0)
                 if node not in visited:
                     visited.append(node)
                     neighbors = node._dcm_dict.keys()
                     for neighbor in neighbors:
                         if neighbor == parent:
-                            pass
+                            warn('Loops are defined among the orientation of frames. \
+                                This is likely not desired and may cause errors in your calculations.')
+                            cont = False
+                            break
                         queue.append(neighbor)
 
         # Add the dcm relationship to _dcm_dict

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -6,6 +6,7 @@ from sympy.physics.vector import (ReferenceFrame, Vector, CoordinateSym,
 from sympy.physics.vector.frame import _check_frame
 from sympy.physics.vector.vector import VectorTypeError
 from sympy.testing.pytest import raises
+import warnings
 
 Vector.simp = True
 
@@ -471,6 +472,22 @@ def test_orient_quaternion():
     B = ReferenceFrame('B')
     B.orient_quaternion(A, (0,0,0,0))
     assert B.dcm(A) == Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+def test_looped_frame_warning():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
+
+    a, b, c = symbols('a b c')
+    B.orient_axis(A, A.x, a)
+    C.orient_axis(B, B.x, b)
+
+    with warnings.catch_warnings(record = True) as w:
+        warnings.simplefilter("always")
+        A.orient_axis(C, C.x, c)
+        assert issubclass(w[-1].category, UserWarning)
+        assert 'Loops are defined among the orientation of frames. ' + \
+            'This is likely not desired and may cause errors in your calculations.' in str(w[-1].message)
 
 def test_frame_dict():
     A = ReferenceFrame('A')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21036

#### Brief description of what is fixed or changed
Do bfs to find loop and raise warning.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * Warning is raised if orientation of frames is looped.
<!-- END RELEASE NOTES -->
