### PR TITLE
fix: `expr_free_symbols` returns symbols

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3919,10 +3919,6 @@ class AtomicExpr(Atom, Expr):
     def _eval_nseries(self, x, n, logx, cdir=0):
         return self
 
-    @property
-    def expr_free_symbols(self):
-        return {self}
-
 
 def _mag(x):
     """Return integer ``i`` such that .1 <= x/10**i < 1

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -354,6 +354,10 @@ class Symbol(AtomicExpr, Boolean):
     def as_set(self):
         return S.UniversalSet
 
+    @property
+    def expr_free_symbols(self):
+        return {self}
+
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, even if they have the same name:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2124,5 +2124,12 @@ def test_non_string_equality():
     assert (x != BadRepr()) is True
 
 def test_expr_free_symbols():
-    assert (2*exp(x)-3).expr_free_symbols == {x}
-    assert (4*y+3*x).expr_free_symbols == {x, y}
+    from sympy import IndexedBase
+    assert pi.expr_free_symbols == set()
+    assert (x + 2*y).expr_free_symbols == {x, y}
+    assert Derivative(2*x, y).expr_free_symbols == {x}
+    i = Integral(2*x, (y, z))
+    assert i.expr_free_symbols == i.function.free_symbols
+    assert Function('f')(x + 4).expr_free_symbols == {x}
+    b = 4 * IndexedBase(x)[y]
+    assert b.expr_free_symbols == {b.args[1]}

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2122,3 +2122,7 @@ def test_non_string_equality():
 
     assert (x == BadRepr()) is False
     assert (x != BadRepr()) is True
+
+def test_expr_free_symbols():
+    assert (2*exp(x)-3).expr_free_symbols == {x}
+    assert (4*y+3*x).expr_free_symbols == {x, y}


### PR DESCRIPTION
`expr_free_symbols`  used to return non-symbols i.e. elements of `AtomicExpr`, which leads to having non-symbols within the result.

#### References to other Issues or PRs
Fixes #21444 

#### Brief description of what is fixed or changed
We have removed the `expr_free_symbols` property from `AtomicExpr` and added it to the `Symbol` class.

#### Other comments
Ouput after the PR:
```py
In [1]: (2*exp(x)-3).expr_free_symbols
Out[1]: {x}

In [2]: (4*y**z+3*x).expr_free_symbols
Out[2]: {x, y, z}
```

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in `expr_free_symbols`.
<!-- END RELEASE NOTES -->
