### PR TITLE
fix(polys): make PolyMatrix use DomainMatrix

### DIFF
--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -350,7 +350,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                         else:
                             if len(m) != 1:
                                 raise ValueError("Length of m should be 1")
-                            n = max(n, m[0])
+                            n = max(n, m[0].as_expr())
 
     elif case == 'exp':
         n = max(0, dc - max(db, da))

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -9,7 +9,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
 
 from sympy.polys.polymatrix import PolyMatrix as Matrix
 
-from sympy import Poly, S, symbols, Rational
+from sympy import Poly, S, symbols, Rational, QQ
 from sympy.abc import x, t, n
 
 t0, t1, t2, t3, k = symbols('t:4 k')
@@ -69,29 +69,30 @@ def test_prde_linear_constraints():
         (Poly(1, x), Poly(x + 1, x))]
     assert prde_linear_constraints(Poly(1, x), Poly(0, x), G, DE) == \
         ((Poly(2*x, x, domain='QQ'), Poly(0, x, domain='QQ'), Poly(0, x, domain='QQ')),
-            Matrix([[1, 1, -1], [5, 1, 1]]))
+            Matrix([[1, 1, -1], [5, 1, 1]], x))
     G = [(Poly(t, t), Poly(1, t)), (Poly(t**2, t), Poly(1, t)), (Poly(t**3, t), Poly(1, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     assert prde_linear_constraints(Poly(t + 1, t), Poly(t**2, t), G, DE) == \
         ((Poly(t, t, domain='QQ'), Poly(t**2, t, domain='QQ'), Poly(t**3, t, domain='QQ')),
-            Matrix(0, 3, []))
+            Matrix(0, 3, [], t))
     G = [(Poly(2*x, t), Poly(t, t)), (Poly(-x, t), Poly(t, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     assert prde_linear_constraints(Poly(1, t), Poly(0, t), G, DE) == \
-        ((Poly(0, t, domain='QQ[x]'), Poly(0, t, domain='QQ[x]')), Matrix([[2*x, -x]]))
+        ((Poly(0, t, domain='QQ[x]'), Poly(0, t, domain='QQ[x]')), Matrix([[2*x, -x]], t))
 
 
 def test_constant_system():
     A = Matrix([[-(x + 3)/(x - 1), (x + 1)/(x - 1), 1],
                 [-x - 3, x + 1, x - 1],
-                [2*(x + 3)/(x - 1), 0, 0]])
-    u = Matrix([(x + 1)/(x - 1), x + 1, 0])
+                [2*(x + 3)/(x - 1), 0, 0]], t)
+    u = Matrix([[(x + 1)/(x - 1)], [x + 1], [0]], t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    R = QQ.frac_field(x)[t]
     assert constant_system(A, u, DE) == \
         (Matrix([[1, 0, 0],
                  [0, 1, 0],
                  [0, 0, 0],
-                 [0, 0, 1]]), Matrix([0, 1, 0, 0]))
+                 [0, 0, 1]], ring=R), Matrix([0, 1, 0, 0], ring=R))
 
 
 def test_prde_spde():
@@ -109,14 +110,14 @@ def test_prde_no_cancel():
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
     assert prde_no_cancel_b_large(Poly(1, x), [Poly(x**2, x), Poly(1, x)], 2, DE) == \
         ([Poly(x**2 - 2*x + 2, x), Poly(1, x)], Matrix([[1, 0, -1, 0],
-                                                        [0, 1, 0, -1]]))
+                                                        [0, 1, 0, -1]], x))
     assert prde_no_cancel_b_large(Poly(1, x), [Poly(x**3, x), Poly(1, x)], 3, DE) == \
         ([Poly(x**3 - 3*x**2 + 6*x - 6, x), Poly(1, x)], Matrix([[1, 0, -1, 0],
-                                                                 [0, 1, 0, -1]]))
+                                                                 [0, 1, 0, -1]], x))
     assert prde_no_cancel_b_large(Poly(x, x), [Poly(x**2, x), Poly(1, x)], 1, DE) == \
         ([Poly(x, x, domain='ZZ'), Poly(0, x, domain='ZZ')], Matrix([[1, -1,  0,  0],
                                                                     [1,  0, -1,  0],
-                                                                    [0,  1,  0, -1]]))
+                                                                    [0,  1,  0, -1]], x))
     # b small
     # XXX: Is there a better example of a monomial with D.degree() > 2?
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**3 + 1, t)]})
@@ -124,6 +125,7 @@ def test_prde_no_cancel():
     # My original q was t**4 + t + 1, but this solution implies q == t**4
     # (c1 = 4), with some of the ci for the original q equal to 0.
     G = [Poly(t**6, t), Poly(x*t**5, t), Poly(t**3, t), Poly(x*t**2, t), Poly(1 + x, t)]
+    R = QQ.frac_field(x)[t]
     assert prde_no_cancel_b_small(Poly(x*t, t), G, 4, DE) == \
         ([Poly(t**4/4 - x/12*t**3 + x**2/24*t**2 + (Rational(-11, 12) - x**3/24)*t + x/24, t),
         Poly(x/3*t**3 - x**2/6*t**2 + (Rational(-1, 3) + x**3/6)*t - x/6, t), Poly(t, t),
@@ -136,7 +138,7 @@ def test_prde_no_cancel():
                                          [0, 1,               0, 0, 0,  0, -1,  0,  0,  0],
                                          [0, 0,               1, 0, 0,  0,  0, -1,  0,  0],
                                          [0, 0,               0, 1, 0,  0,  0,  0, -1,  0],
-                                         [0, 0,               0, 0, 1,  0,  0,  0,  0, -1]]))
+                                         [0, 0,               0, 0, 1,  0,  0,  0,  0, -1]], ring=R))
 
     # TODO: Add test for deg(b) <= 0 with b small
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1 + t**2, t)]})
@@ -144,9 +146,10 @@ def test_prde_no_cancel():
     q = [Poly(x**i*t**j, t, field=True) for i in range(2) for j in range(3)]
     h, A = prde_no_cancel_b_small(b, q, 3, DE)
     V = A.nullspace()
+    R = QQ.frac_field(x)[t]
     assert len(V) == 1
