### PR TITLE
printing - fixes issue 21814 and now some expressions are printed correctly

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -736,23 +736,38 @@ class CoordinateSymbol(Symbol):
     Examples
     ========
 
-    >>> from sympy import symbols
+    >>> from sympy import symbols, Lambda, Matrix, sqrt, atan2, cos, sin
     >>> from sympy.diffgeom import Manifold, Patch, CoordSystem
     >>> m = Manifold('M', 2)
     >>> p = Patch('P', m)
-    >>> _x, _y = symbols('x y', nonnegative=True)
+    >>> x, y = symbols('x y', real=True)
+    >>> r, theta = symbols('r theta', nonnegative=True)
+    >>> relation_dict = {
+    ... ('Car2D', 'Pol'): Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+    ... ('Pol', 'Car2D'): Lambda((r, theta), Matrix([r*cos(theta), r*sin(theta)]))
+    ... }
+    >>> Car2D = CoordSystem('Car2D', p, [x, y], relation_dict)
+    >>> Pol = CoordSystem('Pol', p, [r, theta], relation_dict)
+    >>> x, y = Car2D.symbols
 
-    >>> C = CoordSystem('C', p, [_x, _y])
-    >>> x, y = C.symbols
+    ``CoordinateSymbol`` contains its coordinate symbol and index.
 
     >>> x.name
     'x'
-    >>> x.coord_sys == C
+    >>> x.coord_sys == Car2D
     True
     >>> x.index
     0
-    >>> x.is_nonnegative
+    >>> x.is_real
     True
+
+    You can transform ``CoordinateSymbol`` into other coordinate system using
+    ``rewrite()`` method.
+
+    >>> x.rewrite(Pol)
+    r*cos(theta)
+    >>> sqrt(x**2 + y**2).rewrite(Pol).simplify()
+    r
 
     """
     def __new__(cls, coord_sys, index, **assumptions):
@@ -769,6 +784,11 @@ class CoordinateSymbol(Symbol):
         return (
             self.coord_sys, self.index
         ) + tuple(sorted(self.assumptions0.items()))
+
+    def _eval_rewrite(self, rule, args, **hints):
+        if isinstance(rule, CoordSystem):
+            return rule.transform(self.coord_sys)[self.index]
+        return super()._eval_rewrite(rule, args, **hints)
 
 
 class Point(Basic):

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -134,6 +134,12 @@ def test_R3():
         #TODO assert m == R3_c.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
 
 
+def test_CoordinateSymbol():
+    x, y = R2_r.symbols
+    r, theta = R2_p.symbols
+    assert y.rewrite(R2_p) == r*sin(theta)
+
+
 def test_point():
     x, y = symbols('x, y')
     p = R2_r.point([x, y])

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -799,7 +799,7 @@ class Integral(AddWithLimits):
         return rv
 
     def _eval_integral(self, f, x, meijerg=None, risch=None, manual=None,
-                       heurisch=None, conds='piecewise'):
+                       heurisch=None, conds='piecewise',final=None):
         """
         Calculate the anti-derivative to the function f(x).
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -602,7 +602,11 @@ class Integral(AddWithLimits):
                             function = ret
                             continue
 
-            if not isinstance(antideriv, Integral) and antideriv is not None:
+            final = hints.get('final', True)
+            # dotit may be iterated but floor terms making atan and acot
+            # continous should only be added in the final round
+            if (final and not isinstance(antideriv, Integral) and
+                antideriv is not None):
                 for atan_term in antideriv.atoms(atan):
                     atan_arg = atan_term.args[0]
                     # Checking `atan_arg` to be linear combination of `tan` or `cot`
@@ -1098,6 +1102,7 @@ class Integral(AddWithLimits):
                             # method was set to False already
                             new_eval_kwargs = eval_kwargs
                             new_eval_kwargs["manual"] = False
