### PR TITLE
integrals - fixes issue#21711 and now manual integrate is tried if meijerg returns unevaluated integral

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1568,10 +1568,10 @@ def integrate(*args, meijerg=None, conds='piecewise', risch=None, heurisch=None,
     integral = Integral(*args, **kwargs)
 
     if isinstance(integral, Integral):
-        if not integral.doit(**doit_flags).is_number:
+        if isinstance(integral.doit(**doit_flags), Integral):
+            doit_flags['meijerg'] = False
             return integral.doit(**doit_flags)
         else:
-            doit_flags['meijerg'] = False
             return integral.doit(**doit_flags)
     else:
         new_args = [a.doit(**doit_flags) if isinstance(a, Integral) else a

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1568,7 +1568,11 @@ def integrate(*args, meijerg=None, conds='piecewise', risch=None, heurisch=None,
     integral = Integral(*args, **kwargs)
 
     if isinstance(integral, Integral):
-        return integral.doit(**doit_flags)
+        if not integral.doit(**doit_flags).is_number:
+            return integral.doit(**doit_flags)
+        else:
+            doit_flags['meijerg'] = False
+            return integral.doit(**doit_flags)
     else:
         new_args = [a.doit(**doit_flags) if isinstance(a, Integral) else a
             for a in integral.args]

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1736,3 +1736,8 @@ def test_issue_21034():
 def test_issue_4187():
     assert integrate(log(x)*exp(-x), x) == Ei(-x) - exp(-x)*log(x)
     assert integrate(log(x)*exp(-x), (x, 0, oo)) == -EulerGamma
+
+
+def test_issue_21711():
+    assert integrate(sqrt(1-(x)*(x)), (x, 0, 1)) == pi/4
+    assert integrate(sqrt(1 - (x-1)*(x-1)), (x, 0, 1)) == pi/4


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21711 by trying for manual integration when meijerg returns an unevaluated integral

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