-    assert V[0] == Matrix([Rational(-1, 2), 0, 0, 1, 0, 0]*3)
-    assert (Matrix([h])*V[0][6:, :])[0] == Poly(x**2/2, t, domain='ZZ(x)')
+    assert V[0] == Matrix([Rational(-1, 2), 0, 0, 1, 0, 0]*3, ring=R)
+    assert (Matrix([h])*V[0][6:, :])[0] == Poly(x**2/2, t, domain='QQ(x)')
     assert (Matrix([q])*V[0][:6, :])[0] == Poly(x - S.Half, t, domain='QQ(x)')
 
 
@@ -167,7 +170,7 @@ def test_prde_cancel_liouvillian():
     # Not taken from book
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t, t)]})
     assert prde_cancel_liouvillian(Poly(0, t, domain='QQ[x]'), [Poly(1, t, domain='QQ(x)')], 0, DE) == \
-            ([Poly(1, t, domain='QQ'), Poly(x, t, domain='ZZ(x)')], Matrix([[-1, 0, 1]]))
+            ([Poly(1, t, domain='QQ'), Poly(x, t, domain='ZZ(x)')], Matrix([[-1, 0, 1]], DE.t))
 
 
 def test_param_poly_rischDE():
@@ -177,7 +180,7 @@ def test_param_poly_rischDE():
     q = [Poly(x, x, field=True), Poly(x**2, x, field=True)]
     h, A = param_poly_rischDE(a, b, q, 3, DE)
 
-    assert A.nullspace() == [Matrix([0, 1, 1, 1])]  # c1, c2, d1, d2
+    assert A.nullspace() == [Matrix([0, 1, 1, 1], DE.t)]  # c1, c2, d1, d2
     # Solution of a*Dp + b*p = c1*q1 + c2*q2 = q2 = x**2
     # is d1*h1 + d2*h2 = h1 + h2 = x.
     assert h[0] + h[1] == Poly(x, x, domain='QQ')
@@ -189,7 +192,7 @@ def test_param_poly_rischDE():
          Poly(x**2, x, field=True)]
     h, A = param_poly_rischDE(a, b, q, 3, DE)
 
-    assert A.nullspace() == [Matrix([3, -5, 1, -5, 1, 1])]
+    assert A.nullspace() == [Matrix([3, -5, 1, -5, 1, 1], DE.t)]
     p = -Poly(5, DE.t)*h[0] + h[1] + h[2]  # Poly(1, x)
     assert a*derivation(p, DE) + b*p == Poly(x**2 - 5*x + 3, x, domain='QQ')
 
@@ -203,7 +206,7 @@ def test_param_rischDE():
     p = [hi[0].as_expr()/hi[1].as_expr() for hi in h]
     V = A.nullspace()
     assert len(V) == 2
-    assert V[0] == Matrix([-1, 1, 0, -1, 1, 0])
+    assert V[0] == Matrix([-1, 1, 0, -1, 1, 0], DE.t)
     y = -p[0] + p[1] + 0*p[2]  # x
     assert y.diff(x) - y/x**2 == 1 - 1/x  # Dy + f*y == -G0 + G1 + 0*G2
 
@@ -216,7 +219,7 @@ def test_param_rischDE():
     p = [hi[0].as_expr()/hi[1].as_expr() for hi in h]
     V = A.nullspace()
     assert len(V) == 3
-    assert V[0] == Matrix([0, 0, 0, 0, 1, 0, 0])
+    assert V[0] == Matrix([0, 0, 0, 0, 1, 0, 0], DE.t)
     y = 0*p[0] + 0*p[1] + 1*p[2] + 0*p[3] + 0*p[4]
     assert y.diff(t) - y/(t + x) == 0   # Dy + f*y = 0*G0 + 0*G1
 

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -86,7 +86,12 @@ class FractionField(Field, CompositeDomain):
 
     def from_QQ(K1, a, K0):
         """Convert a Python ``Fraction`` object to ``dtype``. """
-        return K1(K1.domain.convert(a, K0))
+        dom = K1.domain
+        conv = dom.convert_from
+        if dom.is_ZZ:
+            return K1(conv(K0.numer(a), K0)) / K1(conv(K0.denom(a), K0))
+        else:
+            return K1(conv(a, K0))
 
     def from_QQ_python(K1, a, K0):
         """Convert a Python ``Fraction`` object to ``dtype``. """
@@ -125,6 +130,8 @@ class FractionField(Field, CompositeDomain):
 
     def from_PolynomialRing(K1, a, K0):
         """Convert a polynomial to ``dtype``. """
+        if a.is_ground:
+            return K1.convert_from(a.coeff(1), K0.domain)
         try:
             return K1.new(a.set_ring(K1.field.ring))
         except (CoercionFailed, GeneratorsError):

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -142,6 +142,9 @@ class PolynomialRing(Ring, CompositeDomain):
 
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """
+        if K1.domain == K0:
+            return K1.ring.from_list([a])
+
         q, r = K0.numer(a).div(K0.denom(a))
 
         if r.is_zero:

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -3,6 +3,7 @@
 from sympy import I, S, sqrt, sin, oo, Poly, Float, Integer, Rational, pi
 from sympy.abc import x, y, z
 
+from sympy.utilities.iterables import cartes
 from sympy.core.compatibility import HAS_GMPY
 
 from sympy.polys.domains import (ZZ, QQ, RR, CC, FF, GF, EX, ZZ_gmpy,
@@ -603,12 +604,22 @@ def test_Domain_convert():
 
     assert QQ.convert(10e-52) == QQ(1684996666696915, 1684996666696914987166688442938726917102321526408785780068975640576)
 
-    R, x = ring("x", ZZ)
-    assert ZZ.convert(x - x) == 0
-    assert ZZ.convert(x - x, R.to_domain()) == 0
+    R, xr = ring("x", ZZ)
+    assert ZZ.convert(xr - xr) == 0
+    assert ZZ.convert(xr - xr, R.to_domain()) == 0
 
     assert CC.convert(ZZ_I(1, 2)) == CC(1, 2)
     assert CC.convert(QQ_I(1, 2)) == CC(1, 2)
+
+    K1 = QQ.frac_field(x)
+    K2 = ZZ.frac_field(x)
+    K3 = QQ[x]
+    K4 = ZZ[x]
+    Ks = [K1, K2, K3, K4]
+    for Ka, Kb in cartes(Ks, Ks):
+        assert Ka.convert_from(Kb.from_sympy(x), Kb) == Ka.from_sympy(x)
+
+    assert K2.convert_from(QQ(1, 2), QQ) == K2(QQ(1, 2))
 
 
 def test_GlobalPolynomialRing_convert():

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -262,6 +262,25 @@ class DDM(list):
 
         return DDM(Anew, (rows, cols), A.domain)
 
+    def vstack(A, B):
+        Anew = list(A.copy())
+        rows, cols = A.shape
+        domain = A.domain
+
+        Brows, Bcols = B.shape
+        assert Bcols == cols
+        assert B.domain == domain
+
+        rows += Brows
+
+        Anew.extend(B.copy())
+
+        return DDM(Anew, (rows, cols), A.domain)
+
+    def applyfunc(self, func, domain):
+        elements = (list(map(func, row)) for row in self)
+        return DDM(elements, self.shape, domain)
+
     def rref(a):
         """Reduced-row echelon form of a and list of pivots"""
         b = a.copy()

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -550,8 +550,8 @@ class DomainMatrix:
         """
         from sympy.matrices.dense import MutableDenseMatrix
         elemlist = self.rep.to_list()
