### PR TITLE
Fix bugs in _remove_trivial_dims when removed axes were nested with array contractions and diagonalizations

### DIFF
--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -722,7 +722,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
 
         def transform(x):
             for i, e in enumerate(positions):
-                if (isinstance(e, int) and x == e) or (isinstance(e, tuple) and x in e):
+                if (isinstance(e, int) and x == e) or (isinstance(e, (tuple, Tuple)) and (x in e)):
                     return i
 
         return _apply_recursively_over_nested_lists(transform, indices)

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -314,16 +314,28 @@ def _(expr: PermuteDims):
 @_remove_trivial_dims.register(ArrayContraction)
 def _(expr: ArrayContraction):
     newexpr, removed = _remove_trivial_dims(expr.expr)
+    shifts = list(accumulate([1 if i in removed else 0 for i in range(get_rank(expr.expr))]))
     new_contraction_indices = [tuple(j for j in i if j not in removed) for i in expr.contraction_indices]
     # Remove possible empty tuples "()":
-    new_contraction_indices = [i for i in new_contraction_indices if i]
-    return ArrayContraction(newexpr, *new_contraction_indices), removed
+    new_contraction_indices = [i for i in new_contraction_indices if len(i) > 0]
+    contraction_indices_flat = [j for i in expr.contraction_indices for j in i]
+    removed = [i for i in removed if i not in contraction_indices_flat]
+    new_contraction_indices = [tuple(j - shifts[j] for j in i) for i in new_contraction_indices]
+    # Shift removed:
+    removed = ArrayContraction._push_indices_up(expr.contraction_indices, removed)
+    return ArrayContraction(newexpr, *new_contraction_indices), list(removed)
 
 
 @_remove_trivial_dims.register(ArrayDiagonal)
 def _(expr: ArrayDiagonal):
     newexpr, removed = _remove_trivial_dims(expr.expr)
     new_diag_indices = [tuple(j for j in i if j not in removed) for i in expr.diagonal_indices]
+    new_diag_indices = [i for i in new_diag_indices if len(i) > 0]
+    shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_rank(expr.expr))]))
+    new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices]
+    rank = get_rank(expr.expr)
+    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, rank)
+    removed = sorted({i for i in removed})
     return ArrayDiagonal(newexpr, *new_diag_indices), removed
 
 

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,5 +1,5 @@
 from sympy import (
-    symbols, Identity, cos, ZeroMatrix, OneMatrix)
+    symbols, Identity, cos, ZeroMatrix, OneMatrix, sqrt)
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 from sympy.tensor.array.expressions.conv_array_to_matrix import _support_function_tp1_recognize, \
     _array_diag2contr_diagmatrix, convert_array_to_matrix, _remove_trivial_dims, _array2matrix
@@ -352,6 +352,10 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     expr = ArrayDiagonal(tp, (1, 8), (3, 4))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 3, 4, 5, 6]
+
+    cg = ArrayDiagonal(ArrayTensorProduct(PermuteDims(ArrayTensorProduct(x, I1), Permutation(1, 2, 3)), (x.T*x).applyfunc(sqrt)), (2, 4), (3, 5))
+    rexpr, removed = _remove_trivial_dims(cg)
+    assert removed == [1, 2, 3]
 
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,5 +1,5 @@
 from sympy import (
-    symbols, Identity, cos, ZeroMatrix)
+    symbols, Identity, cos, ZeroMatrix, OneMatrix)
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 from sympy.tensor.array.expressions.conv_array_to_matrix import _support_function_tp1_recognize, \
     _array_diag2contr_diagmatrix, convert_array_to_matrix, _remove_trivial_dims, _array2matrix
@@ -326,6 +326,32 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
 
     cg = ArrayContraction(ArrayTensorProduct(M, a), (1, 2))
     assert _remove_trivial_dims(cg) == (cg, [])
+
+    # A few more cases to test the removal and shift of nested removed axes
+    # with array contractions and array diagonals:
+    tp = ArrayTensorProduct(
+        OneMatrix(1, 1),
+        M,
+        x,
+        OneMatrix(1, 1),
+        Identity(1),
+    )
+
+    expr = ArrayContraction(tp, (1, 8))
+    rexpr, removed = _remove_trivial_dims(expr)
+    assert removed == [0, 5, 6, 7]
+
+    expr = ArrayContraction(tp, (1, 8), (3, 4))
+    rexpr, removed = _remove_trivial_dims(expr)
+    assert removed == [0, 3, 4, 5]
+
+    expr = ArrayDiagonal(tp, (1, 8))
+    rexpr, removed = _remove_trivial_dims(expr)
+    assert removed == [0, 5, 6, 7, 8]
+
+    expr = ArrayDiagonal(tp, (1, 8), (3, 4))
+    rexpr, removed = _remove_trivial_dims(expr)
+    assert removed == [0, 3, 4, 5, 6]
 
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():


### PR DESCRIPTION

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
