### PR TITLE
restrict Laplace space var to be strictly complex

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -148,8 +148,8 @@ class TransferFunction(Basic, EvalfMixin):
     def __new__(cls, num, den, var):
         num, den = _sympify(num), _sympify(den)
 
-        if not isinstance(var, Symbol):
-            raise TypeError("Variable input must be a Symbol.")
+        if not isinstance(var, Symbol) or var.is_real:
+            raise TypeError("Variable input must be a strictly complex symbol.")
         if den == 0:
             raise ValueError("TransferFunction can't have a zero denominator.")
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1,4 +1,4 @@
-from sympy import symbols, Matrix, factor, Function, simplify, exp, pi, oo, I, \
+from sympy import symbols, Symbol, Matrix, factor, Function, simplify, exp, pi, oo, I, \
     Rational, sqrt, CRootOf
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
 from sympy.testing.pytest import raises
@@ -102,6 +102,12 @@ def test_TransferFunction_construction():
     raises(TypeError, lambda: TransferFunction(s**2 + 2*s - 1, s + 3, 3))
     raises(TypeError, lambda: TransferFunction(p + 1, 5 - p, 4))
     raises(TypeError, lambda: TransferFunction(3, 4, 8))
+
+    # Laplace space variable must be a strictly complex symbol
+    u, v = Symbol('u', real=True), Symbol('v', complex=True)
+    assert TransferFunction(v**3 + d, v*s**2 + v*s + a, v).var.is_complex
+    raises(TypeError, lambda: TransferFunction(u**2 + s - k**3, u*s**2 + k*p, u))
+    raises(TypeError, lambda: TransferFunction(u*s + a0, u*s**2 + b1*s + b0, u))
 
 
 def test_TransferFunction_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This restricts the Laplace space input variable in `TransferFunction` to be a strictly complex `Symbol`.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  *  Laplace space input variable will be strictly complex
<!-- END RELEASE NOTES -->
