### PR TITLE
Add N-ary DomainMatrix hstack and vstack

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -275,6 +275,23 @@ class DDM(list):
         return DDM(c, a.shape, a.domain)
 
     def hstack(A, *B):
+        """Horizontally stacks :py:class:`~.DDM` matrices.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices.sdm import DDM
+
+        >>> A = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> B = DDM([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
+        >>> A.hstack(B)
+        [[1, 2, 5, 6], [3, 4, 7, 8]]
+
+        >>> C = DDM([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+        >>> A.hstack(B, C)
+        [[1, 2, 5, 6, 9, 10], [3, 4, 7, 8, 11, 12]]
+        """
         Anew = list(A.copy())
         rows, cols = A.shape
         domain = A.domain
@@ -292,6 +309,23 @@ class DDM(list):
         return DDM(Anew, (rows, cols), A.domain)
 
     def vstack(A, *B):
+        """Vertically stacks :py:class:`~.DDM` matrices.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices.sdm import DDM
+
+        >>> A = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> B = DDM([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
+        >>> A.vstack(B)
+        [[1, 2], [3, 4], [5, 6], [7, 8]]
+
+        >>> C = DDM([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+        >>> A.vstack(B, C)
+        [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]
+        """
         Anew = list(A.copy())
         rows, cols = A.shape
         domain = A.domain

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -9,6 +9,7 @@ convenience routines for converting between Expr and the poly domains as well
 as unifying matrices with different domains.
 
 """
+from functools import reduce
 from sympy.core.sympify import _sympify
 
 from ..constructor import construct_domain
@@ -462,36 +463,34 @@ class DomainMatrix:
 
         return self.from_rep(SDM.to_ddm(self.rep))
 
-    def _unify_domain(self, other):
-        """Convert self and other to a common domain"""
-        K1 = self.domain
-        K2 = other.domain
-        if K1 == K2:
-            return self, other
-        K = K1.unify(K2)
-        if K1 != K:
-            self = self.convert_to(K)
-        if K2 != K:
-            other = other.convert_to(K)
-        return self, other
+    @classmethod
+    def _unify_domain(cls, *matrices):
+        """Convert matrices to a common domain"""
+        domains = {matrix.domain for matrix in matrices}
+        if len(domains) == 1:
+            return matrices
+        domain = reduce(lambda x, y: x.unify(y), domains)
+        return tuple(matrix.convert_to(domain) for matrix in matrices)
 
-    def _unify_fmt(self, other, fmt):
-        """Convert self and other to the same format.
+    @classmethod
+    def _unify_fmt(cls, *matrices, fmt=None):
+        """Convert matrices to the same format.
 
-        If both are sparse or both are dense then return both unmodified.
+        If all matrices have the same format, then return unmodified.
         Otherwise convert both to the preferred format given as *fmt* which
         should be 'dense' or 'sparse'.
         """
-        if self.rep.fmt == other.rep.fmt:
-            return self, other
-        elif fmt == 'sparse':
-            return self.to_sparse(), other.to_sparse()
+        formats = {matrix.rep.fmt for matrix in matrices}
+        if len(formats) == 1:
+            return matrices
+        if fmt == 'sparse':
+            return tuple(matrix.to_sparse() for matrix in matrices)
         elif fmt == 'dense':
-            return self.to_dense(), other.to_dense()
+            return tuple(matrix.to_dense() for matrix in matrices)
         else:
             raise ValueError("fmt should be 'sparse' or 'dense'")
 
-    def unify(self, other, *, fmt=None):
+    def unify(self, *others, fmt=None):
         """
         Unifies the domains and the format of self and other
         matrices.
@@ -499,7 +498,8 @@ class DomainMatrix:
         Parameters
         ==========
 
-        other : another DomainMatrix
+        others : DomainMatrix
+
         fmt: string 'dense', 'sparse' or `None` (default)
             The preferred format to convert to if self and other are not
             already in the same format. If `None` or not specified then no
@@ -508,8 +508,8 @@ class DomainMatrix:
         Returns
         =======
 
-        (dM1, dM2)
-            dM1, dM2 DomainMatrix matrices with unified Domain and format
+        Tuple[DomainMatrix]
+            Matrices with unified domain and format
 
         Examples
         ========
@@ -543,11 +543,11 @@ class DomainMatrix:
         convert_to, to_dense, to_sparse
 
         """
-
-        dM1, dM2 = self._unify_domain(other)
+        matrices = (self,) + others
+        matrices = DomainMatrix._unify_domain(*matrices)
         if fmt is not None:
-            dM1, dM2 = dM1._unify_fmt(dM2, fmt)
-        return dM1, dM2
+            matrices = DomainMatrix._unify_fmt(*matrices, fmt=fmt)
+        return matrices
 
     def to_Matrix(self):
         r"""
@@ -608,44 +608,81 @@ class DomainMatrix:
     def is_zero_matrix(self):
         return all(self[i, j].element == self.domain.zero for i in range(self.shape[0]) for j in range(self.shape[1]))
 
-    def hstack(A, B):
-        r"""
-        Horizontally stacks 2 Domain Matrices.
+    def hstack(A, *B):
+        r"""Horizontally stack the given matrices.
 
         Parameters
         ==========
 
-        A, B: DomainMatrix
-            to stack the rows horizontally
+        B: DomainMatrix
+            Matrices to stack horizontally.
 
         Returns
         =======
 
         DomainMatrix
-            DomainMatrix by stacking the rows horizontally
+            DomainMatrix by stacking horizontally.
 
         Examples
         ========
 
-        >>> from sympy import ZZ, QQ
+        >>> from sympy import ZZ
         >>> from sympy.polys.matrices import DomainMatrix
-        >>> A = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)]], (1, 3), ZZ)
-        >>> B = DomainMatrix([[QQ(-1, 2), QQ(1, 2), QQ(1, 3)]],(1, 3), QQ)
+
+        >>> A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> B = DomainMatrix([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
         >>> A.hstack(B)
-        DomainMatrix([[1, 2, 3, -1/2, 1/2, 1/3]], (1, 6), QQ)
+        DomainMatrix([[1, 2, 5, 6], [3, 4, 7, 8]], (2, 4), ZZ)
+
+        >>> C = DomainMatrix([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+        >>> A.hstack(B, C)
+        DomainMatrix([[1, 2, 5, 6, 9, 10], [3, 4, 7, 8, 11, 12]], (2, 6), ZZ)
 
         See Also
         ========
 
         unify
-
         """
-        A, B = A.unify(B, fmt='dense')
-        return A.from_rep(A.rep.hstack(B.rep))
+        A, *B = A.unify(*B, fmt='dense')
+        return DomainMatrix.from_rep(A.rep.hstack(*(Bk.rep for Bk in B)))
 
-    def vstack(A, B):
-        A, B = A.unify(B, fmt='dense')
-        return A.from_rep(A.rep.vstack(B.rep))
+    def vstack(A, *B):
+        r"""Vertically stack the given matrices.
+
+        Parameters
+        ==========
+
+        B: DomainMatrix
+            Matrices to stack vertically.
+
+        Returns
+        =======
+
+        DomainMatrix
+            DomainMatrix by stacking vertically.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+
+        >>> A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> B = DomainMatrix([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
+        >>> A.vstack(B)
+        DomainMatrix([[1, 2], [3, 4], [5, 6], [7, 8]], (4, 2), ZZ)
+
+        >>> C = DomainMatrix([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+        >>> A.vstack(B, C)
+        DomainMatrix([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]], (6, 2), ZZ)
+
+        See Also
+        ========
+
+        unify
+        """
+        A, *B = A.unify(*B, fmt='dense')
+        return DomainMatrix.from_rep(A.rep.vstack(*(Bk.rep for Bk in B)))
 
     def applyfunc(self, func, domain=None):
         if domain is None:

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -706,19 +706,22 @@ class SDM(dict):
         return A.new(rep, (1, ncols-1), A.domain)
 
     def hstack(A, *B):
-        """
-        Horizontally stacks two :py:class:`~.SDM` matrices A & B
+        """Horizontally stacks :py:class:`~.SDM` matrices.
 
         Examples
         ========
 
-        >>> from sympy import QQ
+        >>> from sympy import ZZ
         >>> from sympy.polys.matrices.sdm import SDM
-        >>> B = SDM({0:{0:QQ(1)}, 1:{0:QQ(2)}}, (2, 1), QQ)
-        >>> A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0:QQ(3), 1:QQ(4)}}, (2, 2), QQ)
-        >>> A.hstack(B)
-        {0: {0: 1, 1: 2, 2: 1}, 1: {0: 3, 1: 4, 2: 2}}
 
