### PR TITLE
Fix for LambertW printing error

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2423,14 +2423,14 @@ class LatexPrinter(Printer):
         return self._print(Symbol(object.name))
 
     def _print_LambertW(self, expr, exp=None):
-    	arg0 = self._print(expr.args[0])
-    	exp = r"^{%s}" % (exp,) if exp is not None else ""
-    	if len(expr.args) == 1:
-    		result = r"W%s\left(%s\right)" % (exp, arg0)
-    	else:
-    		arg1 = self._print(expr.args[1])
-    		result = 'W{0}_{{{1}}}\left({2}\\right)'.format(exp, arg1, arg0)
-    	return result
+        arg0 = self._print(expr.args[0])
+        exp = r"^{%s}" % (exp,) if exp is not None else ""
+        if len(expr.args) == 1:
+            result = r"W%s\left(%s\right)" % (exp, arg0)
+        else:
+            arg1 = self._print(expr.args[1])
+            result = 'W{0}_{{{1}}}\left({2}\\right)'.format(exp, arg1, arg0)
+        return result
 
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2429,7 +2429,7 @@ class LatexPrinter(Printer):
             result = r"W%s\left(%s\right)" % (exp, arg0)
         else:
             arg1 = self._print(expr.args[1])
-            result = 'W{0}_{{{1}}}\left({2}\\right)'.format(exp, arg1, arg0)
+            result = "W{0}_{{{1}}}\\left({2}\\right)".format(exp, arg1, arg0)
         return result
 
     def _print_Morphism(self, morphism):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2422,11 +2422,15 @@ class LatexPrinter(Printer):
     def _print_Object(self, object):
         return self._print(Symbol(object.name))
 
-    def _print_LambertW(self, expr):
-        if len(expr.args) == 1:
-            return r"W\left(%s\right)" % self._print(expr.args[0])
-        return r"W_{%s}\left(%s\right)" % \
-            (self._print(expr.args[1]), self._print(expr.args[0]))
+    def _print_LambertW(self, expr, exp=None):
+    	arg0 = self._print(expr.args[0])
+    	exp = r"^{%s}" % (exp,) if exp is not None else ""
+    	if len(expr.args) == 1:
+    		result = r"W%s\left(%s\right)" % (exp, arg0)
+    	else:
+    		arg1 = self._print(expr.args[1])
+    		result = 'W{0}_{{{1}}}\left({2}\\right)'.format(exp, arg1, arg0)
+    	return result
 
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -595,6 +595,7 @@ def test_latex_functions():
     assert latex(LambertW(n, -1)) == r'W_{-1}\left(n\right)'
     assert latex(LambertW(n, k)) == r'W_{k}\left(n\right)'
     assert latex(LambertW(n) * LambertW(n)) == r"W^{2}\left(n\right)"
+    assert latex(Pow(LambertW(n), 2)) == r"W^{2}\left(n\right)"
     assert latex(LambertW(n)**k) == r"W^{k}\left(n\right)"
     assert latex(LambertW(n, k)**p) == r"W^{p}_{k}\left(n\right)"
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -594,6 +594,9 @@ def test_latex_functions():
     assert latex(LambertW(n)) == r'W\left(n\right)'
     assert latex(LambertW(n, -1)) == r'W_{-1}\left(n\right)'
     assert latex(LambertW(n, k)) == r'W_{k}\left(n\right)'
+    assert latex(LambertW(n) * LambertW(n)) == r"W^{2}\left(n\right)"
+    assert latex(LambertW(n)**k) == r"W^{k}\left(n\right)"
+    assert latex(LambertW(n, k)**p) == r"W^{p}_{k}\left(n\right)"
 
     assert latex(Mod(x, 7)) == r'x\bmod{7}'
     assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #21812
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

additional optional argument **exp** has been added which is used
in printing the final result. Previously the exp term was not present
and hence not utilized in the final result

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug in _print_LambertW when LambertW function is raised to some power
<!-- END RELEASE NOTES -->