### PR TITLE
Don't try to guard against non-hashable results in the cache

### DIFF
--- a/sympy/codegen/tests/test_algorithms.py
+++ b/sympy/codegen/tests/test_algorithms.py
@@ -6,7 +6,7 @@ from sympy.codegen.fnodes import bind_C
 from sympy.codegen.futils import render_as_module as f_module
 from sympy.codegen.pyutils import render_as_module as py_module
 from sympy.external import import_module
-from sympy.printing import ccode
+from sympy.printing.codeprinter import ccode
 from sympy.utilities._compilation import compile_link_import_strings, has_c, has_fortran
 from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip, raises

--- a/sympy/codegen/tests/test_applications.py
+++ b/sympy/codegen/tests/test_applications.py
@@ -3,7 +3,7 @@
 import tempfile
 
 from sympy.external import import_module
-from sympy.printing import ccode
+from sympy.printing.codeprinter import ccode
 from sympy.utilities._compilation import compile_link_import_strings, has_c
 from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip

--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -1,5 +1,5 @@
 from sympy.core.symbol import symbols
-from sympy.printing import ccode
+from sympy.printing.codeprinter import ccode
 from sympy.codegen.ast import Declaration, Variable, float64, int64, String, CodeBlock
 from sympy.codegen.cnodes import (
     alignof, CommaOperator, goto, Label, PreDecrement, PostDecrement, PreIncrement, PostIncrement,

--- a/sympy/codegen/tests/test_cxxnodes.py
+++ b/sympy/codegen/tests/test_cxxnodes.py
@@ -1,7 +1,7 @@
 from sympy.core.symbol import Symbol
 from sympy.codegen.ast import Type
 from sympy.codegen.cxxnodes import using
-from sympy.printing import cxxcode
+from sympy.printing.codeprinter import cxxcode
 
 x = Symbol('x')
 

--- a/sympy/codegen/tests/test_fnodes.py
+++ b/sympy/codegen/tests/test_fnodes.py
@@ -13,7 +13,7 @@ from sympy.codegen.fnodes import (
 from sympy.codegen.futils import render_as_module
 from sympy.core.expr import unchanged
 from sympy.external import import_module
-from sympy.printing import fcode
+from sympy.printing.codeprinter import fcode
 from sympy.utilities._compilation import has_fortran, compile_run_strings, compile_link_import_strings
 from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip, XFAIL

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -2,7 +2,7 @@ import tempfile
 from sympy import log, exp, cos, S, Symbol, Pow, sin, MatrixSymbol, sinc, pi
 from sympy.assumptions import assuming, Q
 from sympy.external import import_module
-from sympy.printing import ccode
+from sympy.printing.codeprinter import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -992,7 +992,7 @@ class Add(Expr, AssocOp):
             logflags = dict(deep=True, log=True, mul=False, power_exp=False,
                 power_base=False, multinomial=False, basic=False, force=False,
                 factor=False)
-            old = old.expand(logflags)
+            old = old.expand(**logflags)
         expr = expand_mul(old)
 
         if not expr.is_Add:

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -61,26 +61,7 @@ def __cacheit(maxsize):
         to force cacheit to check returned results mutability and consistency,
         set environment variable SYMPY_USE_CACHE to 'debug'
     """
-    def func_wrapper(func):
-        from .decorators import wraps
-
-        cfunc = lru_cache(maxsize, typed=True)(func)
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                retval = cfunc(*args, **kwargs)
-            except TypeError:
-                retval = func(*args, **kwargs)
-            return retval
-
-        wrapper.cache_info = cfunc.cache_info
-        wrapper.cache_clear = cfunc.cache_clear
-
-        CACHE.append(wrapper)
-        return wrapper
-
-    return func_wrapper
+    return lru_cache(maxsize, typed=True)
 ########################################
 
 

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -71,7 +71,7 @@ def __cacheit(maxsize):
             try:
                 retval = cfunc(*args, **kwargs)
             except TypeError as e:
-                if not e.args[0].startswith('unhashable type:'):
+                if not e.args or not e.args[0].startswith('unhashable type:'):
                     raise
                 retval = func(*args, **kwargs)
             return retval

--- a/sympy/core/tests/test_cache.py
+++ b/sympy/core/tests/test_cache.py
@@ -1,5 +1,5 @@
 from sympy.core.cache import cacheit
-
+from sympy.testing.pytest import raises
 
 def test_cacheit_doc():
     @cacheit
@@ -21,3 +21,36 @@ def test_cacheit_unhashable():
     assert testit(a) == {}
     a[1] = 2
     assert testit(a) == {1: 2}
+
+def test_cachit_exception():
+    # Make sure the cache doesn't call functions multiple times when they
+    # raise TypeError
+
+    a = []
+
+    @cacheit
+    def testf(x):
+        a.append(0)
+        raise TypeError
+
+    raises(TypeError, lambda: testf(1))
+    assert len(a) == 1
+
+    a.clear()
+    # Unhashable type
+    raises(TypeError, lambda: testf([]))
+    assert len(a) == 1
+
+    @cacheit
+    def testf2(x):
+        a.append(0)
+        raise TypeError("Error")
+
+    a.clear()
+    raises(TypeError, lambda: testf2(1))
+    assert len(a) == 1
+
+    a.clear()
+    # Unhashable type
+    raises(TypeError, lambda: testf2([]))
+    assert len(a) == 1


### PR DESCRIPTION
See https://github.com/sympy/sympy/pull/21619#issuecomment-889540868. This can
cause issues when the function itself raises TypeError. Really, if a function
has the cacheit decorator and returns a non-hashable result, that is a bug.
Either the function should be fixed to return a hashable result, or some lower
level function that does always return hashable results should be cached
instead.

This commit is to see what sorts of tests will fail when this change is made.
We may also want to run the test suite in random order to try to find
failures, since that can affect caching.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fix the internal caching code to not run a cached function twice if it raises a TypeError.
<!-- END RELEASE NOTES -->