+                            new_eval_kwargs["final"] = False
                             result = result.func(*[
                                 arg.doit(**new_eval_kwargs) if
                                 arg.has(Integral) else arg

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1736,3 +1736,90 @@ def test_issue_21034():
 def test_issue_4187():
     assert integrate(log(x)*exp(-x), x) == Ei(-x) - exp(-x)*log(x)
     assert integrate(log(x)*exp(-x), (x, 0, oo)) == -EulerGamma
+
+def test_issue_21024():
+    x = Symbol('x', real=True, nonzero=True)
+    f = log(x)*log(4*x) + log(3*x + exp(2))
+    F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
+        (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
+    assert F == integrate(f,x)
+
+    f = (x + exp(3))/x**2
+    F = log(x) - exp(3)/x
+    assert F == integrate(f,x)
+
+    f = (x**2 + exp(5))/x
+    F = x**2/2 + exp(5)*log(x)
+    assert F == integrate(f,x)
+
+    f = x/(2*x + tanh(1))
+    F = x/2 - log(2*x + tanh(1))*tanh(1)/4
+    assert F == integrate(f,x)
+
+    f = x - sinh(4)/x
+    F = x**2/2 - log(x)*sinh(4)
+    assert F == integrate(f,x)
+
+    f = log(x + exp(5)/x)
+    F = x*log(x + exp(5)/x) - x + 2*exp(Rational(5/2))*atan(x*exp(Rational(-5/2)))
+    assert simplify(F - integrate(f,x))==0
+
+    f = x**5/(x + E)
+    F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
+    assert F == integrate(f,x)
+
+    f = 4*x/(x + sinh(5))
+    F = 4*x - 4*log(x + sinh(5))*sinh(5)
+    assert F == integrate(f,x)
+
+    f = x**2/(2*x + sinh(2))
+    F = x**2/4 - x*sinh(2)/4 + (-1 + E)**2*(1 + E)**2*(1 + exp(2))**2*exp(-4)*log(2*x + sinh(2))/32
+    assert F == integrate(f,x)
+
+    f = -x**2/(x + E)
+    F = -x**2/2 + E*x - exp(2)*log(x + E)
+    assert F == integrate(f,x)
+
+    f = (2*x + 3)*exp(5)/x
+    F = 2*x*exp(5) + 3*exp(5)*log(x)
+    assert F == integrate(f,x)
+
+    f = x + 2 + cosh(3)/x
+    F = x**2/2 + 2*x + log(x)*cosh(3)
+    assert F == integrate(f,x)
+
+    f = x - tanh(1)/x**3
+    F = x**2/2 + tanh(1)/(2*x**2)
+    assert F == integrate(f,x)
+
+    f = (3*x - exp(6))/x
+    F = 3*x - exp(6)*log(x)
+    assert F == integrate(f,x)
+
+    f = x**4/(x + exp(5))**2 + x
+    F = x**3/3 + x**2*(1/2 - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
+    assert F == integrate(f,x)
+
+    f = x*(x + exp(10)/x**2) + x
+    F = x**3/3 + x**2/2 + exp(10)*log(x)
+    assert F == integrate(f,x)
+
+    f = x + x/(5*x + sinh(3))
+    F = x**2/2 + x/5 - log(5*x + sinh(3))*sinh(3)/25
+    assert F == integrate(f,x)
+
+    f = (x + exp(3))/(2*x**2 + 2*x)
+    F = exp(3)*log(x)/2 - (-1 + E)*(1 + E + exp(2))*log(x + ((-1 + E)*(1 + E + exp(2)) + exp(3))/(-1 + 2*exp(3)))/2
+    assert F == integrate(f,x)
+
+    f = log(x + 4*sinh(4))
+    F = x*log(x + 4*sinh(4)) - x + 4*log(x + 4*sinh(4))*sinh(4)
+    assert F == integrate(f,x)
+
+    f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
+    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) + (180*x**2*exp(5)*sin(4)*atan(4) - 90*x*exp(10)*sin(4)*atan(4)**2 + 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
+    assert F == integrate(f,x)
+
+    f = 2*x**2*exp(-4) + 6/x
+    F_true = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
+    assert F == integrate(f,x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1736,3 +1736,8 @@ def test_issue_21034():
 def test_issue_4187():
     assert integrate(log(x)*exp(-x), x) == Ei(-x) - exp(-x)*log(x)
     assert integrate(log(x)*exp(-x), (x, 0, oo)) == -EulerGamma
+
+
+def test_issue_21831():
+    theta = symbols('theta')
+    assert integrate(cos(3*theta)/(5-4*cos(theta)), (theta, 0, 2*pi)) == pi/12

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1825,3 +1825,8 @@ def test_issue_21024():
     f = 2*x**2*exp(-4) + 6/x
     F_true = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
     assert F_true == integrate(f, x)
+
+
+def test_issue_21831():
+    theta = symbols('theta')
+    assert integrate(cos(3*theta)/(5-4*cos(theta)), (theta, 0, 2*pi)) == pi/12

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1737,89 +1737,91 @@ def test_issue_4187():
     assert integrate(log(x)*exp(-x), x) == Ei(-x) - exp(-x)*log(x)
     assert integrate(log(x)*exp(-x), (x, 0, oo)) == -EulerGamma
 
+
 def test_issue_21024():
     x = Symbol('x', real=True, nonzero=True)
     f = log(x)*log(4*x) + log(3*x + exp(2))
     F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
         (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = (x + exp(3))/x**2
     F = log(x) - exp(3)/x
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = (x**2 + exp(5))/x
     F = x**2/2 + exp(5)*log(x)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x/(2*x + tanh(1))
     F = x/2 - log(2*x + tanh(1))*tanh(1)/4
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x - sinh(4)/x
     F = x**2/2 - log(x)*sinh(4)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = log(x + exp(5)/x)
-    F = x*log(x + exp(5)/x) - x + 2*exp(Rational(5/2))*atan(x*exp(Rational(-5/2)))
-    assert simplify(F - integrate(f,x))==0
+    F = x*log(x + exp(5)/x) - x + 2*exp(Rational(5, 2))*atan(x*exp(Rational(-5, 2)))
+    assert F == integrate(f, x)
 
     f = x**5/(x + E)
     F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = 4*x/(x + sinh(5))
     F = 4*x - 4*log(x + sinh(5))*sinh(5)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x**2/(2*x + sinh(2))
     F = x**2/4 - x*sinh(2)/4 + log(2*x + sinh(2))*sinh(2)**2/8
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = -x**2/(x + E)
     F = -x**2/2 + E*x - exp(2)*log(x + E)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = (2*x + 3)*exp(5)/x
     F = 2*x*exp(5) + 3*exp(5)*log(x)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x + 2 + cosh(3)/x
     F = x**2/2 + 2*x + log(x)*cosh(3)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x - tanh(1)/x**3
     F = x**2/2 + tanh(1)/(2*x**2)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = (3*x - exp(6))/x
     F = 3*x - exp(6)*log(x)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x**4/(x + exp(5))**2 + x
-    F = x**3/3 + x**2*(Rational(1/2) - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
-    assert F == integrate(f,x)
+    F = x**3/3 + x**2*(Rational(1, 2) - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
+    assert F == integrate(f, x)
 
     f = x*(x + exp(10)/x**2) + x
     F = x**3/3 + x**2/2 + exp(10)*log(x)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = x + x/(5*x + sinh(3))
     F = x**2/2 + x/5 - log(5*x + sinh(3))*sinh(3)/25
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = (x + exp(3))/(2*x**2 + 2*x)
-    F = exp(3)*log(x)/2 + (Rational(1/2) - exp(3)/2)*log(x + 1)
-    assert F == integrate(f,x)
+    F = exp(3)*log(x)/2 + (Rational(1, 2) - exp(3)/2)*log(x + 1)
+    assert F == integrate(f, x)
 
     f = log(x + 4*sinh(4))
     F = x*log(x + 4*sinh(4)) - x + 4*log(x + 4*sinh(4))*sinh(4)
-    assert F == integrate(f,x)
+    assert F == integrate(f, x)
 
     f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
-    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) - (-180*x**2*exp(5)*sin(4)*atan(4) + 90*x*exp(10)*sin(4)*atan(4)**2 - 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
-    assert F == integrate(f,x)
+    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) - (-180*x**2*exp(5)*sin(4)*atan(4) + 90*x*exp(10)*sin(4)*atan(4)**2 - \
+        20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
+    assert F == integrate(f, x)
 
     f = 2*x**2*exp(-4) + 6/x
     F_true = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
-    assert F_true == integrate(f,x)
+    assert F_true == integrate(f, x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1736,3 +1736,90 @@ def test_issue_21034():
 def test_issue_4187():
     assert integrate(log(x)*exp(-x), x) == Ei(-x) - exp(-x)*log(x)
     assert integrate(log(x)*exp(-x), (x, 0, oo)) == -EulerGamma
+
+def test_issue_21024():
+    x = Symbol('x', real=True, nonzero=True)
+    f = log(x)*log(4*x) + log(3*x + exp(2))
+    F = x*log(x)**2 + x*(1 - 2*log(2)) + (-2*x + 2*x*log(2))*log(x) + \
+        (x + exp(2)/6)*log(3*x + exp(2)) + exp(2)*log(3*x + exp(2))/6
+    assert F == integrate(f,x)
+
+    f = (x + exp(3))/x**2
+    F = log(x) - exp(3)/x
+    assert F == integrate(f,x)
+
+    f = (x**2 + exp(5))/x
+    F = x**2/2 + exp(5)*log(x)
+    assert F == integrate(f,x)
+
+    f = x/(2*x + tanh(1))
+    F = x/2 - log(2*x + tanh(1))*tanh(1)/4
+    assert F == integrate(f,x)
+
+    f = x - sinh(4)/x
+    F = x**2/2 - log(x)*sinh(4)
+    assert F == integrate(f,x)
+
+    f = log(x + exp(5)/x)
+    F = x*log(x + exp(5)/x) - x + 2*exp(Rational(5/2))*atan(x*exp(Rational(-5/2)))
+    assert simplify(F - integrate(f,x))==0
+
+    f = x**5/(x + E)
+    F = x**5/5 - E*x**4/4 + x**3*exp(2)/3 - x**2*exp(3)/2 + x*exp(4) - exp(5)*log(x + E)
+    assert F == integrate(f,x)
+
+    f = 4*x/(x + sinh(5))
+    F = 4*x - 4*log(x + sinh(5))*sinh(5)
+    assert F == integrate(f,x)
+
+    f = x**2/(2*x + sinh(2))
+    F = x**2/4 - x*sinh(2)/4 + log(2*x + sinh(2))*sinh(2)**2/8
+    assert F == integrate(f,x)
+
+    f = -x**2/(x + E)
+    F = -x**2/2 + E*x - exp(2)*log(x + E)
+    assert F == integrate(f,x)
+
+    f = (2*x + 3)*exp(5)/x
+    F = 2*x*exp(5) + 3*exp(5)*log(x)
+    assert F == integrate(f,x)
+
+    f = x + 2 + cosh(3)/x
+    F = x**2/2 + 2*x + log(x)*cosh(3)
+    assert F == integrate(f,x)
+
+    f = x - tanh(1)/x**3
+    F = x**2/2 + tanh(1)/(2*x**2)
+    assert F == integrate(f,x)
+
+    f = (3*x - exp(6))/x
+    F = 3*x - exp(6)*log(x)
+    assert F == integrate(f,x)
+
+    f = x**4/(x + exp(5))**2 + x
+    F = x**3/3 + x**2*(Rational(1/2) - exp(5)) + 3*x*exp(10) - 4*exp(15)*log(x + exp(5)) - exp(20)/(x + exp(5))
+    assert F == integrate(f,x)
+
+    f = x*(x + exp(10)/x**2) + x
+    F = x**3/3 + x**2/2 + exp(10)*log(x)
+    assert F == integrate(f,x)
+
+    f = x + x/(5*x + sinh(3))
+    F = x**2/2 + x/5 - log(5*x + sinh(3))*sinh(3)/25
+    assert F == integrate(f,x)
+
+    f = (x + exp(3))/(2*x**2 + 2*x)
+    F = exp(3)*log(x)/2 + (Rational(1/2) - exp(3)/2)*log(x + 1)
+    assert F == integrate(f,x)
+
+    f = log(x + 4*sinh(4))
+    F = x*log(x + 4*sinh(4)) - x + 4*log(x + 4*sinh(4))*sinh(4)
+    assert F == integrate(f,x)
+
+    f = -x + 20*(exp(-5) - atan(4)/x)**3*sin(4)/x
+    F = (-x**2*exp(15)/2 + 20*log(x)*sin(4) - (-180*x**2*exp(5)*sin(4)*atan(4) + 90*x*exp(10)*sin(4)*atan(4)**2 - 20*exp(15)*sin(4)*atan(4)**3)/(3*x**3))*exp(-15)
+    assert F == integrate(f,x)
+
+    f = 2*x**2*exp(-4) + 6/x
+    F_true = (2*x**3/3 + 6*exp(4)*log(x))*exp(-4)
+    assert F_true == integrate(f,x)

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1831,11 +1831,10 @@ class Beam3D(Beam):
     >>> dy = collect(simplify(dy), x)
     >>> dx == dz == 0
     True
-    >>> dy == (x*(12*A*E*G*I*l**3*q - 24*A*E*G*I*l**2*m + 144*E**2*I**2*l*q +
-    ...           x**3*(A**2*G**2*l**2*q + 12*A*E*G*I*q) +
-    ...           x**2*(-2*A**2*G**2*l**3*q - 24*A*E*G*I*l*q - 48*A*E*G*I*m) +
-    ...           x*(A**2*G**2*l**4*q + 72*A*E*G*I*l*m - 144*E**2*I**2*q)
-    ...           )/(24*A*E*G*I*(A*G*l**2 + 12*E*I)))
+    >>> dy == (x*(12*E*I*l*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)
+    ... + x*(A*G*l*(3*l*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q) + x*(-2*A*G*l**2*q + 4*A*G*l*m - 24*E*I*q))
+    ... + A*G*(A*G*l**2 + 12*E*I)*(-2*l**2*q + 6*l*m - 4*m*x + q*x**2)
+    ... - 12*E*I*q*(A*G*l**2 + 12*E*I)))/(24*A*E*G*I*(A*G*l**2 + 12*E*I)))
     True
 
     References
@@ -2705,9 +2704,9 @@ class Beam3D(Beam):
             Plot[1]:Plot object containing:
             [0]: cartesian line: -15*x**2/2 for x over (0.0, 20.0)
             Plot[2]:Plot object containing:
-            [0]: cartesian line: x**2*(150 - 5*x)/8000 - x/8 for x over (0.0, 20.0)
+            [0]: cartesian line: -x**3/1600 + 3*x**2/160 - x/8 for x over (0.0, 20.0)
             Plot[3]:Plot object containing:
-            [0]: cartesian line: x*(105*x**4 - 8026000*x**2/43 + 109200000*x/43 + 304000000/43)/4200000 for x over (0.0, 20.0)
+            [0]: cartesian line: x**5/40000 - 4013*x**3/90300 + 26*x**2/43 + 1520*x/903 for x over (0.0, 20.0)
 
         """
 

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -582,7 +582,7 @@ def test_Beam3D():
     assert b2.reaction_loads == {R1: -750, R2: -750}
 
     b2.solve_slope_deflection()
-    assert b2.slope() == [0, 0, x**2*(50*x - 2250)/(6*E*I) + 3750*x/(E*I)]
+    assert b2.slope() == [0, 0, 25*x**3/(3*E*I) - 375*x**2/(E*I) + 3750*x/(E*I)]
     expected_deflection = (x*(25*A*G*x**3/2 - 750*A*G*x**2 + 4500*E*I +
         15*x*(750*A*G - 10*E*I))/(6*A*E*G*I))
     dx, dy, dz = b2.deflection()

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -583,8 +583,8 @@ def test_Beam3D():
 
     b2.solve_slope_deflection()
     assert b2.slope() == [0, 0, 25*x**3/(3*E*I) - 375*x**2/(E*I) + 3750*x/(E*I)]
-    expected_deflection = (x*(25*A*G*x**3/2 - 750*A*G*x**2 + 4500*E*I +
-        15*x*(750*A*G - 10*E*I))/(6*A*E*G*I))
+    expected_deflection = 25*x**4/(12*E*I) - 125*x**3/(E*I) + 1875*x**2/(E*I) - \
+        25*x**2/(A*G) + 750*x/(A*G)
     dx, dy, dz = b2.deflection()
     assert dx == dz == 0
     assert dy == expected_deflection

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1574,13 +1574,14 @@ class MIMOParallel(MIMOLinearTimeInvariant):
         ========
 
         >>> from sympy.abc import p
-        >>> from sympy.physics.control.lti import TransferFunction, Parallel, Series
+        >>> from sympy.physics.control.lti import TransferFunction, TransferFunctionMatrix, MIMOParallel
         >>> G1 = TransferFunction(p**2 + 2*p + 4, p - 6, p)
         >>> G2 = TransferFunction(p, 4 - p, p)
         >>> G3 = TransferFunction(0, p**4 - 1, p)
-        >>> Parallel(G1, G2).var
-        p
-        >>> Parallel(-G3, Series(G1, G2)).var
+        >>> G4 = TransferFunction(p**2, p**2 - 1, p)
+        >>> tfm_a = TransferFunctionMatrix([[G1, G2], [G3, G4]])
+        >>> tfm_b = TransferFunctionMatrix([[G2, G1], [G4, G3]])
+        >>> MIMOParallel(tfm_a, tfm_b).var
         p
 
         """

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1181,6 +1181,7 @@ def test_Domain_is_nonpositive():
     assert CC.is_nonpositive(a) == False
     assert CC.is_nonpositive(b) == False
 
+
 def test_exponential_domain():
     K = ZZ[E]
     eK = K.from_sympy(E)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1,6 +1,6 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
-from sympy import I, S, sqrt, sin, oo, Poly, Float, Integer, Rational, pi
+from sympy import I, S, sqrt, sin, oo, Poly, Float, Integer, Rational, pi, exp, E
 from sympy.abc import x, y, z
 
 from sympy.utilities.iterables import cartes
@@ -1180,3 +1180,9 @@ def test_Domain_is_nonpositive():
     a, b = [CC.convert(x) for x in (2 + I, 5)]
     assert CC.is_nonpositive(a) == False
     assert CC.is_nonpositive(b) == False
+
+def test_exponential_domain():
+    K = ZZ[E]
+    eK = K.from_sympy(E)
+    assert K.from_sympy(exp(3)) == eK ** 3
+    assert K.convert(exp(3)) == eK ** 3

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -380,10 +380,14 @@ class PolyRing(DefaultPrinting, IPolys):
                 return reduce(add, list(map(_rebuild, expr.args)))
             elif expr.is_Mul:
                 return reduce(mul, list(map(_rebuild, expr.args)))
-            elif expr.is_Pow and expr.exp.is_Integer and expr.exp >= 0:
-                return _rebuild(expr.base)**int(expr.exp)
             else:
-                return self.ground_new(domain.convert(expr))
+                # XXX: Use as_base_exp() to handle Pow(x, n) and also exp(n)
+                # XXX: E can be a generator e.g. sring([exp(2)]) -> ZZ[E]
+                base, exp = expr.as_base_exp()
+                if exp.is_Integer and exp > 1:
+                    return _rebuild(base)**int(exp)
+                else:
+                    return self.ground_new(domain.convert(expr))
 
         return _rebuild(sympify(expr))
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -13,7 +13,7 @@ from sympy.polys.polyerrors import GeneratorsError, \
 from sympy.testing.pytest import raises
 from sympy.core import Symbol, symbols
 
-from sympy import sqrt, pi, oo
+from sympy import sqrt, pi, oo, exp
 
 def test_PolyRing___init__():
     x, y, z, t = map(Symbol, "xyzt")
@@ -275,6 +275,10 @@ def test_PolyElement_from_expr():
 
     f = R.from_expr(x**3*y*z + x**2*y**7 + 1)
     assert f == X**3*Y*Z + X**2*Y**7 + 1 and isinstance(f, R.dtype)
+
+    r, F = sring([exp(2)])
+    f = r.from_expr(exp(2))
+    assert f == F[0] and isinstance(f, r.dtype)
 
     raises(ValueError, lambda: R.from_expr(1/x))
     raises(ValueError, lambda: R.from_expr(2**x))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -546,7 +546,7 @@ class LatexPrinter(Printer):
         # XXX: _print_Pow calls this routine with instances of Pow...
         if isinstance(expr, Mul):
             args = expr.args
-            if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]):
+            if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]) and args[0].is_number:
                 return convert_args(args)
 
         include_parens = False

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1893,7 +1893,7 @@ class PrettyPrinter(Printer):
         # etc so we display in a straight-forward form that fully preserves all
         # args and their order.
         args = product.args
-        if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]):
+        if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]) and args[0].is_number:
             strargs = list(map(self._print, args))
             # XXX: This is a hack to work around the fact that
             # prettyForm.__mul__ absorbs a leading -1 in the args. Probably it

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7561,3 +7561,7 @@ def test_diffgeom():
     assert pretty(rect) == "rect"
     b = BaseScalarField(rect, 0)
     assert pretty(b) == "x"
