### PR TITLE
Fix _FuncMinusOne in codegen/rewriting.py

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -181,9 +181,10 @@ class _FuncMinusOne:
         self.func_m_1 = func_m_1
 
     def _try_func_m_1(self, expr):
-        protected, old_new =  expr.replace(self.func, lambda arg: Dummy(), map=True)
+        old_new = {}
+        protected = expr.replace(self.func, lambda arg: old_new.setdefault(arg, Dummy()))
         factored = protected.factor()
-        new_old = {v: k for k, v in old_new.items()}
+        new_old = {v: self.func(k) for k, v in old_new.items()}
         return factored.replace(_d - 1, lambda d: self.func_m_1(new_old[d].args[0])).xreplace(new_old)
 
     def __call__(self, e):


### PR DESCRIPTION
Code optimizations like `exp(x) - 1 --> expm1(x)` may give unusable results in some situations.
For example:
```python
import sympy as sp
from sympy.codegen.rewriting import optimize, expm1_opt
expr = sp.sympify('(2*exp(x) + 1)/(exp(x) + 1) + 1')
optimize(expr, [expm1_opt])
```
returns `(_Dummy_25 + 2*exp(x) + 2)/(_Dummy_25 + 1)`.

This appears to be a bug in the `_try_func_m_1` method of `_FuncMinusOne`.
If multiple instances of `self.func` with the same argument are present, they are assigned different `Dummy` symbols.
However, only one of these is saved in the `old_new` dictionary, making back substitution impossible.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Fixed a bug in the code optimization for `expm1`
<!-- END RELEASE NOTES -->
