### PR TITLE
feat(assumptions): Introduce predicate fact registration

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import MutableMapping
 
 from sympy.assumptions.ask import Q
 from sympy.core import (Add, Mul, Pow, Number, NumberSymbol, Symbol)
@@ -194,6 +195,96 @@ class ClassFactRegistry:
 class_fact_registry = ClassFactRegistry()
 
 
+class PredFactRegistry(MutableMapping):
+    """
+    Registry to store the handlers which returns the new facts from the
+    predicate.
+
+    Explanation
+    ===========
+
+    ``register()`` method registers the handler function against a predicate.
+
+    ``registry(pred)`` method returns a dictionary of computed facts and their
+    handler functions for *pred*.
+
+    ``remove_handler()`` method removes a handler function from every class.
+    This can be useful when you want to extract a compact registry from the
+    pre-built one.
+
+    Examples
+    ========
+
+    Here, we register simple facts for ``Q.gt``.
+
+    >>> from sympy import Q
+    >>> from sympy.assumptions.sathandlers import PredFactRegistry
+    >>> reg = PredFactRegistry()
+    >>> @reg.register(Q.gt)
+    ... def _(gt):
+    ...     return Q.extended_real(gt.lhs) & Q.extended_real(gt.rhs)
+    >>> @reg.register(Q.gt)
+    ... def _(gt):
+    ...     return Q.positive(gt.lhs - gt.rhs)
+
+    Calling the registry with predicate returns a dictionary of computed facts
+    and their handler functions for the predicate.
+
+    >>> from sympy.abc import x, y
+    >>> reg(Q.gt(x, y)) # doctest: +SKIP
+    {Q.extended_real(x) & Q.extended_real(y): <function _ at 0x7fe27b29a940>,
+     Q.positive(x - y): <function _ at 0x7fe27b15e3a0>}
+
+    You can remove unnecessary handler with ``remove_handler()`` method.
+
+    >>> h = reg(Q.gt(x, y))[Q.positive(x - y)]
+    >>> reg.remove_handler(h)
+    >>> reg(Q.gt(x, y)) # doctest: +SKIP
+    {Q.extended_real(x) & Q.extended_real(y): <function _ at 0x7fe27b29a940>}
+
+    """
+    def __init__(self, d=None):
+        d = d or {}
+        self.d = defaultdict(frozenset, d)
+        super().__init__()
+
+    def __setitem__(self, key, item):
+        self.d[key] = frozenset(item)
+
+    def __delitem__(self, key):
+        del self.d[key]
+
+    def __iter__(self):
+        return self.d.__iter__()
+
+    def __len__(self):
+        return len(self.d)
+
+    def __repr__(self):
+        return repr(self.d)
+
+    def register(self, pred):
+        def _(func):
+            self.d[pred] |= {func}
+            return func
+        return _
+
+    def __getitem__(self, key):
+        funcs = self.d.get(key, {})
+        return list(funcs)
+
+    def __call__(self, expr):
+        handlers = self[expr.function]
+        return  {h(expr): h for h in handlers}
+
+    def remove_handler(self, handler):
+        for key in self.d.keys():
+            old_handlers = self.d[key]
+            new_handlers = old_handlers - {handler}
+            self.d[key] = new_handlers
+
+pred_fact_registry = PredFactRegistry()
+
 
 ### Class fact registration ###
 
@@ -322,3 +413,9 @@ def _(expr):
         if prop is not None:
             ret.append(Equivalent(pred, prop))
     return ret
+
+
+### Predicate fact registration ###
+
+for p in (Q.gt, Q.ge, Q.lt, Q.le):
+    pred_fact_registry.register(p)(lambda rel: Q.extended_real(rel.lhs) & Q.extended_real(rel.rhs))

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -222,25 +222,28 @@ class PredFactRegistry(MutableMapping):
     >>> reg = PredFactRegistry()
     >>> @reg.register(Q.gt)
     ... def _(gt):
-    ...     return Q.extended_real(gt.lhs) & Q.extended_real(gt.rhs)
+    ...     return gt >> (Q.extended_real(gt.lhs) & Q.extended_real(gt.rhs))
     >>> @reg.register(Q.gt)
     ... def _(gt):
-    ...     return Q.positive(gt.lhs - gt.rhs)
+    ...     return gt >> Q.positive(gt.lhs - gt.rhs)
 
     Calling the registry with predicate returns a dictionary of computed facts
     and their handler functions for the predicate.
 
     >>> from sympy.abc import x, y
     >>> reg(Q.gt(x, y)) # doctest: +SKIP
-    {Q.extended_real(x) & Q.extended_real(y): <function _ at 0x7fe27b29a940>,
-     Q.positive(x - y): <function _ at 0x7fe27b15e3a0>}
+    {Implies(Q.gt(x, y), Q.extended_real(x) & Q.extended_real(y)):
+        <function _ at 0x7f292267dd30>,
+     Implies(Q.gt(x, y), Q.positive(x - y)):
+        <function _ at 0x7f29226715e0>}
 
     You can remove unnecessary handler with ``remove_handler()`` method.
 
-    >>> h = reg(Q.gt(x, y))[Q.positive(x - y)]
+    >>> h = reg(Q.gt(x, y))[Q.gt(x, y) >> Q.positive(x - y)]
     >>> reg.remove_handler(h)
     >>> reg(Q.gt(x, y)) # doctest: +SKIP
-    {Q.extended_real(x) & Q.extended_real(y): <function _ at 0x7fe27b29a940>}
+    {Implies(Q.gt(x, y), Q.extended_real(x) & Q.extended_real(y)):
+        <function _ at 0x7f292267dd30>}
 
     """
     def __init__(self, d=None):
@@ -418,4 +421,5 @@ def _(expr):
 ### Predicate fact registration ###
 
 for p in (Q.gt, Q.ge, Q.lt, Q.le):
-    pred_fact_registry.register(p)(lambda rel: Q.extended_real(rel.lhs) & Q.extended_real(rel.rhs))
+    fact = lambda r: r >> (Q.extended_real(r.lhs) & Q.extended_real(r.rhs))
+    pred_fact_registry.register(p)(fact)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Facts for the predicates can now be registered. For example, `Q.gt(x, y) >> Q.extended_real(x) & Q.extended_real(y)` can be registered to let `ask(Q.extended_real(x), x > y)` return `True`.

#### Other comments

This system can be used to register the facts such as `Q.eq(x, y) >> Q.zero(x - y)`. With this, relational predicates can be assumed so that `ask(Q.positive(x+1), x > 0)` returns `True`, which will be a great improvement for `Piecewise`. It will be done in succeeding PRs.

Note : equality/inequality evaluation should use advanced algorithms to be efficiently done. Converting equality to being zero should be done only as a fallback.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
