### PR TITLE
codegen: more capable rewrite to expm1 & cosm1 etc.

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -12,8 +12,8 @@ expressions for this purpose::
     >>> x = Symbol('x')
     >>> optimize(3*exp(2*x) - 3, optims_c99)
     3*expm1(2*x)
-    >>> optimize(exp(2*x) - 3, optims_c99)
-    exp(2*x) - 3
+    >>> optimize(exp(2*x) - 1 - exp(-33), optims_c99)
+    expm1(2*x) - exp(-33)
     >>> optimize(log(3*x + 3), optims_c99)
     log1p(x) + log(3)
     >>> optimize(log(2*x + 3), optims_c99)
@@ -30,8 +30,7 @@ The ``optims_c99`` imported above is tuple containing the following instances
 
 
 """
-from itertools import chain
-from sympy import cos, exp, log, Max, Min, Wild, expand_log, Dummy, sin, sinc
+from sympy import cos, exp, log, Max, Min, Wild, expand_log, sign, sin, sinc, S
 from sympy.assumptions import Q, ask
 from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
 from sympy.codegen.matrix_nodes import MatrixSolve
@@ -175,42 +174,93 @@ logsumexp_2terms_opt = ReplaceOptim(
 )
 
 
-class _FuncMinusOne:
-    def __init__(self, func, func_m_1):
+class FuncMinusOneOptim(ReplaceOptim):
+    """Specialization of ReplaceOptim for functions evaluating "f(x) - 1".
+
+    Explanation
+    ===========
+
+    Numerical functions which go toward one as x go toward zero is often best
+    implemented by a dedicated function in order to avoid catastrophic
+    cancellation. One such example is ``expm1(x)`` in the C standard library
+    which evaluates ``exp(x) - 1``. Such functions preserves many more
+    significant digits when its argument is much smaller than one, compared
+    to subtracting one afterwards.
+
+    Parameters
+    ==========
+
+    func :
+        The function which is subtracted by one.
+    func_m_1 :
+        The specialized function evaluating ``func(x) - 1``.
+    opportunistic : bool
+        When ``True``, apply the transformation as long as the magnitude of the
+        remaining number terms decreases. When ``False``, only apply the
+        transformation if it completely eliminates the number term.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, exp
+    >>> from sympy.codegen.rewriting import FuncMinusOneOptim
+    >>> from sympy.codegen.cfunctions import expm1
+    >>> x, y = symbols('x y')
+    >>> expm1_opt = FuncMinusOneOptim(exp, expm1)
+    >>> expm1_opt(exp(x) + 2*exp(5*y) - 3)
+    expm1(x) + 2*expm1(5*y)
+
+
+    """
+
+    def __init__(self, func, func_m_1, opportunistic=True):
+        super().__init__(lambda e: e.is_Add, self.replace_in_Add)
         self.func = func
         self.func_m_1 = func_m_1
+        self.opportunistic = opportunistic
 
-    def _try_func_m_1(self, expr):
-        old_new = {}
-        protected = expr.replace(self.func, lambda arg: old_new.setdefault(arg, Dummy()))
-        factored = protected.factor()
-        new_old = {v: self.func(k) for k, v in old_new.items()}
-        return factored.replace(_d - 1, lambda d: self.func_m_1(new_old[d].args[0])).xreplace(new_old)
-
-    def __call__(self, e):
-        numbers, non_num = sift(e.args, lambda arg: arg.is_number, binary=True)
-        non_num_func, non_num_other = sift(non_num, lambda arg: arg.has(self.func),
-            binary=True)
+    def _group_Add_terms(self, add):
+        numbers, non_num = sift(add.args, lambda arg: arg.is_number, binary=True)
         numsum = sum(numbers)
-        new_func_terms, done = [], False
-        for func_term in non_num_func:
-            if done:
-                new_func_terms.append(func_term)
-            else:
-                looking_at = func_term + numsum
-                attempt = self._try_func_m_1(looking_at)
-                if looking_at == attempt:
-                    new_func_terms.append(func_term)
+        terms_with_func, other = sift(non_num, lambda arg: arg.has(self.func), binary=True)
+        return numsum, terms_with_func, other
+
+    def replace_in_Add(self, e):
+        """ passed as second argument to Basic.replace(...) """
+        numsum, terms_with_func, other_non_num_terms = self._group_Add_terms(e)
+        if numsum == 0:
+            return e
+
+        substituted, untouched = [], []
+        for with_func in terms_with_func:
+            if with_func.is_Mul:
+                func, coeff = sift(with_func.args, lambda arg: arg.func == self.func, binary=True)
+                if len(func) == 1 and len(coeff) == 1:
+                    func, coeff = func[0], coeff[0]
                 else:
-                    done = True
-                    new_func_terms.append(attempt)
-        if not done:
-            new_func_terms.append(numsum)
-        return e.func(*chain(new_func_terms, non_num_other))
+                    coeff = None
+            elif with_func.func == self.func:
+                func, coeff = with_func, S.One
+            else:
+                coeff = None
+
+            if coeff is not None and coeff.is_number and sign(coeff) == -sign(numsum):
+                if self.opportunistic:
+                    do_substitute = abs(coeff+numsum) < abs(numsum)
+                else:
+                    do_substitute = coeff+numsum == 0
+
+                if do_substitute:  # advantageous substitution
+                    numsum += coeff
+                    substituted.append(coeff*self.func_m_1(*func.args))
+                    continue
+            untouched.append(with_func)
+
+        return e.func(numsum, *substituted, *untouched, *other_non_num_terms)
 
 
-expm1_opt = ReplaceOptim(lambda e: e.is_Add, _FuncMinusOne(exp, expm1))
-cosm1_opt = ReplaceOptim(lambda e: e.is_Add, _FuncMinusOne(cos, cosm1))
+expm1_opt = FuncMinusOneOptim(exp, expm1)
+cosm1_opt = FuncMinusOneOptim(cos, cosm1)
 
 log1p_opt = ReplaceOptim(
     lambda e: isinstance(e, log),

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -82,6 +82,14 @@ def test_expm1_opt():
     assert 3*expm1(2*x) == opt5
     assert opt5.rewrite(exp) == expr5
 
+    expr6 = (2*exp(x) + 1)/(exp(x) + 1) + 1
+    opt6 = optimize(expr6, [expm1_opt])
+    assert opt6.count_ops() < expr6.count_ops()
+
+    def ev(e):
+        return e.subs(x, 3).evalf()
+    assert abs(ev(expr6) - ev(opt6)) < 1e-15
+
 
 @XFAIL  # ideally this test should pass: need to improve `expm1_opt`
 def test_expm1_two_exp_terms():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -333,7 +333,7 @@ class StrPrinter(Printer):
                     b.append(apow(item))
                 else:
                     if (len(item.args[0].args) != 1 and
-                            isinstance(item.base, Mul)):
+                            isinstance(item.base, (Mul, Pow))):
                         # To avoid situations like #14160
                         pow_paren.append(item)
                     b.append(item.base)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -252,6 +252,8 @@ def test_Mul():
     # For issue 14160
     assert str(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False),
                                                 evaluate=False)) == '-2*x/(y*y)'
+    # issue 21537
+    assert str(Mul(x, Pow(1/y, -1, evaluate=False), evaluate=False)) == 'x/(1/y)'
 
 
     class CustomClass1(Expr):

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import warnings
 from distutils.errors import CompileError
-from distutils.sysconfig import get_config_var
+from distutils.sysconfig import get_config_var, get_config_vars
 
 from .runners import (
     CCompilerRunner,
@@ -230,11 +230,12 @@ def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
     else:
         from distutils import sysconfig
         if sysconfig.get_config_var('Py_ENABLE_SHARED'):
-            ABIFLAGS = sysconfig.get_config_var('ABIFLAGS')
-            pythonlib = 'python{}.{}{}'.format(
-                sys.hexversion >> 24, (sys.hexversion >> 16) & 0xff,
-                ABIFLAGS or '')
-            libraries += [pythonlib]
+            cfgDict = get_config_vars()
+            kwargs['linkline'] = kwargs.get('linkline', []) + [cfgDict['PY_LDFLAGS']] # PY_LDFLAGS or just LDFLAGS?
+            library_dirs += [cfgDict['LIBDIR']]
+            for opt in cfgDict['BLDLIBRARY'].split():
+                if opt.startswith('-l'):
+                    libraries += [opt[2:]]
         else:
             pass
 

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -65,7 +65,7 @@ class CompilerRunner:
 
     def __init__(self, sources, out, flags=None, run_linker=True, compiler=None, cwd='.',
                  include_dirs=None, libraries=None, library_dirs=None, std=None, define=None,
-                 undef=None, strict_aliasing=None, preferred_vendor=None, **kwargs):
+                 undef=None, strict_aliasing=None, preferred_vendor=None, linkline=None, **kwargs):
         if isinstance(sources, str):
             raise ValueError("Expected argument sources to be a list of strings.")
         self.sources = list(sources)
@@ -99,7 +99,7 @@ class CompilerRunner:
             self.flags.append(self.std_formater[
                 self.compiler_name](self.std))
 
-        self.linkline = []
+        self.linkline = linkline or []
 
         if strict_aliasing is not None:
             nsa_re = re.compile("no-strict-aliasing$")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This PR also adds a regression test for gh-21531.
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I reworked the logic behind rewriting of e.g. `exp(x)-1` and `cos(x)-1` to `expm1(x)` and `cosm1(x)` respectively. I was able to remove the `@XFAIL` decorators for some tests. Hopefully this is an improvement for all cases.

I also made the underlying logic public in the form of a class `FuncMinusOneOptim`.

#### Other comments
cc @lcontento, just FYI. I'm also interested to hear of your experiences of using these optimizations, if you want/can share that is.

Perhaps FuncMinusOneOptim is not flexible enough and we should have a class which generalizes to functions subtracting a number other than one. I could imagine e.g. `arccos(x)-pi/2` being a canddiate. However, I have not been able to find any references to such a function when I did a quick internet search. (I wonder what it would be named, `acosmhalfpi`?)
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * More capable rewriting of terms such as `2*exp(x) + 3*exp(y) - 5` into `2*expm1(x) + 3*expm1(y)`.
<!-- END RELEASE NOTES -->
