### PR TITLE
feat(diffgeom) : introduce rewriting of CoordinateSymbol wrt CoordSystem

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3901,7 +3901,7 @@ class Catalan(NumberSymbol, metaclass=Singleton):
         elif issubclass(number_cls, Rational):
             return (Rational(9, 10), S.One)
 
-    def _eval_rewrite_as_Sum(self, k_sym=None, symbols=None):
+    def _eval_rewrite_as_Sum(self, k_sym=None, symbols=None, **kwargs):
         from sympy import Sum, Dummy
         if (k_sym is not None) or (symbols is not None):
             return self

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1754,17 +1754,17 @@ class Pow(Expr):
     def _sage_(self):
         return self.args[0]._sage_()**self.args[1]._sage_()
 
-    def _eval_rewrite_as_sin(self, base, exp):
+    def _eval_rewrite_as_sin(self, base, exp, **kwargs):
         from ..functions import sin
         if self.base is S.Exp1:
             return sin(S.ImaginaryUnit*self.exp + S.Pi/2) - S.ImaginaryUnit*sin(S.ImaginaryUnit*self.exp)
 
-    def _eval_rewrite_as_cos(self, base, exp):
+    def _eval_rewrite_as_cos(self, base, exp, **kwargs):
         from ..functions import cos
         if self.base is S.Exp1:
             return cos(S.ImaginaryUnit*self.exp) + S.ImaginaryUnit*cos(S.ImaginaryUnit*self.exp + S.Pi/2)
 
-    def _eval_rewrite_as_tanh(self, base, exp):
+    def _eval_rewrite_as_tanh(self, base, exp, **kwargs):
         from ..functions import tanh
         if self.base is S.Exp1:
             return (1 + tanh(self.exp/2))/(1 - tanh(self.exp/2))

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -36,6 +36,7 @@ def test_R2():
         assert m == R2_p.coord_tuple_transform_to(
             R2_r, R2_r.coord_tuple_transform_to(R2_p, m)).applyfunc(simplify)
 
+
 def test_R3():
     a, b, c = symbols('a b c', positive=True)
     m = Matrix([[a], [b], [c]])
@@ -59,6 +60,12 @@ def test_R3():
         assert m == R3_s.coord_tuple_transform_to(
             R3_c, R3_c.coord_tuple_transform_to(R3_s, m)).applyfunc(simplify)
         #TODO assert m == R3_c.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
+
+
+def test_CoordinateSymbol():
+    x, y = R2_r.symbols
+    r, theta = R2_p.symbols
+    assert y.rewrite(R2_p) == r*sin(theta)
 
 
 def test_point():
@@ -229,6 +236,7 @@ def test_correct_arguments():
 
     raises(ValueError, lambda: contravariant_order(R2.e_x*R2.e_y))
     raises(ValueError, lambda: covariant_order(R2.dx*R2.dy))
+
 
 def test_simplify():
     x, y = R2_r.coord_functions()

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -981,7 +981,7 @@ class Piecewise(Function):
             last = ITE(c, a, last)
         return _canonical(last)
 
