### PR TITLE
Update in measure_all

### DIFF
--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -9,7 +9,7 @@ Todo:
 
 import math
 
-from sympy import Integer, log, Mul, Add, Pow, conjugate
+from sympy import Integer, log, Mul, Add, Pow, conjugate, sqrt
 from sympy.core.basic import sympify
 from sympy.core.compatibility import SYMPY_INTS
 from sympy.matrices import Matrix, zeros
@@ -530,7 +530,7 @@ def qubit_to_matrix(qubit, format='sympy'):
 #-----------------------------------------------------------------------------
 
 
-def measure_all(qubit, format='sympy', normalize=True):
+def measure_all(qubit):
     """Perform an ensemble measurement of all qubits.
 
     Parameters
@@ -562,28 +562,33 @@ def measure_all(qubit, format='sympy', normalize=True):
         H(0)*H(1)*|00>
         >>> q = qapply(c)
         >>> measure_all(q)
-        [(|00>, 1/4), (|01>, 1/4), (|10>, 1/4), (|11>, 1/4)]
+        |00>/2 + |01>/2 + |10>/2 + |11>/2
+        [{'00': 0.25}, {'01': 0.25}, {'10': 0.25}, {'11': 0.25}]
     """
-    m = qubit_to_matrix(qubit, format)
-
-    if format == 'sympy':
-        results = []
-
-        if normalize:
-            m = m.normalized()
-
-        size = max(m.shape)  # Max of shape to account for bra or ket
-        nqubits = int(math.log(size)/math.log(2))
-        for i in range(size):
-            if m[i] != 0.0:
-                results.append(
-                    (Qubit(IntQubit(i, nqubits=nqubits)), m[i]*conjugate(m[i]))
-                )
-        return results
-    else:
-        raise NotImplementedError(
-            "This function can't handle non-sympy matrix formats yet"
-        )
+    print(qubit)
+    me = str(qubit)
+    state = []
+    prob=[]
+    while('|'in me or '>' in me or 'I' in me):
+        if ('|'in me or '>' in me):
+            start = me.find('|')
+            end = me.find('>')
+            newstring = '1'
+            state.append(me[start+1:end])
+            me = me[:start] + newstring + me[end+1:]
+        else:
+            starti = me.find('I')
+            newstringi = 'sqrt(-1)'
+            me = me[:starti] + newstringi + me[starti+1:]
+    me = me.split()
+    while('-'in me or '+' in me):
+        if('-' in me):
+            me.remove('-')
+        elif('+' in me):
+            me.remove('+')
+    for i in range(len(state)):
+        prob.append({state[i]:eval(me[i])*eval(me[i])})
+    return prob
 
 
 def measure_partial(qubit, bits, format='sympy', normalize=True):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -556,7 +556,7 @@ def measure_all(qubit, format='sympy', normalize=True):
         >>> q = qapply(c)
         >>> measure_all(q)
         |00>/2 + |01>/2 + |10>/2 + |11>/2
-        [{'00': 0.25}, {'01': 0.25}, {'10': 0.25}, {'11': 0.25}]
+        [('|00>', 0.25), ('|01>', 0.25), ('|10>', 0.25), ('|11>', 0.25)]
     """
     if format == 'sympy':
         print(qubit)
@@ -568,7 +568,7 @@ def measure_all(qubit, format='sympy', normalize=True):
                 start = qubit.find('|')
                 end = qubit.find('>')
                 newstring = '1'
-                state.append(qubit[start+1:end])
+                state.append(qubit[start:end+1])
                 qubit = qubit[:start] + newstring + qubit[end+1:]
             else:
                 starti = qubit.find('I')
@@ -580,16 +580,16 @@ def measure_all(qubit, format='sympy', normalize=True):
                 qubit.remove('-')
             else:
                 qubit.remove('+')
+        norm = 0
         if normalize==True:
-            norm = 0
             for i in range(len(state)):
                 norm = norm+eval(qubit[i])**2
         if norm!=1:
             for i in range(len(state)):
-                results.append({state[i]:(eval(qubit[i])**2)*(1/norm)})
+                results.append((state[i],(eval(qubit[i])**2)*(1/norm)))
         else:
             for i in range(len(state)):
-                results.append({state[i]:eval(qubit[i])*eval(qubit[i])})
+                results.append((state[i],eval(qubit[i])**2))
         return results
     else:
         raise NotImplementedError(
@@ -799,14 +799,15 @@ def measure_all_oneshot(qubit, format='sympy'):
         import random
         qubit = str(qubit)
         state = []
+        prob=[]
         while('|'in qubit or '>' in qubit):
             start = qubit.find('|')
             end = qubit.find('>')
             newstring = '1'
-            state.append(qubit[start+1:end])
+            state.append(qubit[start:end+1])
             qubit = qubit[:start] + newstring + qubit[end+1:]
         random_number = random.randrange(len(state))
-        return '|{}>'.format(state[random_number])
+        return state[random_number]
     else:
         raise NotImplementedError(
             "This function can't handle non-sympy matrix formats yet"

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -798,7 +798,6 @@ def measure_all_oneshot(qubit, format='sympy'):
         import random
         me = str(qubit)
         state = []
-        prob=[]
         while('|'in me or '>' in me or 'I' in me):
             if ('|'in me or '>' in me):
                 start = me.find('|')

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -530,12 +530,10 @@ def qubit_to_matrix(qubit, format='sympy'):
 #-----------------------------------------------------------------------------
 
 
-def measure_all(qubit, format='sympy'):
+def measure_all(qubit, format='sympy', normalize=True):
     """Perform an ensemble measurement of all qubits.
