### PR TITLE
Inverse Laplace Transform of rational functions in s improved

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -583,29 +583,29 @@ def test_inverse_laplace_transform():
     def simp_hyp(expr):
         return factor_terms(expand_mul(expr)).rewrite(sin)
 
-    assert ILT(1 , s, t) == DiracDelta(t)
-    assert ILT(1/s , s, t) == Heaviside(t)
-    assert ILT(a/(a + s) , s, t) == a*exp(-a*t)*Heaviside(t)
-    assert ILT(s/(a + s) , s, t) == -a*exp(-a*t)*Heaviside(t) + DiracDelta(t)
-    assert ILT((a + s)**(-2) , s, t) == t*exp(-a*t)*Heaviside(t)
-    assert ILT((a + s)**(-5) , s, t) == t**4*exp(-a*t)*Heaviside(t)/24
-    assert ILT(a/(a**2 + s**2) , s, t) == sin(a*t)*Heaviside(t)
+    assert ILT(1, s, t) == DiracDelta(t)
+    assert ILT(1/s, s, t) == Heaviside(t)
+    assert ILT(a/(a + s), s, t) == a*exp(-a*t)*Heaviside(t)
+    assert ILT(s/(a + s), s, t) == -a*exp(-a*t)*Heaviside(t) + DiracDelta(t)
+    assert ILT((a + s)**(-2), s, t) == t*exp(-a*t)*Heaviside(t)
+    assert ILT((a + s)**(-5), s, t) == t**4*exp(-a*t)*Heaviside(t)/24
+    assert ILT(a/(a**2 + s**2), s, t) == sin(a*t)*Heaviside(t)
     assert ILT(s/(s**2 + a**2), s, t) == cos(a*t)*Heaviside(t)
-    assert ILT(b/(b**2 + (a + s)**2) , s, t) == exp(-a*t)*sin(b*t)*Heaviside(t)
-    assert ILT(b*s/(b**2 + (a + s)**2) , s, t) +\
+    assert ILT(b/(b**2 + (a + s)**2), s, t) == exp(-a*t)*sin(b*t)*Heaviside(t)
+    assert ILT(b*s/(b**2 + (a + s)**2), s, t) +\
         (a*sin(b*t) - b*cos(b*t))*exp(-a*t)*Heaviside(t) == 0
-    assert ILT(exp(-a*s)/s , s, t) == Heaviside(-a + t)
-    assert ILT(exp(-a*s)/(b + s) , s, t) == exp(b*(a - t))*Heaviside(-a + t)
-    assert ILT((b + s)/(a**2 + (b + s)**2) , s, t) == \
+    assert ILT(exp(-a*s)/s, s, t) == Heaviside(-a + t)
+    assert ILT(exp(-a*s)/(b + s), s, t) == exp(b*(a - t))*Heaviside(-a + t)
+    assert ILT((b + s)/(a**2 + (b + s)**2), s, t) == \
         exp(-b*t)*cos(a*t)*Heaviside(t)
-    assert ILT(exp(-a*s)/s**b , s, t) == \
+    assert ILT(exp(-a*s)/s**b, s, t) == \
         (-a + t)**(b - 1)*Heaviside(-a + t)/gamma(b)
-    assert ILT(exp(-a*s)/sqrt(s**2 + 1) , s, t) == \
+    assert ILT(exp(-a*s)/sqrt(s**2 + 1), s, t) == \
         Heaviside(-a + t)*besselj(0, a - t)
