### PR TITLE
lambdify: Optimization with a substitution of redundant patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,3 @@ sample.tex
 
 # pytest related data file for slow tests
 .ci/durations.log
-
-test_lambdify.py
-

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ sample.tex
 
 # pytest related data file for slow tests
 .ci/durations.log
+
+test_lambdify.py
+

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -89,7 +89,7 @@ def cse_separate(r, e):
 
 def cse_minimize_memory(r, e):
     """
-    Return tuples giving (a, b) where ``a`` is a symbol and b is
+    Return tuples giving (a, b) where ``a`` is a symbol and ``b`` is
     either an expression or None. The value of None is used when a
     symbol is no longer needed for subsequent expressions.
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -806,7 +806,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     del temp
 
     if optimizations is None:
-        optimizations = list()
+        optimizations = []
     elif optimizations == 'basic':
         optimizations = basic_optimizations
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -744,6 +744,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     >>> from sympy import cse, SparseMatrix
     >>> from sympy.abc import x, y, z, w
+    >>> from sympy.simplify.cse_main import cse
     >>> cse(((w + x + y + z)*(w + y + z))/(w + x)**3)
     ([(x0, y + z), (x1, w + x)], [(w + x0)*(x0 + x1)/x1**3])
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -742,9 +742,8 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     Examples
     ========
 
-    >>> from sympy import cse, SparseMatrix
+    >>> from sympy import cse, SparseMatrix, cos
     >>> from sympy.abc import x, y, z, w
-    >>> from sympy.simplify.cse_main import cse
     >>> cse(((w + x + y + z)*(w + y + z))/(w + x)**3)
     ([(x0, y + z), (x1, w + x)], [(w + x0)*(x0 + x1)/x1**3])
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -89,7 +89,7 @@ def cse_separate(r, e):
 
 def cse_minimize_memory(r, e):
     """
-    Return tuples giving (a, b) where ``a`` is a symbol and ``b`` is
+    Return tuples giving ``(a, b)`` where ``a`` is a symbol and ``b`` is
     either an expression or None. The value of None is used when a
     symbol is no longer needed for subsequent expressions.
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -770,6 +770,12 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     >>> cse([y**2*(x + 1), 3*y**2*(x + 1)], ignore=(y,))
     ([(x0, x + 1)], [x0*y**2, 3*x0*y**2])
 
+    >>> output = lambda x, as_list: type(cse(x, as_list=as_list)[1])
+    >>> output(cos(x), as_list=False)
+    cos
+    >>> output(cos(x), as_list=True)
+    <class 'list'>
+    >>>
     """
     from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                                 SparseMatrix, ImmutableSparseMatrix)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -853,8 +853,8 @@ def _cse_homogeneous(exprs, **kwargs):
     Parameters
     ==========
 
-    exprs : list of sympy expressions, or a single SymPy expression
-        The expressions to reduce.
+    exprs : an Expr, iterable of Expr or dictionary with Expr values
+        the expressions in which repeated subexpressions will be identified
     kwargs : additional arguments for the ``cse`` function
 
     Returns

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -770,12 +770,13 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     >>> cse([y**2*(x + 1), 3*y**2*(x + 1)], ignore=(y,))
     ([(x0, x + 1)], [x0*y**2, 3*x0*y**2])
 
-    >>> output = lambda x, as_list: type(cse(x, as_list=as_list)[1])
-    >>> output(cos(x), as_list=False)
-    cos
-    >>> output(cos(x), as_list=True)
-    <class 'list'>
-    >>>
+    The default return value for the reduced expression(s) is a list, even if there is only
+    one expression. The `as_list` flag preserves the type of the input in the output:
+
+    >>> cse(x)
+    ([], [x])
+    >>> cse(x, as_list=False)
+    ([], x)
     """
     from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                                 SparseMatrix, ImmutableSparseMatrix)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -742,7 +742,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     Examples
     ========
 
-    >>> from sympy import cse, SparseMatrix, cos
+    >>> from sympy import cse, SparseMatrix
     >>> from sympy.abc import x, y, z, w
     >>> cse(((w + x + y + z)*(w + y + z))/(w + x)**3)
     ([(x0, y + z), (x1, w + x)], [(w + x0)*(x0 + x1)/x1**3])

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -137,10 +137,9 @@ def cse_minimize_memory(r, e):
     syms = list(syms)
     p += e
     in_use = ss
