### PR TITLE
Fixed the simplify trace matrix issue 

### DIFF
--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -21,7 +21,7 @@ _gens_order = {
 }
 
 _max_order = 1000
-_re_gen = re.compile(r"^(.+?)(\d*)$")
+_re_gen = re.compile(r"^(.*?)(\d*)$", re.MULTILINE)
 
 
 def _nsort(roots, separated=False):


### PR DESCRIPTION
Fixing of simplified the Trace matrix attribute error.

This Pull request fixes the "Fixes#19353" issue. The issue link is here.(https://github.com/sympy/sympy/issues/19353)

The file changed here is sympy/polys/polyutils.py. In this file I have changed the line 
from this 
#_re_gen = re.compile(r"^(.+?)(\d*)$")
to 
_re_gen = re.compile(r"^(.*?)(\d*)$", re.MULTILINE)

By changing this line we can get rid of the attribution error.  I have attached an image below which is working fine after the changes in polyutils.py file.
![smyp_trace_matrix](https://user-images.githubusercontent.com/17118833/125035320-4b2bea80-e0af-11eb-8db6-e3cbd105d238.PNG)


#### Other comments
I have followed the comments which is incluced [here](https://github.com/sympy/sympy/issues/19353) and fixed the issue. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
