### PR TITLE
Add new abstract base class for methods

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -533,8 +533,8 @@ class KanesMethod(_Methods):
         """
         if bodies is None:
             bodies = self.bodies
-        if  loads is None and self.loads is not None:
-            loads = self.loads
+        if  loads is None and self._forcelist is not None:
+            loads = self._forcelist
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -533,7 +533,7 @@ class KanesMethod(_Methods):
         """
         if bodies is None:
             bodies = self.bodies
-        if  loads is None and self._forcelist is not None:
+        if  loads is None and self._forcelist is not None and self._forcelist != []:
             loads = self._forcelist
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -533,8 +533,11 @@ class KanesMethod(_Methods):
         """
         if bodies is None:
             bodies = self.bodies
-        if  loads is None and self._forcelist is not None and self._forcelist != []:
-            loads = self._forcelist
+        if loads == []:
+            loads = None
+        if  loads is None and self._forcelist is not None:
+            if self._forcelist != []:
+                loads = self._forcelist
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -3,6 +3,7 @@ from sympy import solve_linear_system_LU
 from sympy.utilities import default_sort_key
 from sympy.physics.vector import (ReferenceFrame, dynamicsymbols,
                                   partial_velocity)
+from sympy.physics.mechanics.method import _Methods
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.physics.mechanics.functions import (msubs, find_dynamicsymbols,
@@ -13,7 +14,7 @@ from sympy.utilities.iterables import iterable
 __all__ = ['KanesMethod']
 
 
-class KanesMethod:
+class KanesMethod(_Methods):
     """Kane's method object.
 
     Explanation

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -31,7 +31,7 @@ class KanesMethod(_Methods):
 
     q, u : Matrix
         Matrices of the generalized coordinates and speeds
-    bodylist : iterable
+    bodies : iterable
         Iterable of Point and RigidBody objects in the system.
     forcelist : iterable
         Iterable of (Point, vector) or (ReferenceFrame, vector) tuples
@@ -532,7 +532,7 @@ class KanesMethod(_Methods):
             to a system with no constraints.
         """
         if bodies is None:
-            bodies = self.bodylist
+            bodies = self.bodies
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -533,6 +533,8 @@ class KanesMethod(_Methods):
         """
         if bodies is None:
             bodies = self.bodies
+        if  loads is None and self.loads is not None:
+            loads = self.loads
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -531,7 +531,7 @@ class KanesMethod(_Methods):
             Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
         """
-        if bodies = None:
+        if bodies is None:
             bodies = self.bodylist
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -118,7 +118,7 @@ class KanesMethod(_Methods):
     def __init__(self, frame, q_ind, u_ind, kd_eqs=None, q_dependent=None,
             configuration_constraints=None, u_dependent=None,
             velocity_constraints=None, acceleration_constraints=None,
-            u_auxiliary=None):
+            u_auxiliary=None, bodies=None, forcelist=None):
 
         """Please read the online documentation. """
         if not q_ind:
@@ -132,8 +132,8 @@ class KanesMethod(_Methods):
         self._fr = None
         self._frstar = None
 
-        self._forcelist = None
-        self._bodylist = None
+        self._forcelist = forcelist
+        self._bodylist = bodies
 
         self._initialize_vectors(q_ind, q_dependent, u_ind, u_dependent,
                 u_auxiliary)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -554,6 +554,9 @@ class KanesMethod(_Methods):
             self._frstar = frstar.col_join(frstaraux)
         return (self._fr, self._frstar)
 
+    def _form_eoms(self):
+        return self.kanes_equations(self.bodylist, self.forcelist)
+
     def rhs(self, inv_method=None):
         """Returns the system's equations of motion in first order form. The
         output is the right hand side of::

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -506,7 +506,7 @@ class KanesMethod(_Methods):
         result = linearizer.linearize(**kwargs)
         return result + (linearizer.r,)
 
-    def kanes_equations(self, bodies, loads=None):
+    def kanes_equations(self, bodies=None, loads=None):
         """ Method to form Kane's equations, Fr + Fr* = 0.
 
         Explanation
@@ -531,6 +531,8 @@ class KanesMethod(_Methods):
             Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
         """
+        if bodies = None:
+            bodies = self.bodylist
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')
@@ -655,3 +657,7 @@ class KanesMethod(_Methods):
     @property
     def forcelist(self):
         return self._forcelist
+
+    @property
+    def bodies(self):
+        return self._bodylist

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -226,6 +226,9 @@ class LagrangesMethod(_Methods):
         self.eom = without_lam - self._term3
         return self.eom
 
