### PR TITLE
Fix correctness issues of unify

### DIFF
--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -226,12 +226,14 @@ def unify(
     Notes
     =====
 
-    Also, this is not a standard approach of associative-commutative
-    unification, but rather of list unification, which has similar
-    search like Unger parsing method for context-free grammar.
+    This is not a standard approach of associative-commutative
+    unification, but rather of list-associative-commutative unification,
+    which has similar search algorithm like Unger parsing method for
+    context-free grammar.
 
     So if you don't flatten the expressions in priori, it won't
-    recognize the associativity across nested terms.
+    be able to recognize some associativity or commutativity across
+    nested terms.
     """
     s = s or {}
 
@@ -316,14 +318,14 @@ def subst(s: Dict[VariableBase, Any], x: Any):
     return x
 
 
-def occur_check(var: VariableBase, x, s):
-    """ var occurs in subtree owned by x? """
-    if var == x:
+def occur_check(v: VariableBase, x: Any, s: Dict[VariableBase, Any]) -> bool:
+    """Checks whether the variable $v$ occurs in the term $x$"""
+    if v == x:
         return True
     elif x in s:
-        return occur_check(var, s[x], s)
+        return occur_check(v, s[x], s)
     elif isinstance(x, Compound):
-        return any(occur_check(var, arg, s) for arg in x.args)
+        return any(occur_check(v, arg, s) for arg in x.args)
     return False
 
 

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -20,7 +20,7 @@ from sympy.utilities.iterables import kbins
 from abc import ABC, abstractmethod
 from typing import (
     Sequence, Callable, Optional, Dict, Iterator, Union, Literal, Tuple,
-    TypeVar, Any, Hashable)
+    TypeVar, Any)
 from itertools import permutations
 
 
@@ -134,7 +134,7 @@ class CondVariable(VariableBase):
         The function to test whether the variable should with unify with
         the term or not.
     """
-    def __init__(self, arg: Hashable, valid: Callable[[Any], bool]):
+    def __init__(self, arg: Any, valid: Callable[[Any], bool]):
         self.arg = arg
         self.valid = valid
 
@@ -167,7 +167,7 @@ class Variable(VariableBase):
     arg
         The name of the variable
     """
-    def __init__(self, arg: Hashable):
+    def __init__(self, arg: Any):
         self.arg = arg
 
     def __eq__(self, other) -> bool:

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -6,8 +6,7 @@ http://aima.cs.berkeley.edu/python/logic.html
 We extended the original algorithm with the capability to
 
 - Handle associative-commutative unification capability.
-- Designed type system to make this work across almosst every objects of
-  python by composition.
+- Designed type system to make this work with almost all Python objects by composition.
 
 References
 ==========

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -1,141 +1,300 @@
-""" Generic Unification algorithm for expression trees with lists of children
+"""Unification algorithm
 
-This implementation is a direct translation of
-
-Artificial Intelligence: A Modern Approach by Stuart Russel and Peter Norvig
-Second edition, section 9.2, page 276
-
-It is modified in the following ways:
-
-1.  We allow associative and commutative Compound expressions. This results in
-    combinatorial blowup.
-2.  We explore the tree lazily.
-3.  We provide generic interfaces to symbolic algebra libraries in Python.
-
-A more traditional version can be found here
+The original version (but with some correctness issues) can be found here
 http://aima.cs.berkeley.edu/python/logic.html
+
+We extended the original algorithm with the capability to
+
+- Handle associative-commutative unification capability.
+- Designed type system to make this work across almosst every objects of
+  python by composition.
+
+References
+==========
+
+.. [*] Artificial Intelligence: A Modern Approach by Stuart Russel and
+       Peter Norvig Second edition, section 9.2, page 276
+.. [*] Baader, Franz, and Tobias Nipkow. 1998. Term Rewriting and All That.
+       Cambridge: Cambridge University Press. doi:10.1017/CBO9781139172752.
 """
-
 from sympy.utilities.iterables import kbins
+from abc import ABC, abstractmethod
+from typing import (
+    Sequence, Callable, Optional, Dict, Iterator, Union, Literal, Tuple,
+    TypeVar, List, Any, Hashable)
+from typing_extensions import TypeGuard
+from itertools import permutations
 
-class Compound:
-    """ A little class to represent an interior node in the tree
 
-    This is analogous to SymPy.Basic for non-Atoms
+T = TypeVar('T')
+
+
+class Term(ABC):
+    @abstractmethod
+    def __str__(self) -> str:
+        pass
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class Compound(Term):
+    """A term with function symbol and arguments
+
+    Attributes
+    ==========
+
+    op
+        An argument to define the function head.
+        Can be anything, but we recommend it to be ``str`` or something
+        immutable with well-defined syntactic equality.
+
+    args: Tuple[Term, ...]
+        The arguments of the function.
+        Can be a sequence of anything, but we recommend it to be a
+        immutable sequence of terms.
+
+    Examples
+    ========
+
+    How to represent functions?
+
+    >>> from sympy.unify.core import Variable, Compound
+
+    >>> x = Variable('x')
+    >>> y = Variable('y')
+
+    >>> Compound('f', (x,))
+    f[x]
+    >>> Compound('f', (x, y))
+    f[x, y]
+
+    How to represent constants?
+
+    The standard way of encoding 'constant' as term is defining
+    them as nullary compound term.
+
+    >>> Compound(1, ())
+    1[]
+    >>> Compound(2, ())
+    2[]
+
+    For legacy reason, the following behavior is also supported
+
+    >>> Compound('Add', (1, 2))
+    Add[1, 2]
+
+    However, the identity between the nullary compound term its head is
+    not preserved, so you need to be consistent in the way how to
+    encode constants into the term.
+
+    >>> 1 == Compound(1, ())
+    False
     """
-    def __init__(self, op, args):
+    op: Any
+    args: Tuple[Any, ...]
+
+    def __init__(self, op: Any, args: Tuple[Any, ...] = ()):
         self.op = op
-        self.args = args
+        self.args = tuple(args)
 
-    def __eq__(self, other):
-        return (type(self) is type(other) and self.op == other.op and
-                self.args == other.args)
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Compound):
+            return False
+        if self.op != other.op:
+            return False
+        if len(self.args) != len(other.args):
+            return False
+        return all(x == y for x, y in zip(self.args, other.args))
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((type(self), self.op, self.args))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s[%s]" % (str(self.op), ', '.join(map(str, self.args)))
 
-class Variable:
-    """ A Wild token """
-    def __init__(self, arg):
-        self.arg = arg
 
-    def __eq__(self, other):
-        return type(self) is type(other) and self.arg == other.arg
+class VariableBase(Term, ABC):
+    """A base class for variables"""
+    pass
 
-    def __hash__(self):
-        return hash((type(self), self.arg))
 
-    def __str__(self):
-        return "Variable(%s)" % str(self.arg)
+class CondVariable(VariableBase):
+    """A variable that matches conditionally
 
-class CondVariable:
-    """ A wild token that matches conditionally.
+    Explanation
+    ===========
 
-    arg   - a wild token.
-    valid - an additional constraining function on a match.
+    This only has the semantics in :func:`unify`.
+
+    Attributes
+    ==========
+
+    arg
+        The name of the variable
+
+    valid
+        The function to test whether the variable should with unify with
+        the term or not.
     """
-    def __init__(self, arg, valid):
+    def __init__(self, arg: Hashable, valid: Callable[[Any], bool]):
         self.arg = arg
         self.valid = valid
 
-    def __eq__(self, other):
-        return (type(self) is type(other) and
-                self.arg == other.arg and
-                self.valid == other.valid)
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, CondVariable):
+            return False
+        return self.arg == other.arg and self.valid == other.valid
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((type(self), self.arg, self.valid))
 
