### PR TITLE
perf(matrices): speed up eigenvals for triangular matrices

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -10,7 +10,7 @@ from sympy.core.logic import fuzzy_and, fuzzy_or
 from sympy.core.numbers import Float
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.polys import roots, CRootOf, EX
+from sympy.polys import roots, CRootOf, ZZ, QQ, EX
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.eigen import dom_eigenvects, dom_eigenvects_to_sympy
 from sympy.simplify import nsimplify, simplify as _simplify
@@ -223,7 +223,16 @@ def _eigenvals_dict(
     M, error_when_incomplete=True, simplify=False, **flags):
     iblocks = M.strongly_connected_components()
     all_eigs = {}
+    is_dom = M._rep.domain in (ZZ, QQ)
     for b in iblocks:
+
+        # Fast path for a 1x1 block:
+        if is_dom and len(b) == 1:
+            index = b[0]
+            val = M[index, index]
+            all_eigs[val] = all_eigs.get(val, 0) + 1
+            continue
+
         block = M[b, b]
 
         if isinstance(simplify, FunctionType):

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -157,8 +157,10 @@ def _eigenvals(
     if not M.is_square:
         raise NonSquareMatrixError("{} must be a square matrix.".format(M))
 
-    if all(x.is_number for x in M) and M.has(Float):
-        return _eigenvals_mpmath(M, multiple=multiple)
+    if M._rep.domain not in (ZZ, QQ):
+        # Skip this check for ZZ/QQ because it can be slow
+        if all(x.is_number for x in M) and M.has(Float):
+            return _eigenvals_mpmath(M, multiple=multiple)
 
     if rational:
         M = M.applyfunc(

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -190,7 +190,16 @@ def _eigenvals_list(
     M, error_when_incomplete=True, simplify=False, **flags):
     iblocks = M.strongly_connected_components()
     all_eigs = []
+    is_dom = M._rep.domain in (ZZ, QQ)
     for b in iblocks:
+
+        # Fast path for a 1x1 block:
+        if is_dom and len(b) == 1:
+            index = b[0]
+            val = M[index, index]
+            all_eigs.append(val)
+            continue
+
         block = M[b, b]
 
         if isinstance(simplify, FunctionType):

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -64,6 +64,7 @@ def _strongly_connected_components(M):
     if not M.is_square:
         raise NonSquareMatrixError
 
+    # RepMatrix uses the more efficient DomainMatrix.scc() method
     rep = getattr(M, '_rep', None)
     if rep is not None:
         return rep.scc()

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -64,6 +64,10 @@ def _strongly_connected_components(M):
     if not M.is_square:
         raise NonSquareMatrixError
 
+    rep = getattr(M, '_rep', None)
+    if rep is not None:
+        return rep.scc()
+
     V = range(M.rows)
     E = sorted(M.todok().keys())
     return strongly_connected_components((V, E))

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -174,9 +174,10 @@ class RepMatrix(MatrixBase):
         # has the pattern.  If _smat is full length,
         # the matrix has no zeros.
         zhas = False
-        if len(self.todok()) != self.rows*self.cols:
+        dok = self.todok()
+        if len(dok) != self.rows*self.cols:
             zhas = S.Zero.has(*patterns)
-        return zhas or any(value.has(*patterns) for value in self.values())
+        return zhas or any(value.has(*patterns) for value in dok.values())
 
     def _eval_is_Identity(self):
         if not all(self[i, i] == 1 for i in range(self.rows)):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -345,6 +345,25 @@ class DDM(list):
         elements = (list(map(func, row)) for row in self)
         return DDM(elements, self.shape, domain)
 
+    def scc(a):
+        """Strongly connected components of a square matrix *a*.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices.sdm import DDM
+        >>> A = DDM([[ZZ(1), ZZ(0)], [ZZ(0), ZZ(1)]], (2, 2), ZZ)
+        >>> A.scc()
+        [[0], [1]]
+
+        See also
+        ========
+
+        DomainMatrix.scc
+        """
+        return a.to_sdm().scc()
+
     def rref(a):
         """Reduced-row echelon form of a and list of pivots"""
         b = a.copy()

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -360,7 +360,8 @@ class DDM(list):
         See also
         ========
 
-        DomainMatrix.scc
+        sympy.polys.matrices.domainmatrix.DomainMatrix.scc
+
         """
         return a.to_sdm().scc()
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -11,6 +11,7 @@ as unifying matrices with different domains.
 """
 from functools import reduce
 from sympy.core.sympify import _sympify
+from sympy.utilities.iterables import _strongly_connected_components
 
 from ..constructor import construct_domain
 
@@ -1051,6 +1052,14 @@ class DomainMatrix:
         else:
             sqrtAn = A ** (n // 2)
             return sqrtAn * sqrtAn
+
+    def scc(self):
+        rows, cols = self.shape
+        assert rows == cols
+        V = range(rows)
+        rep = self.rep
+        Emap = {v: list(rep.get(v, [])) for v in V}
+        return _strongly_connected_components(V, Emap)
 
     def rref(self):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -11,7 +11,6 @@ as unifying matrices with different domains.
 """
 from functools import reduce
 from sympy.core.sympify import _sympify
-from sympy.utilities.iterables import _strongly_connected_components
 
 from ..constructor import construct_domain
 
@@ -1054,12 +1053,79 @@ class DomainMatrix:
             return sqrtAn * sqrtAn
 
     def scc(self):
+        """Compute the strongly connected components of a DomainMatrix
+
+        Explanation
+        ===========
+
+        A square matrix can be considered as the adjacency matrix for a
+        directed graph where the row and column indices are the vertices. In
+        this graph if there is an edge from vertex ``i`` to vertex ``j`` if
+        ``M[i, j]`` is nonzero. This routine computes the strongly connected
+        components of that graph which are subsets of the rows and columns that
+        are connected by some nonzero element of the matrix. The strongly
+        connected components are useful because many operations such as the
+        determinant can be computed by working with the submatrices
+        corresponding to each component.
+
+        Examples
+        ========
+
+        Find the strongly connected components of a matrix:
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> M = DomainMatrix([[ZZ(1), ZZ(0), ZZ(2)],
+        ...                   [ZZ(0), ZZ(3), ZZ(0)],
+        ...                   [ZZ(4), ZZ(6), ZZ(5)]], (3, 3), ZZ)
+        >>> M.scc()
+        [[1], [0, 2]]
+
+        Compute the determinant from the components:
+
+        >>> MM = M.to_Matrix()
+        >>> MM
+        Matrix([
+        [1, 0, 2],
+        [0, 3, 0],
+        [4, 6, 5]])
+        >>> MM[[1], [1]]
+        Matrix([[3]])
+        >>> MM[[0, 2], [0, 2]]
+        Matrix([
+        [1, 2],
+        [4, 5]])
+        >>> MM.det()
+        -9
+        >>> MM[[1], [1]].det() * MM[[0, 2], [0, 2]].det()
+        -9
+
+        The components are given in reverse topological order and represent a
+        permutation of the rows and columns that will bring the matrix into
+        block lower-triangular form:
+
+        >>> MM[[1, 0, 2], [1, 0, 2]]
+        Matrix([
+        [3, 0, 0],
+        [0, 1, 2],
+        [6, 4, 5]])
+
+        Returns
+        =======
+
+        List of lists of integers
+            Each list represents a strongly connected component.
+
+        See also
+        ========
+
+        Matrix.strongly_connected_components
+        sympy.utilities.iterables.strongly_connected_components
+
+        """
         rows, cols = self.shape
         assert rows == cols
-        V = range(rows)
-        rep = self.rep
-        Emap = {v: list(rep.get(v, [])) for v in V}
-        return _strongly_connected_components(V, Emap)
+        return self.rep.scc()
 
     def rref(self):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1119,7 +1119,7 @@ class DomainMatrix:
         See also
         ========
 
-        Matrix.strongly_connected_components
+        sympy.matrices.matrices.MatrixBase.strongly_connected_components
         sympy.utilities.iterables.strongly_connected_components
 
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -7,6 +7,8 @@ Module for the SDM class.
 from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
+from sympy.utilities.iterables import _strongly_connected_components
+
 from .exceptions import DDMBadInputError, DDMDomainError, DDMShapeError
 
 from .ddm import DDM
@@ -587,6 +589,29 @@ class SDM(dict):
             return A.copy()
         Ak = unop_dict(A, lambda e: K.convert_from(e, Kold))
         return A.new(Ak, A.shape, K)
+
+    def scc(A):
+        """Strongly connected components of a square matrix *A*.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> A = SDM({0:{0: ZZ(2)}, 1:{1:ZZ(1)}}, (2, 2), ZZ)
+        >>> A.scc()
+        [[0], [1]]
+
+        See also
+        ========
+
+        DomainMatrix.scc
+        """
+        rows, cols = A.shape
+        assert rows == cols
+        V = range(rows)
+        Emap = {v: list(A.get(v, [])) for v in V}
+        return _strongly_connected_components(V, Emap)
 
     def rref(A):
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -605,7 +605,7 @@ class SDM(dict):
         See also
         ========
 
-        DomainMatrix.scc
+        sympy.polys.matrices.domainmatrix.DomainMatrix.scc
         """
         rows, cols = A.shape
         assert rows == cols

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -398,6 +398,17 @@ def test_DomainMatrix_pow():
     raises(NonSquareMatrixError, lambda: A ** 1)
 
 
+def test_DomainMatrix_scc():
+    Ad = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)],
+                       [ZZ(0), ZZ(1), ZZ(0)],
+                       [ZZ(2), ZZ(0), ZZ(4)]], (3, 3), ZZ)
+    As = Ad.to_sparse()
+    Addm = Ad.rep
+    Asdm = As.rep
+    for A in [Ad, As, Addm, Asdm]:
+        assert Ad.scc() == [[1], [0, 2]]
+
+
 def test_DomainMatrix_rref():
     A = DomainMatrix([], (0, 1), QQ)
     assert A.rref() == (A, ())

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1119,7 +1119,10 @@ def strongly_connected_components(G):
     Gmap = {vi: [] for vi in V}
     for v1, v2 in E:
         Gmap[v1].append(v2)
