### PR TITLE
Add kwarg to lambdify: cse

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1103,7 +1103,7 @@ class _EvaluatorPrinter:
         funcbody.extend(self._print_funcargwrapping(funcargs))
 
         funcbody.extend(unpackings)
-        funcbody.extend(['{} = {}'.format(s, e) for s, e in cses])
+        funcbody.extend(['{} = {}'.format(s, self._exprrepr(e)) for s, e in cses])
         funcbody.append('return ({})'.format(self._exprrepr(expr)))
 
         funclines = [funcsig]

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1412,24 +1412,75 @@ def test_cse():
     def dummy_cse(exprs):
         return (), exprs
 
-    args = x, y, z
-    e1 = x + y + z
-    e2 = x + y - z
-    e3 = 2*x + 2*y - z
-    e4 = (x+y)**2 + (y+z)**2
-    exprs = [e1, e2, e3, e4]
-    num_args = (2., 3., 4.)
+    class Case:
+        def __init__(self, *, args, exprs, num_args, requires_numpy=False):
+            self.args = args
+            self.exprs = exprs
+            self.num_args = num_args
+            subs_dict = dict(zip(self.args, self.num_args))
+            self.ref = [e.subs(subs_dict).evalf() for e in exprs]
+            self.requires_numpy = requires_numpy
 
-    subs_dict = dict(zip(args, num_args))
-    ref = [e.subs(subs_dict).evalf() for e in exprs]
-    abstol, reltol = 1e-15, 1e-15
+        def lambdify(self, *, cse):
+            return lambdify(self.args, self.exprs, cse=cse)
 
-    for cse in [False, True, dummy_cse]:
-        f1 = lambdify(args, exprs, cse=cse)
-        result = f1(*num_args)
-        for i, r in enumerate(ref):
-            abs_err = abs(result[i] - r)
-            if r == 0:
-                assert abs_err < abstol
-            else:
-                assert abs_err/abs(r) < reltol
+        def assertAllClose(self, result, *, abstol=1e-15, reltol=1e-15):
+            if self.requires_numpy:
+                assert all(numpy.allclose(result[i], numpy.asarray(r, dtype=float),
+                                          rtol=reltol, atol=abstol)
+                           for i, r in enumerate(self.ref))
+                return
+
+            for i, r in enumerate(self.ref):
+                abs_err = abs(result[i] - r)
+                if r == 0:
+                    assert abs_err < abstol
+                else:
+                    assert abs_err/abs(r) < reltol
+
+    case1 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + y + z,
+            x + y - z,
+            2*x + 2*y - z,
+            (x+y)**2 + (y+z)**2,
+        ],
+        num_args=(2., 3., 4.)
+    )
+    case2 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + sympy.Heaviside(x),
+            y + sympy.Heaviside(x),
+            z + sympy.Heaviside(x, 1),
+            z/sympy.Heaviside(x, 1)
+        ],
+        num_args=(0., 3., 4.)
+    )
+    case3 = Case(
+        args=(x, y, z),
+        exprs=[
+            x + sinc(y),
+            y + sinc(y),
+            z - sinc(y)
+        ],
+        num_args=(0.1, 0.2, 0.3)
+    )
+    case4 = Case(
+        args=(x, y, z),
+        exprs=[
+            Matrix([[x, x*y], [sin(z) + 4, x**z]]),
+            x*y+sin(z)-x**z,
+            Matrix([x*x, sin(z), x**z])
+        ],
+        num_args=(1.,2.,3.),
+        requires_numpy=True
+    )
+    for case in [case1, case2, case3, case4]:
+        if not numpy and case.requires_numpy:
+            continue
+        for cse in [False, True, dummy_cse]:
+            f = case.lambdify(cse=cse)
+            result = f(*case.num_args)
+            case.assertAllClose(result)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This is essentially a minimal subset of gh-21546. No attempt is made here to optimize cse with respect to number of intermediate variables.

This API should, however, allow a user to pass their own `cse` function to reuse intermediate variables, or such an alternative could be included alongside `cse` in `sympy.simplify.cse_main`. I personally don't see where `del` instructions would be useful (as was suggested in mentioned PR), but I'm happy to be proven wrong.
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18916

#### Brief description of what is fixed or changed
`lambdify` gained a keyword argument `cse`

#### Other comments
This PR has not yet been tested with heterogeneous expressions (e.g. mixing scalars and matrices).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the sub-package
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `lambdify` gained the ability to exploit common subexpressions (`cse`).
<!-- END RELEASE NOTES -->
