### PR TITLE
fix(diffgeom): fix indirect transformation

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -435,7 +435,7 @@ class CoordSystem(Basic):
     @classmethod
     @cacheit
     def _indirect_transformation(cls, sys1, sys2):
-        # Find the transformation relation betweentwo indirectly connected
+        # Find the transformation relation between two indirectly connected
         # coordinate systems
         rel = sys1.relations
         path = cls._dijkstra(sys1, sys2)

--- a/sympy/diffgeom/rn.py
+++ b/sympy/diffgeom/rn.py
@@ -30,8 +30,8 @@ x, y = symbols('x y', real=True)
 r, theta = symbols('rho theta', nonnegative=True)
 
 relations_2d = {
-    ('rectangular', 'polar'): (sqrt(x**2 + y**2), atan2(y, x)),
-    ('polar', 'rectangular'): (r*cos(theta), r*sin(theta)),
+    ('rectangular', 'polar'): [(x, y), (sqrt(x**2 + y**2), atan2(y, x))],
+    ('polar', 'rectangular'): [(r, theta), (r*cos(theta), r*sin(theta))],
 }
 
 R2_r = CoordSystem('rectangular', R2_origin, (x, y), relations_2d)  # type: Any
@@ -74,18 +74,24 @@ x, y, z = symbols('x y z', real=True)
 rho, psi, r, theta, phi = symbols('rho psi r theta phi', nonnegative=True)
 
 relations_3d = {
-    ('rectangular', 'cylindrical'): (sqrt(x**2 + y**2), atan2(y, x), z),
-    ('cylindrical', 'rectangular'): (rho*cos(psi), rho*sin(psi), z),
-    ('rectangular', 'spherical'): (sqrt(x**2 + y**2 + z**2),
-                                   acos(z/sqrt(x**2 + y**2 + z**2)),
-                                   atan2(y, x)),
-    ('spherical', 'rectangular'): (r*sin(theta)*cos(phi),
-                                   r*sin(theta)*sin(phi),
-                                   r*cos(theta)),
-    ('cylindrical', 'spherical'): (sqrt(rho**2 + z**2),
-                                   acos(z/sqrt(rho**2 + z**2)),
-                                   psi),
-    ('spherical', 'cylindrical'): (r*sin(theta), phi, r*cos(theta)),
+    ('rectangular', 'cylindrical'): [(x, y, z),
+                                     (sqrt(x**2 + y**2), atan2(y, x), z)],
+    ('cylindrical', 'rectangular'): [(rho, psi, z),
+                                     (rho*cos(psi), rho*sin(psi), z)],
+    ('rectangular', 'spherical'): [(x, y, z),
+                                   (sqrt(x**2 + y**2 + z**2),
+                                    acos(z/sqrt(x**2 + y**2 + z**2)),
+                                    atan2(y, x))],
+    ('spherical', 'rectangular'): [(r, theta, phi),
+                                   (r*sin(theta)*cos(phi),
+                                    r*sin(theta)*sin(phi),
+                                    r*cos(theta))],
+    ('cylindrical', 'spherical'): [(rho, psi, z),
+                                   (sqrt(rho**2 + z**2),
+                                    acos(z/sqrt(rho**2 + z**2)),
+                                    psi)],
+    ('spherical', 'cylindrical'): [(r, theta, phi),
+                                   (r*sin(theta), phi, r*cos(theta))],
 }
 
 R3_r = CoordSystem('rectangular', R3_origin, (x, y, z), relations_3d)  # type: Any

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -1,10 +1,10 @@
+from sympy.core import Lambda, Symbol, symbols
 from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, R3_c, R3_s, R2_origin
 from sympy.diffgeom import (CoordSystem, Commutator, Differential, TensorProduct,
         WedgeProduct, BaseCovarDerivativeOp, CovarDerivativeOp, LieDerivative,
         covariant_order, contravariant_order, twoform_to_matrix, metric_to_Christoffel_1st,
         metric_to_Christoffel_2nd, metric_to_Riemann_components,
         metric_to_Ricci_components, intcurve_diffequ, intcurve_series)
-from sympy.core import Symbol, symbols
 from sympy.simplify import trigsimp, simplify
 from sympy.functions import sqrt, atan2, sin
 from sympy.matrices import Matrix
@@ -12,6 +12,78 @@ from sympy.testing.pytest import raises, nocache_fail
 from sympy.testing.pytest import warns_deprecated_sympy
 
 TP = TensorProduct
