### PR TITLE
Implement `MIMOSeries` and `MIMOParallel`.

### DIFF
--- a/doc/src/modules/physics/control/control.rst
+++ b/doc/src/modules/physics/control/control.rst
@@ -9,7 +9,9 @@ functions are input to output representations of dynamic systems. The additive
 property is used for transfer functions in the ``Parallel`` class, and the
 multiplicative property is used for transfer functions in the ``Series`` class.
 Also, there is a ``Feedback`` class which is used to represent negative feedback
-interconnection between two input/output systems.
+interconnection between two input/output systems. MIMO systems are also supported
+with ``TransferFunctionMatrix`` as the base class for representing one. ``MIMOSeries``
+and ``MIMOParallel`` are MIMO equivalent of ``Series`` and ``Parallel`` classes.
 
 The advantage of this symbolic Control system package is that the solutions obtained
 from it are highly accurate and do not rely on numerical methods to approximate the

--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -13,7 +13,13 @@ lti
 .. autoclass:: Series
    :members:
 
+.. autoclass:: MIMOSeries
+   :members:
+
 .. autoclass:: Parallel
+   :members:
+
+.. autoclass:: MIMOParallel
    :members:
 
 .. autoclass:: Feedback

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4128,6 +4128,16 @@ def test_sympy__physics__control__lti__LinearTimeInvariant():
     pass
 
 
+def test_sympy__physics__control__lti__SISOLinearTimeInvariant():
+    # Direct instances of SISOLinearTimeInvariant class are not allowed.
+    pass
+
+
+def test_sympy__physics__control__lti__MIMOLinearTimeInvariant():
+    # Direct instances of MIMOLinearTimeInvariant class are not allowed.
+    pass
+
+
 def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4140,11 +4140,30 @@ def test_sympy__physics__control__lti__Series():
     assert _test_args(Series(tf1, tf2))
 
 
+def test_sympy__physics__control__lti__MIMOSeries():
+    from sympy.physics.control import MIMOSeries, TransferFunction, TransferFunctionMatrix
+    tf1 = TransferFunction(x**2 - y**3, y - z, x)
+    tf2 = TransferFunction(y - x, z + y, x)
+    tfm_1 = TransferFunctionMatrix([[tf2, tf1]])
+    tfm_2 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
+    tfm_3 = TransferFunctionMatrix([[tf1], [tf2]])
+    assert _test_args(MIMOSeries(tfm_3, tfm_2, tfm_1))
+
+
 def test_sympy__physics__control__lti__Parallel():
     from sympy.physics.control import Parallel, TransferFunction
     tf1 = TransferFunction(x**2 - y**3, y - z, x)
     tf2 = TransferFunction(y - x, z + y, x)
     assert _test_args(Parallel(tf1, tf2))
+
+
+def test_sympy__physics__control__lti__MIMOParallel():
+    from sympy.physics.control import MIMOParallel, TransferFunction, TransferFunctionMatrix
+    tf1 = TransferFunction(x**2 - y**3, y - z, x)
+    tf2 = TransferFunction(y - x, z + y, x)
+    tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
+    tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
+    assert _test_args(MIMOParallel(tfm_1, tfm_2))
 
 
 def test_sympy__physics__control__lti__Feedback():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4121,6 +4121,13 @@ def test_sympy__physics__secondquant__TensorSymbol():
     assert _test_args(TensorSymbol(x))
 
 
+def test_sympy__physics__control__lti__LinearTimeInvariant():
+    # Direct instances of LinearTimeInvariant class are not allowed.
+    # func(*args) tests for its derived classes (TransferFunction,
+    # Series, Parallel and TransferFunctionMatrix) should pass.
+    pass
+
+
 def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,3 +1,3 @@
-from .lti import TransferFunction, Series, Parallel, Feedback, TransferFunctionMatrix
+from .lti import TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel, Feedback, TransferFunctionMatrix
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel', 'Feedback', 'TransferFunctionMatrix']

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,3 +1,3 @@
 from .lti import TransferFunction, Series, Parallel, Feedback, TransferFunctionMatrix
 
-__all__ = ['TransferFunction', 'Series', 'Parallel', 'Feedback', 'TransferFunctionMatrix']
+__all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel', 'Feedback', 'TransferFunctionMatrix']

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -795,7 +795,7 @@ class Series(Basic):
     [ 1 ]{t}*[   6*s ]{t}*[s  1]{t}
     >>> Series(tfm_c, tfm_b, tfm_a).doit()
     TransferFunctionMatrix(((TransferFunction(25*(6*s**3 + 1), 6*s**2, s), TransferFunction(5*(30*s**3 + 1), 6*s, s)), (TransferFunction(25*(6*s**3 + 1), 6*s**3, s), TransferFunction(5*(30*s**3 + 1), 6*s**2, s))))
-    >>> pprint(_, use_unicode=False)  # (2 Inputs -A-> 2 Outputs) -> (2 Inputs -B-> 1 Output) -> (1 Input -C-> 2 Outputs) is equivalent to (2 Inputs -Series Equivalent-> 2 Outputs). 
+    >>> pprint(_, use_unicode=False)  # (2 Inputs -A-> 2 Outputs) -> (2 Inputs -B-> 1 Output) -> (1 Input -C-> 2 Outputs) is equivalent to (2 Inputs -Series Equivalent-> 2 Outputs).
     [   /   3    \    /    3    \]
     [25*\6*s  + 1/  5*\30*s  + 1/]
     [-------------  -------------]
@@ -1346,7 +1346,7 @@ class Parallel(Basic):
 
         self_arg_list = list(self.args)
         return Parallel(*self_arg_list, other)
-    
+
     __radd__ = __add__
 
     def __sub__(self, other):
@@ -1921,11 +1921,14 @@ class TransferFunctionMatrix(Basic):
 
     Addition, subtraction, and multiplication of transfer function matrices can form
     unevaluated ``Series`` or ``Parallel`` objects.
-    For addition and subtraction:
-        All the transfer function matrices must have the same shape.
-    For multiplication (C = A * B):
-        The number of inputs of the first transfer function matrix (A) must be equal to the
-        number of outputs of the second transfer function matrix (B).
+
+    - For addition and subtraction:
+      All the transfer function matrices must have the same shape.
+
+    - For multiplication (C = A * B):
+      The number of inputs of the first transfer function matrix (A) must be equal to the
+      number of outputs of the second transfer function matrix (B).
+
     Also, use pretty-printing (``pprint``) to analyse better.
 
     >>> tfm_8 = TransferFunctionMatrix([[tf_3], [tf_2], [-tf_1]])

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1296,8 +1296,8 @@ class Parallel(LinearTimeInvariant):
 
         def _SISO_doit():
             _arg = (arg.doit().to_expr() for arg in self.args)
-            res = Add(*_arg, evaluate=True)
-            return TransferFunction.from_rational_expression(res, self.var)
+            res = Add(*_arg).as_numer_denom()
+            return TransferFunction(*res, self.var)
 
         def _MIMO_doit():
             _arg = (arg.doit()._expr_mat for arg in self.args)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -716,7 +716,7 @@ class TransferFunction(LinearTimeInvariant):
 
 class Series(LinearTimeInvariant):
     r"""
-    A class for representing series configuration of SISO system.
+    A class for representing series configuration of SISO systems.
 
     Parameters
     ==========
@@ -783,7 +783,7 @@ class Series(LinearTimeInvariant):
     See Also
     ========
 
-    Parallel, TransferFunction, Feedback
+    MIMOSeries, Parallel, TransferFunction, Feedback
 
     """
     def __new__(cls, *args, evaluate=False):
@@ -840,17 +840,13 @@ class Series(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Series, TransferFunctionMatrix
+        >>> from sympy.physics.control.lti import TransferFunction, Series
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Series(tf2, tf1).doit()
         TransferFunction((s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Series(-tf1, -tf2).doit()
         TransferFunction((2 - s**3)*(-a*p**2 - b*s), (-p + s)*(s**4 + 5*s + 6), s)
-        >>> tfm1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf2]])
-        >>> tfm2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf1]])
-        >>> Series(tfm2, tfm1).doit()  # MIMO System
-        TransferFunctionMatrix(((TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)**2*(s**3 - 2)*(a*p**2 + b*s) + (-p + s)*(a*p**2 + b*s)**2*(s**4 + 5*s + 6), (-p + s)**3*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2)**2*(s**4 + 5*s + 6) + (s**3 - 2)*(a*p**2 + b*s)*(s**4 + 5*s + 6)**2, (-p + s)*(s**4 + 5*s + 6)**3, s), TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
 
@@ -1168,16 +1164,12 @@ class MIMOSeries(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Series, TransferFunctionMatrix
+        >>> from sympy.physics.control.lti import TransferFunction, MIMOSeries, TransferFunctionMatrix
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
-        >>> Series(tf2, tf1).doit()
-        TransferFunction((s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s)
-        >>> Series(-tf1, -tf2).doit()
-        TransferFunction((2 - s**3)*(-a*p**2 - b*s), (-p + s)*(s**4 + 5*s + 6), s)
         >>> tfm1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf2]])
         >>> tfm2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf1]])
-        >>> Series(tfm2, tfm1).doit()  # MIMO System
+        >>> MIMOSeries(tfm2, tfm1).doit()
         TransferFunctionMatrix(((TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)**2*(s**3 - 2)*(a*p**2 + b*s) + (-p + s)*(a*p**2 + b*s)**2*(s**4 + 5*s + 6), (-p + s)**3*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2)**2*(s**4 + 5*s + 6) + (s**3 - 2)*(a*p**2 + b*s)*(s**4 + 5*s + 6)**2, (-p + s)*(s**4 + 5*s + 6)**3, s), TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
@@ -1354,17 +1346,13 @@ class Parallel(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Parallel, TransferFunctionMatrix
+        >>> from sympy.physics.control.lti import TransferFunction, Parallel
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Parallel(tf2, tf1).doit()
         TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Parallel(-tf1, -tf2).doit()
         TransferFunction((2 - s**3)*(-p + s) + (-a*p**2 - b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
-        >>> tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
-        >>> tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
-        >>> Parallel(tfm_1, tfm_2).doit()  # MIMO System
-        TransferFunctionMatrix(((TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
 
@@ -1402,7 +1390,7 @@ class Parallel(LinearTimeInvariant):
         if not isinstance(other, LinearTimeInvariant):
              return NotImplemented
 
-        if other.is_SISO:
+        if not other.is_SISO:
             raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if isinstance(other, Series):
@@ -1655,16 +1643,12 @@ class MIMOParallel(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Parallel, TransferFunctionMatrix
+        >>> from sympy.physics.control.lti import TransferFunction, MIMOParallel, TransferFunctionMatrix
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
-        >>> Parallel(tf2, tf1).doit()
-        TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
-        >>> Parallel(-tf1, -tf2).doit()
-        TransferFunction((2 - s**3)*(-p + s) + (-a*p**2 - b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
         >>> tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
         >>> tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
-        >>> Parallel(tfm_1, tfm_2).doit()  # MIMO System
+        >>> MIMOParallel(tfm_1, tfm_2).doit()
         TransferFunctionMatrix(((TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
@@ -1948,7 +1932,8 @@ class TransferFunctionMatrix(LinearTimeInvariant):
     Examples
     ========
 
-    ``pprint()`` can be used for better visualization of ``TransferFunctionMatrix`` objects.
+    .. note::
+        ``pprint()`` can be used for better visualization of ``TransferFunctionMatrix`` objects.
 
     >>> from sympy.abc import s, p, a
     >>> from sympy import pprint
@@ -2187,7 +2172,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
     >>> tfm_11 = TransferFunctionMatrix([[tf_4], [-tf_1]])
     >>> tfm_12 = TransferFunctionMatrix([[tf_4, -tf_1, tf_3], [-tf_2, -tf_4, -tf_3]])
     >>> tfm_8 + tfm_10
-    Parallel(TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(a + s, s**2 + s + 1, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a + p, 9*s - 9, s),))))
+    MIMOParallel(TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(a + s, s**2 + s + 1, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a + p, 9*s - 9, s),))))
     >>> pprint(_, use_unicode=False)
     [     3      ]      [   a + s    ]
     [   -----    ]      [ ---------- ]
@@ -2203,7 +2188,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
     [  2         ]      [  -------   ]
     [ s  + s + 1 ]{t}   [  9*s - 9   ]{t}
     >>> -tfm_10 - tfm_8
-    Parallel(TransferFunctionMatrix(((TransferFunction(-a - s, s**2 + s + 1, s),), (TransferFunction(-p**4 + 3*p - 2, p + s, s),), (TransferFunction(a - p, 9*s - 9, s),))), TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),), (TransferFunction(-p**4 + 3*p - 2, p + s, s),), (TransferFunction(a + s, s**2 + s + 1, s),))))
+    MIMOParallel(TransferFunctionMatrix(((TransferFunction(-a - s, s**2 + s + 1, s),), (TransferFunction(-p**4 + 3*p - 2, p + s, s),), (TransferFunction(a - p, 9*s - 9, s),))), TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),), (TransferFunction(-p**4 + 3*p - 2, p + s, s),), (TransferFunction(a + s, s**2 + s + 1, s),))))
     >>> pprint(_, use_unicode=False)
     [    -a - s    ]      [     -3       ]
     [  ----------  ]      [    -----     ]
