### PR TITLE
Convert various functions to use keyword-only arguments

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -509,8 +509,8 @@ class Add(Expr, AssocOp):
             return terms[0].matches(expr - coeff, repl_dict)
         return
 
-    def matches(self, expr, repl_dict={}, old=False):
-        return self._matches_commutative(expr, repl_dict, old)
+    def matches(self, expr, repl_dict={}, *, old=False):
+        return self._matches_commutative(expr, repl_dict, old=old)
 
     @staticmethod
     def _combine_inverse(lhs, rhs):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -992,7 +992,7 @@ class Add(Expr, AssocOp):
             logflags = dict(deep=True, log=True, mul=False, power_exp=False,
                 power_base=False, multinomial=False, basic=False, force=False,
                 factor=False)
-            old = old.expand(logflags)
+            old = old.expand(**logflags)
         expr = expand_mul(old)
 
         if not expr.is_Add:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1639,10 +1639,10 @@ class Basic(Printable, metaclass=ManagedProperties):
         # done
         return m
 
-    def count_ops(self, visual=None):
+    def count_ops(self, *, visual=None):
         """wrapper for count_ops that returns the operation count."""
         from sympy import count_ops
-        return count_ops(self, visual)
+        return count_ops(self, visual=visual)
 
     def doit(self, **hints):
         """Evaluate objects that are not evaluated by default like limits,

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1521,7 +1521,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         query = _make_find_query(query)
         return sum(bool(query(sub)) for sub in preorder_traversal(self))
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         """
         Helper method for match() that looks for a match between Wild symbols
         in self and expressions in expr.
@@ -1557,7 +1557,7 @@ class Basic(Printable, metaclass=ManagedProperties):
                 return None
         return d
 
-    def match(self, pattern, old=False):
+    def match(self, pattern, *, old=False):
         """
         Pattern matching.
 
@@ -1870,7 +1870,7 @@ class Atom(Basic):
 
     __slots__ = ()
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         if self == expr:
             return repl_dict.copy()
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1302,7 +1302,7 @@ class Expr(Basic, EvalfMixin):
         from .function import count_ops
         return count_ops(self, visual)
 
-    def args_cnc(self, cset=False, warn=True, split_1=True):
+    def args_cnc(self, *, cset=False, warn=True, split_1=True):
         """Return [commutative factors, non-commutative factors] of self.
 
         Explanation

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1133,7 +1133,7 @@ class Expr(Basic, EvalfMixin):
         except PolynomialError:
             return None
 
-    def as_ordered_terms(self, order=None, data=False):
+    def as_ordered_terms(self, order=None, *, data=False):
         """
         Transform an expression to an ordered list of terms.
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -707,7 +707,7 @@ class Expr(Basic, EvalfMixin):
             return None
         return True
 
-    def equals(self, other, failing_expression=False):
+    def equals(self, other, *, failing_expression=False):
         """Return True if self == other, False if it doesn't, or None. If
         failing_expression is True then the expression which did not simplify
         to a 0 will be returned instead of None.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1297,10 +1297,10 @@ class Expr(Basic, EvalfMixin):
 
         raise NotImplementedError('not sure of order of %s' % o)
 
-    def count_ops(self, visual=None):
+    def count_ops(self, *, visual=None):
         """wrapper for count_ops that returns the operation count."""
         from .function import count_ops
-        return count_ops(self, visual)
+        return count_ops(self, visual=visual)
 
     def args_cnc(self, *, cset=False, warn=True, split_1=True):
         """Return [commutative factors, non-commutative factors] of self.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3559,7 +3559,7 @@ class Expr(Basic, EvalfMixin):
         return (expr, hit)
 
     @cacheit
-    def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,
+    def expand(self, *, deep=True, modulus=None, power_base=True, power_exp=True,
             mul=True, log=True, multinomial=True, basic=True, **hints):
         """
         Expand an expression using hints.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1152,7 +1152,7 @@ class Expr(Basic, EvalfMixin):
 
         if order is None and self.is_Add:
             # Spot the special case of Add(Number, Mul(Number, expr)) with the
