### PR TITLE
codegen -  Removed the limits argument in the function cast_check() in ast

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1051,7 +1051,7 @@ class Type(Token):
     def _check(self, value):
         pass
 
-    def cast_check(self, value, rtol=None, atol=0, limits=None, precision_targets=None):
+    def cast_check(self, value, rtol=None, atol=0, precision_targets=None):
         """ Casts a value to the data type of the instance.
 
         Parameters
@@ -1062,8 +1062,6 @@ class Type(Token):
             Relative tolerance. (will be deduced if not given).
         atol : floating point number
             Absolute tolerance (in addition to ``rtol``).
-        limits : dict
-            Values given by ``limits.h``, x86/IEEE754 defaults if not given.
         type_aliases : dict
             Maps substitutions for Type, e.g. {integer: int64, real: float32}
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #17804  by removing limits argument in cast_check() function in ast.py in codegen

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
