### PR TITLE
perf(matrices): use Bareiss algorithm in DomainMatrix.det

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -30,7 +30,7 @@ list of lists:
     >>> ddm_idet([[0, 1], [-1, 0]], QQ)
     1
     >>> A
-    [[-1, 0], [0, 1]]
+    [[-1, 0], [0, -1]]
 
 Note that ddm_idet modifies the input matrix in-place. It is recommended to
 use the DDM.det method as a friendlier interface to this instead which takes

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -149,7 +149,6 @@ def ddm_idet(a, K):
         return K.one
     n = len(a[0])
 
-    is_field = K.is_Field
     exquo = K.exquo
     # uf keeps track of the sign change from row swaps
     uf = K.one


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Use the Bareiss fraction-free algorithm for DomainMatrix.det. This improves performance e.g.:
```python
In [1]: M = Matrix([[random_poly(x, 2, -5, 5)/random_poly(y, 2, -5, 5) for _ in range(5)] for _ in range(5)])

In [2]: M
Out[2]: 
⎡      2                2                2                 2                 2           ⎤
⎢   4⋅x  - 5⋅x     - 2⋅x  + 4⋅x + 3   4⋅x  - 2⋅x - 2    - x  - 4⋅x + 2    4⋅x  - 4⋅x + 3 ⎥
⎢ ──────────────   ────────────────  ────────────────   ──────────────    ────────────── ⎥
⎢    2                  2                 2                 2                 2          ⎥
⎢ 5⋅y  - 3⋅y - 1   - 2⋅y  + 4⋅y - 3  - 3⋅y  + 3⋅y - 1    4⋅y  + y - 4      3⋅y  + y - 2  ⎥
⎢                                                                                        ⎥
⎢    2                 2                2                     2               2          ⎥
⎢ 4⋅x  + 4⋅x + 4    2⋅x  - 5⋅x + 4     x  + 3⋅x - 3        5⋅x  - 4      - 4⋅x  + 4⋅x + 3⎥
⎢ ──────────────    ──────────────    ──────────────    ──────────────   ────────────────⎥
⎢        2              2                2                 2                  2          ⎥
⎢   - 5⋅y  - 4         y  - 4⋅y       3⋅y  + 2⋅y + 4    3⋅y  + 4⋅y - 2     4⋅y  - y - 4  ⎥
⎢                                                                                        ⎥
⎢    2                  2                 2                  2               2           ⎥
⎢ 4⋅x  - 2⋅x + 2     - x  + x + 1      4⋅x  - x - 2     - 3⋅x  - x + 4    - x  - 2⋅x - 3 ⎥
⎢ ──────────────    ──────────────     ────────────    ────────────────   ────────────── ⎥
⎢    2                   2                2                 2                  2         ⎥
⎢ - y  - 3⋅y - 3    - 4⋅y  + y + 3     5⋅y  - y + 2    - 5⋅y  + 5⋅y + 2     3⋅y  - 2⋅y   ⎥
⎢                                                                                        ⎥
⎢    2                   2                2                 2                 2          ⎥
⎢ - x  - 3⋅x + 2    - 3⋅x  - x + 5     2⋅x  - x - 3        x  - 5⋅x      - 3⋅x  + 5⋅x + 5⎥
⎢ ──────────────   ────────────────    ────────────    ────────────────  ────────────────⎥
⎢    2                  2               2                   2                2           ⎥
⎢ - y  - 2⋅y + 3   - 3⋅y  - 5⋅y + 5    y  - 3⋅y - 1    - 3⋅y  - 4⋅y + 4   5⋅y  + 3⋅y - 4 ⎥
⎢                                                                                        ⎥
⎢        2             2                     2             2                  2          ⎥
⎢      -x           5⋅x  - 2⋅x + 4      - 3⋅x  - 4      5⋅x  - 5⋅x - 3     5⋅x  - x - 5  ⎥
⎢────────────────   ──────────────   ────────────────   ──────────────     ────────────  ⎥
⎢     2                2                  2                2                    2        ⎥
⎣- 4⋅y  - 2⋅y + 2   2⋅y  + 4⋅y + 2   - 5⋅y  + 2⋅y - 1   3⋅y  - 5⋅y - 4       3⋅y  + 4    ⎦

In [3]: from sympy.polys.matrices import DomainMatrix

In [4]: dM = DomainMatrix.from_Matrix(M)

In [6]: %time ok = dM.det()
CPU times: user 946 ms, sys: 4.41 ms, total: 951 ms
Wall time: 950 ms
```
On master it's much slower:
```python
In [4]: %time ok = dM.det()
CPU times: user 4min, sys: 383 ms, total: 4min
Wall time: 4min
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
