### PR TITLE
Return correct value of kind attribute for Derivative objects

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1706,6 +1706,10 @@ class Derivative(Expr):
         for var, count in self.variable_count:
             ret.update(count.free_symbols)
         return ret
+    
+    @property
+    def kind(self):
+        return self.args[0].kind
 
     def _eval_subs(self, old, new):
         # The substitution (old, new) cannot be done inside

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1706,7 +1706,7 @@ class Derivative(Expr):
         for var, count in self.variable_count:
             ret.update(count.free_symbols)
         return ret
-    
+
     @property
     def kind(self):
         return self.args[0].kind

--- a/sympy/core/tests/test_kind.py
+++ b/sympy/core/tests/test_kind.py
@@ -5,6 +5,7 @@ from sympy.core.numbers import pi, zoo, I, AlgebraicNumber
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.integrals.integrals import Integral
+from sympy.core.function import Derivative
 from sympy.matrices import (Matrix, SparseMatrix, ImmutableMatrix,
     ImmutableSparseMatrix, MatrixSymbol, MatrixKind, MatMul)
 
@@ -39,6 +40,11 @@ def test_Integral_kind():
     assert Integral(comm_x, comm_x).kind is NumberKind
     assert Integral(A, comm_x).kind is MatrixKind(NumberKind)
 
+def test_Derivative_kind():
+    A = MatrixSymbol('A', 2,2)
+    assert Derivative(comm_x, comm_x).kind is NumberKind
+    assert Derivative(A, comm_x).kind is MatrixKind(NumberKind)
+
 def test_Matrix_kind():
     classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
     for cls in classes:
@@ -49,3 +55,4 @@ def test_MatMul_kind():
     M = Matrix([[1,2],[3,4]])
     assert MatMul(2, M).kind is MatrixKind(NumberKind)
     assert MatMul(comm_x, M).kind is MatrixKind(NumberKind)
+

--- a/sympy/core/tests/test_kind.py
+++ b/sympy/core/tests/test_kind.py
@@ -55,4 +55,3 @@ def test_MatMul_kind():
     M = Matrix([[1,2],[3,4]])
     assert MatMul(2, M).kind is MatrixKind(NumberKind)
     assert MatMul(comm_x, M).kind is MatrixKind(NumberKind)
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21604 


#### Brief description of what is fixed or changed

Thanks to this commit objects of type Derivative returns the correct value of the kind attribute.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->


<!-- BEGIN RELEASE NOTES -->
* core
  * kind attribute of Derivative class now returns the kind of its argument
<!-- END RELEASE NOTES -->