@@ -2219,7 +2204,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
     [   -------    ]      [   2          ]
     [   9*s - 9    ]{t}   [  s  + s + 1  ]{t}
     >>> tfm_12 * tfm_8
-    Series(TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(-a + p, 9*s - 9, s), TransferFunction(-a - s, s**2 + s + 1, s), TransferFunction(3, s + 2, s)), (TransferFunction(-p**4 + 3*p - 2, p + s, s), TransferFunction(a - p, 9*s - 9, s), TransferFunction(-3, s + 2, s)))))
+    MIMOSeries(TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(-a + p, 9*s - 9, s), TransferFunction(-a - s, s**2 + s + 1, s), TransferFunction(3, s + 2, s)), (TransferFunction(-p**4 + 3*p - 2, p + s, s), TransferFunction(a - p, 9*s - 9, s), TransferFunction(-3, s + 2, s)))))
     >>> pprint(_, use_unicode=False)
                                            [     3      ]
                                            [   -----    ]
@@ -2235,7 +2220,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
                                            [  2         ]
                                            [ s  + s + 1 ]{t}
     >>> tfm_12 * tfm_8 * tfm_9
-    Series(TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),),)), TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(-a + p, 9*s - 9, s), TransferFunction(-a - s, s**2 + s + 1, s), TransferFunction(3, s + 2, s)), (TransferFunction(-p**4 + 3*p - 2, p + s, s), TransferFunction(a - p, 9*s - 9, s), TransferFunction(-3, s + 2, s)))))
+    MIMOSeries(TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),),)), TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),))), TransferFunctionMatrix(((TransferFunction(-a + p, 9*s - 9, s), TransferFunction(-a - s, s**2 + s + 1, s), TransferFunction(3, s + 2, s)), (TransferFunction(-p**4 + 3*p - 2, p + s, s), TransferFunction(a - p, 9*s - 9, s), TransferFunction(-3, s + 2, s)))))
     >>> pprint(_, use_unicode=False)
                                            [     3      ]
                                            [   -----    ]
@@ -2251,7 +2236,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
                                            [  2         ]
                                            [ s  + s + 1 ]{t}
     >>> tfm_10 + tfm_8*tfm_9
-    Parallel(TransferFunctionMatrix(((TransferFunction(a + s, s**2 + s + 1, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a + p, 9*s - 9, s),))), Series(TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),),)), TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),)))))
+    MIMOParallel(TransferFunctionMatrix(((TransferFunction(a + s, s**2 + s + 1, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a + p, 9*s - 9, s),))), MIMOSeries(TransferFunctionMatrix(((TransferFunction(-3, s + 2, s),),)), TransferFunctionMatrix(((TransferFunction(3, s + 2, s),), (TransferFunction(p**4 - 3*p + 2, p + s, s),), (TransferFunction(-a - s, s**2 + s + 1, s),)))))
     >>> pprint(_, use_unicode=False)
     [   a + s    ]      [     3      ]
     [ ---------- ]      [   -----    ]
@@ -2279,7 +2264,7 @@ class TransferFunctionMatrix(LinearTimeInvariant):
     See Also
     ========
 
-    TransferFunction, Series, Parallel, Feedback
+    TransferFunction, MIMOSeries, MIMOParallel, Feedback
 
     """
     def __new__(cls, arg):
@@ -2466,13 +2451,13 @@ class TransferFunctionMatrix(LinearTimeInvariant):
         if not isinstance(other, LinearTimeInvariant):
              return NotImplemented
 
-        if self.is_SISO != other.is_SISO:
+        if other.is_SISO:
             raise TypeError("Cannot add SISO and MIMO systems together.")
 
-        if not isinstance(other, Parallel):
-            return Parallel(self, other)
+        if not isinstance(other, MIMOParallel):
+            return MIMOParallel(self, other)
         other_arg_list = list(other.args)
-        return Parallel(self, *other_arg_list)
+        return MIMOParallel(self, *other_arg_list)
 
     def __sub__(self, other):
         return self + (-other)
@@ -2481,13 +2466,13 @@ class TransferFunctionMatrix(LinearTimeInvariant):
         if not isinstance(other, LinearTimeInvariant):
              return NotImplemented
 
-        if self.is_SISO != other.is_SISO:
+        if other.is_SISO:
             raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
-        if not isinstance(other, Series):
-            return Series(other, self)
+        if not isinstance(other, MIMOSeries):
+            return MIMOSeries(other, self)
         other_arg_list = list(other.args)
-        return Series(*other_arg_list, self)
+        return MIMOSeries(*other_arg_list, self)
 
     def __getitem__(self, key):
         trunc = self._expr_mat.__getitem__(key)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2484,3 +2484,18 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
     def _flat(self):
         """Returns flattened list of args in TransferFunctionMatrix"""
         return [elem for tup in self.args[0] for elem in tup]
+
+    def _eval_evalf(self, prec):
+        """Calls evalf() on each transfer function in the transfer function matrix"""
+        mat = self._expr_mat.applyfunc(lambda a: a.evalf(prec))
+        return _to_TFM(mat, self.var)
+
+    def _eval_simplify(self, **kwargs):
+        """Simplifies the transfer function matrix"""
+        simp_mat = self._expr_mat.applyfunc(lambda a: cancel(a, expand=False))
+        return _to_TFM(simp_mat, self.var)
+
+    def expand(self, **hints):
+        """Expands the transfer function matrix"""
+        expand_mat = self._expr_mat.expand(**hints)
+        return _to_TFM(expand_mat, self.var)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -9,7 +9,7 @@ from sympy.series import limit
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions import MatMul, MatAdd
 
-__all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel', \
+__all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel',
     'Feedback', 'TransferFunctionMatrix']
 
 
@@ -716,13 +716,13 @@ class TransferFunction(LinearTimeInvariant):
 
 class Series(LinearTimeInvariant):
     r"""
-    A class for representing series configuration of SISO systems.
+    A class for representing a series configuration of SISO systems.
 
     Parameters
     ==========
 
     args : TransferFunction, Series, Parallel
-        SISO Systems in series configuration.
+        SISO systems in a series configuration.
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
         ``Series(*args).doit()``. Set to ``False`` by default.
@@ -1014,13 +1014,13 @@ def _mat_mul_compatible(*args):
 
 class MIMOSeries(LinearTimeInvariant):
     r"""
-    A class for representing series configuration of MIMO systems.
+    A class for representing a series configuration of MIMO systems.
 
     Parameters
     ==========
 
     args : TransferFunctionMatrix, MIMOSeries, MIMOParallel
-        MIMO Systems in series configuration.
+        MIMO systems in a series configuration.
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
         ``MIMOSeries(*args).doit()``. Set to ``False`` by default.
@@ -1086,8 +1086,6 @@ class MIMOSeries(LinearTimeInvariant):
     All the transfer function matrices should use the same complex variable ``var`` of the Laplace transform.
 
     ``MIMOSeries(A, B)`` is not equivalent to ``A*B``. It is always in the reverse order, that is ``B*A``.
-    In, SISO systems, this order hardly matters, but in MIMO systems, there can be issues due to non-commutative
-    nature of Matrix Multiplication.
 
     See Also
     ========
@@ -1118,7 +1116,7 @@ class MIMOSeries(LinearTimeInvariant):
             obj._is_SISO = False
         else:
             raise ValueError("Number of input signals do not match the number"
-                " of output signals for some args.")
+                " of output signals of adjacent systems for some args.")
 
         return obj.doit() if evaluate else obj
 
@@ -1131,13 +1129,13 @@ class MIMOSeries(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import p
-        >>> from sympy.physics.control.lti import TransferFunction, Series, Parallel
+        >>> from sympy.physics.control.lti import TransferFunction, MIMOSeries, TransferFunctionMatrix
         >>> G1 = TransferFunction(p**2 + 2*p + 4, p - 6, p)
         >>> G2 = TransferFunction(p, 4 - p, p)
         >>> G3 = TransferFunction(0, p**4 - 1, p)
-        >>> Series(G1, G2).var
-        p
-        >>> Series(-G3, Parallel(G1, G2)).var
+        >>> tfm_1 = TransferFunctionMatrix([[G1, G2, G3]])
+        >>> tfm_2 = TransferFunctionMatrix([[G1], [G2], [G3]])
+        >>> MIMOSeries(tfm_2, tfm_1).var
         p
 
         """
@@ -1145,20 +1143,23 @@ class MIMOSeries(LinearTimeInvariant):
 
     @property
     def num_inputs(self):
+        """Returns the number of input signals of the series system."""
         return self.args[0].num_inputs
 
     @property
     def num_outputs(self):
+        """Returns the number of output signals of the series system."""
         return self.args[-1].num_outputs
 
     @property
     def shape(self):
+        """Returns the shape of the equivalent MIMO system."""
         return self.args[-1].num_outputs, self.args[0].num_inputs
 
     def doit(self, **kwargs):
         """
-        Returns the resultant transfer function obtained after evaluating
-        the transfer functions in series configuration.
+        Returns the resultant transfer function matrix obtained after evaluating
+        the MIMO systems arranged in a series configuration.
 
         Examples
         ========
@@ -1224,13 +1225,13 @@ class MIMOSeries(LinearTimeInvariant):
 
 class Parallel(LinearTimeInvariant):
     r"""
-    A class for representing parallel configuration of SISO and MIMO transfer functions.
+    A class for representing a parallel configuration of SISO systems.
 
     Parameters
     ==========
 
     args : TransferFunction, Series, Parallel
-        SISO Systems in parallel arrangement
+        SISO systems in a parallel arrangement.
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
         ``Parallel(*args).doit()``. Set to ``False`` by default.
@@ -1496,13 +1497,13 @@ class Parallel(LinearTimeInvariant):
 
 class MIMOParallel(LinearTimeInvariant):
     r"""
-    A class for representing parallel configuration of MIMO systems.
+    A class for representing a parallel configuration of MIMO systems.
 
     Parameters
     ==========
 
     args : TransferFunctionMatrix, MIMOSeries, MIMOParallel
-        MIMO Systems in parallel arrangement
+        MIMO Systems in a parallel arrangement.
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
         ``MIMOParallel(*args).doit()``. Set to ``False`` by default.
@@ -1624,20 +1625,23 @@ class MIMOParallel(LinearTimeInvariant):
 
     @property
     def num_inputs(self):
+        """Returns the number of input signals of the parallel system."""
         return self.args[0].num_inputs
 
     @property
     def num_outputs(self):
+        """Returns the number of output signals of the parallel system."""
         return self.args[0].num_outputs
 
     @property
     def shape(self):
+        """Returns the shape of the equivalent MIMO system."""
         return self.args[0].num_outputs, self.args[0].num_inputs
 
     def doit(self, **kwargs):
         """
