### PR TITLE
solvers - fixes issue #19814 and nonlinsolve() for some equations returns correct output

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -554,6 +554,7 @@ Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in> BhaskarJoshi-01 <bhaskar.joshi
 Miguel Torres Costa <miguelptcosta1995@gmail.com>
 Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeth <praneethratna@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com> Praneeth Ratna <63547155+praneethratna@users.noreply.github.com>
 Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
 Anup Parikh <parikhanupk@gmail.com> Anup Parikh <84572003+parikhanupk@users.noreply.github.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3303,7 +3303,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         # in the new result list (solution for symbol `s`)
                         # along with old results.
                         for k, v in res.items():
-                            if isinstance(v, Expr) and not sol is S.Complexes:
+                            if isinstance(v, Expr) and isinstance(sol, Expr):
                                 # if any unsolved symbol is present
                                 # Then subs known value
                                 rnew[k] = v.subs(sym, sol)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3303,7 +3303,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         # in the new result list (solution for symbol `s`)
                         # along with old results.
                         for k, v in res.items():
-                            if isinstance(v, Expr):
+                            if isinstance(v, Expr) and not sol is S.Complexes:
                                 # if any unsolved symbol is present
                                 # Then subs known value
                                 rnew[k] = v.subs(sym, sol)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2895,3 +2895,8 @@ def test_issue_21236():
 def test_issue_21908():
     assert nonlinsolve([(x**2 + 2*x - y**2)*exp(x), -2*y*exp(x)], x, y
                       ) == {(-2, 0), (0, 0)}
+
+
+def test_issue_19814():
+    assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n
+                      ) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2898,4 +2898,5 @@ def test_issue_21908():
 
 
 def test_issue_19814():
-    assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))
+    assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n
+                      ) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2898,5 +2898,4 @@ def test_issue_21908():
 
 
 def test_issue_19814():
-    assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n
-                      ) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))
+    assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #19814 and now `nonlinsolve([ 2**m - 2**(2*n),  4*2**m - 2**(4*n) ], m,  n)` returns `FiniteSet((log(2**(2*n))/log(2), S.Complexes))` instead of `AttributeError: 'ConditionSet' object has no attribute 'as_coeff_Mul'` and also added a regression test in test_solveset.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   * fixed a bug in nonlinsolve() method in solveset.
<!-- END RELEASE NOTES -->
