### PR TITLE
Body.apply_torque takes frame as optional argument

### DIFF
--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,5 +1,6 @@
 from sympy.core.backend import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame
+from sympy.physics.vector.frame import _check_frame
 from sympy.physics.mechanics import RigidBody, Particle, inertia
 
 __all__ = ['Body']
@@ -188,13 +189,16 @@ class Body(RigidBody, Particle):  # type: ignore
 
         self.loads.append((point, vec))
 
-    def apply_torque(self, vec):
+    def apply_torque(self, vec, frame=None):
         """
         Adds a torque to the body.
 
         Parameters
         ==========
 
+        frame: ReferenceFrame
+            The frame about which torque is applied. Default value is Body's
+            frame.
         vec: Vector
             Defines the torque vector. Can be any vector w.r.t any frame or
             combinations of frame.
@@ -211,6 +215,9 @@ class Body(RigidBody, Particle):  # type: ignore
             >>> body.apply_torque(T * body.frame.z)
         """
 
+        if frame is None:
+            frame = self.frame
+        _check_frame(frame)
         if not isinstance(vec, Vector):
             raise TypeError("A Vector must be supplied to add torque.")
-        self.loads.append((self.frame, vec))
+        self.loads.append((frame, vec))

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -120,9 +120,14 @@ def test_body_add_force():
 
 def test_body_add_torque():
     body = Body('body')
+    a, b, c = symbols('a b c')
+    N = ReferenceFrame('N')
     torque_vector = body.frame.x
     body.apply_torque(torque_vector)
 
     assert len(body.loads) == 1
     assert body.loads[0] == (body.frame, torque_vector)
+    torq = a* N.x + b * N.y - c * N.z
+    body.apply_torque(torq, N)
+    assert body.loads == [(body.frame, body.frame.x), (N, a*N.x + b*N.y - c*N.z)]
     raises(TypeError, lambda: body.apply_torque(0))


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
An optional parameter, `frame` is added to apply_torque() of Body because it's not necessary that user may want to define Torque only with Body's frame.

#### Other comments

Ping @moorepants @Sc0rpi0n101 
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
    * Torque can be applied to `Body` wrt any frame.
<!-- END RELEASE NOTES -->
