### PR TITLE
fix(matrices): Deprecate non-Expr in Matrix

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -13,7 +13,7 @@ from sympy import (
     EulerGamma, erf, erfc, besselj, bessely, besseli, besselk,
     exp_polar, unpolarify, Function, expint, expand_mul, Rational,
     gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2)
-from sympy.testing.pytest import XFAIL, slow, skip, raises
+from sympy.testing.pytest import XFAIL, slow, skip, raises, warns_deprecated_sympy
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d
 nu, beta, rho = symbols('nu beta rho')
@@ -516,10 +516,26 @@ def test_laplace_transform():
     # What is this testing:
     Ne(1/s, 1) & (0 < cos(Abs(periodic_argument(s, oo)))*Abs(s) - 1)
 
-    assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) == (
-            Matrix([[    1/(s - 1), (s + 1)**(-2)],
-                    [(s + 1)**(-2),     1/(s - 1)]]),
-            1, s > 1)
+    Mt = Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]])
+    Ms = Matrix([[    1/(s - 1), (s + 1)**(-2)],
+                 [(s + 1)**(-2),     1/(s - 1)]])
+
+    # The default behaviour for Laplace tranform of a Matrix returns a Matrix
+    # of Tuples and is deprecated:
+    with warns_deprecated_sympy():
+        Ms_conds = Matrix([[(1/(s - 1), 1, s > 1), ((s + 1)**(-2), 0, True)],
+                           [((s + 1)**(-2), 0, True), (1/(s - 1), 1, s > 1)]])
+    with warns_deprecated_sympy():
+        assert LT(Mt, t, s) == Ms_conds
+
+    # The new behavior is to return a tuple of a Matrix and the convergence
+    # conditions for the matrix as a whole:
+    assert LT(Mt, t, s, legacy_matrix=False) == (Ms, 1, s > 1)
+
+    # With noconds=True the transformed matrix is returned without conditions
+    # either way:
+    assert LT(Mt, t, s, noconds=True) == Ms
+    assert LT(Mt, t, s, legacy_matrix=False, noconds=True) == Ms
 
 
 def test_issue_8368_7173():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -516,11 +516,10 @@ def test_laplace_transform():
     # What is this testing:
     Ne(1/s, 1) & (0 < cos(Abs(periodic_argument(s, oo)))*Abs(s) - 1)
 
-    assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) ==\
-        Matrix([
-            [(1/(s - 1), 1, s > 1), ((s + 1)**(-2), 0, True)],
-            [((s + 1)**(-2), 0, True), (1/(s - 1), 1, s > 1)]
-        ])
+    assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) == (
+            Matrix([[    1/(s - 1), (s + 1)**(-2)],
+                    [(s + 1)**(-2),     1/(s - 1)]]),
+            1, s > 1)
 
 
 def test_issue_8368_7173():

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -7,6 +7,7 @@ from sympy.core.function import Function
 from sympy.core.relational import _canonical, Ge, Gt
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy
+from sympy.functions.elementary.miscellaneous import Max
 from sympy.integrals import integrate, Integral
 from sympy.integrals.meijerint import _dummy
 from sympy.logic.boolalg import to_cnf, conjuncts, disjuncts, Or, And
