### PR TITLE
Check order of arguments in `orient_axis()`

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -647,8 +647,7 @@ class ReferenceFrame:
         _check_frame(parent)
 
         if not isinstance(axis, Vector) and isinstance(angle, Vector):
-            raise TypeError('The order of arguments is incorrect.' +\
-                ' The arguments are orient_axis(frame, axis, angle)')
+            axis, angle = angle, axis
 
         axis = _check_vector(axis)
         amount = sympify(angle)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -646,9 +646,9 @@ class ReferenceFrame:
         from sympy.physics.vector.functions import dynamicsymbols
         _check_frame(parent)
 
+        axis = _check_vector(axis)
         amount = sympify(angle)
         theta = amount
-        axis = _check_vector(axis)
         parent_orient_axis = []
 
         if not axis.dt(parent) == 0:

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -646,6 +646,10 @@ class ReferenceFrame:
         from sympy.physics.vector.functions import dynamicsymbols
         _check_frame(parent)
 
+        if not isinstance(axis, Vector) and isinstance(angle, Vector):
+            raise TypeError('The order of arguments is incorrect.' +\
+                ' The arguments are orient_axis(frame, axis, angle)')
+
         axis = _check_vector(axis)
         amount = sympify(angle)
         theta = amount

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -453,8 +453,14 @@ def test_orient_explicit():
 def test_orient_axis():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, B.x, -1)
-    assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, 1, -B.x)
+    A.orient_axis(B,-B.x, 1)
+    A1 = A.dcm(B)
+    A.orient_axis(B, B.x, -1)
+    A2 = A.dcm(B)
+    A.orient_axis(B, 1, -B.x)
+    A3 = A.dcm(B)
+    assert A1 == A2
+    assert A2 == A3
     raises(TypeError, lambda: A.orient_axis(B, 1, 1))
 
 def test_orient_body():

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -454,6 +454,8 @@ def test_orient_axis():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
     assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, B.x, -1)
+    raises(TypeError, lambda: A.orient_axis(B, 1, -B.x))
+    raises(TypeError, lambda: A.orient_axis(B, 1, 1))
 
 def test_orient_body():
     A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -454,7 +454,7 @@ def test_orient_axis():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
     assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, B.x, -1)
-    raises(TypeError, lambda: A.orient_axis(B, 1, -B.x))
+    assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, 1, -B.x)
     raises(TypeError, lambda: A.orient_axis(B, 1, 1))
 
 def test_orient_body():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21659

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * The `orient_axis()` works if the order of axis and angle is swapped.
<!-- END RELEASE NOTES -->
