### PR TITLE
fix(matrices): don't use mutable _add attribute of Matrix

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -138,7 +138,7 @@ class DenseMatrix(MatrixBase):
         return classof(self, other)._new(self.rows, self.cols, mat, copy=False)
 
     def _eval_extract(self, rowsList, colsList):
-        mat = self._flat
+        mat = self._mat
         cols = self.cols
         indices = (i * cols + j for i in rowsList for j in colsList)
         return self._new(len(rowsList), len(colsList),

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -1060,7 +1060,7 @@ def _jordan_form(M, calc_transform=True, *, chop=False):
 
     if has_floats:
         try:
-            max_prec = max(term._prec for term in M._mat if isinstance(term, Float))
+            max_prec = max(term._prec for term in M._flat if isinstance(term, Float))
         except ValueError:
             # if no term in the matrix is explicitly a Float calling max()
             # will throw a error so setting max_prec to default value of 53

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -91,7 +91,7 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):  # type: ignore
     def _eval_extract(self, rowsList, colsList):
         # self._mat is a Tuple.  It is slightly faster to index a
         # tuple over a Tuple, so grab the internal tuple directly
-        mat = self._flat
+        mat = self._mat
         cols = self.cols
         indices = (i * cols + j for i in rowsList for j in colsList)
         return self._new(len(rowsList), len(colsList),

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -78,6 +78,10 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):  # type: ignore
         obj._mat = flat_list
         return obj
 
+    @property
+    def _flat(self):
+        return list(self._mat)
+
     def _entry(self, i, j, **kwargs):
         return DenseMatrix.__getitem__(self, (i, j))
 
@@ -87,7 +91,7 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):  # type: ignore
     def _eval_extract(self, rowsList, colsList):
         # self._mat is a Tuple.  It is slightly faster to index a
         # tuple over a Tuple, so grab the internal tuple directly