-    del ss
+    # del ss # makes failing the quality code test.
     rv = []
     i = len(p) - 1
-    useless = {}
     while i >= 0:
         _p = p.pop()
         c = in_use & _p.free_symbols

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -695,7 +695,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
 
 
 def cse(exprs, symbols=None, optimizations=None, postprocess=None,
-        order='canonical', ignore=(), as_list=True):
+        order='canonical', ignore=(), list=True):
     """ Perform common subexpression elimination on an expression.
 
     Parameters
@@ -726,7 +726,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
         concern, use the setting order='none'.
     ignore : iterable of Symbols
         Substitutions containing any Symbol from ``ignore`` will be ignored.
-    as_list : bool, (default True)
+    list : bool, (default True)
         Returns expression in list or else with same type as input (when False).
 
     Returns
@@ -771,17 +771,17 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     ([(x0, x + 1)], [x0*y**2, 3*x0*y**2])
 
     The default return value for the reduced expression(s) is a list, even if there is only
-    one expression. The `as_list` flag preserves the type of the input in the output:
+    one expression. The `list` flag preserves the type of the input in the output:
 
     >>> cse(x)
     ([], [x])
-    >>> cse(x, as_list=False)
+    >>> cse(x, list=False)
     ([], x)
     """
     from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                                 SparseMatrix, ImmutableSparseMatrix)
 
-    if not as_list:
+    if not list:
         return _cse_homogeneous(exprs,
             symbols=symbols, optimizations=optimizations,
             postprocess=postprocess, order=order, ignore=ignore)
@@ -879,10 +879,11 @@ def _cse_homogeneous(exprs, **kwargs):
 
     Examples
     ========
+
     >>> from sympy.simplify.cse_main import cse
     >>> from sympy import cos, Tuple, Matrix
     >>> from sympy.abc import x
-    >>> output = lambda x: type(cse(x, as_list=False)[1])
+    >>> output = lambda x: type(cse(x, list=False)[1])
     >>> output(1)
     <class 'sympy.core.numbers.One'>
     >>> output('cos(x)')

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -87,7 +87,7 @@ def cse_separate(r, e):
     return [reps_toposort(r), e]
 
 