-    assert ILT(1/(s*sqrt(s + 1)) , s, t) == Heaviside(t)*erf(sqrt(t))
-    assert ILT(1/(s**2*(s**2 + 1)) , s, t) == (t - sin(t))*Heaviside(t)
-    assert ILT(s**2/(s**2 + 1) , s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
-    assert ILT(1 - 1/(s**2 + 1) , s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
+    assert ILT(1/(s*sqrt(s + 1)), s, t) == Heaviside(t)*erf(sqrt(t))
+    assert ILT(1/(s**2*(s**2 + 1)), s, t) == (t - sin(t))*Heaviside(t)
+    assert ILT(s**2/(s**2 + 1), s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
+    assert ILT(1 - 1/(s**2 + 1), s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
     assert ILT(1/s**2, s, t) == t*Heaviside(t)
     assert ILT(1/s**5, s, t) == t**4*Heaviside(t)/24
     assert simp_hyp(ILT(a/(s**2 - a**2), s, t)) == sinh(a*t)*Heaviside(t)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -574,7 +574,8 @@ def test_issue_8368_7173():
 
 
 def test_inverse_laplace_transform():
-    from sympy import sinh, cosh, besselj, besseli, simplify, factor_terms
+    from sympy import sinh, cosh, besselj, besseli, simplify, factor_terms,\
+        DiracDelta
     ILT = inverse_laplace_transform
     a, b, c, = symbols('a b c', positive=True)
     t = symbols('t')
@@ -582,28 +583,39 @@ def test_inverse_laplace_transform():
     def simp_hyp(expr):
         return factor_terms(expand_mul(expr)).rewrite(sin)
 
-    # just test inverses of all of the above
-    assert ILT(1/s, s, t) == Heaviside(t)
+    assert ILT(1 , s, t) == DiracDelta(t)
+    assert ILT(1/s , s, t) == Heaviside(t)
+    assert ILT(a/(a + s) , s, t) == a*exp(-a*t)*Heaviside(t)
+    assert ILT(s/(a + s) , s, t) == -a*exp(-a*t)*Heaviside(t) + DiracDelta(t)
+    assert ILT((a + s)**(-2) , s, t) == t*exp(-a*t)*Heaviside(t)
+    assert ILT((a + s)**(-5) , s, t) == t**4*exp(-a*t)*Heaviside(t)/24
+    assert ILT(a/(a**2 + s**2) , s, t) == sin(a*t)*Heaviside(t)
+    assert ILT(s/(s**2 + a**2), s, t) == cos(a*t)*Heaviside(t)
+    assert ILT(b/(b**2 + (a + s)**2) , s, t) == exp(-a*t)*sin(b*t)*Heaviside(t)
+    assert ILT(b*s/(b**2 + (a + s)**2) , s, t) +\
+        (a*sin(b*t) - b*cos(b*t))*exp(-a*t)*Heaviside(t) == 0
+    assert ILT(exp(-a*s)/s , s, t) == Heaviside(-a + t)
+    assert ILT(exp(-a*s)/(b + s) , s, t) == exp(b*(a - t))*Heaviside(-a + t)
+    assert ILT((b + s)/(a**2 + (b + s)**2) , s, t) == \
+        exp(-b*t)*cos(a*t)*Heaviside(t)
+    assert ILT(exp(-a*s)/s**b , s, t) == \
+        (-a + t)**(b - 1)*Heaviside(-a + t)/gamma(b)
+    assert ILT(exp(-a*s)/sqrt(s**2 + 1) , s, t) == \
+        Heaviside(-a + t)*besselj(0, a - t)
+    assert ILT(1/(s*sqrt(s + 1)) , s, t) == Heaviside(t)*erf(sqrt(t))
+    assert ILT(1/(s**2*(s**2 + 1)) , s, t) == (t - sin(t))*Heaviside(t)
+    assert ILT(s**2/(s**2 + 1) , s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
+    assert ILT(1 - 1/(s**2 + 1) , s, t) == -sin(t)*Heaviside(t) + DiracDelta(t)
     assert ILT(1/s**2, s, t) == t*Heaviside(t)
     assert ILT(1/s**5, s, t) == t**4*Heaviside(t)/24
-    assert ILT(exp(-a*s)/s, s, t) == Heaviside(t - a)
-    assert ILT(exp(-a*s)/(s + b), s, t) == exp(b*(a - t))*Heaviside(-a + t)
-    assert ILT(a/(s**2 + a**2), s, t) == sin(a*t)*Heaviside(t)
-    assert ILT(s/(s**2 + a**2), s, t) == cos(a*t)*Heaviside(t)
-    # TODO is there a way around simp_hyp?
     assert simp_hyp(ILT(a/(s**2 - a**2), s, t)) == sinh(a*t)*Heaviside(t)
     assert simp_hyp(ILT(s/(s**2 - a**2), s, t)) == cosh(a*t)*Heaviside(t)
-    assert ILT(a/((s + b)**2 + a**2), s, t) == exp(-b*t)*sin(a*t)*Heaviside(t)
-    assert ILT(
-        (s + b)/((s + b)**2 + a**2), s, t) == exp(-b*t)*cos(a*t)*Heaviside(t)
     # TODO sinh/cosh shifted come out a mess. also delayed trig is a mess
     # TODO should this simplify further?
     assert ILT(exp(-a*s)/s**b, s, t) == \
         (t - a)**(b - 1)*Heaviside(t - a)/gamma(b)
-
     assert ILT(exp(-a*s)/sqrt(1 + s**2), s, t) == \
         Heaviside(t - a)*besselj(0, a - t)  # note: besselj(0, x) is even
-
     # XXX ILT turns these branch factor into trig functions ...
     assert simplify(ILT(a**b*(s + sqrt(s**2 - a**2))**(-b)/sqrt(s**2 - a**2),
                     s, t).rewrite(exp)) == \
@@ -619,7 +631,6 @@ def test_inverse_laplace_transform():
 
     assert ILT( (s * eye(2) - Matrix([[1, 0], [0, 2]])).inv(), s, t) ==\
         Matrix([[exp(t)*Heaviside(t), 0], [0, exp(2*t)*Heaviside(t)]])
-
 
 def test_inverse_laplace_transform_delta():
     from sympy import DiracDelta

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1283,7 +1283,7 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
         
     if F.func is Add:
         f = Add(*[_inverse_laplace_transform(X, s, t, plane, simplify)\
-                     for X in F.args])        
+                     for X in F.args])
         return _simplify(f.subs(t, t_), simplify), None
 
     try:
@@ -1314,18 +1314,20 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
     def simp_heaviside(arg, H0=S.Half):
         a = arg.subs(exp(-t), u)
         if a.has(t):
-            return Heaviside(arg,H0)
+            return Heaviside(arg, H0)
         rel = _solve_inequality(a > 0, u)
         if rel.lts == u:
             k = log(rel.gts)
-            return Heaviside(t + k,H0)
+            return Heaviside(t + k, H0)
         else:
             k = log(rel.lts)
-            return Heaviside(-(t + k),H0)
+            return Heaviside(-(t + k), H0)
+        
     f = f.replace(Heaviside, simp_heaviside)
 
     def simp_exp(arg):
         return expand_complex(exp(arg))
+
     f = f.replace(exp, simp_exp)
 
     # TODO it would be nice to fix cosh and sinh ... simplify messes these

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1258,7 +1258,7 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
 def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
     """ The backend function for inverse Laplace transforms. """
     from sympy import exp, Heaviside, log, expand_complex, Integral,\
-        Piecewise, Add, expand_mul
+        Piecewise, Add
     from sympy.integrals.meijerint import meijerint_inversion, _get_coeff_exp
     # There are two strategies we can try:
     # 1) Use inverse mellin transforms - related by a simple change of variables.
@@ -1277,14 +1277,14 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
         e2 = args[1].args[0]
         return Heaviside(1/abs(coeff) - t**exponent)*e1 \
             + Heaviside(t**exponent - 1/abs(coeff))*e2
-    
+
     if F.is_rational_function(s):
         F = F.apart(s)
-        
-    if F.func is Add:
+
+    if F.is_Add:
         f = Add(*[_inverse_laplace_transform(X, s, t, plane, simplify)\
                      for X in F.args])
-        return _simplify(f.subs(t, t_), simplify), None
+        return _simplify(f.subs(t, t_), simplify), True
 
     try:
         f, cond = inverse_mellin_transform(F, s, exp(-t), (None, oo),
@@ -1322,7 +1322,7 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
         else:
             k = log(rel.lts)
             return Heaviside(-(t + k), H0)
-        
+
     f = f.replace(Heaviside, simp_heaviside)
 
     def simp_exp(arg):


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes  #17903
Fixes  #21372
Fixes  #20059
Fixes  #13606
Fixes  #5812

#### Brief description of what is fixed or changed

If `inverse_laplace_transform` recognizes a rational fraction in `s`, then
it will first try to expand it using `.apart(s)` and then recursively 
call itself to transform and add all summands.  Like this it can transform
a far wider range of rational expressions than before.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
  * `inverse_laplace_transform` can now transform a wider range of rational functions

<!-- END RELEASE NOTES -->
