### PR TITLE
Fix: Bug in trigsimplify which did not recognize cosh(1/2) 

### DIFF
--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -446,6 +446,11 @@ def test_Piecewise():
     assert trigsimp(Piecewise((e1, e3 < e2), (e3, True))) == \
         Piecewise((e1, e3 < s2), (e3, True))
 
+
+def test_issue_21594():
+    assert simplify(exp(Rational(1,2)) + exp(Rational(-1,2))) == cosh(S.Half)*2
+
+
 def test_trigsimp_old():
     x, y = symbols('x,y')
 

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -550,13 +550,13 @@ def exptrigsimp(expr):
         rvd = rv.as_powers_dict()
         newd = rvd.copy()
 
-        def signlog(expr, sign=1):
+        def signlog(expr, sign=S.One):
             if expr is S.Exp1:
-                return sign, 1
+                return sign, S.One
             elif isinstance(expr, exp) or (expr.is_Pow and expr.base == S.Exp1):
                 return sign, expr.exp
-            elif sign == 1:
-                return signlog(-expr, sign=-1)
+            elif sign is S.One:
+                return signlog(-expr, sign=-S.One)
             else:
                 return None, None
 


### PR DESCRIPTION


- Add test

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21594 

#### Brief description of what is fixed or changed
earlier,  trigsimplify  did not recognize cosh(1/2) when given as a rational expression and returned a float value
now, the bug is fixed
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
