### PR TITLE
Improve `TransferFunction` docs and add `to_expr`

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -75,10 +75,10 @@ class TransferFunction(Basic, EvalfMixin):
 
             $H(s) = \frac{Y(s)}{X(s)} = \frac{ \mathcal{L}\left\{y(t)\right\} }{ \mathcal{L}\left\{x(t)\right\} }$
 
-    $s$, also known as complex frequency, is a complex variable in the the Laplace domain. It corresponds to the
-    equivalent variable $t$, in the time domain. Independent variable $t$ gets transformed to $s$ after Laplace
-    transform. To get back to the time domain from Laplace domain, Inverse-Laplace transform is used.
-    Transfer function, $H$, is generally given as a rational function in $s$ as-
+    $s$, also known as complex frequency, is a complex variable in the Laplace domain. It corresponds to the
+    equivalent variable $t$, in the time domain. Transfer functions are sometimes also referred as Laplace
+    transform of the system's impulse response. Transfer function, $H$, is generally given as a rational
+    function in $s$ as-
 
             $H(s) =\ \frac{a_{n}s^{n}+a_{n-1}s^{n-1}+\dots+a_{1}s+a_{0}}{b_{m}s^{m}+b_{m-1}s^{m-1}+\dots+b_{1}s+b_{0}}$
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -99,7 +99,7 @@ class TransferFunction(Basic, EvalfMixin):
     TypeError
         When ``var`` is not a Symbol or when ``num`` or ``den`` is not a
         number or a polynomial.
-    ZeroDivisionError
+    ValueError
         When ``den`` is zero.
 
     Examples
@@ -209,7 +209,7 @@ class TransferFunction(Basic, EvalfMixin):
             raise TypeError("Variable input must be a Symbol.")
 
         if den == 0:
-            raise ZeroDivisionError("TransferFunction can't have a zero denominator.")
+            raise ValueError("TransferFunction can't have a zero denominator.")
 
         if (((isinstance(num, Expr) and num.has(Symbol) and not num.has(exp)) or num.is_number) and
             ((isinstance(den, Expr) and den.has(Symbol) and not den.has(exp)) or den.is_number)):
@@ -414,7 +414,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = list(other.args)
             return Parallel(self, *arg_list)
         else:
-            raise TypeError("TransferFunction cannot be added with {}.".
+            raise ValueError("TransferFunction cannot be added with {}.".
                 format(type(other)))
 
     def __radd__(self, other):
@@ -433,7 +433,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = [-i for i in list(other.args)]
             return Parallel(self, *arg_list)
         else:
-            raise TypeError("{} cannot be subtracted from a TransferFunction."
+            raise ValueError("{} cannot be subtracted from a TransferFunction."
                 .format(type(other)))
 
     def __rsub__(self, other):
@@ -452,7 +452,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = list(other.args)
             return Series(self, *arg_list)
         else:
-            raise TypeError("TransferFunction cannot be multiplied with {}."
+            raise ValueError("TransferFunction cannot be multiplied with {}."
                 .format(type(other)))
 
     __rmul__ = __mul__
@@ -480,7 +480,7 @@ class TransferFunction(Basic, EvalfMixin):
             else:
                 return Feedback(self, Series(*other_arg_list))
         else:
-            raise TypeError("TransferFunction cannot be divided by {}.".
+            raise ValueError("TransferFunction cannot be divided by {}.".
                 format(type(other)))
 
     __rtruediv__ = __truediv__

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -19,14 +19,65 @@ def _roots(poly, var):
 
 
 class TransferFunction(Basic, EvalfMixin):
-    """
+    r"""
     A class for representing LTI (Linear, time-invariant) systems that can be strictly described
-    by ratio of polynomials in the Laplace Transform complex variable. The arguments
+    by ratio of polynomials in the Laplace transform complex variable. The arguments
     are ``num``, ``den``, and ``var``, where ``num`` and ``den`` are numerator and
     denominator polynomials of the ``TransferFunction`` respectively, and the third argument is
     a complex variable of the Laplace transform used by these polynomials of the transfer function.
     ``num`` and ``den`` can be either polynomials or numbers, whereas ``var``
     has to be a Symbol.
+
+    Explanation
+    ===========
+
+    Generally, a dynamical system respresenting a physical model can be described in terms of Linear
+    Ordinary Differential Equations like -
+
+            $\small{b_{m}y^{\left(m\right)}+b_{m-1}y^{\left(m-1\right)}+\dots+b_{1}y^{\left(1\right)}+b_{0}y=
+            a_{n}x^{\left(n\right)}+a_{n-1}x^{\left(n-1\right)}+\dots+a_{1}x^{\left(1\right)}+a_{0}x}$
+
+    Here, $x$ is the input signal and $y$ is the output signal and superscript on both is the order of derivative
+    (not exponent). Derivative is taken with respect to the independent variable, $t$. Also, generally $m$ is greater
+    than $n$.
+
+    It is not feasible to analyse the properties of such systems in their native form therefore, we use
+    mathematical tools like Laplace transform to get a better perspective. Taking the Laplace transform
+    of both the sides in the equation (at zero initial conditions), we get -
+
+            $\small{\mathcal{L}[b_{m}y^{\left(m\right)}+b_{m-1}y^{\left(m-1\right)}+\dots+b_{1}y^{\left(1\right)}+b_{0}y]=
+            \mathcal{L}[a_{n}x^{\left(n\right)}+a_{n-1}x^{\left(n-1\right)}+\dots+a_{1}x^{\left(1\right)}+a_{0}x]}$
+
+    Using the linearity property of Laplace transform and also considering zero initial conditions
+    (i.e. $\small{y(0^{-}) = 0}$, $\small{y'(0^{-}) = 0}$ and so on), the equation
+    above gets translated to -
+
+            $\small{b_{m}\mathcal{L}[y^{\left(m\right)}]+\dots+b_{1}\mathcal{L}[y^{\left(1\right)}]+b_{0}\mathcal{L}[y]=
+            a_{n}\mathcal{L}[x^{\left(n\right)}]+\dots+a_{1}\mathcal{L}[x^{\left(1\right)}]+a_{0}\mathcal{L}[x]}$
+
+    Now, applying Derivative property of Laplace transform,
+
+            $\small{b_{m}s^{m}\mathcal{L}[y]+\dots+b_{1}s\mathcal{L}[y]+b_{0}\mathcal{L}[y]=
+            a_{n}s^{n}\mathcal{L}[x]+\dots+a_{1}s\mathcal{L}[x]+a_{0}\mathcal{L}[x]}$
+
+    Here, the superscript on $s$ is **exponent**. Note that the zero initial conditions assumption, mentioned above, is very important
+    and cannot be ignored otherwise the dynamical system cannot be considered time-independent and the simplified equation above
+    cannot be reached.
+
+    Collecting $\mathcal{L}[y]$ and $\mathcal{L}[x]$ terms from both the sides and taking the ratio
+    $\frac{ \mathcal{L}\left\{y\right\} }{ \mathcal{L}\left\{x\right\} }$, we get the typical rational form of transfer
+    function.
+
+    The numerator of the transfer function is therefore, the Laplace transform of the output signal
+    (The signals are represented as functions of time) and similarly the denominator
+    of the transfer function is the Laplace transform of the input signal. It is also a convention
+    to denote the input and output signal's Laplace transform with capital alphabets like shown below.
+
+            $H(s) = \frac{Y(s)}{X(s)} = \frac{ \mathcal{L}\left\{y(t)\right\} }{ \mathcal{L}\left\{x(t)\right\} }$
+
+    Transfer function, $H$, is generally given as a rational function in $s$ as-
+
+            $H(s) =\ \frac{a_{n}s^{n}+a_{n-1}s^{n-1}+\dots+a_{1}s+a_{0}}{b_{m}s^{m}+b_{m-1}s^{m-1}+\dots+b_{1}s+b_{0}}$
 
     Parameters
     ==========
@@ -43,10 +94,9 @@ class TransferFunction(Basic, EvalfMixin):
     ======
 
     TypeError
-        When ``var`` is not a Symbol or when ``num`` or ``den`` is not
-        a number or a polynomial. Also, when ``num`` or ``den`` has
-        a time delay term.
-    ValueError
+        When ``var`` is not a Symbol or when ``num`` or ``den`` is not a
+        number or a polynomial.
+    ZeroDivisionError
         When ``den`` is zero.
 
     Examples
@@ -68,98 +118,104 @@ class TransferFunction(Basic, EvalfMixin):
 
     Any complex variable can be used for ``var``.
 
-    >>> tf2 = TransferFunction(a*p**3 - a*p**2 + s*p, p + a**2, p)
+    >>> tf2 = TransferFunction((p + 3)*(p - 1), (p - 1)*(p + 5), p)
     >>> tf2
-    TransferFunction(a*p**3 - a*p**2 + p*s, a**2 + p, p)
-    >>> tf3 = TransferFunction((p + 3)*(p - 1), (p - 1)*(p + 5), p)
-    >>> tf3
-    TransferFunction((p - 1)*(p + 3), (p - 1)*(p + 5), p)
+    TransferFunction(p**2 + 2*p - 3, p**2 + 4*p - 5, p)
 
     To negate a transfer function the ``-`` operator can be prepended:
 
-    >>> tf4 = TransferFunction(-a + s, p**2 + s, p)
-    >>> -tf4
+    >>> tf3 = TransferFunction(-a + s, p**2 + s, p)
+    >>> -tf3
     TransferFunction(a - s, p**2 + s, p)
-    >>> tf5 = TransferFunction(s**4 - 2*s**3 + 5*s + 4, s + 4, s)
-    >>> -tf5
+    >>> tf4 = TransferFunction(s**4 - 2*s**3 + 5*s + 4, s + 4, s)
+    >>> -tf4
     TransferFunction(-s**4 + 2*s**3 - 5*s - 4, s + 4, s)
 
     You can use a Float or an Integer (or other constants) as numerator and denominator:
 
-    >>> tf6 = TransferFunction(1/2, 4, s)
-    >>> tf6.num
+    >>> tf5 = TransferFunction(1/2, 4, s)
+    >>> tf5.num
     0.500000000000000
-    >>> tf6.den
+    >>> tf5.den
     4
-    >>> tf6.var
+    >>> tf5.var
     s
-    >>> tf6.args
+    >>> tf5.args
     (0.5, 4, s)
 
     You can take the integer power of a transfer function using the ``**`` operator:
 
-    >>> tf7 = TransferFunction(s + a, s - a, s)
-    >>> tf7**3
-    TransferFunction((a + s)**3, (-a + s)**3, s)
-    >>> tf7**0
+    >>> tf6 = TransferFunction(s + a, s - a, s)
+    >>> tf6**3
+    TransferFunction(a**3 + 3*a**2*s + 3*a*s**2 + s**3, -a**3 + 3*a**2*s - 3*a*s**2 + s**3, s)
+    >>> tf6**0
     TransferFunction(1, 1, s)
-    >>> tf8 = TransferFunction(p + 4, p - 3, p)
-    >>> tf8**-1
+    >>> tf7 = TransferFunction(p + 4, p - 3, p)
+    >>> tf7**-1
     TransferFunction(p - 3, p + 4, p)
 
     Addition, subtraction, and multiplication of transfer functions can form
     unevaluated ``Series`` or ``Parallel`` objects.
 
-    >>> tf9 = TransferFunction(s + 1, s**2 + s + 1, s)
-    >>> tf10 = TransferFunction(s - p, s + 3, s)
-    >>> tf11 = TransferFunction(4*s**2 + 2*s - 4, s - 1, s)
-    >>> tf12 = TransferFunction(1 - s, s**2 + 4, s)
-    >>> tf9 + tf10
+    >>> tf8 = TransferFunction(s + 1, s**2 + s + 1, s)
+    >>> tf9 = TransferFunction(s - p, s + 3, s)
+    >>> tf10 = TransferFunction(4*s**2 + 2*s - 4, s - 1, s)
+    >>> tf11 = TransferFunction(1 - s, s**2 + 4, s)
+    >>> tf8 + tf9
     Parallel(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(-p + s, s + 3, s))
-    >>> tf10 - tf11
+    >>> tf9 - tf10
     Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(-4*s**2 - 2*s + 4, s - 1, s))
-    >>> tf9 * tf10
+    >>> tf8 * tf9
     Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(-p + s, s + 3, s))
-    >>> tf10 - (tf9 + tf12)
+    >>> tf9 - (tf8 + tf11)
     Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(-s - 1, s**2 + s + 1, s), TransferFunction(s - 1, s**2 + 4, s))
-    >>> tf10 - (tf9 * tf12)
+    >>> tf9 - (tf8 * tf11)
     Parallel(TransferFunction(-p + s, s + 3, s), Series(TransferFunction(-1, 1, s), Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(1 - s, s**2 + 4, s))))
-    >>> tf11 * tf10 * tf9
+    >>> tf10 * tf9 * tf8
     Series(TransferFunction(4*s**2 + 2*s - 4, s - 1, s), TransferFunction(-p + s, s + 3, s), TransferFunction(s + 1, s**2 + s + 1, s))
-    >>> tf9 * tf11 + tf10 * tf12
+    >>> tf8 * tf10 + tf9 * tf11
     Parallel(Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(4*s**2 + 2*s - 4, s - 1, s)), Series(TransferFunction(-p + s, s + 3, s), TransferFunction(1 - s, s**2 + 4, s)))
-    >>> (tf9 + tf12) * (tf10 + tf11)
+    >>> (tf8 + tf11) * (tf9 + tf10)
     Series(Parallel(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(1 - s, s**2 + 4, s)), Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(4*s**2 + 2*s - 4, s - 1, s)))
 
     These unevaluated ``Series`` or ``Parallel`` objects can convert into the
     resultant transfer function using ``.doit()`` method or by ``.rewrite(TransferFunction)``.
 
-    >>> ((tf9 + tf10) * tf12).doit()
-    TransferFunction((1 - s)*((-p + s)*(s**2 + s + 1) + (s + 1)*(s + 3)), (s + 3)*(s**2 + 4)*(s**2 + s + 1), s)
-    >>> (tf9 * tf10 - tf11 * tf12).rewrite(TransferFunction)
-    TransferFunction(-(1 - s)*(s + 3)*(s**2 + s + 1)*(4*s**2 + 2*s - 4) + (-p + s)*(s - 1)*(s + 1)*(s**2 + 4), (s - 1)*(s + 3)*(s**2 + 4)*(s**2 + s + 1), s)
+    >>> ((tf8 + tf9) * tf11).doit()
+    TransferFunction(p*s**3 - p - s**4 - s**3 - 3*s**2 + 2*s + 3, s**5 + 4*s**4 + 8*s**3 + 19*s**2 + 16*s + 12, s)
+    >>> (tf8 * tf9 - tf10 * tf11).rewrite(TransferFunction)
+    TransferFunction(-p*s**4 - 3*p*s**2 + 4*p + 4*s**6 + 15*s**5 + 2*s**4 - 13*s**3 - 14*s**2 - 6*s + 12, s**6 + 3*s**5 + 4*s**4 + 11*s**3 - 3*s**2 - 4*s - 12, s)
 
     See Also
     ========
 
     Feedback, Series, Parallel
 
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Transfer_function
+    .. [2] https://en.wikipedia.org/wiki/Laplace_transform
+
     """
     def __new__(cls, num, den, var):
         num, den = _sympify(num), _sympify(den)
+        num, den = expand(num), expand(den)
 
         if not isinstance(var, Symbol):
             raise TypeError("Variable input must be a Symbol.")
+
         if den == 0:
-            raise ValueError("TransferFunction can't have a zero denominator.")
+            raise ZeroDivisionError("TransferFunction can't have a zero denominator.")
 
         if (((isinstance(num, Expr) and num.has(Symbol) and not num.has(exp)) or num.is_number) and
             ((isinstance(den, Expr) and den.has(Symbol) and not den.has(exp)) or den.is_number)):
-                obj = super().__new__(cls, num, den, var)
-                obj._num = num
-                obj._den = den
-                obj._var = var
-                return obj
+            obj = super(TransferFunction, cls).__new__(cls, num, den, var)
+            obj._num = num
+            obj._den = den
+            obj._var = var
+            return obj
+
         else:
             raise TypeError("Unsupported type for numerator or denominator of TransferFunction.")
 
@@ -178,7 +234,7 @@ class TransferFunction(Basic, EvalfMixin):
         p*s + s**2 + 3
         >>> G2 = TransferFunction((p + 5)*(p - 3), (p - 3)*(p + 1), p)
         >>> G2.num
-        (p - 3)*(p + 5)
+        p**2 + 2*p - 15
 
         """
         return self._num
