### PR TITLE
Make Predicate not Boolean

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -401,10 +401,10 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
 
-    if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
+    if proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
 
-    if isinstance(assumptions, Predicate) or assumptions.kind is not BooleanKind:
+    if assumptions.kind is not BooleanKind:
         raise TypeError("assumptions must be a valid logical expression")
 
     binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 import inspect
 from sympy.core.assumptions import ManagedProperties
+from sympy.core.basic import Basic
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean, false, true
@@ -222,7 +223,7 @@ class PredicateMeta(ManagedProperties):
         return doc
 
 
-class Predicate(Boolean, metaclass=PredicateMeta):
+class Predicate(Basic, metaclass=PredicateMeta):
     """
     Base class for mathematical predicates. It also serves as a
     constructor for undefined predicate objects.
@@ -385,7 +386,7 @@ class UndefinedPredicate(Predicate):
         # "handlers" parameter supports old design
         if not isinstance(name, Str):
             name = Str(name)
-        obj = super(Boolean, cls).__new__(cls, name)
+        obj = super().__new__(cls, name)
         obj.handlers = handlers or []
         return obj
 

--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -140,10 +140,17 @@ class AND:
     __repr__ = __str__
 
 
-def to_NNF(expr, composite_map={}):
+def to_NNF(expr, decomposer=None):
     """
     Generates the Negation Normal Form of any boolean expression in terms
     of AND, OR, and Literal objects.
+
+    Parameters
+    ==========
+
+    expr : Boolean
+
+    decomposer : function which decomposes the predicate, optional.
 
     Examples
     ========
@@ -160,17 +167,15 @@ def to_NNF(expr, composite_map={}):
     >>> to_NNF(Eq(x, y))
     Literal(Q.eq(x, y), False)
 
-    If ``composite_map`` argument is given, ``to_NNF`` decomposes the
-    specified predicate into a combination of primitive predicates.
+    If *decomposer* parameter is given, ``to_NNF`` decomposes the
+    predicate into a combination of primitive predicates.
 
