### PR TITLE
19501: do not cast Symbol to Function

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -98,10 +98,10 @@ _clash2 = {}
 while ns:
     _k, _ = ns.popitem()
     if _k in _greek:
-        _clash2[_k] = Symbol(_k)
+        _clash2[_k] = None
         _greek.remove(_k)
     elif _k in _latin:
-        _clash1[_k] = Symbol(_k)
+        _clash1[_k] = None
         _latin.remove(_k)
 _clash = {}
 _clash.update(_clash1)

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -385,6 +385,14 @@ def check_assumptions(expr, against=None, **assume):
     >>> check_assumptions(2*x + 1, x)
     True
 
+    To see if a number matches the assumptions of an expression, pass
+    the number as the first argument, else its specific assumptions
+    may not have a non-None value in the expression:
+
+    >>> check_assumptions(x, 3)
+    >>> check_assumptions(3, x)
+    True
+
     ``None`` is returned if ``check_assumptions()`` could not conclude.
 
     >>> check_assumptions(2*x - 1, x)
@@ -399,8 +407,8 @@ def check_assumptions(expr, against=None, **assume):
 
     """
     expr = sympify(expr)
-    if against:
-        if against is not None and assume:
+    if against is not None:
+        if assume:
             raise ValueError(
                 'Expecting `against` or `assume`, not both.')
         assume = assumptions(against)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -180,8 +180,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     names that are defined in abc).
 
     >>> from sympy.abc import _clash1
-    >>> _clash1
-    {'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
+    >>> set(_clash1)
+    {'E', 'I', 'N', 'O', 'Q', 'S'}
     >>> sympify('I & Q', _clash1)
     I & Q
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1238,6 +1238,7 @@ def test_assumptions_copy():
 
 
 def test_check_assumptions():
+    assert check_assumptions(1, 0) is False
     x = Symbol('x', positive=True)
     assert check_assumptions(1, x) is True
     assert check_assumptions(1, 1) is True

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -530,10 +530,16 @@ def test_issue_6540_6552():
 def test_issue_6046():
     assert str(S("Q & C", locals=_clash1)) == 'C & Q'
     assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
-    assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
     locals = {}
     exec("from sympy.abc import Q, C", locals)
     assert str(S('C&Q', locals)) == 'C & Q'
+    # clash can act as Symbol or Function
+    assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
+    assert len(S('pi + x', locals=_clash2).free_symbols) == 2
+    # but not both
+    raises(TypeError, lambda: S('pi + pi(x)', locals=_clash2))
+    assert all(set(i.values()) == {None} for i in (
+        _clash, _clash1, _clash2))
 
 
 def test_issue_8821_highprec_from_str():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -131,9 +131,8 @@ def test_local_dict_symbol_to_fcn():
     x = Symbol('x')
     d = {'foo': Function('bar')}
     assert parse_expr('foo(x)', local_dict=d) == d['foo'](x)
-    # XXX: bit odd, but would be error if parser left the Symbol
     d = {'foo': Symbol('baz')}
-    assert parse_expr('foo(x)', local_dict=d) == Function('baz')(x)
+    raises(TypeError, lambda: parse_expr('foo(x)', local_dict=d))
 
 
 def test_global_dict():
@@ -270,3 +269,11 @@ def test_python3_features():
     assert parse_expr('.[3_4]') == parse_expr('.[34]') == Rational(34, 99)
     assert parse_expr('.1[3_4]') == parse_expr('.1[34]') == Rational(133, 990)
     assert parse_expr('123_123.123_123[3_4]') == parse_expr('123123.123123[34]') == Rational(12189189189211, 99000000)
+
+
+def test_issue_19501():
+    x = Symbol('x')
+    eq = parse_expr('E**x(1+x)', local_dict={'x': x}, transformations=(
+        standard_transformations +
+        (implicit_multiplication_application,)))
+    assert eq.free_symbols == {x}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #19501

#### Brief description of what is fixed or changed

The `auto_symbol` casting Symbol to Function if necessary -- a legacy action when Symbols would automatically cast to Function during parsing -- has been removed. A given name can be used as a Function or a Symbol but not both. So although `Function('x')(Symbol('x'))` is a legitimate expression (currently) I don't think such an expression could be parsed unless different names were used, e.g. `parse_expr('f(x)', local_dict={'f': Function('x')})`

A secondary issue with `check_assumptions` is also addressed and added as a discrete commit.

#### Other comments

The ability to use `_clash*` from `abc.py` as Function or Symbol has been retained by allowing the parser to declare them at parse time as one or the other and then restore their neutral status (with value None) when done.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
    * `parse_expr` will no longer cast Symbols in `local_dict` to Function
* core
    * `check_assumptions` now properly tests against 0
<!-- END RELEASE NOTES -->
