### PR TITLE
Compact printing of FiniteSet. Fixes #21823

### DIFF
--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -863,12 +863,12 @@ above.  Another example is the ``is_empty`` property of sets:
     >>> from sympy import FiniteSet, Intersection
     >>> S1 = FiniteSet(1, 2)
     >>> S1
-    FiniteSet(1, 2)
+    {1, 2}
     >>> print(S1.is_empty)
     False
     >>> S2 = Intersection(FiniteSet(1), FiniteSet(Symbol('x')))
     >>> S2
-    Intersection(FiniteSet(1), FiniteSet(x))
+    Intersection({1}, {x})
     >>> print(S2.is_empty)
     None
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -182,9 +182,9 @@ For example:
 
  >>> from sympy import FiniteSet
  >>> FiniteSet(1, 2, 3)   # Unordered
- FiniteSet(1, 2, 3)
+ {1, 2, 3}
  >>> FiniteSet((1, 2, 3))  # Ordered
- FiniteSet((1, 2, 3))
+ {(1, 2, 3)}
 
 
 Why not use dicts as output?
@@ -256,7 +256,7 @@ What is this domain argument about?
     >>> from sympy import solveset, S
     >>> from sympy.abc import x
     >>> solveset(x**2 + 1, x) # domain=S.Complexes is default
-    FiniteSet(I, -I)
+    {-I, I}
     >>> solveset(x**2 + 1, x, domain=S.Reals)
     EmptySet
 
@@ -552,12 +552,12 @@ Solving an equation like `x^2 == 1` can be done as follows::
     >>> from sympy import Symbol, Eq
     >>> x = Symbol('x')
     >>> solveset(Eq(x**2, 1), x)
-    FiniteSet(-1, 1)
+    {-1, 1}
 
 Or one may manually rewrite the equation as an expression equal to 0::
 
     >>> solveset(x**2 - 1, x)
-    FiniteSet(-1, 1)
+    {-1, 1}
 
 The first argument for :func:`solveset` is an expression (equal to zero) or an equation and the second argument
 is the symbol that we want to solve the equation for.

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -73,13 +73,13 @@ def singularities(expression, symbol, domain=None):
     >>> singularities(x**2 + x + 1, x)
     EmptySet
     >>> singularities(1/(x + 1), x)
-    FiniteSet(-1)
+    {-1}
     >>> singularities(1/(y**2 + 1), y)
-    FiniteSet(I, -I)
+    {-I, I}
     >>> singularities(1/(y**3 + 1), y)
-    FiniteSet(-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2)
+    {-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2}
     >>> singularities(log(x), x)
-    FiniteSet(0)
+    {0}
 
     """
     from sympy.functions.elementary.exponential import log

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -735,7 +735,7 @@ def stationary_points(f, symbol, domain=S.Reals):
               2                                2
 
     >>> stationary_points(sin(x),x, Interval(0, 4*pi))
-    FiniteSet(pi/2, 3*pi/2, 5*pi/2, 7*pi/2)
+    {pi/2, 3*pi/2, 5*pi/2, 7*pi/2}
 
     """
     from sympy import solveset, diff
@@ -1492,7 +1492,7 @@ class AccumulationBounds(AtomicExpr):
         EmptySet
 
         >>> AccumBounds(1, 4).intersection(FiniteSet(1, 2, 5))
-        FiniteSet(1, 2)
+        {1, 2}
 
         """
         if not isinstance(other, (AccumBounds, FiniteSet)):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -727,7 +727,7 @@ class Diagram(Basic):
         True
         >>> d = Diagram([f, g], {g * f: "unique"})
         >>> d.conclusions[g * f]
-        FiniteSet(unique)
+        {unique}
 
         """
         premises = {}
@@ -859,7 +859,7 @@ class Diagram(Basic):
         >>> g = NamedMorphism(B, C, "g")
         >>> d = Diagram([f, g])
         >>> d.objects
-        FiniteSet(Object("A"), Object("B"), Object("C"))
+        {Object("A"), Object("B"), Object("C")}
 
         """
         return self.args[2]

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -522,7 +522,7 @@ class Category(Basic):
         >>> B = Object("B")
         >>> K = Category("K", FiniteSet(A, B))
         >>> K.objects
-        Class(FiniteSet(Object("A"), Object("B")))
+        Class({Object("A"), Object("B")})
 
         """
         return self.args[1]

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -40,7 +40,7 @@ class Partition(FiniteSet):
         >>> from sympy.combinatorics.partitions import Partition
         >>> a = Partition([1, 2], [3])
         >>> a
-        Partition(FiniteSet(1, 2), FiniteSet(3))
+        Partition({3}, {1, 2})
         >>> a.partition
         [[1, 2], [3]]
         >>> len(a)
@@ -51,7 +51,7 @@ class Partition(FiniteSet):
         Creating Partition from Python sets:
 
         >>> Partition({1, 2, 3}, {4, 5})
-        Partition(FiniteSet(1, 2, 3), FiniteSet(4, 5))
+        Partition({4, 5}, {1, 2, 3})
 
         Creating Partition from SymPy finite sets:
 
