### PR TITLE
monomials: fixed min_degrees functionality of itermonomials

### DIFF
--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -127,7 +127,7 @@ def itermonomials(variables, max_degrees, min_degrees=None):
                 for variable in item:
                     if variable != 1:
                         powers[variable] += 1
-                if max(powers.values()) >= min_degree:
+                if sum(powers.values()) >= min_degree:
                     monomials_list_comm.append(Mul(*item))
             yield from set(monomials_list_comm)
         else:
@@ -139,7 +139,7 @@ def itermonomials(variables, max_degrees, min_degrees=None):
                 for variable in item:
                     if variable != 1:
                         powers[variable] += 1
-                if max(powers.values()) >= min_degree:
+                if sum(powers.values()) >= min_degree:
                     monomials_list_non_comm.append(Mul(*item))
             yield from set(monomials_list_non_comm)
     else:

--- a/sympy/polys/tests/test_monomials.py
+++ b/sympy/polys/tests/test_monomials.py
@@ -15,7 +15,6 @@ from sympy.abc import a, b, c, x, y, z
 from sympy.core import S, symbols
 from sympy.testing.pytest import raises
 
-
 def test_monomials():
 
     # total_degree tests
@@ -114,6 +113,9 @@ def test_monomials():
     assert set(itermonomials([x], [3], [1])) == {x, x**3, x**2}
     assert set(itermonomials([x], [3], [2])) == {x**3, x**2}
 
+    assert set(itermonomials([x, y], 3, 3)) == {x**3, x**2*y, x*y**2, y**3}
+    assert set(itermonomials([x, y], 3, 2)) == {x**2, x*y, y**2, x**3, x**2*y, x*y**2, y**3}
+
     assert set(itermonomials([x, y], [0, 0])) == {S.One}
     assert set(itermonomials([x, y], [0, 1])) == {S.One, y}
     assert set(itermonomials([x, y], [0, 2])) == {S.One, y, y**2}
@@ -132,6 +134,15 @@ def test_monomials():
             {S.One, y**2, x*y**2, x, x*y, x**2, x**2*y**2, y, x**2*y}
 
     i, j, k = symbols('i j k', commutative=False)
+    assert set(itermonomials([i, j, k], 2, 2)) == \
+            {k*i, i**2, i*j, j*k, j*i, k**2, j**2, k*j, i*k}
+    assert set(itermonomials([i, j, k], 3, 2)) == \
+            {j*k**2, i*k**2, k*i*j, k*i**2, k**2, j*k*j, k*j**2, i*k*i, i*j,
+                    j**2*k, i**2*j, j*i*k, j**3, i**3, k*j*i, j*k*i, j*i,
+                    k**2*j, j*i**2, k*j, k*j*k, i*j*i, j*i*j, i*j**2, j**2,
+                    k*i*k, i**2, j*k, i*k, i*k*j, k**3, i**2*k, j**2*i, k**2*i,
+                    i*j*k, k*i
+            }
     assert set(itermonomials([i, j, k], [0, 0, 0])) == {S.One}
     assert set(itermonomials([i, j, k], [0, 0, 1])) == {1, k}
     assert set(itermonomials([i, j, k], [0, 1, 0])) == {1, j}


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #21845
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

min_degree is an optional argument that enforces a lower bound
on the degree of the monomials generated by itermonomials. Previously,
itertools returned monomials with maximum degree greater than or
equal to the lower bound. This is now changed to monomials with
total degree greater than of equal to the lower bound. Test have also
been introduced to ensure the proper functionality.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug in itermonomials when using min_degrees argument
<!-- END RELEASE NOTES -->
