### PR TITLE
sets - fixes imageset does not work over range

### DIFF
--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -148,11 +148,15 @@ def _set_function(f, x): # noqa:F811
 @dispatch(FunctionUnion, Range)  # type: ignore # noqa:F811
 def _set_function(f, self): # noqa:F811
     from sympy.core.function import expand_mul
-    if not self:
+    try:
+        n = self.size
+    except ValueError:
+        n = None
+    if n == 0:        
         return S.EmptySet
     if not isinstance(f.expr, Expr):
         return
-    if self.size == 1:
+    if n == 1:
         return FiniteSet(f(self[0]))
     if f is S.IdentityFunction:
         return self

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -152,7 +152,7 @@ def _set_function(f, self): # noqa:F811
         n = self.size
     except ValueError:
         n = None
-    if n == 0:        
+    if n == 0:
         return S.EmptySet
     if not isinstance(f.expr, Expr):
         return

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1621,3 +1621,6 @@ def test_issue_20379():
 def test_finiteset_simplify():
     S = FiniteSet(1, cos(1)**2 + sin(1)**2)
     assert S.simplify() == {1}
+
+def test_issue_18400():
+    assert imageset(lambda x: x*2, Range(n))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #18400 by changing code in sympy/sets/handlers/functions.py and also added a test case function test_issue_18400() in sympy/sets/tests/test_sets.py
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