+
+def test_issue_21814():
+    assert upretty(Mul(x + y, Rational(1, 2), evaluate=False)) == 'x + y\n─────\n  2  '
+    assert upretty(Mul(Rational(1, 2), x + y, evaluate=False)) == 'x + y\n─────\n  2  '

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -996,6 +996,8 @@ y   \
     expr = Mul(Rational(2, 3), Rational(5, 7), evaluate=False)
     assert pretty(expr) == "2/3*5/7"
     assert upretty(expr) == "2/3⋅5/7"
+    assert upretty(Mul(x + y, Rational(1, 2), evaluate=False)) == 'x + y\n─────\n  2  '
+    assert upretty(Mul(Rational(1, 2), x + y, evaluate=False)) == 'x + y\n─────\n  2  '
 
 def test_issue_5524():
     assert pretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \
@@ -7561,7 +7563,3 @@ def test_diffgeom():
     assert pretty(rect) == "rect"
     b = BaseScalarField(rect, 0)
     assert pretty(b) == "x"
-
-def test_issue_21814():
-    assert upretty(Mul(x + y, Rational(1, 2), evaluate=False)) == 'x + y\n─────\n  2  '
-    assert upretty(Mul(Rational(1, 2), x + y, evaluate=False)) == 'x + y\n─────\n  2  '

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -996,8 +996,31 @@ y   \
     expr = Mul(Rational(2, 3), Rational(5, 7), evaluate=False)
     assert pretty(expr) == "2/3*5/7"
     assert upretty(expr) == "2/3⋅5/7"
