### PR TITLE
don't expand Integer args with expand_trig

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -196,6 +196,17 @@ def test_sin_rewrite():
     assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
 
 
+def _test_extrig(f, i, e):
+    from sympy.core.expr import unchanged
+    from sympy.core.function import expand_trig
+    assert unchanged(f, i)
+    assert expand_trig(f(i)) == f(i)
+    # testing directly instead of with .expand(trig=True)
+    # because the other expansions undo the unevaluated Mul
+    assert expand_trig(f(Mul(i, 1, evaluate=False))) == e
+    assert abs(f(i) - e).n() < 1e-10
+
+
 def test_sin_expansion():
     # Note: these formulas are not unique.  The ones here come from the
     # Chebyshev formulas.
@@ -205,8 +216,8 @@ def test_sin_expansion():
     assert sin(2*x).expand(trig=True) == 2*sin(x)*cos(x)
     assert sin(3*x).expand(trig=True) == -4*sin(x)**3 + 3*sin(x)
     assert sin(4*x).expand(trig=True) == -8*sin(x)**3*cos(x) + 4*sin(x)*cos(x)
-    assert sin(2).expand(trig=True) == 2*sin(1)*cos(1)
-    assert sin(3).expand(trig=True) == -4*sin(1)**3 + 3*sin(1)
+    _test_extrig(sin, 2, 2*sin(1)*cos(1))
+    _test_extrig(sin, 3, -4*sin(1)**3 + 3*sin(1))
 
 
 def test_sin_AccumBounds():
@@ -410,8 +421,8 @@ def test_cos_expansion():
     assert cos(2*x).expand(trig=True) == 2*cos(x)**2 - 1
     assert cos(3*x).expand(trig=True) == 4*cos(x)**3 - 3*cos(x)
     assert cos(4*x).expand(trig=True) == 8*cos(x)**4 - 8*cos(x)**2 + 1
-    assert cos(2).expand(trig=True) == 2*cos(1)**2 - 1
-    assert cos(3).expand(trig=True) == 4*cos(1)**3 - 3*cos(1)
+    _test_extrig(cos, 2, 2*cos(1)**2 - 1)
+    _test_extrig(cos, 3, 4*cos(1)**3 - 3*cos(1))
 
 
 def test_cos_AccumBounds():
@@ -585,6 +596,8 @@ def test_tan_expansion():
     assert 0 == tan(2*x).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 7))])*24 - 7
     assert 0 == tan(3*x).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 5))])*55 - 37
     assert 0 == tan(4*x - pi/4).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 5))])*239 - 1
+    _test_extrig(tan, 2, 2*tan(1)/(1 - tan(1)**2))
+    _test_extrig(tan, 3, (-tan(1)**3 + 3*tan(1))/(1 - 3*tan(1)**2))
 
 
 def test_tan_AccumBounds():
@@ -745,15 +758,23 @@ def test_cot_subs():
 
 
 def test_cot_expansion():
-    assert cot(x + y).expand(trig=True) == ((cot(x)*cot(y) - 1)/(cot(x) + cot(y))).expand()
-    assert cot(x - y).expand(trig=True) == (-(cot(x)*cot(y) + 1)/(cot(x) - cot(y))).expand()
-    assert cot(x + y + z).expand(trig=True) == (
+    assert cot(x + y).expand(trig=True).together() == (
+        (cot(x)*cot(y) - 1)/(cot(x) + cot(y)))
+    assert cot(x - y).expand(trig=True).together() == (
+        cot(x)*cot(-y) - 1)/(cot(x) + cot(-y))
+    assert cot(x + y + z).expand(trig=True).together() == (
         (cot(x)*cot(y)*cot(z) - cot(x) - cot(y) - cot(z))/
-        (-1 + cot(x)*cot(y) + cot(x)*cot(z) + cot(y)*cot(z))).expand()
-    assert cot(3*x).expand(trig=True) == ((cot(x)**3 - 3*cot(x))/(3*cot(x)**2 - 1)).expand()
-    assert 0 == cot(2*x).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 3))])*3 + 4
-    assert 0 == cot(3*x).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 5))])*55 - 37
-    assert 0 == cot(4*x - pi/4).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 7))])*863 + 191
+        (-1 + cot(x)*cot(y) + cot(x)*cot(z) + cot(y)*cot(z)))
+    assert cot(3*x).expand(trig=True).together() == (
+        (cot(x)**2 - 3)*cot(x)/(3*cot(x)**2 - 1))
+    assert cot(2*x).expand(trig=True) == cot(x)/2 - 1/(2*cot(x))
+    assert cot(3*x).expand(trig=True).together() == (
+        cot(x)**2 - 3)*cot(x)/(3*cot(x)**2 - 1)
+    assert cot(4*x - pi/4).expand(trig=True).cancel() == (
+        -tan(x)**4 + 4*tan(x)**3 + 6*tan(x)**2 - 4*tan(x) - 1
+        )/(tan(x)**4 + 4*tan(x)**3 - 6*tan(x)**2 - 4*tan(x) + 1)
+    _test_extrig(cot, 2, (-1 + cot(1)**2)/(2*cot(1)))
+    _test_extrig(cot, 3, (-3*cot(1) + cot(1)**3)/(-1 + 3*cot(1)**2))
 
 
 def test_cot_AccumBounds():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1574,7 +1574,7 @@ class cot(TrigonometricFunction):
                 z = Symbol('dummy', real=True)
                 P = ((z + I)**coeff).expand()
                 return (re(P)/im(P)).subs([(z, cot(terms))])
