### PR TITLE
matrices - is_positive_semidefinite() now gives correct result

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -844,6 +844,8 @@ def _is_positive_semidefinite_cholesky(M):
 
         if M[k, k].is_negative or pivot_val.is_negative:
             return False
+        elif not (M[k, k].is_nonnegative and pivot_val.is_nonnegative):
+            return None
 
         if pivot > 0:
             M.col_swap(k, k+pivot)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -681,3 +681,9 @@ def test_issue_20275():
         [Matrix([[S(1)/2 + sqrt(5)/2], [0], [1], [1], [0]]),
          Matrix([[S(1)/2 + sqrt(5)/2], [1], [0], [0], [1]])]
     )
+
+
+def test_issue_20752():
+    b = symbols('b',nonzero=True)
+    m = Matrix([[0, 0, 0], [0, b, 0], [0, 0, b]])
+    assert m.is_positive_semidefinite == None

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -684,6 +684,6 @@ def test_issue_20275():
 
 
 def test_issue_20752():
-    b = symbols('b',nonzero=True)
+    b = symbols('b', nonzero=True)
     m = Matrix([[0, 0, 0], [0, b, 0], [0, 0, b]])
-    assert m.is_positive_semidefinite == None
+    assert m.is_positive_semidefinite is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #20752 and now is_positive_semidefinite returns `None` for `Matrix([[0, 0, 0], [0, b, 0], [0, 0, b]])` where b is nonzero instead of `True`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * fixed bug in is_positive_semidefinite() in eigen.py. 
<!-- END RELEASE NOTES -->