@@ -240,26 +296,6 @@ class TransferFunction(Basic, EvalfMixin):
         tf = cancel(Mul(self.num, 1/self.den, evaluate=False), expand=False).as_numer_denom()
         num_, den_ = tf[0], tf[1]
         return TransferFunction(num_, den_, self.var)
-
-    def expand(self):
-        """
-        Returns the transfer function with numerator and denominator
-        in expanded form.
-
-        Examples
-        ========
-
-        >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction
-        >>> G1 = TransferFunction((a - s)**2, (s**2 + a)**2, s)
-        >>> G1.expand()
-        TransferFunction(a**2 - 2*a*s + s**2, a**2 + 2*a*s**2 + s**4, s)
-        >>> G2 = TransferFunction((p + 3*b)*(p - b), (p - b)*(p + 2*b), p)
-        >>> G2.expand()
-        TransferFunction(-3*b**2 + 2*b*p + p**2, -2*b**2 + b*p + p**2, p)
-
-        """
-        return TransferFunction(expand(self.num), expand(self.den), self.var)
 
     def dc_gain(self):
         """
@@ -375,7 +411,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = list(other.args)
             return Parallel(self, *arg_list)
         else:
-            raise ValueError("TransferFunction cannot be added with {}.".
+            raise TypeError("TransferFunction cannot be added with {}.".
                 format(type(other)))
 
     def __radd__(self, other):
@@ -394,7 +430,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = [-i for i in list(other.args)]
             return Parallel(self, *arg_list)
         else:
-            raise ValueError("{} cannot be subtracted from a TransferFunction."
+            raise TypeError("{} cannot be subtracted from a TransferFunction."
                 .format(type(other)))
 
     def __rsub__(self, other):
@@ -413,7 +449,7 @@ class TransferFunction(Basic, EvalfMixin):
             arg_list = list(other.args)
             return Series(self, *arg_list)
         else:
-            raise ValueError("TransferFunction cannot be multiplied with {}."
+            raise TypeError("TransferFunction cannot be multiplied with {}."
                 .format(type(other)))
 
     __rmul__ = __mul__
@@ -441,7 +477,7 @@ class TransferFunction(Basic, EvalfMixin):
             else:
                 return Feedback(self, Series(*other_arg_list))
         else:
-            raise ValueError("TransferFunction cannot be divided by {}.".
+            raise TypeError("TransferFunction cannot be divided by {}.".
                 format(type(other)))
 
     __rtruediv__ = __truediv__
@@ -526,6 +562,12 @@ class TransferFunction(Basic, EvalfMixin):
         """
         return degree(self.num, self.var) == degree(self.den, self.var)
 
+    def _to_expr(self):
+        """
+        To convert TransferFunction type to SymPy Expr
+        """
+        return Mul(self.num, Pow(self.den, -1, evaluate=False), evaluate=False)
+
 
 class Series(Basic):
     """
@@ -560,10 +602,10 @@ class Series(Basic):
 
     >>> S3 = Series(tf1, tf2, -tf3)
     >>> S3.doit()
-    TransferFunction(-p**2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
+    TransferFunction(-a*p**4*s**3 + 2*a*p**4 - b*p**2*s**4 + 2*b*p**2*s, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
     >>> S4 = Series(tf2, Parallel(tf1, -tf3))
     >>> S4.doit()
-    TransferFunction((s**3 - 2)*(-p**2*(-p + s) + (p + s)*(a*p**2 + b*s)), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
+    TransferFunction(a*p**3*s**3 - 2*a*p**3 + a*p**2*s**4 - 2*a*p**2*s + b*p*s**4 - 2*b*p*s + b*s**5 - 2*b*s**2 + p**3*s**3 - 2*p**3 - p**2*s**4 + 2*p**2*s, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
 
     Notes
     =====
@@ -627,9 +669,9 @@ class Series(Basic):
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Series(tf2, tf1).doit()
-        TransferFunction((s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s)
+        TransferFunction(a*p**2*s**3 - 2*a*p**2 + b*s**4 - 2*b*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
         >>> Series(-tf1, -tf2).doit()
-        TransferFunction((2 - s**3)*(-a*p**2 - b*s), (-p + s)*(s**4 + 5*s + 6), s)
+        TransferFunction(a*p**2*s**3 - 2*a*p**2 + b*s**4 - 2*b*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
 
         """
         res = None
@@ -834,9 +876,9 @@ class Parallel(Basic):
     You can get the resultant transfer function by using ``.doit()`` method:
 
     >>> Parallel(tf1, tf2, -tf3).doit()