-    def _eval_rewrite_as_KroneckerDelta(self, *args):
+    def _eval_rewrite_as_KroneckerDelta(self, *args, **kwargs):
         from sympy import Ne, Eq, Not, KroneckerDelta
 
         rules = {

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -679,9 +679,9 @@ class hankel2(BesselBase):
 
 def assume_integer_order(fn):
     @wraps(fn)
-    def g(self, nu, z):
+    def g(self, nu, z, **kwargs):
         if nu.is_integer:
-            return fn(self, nu, z)
+            return fn(self, nu, z, **kwargs)
     return g
 
 
@@ -865,8 +865,8 @@ class yn(SphericalBesselBase):
 
     """
 
-    def _rewrite(self):
-        return self._eval_rewrite_as_bessely(self.order, self.argument)
+    def _rewrite(self, **kwargs):
+        return self._eval_rewrite_as_bessely(self.order, self.argument, **kwargs)
 
     @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -92,7 +92,7 @@ class elliptic_k(Function):
         if m.is_infinite:
             return True
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy import Integral, Dummy
         t = Dummy('t')
         m = self.args[0]
@@ -174,7 +174,7 @@ class elliptic_f(Function):
         if (m.is_real and (m - 1).is_positive) is False:
             return self.func(z.conjugate(), m.conjugate())
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy import Integral, Dummy
         t = Dummy('t')
         z, m = self.args[0], self.args[1]
@@ -303,7 +303,7 @@ class elliptic_e(Function):
             return -meijerg(((S.Half, Rational(3, 2)), []), \
                             ((S.Zero,), (S.Zero,)), -m)/4
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy import Integral, Dummy
         z, m = (pi/2, self.args[0]) if len(self.args) == 1 else self.args
         t = Dummy('t')
@@ -438,7 +438,7 @@ class elliptic_pi(Function):
                 return (elliptic_e(m)/(m - 1) + elliptic_pi(n, m))/(2*(n - m))
         raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy import Integral, Dummy
         if len(self.args) == 2:
             n, m, z = self.args[0], self.args[1], pi/2

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -141,9 +141,9 @@ class TensorProduct(Expr):
     def _eval_adjoint(self):
         return TensorProduct(*[Dagger(i) for i in self.args])
 
-    def _eval_rewrite(self, pattern, rule, **hints):
+    def _eval_rewrite(self, pattern, method, rule, **hints):
         sargs = self.args
-        terms = [t._eval_rewrite(pattern, rule, **hints) for t in sargs]
+        terms = [t._eval_rewrite(pattern, method, rule, **hints) for t in sargs]
         return TensorProduct(*terms).expand(tensorproduct=True)
 
     def _sympystr(self, printer, *args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2099,7 +2099,7 @@ class DisjointUnion(Set):
                 iter_flag = iter_flag and set_i.is_iterable
         return iter_flag
 
-    def _eval_rewrite_as_Union(self, *sets):
+    def _eval_rewrite_as_Union(self, *sets, **kwargs):
         """
         Rewrites the disjoint union as the union of (``set`` x {``i``})
         where ``set`` is the element in ``sets`` at index = ``i``

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2643,7 +2643,7 @@ class TensAdd(TensExpr, AssocOp):
             raise ValueError("No iteration on abstract tensors")
         return self.data.flatten().__iter__()
 
-    def _eval_rewrite_as_Indexed(self, *args):
+    def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         return Add.fromiter(args)
 
     def _eval_partial_derivative(self, s):
@@ -3069,7 +3069,7 @@ class Tensor(TensExpr):
     def contract_delta(self, metric):
         return self.contract_metric(metric)
 
-    def _eval_rewrite_as_Indexed(self, tens, indices):
+    def _eval_rewrite_as_Indexed(self, tens, indices, **kwargs):
         from sympy import Indexed
         # TODO: replace .args[0] with .name:
         index_symbols = [i.args[0] for i in self.get_indices()]
@@ -3899,7 +3899,7 @@ class TensMul(TensExpr, AssocOp):
             raise ValueError("No iteration on abstract tensors")
         return self.data.__iter__()
 
-    def _eval_rewrite_as_Indexed(self, *args):
+    def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         from sympy import Sum
         index_symbols = [i.args[0] for i in self.get_indices()]
         args = [arg.args[0] if isinstance(arg, Sum) else arg for arg in args]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`CoordinateSymbol` can now be rewritten with respect to another coordnate system. For example, for Cartesian `x, y` and Polar `r, theta`, `x.rewrite(Polar)` returns `r*cos(theta)`.

#### Other comments

For this, `Basic.rewrite()` is modified to be able to take instance as rewrite rule. This does not change public API.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* diffgeom
    * `CoordinateSymbol` now can be rewritten to the expression containing the coordinate symbols of other coordinate system.
<!-- END RELEASE NOTES -->
