### PR TITLE
nD (counting) and multiset_derangements (generating)

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2189,37 +2189,34 @@ def nD(i=None, brute=None, *, n=None, m=None):
     >>> nD('abc')
     2
 
-    Input as an int, iterable or dictionary (multiset form) is accepted:
+    Input as iterable or dictionary (multiset form) is accepted:
 
-    >>> nD(3)
-    2
     >>> assert nD([1, 2, 2, 3, 3, 3]) == nD({1: 1, 2: 2, 3: 3})
 
     By default, a brute-force enumeration and count of multiset permutations
     is only done if there are fewer than 9 elements. There may be cases when
     there is high multiplicty with few unique elements that will benefit
     from a brute-force enumeration, too. For this reason, the `brute`
-    keyword is provided; None is the default. When False, the brute-force
+    keyword (default None) is provided. When False, the brute-force
     enumeration will never be used. When True, it will always be used.
 
     >>> nD('1111222233', brute=True)
     44
 
-    When ``multiplicity=True`` the input is interpreted as the counts
-    of each element; this is convenient because the identity of the
-    elements does not affect the number of derangements.
+    For convenience, one may specify ``n`` distinct items using the
+    ``n`` keyword:
 
-    >>> nD('1111222233')
-    44
-    >>> nD([4, 4, 2], multiplicity=True, brute=True)
-    44
-    >>> nD({2: 1, 4: 2}, multiplicity=True, brute=True)
-    44
+    >>> assert nD(n=3) == nD('abc') == 2
+
+    Since the number of derangments depends on the multiplicity of the
+    elements and not the elements themselves, it may be more convenient
+    to give a list or multiset of multiplicities using keyword ``m``:
+
+    >>> assert nD('abc') == nD(m=(1,1,1)) == nD(m={1:3}) == 2
 
     """
-    from sympy.core.compatibility import SYMPY_INTS
     from sympy.utilities.iterables import multiset, multiset_derangements, iterable
-    from sympy.integrals.integrals import integrate, Integral
+    from sympy.integrals.integrals import integrate
     from sympy.functions.elementary.exponential import exp
     from sympy.functions.special.polynomials import laguerre
     from sympy.abc import x

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2172,7 +2172,15 @@ class motzkin(Function):
 
 
 def nD(s, brute=None):
-    """return the number of derangements for the elements in multiset `s`
+    """return the number of derangements for the elements in ``s``
+
+    Possible values for ``s``:
+
+        integer - set of length ``s``
+
+        sequence - converted to a multiset internally
+
+        multiset - {element: multiplicity}
 
     Examples
     ========
@@ -2187,8 +2195,10 @@ def nD(s, brute=None):
     >>> nD('abc')
     2
 
-    Input as an iterable or dictionary (multiset form) is accepted:
+    Input as an int, iterable or dictionary (multiset form) is accepted:
 
+    >>> nD(3)
+    2
     >>> assert nD([1, 2, 2, 3, 3, 3]) == nD({1: 1, 2: 2, 3: 3})
 
     By default, a brute-force enumeration and count of multiset permutations
@@ -2208,7 +2218,9 @@ def nD(s, brute=None):
     from sympy.functions.special.polynomials import laguerre
     if not s:
         return S.Zero
-    if type(s) is dict:
+    if isinstance(s, SYMPY_INTS):
+        return subfactorial(s)
+    elif type(s) is dict:
         if any(i < 0 for i in s.values()):
             raise ValueError('no count should be negative')
         ms = {k: v for k, v in s.items() if v}

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -724,3 +724,4 @@ def test_nD_derangements():
     assert nD({1: 0}) == 0
     raises(ValueError, lambda: nD({1: -1}))
     assert nD('112') == 0
+    assert [nD(i) for i in range(6)] == [0, 0, 1, 2, 9, 44]

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -722,20 +722,15 @@ def test_nD_derangements():
     assert nD({1: 0}) == 0
     raises(ValueError, lambda: nD({1: -1}))
     assert nD('112') == 0
-    assert [nD(i) for i in range(6)] == [0, 0, 1, 2, 9, 44]
+    assert [nD(n=i) for i in range(6)] == [0, 0, 1, 2, 9, 44]
     assert nD((i for i in range(4))) == nD('0123') == 9
-    assert nD((i for i in range(4)), multiplicity=True) == 3
-    assert nD({0: 1, 1: 1, 2: 1, 3: 1}, multiplicity=True) == 3
-    assert nD([0, 1, 2, 3], multiplicity=True) == 3
-    raises(ValueError, lambda: nD(0, multiplicity=True))
-    raises(ValueError, lambda: nD(-1))
+    assert nD(m=(i for i in range(4))) == 3
+    assert nD(m={0: 1, 1: 1, 2: 1, 3: 1}) == 3
+    assert nD(m=[0, 1, 2, 3]) == 3
+    raises(TypeError, lambda: nD(m=0))
+    raises(TypeError, lambda: nD(-1))
     assert nD({-1: 1, -2: 1}) == 1
     raises(ValueError, lambda: nD({1: -1}))
-    raises(ValueError, lambda: nD(0, multiplicity=True))
-    raises(ValueError, lambda: nD({-1: 1, 2: 1}, multiplicity=True))
-    raises(ValueError, lambda: nD({1: -1, 2: 1}, multiplicity=True))
-    raises(ValueError, lambda: nD([-1, 2], multiplicity=True))
-    assert str(nD({1: x}, multiplicity=True)) == 'subfactorial(x)'
-    assert str(nD({1: x, 2: y}, multiplicity=True)) == (
-        'floor(Abs(Integral((1 - _x)**x'
-        '*(_x**2/2 - 2*_x + 1)**y*exp(-_x), (_x, 0, oo))))')
+    raises(ValueError, lambda: nD(m={-1: 1, 2: 1}))
+    raises(ValueError, lambda: nD(m={1: -1, 2: 1}))
+    raises(ValueError, lambda: nD(m=[-1, 2]))

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -22,9 +22,7 @@ from sympy.core.expr import unchanged
 from sympy.core.numbers import GoldenRatio, Integer
 
 from sympy.testing.pytest import XFAIL, raises, nocache_fail
-
-
-x = Symbol('x')
+from sympy.abc import x, y
 
 
 def test_carmichael():
@@ -725,3 +723,19 @@ def test_nD_derangements():
     raises(ValueError, lambda: nD({1: -1}))
     assert nD('112') == 0
     assert [nD(i) for i in range(6)] == [0, 0, 1, 2, 9, 44]
+    assert nD((i for i in range(4))) == nD('0123') == 9
+    assert nD((i for i in range(4)), multiplicity=True) == 3
+    assert nD({0: 1, 1: 1, 2: 1, 3: 1}, multiplicity=True) == 3
+    assert nD([0, 1, 2, 3], multiplicity=True) == 3
+    raises(ValueError, lambda: nD(0, multiplicity=True))
+    raises(ValueError, lambda: nD(-1))
+    assert nD({-1: 1, -2: 1}) == 1
+    raises(ValueError, lambda: nD({1: -1}))
+    raises(ValueError, lambda: nD(0, multiplicity=True))
+    raises(ValueError, lambda: nD({-1: 1, 2: 1}, multiplicity=True))
+    raises(ValueError, lambda: nD({1: -1, 2: 1}, multiplicity=True))
+    raises(ValueError, lambda: nD([-1, 2], multiplicity=True))
+    assert str(nD({1: x}, multiplicity=True)) == 'subfactorial(x)'
+    assert str(nD({1: x, 2: y}, multiplicity=True)) == (
+        'floor(Abs(Integral((1 - _x)**x'
+        '*(_x**2/2 - 2*_x + 1)**y*exp(-_x), (_x, 0, oo))))')

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -218,6 +218,13 @@ def test_harmonic():
     assert harmonic(oo, 1) is oo
     assert harmonic(oo, 2) == (pi**2)/6
     assert harmonic(oo, 3) == zeta(3)
+    assert harmonic(oo, Dummy(negative=True)) is S.NaN
+    ip = Dummy(integer=True, positive=True)
+    if (1/ip <= 1) is True:  #---------------------------------+
+        assert None, 'delete this if-block and the next line' #|
+    ip = Dummy(even=True, positive=True)  #--------------------+
+    assert harmonic(oo, 1/ip) is oo
+    assert harmonic(oo, 1 + ip) is zeta(1 + ip)
 
     assert harmonic(0, m) == 0
 
@@ -685,3 +692,35 @@ def test_motzkin():
     raises(ValueError, lambda: motzkin.find_motzkin_numbers_in_range(-2,7))
     raises(ValueError, lambda: motzkin.find_motzkin_numbers_in_range(13,7))
     raises(ValueError, lambda: motzkin.find_first_n_motzkins(112.8))
+
+
+def test_nD_derangements():
+    from sympy.utilities.iterables import (partitions, multiset,
+        multiset_derangements, multiset_permutations)
+    from sympy.functions.combinatorial.numbers import nD
+
+    got = []
+    for i in partitions(8, k=4):
+        s = []
+        it = 0
+        for k, v in i.items():
+            for i in range(v):
+                s.extend([it]*k)
+                it += 1
+        ms = multiset(s)
+        c1 = sum(1 for i in multiset_permutations(s) if
+            all(i != j for i, j in zip(i, s)))
+        assert c1 == nD(ms) == nD(ms, 0) == nD(ms, 1)
+        v = [tuple(i) for i in multiset_derangements(s)]
+        c2 = len(v)
+        assert c2 == len(set(v))
+        assert c1 == c2
+        got.append(c1)
+    assert got == [1, 4, 6, 12, 24, 24, 61, 126, 315, 780, 297, 772,
+        2033, 5430, 14833]
+
+    assert nD('1112233456', brute=True) == nD('1112233456') == 16356
+    assert nD('') == nD([]) == nD({}) == 0
+    assert nD({1: 0}) == 0
+    raises(ValueError, lambda: nD({1: -1}))
+    assert nD('112') == 0

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -22,7 +22,7 @@ from sympy.core.expr import unchanged
 from sympy.core.numbers import GoldenRatio, Integer
 
 from sympy.testing.pytest import XFAIL, raises, nocache_fail
-from sympy.abc import x, y
+from sympy.abc import x
 
 
 def test_carmichael():
@@ -722,6 +722,7 @@ def test_nD_derangements():
     assert nD({1: 0}) == 0
     raises(ValueError, lambda: nD({1: -1}))
     assert nD('112') == 0
+    assert nD(i='112') == 0
     assert [nD(n=i) for i in range(6)] == [0, 0, 1, 2, 9, 44]
     assert nD((i for i in range(4))) == nD('0123') == 9
     assert nD(m=(i for i in range(4))) == 3
@@ -730,7 +731,14 @@ def test_nD_derangements():
     raises(TypeError, lambda: nD(m=0))
     raises(TypeError, lambda: nD(-1))
     assert nD({-1: 1, -2: 1}) == 1
+    assert nD(m={0: 3}) == 0
+    raises(ValueError, lambda: nD(i='123', n=3))
+    raises(ValueError, lambda: nD(i='123', m=(1,2)))
+    raises(ValueError, lambda: nD(n=0, m=(1,2)))
     raises(ValueError, lambda: nD({1: -1}))
     raises(ValueError, lambda: nD(m={-1: 1, 2: 1}))
     raises(ValueError, lambda: nD(m={1: -1, 2: 1}))
     raises(ValueError, lambda: nD(m=[-1, 2]))
+    raises(TypeError, lambda: nD({1: x}))
+    raises(TypeError, lambda: nD(m={1: x}))
+    raises(TypeError, lambda: nD(m={x: 1}))

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2326,29 +2326,27 @@ def random_derangement(t, choice=None, strict=True):
   # the normal derangement calculated from here
     if n == len(ms):
       # approx 1/3 will succeed
+        rv = list(t)
         while True:
-            rv = list(t)
             shuffle(rv)
             if all(i != j for i,j in zip(rv, t)):
                 break
     else:
       # general case
+        rv = [None]*n
         while True:
-            rv = [None]*n
             j = 0
             while j > -len(ms):  # do most numerous first
                 j -= 1
                 e, c = ms[j]
                 opts = [i for i in range(n) if rv[i] is None and t[i] != e]
                 if len(opts) < c:
-                    j += 2 # try again
-                    for i in was:
+                    for i in range(n):
                         rv[i] = None
-                    continue
+                    break # try again
                 pick(opts, c)
-                was = opts[:c]
-                for i in was:
-                    rv[i] = e
+                for i in range(c):
+                    rv[opts[i]] = e
             else:
                 return rv
     return rv

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2256,6 +2256,104 @@ def multiset_derangements(s):
     yield from do(len(take) - 1)
 
 
+def random_derangement(t, choice=None, strict=True):
+    """Return a list of elements in which none are in the same positions
+    as they were originally. If an element fills more than half of the positions
+    then an error will be raised since no derangement is possible. To obtain
+    a derangement of as many items as possible--with some of the most numerous
+    remaining in their original positions--pass `strict=False`. To produce a
+    pseudorandom derangment, pass a pseudorandom selector like `Random(seed).choice`.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import random_derangement
+    >>> from random import Random
+    >>> t = 'SymPy: a CAS in pure Python'
+    >>> d = random_derangement(t)
+    >>> all(i != j for i, j in zip(d, t))
+    True
+
+    A predictable result can be obtained by using a pseudorandom
+    generator for the choice:
+
+    >>> c = Random(1).choice
+    >>> d = [''.join(random_derangement(t, c)) for i in range(5)]
+    >>> assert len(set(d)) != 1  # we got different values
+
+    By resetting c, the same sequence can be obtained:
+
+    >>> c = Random(1).choice
+    >>> d2 = [''.join(random_derangement(t, c)) for i in range(5)]
+    >>> assert d == d2
+    """
+    if choice is None:
+        import secrets
+        choice = secrets.choice
+    def shuffle(rv):
+        '''Knuth shuffle'''
+        for i in range(len(rv) - 1, 0, -1):
+            x = choice(rv[:i + 1])
+            j = rv.index(x)
+            rv[i], rv[j] = rv[j], rv[i]
+    def pick(rv, n):
+        '''shuffle rv and return the first n values
+        '''
+        shuffle(rv)
+        return rv[:n]
+    ms = multiset(t)
+    tot = len(t)
+    ms = sorted(ms.items(), key=lambda x: x[1])
+  # if there are not enough spaces for the most
+  # plentiful element to move to then some of them
+  # will have to stay in place
+    M, mx = ms[-1]
+    n = len(t)
+    xs = 2*mx - tot
+    if xs > 0:
+        if strict:
+            raise ValueError('no derangement possible')
+        opts = [i for (i, c) in enumerate(t) if c == ms[-1][0]]
+        pick(opts, xs)
+        stay = sorted(opts[:xs])
+        rv = list(t)
+        for i in reversed(stay):
+            rv.pop(i)
+        rv = random_derangement(rv, choice)
+        for i in stay:
+            rv.insert(i, ms[-1][0])
+        return ''.join(rv) if type(t) is str else rv
+  # the normal derangement calculated from here
+    if n == len(ms):
+      # approx 1/3 will succeed
+        while True:
+            rv = list(t)
+            shuffle(rv)
+            if all(i != j for i,j in zip(rv, t)):
+                break
+    else:
+      # general case
+        while True:
+            rv = [None]*n
+            j = 0
+            while j > -len(ms):  # do most numerous first
+                j -= 1
+                e, c = ms[j]
+                opts = [i for i in range(n) if rv[i] is None and t[i] != e]
+                if len(opts) < c:
+                    j += 2 # try again
+                    for i in was:
+                        rv[i] = None
+                    continue
+                pick(opts, c)
+                was = opts[:c]
+                for i in was:
+                    rv[i] = e
+            else:
+                return rv
+    return rv
+
+
 def generate_derangements(perm):
     """
     Routine to generate unique derangements.

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2239,8 +2239,58 @@ def multiset_derangements(s):
                     i1 = j
         return
 