-def cse_minimize_memory(r, e):
+def cse_release_variables(r, e):
     """
     Return tuples giving ``(a, b)`` where ``a`` is a symbol and ``b`` is
     either an expression or None. The value of None is used when a
@@ -100,10 +100,10 @@ def cse_minimize_memory(r, e):
     ========
 
     >>> from sympy import cse
-    >>> from sympy.simplify.cse_main import cse_minimize_memory
+    >>> from sympy.simplify.cse_main import cse_release_variables
     >>> from sympy.abc import x, y
     >>> eqs = [(x + y - 1)**2, x, x + y, (x + y)/(2*x + 1) + (x + y - 1)**2, (2*x + 1)**(x + y)]
-    >>> defs, rvs = cse_minimize_memory(*cse(eqs))
+    >>> defs, rvs = cse_release_variables(*cse(eqs))
     >>> for i in defs:
     ...   print(i)
     ...

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -561,8 +561,8 @@ def test_cse_minimize_memory():
     r.reverse()
     assert eqs == [i.subs(r) for i in e]
 
-def test_cse_as_list():
-    _cse = lambda x: cse(x, as_list=False)
+def test_cse_list():
+    _cse = lambda x: cse(x, list=False)
     assert _cse(x) == ([], x)
     assert _cse('x') == ([], 'x')
     it = [x]

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -546,13 +546,13 @@ def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
 
-def test_cse_minimize_memory():
-    from sympy.simplify.cse_main import cse_minimize_memory
+def test_cse_release_variables():
+    from sympy.simplify.cse_main import cse_release_variables
     _0, _1, _2, _3, _4 = symbols('_:5')
     eqs = [(x + y - 1)**2, x,
         x + y, (x + y)/(2*x + 1) + (x + y - 1)**2,
         (2*x + 1)**(x + y)]
-    r, e = cse(eqs, postprocess=cse_minimize_memory)
+    r, e = cse(eqs, postprocess=cse_release_variables)
     # this can change in keeping with the intention of the function
     assert r, e == ([
     (x0, x + y), (x1, (x0 - 1)**2), (x2, 2*x + 1),

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -548,9 +548,10 @@ def test_unevaluated_mul():
 
 def test_cse_minimize_memory():
     from sympy.simplify.cse_main import cse_minimize_memory
+    _0, _1, _2, _3, _4 = symbols('_:5')
     eqs = [(x + y - 1)**2, x,
-    x + y, (x + y)/(2*x + 1) + (x + y - 1)**2,
-    (2*x + 1)**(x + y)]
+        x + y, (x + y)/(2*x + 1) + (x + y - 1)**2,
+        (2*x + 1)**(x + y)]
     r, e = cse(eqs, postprocess=cse_minimize_memory)
     # this can change in keeping with the intention of the function
     assert r, e == ([

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -561,8 +561,8 @@ def test_cse_minimize_memory():
     r.reverse()
     assert eqs == [i.subs(r) for i in e]
 
-def test_cse_asList():
-    _cse = lambda x: cse(x, asList=False)
+def test_cse_as_list():
+    _cse = lambda x: cse(x, as_list=False)
     assert _cse(x) == ([], x)
     assert _cse('x') == ([], 'x')
     it = [x]

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -546,6 +546,29 @@ def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
 
+def test_cse_minimize_memory():
+    from sympy.simplify.cse_main import cse_minimize_memory
+    eqs = [(x + y - 1)**2, x,
+    x + y, (x + y)/(2*x + 1) + (x + y - 1)**2,
+    (2*x + 1)**(x + y)]
+    r, e = cse(eqs, postprocess=cse_minimize_memory)
+    # this can change in keeping with the intention of the function
+    assert r, e == ([
+    (x0, x + y), (x1, (x0 - 1)**2), (x2, 2*x + 1),
+    (_3, x0/x2 + x1), (_4, x2**x0), (x2, None), (_0, x1),
+    (x1, None), (_2, x0), (x0, None), (_1, x)], (_0, _1, _2, _3, _4))
+    r.reverse()
+    assert eqs == [i.subs(r) for i in e]
+
+def test_cse_asList():
+    _cse = lambda x: cse(x, asList=False)
+    assert _cse(x) == ([], x)
+    assert _cse('x') == ([], 'x')
+    it = [x]
+    for c in (list, tuple, set, Tuple):
+        assert _cse(c(it)) == ([], c(it))
+    d = {x: 1}
+    assert _cse(d) == ([], d)
 
 def test_issue_18991():
     A = MatrixSymbol('A', 2, 2)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -336,21 +336,16 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         (if ``args`` is not a string) - for example, to ensure that the
         arguments do not redefine any built-in names.
 
-    cse : bool or callable, optional
-        When vectorializing a large expression as efficient as possible,
-        set this parameter to True.
-        Whether or not common subexpression elimination should be performed on
-        the expressions, This can potentially improve performance of the generated
-
-        However, the step of finding redundant paterns can be slow.
-        So, if the creation of the 'lambdify' function should be fast,
-        set this parameter to False.
+    cse : bool, None or callable, optional
+        Large expressions can be computed more efficiently when
+        common subexpressions are identified and precomputed before
+        being used multiple time. Finding the subexpressions will make
+        creation of the 'lambdify' function slower, however.
 
         Whether or not common subexpression elimination should be performed on
         the expressions. This can potentially improve performance of the generated
         function. When ``True``, then ``sympy.simplify.cse`` is used, the user
         may pass their own function matching the signature of said function.
-
 
 
     Examples
@@ -864,9 +859,10 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
-    if cse:
-        from sympy.simplify.cse_main import _cse_homogeneous
-        cses, expr = _cse_homogeneous(expr, memory=True)
+    if cse != False:
+        from sympy.simplify.cse_main import _cse_homogeneous, cse_minimize_memory
+        cses, expr = _cse_homogeneous(expr,
+            postprocess=None if cse else cse_minimize_memory)
     else:
         cses = ()
     funcstr = funcprinter.doprint(funcname, args, expr, cses=cses)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -860,7 +860,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     if cse == True:
         from sympy.simplify.cse_main import cse
         cses, _expr = cse(expr, as_list=False)
-    elif cse:  # assume callable
+    elif callable(cse):
         cses, _expr = cse(expr)
     else:
         cses, _expr = (), expr

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1103,7 +1103,7 @@ class _EvaluatorPrinter:
         funcbody.extend(self._print_funcargwrapping(funcargs))
 
         funcbody.extend(unpackings)
-        funcbody.extend(['{} = {}'.format(s, e) for s, e in cses])
+        funcbody.extend(['{} = {}'.format(s, self._exprrepr(e)) for s, e in cses])
         funcbody.append('return ({})'.format(self._exprrepr(expr)))
 
         funclines = [funcsig]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -934,9 +934,12 @@ def _cse_del(expr):
     ([(x0, x + cos(x)), (x1, x0*sin(x0))], [set(), {x0}], sqrt(x1) + x1)
     """
     def get_free_symbols(expr):