@@ -1181,8 +1182,13 @@ def laplace_transform(f, t, s, **hints):
     inverse_laplace_transform, mellin_transform, fourier_transform
     hankel_transform, inverse_hankel_transform
     """
+
     if isinstance(f, MatrixBase) and hasattr(f, 'applyfunc'):
-        return f.applyfunc(lambda fij: laplace_transform(fij, t, s, **hints))
+        elements_trans = [laplace_transform(fij, t, s, **hints) for fij in f]
+        elements, avals, conditions = zip(*elements_trans)
+        f_laplace = type(f)(*f.shape, elements)
+        return f_laplace, Max(*avals), And(*conditions)
+
     return LaplaceTransform(f, t, s).doit(**hints)
 
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -3190,11 +3190,11 @@ class MatrixKind(Kind):
     >>> from sympy import Matrix
     >>> from sympy.matrices import MatrixKind
     >>> from sympy.core.kind import NumberKind
-    >>> boolM = Matrix([True, False])
-    >>> isinstance(boolM.kind, MatrixKind)
+    >>> M = Matrix([1, 2])
+    >>> isinstance(M.kind, MatrixKind)
     True
-    >>> boolM.kind is MatrixKind(NumberKind)
-    False
+    >>> M.kind is MatrixKind(NumberKind)
+    True
 
     See Also
     ========

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -16,6 +16,8 @@ from sympy.simplify.simplify import simplify as _simplify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.misc import filldedent
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 from .decompositions import _cholesky, _LDLdecomposition
 from .solvers import _lower_triangular_solve, _upper_triangular_solve
 
@@ -313,10 +315,21 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         else:
             rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
             flat_list = list(flat_list) # create a shallow copy
+
+            types = set(map(type, flat_list))
+            if not all(issubclass(typ, Expr) for typ in types):
+                SymPyDeprecationWarning(
+                    feature="non-Expr objects in a Matrix",
+                    useinstead="list of lists or some other data structure",
+                    issue=21497,
+                    deprecated_since_version="1.9"
+                ).warn()
+
         self = object.__new__(cls)
         self.rows = rows
         self.cols = cols
         self._mat = flat_list
+
         return self
 
     def __setitem__(self, key, value):

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -320,7 +320,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
             if not all(issubclass(typ, Expr) for typ in types):
                 SymPyDeprecationWarning(
                     feature="non-Expr objects in a Matrix",
-                    useinstead="list of lists or some other data structure",
+                    useinstead="list of lists, TableForm or some other data structure",
                     issue=21497,
                     deprecated_since_version="1.9"
                 ).warn()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1004,7 +1004,7 @@ class MatrixBase(MatrixDeprecated,
                                 isinstance(x, MatrixSymbol) and \
                                 all(_.is_Integer for _ in x.shape):
                             return x.as_explicit()
-                        return x
+                        return cls._sympify(x)
                     dat = do(dat)
 
                 if dat == [] or dat == [[]]:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -656,9 +656,11 @@ def test_creation():
         Matrix((1, 2))[3] = 5
 
     assert Matrix() == Matrix([]) == Matrix([[]]) == Matrix(0, 0, [])
-    # anything can go into a matrix (laplace_transform uses tuples)
-    assert Matrix([[[], ()]]).tolist() == [[[], ()]]
-    assert Matrix([[[], ()]]).T.tolist() == [[[]], [()]]
+    # anything used to be allowed in a matrix
+    with warns_deprecated_sympy():
+        assert Matrix([[[], ()]]).tolist() == [[[], ()]]
+    with warns_deprecated_sympy():
+        assert Matrix([[[], ()]]).T.tolist() == [[[]], [()]]
 
     a = Matrix([[x, 0], [0, 0]])
     m = a
@@ -708,7 +710,8 @@ def test_creation():
     [      1,       1],
     [A[0, 0], A[0, 1]],
     [A[1, 0], A[1, 1]]])
-    assert Matrix(dat, evaluate=False).tolist() == [[i] for i in dat]
+    with warns_deprecated_sympy():
+        assert Matrix(dat, evaluate=False).tolist() == [[i] for i in dat]
 
     # 0-dim tolerance
     assert Matrix([ones(2), ones(0)]) == Matrix([ones(2)])
@@ -2535,11 +2538,14 @@ def test_replace():
 def test_replace_map():
     from sympy import symbols, Function, Matrix
     F, G = symbols('F, G', cls=Function)
-    K = Matrix(2, 2, [(G(0), {F(0): G(0)}), (G(1), {F(1): G(1)}), (G(1), {F(1)\
-    : G(1)}), (G(2), {F(2): G(2)})])
+    with warns_deprecated_sympy():
+        K = Matrix(2, 2, [(G(0), {F(0): G(0)}), (G(1), {F(1): G(1)}),
+                          (G(1), {F(1): G(1)}), (G(2), {F(2): G(2)})])
     M = Matrix(2, 2, lambda i, j: F(i+j))
-    N = M.replace(F, G, True)
-    assert N == K
+    with warns_deprecated_sympy():
+        N = M.replace(F, G, True)
+    with warns_deprecated_sympy():
+        assert N == K
 
 def test_atoms():
     m = Matrix([[1, 2], [x, 1 - 1/x]])

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -12,9 +12,10 @@ def test_smith_normal():
     assert smith_normal_form(m) == smf
 
     x = Symbol('x')
-    m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
-                [0, Poly(x), Poly(-1,x)],
-                [Poly(0,x),Poly(-1,x),Poly(x)]])
+    with warns_deprecated_sympy():
+        m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
+                    [0, Poly(x), Poly(-1,x)],
+                    [Poly(0,x),Poly(-1,x),Poly(x)]])
     invs = 1, x - 1, x**2 - 1
     assert invariant_factors(m, domain=QQ[x]) == invs
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3417,8 +3417,10 @@ def test_issue_15669():
 def test_issue_17988():
     x = Symbol('x')
     p = poly(x - 1)
-    M = Matrix([[poly(x + 1), poly(x + 1)]])
-    assert p * M == M * p == Matrix([[poly(x**2 - 1), poly(x**2 - 1)]])
+    with warns_deprecated_sympy():
+        M = Matrix([[poly(x + 1), poly(x + 1)]])
+    with warns_deprecated_sympy():
+        assert p * M == M * p == Matrix([[poly(x**2 - 1), poly(x**2 - 1)]])
 
 
 def test_issue_18205():

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -1,7 +1,7 @@
 from sympy.core import (pi, symbols, Rational, Integer, GoldenRatio, EulerGamma,
                         Catalan, Lambda, Dummy, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.printing.glsl import GLSLPrinter
 from sympy.printing.str import StrPrinter
 from sympy.utilities.lambdify import implemented_function
@@ -455,7 +455,8 @@ def test_spread_assign_to_deeply_nested_symbols():
 
 def test_matrix_of_tuples_spread_assign_to_symbols():
     gl = glsl_code
-    expr = Matrix([[(1,2),(3,4)],[(5,6),(7,8)]])
+    with warns_deprecated_sympy():
+        expr = Matrix([[(1,2),(3,4)],[(5,6),(7,8)]])
     assign_to = (symbols('a b'), symbols('c d'), symbols('e f'), symbols('g h'))
     assert gl(expr, assign_to) == textwrap.dedent('''\
         a = 1;


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

The deprecation issue for this is #21497
The deprecation issue for the change to `laplace_transform` is https://github.com/sympy/sympy/issues/21504

Follows on from #21441, #21427, #21402

#### Brief description of what is fixed or changed

This PR deprecates using non-Expr objects as the elements of a Matrix. The codebase previously contained a number of Matrix subclasses (`NewMatrix`, `RawMatrix` and `PolyMatrix`) that would use non-Expr elements for the entries. In most cases this was done so that the elements could be domain elements or Poly rather than Expr but a better solution to this is to use the new `DomainMatrix` class. After various other PRs it is now possible to deprecate having non-Expr elements in a Matrix.

One notable obstacle to refusing non-Expr elements is the behaviour of the `laplace_transform` function:
```python
In [2]: laplace_transform(eye(2), t, z)
Out[2]: 
⎡⎛1         ⎞                ⎤
⎢⎜─, 0, True⎟   (0, -∞, True)⎥
⎢⎝z         ⎠                ⎥
⎢                            ⎥
⎢               ⎛1         ⎞ ⎥
⎢(0, -∞, True)  ⎜─, 0, True⎟ ⎥
⎣               ⎝z         ⎠ ⎦
```
This has returned a Matrix where each element is a tuple consisting of an Expr and the convergence conditions.In this PR the above Matrix of tuples is deprecated and it is possible to obtain a new behaviour:
```python
In [2]: laplace_transform(eye(2), t, z, legacy_matrix=False)
Out[2]: 
⎛⎡1   ⎤         ⎞
⎜⎢─  0⎥         ⎟
⎜⎢z   ⎥         ⎟
⎜⎢    ⎥, 0, True⎟
⎜⎢   1⎥         ⎟
⎜⎢0  ─⎥         ⎟
⎝⎣   z⎦         ⎠
```
This returns a tuple of the transformed matrix and the convergence conditions for the matrix as a whole and is more consistent with the general behaviour of the `laplace_transform` function for other kinds of inputs. A future PR will make this behaviour the default.

#### Other comments

I plan to use `DomainMatrix` as the internal implementation of `Matrix` but that means that `Matrix` needs to be stricter about the types of its elements. Needing to accommodate for non-Expr elements in the internal routines of `Matrix` has constrained improvements to this important class for some time.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * DEPRECATION: Using non-Expr elements in a Matrix is now deprecated.
* integrals
    * DEPRECATION: Using `laplace_transform` with a `Matrix` and without passing `noconds=True` is now deprecated. The behaviour of this function will change in future to return the conditions separately from the Matrix. The new behaviour can be obtained by passing the keyword argument `legacy_matrix=False`. 
<!-- END RELEASE NOTES -->