-        rows_sympy = [[self.domain.to_sympy(e) for e in row] for row in elemlist]
-        return MutableDenseMatrix(rows_sympy)
+        elements_sympy = [self.domain.to_sympy(e) for row in elemlist for e in row]
+        return MutableDenseMatrix(*self.shape, elements_sympy)
 
     def __repr__(self):
         return 'DomainMatrix(%s, %r, %r)' % (str(self.rep), self.shape, self.domain)
@@ -602,6 +602,15 @@ class DomainMatrix:
         """
         A, B = A.unify(B, fmt='dense')
         return A.from_rep(A.rep.hstack(B.rep))
+
+    def vstack(A, B):
+        A, B = A.unify(B, fmt='dense')
+        return A.from_rep(A.rep.vstack(B.rep))
+
+    def applyfunc(self, func, domain=None):
+        if domain is None:
+            domain = self.domain
+        return self.from_rep(self.rep.applyfunc(func, domain))
 
     def __add__(A, B):
         if not isinstance(B, DomainMatrix):
@@ -1017,6 +1026,8 @@ class DomainMatrix:
         DomainMatrix([[1, 1]], (1, 2), QQ)
 
         """
+        if not self.domain.is_Field:
+            raise ValueError('Not a field')
         return self.from_rep(self.rep.nullspace()[0])
 
     def inv(self):
@@ -1343,6 +1354,6 @@ class DomainMatrix:
         False
 
         """
-        if not isinstance(B, DomainMatrix):
+        if not isinstance(A, type(B)):
             return NotImplemented
-        return A.rep == B.rep
+        return A.domain == B.domain and A.rep == B.rep

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -653,6 +653,26 @@ class SDM(dict):
 
         return A.new(Anew, (rows, cols), A.domain)
 
+    def vstack(A, *B):
+        Anew = dict(A.copy())
+        rows, cols = A.shape
+        domain = A.domain
+
+        for Bk in B:
+            Bkrows, Bkcols = Bk.shape
+            assert Bkcols == cols
+            assert Bk.domain == domain
+
+            for i, Bki in Bk.items():
+                Anew[i + rows] = Bki
+            rows += Bkrows
+
+        return A.new(Anew, (rows, cols), A.domain)
+
+    def applyfunc(self, func, domain):
+        sdm = {i: {j: func(e) for j, e in row.items()} for i, row in self.items()}
+        return self.new(sdm, self.shape, domain)
+
     def charpoly(A):
         """
         Returns the coefficients of the characteristic polynomial

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -224,6 +224,21 @@ def test_DDM_hstack():
     assert Ah.domain == ZZ
     assert Ah == DDM([[ZZ(1), ZZ(2), ZZ(3), ZZ(4), ZZ(5)]], (1, 5), ZZ)
 
+def test_DDM_vstack():
+
+    A = DDM([[ZZ(1)], [ZZ(2)], [ZZ(3)]], (3, 1), ZZ)
+    B = DDM([[ZZ(4)], [ZZ(5)]], (2, 1), ZZ)
+    Ah = A.vstack(B)
+
+    assert Ah.shape == (5, 1)
+    assert Ah.domain == ZZ
+    assert Ah == DDM([[ZZ(1)], [ZZ(2)], [ZZ(3)], [ZZ(4)], [ZZ(5)]], (5, 1), ZZ)
+
+def test_DDM_applyfunc():
+    A = DDM([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
+    B = DDM([[ZZ(2), ZZ(4), ZZ(6)]], (1, 3), ZZ)
+    assert A.applyfunc(lambda x: 2*x, ZZ) == B
+
 def test_DDM_rref():
 
     A = DDM([], (0, 4), QQ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -390,9 +390,12 @@ def test_DomainMatrix_rref():
 
 
 def test_DomainMatrix_nullspace():
-    A = DomainMatrix([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), ZZ)
-    Anull = DomainMatrix([[QQ(-1), QQ(1)]], (1, 2), ZZ)
+    A = DomainMatrix([[QQ(1), QQ(1)], [QQ(1), QQ(1)]], (2, 2), QQ)
+    Anull = DomainMatrix([[QQ(-1), QQ(1)]], (1, 2), QQ)
     assert A.nullspace() == Anull
+
+    Az = DomainMatrix([[ZZ(1), ZZ(1)], [ZZ(1), ZZ(1)]], (2, 2), ZZ)
+    raises(ValueError, lambda: Az.nullspace())
 
 
 def test_DomainMatrix_solve():
@@ -607,6 +610,19 @@ def test_DomainMatrix_hstack():
     B = DomainMatrix([[QQ(3), QQ(4)], [QQ(5), QQ(6)]], (2, 2), QQ)
     AB = DomainMatrix([[QQ(1), QQ(3), QQ(4)], [QQ(2), QQ(5), QQ(6)]], (2, 3), QQ)
     assert A.hstack(B) == AB
+
+
+def test_DomainMatrix_vstack():
+    A = DomainMatrix([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
+    B = DomainMatrix([[QQ(3), QQ(4)], [QQ(5), QQ(6)]], (2, 2), QQ)
+    AB = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)], [QQ(5), QQ(6)]], (3, 2), QQ)
+    assert A.vstack(B) == AB
+
+
+def test_DomainMatrix_applyfunc():
+    A = DomainMatrix([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
+    B = DomainMatrix([[ZZ(2), ZZ(4)]], (1, 2), ZZ)
+    assert A.applyfunc(lambda x: 2*x) == B
 
 
 def test_DomainMatrix_scalarmul():

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -124,14 +124,14 @@ def test_SDM_mul():
 def test_SDM_matmul():
     A = SDM({0:{0:ZZ(2)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(4)}}, (2, 2), ZZ)
-    assert A.matmul(A) == B
+    assert A.matmul(A) == A*A == B
 
     C = SDM({0:{0:ZZ(2)}}, (2, 2), QQ)
     raises(DDMDomainError, lambda: A.matmul(C))
 
     A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(7), 1:ZZ(10)}, 1:{0:ZZ(15), 1:ZZ(22)}}, (2, 2), ZZ)