-        Returns the resultant transfer function obtained after evaluating
-        the transfer functions in parallel configuration.
+        Returns the resultant transfer function matrix obtained after evaluating
+        the MIMO systems arranged in a parallel configuration.
 
         Examples
         ========
@@ -1657,9 +1661,6 @@ class MIMOParallel(LinearTimeInvariant):
         return TransferFunctionMatrix.from_Matrix(res, self.var)
 
     def _eval_rewrite_as_TransferFunctionMatrix(self, *args, **kwargs):
-        if self.is_SISO:
-            raise ValueError("Only transfer function matrices or a collection of transfer function"
-                " matrices is allowed in the arguments.")
         return self.doit()
 
     def __add__(self, other):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -722,7 +722,7 @@ class Series(Basic):
         Systems in series configuration.
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
-        Series(*args).doit(). Set to ``False`` by default.
+        ``Series(*args).doit()``. Set to ``False`` by default.
 
     Raises
     ======
@@ -1075,7 +1075,7 @@ class Parallel(Basic):
         Systems in parallel arrangement
     evaluate : Boolean, Keyword
         When passed ``True``, returns the equivalent
-        Parallel(*args).doit(). Set to ``False`` by default.
+        ``Parallel(*args).doit()``. Set to ``False`` by default.
 
     Raises
     ======

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -35,7 +35,7 @@ class LinearTimeInvariant(Basic, EvalfMixin):
         if not args:
             raise ValueError("Atleast 1 argument must be passed.")
         if not all(isinstance(arg, cls._clstype) for arg in args):
-            raise TypeError(f"All arguments must be of type {cls._clstype}.")        
+            raise TypeError(f"All arguments must be of type {cls._clstype}.")
         var_set = {arg.var for arg in args}
         if len(var_set) != 1:
             raise ValueError("All transfer functions should use the same complex variable"

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -869,11 +869,8 @@ class Series(SISOLinearTimeInvariant):
         return self.doit()
 
     def __add__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, SISOLinearTimeInvariant):
              return NotImplemented
-
-        if not other.is_SISO:
-            raise TypeError("Cannot add SISO and MIMO systems together.")
 
         if isinstance(other, Parallel):
             arg_list = list(other.args)
@@ -892,11 +889,8 @@ class Series(SISOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, SISOLinearTimeInvariant):
              return NotImplemented
-
-        if not other.is_SISO:
-            raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if isinstance(other, Series):
             self_arg_list = list(self.args)
@@ -1169,11 +1163,8 @@ class MIMOSeries(MIMOLinearTimeInvariant):
         return self.doit()
 
     def __add__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if self.is_SISO != other.is_SISO:
-            raise TypeError("Cannot add SISO and MIMO systems together.")
 
         if isinstance(other, MIMOParallel):
             arg_list = list(other.args)
@@ -1192,11 +1183,8 @@ class MIMOSeries(MIMOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if other.is_SISO:
-            raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if isinstance(other, MIMOSeries):
             self_arg_list = list(self.args)
@@ -1337,11 +1325,8 @@ class Parallel(SISOLinearTimeInvariant):
         return self.doit()
 
     def __add__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, SISOLinearTimeInvariant):
              return NotImplemented
-
-        if not other.is_SISO:
-            raise TypeError("Cannot add SISO and MIMO systems together.")
 
         if isinstance(other, Parallel):
             self_arg_list = list(self.args)
@@ -1362,11 +1347,8 @@ class Parallel(SISOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, SISOLinearTimeInvariant):
              return NotImplemented
-
-        if not other.is_SISO:
-            raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if isinstance(other, Series):
             arg_list = list(other.args)
@@ -1611,11 +1593,8 @@ class MIMOParallel(MIMOLinearTimeInvariant):
         return self.doit()
 
     def __add__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if other.is_SISO:
-            raise TypeError("Cannot add SISO and MIMO systems together.")
 
         if isinstance(other, MIMOParallel):
             self_arg_list = list(self.args)
@@ -1636,11 +1615,8 @@ class MIMOParallel(MIMOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if other.is_SISO:
-            raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if isinstance(other, MIMOSeries):
             arg_list = list(other.args)
@@ -2392,11 +2368,8 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         return _to_TFM(neg, self.var)
 
     def __add__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if other.is_SISO:
-            raise TypeError("Cannot add SISO and MIMO systems together.")
 
         if not isinstance(other, MIMOParallel):
             return MIMOParallel(self, other)
@@ -2409,11 +2382,8 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         return self + (-other)
 
     def __mul__(self, other):
-        if not isinstance(other, LinearTimeInvariant):
+        if not isinstance(other, MIMOLinearTimeInvariant):
              return NotImplemented
-
-        if other.is_SISO:
-            raise TypeError("Cannot multiply SISO and MIMO systems together.")
 
         if not isinstance(other, MIMOSeries):
             return MIMOSeries(other, self)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -905,13 +905,17 @@ class Series(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Series
+        >>> from sympy.physics.control.lti import TransferFunction, Series, TransferFunctionMatrix
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Series(tf2, tf1).doit()
         TransferFunction((s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Series(-tf1, -tf2).doit()
         TransferFunction((2 - s**3)*(-a*p**2 - b*s), (-p + s)*(s**4 + 5*s + 6), s)
+        >>> tfm1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf2]])
+        >>> tfm2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf1]])
+        >>> Series(tfm2, tfm1).doit()  # MIMO System
+        TransferFunctionMatrix(((TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)**2*(s**3 - 2)*(a*p**2 + b*s) + (-p + s)*(a*p**2 + b*s)**2*(s**4 + 5*s + 6), (-p + s)**3*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2)**2*(s**4 + 5*s + 6) + (s**3 - 2)*(a*p**2 + b*s)*(s**4 + 5*s + 6)**2, (-p + s)*(s**4 + 5*s + 6)**3, s), TransferFunction(2*(s**3 - 2)*(a*p**2 + b*s), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
         def _SISO_doit():
@@ -1280,13 +1284,17 @@ class Parallel(LinearTimeInvariant):
         ========
 
         >>> from sympy.abc import s, p, a, b
-        >>> from sympy.physics.control.lti import TransferFunction, Parallel
+        >>> from sympy.physics.control.lti import TransferFunction, Parallel, TransferFunctionMatrix
         >>> tf1 = TransferFunction(a*p**2 + b*s, s - p, s)
         >>> tf2 = TransferFunction(s**3 - 2, s**4 + 5*s + 6, s)
         >>> Parallel(tf2, tf1).doit()
         TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
         >>> Parallel(-tf1, -tf2).doit()
         TransferFunction((2 - s**3)*(-p + s) + (-a*p**2 - b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)
+        >>> tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
+        >>> tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
+        >>> Parallel(tfm_1, tfm_2).doit()  # MIMO System
+        TransferFunctionMatrix(((TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s)), (TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s), TransferFunction((-p + s)*(s**3 - 2) + (a*p**2 + b*s)*(s**4 + 5*s + 6), (-p + s)*(s**4 + 5*s + 6), s))))
 
         """
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1135,7 +1135,7 @@ class MIMOSeries(MIMOLinearTimeInvariant):
     @property
     def shape(self):
         """Returns the shape of the equivalent MIMO system."""
-        return self.args[-1].num_outputs, self.args[0].num_inputs
+        return self.num_outputs, self.num_inputs
 
     def doit(self, **kwargs):
         """
@@ -1565,7 +1565,7 @@ class MIMOParallel(MIMOLinearTimeInvariant):
     @property
     def shape(self):
         """Returns the shape of the equivalent MIMO system."""
-        return self.args[0].num_outputs, self.args[0].num_inputs
+        return self.num_outputs, self.num_inputs
 
     def doit(self, **kwargs):
         """

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -64,6 +64,24 @@ SISOLinearTimeInvariant._clstype = SISOLinearTimeInvariant
 MIMOLinearTimeInvariant._clstype = MIMOLinearTimeInvariant
 
 
+def _check_other_SISO(func):
+    def wrapper(*args, **kwargs):
+        if not isinstance(args[-1], SISOLinearTimeInvariant):
+            return NotImplemented
+        else:
+            return func(*args, **kwargs)
+    return wrapper
+
+
+def _check_other_MIMO(func):
+    def wrapper(*args, **kwargs):
+        if not isinstance(args[-1], MIMOLinearTimeInvariant):
+            return NotImplemented
+        else:
+            return func(*args, **kwargs)
+    return wrapper
+
+
 class TransferFunction(SISOLinearTimeInvariant):
     r"""
     A class for representing LTI (Linear, time-invariant) systems that can be strictly described
@@ -893,9 +911,8 @@ class Series(SISOLinearTimeInvariant):
     def _eval_rewrite_as_TransferFunction(self, *args, **kwargs):
         return self.doit()
 
+    @_check_other_SISO
     def __add__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
 
         if isinstance(other, Parallel):
             arg_list = list(other.args)
@@ -905,17 +922,15 @@ class Series(SISOLinearTimeInvariant):
 
     __radd__ = __add__
 
+    @_check_other_SISO
     def __sub__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
         return -self + other
 
+    @_check_other_SISO
     def __mul__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
 
         arg_list = list(self.args)
         return Series(*arg_list, other)
@@ -1189,9 +1204,8 @@ class MIMOSeries(MIMOLinearTimeInvariant):
     def _eval_rewrite_as_TransferFunctionMatrix(self, *args, **kwargs):
         return self.doit()
 
+    @_check_other_MIMO
     def __add__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         if isinstance(other, MIMOParallel):
             arg_list = list(other.args)
@@ -1201,17 +1215,15 @@ class MIMOSeries(MIMOLinearTimeInvariant):
 
     __radd__ = __add__
 
+    @_check_other_MIMO
     def __sub__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
         return -self + other
 
+    @_check_other_MIMO
     def __mul__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         if isinstance(other, MIMOSeries):
             self_arg_list = list(self.args)
@@ -1352,26 +1364,23 @@ class Parallel(SISOLinearTimeInvariant):
     def _eval_rewrite_as_TransferFunction(self, *args, **kwargs):
         return self.doit()
 
+    @_check_other_SISO
     def __add__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
 
         self_arg_list = list(self.args)
         return Parallel(*self_arg_list, other)
 
     __radd__ = __add__
 
+    @_check_other_SISO
     def __sub__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
         return -self + other
 
+    @_check_other_SISO
     def __mul__(self, other):
-        if not isinstance(other, SISOLinearTimeInvariant):
-             return NotImplemented
 
         if isinstance(other, Series):
             arg_list = list(other.args)
@@ -1617,26 +1626,23 @@ class MIMOParallel(MIMOLinearTimeInvariant):
     def _eval_rewrite_as_TransferFunctionMatrix(self, *args, **kwargs):
         return self.doit()
 
+    @_check_other_MIMO
     def __add__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         self_arg_list = list(self.args)
         return MIMOParallel(*self_arg_list, other)
 
     __radd__ = __add__
 
+    @_check_other_MIMO
     def __sub__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
         return -self + other
 
+    @_check_other_MIMO
     def __mul__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         if isinstance(other, MIMOSeries):
             arg_list = list(other.args)
@@ -2387,23 +2393,20 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         neg = -self._expr_mat
         return _to_TFM(neg, self.var)
 
+    @_check_other_MIMO
     def __add__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         if not isinstance(other, MIMOParallel):
             return MIMOParallel(self, other)
         other_arg_list = list(other.args)
         return MIMOParallel(self, *other_arg_list)
 
+    @_check_other_MIMO
     def __sub__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
         return self + (-other)
 
+    @_check_other_MIMO
     def __mul__(self, other):