-    def __str__(self):
-        return "CondVariable(%s)" % str(self.arg)
+    def __str__(self) -> str:
+        return str(self.arg)
 
-def unify(x, y, s=None, **fns):
-    """Returns idempotent most general unifier of the pairs of expressions
+
+class Variable(VariableBase):
+    """A variable term
+
+    Explanation
+    ===========
+
+    It is similar as :class:`Symbol` in sympy, however, unlike sympy's
+    :class:`Symbol` has ambiguous semantics betweeen arbitrary
+    mathematical constant and functional variable, it has clear semantics
+    under the substitution operation.
+
+    Attributes
+    ==========
+
+    arg
+        The name of the variable
+    """
+    def __init__(self, arg: Hashable):
+        self.arg = arg
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Variable):
+            return False
+        return self.arg == other.arg
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.arg))
+
+    def __str__(self) -> str:
+        return str(self.arg)
+
+
+def unify(
+    x: Any, y: Any,
+    s: Optional[Dict[VariableBase, Any]] = None,
+    **fns
+) -> Iterator[Dict[VariableBase, Any]]:
+    """Yields unifiers for $x$ and $y$.
 
     Parameters
     ==========
 
     x
-        Expression trees containing leaves, Compounds and Variables.
+        Any term
 
     y
-        Expression trees containing leaves, Compounds and Variables.
+        Any term
 
     s : dict, optional
-        A mapping of variables to subtrees.
+        The initial substitution to be given.
+        It is only needed for handling recursion internally
 