-        if hasattr(expr, "__iter__"):
+        if hasattr(expr, "__iter__") and not isinstance(expr, str):
             return set.union(*map(get_free_symbols, expr))
-        return expr.free_symbols
+        try:
+            return expr.free_symbols
+        except AttributeError:
+            return set()
 
     from sympy import cse
     replacements, reduced_exprs = cse([expr])

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -6,6 +6,7 @@ lambda functions which can be used to calculate numerical values very fast.
 from typing import Any, Dict, Iterable
 
 import builtins
+import collections
 import inspect
 import keyword
 import textwrap
@@ -845,7 +846,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _TensorflowEvaluatorPrinter(printer, dummify) # type: _EvaluatorPrinter
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
-    funcstr = funcprinter.doprint(funcname, args, expr)
+    final_expr, stages = _RedundancySliter(expr).split_redundancy() # Delete redundancy.
+    funcstr = funcprinter.doprint(funcname, args, final_expr, *stages)
 
     # Collect the module imports from the code printers.
     imp_mod_lines = []
@@ -903,6 +905,97 @@ def _module_present(modname, modlist):
             return True
     return False
 
+class _RedundancySliter:
+    """
+    Groups the methods used to extract redundant patterns.
+    """
+    def __init__(self, expr):
+        """
+        expr: sympy.core.basic.Basic
+            This is the expression that we want to optimize.
+        """
+        self.stages = [] # The FIFO of intermediaite stapes.
+        self.sub_var_cmp = 0 # Counter in order to create new sympy variables.
+        self.forbidden_symbols = expr.free_symbols # Juste a protection.
+        self.final_expr = self._gather(variables=set(), expr=expr.copy())
+
+    def split_redundancy(self):
+        """
+        Find patterns that appear more than once in order to factor them.
+
+        :returns: The factorised expression and a list of 3_tuples.
+            final_expr, [(var, sub_expr, (var_to_delete,)), ...]
+        """
+        return self.final_expr, self.stages
+
+    def _gather(self, variables, expr):
+        """
+        Find recursively all the redondants patterns.
+        Start by isolating the patterns that appear the most times and then isolate the largest
+        of these patterns in order to minimize the steps of calculations.
+        """
+        from sympy.core.symbol import Symbol
+
+        if expr.is_number or expr.is_symbol: # If the expression can not be simplify.
+            return expr
+
+        complete_hist = self._hist_sub_expr(expr) # Exaustive histogram of childs.
+        if not complete_hist: # If their are nothind to symplify.
+            return expr
+
+        max_red = max(complete_hist.values())
+        if max_red == 1: # If the expressioin is not redondante.
+            return expr
+
+
+        dephs_expr = {self._len(expr): expr for expr in
+                    (expr for expr, red in complete_hist.items() if red == max_red)
+                } # Size of each candidates expressions.
+        sub_expr = dephs_expr[max(dephs_expr.keys())] # The patern to replace.
+        while True: # To append a verification.
+            self.sub_var_cmp += 1
+            sub_var = Symbol('subvar_{}'.format(self.sub_var_cmp)) # Intermediate var.
+            if sub_var not in self.forbidden_symbols:
+                break # We guarantee the uniqueness of this variable.
+        expr = expr.xreplace({sub_expr: sub_var}) # New symplify expression.
+
+        useless_vars = set(variables) - expr.free_symbols # Variables that we can delete.
+        self.stages.append([
+            sub_var,
+            sub_expr,
+            useless_vars])
+
+        variables = variables - useless_vars
+        variables.add(sub_var)
+
+        return self._gather(variables, expr)
+
+    def _hist_sub_expr(self, expr):
+        """
+        Compute the child histogram.
+
+        * Don't consider atomic node.
+
+        expr : sympy.core.basic.Basic
+            Top of syntaxical tree.
+        :returns: The dictionary witch for each childrens and descendents in general,
+            associate, each number of apparitions.
+        """
+        hist = collections.defaultdict(lambda: 0)
+        for child in expr.args:
+            if child.is_number or child.is_symbol:
+                continue
+            hist[child] += 1
+            for little_child, occur in self._hist_sub_expr(child).items():
+                hist[little_child] += occur
+        return hist
+
+    def _len(self, expr):
+        """
+        Find the number of nodes present in the sntaxic tree.
+        Lets you estimate the size of the expression.
+        """
+        return 1 + sum(self._len(child) for child in expr.args)
 
 def _get_namespace(m):
     """
@@ -1059,8 +1152,17 @@ class _EvaluatorPrinter:
         # Used to print the generated function arguments in a standard way
         self._argrepr = LambdaPrinter().doprint
 
-    def doprint(self, funcname, args, expr):
-        """Returns the function definition code as a string."""
+    def doprint(self, funcname, args, expr, *stages):
+        """
+        Returns the function definition code as a string.
+
+        :param stages: These are the intermediate calculation steps.
+            Represented as a tuple with 3 coordinates:
+            -The first indicates the number of the variable to be
+                substituted.
+            -The second element is the sub expression.
+            -The list of useless variable.
+        """
         from sympy import Dummy
 
         funcbody = []
@@ -1088,7 +1190,12 @@ class _EvaluatorPrinter:
 
         funcbody.extend(unpackings)
 
-        funcbody.append('return ({})'.format(self._exprrepr(expr)))
+        for var_name, sub_expr, useless_vars in stages:
+            funcbody.append('{} = {}'.format(var_name, self._exprrepr(sub_expr)))
+            if useless_vars:
+                funcbody.append('del {}'.format(', '.join(map(str, useless_vars))))
+
+        funcbody.append('return {}'.format(self._exprrepr(expr)))
 
         funclines = [funcsig]
         funclines.extend('    ' + line for line in funcbody)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -173,9 +173,9 @@ def _import(module, reload=False):
 # linecache.
 _lambdify_generated_counter = 1
 
-@doctest_depends_on(modules=('numpy', 'tensorflow', ), python_version=(3,))
+@doctest_depends_on(modules=('numpy', 'tensorflow',), python_version=(3,))
 def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
-             dummify=False, cse=False):
+             dummify=False, cse=True):
     """Convert a SymPy expression into a function that allows for fast
     numeric evaluation.
 
