### PR TITLE
[GSoC] Improvements to `Limit.doit`

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1127,7 +1127,7 @@ def test_issue_14111():
 
 
 def test_issue_14484():
-    raises(NotImplementedError, lambda: Sum(sin(n)/log(log(n)), (n, 22, oo)).is_convergent())
+    assert Sum(sin(n)/log(log(n)), (n, 22, oo)).is_convergent() is S.false
 
 
 def test_issue_14640():

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1019,7 +1019,7 @@ class Expr(Basic, EvalfMixin):
             arg = arg.diff(x)
             coeff = arg.subs(x, 0)
             if coeff is S.NaN:
-                raise ValueError()
+                coeff = arg.limit(x, 0)
             if coeff is S.ComplexInfinity:
                 try:
                     coeff, _ = arg.leadterm(x)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1863,18 +1863,13 @@ class Mul(Expr, AssocOp):
         from itertools import product
 
         def coeff_exp(term, x):
-            coeff, exp = S.One, S.Zero
-            for factor in Mul.make_args(term):
-                if factor.has(x):
-                    base, exp = factor.as_base_exp()
-                    if base != x:
-                        try:
-                            return term.leadterm(x)
-                        except ValueError:
-                            return term, S.Zero
-                else:
-                    coeff *= factor
-            return coeff, exp
+            lt = term.as_coeff_exponent(x)
+            if lt[0].has(x):
+                try:
+                    lt = term.leadterm(x)
+                except ValueError:
+                    return term, S.Zero
+            return lt
 
         ords = []
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1914,7 +1914,7 @@ class Mul(Expr, AssocOp):
             ords3 = [coeff_exp(term, x) for term in fac]
             coeffs, powers = zip(*ords3)
             power = sum(powers)
-            if power < n:
+            if (power - n).is_negative:
                 res += Mul(*coeffs)*(x**power)
 
         def max_degree(e, x):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -978,7 +978,7 @@ class log(Function):
         try:
             a, b = arg.leadterm(x)
             s = arg.nseries(x, n=n+b, logx=logx)
-        except (ValueError, NotImplementedError):
+        except (ValueError, NotImplementedError, PoleError):
             s = arg.nseries(x, n=n, logx=logx)
             while s.is_Order:
                 n += 1
@@ -1035,6 +1035,8 @@ class log(Function):
         x0 = arg0.subs(x, 0)
         if x0 is S.NaN and logx is None:
             x0 = arg.limit(x, 0)
+        if x0 in (S.NegativeInfinity, S.Infinity):
+            raise PoleError("Cannot expand %s around 0" % (self))
         if x0 == 1:
             return (arg0 - S.One).as_leading_term(x)
         if cdir != 0:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -234,7 +234,7 @@ class sinh(HyperbolicFunction):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return arg
         elif arg0.is_finite:
@@ -424,7 +424,7 @@ class cosh(HyperbolicFunction):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return S.One
         elif arg0.is_finite:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -230,13 +230,17 @@ class sinh(HyperbolicFunction):
         return 2*coth_half/(coth_half**2 - 1)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy import Order
-        arg = self.args[0].as_leading_term(x)
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        if arg0.is_zero:
             return arg
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_is_real(self):
         arg = self.args[0]
@@ -416,13 +420,17 @@ class cosh(HyperbolicFunction):
         return (coth_half + 1)/(coth_half - 1)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy import Order
-        arg = self.args[0].as_leading_term(x)
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        if arg0.is_zero:
             return S.One
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_is_real(self):
         arg = self.args[0]

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -137,7 +137,7 @@ class floor(RoundFunction):
         if arg0 is S.NaN:
             arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
         r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-        if r.is_finite:
+        if arg0.is_finite:
             if r == arg0:
                 direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
                 if direction.is_positive and cdir != -1:
@@ -296,7 +296,7 @@ class ceiling(RoundFunction):
         if arg0 is S.NaN:
             arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
         r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-        if r.is_finite:
+        if arg0.is_finite:
             if r == arg0:
                 direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
                 if direction.is_positive and cdir != -1:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -135,12 +135,12 @@ class floor(RoundFunction):
         arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
         arg0 = arg.subs(x, 0)
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
         if arg0.is_finite:
             if r == arg0:
                 direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-                if direction.is_positive and cdir != -1:
+                if direction.is_positive and arg.dir(x, cdir) != -1:
                     return r
                 else:
                     return r - 1
@@ -294,12 +294,12 @@ class ceiling(RoundFunction):
         arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
         arg0 = arg.subs(x, 0)
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
         if arg0.is_finite:
             if r == arg0:
                 direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-                if direction.is_positive and cdir != -1:
+                if direction.is_positive and arg.dir(x, cdir) != -1:
                     return r + 1
                 else:
                     return r

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -132,21 +132,23 @@ class floor(RoundFunction):
             return arg.approximation_interval(Integer)[0]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg = self.args[0]
         arg0 = arg.subs(x, 0)
-        if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
-        r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        r = self.subs(x, 0)
         if arg0.is_finite:
-            if r == arg0:
-                direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-                if direction.is_positive and arg.dir(x, cdir) != -1:
-                    return r
+            if arg0 == r:
+                if cdir == 0:
+                    ndirl = arg.dir(x, cdir=-1)
+                    ndir = arg.dir(x, cdir=1)
+                    if ndir != ndirl:
+                        raise ValueError("Two sided limit of %s around 0"
+                                    "does not exist" % self)
                 else:
-                    return r - 1
+                    ndir = arg.dir(x, cdir=cdir)
+                return r - 1 if ndir.is_negative else r
             else:
                 return r
-        return arg
+        return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
@@ -159,11 +161,8 @@ class floor(RoundFunction):
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:
-            direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-            if direction.is_positive and cdir != -1:
-                return r
-            else:
-                return r - 1
+            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+            return r - 1 if ndir.is_negative else r
         else:
             return r
 
@@ -291,21 +290,23 @@ class ceiling(RoundFunction):
             return arg.approximation_interval(Integer)[1]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg = self.args[0]
         arg0 = arg.subs(x, 0)
-        if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
-        r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        r = self.subs(x, 0)
         if arg0.is_finite:
-            if r == arg0:
-                direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-                if direction.is_positive and arg.dir(x, cdir) != -1:
-                    return r + 1
+            if arg0 == r:
+                if cdir == 0:
+                    ndirl = arg.dir(x, cdir=-1)
+                    ndir = arg.dir(x, cdir=1)
+                    if ndir != ndirl:
+                        raise ValueError("Two sided limit of %s around 0"
+                                    "does not exist" % self)
                 else:
-                    return r
+                    ndir = arg.dir(x, cdir=cdir)
+                return r if ndir.is_negative else r + 1
             else:
                 return r
-        return arg
+        return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
@@ -314,15 +315,12 @@ class ceiling(RoundFunction):
             from sympy.calculus.util import AccumBounds
             from sympy.series.order import Order
             s = arg._eval_nseries(x, n, logx, cdir)
-            o = Order(1, (x, 0)) if n <= 0  else AccumBounds(0, 1)
+            o = Order(1, (x, 0)) if n <= 0 else AccumBounds(0, 1)
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:
-            direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
-            if direction.is_positive and cdir != -1:
-                return r + 1
-            else:
-                return r
+            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+            return r if ndir.is_negative else r + 1
         else:
             return r
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -132,11 +132,21 @@ class floor(RoundFunction):
             return arg.approximation_interval(Integer)[0]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        arg = self.args[0]
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
         arg0 = arg.subs(x, 0)
-        if arg0.is_finite:
-            return self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-        return arg.as_leading_term(x)
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        if r.is_finite:
+            if r == arg0:
+                direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
+                if direction.is_positive and cdir != -1:
+                    return r
+                else:
+                    return r - 1
+            else:
+                return r
+        return arg
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
@@ -149,8 +159,8 @@ class floor(RoundFunction):
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:
-            direction = (arg - arg0).leadterm(x)[0]
-            if direction.is_positive:
+            direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
+            if direction.is_positive and cdir != -1:
                 return r
             else:
                 return r - 1
@@ -281,11 +291,21 @@ class ceiling(RoundFunction):
             return arg.approximation_interval(Integer)[1]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        arg = self.args[0]
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
         arg0 = arg.subs(x, 0)