-    Returns
-    =======
+    is_associative : Callable[[Compound], bool], optional
+        A check to whether the function should be associatively-unified.
 
-    generator
-        Lazy sequence of dictionaries in the form of
-        ``Variable: Union[Variable, Compound]``
+    is_commutative : Callable[[Compound], bool], optional
+        A check to whether the function should be commutatively-unified.
+
+    Yields
+    ======
+
+    Dict[Union[Variable, CondVariable], Any]
+        A unifier
 
     Examples
     ========
 
     >>> from sympy.unify.core import unify, Compound, Variable
-    >>> expr    = Compound("Add", ("x", "y"))
+    >>> expr = Compound("Add", ("x", "y"))
     >>> pattern = Compound("Add", ("x", Variable("a")))
     >>> next(unify(expr, pattern, {}))
-    {Variable(a): 'y'}
+    {a: 'y'}
+
+    Notes
+    =====
+
+    Also, this is not a standard approach of associative-commutative
+    unification, but rather be list unification, which has similar
+    search like Unger parsing method for context-free grammar.
+
+    So if you don't flatten the expressions in priori, it won't
+    recognize the associativity across nested terms.
     """
     s = s or {}
 
     if x == y:
         yield s
-    elif isinstance(x, (Variable, CondVariable)):
+
+    elif isinstance(x, VariableBase):
         yield from unify_var(x, y, s, **fns)
-    elif isinstance(y, (Variable, CondVariable)):
+    elif isinstance(y, VariableBase):
         yield from unify_var(y, x, s, **fns)
+
     elif isinstance(x, Compound) and isinstance(y, Compound):
-        is_commutative = fns.get('is_commutative', lambda x: False)
-        is_associative = fns.get('is_associative', lambda x: False)
-        for sop in unify(x.op, y.op, s, **fns):
-            if is_associative(x) and is_associative(y):
-                a, b = (x, y) if len(x.args) < len(y.args) else (y, x)
-                if is_commutative(x) and is_commutative(y):
-                    combs = allcombinations(a.args, b.args, 'commutative')
-                else:
-                    combs = allcombinations(a.args, b.args, 'associative')
-                for aaargs, bbargs in combs:
-                    aa = [unpack(Compound(a.op, arg)) for arg in aaargs]
-                    bb = [unpack(Compound(b.op, arg)) for arg in bbargs]
-                    yield from unify(aa, bb, sop, **fns)
-            elif len(x.args) == len(y.args):
-                yield from unify(x.args, y.args, sop, **fns)
+        is_commutative: Callable[[Compound], bool] = fns.get('is_commutative', lambda x: False)
+        is_associative: Callable[[Compound], bool] = fns.get('is_associative', lambda x: False)
 
-    elif is_args(x) and is_args(y) and len(x) == len(y):
-        if len(x) == 0:
-            yield s
-        else:
-            for shead in unify(x[0], y[0], s, **fns):
-                yield from unify(x[1:], y[1:], shead, **fns)
+        if x.op != y.op:
+            return
 
-def unify_var(var, x, s, **fns):
+        if is_associative(x) and is_associative(y):
+            a, b = (x, y) if len(x.args) < len(y.args) else (y, x)
+
+            if is_commutative(x) and is_commutative(y):
+                combs = allcombinations(a.args, b.args, 'commutative')
+            else:
+                combs = allcombinations(a.args, b.args, 'associative')
+
+            for aaargs, bbargs in combs:
+                aa = [unpack(Compound(a.op, arg)) for arg in aaargs]
+                bb = [unpack(Compound(b.op, arg)) for arg in bbargs]
+                yield from unify_multi(*zip(aa, bb), subs=s, **fns)
+
+        elif len(x.args) == len(y.args):
+            if is_commutative(x) and is_commutative(y):
+                for xargs in permutations(x.args):
+                    yield from unify_multi(*zip(xargs, y.args), subs=s, **fns)
+            else:
+                yield from unify_multi(*zip(x.args, y.args), subs=s, **fns)
+
+    elif is_args(x) and is_args(y):
+        if len(x) == len(y):
+            yield from unify_multi(*zip(x, y), subs=s, **fns)
+
+
+def unify_multi(
+    *eqns: Tuple[Any, Any],
+    subs: Dict[VariableBase, Any], **kwargs
+) -> Iterator[Dict[VariableBase, Any]]:
+    """Solve the simultaneous equation for unification"""
+    if not eqns:
+        yield subs
+        return
+
+    x, y = eqns[0]
+    for _subs in unify(x, y, subs, **kwargs):
+        yield from unify_multi(*eqns[1:], subs=_subs, **kwargs)
+
+
+def unify_var(
+    var: VariableBase, x: Any, s: Dict[VariableBase, Any], **fns
+) -> Iterator[Dict[VariableBase, Any]]:
     if var in s:
         val = s[var]
         yield from unify(val, x, s, **fns)
@@ -143,7 +302,7 @@ def unify_var(var, x, s, **fns):
         val = s[x]
         yield from unify(var, val, s, **fns)
     elif occur_check(var, x, s):
-        pass
+        return
     elif (isinstance(var, CondVariable) and var.valid(x)) or isinstance(var, Variable):
         s = assoc(s, var, x)
         # Cascade Substitution
@@ -151,14 +310,16 @@ def unify_var(var, x, s, **fns):
             s[x] = subst(s, s[x])
         yield s
 
-def subst(s, x):
+
+def subst(s: Dict[VariableBase, Any], x: Any):
     if x in s:
         return s[x]
     if isinstance(x, Compound):
         return Compound(x.op, tuple(subst(s, arg) for arg in x.args))
     return x
 
-def occur_check(var, x, s):
+
+def occur_check(var: VariableBase, x, s):
     """ var occurs in subtree owned by x? """
     if var == x:
         return True
@@ -168,33 +329,36 @@ def occur_check(var, x, s):
         return any(occur_check(var, arg, s) for arg in x.args)
     return False
 
+
 def assoc(d, key, val):
     """ Return copy of d with key associated to val """
     d = d.copy()
     d[key] = val
     return d
 
-def is_args(x):
-    """ Is x a traditional iterable? """
-    return type(x) in (tuple, list, set)
 
-def unpack(x):
+def is_args(x) -> TypeGuard[Union[List, Tuple]]:
+    """ Is x a traditional iterable? """
+    return type(x) in (tuple, list)
+
+
+def unpack(x: Any):
     if isinstance(x, Compound) and len(x.args) == 1:
         return x.args[0]
-    else:
-        return x
+    return x
 
-def allcombinations(A, B, ordered):
-    """
-    Restructure A and B to have the same number of elements.
+
+def allcombinations(
+    A: Sequence[T], B: Sequence[T], ordered: str
+) -> Iterator[Tuple[Tuple[Tuple[T, ...], ...], Tuple[Tuple[T, ...], ...]]]:
+    """Restructure A and B to have the same number of elements.
 
     Parameters
     ==========
 
-    ordered must be either 'commutative' or 'associative'.
-
-    A and B can be rearranged so that the larger of the two lists is
-    reorganized into smaller sublists.
+    ordered
+        If ``'commutative'``, it gives all associative-commutative matches
+        Otherwise, it only gives the associative matches
 
     Examples
     ========
@@ -218,17 +382,19 @@ def allcombinations(A, B, ordered):
         (((3,), (2, 1)), ((5,), (6,)))
         (((3, 2), (1,)), ((5,), (6,)))
     """