-        if not isinstance(other, MIMOLinearTimeInvariant):
-             return NotImplemented
 
         if not isinstance(other, MIMOSeries):
             return MIMOSeries(other, self)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -884,6 +884,8 @@ class Series(SISOLinearTimeInvariant):
     __radd__ = __add__
 
     def __sub__(self, other):
+        if not isinstance(other, SISOLinearTimeInvariant):
+             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
@@ -1182,6 +1184,8 @@ class MIMOSeries(MIMOLinearTimeInvariant):
     __radd__ = __add__
 
     def __sub__(self, other):
+        if not isinstance(other, MIMOLinearTimeInvariant):
+             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
@@ -1350,6 +1354,8 @@ class Parallel(SISOLinearTimeInvariant):
     __radd__ = __add__
 
     def __sub__(self, other):
+        if not isinstance(other, SISOLinearTimeInvariant):
+             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
@@ -1622,6 +1628,8 @@ class MIMOParallel(MIMOLinearTimeInvariant):
     __radd__ = __add__
 
     def __sub__(self, other):
+        if not isinstance(other, MIMOLinearTimeInvariant):
+             return NotImplemented
         return self + (-other)
 
     def __rsub__(self, other):
@@ -2396,6 +2404,8 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         return MIMOParallel(self, *other_arg_list)
 
     def __sub__(self, other):
+        if not isinstance(other, MIMOLinearTimeInvariant):
+             return NotImplemented
         return self + (-other)
 
     def __mul__(self, other):

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -610,14 +610,16 @@ def test_MIMOSeries_functions():
             (a2*s + p)**2, (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2, s),), (TransferFunction(k**2, 1, s),)))
 
     # calling doit() will expand the internal Series and Parallel objects.
-    assert MIMOSeries(-tfm3, -tfm2, tfm1, evaluate=True) == MIMOSeries(-tfm3, -tfm2, tfm1).doit() == \
-        TransferFunctionMatrix(((TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*p - s)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*s + p)**2, \
+    assert (MIMOSeries(-tfm3, -tfm2, tfm1, evaluate=True)
+        == MIMOSeries(-tfm3, -tfm2, tfm1).doit() 
+        == TransferFunctionMatrix(((TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*p - s)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*s + p)**2, \
             (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**3, s),), (TransferFunction(-k**2*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s),))) \
-                == MIMOSeries(-tfm3, -tfm2, tfm1).rewrite(TransferFunctionMatrix)
-    assert MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5, evaluate=True) == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).doit() == \
-        TransferFunctionMatrix(((TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), TransferFunction(k*(-a2*p - \
+        == MIMOSeries(-tfm3, -tfm2, tfm1).rewrite(TransferFunctionMatrix))
+    assert (MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5, evaluate=True)
+        == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).doit() 
+        == TransferFunctionMatrix(((TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), TransferFunction(k*(-a2*p - \
             k*(a2*s + p) + s), a2*s + p, s)), (TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), \
-                TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s)))) == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).rewrite(TransferFunctionMatrix)
+            TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s)))) == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).rewrite(TransferFunctionMatrix))
 
 
 def test_Parallel_construction():
@@ -834,10 +836,11 @@ def test_MIMOParallel_functions():
     raises(ValueError, lambda: (tfm1 - tfm2)*tfm5)
 
     # TFM in the arguments.
-    assert MIMOParallel(tfm1, tfm2, evaluate=True) == MIMOParallel(tfm1, tfm2).doit() == MIMOParallel(tfm1, tfm2).rewrite(TransferFunctionMatrix) == \
-        TransferFunctionMatrix(((TransferFunction(-k*(s**2 + 2*s*wn*zeta + wn**2) + 1, s**2 + 2*s*wn*zeta + wn**2, s),), \
-            (TransferFunction(-a0 + a1*s**2 + a2*s + k*(a0 + s), a0 + s, s),), (TransferFunction(-a2*s - p + (a2*p - s)* \
-                (s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s),)))
+    assert (MIMOParallel(tfm1, tfm2, evaluate=True) == MIMOParallel(tfm1, tfm2).doit()
+    == MIMOParallel(tfm1, tfm2).rewrite(TransferFunctionMatrix) 
+    == TransferFunctionMatrix(((TransferFunction(-k*(s**2 + 2*s*wn*zeta + wn**2) + 1, s**2 + 2*s*wn*zeta + wn**2, s),), \
+        (TransferFunction(-a0 + a1*s**2 + a2*s + k*(a0 + s), a0 + s, s),), (TransferFunction(-a2*s - p + (a2*p - s)* \
+        (s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s),))))
 
 
 def test_Feedback_construction():

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1067,7 +1067,7 @@ def test_TransferFunctionMatrix_functions():
     # expand()
 
     assert (H_1.expand()
-            == TransferFunctionMatrix(((TransferFunction(s**3 - 2*s**2 - 3*s, s**4 + 1, s), TransferFunction(2, 1, s)), 
+            == TransferFunctionMatrix(((TransferFunction(s**3 - 2*s**2 - 3*s, s**4 + 1, s), TransferFunction(2, 1, s)),
             (TransferFunction(p, 1, s), TransferFunction(p, s, s)))))
     assert H_5.expand() == \
         TransferFunctionMatrix(((TransferFunction(s**5 + s**3 + s, -s**2 + s, s), TransferFunction(s**2 + 2*s - 3, s**2 + 4*s - 5, s)),))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -419,7 +419,6 @@ def test_TransferFunction_is_biproper():
 
 
 def test_Series_construction():
-    zeta, wn = symbols('zeta, wn')
     tf = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)
     tf2 = TransferFunction(a2*p - s, a2*s + p, s)
     tf3 = TransferFunction(a0*p + p**a1 - s, p, p)
@@ -503,10 +502,10 @@ def test_MIMO_Series_construction():
     # Number or expression not allowed in the arguments.
     raises(TypeError, lambda: Series(2, tfm_2, tfm_3))
     raises(TypeError, lambda: Series(s**2 + p*s, -tfm_2, tfm_3))
+    raises(TypeError, lambda: Series(Matrix([1/p]), tfm_3))
 
 
 def test_Series_functions():
-    zeta, wn = symbols('zeta, wn')
     tf1 = TransferFunction(1, s**2 + 2*zeta*wn*s + wn**2, s)
     tf2 = TransferFunction(k, 1, s)
     tf3 = TransferFunction(a2*p - s, a2*s + p, s)
@@ -583,10 +582,10 @@ def test_MIMO_Series_functions():
     assert tfm4*-tfm6 + (-tfm4*tfm6) == Parallel(Series(-tfm6, tfm4), Series(tfm6, -tfm4))
 
     raises(TypeError, lambda: tfm1*tfm2 + TF1)
-    raises(ValueError, lambda: tfm1*tfm2 + a0)
-    raises(ValueError, lambda: tfm4*tfm6 - (s - 1))
-    raises(ValueError, lambda: tfm4*-tfm6 - 8)
-    raises(ValueError, lambda: (-1 + p**5) + tfm1*tfm2)
+    raises(TypeError, lambda: tfm1*tfm2 + a0)
+    raises(TypeError, lambda: tfm4*tfm6 - (s - 1))
+    raises(TypeError, lambda: tfm4*-tfm6 - 8)
+    raises(TypeError, lambda: (-1 + p**5) + tfm1*tfm2)
 
     # Shape criteria.
 
@@ -600,9 +599,9 @@ def test_MIMO_Series_functions():
     # Multiplication of a Series object with a SISO TF not allowed.
 
     raises(TypeError, lambda: tfm4*tfm5*TF1)
-    raises(ValueError, lambda: tfm4*tfm5*a1)
-    raises(ValueError, lambda: tfm4*-tfm5*(s - 2))
-    raises(ValueError, lambda: tfm5*tfm4*9)
+    raises(TypeError, lambda: tfm4*tfm5*a1)
+    raises(TypeError, lambda: tfm4*-tfm5*(s - 2))
+    raises(TypeError, lambda: tfm5*tfm4*9)
     raises(TypeError, lambda: (-p**3 + 1)*tfm5*tfm4)
 
     # Transfer function matrix in the arguments.
@@ -610,14 +609,17 @@ def test_MIMO_Series_functions():
         TransferFunctionMatrix(((TransferFunction(-k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (-a2*p + s)*(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2)**2 - \
             (a2*s + p)**2, (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2, s),), (TransferFunction(k**2, 1, s),)))
 
-    # calling doit() once will not expand the internal Series and Parallel objects.
+    # calling doit() will expand the internal Series and Parallel objects.
     assert Series(-tfm3, -tfm2, tfm1, evaluate=True) == Series(-tfm3, -tfm2, tfm1).doit() == \
         TransferFunctionMatrix(((TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*p - s)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*s + p)**2, \
             (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**3, s),), (TransferFunction(-k**2*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s),)))
+    assert Series(Parallel(tfm4, tfm5), tfm5, evaluate=True) == Series(Parallel(tfm4, tfm5), tfm5).doit() == \
+        TransferFunctionMatrix(((TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), TransferFunction(k*(-a2*p - \
+            k*(a2*s + p) + s), a2*s + p, s)), (TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), \
+                TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s))))
 
 
 def test_Parallel_construction():
-    zeta, wn = symbols('zeta, wn')
     tf = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)
     tf2 = TransferFunction(a2*p - s, a2*s + p, s)
     tf3 = TransferFunction(a0*p + p**a1 - s, p, p)
@@ -664,7 +666,6 @@ def test_Parallel_construction():
 
 
 def test_Parallel_functions():
-    zeta, wn = symbols('zeta, wn')
     tf1 = TransferFunction(1, s**2 + 2*zeta*wn*s + wn**2, s)
     tf2 = TransferFunction(k, 1, s)
     tf3 = TransferFunction(a2*p - s, a2*s + p, s)
@@ -735,7 +736,6 @@ def test_Parallel_functions():
 
 
 def test_Feedback_construction():
-    zeta, wn = symbols('zeta, wn')
     tf1 = TransferFunction(1, s**2 + 2*zeta*wn*s + wn**2, s)
     tf2 = TransferFunction(k, 1, s)
     tf3 = TransferFunction(a2*p - s, a2*s + p, s)
@@ -786,7 +786,6 @@ def test_Feedback_construction():
 
 
 def test_Feedback_functions():
-    zeta, wn = symbols('zeta, wn')
     tf = TransferFunction(1, 1, s)
     tf1 = TransferFunction(1, s**2 + 2*zeta*wn*s + wn**2, s)
     tf2 = TransferFunction(k, 1, s)
@@ -804,7 +803,7 @@ def test_Feedback_functions():
     assert tf4 / (TransferFunction(1, 1, p) + tf4*tf6) == Feedback(tf4, tf6)
     assert tf5 / (tf + tf5) == Feedback(tf5, tf)
 
-    raises(ValueError, lambda: tf1*tf2*tf3 / (1 + tf1*tf2*tf3))
+    raises(TypeError, lambda: tf1*tf2*tf3 / (1 + tf1*tf2*tf3))
     raises(ValueError, lambda: tf1*tf2*tf3 / tf3*tf5)
     raises(ValueError, lambda: tf2*tf3 / (tf + tf2*tf3*tf4))
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -600,30 +600,31 @@ def test_Parallel_functions():
     assert Parallel(tf1, tf2, evaluate=True) == Parallel(tf1, tf2).doit() == \
         TransferFunction(k*(s**2 + 2*s*wn*zeta + wn**2) + 1, s**2 + 2*s*wn*zeta + wn**2, s)
     assert Parallel(tf1, tf2, Series(-tf1, tf3), evaluate=True) == \
-        Parallel(tf1, tf2, Series(-tf1, tf3)).doit()== TransferFunction((-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2) + \
-        (a2*s + p)*(k*(s**2 + 2*s*wn*zeta + wn**2) + 1)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s)
+        Parallel(tf1, tf2, Series(-tf1, tf3)).doit() == TransferFunction(k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2 + \
+            (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + \
+                2*s*wn*zeta + wn**2)**2, s)
     assert Parallel(tf2, tf1, -tf3, evaluate=True) == Parallel(tf2, tf1, -tf3).doit() == \
