### PR TITLE
Faster Rational power of Rational

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1799,9 +1799,9 @@ class Rational(Number):
                 # (3/4)**-2 -> (4/3)**2
                 ne = -expt
                 if (ne is S.One):
-                    return Rational(self.q, self.p)
+                    return Rational(self.q, self.p, 1)
                 if self.is_negative:
-                    return S.NegativeOne**expt*Rational(self.q, -self.p)**ne
+                    return S.NegativeOne**expt*Rational(self.q, -self.p, 1)**ne
                 else:
                     return Rational(self.q, self.p)**ne
             if expt is S.Infinity:  # -oo already caught by test for negative
@@ -1822,14 +1822,14 @@ class Rational(Number):
                     remfracpart = intpart*expt.q - expt.p
                     ratfracpart = Rational(remfracpart, expt.q)
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q**intpart)
-                    return Integer(self.q)**ratfracpart*Rational(1, self.q**intpart)
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q**intpart, 1)
+                    return Integer(self.q)**ratfracpart*Rational(1, self.q**intpart, 1)
                 else:
                     remfracpart = expt.q - expt.p
                     ratfracpart = Rational(remfracpart, expt.q)
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q)
-                    return Integer(self.q)**ratfracpart*Rational(1, self.q)
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q, 1)
+                    return Integer(self.q)**ratfracpart*Rational(1, self.q, 1)
 
         if self.is_extended_negative and expt.is_even:
             return (-self)**expt
@@ -1843,7 +1843,7 @@ class Rational(Number):
         return mpmath.make_mpf(mlib.from_rational(self.p, self.q, prec, rnd))
 
     def __abs__(self):
-        return Rational(abs(self.p), self.q)
+        return Rational(abs(self.p), self.q, 1)
 
     def __int__(self):
         p, q = self.p, self.q
@@ -2325,7 +2325,7 @@ class Integer(Rational):
             # cases -1, 0, 1 are done in their respective classes
             return S.Infinity + S.ImaginaryUnit*S.Infinity
         if expt is S.NegativeInfinity:
-            return Rational(1, self)**S.Infinity
+            return Rational(1, self, 1)**S.Infinity
         if not isinstance(expt, Number):
             # simplify when expt is even
             # (-2)**k --> 2**k
@@ -2343,9 +2343,9 @@ class Integer(Rational):
             # invert base and change sign on exponent
             ne = -expt
             if self.is_negative:
-                    return S.NegativeOne**expt*Rational(1, -self)**ne
+                    return S.NegativeOne**expt*Rational(1, -self, 1)**ne
             else:
-                return Rational(1, self.p)**ne
+                return Rational(1, self.p, 1)**ne
         # see if base is a perfect root, sqrt(4) --> 2
         x, xexact = integer_nthroot(abs(self.p), expt.q)
         if xexact:
@@ -2383,7 +2383,7 @@ class Integer(Rational):
                 # (2**2)**(1/10) -> 2**(1/5)
                 g = igcd(div_m, expt.q)
                 if g != 1:
-                    out_rad *= Pow(prime, Rational(div_m//g, expt.q//g))
+                    out_rad *= Pow(prime, Rational(div_m//g, expt.q//g, 1))
                 else:
                     sqr_dict[prime] = div_m
         # identify gcd of remaining powers
@@ -3719,7 +3719,7 @@ class Pi(NumberSymbol, metaclass=Singleton):
         if issubclass(number_cls, Integer):
             return (Integer(3), Integer(4))
         elif issubclass(number_cls, Rational):
-            return (Rational(223, 71), Rational(22, 7))
+            return (Rational(223, 71, 1), Rational(22, 7, 1))
 
     def _sage_(self):
         import sage.all as sage
@@ -3920,7 +3920,7 @@ class EulerGamma(NumberSymbol, metaclass=Singleton):
         if issubclass(number_cls, Integer):
             return (S.Zero, S.One)
         elif issubclass(number_cls, Rational):
-            return (S.Half, Rational(3, 5))
+            return (S.Half, Rational(3, 5, 1))
 
     def _sage_(self):
         import sage.all as sage
@@ -3976,7 +3976,7 @@ class Catalan(NumberSymbol, metaclass=Singleton):
         if issubclass(number_cls, Integer):
             return (S.Zero, S.One)
         elif issubclass(number_cls, Rational):
-            return (Rational(9, 10), S.One)
+            return (Rational(9, 10, 1), S.One)
 
     def _eval_rewrite_as_Sum(self, k_sym=None, symbols=None):
         from sympy import Sum, Dummy

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1799,9 +1799,9 @@ class Rational(Number):
                 # (3/4)**-2 -> (4/3)**2
                 ne = -expt
                 if (ne is S.One):
-                    return Rational(self.q, self.p, 1)
+                    return Rational(self.q, self.p)
                 if self.is_negative:
-                    return S.NegativeOne**expt*Rational(self.q, -self.p, 1)**ne
+                    return S.NegativeOne**expt*Rational(self.q, -self.p)**ne
                 else:
                     return Rational(self.q, self.p)**ne
             if expt is S.Infinity:  # -oo already caught by test for negative
@@ -1843,7 +1843,7 @@ class Rational(Number):
         return mpmath.make_mpf(mlib.from_rational(self.p, self.q, prec, rnd))
 
     def __abs__(self):
-        return Rational(abs(self.p), self.q, 1)
+        return Rational(abs(self.p), self.q)
 
     def __int__(self):
         p, q = self.p, self.q

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1818,16 +1818,18 @@ class Rational(Number):
             if isinstance(expt, Rational):
                 intpart = expt.p // expt.q
                 if intpart:
-                    remfracpart = expt.q - expt.p
-                    if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q)
-                    return Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q)
-                else:
                     intpart += 1
                     remfracpart = intpart*expt.q - expt.p
+                    ratfracpart = Rational(remfracpart, expt.q)
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q**intpart)
-                    return Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q**intpart)
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q**intpart)
+                    return Integer(self.q)**ratfracpart*Rational(1, self.q**intpart)
+                else:
+                    remfracpart = expt.q - expt.p
+                    ratfracpart = Rational(remfracpart, expt.q)
+                    if self.p != 1:
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q)
+                    return Integer(self.q)**ratfracpart*Rational(1, self.q)
 
         if self.is_extended_negative and expt.is_even:
             return (-self)**expt

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1816,13 +1816,18 @@ class Rational(Number):
                 # (4/3)**2 -> 4**2 / 3**2
                 return Rational(self.p**expt.p, self.q**expt.p, 1)
             if isinstance(expt, Rational):
