### PR TITLE
Quaternion - Fixes the issue 21752 by adding the evalf method in Quaternion class

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -490,6 +490,29 @@ class Quaternion(Expr):
 
         return Quaternion(a, b, c, d)
 
+    def evalf(self, *args):
+        """Returns the evalf of the quaternion.
+
+        Examples
+        ========
+
+        >>> from sympy.algebras.quaternion import Quaternion
+        >>> q = Quaternion(1/sqrt(1), 1/sqrt(2), 1/sqrt(3), 1/sqrt(4))
+        >>> q.evalf()
+        1.00000000000000
+        + 0.707106781186547*i
+        + 0.577350269189626*j
+        + 0.500000000000000*k
+
+        """
+        q = self
+        a = q.a.evalf(*args)
+        b = q.b.evalf(*args)
+        c = q.c.evalf(*args)
+        d = q.d.evalf(*args)
+
+        return Quaternion(a, b, c, d)
+
     def pow_cos_sin(self, p):
         """Computes the pth power in the cos-sin form.
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -491,7 +491,7 @@ class Quaternion(Expr):
         return Quaternion(a, b, c, d)
 
     def evalf(self, *args):
-        """Returns the evalf of the quaternion.
+        """Returns the evalf of the quaternion (q.evalf()).
 
         Examples
         ========

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -8,8 +8,8 @@ from sympy import trigsimp
 from sympy import integrate
 from sympy import Matrix
 from sympy import sympify
-from sympy.core.expr import Expr
 from sympy.core.evalf import prec_to_dps
+from sympy.core.expr import Expr
 
 
 class Quaternion(Expr):

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -491,12 +491,19 @@ class Quaternion(Expr):
         return Quaternion(a, b, c, d)
 
     def evalf(self, *args):
-        """Returns the evalf of the quaternion (q.evalf()).
+        """Returns the floating point approximations (decimal numbers) of the quaternion.
+
+        Returns
+        =======
+
+        Quaternion
+            Floating point approximations of quaternion(self)
 
         Examples
         ========
 
         >>> from sympy.algebras.quaternion import Quaternion
+        >>> from sympy import sqrt
         >>> q = Quaternion(1/sqrt(1), 1/sqrt(2), 1/sqrt(3), 1/sqrt(4))
         >>> q.evalf()
         1.00000000000000

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -9,6 +9,7 @@ from sympy import integrate
 from sympy import Matrix
 from sympy import sympify
 from sympy.core.expr import Expr
+from sympy.core.evalf import prec_to_dps
 
 
 class Quaternion(Expr):
@@ -490,7 +491,7 @@ class Quaternion(Expr):
 
         return Quaternion(a, b, c, d)
 
-    def evalf(self, *args):
+    def _eval_evalf(self, prec):
         """Returns the floating point approximations (decimal numbers) of the quaternion.
 
         Returns
@@ -512,13 +513,8 @@ class Quaternion(Expr):
         + 0.500000000000000*k
 
         """
-        q = self
-        a = q.a.evalf(*args)
-        b = q.b.evalf(*args)
-        c = q.c.evalf(*args)
-        d = q.d.evalf(*args)
 
-        return Quaternion(a, b, c, d)
+        return Quaternion(*[arg.evalf(n=prec_to_dps(prec)) for arg in self.args])
 
     def pow_cos_sin(self, p):
         """Computes the pth power in the cos-sin form.

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,6 +1,6 @@
 from sympy import symbols, re, im, sign, I, Abs, Symbol, \
      cos, sin, sqrt, conjugate, log, acos, E, pi, \
-     Matrix, diff, integrate, trigsimp, S, Rational
+     Matrix, diff, integrate, trigsimp, S, Rational, Float
 from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
 
@@ -55,6 +55,11 @@ def test_quaternion_complex_real_addition():
     assert q1 + q0 == q1
     assert q1 - q0 == q1
     assert q1 - q1 == q0
+
+
+def test_quaternion_evalf():
+    assert Quaternion(1, 2, 3, 4).evalf() == Quaternion(Float(1), Float(2), Float(3), Float(4))
+    assert Quaternion(1 + 2*I, 0, 0, 3+4*I).evalf() == Quaternion(Float(1) + Float(2)*I, 0, 0, Float(3) + Float(4)*I)
 
 
 def test_quaternion_functions():

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -59,6 +59,7 @@ def test_quaternion_complex_real_addition():
 
 def test_quaternion_evalf():
     assert Quaternion(sqrt(2), 0, 0, sqrt(3)).evalf() == Quaternion(sqrt(2).evalf(), 0, 0, sqrt(3).evalf())
+    assert Quaternion(1/sqrt(2), 0, 0, 1/sqrt(2)).evalf() == Quaternion((1/sqrt(2)).evalf(), 0, 0, (1/sqrt(2)).evalf())
 
 
 def test_quaternion_functions():

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -59,8 +59,6 @@ def test_quaternion_complex_real_addition():
 
 def test_quaternion_evalf():
     assert Quaternion(sqrt(2), 0, 0, sqrt(3)).evalf() == Quaternion(sqrt(2).evalf(), 0, 0, sqrt(3).evalf())
-    assert Quaternion(sqrt(2)*I, 0, 0, sqrt(3)+sqrt(4)*I).evalf() == \
-    Quaternion(sqrt(2).evalf()*I, 0, 0, sqrt(3).evalf() + sqrt(4).evalf()*I)
 
 
 def test_quaternion_functions():

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,6 +1,6 @@
 from sympy import symbols, re, im, sign, I, Abs, Symbol, \
      cos, sin, sqrt, conjugate, log, acos, E, pi, \
-     Matrix, diff, integrate, trigsimp, S, Rational, Float
+     Matrix, diff, integrate, trigsimp, S, Rational
 from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
 
@@ -58,8 +58,9 @@ def test_quaternion_complex_real_addition():
 
 
 def test_quaternion_evalf():
-    assert Quaternion(1, 2, 3, 4).evalf() == Quaternion(Float(1), Float(2), Float(3), Float(4))
-    assert Quaternion(1 + 2*I, 0, 0, 3+4*I).evalf() == Quaternion(Float(1) + Float(2)*I, 0, 0, Float(3) + Float(4)*I)
+    assert Quaternion(sqrt(2), 0, 0, sqrt(3)).evalf() == Quaternion(sqrt(2).evalf(), 0, 0, sqrt(3).evalf())
+    assert Quaternion(sqrt(2)*I, 0, 0, sqrt(3)+sqrt(4)*I).evalf() == \
+    Quaternion(sqrt(2).evalf()*I, 0, 0, sqrt(3).evalf() + sqrt(4).evalf()*I)
 
 
 def test_quaternion_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21752 by adding a overridden method evalf in the Quaternion class
Now Quaternion expressions can also be converted to floating point approximations using .evalf() method.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* algebras
   * Added evalf method for Quaternion Class

<!-- END RELEASE NOTES -->