-    assert A.matmul(A) == B
+    assert A.matmul(A) == A*A == B
 
     A22 = SDM({0:{0:ZZ(4)}}, (2, 2), ZZ)
     A32 = SDM({0:{0:ZZ(2)}}, (3, 2), ZZ)
@@ -148,33 +148,36 @@ def test_SDM_matmul():
 
     A = SDM({0: {0: ZZ(-1), 1: ZZ(1)}}, (1, 2), ZZ)
     B = SDM({0: {0: ZZ(-1)}, 1: {0: ZZ(-1)}}, (2, 1), ZZ)
-    assert A.matmul(B) == SDM({}, (1, 1), ZZ)
+    assert A.matmul(B) == A*B == SDM({}, (1, 1), ZZ)
 
 
 def test_SDM_add():
     A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
     C = SDM({0:{0:ZZ(1), 1:ZZ(1)}, 1:{1:ZZ(6)}}, (2, 2), ZZ)
-    assert A.add(B) == C
+    assert A.add(B) == B.add(A) == A + B == B + A == C
 
     A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
     C = SDM({0:{0:ZZ(1), 1:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
-    assert A.add(B) == C
-    assert B.add(A) == C
+    assert A.add(B) == B.add(A) == A + B == B + A == C
+
+    raises(TypeError, lambda: A + [])
 
 
 def test_SDM_sub():
     A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
     B = SDM({0:{0:ZZ(1)}, 1:{0:ZZ(-2), 1:ZZ(3)}}, (2, 2), ZZ)
     C = SDM({0:{0:ZZ(-1), 1:ZZ(1)}, 1:{0:ZZ(4)}}, (2, 2), ZZ)
-    assert A.sub(B) == C
+    assert A.sub(B) == A - B == C
+
+    raises(TypeError, lambda: A - [])
 
 
 def test_SDM_neg():
     A = SDM({0:{1:ZZ(1)}, 1:{0:ZZ(2), 1:ZZ(3)}}, (2, 2), ZZ)
     B = SDM({0:{1:ZZ(-1)}, 1:{0:ZZ(-2), 1:ZZ(-3)}}, (2, 2), ZZ)
-    assert A.neg() == B
+    assert A.neg() == -A == B
 
 
 def test_SDM_convert_to():
@@ -197,6 +200,22 @@ def test_SDM_hstack():
     assert SDM.hstack(A) == A
     assert SDM.hstack(A, A) == AA
     assert SDM.hstack(A, B) == AB
+
+
+def test_SDM_vstack():
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    B = SDM({1:{1:ZZ(1)}}, (2, 2), ZZ)
+    AA = SDM({0:{1:ZZ(1)}, 2:{1:ZZ(1)}}, (4, 2), ZZ)
+    AB = SDM({0:{1:ZZ(1)}, 3:{1:ZZ(1)}}, (4, 2), ZZ)
+    assert SDM.vstack(A) == A
+    assert SDM.vstack(A, A) == AA
+    assert SDM.vstack(A, B) == AB
+
+
+def test_SDM_applyfunc():
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    B = SDM({0:{1:ZZ(2)}}, (2, 2), ZZ)
+    assert A.applyfunc(lambda x: 2*x, ZZ) == B
 
 
 def test_SDM_inv():

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -1,10 +1,16 @@
-from sympy.matrices.dense import MutableDenseMatrix
+from sympy.core.expr import Expr
+from sympy.core.symbol import Dummy
+from sympy.core.sympify import _sympify
 
-from sympy.polys.polytools import Poly
-from sympy.polys.domains import EX
+from sympy.polys.polyerrors import CoercionFailed
+from sympy.polys.polytools import Poly, parallel_poly_from_expr
+from sympy.polys.domains import QQ
+
+from sympy.polys.matrices import DomainMatrix
+from sympy.polys.matrices.domainscalar import DomainScalar
 
 
-class MutablePolyDenseMatrix(MutableDenseMatrix):
+class MutablePolyDenseMatrix:
     """
     A mutable matrix of objects from poly module or to operate with them.
 
@@ -12,76 +18,275 @@ class MutablePolyDenseMatrix(MutableDenseMatrix):
     ========
 
     >>> from sympy.polys.polymatrix import PolyMatrix
-    >>> from sympy import Symbol, Poly, ZZ
+    >>> from sympy import Symbol, Poly
     >>> x = Symbol('x')
     >>> pm1 = PolyMatrix([[Poly(x**2, x), Poly(-x, x)], [Poly(x**3, x), Poly(-1 + x, x)]])
-    >>> v1 = PolyMatrix([[1, 0], [-1, 0]])
+    >>> v1 = PolyMatrix([[1, 0], [-1, 0]], x)
     >>> pm1*v1
-    Matrix([
-    [    Poly(x**2 + x, x, domain='ZZ'), Poly(0, x, domain='ZZ')],
-    [Poly(x**3 - x + 1, x, domain='ZZ'), Poly(0, x, domain='ZZ')]])
+    PolyMatrix([
+    [    x**2 + x, 0],
+    [x**3 - x + 1, 0]], ring=QQ[x])
 
     >>> pm1.ring
     ZZ[x]
 
     >>> v1*pm1
-    Matrix([
-    [ Poly(x**2, x, domain='ZZ'), Poly(-x, x, domain='ZZ')],
-    [Poly(-x**2, x, domain='ZZ'),  Poly(x, x, domain='ZZ')]])
+    PolyMatrix([
+    [ x**2, -x],
+    [-x**2,  x]], ring=QQ[x])
 
     >>> pm2 = PolyMatrix([[Poly(x**2, x, domain='QQ'), Poly(0, x, domain='QQ'), Poly(1, x, domain='QQ'), \
             Poly(x**3, x, domain='QQ'), Poly(0, x, domain='QQ'), Poly(-x**3, x, domain='QQ')]])
-    >>> v2 = PolyMatrix([1, 0, 0, 0, 0, 0], ring=ZZ)
+    >>> v2 = PolyMatrix([1, 0, 0, 0, 0, 0], x)
     >>> v2.ring
-    ZZ
+    QQ[x]
     >>> pm2*v2
-    Matrix([[Poly(x**2, x, domain='QQ')]])
+    PolyMatrix([[x**2]], ring=QQ[x])
 
     """
-    _class_priority = 10
-    # we don't want to sympify the elements of PolyMatrix
-    _sympify = staticmethod(lambda x: x)
 
-    def __init__(self, *args, ring=EX, **kwargs):
-        # kwargs are consumed by __new__, so need to be allowed here.
-        # if any non-Poly element is given as input then
-        # 'ring' defaults 'EX'
-        if all(isinstance(p, Poly) for p in self._mat) and self._mat:
-            domain = tuple([p.domain[p.gens] for p in self._mat])
-            ring = domain[0]
-            for i in range(1, len(domain)):
-                ring = ring.unify(domain[i])
-        self.ring = ring
+    def __new__(cls, *args, ring=None):
 
-    def _eval_matrix_mul(self, other):
-        self_cols = self.cols
-        other_rows, other_cols = other.rows, other.cols
-        other_len = other_rows*other_cols
-        new_mat_rows = self.rows
-        new_mat_cols = other.cols
+        if not args:
+            # PolyMatrix(ring=QQ[x])
+            if ring is None:
+                raise TypeError("The ring needs to be specified for an empty PolyMatrix")
+            rows, cols, items, gens = 0, 0, [], ()
+        elif isinstance(args[0], list):
+            elements, gens = args[0], args[1:]
+            if not elements:
+                # PolyMatrix([])
+                rows, cols, items = 0, 0, []
+            elif isinstance(elements[0], (list, tuple)):
+                # PolyMatrix([[1, 2]], x)
+                rows, cols = len(elements), len(elements[0])
+                items = [e for row in elements for e in row]
+            else:
+                # PolyMatrix([1, 2], x)
+                rows, cols = len(elements), 1
+                items = elements
+        elif [type(a) for a in args[:3]] == [int, int, list]:
+            # PolyMatrix(2, 2, [1, 2, 3, 4], x)
+            rows, cols, items, gens = args[0], args[1], args[2], args[3:]
+        elif [type(a) for a in args[:3]] == [int, int, type(lambda: 0)]:
+            # PolyMatrix(2, 2, lambda i, j: i+j, x)
+            rows, cols, func, gens = args[0], args[1], args[2], args[3:]
+            items = [func(i, j) for i in range(rows) for j in range(cols)]
+        else:
+            raise TypeError("Invalid arguments")
 
-        new_mat = [0]*new_mat_rows*new_mat_cols
+        # PolyMatrix([[1]], x, y) vs PolyMatrix([[1]], (x, y))
+        if len(gens) == 1 and isinstance(gens[0], tuple):
+            gens = gens[0]
+            # gens is now a tuple (x, y)
 
-        if self.cols != 0 and other.rows != 0:
-            mat = self._mat
-            other_mat = other._mat
-            for i in range(len(new_mat)):
-                row, col = i // new_mat_cols, i % new_mat_cols
-                row_indices = range(self_cols*row, self_cols*(row+1))
-                col_indices = range(col, other_len, other_cols)
-                vec = (mat[a]*other_mat[b] for a,b in zip(row_indices, col_indices))
-                # 'Add' shouldn't be used here
-                new_mat[i] = sum(vec)
+        return cls.from_list(rows, cols, items, gens, ring)
 
-        return self.__class__(new_mat_rows, new_mat_cols, new_mat, copy=False)
+    @classmethod
+    def from_list(cls, rows, cols, items, gens, ring):
 
-    def _eval_scalar_mul(self, other):
-        mat = [Poly(a.as_expr()*other, *a.gens) if isinstance(a, Poly) else a*other for a in self._mat]
-        return self.__class__(self.rows, self.cols, mat, copy=False)
+        # items can be Expr, Poly, or a mix of Expr and Poly
+        items = [_sympify(item) for item in items]
+        if items and all(isinstance(item, Poly) for item in items):
+            polys = True
+        else:
+            polys = False
 
-    def _eval_scalar_rmul(self, other):
-        mat = [Poly(other*a.as_expr(), *a.gens) if isinstance(a, Poly) else other*a for a in self._mat]
-        return self.__class__(self.rows, self.cols, mat, copy=False)
+        # Identify the ring for the polys
+        if ring is not None:
+            # Parse a domain string like 'QQ[x]'
+            if isinstance(ring, str):
+                ring = Poly(0, Dummy(), domain=ring).domain
+        elif polys:
+            p = items[0]
+            for p2 in items[1:]:
+                p, _ = p.unify(p2)
+            ring = p.domain[p.gens]
+        else:
+            items, info = parallel_poly_from_expr(items, gens, field=True)
+            ring = info['domain'][info['gens']]
+            polys = True
 
+        # Efficiently convert when all elements are Poly
+        if polys:
+            p_ring = Poly(0, ring.symbols, domain=ring.domain)
+            to_ring = ring.ring.from_list
+            convert_poly = lambda p: to_ring(p.unify(p_ring)[0].rep.rep)
+            elements = [convert_poly(p) for p in items]
+        else:
+            convert_expr = ring.from_sympy
+            elements = [convert_expr(e.as_expr()) for e in items]
+
+        # Convert to domain elements and construct DomainMatrix
+        elements_lol = [[elements[i*cols + j] for j in range(cols)] for i in range(rows)]
+        dm = DomainMatrix(elements_lol, (rows, cols), ring)
+        return cls.from_dm(dm)
+
+    @classmethod
+    def from_dm(cls, dm):
+        obj = super().__new__(cls)
+        dm = dm.to_sparse()
+        R = dm.domain
+        obj._dm = dm
+        obj.ring = R
+        obj.domain = R.domain
+        obj.gens = R.symbols
+        return obj
+
+    def to_Matrix(self):
+        return self._dm.to_Matrix()
+
+    @classmethod
+    def from_Matrix(cls, other, *gens, ring=None):
+        return cls(*other.shape, other._mat, *gens, ring=ring)
+
+    def set_gens(self, gens):
+        return self.from_Matrix(self.to_Matrix(), gens)
+
+    def __repr__(self):
+        if self.rows * self.cols:
+            return 'Poly' + repr(self.to_Matrix())[:-1] + f', ring={self.ring})'
+        else:
+            return f'PolyMatrix({self.rows}, {self.cols}, [], ring={self.ring})'
+
+    @property
+    def shape(self):
+        return self._dm.shape
+
+    @property
+    def rows(self):
+        return self.shape[0]
+
+    @property
+    def cols(self):
+        return self.shape[1]
+
+    def __len__(self):
+        return self.rows * self.cols
+
+    def __getitem__(self, key):
+
+        def to_poly(v):
+            ground = self._dm.domain.domain
+            gens = self._dm.domain.symbols
+            return Poly(v.to_dict(), gens, domain=ground)
+
+        dm = self._dm
+
+        if isinstance(key, slice):
+            items = dm.flat()[key]
+            return [to_poly(item) for item in items]
+        elif isinstance(key, int):
+            i, j = divmod(key, self.cols)
+            e = dm[i,j]
+            return to_poly(e.element)
+
+        i, j = key
+        if isinstance(i, int) and isinstance(j, int):
+            return to_poly(dm[i, j].element)
+        else:
+            return self.from_dm(dm[i, j])
+
+    def __eq__(self, other):
+        if not isinstance(self, type(other)):
+            return NotImplemented
+        return self._dm == other._dm
+
+    def __add__(self, other):
+        if isinstance(other, type(self)):
+            return self.from_dm(self._dm + other._dm)
+        return NotImplemented
+
+    def __sub__(self, other):
+        if isinstance(other, type(self)):
+            return self.from_dm(self._dm - other._dm)
+        return NotImplemented
+
+    def __mul__(self, other):
+        if isinstance(other, type(self)):
+            return self.from_dm(self._dm * other._dm)
+        elif isinstance(other, int):
+            other = _sympify(other)
+        if isinstance(other, Expr):
+            Kx = self.ring
+            try:
+                other_ds = DomainScalar(Kx.from_sympy(other), Kx)
+            except (CoercionFailed, ValueError):
+                other_ds = DomainScalar.from_sympy(other)
+            return self.from_dm(self._dm * other_ds)
+        return NotImplemented
+
+    def __rmul__(self, other):
+        if isinstance(other, int):
+            other = _sympify(other)
+        if isinstance(other, Expr):
+            other_ds = DomainScalar.from_sympy(other)
+            return self.from_dm(other_ds * self._dm)
+        return NotImplemented
+
+    def __truediv__(self, other):
+
+        if isinstance(other, Poly):
+            other = other.as_expr()
+        elif isinstance(other, int):
+            other = _sympify(other)
+        if not isinstance(other, Expr):
+            return NotImplemented
+
+        other = self.domain.from_sympy(other)
+        inverse = self.ring.convert_from(1/other, self.domain)
+        inverse = DomainScalar(inverse, self.ring)
+        dm = self._dm * inverse
+        return self.from_dm(dm)
+
+    def __neg__(self):
+        return self.from_dm(-self._dm)
+
+    def transpose(self):
+        return self.from_dm(self._dm.transpose())
+
+    def row_join(self, other):
+        dm = DomainMatrix.hstack(self._dm, other._dm)
+        return self.from_dm(dm)
+
+    def col_join(self, other):
+        dm = DomainMatrix.vstack(self._dm, other._dm)
+        return self.from_dm(dm)
+
+    def applyfunc(self, func):
+        M = self.to_Matrix().applyfunc(func)
+        return self.from_Matrix(M, self.gens)
+
+    @classmethod
+    def eye(cls, n, gens):
+        return cls.from_dm(DomainMatrix.eye(n, QQ[gens]))
+
+    @classmethod
+    def zeros(cls, m, n, gens):
+        return cls.from_dm(DomainMatrix.zeros((m, n), QQ[gens]))
+
+    def rref(self, simplify='ignore', normalize_last='ignore'):
+        # If this is K[x] then computes RREF in ground field K.
+        if not (self.domain.is_Field and all(p.is_ground for p in self)):
+            raise ValueError("PolyMatrix rref is only for ground field elements")
+        dm = self._dm
+        dm_ground = dm.convert_to(dm.domain.domain)
+        dm_rref, pivots = dm_ground.rref()
+        dm_rref = dm_rref.convert_to(dm.domain)
+        return self.from_dm(dm_rref), pivots
+
+    def nullspace(self):
+        # If this is K[x] then computes nullspace in ground field K.
+        if not (self.domain.is_Field and all(p.is_ground for p in self)):
+            raise ValueError("PolyMatrix nullspace is only for ground field elements")
+        dm = self._dm
+        K, Kx = self.domain, self.ring
+        dm_null_rows = dm.convert_to(K).nullspace().convert_to(Kx)
+        dm_null = dm_null_rows.transpose()
+        dm_basis = [dm_null[:,i] for i in range(dm_null.shape[1])]
+        return [self.from_dm(dmvec) for dmvec in dm_basis]
+
+    def rank(self):
+        return self.cols - len(self.nullspace())
 
 MutablePolyMatrix = PolyMatrix = MutablePolyDenseMatrix

--- a/sympy/polys/tests/test_polymatrix.py
+++ b/sympy/polys/tests/test_polymatrix.py
@@ -1,16 +1,17 @@
-from sympy.matrices.dense import Matrix
+from sympy.testing.pytest import raises
+
 from sympy.polys.polymatrix import PolyMatrix
 from sympy.polys import Poly
 
-from sympy import S, ZZ, QQ, EX
+from sympy import S, QQ, ZZ, Matrix
 
-from sympy.abc import x
+from sympy.abc import x, y
 
 
-def test_polymatrix():
+def _test_polymatrix():
     pm1 = PolyMatrix([[Poly(x**2, x), Poly(-x, x)], [Poly(x**3, x), Poly(-1 + x, x)]])
     v1 = PolyMatrix([[1, 0], [-1, 0]], ring='ZZ[x]')
-    m1 = Matrix([[1, 0], [-1, 0]], ring='ZZ[x]')
+    m1 = PolyMatrix([[1, 0], [-1, 0]], ring='ZZ[x]')
     A = PolyMatrix([[Poly(x**2 + x, x), Poly(0, x)], \
                     [Poly(x**3 - x + 1, x), Poly(0, x)]])
     B = PolyMatrix([[Poly(x**2, x), Poly(-x, x)], [Poly(-x**2, x), Poly(x, x)]])
@@ -24,20 +25,158 @@ def test_polymatrix():
                     Poly(x**3, x, domain='QQ'), Poly(0, x, domain='QQ'), Poly(-x**3, x, domain='QQ')]])
     assert pm2.ring == QQ[x]
     v2 = PolyMatrix([1, 0, 0, 0, 0, 0], ring='ZZ[x]')
