### PR TITLE
Docs: remove spurious comma

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -40,7 +40,7 @@ Here follows a list of possible assumption names:
     imaginary
         object value is a number that can be written as a real
         number multiplied by the imaginary unit ``I``.  See
-        [3]_.  Please note, that ``0`` is not considered to be an
+        [3]_.  Please note that ``0`` is not considered to be an
         imaginary number, see
         `issue #7649 <https://github.com/sympy/sympy/issues/7649>`_.
 


### PR DESCRIPTION
A grammatically wrong comma before "that" is removed.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->