-
     Parameters
     ==========
-
     qubit : Qubit, Add
         The qubit to measure. This can be any Qubit or a linear combination
         of them.
@@ -543,20 +541,15 @@ def measure_all(qubit, format='sympy'):
         The format of the intermediate matrices to use. Possible values are
         ('sympy','numpy','scipy.sparse'). Currently only 'sympy' is
         implemented.
-
     Returns
     =======
-
     result : list
         A list that consists of primitive states and their probabilities.
-
     Examples
     ========
-
         >>> from sympy.physics.quantum.qubit import Qubit, measure_all
         >>> from sympy.physics.quantum.gate import H
         >>> from sympy.physics.quantum.qapply import qapply
-
         >>> c = H(0)*H(1)*Qubit('00')
         >>> c
         H(0)*H(1)*|00>
@@ -567,29 +560,37 @@ def measure_all(qubit, format='sympy'):
     """
     if format == 'sympy':
         print(qubit)
-        me = str(qubit)
+        qubit = str(qubit)
         state = []
-        prob=[]
-        while('|'in me or '>' in me or 'I' in me):
-            if ('|'in me or '>' in me):
-                start = me.find('|')
-                end = me.find('>')
+        results = []
+        while('|'in qubit or '>' in qubit or 'I' in qubit):
+            if ('|'in qubit or '>' in qubit):
+                start = qubit.find('|')
+                end = qubit.find('>')
                 newstring = '1'
-                state.append(me[start+1:end])
-                me = me[:start] + newstring + me[end+1:]
+                state.append(qubit[start+1:end])
+                qubit = qubit[:start] + newstring + qubit[end+1:]
             else:
-                starti = me.find('I')
+                starti = qubit.find('I')
                 newstringi = 'sqrt(-1)'
-                me = me[:starti] + newstringi + me[starti+1:]
-        me = me.split()
-        while('-'in me or '+' in me):
-            if('-' in me):
-                me.remove('-')
-            elif('+' in me):
-                me.remove('+')
-        for i in range(len(state)):
-            prob.append({state[i]:eval(me[i])*eval(me[i])})
-        return prob
+                qubit = qubit[:starti] + newstringi + qubit[starti+1:]
+        qubit = qubit.split()
+        while('-'in qubit or '+' in qubit):
+            if('-' in qubit):
+                qubit.remove('-')
+            else:
+                qubit.remove('+')
+        if normalize==True:
+            norm = 0
+            for i in range(len(state)):
+                norm = norm+eval(qubit[i])**2
+        if norm!=1:
+            for i in range(len(state)):
+                results.append({state[i]:(eval(qubit[i])**2)*(1/norm)})
+        else:
+            for i in range(len(state)):
+                results.append({state[i]:eval(qubit[i])*eval(qubit[i])})
+        return results
     else:
         raise NotImplementedError(
             "This function can't handle non-sympy matrix formats yet"
@@ -796,19 +797,14 @@ def measure_all_oneshot(qubit, format='sympy'):
     """
     if format == 'sympy':
         import random
-        me = str(qubit)
+        qubit = str(qubit)
         state = []
-        while('|'in me or '>' in me or 'I' in me):
-            if ('|'in me or '>' in me):
-                start = me.find('|')
-                end = me.find('>')
-                newstring = '1'
-                state.append(me[start+1:end])
-                me = me[:start] + newstring + me[end+1:]
-            else:
-                starti = me.find('I')
-                newstringi = 'sqrt(-1)'
-                me = me[:starti] + newstringi + me[starti+1:]
+        while('|'in qubit or '>' in qubit):
+            start = qubit.find('|')
+            end = qubit.find('>')
+            newstring = '1'
+            state.append(qubit[start+1:end])
+            qubit = qubit[:start] + newstring + qubit[end+1:]
         random_number = random.randrange(len(state))
         return '|{}>'.format(state[random_number])
     else:

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -9,7 +9,7 @@ Todo:
 
 import math
 
