### PR TITLE
Fixed bug when trying to simplify non-linear relationals 

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -752,10 +752,11 @@ class And(LatticeOp, BooleanFunction):
                 (i.free_symbols, i) for i in eqs]),
                 lambda x: len(x[0]))
             eqs = []
+            nonlineqs = []
             while 1 in sifted:
                 for free, e in sifted.pop(1):
                     x = free.pop()
-                    if e.lhs != x or x in e.rhs.free_symbols:
+                    if (e.lhs != x or x in e.rhs.free_symbols) and x not in reps:
                         try:
                             m, b = linear_coeffs(
                                 e.rewrite(Add, evaluate=False), x)
@@ -768,12 +769,13 @@ class And(LatticeOp, BooleanFunction):
                         except ValueError:
                             pass
                     if x in reps:
-                        eqs.append(e.func(e.rhs, reps[x]))
-                    elif e.lhs == x:
+                        eqs.append(e.subs(x, reps[x]))
+                    elif e.lhs == x and x not in e.rhs.free_symbols:
                         reps[x] = e.rhs
                         eqs.append(e)
                     else:
-                        eqs.append(e)
+                        # x is not yet identified, but may be later
+                        nonlineqs.append(e)
                 resifted = defaultdict(list)
                 for k in sifted:
                     for f, e in sifted[k]:
@@ -783,8 +785,9 @@ class And(LatticeOp, BooleanFunction):
                 sifted = resifted
         for k in sifted:
             eqs.extend([e for f, e in sifted[k]])
+        nonlineqs = [ei.subs(reps) for ei in nonlineqs]
         other = [ei.subs(reps) for ei in other]
-        rv = rv.func(*([i.canonical for i in (eqs + other)] + nonRel))
+        rv = rv.func(*([i.canonical for i in (eqs + nonlineqs + other)] + nonRel))
         patterns = simplify_patterns_and()
         return self._apply_patternbased_simplification(rv, patterns,
                                                        measure, False)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -769,8 +769,10 @@ class And(LatticeOp, BooleanFunction):
                             pass
                     if x in reps:
                         eqs.append(e.func(e.rhs, reps[x]))
-                    else:
+                    elif e.lhs == x:
                         reps[x] = e.rhs
+                        eqs.append(e)
+                    else:
                         eqs.append(e)
                 resifted = defaultdict(list)
                 for k in sifted:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -779,7 +779,7 @@ class And(LatticeOp, BooleanFunction):
                 resifted = defaultdict(list)
                 for k in sifted:
                     for f, e in sifted[k]:
-                        e = e.subs(reps)
+                        e = e.xreplace(reps)
                         f = e.free_symbols
                         resifted[len(f)].append((f, e))
                 sifted = resifted

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -7,7 +7,7 @@ from sympy import (
     Matrix, MatrixSymbol, Mul, nsimplify, oo, pi, Piecewise, Poly, posify, rad,
     Rational, S, separatevars, signsimp, simplify, sign, sin,
     sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan,
-    zoo)
+    zoo, And, Le)
 from sympy.core.mul import _keep_coeff
 from sympy.core.expr import unchanged
 from sympy.simplify.simplify import nthroot, inversecombine
@@ -862,6 +862,13 @@ def test_issue_15965():
 def test_issue_17137():
     assert simplify(cos(x)**I) == cos(x)**I
     assert simplify(cos(x)**(2 + 3*I)) == cos(x)**(2 + 3*I)
+
+
+def test_issue_21869():
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
+    expr = And(Eq(x**2, 4), Le(x, y))
+    assert expr.simplify() == expr
 
 
 def test_issue_7971():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -870,6 +870,30 @@ def test_issue_21869():
     expr = And(Eq(x**2, 4), Le(x, y))
     assert expr.simplify() == expr
 
+    expr = And(Eq(x**2, 4), Eq(x, 2))
+    assert expr.simplify() == Eq(x, 2)
+
+    expr = And(Eq(x**3, x**2), Eq(x, 1))
+    assert expr.simplify() == Eq(x, 1)
+
+    expr = And(Eq(sin(x), x**2), Eq(x, 0))
+    assert expr.simplify() == Eq(x, 0)
+
+    expr = And(Eq(x**3, x**2), Eq(x, 2))
+    assert expr.simplify() == S.false
+
+    expr = And(Eq(y, x**2), Eq(x, 1))
+    assert expr.simplify() == And(Eq(y,1), Eq(x, 1))
+
+    expr = And(Eq(y**2, 1), Eq(y, x**2), Eq(x, 1))
+    assert expr.simplify() == And(Eq(y,1), Eq(x, 1))
+
+    expr = And(Eq(y**2, 4), Eq(y, 2*x**2), Eq(x, 1))
+    assert expr.simplify() == And(Eq(y,2), Eq(x, 1))
+
+    expr = And(Eq(y**2, 4), Eq(y, x**2), Eq(x, 1))
+    assert expr.simplify() == S.false
+
 
 def test_issue_7971():
     z = Integral(x, (x, 1, 1))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #21869

#### Brief description of what is fixed or changed
The previous code indirectly assumed that certain forms of non-linear expressions didn't show up. Here, it is fixed so that this doesn't happen. Also, this will simplify slightly better in terms of several Eq with the same variable, earlier, if the first one didn't allow extraction of the value (i.e. being linear) it was not simplified later either.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed simplification bug when equalities contained certain non-linear expressions.
<!-- END RELEASE NOTES -->
