### PR TITLE
Minor docstring-fix in boolalg.py in the logic module

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -369,7 +369,7 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
     Notes
     ======
 
-    See note in :py:class`sympy.logic.boolalg.BooleanTrue`
+    See the notes section in :py:class:`sympy.logic.boolalg.BooleanTrue`
 
     Examples
     ========


### PR DESCRIPTION
Fixes #21490

Fixed the docstring on the class BooleanFalse.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->