-        TransferFunction(-(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*s + p)*(k*(s**2 + 2*s*wn*zeta + wn**2) + 1), \
-        (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
+        TransferFunction(a2*s + k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) + p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2) \
+            , (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
     assert not Parallel(tf1, -tf2, evaluate=False) == Parallel(tf1, -tf2).doit()
 
     assert Parallel(Series(tf1, tf2), Series(tf2, tf3)).doit() == \
         TransferFunction(k*(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2) + k*(a2*s + p), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
     assert Parallel(-tf1, -tf2, -tf3).doit() == \
-        TransferFunction(-(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2) + \
-        (a2*s + p)*(-k*(s**2 + 2*s*wn*zeta + wn**2) - 1), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
+        TransferFunction(-a2*s - k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2), \
+            (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
     assert -Parallel(tf1, tf2, tf3).doit() == \
-        TransferFunction(-((a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*s + p)*(k*(s**2 + 2*s*wn*zeta + wn**2) + 1)),
-        (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
+        TransferFunction(-a2*s - k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) - p - (a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2), \
+            (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
     assert Parallel(tf2, tf3, Series(tf2, -tf1), tf3).doit() == \
-        TransferFunction((a2*p - s)*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*s + p)*(-k*(a2*s + p) + \
-        (s**2 + 2*s*wn*zeta + wn**2)*(a2*p + k*(a2*s + p) - s)), (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2), s)
+        TransferFunction(k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) - k*(a2*s + p) + (2*a2*p - 2*s)*(s**2 + 2*s*wn*zeta \
+            + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
 
     assert Parallel(tf1, tf2).rewrite(TransferFunction) == \
         TransferFunction(k*(s**2 + 2*s*wn*zeta + wn**2) + 1, s**2 + 2*s*wn*zeta + wn**2, s)
     assert Parallel(tf2, tf1, -tf3).rewrite(TransferFunction) == \
-        TransferFunction(-(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*s + p)*(k*(s**2 + 2*s*wn*zeta + wn**2) + 1), \
-        (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
+        TransferFunction(a2*s + k*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) + p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + \
+             wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s)
 
     P1 = Parallel(Series(tf1, tf2), Series(tf2, tf3))
     assert P1.is_proper
@@ -839,8 +840,7 @@ def test_TransferFunctionMatrix_functions():
     H_4 = TransferFunctionMatrix([[Parallel(TransferFunction(s**3 - 3, 4*s**4 - s**2 - 2*s + 5, s), TransferFunction(4 - s**3, 4*s**4 - s**2 - 2*s + 5, s))]])
 
     assert H_3.doit() == TransferFunctionMatrix([[TransferFunction(s**2 - 2*s + 5, s*(s**3 - 3), s)]])
-    assert H_4.doit() == TransferFunctionMatrix([[TransferFunction((4 - s**3)*(4*s**4 - s**2 - 2*s + 5) + (s**3 - 3)*(4*s**4 - s**2 - 2*s + 5),
-        (4*s**4 - s**2 - 2*s + 5)**2, s)]])
+    assert H_4.doit() == TransferFunctionMatrix([[TransferFunction(1, 4*s**4 - s**2 - 2*s + 5, s)]])
 
     # _flat()
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -581,7 +581,7 @@ def test_MIMOSeries_functions():
     assert tfm4*tfm5 + (tfm4 - tfm5) == MIMOParallel(MIMOSeries(tfm5, tfm4), tfm4, -tfm5)
     assert tfm4*-tfm6 + (-tfm4*tfm6) == MIMOParallel(MIMOSeries(-tfm6, tfm4), MIMOSeries(tfm6, -tfm4))
 
-    raises(TypeError, lambda: tfm1*tfm2 + TF1)
+    raises(ValueError, lambda: tfm1*tfm2 + TF1)
     raises(TypeError, lambda: tfm1*tfm2 + a0)
     raises(TypeError, lambda: tfm4*tfm6 - (s - 1))
     raises(TypeError, lambda: tfm4*-tfm6 - 8)
@@ -598,7 +598,7 @@ def test_MIMOSeries_functions():
 
     # Multiplication of a Series object with a SISO TF not allowed.
 
-    raises(TypeError, lambda: tfm4*tfm5*TF1)
+    raises(ValueError, lambda: tfm4*tfm5*TF1)
     raises(TypeError, lambda: tfm4*tfm5*a1)
     raises(TypeError, lambda: tfm4*-tfm5*(s - 2))
     raises(TypeError, lambda: tfm5*tfm4*9)
@@ -809,7 +809,7 @@ def test_MIMOParallel_functions():
     assert tfm1 + tfm1 - (-tfm1*tfm6) == MIMOParallel(tfm1, tfm1, -MIMOSeries(tfm6, -tfm1))
     assert tfm2 - tfm3 - tfm1 + tfm2 == MIMOParallel(tfm2, -tfm3, -tfm1, tfm2)
     assert tfm1 + tfm2 - tfm3 - tfm1 == MIMOParallel(tfm1, tfm2, -tfm3, -tfm1)
-    raises(TypeError, lambda: tfm1 + tfm2 + TF2)
+    raises(ValueError, lambda: tfm1 + tfm2 + TF2)
     raises(TypeError, lambda: tfm1 - tfm2 - a1)
     raises(TypeError, lambda: tfm2 - tfm3 - (s - 1))
     raises(TypeError, lambda: -tfm3 - tfm2 - 9)
@@ -824,7 +824,7 @@ def test_MIMOParallel_functions():
     assert (tfm1 + tfm2)*tfm6 == MIMOSeries(tfm6, MIMOParallel(tfm1, tfm2))
     assert (tfm2 - tfm3)*tfm6*-tfm6 == MIMOSeries(-tfm6, tfm6, MIMOParallel(tfm2, -tfm3))
     assert (tfm2 - tfm1 - tfm3)*(tfm6 + tfm6) == MIMOSeries(MIMOParallel(tfm6, tfm6), MIMOParallel(tfm2, -tfm1, -tfm3))
-    raises(TypeError, lambda: (tfm4 + tfm5)*TF1)
+    raises(ValueError, lambda: (tfm4 + tfm5)*TF1)
     raises(TypeError, lambda: (tfm2 - tfm3)*a2)
     raises(TypeError, lambda: (tfm3 + tfm2)*(s - 6))
     raises(TypeError, lambda: (tfm1 + tfm2 + tfm3)*0)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -611,12 +611,12 @@ def test_MIMOSeries_functions():
 
     # calling doit() will expand the internal Series and Parallel objects.
     assert (MIMOSeries(-tfm3, -tfm2, tfm1, evaluate=True)
-        == MIMOSeries(-tfm3, -tfm2, tfm1).doit() 
+        == MIMOSeries(-tfm3, -tfm2, tfm1).doit()
         == TransferFunctionMatrix(((TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*p - s)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*s + p)**2, \
             (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**3, s),), (TransferFunction(-k**2*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s),))) \
         == MIMOSeries(-tfm3, -tfm2, tfm1).rewrite(TransferFunctionMatrix))
     assert (MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5, evaluate=True)
-        == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).doit() 
+        == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).doit()
         == TransferFunctionMatrix(((TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), TransferFunction(k*(-a2*p - \
             k*(a2*s + p) + s), a2*s + p, s)), (TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), \
             TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s)))) == MIMOSeries(MIMOParallel(tfm4, tfm5), tfm5).rewrite(TransferFunctionMatrix))
@@ -837,7 +837,7 @@ def test_MIMOParallel_functions():
 
     # TFM in the arguments.
     assert (MIMOParallel(tfm1, tfm2, evaluate=True) == MIMOParallel(tfm1, tfm2).doit()
-    == MIMOParallel(tfm1, tfm2).rewrite(TransferFunctionMatrix) 
+    == MIMOParallel(tfm1, tfm2).rewrite(TransferFunctionMatrix)
     == TransferFunctionMatrix(((TransferFunction(-k*(s**2 + 2*s*wn*zeta + wn**2) + 1, s**2 + 2*s*wn*zeta + wn**2, s),), \
         (TransferFunction(-a0 + a1*s**2 + a2*s + k*(a0 + s), a0 + s, s),), (TransferFunction(-a2*s - p + (a2*p - s)* \
         (s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s),))))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1047,3 +1047,27 @@ def test_TransferFunctionMatrix_functions():
     assert H_2._flat() == [TransferFunction(a*p*s, k*s**2, s), TransferFunction(p*s, k*(-a + s**2), s)]
     assert H_3._flat() == [Series(TransferFunction(1, s**3 - 3, s), TransferFunction(s**2 - 2*s + 5, 1, s), TransferFunction(1, s, s))]
     assert H_4._flat() == [Parallel(TransferFunction(s**3 - 3, 4*s**4 - s**2 - 2*s + 5, s), TransferFunction(4 - s**3, 4*s**4 - s**2 - 2*s + 5, s))]
+
+    # evalf()
+
+    assert H_1.evalf() == \
+        TransferFunctionMatrix(((TransferFunction(s*(s - 3.0)*(s + 1.0), s**4 + 1.0, s), TransferFunction(2.0, 1, s)), (TransferFunction(1.0*p, 1, s), TransferFunction(p, s, s))))
+    assert H_2.subs({a:3.141, p:2.88, k:2}).evalf() == \
+        TransferFunctionMatrix(((TransferFunction(4.5230399999999999494093572138808667659759521484375, s, s),
+        TransferFunction(2.87999999999999989341858963598497211933135986328125*s, 2.0*s**2 - 6.282000000000000028421709430404007434844970703125, s)),))
+
+    # simplify()
+
+    H_5 = TransferFunctionMatrix([[TransferFunction(s**5 + s**3 + s, s - s**2, s),
+        TransferFunction((s + 3)*(s - 1), (s - 1)*(s + 5), s)]])
+
+    assert H_5.simplify() == simplify(H_5) == \
+        TransferFunctionMatrix(((TransferFunction(-s**4 - s**2 - 1, s - 1, s), TransferFunction(s + 3, s + 5, s)),))
+
+    # expand()
+
+    assert (H_1.expand()
+            == TransferFunctionMatrix(((TransferFunction(s**3 - 2*s**2 - 3*s, s**4 + 1, s), TransferFunction(2, 1, s)), 
+            (TransferFunction(p, 1, s), TransferFunction(p, s, s)))))
+    assert H_5.expand() == \
+        TransferFunctionMatrix(((TransferFunction(s**5 + s**3 + s, -s**2 + s, s), TransferFunction(s**2 + 2*s - 3, s**2 + 4*s - 5, s)),))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -612,11 +612,12 @@ def test_MIMO_Series_functions():
     # calling doit() will expand the internal Series and Parallel objects.
     assert Series(-tfm3, -tfm2, tfm1, evaluate=True) == Series(-tfm3, -tfm2, tfm1).doit() == \
         TransferFunctionMatrix(((TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*p - s)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (a2*s + p)**2, \
-            (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**3, s),), (TransferFunction(-k**2*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s),)))
+            (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**3, s),), (TransferFunction(-k**2*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2)**2, s),))) \
+                == Series(-tfm3, -tfm2, tfm1).rewrite(TransferFunctionMatrix)
     assert Series(Parallel(tfm4, tfm5), tfm5, evaluate=True) == Series(Parallel(tfm4, tfm5), tfm5).doit() == \
         TransferFunctionMatrix(((TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), TransferFunction(k*(-a2*p - \
             k*(a2*s + p) + s), a2*s + p, s)), (TransferFunction(-k*(-a2*s - p + (-a2*p + s)*(s**2 + 2*s*wn*zeta + wn**2)), (a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2), s), \
-                TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s))))
+                TransferFunction((-a2*p + s)*(-a2*p - k*(a2*s + p) + s), (a2*s + p)**2, s)))) == Series(Parallel(tfm4, tfm5), tfm5).rewrite(TransferFunctionMatrix)
 
 
 def test_Parallel_construction():

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -608,7 +608,7 @@ def test_MIMOSeries_functions():
     # Transfer function matrix in the arguments.
     assert (MIMOSeries(tfm2, tfm1, evaluate=True) == MIMOSeries(tfm2, tfm1).doit()
         == TransferFunctionMatrix(((TransferFunction(-k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (-a2*p + s)*(a2*p - s)*(s**2 + 2*s*wn*zeta + wn**2)**2 - (a2*s + p)**2,
-        (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2, s),), 
+        (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2, s),),
         (TransferFunction(k**2*(a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2 + (-a2*p + s)*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2) + (a2*p - s)*(a2*s + p)*(s**2 + 2*s*wn*zeta + wn**2),
         (a2*s + p)**2*(s**2 + 2*s*wn*zeta + wn**2)**2, s),))))
 