@@ -59,7 +59,7 @@ class Partition(FiniteSet):
         >>> a = FiniteSet(1, 2, 3)
         >>> b = FiniteSet(4, 5)
         >>> Partition(a, b)
-        Partition(FiniteSet(1, 2, 3), FiniteSet(4, 5))
+        Partition({4, 5}, {1, 2, 3})
         """
         args = []
         dups = False
@@ -105,7 +105,7 @@ class Partition(FiniteSet):
         >>> d = Partition(list(range(4)))
         >>> l = [d, b, a + 1, a, c]
         >>> l.sort(key=default_sort_key); l
-        [Partition(FiniteSet(1, 2)), Partition(FiniteSet(1), FiniteSet(2)), Partition(FiniteSet(1, x)), Partition(FiniteSet(3, 4)), Partition(FiniteSet(0, 1, 2, 3))]
+        [Partition({1, 2}), Partition({1}, {2}), Partition({1, x}), Partition({3, 4}), Partition({0, 1, 2, 3})]
         """
         if order is None:
             members = self.members
@@ -251,7 +251,7 @@ class Partition(FiniteSet):
         >>> a.RGS
         (0, 0, 1, 2, 2)
         >>> a + 1
-        Partition(FiniteSet(1, 2), FiniteSet(3), FiniteSet(4), FiniteSet(5))
+        Partition({3}, {4}, {5}, {1, 2})
         >>> _.RGS
         (0, 0, 1, 2, 3)
         """
@@ -282,12 +282,12 @@ class Partition(FiniteSet):
 
         >>> from sympy.combinatorics.partitions import Partition
         >>> Partition.from_rgs([0, 1, 2, 0, 1], list('abcde'))
-        Partition(FiniteSet(c), FiniteSet(a, d), FiniteSet(b, e))
+        Partition({c}, {a, d}, {b, e})
         >>> Partition.from_rgs([0, 1, 2, 0, 1], list('cbead'))
-        Partition(FiniteSet(e), FiniteSet(a, c), FiniteSet(b, d))
+        Partition({e}, {a, c}, {b, d})
         >>> a = Partition([1, 4], [2], [3, 5])
         >>> Partition.from_rgs(a.RGS, a.members)
-        Partition(FiniteSet(1, 4), FiniteSet(2), FiniteSet(3, 5))
+        Partition({2}, {1, 4}, {3, 5})
         """
         if len(rgs) != len(elements):
             raise ValueError('mismatch in rgs and element lengths')

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -52,9 +52,9 @@ class Polyhedron(Basic):
 
             >>> from sympy.combinatorics.polyhedron import Polyhedron
             >>> Polyhedron(list('abc'), [(1, 2, 0)]).faces
-            FiniteSet((0, 1, 2))
+            {(0, 1, 2)}
             >>> Polyhedron(list('abc'), [(1, 0, 2)]).faces
-            FiniteSet((0, 1, 2))
+            {(0, 1, 2)}
 
         The allowed transformations are entered as allowable permutations
         of the vertices for the polyhedron. Instance of Permutations
@@ -98,7 +98,7 @@ class Polyhedron(Basic):
         >>> tetra.size
         4
         >>> tetra.edges
-        FiniteSet((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3))
+        {(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)}
         >>> tetra.corners
         (w, x, y, z)
 
@@ -371,7 +371,7 @@ class Polyhedron(Basic):
 
         >>> from sympy.combinatorics.polyhedron import cube
         >>> cube.edges
-        FiniteSet((0, 1), (0, 3), (0, 4), (1, 2), (1, 5), (2, 3), (2, 6), (3, 7), (4, 5), (4, 7), (5, 6), (6, 7))
+        {(0, 1), (0, 3), (0, 4), (1, 2), (1, 5), (2, 3), (2, 6), (3, 7), (4, 5), (4, 7), (5, 6), (6, 7)}
 
         If you want to use letters or other names for the corners you
         can still use the pre-calculated faces:
@@ -498,7 +498,7 @@ class Polyhedron(Basic):
         >>> corners = (a, b, c)
         >>> faces = [(0, 1, 2)]
         >>> Polyhedron(corners, faces).edges
