### PR TITLE
Added Heaviside to NUMPY_TRANSLATIONS in lambdify

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -83,7 +83,9 @@ MPMATH_TRANSLATIONS = {
     "betainc_regularized": "betainc",
 }
 
-NUMPY_TRANSLATIONS = {}  # type: Dict[str, str]
+NUMPY_TRANSLATIONS = {
+    "Heaviside": "heaviside",
+    }  # type: Dict[str, str]
 SCIPY_TRANSLATIONS = {}  # type: Dict[str, str]
 CUPY_TRANSLATIONS = {}  # type: Dict[str, str]
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1256,10 +1256,23 @@ def test_issue_17898():
     f_ = lambdify([x], sympy.LambertW(x,-1), modules='scipy')
     assert f_(0.1) == mpmath.lambertw(0.1, -1)
 
+def test_issue_13167_21411():
+    if not numpy:
+        skip("numpy not installed")
+    f1 = lambdify(x, sympy.Heaviside(x))
+    f2 = lambdify(x, sympy.Heaviside(x, 1))
+    res1 = f1([-1, 0, 1])
+    res2 = f2([-1, 0, 1])
+    assert Abs(res1[0]).n() < 1e-15        # First functionality: only one argument passed
+    assert Abs(res1[1] - 1/2).n() < 1e-15
+    assert Abs(res1[2] - 1).n() < 1e-15
+    assert Abs(res2[0]).n() < 1e-15        # Second functionality: two arguments passed
+    assert Abs(res2[1] - 1).n() < 1e-15
+    assert Abs(res2[2] - 1).n() < 1e-15
+
 def test_single_e():
     f = lambdify(x, E)
     assert f(23) == exp(1.0)
-
 
 def test_issue_16536():
     if not scipy:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #21411
Fixes #13176
Related to #18003
Related to #20411 

#### Brief description of what is fixed or changed

Added Heaviside to NUMPY_TRANSLATIONS in lambdify.  `lambdify(x, Heaviside(x), modules="numpy")` will now work.

I took the code from the test from pull request #20411; with thanks to @Ickaser for writing this code.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `lambdify` now works with `Heaviside` 
<!-- END RELEASE NOTES -->