@@ -616,7 +616,7 @@ def test_MIMOSeries_functions():
     mat_1 = Matrix([[1/(1+s), (1+s)/(1+s**2+2*s)**3]])
     mat_2 = Matrix([[(1+s)], [(1+s**2+2*s)**3/(1+s)]])
     tm_1, tm_2 = TransferFunctionMatrix.from_Matrix(mat_1, s), TransferFunctionMatrix.from_Matrix(mat_2, s)
-    assert (MIMOSeries(tm_2, tm_1).doit() 
+    assert (MIMOSeries(tm_2, tm_1).doit()
         == TransferFunctionMatrix(((TransferFunction(2*(s + 1)**2*(s**2 + 2*s + 1)**3, (s + 1)**2*(s**2 + 2*s + 1)**3, s),),)))
     assert MIMOSeries(tm_2, tm_1).doit().simplify() == TransferFunctionMatrix(((TransferFunction(2, 1, s),),))
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2449,7 +2449,7 @@ class LatexPrinter(Printer):
         args = list(expr.args)
         parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
                                              False)
-        return ' '.join(map(parens, args))
+        return '+'.join(map(parens, args))
 
     def _print_Feedback(self, expr):
         from sympy.physics.control import TransferFunction, Parallel, Series

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2438,18 +2438,24 @@ class LatexPrinter(Printer):
         return r"\frac{%s}{%s}" % (num, den)
 
     def _print_Series(self, expr):
-        from sympy.physics.control.lti import Parallel
-        if expr.is_SISO:
-            args = list(expr.args)
-            parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
-                                                False)
-            return ' '.join(map(parens, args))
+        args = list(expr.args)
+        parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
+                                            False)
+        return ' '.join(map(parens, args))
+
+    def _print_MIMOSeries(self, expr):
+        from sympy.physics.control.lti import MIMOParallel
         args = list(expr.args)[::-1]
         parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
-                                             False) if isinstance(x, Parallel) else self._print(x)
+                                             False) if isinstance(x, MIMOParallel) else self._print(x)
         return r"\cdot".join(map(parens, args))
 
     def _print_Parallel(self, expr):
+        args = list(expr.args)
+        func = lambda x: self._print(x)
+        return '+'.join(map(func, args))
+
+    def _print_MIMOParallel(self, expr):
         args = list(expr.args)
         func = lambda x: self._print(x)
         return '+'.join(map(func, args))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2453,12 +2453,12 @@ class LatexPrinter(Printer):
     def _print_Parallel(self, expr):
         args = list(expr.args)
         func = lambda x: self._print(x)
-        return '+'.join(map(func, args))
+        return ' + '.join(map(func, args))
 
     def _print_MIMOParallel(self, expr):
         args = list(expr.args)
         func = lambda x: self._print(x)
-        return '+'.join(map(func, args))
+        return ' + '.join(map(func, args))
 
     def _print_Feedback(self, expr):
         from sympy.physics.control import TransferFunction, Parallel, Series

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2434,22 +2434,25 @@ class LatexPrinter(Printer):
         return "%s\\rightarrow %s" % (domain, codomain)
 
     def _print_TransferFunction(self, expr):
-        from sympy.core import Mul, Pow
-        num, den = expr.num, expr.den
-        res = Mul(num, Pow(den, -1, evaluate=False), evaluate=False)
-        return self._print_Mul(res)
+        num, den = self._print(expr.num), self._print(expr.den)
+        return r"\frac{%s}{%s}" % (num, den)
 
     def _print_Series(self, expr):
-        args = list(expr.args)
+        from sympy.physics.control.lti import Parallel
+        if expr.is_SISO:
+            args = list(expr.args)
+            parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
+                                                False)
+            return ' '.join(map(parens, args))
+        args = list(expr.args)[::-1]
         parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
-                                             False)
-        return ' '.join(map(parens, args))
+                                             False) if isinstance(x, Parallel) else self._print(x)
+        return r"\cdot".join(map(parens, args))
 
     def _print_Parallel(self, expr):
         args = list(expr.args)
-        parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
-                                             False)
-        return '+'.join(map(parens, args))
+        func = lambda x: self._print(x)
+        return '+'.join(map(func, args))
 
     def _print_Feedback(self, expr):
         from sympy.physics.control import TransferFunction, Parallel, Series

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -968,10 +968,20 @@ class PrettyPrinter(Printer):
             return self._print(1)/self._print(expr.den)
 
     def _print_Series(self, expr):
+        from sympy.physics.control.lti import Parallel
+        if expr.is_SISO:
+            args = list(expr.args)
+            for i, a in enumerate(expr.args):
+                args[i] = prettyForm(*self._print(a).parens())
+            return prettyForm.__mul__(*args)
         args = list(expr.args)
-        for i, a in enumerate(expr.args):
-            args[i] = prettyForm(*self._print(a).parens())
-        return prettyForm.__mul__(*args)
+        pretty_args = []
+        for i, a in enumerate(reversed(args)):
+            if (isinstance(a, Parallel) and len(expr.args) > 1):
+                pretty_args.append(prettyForm(*self._print(a).parens()))
+            else:
+                pretty_args.append(self._print(a))
+        return prettyForm.__mul__(*pretty_args)
 
     def _print_Parallel(self, expr):
         s = None

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -978,20 +978,30 @@ class PrettyPrinter(Printer):
         pretty_args = []
         for i, a in enumerate(reversed(args)):
             if (isinstance(a, Parallel) and len(expr.args) > 1):
-                pretty_args.append(prettyForm(*self._print(a).parens()))
+                expression = self._print(a)
+                expression.baseline = expression.height()//2
+                pretty_args.append(prettyForm(*expression.parens()))
             else:
-                pretty_args.append(self._print(a))
+                expression = self._print(a)
+                expression.baseline = expression.height()//2
+                pretty_args.append(expression)
         return prettyForm.__mul__(*pretty_args)
 
     def _print_Parallel(self, expr):
+        from sympy.physics.control.lti import TransferFunctionMatrix
         s = None
         for item in expr.args:
             pform = self._print(item)
             if s is None:
                 s = pform     # First element
             else:
+                s = prettyForm(*stringPict.next(s))
+                s.baseline = s.height()//2
                 s = prettyForm(*stringPict.next(s, ' + '))
+                if isinstance(item, TransferFunctionMatrix):
+                    s.baseline = s.height() - 1
                 s = prettyForm(*stringPict.next(s, pform))
+            # s.baseline = s.height()//2
         return s
 
     def _print_Feedback(self, expr):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2379,6 +2379,14 @@ def test_pretty_Series():
     tf1 = TransferFunction(x + y, x - 2*y, y)
     tf2 = TransferFunction(x - y, x + y, y)
     tf3 = TransferFunction(x**2 + y, y - x, y)
+    tf4 = TransferFunction(2, 3, y)
+
+    tfm1 = TransferFunctionMatrix([[tf1, tf2], [tf3, tf4]])
+    tfm2 = TransferFunctionMatrix([[tf3], [-tf4]])
+    tfm3 = TransferFunctionMatrix([[tf1, -tf2, -tf3], [tf3, -tf4, tf2]])
+    tfm4 = TransferFunctionMatrix([[tf1, tf2], [tf3, -tf4], [-tf2, -tf1]])
+    tfm5 = TransferFunctionMatrix([[-tf2, -tf1], [tf4, -tf3], [tf1, tf2]])
+
     expected1 = \
 """\
           ⎛ 2    ⎞\n\
@@ -2406,16 +2414,52 @@ def test_pretty_Series():
 ⎜─────── + ─────⎟⋅⎜───── + ──────⎟\n\
 ⎝x - 2⋅y   x + y⎠ ⎝x + y   -x + y⎠\
 """
+    expected5 = \
+"""\
+⎡ x + y   x - y⎤  ⎡ 2    ⎤ \n\
+⎢───────  ─────⎥  ⎢x  + y⎥ \n\
+⎢x - 2⋅y  x + y⎥  ⎢──────⎥ \n\
+⎢              ⎥  ⎢-x + y⎥ \n\
+⎢ 2            ⎥ ⋅⎢      ⎥ \n\
+⎢x  + y     2  ⎥  ⎢ -2   ⎥ \n\
+⎢──────     ─  ⎥  ⎢ ───  ⎥ \n\
+⎣-x + y     3  ⎦τ ⎣  3   ⎦τ\
+"""
+    expected6 = \
+"""\
+                                               ⎛⎡ x + y    x - y ⎤    ⎡ x - y    x + y ⎤ ⎞\n\
+                                               ⎜⎢───────   ───── ⎥    ⎢ ─────   ───────⎥ ⎟\n\
+⎡ x + y   x - y⎤  ⎡                    2    ⎤  ⎜⎢x - 2⋅y   x + y ⎥    ⎢ x + y   x - 2⋅y⎥ ⎟\n\
+⎢───────  ─────⎥  ⎢ x + y   -x + y  - x  - y⎥  ⎜⎢                ⎥    ⎢                ⎥ ⎟\n\
+⎢x - 2⋅y  x + y⎥  ⎢───────  ──────  ────────⎥  ⎜⎢ 2              ⎥    ⎢          2     ⎥ ⎟\n\
+⎢              ⎥  ⎢x - 2⋅y  x + y    -x + y ⎥  ⎜⎢x  + y     -2   ⎥    ⎢  -2     x  + y ⎥ ⎟\n\
+⎢ 2            ⎥ ⋅⎢                         ⎥ ⋅⎜⎢──────     ───  ⎥  + ⎢  ───    ────── ⎥ ⎟\n\
+⎢x  + y     2  ⎥  ⎢ 2                       ⎥  ⎜⎢-x + y      3   ⎥    ⎢   3     -x + y ⎥ ⎟\n\
+⎢──────     ─  ⎥  ⎢x  + y    -2      x - y  ⎥  ⎜⎢                ⎥    ⎢                ⎥ ⎟\n\
+⎣-x + y     3  ⎦τ ⎢──────    ───     ─────  ⎥  ⎜⎢-x + y    -x - y⎥    ⎢ -x - y  -x + y ⎥ ⎟\n\
+                  ⎣-x + y     3      x + y  ⎦τ ⎜⎢──────   ───────⎥    ⎢───────  ────── ⎥ ⎟\n\
+                                               ⎝⎣x + y    x - 2⋅y⎦τ   ⎣x - 2⋅y  x + y  ⎦τ⎠\
+"""
+
     assert upretty(Series(tf1, tf3)) == expected1
     assert upretty(Series(-tf2, -tf1)) == expected2
     assert upretty(Series(tf3, tf1, Parallel(-tf1, tf2))) == expected3
     assert upretty(Series(Parallel(tf1, tf2), Parallel(tf2, tf3))) == expected4
+    assert upretty(Series(tfm2, tfm1)) == expected5
+    assert upretty(Series(Parallel(tfm4, -tfm5), tfm3, tfm1)) == expected6
 
 
 def test_pretty_Parallel():
     tf1 = TransferFunction(x + y, x - 2*y, y)
     tf2 = TransferFunction(x - y, x + y, y)
     tf3 = TransferFunction(x**2 + y, y - x, y)