-        FiniteSet((0, 1), (0, 2), (1, 2))
+        {(0, 1), (0, 2), (1, 2)}
 
         """
         if self._edges is None:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -231,9 +231,9 @@ class FunctionClass(ManagedProperties):
         corresponding set will be returned:
 
         >>> Function('f', nargs=1).nargs
-        FiniteSet(1)
+        {1}
         >>> Function('f', nargs=(2, 1)).nargs
-        FiniteSet(1, 2)
+        {1, 2}
 
         The undefined function, after application, also has the nargs
         attribute; the actual number of arguments is always available by
@@ -1003,7 +1003,7 @@ class WildFunction(Function, AtomicExpr):  # type: ignore
 
     >>> F = WildFunction('F', nargs=2)
     >>> F.nargs
-    FiniteSet(2)
+    {2}
     >>> f(x).match(F)
     >>> f(x, y).match(F)
     {F_: f(x, y)}
@@ -1014,7 +1014,7 @@ class WildFunction(Function, AtomicExpr):  # type: ignore
 
     >>> F = WildFunction('F', nargs=(1, 2))
     >>> F.nargs
-    FiniteSet(1, 2)
+    {1, 2}
     >>> f(x).match(F)
     {F_: f(x)}
     >>> f(x, y).match(F)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -141,7 +141,7 @@ class Boolean(Basic):
         >>> from sympy import Symbol, Eq, Or, And
         >>> x = Symbol('x', real=True)
         >>> Eq(x, 0).as_set()
-        FiniteSet(0)
+        {0}
         >>> (x > 0).as_set()
         Interval.open(0, oo)
         >>> And(-2 < x, x < 2).as_set()

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -796,6 +796,8 @@ class StrPrinter(Printer):
             return "set()"
         return '{%s}' % args
 
+    _print_FiniteSet = _print_set
+
     def _print_frozenset(self, s):
         if not s:
             return "frozenset()"

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
 from sympy.core.function import _coeff_isneg
+from sympy.sets.sets import FiniteSet
 from .printer import Printer, print_function
 from sympy.printing.precedence import precedence, PRECEDENCE
 
@@ -796,7 +797,19 @@ class StrPrinter(Printer):
             return "set()"
         return '{%s}' % args
 
-    _print_FiniteSet = _print_set
+    def _print_FiniteSet(self, s):
+        items = sorted(s, key=default_sort_key)
+
+        args = ', '.join(self._print(item) for item in items)
+        if any(item.has(FiniteSet) for item in items):
+            return 'FiniteSet({})'.format(args)
+        return '{{{}}}'.format(args)
+
+    def _print_Partition(self, s):
+        items = sorted(s, key=default_sort_key)
+
+        args = ', '.join(self._print(arg) for arg in items)
+        return 'Partition({})'.format(args)
 
     def _print_frozenset(self, s):
         if not s:

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -892,11 +892,12 @@ def test_RandomDomain():
 
 def test_FiniteSet():
     assert str(FiniteSet(*range(1, 51))) == (
-        'FiniteSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,'
+        '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,'
         ' 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,'
-        ' 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50)'
+        ' 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}'
     )
-    assert str(FiniteSet(*range(1, 6))) == 'FiniteSet(1, 2, 3, 4, 5)'
+    assert str(FiniteSet(*range(1, 6))) == '{1, 2, 3, 4, 5}'
+    assert str(FiniteSet(*[x*y, x**2])) == '{x**2, x*y}'
 
 
 def test_UniversalSet():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -5,7 +5,8 @@ from sympy import (Add, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
     AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice,
-    Q)
+    Q,)
+from sympy.combinatorics.partitions import Partition
 from sympy.core import Expr, Mul
 from sympy.core.parameters import _exp_is_pow
 from sympy.external import import_module
@@ -898,7 +899,12 @@ def test_FiniteSet():
     )
     assert str(FiniteSet(*range(1, 6))) == '{1, 2, 3, 4, 5}'
     assert str(FiniteSet(*[x*y, x**2])) == '{x**2, x*y}'
+    assert str(FiniteSet(FiniteSet(FiniteSet(x, y), 5), FiniteSet(x,y), 5)
+               ) == 'FiniteSet(5, FiniteSet(5, {x, y}), {x, y})'
 
+
+def test_Partition():
+    assert str(Partition(FiniteSet(x, y), {z})) == 'Partition({z}, {x, y})'
 
 def test_UniversalSet():
     assert str(S.UniversalSet) == 'UniversalSet'
@@ -1065,6 +1071,11 @@ def test_str_special_matrices():
 
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
+
+
+def test_issue_21823():
+    assert str(Partition([1, 2])) == 'Partition({1, 2})'
+    assert str(Partition({1, 2})) == 'Partition({1, 2})'
 
 
 def test_issue_21119_21460():

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -60,7 +60,7 @@ class ConditionSet(Set):
 
     >>> c = ConditionSet(x, x < 1, {x, z})
     >>> c.subs(x, y)
-    ConditionSet(x, x < 1, FiniteSet(y, z))
+    ConditionSet(x, x < 1, {y, z})
 
     To check if ``pi`` is in ``c`` use:
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -306,7 +306,7 @@ class ImageSet(Set):
     False
 
     >>> FiniteSet(0, 1, 2, 3, 4, 5, 6, 7, 9, 10).intersect(squares)
-    FiniteSet(1, 4, 9)
+    {1, 4, 9}
 
     >>> square_iterable = iter(squares)
     >>> for i in range(4):
@@ -328,7 +328,7 @@ class ImageSet(Set):
     >>> solutions = ImageSet(Lambda(n, n*pi), S.Integers) # solutions of sin(x) = 0
     >>> dom = Interval(-1, 1)
     >>> dom.intersect(solutions)
-    FiniteSet(0)
+    {0}
 
     See Also
     ========
@@ -1021,7 +1021,7 @@ def normalize_theta_set(theta):
     >>> normalize_theta_set(Interval(-3*pi/2, -pi/2))
     Interval(pi/2, 3*pi/2)
     >>> normalize_theta_set(FiniteSet(0, pi, 3*pi))
-    FiniteSet(0, pi)
+    {0, pi}
 
     """
     from sympy.functions.elementary.trigonometric import _pi_coeff as coeff

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1300,7 +1300,7 @@ class ComplexRegion(Set):
         >>> from sympy import Interval, ComplexRegion
         >>> unit = Interval(0,1)
         >>> ComplexRegion.from_real(unit)
