### PR TITLE
Fixed rendering of Clebsch-Gordan (CG) class

### DIFF
--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -10,6 +10,7 @@ from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.wigner import clebsch_gordan, wigner_3j, wigner_6j, wigner_9j
+from sympy.printing.precedence import PRECEDENCE
 
 __all__ = [
     'CG',
@@ -202,6 +203,7 @@ class CG(Wigner3j):
         in P.A. Zyla *et al.* (Particle Data Group), Prog. Theor. Exp. Phys.
         2020, 083C01 (2020).
     """
+    precedence = PRECEDENCE["Pow"] - 1
 
     def doit(self, **hints):
         if self.is_symbolic:

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -164,9 +164,11 @@ class CG(Wigner3j):
     Parameters
     ==========
 
-    j1, m1, j2, m2, j3, m3 : Number, Symbol
-        Terms determining the angular momentum of coupled angular momentum
-        systems.
+    j1, m1, j2, m2 : Number, Symbol
+        Angular momenta of states 1 and 2.
+
+    j3, m3: Number, Symbol
+        Total angular momentum of the coupled system.
 
     Examples
     ========
@@ -180,6 +182,11 @@ class CG(Wigner3j):
         CG(3/2, 3/2, 1/2, -1/2, 1, 1)
         >>> cg.doit()
         sqrt(3)/2
+        >>> CG(j1=S(1)/2, m1=-S(1)/2, j2=S(1)/2, m2=+S(1)/2, j3=1, m3=0).doit()
+        sqrt(2)/2
+
+
+    Compare [2]_.
 
     See Also
     ========
@@ -190,6 +197,10 @@ class CG(Wigner3j):
     ==========
 
     .. [1] Varshalovich, D A, Quantum Theory of Angular Momentum. 1988.
+    .. [2] `Clebsch-Gordan Coefficients, Spherical Harmonics, and d Functions
+        <https://pdg.lbl.gov/2020/reviews/rpp2020-rev-clebsch-gordan-coefs.pdf>`_
+        in P.A. Zyla *et al.* (Particle Data Group), Prog. Theor. Exp. Phys.
+        2020, 083C01 (2020).
     """
 
     def doit(self, **hints):

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -159,7 +159,7 @@ class CG(Wigner3j):
     coefficients are defined as [1]_:
 
     .. math ::
-        C^{j_1,m_1}_{j_2,m_2,j_3,m_3} = \left\langle j_1,m_1;j_2,m_2 | j_3,m_3\right\rangle
+        C^{j_3,m_3}_{j_1,m_1,j_2,m_2} = \left\langle j_1,m_1;j_2,m_2 | j_3,m_3\right\rangle
 
     Parameters
     ==========

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -114,7 +114,8 @@ C       \n\
 """
     assert pretty(cg) == ascii_str
     assert upretty(cg) == ucode_str
-    assert latex(cg) == r'C^{5,6}_{1,2,3,4}'
+    assert latex(cg) == 'C^{5,6}_{1,2,3,4}'
+    assert latex(cg ** 2) == R'\left(C^{5,6}_{1,2,3,4}\right)^{2}'
     sT(cg, "CG(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
     assert str(wigner3j) == 'Wigner3j(1, 2, 3, 4, 5, 6)'
     ascii_str = \

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -156,8 +156,6 @@ PRECEDENCE_TRADITIONAL['Complement'] = PRECEDENCE['Xor']
 PRECEDENCE_TRADITIONAL['SymmetricDifference'] = PRECEDENCE['Xor']
 PRECEDENCE_TRADITIONAL['ProductSet'] = PRECEDENCE['Xor']
 
-PRECEDENCE_TRADITIONAL["CG"] = PRECEDENCE["Pow"] - 1
-
 
 def precedence_traditional(item):
     """Returns the precedence of a given object according to the

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -156,6 +156,8 @@ PRECEDENCE_TRADITIONAL['Complement'] = PRECEDENCE['Xor']
 PRECEDENCE_TRADITIONAL['SymmetricDifference'] = PRECEDENCE['Xor']
 PRECEDENCE_TRADITIONAL['ProductSet'] = PRECEDENCE['Xor']
 
+PRECEDENCE_TRADITIONAL["CG"] = PRECEDENCE["Pow"] - 1
+
 
 def precedence_traditional(item):
     """Returns the precedence of a given object according to the


### PR DESCRIPTION
#### References to other Issues or PRs

- Fixes #18781
- Fixes #21001


#### Brief description of what is fixed or changed

- Fixed the order of the formula in the docstring (#18781)
- Added a link to the Particle Data Group for comparing the doctests
- Improved the LaTeX rendering so that it also renders if a `CG` is squared, for instance (#21001)


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Added a precedence attribute to `CG` to fix latex rendering
  * Fixed argument order of the math in the `CG` documentation
<!-- END RELEASE NOTES -->