+    tf4 = TransferFunction(y**2 - x, x**3 + x, y)
+
+    tfm1 = TransferFunctionMatrix([[tf1, tf2], [tf3, -tf4], [-tf2, -tf1]])
+    tfm2 = TransferFunctionMatrix([[-tf2, -tf1], [tf4, -tf3], [tf1, tf2]])
+    tfm3 = TransferFunctionMatrix([[-tf1, tf2], [-tf3, tf4], [tf2, tf1]])
+    tfm4 = TransferFunctionMatrix([[-tf1, -tf2], [-tf3, -tf4]])
+
     expected1 = \
 """\
  x + y    x - y\n\
@@ -2442,10 +2486,45 @@ x  + y    x + y    ⎛ -x - y⎞ ⎛x - y⎞\n\
 ⎜───────⎟⋅⎜─────⎟ + ⎜─────⎟⋅⎜──────⎟\n\
 ⎝x - 2⋅y⎠ ⎝x + y⎠   ⎝x + y⎠ ⎝-x + y⎠\
 """
+    expected5 = \
+"""\
+⎡ x + y   -x + y ⎤    ⎡ x - y    x + y ⎤    ⎡ x + y    x - y ⎤ \n\
+⎢───────  ────── ⎥    ⎢ ─────   ───────⎥    ⎢───────   ───── ⎥ \n\
+⎢x - 2⋅y  x + y  ⎥    ⎢ x + y   x - 2⋅y⎥    ⎢x - 2⋅y   x + y ⎥ \n\
+⎢                ⎥    ⎢                ⎥    ⎢                ⎥ \n\
+⎢ 2            2 ⎥    ⎢     2    2     ⎥    ⎢ 2            2 ⎥ \n\
+⎢x  + y   x - y  ⎥    ⎢x - y    x  + y ⎥    ⎢x  + y   x - y  ⎥ \n\
+⎢──────   ────── ⎥  + ⎢──────   ────── ⎥  + ⎢──────   ────── ⎥ \n\
+⎢-x + y    3     ⎥    ⎢ 3       -x + y ⎥    ⎢-x + y    3     ⎥ \n\
+⎢         x  + x ⎥    ⎢x  + x          ⎥    ⎢         x  + x ⎥ \n\
+⎢                ⎥    ⎢                ⎥    ⎢                ⎥ \n\
+⎢-x + y    -x - y⎥    ⎢ -x - y  -x + y ⎥    ⎢-x + y    -x - y⎥ \n\
+⎢──────   ───────⎥    ⎢───────  ────── ⎥    ⎢──────   ───────⎥ \n\
+⎣x + y    x - 2⋅y⎦τ   ⎣x - 2⋅y  x + y  ⎦τ   ⎣x + y    x - 2⋅y⎦τ\
+"""
+    expected6 = \
+"""\
+⎡ x - y    x + y ⎤                        ⎡-x + y    -x - y ⎤ \n\
+⎢ ─────   ───────⎥                        ⎢──────   ─────── ⎥ \n\
+⎢ x + y   x - 2⋅y⎥  ⎡ -x - y   -x + y⎤    ⎢x + y    x - 2⋅y ⎥ \n\
+⎢                ⎥  ⎢───────   ──────⎥    ⎢                 ⎥ \n\
+⎢     2    2     ⎥  ⎢x - 2⋅y   x + y ⎥    ⎢      2     2    ⎥ \n\
+⎢x - y    x  + y ⎥  ⎢                ⎥    ⎢-x + y   - x  - y⎥ \n\
+⎢──────   ────── ⎥ ⋅⎢   2           2⎥  + ⎢───────  ────────⎥ \n\
+⎢ 3       -x + y ⎥  ⎢- x  - y  x - y ⎥    ⎢  3       -x + y ⎥ \n\
+⎢x  + x          ⎥  ⎢────────  ──────⎥    ⎢ x  + x          ⎥ \n\
+⎢                ⎥  ⎢ -x + y    3    ⎥    ⎢                 ⎥ \n\
+⎢ -x - y  -x + y ⎥  ⎣          x  + x⎦τ   ⎢ x + y    x - y  ⎥ \n\
+⎢───────  ────── ⎥                        ⎢───────   ─────  ⎥ \n\
+⎣x - 2⋅y  x + y  ⎦τ                       ⎣x - 2⋅y   x + y  ⎦τ\
+"""
+
     assert upretty(Parallel(tf1, tf2)) == expected1
     assert upretty(Parallel(-tf2, -tf1)) == expected2
     assert upretty(Parallel(tf3, tf1, Series(-tf1, tf2))) == expected3
     assert upretty(Parallel(Series(tf1, tf2), Series(tf2, tf3))) == expected4
+    assert upretty(Parallel(-tfm3, -tfm2, tfm1)) == expected5
+    assert upretty(Parallel(Series(tfm4, -tfm2), tfm2)) == expected6
 
 
 def test_pretty_Feedback():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -29,7 +29,7 @@ from sympy.matrices.expressions import hadamard_power
 
 from sympy.physics import mechanics
 from sympy.physics.control.lti import (TransferFunction, Feedback, TransferFunctionMatrix,
-    Series, Parallel)
+    Series, Parallel, MIMOSeries, MIMOParallel)
 from sympy.physics.units import joule, degree
 from sympy.printing.pretty import pprint, pretty as xpretty
 from sympy.printing.pretty.pretty_symbology import center_accent, is_combining
@@ -2445,8 +2445,8 @@ def test_pretty_Series():
     assert upretty(Series(-tf2, -tf1)) == expected2
     assert upretty(Series(tf3, tf1, Parallel(-tf1, tf2))) == expected3
     assert upretty(Series(Parallel(tf1, tf2), Parallel(tf2, tf3))) == expected4
-    assert upretty(Series(tfm2, tfm1)) == expected5
-    assert upretty(Series(Parallel(tfm4, -tfm5), tfm3, tfm1)) == expected6
+    assert upretty(MIMOSeries(tfm2, tfm1)) == expected5
+    assert upretty(MIMOSeries(MIMOParallel(tfm4, -tfm5), tfm3, tfm1)) == expected6
 
 
 def test_pretty_Parallel():
@@ -2523,8 +2523,8 @@ x  + y    x + y    ⎛ -x - y⎞ ⎛x - y⎞\n\
     assert upretty(Parallel(-tf2, -tf1)) == expected2
     assert upretty(Parallel(tf3, tf1, Series(-tf1, tf2))) == expected3
     assert upretty(Parallel(Series(tf1, tf2), Series(tf2, tf3))) == expected4
-    assert upretty(Parallel(-tfm3, -tfm2, tfm1)) == expected5
-    assert upretty(Parallel(Series(tfm4, -tfm2), tfm2)) == expected6
+    assert upretty(MIMOParallel(-tfm3, -tfm2, tfm1)) == expected5
+    assert upretty(MIMOParallel(MIMOSeries(tfm4, -tfm2), tfm2)) == expected6
 
 
 def test_pretty_Feedback():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2283,9 +2283,9 @@ def test_Parallel_printing():
     tf1 = TransferFunction(x*y**2 - z, y**3 - t**3, y)
     tf2 = TransferFunction(x - y, x + y, y)
     assert latex(Parallel(tf1, tf2)) == \
-        r'\left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right) \left(\frac{x - y}{x + y}\right)'
+        r'\left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)+\left(\frac{x - y}{x + y}\right)'
     assert latex(Parallel(-tf2, tf1)) == \
-        r'\left(\frac{- x + y}{x + y}\right) \left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)'
+        r'\left(\frac{- x + y}{x + y}\right)+\left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)'
 
 
 def test_TransferFunctionMatrix_printing():
@@ -2302,9 +2302,9 @@ def test_Feedback_printing():
     tf1 = TransferFunction(p, p + x, p)
     tf2 = TransferFunction(-s + p, p + s, p)
     assert latex(Feedback(tf1, tf2)) == \
-        r'\frac{\frac{p}{p + x}}{\left(1 \cdot 1^{-1}\right) \left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
+        r'\frac{\frac{p}{p + x}}{\left(1 \cdot 1^{-1}\right)+\left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
     assert latex(Feedback(tf1*tf2, TransferFunction(1, 1, p))) == \
-        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\left(1 \cdot 1^{-1}\right) \left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
+        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\left(1 \cdot 1^{-1}\right)+\left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
 
 
 def test_Quaternion_latex_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2283,9 +2283,9 @@ def test_Parallel_printing():
     tf1 = TransferFunction(x*y**2 - z, y**3 - t**3, y)
     tf2 = TransferFunction(x - y, x + y, y)
     assert latex(Parallel(tf1, tf2)) == \
-        r'\left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)+\left(\frac{x - y}{x + y}\right)'
+        r'\frac{x y^{2} - z}{- t^{3} + y^{3}}+\frac{x - y}{x + y}'
     assert latex(Parallel(-tf2, tf1)) == \
-        r'\left(\frac{- x + y}{x + y}\right)+\left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)'
+        r'\frac{- x + y}{x + y}+\frac{x y^{2} - z}{- t^{3} + y^{3}}'
 
 
 def test_TransferFunctionMatrix_printing():
@@ -2302,9 +2302,9 @@ def test_Feedback_printing():
     tf1 = TransferFunction(p, p + x, p)
     tf2 = TransferFunction(-s + p, p + s, p)
     assert latex(Feedback(tf1, tf2)) == \
-        r'\frac{\frac{p}{p + x}}{\left(1 \cdot 1^{-1}\right)+\left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
+        r'\frac{\frac{p}{p + x}}{\frac{1}{1}+\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
     assert latex(Feedback(tf1*tf2, TransferFunction(1, 1, p))) == \
-        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\left(1 \cdot 1^{-1}\right)+\left(\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)\right)}'
+        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\frac{1}{1}+\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
 
 
 def test_Quaternion_latex_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2276,13 +2276,13 @@ def test_Series_printing():
     # Brackets
     assert latex(T_1*(T_2 + T_2)) == \
         r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left(\left[\begin{matrix}\frac{5}{1} &' \
-        r' \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau\right)' \
+        r' \frac{6 s^{3}}{1}\end{matrix}\right]_\tau + \left[\begin{matrix}\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau\right)' \
             == latex(MIMOSeries(MIMOParallel(T_2, T_2), T_1))
     # No Brackets
     M_3 = Matrix([[5, 6], [6, 5/s]])
     T_3 = TransferFunctionMatrix.from_Matrix(M_3, s)
     assert latex(T_1*T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left[\begin{matrix}' \
-        r'\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & ' \
+        r'\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau + \left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & ' \
             r'\frac{5}{s}\end{matrix}\right]_\tau' == latex(MIMOParallel(MIMOSeries(T_2, T_1), T_3))
 
 
@@ -2299,9 +2299,9 @@ def test_Parallel_printing():
     tf1 = TransferFunction(x*y**2 - z, y**3 - t**3, y)
     tf2 = TransferFunction(x - y, x + y, y)
     assert latex(Parallel(tf1, tf2)) == \
-        r'\frac{x y^{2} - z}{- t^{3} + y^{3}}+\frac{x - y}{x + y}'
+        r'\frac{x y^{2} - z}{- t^{3} + y^{3}} + \frac{x - y}{x + y}'
     assert latex(Parallel(-tf2, tf1)) == \
-        r'\frac{- x + y}{x + y}+\frac{x y^{2} - z}{- t^{3} + y^{3}}'
+        r'\frac{- x + y}{x + y} + \frac{x y^{2} - z}{- t^{3} + y^{3}}'
 
     M_1 = Matrix([[5, 6], [6, 5/s]])
     T_1 = TransferFunctionMatrix.from_Matrix(M_1, s)
@@ -2310,7 +2310,7 @@ def test_Parallel_printing():
     M_3 = Matrix([[6, 5/(s*(s - 1))], [5, 6]])
     T_3 = TransferFunctionMatrix.from_Matrix(M_3, s)
     assert latex(T_1 + T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s}\end{matrix}\right]' \
-        r'_\tau+\left[\begin{matrix}\frac{5}{s} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s - 1}\end{matrix}\right]_\tau+\left[\begin{matrix}' \
+        r'_\tau + \left[\begin{matrix}\frac{5}{s} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s - 1}\end{matrix}\right]_\tau + \left[\begin{matrix}' \
             r'\frac{6}{1} & \frac{5}{s \left(s - 1\right)}\\\frac{5}{1} & \frac{6}{1}\end{matrix}\right]_\tau' \
                 == latex(MIMOParallel(T_1, T_2, T_3)) == latex(MIMOParallel(T_1, MIMOParallel(T_2, T_3))) == latex(MIMOParallel(MIMOParallel(T_1, T_2), T_3))
 