-    m2 = Matrix([1, 0, 0, 0, 0, 0], ring='ZZ[x]')
+    m2 = PolyMatrix([1, 0, 0, 0, 0, 0], ring='ZZ[x]')
     C = PolyMatrix([[Poly(x**2, x, domain='QQ')]])
     assert pm2*v2 == C
     assert pm2*m2 == C
 
     pm3 = PolyMatrix([[Poly(x**2, x), S.One]], ring='ZZ[x]')
     v3 = S.Half*pm3
-    assert v3 == PolyMatrix([[Poly(S.Half*x**2, x, domain='QQ'), S.Half]], ring='EX')
+    assert v3 == PolyMatrix([[Poly(S.Half*x**2, x, domain='QQ'), S.Half]], ring='QQ[x]')
     assert pm3*S.Half == v3
-    assert v3.ring == EX
+    assert v3.ring == QQ[x]
 
     pm4 = PolyMatrix([[Poly(x**2, x, domain='ZZ'), Poly(-x**2, x, domain='ZZ')]])
-    v4 = Matrix([1, -1], ring='ZZ[x]')
+    v4 = PolyMatrix([1, -1], ring='ZZ[x]')
     assert pm4*v4 == PolyMatrix([[Poly(2*x**2, x, domain='ZZ')]])
 
