### PR TITLE
quaternion - to_axis_angle supports negative rotations

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -651,8 +651,6 @@ class Quaternion(Expr):
 
         """
         q = self
-        if q.a.is_negative:
-            q = q * -1
 
         q = q.normalize()
         angle = trigsimp(2 * acos(q.a))

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -189,6 +189,6 @@ def test_issue_16318():
     assert Quaternion.rotate_point((1, 1, 1), (axis, angle)) == (S.One / 5, 1, S(7) / 5)
     #test for to_axis_angle
     q = Quaternion(-1, 1, 1, 1)
-    axis = (-sqrt(3)/3, -sqrt(3)/3, -sqrt(3)/3)
-    angle = 2*pi/3
+    axis = (sqrt(3)/3, sqrt(3)/3, sqrt(3)/3)
+    angle = 4*pi/3
     assert (axis, angle) == q.to_axis_angle()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21398 and now to_axis_angle function can give Rotations in either way and the angle can be negative.
`Quaternion(-1,1,1,1)` returns an angle of `4 * pie/3` instead of `2*pie/3`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