-        if arg0.is_finite:
-            return self._eval_nseries(x, n=1, logx=None, cdir=cdir)
-        return arg.as_leading_term(x)
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        r = self._eval_nseries(x, n=1, logx=None, cdir=cdir)
+        if r.is_finite:
+            if r == arg0:
+                direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
+                if direction.is_positive and cdir != -1:
+                    return r + 1
+                else:
+                    return r
+            else:
+                return r
+        return arg
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
@@ -298,8 +318,8 @@ class ceiling(RoundFunction):
             return s + o
         r = self.subs(x, 0)
         if arg0 == r:
-            direction = (arg - arg0).leadterm(x)[0]
-            if direction.is_positive:
+            direction = (arg - arg0).leadterm(x, cdir=cdir)[0]
+            if direction.is_positive and cdir != -1:
                 return r + 1
             else:
                 return r

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1255,7 +1255,12 @@ def test_as_leading_term_issue_5272():
 
 
 def test_leading_terms():
-    for func in [sin, cos, tan, cot]:
+    assert sin(1/x).as_leading_term(x) == AccumBounds(-1 , 1)
+    assert sin(S.Half).as_leading_term(x) == sin(S.Half)
+    assert cos(1/x).as_leading_term(x) == AccumBounds(-1 , 1)
+    assert cos(S.Half).as_leading_term(x) == cos(S.Half)
+
+    for func in [tan, cot]:
         for a in (1/x, S.Half):
             eq = func(a)
             assert eq.as_leading_term(x) == eq

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -478,12 +478,15 @@ class sin(TrigonometricFunction):
         return sin(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.calculus.util import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         n = x0/S.Pi
         if n.is_integer:
             lt = (arg - n*S.Pi).as_leading_term(x)
             return ((-1)**n)*lt
+        if x0.is_infinite:
+            return AccumBounds(-1, 1)
         return self.func(x0) if x0.is_finite else self
 
     def _eval_is_extended_real(self):
@@ -929,15 +932,16 @@ class cos(TrigonometricFunction):
         return cos(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.calculus.util import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         n = (x0 + S.Pi/2)/S.Pi
         if n.is_integer:
             lt = (arg - n*S.Pi + S.Pi/2).as_leading_term(x)
             return ((-1)**n)*lt
-        if not x0.is_finite:
-            return self
-        return self.func(x0)
+        if x0.is_infinite:
+            return AccumBounds(-1, 1)
+        return self.func(x0) if x0.is_finite else self
 
     def _eval_is_extended_real(self):
         if self.args[0].is_extended_real:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -485,7 +485,9 @@ class sin(TrigonometricFunction):
         if n.is_integer:
             lt = (arg - n*S.Pi).as_leading_term(x)
             return ((-1)**n)*lt
-        if x0.is_infinite:
+        if x0 is S.ComplexInfinity:
+            x0 = arg.limit(x, 0, dir='-' if cdir < 0 else '+')
+        if x0 in [S.Infinity, S.NegativeInfinity]:
             return AccumBounds(-1, 1)
         return self.func(x0) if x0.is_finite else self
 
@@ -939,7 +941,9 @@ class cos(TrigonometricFunction):
         if n.is_integer:
             lt = (arg - n*S.Pi + S.Pi/2).as_leading_term(x)
             return ((-1)**n)*lt
-        if x0.is_infinite:
+        if x0 is S.ComplexInfinity:
+            x0 = arg.limit(x, 0, dir='-' if cdir < 0 else '+')
+        if x0 in [S.Infinity, S.NegativeInfinity]:
             return AccumBounds(-1, 1)
         return self.func(x0) if x0.is_finite else self
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -218,9 +218,9 @@ class besselj(BesselBase):
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         nu, z = self.args
-        arg = (z/2).as_leading_term(x)
+        arg = z.as_leading_term(x)
         if x in arg.free_symbols:
-            return arg**nu
+            return arg**nu/(2**nu*gamma(nu + 1))
         else:
             return self.func(nu, z.subs(x, 0))
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2015,7 +2015,7 @@ class Ci(TrigonometricIntegral):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return S.EulerGamma
         elif arg0.is_finite:
@@ -2142,7 +2142,7 @@ class Shi(TrigonometricIntegral):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return arg
         elif not arg0.is_infinite:
@@ -2260,7 +2260,7 @@ class Chi(TrigonometricIntegral):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.NaN:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return S.EulerGamma
         elif arg0.is_finite:
@@ -2451,7 +2451,7 @@ class fresnels(FresnelIntegral):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.ComplexInfinity:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if arg0.is_zero:
             return pi*arg**3/6
         else:
@@ -2603,7 +2603,7 @@ class fresnelc(FresnelIntegral):
         arg0 = arg.subs(x, 0)
 
         if arg0 is S.ComplexInfinity:
-            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
         if x in arg.free_symbols and arg0.is_zero:
             return arg
         else:

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2452,7 +2452,7 @@ class fresnels(FresnelIntegral):
 
         if arg0 is S.ComplexInfinity:
             arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
-        if x in arg.free_symbols and arg0.is_zero:
+        if arg0.is_zero:
             return pi*arg**3/6
         else:
             return self.func(arg0)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1199,6 +1199,13 @@ class Ei(Function):
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):
         return exp(z) * _eis(z)
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_Si(*self.args)
+            return f._eval_as_leading_term(x, logx=logx, cdir=cdir)
+        return super()._eval_as_leading_term(x, logx=logx, cdir=cdir)
+
     def _eval_nseries(self, x, n, logx, cdir=0):
         x0 = self.args[0].limit(x, 0)
         if x0.is_zero:
@@ -2003,6 +2010,19 @@ class Ci(TrigonometricIntegral):
     def _eval_rewrite_as_expint(self, z, **kwargs):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg0 = arg.subs(x, 0)
+
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        if arg0.is_zero:
+            return S.EulerGamma
+        elif arg0.is_finite:
+            return self.func(arg0)
+        else:
+            return self
+
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.series.order import Order
         point = args0[0]
@@ -2117,6 +2137,21 @@ class Shi(TrigonometricIntegral):
         if z.is_zero:
             return True
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
+
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        if arg0.is_zero:
+            return arg
+        elif not arg0.is_infinite:
+            return self.func(arg0)
+        elif arg0.is_infinite:
+            return -pi*S.ImaginiryUnit/2
+        else:
+            return self
+
     def _sage_(self):
         import sage.all as sage
         return sage.sinh_integral(self.args[0]._sage_())
@@ -2219,6 +2254,19 @@ class Chi(TrigonometricIntegral):
     def _eval_rewrite_as_expint(self, z, **kwargs):
         from sympy import exp_polar
         return -I*pi/2 - (E1(z) + E1(exp_polar(I*pi)*z))/2
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
+        arg0 = arg.subs(x, 0)
+
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir == -1 else '+')
+        if arg0.is_zero:
+            return S.EulerGamma
+        elif arg0.is_finite:
+            return self.func(arg0)
+        else:
+            return self
 
     def _sage_(self):
         import sage.all as sage
