### PR TITLE
MAINT: Python fixes

### DIFF
--- a/release/github_release.py
+++ b/release/github_release.py
@@ -448,7 +448,6 @@ def _sha256(version, print_=True, local=False):
         out = run(*(['shasum', '-a', '256'] + release_files(version)))
     else:
         raise ValueError('Should not get here...')
-        out = run(*(['shasum', '-a', '256', '/root/release/*']))
     # Remove the release/ part for printing. Useful for copy-pasting into the
     # release notes.
     out = [i.split() for i in out]

--- a/release/github_release.py
+++ b/release/github_release.py
@@ -448,6 +448,7 @@ def _sha256(version, print_=True, local=False):
         out = run(*(['shasum', '-a', '256'] + release_files(version)))
     else:
         raise ValueError('Should not get here...')
+        # out = run(*(['shasum', '-a', '256', '/root/release/*']))
     # Remove the release/ part for printing. Useful for copy-pasting into the
     # release notes.
     out = [i.split() for i in out]

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,6 @@ class audit(Command):
         pass
 
     def run(self):
-        import os
         try:
             import pyflakes.scripts.pyflakes as flakes
         except ImportError:

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -445,9 +445,6 @@ class UndefinedPredicate(Predicate):
                     continue
                 if _res is None:
                     _res = res
-                elif res is None:
-                    # since first resolutor was conclusive, we keep that value
-                    res = _res
                 else:
                     # only check consistency if both resolutors have concluded
                     if _res != res:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -437,7 +437,7 @@ def _(mat, assumptions):
     for i in range(rows):
         for j in range(i, cols):
             cond = fuzzy_bool(Eq(mat[i, j], conjugate(mat[j, i])))
-            if cond == None:
+            if cond is None:
                 ret_val = None
             if cond == False:
                 return False
@@ -708,7 +708,7 @@ def _(mat, assumptions):
     for i in range(rows):
         for j in range(i, cols):
             cond = fuzzy_bool(Eq(mat[i, j], -conjugate(mat[j, i])))
-            if cond == None:
+            if cond is None:
                 ret_val = None
             if cond == False:
                 return False

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1092,7 +1092,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     if not base and list_free_indices.count([]) < 2:
         n = len(list_free_indices)
         size = gens[0].size
-        size = n * (gens[0].size - 2) + 2
+        size = n * (size - 2) + 2
         return size, [], [_af_new(list(range(size)))]
 
     # if any(list_free_indices) one needs to compute the pointwise

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2146,9 +2146,7 @@ class motzkin(Function):
             raise ValueError('The provided number must be a positive integer')
         if n < 0:
             raise ValueError('The provided number must be a positive integer')
-        motzkins = list()
-        if n >= 0:
-            motzkins.append(1)
+        motzkins = [1]
         if n >= 1:
             motzkins.append(1)
         tn1 = 1

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -455,7 +455,7 @@ class LinearEntity(GeometrySet):
                 return [seg]
             elif st1 >= 0:  # st2 < 0:
                 return [Segment(ray.p1, seg.p1)]
-            elif st2 >= 0:  # st1 < 0:
+            else:  # st1 < 0:
                 return [Segment(ray.p1, seg.p2)]
 
         def intersect_parallel_segments(seg1, seg2):

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -455,7 +455,7 @@ class LinearEntity(GeometrySet):
                 return [seg]
             elif st1 >= 0:  # st2 < 0:
                 return [Segment(ray.p1, seg.p1)]
-            else:  # st1 < 0:
+            else:  # st1 < 0 and st2 >= 0:
                 return [Segment(ray.p1, seg.p2)]
 
         def intersect_parallel_segments(seg1, seg2):

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -997,8 +997,6 @@ class Point2D(Point):
         """
         if not (matrix.is_Matrix and matrix.shape == (3, 3)):
             raise ValueError("matrix must be a 3x3 matrix")
-
-        col, row = matrix.shape
         x, y = self.args
         return Point(*(Matrix(1, 3, [x, y, 1])*matrix).tolist()[0][:2])
 
@@ -1289,8 +1287,6 @@ class Point3D(Point):
         """
         if not (matrix.is_Matrix and matrix.shape == (4, 4)):
             raise ValueError("matrix must be a 4x4 matrix")
-
-        col, row = matrix.shape
         from sympy.matrices.expressions import Transpose
         x, y, z = self.args
         m = Transpose(matrix)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -498,9 +498,7 @@ class Polygon(GeometrySet):
 
         h_poly = self.cut_section(h_line)
         v_poly = self.cut_section(v_line)
