### PR TITLE
fix AccumBounds.__mul__

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -360,7 +360,12 @@ def test_AccumBounds_mul():
     assert 2*AccumBounds(1, 2) == AccumBounds(2, 4)
     assert AccumBounds(1, 2)*AccumBounds(2, 3) == AccumBounds(2, 6)
     assert AccumBounds(0, 2)*AccumBounds(2, oo) == AccumBounds(0, oo)
-
+    l, r = AccumBounds(-oo, oo), AccumBounds(-a, a)
+    assert l*r == AccumBounds(-oo, oo)
+    assert r*l == AccumBounds(-oo, oo)
+    l, r = AccumBounds(1, oo), AccumBounds(-3, -2)
+    assert l*r == AccumBounds(-oo, -2)
+    assert r*l == AccumBounds(-oo, -2)
     assert AccumBounds(1, 2)*0 == 0
     assert AccumBounds(1, oo)*0 == AccumBounds(0, oo)
     assert AccumBounds(-oo, 1)*0 == AccumBounds(-oo, 0)

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -359,6 +359,7 @@ def test_AccumBounds_mul():
     assert AccumBounds(1, 2)*2 == AccumBounds(2, 4)
     assert 2*AccumBounds(1, 2) == AccumBounds(2, 4)
     assert AccumBounds(1, 2)*AccumBounds(2, 3) == AccumBounds(2, 6)
+    assert AccumBounds(0, 2)*AccumBounds(2, oo) == AccumBounds(0, oo)
 
     assert AccumBounds(1, 2)*0 == 0
     assert AccumBounds(1, oo)*0 == AccumBounds(0, oo)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1161,14 +1161,8 @@ class AccumulationBounds(AtomicExpr):
     def __mul__(self, other):
         if isinstance(other, Expr):
             if isinstance(other, AccumBounds):
-                return AccumBounds(Min(Mul(self.min, other.min),
-                                       Mul(self.min, other.max),
-                                       Mul(self.max, other.min),
-                                       Mul(self.max, other.max)),
-                                   Max(Mul(self.min, other.min),
-                                       Mul(self.min, other.max),
-                                       Mul(self.max, other.min),
-                                       Mul(self.max, other.max)))
+                v = set((self.min*other).args + (self.max*other).args)
+                return AccumBounds(Min(*v), Max(*v))
             if other is S.Infinity:
                 if self.min.is_zero:
                     return AccumBounds(0, oo)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1159,9 +1159,17 @@ class AccumulationBounds(AtomicExpr):
 
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
+        if self.args == (-oo, oo):
+            return self
         if isinstance(other, Expr):
             if isinstance(other, AccumBounds):
-                v = set((self.min*other).args + (self.max*other).args)
+                if other.args == (-oo, oo):
+                    return other
+                v = set()
+                for i in self.args:
+                    vi = other*i
+                    for i in vi.args or (vi,):
+                        v.add(i)
                 return AccumBounds(Min(*v), Max(*v))
             if other is S.Infinity:
                 if self.min.is_zero:
@@ -1175,8 +1183,6 @@ class AccumulationBounds(AtomicExpr):
                     return AccumBounds(0, oo)
             if other.is_extended_real:
                 if other.is_zero:
-                    if self == AccumBounds(-oo, oo):
-                        return AccumBounds(-oo, oo)
                     if self.max is S.Infinity:
                         return AccumBounds(0, oo)
                     if self.min is S.NegativeInfinity:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #16611
#### Brief description of what is fixed or changed

delegate multiplication to existing `AccumBound*x` instead of naive enumeration of possibilities for `AccumBound*AccumBound`; this avoids `nan` generation when encountering `0*oo`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * fix bug in AccumBounds.__mul__
<!-- END RELEASE NOTES -->
