### PR TITLE
Make inverse of matrix containing matrix elements work

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -718,7 +718,10 @@ class MatrixElement(Expr):
             args = [arg.doit(**kwargs) for arg in self.args]
         else:
             args = self.args
-        return args[0][args[1], args[2]]
+        if isinstance(args[0], Transpose):
+            return self.func(args[0].arg, args[2], args[1])
+        else:
+            return self.func(*args)
 
     @property
     def indices(self):

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -505,3 +505,12 @@ def test_matrixsymbol_solving():
     assert (-(-A + B) - A + B).expand() == Z
     assert (-(-A + B) - A + B - Z).simplify() == Z
     assert (-(-A + B) - A + B - Z).expand() == Z
+
+
+def test_issue_19162():
+    X = Matrix(MatrixSymbol('X', 2, 2))
+    det = X.det()
+    assert X.inv() == Matrix([
+        [X[1, 1] / det, -X[0, 1] / det],
+        [-X[1, 0] / det, X[0, 0] / det],
+    ])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19162
Fixes #19217
Fixes https://github.com/sympy/sympy/pull/20691


#### Brief description of what is fixed or changed

MatrixElement.doit( ) method used to raise exceptions if the symbol of the matrix was not a matrix symbol. It usually makes sense, but some algorithms testing for constantness of the expressions were trying some random substitutions.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * inversion of matrices containing matrix elements now work
<!-- END RELEASE NOTES -->