+
+
+def test_coordsys_transform():
+    # test inverse transforms
+    p, q, r, s = symbols('p q r s')
+    rel = {('first', 'second'): [(p, q), (q, -p)]}
+    R2_pq = CoordSystem('first', R2_origin, [p, q], rel)
+    R2_rs = CoordSystem('second', R2_origin, [r, s], rel)
+    r, s = R2_rs.symbols
+    assert R2_rs.transform(R2_pq) == Matrix([[-s], [r]])
+
+    # inverse transform impossible case
+    a, b = symbols('a b', positive=True)
+    rel = {('first', 'second'): [(a,), (-a,)]}
+    R2_a = CoordSystem('first', R2_origin, [a], rel)
+    R2_b = CoordSystem('second', R2_origin, [b], rel)
+    # This transformation is uninvertible because there is no positive a, b satisfying a = -b
+    with raises(NotImplementedError):
+        R2_b.transform(R2_a)
+
+    # inverse transform ambiguous case
+    c, d = symbols('c d')
+    rel = {('first', 'second'): [(c,), (c**2,)]}
+    R2_c = CoordSystem('first', R2_origin, [c], rel)
+    R2_d = CoordSystem('second', R2_origin, [d], rel)
+    # The transform method should throw if it finds multiple inverses for a coordinate transformation.
+    with raises(ValueError):
+        R2_d.transform(R2_c)
+
+    # test indirect transformation
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    rel = {('C1', 'C2'): [(a, b), (2*a, 3*b)],
+        ('C2', 'C3'): [(c, d), (3*c, 2*d)]}
+    C1 = CoordSystem('C1', R2_origin, (a, b), rel)
+    C2 = CoordSystem('C2', R2_origin, (c, d), rel)
+    C3 = CoordSystem('C3', R2_origin, (e, f), rel)
+    a, b = C1.symbols
+    c, d = C2.symbols
+    e, f = C3.symbols
+    assert C2.transform(C1) == Matrix([c/2, d/3])
+    assert C1.transform(C3) == Matrix([6*a, 6*b])
+    assert C3.transform(C1) == Matrix([e/6, f/6])
+    assert C3.transform(C2) == Matrix([e/3, f/2])
+
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    rel = {('C1', 'C2'): [(a, b), (2*a, 3*b + 1)],
+        ('C3', 'C2'): [(e, f), (-e - 2, 2*f)]}
+    C1 = CoordSystem('C1', R2_origin, (a, b), rel)
+    C2 = CoordSystem('C2', R2_origin, (c, d), rel)
+    C3 = CoordSystem('C3', R2_origin, (e, f), rel)
+    a, b = C1.symbols
+    c, d = C2.symbols
+    e, f = C3.symbols
+    assert C2.transform(C1) == Matrix([c/2, (d - 1)/3])
+    assert C1.transform(C3) == Matrix([-2*a - 2, (3*b + 1)/2])
+    assert C3.transform(C1) == Matrix([-e/2 - 1, (2*f - 1)/3])
+    assert C3.transform(C2) == Matrix([-e - 2, 2*f])
+
+    # old signature uses Lambda
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    rel = {('C1', 'C2'): Lambda((a, b), (2*a, 3*b + 1)),
+        ('C3', 'C2'): Lambda((e, f), (-e - 2, 2*f))}
+    C1 = CoordSystem('C1', R2_origin, (a, b), rel)
+    C2 = CoordSystem('C2', R2_origin, (c, d), rel)
+    C3 = CoordSystem('C3', R2_origin, (e, f), rel)
+    a, b = C1.symbols
+    c, d = C2.symbols
+    e, f = C3.symbols
+    assert C2.transform(C1) == Matrix([c/2, (d - 1)/3])
+    assert C1.transform(C3) == Matrix([-2*a - 2, (3*b + 1)/2])
+    assert C3.transform(C1) == Matrix([-e/2 - 1, (2*f - 1)/3])
+    assert C3.transform(C2) == Matrix([-e - 2, 2*f])
 
 
 def test_R2():
@@ -35,45 +107,6 @@ def test_R2():
     with warns_deprecated_sympy():
         assert m == R2_p.coord_tuple_transform_to(
             R2_r, R2_r.coord_tuple_transform_to(R2_p, m)).applyfunc(simplify)
-
-
-def test_inverse_transformations():
-    p, q, r, s = symbols('p q r s')
-
-    relations_quarter_rotation = {
-        ('first', 'second'): (q, -p)
-    }
-
-    R2_pq = CoordSystem('first', R2_origin, [p, q], relations_quarter_rotation)
-    R2_rs = CoordSystem('second', R2_origin, [r, s], relations_quarter_rotation)
-
-    # The transform method should derive the inverse transformation if not given explicitly
-    assert R2_rs.transform(R2_pq) == Matrix([[-R2_rs.symbols[1]], [R2_rs.symbols[0]]])
-
-    a, b = symbols('a b', positive=True)
-    relations_uninvertible_transformation = {
-        ('first', 'second'): (-a,)
-    }
-
-    R2_a = CoordSystem('first', R2_origin, [a], relations_uninvertible_transformation)
-    R2_b = CoordSystem('second', R2_origin, [b], relations_uninvertible_transformation)
-
-    # The transform method should throw if it cannot invert the coordinate transformation.
-    # This transformation is uninvertible because there is no positive a, b satisfying a = -b
-    with raises(NotImplementedError):
-        R2_b.transform(R2_a)
-
-    c, d = symbols('c d')
-    relations_ambiguous_inverse = {
-        ('first', 'second'): (c**2,)
-    }
-
-    R2_c = CoordSystem('first', R2_origin, [c], relations_ambiguous_inverse)
-    R2_d = CoordSystem('second', R2_origin, [d], relations_ambiguous_inverse)
-
-    # The transform method should throw if it finds multiple inverses for a coordinate transformation.
-    with raises(ValueError):
-        R2_d.transform(R2_c)
 
 
 def test_R3():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20742

#### Brief description of what is fixed or changed

Allow indirect transformation
Change signature of relation in order to allow indirect transformation
#### Other comments

Before #21464, transformation relation for `CoordSystem` used `Lambda` e.g. `Lambda((x, y), (y, -x))`.
In #21464, the signature was changed to use only the expression, e.g. `(y, -x)`.

However, to allow indirect transformation it is crucial to store the original symbol and transformed expression altogether. Therefore, the signature is now `((x, y), (y, -x))`. Old signature with `Lambda` is still supported, so it won't break backwards compatibility.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* diffgeom
    * Bug in indirect transformation between coordinate systems is fixed.
    * Transform relation between coordinate systems now consists of two tuples instead of `Lambda`.
<!-- END RELEASE NOTES -->
