### PR TITLE
adds degree limit to `primitive_element` and `minpoly`

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -103,6 +103,9 @@ def _construct_algebraic(coeffs, opt):
     exts = list(ordered(exts))
 
     g, span, H = primitive_element(exts, ex=True, polys=True)
+    if (g, span, H) == (False, False, False):
+        return EX, None
+
     root = sum([ s*ext for s, ext in zip(span, exts) ])
 
     domain, g = QQ.algebraic_field((g, root)), g.rep.rep
@@ -365,6 +368,8 @@ def construct_domain(obj, **args):
 
     coeffs = list(map(sympify, coeffs))
     result = _construct_simple(coeffs, opt)
+    if result == (EX, None):
+        return _construct_expression(coeffs, opt)
 
     if result is not None:
         if result is not False:

--- a/sympy/polys/polyerrors.py
+++ b/sympy/polys/polyerrors.py
@@ -175,3 +175,7 @@ class OptionError(BasePolynomialError):
 @public
 class FlagError(OptionError):
     pass
+
+@public
+class DegreeLimitExceeded(BasePolynomialError):
+    pass


### PR DESCRIPTION
We added a limit to `primitive_element` and `minpoly` functions based on the maximum degree of the polynomial.

#### References to other Issues or PRs

#### Brief description of what is fixed or changed
We have added the limit argument in `minpoly` and added a mechanism to decide for the `EX` domain depending on the degree of the polynomial, which will be provided by the user, and if the maximum degree is greater than the limit, the domain will fallback to `EX `for `minpoly`.
While for `primitive_element`, we have set the pre-defined limit of `100` as of now.

#### Other comments
The working is as follows:
We try to calculate the maximum degree of the polynomial that the extension elements will generate, using the `minpoly_compose` return types. In general, we will try to calculate the exact degree, but mainly in functions like `sin`, `cos` etc., the degree reduces in general due to factoring of the polynomial results. Since we don't want to be calculating minimal polynomial and using slow method `factor` while calculating degree, we are using the maximum degree possible for that case, like for `sin`, it cannot be more than `q` for odd `q`'s, and `q / 2` for even `q`'s, where `q = sympify(c.q)`, `c` is in `sin(c*pi)`.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* polys
  * Added degree limit to `primitive_element` and `minpoly`.
<!-- END RELEASE NOTES -->