-
-        x_min, y_min, x_max, y_max = self.bounds
-
+        
         poly_1 = h_poly[0] if h_poly[0].area <= h_poly[1].area else h_poly[1]
         poly_2 = v_poly[0] if v_poly[0].area <= v_poly[1].area else v_poly[1]
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -498,7 +498,7 @@ class Polygon(GeometrySet):
 
         h_poly = self.cut_section(h_line)
         v_poly = self.cut_section(v_line)
-        
+
         poly_1 = h_poly[0] if h_poly[0].area <= h_poly[1].area else h_poly[1]
         poly_2 = v_poly[0] if v_poly[0].area <= v_poly[1].area else v_poly[1]
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1210,8 +1210,6 @@ class HolonomicFunction:
         coeffs[0] = S.One
         system = [coeffs]
         homogeneous = Matrix([[S.Zero for i in range(a)]]).transpose()
-        sol = S.Zero
-
         while True:
             coeffs_next = [p.diff(self.x) for p in coeffs]
             for i in range(a - 1):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -334,7 +334,6 @@ def alternatives(*rules):
     return _alternatives
 
 def constant_rule(integral):
-    integrand, symbol = integral
     return ConstantRule(integral.integrand, *integral)
 
 def power_rule(integral):

--- a/sympy/integrals/rubi/parsetools/parse.py
+++ b/sympy/integrals/rubi/parsetools/parse.py
@@ -158,7 +158,6 @@ def parse_full_form(wmexpr):
             if last_expr != '':
                 stack[-1].append(last_expr)
             stack.pop()
-            current_pos = stack[-1]
         elif match.group() == '[':
             stack[-1].append([last_expr])
             stack.append(stack[-1][-1])
@@ -710,9 +709,7 @@ def rubi_rule_parser(fullform, header=None, module_name='rubi_object'):
             rules.append(i)
     parsed = downvalues_rules(rules, header, cons_dict, cons_index, index)
     result = parsed[0].strip() + '\n'
-    cons_index = parsed[1]
     cons += parsed[2]
-    index = parsed[3]
     # Replace temporary variables by actual values
     for i in temporary_variable_replacement:
         cons = cons.replace(temporary_variable_replacement[i], i)

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -5264,7 +5264,6 @@ def IntSum(u, x):
     # If u is free of x or of the form c*(a+b*x)^m, IntSum[u,x] returns the antiderivative of u wrt x;
     # else it returns d*Int[v,x] where d*v=u and d is free of x.
     return Add(*[Integral(i, x) for i in u.args])
-    return Simp(FreeTerms(u, x)*x, x) + IntTerm(NonfreeTerms(u, x), x)
 
 def IntTerm(expr, x):
     # If u is of the form c*(a+b*x)**m, IntTerm(u,x) returns the antiderivative of u wrt x;

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -209,8 +209,6 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     k = 1
     for p in sieve.primerange(1, B1 + 1):
         k *= pow(p, integer_log(B1, p)[0])
-    g = 1
-
     while(curve <= max_curve):
         curve += 1
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1543,9 +1543,6 @@ class Beam:
                 raise ValueError('Value of %s was not passed.' %sym)
         if self.length in subs:
             length = subs[self.length]
-        else:
-            length = self.length
-
         ax1 = plot(self.shear_force().subs(subs), (variable, 0, length),
                    title="Shear Force", xlabel=r'$\mathrm{x}$', ylabel=r'$\mathrm{V}$',
                    line_color='g', show=False)

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1541,8 +1541,8 @@ class Beam:
                 continue
             if sym not in subs:
                 raise ValueError('Value of %s was not passed.' %sym)
-        if self.length in subs:
-            length = subs[self.length]
+        if length in subs:
+            length = subs[length]
         ax1 = plot(self.shear_force().subs(subs), (variable, 0, length),
                    title="Shear Force", xlabel=r'$\mathrm{x}$', ylabel=r'$\mathrm{V}$',
                    line_color='g', show=False)

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -239,11 +239,12 @@ class Joint(ABC):
                     return parent_frame.x
                 return parent_frame.z
             return parent_frame.y
-        if y!=0:
-            if z!=0:
-                return parent_frame.x
-            return parent_frame.z
-        return parent_frame.x
+        else:
+            if y!=0:
+                if z!=0:
+                    return parent_frame.x
+                return parent_frame.z
+            return parent_frame.x
 
 
 class PinJoint(Joint):

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -239,13 +239,11 @@ class Joint(ABC):
                     return parent_frame.x
                 return parent_frame.z
             return parent_frame.y
-
-        if x == 0:
-            if y!=0:
-                if z!=0:
-                    return parent_frame.x
-                return parent_frame.z
-            return parent_frame.x
+        if y!=0:
+            if z!=0:
+                return parent_frame.x
+            return parent_frame.z
+        return parent_frame.x
 
 
 class PinJoint(Joint):

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -269,7 +269,7 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
     except ValueError:
         angle_of_total_internal_reflection_onset = None
 