-    assert upretty(Mul(x + y, Rational(1, 2), evaluate=False)) == 'x + y\n─────\n  2  '
-    assert upretty(Mul(Rational(1, 2), x + y, evaluate=False)) == 'x + y\n─────\n  2  '
+    expr = Mul(x + y, Rational(1, 2), evaluate=False)
+    assert pretty(expr) == "x + y\n-----\n  2  "
+    assert upretty(expr) == "x + y\n─────\n  2  "
+    expr = Mul(Rational(1, 2), x + y, evaluate=False)
+    assert pretty(expr) == "x + y\n-----\n  2  "
+    assert upretty(expr) == "x + y\n─────\n  2  "
+    expr = Mul(S.One, x + y, evaluate=False)
+    assert pretty(expr) == "1*(x + y)"
+    assert upretty(expr) == "1⋅(x + y)"
+    expr = Mul(x - y, S.One, evaluate=False)
+    assert pretty(expr) == "x - y"
+    assert upretty(expr) == "x - y"
+    expr = Mul(Rational(1, 2), x - y, S.One, x + y, evaluate=False)
+    assert pretty(expr) == "1/2*(x - y)*1*(x + y)"
+    assert upretty(expr) == "1/2⋅(x - y)⋅1⋅(x + y)"
+    expr = Mul(x + y, Rational(3, 4), S.One, y - z, evaluate=False)
+    assert pretty(expr) == "3*(x + y)*(y - z)\n-----------------\n        4        "
+    assert upretty(expr) == "3⋅(x + y)⋅(y - z)\n─────────────────\n        4        "
+    expr = Mul(x + y, Rational(1, 1), Rational(3, 4), Rational(5, 6),evaluate=False)
+    assert pretty(expr) == "3*5*(x + y)\n-----------\n    4*6    "
+    assert upretty(expr) == "3⋅5⋅(x + y)\n───────────\n    4⋅6    "
+    expr = Mul(Rational(3, 4), x + y, S.One, y - z, evaluate=False)
+    assert pretty(expr) == "3/4*(x + y)*1*(y - z)"
+    assert upretty(expr) == "3/4⋅(x + y)⋅1⋅(y - z)"
+
 
 def test_issue_5524():
     assert pretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2755,3 +2755,7 @@ def test_pickleable():
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+
+def test_issue_21814():
+    assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == "\\frac{x + y}{2}"
+    assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == "\\frac{x + y}{2}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -115,9 +115,9 @@ def test_latex_basic():
     assert latex(Mul(x + y, Rational(3, 4), S.One, y - z, evaluate=False)) == \
         r'\frac{1 \cdot 3 \left(x + y\right) \left(y - z\right)}{4}'
     assert latex(Mul(x + y, Rational(1, 1), Rational(3, 4), Rational(5, 6), evaluate=False)) == \
