### PR TITLE
`_keep coeff` is more careful about not evaluating expressions

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2050,24 +2050,24 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
     >>> _keep_coeff(S(-1), x + y, sign=True)
     -(x + y)
     """
-
     if not coeff.is_Number:
         if factors.is_Number:
             factors, coeff = coeff, factors
         else:
             return coeff*factors
+    if factors is S.One:
+        return coeff
     if coeff is S.One:
         return factors
     elif coeff is S.NegativeOne and not sign:
         return -factors
     elif factors.is_Add:
         if not clear and coeff.is_Rational and coeff.q != 1:
-            q = S(coeff.q)
-            for i in factors.args:
-                c, t = i.as_coeff_Mul()
-                r = c/q
-                if r == int(r):
-                    return coeff*factors
+            args = [i.as_coeff_Mul() for i in factors.args]
+            args = [(c*coeff, m) for c, m in args]
+            if any(c == int(c) for c, _ in args):
+                return Add._from_args([Mul._from_args(
+                    i[1:] if i[0] == 1 else i) for i in args])
         return Mul(coeff, factors, evaluate=False)
     elif factors.is_Mul:
         margs = list(factors.args)
@@ -2079,7 +2079,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
             margs.insert(0, coeff)
         return Mul._from_args(margs)
     else:
-        return coeff*factors
+        return Mul._from_args((coeff, factors))
 
 
 def expand_2arg(e):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2064,7 +2064,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
     elif factors.is_Add:
         if not clear and coeff.is_Rational and coeff.q != 1:
             args = [i.as_coeff_Mul() for i in factors.args]
-            args = [(c*coeff, m) for c, m in args]
+            args = [(_keep_coeff(c, coeff), m) for c, m in args]
             if any(c == int(c) for c, _ in args):
                 return Add._from_args([Mul._from_args(
                     i[1:] if i[0] == 1 else i) for i in args])
@@ -2079,8 +2079,10 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
             margs.insert(0, coeff)
         return Mul._from_args(margs)
     else:
-        return Mul._from_args((coeff, factors))
-
+        m = coeff*factors
+        if m.is_Number and not factors.is_Number:
+            m = Mul._from_args((coeff, factors))
+        return m
 
 def expand_2arg(e):
     from sympy.simplify.simplify import bottom_up

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -164,11 +164,8 @@ def convert_unary(unary):
         return convert_unary(nested_unary)
     elif unary.SUB():
         numabs = convert_unary(nested_unary)
-        if numabs == 1:
-            # Use Integer(-1) instead of Mul(-1, 1)
-            return -numabs
-        else:
-            return sympy.Mul(-1, convert_unary(nested_unary), evaluate=False)
+        # Use Integer(-n) instead of Mul(-1, n)
+        return -numabs
     elif postfix:
         return convert_postfix_list(postfix)
 

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -76,8 +76,8 @@ def test_import():
 GOOD_PAIRS = [
     (r"0", 0),
     (r"1", 1),
-    (r"-3.14", _Mul(-1, 3.14)),
-    (r"(-7.13)(1.5)", _Mul(_Mul(-1, 7.13), 1.5)),
+    (r"-3.14", -3.14),
+    (r"(-7.13)(1.5)", _Mul(-7.13, 1.5)),
     (r"x", x),
     (r"2x", 2*x),
     (r"x^2", x**2),
@@ -242,8 +242,10 @@ GOOD_PAIRS = [
     (r"\int x \, dx", Integral(x, x)),
     (r"\log_2 x", _log(x, 2)),
     (r"\log_a x", _log(x, a)),
-    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
+    ("5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
+    ("x - 2*(y + z)", _Add(x, _Mul(-2, y + z))),
 ]
+
 
 def test_parseable():
     from sympy.parsing.latex import parse_latex

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -242,15 +242,14 @@ GOOD_PAIRS = [
     (r"\int x \, dx", Integral(x, x)),
     (r"\log_2 x", _log(x, 2)),
     (r"\log_a x", _log(x, a)),
-    ("5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
-    ("x - 2*(y + z)", _Add(x, _Mul(-2, y + z))),
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
 ]
 
 
 def test_parseable():
     from sympy.parsing.latex import parse_latex
     for latex_str, sympy_expr in GOOD_PAIRS:
-        assert parse_latex(latex_str) == sympy_expr
+        assert parse_latex(latex_str) == sympy_expr, latex_str
 
 # These bad LaTeX strings should raise a LaTeXParsingError when parsed
 BAD_STRINGS = [

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -57,9 +57,11 @@ from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
     exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
 
+from sympy.core.add import Add
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
+from sympy.core.power import Pow
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 from sympy.abc import a, b, c, d, p, q, t, w, x, y, z
@@ -3324,6 +3326,14 @@ def test_keep_coeff():
     assert _keep_coeff(S(2), x + 1) == u
     assert _keep_coeff(x, 1/x) == 1
     assert _keep_coeff(x + 1, S(2)) == u
+    assert _keep_coeff(S.Half, S.One) == S.Half
+    p = Pow(2, 3, evaluate=False)
+    assert _keep_coeff(S(-1), p) == Mul(-1, p, evaluate=False)
+    a = Add(2, p, evaluate=False)
+    assert _keep_coeff(S.Half, a, clear=True
+        ) == Mul(S.Half, a, evaluate=False)
+    assert _keep_coeff(S.Half, a, clear=False
+        ) == Add(1, Mul(S.Half, p, evaluate=False), evaluate=False)
 
 
 def test_poly_matching_consistency():

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -199,6 +199,8 @@ class FuncArgTracker:
         """
         from collections import defaultdict
         count_map = defaultdict(lambda: 0)
+        if not argset:
+            return count_map
 
         funcsets = [self.arg_to_funcset[arg] for arg in argset]
         # As an optimization below, we handle the largest funcset separately from

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -546,6 +546,12 @@ def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
 
+
 def test_issue_18991():
     A = MatrixSymbol('A', 2, 2)
     assert signsimp(-A * A - A) == -A * A - A
+
+
+def test_unevaluated_Mul():
+    m = [Mul(1, 2, evaluate=False)]
+    assert cse(m) == ([], m)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

solves part of #21517

#### Brief description of what is fixed or changed

In some cases, `_keep_coeff` evaluates portions of the expression which were not already evaluated. More care is now taken to avoid that (as shown in the added tests). But initial failings show that care must be taken to allow autoevaluation in some cases (like multiplying Order by a constant that gets absorbed).

#### Other comments

`cse` now processes unevaluated Mul without error, too. Formerly,
```python
>>> cse(Mul(1, 2, evaluate=False))
Traceback (most recent call last):
...
ValueError: max() arg is an empty sequence
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  *  `parse_latex` does not introduce a factor of -1 on numbers
* core
  * `_keep_coeff` will distribute coeff on non-rational if doing so does not produce a rational
* simplify
  * `cse` will no longer generate an error when passed an unevaluated 2-arg Mul with a Rational arg
<!-- END RELEASE NOTES -->
