### PR TITLE
Implement N-ary hstack and vstack for DDM

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -274,34 +274,36 @@ class DDM(list):
         c = [[aij * bij for aij, bij in zip(ai, bi)] for ai, bi in zip(a, b)]
         return DDM(c, a.shape, a.domain)
 
-    def hstack(A, B):
+    def hstack(A, *B):
         Anew = list(A.copy())
         rows, cols = A.shape
         domain = A.domain
 
-        Brows, Bcols = B.shape
-        assert Brows == rows
-        assert B.domain == domain
+        for Bk in B:
+            Bkrows, Bkcols = Bk.shape
+            assert Bkrows == rows
+            assert Bk.domain == domain
 
-        cols += Bcols
+            cols += Bkcols
 
-        for i, Bi in enumerate(B):
-            Anew[i].extend(Bi)
+            for i, Bki in enumerate(Bk):
+                Anew[i].extend(Bki)
 
         return DDM(Anew, (rows, cols), A.domain)
 
-    def vstack(A, B):
+    def vstack(A, *B):
         Anew = list(A.copy())
         rows, cols = A.shape
         domain = A.domain
 
-        Brows, Bcols = B.shape
-        assert Bcols == cols
-        assert B.domain == domain
+        for Bk in B:
+            Bkrows, Bkcols = Bk.shape
+            assert Bkcols == cols
+            assert Bk.domain == domain
 
-        rows += Brows
+            rows += Bkrows
 
-        Anew.extend(B.copy())
+            Anew.extend(Bk.copy())
 
         return DDM(Anew, (rows, cols), A.domain)
 

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -214,25 +214,38 @@ def test_DDM_matmul():
     raises(DDMShapeError, lambda: Z05 @ Z40)
     raises(DDMShapeError, lambda: Z05.matmul(Z40))
 
-def test_DDM_hstack():
 
+def test_DDM_hstack():
     A = DDM([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
     B = DDM([[ZZ(4), ZZ(5)]], (1, 2), ZZ)
-    Ah = A.hstack(B)
+    C = DDM([[ZZ(6)]], (1, 1), ZZ)
 
+    Ah = A.hstack(B)
     assert Ah.shape == (1, 5)
     assert Ah.domain == ZZ
     assert Ah == DDM([[ZZ(1), ZZ(2), ZZ(3), ZZ(4), ZZ(5)]], (1, 5), ZZ)
 
-def test_DDM_vstack():
+    Ah = A.hstack(B, C)
+    assert Ah.shape == (1, 6)
+    assert Ah.domain == ZZ
+    assert Ah == DDM([[ZZ(1), ZZ(2), ZZ(3), ZZ(4), ZZ(5), ZZ(6)]], (1, 6), ZZ)
 
+
+def test_DDM_vstack():
     A = DDM([[ZZ(1)], [ZZ(2)], [ZZ(3)]], (3, 1), ZZ)
     B = DDM([[ZZ(4)], [ZZ(5)]], (2, 1), ZZ)
-    Ah = A.vstack(B)
+    C = DDM([[ZZ(6)]], (1, 1), ZZ)
 
+    Ah = A.vstack(B)
     assert Ah.shape == (5, 1)
     assert Ah.domain == ZZ
     assert Ah == DDM([[ZZ(1)], [ZZ(2)], [ZZ(3)], [ZZ(4)], [ZZ(5)]], (5, 1), ZZ)
+
+    Ah = A.vstack(B, C)
+    assert Ah.shape == (6, 1)
+    assert Ah.domain == ZZ
+    assert Ah == DDM([[ZZ(1)], [ZZ(2)], [ZZ(3)], [ZZ(4)], [ZZ(5)], [ZZ(6)]], (6, 1), ZZ)
+
 
 def test_DDM_applyfunc():
     A = DDM([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I've added n-ary version of hstack and vstack for DDM before implementing in DomainMatrix

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - Made `DDM.hstack` and `DDM.vstack` work with n-ary arguments
<!-- END RELEASE NOTES -->