-    >>> cmap = {Q.nonpositive: Q.negative | Q.zero}
-    >>> to_NNF(Q.nonpositive, cmap)
-    (Literal(Q.negative, False) | Literal(Q.zero, False))
-    >>> to_NNF(Q.nonpositive(x), cmap)
+    >>> from sympy.assumptions.facts import decompose_predicate
+    >>> to_NNF(Q.nonpositive(x), decompose_predicate)
     (Literal(Q.negative(x), False) | Literal(Q.zero(x), False))
     """
     from sympy.assumptions.ask import Q
-    from sympy.assumptions.assume import AppliedPredicate, Predicate
+    from sympy.assumptions.assume import AppliedPredicate
 
     binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}
     if type(expr) in binrelpreds:
@@ -179,28 +184,28 @@ def to_NNF(expr, composite_map={}):
 
     if isinstance(expr, Not):
         arg = expr.args[0]
-        tmp = to_NNF(arg, composite_map)  # Strategy: negate the NNF of expr
+        tmp = to_NNF(arg, decomposer)  # Strategy: negate the NNF of expr
         return ~tmp
 
     if isinstance(expr, Or):
-        return OR(*[to_NNF(x, composite_map) for x in Or.make_args(expr)])
+        return OR(*[to_NNF(x, decomposer) for x in Or.make_args(expr)])
 
     if isinstance(expr, And):
-        return AND(*[to_NNF(x, composite_map) for x in And.make_args(expr)])
+        return AND(*[to_NNF(x, decomposer) for x in And.make_args(expr)])
 
     if isinstance(expr, Nand):
-        tmp = AND(*[to_NNF(x, composite_map) for x in expr.args])
+        tmp = AND(*[to_NNF(x, decomposer) for x in expr.args])
         return ~tmp
 
     if isinstance(expr, Nor):
-        tmp = OR(*[to_NNF(x, composite_map) for x in expr.args])
+        tmp = OR(*[to_NNF(x, decomposer) for x in expr.args])
         return ~tmp
 
     if isinstance(expr, Xor):
         cnfs = []
         for i in range(0, len(expr.args) + 1, 2):
             for neg in combinations(expr.args, i):
-                clause = [~to_NNF(s, composite_map) if s in neg else to_NNF(s, composite_map)
+                clause = [~to_NNF(s, decomposer) if s in neg else to_NNF(s, decomposer)
                           for s in expr.args]
                 cnfs.append(OR(*clause))
         return AND(*cnfs)
@@ -209,39 +214,34 @@ def to_NNF(expr, composite_map={}):
         cnfs = []
         for i in range(0, len(expr.args) + 1, 2):
             for neg in combinations(expr.args, i):
-                clause = [~to_NNF(s, composite_map) if s in neg else to_NNF(s, composite_map)
+                clause = [~to_NNF(s, decomposer) if s in neg else to_NNF(s, decomposer)
                           for s in expr.args]
                 cnfs.append(OR(*clause))
         return ~AND(*cnfs)
 
     if isinstance(expr, Implies):
-        L, R = to_NNF(expr.args[0], composite_map), to_NNF(expr.args[1], composite_map)
+        L, R = to_NNF(expr.args[0], decomposer), to_NNF(expr.args[1], decomposer)
         return OR(~L, R)
 
     if isinstance(expr, Equivalent):
         cnfs = []
         for a, b in zip_longest(expr.args, expr.args[1:], fillvalue=expr.args[0]):
-            a = to_NNF(a, composite_map)
-            b = to_NNF(b, composite_map)
+            a = to_NNF(a, decomposer)
+            b = to_NNF(b, decomposer)
             cnfs.append(OR(~a, b))
         return AND(*cnfs)
 
     if isinstance(expr, ITE):
-        L = to_NNF(expr.args[0], composite_map)
-        M = to_NNF(expr.args[1], composite_map)
-        R = to_NNF(expr.args[2], composite_map)
+        L = to_NNF(expr.args[0], decomposer)
+        M = to_NNF(expr.args[1], decomposer)
+        R = to_NNF(expr.args[2], decomposer)
         return AND(OR(~L, M), OR(L, R))
 
     if isinstance(expr, AppliedPredicate):
-        pred, args = expr.function, expr.arguments
-        newpred = composite_map.get(pred, None)
-        if newpred is not None:
-            return to_NNF(newpred.rcall(*args), composite_map)
-
-    if isinstance(expr, Predicate):
-        newpred = composite_map.get(expr, None)
-        if newpred is not None:
-            return to_NNF(newpred, composite_map)
+        if decomposer is not None:
+            newexpr = decomposer(expr)
+            if expr != newexpr:
+                return to_NNF(newexpr, decomposer)
 
     return Literal(expr)
 
@@ -378,8 +378,8 @@ class CNF:
 
     @classmethod
     def to_CNF(cls, expr):
-        from sympy.assumptions.facts import get_composite_predicates
-        expr = to_NNF(expr, get_composite_predicates())
+        from sympy.assumptions.facts import decompose_predicate
+        expr = to_NNF(expr, decompose_predicate)
         expr = distribute_AND_over_OR(expr)
         return expr
 

--- a/sympy/assumptions/facts.py
+++ b/sympy/assumptions/facts.py
@@ -11,7 +11,7 @@ from sympy.assumptions.assume import AppliedPredicate
 from sympy.core.cache import cacheit
 from sympy.core.symbol import Symbol
 from sympy.logic.boolalg import (to_cnf, And, Not, Implies, Equivalent,
-    Exclusive,)
+    Exclusive, Or,)
 from sympy.logic.inference import satisfiable
 
 
@@ -36,32 +36,28 @@ def decompose_predicate(pred):
     Q.negative(x) | Q.positive(x) | Q.zero(x)
 
     """
+    mapping = {
+        Q.real : [Q.negative, Q.zero, Q.positive],
+        Q.integer : [Q.even, Q.odd],
+        Q.nonpositive : [Q.negative, Q.zero],
+        Q.nonzero : [Q.negative, Q.positive],
+        Q.nonnegative : [Q.zero, Q.positive],
+        Q.extended_real : [Q.negative_infinite, Q.negative, Q.zero, Q.positive,
+                           Q.positive_infinite],
+        Q.extended_positive: [Q.positive, Q.positive_infinite],
+        Q.extended_negative: [Q.negative, Q.negative_infinite],
+        Q.extended_nonzero: [Q.negative_infinite, Q.negative, Q.positive,
+                             Q.positive_infinite],
+        Q.extended_nonpositive: [Q.negative_infinite, Q.negative, Q.zero],
+        Q.extended_nonnegative: [Q.zero, Q.positive, Q.positive_infinite],
+        Q.complex : [Q.algebraic, Q.transcendental],
+    }
+
     p, args = pred.function, pred.arguments
 
