### PR TITLE
Core: Fixes PoleError by invoking aseries() when series() fails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -582,3 +582,4 @@ Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Rahil Parikh <r.parikh@somaiya.edu> rprkh <r.parikh@somaiya.edu>
 Yaser AlOsh <yaseralosh@outlook.com> Yaser <yaseralosh@outlook.com>
 Joannah Nanjekye <joannah.nanjekye@ibm.com> nanjekyejoannah <joannah.nanjekye@ibm.com>
+Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1091 authors.
+There are a total of 1092 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1097,3 +1097,4 @@ Rahil Parikh <r.parikh@somaiya.edu>
 Jason Ross <jasonross1024@gmail.com>
 Joannah Nanjekye <joannah.nanjekye@ibm.com>
 Ayush Kumar <ayushk7102@gmail.com>
+Kshitij <kshitijparwani.mat18@itbhu.ac.in>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2939,7 +2939,7 @@ class Expr(Basic, EvalfMixin):
             If "x0" is an infinity object
 
         """
-        from sympy import collect, Dummy, Order, Rational, Symbol, ceiling
+        from sympy import collect, Dummy, Order, Rational, Symbol, ceiling, PoleError
         if x is None:
             syms = self.free_symbols
             if not syms:
@@ -2963,11 +2963,15 @@ class Expr(Basic, EvalfMixin):
             raise ValueError("Dir must be '+' or '-'")
 
         if x0 in [S.Infinity, S.NegativeInfinity]:
-            sgn = 1 if x0 is S.Infinity else -1
-            s = self.subs(x, sgn/x).series(x, n=n, dir='+', cdir=cdir)
-            if n is None:
-                return (si.subs(x, sgn/x) for si in s)
-            return s.subs(x, sgn/x)
+            try:
+                sgn = 1 if x0 is S.Infinity else -1
+                s = self.subs(x, sgn/x).series(x, n=n, dir='+', cdir=cdir)
+                if n is None:
+                    return (si.subs(x, sgn/x) for si in s)
+                return s.subs(x, sgn/x)
+            except PoleError:
+                s = self.subs(x, sgn*x).aseries(x, n=n)
+                return s.subs(x, sgn*x)
 
         # use rep to shift origin to x0 and change sign (if dir is negative)
         # and undo the process with rep2

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -337,3 +337,8 @@ def test_issue_21245():
         (-6964*sqrt(5) - 15572 + 2440*sqrt(5)*x + 5456*x\
         + O((x - 2/(1 + sqrt(5)))**2, (x, 2/(1 + sqrt(5)))))/((1 + sqrt(5))**2\
         *(20 + 9*sqrt(5))**2*(x + sqrt(5)*x - 2))
+
+
+def test_issue_21938():
+    expr = sin(1/x + exp(-x)) - sin(1/x)
+    assert expr.series(x, oo) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)


### PR DESCRIPTION
Fixes: #21938 

#### Brief description of what is fixed or changed
 Earlier, calling `series()` on `sin(1/x + exp(-x)) - sin(1/x)` at `oo` would give `PoleError` although `aseries()` was able to return a correct expansion. 

`PoleError` indicates that the power series expansion for this function does not exist at `oo` and therefore it makes sense to invoke `aseries()` to resolve this issue.

#### Other Comments
Regression Test has been added.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
  * Fixes `PoleError` by invoking `aseries()` when `series()` fails
<!-- END RELEASE NOTES -->