+    def _form_eoms(self):
+        self.form_lagranges_equations()
+
     @property
     def mass_matrix(self):
         """Returns the mass matrix, which is augmented by the Lagrange

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -227,7 +227,7 @@ class LagrangesMethod(_Methods):
         return self.eom
 
     def _form_eoms(self):
-        self.form_lagranges_equations()
+        return self.form_lagranges_equations()
 
     @property
     def mass_matrix(self):

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -470,7 +470,3 @@ class LagrangesMethod(_Methods):
     @property
     def forcelist(self):
         return self._forcelist
-
-    @property
-    def bodylist(self):
-        return self._bodies

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -1,5 +1,6 @@
 from sympy.core.backend import diff, zeros, Matrix, eye, sympify
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
+from sympy.physics.mechanics.method import _Methods
 from sympy.physics.mechanics.functions import (find_dynamicsymbols, msubs,
                                                _f_list_parser)
 from sympy.physics.mechanics.linearize import Linearizer
@@ -9,7 +10,7 @@ from sympy.utilities.iterables import iterable
 __all__ = ['LagrangesMethod']
 
 
-class LagrangesMethod:
+class LagrangesMethod(_Methods):
     """Lagrange's method object.
 
     Explanation
@@ -466,3 +467,7 @@ class LagrangesMethod:
     @property
     def forcelist(self):
         return self._forcelist
+
+    @property
+    def bodylist(self):
+        return self._bodies

--- a/sympy/physics/mechanics/method.py
+++ b/sympy/physics/mechanics/method.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+
+class _Methods(ABC):
+    """Abstract Base Class for all methods."""
+
+    @abstractmethod
+    def q(self):
+        pass
+
+    @abstractmethod
+    def u(self):
+        pass
+
+    @abstractmethod
+    def bodylist(self):
+        pass
+
+    @abstractmethod
+    def forcelist(self):
+        pass
+
+    @abstractmethod
+    def mass_matrix(self):
+        pass
+
+    @abstractmethod
+    def forcing(self):
+        pass
+
+    @abstractmethod
+    def mass_matrix_full(self):
+        pass
+
+    @abstractmethod
+    def forcing_full(self):
+        pass

--- a/sympy/physics/mechanics/method.py
+++ b/sympy/physics/mechanics/method.py
@@ -12,7 +12,7 @@ class _Methods(ABC):
         pass
 
     @abstractmethod
-    def bodylist(self):
+    def bodies(self):
         pass
 
     @abstractmethod

--- a/sympy/physics/mechanics/method.py
+++ b/sympy/physics/mechanics/method.py
@@ -34,3 +34,6 @@ class _Methods(ABC):
     @abstractmethod
     def forcing_full(self):
         pass
+
+    def _form_eoms(self):
+        raise NotImplementedError("Subclasses must implement this.")

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -21,8 +21,10 @@ def test_one_dof():
     pa = Particle('pa', P, m)
     BL = [pa]
 
-    KM = KanesMethod(N, [q], [u], kd)
-    KM.kanes_equations(BL, FL)
+    KM = KanesMethod(N, [q], [u], kd, bodies=BL, forcelist=FL)
+    KM.kanes_equations()
+
+    assert KM.bodies == BL
 
     MM = KM.mass_matrix
     forcing = KM.forcing

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -305,9 +305,15 @@ def test_input_format():
     assert KM.kanes_equations(BL, loads=None)[0] == Matrix([0])
     # test for input format kane.kanes_equations(bodies=(body1, body 2))
     assert KM.kanes_equations(BL)[0] == Matrix([0])
+    # test for input format kane.kanes_equations(bodies=(body1, body2), loads=[])
+    assert KM.kanes_equations(BL, [])[0] == Matrix([0])
     # test for error raised when a wrong force list (in this case a string) is provided
     from sympy.testing.pytest import raises
     raises(ValueError, lambda: KM._form_fr('bad input'))
+
+    # 1 dof problem from test_one_dof with FL & BL in instance
+    KM = KanesMethod(N, [q], [u], kd, bodies=BL, forcelist=FL)
+    assert KM.kanes_equations()[0] == Matrix([-c*u - k*q])
 
     # 2 dof problem from test_two_dof
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -21,8 +21,8 @@ def test_one_dof():
     pa = Particle('pa', P, m)
     BL = [pa]
 
-    KM = KanesMethod(N, [q], [u], kd, bodies=BL, forcelist=FL)
-    KM.kanes_equations()
+    KM = KanesMethod(N, [q], [u], kd)
+    KM.kanes_equations(BL, FL)
 
     assert KM.bodies == BL
 

--- a/sympy/physics/mechanics/tests/test_method.py
+++ b/sympy/physics/mechanics/tests/test_method.py
@@ -1,0 +1,5 @@
+from sympy.physics.mechanics.method import _Methods
+from sympy.testing.pytest import raises
+
+def test_method():
+    raises(TypeError, lambda: _Methods())


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially deals with #21772 

#### Brief description of what is fixed or changed
Added a new class `_Methods` which would serve as an abstract base class for all method(KanesMethod, JointsMethod etc)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
    * `KanesMethod`  can now take body list and force list in object instantiation.
    * `KanesMethod.kanes_equations` both parameters are optional and can be taken automaticaly if they are passed at object instantiation. 
    * `.bodies` attribute is added to `KanesMethod` which is advised to use instead of `.bodylist` attribute.
<!-- END RELEASE NOTES -->