-from sympy import Integer, log, Mul, Add, Pow, conjugate, sqrt
+from sympy import Integer, log, Mul, Add, Pow, conjugate
 from sympy.core.basic import sympify
 from sympy.core.compatibility import SYMPY_INTS
 from sympy.matrices import Matrix, zeros

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -9,7 +9,7 @@ Todo:
 
 import math
 
-from sympy import Integer, log, Mul, Add, Pow, conjugate
+from sympy import Integer, log, Mul, Add, Pow
 from sympy.core.basic import sympify
 from sympy.core.compatibility import SYMPY_INTS
 from sympy.matrices import Matrix, zeros
@@ -765,7 +765,7 @@ def _get_possible_outcomes(m, bits):
     return output_matrices
 
 
-def measure_all_oneshot(qubit, format='sympy'):
+def measure_all_oneshot(qubit):
     """Perform a oneshot ensemble measurement on all qubits.
 
     A oneshot measurement is equivalent to performing a measurement on a
@@ -790,20 +790,19 @@ def measure_all_oneshot(qubit, format='sympy'):
         The qubit that the system collapsed to upon measurement.
     """
     import random
-    m = qubit_to_matrix(qubit)
-
-    if format == 'sympy':
-        m = m.normalized()
-        random_number = random.random()
-        total = 0
-        result = 0
-        for i in m:
-            total += i*i.conjugate()
-            if total > random_number:
-                break
-            result += 1
-        return Qubit(IntQubit(result, int(math.log(max(m.shape), 2) + .1)))
-    else:
-        raise NotImplementedError(
-            "This function can't handle non-sympy matrix formats yet"
-        )
+    me = str(qubit)
+    state = []
+    prob=[]
+    while('|'in me or '>' in me or 'I' in me):
+        if ('|'in me or '>' in me):
+            start = me.find('|')
+            end = me.find('>')
+            newstring = '1'
+            state.append(me[start+1:end])
+            me = me[:start] + newstring + me[end+1:]
+        else:
+            starti = me.find('I')
+            newstringi = 'sqrt(-1)'
+            me = me[:starti] + newstringi + me[starti+1:]
+    random_number = random.randrange(len(state))
+    return '|{}>'.format(state[random_number])

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -530,7 +530,7 @@ def qubit_to_matrix(qubit, format='sympy'):
 #-----------------------------------------------------------------------------
 
 
-def measure_all(qubit):
+def measure_all(qubit, format='sympy'):
     """Perform an ensemble measurement of all qubits.
 
     Parameters
@@ -565,30 +565,35 @@ def measure_all(qubit):
         |00>/2 + |01>/2 + |10>/2 + |11>/2
         [{'00': 0.25}, {'01': 0.25}, {'10': 0.25}, {'11': 0.25}]
     """
-    print(qubit)
-    me = str(qubit)
-    state = []
-    prob=[]
-    while('|'in me or '>' in me or 'I' in me):
-        if ('|'in me or '>' in me):
-            start = me.find('|')
-            end = me.find('>')
-            newstring = '1'
-            state.append(me[start+1:end])
-            me = me[:start] + newstring + me[end+1:]
-        else:
-            starti = me.find('I')
-            newstringi = 'sqrt(-1)'
-            me = me[:starti] + newstringi + me[starti+1:]
-    me = me.split()
-    while('-'in me or '+' in me):
-        if('-' in me):
-            me.remove('-')
-        elif('+' in me):
-            me.remove('+')
-    for i in range(len(state)):
-        prob.append({state[i]:eval(me[i])*eval(me[i])})
-    return prob
+    if format == 'sympy':
+        print(qubit)
+        me = str(qubit)
+        state = []
+        prob=[]
+        while('|'in me or '>' in me or 'I' in me):
+            if ('|'in me or '>' in me):
+                start = me.find('|')
+                end = me.find('>')
+                newstring = '1'
+                state.append(me[start+1:end])
+                me = me[:start] + newstring + me[end+1:]
+            else:
+                starti = me.find('I')
+                newstringi = 'sqrt(-1)'
+                me = me[:starti] + newstringi + me[starti+1:]
+        me = me.split()
+        while('-'in me or '+' in me):
+            if('-' in me):
+                me.remove('-')
+            elif('+' in me):
+                me.remove('+')
+        for i in range(len(state)):
+            prob.append({state[i]:eval(me[i])*eval(me[i])})
+        return prob
+    else:
+        raise NotImplementedError(
+            "This function can't handle non-sympy matrix formats yet"
+        )
 
 
 def measure_partial(qubit, bits, format='sympy', normalize=True):