-
+    arg: Union[Literal[11], None]
     if ordered == "commutative":
-        ordered = 11
-    if ordered == "associative":
-        ordered = None
+        arg = 11
+    else:
+        arg = None
+
     sm, bg = (A, B) if len(A) < len(B) else (B, A)
-    for part in kbins(list(range(len(bg))), len(sm), ordered=ordered):
+    for part in kbins(list(range(len(bg))), len(sm), ordered=arg):
         if bg == B:
             yield tuple((a,) for a in A), partition(B, part)
         else:
             yield partition(A, part), tuple((b,) for b in B)
+
 
 def partition(it, part):
     """ Partition a tuple/list into pieces defined by indices.
@@ -240,16 +406,17 @@ def partition(it, part):
     >>> partition((10, 20, 30, 40), [[0, 1, 2], [3]])
     ((10, 20, 30), (40,))
     """
-    return type(it)([index(it, ind) for ind in part])
+    return tuple(index(it, ind) for ind in part)
+
 
 def index(it, ind):
-    """ Fancy indexing into an indexable iterable (tuple, list).
+    """Fancy indexing into an indexable iterable (tuple, list).
 
     Examples
     ========
 
     >>> from sympy.unify.core import index
     >>> index([10, 20, 30], (1, 2, 0))
-    [20, 30, 10]
+    (20, 30, 10)
     """
-    return type(it)([it[i] for i in ind])
+    return tuple(it[i] for i in ind)

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -81,9 +81,9 @@ class Compound(Term):
     >>> Compound('Add', (1, 2))
     Add[1, 2]
 
-    However, the identity between the nullary compound term its head is
-    not preserved, so you need to be consistent in the way how to
-    encode constants into the term.
+    However, the identity between the nullary compound term and its head is
+    not preserved, so you need to be consistent in how constants are encoded
+    into the term.
 
     >>> 1 == Compound(1, ())
     False

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -69,8 +69,7 @@ class Compound(Term):
 
     How to represent constants?
 
-    The standard way of encoding 'constant' as term is defining
-    them as nullary compound term.
+    A 'constant' term is defined as a nullary compound term.
 
     >>> Compound(1, ())
     1[]

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -21,8 +21,7 @@ from sympy.utilities.iterables import kbins
 from abc import ABC, abstractmethod
 from typing import (
     Sequence, Callable, Optional, Dict, Iterator, Union, Literal, Tuple,
-    TypeVar, List, Any, Hashable)
-from typing_extensions import TypeGuard
+    TypeVar, Any, Hashable)
 from itertools import permutations
 
 
@@ -273,7 +272,7 @@ def unify(
             else:
                 yield from unify_multi(*zip(x.args, y.args), subs=s, **fns)
 
-    elif is_args(x) and is_args(y):
+    elif isinstance(x, (list, tuple)) and isinstance(y, (list, tuple)):
         if len(x) == len(y):
             yield from unify_multi(*zip(x, y), subs=s, **fns)
 
@@ -335,11 +334,6 @@ def assoc(d, key, val):
     d = d.copy()
     d[key] = val
     return d
-
-
-def is_args(x) -> TypeGuard[Union[List, Tuple]]:
-    """ Is x a traditional iterable? """
-    return type(x) in (tuple, list)
 
 
 def unpack(x: Any):

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -156,7 +156,7 @@ class Variable(VariableBase):
     Explanation
     ===========
 
-    It is similar as :class:`Symbol` in sympy, however, unlike sympy's
+    It is similar as :class:`Symbol` in SymPy, however, unlike SymPy's
     :class:`Symbol` has ambiguous semantics betweeen arbitrary
     mathematical constant and functional variable, it has clear semantics
     under the substitution operation.

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -227,7 +227,7 @@ def unify(
     =====
 
     Also, this is not a standard approach of associative-commutative
-    unification, but rather be list unification, which has similar
+    unification, but rather of list unification, which has similar
     search like Unger parsing method for context-free grammar.
 
     So if you don't flatten the expressions in priori, it won't

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -139,10 +139,10 @@ def unify_var(var, x, s, **fns):
     if var in s:
         val = s[var]
         yield from unify(val, x, s, **fns)
-    elif any(occur_check(k, x) for k in s):
-        val = subst(s, x)
+    elif x in s:
+        val = s[x]
         yield from unify(var, val, s, **fns)
-    elif occur_check(var, x):
+    elif occur_check(var, x, s):
         pass
     elif (isinstance(var, CondVariable) and var.valid(x)) or isinstance(var, Variable):
         s = assoc(s, var, x)
@@ -158,12 +158,14 @@ def subst(s, x):
         return Compound(x.op, tuple(subst(s, arg) for arg in x.args))
     return x
 
-def occur_check(var, x):
+def occur_check(var, x, s):
     """ var occurs in subtree owned by x? """
     if var == x:
         return True
+    elif x in s:
+        return occur_check(var, s[x], s)
     elif isinstance(x, Compound):
-        return any(occur_check(var, arg) for arg in x.args)
+        return any(occur_check(var, arg, s) for arg in x.args)
     return False
 
 def assoc(d, key, val):

--- a/sympy/unify/tests/test_unify.py
+++ b/sympy/unify/tests/test_unify.py
@@ -1,4 +1,4 @@
-from sympy.unify.core import Compound, Variable, CondVariable, allcombinations
+from sympy.unify.core import Compound, Variable, CondVariable, allcombinations, subst
 from sympy.unify import core
 
 a,b,c = 'a', 'b', 'c'
@@ -86,3 +86,36 @@ def test_CondVariable():
 
 def test_defaultdict():
     assert next(unify(Variable('x'), 'foo')) == {Variable('x'): 'foo'}
+
+
+def test_issue_21917():
+    x = Variable('x')
+    y = Variable('y')
+    a = Compound('a', ())
+
+    A = Compound('f', (x, y))
+    B = Compound('f', (Compound('h', (a,)), x))
+    for s in unify(A, B):
+        assert subst(s, A) == subst(s, B)
+
+    A = Compound('f', (x, y))
+    B = Compound('f', (y, x))
+    for s in unify(A, B):
+        assert subst(s, A) == subst(s, B)
+
+    A = Compound('f', (x, y))
+    B = Compound('f', (Compound('f', (y,)), Compound('f', (x,))))
+    for s in unify(A, B):
+        assert subst(s, A) == subst(s, B)
+
+    z = Variable('z')
+    g_a = Compound('g', (a,))
+    g_x = Compound('g', (x,))
+    g_y = Compound('g', (y,))
+    g_z = Compound('g', (z,))
+    g_g_x = Compound('g', (g_x,))
+
+    A = Compound('f', (x, g_a, g_z))
+    B = Compound('f', (g_y, g_y, g_g_x))
+    for s in unify(A, B):
+        assert subst(s, A) == subst(s, B)

--- a/sympy/unify/tests/test_unify.py
+++ b/sympy/unify/tests/test_unify.py
@@ -1,88 +1,117 @@
 from sympy.unify.core import Compound, Variable, CondVariable, allcombinations, subst
 from sympy.unify import core
-
-a,b,c = 'a', 'b', 'c'
-w,x,y,z = map(Variable, 'wxyz')
-
-C = Compound
-
-def is_associative(x):
-    return isinstance(x, Compound) and (x.op in ('Add', 'Mul', 'CAdd', 'CMul'))
-def is_commutative(x):
-    return isinstance(x, Compound) and (x.op in ('CAdd', 'CMul'))
+from typing import Any
 
 
-def unify(a, b, s={}):
-    return core.unify(a, b, s=s, is_associative=is_associative,
-                          is_commutative=is_commutative)
+a, b, c = 'a', 'b', 'c'
+w, x, y, z = map(Variable, 'wxyz')
+
+
+class Function:
+    """A helper for building compound term.
+    This should be added in the core for convenience
+    """
+    def __init__(self, name: str):
+        self.name = name
+
+    def __call__(self, *args: Any) -> Compound:
+        return Compound(self.name, args)
+
+
+Add = Function('Add')
+Mul = Function('Mul')
+A = Function('A')
+C = Function('C')
+AC = Function('AC')
+
+
+def is_associative(x) -> bool:
+    return isinstance(x, Compound) and (x.op in ('A', 'AC'))
+
+
+def is_commutative(x) -> bool:
+    return isinstance(x, Compound) and (x.op in ('C', 'AC'))
+
+
+def unify(a: Any, b: Any, s={}):
+    return core.unify(
+        a, b, s=s,
+        is_associative=is_associative,
+        is_commutative=is_commutative
+    )
+
 
 def test_basic():
     assert list(unify(a, x, {})) == [{x: a}]
     assert list(unify(a, x, {x: 10})) == []
     assert list(unify(1, x, {})) == [{x: 1}]
     assert list(unify(a, a, {})) == [{}]
-    assert list(unify((w, x), (y, z), {})) == [{w: y, x: z}]
     assert list(unify(x, (a, b), {})) == [{x: (a, b)}]
-
-    assert list(unify((a, b), (x, x), {})) == []
-    assert list(unify((y, z), (x, x), {}))!= []
     assert list(unify((a, (b, c)), (a, (x, y)), {})) == [{x: b, y: c}]
 
-def test_ops():
-    assert list(unify(C('Add', (a,b,c)), C('Add', (a,x,y)), {})) == \
-            [{x:b, y:c}]
-    assert list(unify(C('Add', (C('Mul', (1,2)), b,c)), C('Add', (x,y,c)), {})) == \
-            [{x: C('Mul', (1,2)), y:b}]
+    assert list(unify((a, b), (x, x), {})) == []
+    assert list(unify((y, z), (x, x), {})) == [{y: x, z: x}]
+
+    assert list(unify((w, x), (y, z), {})) == [{w: y, x: z}]
+    assert list(unify((w, x), (w, x), {})) == [{}]
+
+
+def test_operators():
+    assert list(unify(Add(a, b, c), Add(a, x, y), {})) == [{x: b, y: c}]
+    assert list(unify(Add(Mul(1, 2), b, c), Add(x, y, c), {})) == [{x: Mul(1, 2), y: b}]
+
 
 def test_associative():
-    c1 = C('Add', (1,2,3))
-    c2 = C('Add', (x,y))
-    assert tuple(unify(c1, c2, {})) == ({x: 1, y: C('Add', (2, 3))},
-                                         {x: C('Add', (1, 2)), y: 3})
+    assert list(unify(A(1, 2, 3), A(x, y), {})) == [
+        {x: 1, y: A(2, 3)},
+        {x: A(1, 2), y: 3}
+    ]
+
 
 def test_commutative():
-    c1 = C('CAdd', (1,2,3))
-    c2 = C('CAdd', (x,y))
-    result = list(unify(c1, c2, {}))
-    assert  {x: 1, y: C('CAdd', (2, 3))} in result
-    assert ({x: 2, y: C('CAdd', (1, 3))} in result or
-            {x: 2, y: C('CAdd', (3, 1))} in result)
+    assert list(unify(C(1, 2, 3), C(x, y, z), {})) == [
+        {x: 1, y: 2, z: 3},
+        {x: 1, y: 3, z: 2},
+        {x: 2, y: 1, z: 3},
+        {x: 2, y: 3, z: 1},
+        {x: 3, y: 1, z: 2},
+        {x: 3, y: 2, z: 1},
+    ]
 
-def _test_combinations_assoc():
-    assert set(allcombinations((1,2,3), (a,b), True)) == \
-        {(((1, 2), (3,)), (a, b)), (((1,), (2, 3)), (a, b))}
 
-def _test_combinations_comm():
-    assert set(allcombinations((1,2,3), (a,b), None)) == \
-        {(((1,), (2, 3)), ('a', 'b')), (((2,), (3, 1)), ('a', 'b')),
-             (((3,), (1, 2)), ('a', 'b')), (((1, 2), (3,)), ('a', 'b')),
-             (((2, 3), (1,)), ('a', 'b')), (((3, 1), (2,)), ('a', 'b'))}
+def test_associative_commutative():
+    assert list(unify(AC(1, 2, 3), AC(x, y), {})) == [
+        {x: 1, y: AC(2, 3)},
+        {x: AC(1, 2), y: 3},
+        {x: 1, y: AC(3, 2)},
+        {x: AC(1, 3), y: 2},
+        {x: 2, y: AC(1, 3)},
+        {x: AC(2, 1), y: 3},
+        {x: 2, y: AC(3, 1)},
+        {x: AC(2, 3), y: 1},
+        {x: 3, y: AC(1, 2)},
+        {x: AC(3, 1), y: 2},
+        {x: 3, y: AC(2, 1)},
+        {x: AC(3, 2), y: 1}
+    ]
+
 
 def test_allcombinations():
-    assert set(allcombinations((1,2), (1,2), 'commutative')) ==\
-        {(((1,),(2,)), ((1,),(2,))), (((1,),(2,)), ((2,),(1,)))}
+    assert set(allcombinations((1, 2), (1, 2), 'commutative')) ==\
+        {(((1,), (2,)), ((1,), (2,))), (((1,), (2,)), ((2,), (1,)))}
 
 
-def test_commutativity():
-    c1 = Compound('CAdd', (a, b))
-    c2 = Compound('CAdd', (x, y))
-    assert is_commutative(c1) and is_commutative(c2)
-    assert len(list(unify(c1, c2, {}))) == 2
-
-
-def test_CondVariable():
-    expr = C('CAdd', (1, 2))
+def test_conditional():
+    expr = Add(1, 2)
     x = Variable('x')
     y = CondVariable('y', lambda a: a % 2 == 0)
     z = CondVariable('z', lambda a: a > 3)
-    pattern = C('CAdd', (x, y))
-    assert list(unify(expr, pattern, {})) == \
-            [{x: 1, y: 2}]
 
-    z = CondVariable('z', lambda a: a > 3)
-    pattern = C('CAdd', (z, y))
-
+    pattern = Add(x, y)
+    assert list(unify(expr, pattern, {})) == [{x: 1, y: 2}]
+    pattern = Add(z, y)
     assert list(unify(expr, pattern, {})) == []
+
 
 def test_defaultdict():
     assert next(unify(Variable('x'), 'foo')) == {Variable('x'): 'foo'}

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -1,7 +1,8 @@
-""" SymPy interface to Unification engine
+"""SymPy interface to Unification engine
 
 See sympy.unify for module level docstring
-See sympy.unify.core for algorithmic docstring """
+See sympy.unify.core for algorithmic docstring
+"""
 
 from sympy.core import Basic, Add, Mul, Pow
 from sympy.core.operations import AssocOp, LatticeOp
@@ -10,20 +11,25 @@ from sympy.sets.sets import Union, Intersection, FiniteSet
 from sympy.unify.core import Compound, Variable, CondVariable
 from sympy.unify import core
 
+
 basic_new_legal = [MatrixExpr]
 eval_false_legal = [AssocOp, Pow, FiniteSet]
 illegal = [LatticeOp]
+
 
 def sympy_associative(op):
     assoc_ops = (AssocOp, MatAdd, MatMul, Union, Intersection, FiniteSet)
     return any(issubclass(op, aop) for aop in assoc_ops)
 
+
 def sympy_commutative(op):
     comm_ops = (Add, MatAdd, Union, Intersection, FiniteSet)
     return any(issubclass(op, cop) for cop in comm_ops)
 
+
 def is_associative(x):
     return isinstance(x, Compound) and sympy_associative(x.op)
+
 
 def is_commutative(x):
     if not isinstance(x, Compound):
@@ -33,11 +39,13 @@ def is_commutative(x):
     if issubclass(x.op, Mul):
         return all(construct(arg).is_commutative for arg in x.args)
 
+
 def mk_matchtype(typ):
     def matchtype(x):
         return (isinstance(x, typ) or
                 isinstance(x, Compound) and issubclass(x.op, typ))
     return matchtype
+
 
 def deconstruct(s, variables=()):
     """ Turn a SymPy object into a Compound """
@@ -49,6 +57,7 @@ def deconstruct(s, variables=()):
         return s
     return Compound(s.__class__,
                     tuple(deconstruct(arg, variables) for arg in s.args))
+
 
 def construct(t):
     """ Turn a Compound into a SymPy object """
@@ -63,6 +72,7 @@ def construct(t):
     else:
         return t.op(*map(construct, t.args))
 
+
 def rebuild(s):
     """ Rebuild a SymPy expression.
 
