### PR TITLE
Fix: Bug in MinMax which returned an incorrect simplication which is not true for all ranges of the variables

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -433,8 +433,6 @@ class MinMaxBase(Expr, LatticeOp):
 
         >>> Min(a, Max(b, Min(c, d, Max(a, e))))
         Min(a, Max(b, Min(a, c, d)))
-        >>> Max( Min(a, b), Min(a, b, c))
-        Min(a,b)
         """
         from sympy.utilities.iterables import ordered
         from sympy.simplify.simplify import walk

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,4 +1,5 @@
 from sympy.core import Function, S, sympify
+from sympy.utilities.iterables import sift
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import ordered
@@ -432,7 +433,8 @@ class MinMaxBase(Expr, LatticeOp):
 
         >>> Min(a, Max(b, Min(c, d, Max(a, e))))
         Min(a, Max(b, Min(a, c, d)))
-
+        >>> Max( Min(a, b), Min(a, b, c))
+        Min(a,b)
         """
         from sympy.utilities.iterables import ordered
         from sympy.simplify.simplify import walk
@@ -518,28 +520,33 @@ class MinMaxBase(Expr, LatticeOp):
         # easy case where all functions contain something in common;
         # trying to find some optimal subset of args to modify takes
         # too long
+
+        def factor_minmax(args):
+            is_other = lambda arg: isinstance(arg, other)
+            other_args, remaining_args = sift(args, is_other, binary=True)
+            if not other_args:
+                return args
+
+            # Min(Max(x, y, z), Max(x, y, u, v)) -> {x,y}, ({z}, {u,v})
+            arg_sets = [set(arg.args) for arg in other_args]
+            common = set.intersection(*arg_sets)
+            if not common:
+                return args
+
+            new_other_args = list(common)
+            arg_sets_diff = [arg_set - common for arg_set in arg_sets]
+
+            # If any set is empty after removing common then all can be
+            # discarded e.g. Min(Max(a, b, c), Max(a, b)) -> Max(a, b)
+            if all(arg_sets_diff):
+                other_args_diff = [other(*s, evaluate=False) for s in arg_sets_diff]
+                new_other_args.append(cls(*other_args_diff, evaluate=False))
+
+            other_args_factored = other(*new_other_args, evaluate=False)
+            return remaining_args + [other_args_factored]
+
         if len(args) > 1:
-            common = None
-            remove = []
-            sets = []
-            for i in range(len(args)):
-                a = args[i]
-                if not isinstance(a, other):
-                    continue
-                s = set(a.args)
-                common = s if common is None else (common & s)
-                if not common:
-                    break
-                sets.append(s)
-                remove.append(i)
-            if common:
-                sets = filter(None, [s - common for s in sets])
-                sets = [other(*s, evaluate=False) for s in sets]
-                for i in reversed(remove):
-                    args.pop(i)
-                oargs = [cls(*sets)] if sets else []
-                oargs.extend(common)
-                args.append(other(*oargs, evaluate=False))
+            args = factor_minmax(args)
 
         return args
 

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -412,7 +412,7 @@ def test_issue_12638():
 
 def test_issue_21399():
     from sympy.abc import a, b, c
-    assert Max( Min(a, b), Min(a, b, c)) == Min(a,b)
+    assert Max(Min(a, b), Min(a, b, c)) == Min(a, b)
 
 
 def test_instantiation_evaluation():

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -410,6 +410,10 @@ def test_issue_12638():
     assert Min(a, b, Max(a, b, c)) == Min(a, b)
     assert Min(a, b, Max(a, c)) == Min(a, b)
 
+def test_issue_21399():
+    from sympy.abc import a, b, c
+    assert Max( Min(a, b), Min(a, b, c)) == Min(a,b)
+
 
 def test_instantiation_evaluation():
     from sympy.abc import v, w, x, y, z

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -233,37 +233,39 @@ def test_piecewise_integrate1ca():
     assert g.integrate((x, 1, -2)) == g1y.subs(y, -2)
     assert g.integrate((x, 0, 1)) == gy1.subs(y, 0)
     assert g.integrate((x, 1, 0)) == g1y.subs(y, 0)
-    # XXX Make test pass without simplify
-    assert g.integrate((x, 2, 1)) == gy1.subs(y, 2).simplify()
-    assert g.integrate((x, 1, 2)) == g1y.subs(y, 2).simplify()
-
+    # since xreplace is followed by doit with deep=False
+    # to Min/Max don't get resolved so doit is needed
+    assert g.integrate((x, 2, 1)) == gy1.subs(y, 2).doit()
+    assert g.integrate((x, 1, 2)) == g1y.subs(y, 2).doit()
     assert piecewise_fold(gy1.rewrite(Piecewise)) == \
         Piecewise(
-            (1, y <= -1),
-            (-y**2/2 - y + S.Half, y <= 0),
-            (y**2/2 - y + S.Half, y < 1),
+            (-y**2/2 - y + S.Half, (y >= -1) & (y <= 0)),
+            (y**2/2 - y + S.Half, (y >= -1) & (y < 1)),
+            (1, y <= 0),
+            (y**2 + 1, y < 1),
             (0, True))
     assert piecewise_fold(g1y.rewrite(Piecewise)) == \
         Piecewise(
-            (-1, y <= -1),
-            (y**2/2 + y - S.Half, y <= 0),
-            (-y**2/2 + y - S.Half, y < 1),
+            (y**2/2 + y - S.Half, (y >= -1) & (y <= 0)),
+            (-y**2/2 + y - S.Half, (y >= -1) & (y < 1)),
+            (-1, y <= 0),
+            (-y**2 - 1, y < 1),
             (0, True))
 
-    # g1y and gy1 should simplify if the condition that y < 1
+    # g1y and gy1 simplify if the condition that y < 1
     # is applied, e.g. Min(1, Max(-1, y)) --> Max(-1, y)
-    # XXX Make test pass without simplify
-    assert gy1.simplify() == Piecewise(
+    assert gy1.doit() == Piecewise(
         (
             -Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
             Min(1, Max(0, y))**2 + S.Half, y < 1),
         (0, True)
         )
-    assert g1y.simplify() == Piecewise(
+    assert g1y.doit() == Piecewise(
         (
             Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
             Min(1, Max(0, y))**2 - S.Half, y < 1),
         (0, True))
+
 
 @slow
 def test_piecewise_integrate1cb():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21399 

#### Brief description of what is fixed or changed
earlier, Max( Min(a, b), Min(a, b, c)) returned Min(a,b,c)
now, Max( Min(a, b), Min(a, b, c)) returns Min(a,b)

- Add test for the above fix
- Add the above example in doc

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Fixed a bug in MaxMin of elementary functions  
<!-- END RELEASE NOTES -->
