### PR TITLE
fix issue in the parse_latex by not evaluating multiplication with -1

### DIFF
--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -119,7 +119,8 @@ def convert_add(add):
     elif add.SUB():
         lh = convert_add(add.additive(0))
         rh = convert_add(add.additive(1))
-        return sympy.Add(lh, -1 * rh, evaluate=False)
+        return sympy.Add(lh, sympy.Mul(-1, rh, evaluate=False),
+                         evaluate=False)
     else:
         return convert_mp(add.mp())
 

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -242,6 +242,7 @@ GOOD_PAIRS = [
     (r"\int x \, dx", Integral(x, x)),
     (r"\log_2 x", _log(x, 2)),
     (r"\log_a x", _log(x, a)),
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
 ]
 
 def test_parseable():


### PR DESCRIPTION
Before:
```
>>> latex_string = "5^0 - 4^0"
>>> parse_latex(latex_string)
−1+5^0
```

Now
```
>>> latex_string = "5^0 - 4^0"
>>> r = parse_latex(latex_string)
>>> print(r)
−4^0+5^0
>>> srepr(r)
_Add(Mul(Integer(-1), Pow(Integer(4), Integer(0),
			  evaluate=0),
	 evaluate=False),
     Pow(Integer(5), Integer(0),
	 evaluate=False),
     evaluate=False)
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Link to a chat message on gitter: https://gitter.im/sympy/sympy?at=60a3e9b12ee2b13d95b7c3a1

#### Brief description of what is fixed or changed

Solution as suggested by @jksuom in the above gitter chat.

#### Other comments

<!-- BEGIN RELEASE NOTES -->

* parsing
  * Fixed a bug in `parse_latex` function for rendering of `-1` Mul to not evaluate in Add operation


<!-- END RELEASE NOTES -->
