### PR TITLE
Implemented expand_trig for csch, sech and coth

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -9,7 +9,8 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
 
 from sympy.core.logic import fuzzy_or, fuzzy_and
-
+from sympy.utilities.iterables import numbered_symbols
+from sympy.core.symbol import Symbol
 
 
 def _rewrite_hyperbolics_as_exp(expr):
@@ -877,6 +878,35 @@ class coth(HyperbolicFunction):
         else:
             return self.func(arg)
 
+    def _eval_expand_trig(self, **hints):
+        arg = self.args[0]
+        x = None
+        if arg.is_Add:
+            from sympy import symmetric_poly
+            n = len(arg.args)
+            CX = []
+            for x in arg.args:
+                cx = coth(x, evaluate=False)._eval_expand_trig()
+                CX.append(cx)
+
+            Yg = numbered_symbols('Y')
+            Y = [next(Yg) for i in range(n)]
+
+            p = [0, 0]
+            for i in range(n, -1, -1):
+                p[(n - i) % 2] += symmetric_poly(i, Y)
+            return (p[0] / p[1]).subs(list(zip(Y, CX)))
+        elif arg.is_Mul:
+            from sympy import binomial
+            coeff, terms = arg.as_coeff_Mul(rational=True)
+            if coeff.is_Integer and coeff > 1:
+                z = Symbol('dummy', real=True)
+                p = [0, 0]
+                for i in range(coeff, -1, -1):
+                    p[(coeff - i) % 2] += binomial(coeff, i) * z ** i
+                return (p[0] / p[1]).subs([(z, coth(terms))])
+        return coth(arg)
+
 
 class ReciprocalHyperbolicFunction(HyperbolicFunction):
     """Base class for reciprocal functions of hyperbolic functions. """
@@ -938,6 +968,9 @@ class ReciprocalHyperbolicFunction(HyperbolicFunction):
     def _eval_expand_complex(self, deep=True, **hints):
         re_part, im_part = self.as_real_imag(deep=True, **hints)
         return re_part + S.ImaginaryUnit*im_part
+
+    def _eval_expand_trig(self, **hints):
+        return self._calculate_reciprocal("_eval_expand_trig", **hints)
 
     def _eval_as_leading_term(self, x, cdir=0):
         return (1/self._reciprocal_of(self.args[0]))._eval_as_leading_term(x)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -9,9 +9,6 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
 
 from sympy.core.logic import fuzzy_or, fuzzy_and
-from sympy.utilities.iterables import numbered_symbols
-from sympy.core.symbol import Symbol
-
 
 def _rewrite_hyperbolics_as_exp(expr):
     expr = sympify(expr)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -894,7 +894,6 @@ class coth(HyperbolicFunction):
             if coeff.is_Integer and coeff > 1:
                 c = coth(x, evaluate=False)
                 p = [[], []]
-                u = dict(evaluate=False)
                 for i in range(coeff, -1, -1):
                     p[(coeff - i) % 2].append(binomial(coeff, i)*c**i)
                 return Add(*p[0])/Add(*p[1])

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -880,31 +880,24 @@ class coth(HyperbolicFunction):
 
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
-        x = None
         if arg.is_Add:
             from sympy import symmetric_poly
+            CX = [coth(x, evaluate=False)._eval_expand_trig() for x in arg.args]
+            p = [[], []]
             n = len(arg.args)
-            CX = []
-            for x in arg.args:
-                cx = coth(x, evaluate=False)._eval_expand_trig()
-                CX.append(cx)
-
-            Yg = numbered_symbols('Y')
-            Y = [next(Yg) for i in range(n)]
-
-            p = [0, 0]
             for i in range(n, -1, -1):
-                p[(n - i) % 2] += symmetric_poly(i, Y)
-            return (p[0] / p[1]).subs(list(zip(Y, CX)))
+                p[(n - i) % 2].append(symmetric_poly(i, CX))
+            return Add(*p[0])/Add(*p[1])
         elif arg.is_Mul:
             from sympy import binomial
