### PR TITLE
Check if velocity is defined in frame before taking derivative of pos

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -554,7 +554,15 @@ class Point:
                             continue
                         candidate_neighbor.append(neighbor)
                         if not valid_neighbor_found:
-                            self.set_vel(frame, self.pos_from(neighbor).dt(frame) + neighbor_velocity)
+                            vel = None
+                            for f in self.pos_from(neighbor).args:
+                                if f[1] in self._vel_dict.keys():
+                                    if self._vel_dict[f[1]] != 0:
+                                        vel = self._vel_dict[f[1]]
+                                        break
+                            if vel is None:
+                                vel = self.pos_from(neighbor).dt(frame)
+                            self.set_vel(frame, vel + neighbor_velocity)
                             valid_neighbor_found = True
             if is_cyclic:
                 warn('Kinematic loops are defined among the positions of points. This is likely not desired and may cause errors in your calculations.')

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -298,3 +298,14 @@ def test_auto_vel_multiple_path_warning_msg():
         assert issubclass(w[-1].category, UserWarning)
         assert 'Velocity automatically calculated based on point' in str(w[-1].message)
         assert 'Velocities from these points are not necessarily the same. This may cause errors in your calculations.' in str(w[-1].message)
+
+def test_vel_frame():
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+    A.orient_axis(N, N.x, 0)
+    P = Point('P')
+    P.set_vel(N, 5*N.x)
+    P1 = Point('P1')
+    P1.set_pos(P, A.x+N.x)
+    P1.set_vel(A, 10*A.x)
+    assert P1.vel(N) == 5*N.x + 10*A.x


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier when velocity was not defined in a frame but pos vector was given, the velocity was calculated(#20049) . But now if we have a point defined with velocity in that frame, then we first check if current point's velocity is available in given frame or not.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * `Point.vel()` checks velocity in intermediate frames before taking derivative of position vector. 
<!-- END RELEASE NOTES -->
