### PR TITLE
Fix: Solve bug in intersect_reals

### DIFF
--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -306,9 +306,9 @@ def intersection_sets(self, other): # noqa:F811
             # univarite imaginary part in same variable
             x, xis = zip(*[solve_linear(i, 0) for i in Mul.make_args(im) if n in i.free_symbols])
             if x and all(i == n for i in x):
-                base_set = FiniteSet(*xis)
+                base_set &= FiniteSet(*xis)
             else:
-                base_set -= ConditionSet(n, Eq(im, 0), S.Integers)
+                base_set = ConditionSet(n, Eq(im, 0), base_set)
         # exclude values that make denominators 0
         for i in denoms(f):
             if i.has(n):
@@ -316,7 +316,7 @@ def intersection_sets(self, other): # noqa:F811
                 if sol != []:
                     x, xis = sol
                     if x and all(i == n for i in x):
-                        base_set -= FiniteSet(xis)
+                        base_set &= FiniteSet(*xis)
                 else:
                     base_set -= ConditionSet(n, Eq(i, 0), S.Integers)
         return imageset(lam, base_set)

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -316,9 +316,9 @@ def intersection_sets(self, other): # noqa:F811
                 if sol != []:
                     x, xis = sol
                     if x and all(i == n for i in x):
-                        base_set &= FiniteSet(*xis)
+                        base_set -= FiniteSet(*xis)
                 else:
-                    base_set -= ConditionSet(n, Eq(i, 0), S.Integers)
+                    base_set -= ConditionSet(n, Eq(i, 0), base_set)
         return imageset(lam, base_set)
 
     elif isinstance(other, Interval):

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -306,7 +306,7 @@ def intersection_sets(self, other): # noqa:F811
             # univarite imaginary part in same variable
             x, xis = zip(*[solve_linear(i, 0) for i in Mul.make_args(im) if n in i.free_symbols])
             if x and all(i == n for i in x):
-                base_set -= FiniteSet(xis)
+                base_set = FiniteSet(*xis)
             else:
                 base_set -= ConditionSet(n, Eq(im, 0), S.Integers)
         # exclude values that make denominators 0

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -662,15 +662,19 @@ def test_imageset_intersect_real():
     im = (n - 1)*(n + S.Half)
     assert imageset(Lambda(n, n + im*I), S.Integers
         ).intersect(S.Reals) == FiniteSet(1)
-    assert imageset(Lambda(n, n + im*(n + 1)*I), S.Naturals0).intersect(S.Reals) == FiniteSet(1)
+    assert imageset(Lambda(n, n + im*(n + 1)*I), S.Naturals0
+        ).intersect(S.Reals) == FiniteSet(1)
     assert imageset(Lambda(n, n/2 + im.expand()*I), S.Integers
-).intersect(S.Reals) == ImageSet(Lambda(x, x/2), ConditionSet(
+        ).intersect(S.Reals) == ImageSet(Lambda(x, x/2), ConditionSet(
         n, Eq(n**2 - n/2 - S(1)/2, 0), S.Integers))
-    assert imageset(Lambda(n, n/(1/n - 1) + im*(n + 1)*I), S.Integers).intersect(S.Reals) == FiniteSet(S.Half)
+    assert imageset(Lambda(n, n/(1/n - 1) + im*(n + 1)*I), S.Integers
+        ).intersect(S.Reals) == FiniteSet(S.Half)
     assert imageset(Lambda(n, n/(n - 6) +
-        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(S.Reals) == FiniteSet(-1)
+        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(
+        S.Reals) == FiniteSet(-1)
     assert imageset(Lambda(n, n/(n**2 - 9) +
-        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(S.Reals) is S.EmptySet
+        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(
+        S.Reals) is S.EmptySet
     s = ImageSet(
         Lambda(n, -I*(I*(2*pi*n - pi/4) + log(Abs(sqrt(-I))))),
         S.Integers)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -2,7 +2,7 @@
 from sympy.core.expr import unchanged
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
-from sympy.sets.sets import (Complement, FiniteSet, Interval, Union, imageset,
+from sympy.sets.sets import (FiniteSet, Interval, Union, imageset,
                              Intersection, ProductSet, Contains)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -4,6 +4,7 @@ from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
 from sympy.sets.sets import (FiniteSet, Interval, Union, imageset,
                              Intersection, ProductSet, Contains)
+from sympy.sets.conditionset import ConditionSet
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, exp, Abs, I, Tuple, eye,
@@ -658,7 +659,18 @@ def test_imageset_intersect_real():
     from sympy import I
     from sympy.abc import n
     assert imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) == FiniteSet(-1, 1)
-    assert imageset(Lambda(n, n + (n - 1)*(n + S.Half)*I), S.Integers).intersect(S.Reals) == FiniteSet(1)
+    im = (n - 1)*(n + S.Half)
+    assert imageset(Lambda(n, n + im*I), S.Integers
+        ).intersect(S.Reals) == FiniteSet(1)
+    assert imageset(Lambda(n, n + im*(n + 1)*I), S.Naturals0).intersect(S.Reals) == FiniteSet(1)
+    assert imageset(Lambda(n, n/2 + im.expand()*I), S.Integers
+).intersect(S.Reals) == ImageSet(Lambda(x, x/2), ConditionSet(
+        n, Eq(n**2 - n/2 - S(1)/2, 0), S.Integers))
+    assert imageset(Lambda(n, n/(1/n - 1) + im*(n + 1)*I), S.Integers).intersect(S.Reals) == FiniteSet(S.Half)
+    assert imageset(Lambda(n, n/(n - 6) +
+        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(S.Reals) == FiniteSet(-1)
+    assert imageset(Lambda(n, n/(n**2 - 9) +
+        (n - 3)*(n + 1)*I/(2*n + 2)), S.Integers).intersect(S.Reals) is S.EmptySet
     s = ImageSet(
         Lambda(n, -I*(I*(2*pi*n - pi/4) + log(Abs(sqrt(-I))))),
         S.Integers)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -658,6 +658,7 @@ def test_imageset_intersect_real():
     from sympy import I
     from sympy.abc import n
     assert imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) == FiniteSet(-1, 1)
+    assert imageset(Lambda(n, n + (n - 1)*(n + S.Half)*I), S.Integers).intersect(S.Reals) == FiniteSet(1)
     s = ImageSet(
         Lambda(n, -I*(I*(2*pi*n - pi/4) + log(Abs(sqrt(-I))))),
         S.Integers)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -657,7 +657,7 @@ def test_infinitely_indexed_set_2():
 def test_imageset_intersect_real():
     from sympy import I
     from sympy.abc import n
-    assert imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) == Complement(S.Integers, FiniteSet((-1, 1)))
+    assert imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) == FiniteSet(-1, 1)
     s = ImageSet(
         Lambda(n, -I*(I*(2*pi*n - pi/4) + log(Abs(sqrt(-I))))),
         S.Integers)


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21595


#### Brief description of what is fixed or changed
earlier, imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) returned an incorrect result
now, the solution is FiniteSet(1,1) which is the correct solution

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
   * Fixed a bug in is_subset()
<!-- END RELEASE NOTES -->