-    if angle_of_total_internal_reflection_onset == None or\
+    if angle_of_total_internal_reflection_onset is None or\
     angle_of_total_internal_reflection_onset > angle_of_incidence:
         R_s = -sin(angle_of_incidence - angle_of_refraction)\
                 /sin(angle_of_incidence + angle_of_refraction)

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -137,9 +137,6 @@ def refraction_angle(incident, medium1, medium2, normal=None, plane=None):
             raise ValueError('Ray undergoes total internal reflection')
         return asin(n1*sin(angle_of_incidence)/n2)
 
-    if angle_of_incidence and not 0 <= angle_of_incidence < pi*0.5:
-        raise ValueError
-
     # Treat the incident as ray below
     # A flag to check whether to return Ray3D or not
     return_ray = False

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -26,8 +26,6 @@ class GenericPoly(PicklableWithSlots):
     def _perify_factors(per, result, include):
         if include:
             coeff, factors = result
-        else:
-            coeff = result
 
         factors = [ (per(g), k) for g, k in factors ]
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -446,7 +446,6 @@ class PrettyPrinter(Printer):
         firstterm = True
         s = None
         for lim in integral.limits:
-            x = lim[0]
             # Create bar based on the height of the argument
             h = arg.height()
             H = h + 2

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -941,7 +941,6 @@ class StrPrinter(Printer):
 
     def _print_AppliedBinaryRelation(self, expr):
         rel, args = expr.function, expr.arguments
-        lhs, rhs = args
         return '%s(%s, %s)' % (self._print(rel),
                                self._print(expr.lhs),
                                self._print(expr.rhs))

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -940,7 +940,7 @@ class StrPrinter(Printer):
         return self._print(s.name)
 
     def _print_AppliedBinaryRelation(self, expr):
-        rel, args = expr.function, expr.arguments
+        rel = expr.function
         return '%s(%s, %s)' % (self._print(rel),
                                self._print(expr.lhs),
                                self._print(expr.rhs))

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1244,8 +1244,6 @@ class FormalPowerSeries(SeriesBase):
 
         """
 
-        if x is None:
-            x = self.x
         if n is None:
             return iter(self)
 
@@ -1347,8 +1345,6 @@ class FormalPowerSeries(SeriesBase):
 
         """
 
-        if x is None:
-            x = self.x
         if n is None:
             return iter(self)
 