@@ -858,11 +858,11 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
     if cse != False:
-        from sympy.simplify.cse_main import _cse_homogeneous
-        cses, expr = _cse_homogeneous(expr)
+        from sympy.simplify.cse_main import cse, cse_minimize_memory
+        cses, _expr = cse(expr, as_list=False, postprocess=cse_minimize_memory)
     else:
-        cses = ()
-    funcstr = funcprinter.doprint(funcname, args, expr, cses=cses)
+        cses, _expr = (), expr
+    funcstr = funcprinter.doprint(funcname, args, _expr, cses=cses)
 
     # Collect the module imports from the code printers.
     imp_mod_lines = []

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -336,16 +336,14 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         (if ``args`` is not a string) - for example, to ensure that the
         arguments do not redefine any built-in names.
 
-    cse : bool, None or callable, optional
+    cse : bool, or callable, optional
         Large expressions can be computed more efficiently when
         common subexpressions are identified and precomputed before
         being used multiple time. Finding the subexpressions will make
         creation of the 'lambdify' function slower, however.
 
-        Whether or not common subexpression elimination should be performed on
-        the expressions. This can potentially improve performance of the generated
-        function. When ``True``, then ``sympy.simplify.cse`` is used, the user
-        may pass their own function matching the signature of said function.
+        When ``True``, the default ``sympy.simplify.cse`` is used, otherwise the user
+        may pass a function matching the signature ``cse``.
 
 
     Examples
@@ -860,9 +858,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
     if cse != False:
-        from sympy.simplify.cse_main import _cse_homogeneous, cse_minimize_memory
-        cses, expr = _cse_homogeneous(expr,
-            postprocess=None if cse else cse_minimize_memory)
+        from sympy.simplify.cse_main import _cse_homogeneous
+        cses, expr = _cse_homogeneous(expr)
     else:
         cses = ()
     funcstr = funcprinter.doprint(funcname, args, expr, cses=cses)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -175,7 +175,7 @@ _lambdify_generated_counter = 1
 
 @doctest_depends_on(modules=('numpy', 'tensorflow',), python_version=(3,))
 def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
