### PR TITLE
perf(polys): make EX faster for trivial operations

### DIFF
--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -64,10 +64,14 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __add__(f, g):
             g = f._to_ex(g)
 
-            if g is not None:
-                return f.simplify(f.ex + g.ex)
-            else:
+            if g is None:
                 return NotImplemented
+            elif g == EX.zero:
+                return f
+            elif f == EX.zero:
+                return g
+            else:
+                return f.simplify(f.ex + g.ex)
 
         def __radd__(f, g):
             return f.simplify(f.__class__(g).ex + f.ex)
@@ -75,10 +79,14 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __sub__(f, g):
             g = f._to_ex(g)
 
-            if g is not None:
-                return f.simplify(f.ex - g.ex)
-            else:
+            if g is None:
                 return NotImplemented
+            elif g == EX.zero:
+                return f
+            elif f == EX.zero:
+                return -g
+            else:
+                return f.simplify(f.ex - g.ex)
 
         def __rsub__(f, g):
             return f.simplify(f.__class__(g).ex - f.ex)
@@ -86,10 +94,15 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __mul__(f, g):
             g = f._to_ex(g)
 
-            if g is not None:
-                return f.simplify(f.ex*g.ex)
-            else:
+            if g is None:
                 return NotImplemented
+
+            if EX.zero in (f, g):
+                return EX.zero
+            elif f.ex.is_Number and g.ex.is_Number:
+                return f.__class__(f.ex*g.ex)
+
+            return f.simplify(f.ex*g.ex)
 
         def __rmul__(f, g):
             return f.simplify(f.__class__(g).ex*f.ex)


### PR DESCRIPTION
This commit avoids calls to cancel for some trivial operations in the EX
domain. This can lead to a big speed up for some integrals. For example
```
z1, z2 = symbols('z1, z2')
I = Integral(exp(-0.5*(((-1/z1)+1.39)**2+((-1/z2)+1.23)**2))*(1/(z1**2))*(1/(z2**2)),(z1,0,1),(z2,0,1))
I.doit()
```
In this case the integral is not computed with or without this change
but heurisch completes much faster with the change reducing the overall
time by 50%. Previously most of the time was spent in trivial calls to
cancel like cancel(0), cancel(3), etc.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

The integral example here is from #21533

#### Brief description of what is fixed or changed

The EX arithmetic is changed to reduce unnecessary calls to cancel for trivial cases like `EX(0)*EX(1)`.

#### Other comments

Further improvements could be made but it looks like a bit of a restructure of `ExtensionElement.__new__` would be needed. Ideally all EX elements would be canonicalised at creation time and then further calls to cancel could be eliminated from internal routines.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