+    def finish_derangements():
+        """Place the last two elements into the partially completed
+        derangement, and yield the results.
+        In non-recursive version, this will be inlined, but a little
+        easier to understand as a function for now.
+        """
+
+        a = take[1][0]  # penultimate element
+        a_ct = take[1][1]
+        b = take[0][0]  # last element to be placed
+        b_ct = take[0][1]
+
+        # split the indexes of the not-already-assigned elemements of rv into
+        # three categories
+        forced_a = []  # positions which must have an a
+        forced_b = []  # positions which must have a b
+        open_free = []  # positions which could take either
+        for i in range(len(s)):
+            if rv[i] is None:
+                if s[i] == a:
+                    forced_b.append(i)
+                elif s[i] == b:
+                    forced_a.append(i)
+                else:
+                    open_free.append(i)
+
+        if len(forced_a) > a_ct or len(forced_b) > b_ct:
+            # No derangement possible
+            return
+        for i in forced_a:
+            rv[i] = a
+        for i in forced_b:
+            rv[i] = b
+        for a_place in subsets(open_free, a_ct - len(forced_a)):
+            for a_pos in a_place:
+                rv[a_pos] = a
+            for i in open_free:
+                if rv[i] is None:  # anything not in the subset is set to b
+                    rv[i] = b
+            yield rv
+            # Clean up/undo the final placements
+            for i in open_free:
+                rv[i] = None
+        # additional cleanup - clear forced_a, forced_b
+        for i in forced_a:
+            rv[i] = None
+        for i in forced_b:
+            rv[i] = None
+
     def iopen(v):
         return [i for i in range(n) if rv[i] is None and s[i] != v]
