### PR TITLE
feat(matrices): add setitem and pickling to DomainMatrix

### DIFF
--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -112,6 +112,16 @@ class DomainMatrix:
 
         return cls.from_rep(rep)
 
+    def __getnewargs__(self):
+        rep = self.rep
+        if isinstance(rep, DDM):
+            arg = list(rep)
+        elif isinstance(rep, SDM):
+            arg = dict(rep)
+        else:
+            raise RuntimeError # pragma: no cover
+        return arg, self.shape, self.domain
+
     def __getitem__(self, key):
         i, j = key
         m, n = self.shape
@@ -130,6 +140,15 @@ class DomainMatrix:
             j = slice(j, j+1)
 
         return self.from_rep(self.rep.extract_slice(i, j))
+
+    def __setitem__(self, key, value):
+        i, j = key
+        if not self.domain.of_type(value):
+            raise TypeError
+        if isinstance(i, int) and isinstance(j, int):
+            self.rep.setitem(i, j, value)
+        else:
+            raise NotImplementedError
 
     @classmethod
     def from_rep(cls, rep):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -86,6 +86,27 @@ class SDM(dict):
             else:
                 raise IndexError("index out of range")
 
+    def setitem(self, i, j, value):
+        m, n = self.shape
+        if not (-m <= i < m and -n <= j < n):
+            raise IndexError("index out of range")
+        i, j = i % m, j % n
+        if value:
+            try:
+                self[i][j] = value
+            except KeyError:
+                self[i] = {j: value}
+        else:
+            rowi = self.get(i, None)
+            if rowi is not None:
+                try:
+                    del rowi[j]
+                except KeyError:
+                    pass
+                else:
+                    if not rowi:
+                        del self[i]
+
     def extract_slice(self, slice1, slice2):
         m, n = self.shape
         ri = range(m)[slice1]

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -693,3 +693,21 @@ def test_DomainMatrix_getitem():
     assert dM[2:,2:] == DomainMatrix({0: {0: 1}, 2: {2: 1}}, (3, 3), ZZ)
     assert dM[3:,3:] == DomainMatrix({1: {1: 1}}, (2, 2), ZZ)
     assert dM[2:, 6:] == DomainMatrix({}, (3, 0), ZZ)
+
+
+def test_DomainMatrix_setitem():
+    dM = DomainMatrix({2: {2: ZZ(1)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)
+    dM[2, 2] = ZZ(2)
+    assert dM == DomainMatrix({2: {2: ZZ(2)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)
+    def setitem(i, j, val):
+        dM[i, j] = val
+    raises(TypeError, lambda: setitem(2, 2, QQ(1, 2)))
+    raises(NotImplementedError, lambda: setitem(slice(1, 2), 2, ZZ(1)))
+
+
+def test_DomainMatrix_pickling():
+    import pickle
+    dM = DomainMatrix({2: {2: ZZ(1)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)
+    assert pickle.loads(pickle.dumps(dM)) == dM
+    dM = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    assert pickle.loads(pickle.dumps(dM)) == dM

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -78,6 +78,49 @@ def test_SDM_to_ddm():
     assert A.to_ddm() == B
 
 
+def test_SDM_to_sdm():
+    A = SDM({0:{1: ZZ(1)}}, (2, 2), ZZ)
+    assert A.to_sdm() == A
+
+
+def test_SDM_getitem():
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    assert A.getitem(0, 0) == ZZ.zero
+    assert A.getitem(0, 1) == ZZ.one
+    assert A.getitem(1, 0) == ZZ.zero
+    assert A.getitem(-2, -2) == ZZ.zero
+    assert A.getitem(-2, -1) == ZZ.one
+    assert A.getitem(-1, -2) == ZZ.zero
+    raises(IndexError, lambda: A.getitem(2, 0))
+    raises(IndexError, lambda: A.getitem(0, 2))
+
+
+def test_SDM_setitem():
+    A = SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    A.setitem(0, 0, ZZ(1))
+    assert A == SDM({0:{0:ZZ(1), 1:ZZ(1)}}, (2, 2), ZZ)
+    A.setitem(1, 0, ZZ(1))
+    assert A == SDM({0:{0:ZZ(1), 1:ZZ(1)}, 1:{0:ZZ(1)}}, (2, 2), ZZ)
+    A.setitem(1, 0, ZZ(0))
+    assert A == SDM({0:{0:ZZ(1), 1:ZZ(1)}}, (2, 2), ZZ)
+    # Repeat the above test so that this time the row is empty
+    A.setitem(1, 0, ZZ(0))
+    assert A == SDM({0:{0:ZZ(1), 1:ZZ(1)}}, (2, 2), ZZ)
+    A.setitem(0, 0, ZZ(0))
+    assert A == SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    # This time the row is there but column is empty
+    A.setitem(0, 0, ZZ(0))
+    assert A == SDM({0:{1:ZZ(1)}}, (2, 2), ZZ)
+    raises(IndexError, lambda: A.setitem(2, 0, ZZ(1)))
+    raises(IndexError, lambda: A.setitem(0, 2, ZZ(1)))
+
+
+def test_SDM_extract_slice():
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    B = A.extract_slice(slice(1, 2), slice(1, 2))
+    assert B == SDM({0:{0:ZZ(4)}}, (1, 1), ZZ)
+
+
 def test_SDM_zeros():
     A = SDM.zeros((2, 2), ZZ)
     assert A.domain == ZZ
@@ -95,6 +138,11 @@ def test_SDM_eye():
     assert A.domain == ZZ
     assert A.shape == (2, 2)
     assert dict(A) == {0:{0:ZZ(1)}, 1:{1:ZZ(1)}}
+
+
+def test_SDM_diag():
+    A = SDM.diag([ZZ(1), ZZ(2)], ZZ, (2, 3))
+    assert A == SDM({0:{0:ZZ(1)}, 1:{1:ZZ(2)}}, (2, 3), ZZ)
 
 
 def test_SDM_transpose():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracted from #21626

#### Brief description of what is fixed or changed

Adds pickling, setitem and some tests to DomainMatrix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