-            # first number positive and thhe second number nagative
+            # first number positive and the second number negative
             key = lambda x:not isinstance(x, (Number, NumberSymbol))
             add_args = sorted(Add.make_args(self), key=key)
             if (len(add_args) == 2

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2525,7 +2525,7 @@ def diff(f, *symbols, **kwargs):
     return _derivative_dispatch(f, *symbols, **kwargs)
 
 
-def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
+def expand(e, *, deep=True, modulus=None, power_base=True, power_exp=True,
         mul=True, log=True, multinomial=True, basic=True, **hints):
     r"""
     Expand an expression using methods given as hints.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1039,7 +1039,7 @@ class WildFunction(Function, AtomicExpr):  # type: ignore
             nargs = FiniteSet(*nargs)
         cls.nargs = nargs
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         if not isinstance(expr, (AppliedUndef, Function)):
             return None
         if len(expr.args) not in self.nargs:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3089,7 +3089,7 @@ def expand_power_exp(expr, deep=True):
     log=False, mul=False, power_exp=True, power_base=False, multinomial=False)
 
 
-def count_ops(expr, visual=False):
+def count_ops(expr, *, visual=False):
     """
     Return a representation (integer or expression) of the operations in expr.
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1026,11 +1026,11 @@ class Mul(Expr, AssocOp):
             return terms[0].matches(newexpr, repl_dict)
         return
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         expr = sympify(expr)
         repl_dict = repl_dict.copy()
         if self.is_commutative and expr.is_commutative:
-            return self._matches_commutative(expr, repl_dict, old)
+            return self._matches_commutative(expr, repl_dict, old=old)
         elif self.is_commutative is not expr.is_commutative:
             return None
 
@@ -1043,7 +1043,7 @@ class Mul(Expr, AssocOp):
         comm_mul_self = Mul(*c1)
         comm_mul_expr = Mul(*c2)
 
-        repl_dict = comm_mul_self.matches(comm_mul_expr, repl_dict, old)
+        repl_dict = comm_mul_self.matches(comm_mul_expr, repl_dict, old=old)
 
         # If the commutative arguments didn't match and aren't equal, then
         # then the expression as a whole doesn't match

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1528,7 +1528,7 @@ class Pow(Expr):
                 return self.func(n, exp), d
         return self.func(n, exp), self.func(d, exp)
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         expr = _sympify(expr)
         repl_dict = repl_dict.copy()
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1305,8 +1305,8 @@ class Pow(Expr):
             from ..functions import exp
             re_e, im_e = self.exp.as_real_imag()
             if deep:
-                re_e = re_e.expand(deep, **hints)
-                im_e = im_e.expand(deep, **hints)
+                re_e = re_e.expand(deep=deep, **hints)
+                im_e = im_e.expand(deep=deep, **hints)
             c, s = cos(im_e), sin(im_e)
             return exp(re_e)*c, exp(re_e)*s
         else:
@@ -1314,7 +1314,7 @@ class Pow(Expr):
             if deep:
                 hints['complex'] = False
 
-                expanded = self.expand(deep, **hints)
+                expanded = self.expand(deep=deep, **hints)
                 if hints.get('ignore') == expanded:
                     return None
                 else:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -252,7 +252,7 @@ class Relational(Boolean, EvalfMixin):
 
         return r
 
-    def equals(self, other, failing_expression=False):
+    def equals(self, other, *, failing_expression=False):
         """Return True if the sides of the relationship are mathematically
         identical and the type of relationship is the same.
         If failing_expression is True, return the expression whose truth value

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -537,7 +537,7 @@ class Wild(Symbol):
         return super()._hashable_content() + (self.exclude, self.properties)
 
     # TODO add check against another Wild
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict={}, *, old=False):
         if any(expr.has(x) for x in self.exclude):
             return None
         if any(not f(expr) for f in self.properties):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -792,19 +792,19 @@ def test_equals():
     w, x, y, z = symbols('w:z')
     f = Function('f')
     assert Eq(x, 1).equals(Eq(x*(y + 1) - x*y - x + 1, x))
-    assert Eq(x, y).equals(x < y, True) == False
-    assert Eq(x, f(1)).equals(Eq(x, f(2)), True) == f(1) - f(2)
-    assert Eq(f(1), y).equals(Eq(f(2), y), True) == f(1) - f(2)
-    assert Eq(x, f(1)).equals(Eq(f(2), x), True) == f(1) - f(2)
-    assert Eq(f(1), x).equals(Eq(x, f(2)), True) == f(1) - f(2)
-    assert Eq(w, x).equals(Eq(y, z), True) == False
-    assert Eq(f(1), f(2)).equals(Eq(f(3), f(4)), True) == f(1) - f(3)
-    assert (x < y).equals(y > x, True) == True
-    assert (x < y).equals(y >= x, True) == False
-    assert (x < y).equals(z < y, True) == False
-    assert (x < y).equals(x < z, True) == False
-    assert (x < f(1)).equals(x < f(2), True) == f(1) - f(2)
-    assert (f(1) < x).equals(f(2) < x, True) == f(1) - f(2)
+    assert Eq(x, y).equals(x < y, failing_expression=True) == False
+    assert Eq(x, f(1)).equals(Eq(x, f(2)), failing_expression=True) == f(1) - f(2)
+    assert Eq(f(1), y).equals(Eq(f(2), y), failing_expression=True) == f(1) - f(2)
+    assert Eq(x, f(1)).equals(Eq(f(2), x), failing_expression=True) == f(1) - f(2)
+    assert Eq(f(1), x).equals(Eq(x, f(2)), failing_expression=True) == f(1) - f(2)
+    assert Eq(w, x).equals(Eq(y, z), failing_expression=True) == False
+    assert Eq(f(1), f(2)).equals(Eq(f(3), f(4)), failing_expression=True) == f(1) - f(3)
+    assert (x < y).equals(y > x, failing_expression=True) == True
+    assert (x < y).equals(y >= x, failing_expression=True) == False
+    assert (x < y).equals(z < y, failing_expression=True) == False
+    assert (x < y).equals(x < z, failing_expression=True) == False
+    assert (x < f(1)).equals(x < f(2), failing_expression=True) == f(1) - f(2)
+    assert (f(1) < x).equals(f(2) < x, failing_expression=True) == f(1) - f(2)
 
 
 def test_reversed():

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -421,8 +421,8 @@ class exp(ExpBase, metaclass=ExpMeta):
         from sympy.functions.elementary.trigonometric import cos, sin
         re, im = self.args[0].as_real_imag()
         if deep:
-            re = re.expand(deep, **hints)
-            im = im.expand(deep, **hints)
+            re = re.expand(deep=deep, **hints)
+            im = im.expand(deep=deep, **hints)
         cos, sin = cos(im), sin(im)
         return (exp(re)*cos, exp(re)*sin)
 
@@ -888,14 +888,14 @@ class log(Function):
         from sympy import Abs, arg
         sarg = self.args[0]
         if deep:
-            sarg = self.args[0].expand(deep, **hints)
+            sarg = self.args[0].expand(deep=deep, **hints)
         abs = Abs(sarg)
         if abs == sarg:
             return self, S.Zero
         arg = arg(sarg)
         if hints.get('log', False):  # Expand the log
             hints['complex'] = False
-            return (log(abs).expand(deep, **hints), arg)
+            return (log(abs).expand(deep=deep, **hints), arg)
         else:
             return log(abs), arg
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -182,11 +182,11 @@ class sinh(HyperbolicFunction):
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
+                return (self.expand(deep=deep, **hints), S.Zero)
             else:
                 return (self, S.Zero)
         if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
+            re, im = self.args[0].expand(deep=deep, **hints).as_real_imag()
         else:
             re, im = self.args[0].as_real_imag()
         return (sinh(re)*cos(im), cosh(re)*sin(im))
@@ -197,7 +197,7 @@ class sinh(HyperbolicFunction):
 
     def _eval_expand_trig(self, deep=True, **hints):
         if deep:
-            arg = self.args[0].expand(deep, **hints)
+            arg = self.args[0].expand(deep=deep, **hints)
         else:
             arg = self.args[0]
         x = None
@@ -371,11 +371,11 @@ class cosh(HyperbolicFunction):
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
+                return (self.expand(deep=deep, **hints), S.Zero)
             else:
                 return (self, S.Zero)
         if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
+            re, im = self.args[0].expand(deep=deep, **hints).as_real_imag()
         else:
             re, im = self.args[0].as_real_imag()
 
@@ -387,7 +387,7 @@ class cosh(HyperbolicFunction):
 
     def _eval_expand_trig(self, deep=True, **hints):
         if deep:
-            arg = self.args[0].expand(deep, **hints)
+            arg = self.args[0].expand(deep=deep, **hints)
         else:
             arg = self.args[0]
         x = None
@@ -620,11 +620,11 @@ class tanh(HyperbolicFunction):
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
+                return (self.expand(deep=deep, **hints), S.Zero)
             else:
                 return (self, S.Zero)
         if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
+            re, im = self.args[0].expand(deep=deep, **hints).as_real_imag()
         else:
             re, im = self.args[0].as_real_imag()
         denom = sinh(re)**2 + cos(im)**2
@@ -839,11 +839,11 @@ class coth(HyperbolicFunction):
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
+                return (self.expand(deep=deep, **hints), S.Zero)
             else:
                 return (self, S.Zero)
         if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
+            re, im = self.args[0].expand(deep=deep, **hints).as_real_imag()
         else:
             re, im = self.args[0].as_real_imag()
         denom = sinh(re)**2 + sin(im)**2

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -57,11 +57,11 @@ class TrigonometricFunction(Function):
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
-                return (self.args[0].expand(deep, **hints), S.Zero)
+                return (self.args[0].expand(deep=deep, **hints), S.Zero)
             else:
                 return (self.args[0], S.Zero)
         if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
+            re, im = self.args[0].expand(deep=deep, **hints).as_real_imag()
         else:
             re, im = self.args[0].as_real_imag()
         return (re, im)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -21,11 +21,11 @@ def real_to_real_as_real_imag(self, deep=True, **hints):
     if self.args[0].is_extended_real:
         if deep:
             hints['complex'] = False
-            return (self.expand(deep, **hints), S.Zero)
+            return (self.expand(deep=deep, **hints), S.Zero)
         else:
             return (self, S.Zero)
     if deep:
-        x, y = self.args[0].expand(deep, **hints).as_real_imag()
+        x, y = self.args[0].expand(deep=deep, **hints).as_real_imag()
     else:
         x, y = self.args[0].as_real_imag()
     re = (self.func(x + I*y) + self.func(x - I*y))/2

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2089,7 +2089,7 @@ class MatrixOperations(MatrixRequired):
                 'quad':quad, 'verbose':verbose}
         return self.applyfunc(lambda i: i.evalf(n, **options))
 
-    def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,
+    def expand(self, *, deep=True, modulus=None, power_base=True, power_exp=True,
                mul=True, log=True, multinomial=True, basic=True, **hints):
         """Apply core.function.expand to each entry of the matrix.
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2104,9 +2104,12 @@ class MatrixOperations(MatrixRequired):
         Matrix([[x**2 + x]])
 
         """
-        return self.applyfunc(lambda x: x.expand(
-            deep, modulus, power_base, power_exp, mul, log, multinomial, basic,
-            **hints))
+        return self.applyfunc(lambda x: x.expand(deep=deep, modulus=modulus,
+                                                 power_base=power_base,
+                                                 power_exp=power_exp,
+                                                 mul=mul, log=log,
+                                                 multinomial=multinomial,
+                                                 basic=basic, **hints))
 
     @property
     def H(self):

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -257,7 +257,7 @@ class RepMatrix(MatrixBase):
         else:
             return self._fromrep(rep.applyfunc(lambda e: e.conjugate()))
 
-    def equals(self, other, failing_expression=False):
+    def equals(self, other, *, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,
         trying to prove that the elements are equivalent, returning True
         if they are, False if any pair is not, and None (or the first
@@ -291,7 +291,7 @@ class RepMatrix(MatrixBase):
         rv = True
         for i in range(self.rows):
             for j in range(self.cols):
-                ans = self[i, j].equals(other[i, j], failing_expression)
+                ans = self[i, j].equals(other[i, j], failing_expression=failing_expression)
                 if ans is False:
                     return False
                 elif ans is not True and rv is True:

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -161,7 +161,7 @@ def link(obj_files, out_file=None, shared=False, Runner=None,
                 )
             for k, v in extra_kwargs.items():
                 if k in kwargs:
-                    kwargs[k].expand(v)
+                    kwargs[k].extend(v)
                 else:
                     kwargs[k] = v
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/17944 (shouldn't mark as closed because this PR isn't going to cover every function in SymPy)

#### Brief description of what is fixed or changed

I am fixing various function signatures to use keyword only arguments. So for example,

```py
def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,
           mul=True, log=True, multinomial=True, basic=True, **hints):
```

becomes

```py
def expand(self, *, deep=True, modulus=None, power_base=True, power_exp=True,
           mul=True, log=True, multinomial=True, basic=True, **hints):
```

This means that things like `expr.expand(True)` are no longer valid. You will have to use `expr.expand(deep=True)` instead.

#### Other comments

This is a huge undertaking and I probably won't get to every function in SymPy. Please feel free to merge this at any time if the tests are passing, and to pick up this work. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Change several function signatures to use keyword-only arguments.
- functions
  - Change several function signatures to use keyword-only arguments.
<!-- END RELEASE NOTES -->
