### PR TITLE
Make sinc(x).diff(x) not return a Piecewise

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -3,7 +3,7 @@ from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, pi, atan,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
         Float, Pow, gcd, sec, csc, cot, diff, simplify, Heaviside, arg,
         conjugate, series, FiniteSet, asec, acsc, Mul, sinc, jn,
-        AccumBounds, Interval, ImageSet, Lambda, besselj, Add)
+        AccumBounds, Interval, ImageSet, Lambda, besselj, Add, limit)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.core.relational import Ne, Eq
@@ -808,11 +808,20 @@ def test_sinc():
 
     assert sinc(-x) == sinc(x)
 
-    assert sinc(x).diff() == Piecewise(((x*cos(x) - sin(x)) / x**2, Ne(x, 0)), (0, True))
+    assert sinc(x).diff(x) == cos(x)/x - sin(x)/x**2
+    assert sinc(x).diff(x) == (sin(x)/x).diff(x)
+    assert sinc(x).diff(x, x) == (-sin(x) - 2*cos(x)/x + 2*sin(x)/x**2)/x
+    assert sinc(x).diff(x, x) == (sin(x)/x).diff(x, x)
+    assert limit(sinc(x).diff(x), x, 0) == 0
+    assert limit(sinc(x).diff(x, x), x, 0) == -S(1)/3
 
-    assert sinc(x).diff(x).equals(sinc(x).rewrite(sin).diff(x))
-
-    assert sinc(x).diff().subs(x, 0) is S.Zero
+    # https://github.com/sympy/sympy/issues/11402
+    #
+    # assert sinc(x).diff(x) == Piecewise(((x*cos(x) - sin(x)) / x**2, Ne(x, 0)), (0, True))
+    #
+    # assert sinc(x).diff(x).equals(sinc(x).rewrite(sin).diff(x))
+    #
+    # assert sinc(x).diff(x).subs(x, 0) is S.Zero
 
     assert sinc(x).series() == 1 - x**2/6 + x**4/120 + O(x**6)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1961,7 +1961,13 @@ class sinc(Function):
     def fdiff(self, argindex=1):
         x = self.args[0]
         if argindex == 1:
-            return Piecewise(((x*cos(x) - sin(x))/x**2, Ne(x, S.Zero)), (S.Zero, S.true))
+            # We would like to return the Piecewise here, but Piecewise.diff
+            # currently can't handle removable singularities, meaning things
+            # like sinc(x).diff(x, 2) give the wrong answer at x = 0. See
+            # https://github.com/sympy/sympy/issues/11402.
+            #
+            # return Piecewise(((x*cos(x) - sin(x))/x**2, Ne(x, S.Zero)), (S.Zero, S.true))
+            return cos(x)/x - sin(x)/x**2
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1933,7 +1933,7 @@ class sinc(Function):
     * Differentiation
 
     >>> sinc(x).diff()
-    Piecewise(((x*cos(x) - sin(x))/x**2, Ne(x, 0)), (0, True))
+    cos(x)/x - sin(x)/x**2
 
     * Series Expansion
 


### PR DESCRIPTION
Currently, Piecewise.diff() is wrong for pointwise removable singularities.
This lead to sinc(x).diff(x, x) being wrong at x = 0. See
https://github.com/sympy/sympy/issues/11402.

The issue with Piecewise is difficult to solve, but we can work around sinc()
specifically by just returning cos(x)/x - sin(x)/x**2 for sinc(x).diff(x)
rather than a Piecewise. The value of the derivatives of sinc at 0 will have
to be evaluated with limit(), but this is preferable to having an incorrect
answer.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - The derivatives of sinc(x) no longer return Piecewise results, which were previously incorrect at x=0. The value of the derivatives at x=0 can be computed with `limit`. 
<!-- END RELEASE NOTES -->
