### PR TITLE
simplify - fixes issue #21355 and now some equations give correct result

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -967,8 +967,7 @@ def radsimp(expr, symbolic=True, max_terms=4):
             d *= num
             d = powdenest(_mexpand(d), force=symbolic)
             if d.has(S.Zero, nan, zoo):
-                n, d = fraction(expr)
-                return _unevaluated_Mul(n, 1/d)
+                return expr
             if d.is_Atom:
                 break
 

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -961,6 +961,7 @@ def radsimp(expr, symbolic=True, max_terms=4):
                     keep = False
                 break
             from sympy.simplify.powsimp import powsimp, powdenest
+
             num = powsimp(_num(rterms))
             n *= num
             d *= num

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -9,7 +9,7 @@ from sympy.core.parameters import global_parameters
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.function import _mexpand
 from sympy.core.mul import _keep_coeff, _unevaluated_Mul
-from sympy.core.numbers import Rational
+from sympy.core.numbers import Rational, zoo, nan
 from sympy.functions import exp, sqrt, log
 from sympy.functions.elementary.complexes import Abs
 from sympy.polys import gcd
@@ -961,11 +961,13 @@ def radsimp(expr, symbolic=True, max_terms=4):
                     keep = False
                 break
             from sympy.simplify.powsimp import powsimp, powdenest
-
             num = powsimp(_num(rterms))
             n *= num
             d *= num
             d = powdenest(_mexpand(d), force=symbolic)
+            if d.has(S.Zero, nan, zoo):
+                n, d = fraction(expr)
+                return _unevaluated_Mul(n, 1/d)
             if d.is_Atom:
                 break
 

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -467,3 +467,8 @@ def test_issue_19719():
     collected = collect(expr, (a**2, 1/a), evaluate=False)
     # Would return {_Dummy_20**(-2): b + 1, 1/a: 7 + 1/b} without xreplace
     assert collected == {a**2: b + 1, 1/a: 7 + 1/b}
+
+
+def test_issue_21355():
+    assert radsimp(1/(x + sqrt(x**2))) == 1/(x + sqrt(x**2))
+    assert radsimp(1/(x - sqrt(x**2))) == 1/(x - sqrt(x**2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21355 and now `radsimp(1/(x + sqrt(x**2)))` returns `1/(x + sqrt(x**2))` instead of `zoo*(x + sqrt(x**2))` and also added regression test in test_radsimp.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
   * fixed bug in radsimp.
<!-- END RELEASE NOTES -->