-    assert len(PolyMatrix()) == 0
-    assert PolyMatrix([1, 0, 0, 1])/(-1) == PolyMatrix([-1, 0, 0, -1])
+    assert len(PolyMatrix(ring=ZZ[x])) == 0
+    assert PolyMatrix([1, 0, 0, 1], x)/(-1) == PolyMatrix([-1, 0, 0, -1], x)
+
+
+def test_polymatrix_constructor():
+    M1 = PolyMatrix([[x, y]], ring=QQ[x,y])
+    assert M1.ring == QQ[x,y]
+    assert M1.domain == QQ
+    assert M1.gens == (x, y)
+    assert M1.shape == (1, 2)
+    assert M1.rows == 1
+    assert M1.cols == 2
+    assert len(M1) == 2
+    assert list(M1) == [Poly(x, (x, y), domain=QQ), Poly(y, (x, y), domain=QQ)]
+
+    M2 = PolyMatrix([[x, y]], ring=QQ[x][y])
+    assert M2.ring == QQ[x][y]
+    assert M2.domain == QQ[x]
+    assert M2.gens == (y,)
+    assert M2.shape == (1, 2)
+    assert M2.rows == 1
+    assert M2.cols == 2
+    assert len(M2) == 2
+    assert list(M2) == [Poly(x, (y,), domain=QQ[x]), Poly(y, (y,), domain=QQ[x])]
+
+    assert PolyMatrix([[x, y]], y) == PolyMatrix([[x, y]], ring=ZZ.frac_field(x)[y])
+    assert PolyMatrix([[x, y]], ring='ZZ[x,y]') == PolyMatrix([[x, y]], ring=ZZ[x,y])
+
+    assert PolyMatrix([[x, y]], (x, y)) == PolyMatrix([[x, y]], ring=QQ[x,y])
+    assert PolyMatrix([[x, y]], x, y) == PolyMatrix([[x, y]], ring=QQ[x,y])
+    assert PolyMatrix([x, y]) == PolyMatrix([[x], [y]], ring=QQ[x,y])
+    assert PolyMatrix(1, 2, [x, y]) == PolyMatrix([[x, y]], ring=QQ[x,y])
+    assert PolyMatrix(1, 2, lambda i,j: [x,y][j]) == PolyMatrix([[x, y]], ring=QQ[x,y])
+    assert PolyMatrix(0, 2, [], x, y).shape == (0, 2)
+    assert PolyMatrix(2, 0, [], x, y).shape == (2, 0)
+    assert PolyMatrix([[], []], x, y).shape == (2, 0)
+    assert PolyMatrix(ring=QQ[x,y]) == PolyMatrix(0, 0, [], ring=QQ[x,y]) == PolyMatrix([], ring=QQ[x,y])
+    raises(TypeError, lambda: PolyMatrix())
+    raises(TypeError, lambda: PolyMatrix(1))
+
+    assert PolyMatrix([Poly(x), Poly(y)]) == PolyMatrix([[x], [y]], ring=ZZ[x,y])
+
+    # XXX: Maybe a bug in parallel_poly_from_expr (x lost from gens and domain):
+    assert PolyMatrix([Poly(y, x), 1]) == PolyMatrix([[y], [1]], ring=QQ[y])
+
+
+def test_polymatrix_eq():
+    assert (PolyMatrix([x]) == PolyMatrix([x])) is True
+    assert (PolyMatrix([y]) == PolyMatrix([x])) is False
+    assert (PolyMatrix([x]) != PolyMatrix([x])) is False
+    assert (PolyMatrix([y]) != PolyMatrix([x])) is True
+
+    assert PolyMatrix([[x, y]]) != PolyMatrix([x, y]) == PolyMatrix([[x], [y]])
+
+    assert PolyMatrix([x], ring=QQ[x]) != PolyMatrix([x], ring=ZZ[x])
+
+    assert PolyMatrix([x]) != Matrix([x])
+    assert PolyMatrix([x]).to_Matrix() == Matrix([x])
+
+    assert PolyMatrix([1], x) == PolyMatrix([1], x)
+    assert PolyMatrix([1], x) != PolyMatrix([1], y)
+
+
+def test_polymatrix_from_Matrix():
+    assert PolyMatrix.from_Matrix(Matrix([1, 2]), x) == PolyMatrix([1, 2], x, ring=QQ[x])
+    assert PolyMatrix.from_Matrix(Matrix([1]), ring=QQ[x]) == PolyMatrix([1], x)
+    pmx = PolyMatrix([1, 2], x)
+    pmy = PolyMatrix([1, 2], y)
+    assert pmx != pmy
+    assert pmx.set_gens(y) == pmy
+
+
+def test_polymatrix_repr():
+    assert repr(PolyMatrix([[1, 2]], x)) == 'PolyMatrix([[1, 2]], ring=QQ[x])'
+    assert repr(PolyMatrix(0, 2, [], x)) == 'PolyMatrix(0, 2, [], ring=QQ[x])'
+
+
+def test_polymatrix_getitem():
+    M = PolyMatrix([[1, 2], [3, 4]], x)
+    assert M[:, :] == M
+    assert M[0, :] == PolyMatrix([[1, 2]], x)
+    assert M[:, 0] == PolyMatrix([1, 3], x)
+    assert M[0, 0] == Poly(1, x, domain=QQ)
+    assert M[0] == Poly(1, x, domain=QQ)
+    assert M[:2] == [Poly(1, x, domain=QQ), Poly(2, x, domain=QQ)]
+
+
+def test_polymatrix_arithmetic():
+    M = PolyMatrix([[1, 2], [3, 4]], x)
+    assert M + M == PolyMatrix([[2, 4], [6, 8]], x)
+    assert M - M == PolyMatrix([[0, 0], [0, 0]], x)
+    assert -M == PolyMatrix([[-1, -2], [-3, -4]], x)
+    raises(TypeError, lambda: M + 1)
+    raises(TypeError, lambda: M - 1)
+    raises(TypeError, lambda: 1 + M)
+    raises(TypeError, lambda: 1 - M)
+
+    assert M * M == PolyMatrix([[7, 10], [15, 22]], x)
+    assert 2 * M == PolyMatrix([[2, 4], [6, 8]], x)
+    assert M * 2 == PolyMatrix([[2, 4], [6, 8]], x)
+    assert S(2) * M == PolyMatrix([[2, 4], [6, 8]], x)
+    assert M * S(2) == PolyMatrix([[2, 4], [6, 8]], x)
+    raises(TypeError, lambda: [] * M)
+    raises(TypeError, lambda: M * [])
+    M2 = PolyMatrix([[1, 2]], ring=ZZ[x])
+    assert S.Half * M2 == PolyMatrix([[S.Half, 1]], ring=QQ[x])
+    assert M2 * S.Half == PolyMatrix([[S.Half, 1]], ring=QQ[x])
+
+    assert M / 2 == PolyMatrix([[S(1)/2, 1], [S(3)/2, 2]], x)
+    assert M / Poly(2, x) == PolyMatrix([[S(1)/2, 1], [S(3)/2, 2]], x)
+    raises(TypeError, lambda: M / [])
+
+
+def test_polymatrix_manipulations():
+    M1 = PolyMatrix([[1, 2], [3, 4]], x)
+    assert M1.transpose() == PolyMatrix([[1, 3], [2, 4]], x)
+    M2 = PolyMatrix([[5, 6], [7, 8]], x)
+    assert M1.row_join(M2) == PolyMatrix([[1, 2, 5, 6], [3, 4, 7, 8]], x)
+    assert M1.col_join(M2) == PolyMatrix([[1, 2], [3, 4], [5, 6], [7, 8]], x)
+    assert M1.applyfunc(lambda e: 2*e) == PolyMatrix([[2, 4], [6, 8]], x)
+
+
+def test_polymatrix_ones_zeros():
+    assert PolyMatrix.zeros(1, 2, x) == PolyMatrix([[0, 0]], x)
+    assert PolyMatrix.eye(2, x) == PolyMatrix([[1, 0], [0, 1]], x)
+
+
+def test_polymatrix_rref():
+    M = PolyMatrix([[1, 2], [3, 4]], x)
+    assert M.rref() == (PolyMatrix.eye(2, x), (0, 1))
+    raises(ValueError, lambda: PolyMatrix([1, 2], ring=ZZ[x]).rref())
+    raises(ValueError, lambda: PolyMatrix([1, x], ring=QQ[x]).rref())
+
+
+def test_polymatrix_nullspace():
+    M = PolyMatrix([[1, 2], [3, 6]], x)
+    assert M.nullspace() == [PolyMatrix([-2, 1], x)]
+    raises(ValueError, lambda: PolyMatrix([1, 2], ring=ZZ[x]).nullspace())
+    raises(ValueError, lambda: PolyMatrix([1, x], ring=QQ[x]).nullspace())
+    assert M.rank() == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Built on top of #21427

#### Brief description of what is fixed or changed

    This commit makes PolyMatrix a wrapper around DomainMatrix rather than a
    subclass of Matrix. This is done so that Matrix can enforce the expected
    invariant that its elements should of type Expr. Ideally the Risch code
    would use DomainMatrix directly but it is not easy to figure out what
    the domain should be in all cases because the Risch code does not keep
    track of that.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The (internal) PolyMatrix class has been changed and now requires generators to be provided on construction.
<!-- END RELEASE NOTES -->
