### PR TITLE
Fix the docs build when gmpy2 is installed

### DIFF
--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -131,6 +131,7 @@ when available.
 .. autoclass:: PythonIntegerRing
 .. autoclass:: GMPYIntegerRing
    :members:
+   :exclude-members: dtype, tp
 
 .. _QQ:
 
@@ -186,6 +187,7 @@ preferred because it is significantly faster.
 .. autoclass:: PythonRationalField
 .. autoclass:: GMPYRationalField
    :members:
+   :exclude-members: dtype, tp
 
 .. autoclass:: sympy.external.pythonmpq.PythonMPQ
 


### PR DESCRIPTION
Previously the Sphinx would try to automatically generate a cross-reference to
gmpy2.mpz and gmpy2.mpq because of the dtype and tp attributes of the
GMPYIntegerRing and GMPYRationalField classes, which fails because we don't
have references to those classes in our docs. We don't really need to document
these, so we exclude them.

Ideally, we would be installing gmpy2 on CI when building the docs, which
would have caught this issue sooner, but this does not address that.

Fixes #21697.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