-        r'\frac{1 \cdot 3 \cdot 5 \left(x + y\right)}{4 \cdot 6}'  
+        r'\frac{1 \cdot 3 \cdot 5 \left(x + y\right)}{4 \cdot 6}'
     assert latex(Mul(Rational(3, 4), x + y, S.One, y - z, evaluate=False)) == \
-        r'\frac{3}{4} \left(x + y\right) 1 \left(y - z\right)'    
+        r'\frac{3}{4} \left(x + y\right) 1 \left(y - z\right)'
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == r"1 / x"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -106,8 +106,18 @@ def test_latex_basic():
         r'4 \cdot 3 \cdot 2 \left(z + 1\right) 0 y x'
     assert latex(Mul(Rational(2, 3), Rational(5, 7), evaluate=False)) == \
         r'\frac{2}{3} \frac{5}{7}'
-    assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == "\\frac{x + y}{2}"
-    assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == "\\frac{x + y}{2}"
+    assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == r'\frac{x + y}{2}'
+    assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == r'\frac{x + y}{2}'
+    assert latex(Mul(S.One, x + y, evaluate=False)) == r'1 \left(x + y\right)'
+    assert latex(Mul(x - y, S.One, evaluate=False)) == r'1 \left(x - y\right)'
+    assert latex(Mul(Rational(1, 2), x - y, S.One, x + y, evaluate=False)) == \
+        r'\frac{1}{2} \left(x - y\right) 1 \left(x + y\right)'
+    assert latex(Mul(x + y, Rational(3, 4), S.One, y - z, evaluate=False)) == \
+        r'\frac{1 \cdot 3 \left(x + y\right) \left(y - z\right)}{4}'
+    assert latex(Mul(x + y, Rational(1, 1), Rational(3, 4), Rational(5, 6), evaluate=False)) == \
+        r'\frac{1 \cdot 3 \cdot 5 \left(x + y\right)}{4 \cdot 6}'  
+    assert latex(Mul(Rational(3, 4), x + y, S.One, y - z, evaluate=False)) == \
+        r'\frac{3}{4} \left(x + y\right) 1 \left(y - z\right)'    
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == r"1 / x"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -105,7 +105,9 @@ def test_latex_basic():
     assert latex(Mul(4, 3, 2, 1+z, 0, y, x, evaluate=False)) == \
         r'4 \cdot 3 \cdot 2 \left(z + 1\right) 0 y x'
     assert latex(Mul(Rational(2, 3), Rational(5, 7), evaluate=False)) == \
