### PR TITLE
Fix MultivariateNormal density calculation when symbolic parameters are used

### DIFF
--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -204,7 +204,7 @@ def MultivariateNormal(name, mu, sigma):
     >>> marginal_distribution(X, X[0])(y)
     exp(-(y - 3)**2/4)/(2*sqrt(pi))
 
-    The example below shows it is also possible to use
+    The example below shows that it is also possible to use
     symbolic parameters to define the MultivariateNormal class.
 
     >>> n = symbols('n', natural=True)
@@ -213,7 +213,7 @@ def MultivariateNormal(name, mu, sigma):
     >>> obs = MatrixSymbol('obs', n, 1)
     >>> X = MultivariateNormal('X', mu, Sg)
 
-    The density of a multivariate normal can also be
+    The density of a multivariate normal can be
     calculated using a matrix argument, as shown below.
 
     >>> density(X)(obs)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -203,12 +203,19 @@ def MultivariateNormal(name, mu, sigma):
     exp(-(y - 4)**2/4)/(2*sqrt(pi))
     >>> marginal_distribution(X, X[0])(y)
     exp(-(y - 3)**2/4)/(2*sqrt(pi))
-    >>> # symbolic parameters
+
+    The example below shows it is also possible to use
+    symbolic parameters to define the MultivariateNormal class.
+
     >>> n = symbols('n', natural=True)
     >>> Sg = MatrixSymbol('Sg', n, n)
     >>> mu = MatrixSymbol('mu', n, 1)
     >>> obs = MatrixSymbol('obs', n, 1)
     >>> X = MultivariateNormal('X', mu, Sg)
+
+    The density of a multivariate normal can also be
+    calculated using a matrix argument, as shown below.
+
     >>> density(X)(obs)
     (exp(((1/2)*mu.T - (1/2)*obs.T)*Sg**(-1)*(-mu + obs))/sqrt((2*pi)**n*Determinant(Sg)))[0, 0]
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -192,7 +192,7 @@ def MultivariateNormal(name, mu, sigma):
     ========
 
     >>> from sympy.stats import MultivariateNormal, density, marginal_distribution
-    >>> from sympy import symbols
+    >>> from sympy import symbols, MatrixSymbol
     >>> X = MultivariateNormal('X', [3, 4], [[2, 1], [1, 2]])
     >>> y, z = symbols('y z')
     >>> density(X)(y, z)
@@ -203,6 +203,14 @@ def MultivariateNormal(name, mu, sigma):
     exp(-(y - 4)**2/4)/(2*sqrt(pi))
     >>> marginal_distribution(X, X[0])(y)
     exp(-(y - 3)**2/4)/(2*sqrt(pi))
+    >>> # symbolic parameters
+    >>> n = symbols('n', natural=True)
+    >>> Sg = MatrixSymbol('Sg', n, n)
+    >>> mu = MatrixSymbol('mu', n, 1)
+    >>> obs = MatrixSymbol('obs', n, 1)
+    >>> X = MultivariateNormal('X', mu, Sg)
+    >>> density(X)(obs)
+    (exp(((1/2)*mu.T - (1/2)*obs.T)*Sg**(-1)*(-mu + obs))/sqrt((2*pi)**n*Determinant(Sg)))[0, 0]
 
     References
     ==========

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -4,6 +4,7 @@ from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, besselk, gamma, I
                    Intersection, Matrix, symbols, Product, IndexedBase)
 from sympy.matrices import ImmutableMatrix, MatrixSymbol
 from sympy.matrices.expressions.determinant import det
+from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.stats.joint_rv import JointDistribution, JointPSpace, MarginalDistribution
 from sympy.stats.rv import _value_check, random_symbols
 
@@ -146,11 +147,14 @@ class MultivariateNormalDistribution(JointDistribution):
     def pdf(self, *args):
         mu, sigma = self.mu, self.sigma
         k = mu.shape[0]
