### PR TITLE
strengthen equality test in replace/bottom_up

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1466,14 +1466,16 @@ class Basic(Printable, metaclass=ManagedProperties):
             if args is not None:
                 if args:
                     newargs = tuple([walk(a, F) for a in args])
-                    if args != newargs:
+                    if not all(_aresame(i, j)
+                            for i, j in zip(args, newargs)):
                         rv = rv.func(*newargs)
                         if simultaneous:
                             # if rv is something that was already
                             # matched (that was changed) then skip
                             # applying F again
                             for i, e in enumerate(args):
-                                if rv == e and e != newargs[i]:
+                                if _aresame(rv, e
+                                        ) and not _aresame(e, newargs[i]):
                                     return rv
                 rv = F(rv)
             return rv
@@ -1485,7 +1487,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             result = _query(expr)
             if result or result == {}:
                 v = _value(expr, result)
-                if v is not None and v != expr:
+                if v is not None and not _aresame(v, expr):
                     if map:
                         mapping[expr] = v
                     expr = v

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -863,6 +863,8 @@ def test_call_2():
 
 
 def test_replace():
+    assert S(.5).replace(.5, S.Half) is S.Half
+
     f = log(sin(x)) + tan(sin(x**2))
 
     assert f.replace(sin, cos) == log(cos(x)) + tan(cos(x**2))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1189,11 +1189,12 @@ def bottom_up(rv, F, atoms=False, nonbasic=False):
     bottom up. If ``atoms`` is True, apply ``F`` even if there are no args;
     if ``nonbasic`` is True, try to apply ``F`` to non-Basic objects.
     """
+    from sympy.core.basic import _aresame
     args = getattr(rv, 'args', None)
     if args is not None:
         if args:
             args = tuple([bottom_up(a, F, atoms, nonbasic) for a in args])
-            if args != rv.args:
+            if not all(_aresame(i, j) for i, j in zip(args, rv.args)):
                 rv = rv.func(*args)
             rv = F(rv)
         elif atoms:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -916,6 +916,7 @@ def test_issue_17292():
     # this is bigger than the issue: check that deep processing works
     assert simplify(5*abs((x**2 - 1)/(x - 1))) == 5*Abs(x + 1)
 
+
 def test_issue_19484():
     assert simplify(sign(x) * Abs(x)) == x
 
@@ -929,6 +930,19 @@ def test_issue_19484():
     e = x + sign(x + f(x)**3)
     assert simplify(Abs(x + f(x)**3) * e) == x*Abs(x + f(x)**3) + x + f(x)**3
 
+
 def test_issue_19161():
     polynomial = Poly('x**2').simplify()
     assert (polynomial-x**2).simplify() == 0
+
+
+def test_bottom_up():
+    from sympy.simplify.simplify import bottom_up
+    # if these break (via #20033 or similar) then revert the
+    # commit that introduced this test
+    assert S(2) == S(2.)
+    assert S(.5) == S.Half
+    def half(x):
+        return S.Half if x == .5 else x
+    assert bottom_up(x**.5, half).exp is not S.Half
+    assert bottom_up(x**.5, half, atoms=True).exp is S.Half


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #19976

#### Brief description of what is fixed or changed

Although `xreplace` can change alternate forms of an object which compare equal -- does anything else besides floats that are exact rationals do this? -- `replace` and `simplify.bottom_up` use weaker testing for equality, making replacements fail, e.g. `0.5 -> S.Half` fails.

#### Other comments

A test was added so that if it fails the note will instruct the developer to revert this commit.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * replace uses exact equality testing so 0.5 can be changed to 1/2
* simplify
  * bottom_up uses exact equality testing so 0.5 can be changed to 1/2
<!-- END RELEASE NOTES -->
