### PR TITLE
Fixed issue with determining is_integer for round functions (#21651)

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1429,6 +1429,13 @@ def test_matrixsymbol_summation_numerical_limits():
     assert Sum(A**n*B**n, (n, 1, 3)).doit() == ans
 
 
+def test_issue_21651():
+    from sympy import floor, Sum, Symbol
+    i = Symbol('i')
+    a = Sum(floor(2*2**(-i)), (i, S.One, 2))
+    assert a.doit() == S.One
+
+
 @XFAIL
 def test_matrixsymbol_summation_symbolic_limits():
     N = Symbol('N', integer=True, positive=True)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1351,7 +1351,7 @@ class Mul(Expr, AssocOp):
                 b, e = a.as_base_exp()
                 if not b.is_integer or not e.is_integer: return
                 if e.is_negative:
-                    denominators.append(Pow(b, S.NegativeOne*e))
+                    denominators.append(2 if a is S.Half else Pow(a, S.NegativeOne, evaluate=False))
                 else:
                     # for integer b and positive integer e: a = b**e would be integer
                     assert not e.is_positive

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1351,7 +1351,7 @@ class Mul(Expr, AssocOp):
                 b, e = a.as_base_exp()
                 if not b.is_integer or not e.is_integer: return
                 if e.is_negative:
-                    denominators.append(b)
+                    denominators.append(Pow(b, S.NegativeOne*e))
                 else:
                     # for integer b and positive integer e: a = b**e would be integer
                     assert not e.is_positive

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1351,7 +1351,7 @@ class Mul(Expr, AssocOp):
                 b, e = a.as_base_exp()
                 if not b.is_integer or not e.is_integer: return
                 if e.is_negative:
-                    denominators.append(2 if a is S.Half else Pow(a, S.NegativeOne, evaluate=False))
+                    denominators.append(2 if a is S.Half else Pow(a, S.NegativeOne))
                 else:
                     # for integer b and positive integer e: a = b**e would be integer
                     assert not e.is_positive

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1198,6 +1198,12 @@ def test_issue_17556():
     assert z.is_finite is False
 
 
+def test_issue_21651():
+    k = Symbol('k', positive=True, integer=True)
+    exp = 2*2**(-k)
+    assert exp.is_integer is None
+
+
 def test_assumptions_copy():
     assert assumptions(Symbol('x'), dict(commutative=True)
         ) == {'commutative': True}

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -548,6 +548,12 @@ def test_issue_4149():
     assert floor(3 + E + pi*I + y*I) == 5 + floor(pi + y)*I
 
 
+def test_issue_21651():
+    k = Symbol('k', positive=True, integer=True)
+    exp = 2*2**(-k)
+    assert isinstance(floor(exp), floor)
+
+
 def test_issue_11207():
     assert floor(floor(x)) == floor(x)
     assert floor(ceiling(x)) == ceiling(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #21651

#### Brief description of what is fixed or changed
For some odd cases, `Mul.is_integer` returned `True` where it should have been `None`.

#### Other comments
There are three tests added:
1. To check that the final result in #21651 is correct.
2. To check that the floor is not removed from the expression.
3. To check that `is_integer` returns correctly.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Fixed issue where `is_integer` returned incorrectly for multiplications.
<!-- END RELEASE NOTES -->