@@ -2674,6 +2722,13 @@ class _eis(Function):
 
     def _eval_rewrite_as_intractable(self, z, **kwargs):
         return exp(-z)*Ei(z)
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_as_leading_term(x, logx=logx, cdir=cdir)
+        return super()._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         x0 = self.args[0].limit(x, 0)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -39,6 +39,9 @@ def test_besselj_leading_term():
     assert besselj(1, sin(x)).as_leading_term(x) == x/2
     assert besselj(1, 2*sqrt(x)).as_leading_term(x) == sqrt(x)
 
+    # https://github.com/sympy/sympy/issues/21701
+    assert (besselj(z, x)/x**z).as_leading_term(x) == 1/(2**z*gamma(z + 1))
+
 
 def test_bessely_leading_term():
     assert bessely(0, x).as_leading_term(x) == (2*log(x) - 2*log(2))/pi

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -485,7 +485,7 @@ def test__eis():
         == Ei(z).diff(z)
 
     assert _eis(z).series(z, n=3) == EulerGamma + log(z) + z*(-log(z) - \
-        EulerGamma + 1) + z**2*(log(z)/2 - Rational(3, 4) + EulerGamma/2) + O(z**3*log(z))
+        EulerGamma + 1) + z**2*(log(z)/2 - Rational(3, 4) + EulerGamma/2) + O(z**3)
     raises(ArgumentIndexError, lambda: _eis(z).fdiff(2))
 
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -123,6 +123,7 @@ from sympy.core import Basic, S, oo, I, Dummy, Wild, Mul, PoleError
 
 from sympy.functions import log, exp
 from sympy.series.order import Order