@@ -70,17 +80,19 @@ def rebuild(s):
     """
     return construct(deconstruct(s))
 
+
 def unify(x, y, s=None, variables=(), **kwargs):
-    """ Structural unification of two expressions/patterns.
+    """Structural unification of two expressions/patterns.
 
     Examples
     ========
 
     >>> from sympy.unify.usympy import unify
-    >>> from sympy import Basic, S
+    >>> from sympy import Function
     >>> from sympy.abc import x, y, z, p, q
 
-    >>> next(unify(Basic(S(1), S(2)), Basic(S(1), x), variables=[x]))
+    >>> f = Function('f')
+    >>> next(unify(f(1, 2), f(1, x), variables=[x]))
     {x: 2}
 
     >>> expr = 2*x + y + z
@@ -98,10 +110,10 @@ def unify(x, y, s=None, variables=(), **kwargs):
     Symbols not indicated to be variables are treated as literal,
     else they are wild-like and match anything in a sub-expression.
 
-    >>> expr = x*y*z + 3
+    >>> expr = x*z + 3
     >>> pattern = x*y + 3
     >>> next(unify(expr, pattern, {}, variables=[x, y]))
-    {x: y, y: x*z}
+    {y: z}
 
     The x and y of the pattern above were in a Mul and matched factors
     in the Mul of expr. Here, a single symbol matches an entire term:
@@ -110,15 +122,16 @@ def unify(x, y, s=None, variables=(), **kwargs):
     >>> pattern = p + 3
     >>> next(unify(expr, pattern, {}, variables=[p]))
     {p: x*y}
-
     """
     decons = lambda x: deconstruct(x, variables)
     s = s or {}
     s = {decons(k): decons(v) for k, v in s.items()}
 
