### PR TITLE
simplify -  fixes issue #21340 and now trigsimp with fu method returns nan for zero denominator

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -554,6 +554,7 @@ Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in> BhaskarJoshi-01 <bhaskar.joshi
 Miguel Torres Costa <miguelptcosta1995@gmail.com>
 Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeth <praneethratna@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com> Praneeth Ratna <63547155+praneethratna@users.noreply.github.com>
 Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
 Anup Parikh <parikhanupk@gmail.com> Anup Parikh <84572003+parikhanupk@users.noreply.github.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
@@ -567,7 +568,6 @@ Aman Sharma <amansharma110603@gmail.com> mostlyaman <85072876+mostlyaman@users.n
 Robin Richard <raisin@ecomail.fr> robinechuca <raisin@ecomail.fr>
 Robin Richard <raisin@ecomail.fr> robinechuca <61911191+robinechuca@users.noreply.github.com>
 Robin Richard <raisin@ecomail.fr> Nornort <francois.lalleve@laposte.net>
-Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
 Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
 Jonathan Gutow <gutow@uwosh.edu> gutow <gutow@uwosh.edu>
 Ben Oostendorp <oostben@umich.edu> oostben <oostben@umich.edu>

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1646,11 +1646,6 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
     rv = sympify(rv)
     if not isinstance(rv, Expr):
         return rv.func(*[fu(a, measure=measure) for a in rv.args])
-    else:
-        n, d = fraction(rv)
-        if d.is_zero is None:
-            if simplify(d) is S.Zero:
-                return nan
     rv = TR1(rv)
     if rv.has(tan, cot):
         rv1 = fRL1(rv)
@@ -1659,6 +1654,10 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
         if rv.has(tan, cot):
             rv = TR2(rv)
     if rv.has(sin, cos):
+        n, d = fraction(rv)
+        if d.is_zero is None:
+            if TR8(TRmorrie(d)) is S.Zero:
+                return nan
         rv1 = fRL2(rv)
         rv2 = TR8(TRmorrie(rv1))
         rv = min([was, rv, rv1, rv2], key=measure)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1648,8 +1648,9 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
         return rv.func(*[fu(a, measure=measure) for a in rv.args])
     else:
         n, d = fraction(rv)
-        if d is S.Zero:
-            return nan    
+        if d.is_zero is None:
+            if simplify(d) is S.Zero:
+                return nan
     rv = TR1(rv)
     if rv.has(tan, cot):
         rv1 = fRL1(rv)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1644,12 +1644,12 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
 
     was = rv
     rv = sympify(rv)
-    if isinstance(rv, Expr):
-        n, d = fraction(rv)
-        if simplify(d) is S.Zero:
-            return nan
     if not isinstance(rv, Expr):
         return rv.func(*[fu(a, measure=measure) for a in rv.args])
+    else:
+        n, d = fraction(rv)
+        if d is S.Zero:
+            return nan    
     rv = TR1(rv)
     if rv.has(tan, cot):
         rv1 = fRL1(rv)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -7,7 +7,7 @@ from sympy.core.expr import Expr
 from sympy.core.exprtools import Factors, gcd_terms, factor_terms
 from sympy.core.function import expand_mul
 from sympy.core.mul import Mul
-from sympy.core.numbers import pi, I
+from sympy.core.numbers import pi, I, nan
 from sympy.core.power import Pow
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
@@ -18,7 +18,8 @@ from sympy.functions.elementary.trigonometric import (
     cos, sin, tan, cot, sec, csc, sqrt, TrigonometricFunction)
 from sympy.ntheory.factor_ import perfect_power
 from sympy.polys.polytools import factor
-from sympy.simplify.simplify import bottom_up
+from sympy.simplify.simplify import bottom_up, simplify
+from sympy.simplify.radsimp import fraction
 from sympy.strategies.tree import greedy
 from sympy.strategies.core import identity, debug
 
@@ -1643,6 +1644,10 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
 
     was = rv
     rv = sympify(rv)
+    if isinstance(rv, Expr):
+        n, d = fraction(rv)
+        if simplify(d) is S.Zero:
+            return nan
     if not isinstance(rv, Expr):
         return rv.func(*[fu(a, measure=measure) for a in rv.args])
     rv = TR1(rv)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -18,7 +18,7 @@ from sympy.functions.elementary.trigonometric import (
     cos, sin, tan, cot, sec, csc, sqrt, TrigonometricFunction)
 from sympy.ntheory.factor_ import perfect_power
 from sympy.polys.polytools import factor
-from sympy.simplify.simplify import bottom_up, simplify
+from sympy.simplify.simplify import bottom_up
 from sympy.simplify.radsimp import fraction
 from sympy.strategies.tree import greedy
 from sympy.strategies.core import identity, debug

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -1,6 +1,6 @@
 from sympy import (
     Add, Mul, S, Symbol, cos, cot, pi, I, sin, sqrt, tan, root, csc, sec,
-    powsimp, symbols, sinh, cosh, tanh, coth, sech, csch, Dummy, Rational)
+    powsimp, symbols, sinh, cosh, tanh, coth, sech, csch, Dummy, Rational, nan)
 from sympy.simplify.fu import (
     L, TR1, TR10, TR10i, TR11, _TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
     TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
@@ -460,3 +460,8 @@ def test_as_f_sign_1():
     assert as_f_sign_1(2*x + 2) == (2, x, 1)
     assert as_f_sign_1(x*y - y) == (y, x, -1)
     assert as_f_sign_1(-x*y + y) == (-y, x, -1)
+
+
+def test_issue_21340():
+    expr = (tan(x)**2 - sec(x)**2 + 1) / (sin(x)**2 + cos(x)**2 - 1)
+    assert fu(expr) == nan


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21340 and now `trigsimp((tan(x)**2 - sec(x)**2 + 1) / (sin(x)**2 + cos(x)**2 - 1), method='fu')` returns `nan` instead of `cos(x)**(-2)`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
   * fixed bug in fu.py
<!-- END RELEASE NOTES -->
