### PR TITLE
Edited sympify to check evaluate in case of iterable inputs

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -435,14 +435,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if iterable(a):
         try:
             return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
-                rational=rational) for x in a])
-        except TypeError:
-            # Not all iterables are rebuildable with their type.
-            pass
-    if isinstance(a, dict):
-        try:
-            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
-                rational=rational) for x in a.items()])
+                rational=rational, evaluate=evaluate) for x in a])
         except TypeError:
             # Not all iterables are rebuildable with their type.
             pass

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -769,3 +769,29 @@ def test_issue_14706():
     raises(SympifyError, lambda: sympify(numpy.array([1]), strict=True))
     raises(SympifyError, lambda: sympify(z1, strict=True))
     raises(SympifyError, lambda: sympify(z2, strict=True))
+
+
+def test_issue_21536():
+    #test to check evaluate=False in case of iterable input
+    u = sympify("x+3*x+2", evaluate=False)
+    v = sympify("2*x+4*x+2+4", evaluate=False)
+
+    assert u.is_Add and set(u.args) == {x, 3*x, 2}
+    assert v.is_Add and set(v.args) == {2*x, 4*x, 2, 4}
+    assert sympify(["x+3*x+2", "2*x+4*x+2+4"], evaluate=False) == [u, v]
+
+    #test to check evaluate=True in case of iterable input
+    u = sympify("x+3*x+2", evaluate=True)
+    v = sympify("2*x+4*x+2+4", evaluate=True)
+
+    assert u.is_Add and set(u.args) == {4*x, 2}
+    assert v.is_Add and set(v.args) == {6*x, 6}
+    assert sympify(["x+3*x+2", "2*x+4*x+2+4"], evaluate=True) == [u, v]
+
+    #test to check evaluate with no input in case of iterable input
+    u = sympify("x+3*x+2")
+    v = sympify("2*x+4*x+2+4")
+
+    assert u.is_Add and set(u.args) == {4*x, 2}
+    assert v.is_Add and set(v.args) == {6*x, 6}
+    assert sympify(["x+3*x+2", "2*x+4*x+2+4"]) == [u, v]


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #21536


#### Brief description of what is fixed or changed\
The evaluate parameter was missing in sympify in case of a iterable input causing it to ignore the user input value of the parameter. Adding the parameter solves the issue.


#### Other comments
Other parameters namely rational, convert_xor were already present. Only evaluate seemed to be skipped over which has now been added. strict parameter seems to be absent but has been confirmed to register nonetheless.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
    * `sympify` now obeys evaluate flag in case of iterable input.
<!-- END RELEASE NOTES -->
