### PR TITLE
docs(physics): remove duplicate entry for units/index.rst

### DIFF
--- a/doc/src/modules/physics/index.rst
+++ b/doc/src/modules/physics/index.rst
@@ -26,5 +26,4 @@ Contents
     quantum/index.rst
     optics/index.rst
     control/index.rst
-    units/index.rst
     continuum_mechanics/index.rst


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Remove duplicate entry for physic/units.rst in the rst docs

#### Other comments

This should fix the Travis CI so that doctr still works.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
