### PR TITLE
Adds _minpoly_tan for minimal_polynomial

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -462,22 +462,13 @@ def _minpoly_tan(ex):
         if c.is_rational:
             c = c * 2
             n = int(c.q)
-            d = [1] * (n + 1)
-            a = 1
-            for k in range(1, n + 1):
-                a = (a * (n - k + 1))//k
-                if k % 4 == 2 or k % 4 == 3:
-                    d[k] = -a
-                else:
-                    d[k] = a
+            a = n if c.p % 2 == 0 else 1
+            terms = []
+            for k in range((c.p+1)%2, n+1, 2):
+                terms.append(a*x**k)
+                a = -(a*(n-k-1)*(n-k)) // ((k+1)*(k+2))
 
-            if c.p % 2 == 0:
-                coeff = {j : d[j] for j in range(1, n+1, 2)}
-            else:
-                coeff = {j : d[j] for j in range(0, n+1, 2)}
-
-            a = [x**i*coeff[i] for i in coeff.keys()]
-            r = Add(*a)
+            r = Add(*terms)
             _, factors = factor_list(r)
             res = _choose_factor(factors, x, ex)
             return res

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -10,7 +10,6 @@ from sympy.functions import sqrt, cbrt
 
 from sympy.core.exprtools import Factors
 from sympy.core.function import _mexpand
-from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.trigonometric import cos, sin, tan
 from sympy.ntheory import sieve
@@ -451,12 +450,11 @@ def _minpoly_cos(ex, x):
     raise NotAlgebraic("%s doesn't seem to be an algebraic element" % ex)
 
 
-def _minpoly_tan(ex):
+def _minpoly_tan(ex, x):
     """
     Returns the minimal polynomial of ``tan(ex)``
     see https://github.com/sympy/sympy/issues/21430
     """
-    x = Symbol('x', real=True)
     c, a = ex.args[0].as_coeff_Mul()
     if a is pi:
         if c.is_rational:
@@ -605,7 +603,7 @@ def _minpoly_compose(ex, x, dom):
     elif ex.__class__ is cos:
         res = _minpoly_cos(ex, x)
     elif ex.__class__ is tan:
-        res = _minpoly_tan(ex)
+        res = _minpoly_tan(ex, x)
     elif ex.__class__ is exp:
         res = _minpoly_exp(ex, x)
     elif ex.__class__ is CRootOf:

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -1,7 +1,7 @@
 """Tests for computational algebraic number field theory. """
 
 from sympy import (S, Rational, Symbol, Poly, sqrt, I, oo, Tuple, expand,
-    pi, cos, sin, exp, GoldenRatio, TribonacciConstant, cbrt)
+    pi, cos, sin, tan, exp, GoldenRatio, TribonacciConstant, cbrt)
 from sympy.solvers.solveset import nonlinsolve
 from sympy.geometry import Circle, intersection
 from sympy.testing.pytest import raises, slow
@@ -262,6 +262,20 @@ def test_minpoly_compose():
     ex = sqrt(1 + 2**Rational(1,3)) + sqrt(1 + 2**Rational(1,4)) + sqrt(2)
     mp = minimal_polynomial(ex, x)
     assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576
+
+    ex = tan(13*pi/45)
+    mp = minimal_polynomial(ex, x)
+    a = Poly(mp).nroots()
+    b = ex.n()
+    assert b in a
+
+    ex = tan(5*pi/46)
+    mp = minimal_polynomial(ex, x)
+    a = Poly(mp).nroots()
+    b = ex.n()
+    assert b in a
+
+    raises(NotAlgebraic, lambda: minimal_polynomial(tan(pi*sqrt(2)), x))
 
 
 def test_minpoly_issue_7113():

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -263,21 +263,15 @@ def test_minpoly_compose():
     mp = minimal_polynomial(ex, x)
     assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576
 
-    ex = tan(13*pi/45)
+    ex = tan(pi/5, evaluate=False)
     mp = minimal_polynomial(ex, x)
-    assert mp == x**24 - 852*x**22 + 26562*x**20 - 288452*x**18 + 1465839*x**16 - \
-            3852456*x**14 + 5407388*x**12 - 3994152*x**10 + 1475055*x**8 - 250372*x**6 + 15810*x**4 - 276*x**2 + 1
-    a = Poly(mp).nroots()
-    b = ex.n()
-    assert b in a
+    assert mp == x**4 - 10*x**2 + 5
+    assert mp.subs(x, tan(pi/5)).is_zero
 
-    ex = tan(5*pi/46)
+    ex = tan(pi/6, evaluate=False)
     mp = minimal_polynomial(ex, x)
-    assert mp == 23*x**22 - 1771*x**20 + 33649*x**18 - 245157*x**16 + 817190*x**14 - \
-            1352078*x**12 + 1144066*x**10 - 490314*x**8 + 100947*x**6 - 8855*x**4 + 253*x**2 - 1
-    a = Poly(mp).nroots()
-    b = ex.n()
-    assert b in a
+    assert mp == 3*x**2 - 1
+    assert mp.subs(x, tan(pi/6)).is_zero
 
     raises(NotAlgebraic, lambda: minimal_polynomial(tan(pi*sqrt(2)), x))
 

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -273,6 +273,11 @@ def test_minpoly_compose():
     assert mp == 3*x**2 - 1
     assert mp.subs(x, tan(pi/6)).is_zero
 
+    ex = tan(pi/10, evaluate=False)
+    mp = minimal_polynomial(ex, x)
+    assert mp == 5*x**4 - 10*x**2 + 1
+    assert mp.subs(x, tan(pi/10)).is_zero
+
     raises(NotAlgebraic, lambda: minimal_polynomial(tan(pi*sqrt(2)), x))
 
 

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -265,12 +265,16 @@ def test_minpoly_compose():
 
     ex = tan(13*pi/45)
     mp = minimal_polynomial(ex, x)
+    assert mp == x**24 - 852*x**22 + 26562*x**20 - 288452*x**18 + 1465839*x**16 - \
+            3852456*x**14 + 5407388*x**12 - 3994152*x**10 + 1475055*x**8 - 250372*x**6 + 15810*x**4 - 276*x**2 + 1
     a = Poly(mp).nroots()
     b = ex.n()
     assert b in a
 
     ex = tan(5*pi/46)
     mp = minimal_polynomial(ex, x)
+    assert mp == 23*x**22 - 1771*x**20 + 33649*x**18 - 245157*x**16 + 817190*x**14 - \
+            1352078*x**12 + 1144066*x**10 - 490314*x**8 + 100947*x**6 - 8855*x**4 + 253*x**2 - 1
     a = Poly(mp).nroots()
     b = ex.n()
     assert b in a


### PR DESCRIPTION
This PR adds the `_minpoly_tan` method which calculates minimal polynomial of tan(n*pi), if n is rational.

#### References to other Issues or PRs
Fixes #21430 


#### Brief description of what is fixed or changed
The `_minpoly_tan` method evaluates minimal polynomial by first calculating the binomial coefficient for `(1 + I*x)**n`, then we take the real or imaginary part according to the numerator of the argument of `tan` `* n`, as real part if odd multiple of `pi/2` else imaginary.

#### Other comments
For reference - https://github.com/sympy/sympy/issues/21430#issuecomment-833428491

<!-- BEGIN RELEASE NOTES -->
* polys
    * `_minpoly_tan` method is added for calculating minimal polynomial for tan(n*pi), if n is rational.
<!-- END RELEASE NOTES -->