+    return _strongly_connected_components(V, Gmap)
 
+
+def _strongly_connected_components(V, Gmap):
     # Non-recursive Tarjan's algorithm:
     lowlink = {}
     indices = {}

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1123,6 +1123,24 @@ def strongly_connected_components(G):
 
 
 def _strongly_connected_components(V, Gmap):
+    """More efficient internal routine for strongly_connected_components"""
+    #
+    # Here V is an iterable of vertices and Gmap is a dict mapping each vertex
+    # to a list of neighbours e.g.:
+    #
+    #   V = [0, 1, 2, 3]
+    #   Gmap = {0: [2, 3], 1: [0]}
+    #
+    # For a large graph these data structures can often be created more
+    # efficiently then those expected by strongly_connected_components() which
+    # in this case would be
+    #
+    #   V = [0, 1, 2, 3]
+    #   Gmap = [(0, 2), (0, 3), (1, 0)]
+    #
+    # XXX: Maybe this should be the recommended function to use instead...
+    #
+
     # Non-recursive Tarjan's algorithm:
     lowlink = {}
     indices = {}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Corrects a small performance regression from #21474

#### Brief description of what is fixed or changed

Speed up eigenvals for triangular matrices e.g.:
```python
def make(n):
    def entry(i, j):
        if i == j:
            return i
        elif i > j:
            return j
        else:
            return 0
    return Matrix(n, n, entry)

In [3]: M = make(5)

In [4]: M
Out[4]: 
⎡0  0  0  0  0⎤
⎢             ⎥
⎢0  1  0  0  0⎥
⎢             ⎥
⎢0  1  2  0  0⎥
⎢             ⎥
⎢0  1  2  3  0⎥
⎢             ⎥
⎣0  1  2  3  4⎦

In [5]: %time M.eigenvals()
CPU times: user 810 µs, sys: 313 µs, total: 1.12 ms
Wall time: 1.42 ms
Out[5]: {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}
```
This had slowed down on master since 1.8 as a result of https://github.com/sympy/sympy/pull/21474 which is a performance improvement in general but slows down the particular case of a perfectly triangular matrix that factors completely into 1x1 blocks. The slowdown is due to calling calling charpoly and roots for trivial 1x1 matrices. This  PR just uses the value from the matrix directly as the eigenvalue if it is 1x1 which mostly restores the previous performance.

#### Other comments

This routine could become a lot faster for this kind of matrix after #21626.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
