### PR TITLE
poly - Fixes the issue#19353 of simplified trace matrix error attribute

### DIFF
--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -561,6 +561,9 @@ def test_simplify():
     assert M.simplify() == Matrix([[eq]])
     assert M.simplify(ratio=oo) == Matrix([[eq.simplify(ratio=oo)]])
 
+    # https://github.com/sympy/sympy/issues/19353
+    m = Matrix([[30, 2], [3, 4]])
+    assert (1/(m.trace())).simplify() == Rational(1, 34)
 
 def test_subs():
     assert OperationsOnlyMatrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -565,6 +565,7 @@ def test_simplify():
     m = Matrix([[30, 2], [3, 4]])
     assert (1/(m.trace())).simplify() == Rational(1, 34)
 
+
 def test_subs():
     assert OperationsOnlyMatrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])
     assert OperationsOnlyMatrix([[x, 2], [x + y, 4]]).subs([[x, -1], [y, -2]]) == \

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -21,7 +21,7 @@ _gens_order = {
 }
 
 _max_order = 1000
-_re_gen = re.compile(r"^(.+?)(\d*)$")
+_re_gen = re.compile(r"^(.*?)(\d*)$", re.MULTILINE)
 
 
 def _nsort(roots, separated=False):

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -1,7 +1,7 @@
 """Tests for useful utilities for higher level polynomial classes. """
 
 from sympy import (S, Integer, sin, cos, sqrt, symbols, pi,
-    Eq, Integral, exp, Mul, Poly, Symbol)
+    Eq, Integral, exp, Mul, Poly, Symbol, Matrix, Trace, simplify, Rational)
 from sympy.testing.pytest import raises
 
 from sympy.polys.polyutils import (
@@ -289,4 +289,6 @@ def test_dict_from_expr():
 
 
 def test_issue_19353():
+    m = Matrix([[30, 2], [3, 4]])
     assert Poly(Symbol('\n1'))
+    assert simplify(1/Trace(m)) == Rational('1/34')

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -1,7 +1,7 @@
 """Tests for useful utilities for higher level polynomial classes. """
 
 from sympy import (S, Integer, sin, cos, sqrt, symbols, pi,
-    Eq, Integral, exp, Mul)
+    Eq, Integral, exp, Mul, Poly, Symbol)
 from sympy.testing.pytest import raises
 
 from sympy.polys.polyutils import (
@@ -286,3 +286,7 @@ def test_dict_from_expr():
         ({(0,): -Integer(1), (1,): Integer(1)}, (x,))
     raises(PolynomialError, lambda: dict_from_expr(A*B - B*A))
     raises(PolynomialError, lambda: dict_from_expr(S.true))
+
+
+def test_issue_19353():
+    assert Poly(Symbol('\n1'))

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -1,7 +1,7 @@
 """Tests for useful utilities for higher level polynomial classes. """
 
 from sympy import (S, Integer, sin, cos, sqrt, symbols, pi,
-    Eq, Integral, exp, Mul, Poly, Symbol, Matrix, Trace, simplify, Rational)
+    Eq, Integral, exp, Mul, Symbol)
 from sympy.testing.pytest import raises
 
 from sympy.polys.polyutils import (
@@ -98,6 +98,11 @@ def test__sort_gens():
     assert _sort_gens([x, p, q], wrt='x', sort='q > p') == (x, q, p)
     assert _sort_gens([x, p, q], wrt='p', sort='q > x') == (p, q, x)
     assert _sort_gens([x, p, q], wrt='q', sort='p > x') == (q, p, x)
+
+    # https://github.com/sympy/sympy/issues/19353
+    n1 = Symbol('\n1')
+    assert _sort_gens([n1]) == (n1,)
+    assert _sort_gens([x, n1]) == (x, n1)
 
     X = symbols('x0,x1,x2,x10,x11,x12,x20,x21,x22')
 
@@ -286,9 +291,3 @@ def test_dict_from_expr():
         ({(0,): -Integer(1), (1,): Integer(1)}, (x,))
     raises(PolynomialError, lambda: dict_from_expr(A*B - B*A))
     raises(PolynomialError, lambda: dict_from_expr(S.true))
-
-
-def test_issue_19353():
-    m = Matrix([[30, 2], [3, 4]])
-    assert Poly(Symbol('\n1'))
-    assert simplify(1/Trace(m)) == Rational('1/34')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #19353 by changing the sympy/polys/polyutils.py file. In this file the line changed is
from this  _re_gen = re.compile(r"^(.+?)(\d*)$")
to this  _re_gen = re.compile(r"^(.*?)(\d*)$", re.MULTILINE)
A test case function test_issue_19353() has also been added in sympy/polys/tests/test_polyutils.py
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
