### PR TITLE
feat(matrices): add EXRAW multiplication routine for DomainMatrix

### DIFF
--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -602,6 +602,9 @@ class Domain:
         """
         raise NotImplementedError
 
+    def sum(self, args):
+        return sum(args)
+
     def from_FF(K1, a, K0):
         """Convert ``ModularInteger(int)`` to ``dtype``. """
         return None

--- a/sympy/polys/domains/expressionrawdomain.py
+++ b/sympy/polys/domains/expressionrawdomain.py
@@ -1,7 +1,7 @@
 """Implementation of :class:`ExpressionRawDomain` class. """
 
 
-from sympy.core import Expr, S, sympify
+from sympy.core import Expr, S, sympify, Add
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -49,6 +49,9 @@ class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain):
     def get_field(self):
         """Returns a field associated with ``self``. """
         return self
+
+    def sum(self, items):
+        return Add(*items)
 
 
 EXRAW = ExpressionRawDomain()

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -7,8 +7,7 @@ from sympy.functions import sqrt
 from sympy.matrices.common import (NonInvertibleMatrixError,
     NonSquareMatrixError, ShapeError)
 from sympy.matrices.dense import Matrix
-from sympy.polys import ZZ, QQ
-
+from sympy.polys.domains import ZZ, QQ, EXRAW
 
 from sympy.polys.matrices.domainmatrix import DomainMatrix, DomainScalar
 from sympy.polys.matrices.exceptions import (DDMBadInputError, DDMDomainError,
@@ -162,6 +161,11 @@ def test_DomainMatrix_convert_to():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     Aq = A.convert_to(QQ)
     assert Aq == DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
+
+
+def test_DomainMatrix_to_sympy():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    assert A.to_sympy() == A.convert_to(EXRAW)
 
 
 def test_DomainMatrix_to_field():

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -2,10 +2,13 @@
 Tests for the basic functionality of the SDM class.
 """
 
+from itertools import product
+
+from sympy.core.numbers import oo
 from sympy.core.compatibility import HAS_GMPY
 from sympy.testing.pytest import raises
 
-from sympy import QQ, ZZ
+from sympy.polys.domains import QQ, ZZ, EXRAW
 from sympy.polys.matrices.sdm import SDM
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.exceptions import (DDMBadInputError, DDMDomainError,
@@ -247,6 +250,23 @@ def test_SDM_matmul():
     A = SDM({0: {0: ZZ(-1), 1: ZZ(1)}}, (1, 2), ZZ)
     B = SDM({0: {0: ZZ(-1)}, 1: {0: ZZ(-1)}}, (2, 1), ZZ)
     assert A.matmul(B) == A*B == SDM({}, (1, 1), ZZ)
+
+
+def test_matmul_exraw():
+
+    def dm(d):
+        result = {}
+        for i, row in d.items():
+            row = {j:val for j, val in row.items() if val}
+            if row:
+                result[i] = row
+        return SDM(result, (2, 2), EXRAW)
+
+    values = [-oo, -1, 0, 1, oo]
+    for a, b, c, d in product(*[values]*4):
+        Ad = dm({0: {0:a, 1:b}, 1: {0:c, 1:d}})
+        Ad2 = dm({0: {0:a*a + b*c, 1:a*b + b*d}, 1:{0:c*a + d*c, 1: c*b + d*d}})
+        assert Ad * Ad == Ad2
 
 
 def test_SDM_add():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

These changes are split out from #21626

#### Brief description of what is fixed or changed

Adds a sparse matrix multiplication routine for DomainMatrix and the internal SDM class to be used specifically with the EXRAW domain. Unlike the other sparse multiplication routine this one can handle cases like `0*oo=nan` because it does not skip multiplication by zero (unless both elements are zero). This also uses `Add(*args)` rather than `sum` so that it has linear rather than quadratic complexity in the summations.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
