### PR TITLE
fix _eval_expand_trig for trig functions when expanding a constant

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -460,7 +460,7 @@ class sin(TrigonometricFunction):
             cx = cos(x, evaluate=False)._eval_expand_trig()
             cy = cos(y, evaluate=False)._eval_expand_trig()
             return sx*cy + sy*cx
-        else:
+        elif arg.is_Mul:
             n, x = arg.as_coeff_Mul(rational=True)
             if n.is_Integer:  # n will be positive because of .eval
                 # canonicalization
@@ -918,7 +918,7 @@ class cos(TrigonometricFunction):
             cx = cos(x, evaluate=False)._eval_expand_trig()
             cy = cos(y, evaluate=False)._eval_expand_trig()
             return cx*cy - sx*sy
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer:
                 return chebyshevt(coeff, cos(terms))
@@ -1202,7 +1202,7 @@ class tan(TrigonometricFunction):
                 p[1 - i % 2] += symmetric_poly(i, Y)*(-1)**((i % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, TX)))
 
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
                 I = S.ImaginaryUnit
@@ -1567,14 +1567,14 @@ class cot(TrigonometricFunction):
             for i in range(n, -1, -1):
                 p[(n - i) % 2] += symmetric_poly(i, Y)*(-1)**(((n - i) % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, CX)))
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
                 I = S.ImaginaryUnit
                 z = Symbol('dummy', real=True)
                 P = ((z + I)**coeff).expand()
                 return (re(P)/im(P)).subs([(z, cot(terms))])
-        return cot(arg)
+        return 1/tan(arg)
 
     def _eval_is_finite(self):
         arg = self.args[0]
@@ -3439,3 +3439,5 @@ class atan2(InverseTrigonometricFunction):
         y, x = self.args
         if x.is_extended_real and y.is_extended_real:
             return super()._eval_evalf(prec)
+
+

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3439,5 +3439,3 @@ class atan2(InverseTrigonometricFunction):
         y, x = self.args
         if x.is_extended_real and y.is_extended_real:
             return super()._eval_evalf(prec)
-
-


### PR DESCRIPTION
#### References to other Issues or PRs

This PR is in response to discussion from PR #21380
See this comment: https://github.com/sympy/sympy/pull/21380#issuecomment-833465725

#### Brief description of what is fixed or changed
Right now when expanding many of the trig functions with a constant argument, the _eval_expand_trig function will implicitly treat the expansion as a multiplication of the constant times Symbol('1').  _eval_expand_trig methods either treat an argument as an addition or a multiplication (and nothing else). In the case when a constant is passed in it is treated as a multiplication because of an unconditional else. This can be confusing in some cases, and the user can invoke this behavior by simply calling with an argument of constant*Symbol('1').

**Examples**

Before Changes:
```
expand_trig(tan(5))->
(-10*tan(1)**3 + 5*tan(1) + tan(1)**5)/(-10*tan(1)**2 + 1 + 5*tan(1)**4)

expand_trig(sin(5))->
-20*sin(1)**3 + 5*sin(1) + 16*sin(1)**5

expand_trig(cos(5))->
-20*cos(1)**3 + 16*cos(1)**5 + 5*cos(1)

expand_trig(cot(5))->
(-10*cot(1)**3 + cot(1)**5 + 5*cot(1))/(-10*cot(1)**2 + 5*cot(1)**4 + 1)

expand_trig(sec(5))->
1/(-20*cos(1)**3 + 16*cos(1)**5 + 5*cos(1))

expand_trig(csc(5))->
1/(-20*sin(1)**3 + 5*sin(1) + 16*sin(1)**5)
```

After Changes:

```
expand_trig(tan(5))->
tan(5)

expand_trig(sin(5))->
sin(5)

expand_trig(cos(5))->
cos(5)

expand_trig(cot(5))->
1/tan(5)

expand_trig(sec(5))->
1/cos(5)

expand_trig(csc(5))->
1/sin(5)

expand_trig(tan(2*Symbol('2')))->
2*tan(2)/(1 - tan(2)**2)

expand_trig(sin(5*Symbol('1')))->
16*sin(1)**5 - 20*sin(1)**3 + 5*sin(1)
```

#### Other comments
This PR is an implementation detail, and really a matter of what is best for the end user. It should be subject to discussion by the community.

Also I change this behavior in : tan, sin, cos, cot, sec, and csc. If we want this behavior in only some of these functions that, that might also be something for discussion.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Change _eval_expand_trig for trig functions when expanding a constant
<!-- END RELEASE NOTES -->