### PR TITLE
feat(matrices): add DomainMatrix.extract method

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -105,6 +105,13 @@ class DDM(list):
         cols = len(ddm[0]) if ddm else len(range(self.shape[1])[slice2])
         return DDM(ddm, (rows, cols), self.domain)
 
+    def extract(self, rows, cols):
+        ddm = []
+        for i in rows:
+            rowi = self[i]
+            ddm.append([rowi[j] for j in cols])
+        return DDM(ddm, (len(rows), len(cols)), self.domain)
+
     def to_list(self):
         return list(self)
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -141,6 +141,9 @@ class DomainMatrix:
 
         return self.from_rep(self.rep.extract_slice(i, j))
 
+    def extract(self, rowslist, colslist):
+        return self.from_rep(self.rep.extract(rowslist, colslist))
+
     def __setitem__(self, key, value):
         i, j = key
         if not self.domain.of_type(value):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -122,6 +122,9 @@ class SDM(dict):
         return self.new(sdm, (len(ri), len(ci)), self.domain)
 
     def extract(self, rows, cols):
+        if not (self and rows and cols):
+            return self.zeros((len(rows), len(cols)), self.domain)
+
         m, n = self.shape
         if not (-m <= min(rows) <= max(rows) < m):
             raise IndexError('Row index out of range')

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -121,6 +121,41 @@ class SDM(dict):
 
         return self.new(sdm, (len(ri), len(ci)), self.domain)
 
+    def extract(self, rows, cols):
+        m, n = self.shape
+        if not (-m <= min(rows) <= max(rows) < m):
+            raise IndexError('Row index out of range')
+        if not (-n <= min(cols) <= max(cols) < n):
+            raise IndexError('Column index out of range')
+
+        # rows and cols can contain duplicates e.g. M[[1, 2, 2], [0, 1]]
+        # Build a map from row/col in self to list of rows/cols in output
+        rowmap = defaultdict(list)
+        colmap = defaultdict(list)
+        for i2, i1 in enumerate(rows):
+            rowmap[i1 % m].append(i2)
+        for j2, j1 in enumerate(cols):
+            colmap[j1 % n].append(j2)
+
+        # Used to efficiently skip zero rows/cols
+        rowset = set(rowmap)
+        colset = set(colmap)
+
+        sdm1 = self
+        sdm2 = {}
+        for i1 in rowset & set(sdm1):
+            row1 = sdm1[i1]
+            row2 = {}
+            for j1 in colset & set(row1):
+                row1_j1 = row1[j1]
+                for j2 in colmap[j1]:
+                    row2[j2] = row1_j1
+            if row2:
+                for i2 in rowmap[i1]:
+                    sdm2[i2] = row2.copy()
+
+        return self.new(sdm2, (len(rows), len(cols)), self.domain)
+
     def __str__(self):
         rowsstr = []
         for i, row in self.items():

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -446,6 +446,10 @@ def test_DDM_extract():
     assert dm1.extract([1, 0], [2, 0]) == dm2
     assert dm1.extract([-2, 0], [-1, 0]) == dm2
 
+    assert dm1.extract([], []) == DDM.zeros((0, 0), ZZ)
+    assert dm1.extract([1], []) == DDM.zeros((1, 0), ZZ)
+    assert dm1.extract([], [1]) == DDM.zeros((0, 1), ZZ)
+
     raises(IndexError, lambda: dm2.extract([2], [0]))
     raises(IndexError, lambda: dm2.extract([0], [2]))
     raises(IndexError, lambda: dm2.extract([-3], [0]))

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -433,3 +433,20 @@ def test_DDM_extract_slice():
     assert dm.extract_slice(slice(2), slice(3, 4)) == DDM([[], []], (2, 0), ZZ)
     assert dm.extract_slice(slice(3, 4), slice(2)) == DDM([], (0, 2), ZZ)
     assert dm.extract_slice(slice(3, 4), slice(3, 4)) == DDM([], (0, 0), ZZ)