-        return 1/tan(arg)
+        return cot(arg)  # XXX sec and csc return 1/cos and 1/sin
 
     def _eval_is_finite(self):
         arg = self.args[0]

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -460,7 +460,7 @@ class sin(TrigonometricFunction):
             cx = cos(x, evaluate=False)._eval_expand_trig()
             cy = cos(y, evaluate=False)._eval_expand_trig()
             return sx*cy + sy*cx
-        else:
+        elif arg.is_Mul:
             n, x = arg.as_coeff_Mul(rational=True)
             if n.is_Integer:  # n will be positive because of .eval
                 # canonicalization
@@ -918,7 +918,7 @@ class cos(TrigonometricFunction):
             cx = cos(x, evaluate=False)._eval_expand_trig()
             cy = cos(y, evaluate=False)._eval_expand_trig()
             return cx*cy - sx*sy
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer:
                 return chebyshevt(coeff, cos(terms))
@@ -1202,7 +1202,7 @@ class tan(TrigonometricFunction):
                 p[1 - i % 2] += symmetric_poly(i, Y)*(-1)**((i % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, TX)))
 
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
                 I = S.ImaginaryUnit
@@ -1567,14 +1567,14 @@ class cot(TrigonometricFunction):
             for i in range(n, -1, -1):
                 p[(n - i) % 2] += symmetric_poly(i, Y)*(-1)**(((n - i) % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, CX)))
-        else:
+        elif arg.is_Mul:
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
                 I = S.ImaginaryUnit
                 z = Symbol('dummy', real=True)
                 P = ((z + I)**coeff).expand()
                 return (re(P)/im(P)).subs([(z, cot(terms))])
-        return cot(arg)
+        return 1/tan(arg)
 
     def _eval_is_finite(self):
         arg = self.args[0]
@@ -3439,3 +3439,5 @@ class atan2(InverseTrigonometricFunction):
         y, x = self.args
         if x.is_extended_real and y.is_extended_real:
             return super()._eval_evalf(prec)
+
+

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3439,5 +3439,3 @@ class atan2(InverseTrigonometricFunction):
         y, x = self.args
         if x.is_extended_real and y.is_extended_real:
             return super()._eval_evalf(prec)
-
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

close #21440 with modified tests

#### Brief description of what is fixed or changed
Before
```python
expand_trig(tan(5))->
(-10*tan(1)**3 + 5*tan(1) + tan(1)**5)/(-10*tan(1)**2 + 1 + 5*tan(1)**4)
```
after:
```
tan(5)
```
The old behavior can be obtained by using an unevaluated Mul:
```python
>>> expand_trig(tan(Mul(2,3,evaluate=False)))
2*tan(3)/(1 - tan(3)**2)
>>> expand_trig(tan(Mul(2,1,evaluate=False)))
2*tan(1)/(1 - tan(1)**2)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * `expand_trig` no longer expands functions with integer args, e.g. cos(2) is unchanged
<!-- END RELEASE NOTES -->