+from sympy.simplify import logcombine
 from sympy.simplify.powsimp import powsimp, powdenest
 
 from sympy.utilities.misc import debug_decorator as debug
@@ -391,6 +392,7 @@ def sign(e, x):
         return 0
 
     elif not e.has(x):
+        e = logcombine(e)
         return _sign(e)
     elif e == x:
         return 1

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -276,9 +276,7 @@ class Limit(Expr):
                 # cdir changes sign as oo- should become 0+
                 coeff, ex = newe.leadterm(z, cdir=cdir)
             except (ValueError, NotImplementedError, PoleError, AttributeError):
-                # The NotImplementedError catching may be removed after leading
-                # term methods are defined for some special functions (_eis
-                # and Ci)
+                # The NotImplementedError catching is for custom functions
                 # AttributeError may be removed one TupleArg leading term
                 # is handled
                 pass
@@ -292,7 +290,7 @@ class Limit(Expr):
                         return coeff
                     elif ex.is_negative:
                         if ex.is_integer:
-                            if str(dir) == "-":
+                            if str(dir) == "-" or ex.is_even:
                                 return S.Infinity*sign(coeff)
                             elif str(dir) == "+":
                                 return S.NegativeInfinity*sign(coeff)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -323,15 +323,17 @@ class Limit(Expr):
             ex_lim = limit(e1, z, z0)
             base_lim = limit(b1, z, z0)
 
-            if ex_lim in (S.Infinity, S.NegativeInfinity):
-                if base_lim is S.One:
+            if base_lim is S.One:
+                if ex_lim in (S.Infinity, S.NegativeInfinity):
                     res = limit(e1*(b1 - 1), z, z0)
                     return exp(res)