+
     def do(j):
         if j == -1:
             yield rv

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2223,7 +2223,7 @@ def multiset_derangements(s):
         return
 
     # 4) single repeat covers all but 1 of the non-repeats
-    if n - 2*mx == 1:
+    if n - 2*mx == 1 and len(ms.values()) - 1 == n - mx:
         for i in range(len(inonM)):
             i1 = inonM[i]
             ifill = inonM[:i] + inonM[i+1:]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2188,11 +2188,11 @@ def multiset_derangements(s):
     ms = multiset(s)
     mx = max(ms.values())
     n = len(s)
-    # impossible case
+    # special cases
+
+    # 0) impossible case
     if mx*2 > n:
         return
-    rv = [None]*n
-    # special cases
 
     # 1) singletons
     if len(ms) == n:
@@ -2200,19 +2200,14 @@ def multiset_derangements(s):
             yield p
         return
 
-    # 2) aaabbb-like
-    if len(ms) == 2 and len(set(ms.values())) == 1:
-        x, y = list(ms)
-        yield [x if i == y else y for i in s]
-        return
-
     for M in ms:
         if ms[M] == mx:
             break
     inonM = [i for i in range(n) if s[i] != M]
     iM = [i for i in range(n) if s[i] == M]
+    rv = [None]*n
 