-    if p == Q.real:
-        return Q.negative(*args) | Q.zero(*args) | Q.positive(*args)
-    if p == Q.integer:
-        return Q.even(*args) | Q.odd(*args)
-    if p == Q.nonpositive:
-        return Q.negative(*args) | Q.zero(*args)
-    if p == Q.nonzero:
-        return Q.negative(*args) | Q.positive(*args)
-    if p == Q.nonnegative:
-        return Q.zero(*args) | Q.positive(*args)
-    if p == Q.extended_real:
-        return Q.negative_infinite(*args) | Q.negative(*args) | Q.zero(*args) | Q.positive(*args) | Q.positive_infinite(*args)
-    if p == Q.extended_positive:
-        return Q.positive(*args) | Q.positive_infinite(*args)
-    if p == Q.extended_negative:
-        return Q.negative(*args) | Q.negative_infinite(*args)
-    if p == Q.extended_nonzero:
-        return Q.negative_infinite(*args) | Q.negative(*args) | Q.positive(*args) | Q.positive_infinite(*args)
-    if p == Q.extended_nonpositive:
-        return Q.negative_infinite(*args) | Q.negative(*args) | Q.zero(*args)
-    if p == Q.extended_nonnegative:
-        return Q.zero(*args) | Q.positive(*args) | Q.positive_infinite(*args)
-    if p == Q.complex:
-        return Q.algebraic(*args) | Q.transcendental(*args)
+    if p in mapping:
+        return Or(*[f(*args) for f in mapping[p]])
+
     return pred
 
 