-    ds = core.unify(decons(x), decons(y), s,
-                                     is_associative=is_associative,
-                                     is_commutative=is_commutative,
-                                     **kwargs)
+    ds = core.unify(
+        decons(x), decons(y), s,
+        is_associative=is_associative,
+        is_commutative=is_commutative,
+        **kwargs)
+
     for d in ds:
         yield {construct(k): construct(v) for k, v in d.items()}

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -10,6 +10,7 @@ from sympy.matrices import MatAdd, MatMul, MatrixExpr
 from sympy.sets.sets import Union, Intersection, FiniteSet
 from sympy.unify.core import Compound, Variable, CondVariable
 from sympy.unify import core
+from typing import Any
 
 
 basic_new_legal = [MatrixExpr]
@@ -47,7 +48,7 @@ def mk_matchtype(typ):
     return matchtype
 
 
-def deconstruct(s, variables=()):
+def deconstruct(s, variables=()) -> Any:
     """ Turn a SymPy object into a Compound """
     if s in variables:
         return Variable(s)
@@ -59,7 +60,7 @@ def deconstruct(s, variables=()):
                     tuple(deconstruct(arg, variables) for arg in s.args))
 
 
-def construct(t):
+def construct(t) -> Basic:
     """ Turn a Compound into a SymPy object """
     if isinstance(t, (Variable, CondVariable)):
         return t.arg


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21917

#### Brief description of what is fixed or changed

Unify should satisfy the identity `all(substitute(A, s) == substitute(B, s) for s in unify(A, B))` but the previous results does not guarantee this for some expressions.
This is explainable by the lack of variable elimination step where similar references all has.
I also find that the second statement of `unify_var` is missing as in the original source, but I see the original textbook implementation was also questioned by https://github.com/aimacode/aima-python/issues/1053 so I ported the changes from the update of the reference source.

This also fixes the issue with function with commutativity, but not with associativity $C$
$C(1, 2, 3) = C(x, y, z)$ should give the 6 permutation of the result.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- unify
  - Fixed wrong results of `unify` not giving the idempotent unifier, and not giving correct result for function symbols only with `is_commutative` defined
<!-- END RELEASE NOTES -->