-            coeff, terms = arg.as_coeff_Mul(rational=True)
+            coeff, x = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
-                z = Symbol('dummy', real=True)
-                p = [0, 0]
+                c = coth(x, evaluate=False)
+                p = [[], []]
+                u = dict(evaluate=False)
                 for i in range(coeff, -1, -1):
-                    p[(coeff - i) % 2] += binomial(coeff, i) * z ** i
-                return (p[0] / p[1]).subs([(z, coth(terms))])
+                    p[(coeff - i) % 2].append(binomial(coeff, i)*c**i)
+                return Add(*p[0])/Add(*p[1])
         return coth(arg)
 
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -327,10 +327,10 @@ def test_coth():
     x = Symbol('x', extended_real=True)
     assert coth(x).as_real_imag(deep=False) == (coth(x), 0)
 
-    assert expand_trig(coth(2*x)) == (coth(x)**2+1)/(2*coth(x))
-    assert expand_trig(coth(3*x)) == (coth(x)**3+3*coth(x))/(1+3*coth(x)**2)
+    assert expand_trig(coth(2*x)) == (coth(x)**2 + 1)/(2*coth(x))
+    assert expand_trig(coth(3*x)) == (coth(x)**3 + 3*coth(x))/(1 + 3*coth(x)**2)
 
-    assert expand_trig(coth(x+y)) == (1+coth(x)*coth(y))/(coth(x)+coth(y))
+    assert expand_trig(coth(x + y)) == (1 + coth(x)*coth(y))/(coth(x) + coth(y))
 
 
 def test_coth_series():
@@ -402,7 +402,7 @@ def test_csch():
 
     assert csch(n).is_real is True
 
-    assert expand_trig(csch(x+y)) == 1/(sinh(x)*cosh(y)+cosh(x)*sinh(y))
+    assert expand_trig(csch(x + y)) == 1/(sinh(x)*cosh(y) + cosh(x)*sinh(y))
 
 
 def test_csch_series():
@@ -472,7 +472,7 @@ def test_sech():
 
     assert sech(n).is_real is True
 
-    assert expand_trig(sech(x+y)) == 1/(cosh(x)*cosh(y)+sinh(x)*sinh(y))
+    assert expand_trig(sech(x + y)) == 1/(cosh(x)*cosh(y) + sinh(x)*sinh(y))
 
 
 def test_sech_series():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log,
     sqrt, coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth,
     Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul,
-    AccumBounds, im, re)
+    AccumBounds, im, re, expand_trig)
 
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -327,6 +327,11 @@ def test_coth():
     x = Symbol('x', extended_real=True)
     assert coth(x).as_real_imag(deep=False) == (coth(x), 0)
 
+    assert expand_trig(coth(2*x)) == (coth(x)**2+1)/(2*coth(x))
+    assert expand_trig(coth(3*x)) == (coth(x)**3+3*coth(x))/(1+3*coth(x)**2)
+
+    assert expand_trig(coth(x+y)) == (1+coth(x)*coth(y))/(coth(x)+coth(y))
+
 
 def test_coth_series():
     x = Symbol('x')
@@ -397,6 +402,8 @@ def test_csch():
 
     assert csch(n).is_real is True
 
+    assert expand_trig(csch(x+y)) == 1/(sinh(x)*cosh(y)+cosh(x)*sinh(y))
+
 
 def test_csch_series():
     x = Symbol('x')
@@ -464,6 +471,8 @@ def test_sech():
     assert sech(17*k*pi*I) == 1/cos(17*k*pi)
 
     assert sech(n).is_real is True
+
+    assert expand_trig(sech(x+y)) == 1/(cosh(x)*cosh(y)+sinh(x)*sinh(y))
 
 
 def test_sech_series():


### PR DESCRIPTION
Fixes #21495 

Implemented expand_trig for csch, sech and coth. Both cases handled; 1. argument is a sum of terms, 2. (for coth) argument is an integer multiple of another expression

<!-- BEGIN RELEASE NOTES -->
* functions
  * Implemented expand_trig for csch, sech and coth
<!-- END RELEASE NOTES -->
