### PR TITLE
21426 heaviside integration

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -398,9 +398,9 @@ class CoordSystem(Basic):
         elif key in self.relations:
             expr = Matrix(self.relations[key])
         elif key[::-1] in self.relations:
-            expr = Matrix(self._inverse_transformations(sys, self))
+            expr = Matrix(self._inverse_transformation(sys, self))
         else:
-            expr = Matrix(self._indirect_transformations(self, sys))
+            expr = Matrix(self._indirect_transformation(self, sys))
         return Lambda(signature, expr)
 
     @staticmethod
@@ -419,8 +419,7 @@ class CoordSystem(Basic):
 
         inv_results = inv_results[0]
         signature = tuple(sys1.symbols)
-        expr = Matrix([inv_results[s] for s in signature])
-        return Lambda(signature, expr)
+        return [inv_results[s] for s in signature]
 
     @classmethod
     @cacheit

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -407,15 +407,17 @@ class CoordSystem(Basic):
     def _inverse_transformation(sys1, sys2):
         # Find the transformation relation from sys2 to sys1
         forward_transform_expressions = sys1.transform(sys2)
-        # Coordinate transformations are defined in terms of Symbols rather than CoordSymbols, so must be converted
-        forward_transform_expressions = to_coord_symbol(sys1.symbols, forward_transform_expressions)
 
         inv_results = solve(
             [t[0] - t[1] for t in zip(sys2.symbols, forward_transform_expressions)],
             list(sys1.symbols), dict=True)
         if len(inv_results) == 0:
             raise NotImplementedError(
-                "Cannot solve inverse transformation of {}".format(forward_transform_expressions))
+                "Cannot solve inverse of transformation from {} to {}".format(sys1, sys2))
+        elif len(inv_results) > 1:
+            raise ValueError(
+                "Obtained multiple results for inverse of transformation from {} to {}".format(sys1, sys2)
+            )
 
         inv_results = inv_results[0]
         signature = tuple(sys1.symbols)
@@ -1838,12 +1840,6 @@ def dummyfy(args, exprs):
     reps = dict(zip(args, d_args))
     d_exprs = Matrix([_sympify(expr).subs(reps) for expr in exprs])
     return d_args, d_exprs
-
-
-def to_coord_symbol(args, exprs):
-    coord_symbols = {Symbol(arg.name, **arg.assumptions0): arg for arg in args}
-    return Matrix([expr.subs(coord_symbols) for expr in exprs])
-
 
 ###############################################################################
 # Helpers

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -406,17 +406,20 @@ class CoordSystem(Basic):
     @staticmethod
     def _inverse_transformation(sys1, sys2):
         # Find the transformation relation from sys2 to sys1
-        forward_transform = sys1.transform(sys2)
-        forward_syms, forward_results = forward_transform.args
+        forward_transform_expressions = sys1.transform(sys2)
+        # Coordinate transformations are defined in terms of Symbols rather than CoordSymbols, so must be converted
+        forward_transform_expressions = to_coord_symbol(sys1.symbols, forward_transform_expressions)
 
-        inv_syms = [i.as_dummy() for i in forward_syms]
         inv_results = solve(
-            [t[0] - t[1] for t in zip(inv_syms, forward_results)],
-            list(forward_syms), dict=True)[0]
-        inv_results = [inv_results[s] for s in forward_syms]
+            [t[0] - t[1] for t in zip(sys2.symbols, forward_transform_expressions)],
+            list(sys1.symbols), dict=True)
+        if len(inv_results) == 0:
+            raise NotImplementedError(
+                "Cannot solve inverse transformation of {}".format(forward_transform_expressions))
 
-        signature = tuple(inv_syms)
-        expr = Matrix(inv_results)
+        inv_results = inv_results[0]
+        signature = tuple(sys1.symbols)
+        expr = Matrix([inv_results[s] for s in signature])
         return Lambda(signature, expr)
 
     @classmethod
@@ -1836,6 +1839,11 @@ def dummyfy(args, exprs):
     reps = dict(zip(args, d_args))
     d_exprs = Matrix([_sympify(expr).subs(reps) for expr in exprs])
     return d_args, d_exprs