-        CartesianComplexRegion(ProductSet(Interval(0, 1), FiniteSet(0)))
+        CartesianComplexRegion(ProductSet(Interval(0, 1), {0}))
 
         """
         if not sets.is_subset(S.Reals):

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -41,7 +41,7 @@ class PowerSet(Set):
     A power set of a finite set:
 
     >>> PowerSet(FiniteSet(1, 2, 3))
-    PowerSet(FiniteSet(1, 2, 3))
+    PowerSet({1, 2, 3})
 
     A power set of an empty set:
 
@@ -58,9 +58,7 @@ class PowerSet(Set):
     Evaluating the power set of a finite set to its explicit form:
 
     >>> PowerSet(FiniteSet(1, 2, 3)).rewrite(FiniteSet)
-    FiniteSet(FiniteSet(1), FiniteSet(1, 2), FiniteSet(1, 3),
-            FiniteSet(1, 2, 3), FiniteSet(2), FiniteSet(2, 3),
-            FiniteSet(3), EmptySet)
+    {EmptySet, {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
 
     References
     ==========

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -58,7 +58,7 @@ class PowerSet(Set):
     Evaluating the power set of a finite set to its explicit form:
 
     >>> PowerSet(FiniteSet(1, 2, 3)).rewrite(FiniteSet)
-    {EmptySet, {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
+    FiniteSet(EmptySet, {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3})
 
     References
     ==========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -492,7 +492,7 @@ class Set(Basic, EvalfMixin):
 
         >>> A = EmptySet
         >>> A.powerset()
-        FiniteSet(EmptySet)
+        {EmptySet}
 
         A power set of a finite set:
 
@@ -558,9 +558,9 @@ class Set(Basic, EvalfMixin):
 
         >>> from sympy import Interval
         >>> Interval(0, 1).boundary
-        FiniteSet(0, 1)
+        {0, 1}
         >>> Interval(0, 1, True, False).boundary
-        FiniteSet(0, 1)
+        {0, 1}
         """
         return self._boundary
 
@@ -1546,7 +1546,7 @@ class Complement(Set):
 
     >>> from sympy import Complement, FiniteSet
     >>> Complement(FiniteSet(0, 1, 2), FiniteSet(1))
-    FiniteSet(0, 2)
+    {0, 2}
 
     See Also
     =========
@@ -1979,7 +1979,7 @@ class SymmetricDifference(Set):
 
     >>> from sympy import SymmetricDifference, FiniteSet
     >>> SymmetricDifference(FiniteSet(1, 2, 3), FiniteSet(3, 4, 5))
-    FiniteSet(1, 2, 4, 5)
+    {1, 2, 4, 5}
 
     See Also
     ========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1748,18 +1748,18 @@ class FiniteSet(Set):
 
     >>> from sympy import FiniteSet
     >>> FiniteSet(1, 2, 3, 4)
-    FiniteSet(1, 2, 3, 4)
+    {1, 2, 3, 4}
     >>> 3 in FiniteSet(1, 2, 3, 4)
     True
 
     >>> members = [1, 2, 3, 4]
     >>> f = FiniteSet(*members)
     >>> f
-    FiniteSet(1, 2, 3, 4)
+    {1, 2, 3, 4}
     >>> f - FiniteSet(2)
-    FiniteSet(1, 3, 4)
+    {1, 3, 4}
     >>> f + FiniteSet(2, 5)
-    FiniteSet(1, 2, 3, 4, 5)
+    {1, 2, 3, 4, 5}
 
     References
     ==========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -101,7 +101,7 @@ class Set(Basic, EvalfMixin):
         >>> Interval(0, 1) + Interval(2, 3)
         Union(Interval(0, 1), Interval(2, 3))
         >>> Interval(1, 2, True, True) + FiniteSet(2, 3)
-        Union(FiniteSet(3), Interval.Lopen(1, 2))
+        Union({3}, Interval.Lopen(1, 2))
 
         Similarly it is possible to use the '-' operator for set differences:
 
@@ -711,7 +711,7 @@ class ProductSet(Set):
     >>> from sympy import Interval, FiniteSet, ProductSet
     >>> I = Interval(0, 5); S = FiniteSet(1, 2, 3)
     >>> ProductSet(I, S)