@@ -1423,8 +1419,6 @@ class FormalPowerSeries(SeriesBase):
 
         """
 
-        if x is None:
-            x = self.x
         if n is None:
             return iter(self)
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -523,7 +523,6 @@ def mrv_leadterm(e, x):
         e_up = moveup([e], x)[0]
         exps_up = moveup([exps], x)[0]
         # NOTE: there is no need to move this down!
-        e = e_up
         Omega = Omega_up
         exps = exps_up
     #

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -520,7 +520,6 @@ def mrv_leadterm(e, x):
     if x in Omega:
         # move the whole omega up (exponentiate each term):
         Omega_up = moveup2(Omega, x)
-        e_up = moveup([e], x)[0]
         exps_up = moveup([exps], x)[0]
         # NOTE: there is no need to move this down!
         Omega = Omega_up

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -313,7 +313,6 @@ def mrv(e, x):
     elif e.is_Derivative:
         raise NotImplementedError("MRV set computation for derviatives"
                                   " not implemented yet.")
-        return mrv(e.args[0], x)
     raise NotImplementedError(
         "Don't know how to calculate the mrv of '%s'" % e)
 

--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -72,8 +72,6 @@ def equivalence_hypergeometric(A, B, func):
     num, dem = J1.as_numer_denom()
     num = powdenest(expand(num))
     dem = powdenest(expand(dem))
-    pow_num = set()
-    pow_dem = set()
     # this function will compute the different powers of variable(x) in J1.
     # then it will help in finding value of k. k is power of x such that we can express
     # J1 = x**k * J0(x**k) then all the powers in J0 become integers.
@@ -138,8 +136,6 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     beta = Wild("beta")
     gamma = Wild("gamma")
     delta = Wild("delta")
-
-    rn = {'type':None}
     # I0 of the standerd 2F1 equation.
     I0 = ((a-b+1)*(a-b-1)*x**2 + 2*((1-a-b)*c + 2*a*b)*x + c*(c-2))/(4*x**2*(x-1)**2)
     if sing_point != [0, 1]:

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -3192,7 +3192,6 @@ def _ode_lie_group( s, func, order, match):
     y = match.pop('y', None)
     if y:
         h = -simplify(match[match['d']]/match[match['e']])
-        y = y
     else:
         y = Dummy("y")
         h = s.subs(func, y)

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1489,9 +1489,7 @@ def _classify_linear_system(eqs, funcs, t, is_canon=False):
             match['commutative_antiderivative'] = antiderivative
 
         return match
-
-    if is_higher_order:
-
+    else:
         match['type_of_equation'] = "type0"
 
         if is_second_order:
@@ -1525,9 +1523,6 @@ def _classify_linear_system(eqs, funcs, t, is_canon=False):
         match['is_higher_order'] = is_higher_order
 
         return match
-
-    return None
-
 
 def _preprocess_eqs(eqs):
     processed_eqs = []

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3336,8 +3336,6 @@ def unrad(eq, *syms, **flags):
         newsyms.update(syms & r.free_symbols)
     if newsyms != syms:
         syms = newsyms
-        gens = [g for g in gens if g.free_symbols & syms]
-
     # get terms together that have common generators
     drad = dict(list(zip(rads, list(range(len(rads))))))
     rterms = {(): []}

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2746,8 +2746,6 @@ def linsolve(system, *symbols):
     sym_gen = isinstance(symbols, GeneratorType)
 
     b = None  # if we don't get b the input was bad
-    syms_needed_msg = None
-
     # unpack system
 
     if hasattr(system, '__iter__'):
@@ -2793,9 +2791,6 @@ def linsolve(system, *symbols):
 
     if b is None:
         raise ValueError("Invalid arguments")
-
-    syms_needed_msg  = syms_needed_msg or 'columns of A'
-
     if sym_gen:
         symbols = [next(symbols) for i in range(A.cols)]
         if any(set(symbols) & (A.free_symbols | b.free_symbols)):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -471,8 +471,8 @@ class MarkovProcess(StochasticProcess):
 
         # given_condition does not have sufficient information
         # for computations
-        if trans_probs == None or \
-            given_condition == None:
+        if trans_probs is None or \
+            given_condition is None:
             is_insufficient = True
         else:
             # checking transition probabilities
@@ -1572,7 +1572,7 @@ class ContinuousMarkovChain(ContinuousTimeStochasticProcess, MarkovProcess):
 
     def limiting_distribution(self):
         gen_mat = self.generator_matrix
-        if gen_mat == None:
+        if gen_mat is None:
             return None
         if isinstance(gen_mat, MatrixSymbol):
             wm = MatrixSymbol('wm', 1, gen_mat.shape[0])

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -964,7 +964,6 @@ class ArrayContraction(_CodegenArrayAbstract):
                 arg2, pos2 = new_sequence[i+1]
                 if arg1 == arg2:
                     raise NotImplementedError
-                    continue
                 abspos1 = reverse_mapping[arg1, pos1]
                 abspos2 = reverse_mapping[arg2, pos2]
                 new_contraction_indices.append((abspos1, abspos2))

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -234,7 +234,7 @@ def _(expr: ArrayTensorProduct):
                 newargs.append(arg)
                 pending = k
                 prev_i = i
-            elif pending != k:
+            else:
                 pending = k
                 prev_i = i
                 newargs.append(arg)

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -113,7 +113,6 @@ def copy(src, dst, only_update=False, copystat=True, cwd=None,
         dst = os.path.join(dest_dir, dest_fname)
     else:
         dest_dir = os.path.dirname(dst)
-        dest_fname = os.path.basename(dst)
 
     if not os.path.exists(dest_dir):
         if create_dest_dirs:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -605,8 +605,6 @@ class CodeGen:
                 # pack the simplified expressions back up with their left hand sides
                 expr = [Equality(e.lhs, rhs) for e, rhs in zip(expr, simplified)]
             else:
-                rhs = [expr]
-
                 if isinstance(expr, Equality):
                     common, simplified = cse(expr.rhs) #, ignore=in_out_args)
                     expr = Equality(expr.lhs, simplified[0])

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1770,14 +1770,6 @@ def partitions(n, m=None, k=None, size=False):
         m = n
     else:
         m = min(m, n)
-
-    if n == 0:
-        if size:
-            yield 1, {0: 1}
-        else:
-            yield {0: 1}
-        return
-
     k = min(k or n, n)
 
     n, m, k = as_int(n), as_int(m), as_int(k)

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -401,8 +401,6 @@ class ImplicitRegion(Basic):
             # For degree 2 curves, either a regular point or a singular point can be used.
             if reg_point is not None:
                 # Using point provided by the user as regular point
-                if isinstance(point, Point):
-                    point = point.args
                 point = reg_point
             else:
                 if len(self.singular_points()) != 0:


### PR DESCRIPTION
# Changes

- Removals
  - Unnecessary code
    - Reassignments
    - Reimports
    - Unused variables
  - Useless conditions
  - Never reached return
  - Definitions where a redefinition will occur before usage
  - `continue` and `return` after `raise` and `return` makes no sense
- Fix `if`-`elif`-`else` usage
- Use `is` for `None`
- Actually use the size variable


<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
