### PR TITLE
Correct calculation of variance and central moment for non-random expressions

### DIFF
--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -422,6 +422,9 @@ def median(X, evaluate=True, **kwargs):
     .. [1] https://en.wikipedia.org/wiki/Median#Probability_distributions
 
     """
+    if not is_random(X):
+        return X
+
     from sympy.stats.crv import ContinuousPSpace
     from sympy.stats.drv import DiscretePSpace
     from sympy.stats.frv import FinitePSpace

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -609,8 +609,6 @@ class Moment(Expr):
             return super().__new__(cls, X, n, c)
 
     def doit(self, **hints):
-        if not is_random(self.args[0]):
-            return self.args[0]
         return self.rewrite(Expectation).doit(**hints)
 
     def _eval_rewrite_as_Expectation(self, X, n, c=0, condition=None, **kwargs):
@@ -668,8 +666,6 @@ class CentralMoment(Expr):
             return super().__new__(cls, X, n)
 
     def doit(self, **hints):
-        if not is_random(self.args[0]):
-            return self.args[0]
         return self.rewrite(Expectation).doit(**hints)
 
     def _eval_rewrite_as_Expectation(self, X, n, condition=None, **kwargs):

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -6,7 +6,7 @@ from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
         DiscreteUniform, Poisson, characteristic_function, moment_generating_function,
         BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance, cmoment,
-        moment)
+        moment, median)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace, is_random, RandomIndexedSymbol, RandomMatrixSymbol)
 from sympy.testing.pytest import raises, skip, XFAIL
@@ -329,6 +329,11 @@ def test_moment_constant():
     assert moment(3, 2) == 9
     x = Symbol('x')
     assert moment(x, 2) == x**2
+
+def test_median_constant():
+    assert median(3) == 3
+    x = Symbol('x')
+    assert median(x) == x
 
 def test_real():
     x = Normal('x', 0, 1)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -5,7 +5,8 @@ from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
         density, given, independent, dependent, where, pspace, GaussianUnitaryEnsemble,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
         DiscreteUniform, Poisson, characteristic_function, moment_generating_function,
-        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance)
+        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance, cmoment,
+        moment)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace, is_random, RandomIndexedSymbol, RandomMatrixSymbol)
 from sympy.testing.pytest import raises, skip, XFAIL
@@ -312,6 +313,22 @@ def test_NamedArgsMixin():
 def test_density_constant():
     assert density(3)(2) == 0
     assert density(3)(3) == DiracDelta(0)
+
+def test_cmoment_constant():
+    assert variance(3) == 0
+    assert cmoment(3, 3) == 0
+    assert cmoment(3, 4) == 0
+    x = Symbol('x')
+    assert variance(x) == 0
+    assert cmoment(x, 15) == 0
+    assert cmoment(x, 0) == 1
+
+def test_moment_constant():
+    assert moment(3, 0) == 1
+    assert moment(3, 1) == 3
+    assert moment(3, 2) == 9
+    x = Symbol('x')
+    assert moment(x, 2) == x**2
 
 def test_real():
     x = Normal('x', 0, 1)

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -145,7 +145,7 @@ def test_symbolic_Moment():
     assert M.doit() == (mu**4 - 8*mu**3 + 6*mu**2*sigma**2 + \
                 24*mu**2 - 24*mu*sigma**2 - 32*mu + 3*sigma**4 + 24*sigma**2 + 16)
     M = Moment(2, 5)
-    assert M.doit() == 2
+    assert M.doit() == 2**5
 
 
 def test_symbolic_CentralMoment():
@@ -164,4 +164,4 @@ def test_symbolic_CentralMoment():
     assert CM.rewrite(Integral).dummy_eq(expri)
     assert CM.doit().simplify() == 15*sigma**6
     CM = Moment(5, 5)
-    assert CM.doit() == 5
+    assert CM.doit() == 5**5


### PR DESCRIPTION
Calculate `sympy.stats.variance` and `sympy.stats.cmoment` correctly for non-random expressions.



#### References to other Issues or PRs

This is a small part of the solution to #21057

#### Brief description of what is fixed or changed

Before:

```
>>> sympy.stats.variance(4 + x)
x + 4
```

After:

```
>>> sympy.stats.variance(4 + x)
0
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