-    ProductSet(Interval(0, 5), FiniteSet(1, 2, 3))
+    ProductSet(Interval(0, 5), {1, 2, 3})
 
     >>> (2, 2) in ProductSet(I, S)
     True
@@ -2050,14 +2050,14 @@ class DisjointUnion(Set):
     >>> A = FiniteSet(1, 2, 3)
     >>> B = Interval(0, 5)
     >>> DisjointUnion(A, B)
-    DisjointUnion(FiniteSet(1, 2, 3), Interval(0, 5))
+    DisjointUnion({1, 2, 3}, Interval(0, 5))
     >>> DisjointUnion(A, B).rewrite(Union)
-    Union(ProductSet(FiniteSet(1, 2, 3), FiniteSet(0)), ProductSet(Interval(0, 5), FiniteSet(1)))
+    Union(ProductSet({1, 2, 3}, {0}), ProductSet(Interval(0, 5), {1}))
     >>> C = FiniteSet(Symbol('x'), Symbol('y'), Symbol('z'))
     >>> DisjointUnion(C, C)
-    DisjointUnion(FiniteSet(x, y, z), FiniteSet(x, y, z))
+    DisjointUnion({x, y, z}, {x, y, z})
     >>> DisjointUnion(C, C).rewrite(Union)
-    ProductSet(FiniteSet(x, y, z), FiniteSet(0, 1))
+    ProductSet({x, y, z}, {0, 1})
 
     References
     ==========

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -140,7 +140,7 @@ def solve_rational_inequalities(eqs):
     >>> solve_rational_inequalities([[
     ... ((Poly(-x + 1), Poly(1, x)), '>='),
     ... ((Poly(-x + 1), Poly(1, x)), '<=')]])
-    FiniteSet(1)
+    {1}
 
     >>> solve_rational_inequalities([[
     ... ((Poly(x), Poly(1, x)), '!='),

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -28,13 +28,13 @@ def solve_poly_inequality(poly, rel):
     >>> from sympy.solvers.inequalities import solve_poly_inequality
 
     >>> solve_poly_inequality(Poly(x, x, domain='ZZ'), '==')
-    [FiniteSet(0)]
+    [{0}]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '!=')
     [Interval.open(-oo, -1), Interval.open(-1, 1), Interval.open(1, oo)]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '==')
-    [FiniteSet(-1), FiniteSet(1)]
+    [{-1}, {1}]
 
     See Also
     ========

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -914,7 +914,7 @@ def solve_decomposition(f, symbol, domain):
     >>> x = Symbol('x')
     >>> f1 = exp(2*x) - 3*exp(x) + 2
     >>> sd(f1, x, S.Reals)
-    FiniteSet(0, log(2))
+    {0, log(2)}
     >>> f2 = sin(x)**2 + 2*sin(x) + 1
     >>> pprint(sd(f2, x, S.Reals), use_unicode=False)
               3*pi
@@ -1494,9 +1494,9 @@ def _solve_exponential(lhs, rhs, symbol, domain):
     >>> solve_expo(a**x - b**x, 0, x, S.Reals)  # solvable but incorrect assumptions
     ConditionSet(x, (a > 0) & (b > 0), FiniteSet(0))
     >>> solve_expo(3**(2*x) - 2**(x + 3), 0, x, S.Reals)
-    FiniteSet(-3*log(2)/(-2*log(3) + log(2)))
+    {-3*log(2)/(-2*log(3) + log(2))}
     >>> solve_expo(2**x - 4**x, 0, x, S.Reals)
-    FiniteSet(0)
+    {0}
 
     * Proof of correctness of the method
 
@@ -1654,7 +1654,7 @@ def _solve_logarithm(lhs, rhs, symbol, domain):
     >>> x = symbols('x')
     >>> f = log(x - 3) + log(x + 3)
     >>> solve_log(f, 0, x, S.Reals)
-    FiniteSet(sqrt(10), -sqrt(10))
+    {sqrt(10), -sqrt(10)}
 
     * Proof of correctness
 
@@ -1900,7 +1900,7 @@ def _transolve(f, symbol, domain):
     >>> from sympy import symbols, S, pprint
     >>> x = symbols('x', real=True) # assumption added
     >>> transolve(5**(x - 3) - 3**(2*x + 1), x, S.Reals)
-    FiniteSet(-(log(3) + 3*log(5))/(-log(5) + 2*log(3)))
+    {-(log(3) + 3*log(5))/(-log(5) + 2*log(3))}
 
     How ``_transolve`` works
     ========================
@@ -2142,9 +2142,9 @@ def solveset(f, symbol=None, domain=S.Complexes):
     >>> R = S.Reals
     >>> x = Symbol('x')
     >>> solveset(exp(x) - 1, x, R)
-    FiniteSet(0)
+    {0}
     >>> solveset_real(exp(x) - 1, x)
-    FiniteSet(0)
+    {0}
 
     The solution is unaffected by assumptions on the symbol:
 
@@ -2673,7 +2673,7 @@ def linsolve(system, *symbols):
     [6],
     [9]])
     >>> linsolve((A, b), [x, y, z])