-        r'\frac{2}{3} \frac{5}{7}'
+        r'\frac{2}{3} \frac{5}{7}'    
+    assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == "\\frac{x + y}{2}"
+    assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == "\\frac{x + y}{2}"
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == r"1 / x"
@@ -2755,7 +2757,3 @@ def test_pickleable():
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
-
-def test_issue_21814():
-    assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == "\\frac{x + y}{2}"
-    assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == "\\frac{x + y}{2}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -105,7 +105,7 @@ def test_latex_basic():
     assert latex(Mul(4, 3, 2, 1+z, 0, y, x, evaluate=False)) == \
         r'4 \cdot 3 \cdot 2 \left(z + 1\right) 0 y x'
     assert latex(Mul(Rational(2, 3), Rational(5, 7), evaluate=False)) == \
-        r'\frac{2}{3} \frac{5}{7}'    
+        r'\frac{2}{3} \frac{5}{7}'
     assert latex(Mul(x + y, Rational(1, 2), evaluate=False)) == "\\frac{x + y}{2}"
     assert latex(Mul(Rational(1, 2), x + y, evaluate=False)) == "\\frac{x + y}{2}"
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2971,6 +2971,10 @@ class LieGroup(SingleODESolver):
 
 solver_map = {
     'factorable': Factorable,
+    'nth_linear_constant_coeff_homogeneous': NthLinearConstantCoeffHomogeneous,
+    'nth_linear_euler_eq_homogeneous': NthLinearEulerEqHomogeneous,
+    'nth_linear_constant_coeff_undetermined_coefficients': NthLinearConstantCoeffUndeterminedCoefficients,
+    'nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients': NthLinearEulerEqNonhomogeneousUndeterminedCoefficients,
     'separable': Separable,
     '1st_exact': FirstExact,
     '1st_linear': FirstLinear,
@@ -2983,10 +2987,6 @@ solver_map = {
     'almost_linear': AlmostLinear,
     'linear_coefficients': LinearCoefficients,
     'separable_reduced': SeparableReduced,
-    'nth_linear_constant_coeff_homogeneous': NthLinearConstantCoeffHomogeneous,
-    'nth_linear_euler_eq_homogeneous': NthLinearEulerEqHomogeneous,
-    'nth_linear_constant_coeff_undetermined_coefficients': NthLinearConstantCoeffUndeterminedCoefficients,
-    'nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients': NthLinearEulerEqNonhomogeneousUndeterminedCoefficients,
     'nth_linear_constant_coeff_variation_of_parameters': NthLinearConstantCoeffVariationOfParameters,
     'nth_linear_euler_eq_nonhomogeneous_variation_of_parameters': NthLinearEulerEqNonhomogeneousVariationOfParameters,
     'Liouville': Liouville,

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2971,7 +2971,6 @@ class LieGroup(SingleODESolver):
 
 solver_map = {
     'factorable': Factorable,
-    'nth_algebraic': NthAlgebraic,
     'separable': Separable,
     '1st_exact': FirstExact,
     '1st_linear': FirstLinear,
@@ -2984,7 +2983,6 @@ solver_map = {
     'almost_linear': AlmostLinear,
     'linear_coefficients': LinearCoefficients,
     'separable_reduced': SeparableReduced,
-    'lie_group': LieGroup,
     'nth_linear_constant_coeff_homogeneous': NthLinearConstantCoeffHomogeneous,
     'nth_linear_euler_eq_homogeneous': NthLinearEulerEqHomogeneous,
     'nth_linear_constant_coeff_undetermined_coefficients': NthLinearConstantCoeffUndeterminedCoefficients,
@@ -2997,6 +2995,8 @@ solver_map = {
     '2nd_hypergeometric': SecondHypergeometric,
     'nth_order_reducible': NthOrderReducible,
     '2nd_nonlinear_autonomous_conserved': SecondNonlinearAutonomousConserved,
+    'nth_algebraic': NthAlgebraic,
+    'lie_group': LieGroup,
     }
 
 # Avoid circular import:

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -301,7 +301,7 @@ def test_classify_ode():
     #This is for new behavior of classify_ode when called internally with default, It should
     # return the first hint which matches therefore, 'ordered_hints' key will not be there.
     assert sorted(classify_ode(Eq(f(x).diff(x), 0), f(x), dict=True).keys()) == \
-        ['default', 'nth_algebraic', 'nth_algebraic_Integral', 'order']
+        ['default', 'order', 'separable', 'separable_Integral']
     a = classify_ode(2*x*f(x)*f(x).diff(x) + (1 + x)*f(x)**2 - exp(x), f(x), dict=True, hint='Bernoulli')
     assert sorted(a.keys()) == ['Bernoulli', 'Bernoulli_Integral', 'default', 'order', 'ordered_hints']
 

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -301,7 +301,7 @@ def test_classify_ode():
     #This is for new behavior of classify_ode when called internally with default, It should
     # return the first hint which matches therefore, 'ordered_hints' key will not be there.
     assert sorted(classify_ode(Eq(f(x).diff(x), 0), f(x), dict=True).keys()) == \
-        ['default', 'order', 'separable', 'separable_Integral']
+        ['default', 'nth_linear_constant_coeff_homogeneous', 'order']
     a = classify_ode(2*x*f(x)*f(x).diff(x) + (1 + x)*f(x)**2 - exp(x), f(x), dict=True, hint='Bernoulli')
     assert sorted(a.keys()) == ['Bernoulli', 'Bernoulli_Integral', 'default', 'order', 'ordered_hints']
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1343,7 +1343,7 @@ def _get_examples_ode_sol_nth_order_reducible():
 
     'reducible_10': {
         'eq': f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x),
-        'sol': [Eq(f(x), C1 + C2*(x*sin(x) + cos(x)) + C3*(-x*cos(x) + sin(x)) + C4*sin(x) + C5*cos(x))],
+        'sol': [Eq(f(x), C1 + C2*x*sin(x) + C2*cos(x) - C3*x*cos(x) + C3*sin(x) + C4*sin(x) + C5*cos(x))],
         'slow': True,
     },
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1021,7 +1021,7 @@ def _get_examples_ode_sol_factorable():
     # This is from issue: https://github.com/sympy/sympy/issues/7093
     'fact_19': {
         'eq': Derivative(f(x), x)**2 - x**3,
-        'sol': [Eq(f(x), C1 - 2*x*sqrt(x**3)/5), Eq(f(x), C1 + 2*x*sqrt(x**3)/5)],
+        'sol': [Eq(f(x), C1 - 2*x**Rational(5,2)/5), Eq(f(x), C1 + 2*x**Rational(5,2)/5)],
     },
 
     'fact_20': {

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1014,7 +1014,7 @@ def _get_examples_ode_sol_factorable():
     # This is from issue: https://github.com/sympy/sympy/issues/9446
     'fact_18':{
         'eq': Eq(f(2 * x), sin(Derivative(f(x)))),
-        'sol': [Eq(f(x), C1 + pi*x - Integral(asin(f(2*x)), x)), Eq(f(x), C1 + Integral(asin(f(2*x)), x))],
+        'sol': [Eq(f(x), C1 + Integral(pi - asin(f(2*x)), x)), Eq(f(x), C1 + Integral(asin(f(2*x)), x))],
         'checkodesol_XFAIL':True
     },
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1357,7 +1357,8 @@ def _get_examples_ode_sol_nth_order_reducible():
     # Needs to be a way to know how to combine derivatives in the expression
     'reducible_12': {
         'eq': Derivative(x*f(x), x, x, x) + Derivative(f(x), x, x, x),
-        'sol': [Eq(f(x), C1 + C2*x + C3/Mul(2, (x + 1), evaluate=False))], # 2-arg Mul!
+        'sol': [Eq(f(x), C1 + C3/Mul(2, (x**2 + 2*x + 1), evaluate=False) +
+        x*(C2 + C3/Mul(2, (x**2 + 2*x + 1), evaluate=False)))], # 2-arg Mul!
         'slow': True,
     },
     }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21814 and the now the Mul expression Mul(x + y, Rational(1, 2), evaluate=False) is printed as (x+y)*2 also fixed the printing in pretty and upretty.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
     * Fixed printing of unevaluated Mul which now outputs with brackets 
<!-- END RELEASE NOTES -->
