### PR TITLE
fix(physics.control): order of classes in doc

### DIFF
--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -5,5 +5,16 @@ Control API
 lti
 ===
 
-.. automodule:: sympy.physics.control.lti
+.. module:: sympy.physics.control.lti
+
+.. autoclass:: TransferFunction
+   :members:
+
+.. autoclass:: Series
+   :members:
+
+.. autoclass:: Parallel
+   :members:
+
+.. autoclass:: Feedback
    :members:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The way in which the classes are ordered in the docs of `sympy.physics.control.lti` is not appropriate for beginners. I fixed it according to the general relevance.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