-                if self.p != 1:
-                    # (4/3)**(5/6) -> 4**(5/6)*3**(-5/6)
-                    return Integer(self.p)**expt*Integer(self.q)**(-expt)
-                # as the above caught negative self.p, now self is positive
-                return Integer(self.q)**Rational(
-                expt.p*(expt.q - 1), expt.q) / \
-                    Integer(self.q)**Integer(expt.p)
+                intpart = expt.p // expt.q
+                if intpart:
+                    remfracpart = expt.q - expt.p
+                    if self.p != 1:
+                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)
+                    return Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)
+                else:
+                    intpart += 1
+                    remfracpart = intpart*expt.q - expt.p
+                    if self.p != 1:
+                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)**intpart
+                    return Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)**intpart
 
         if self.is_extended_negative and expt.is_even:
             return (-self)**expt

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1820,14 +1820,14 @@ class Rational(Number):
                 if intpart:
                     remfracpart = expt.q - expt.p
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)
-                    return Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)
+                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q)
+                    return Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q)
                 else:
                     intpart += 1
                     remfracpart = intpart*expt.q - expt.p
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)**intpart
-                    return Integer(self.q)**Rational(remfracpart, expt.q)/Integer(self.q)**intpart
+                        return Integer(self.p)**expt*Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q**intpart)
+                    return Integer(self.q)**Rational(remfracpart, expt.q)*Rational(1, self.q**intpart)
 
         if self.is_extended_negative and expt.is_even:
             return (-self)**expt

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -563,6 +563,37 @@ def test_issue_18762():
     g0 = sqrt(1 + e**2 - 2*e*cos(p))
     assert len(g0.series(e, 1, 3).args) == 4
 
+
+def test_issue_21860():
+    x = Symbol('x')
+    e = 3*2**Rational(66666666667,200000000000)*3**Rational(16666666667,50000000000)*x**Rational(66666666667, 200000000000)
+    ans = Mul(Rational(3, 2),
+              Pow(Integer(2), Rational(33333333333, 100000000000)),
+              Pow(Integer(3), Rational(26666666667, 40000000000)))
+    assert e.xreplace({x: Rational(3,8)}) == ans
+
+
+def test_issue_21647():
+    x = Symbol('x')
+    e = log((Integer(567)/500)**(811*(Integer(567)/500)**x/100))
+    ans = log(Mul(Rational(64701150190720499096094005280169087619821081527,
+                           76293945312500000000000000000000000000000000000),
+                  Pow(Integer(2), Rational(396204892125479941, 781250000000000000)),
+                  Pow(Integer(3), Rational(385045107874520059, 390625000000000000)),
+                  Pow(Integer(5), Rational(407364676376439823, 1562500000000000000)),
+                  Pow(Integer(7), Rational(385045107874520059, 1562500000000000000))))
+    assert e.xreplace({x: 6}) == ans
+
+
+def test_issue_21762():
+    x = Symbol('x')
+    e = (x**2 + 6)**(Integer(33333333333333333)/50000000000000000)
+    ans = Mul(Rational(5, 4),
+              Pow(Integer(2), Rational(16666666666666667, 25000000000000000)),
+              Pow(Integer(5), Rational(8333333333333333, 25000000000000000)))
+    assert e.xreplace({x: S.Half}) == ans
+
+
 def test_power_dispatcher():
 
     class NewBase(Expr):

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -594,6 +594,12 @@ def test_issue_21762():
     assert e.xreplace({x: S.Half}) == ans
 
 
+def test_rational_powers_larger_than_one():
+    assert Rational(2, 3)**Rational(3, 2) == 2*sqrt(6)/9
+    assert Rational(1, 6)**Rational(9, 4) == 6**Rational(3, 4)/216
+    assert Rational(3, 7)**Rational(7, 3) == 9*3**Rational(1, 3)*7**Rational(2, 3)/343
+
+
 def test_power_dispatcher():
 
     class NewBase(Expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21647
Part of #21762 (original issue not example in https://github.com/sympy/sympy/issues/21762#issuecomment-882655739)
Part of #21860

#### Brief description of what is fixed or changed
Rewrote parts of `Rational**Rational` code to direct it to a wanted form. 

#### Other comments
Maybe one would like to do something similar for `Integer**Rational`, but I have not figured out the logic there yet, basically, factor out the integer multiple of the rational number (it might already be done though, not clear).

Not really sure that this is the "minimal" solution, i.e., that all the branches are needed etc, but it seems to work...

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * `Rational**Rational` works better for large numbers.
<!-- END RELEASE NOTES -->