-    FiniteSet((-1, 2, 0))
+    {(-1, 2, 0)}
 
     * Parametric Solution: In case the system is underdetermined, the
       function will return a parametric solution in terms of the given
@@ -2684,20 +2684,20 @@ def linsolve(system, *symbols):
     >>> A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> b = Matrix([3, 6, 9])
     >>> linsolve((A, b), x, y, z)
-    FiniteSet((z - 1, 2 - 2*z, z))
+    {(z - 1, 2 - 2*z, z)}
 
     If no symbols are given, internally generated symbols will be used.
     The `tau0` in the 3rd position indicates (as before) that the 3rd
     variable -- whatever it's named -- can take on any value:
 
     >>> linsolve((A, b))
-    FiniteSet((tau0 - 1, 2 - 2*tau0, tau0))
+    {(tau0 - 1, 2 - 2*tau0, tau0)}
 
     * List of Equations as input
 
     >>> Eqns = [3*x + 2*y - z - 1, 2*x - 2*y + 4*z + 2, - x + y/2 - z]
     >>> linsolve(Eqns, x, y, z)
-    FiniteSet((1, -2, -2))
+    {(1, -2, -2)}
 
     * Augmented Matrix as input
 
@@ -2708,21 +2708,21 @@ def linsolve(system, *symbols):
     [2, 6,  8, 3],
     [6, 8, 18, 5]])
     >>> linsolve(aug, x, y, z)
-    FiniteSet((3/10, 2/5, 0))
+    {(3/10, 2/5, 0)}
 
     * Solve for symbolic coefficients
 
     >>> a, b, c, d, e, f = symbols('a, b, c, d, e, f')
     >>> eqns = [a*x + b*y - c, d*x + e*y - f]
     >>> linsolve(eqns, x, y)
-    FiniteSet(((-b*f + c*e)/(a*e - b*d), (a*f - c*d)/(a*e - b*d)))
+    {((-b*f + c*e)/(a*e - b*d), (a*f - c*d)/(a*e - b*d))}
 
     * A degenerate system returns solution as set of given
       symbols.
 
     >>> system = Matrix(([0, 0, 0], [0, 0, 0], [0, 0, 0]))
     >>> linsolve(system, x, y)
-    FiniteSet((x, y))
+    {(x, y)}
 
     * For an empty system linsolve returns empty set
 
@@ -2733,7 +2733,7 @@ def linsolve(system, *symbols):
       is detected:
 
     >>> linsolve([x*(1/x - 1), (y - 1)**2 - y**2 + 1], x, y)
-    FiniteSet((1, 1))
+    {(1, 1)}
     >>> linsolve([x**2 - 1], x)
     Traceback (most recent call last):
     ...
@@ -2906,28 +2906,28 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
     >>> x, y = symbols('x, y', real=True)
     >>> from sympy.solvers.solveset import substitution
     >>> substitution([x + y], [x], [{y: 1}], [y], set([]), [x, y])
-    FiniteSet((-1, 1))
+    {(-1, 1)}
 
     * when you want soln should not satisfy eq `x + 1 = 0`
 
     >>> substitution([x + y], [x], [{y: 1}], [y], set([x + 1]), [y, x])
     EmptySet
     >>> substitution([x + y], [x], [{y: 1}], [y], set([x - 1]), [y, x])
-    FiniteSet((1, -1))
+    {(1, -1)}
     >>> substitution([x + y - 1, y - x**2 + 5], [x, y])
-    FiniteSet((-3, 4), (2, -1))
+    {(-3, 4), (2, -1)}
 
     * Returns both real and complex solution
 
     >>> x, y, z = symbols('x, y, z')
     >>> from sympy import exp, sin
     >>> substitution([exp(x) - sin(y), y**2 - 4], [x, y])