+
+
+def to_coord_symbol(args, exprs):
+    coord_symbols = {Symbol(arg.name, **arg.assumptions0): arg for arg in args}
+    return Matrix([expr.subs(coord_symbols) for expr in exprs])
 
 
 ###############################################################################

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -41,7 +41,7 @@ def test_inverse_transformations():
     p, q, r, s = symbols('p q r s')
 
     relations_quarter_rotation = {
-        ('first', 'second'): Lambda((p, q), Matrix([q, - p]))
+        ('first', 'second'): (q, - p)
     }
 
     R2_pq = CoordSystem('first', R2_origin, [p, q], relations_quarter_rotation)
@@ -52,14 +52,14 @@ def test_inverse_transformations():
 
     a, b = symbols('a b', positive=True)
     relations_uninvertible_transformation = {
-        ('first', 'second'): Lambda((a), Matrix([- a]))
+        ('first', 'second'): (- a,)
     }
 
     R2_a = CoordSystem('first', R2_origin, [a], relations_uninvertible_transformation)
     R2_b = CoordSystem('second', R2_origin, [b], relations_uninvertible_transformation)
 
     # The transform method should throw if it cannot invert the coordinate transformation.
-    # This tranformation is uninvertible because there is no positive a, b satisfying a = -b
+    # This transformation is uninvertible because there is no positive a, b satisfying a = -b
     with raises(NotImplementedError):
         R2_b.transform(R2_a)
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -1,10 +1,10 @@
-from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, R3_c, R3_s
-from sympy.diffgeom import (Commutator, Differential, TensorProduct,
+from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, R3_c, R3_s, R2_origin
+from sympy.diffgeom import (CoordSystem, Commutator, Differential, TensorProduct,
         WedgeProduct, BaseCovarDerivativeOp, CovarDerivativeOp, LieDerivative,
         covariant_order, contravariant_order, twoform_to_matrix, metric_to_Christoffel_1st,
         metric_to_Christoffel_2nd, metric_to_Riemann_components,
         metric_to_Ricci_components, intcurve_diffequ, intcurve_series)
-from sympy.core import Symbol, symbols
+from sympy.core import Lambda, Symbol, symbols
 from sympy.simplify import trigsimp, simplify
 from sympy.functions import sqrt, atan2, sin
 from sympy.matrices import Matrix
@@ -35,6 +35,34 @@ def test_R2():
     with warns_deprecated_sympy():
         assert m == R2_p.coord_tuple_transform_to(
             R2_r, R2_r.coord_tuple_transform_to(R2_p, m)).applyfunc(simplify)
+
+
+def test_inverse_transformations():
+    p, q, r, s = symbols('p q r s')
+
+    relations_quarter_rotation = {
+        ('first', 'second'): Lambda((p, q), Matrix([q, - p]))
+    }
+
+    R2_pq = CoordSystem('first', R2_origin, [p, q], relations_quarter_rotation)
+    R2_rs = CoordSystem('second', R2_origin, [r, s], relations_quarter_rotation)
+
+    # The transform method should derive the inverse transformation if not given explicitly
+    assert R2_rs.transform(R2_pq) == Matrix([[- R2_rs.symbols[1]], [R2_rs.symbols[0]]])
+
+    a, b = symbols('a b', positive=True)
+    relations_uninvertible_transformation = {
+        ('first', 'second'): Lambda((a), Matrix([- a]))
+    }
+
+    R2_a = CoordSystem('first', R2_origin, [a], relations_uninvertible_transformation)
+    R2_b = CoordSystem('second', R2_origin, [b], relations_uninvertible_transformation)
+
+    # The transform method should throw if it cannot invert the coordinate transformation.
+    # This tranformation is uninvertible because there is no positive a, b satisfying a = -b
+    with raises(NotImplementedError):
+        R2_b.transform(R2_a)
+
 
 def test_R3():
     a, b, c = symbols('a b c', positive=True)

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -4,7 +4,7 @@ from sympy.diffgeom import (CoordSystem, Commutator, Differential, TensorProduct
         covariant_order, contravariant_order, twoform_to_matrix, metric_to_Christoffel_1st,
         metric_to_Christoffel_2nd, metric_to_Riemann_components,
         metric_to_Ricci_components, intcurve_diffequ, intcurve_series)
-from sympy.core import Lambda, Symbol, symbols
+from sympy.core import Symbol, symbols
 from sympy.simplify import trigsimp, simplify
 from sympy.functions import sqrt, atan2, sin
 from sympy.matrices import Matrix

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -41,18 +41,18 @@ def test_inverse_transformations():
     p, q, r, s = symbols('p q r s')
 
     relations_quarter_rotation = {
-        ('first', 'second'): (q, - p)
+        ('first', 'second'): (q, -p)
     }
 
     R2_pq = CoordSystem('first', R2_origin, [p, q], relations_quarter_rotation)
     R2_rs = CoordSystem('second', R2_origin, [r, s], relations_quarter_rotation)
 
     # The transform method should derive the inverse transformation if not given explicitly
-    assert R2_rs.transform(R2_pq) == Matrix([[- R2_rs.symbols[1]], [R2_rs.symbols[0]]])
+    assert R2_rs.transform(R2_pq) == Matrix([[-R2_rs.symbols[1]], [R2_rs.symbols[0]]])
 
     a, b = symbols('a b', positive=True)
     relations_uninvertible_transformation = {
-        ('first', 'second'): (- a,)
+        ('first', 'second'): (-a,)
     }
 
     R2_a = CoordSystem('first', R2_origin, [a], relations_uninvertible_transformation)
@@ -62,6 +62,18 @@ def test_inverse_transformations():
     # This transformation is uninvertible because there is no positive a, b satisfying a = -b
     with raises(NotImplementedError):
         R2_b.transform(R2_a)
+
+    c, d = symbols('c d')
+    relations_ambiguous_inverse = {
+        ('first', 'second'): (c**2,)
+    }
+
+    R2_c = CoordSystem('first', R2_origin, [c], relations_ambiguous_inverse)
+    R2_d = CoordSystem('second', R2_origin, [d], relations_ambiguous_inverse)
+
+    # The transform method should throw if it finds multiple inverses for a coordinate transformation.
+    with raises(ValueError):
+        R2_d.transform(R2_c)
 
 
 def test_R3():

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1082,6 +1082,9 @@ class Integral(AddWithLimits):
                 except NotImplementedError:
                     from sympy.integrals.meijerint import _debug
                     _debug('NotImplementedError from meijerint_definite')
+                if isinstance(h, Piecewise) and len(self.limits[-1]) == 3:
+                    # special methods are needed for definite integrals
+                    h = None
                 if h is not None:
                     parts.append(coeff * h)
                     continue

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -5,7 +5,7 @@ from sympy import (
     integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol, summation,
-    symbols, sympify, tan, trigsimp, Tuple, lerchphi, exp_polar, li, hyper
+    symbols, sympify, tan, trigsimp, Tuple, lerchphi, exp_polar, li, hyper, Heaviside
 )
 from sympy.core.expr import unchanged
 from sympy.functions.elementary.complexes import periodic_argument
@@ -402,6 +402,11 @@ def test_issue_13749():
 def test_issue_18133():
     assert integrate(exp(x)/(1 + x)**2, x) == NonElementaryIntegral(exp(x)/(x + 1)**2, x)
 
+
+def test_issue_21426():
+    # test integration of the Heaviside function
+    assert simplify(integrate(Heaviside(x - y), (x, a, b)) \
+        + (a - y)*Heaviside(a - y, Rational(1, 2)) - (b - y)*Heaviside(b - y, Rational(1, 2))) == 0
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))


### PR DESCRIPTION
Fix definite integrals of Heaviside function

#### References to other Issues or PRs
Partially fixes #21426

#### Brief description of what is fixed or changed
Definite integration of Heaviside function now returns correct result, as long as H0 is S.Half (or omitted).
For all other values the integral is not performed.

#### Other comments
In a future version, integration should be extended such that it works for any arbitrary value H0, as it does not affect the result of the integration anyways.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fix definite integration issue of Heaviside function
<!-- END RELEASE NOTES -->