-        mat = self._mat
+        mat = self._flat
         cols = self.cols
         indices = (i * cols + j for i in rowsList for j in colsList)
         return self._new(len(rowsList), len(colsList),

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -782,7 +782,7 @@ class MatrixBase(MatrixDeprecated,
 
     @property
     def kind(self):
-        elem_kinds = set(e.kind for e in self._mat)
+        elem_kinds = set(e.kind for e in self._flat)
         if len(elem_kinds) == 1:
             elemkind, = elem_kinds
         else:
@@ -970,11 +970,11 @@ class MatrixBase(MatrixDeprecated,
 
             # Matrix(Matrix(...))
             elif isinstance(args[0], MatrixBase):
-                return args[0].rows, args[0].cols, args[0]._mat
+                return args[0].rows, args[0].cols, args[0]._flat
 
             # Matrix(MatrixSymbol('X', 2, 2))
             elif isinstance(args[0], Basic) and args[0].is_Matrix:
-                return args[0].rows, args[0].cols, args[0].as_explicit()._mat
+                return args[0].rows, args[0].cols, args[0].as_explicit()._flat
 
             elif isinstance(args[0], mp.matrix):
                 M = args[0]
@@ -1239,7 +1239,7 @@ class MatrixBase(MatrixDeprecated,
         [3, 4]])
 
         """
-        return self._new(self.rows, self.cols, self._mat)
+        return self._new(self.rows, self.cols, self._flat)
 
     def cross(self, b):
         r"""

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -422,7 +422,7 @@ def _QRsolve(M, b):
 
         x.append(tmp / R[j, j])
 
-    return M._new([row._mat for row in reversed(x)])
+    return M._new([row._flat for row in reversed(x)])
 
 
 def _gauss_jordan_solve(M, B, freevar=False):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -491,6 +491,10 @@ class SparseMatrix(MatrixBase):
         in DenseMatrix use `_mat` directly to speed up operations."""
         return list(self)
 
+    @property
+    def _flat(self):
+        return list(self)
+
     def applyfunc(self, f):
         """Apply a function to each element of the matrix.
 
@@ -855,7 +859,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         A = A.copy()
         if not isinstance(B, SparseMatrix):
             k = 0
-            b = B._mat
+            b = B._flat
             for i in range(B.rows):
                 for j in range(B.cols):
                     v = b[k]
@@ -1030,7 +1034,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         A = A.copy()
         if not isinstance(B, SparseMatrix):
             k = 0
-            b = B._mat
+            b = B._flat
             for i in range(B.rows):
                 for j in range(B.cols):
                     v = b[k]

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -39,7 +39,7 @@ def test_args():
         assert m.rows == 3 and type(m.rows) is int
         assert m.cols == 2 and type(m.cols) is int
         if not n % 2:
-            assert type(m._mat) in (list, tuple, Tuple)
+            assert type(m._flat) in (list, tuple, Tuple)
         else:
             assert type(m._smat) is dict
 
@@ -1619,7 +1619,7 @@ def test_jordan_form():
     m = Matrix([[Float('1.0', precision=110), Float('2.0', precision=110)],
                 [Float('3.14159265358979323846264338327', precision=110), Float('4.0', precision=110)]])
     P, J = m.jordan_form()
-    for term in J._mat:
+    for term in J._flat:
         if isinstance(term, Float):
             assert term._prec == 110
 
@@ -2041,8 +2041,8 @@ def test_matrix_norm():
     # Test Rows
     A = Matrix([[5, Rational(3, 2)]])
     assert A.norm() == Pow(25 + Rational(9, 4), S.Half)
-    assert A.norm(oo) == max(A._mat)
-    assert A.norm(-oo) == min(A._mat)
+    assert A.norm(oo) == max(A)
+    assert A.norm(-oo) == min(A)
 
     # Matrix Tests
     # Intuitive test

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -138,7 +138,7 @@ class MutablePolyDenseMatrix:
 
     @classmethod
     def from_Matrix(cls, other, *gens, ring=None):
-        return cls(*other.shape, other._flat, *gens, ring=ring)
+        return cls(*other.shape, other[:], *gens, ring=ring)
 
     def set_gens(self, gens):
         return self.from_Matrix(self.to_Matrix(), gens)

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -138,7 +138,7 @@ class MutablePolyDenseMatrix:
 
     @classmethod
     def from_Matrix(cls, other, *gens, ring=None):
-        return cls(*other.shape, other._mat, *gens, ring=ring)
+        return cls(*other.shape, other._flat, *gens, ring=ring)
 
     def set_gens(self, gens):
         return self.from_Matrix(self.to_Matrix(), gens)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -714,7 +714,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     temp = []
     for e in exprs:
         if isinstance(e, (Matrix, ImmutableMatrix)):
-            temp.append(Tuple(*e._flat))
+            temp.append(Tuple(*e[:]))
         elif isinstance(e, (SparseMatrix, ImmutableSparseMatrix)):
             temp.append(Tuple(*e._smat.items()))
         else:

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -714,7 +714,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     temp = []
     for e in exprs:
         if isinstance(e, (Matrix, ImmutableMatrix)):
-            temp.append(Tuple(*e._mat))
+            temp.append(Tuple(*e._flat))
         elif isinstance(e, (SparseMatrix, ImmutableSparseMatrix)):
             temp.append(Tuple(*e._smat.items()))
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracted from #21626

#### Brief description of what is fixed or changed

Don't use the mutable `_mat` attribute of `Matrix`. A new `._flat` attribute that returns a copy of the internal list is added and all places that used `_mat` are changed to use that. This is in preparation for replacing the internal `_mat` attribute with a DomainMatrix that would not be mutable in the same way.

#### Other comments

Although this means that accessing `self._flat` now invokes a call to list calling list on a list is very fast so this is unlikely to be slow in any significant usage. Ultimately the plan is that all of these places that currently access `._mat` will be superseded by calls to `DomainMatrix` methods.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
