### PR TITLE
Change check of matrix in stats.Normal to allow symengine matrix input

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -64,7 +64,7 @@ from sympy import (log, sqrt, pi, S, Dummy, Interval, sympify, gamma, sign,
                    Piecewise, And, Eq, binomial, factorial, Sum, floor, Abs,
                    Lambda, Basic, lowergamma, erf, erfc, erfi, erfinv, I, asin,
                    hyper, uppergamma, sinh, Ne, expint, Rational, integrate)
-from sympy.matrices import MatrixBase, MatrixExpr
+from sympy.matrices import MatrixBase
 from sympy.stats.crv import SingleContinuousPSpace, SingleContinuousDistribution
 from sympy.stats.rv import _value_check, is_random
 
@@ -3222,8 +3222,8 @@ def Normal(name, mean, std):
 
     """
 
-    if isinstance(mean, (list, MatrixBase, MatrixExpr)) and\
-        isinstance(std, (list, MatrixBase, MatrixExpr)):
+    if isinstance(mean, list) or getattr(mean, 'is_Matrix', False) and\
+        isinstance(std, list) or getattr(std, 'is_Matrix', False):
         from sympy.stats.joint_rv_types import MultivariateNormal
         return MultivariateNormal(name, mean, std)
     return rv(name, NormalDistribution, (mean, std))


### PR DESCRIPTION
#### References to other Issues or PRs


#### Brief description of what is fixed or changed

Use `is_Matrix` to check if input is a matrix in `stats.Normal`. This allows for symengine matrices to be used as input.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->