@@ -2329,9 +2329,9 @@ def test_Feedback_printing():
     tf1 = TransferFunction(p, p + x, p)
     tf2 = TransferFunction(-s + p, p + s, p)
     assert latex(Feedback(tf1, tf2)) == \
-        r'\frac{\frac{p}{p + x}}{\frac{1}{1}+\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
+        r'\frac{\frac{p}{p + x}}{\frac{1}{1} + \left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
     assert latex(Feedback(tf1*tf2, TransferFunction(1, 1, p))) == \
-        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\frac{1}{1}+\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
+        r'\frac{\left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}{\frac{1}{1} + \left(\frac{p}{p + x}\right) \left(\frac{p - s}{p + s}\right)}'
 
 
 def test_Quaternion_latex_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2269,6 +2269,22 @@ def test_Series_printing():
     assert latex(Series(-tf2, tf1)) == \
         r'\left(\frac{- x + y}{x + y}\right) \left(\frac{x y^{2} - z}{- t^{3} + y^{3}}\right)'
 
+    M_1 = Matrix([[5/s], [5/(2*s)]])
+    T_1 = TransferFunctionMatrix.from_Matrix(M_1, s)
+    M_2 = Matrix([[5, 6*s**3]])
+    T_2 = TransferFunctionMatrix.from_Matrix(M_2, s)
+    # Brackets
+    assert latex(T_1*(T_2 + T_2)) == \
+        r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left(\left[\begin{matrix}\frac{5}{1} &' \
+        r' \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau\right)' \
+            == latex(Series(Parallel(T_2, T_2), T_1))
+    # No Brackets
+    M_3 = Matrix([[5, 6], [6, 5/s]])
+    T_3 = TransferFunctionMatrix.from_Matrix(M_3, s)
+    assert latex(T_1*T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left[\begin{matrix}' \
+        r'\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & ' \
+            r'\frac{5}{s}\end{matrix}\right]_\tau' == latex(Parallel(Series(T_2, T_1), T_3))
+
 
 def test_TransferFunction_printing():
     tf1 = TransferFunction(x - 1, x + 1, x)
@@ -2286,6 +2302,17 @@ def test_Parallel_printing():
         r'\frac{x y^{2} - z}{- t^{3} + y^{3}}+\frac{x - y}{x + y}'
     assert latex(Parallel(-tf2, tf1)) == \
         r'\frac{- x + y}{x + y}+\frac{x y^{2} - z}{- t^{3} + y^{3}}'
+
+    M_1 = Matrix([[5, 6], [6, 5/s]])
+    T_1 = TransferFunctionMatrix.from_Matrix(M_1, s)
+    M_2 = Matrix([[5/s, 6], [6, 5/(s - 1)]])
+    T_2 = TransferFunctionMatrix.from_Matrix(M_2, s)
+    M_3 = Matrix([[6, 5/(s*(s - 1))], [5, 6]])
+    T_3 = TransferFunctionMatrix.from_Matrix(M_3, s)
+    assert latex(T_1 + T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s}\end{matrix}\right]' \
+        r'_\tau+\left[\begin{matrix}\frac{5}{s} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s - 1}\end{matrix}\right]_\tau+\left[\begin{matrix}' \
+            r'\frac{6}{1} & \frac{5}{s \left(s - 1\right)}\\\frac{5}{1} & \frac{6}{1}\end{matrix}\right]_\tau' \
+                == latex(Parallel(T_1, T_2, T_3)) == latex(Parallel(T_1, Parallel(T_2, T_3))) == latex(Parallel(Parallel(T_1, T_2), T_3))
 
 
 def test_TransferFunctionMatrix_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -41,7 +41,7 @@ from sympy.functions.combinatorial.numbers import bernoulli, bell, lucas, \
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, \
-    Feedback, TransferFunctionMatrix
+    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel
 from sympy.physics.quantum import Commutator, Operator
 from sympy.physics.units import meter, gibibyte, microgram, second
 from sympy.core.trace import Tr
@@ -2277,13 +2277,13 @@ def test_Series_printing():
     assert latex(T_1*(T_2 + T_2)) == \
         r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left(\left[\begin{matrix}\frac{5}{1} &' \
         r' \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau\right)' \
-            == latex(Series(Parallel(T_2, T_2), T_1))
+            == latex(MIMOSeries(MIMOParallel(T_2, T_2), T_1))
     # No Brackets
     M_3 = Matrix([[5, 6], [6, 5/s]])
     T_3 = TransferFunctionMatrix.from_Matrix(M_3, s)
     assert latex(T_1*T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{s}\\\frac{5}{2 s}\end{matrix}\right]_\tau\cdot\left[\begin{matrix}' \
         r'\frac{5}{1} & \frac{6 s^{3}}{1}\end{matrix}\right]_\tau+\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & ' \
-            r'\frac{5}{s}\end{matrix}\right]_\tau' == latex(Parallel(Series(T_2, T_1), T_3))
+            r'\frac{5}{s}\end{matrix}\right]_\tau' == latex(MIMOParallel(MIMOSeries(T_2, T_1), T_3))
 
 
 def test_TransferFunction_printing():
@@ -2312,7 +2312,7 @@ def test_Parallel_printing():
     assert latex(T_1 + T_2 + T_3) == r'\left[\begin{matrix}\frac{5}{1} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s}\end{matrix}\right]' \
         r'_\tau+\left[\begin{matrix}\frac{5}{s} & \frac{6}{1}\\\frac{6}{1} & \frac{5}{s - 1}\end{matrix}\right]_\tau+\left[\begin{matrix}' \
             r'\frac{6}{1} & \frac{5}{s \left(s - 1\right)}\\\frac{5}{1} & \frac{6}{1}\end{matrix}\right]_\tau' \
-                == latex(Parallel(T_1, T_2, T_3)) == latex(Parallel(T_1, Parallel(T_2, T_3))) == latex(Parallel(Parallel(T_1, T_2), T_3))
+                == latex(MIMOParallel(T_1, T_2, T_3)) == latex(MIMOParallel(T_1, MIMOParallel(T_2, T_3))) == latex(MIMOParallel(MIMOParallel(T_1, T_2), T_3))
 
 
 def test_TransferFunctionMatrix_printing():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -10,7 +10,7 @@ from sympy.core import Expr, Mul
 from sympy.core.parameters import _exp_is_pow
 from sympy.external import import_module
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, \
-    Feedback, TransferFunctionMatrix
+    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel
 from sympy.physics.units import second, joule
 from sympy.polys import (Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ,
     ZZ_I, QQ_I, lex, grlex)
@@ -672,6 +672,18 @@ def test_Series_str():
         "Series(TransferFunction(-x + y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y))"
 
 
+def test_MIMOSeries_str():
+    tf1 = TransferFunction(x*y**2 - z, y**3 - t**3, y)
+    tf2 = TransferFunction(x - y, x + y, y)
+    tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
+    tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
+    assert str(MIMOSeries(tfm_1, tfm_2)) == \
+        "MIMOSeries(TransferFunctionMatrix(((TransferFunction(x*y**2 - z, -t**3 + y**3, y), TransferFunction(x - y, x + y, y)), "\
+            "(TransferFunction(x - y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y)))), "\
+                "TransferFunctionMatrix(((TransferFunction(x - y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y)), "\
+                    "(TransferFunction(x*y**2 - z, -t**3 + y**3, y), TransferFunction(x - y, x + y, y)))))"
+
+
 def test_TransferFunction_str():
     tf1 = TransferFunction(x - 1, x + 1, x)
     assert str(tf1) == "TransferFunction(x - 1, x + 1, x)"
@@ -691,6 +703,18 @@ def test_Parallel_str():
         "Parallel(TransferFunction(x*y**2 - z, -t**3 + y**3, y), TransferFunction(x - y, x + y, y), TransferFunction(t*x**2 - t**w*x + w, t - y, y))"
     assert str(Parallel(-tf2, tf1)) == \
         "Parallel(TransferFunction(-x + y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y))"
+
+
+def test_MIMOParallel_str():
+    tf1 = TransferFunction(x*y**2 - z, y**3 - t**3, y)
+    tf2 = TransferFunction(x - y, x + y, y)
+    tfm_1 = TransferFunctionMatrix([[tf1, tf2], [tf2, tf1]])
+    tfm_2 = TransferFunctionMatrix([[tf2, tf1], [tf1, tf2]])
+    assert str(MIMOParallel(tfm_1, tfm_2)) == \
+        "MIMOParallel(TransferFunctionMatrix(((TransferFunction(x*y**2 - z, -t**3 + y**3, y), TransferFunction(x - y, x + y, y)), "\
+            "(TransferFunction(x - y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y)))), "\
+                "TransferFunctionMatrix(((TransferFunction(x - y, x + y, y), TransferFunction(x*y**2 - z, -t**3 + y**3, y)), "\
+                    "(TransferFunction(x*y**2 - z, -t**3 + y**3, y), TransferFunction(x - y, x + y, y)))))"
 
 
 def test_Feedback_str():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`MIMOSeries` and `MIMOParallel` classes will support [valid] MIMO transfer functions as arguments. `*` and `+` operators between two `TransferFunctionMatrix` object will return equivalent `MIMOSeries` and `MIMOParallel` objects.

#### Other comments

Checklist:

- [x] ~~Add MIMO support in the constructor of `Series` and `Parallel` classes respectively.~~ Add `MIMOSeries` and `MIMOParallel` classes.
- [x] Implement `doit()` in both `MIMOSeries` and `MIMOParallel`.
- [x] Add `num_input`, `num_output`, and `shape` properties in `MIMOSeries` and `MIMOParallel`.
- [x] ~~Modify `to_expr`, `is_proper`, `is_strictly_proper` and `is_biproper` in `Series` and `Parallel`.~~
- [x] Implement `_eval_rewrite_as_TransferFunctionMatrix()` method in both the classes.
- [x] Modify `__add__` and `__mul__` of the `TransferFunctionMatrix` class to return `MIMOParallel` and `MIMOSeries` objects respectively.
- [x] Modify `__add__`, `__mul__` and `__neg__` in `MIMOSeries` and `MIMOParallel`.
- [x] Add proper docstrings in both the classes with examples.
- [x] Add a common superclass for all the LTI systems.
- [x] Add unit tests for MIMO `Series` and `Parallel` classes covering all the possible outcomes.
  - [x] Tests for `MIMOSeries`
  - [x] Tests for `MIMOParallel`
- [x] Modify `latex.py` and add tests.
  - [x] Update `_print_MIMOSeries()`.
  - [x] Update `_print_MIMOParallel()`.
  - [x] Add tests.
- [x] Modify `pretty.py` and add tests.
  - [x] Update `_print_MIMOSeries()`.
  - [x] Update `_print_MIMOParallel()`.
  - [x] Add tests.
- [x] Modify `_SISO_doit()` to return `Add(*args)` and `Mul(*args)` instead of present implementation. Some tests need to be modified in that case. (**Disussion required before implementing**)
- [x] Add `evalf`, `expand` and `simplify` methods in `TransferFunctionMatrix` class.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added Series and Parallel configuration's support for MIMO systems (`MIMOSeries` and `MIMOParallel` classes).
<!-- END RELEASE NOTES -->