-        args = ImmutableMatrix(args)
+        if len(args) == 1 and args[0].is_Matrix:
+            args = args[0]
+        else:
+            args = ImmutableMatrix(args)
         x = args - mu
-        return  S.One/sqrt((2*pi)**(k)*det(sigma))*exp(
-            Rational(-1, 2)*x.transpose()*(sigma.inv()*\
-                x))[0]
+        density = S.One/sqrt((2*pi)**(k)*det(sigma))*exp(
+            Rational(-1, 2)*x.transpose()*(sigma.inv()*x))
+        return MatrixElement(density, 0, 0)
 
     def _marginal_distribution(self, indices, sym):
         sym = ImmutableMatrix([Indexed(sym, i) for i in indices])

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -75,8 +75,8 @@ def test_Normal():
     density_X_at_obs = density(X)(obs)
 
     expected_density = MatrixElement(
-        (exp(((S(1)/2)*mu.T - (S(1)/2)*obs.T)*Sg**(-1)*(-mu + obs)) / \
-         sqrt((2*pi)**n*Determinant(Sg))), 0, 0)
+        exp((S(1)/2) * (mu.T - obs.T) * Sg**(-1) * (-mu + obs)) / \
+        sqrt((2*pi)**n * Determinant(Sg)), 0, 0)
 
     assert density_X_at_obs == expected_density
 

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, Sum, simplify,
                    Rational, factorial, gamma, Piecewise, Eq, Product, Interval,
-                   IndexedBase, RisingFactorial, polar_lift, ProductSet, Range)
+                   IndexedBase, RisingFactorial, polar_lift, ProductSet, Range, eye)
 from sympy.core.numbers import comp
 from sympy.integrals.integrals import integrate
 from sympy.matrices import Matrix, MatrixSymbol
@@ -45,6 +45,31 @@ def test_Normal():
     # Below tests should work after issue #17267 is resolved
     # assert E(X) == mu
     # assert variance(X) == sigma
+
+    # test symbolic multivariate normal densities
+    n = 3
+
+    Sg = MatrixSymbol('Sg', n, n)
+    mu = MatrixSymbol('mu', n, 1)
+    obs = MatrixSymbol('obs', n, 1)
+
+    X = MultivariateNormal('X', mu, Sg)
+    density_X = density(X)
+
+    eval_a = density_X(obs)
+    eval_b = density_X(0, 0, 0).subs({Sg: eye(3), mu: Matrix([0, 0, 0])}).doit()
+
+    assert eval_b == sqrt(2)/(4*pi**Rational(3/2))
+
+    n = symbols('n', natural=True)
+
+    Sg = MatrixSymbol('Sg', n, n)
+    mu = MatrixSymbol('mu', n, 1)
+    obs = MatrixSymbol('obs', n, 1)
+
+    X = MultivariateNormal('X', mu, Sg)
+    density_X_at_obs = density(X)(obs)
+
 
 def test_MultivariateTDist():
     t1 = MultivariateT('T', [0, 0], [[1, 0], [0, 1]], 2)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #21635

#### Brief description of what is fixed or changed
The `pdf` method for the `MultivariateNormalDistribution` has been updated:
 * to use `MatrixElement` to return the `[0, 0]` value of the density calculation, that returns a `[1, 1]` matrix. This has been changed from accessing the element directly using `[0]`, as this throws an error when certain arguments are symbolic.
 * to check if the input is a single matrix, if not, _*then*_ coerce the inputs to an `ImmutableMatrix`. I've added this because passing a matrix with a symbolic number of elements causes the argument to be coerced to a `1x1` matrix, with the original matrix at the `[0, 0]` index.

#### Other comments

While running tests, I noticed that the `test_sample_pymc3` test breaks (I have pymc3 installed). This is also true for the code on master and is unrelated to this PR.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
  * Fixed a bug regarding symbolic arguments to the multivariate normal distribution.
<!-- END RELEASE NOTES -->