-    # 3) half are the same
+    # 2) half are the same
     if 2*mx == n:
         for i in inonM:
             rv[i] = M
@@ -2222,7 +2217,7 @@ def multiset_derangements(s):
             yield rv
         return
 
-    # 4) single repeat covers all but 1 of the non-repeats
+    # 3) single repeat covers all but 1 of the non-repeats
     if n - 2*mx == 1 and len(ms.values()) - 1 == n - mx:
         for i in range(len(inonM)):
             i1 = inonM[i]
@@ -2404,7 +2399,7 @@ def random_derangement(t, choice=None, strict=True):
 
 def generate_derangements(perm):
     """
-    Routine to generate unique derangements.
+    Routine to generate unique derangements or sets or multisets.
 
     Examples
     ========

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -19,7 +19,7 @@ from sympy.utilities.iterables import (
     prefixes, reshape, rotate_left, rotate_right, runs, sift,
     strongly_connected_components, subsets, take, topological_sort, unflatten,
     uniq, variations, ordered_partitions, rotations, is_palindromic, iterable,
-    NotIterable)
+    NotIterable, multiset_derangements)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -547,6 +547,19 @@ def test_derangements():
     assert list(generate_derangements([0, 1, 2, 2])) == [
         [2, 2, 0, 1], [2, 2, 1, 0]]
     assert list(generate_derangements('ba')) == [list('ab')]
+    # multiset_derangements
+    D = multiset_derangements
+    assert list(D('abb')) == []
+    assert [''.join(i) for i in D('ab')] == ['ba']
+    assert [''.join(i) for i in D('abc')] == ['bca', 'cab']
+    assert [''.join(i) for i in D('aabb')] == ['bbaa']
+    assert [''.join(i) for i in D('aabbcccc')] == [
+        'ccccaabb', 'ccccabab', 'ccccabba', 'ccccbaab', 'ccccbaba',
+        'ccccbbaa']
+    assert [''.join(i) for i in D('aabbccc')] == [
+        'cccabba', 'cccabab', 'cccaabb', 'ccacbba', 'ccacbab',
+        'ccacabb', 'cbccbaa', 'cbccaba', 'cbccaab', 'bcccbaa',
+        'bcccaba', 'bcccaab']
 
 
 def test_necklaces():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A function for counting derangements of a sequence and another for generating the derangement of elements of the sequence is added.

#### Other comments

There have been many comments about combinatorial functions in general and possibilities for enhancement of the generation of the function added here in #6662. This PR is intended as a place to now elicit comments for improvement from the wider community.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * combinatorial numbers enumeration function for deranngements, nD, added that is similar to nP, nC and nT.
* utilities
  * iterables function for generating derangements of a sequence was added
<!-- END RELEASE NOTES -->