-                elif base_lim is S.NegativeInfinity:
-                    if ex_lim is S.NegativeInfinity:
-                        return S.Zero
-                    else:
-                        return S.ComplexInfinity
+                elif ex_lim.is_real:
+                    return S.One
+            elif base_lim is S.NegativeInfinity:
+                if ex_lim is S.NegativeInfinity:
+                    return S.Zero
+                elif ex_lim is S.Infinity:
+                    return S.ComplexInfinity
 
         l = None
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,6 +1,5 @@
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
-from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys import PolynomialError, factor
@@ -186,8 +185,7 @@ class Limit(Expr):
         hints : optional keyword arguments
             To be passed to ``doit`` methods; only used if deep is True.
         """
-        from sympy import Abs, exp, log, sign, floor, ceiling, binomial
-        from sympy.calculus.util import AccumBounds
+        from sympy import Abs, exp, log, sign, binomial
 
         e, z, z0, dir = self.args
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -263,7 +263,7 @@ class Limit(Expr):
         # is_meromorphic does not capture all meromorphic functions, and such
         # functions may have a leading term computation which can help find the
         # limit without entering gruntz
-        if not e.has(floor, ceiling, factorial, binomial):
+        if not e.has(factorial, binomial):
             if abs(z0) is S.Infinity:
                 newe = e.subs(z, 1/z)
                 cdir = -cdir

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -243,7 +243,7 @@ def test_series_AccumBounds():
     t1 = Mul(S.Half, 1/(-1 + cos(1)), Add(AccumBounds(-3, 1), cos(1)))
     assert limit(simplify(Sum(cos(n).rewrite(exp), (n, 0, k)).doit().rewrite(sin)), k, oo) == t1
 
-    t2 = Mul(S.Half, Add(AccumBounds(-2, 2), sin(1)), 1/(-cos(1) + 1))
+    t2 = Mul(S.Half, Add(AccumBounds(-2, 2), sin(1))*1/(-cos(1) + 1))
     assert limit(simplify(Sum(sin(n).rewrite(exp), (n, 0, k)).doit().rewrite(sin)), k, oo) == t2
 
     assert limit(frac(x)**x, x, oo) == AccumBounds(0, oo)  # wolfram gives (0, 1)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -9,7 +9,6 @@ from sympy import (
     Ei, EulerGamma, asin, atanh, acot, acoth, asec, acsc, cbrt, besselk)
 
 from sympy.calculus.util import AccumBounds
-from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
@@ -240,10 +239,10 @@ def test_series_AccumBounds():
     assert limit(sin(k) - sin(k)*cos(k), k, oo) == AccumBounds(-2, 2)
 
     # test for issue #9934
-    t1 = Mul(S.Half, 1/(-1 + cos(1)), Add(AccumBounds(-3, 1), cos(1)))
+    t1 = Mul(AccumBounds(-S(3)/2 + cos(1)/2, cos(1)/2 + S.Half), 1/(-1 + cos(1)))
     assert limit(simplify(Sum(cos(n).rewrite(exp), (n, 0, k)).doit().rewrite(sin)), k, oo) == t1
 
-    t2 = Mul(S.Half, Add(AccumBounds(-2, 2), sin(1))*1/(-cos(1) + 1))
+    t2 = Mul(AccumBounds(-1 + sin(1)/2, sin(1)/2 + 1), 1/(1 - cos(1)))
     assert limit(simplify(Sum(sin(n).rewrite(exp), (n, 0, k)).doit().rewrite(sin)), k, oo) == t2
 
     assert limit(frac(x)**x, x, oo) == AccumBounds(0, oo)  # wolfram gives (0, 1)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -2,7 +2,7 @@ from itertools import product as cartes
 
 from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
-    atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I, E,
+    atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I, E, besselj,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
     acos, erf, erfc, erfi, LambertW, factorial, digamma, uppergamma,
@@ -962,3 +962,13 @@ def test_issue_21550():
 def test_issue_21661():
     out = limit((x**(x + 1) * (log(x) + 1) + 1) / x, x, 11)
     assert out == S(3138428376722)/11 + 285311670611*log(11)
+
+
+def test_issue_21701():
+    assert limit((besselj(z, x)/x**z).subs(z, 7), x, 0) == S(1)/645120
+
+
+def test_issue_21721():
+    a = Symbol('a', real=True)
+    I = integrate(1/(pi*(1 + (x - a)**2)), x)
+    assert I.limit(x, oo) == S.Half

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,7 +1,7 @@
 from itertools import product as cartes
 
 from sympy import (
-    limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,, sinh
+    limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling, sinh,
     atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I, E, besselj,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,7 +1,7 @@
 from itertools import product as cartes
 
 from sympy import (
-    limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
+    limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,, sinh
     atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I, E, besselj,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
@@ -952,6 +952,10 @@ def test_issue_21031():
 
 def test_issue_21038():
     assert limit(sin(pi*x)/(3*x - 12), x, 4) == pi/3
+
+
+def test_issue_21530():
+    assert limit(sinh(n + 1)/sinh(n), n, oo) == E
 
 
 def test_issue_21550():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -134,8 +134,8 @@ def test_contains_3():
 
 
 def test_contains_4():
-    assert Order(sin(1/x**2)).contains(Order(cos(1/x**2))) is None
-    assert Order(cos(1/x**2)).contains(Order(sin(1/x**2))) is None
+    assert Order(sin(1/x**2)).contains(Order(cos(1/x**2))) is True
+    assert Order(cos(1/x**2)).contains(Order(sin(1/x**2))) is True
 
 
 def test_contains():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2538,7 +2538,7 @@ def test_W22():
 def test_W23():
     a, b = symbols('a b', real=True, positive=True)
     r1 = integrate(integrate(x/(x**2 + y**2), (x, a, b)), (y, -oo, oo))
-    assert r1.collect(pi) == -pi*(a - b)
+    assert r1.collect(pi).cancel() == -pi*a + pi*b
 
 
 def test_W23b():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21530 
Fixes #21701 
#21721 

#### Brief description of what is fixed or changed
Some heuristics present in the `Limit.doit` code are no longer needed after #21589, so they are removed.
A factor of `1/gamma(nu + 1)` was missing from the `besselj._eval_as_leading_term`, which is now added.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed bugs related to direction in `floor` and `ceiling` leading terms
  * Fixed bugs in `sinh` and `cosh` leading terms
  * Added `Ei`, `Ci`, `Shi`, `Chi` leading term methods 
  * `sin` and `cos` now return `AccumBounds(-1, 1)` as the leading term at real infinities
<!-- END RELEASE NOTES -->