+
+
+def test_DDM_extract():
+    dm1 = DDM([
+        [ZZ(1), ZZ(2), ZZ(3)],
+        [ZZ(4), ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)
+    dm2 = DDM([
+        [ZZ(6), ZZ(4)],
+        [ZZ(3), ZZ(1)]], (2, 2), ZZ)
+    assert dm1.extract([1, 0], [2, 0]) == dm2
+    assert dm1.extract([-2, 0], [-1, 0]) == dm2
+
+    raises(IndexError, lambda: dm2.extract([2], [0]))
+    raises(IndexError, lambda: dm2.extract([0], [2]))
+    raises(IndexError, lambda: dm2.extract([-3], [0]))
+    raises(IndexError, lambda: dm2.extract([0], [-3]))

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -695,6 +695,33 @@ def test_DomainMatrix_getitem():
     assert dM[2:, 6:] == DomainMatrix({}, (3, 0), ZZ)
 
 
+def test_DomainMatrix_extract():
+    dM1 = DomainMatrix([
+        [ZZ(1), ZZ(2), ZZ(3)],
+        [ZZ(4), ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8), ZZ(9)]], (3, 3), ZZ)
+    dM2 = DomainMatrix([
+        [ZZ(1), ZZ(3)],
+        [ZZ(7), ZZ(9)]], (2, 2), ZZ)
+    assert dM1.extract([0, 2], [0, 2]) == dM2
+    assert dM1.to_sparse().extract([0, 2], [0, 2]) == dM2.to_sparse()
+    assert dM1.extract([0, -1], [0, -1]) == dM2
+    assert dM1.to_sparse().extract([0, -1], [0, -1]) == dM2.to_sparse()
+
+    dM3 = DomainMatrix([
+        [ZZ(1), ZZ(2), ZZ(2)],
+        [ZZ(4), ZZ(5), ZZ(5)],
+        [ZZ(4), ZZ(5), ZZ(5)]], (3, 3), ZZ)
+    assert dM1.extract([0, 1, 1], [0, 1, 1]) == dM3
+    assert dM1.to_sparse().extract([0, 1, 1], [0, 1, 1]) == dM3.to_sparse()
+
+    dM = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    bad_indices = [([2], [0]), ([0], [2]), ([-3], [0]), ([0], [-3])]
+    for rows, cols in bad_indices:
+        raises(IndexError, lambda: dM.extract(rows, cols))
+        raises(IndexError, lambda: dM.to_sparse().extract(rows, cols))
+
+
 def test_DomainMatrix_setitem():
     dM = DomainMatrix({2: {2: ZZ(1)}, 4: {4: ZZ(1)}}, (5, 5), ZZ)
     dM[2, 2] = ZZ(2)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -715,6 +715,15 @@ def test_DomainMatrix_extract():
     assert dM1.extract([0, 1, 1], [0, 1, 1]) == dM3
     assert dM1.to_sparse().extract([0, 1, 1], [0, 1, 1]) == dM3.to_sparse()
 
+    empty = [
+        ([], [], (0, 0)),
+        ([1], [], (1, 0)),
+        ([], [1], (0, 1)),
+    ]
+    for rows, cols, size in empty:
+        assert dM1.extract(rows, cols) == DomainMatrix.zeros(size, ZZ).to_dense()
+        assert dM1.to_sparse().extract(rows, cols) == DomainMatrix.zeros(size, ZZ)
+
     dM = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     bad_indices = [([2], [0]), ([0], [2]), ([-3], [0]), ([0], [-3])]
     for rows, cols in bad_indices:

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -121,6 +121,27 @@ def test_SDM_extract_slice():
     assert B == SDM({0:{0:ZZ(4)}}, (1, 1), ZZ)
 
 
+def test_SDM_extract():
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    B = A.extract([1], [1])
+    assert B == SDM({0:{0:ZZ(4)}}, (1, 1), ZZ)
+    B = A.extract([1, 0], [1, 0])
+    assert B == SDM({0:{0:ZZ(4), 1:ZZ(3)}, 1:{0:ZZ(2), 1:ZZ(1)}}, (2, 2), ZZ)
+    B = A.extract([1, 1], [1, 1])
+    assert B == SDM({0:{0:ZZ(4), 1:ZZ(4)}, 1:{0:ZZ(4), 1:ZZ(4)}}, (2, 2), ZZ)
+    B = A.extract([-1], [-1])
+    assert B == SDM({0:{0:ZZ(4)}}, (1, 1), ZZ)
+
+    A = SDM({}, (2, 2), ZZ)
+    B = A.extract([0, 1, 0], [0, 0])
+    assert B == SDM({}, (3, 2), ZZ)
+
+    raises(IndexError, lambda: A.extract([2], [0]))
+    raises(IndexError, lambda: A.extract([0], [2]))
+    raises(IndexError, lambda: A.extract([-3], [0]))
+    raises(IndexError, lambda: A.extract([0], [-3]))
+
+
 def test_SDM_zeros():
     A = SDM.zeros((2, 2), ZZ)
     assert A.domain == ZZ

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -136,6 +136,11 @@ def test_SDM_extract():
     B = A.extract([0, 1, 0], [0, 0])
     assert B == SDM({}, (3, 2), ZZ)
 
+    A = SDM({0:{0:ZZ(1), 1:ZZ(2)}, 1:{0:ZZ(3), 1:ZZ(4)}}, (2, 2), ZZ)
+    assert A.extract([], []) == SDM.zeros((0, 0), ZZ)
+    assert A.extract([1], []) == SDM.zeros((1, 0), ZZ)
+    assert A.extract([], [1]) == SDM.zeros((0, 1), ZZ)
+
     raises(IndexError, lambda: A.extract([2], [0]))
     raises(IndexError, lambda: A.extract([0], [2]))
     raises(IndexError, lambda: A.extract([-3], [0]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is a spin out from #21626

#### Brief description of what is fixed or changed

Add `DomainMatrix.extract` method analogous to `Matrix.extract`. This is needed because otherwise changing `Matrix.extract` to use `._flat` instead of `._mat` leads to slowdowns as seen in the `sympy/matrices/tests/test_eigen.py::test_issue_8240` test which uses `extract` many times to select small 1x1 submatrices from a large matrix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