-             dummify=False, cse=True):
+             dummify=False, cse=False):
     """Convert a SymPy expression into a function that allows for fast
     numeric evaluation.
 
@@ -342,8 +342,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         being used multiple time. Finding the subexpressions will make
         creation of the 'lambdify' function slower, however.
 
-        When ``True``, the default ``sympy.simplify.cse`` is used, otherwise the user
-        may pass a function matching the signature ``cse``.
+        When ``True``, ``sympy.simplify.cse`` is used, otherwise (the default)
+        the user may pass a function matching the signature ``cse``.
 
 
     Examples

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -857,9 +857,11 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
-    if cse != False:
-        from sympy.simplify.cse_main import cse, cse_minimize_memory
-        cses, _expr = cse(expr, as_list=False, postprocess=cse_minimize_memory)
+    if cse == True:
+        from sympy.simplify.cse_main import cse
+        cses, _expr = cse(expr, as_list=False)
+    elif cse != False:
+        cses, _expr = cse(expr)
     else:
         cses, _expr = (), expr
     funcstr = funcprinter.doprint(funcname, args, _expr, cses=cses)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -934,16 +934,18 @@ def _cse_del(expr):
     ([(x0, x + cos(x)), (x1, x0*sin(x0))], [set(), {x0}], sqrt(x1) + x1)
     """
     def get_free_symbols(expr):
-        if hasattr(expr, "__iter__") and not isinstance(expr, str):
-            return set.union(*map(get_free_symbols, expr))
         try:
             return expr.free_symbols
         except AttributeError:
             return set()
+        if hasattr(expr, "__iter__") and not isinstance(expr, str):
+            return set.union(*map(get_free_symbols, expr))
+        return set()
 
     from sympy import cse
-    replacements, reduced_exprs = cse([expr])
-    reduced_exprs = reduced_exprs.pop() # No raison to cast in a list!
+    replacements, reduced_exprs = cse(expr)
+    if not hasattr(expr, "__iter__"): # If cse makes cast to a list because cse(x) == cse([x]).
+        reduced_exprs = reduced_exprs.pop() # We keep the homogeneity of the expression.
 
     # Cumulate union of symbols.
     free_symbols = [pattern.free_symbols for _, pattern in replacements]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -933,16 +933,17 @@ def _cse_del(expr):
     >>> _cse_del(expr)
     ([(x0, x + cos(x)), (x1, x0*sin(x0))], [set(), {x0}], sqrt(x1) + x1)
     """
+    from sympy import cse
+    from sympy.core.compatibility import iterable
+
     def get_free_symbols(expr):
         try:
             return expr.free_symbols
         except AttributeError:
-            return set()
-        if hasattr(expr, "__iter__") and not isinstance(expr, str):
-            return set.union(*map(get_free_symbols, expr))
+            if iterable(expr):
+                return set.union(*map(get_free_symbols, expr))
         return set()
 
-    from sympy import cse
     replacements, reduced_exprs = cse(expr)
     if not hasattr(expr, "__iter__"): # If cse makes cast to a list because cse(x) == cse([x]).
         reduced_exprs = reduced_exprs.pop() # We keep the homogeneity of the expression.

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -864,9 +864,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
-    if cse is True:
-        from sympy.simplify.cse_main import _cse_homogeneous
     if cse:
+        from sympy.simplify.cse_main import _cse_homogeneous
         cses, expr = _cse_homogeneous(expr, memory=True)
     else:
         cses = ()

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -930,7 +930,7 @@ def _cse_del(expr):
     >>> x1 = x0 * sin(x0)
     >>> x2 = x1 + sqrt(x1)
     >>> _cse_del(x2)
-    ([(x0, x + cos(x)), (x1, x0*sin(x0))], [{x}, {x0}], [sqrt(x1) + x1])
+    ([(x0, x + cos(x)), (x1, x0*sin(x0))], [{}, {x0}], [sqrt(x1) + x1])
     """
     from sympy import cse
     replacements, reduced_exprs = cse(expr)
@@ -940,12 +940,12 @@ def _cse_del(expr):
     free_symbols.reverse()
     symbols_cum = [set.union(*(pattern.free_symbols for pattern in reduced_exprs))]
     for free_symbol in free_symbols:
-        symbols_cum.insert(0, free_symbol | symbols_cum[-1])
+        symbols_cum.insert(0, free_symbol | symbols_cum[0])
 
     # Detection of useless symbols.
     useless_symbols = []
     current_symbols = set() # Buffers memory.
-    for (new_symb, _), following_symb in zip(replacements, symbols_cum):
+    for (new_symb, _), following_symb in zip(replacements, symbols_cum[1:]):
         current_symbols.add(new_symb)
         useless_symbols.append(current_symbols - following_symb) # The set of useless symbols.
         current_symbols -= useless_symbols[-1]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -926,11 +926,12 @@ def _cse_del(expr):
     Examples
     ========
 
-    >>> x0 = x + cos(x)
-    >>> x1 = x0 * sin(x0)
-    >>> x2 = x1 + sqrt(x1)
-    >>> _cse_del(x2)
-    ([(x0, x + cos(x)), (x1, x0*sin(x0))], [{}, {x0}], sqrt(x1) + x1)
+    >>> from sympy.utilities.lambdify import _cse_del
+    >>> from sympy import sqrt, cos, sin, Symbol
+    >>> x = Symbol("x")
+    >>> expr = sqrt((x + cos(x))*sin(x + cos(x))) + (x + cos(x))*sin(x + cos(x))
+    >>> _cse_del(expr)
+    ([(x0, x + cos(x)), (x1, x0*sin(x0))], [set(), {x0}], sqrt(x1) + x1)
     """
     def get_free_symbols(expr):
         if hasattr(expr, "__iter__"):
@@ -938,9 +939,8 @@ def _cse_del(expr):
         return expr.free_symbols
 
     from sympy import cse
-    replacements, reduced_exprs = cse(expr)
-    if not hasattr(expr, "__iter__"): # If the expression is a sympy expr.
-        reduced_exprs = reduced_exprs.pop() # No raison to cast in a list!
+    replacements, reduced_exprs = cse([expr])
+    reduced_exprs = reduced_exprs.pop() # No raison to cast in a list!
 
     # Cumulate union of symbols.
     free_symbols = [pattern.free_symbols for _, pattern in replacements]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -343,7 +343,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
         creation of the 'lambdify' function slower, however.
 
         When ``True``, ``sympy.simplify.cse`` is used, otherwise (the default)
-        the user may pass a function matching the signature ``cse``.
+        the user may pass a function matching the ``cse`` signature.
 
 
     Examples
@@ -859,7 +859,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
 
     if cse == True:
         from sympy.simplify.cse_main import cse
-        cses, _expr = cse(expr, as_list=False)
+        cses, _expr = cse(expr, list=False)
     elif callable(cse):
         cses, _expr = cse(expr)
     else:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -860,7 +860,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     if cse == True:
         from sympy.simplify.cse_main import cse
         cses, _expr = cse(expr, as_list=False)
-    elif cse != False:
+    elif cse:  # assume callable
         cses, _expr = cse(expr)
     else:
         cses, _expr = (), expr

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1413,7 +1413,7 @@ def test_lambdify_cse():
         return (), exprs
 
     def minmem(exprs):
-        from sympy.simplify.cse_main import cse_minimize_memory
+        from sympy.simplify.cse_main import cse_minimize_memory, cse
         return cse(exprs, postprocess=cse_minimize_memory)
 
     class Case:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1414,7 +1414,7 @@ def test_lambdify_cse():
 
     def minmem(exprs):
         from sympy.simplify.cse_main import cse_minimize_memory
-        return cse(expr, postprocess=cse_minimize_memory)
+        return cse(exprs, postprocess=cse_minimize_memory)
 
     class Case:
         def __init__(self, *, args, exprs, num_args, requires_numpy=False):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1408,11 +1408,13 @@ def test_cupy_dotproduct():
         cupy.array([14])
 
 
-
-
 def test_lambdify_cse():
     def dummy_cse(exprs):
         return (), exprs
+
+    def minmem(exprs):
+        from sympy.simplify.cse_main import cse_minimize_memory
+        return cse(expr, postprocess=cse_minimize_memory)
 
     class Case:
         def __init__(self, *, args, exprs, num_args, requires_numpy=False):
@@ -1490,7 +1492,7 @@ def test_lambdify_cse():
     for case in cases:
         if not numpy and case.requires_numpy:
             continue
-        for cse in [False, True, None, dummy_cse]:
+        for cse in [False, True, minmem, dummy_cse]:
             f = case.lambdify(cse=cse)
             result = f(*case.num_args)
             case.assertAllClose(result)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1413,8 +1413,8 @@ def test_lambdify_cse():
         return (), exprs
 
     def minmem(exprs):
-        from sympy.simplify.cse_main import cse_minimize_memory, cse
-        return cse(exprs, postprocess=cse_minimize_memory)
+        from sympy.simplify.cse_main import cse_release_variables, cse
+        return cse(exprs, postprocess=cse_release_variables)
 
     class Case:
         def __init__(self, *, args, exprs, num_args, requires_numpy=False):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1412,24 +1412,75 @@ def test_cse():
     def dummy_cse(exprs):
         return (), exprs
 
-    args = x, y, z
-    e1 = x + y + z
-    e2 = x + y - z
-    e3 = 2*x + 2*y - z
-    e4 = (x+y)**2 + (y+z)**2
-    exprs = [e1, e2, e3, e4]
-    num_args = (2., 3., 4.)
+    class Case:
+        def __init__(self, *, args, exprs, num_args, requires_numpy=False):
+            self.args = args
+            self.exprs = exprs
+            self.num_args = num_args
+            subs_dict = dict(zip(self.args, self.num_args))
+            self.ref = [e.subs(subs_dict).evalf() for e in exprs]
+            self.requires_numpy = requires_numpy
 
-    subs_dict = dict(zip(args, num_args))
-    ref = [e.subs(subs_dict).evalf() for e in exprs]
-    abstol, reltol = 1e-15, 1e-15
+        def lambdify(self, *, cse):
+            return lambdify(self.args, self.exprs, cse=cse)
 
-    for cse in [False, True, dummy_cse]:
-        f1 = lambdify(args, exprs, cse=cse)
-        result = f1(*num_args)
-        for i, r in enumerate(ref):
-            abs_err = abs(result[i] - r)
-            if r == 0:
-                assert abs_err < abstol
-            else:
-                assert abs_err/abs(r) < reltol
+        def assertAllClose(self, result, *, abstol=1e-15, reltol=1e-15):
+            if self.requires_numpy:
+                assert all(numpy.allclose(result[i], numpy.asarray(r, dtype=float),
+                                          rtol=reltol, atol=abstol)
+                           for i, r in enumerate(self.ref))
+                return
+
+            for i, r in enumerate(self.ref):
+                abs_err = abs(result[i] - r)
+                if r == 0:
+                    assert abs_err < abstol
+                else:
+                    assert abs_err/abs(r) < reltol
+
+    case1 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + y + z,
+            x + y - z,
+            2*x + 2*y - z,
+            (x+y)**2 + (y+z)**2,
+        ],
+        num_args=(2., 3., 4.)
+    )
+    case2 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + sympy.Heaviside(x),
+            y + sympy.Heaviside(x),
+            z + sympy.Heaviside(x, 1),
+            z/sympy.Heaviside(x, 1)
+        ],
+        num_args=(0., 3., 4.)
+    )
+    case3 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + sinc(y),
+            y + sinc(y),
+            z - sinc(y)
+        ],
+        num_args=(0.1, 0.2, 0.3)
+    )
+    case4 = Case(
+        args=(x, y, z),
+        exprs=[
+            Matrix([[x, x*y], [sin(z) + 4, x**z]]),
+            x*y+sin(z)-x**z,
+            Matrix([x*x, sin(z), x**z])
+        ],
+        num_args=(1.,2.,3.),
+        requires_numpy=True
+    )
+    for case in [case1, case2, case3, case4]:
+        if not numpy and case.requires_numpy:
+            continue
+        for cse in [False, True, dummy_cse]:
+            f = case.lambdify(cse=cse)
+            result = f(*case.num_args)
+            case.assertAllClose(result)


### PR DESCRIPTION
In the event that we want to vectorize big sympathetic expressions. Often this one comes from a sympy algorithm which does not give very compact equations. So there is very often a lot of redundancy.
The modification that I propose is to make "change of variables" in order to calculate only once the redundant patterns.

<!-- BEGIN RELEASE NOTES -->
* utilities
  * lambdify has keyword `cse` which allows for more efficient calculation of expressions with highly-repeated subexpressions
<!-- END RELEASE NOTES -->