### PR TITLE
Add `warnings` to magnitude and angle_between

### DIFF
--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -678,7 +678,17 @@ class Vector(Printable, EvalfMixin):
         return Vector(d)
 
     def magnitude(self):
-        """Returns the magnitude (Euclidean norm) of self."""
+        """Returns the magnitude (Euclidean norm) of self.
+
+        Warnings
+        ========
+
+        Python ignores the leading negative sign so that might
+        give wrong results.
+        ``-A.x.magnitude()`` would be treated as ``-(A.x.magnitude())``,
+        instead of ``(-A.x).magnitude()``.
+
+        """
         return sqrt(self & self)
 
     def normalize(self):
@@ -718,6 +728,14 @@ class Vector(Printable, EvalfMixin):
         >>> v3 = A.x + A.y + A.z
         >>> v1.angle_between(v3)
         acos(sqrt(3)/3)
+
+        Warnings
+        ========
+
+        Python ignores the leading negative sign so that might
+        give wrong results.
+        ``-A.x.angle_between()`` would be treated as ``-(A.x.angle_between())``,
+        instead of ``(-A.x).angle_between()``.
 
         """
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#21729 

#### Brief description of what is fixed or changed
Added a `warnings` section to `.magnitude()` and `.angle_between()` to inform user.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * `Vector.angle_between()` has a new section `Warnings`.
    * `Vector.magnitude()` has a new section `Warnings`.
<!-- END RELEASE NOTES -->