--- a/sympy/assumptions/facts.py
+++ b/sympy/assumptions/facts.py
@@ -15,24 +15,54 @@ from sympy.logic.boolalg import (to_cnf, And, Not, Implies, Equivalent,
 from sympy.logic.inference import satisfiable
 
 
-@cacheit
-def get_composite_predicates():
-    # To reduce the complexity of sat solver, these predicates are
-    # transformed into the combination of primitive predicates.
-    return {
-        Q.real : Q.negative | Q.zero | Q.positive,
-        Q.integer : Q.even | Q.odd,
-        Q.nonpositive : Q.negative | Q.zero,
-        Q.nonzero : Q.negative | Q.positive,
-        Q.nonnegative : Q.zero | Q.positive,
-        Q.extended_real : Q.negative_infinite | Q.negative | Q.zero | Q.positive | Q.positive_infinite,
-        Q.extended_positive: Q.positive | Q.positive_infinite,
-        Q.extended_negative: Q.negative | Q.negative_infinite,
-        Q.extended_nonzero: Q.negative_infinite | Q.negative | Q.positive | Q.positive_infinite,
-        Q.extended_nonpositive: Q.negative_infinite | Q.negative | Q.zero,
-        Q.extended_nonnegative: Q.zero | Q.positive | Q.positive_infinite,
-        Q.complex : Q.algebraic | Q.transcendental
-    }
+def decompose_predicate(pred):
+    """
+    Decompose the predicate into the combination of primitive predicates.
+
+    Explanation
+    ===========
+
+    To reduce the complexity of sat solver, facts are built using the
+    primitive predicates. This function decomposes the predicate into
+    the combination of such predicates if possible.
+
+    Examples
+    ========
+
+    >>> from sympy import Q
+    >>> from sympy.assumptions.facts import decompose_predicate
+    >>> from sympy.abc import x
+    >>> decompose_predicate(Q.real(x))
+    Q.negative(x) | Q.positive(x) | Q.zero(x)
+
+    """
+    p, args = pred.function, pred.arguments
+
+    if p == Q.real:
+        return Q.negative(*args) | Q.zero(*args) | Q.positive(*args)
+    if p == Q.integer:
+        return Q.even(*args) | Q.odd(*args)
+    if p == Q.nonpositive:
+        return Q.negative(*args) | Q.zero(*args)
+    if p == Q.nonzero:
+        return Q.negative(*args) | Q.positive(*args)
+    if p == Q.nonnegative:
+        return Q.zero(*args) | Q.positive(*args)
+    if p == Q.extended_real:
+        return Q.negative_infinite(*args) | Q.negative(*args) | Q.zero(*args) | Q.positive(*args) | Q.positive_infinite(*args)
+    if p == Q.extended_positive:
+        return Q.positive(*args) | Q.positive_infinite(*args)
+    if p == Q.extended_negative:
+        return Q.negative(*args) | Q.negative_infinite(*args)
+    if p == Q.extended_nonzero:
+        return Q.negative_infinite(*args) | Q.negative(*args) | Q.positive(*args) | Q.positive_infinite(*args)
+    if p == Q.extended_nonpositive:
+        return Q.negative_infinite(*args) | Q.negative(*args) | Q.zero(*args)
+    if p == Q.extended_nonnegative:
+        return Q.zero(*args) | Q.positive(*args) | Q.positive_infinite(*args)
+    if p == Q.complex:
+        return Q.algebraic(*args) | Q.transcendental(*args)
+    return pred
 
 
 @cacheit

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2128,15 +2128,15 @@ def test_type_extensibility():
 
 
 def test_single_fact_lookup():
-    known_facts = And(Implies(Q.integer, Q.rational),
-                      Implies(Q.rational, Q.real),
-                      Implies(Q.real, Q.complex))
-    known_facts_keys = {Q.integer, Q.rational, Q.real, Q.complex}
+    known_facts = And(Implies(Q.integer(x), Q.rational(x)),
+                      Implies(Q.rational(x), Q.real(x)),
+                      Implies(Q.real(x), Q.complex(x)))
+    known_facts_keys = {Q.integer(x), Q.rational(x), Q.real(x), Q.complex(x)}
 
     known_facts_cnf = to_cnf(known_facts)
     mapping = single_fact_lookup(known_facts_keys, known_facts_cnf)
 
-    assert mapping[Q.rational] == {Q.real, Q.rational, Q.complex}
+    assert mapping[Q.rational(x)] == {Q.real(x), Q.rational(x), Q.complex(x)}
 
 
 def test_generate_known_facts_dict():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,6 +1,7 @@
 from sympy.abc import t, w, x, y, z, n, k, m, p, i
 from sympy.assumptions import (ask, AssumptionsContext, Q, register_handler,
         remove_handler)
+from sympy.assumptions.ask import unary_ask
 from sympy.assumptions.assume import assuming, global_assumptions, Predicate
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.facts import (single_fact_lookup,
@@ -2405,3 +2406,10 @@ def test_relational():
     assert not ask(Q.eq(x, 0), Q.nonzero(x))
     assert not ask(Q.ne(x, 0), Q.zero(x))
     assert ask(Q.ne(x, 0), Q.nonzero(x))
+
+
+def test_unary_ask():
+    assert unary_ask(Q.zero(x), ~Q.zero(x)) is False
+    assert unary_ask(Q.zero(x), ~Q.even(x)) is False
+    assert unary_ask(Q.even(x), Q.zero(x)) is True
+    assert unary_ask(Q.even(x), Q.odd(x)) is False

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -11,7 +11,7 @@ from sympy.core.sympify import SympifyError
 from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
-from sympy import sin, Q, cos, gamma, Tuple, Integral, Sum
+from sympy import sin, cos, gamma, Tuple, Integral, Sum
 from sympy.functions.elementary.exponential import exp
 from sympy.testing.pytest import raises
 from sympy.core import I, pi
@@ -221,8 +221,6 @@ def test_call():
     # TODO UndefinedFunction does not subclass Expr
     #f = Function('f')
     #assert (2*f)(x) == 2*f(x)
-
-    assert (Q.real & Q.positive).rcall(x) == Q.real(x) & Q.positive(x)
 
 
 def test_rewrite():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`Predicate` is no more `Boolean`.

#### Other comments

Internal structure of `ask` module is enhanced for cleaner code and documentation.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * `Predicate` class is no more a subclass of `Boolean`.
<!-- END RELEASE NOTES -->