+        >>> A = SDM({0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(4)}}, (2, 2), ZZ)
+        >>> B = SDM({0: {0: ZZ(5), 1: ZZ(6)}, 1: {0: ZZ(7), 1: ZZ(8)}}, (2, 2), ZZ)
+        >>> A.hstack(B)
+        {0: {0: 1, 1: 2, 2: 5, 3: 6}, 1: {0: 3, 1: 4, 2: 7, 3: 8}}
+
+        >>> C = SDM({0: {0: ZZ(9), 1: ZZ(10)}, 1: {0: ZZ(11), 1: ZZ(12)}}, (2, 2), ZZ)
+        >>> A.hstack(B, C)
+        {0: {0: 1, 1: 2, 2: 5, 3: 6, 4: 9, 5: 10}, 1: {0: 3, 1: 4, 2: 7, 3: 8, 4: 11, 5: 12}}
         """
         Anew = dict(A.copy())
         rows, cols = A.shape
@@ -740,6 +743,23 @@ class SDM(dict):
         return A.new(Anew, (rows, cols), A.domain)
 
     def vstack(A, *B):
+        """Vertically stacks :py:class:`~.SDM` matrices.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices.sdm import SDM
+
+        >>> A = SDM({0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(4)}}, (2, 2), ZZ)
+        >>> B = SDM({0: {0: ZZ(5), 1: ZZ(6)}, 1: {0: ZZ(7), 1: ZZ(8)}}, (2, 2), ZZ)
+        >>> A.vstack(B)
+        {0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}, 2: {0: 5, 1: 6}, 3: {0: 7, 1: 8}}
+
+        >>> C = SDM({0: {0: ZZ(9), 1: ZZ(10)}, 1: {0: ZZ(11), 1: ZZ(12)}}, (2, 2), ZZ)
+        >>> A.vstack(B, C)
+        {0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}, 2: {0: 5, 1: 6}, 3: {0: 7, 1: 8}, 4: {0: 9, 1: 10}, 5: {0: 11, 1: 12}}
+        """
         Anew = dict(A.copy())
         rows, cols = A.shape
         domain = A.domain

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -644,17 +644,39 @@ def test_DomainMatrix_diag():
 
 
 def test_DomainMatrix_hstack():
-    A = DomainMatrix([[ZZ(1)], [ZZ(2)]], (2, 1), ZZ)
-    B = DomainMatrix([[QQ(3), QQ(4)], [QQ(5), QQ(6)]], (2, 2), QQ)
-    AB = DomainMatrix([[QQ(1), QQ(3), QQ(4)], [QQ(2), QQ(5), QQ(6)]], (2, 3), QQ)
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    B = DomainMatrix([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
+    C = DomainMatrix([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+
+    AB = DomainMatrix([
+        [ZZ(1), ZZ(2), ZZ(5), ZZ(6)],
+        [ZZ(3), ZZ(4), ZZ(7), ZZ(8)]], (2, 4), ZZ)
+    ABC = DomainMatrix([
+        [ZZ(1), ZZ(2), ZZ(5), ZZ(6), ZZ(9), ZZ(10)],
+        [ZZ(3), ZZ(4), ZZ(7), ZZ(8), ZZ(11), ZZ(12)]], (2, 6), ZZ)
     assert A.hstack(B) == AB
+    assert A.hstack(B, C) == ABC
 
 
 def test_DomainMatrix_vstack():
-    A = DomainMatrix([[ZZ(1), ZZ(2)]], (1, 2), ZZ)
-    B = DomainMatrix([[QQ(3), QQ(4)], [QQ(5), QQ(6)]], (2, 2), QQ)
-    AB = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)], [QQ(5), QQ(6)]], (3, 2), QQ)
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    B = DomainMatrix([[ZZ(5), ZZ(6)], [ZZ(7), ZZ(8)]], (2, 2), ZZ)
+    C = DomainMatrix([[ZZ(9), ZZ(10)], [ZZ(11), ZZ(12)]], (2, 2), ZZ)
+
+    AB = DomainMatrix([
+        [ZZ(1), ZZ(2)],
+        [ZZ(3), ZZ(4)],
+        [ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8)]], (4, 2), ZZ)
+    ABC = DomainMatrix([
+        [ZZ(1), ZZ(2)],
+        [ZZ(3), ZZ(4)],
+        [ZZ(5), ZZ(6)],
+        [ZZ(7), ZZ(8)],
+        [ZZ(9), ZZ(10)],
+        [ZZ(11), ZZ(12)]], (6, 2), ZZ)
     assert A.vstack(B) == AB
+    assert A.vstack(B, C) == ABC
 
 
 def test_DomainMatrix_applyfunc():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I made `hstack` and `vstack` work with n-ary arguments, and in the requirements, I also had to change `unify` to work with n-ary arguments.
The documentation should be edited, but before that, I want to make sure that this design is agreed on.
I think that those APIs could better be designed as `classmethod`, but it's fine as long as `DomainMatrix.hstack` doesn't have problem even if it's not invoked from the instance

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- polys
  - Made `DomainMatrix.hstack`, `DomainMatrix.vstack` and `DomainMatrix.unify` work with N-ary arguments.

<!-- END RELEASE NOTES -->