-    TransferFunction(-p**2*(-p + s)*(s**4 + 5*s + 6) + (p + s)*((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6)), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
+    TransferFunction(a*p**3*s**4 + 5*a*p**3*s + 6*a*p**3 + a*p**2*s**5 + 5*a*p**2*s**2 + 6*a*p**2*s + b*p*s**5 + 5*b*p*s**2 + 6*b*p*s + b*s**6 + 5*b*s**3 + 6*b*s**2 + p**3*s**4 + 5*p**3*s + 6*p**3 - p**2*s**5 - p**2*s**3 - 5*p**2*s**2 - 6*p**2*s + 2*p**2 + s**5 - 2*s**2, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
     >>> Parallel(tf2, Series(tf1, -tf3)).doit()
-    TransferFunction(-p**2*(a*p**2 + b*s)*(s**4 + 5*s + 6) + (-p + s)*(p + s)*(s**3 - 2), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
+    TransferFunction(-a*p**4*s**4 - 5*a*p**4*s - 6*a*p**4 - b*p**2*s**5 - 5*b*p**2*s**2 - 6*b*p**2*s - p**2*s**3 + 2*p**2 + s**5 - 2*s**2, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
 
     Notes
     =====
@@ -900,9 +942,9 @@ class Parallel(Basic):
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Parallel(tf2, tf1).doit()
-        TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
+        TransferFunction(a*p**2*s**4 + 5*a*p**2*s + 6*a*p**2 + b*s**5 + 5*b*s**2 + 6*b*s - p*s**3 + 2*p + s**4 - 2*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
         >>> Parallel(-tf1, -tf2).doit()
-        TransferFunction((2 - s**3)*(-p + s) + (-a*p**2 - b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
+        TransferFunction(-a*p**2*s**4 - 5*a*p**2*s - 6*a*p**2 - b*s**5 - 5*b*s**2 - 6*b*s + p*s**3 - 2*p - s**4 + 2*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
 
         """
         res = None
@@ -1110,12 +1152,12 @@ class Feedback(Basic):
     interconnection using ``.doit()`` method.
 
     >>> F1.doit()
-    TransferFunction((s + 7)*(s**2 - 4*s + 2)*(3*s**2 + 7*s - 3), ((s + 7)*(s**2 - 4*s + 2) + (5*s - 10)*(3*s**2 + 7*s - 3))*(s**2 - 4*s + 2), s)
+    TransferFunction(3*s**5 + 16*s**4 - 60*s**3 - 149*s**2 + 176*s - 42, 16*s**5 - 56*s**4 - 111*s**3 + 504*s**2 - 398*s + 88, s)
     >>> G = TransferFunction(2*s**2 + 5*s + 1, s**2 + 2*s + 3, s)
     >>> C = TransferFunction(5*s + 10, s + 10, s)
     >>> F2 = Feedback(G*C, TransferFunction(1, 1, s))
     >>> F2.doit()
-    TransferFunction((s + 10)*(5*s + 10)*(s**2 + 2*s + 3)*(2*s**2 + 5*s + 1), (s + 10)*((s + 10)*(s**2 + 2*s + 3) + (5*s + 10)*(2*s**2 + 5*s + 1))*(s**2 + 2*s + 3), s)
+    TransferFunction(10*s**6 + 165*s**5 + 825*s**4 + 2005*s**3 + 2735*s**2 + 1880*s + 300, 11*s**6 + 189*s**5 + 1015*s**4 + 2617*s**3 + 3984*s**2 + 3260*s + 1200, s)
 
     To negate a ``Feedback`` object, the ``-`` operator can be prepended:
 
@@ -1238,11 +1280,11 @@ class Feedback(Basic):
         >>> controller = TransferFunction(5*s - 10, s + 7, s)
         >>> F1 = Feedback(plant, controller)
         >>> F1.doit()
-        TransferFunction((s + 7)*(s**2 - 4*s + 2)*(3*s**2 + 7*s - 3), ((s + 7)*(s**2 - 4*s + 2) + (5*s - 10)*(3*s**2 + 7*s - 3))*(s**2 - 4*s + 2), s)
+        TransferFunction(3*s**5 + 16*s**4 - 60*s**3 - 149*s**2 + 176*s - 42, 16*s**5 - 56*s**4 - 111*s**3 + 504*s**2 - 398*s + 88, s)
         >>> G = TransferFunction(2*s**2 + 5*s + 1, s**2 + 2*s + 3, s)
         >>> F2 = Feedback(G, TransferFunction(1, 1, s))
         >>> F2.doit()
-        TransferFunction((s**2 + 2*s + 3)*(2*s**2 + 5*s + 1), (s**2 + 2*s + 3)*(3*s**2 + 7*s + 4), s)
+        TransferFunction(2*s**4 + 9*s**3 + 17*s**2 + 17*s + 3, 3*s**4 + 13*s**3 + 27*s**2 + 29*s + 12, s)
 
         """
         arg_list = list(self.num.args) if isinstance(self.num, Series) else [self.num]

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -31,7 +31,7 @@ class TransferFunction(Basic, EvalfMixin):
     Explanation
     ===========
 
-    Generally, a dynamical system respresenting a physical model can be described in terms of Linear
+    Generally, a dynamical system representing a physical model can be described in terms of Linear
     Ordinary Differential Equations like -
 
             $\small{b_{m}y^{\left(m\right)}+b_{m-1}y^{\left(m-1\right)}+\dots+b_{1}y^{\left(1\right)}+b_{0}y=
@@ -75,6 +75,9 @@ class TransferFunction(Basic, EvalfMixin):
 
             $H(s) = \frac{Y(s)}{X(s)} = \frac{ \mathcal{L}\left\{y(t)\right\} }{ \mathcal{L}\left\{x(t)\right\} }$
 
+    $s$, also known as complex frequency, is a complex variable in the the Laplace domain. It corresponds to the
+    equivalent variable $t$, in the time domain. Independent variable $t$ gets transformed to $s$ after Laplace
+    transform. To get back to the time domain from Laplace domain, Inverse-Laplace transform is used.
     Transfer function, $H$, is generally given as a rational function in $s$ as-
 
             $H(s) =\ \frac{a_{n}s^{n}+a_{n-1}s^{n-1}+\dots+a_{1}s+a_{0}}{b_{m}s^{m}+b_{m-1}s^{m-1}+\dots+b_{1}s+b_{0}}$
@@ -563,9 +566,7 @@ class TransferFunction(Basic, EvalfMixin):
         return degree(self.num, self.var) == degree(self.den, self.var)
 
     def _to_expr(self):
-        """
-        To convert TransferFunction type to SymPy Expr
-        """
+        """To convert TransferFunction type to SymPy Expr"""
         return Mul(self.num, Pow(self.den, -1, evaluate=False), evaluate=False)
 
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -213,8 +213,8 @@ class TransferFunction(Basic, EvalfMixin):
         if den == 0:
             raise ValueError("TransferFunction can't have a zero denominator.")
 
-        if (((isinstance(num, Expr) and num.has(Symbol) and not num.has(exp)) or num.is_number) and
-            ((isinstance(den, Expr) and den.has(Symbol) and not den.has(exp)) or den.is_number)):
+        if (((isinstance(num, Expr) and num.has(Symbol)) or num.is_number) and
+            ((isinstance(den, Expr) and den.has(Symbol)) or den.is_number)):
             obj = super(TransferFunction, cls).__new__(cls, num, den, var)
             obj._num = num
             obj._den = den
@@ -227,13 +227,11 @@ class TransferFunction(Basic, EvalfMixin):
     @classmethod
     def from_rational_expression(cls, expr, var=None):
         r"""
-        Allows an alternative way for the users to instantiate a ``TransferFunction`` object.
-        ``TransferFunction`` objects can be created simply by passing the rational expression.
-        SymPy will smartly create a ``TransferFunction`` object with the properties of the
-        expression.
+        Creates a new ``TransferFunction`` efficiently from a rational expression.
 
         Parameters
         ==========
+
         expr : Expr, Number
             The rational expression representing the ``TransferFunction``.
         var : Symbol, optional
@@ -247,7 +245,7 @@ class TransferFunction(Basic, EvalfMixin):
             When ``expr`` is of type ``Number`` and optional parameter ``var``
             is not passed.
 
-            Wen ``expr`` has more than one variables and optional parameter
+            When ``expr`` has more than one variables and an optional parameter
             ``var`` is not passed.
         ZeroDivisionError
             When denominator of ``expr`` is zero or it has ``ComplexInfinity``
@@ -663,7 +661,7 @@ class TransferFunction(Basic, EvalfMixin):
 
     def to_expr(self):
         """
-        To convert ``TransferFunction`` object to SymPy Expr.
+        Converts a ``TransferFunction`` object to SymPy Expr.
 
         Examples
         ========

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,4 +1,4 @@
-from sympy import Basic, Mul, Pow, degree, Symbol, expand, cancel, Expr, exp, roots
+from sympy import Basic, Mul, Pow, degree, Symbol, expand, cancel, Expr, roots
 from sympy.core.evalf import EvalfMixin
 from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import Integer, ComplexInfinity

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -279,6 +279,12 @@ class TransferFunction(Basic, EvalfMixin):
         >>> tf
         TransferFunction(a*s + a, s**2 + s + 1, s)
 
+        ``var`` also need to be specified when ``expr`` is a ``Number``
+
+        >>> tf3 = TransferFunction.from_rational_expression(10, s)
+        >>> tf3
+        TransferFunction(10, 1, s)
+
         """
         expr = _sympify(expr)
         if var is None:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -68,17 +68,17 @@ class TransferFunction(Basic, EvalfMixin):
     $\frac{ \mathcal{L}\left\{y\right\} }{ \mathcal{L}\left\{x\right\} }$, we get the typical rational form of transfer
     function.
 
-    The numerator of the transfer function is therefore, the Laplace transform of the output signal
-    (The signals are represented as functions of time) and similarly the denominator
+    The numerator of the transfer function is, therefore, the Laplace transform of the output signal
+    (The signals are represented as functions of time) and similarly, the denominator
     of the transfer function is the Laplace transform of the input signal. It is also a convention
     to denote the input and output signal's Laplace transform with capital alphabets like shown below.
 
             $H(s) = \frac{Y(s)}{X(s)} = \frac{ \mathcal{L}\left\{y(t)\right\} }{ \mathcal{L}\left\{x(t)\right\} }$
 
     $s$, also known as complex frequency, is a complex variable in the Laplace domain. It corresponds to the
-    equivalent variable $t$, in the time domain. Transfer functions are sometimes also referred as Laplace
-    transform of the system's impulse response. Transfer function, $H$, is generally given as a rational
-    function in $s$ as-
+    equivalent variable $t$, in the time domain. Transfer functions are sometimes also referred to as the Laplace
+    transform of the system's impulse response. Transfer function, $H$, is represented as a rational
+    function in $s$ like,
 
             $H(s) =\ \frac{a_{n}s^{n}+a_{n-1}s^{n-1}+\dots+a_{1}s+a_{0}}{b_{m}s^{m}+b_{m-1}s^{m-1}+\dots+b_{1}s+b_{0}}$
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -121,73 +121,76 @@ class TransferFunction(Basic, EvalfMixin):
 
     Any complex variable can be used for ``var``.
 
-    >>> tf2 = TransferFunction((p + 3)*(p - 1), (p - 1)*(p + 5), p)
+    >>> tf2 = TransferFunction(a*p**3 - a*p**2 + s*p, p + a**2, p)
     >>> tf2
-    TransferFunction(p**2 + 2*p - 3, p**2 + 4*p - 5, p)
+    TransferFunction(a*p**3 - a*p**2 + p*s, a**2 + p, p)
+    >>> tf3 = TransferFunction((p + 3)*(p - 1), (p - 1)*(p + 5), p)
+    >>> tf3
+    TransferFunction((p - 1)*(p + 3), (p - 1)*(p + 5), p)
 
     To negate a transfer function the ``-`` operator can be prepended:
 
-    >>> tf3 = TransferFunction(-a + s, p**2 + s, p)
-    >>> -tf3
-    TransferFunction(a - s, p**2 + s, p)
-    >>> tf4 = TransferFunction(s**4 - 2*s**3 + 5*s + 4, s + 4, s)
+    >>> tf4 = TransferFunction(-a + s, p**2 + s, p)
     >>> -tf4
+    TransferFunction(a - s, p**2 + s, p)
+    >>> tf5 = TransferFunction(s**4 - 2*s**3 + 5*s + 4, s + 4, s)
+    >>> -tf5
     TransferFunction(-s**4 + 2*s**3 - 5*s - 4, s + 4, s)
 
     You can use a Float or an Integer (or other constants) as numerator and denominator:
 
-    >>> tf5 = TransferFunction(1/2, 4, s)
-    >>> tf5.num
+    >>> tf6 = TransferFunction(1/2, 4, s)
+    >>> tf6.num
     0.500000000000000
-    >>> tf5.den
+    >>> tf6.den
     4
-    >>> tf5.var
+    >>> tf6.var
     s
-    >>> tf5.args
+    >>> tf6.args
     (0.5, 4, s)
 
     You can take the integer power of a transfer function using the ``**`` operator:
 
-    >>> tf6 = TransferFunction(s + a, s - a, s)
-    >>> tf6**3
-    TransferFunction(a**3 + 3*a**2*s + 3*a*s**2 + s**3, -a**3 + 3*a**2*s - 3*a*s**2 + s**3, s)
-    >>> tf6**0
+    >>> tf7 = TransferFunction(s + a, s - a, s)
+    >>> tf7**3
+    TransferFunction((a + s)**3, (-a + s)**3, s)
+    >>> tf7**0
     TransferFunction(1, 1, s)
-    >>> tf7 = TransferFunction(p + 4, p - 3, p)
-    >>> tf7**-1
+    >>> tf8 = TransferFunction(p + 4, p - 3, p)
+    >>> tf8**-1
     TransferFunction(p - 3, p + 4, p)
 
     Addition, subtraction, and multiplication of transfer functions can form
     unevaluated ``Series`` or ``Parallel`` objects.
 
-    >>> tf8 = TransferFunction(s + 1, s**2 + s + 1, s)
-    >>> tf9 = TransferFunction(s - p, s + 3, s)
-    >>> tf10 = TransferFunction(4*s**2 + 2*s - 4, s - 1, s)
-    >>> tf11 = TransferFunction(1 - s, s**2 + 4, s)
-    >>> tf8 + tf9
+    >>> tf9 = TransferFunction(s + 1, s**2 + s + 1, s)
+    >>> tf10 = TransferFunction(s - p, s + 3, s)
+    >>> tf11 = TransferFunction(4*s**2 + 2*s - 4, s - 1, s)
+    >>> tf12 = TransferFunction(1 - s, s**2 + 4, s)
+    >>> tf9 + tf10
     Parallel(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(-p + s, s + 3, s))
-    >>> tf9 - tf10
+    >>> tf10 - tf11
     Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(-4*s**2 - 2*s + 4, s - 1, s))
-    >>> tf8 * tf9
+    >>> tf9 * tf10
     Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(-p + s, s + 3, s))
-    >>> tf9 - (tf8 + tf11)
+    >>> tf10 - (tf9 + tf12)
     Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(-s - 1, s**2 + s + 1, s), TransferFunction(s - 1, s**2 + 4, s))
-    >>> tf9 - (tf8 * tf11)
+    >>> tf10 - (tf9 * tf12)
     Parallel(TransferFunction(-p + s, s + 3, s), Series(TransferFunction(-1, 1, s), Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(1 - s, s**2 + 4, s))))
-    >>> tf10 * tf9 * tf8
+    >>> tf11 * tf10 * tf9
     Series(TransferFunction(4*s**2 + 2*s - 4, s - 1, s), TransferFunction(-p + s, s + 3, s), TransferFunction(s + 1, s**2 + s + 1, s))
-    >>> tf8 * tf10 + tf9 * tf11
+    >>> tf9 * tf11 + tf10 * tf12
     Parallel(Series(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(4*s**2 + 2*s - 4, s - 1, s)), Series(TransferFunction(-p + s, s + 3, s), TransferFunction(1 - s, s**2 + 4, s)))
-    >>> (tf8 + tf11) * (tf9 + tf10)
+    >>> (tf9 + tf12) * (tf10 + tf11)
     Series(Parallel(TransferFunction(s + 1, s**2 + s + 1, s), TransferFunction(1 - s, s**2 + 4, s)), Parallel(TransferFunction(-p + s, s + 3, s), TransferFunction(4*s**2 + 2*s - 4, s - 1, s)))
 
     These unevaluated ``Series`` or ``Parallel`` objects can convert into the
     resultant transfer function using ``.doit()`` method or by ``.rewrite(TransferFunction)``.
 
-    >>> ((tf8 + tf9) * tf11).doit()
-    TransferFunction(p*s**3 - p - s**4 - s**3 - 3*s**2 + 2*s + 3, s**5 + 4*s**4 + 8*s**3 + 19*s**2 + 16*s + 12, s)
-    >>> (tf8 * tf9 - tf10 * tf11).rewrite(TransferFunction)
-    TransferFunction(-p*s**4 - 3*p*s**2 + 4*p + 4*s**6 + 15*s**5 + 2*s**4 - 13*s**3 - 14*s**2 - 6*s + 12, s**6 + 3*s**5 + 4*s**4 + 11*s**3 - 3*s**2 - 4*s - 12, s)
+    >>> ((tf9 + tf10) * tf12).doit()
+    TransferFunction((1 - s)*((-p + s)*(s**2 + s + 1) + (s + 1)*(s + 3)), (s + 3)*(s**2 + 4)*(s**2 + s + 1), s)
+    >>> (tf9 * tf10 - tf11 * tf12).rewrite(TransferFunction)
+    TransferFunction(-(1 - s)*(s + 3)*(s**2 + s + 1)*(4*s**2 + 2*s - 4) + (-p + s)*(s - 1)*(s + 1)*(s**2 + 4), (s - 1)*(s + 3)*(s**2 + 4)*(s**2 + s + 1), s)
 
     See Also
     ========
@@ -203,7 +206,6 @@ class TransferFunction(Basic, EvalfMixin):
     """
     def __new__(cls, num, den, var):
         num, den = _sympify(num), _sympify(den)
-        num, den = expand(num), expand(den)
 
         if not isinstance(var, Symbol):
             raise TypeError("Variable input must be a Symbol.")
@@ -237,7 +239,7 @@ class TransferFunction(Basic, EvalfMixin):
         p*s + s**2 + 3
         >>> G2 = TransferFunction((p + 5)*(p - 3), (p - 3)*(p + 1), p)
         >>> G2.num
-        p**2 + 2*p - 15
+        (p - 3)*(p + 5)
 
         """
         return self._num
@@ -299,6 +301,26 @@ class TransferFunction(Basic, EvalfMixin):
         tf = cancel(Mul(self.num, 1/self.den, evaluate=False), expand=False).as_numer_denom()
         num_, den_ = tf[0], tf[1]
         return TransferFunction(num_, den_, self.var)
+
+    def expand(self):
+        """
+        Returns the transfer function with numerator and denominator
+        in expanded form.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s, p, a, b
+        >>> from sympy.physics.control.lti import TransferFunction
+        >>> G1 = TransferFunction((a - s)**2, (s**2 + a)**2, s)
+        >>> G1.expand()
+        TransferFunction(a**2 - 2*a*s + s**2, a**2 + 2*a*s**2 + s**4, s)
+        >>> G2 = TransferFunction((p + 3*b)*(p - b), (p - b)*(p + 2*b), p)
+        >>> G2.expand()
+        TransferFunction(-3*b**2 + 2*b*p + p**2, -2*b**2 + b*p + p**2, p)
+
+        """
+        return TransferFunction(expand(self.num), expand(self.den), self.var)
 
     def dc_gain(self):
         """
@@ -603,10 +625,10 @@ class Series(Basic):
 
     >>> S3 = Series(tf1, tf2, -tf3)
     >>> S3.doit()
-    TransferFunction(-a*p**4*s**3 + 2*a*p**4 - b*p**2*s**4 + 2*b*p**2*s, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
+    TransferFunction(-p**2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
     >>> S4 = Series(tf2, Parallel(tf1, -tf3))
     >>> S4.doit()
-    TransferFunction(a*p**3*s**3 - 2*a*p**3 + a*p**2*s**4 - 2*a*p**2*s + b*p*s**4 - 2*b*p*s + b*s**5 - 2*b*s**2 + p**3*s**3 - 2*p**3 - p**2*s**4 + 2*p**2*s, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
+    TransferFunction((s**3 - 2)*(-p**2*(-p + s) + (p + s)*(a*p**2 + b*s)), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
 
     Notes
     =====
@@ -670,9 +692,9 @@ class Series(Basic):
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Series(tf2, tf1).doit()
-        TransferFunction(a*p**2*s**3 - 2*a*p**2 + b*s**4 - 2*b*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
+        TransferFunction((s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Series(-tf1, -tf2).doit()
-        TransferFunction(a*p**2*s**3 - 2*a*p**2 + b*s**4 - 2*b*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
+        TransferFunction((2 - s**3)*(-a*p**2 - b*s), (-p + s)*(s**4 + 5*s + 6), s)
 
         """
         res = None
@@ -877,9 +899,9 @@ class Parallel(Basic):
     You can get the resultant transfer function by using ``.doit()`` method:
 
     >>> Parallel(tf1, tf2, -tf3).doit()
-    TransferFunction(a*p**3*s**4 + 5*a*p**3*s + 6*a*p**3 + a*p**2*s**5 + 5*a*p**2*s**2 + 6*a*p**2*s + b*p*s**5 + 5*b*p*s**2 + 6*b*p*s + b*s**6 + 5*b*s**3 + 6*b*s**2 + p**3*s**4 + 5*p**3*s + 6*p**3 - p**2*s**5 - p**2*s**3 - 5*p**2*s**2 - 6*p**2*s + 2*p**2 + s**5 - 2*s**2, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
+    TransferFunction(-p**2*(-p + s)*(s**4 + 5*s + 6) + (p + s)*((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6)), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
     >>> Parallel(tf2, Series(tf1, -tf3)).doit()
-    TransferFunction(-a*p**4*s**4 - 5*a*p**4*s - 6*a*p**4 - b*p**2*s**5 - 5*b*p**2*s**2 - 6*b*p**2*s - p**2*s**3 + 2*p**2 + s**5 - 2*s**2, -p**2*s**4 - 5*p**2*s - 6*p**2 + s**6 + 5*s**3 + 6*s**2, s)
+    TransferFunction(-p**2*(a*p**2 + b*s)*(s**4 + 5*s + 6) + (-p + s)*(p + s)*(s**3 - 2), (-p + s)*(p + s)*(s**4 + 5*s + 6), s)
 
     Notes
     =====
@@ -943,9 +965,9 @@ class Parallel(Basic):
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Parallel(tf2, tf1).doit()
-        TransferFunction(a*p**2*s**4 + 5*a*p**2*s + 6*a*p**2 + b*s**5 + 5*b*s**2 + 6*b*s - p*s**3 + 2*p + s**4 - 2*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
+        TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Parallel(-tf1, -tf2).doit()
-        TransferFunction(-a*p**2*s**4 - 5*a*p**2*s - 6*a*p**2 - b*s**5 - 5*b*s**2 - 6*b*s + p*s**3 - 2*p - s**4 + 2*s, -p*s**4 - 5*p*s - 6*p + s**5 + 5*s**2 + 6*s, s)
+        TransferFunction((2 - s**3)*(-p + s) + (-a*p**2 - b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
 
         """
         res = None
@@ -1153,12 +1175,12 @@ class Feedback(Basic):
     interconnection using ``.doit()`` method.
 
     >>> F1.doit()
-    TransferFunction(3*s**5 + 16*s**4 - 60*s**3 - 149*s**2 + 176*s - 42, 16*s**5 - 56*s**4 - 111*s**3 + 504*s**2 - 398*s + 88, s)
+    TransferFunction((s + 7)*(s**2 - 4*s + 2)*(3*s**2 + 7*s - 3), ((s + 7)*(s**2 - 4*s + 2) + (5*s - 10)*(3*s**2 + 7*s - 3))*(s**2 - 4*s + 2), s)
     >>> G = TransferFunction(2*s**2 + 5*s + 1, s**2 + 2*s + 3, s)
     >>> C = TransferFunction(5*s + 10, s + 10, s)
     >>> F2 = Feedback(G*C, TransferFunction(1, 1, s))
     >>> F2.doit()
-    TransferFunction(10*s**6 + 165*s**5 + 825*s**4 + 2005*s**3 + 2735*s**2 + 1880*s + 300, 11*s**6 + 189*s**5 + 1015*s**4 + 2617*s**3 + 3984*s**2 + 3260*s + 1200, s)
+    TransferFunction((s + 10)*(5*s + 10)*(s**2 + 2*s + 3)*(2*s**2 + 5*s + 1), (s + 10)*((s + 10)*(s**2 + 2*s + 3) + (5*s + 10)*(2*s**2 + 5*s + 1))*(s**2 + 2*s + 3), s)
 
     To negate a ``Feedback`` object, the ``-`` operator can be prepended:
 
@@ -1281,11 +1303,11 @@ class Feedback(Basic):
         >>> controller = TransferFunction(5*s - 10, s + 7, s)
         >>> F1 = Feedback(plant, controller)
         >>> F1.doit()
-        TransferFunction(3*s**5 + 16*s**4 - 60*s**3 - 149*s**2 + 176*s - 42, 16*s**5 - 56*s**4 - 111*s**3 + 504*s**2 - 398*s + 88, s)
+        TransferFunction((s + 7)*(s**2 - 4*s + 2)*(3*s**2 + 7*s - 3), ((s + 7)*(s**2 - 4*s + 2) + (5*s - 10)*(3*s**2 + 7*s - 3))*(s**2 - 4*s + 2), s)
         >>> G = TransferFunction(2*s**2 + 5*s + 1, s**2 + 2*s + 3, s)
         >>> F2 = Feedback(G, TransferFunction(1, 1, s))
         >>> F2.doit()
-        TransferFunction(2*s**4 + 9*s**3 + 17*s**2 + 17*s + 3, 3*s**4 + 13*s**3 + 27*s**2 + 29*s + 12, s)
+        TransferFunction((s**2 + 2*s + 3)*(2*s**2 + 5*s + 1), (s**2 + 2*s + 3)*(3*s**2 + 7*s + 4), s)
 
         """
         arg_list = list(self.num.args) if isinstance(self.num, Series) else [self.num]

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -105,6 +105,26 @@ def test_TransferFunction_construction():
 
 
 def test_TransferFunction_functions():
+    # classmethod from_rational_expression
+    expr_1 = Mul(0, Pow(s, -1, evaluate=False), evaluate=False)
+    expr_2 = s/0
+    expr_3 = (p*s**2 + 5*s)/(s + 1)**3
+    expr_4 = 6
+    expr_5 = ((2 + 3*s)*(5 + 2*s))/((9 + 3*s)*(5 + 2*s**2))
+    expr_6 = (9*s**4 + 4*s**2 + 8)/((s + 1)*(s + 9))
+
+    assert TransferFunction.from_rational_expression(expr_1) == TransferFunction(0, s, s)
+    raises(ZeroDivisionError, lambda: TransferFunction.from_rational_expression(expr_2))
+    raises(ValueError, lambda: TransferFunction.from_rational_expression(expr_3))
+    assert TransferFunction.from_rational_expression(expr_3, s) == TransferFunction((p*s**2 + 5*s), (s + 1)**3, s)
+    assert TransferFunction.from_rational_expression(expr_3, p) == TransferFunction((p*s**2 + 5*s), (s + 1)**3, p)
+    raises(ValueError, lambda: TransferFunction.from_rational_expression(expr_4))
+    assert TransferFunction.from_rational_expression(expr_4, s) == TransferFunction(6, 1, s)
+    assert TransferFunction.from_rational_expression(expr_5, s) == \
+        TransferFunction((2 + 3*s)*(5 + 2*s), (9 + 3*s)*(5 + 2*s**2), s)
+    assert TransferFunction.from_rational_expression(expr_6, s) == \
+        TransferFunction((9*s**4 + 4*s**2 + 8), (s + 1)*(s + 9), s)
+
     # explicitly cancel poles and zeros.
     tf0 = TransferFunction(s**5 + s**3 + s, s - s**2, s)
     a = TransferFunction(-(s**4 + s**2 + 1), s - 1, s)
@@ -268,10 +288,10 @@ def test_TransferFunction_functions():
     tf9 = TransferFunction((5 + s), (5 + s)*(6 + s), s)
     tf10 = TransferFunction(0, 1, s)
     tf11 = TransferFunction(1, 1, s)
-    assert tf8._to_expr() == Mul((a0*s**5 + 5*s**2 + 3), Pow((s**6 - 3), -1, evaluate=False), evaluate=False)
-    assert tf9._to_expr() == Mul((s + 5), Pow((5 + s)*(6 + s), -1, evaluate=False), evaluate=False)
-    assert tf10._to_expr() == Mul(S(0), Pow(1, -1, evaluate=False), evaluate=False)
-    assert tf11._to_expr() == Mul(S(1), Pow(1, -1, evaluate=False), evaluate=False)
+    assert tf8.to_expr() == Mul((a0*s**5 + 5*s**2 + 3), Pow((s**6 - 3), -1, evaluate=False), evaluate=False)
+    assert tf9.to_expr() == Mul((s + 5), Pow((5 + s)*(6 + s), -1, evaluate=False), evaluate=False)
+    assert tf10.to_expr() == Mul(S(0), Pow(1, -1, evaluate=False), evaluate=False)
+    assert tf11.to_expr() == Mul(S(1), Pow(1, -1, evaluate=False), evaluate=False)
 
 def test_TransferFunction_addition_and_subtraction():
     tf1 = TransferFunction(s + 6, s - 5, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -91,10 +91,10 @@ def test_TransferFunction_construction():
     assert tf18.num == k_i/s + k_o*s + k_p
     assert tf18.args == (k_i/s + k_o*s + k_p, omega_o**2 + 2*omega_o*s + s**2, s)
 
-    # ZeroDivisionError when denominator is zero.
-    raises(ZeroDivisionError, lambda: TransferFunction(4, 0, s))
-    raises(ZeroDivisionError, lambda: TransferFunction(s, 0, s))
-    raises(ZeroDivisionError, lambda: TransferFunction(0, 0, s))
+    # ValueError when denominator is zero.
+    raises(ValueError, lambda: TransferFunction(4, 0, s))
+    raises(ValueError, lambda: TransferFunction(s, 0, s))
+    raises(ValueError, lambda: TransferFunction(0, 0, s))
 
     raises(TypeError, lambda: TransferFunction(Matrix([1, 2, 3]), s, s))
     raises(TypeError, lambda: TransferFunction(s**pi*exp(s), s, s))
@@ -272,12 +272,12 @@ def test_TransferFunction_addition_and_subtraction():
     assert tf1 + (tf2 + tf3) == Parallel(tf1, tf2, tf3)
 
     c = symbols("c", commutative=False)
-    raises(TypeError, lambda: tf1 + Matrix([1, 2, 3]))
-    raises(TypeError, lambda: tf2 + c)
+    raises(ValueError, lambda: tf1 + Matrix([1, 2, 3]))
+    raises(ValueError, lambda: tf2 + c)
     raises(ValueError, lambda: tf3 + tf4)
-    raises(TypeError, lambda: tf1 + (s - 1))
-    raises(TypeError, lambda: tf1 + 8)
-    raises(TypeError, lambda: (1 - p**3) + tf1)
+    raises(ValueError, lambda: tf1 + (s - 1))
+    raises(ValueError, lambda: tf1 + 8)
+    raises(ValueError, lambda: (1 - p**3) + tf1)
 
     # subtraction
     assert tf1 - tf2 == Parallel(tf1, -tf2)
@@ -285,12 +285,12 @@ def test_TransferFunction_addition_and_subtraction():
     assert -tf1 - tf3 == Parallel(-tf1, -tf3)
     assert tf1 - tf2 + tf3 == Parallel(tf1, -tf2, tf3)
 
-    raises(TypeError, lambda: tf1 - Matrix([1, 2, 3]))
+    raises(ValueError, lambda: tf1 - Matrix([1, 2, 3]))
     raises(ValueError, lambda: tf3 - tf4)
-    raises(TypeError, lambda: tf1 - (s - 1))
-    raises(TypeError, lambda: tf1 - 8)
-    raises(TypeError, lambda: (s + 5) - tf2)
-    raises(TypeError, lambda: (1 + p**4) - tf1)
+    raises(ValueError, lambda: tf1 - (s - 1))
+    raises(ValueError, lambda: tf1 - 8)
+    raises(ValueError, lambda: (s + 5) - tf2)
+    raises(ValueError, lambda: (1 + p**4) - tf1)
 
 
 def test_TransferFunction_multiplication_and_division():
@@ -313,24 +313,24 @@ def test_TransferFunction_multiplication_and_division():
     assert G1*G2*(G5 + G6) == Series(G1, G2, Parallel(G5, G6))
 
     c = symbols("c", commutative=False)
-    raises(TypeError, lambda: G3 * Matrix([1, 2, 3]))
-    raises(TypeError, lambda: G1 * c)
+    raises(ValueError, lambda: G3 * Matrix([1, 2, 3]))
+    raises(ValueError, lambda: G1 * c)
     raises(ValueError, lambda: G3 * G5)
-    raises(TypeError, lambda: G5 * (s - 1))
-    raises(TypeError, lambda: 9 * G5)
+    raises(ValueError, lambda: G5 * (s - 1))
+    raises(ValueError, lambda: 9 * G5)
 
-    raises(TypeError, lambda: G3 / Matrix([1, 2, 3]))
-    raises(TypeError, lambda: G6 / 0)
-    raises(TypeError, lambda: G3 / G5)
-    raises(TypeError, lambda: G5 / 2)
-    raises(TypeError, lambda: G5 / s**2)
-    raises(TypeError, lambda: (s - 4*s**2) / G2)
-    raises(TypeError, lambda: 0 / G4)
-    raises(TypeError, lambda: G5 / G6)
-    raises(TypeError, lambda: -G3 /G4)
-    raises(TypeError, lambda: G7 / (1 + G6))
-    raises(TypeError, lambda: G7 / (G5 * G6))
-    raises(TypeError, lambda: G7 / (G7 + (G5 + G6)))
+    raises(ValueError, lambda: G3 / Matrix([1, 2, 3]))
+    raises(ValueError, lambda: G6 / 0)
+    raises(ValueError, lambda: G3 / G5)
+    raises(ValueError, lambda: G5 / 2)
+    raises(ValueError, lambda: G5 / s**2)
+    raises(ValueError, lambda: (s - 4*s**2) / G2)
+    raises(ValueError, lambda: 0 / G4)
+    raises(ValueError, lambda: G5 / G6)
+    raises(ValueError, lambda: -G3 /G4)
+    raises(ValueError, lambda: G7 / (1 + G6))
+    raises(ValueError, lambda: G7 / (G5 * G6))
+    raises(ValueError, lambda: G7 / (G7 + (G5 + G6)))
 
 
 def test_TransferFunction_is_proper():
@@ -435,7 +435,7 @@ def test_Series_functions():
     assert -(tf1*tf2) == Series(TransferFunction(-1, 1, s), Series(tf1, tf2))
     raises(ValueError, lambda: tf1*tf2*tf4)
     raises(ValueError, lambda: tf1*(tf2 - tf4))
-    raises(TypeError, lambda: tf3*Matrix([1, 2, 3]))
+    raises(ValueError, lambda: tf3*Matrix([1, 2, 3]))
 
     # evaluate=True -> doit()
     assert Series(tf1, tf2, evaluate=True) == Series(tf1, tf2).doit() == \
@@ -545,7 +545,7 @@ def test_Parallel_functions():
     assert (tf1 + tf2 + tf5)*(tf3 + tf5) == Series(Parallel(tf1, tf2, tf5), Parallel(tf3, tf5))
     raises(ValueError, lambda: tf1 + tf2 + tf4)
     raises(ValueError, lambda: tf1 - tf2*tf4)
-    raises(TypeError, lambda: tf3 + Matrix([1, 2, 3]))
+    raises(ValueError, lambda: tf3 + Matrix([1, 2, 3]))
 
     # evaluate=True -> doit()
     assert Parallel(tf1, tf2, evaluate=True) == Parallel(tf1, tf2).doit() == \

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1,5 +1,5 @@
 from sympy import symbols, Matrix, factor, Function, simplify, exp, pi, oo, I, \
-    Rational, sqrt, CRootOf, sympify, Mul, Pow
+    Rational, sqrt, CRootOf, S, Mul, Pow
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
 from sympy.testing.pytest import raises
 
@@ -256,8 +256,8 @@ def test_TransferFunction_functions():
     tf11 = TransferFunction(1, 1, s)
     assert tf8._to_expr() == Mul((a0*s**5 + 5*s**2 + 3), Pow((s**6 - 3), -1, evaluate=False), evaluate=False)
     assert tf9._to_expr() == Mul((s + 5), Pow((s**2 + 11*s + 30), -1, evaluate=False), evaluate=False)
-    assert tf10._to_expr() == Mul(sympify(0), Pow(simplify(1), -1, evaluate=False), evaluate=False)
-    assert tf11._to_expr() == Mul(sympify(1), Pow(simplify(1), -1, evaluate=False), evaluate=False)
+    assert tf10._to_expr() == Mul(S(0), Pow(1, -1, evaluate=False), evaluate=False)
+    assert tf11._to_expr() == Mul(S(1), Pow(1, -1, evaluate=False), evaluate=False)
 
 def test_TransferFunction_addition_and_subtraction():
     tf1 = TransferFunction(s + 6, s - 5, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -28,8 +28,8 @@ def test_TransferFunction_construction():
 
     # no pole-zero cancellation on its own.
     tf4 = TransferFunction((s + 3)*(s - 1), (s - 1)*(s + 5), s)
-    assert tf4.den == s**2 + 4*s - 5
-    assert tf4.args == (s**2 + 2*s - 3, s**2 + 4*s - 5, s)
+    assert tf4.den == (s - 1)*(s + 5)
+    assert tf4.args == ((s + 3)*(s - 1), (s - 1)*(s + 5), s)
 
     tf4_ = TransferFunction(p + 2, p + 2, p)
     assert tf4_.args == (p + 2, p + 2, p)
@@ -114,8 +114,22 @@ def test_TransferFunction_functions():
     b = TransferFunction(p + 3, p + 5, p)
     assert tf1.simplify() == simplify(tf1) == b
 
+    # expand the numerator and the denominator.
     G1 = TransferFunction((1 - s)**2, (s**2 + 1)**2, s)
     G2 = TransferFunction(1, -3, p)
+    c = (a2*s**p + a1*s**s + a0*p**p)*(p**s + s**p)
+    d = (b0*s**s + b1*p**s)*(b2*s*p + p**p)
+    e = a0*p**p*p**s + a0*p**p*s**p + a1*p**s*s**s + a1*s**p*s**s + a2*p**s*s**p + a2*s**(2*p)
+    f = b0*b2*p*s*s**s + b0*p**p*s**s + b1*b2*p*p**s*s + b1*p**p*p**s
+    g = a1*a2*s*s**p + a1*p*s + a2*b1*p*s*s**p + b1*p**2*s
+    G3 = TransferFunction(c, d, s)
+    G4 = TransferFunction(a0*s**s - b0*p**p, (a1*s + b1*s*p)*(a2*s**p + p), p)
+
+    assert G1.expand() == TransferFunction(s**2 - 2*s + 1, s**4 + 2*s**2 + 1, s)
+    assert tf1.expand() == TransferFunction(p**2 + 2*p - 3, p**2 + 4*p - 5, p)
+    assert G2.expand() == G2
+    assert G3.expand() == TransferFunction(e, f, s)
+    assert G4.expand() == TransferFunction(a0*s**s - b0*p**p, g, p)
 
     # purely symbolic polynomials.
     p1 = a1*s + a0
@@ -255,7 +269,7 @@ def test_TransferFunction_functions():
     tf10 = TransferFunction(0, 1, s)
     tf11 = TransferFunction(1, 1, s)
     assert tf8._to_expr() == Mul((a0*s**5 + 5*s**2 + 3), Pow((s**6 - 3), -1, evaluate=False), evaluate=False)
-    assert tf9._to_expr() == Mul((s + 5), Pow((s**2 + 11*s + 30), -1, evaluate=False), evaluate=False)
+    assert tf9._to_expr() == Mul((s + 5), Pow((5 + s)*(6 + s), -1, evaluate=False), evaluate=False)
     assert tf10._to_expr() == Mul(S(0), Pow(1, -1, evaluate=False), evaluate=False)
     assert tf11._to_expr() == Mul(S(1), Pow(1, -1, evaluate=False), evaluate=False)
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1,4 +1,4 @@
-from sympy import symbols, Matrix, factor, Function, simplify, exp, pi, oo, I, \
+from sympy import symbols, Matrix, factor, Function, simplify, exp, oo, I, \
     Rational, sqrt, CRootOf, S, Mul, Pow, Add
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
 from sympy.testing.pytest import raises


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Updated the documentation of `TransferFunction`. Made it more beginner-friendly.
* Added a method `to_expr()` for conversion from `TransferFunction` type to `Expr` along with unit tests.
* Added a classmethod for instantiating `TransferFunction` objects from rational expressions (`from_rational_expression`).
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * `to_expr` method added in `TransferFunction` for converting `TransferFunction` to sympy expr.
  * `from_rational_expression` classmethod added for creating `TransferFunction` objects directly from rational expressions.
<!-- END RELEASE NOTES -->