@@ -765,7 +770,7 @@ def _get_possible_outcomes(m, bits):
     return output_matrices
 
 
-def measure_all_oneshot(qubit):
+def measure_all_oneshot(qubit, format='sympy'):
     """Perform a oneshot ensemble measurement on all qubits.
 
     A oneshot measurement is equivalent to performing a measurement on a
@@ -789,19 +794,25 @@ def measure_all_oneshot(qubit):
     result : Qubit
         The qubit that the system collapsed to upon measurement.
     """
-    import random
-    me = str(qubit)
-    state = []
-    while('|'in me or '>' in me or 'I' in me):
-        if ('|'in me or '>' in me):
-            start = me.find('|')
-            end = me.find('>')
-            newstring = '1'
-            state.append(me[start+1:end])
-            me = me[:start] + newstring + me[end+1:]
-        else:
-            starti = me.find('I')
-            newstringi = 'sqrt(-1)'
-            me = me[:starti] + newstringi + me[starti+1:]
-    random_number = random.randrange(len(state))
-    return '|{}>'.format(state[random_number])
+    if format == 'sympy':
+        import random
+        me = str(qubit)
+        state = []
+        prob=[]
+        while('|'in me or '>' in me or 'I' in me):
+            if ('|'in me or '>' in me):
+                start = me.find('|')
+                end = me.find('>')
+                newstring = '1'
+                state.append(me[start+1:end])
+                me = me[:start] + newstring + me[end+1:]
+            else:
+                starti = me.find('I')
+                newstringi = 'sqrt(-1)'
+                me = me[:starti] + newstringi + me[starti+1:]
+        random_number = random.randrange(len(state))
+        return '|{}>'.format(state[random_number])
+    else:
+        raise NotImplementedError(
+            "This function can't handle non-sympy matrix formats yet"
+        )

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -572,7 +572,7 @@ def measure_all(qubit, format='sympy', normalize=True):
                 qubit = qubit[:start] + newstring + qubit[end+1:]
             else:
                 starti = qubit.find('I')
-                newstringi = '{}(-1)'.sqrt
+                newstringi = '{}(-1)'.format(sqrt)
                 qubit = qubit[:starti] + newstringi + qubit[starti+1:]
         qubit = qubit.split()
         while('-'in qubit or '+' in qubit):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -9,7 +9,7 @@ Todo:
 
 import math
 
-from sympy import Integer, log, Mul, Add, Pow
+from sympy import Integer, log, Mul, Add, Pow, sqrt
 from sympy.core.basic import sympify
 from sympy.core.compatibility import SYMPY_INTS
 from sympy.matrices import Matrix, zeros
@@ -572,7 +572,7 @@ def measure_all(qubit, format='sympy', normalize=True):
                 qubit = qubit[:start] + newstring + qubit[end+1:]
             else:
                 starti = qubit.find('I')
-                newstringi = 'sqrt(-1)'
+                newstringi = '{}(-1)'.sqrt
                 qubit = qubit[:starti] + newstringi + qubit[starti+1:]
         qubit = qubit.split()
         while('-'in qubit or '+' in qubit):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -792,7 +792,6 @@ def measure_all_oneshot(qubit):
     import random
     me = str(qubit)
     state = []
-    prob=[]
     while('|'in me or '>' in me or 'I' in me):
         if ('|'in me or '>' in me):
             start = me.find('|')


### PR DESCRIPTION
Now the measure_all returns the probability in dictionary type without matrix conversion.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously the measure_all function was based on matrix representation and was not perfect for a large number of qubits. Now measure_all can measure the probability of the state for around 1M qubits but again as it's still performing an operation on a classical hardware time taken is large for a large number of qubits.

#### Other comments
The representation of the output state probabilities is changed:
        >>> from sympy.physics.quantum.qubit import Qubit, measure_all
        >>> from sympy.physics.quantum.gate import H
        >>> from sympy.physics.quantum.qapply import qapply
        >>> c = H(0)*H(1)*Qubit('00')
        >>> c
        H(0)*H(1)*|00>
        >>> q = qapply(c)
        >>> measure_all(q)
        |00>/2 + |01>/2 + |10>/2 + |11>/2
        [{'00': 0.25}, {'01': 0.25}, {'10': 0.25}, {'11': 0.25}]

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*measure_all and measurement_all_oneshot
   * Fixed measurement logic
<!-- END RELEASE NOTES -->
