### PR TITLE
perf(matrices): make randMatrix faster for sparse matrices

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1183,32 +1183,31 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     [70,  0,  0],
     [ 0,  0, 88]
     """
-    if c is None:
-        c = r
     # Note that ``Random()`` is equivalent to ``Random(None)``
     prng = prng or random.Random(seed)
 
-    if not symmetric:
-        m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
-        if percent == 100:
-            return m
-        z = int(r*c*(100 - percent) // 100)
-        m._mat[:z] = [S.Zero]*z
-        prng.shuffle(m._mat)
+    if c is None:
+        c = r
 
-        return m
-
-    # Symmetric case
-    if r != c:
+    if symmetric and r != c:
         raise ValueError('For symmetric matrices, r must equal c, but %i != %i' % (r, c))
-    m = zeros(r)
-    ij = [(i, j) for i in range(r) for j in range(i, r)]
+
+    ij = range(r * c)
     if percent != 100:
         ij = prng.sample(ij, int(len(ij)*percent // 100))
 
-    for i, j in ij:
-        value = prng.randint(min, max)
-        m[i, j] = m[j, i] = value
+    m = zeros(r, c)
+
+    if not symmetric:
+        for ijk in ij:
+            i, j = divmod(ijk, c)
+            m[i, j] = prng.randint(min, max)
+    else:
+        for ijk in ij:
+            i, j = divmod(ijk, c)
+            if i <= j:
+                m[i, j] = m[j, i] = prng.randint(min, max)
+
     return m
 
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -5,7 +5,6 @@ from sympy.core import SympifyError, Add
 from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
-from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.elementary.trigonometric import cos, sin

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -20,7 +20,7 @@ from sympy.core.compatibility import iterable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture
-from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
+from sympy.testing.pytest import raises, XFAIL, slow, skip, warns_deprecated_sympy
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
@@ -2592,6 +2592,7 @@ def test_pinv():
         )
 
 
+@slow
 @XFAIL
 def test_pinv_rank_deficient_when_diagonalization_fails():
     # Test the four properties of the pseudoinverse for matrices when


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Makes randMatrix faster for sparse matrices e.g.:
```python
In [1]: %time ok = randMatrix(1000, percent=1)
CPU times: user 139 ms, sys: 5.56 ms, total: 145 ms
Wall time: 144 ms
```
On master it is much slower:
```python
In [1]: %time ok = randMatrix(1000, percent=1)
CPU times: user 6.69 s, sys: 48 ms, total: 6.74 s
Wall time: 6.79 s
```
Also  a slow test was marked as `@slow` because it takes ~3 minutes

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