-    FiniteSet((ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2),
+    {(ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2},
             (ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2))
 
     >>> eqs = [z**2 + exp(2*x) - sin(y), -3 + exp(-y)]
     >>> substitution(eqs, [y, z])
-    FiniteSet((-log(3), sqrt(-exp(2*x) - sin(log(3)))),
+    {(-log(3), sqrt(-exp(2*x) - sin(log(3)))},
     (-log(3), -sqrt(-exp(2*x) - sin(log(3)))),
     (ImageSet(Lambda(_n, 2*_n*I*pi - log(3)), Integers),
        ImageSet(Lambda(_n, sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers)),
@@ -3527,7 +3527,7 @@ def nonlinsolve(system, *symbols):
     >>> from sympy.solvers.solveset import nonlinsolve
     >>> x, y, z = symbols('x, y, z', real=True)
     >>> nonlinsolve([x*y - 1, 4*x**2 + y**2 - 5], [x, y])
-    FiniteSet((-1, -1), (-1/2, -2), (1/2, 2), (1, 1))
+    {(-1, -1), (-1/2, -2), (1/2, 2), (1, 1)}
 
     1. Positive dimensional system and complements:
 
@@ -3546,7 +3546,7 @@ def nonlinsolve(system, *symbols):
     {(---, -d, -, {d} \ {0}), (-, -d, ---, {d} \ {0})}
        d       d               d       d
     >>> nonlinsolve([(x+y)**2 - 4, x + y - 2], [x, y])
-    FiniteSet((2 - y, y))
+    {(2 - y, y)}
 
     2. If some of the equations are non-polynomial then `nonlinsolve`
     will call the `substitution` function and return real and complex solutions,
@@ -3554,7 +3554,7 @@ def nonlinsolve(system, *symbols):
 
     >>> from sympy import exp, sin
     >>> nonlinsolve([exp(x) - sin(y), y**2 - 4], [x, y])
-    FiniteSet((ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2),
+    {(ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2},
             (ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2))
 
 
@@ -3564,7 +3564,7 @@ def nonlinsolve(system, *symbols):
 
     >>> from sympy import sqrt
     >>> nonlinsolve([x**2 - 2*y**2 -2, x*y - 2], [x, y])
-    FiniteSet((-2, -1), (2, 1), (-sqrt(2)*I, sqrt(2)*I), (sqrt(2)*I, -sqrt(2)*I))
+    {(-2, -1), (2, 1), (-sqrt(2)*I, sqrt(2)*I), (sqrt(2)*I, -sqrt(2)*I)}
 
     4. `nonlinsolve` can solve some linear (zero or positive dimensional)
     system (because it uses the `groebner` function to get the
@@ -3573,7 +3573,7 @@ def nonlinsolve(system, *symbols):
     `nonlinsolve`, because `linsolve` is better for general linear systems.
 
     >>> nonlinsolve([x + 2*y -z - 3, x - y - 4*z + 9 , y + z - 4], [x, y, z])
-    FiniteSet((3*z - 5, 4 - z, z))
+    {(3*z - 5, 4 - z, z)}
 
     5. System having polynomial equations and only real solution is
     solved using `solve_poly_system`:
@@ -3581,11 +3581,11 @@ def nonlinsolve(system, *symbols):
     >>> e1 = sqrt(x**2 + y**2) - 10
     >>> e2 = sqrt(y**2 + (-x + 10)**2) - 3
     >>> nonlinsolve((e1, e2), (x, y))
-    FiniteSet((191/20, -3*sqrt(391)/20), (191/20, 3*sqrt(391)/20))
+    {(191/20, -3*sqrt(391)/20), (191/20, 3*sqrt(391)/20)}
     >>> nonlinsolve([x**2 + 2/y - 2, x + y - 3], [x, y])
-    FiniteSet((1, 2), (1 - sqrt(5), 2 + sqrt(5)), (1 + sqrt(5), 2 - sqrt(5)))
+    {(1, 2), (1 - sqrt(5), 2 + sqrt(5)), (1 + sqrt(5), 2 - sqrt(5))}
     >>> nonlinsolve([x**2 + 2/y - 2, x + y - 3], [y, x])
-    FiniteSet((2, 1), (2 - sqrt(5), 1 + sqrt(5)), (2 + sqrt(5), 1 - sqrt(5)))
+    {(2, 1), (2 - sqrt(5), 1 + sqrt(5)), (2 + sqrt(5), 1 - sqrt(5))}
 
     6. It is better to use symbols instead of Trigonometric Function or
     Function (e.g. replace `sin(x)` with symbol, replace `f(x)` with symbol

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -144,14 +144,14 @@ def _invert(f_x, y, x, domain=S.Complexes):
     >>> invert_complex(exp(x), y, x)
     (x, ImageSet(Lambda(_n, I*(2*_n*pi + arg(y)) + log(Abs(y))), Integers))
     >>> invert_real(exp(x), y, x)
-    (x, Intersection(FiniteSet(log(y)), Reals))
+    (x, Intersection({log(y)}, Reals))
 
     When does exp(x) == 1?
 
     >>> invert_complex(exp(x), 1, x)
     (x, ImageSet(Lambda(_n, 2*_n*I*pi), Integers))
     >>> invert_real(exp(x), 1, x)
-    (x, FiniteSet(0))
+    (x, {0})
 
     See Also
     ========
@@ -1492,7 +1492,7 @@ def _solve_exponential(lhs, rhs, symbol, domain):
     >>> solve_expo(2**x + 3**x - 5**x, 0, x, S.Reals)  # not solvable
     ConditionSet(x, Eq(2**x + 3**x - 5**x, 0), Reals)
     >>> solve_expo(a**x - b**x, 0, x, S.Reals)  # solvable but incorrect assumptions
-    ConditionSet(x, (a > 0) & (b > 0), FiniteSet(0))
+    ConditionSet(x, (a > 0) & (b > 0), {0})
     >>> solve_expo(3**(2*x) - 2**(x + 3), 0, x, S.Reals)
     {-3*log(2)/(-2*log(3) + log(2))}
     >>> solve_expo(2**x - 4**x, 0, x, S.Reals)
@@ -1654,7 +1654,7 @@ def _solve_logarithm(lhs, rhs, symbol, domain):
     >>> x = symbols('x')
     >>> f = log(x - 3) + log(x + 3)
     >>> solve_log(f, 0, x, S.Reals)
-    {sqrt(10), -sqrt(10)}
+    {-sqrt(10), sqrt(10)}
 
     * Proof of correctness
 
@@ -2922,17 +2922,17 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
     >>> x, y, z = symbols('x, y, z')
     >>> from sympy import exp, sin
     >>> substitution([exp(x) - sin(y), y**2 - 4], [x, y])
-    {(ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2},
-            (ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2))
+    {(ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2),
+     (ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2)}
 
     >>> eqs = [z**2 + exp(2*x) - sin(y), -3 + exp(-y)]
     >>> substitution(eqs, [y, z])
-    {(-log(3), sqrt(-exp(2*x) - sin(log(3)))},
-    (-log(3), -sqrt(-exp(2*x) - sin(log(3)))),
-    (ImageSet(Lambda(_n, 2*_n*I*pi - log(3)), Integers),
-       ImageSet(Lambda(_n, sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers)),
-    (ImageSet(Lambda(_n, 2*_n*I*pi - log(3)), Integers),
-       ImageSet(Lambda(_n, -sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers)))
+    {(-log(3), -sqrt(-exp(2*x) - sin(log(3)))),
+     (-log(3), sqrt(-exp(2*x) - sin(log(3)))),
+     (ImageSet(Lambda(_n, 2*_n*I*pi - log(3)), Integers),
+      ImageSet(Lambda(_n, -sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers)),
+     (ImageSet(Lambda(_n, 2*_n*I*pi - log(3)), Integers),
+      ImageSet(Lambda(_n, sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers))}
 
     """
 
@@ -3554,9 +3554,8 @@ def nonlinsolve(system, *symbols):
 
     >>> from sympy import exp, sin
     >>> nonlinsolve([exp(x) - sin(y), y**2 - 4], [x, y])
-    {(ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2},
-            (ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2))
-
+    {(ImageSet(Lambda(_n, I*(2*_n*pi + pi) + log(sin(2))), Integers), -2),
+     (ImageSet(Lambda(_n, 2*_n*I*pi + log(sin(2))), Integers), 2)}
 
     3. If system is non-linear polynomial and zero-dimensional then it
     returns both solution (real and complex solutions, if present) using

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -411,10 +411,10 @@ def median(X, evaluate=True, **kwargs):
     >>> from sympy.stats import Normal, Die, median
     >>> N = Normal('N', 3, 1)
     >>> median(N)
-    FiniteSet(3)
+    {3}
     >>> D = Die('D')
     >>> median(D)
-    FiniteSet(3, 4)
+    {3, 4}
 
     References
     ==========

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -816,7 +816,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     >>> YS = DiscreteMarkovChain("Y")
 
     >>> Y.state_space
-    FiniteSet(0, 1, 2)
+    {0, 1, 2}
     >>> Y.transition_probabilities
     Matrix([
     [0.5, 0.2, 0.3],
@@ -1489,7 +1489,7 @@ class ContinuousMarkovChain(ContinuousTimeStochasticProcess, MarkovProcess):
     >>> C.limiting_distribution()
     Matrix([[1/2, 1/2]])
     >>> C.state_space
-    FiniteSet(0, 1)
+    {0, 1}
     >>> C.generator_matrix
     Matrix([
     [-1,  1],
@@ -1613,7 +1613,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     >>> from sympy import Eq, Gt
     >>> B = BernoulliProcess("B", p=0.7, success=1, failure=0)
     >>> B.state_space
-    FiniteSet(0, 1)
+    {0, 1}
     >>> (B.p).round(2)
     0.70
     >>> B.success

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -36,7 +36,7 @@ class ImplicitRegion(Basic):
     >>> r.variables
     (x, y, z)
     >>> r.singular_points()
-    FiniteSet((0, 0, 0))
+    {(0, 0, 0)}
     >>> r.regular_point()
     (-10, -10, 200)
 
@@ -288,7 +288,7 @@ class ImplicitRegion(Basic):
         >>> from sympy.vector import ImplicitRegion
         >>> I = ImplicitRegion((x, y), (y-1)**2 -x**3 + 2*x**2 -x)
         >>> I.singular_points()
-        FiniteSet((1, 1))
+        {(1, 1)}
 
         """
         eq_list = [self.equation]
@@ -311,7 +311,7 @@ class ImplicitRegion(Basic):
         >>> from sympy.vector import ImplicitRegion
         >>> I = ImplicitRegion((x, y, z), x**2 + y**3 - z**4)
         >>> I.singular_points()
-        FiniteSet((0, 0, 0))
+        {(0, 0, 0)}
         >>> I.multiplicity((0, 0, 0))
         2
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #21823

#### Brief description of what is fixed or changed
`FiniteSet` is now printed with `{}`, see #21823.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
     * `FiniteSet` now prints as `{...}` instead of `FiniteSet(...)` in the string printer, unless it contains a `FiniteSet`.   
<!-- END RELEASE NOTES -->
