### PR TITLE
Removed unnecessary normalization of the created quaternion in from_axis_angle

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -583,3 +583,4 @@ Rahil Parikh <r.parikh@somaiya.edu> rprkh <r.parikh@somaiya.edu>
 Yaser AlOsh <yaseralosh@outlook.com> Yaser <yaseralosh@outlook.com>
 Joannah Nanjekye <joannah.nanjekye@ibm.com> nanjekyejoannah <joannah.nanjekye@ibm.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>
+Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1098,3 +1098,4 @@ Jason Ross <jasonross1024@gmail.com>
 Joannah Nanjekye <joannah.nanjekye@ibm.com>
 Ayush Kumar <ayushk7102@gmail.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in>
+Daniel Hyams <dhyams@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1092 authors.
+There are a total of 1093 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>

--- a/bin/authors_update.py
+++ b/bin/authors_update.py
@@ -163,4 +163,5 @@ else:
     print(yellow("The AUTHORS file was updated."))
 
 print(red("Changes were made in the authors file"))
+run(['git', 'diff']) # Show the changes
 sys.exit(1)

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -116,7 +116,11 @@ class Quaternion(Expr):
         c = y * s
         d = z * s
 
-        return cls(a, b, c, d).normalize()
+        # note that this quaternion is already normalized by construction:
+        # c^2 + (s*x)^2 + (s*y)^2 + (s*z)^2 = c^2 + s^2*(x^2 + y^2 + z^2) = c^2 + s^2 * 1 = c^2 + s^2 = 1
+        # so, what we return is a normalized quaternion
+
+        return cls(a, b, c, d)
 
     @classmethod
     def from_rotation_matrix(cls, M):

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,5 +1,5 @@
 from sympy import symbols, re, im, sign, I, Abs, Symbol, \
-     cos, sin, sqrt, conjugate, log, acos, E, pi, \
+     cos, sin, sqrt, conjugate, log, acos, asin, E, pi, \
      Matrix, diff, integrate, trigsimp, S, Rational
 from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
@@ -24,7 +24,6 @@ def test_quaternion_construction():
     raises(ValueError, lambda: Quaternion(w, x, nc, z))
 
 
-
 def test_quaternion_axis_angle():
 
     test_data = [ # axis, angle, expected_quaternion
@@ -41,6 +40,14 @@ def test_quaternion_axis_angle():
 
     for axis, angle, expected in test_data:
         assert Quaternion.from_axis_angle(axis, angle) == Quaternion(*expected)
+
+
+def test_quaternion_axis_angle_simplification():
+    result = Quaternion.from_axis_angle((1, 2, 3), asin(4))
+    assert result.a == cos(asin(4)/2)
+    assert result.b == sqrt(14)*sin(asin(4)/2)/14
+    assert result.c == sqrt(14)*sin(asin(4)/2)/7
+    assert result.d == 3*sqrt(14)*sin(asin(4)/2)/14
 
 def test_quaternion_complex_real_addition():
     a = symbols("a", complex=True)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -24,6 +24,24 @@ def test_quaternion_construction():
     raises(ValueError, lambda: Quaternion(w, x, nc, z))
 
 
+
+def test_quaternion_axis_angle():
+
+    test_data = [ # axis, angle, expected_quaternion
+        ((1, 0, 0), 0, (1, 0, 0, 0)),
+        ((1, 0, 0), pi/2, (sqrt(2)/2, sqrt(2)/2, 0, 0)),
+        ((0, 1, 0), pi/2, (sqrt(2)/2, 0, sqrt(2)/2, 0)),
+        ((0, 0, 1), pi/2, (sqrt(2)/2, 0, 0, sqrt(2)/2)),
+        ((1, 0, 0), pi, (0, 1, 0, 0)),
+        ((0, 1, 0), pi, (0, 0, 1, 0)),
+        ((0, 0, 1), pi, (0, 0, 0, 1)),
+        ((1, 1, 1), pi, (0, 1/sqrt(3),1/sqrt(3),1/sqrt(3))),
+        ((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), pi*2/3, (S.Half, S.Half, S.Half, S.Half))
+    ]
+
+    for axis, angle, expected in test_data:
+        assert Quaternion.from_axis_angle(axis, angle) == Quaternion(*expected)
+
 def test_quaternion_complex_real_addition():
     a = symbols("a", complex=True)
     b = symbols("b", real=True)


### PR DESCRIPTION



Removed unnecessary normalization of the created quaternion in the from_axis_angle Quaternion method. The quaternion is normalized by construction.

Foregoing these normalizations is sometimes a key operation to be able to successfully simplify complex algebraic output from these routines.

References to other Issues or PRs
None

Brief description of what is fixed or changed
Removed unnecessary normalization of the created quaternion in the from_axis_angle Quaternion method. The quaternion is normalized by construction.

Other comments
Foregoing these normalizations is sometimes a key operation to be able to successfully simplify complex algebraic output from these routines.

Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->