### PR TITLE
Rational works with ints at instantiation

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1624,18 +1624,22 @@ class Rational(Number):
 
             q = 1
             gcd = 1
-        else:
-            p = Rational(p)
-            q = Rational(q)
 
-        if isinstance(q, Rational):
-            p *= q.q
-            q = q.p
-        if isinstance(p, Rational):
+        if not isinstance(p, SYMPY_INTS):
+            p = Rational(p)
             q *= p.q
             p = p.p
+        else:
+            p = int(p)
 
-        # p and q are now integers
+        if not isinstance(q, SYMPY_INTS):
+            q = Rational(q)
+            p *= q.q
+            q = q.p
+        else:
+            q = int(q)
+
+        # p and q are now ints
         if q == 0:
             if p == 0:
                 if _errdict["divide"]:

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1341,6 +1341,7 @@ class _EditArrayContraction:
         if array_contraction is None:
             self.args_with_ind: List[_ArgE] = []
             self.number_of_contraction_indices: int = 0
+            self._track_permutation: Optional[List[int]] = None
             return
         expr = array_contraction.expr
         if isinstance(expr, ArrayTensorProduct):
@@ -1355,6 +1356,7 @@ class _EditArrayContraction:
                 args_with_ind[arg_pos].indices[rel_pos] = i
         self.args_with_ind: List[_ArgE] = args_with_ind
         self.number_of_contraction_indices: int = len(array_contraction.contraction_indices)
+        self._track_permutation: Optional[List[int]] = None
 
     def insert_after(self, arg: _ArgE, new_arg: _ArgE):
         pos = self.args_with_ind.index(arg)
@@ -1393,7 +1395,7 @@ class _EditArrayContraction:
         args = [arg.element for arg in self.args_with_ind]
         contraction_indices = self.get_contraction_indices()
         expr = ArrayContraction(ArrayTensorProduct(*args), *contraction_indices)
-        if hasattr(self, '_track_permutation'):
+        if self._track_permutation is not None:
             permutation = _af_invert([j for i in self._track_permutation for j in i])
             expr = PermuteDims(expr, permutation)
         return expr

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1289,9 +1289,12 @@ class _ArgE:
     the second index is contracted to the 4th (i.e. number ``3``) group of the
     array contraction object.
     """
-    def __init__(self, element):
+    def __init__(self, element, indices: Optional[List[Optional[int]]] = None):
         self.element = element
-        self.indices: List[Optional[int]] = [None for i in range(get_rank(element))]
+        if indices is None:
+            self.indices: List[Optional[int]] = [None for i in range(get_rank(element))]
+        else:
+            self.indices: List[Optional[int]] = indices
 
     def __str__(self):
         return "_ArgE(%s, %s)" % (self.element, self.indices)
@@ -1334,7 +1337,11 @@ class _EditArrayContraction:
     by calling the ``.to_array_contraction()`` method.
     """
 
-    def __init__(self, array_contraction: ArrayContraction):
+    def __init__(self, array_contraction: Optional[ArrayContraction]):
+        if array_contraction is None:
+            self.args_with_ind: List[_ArgE] = []
+            self.number_of_contraction_indices: int = 0
+            return
         expr = array_contraction.expr
         if isinstance(expr, ArrayTensorProduct):
             args = list(expr.args)

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -1,5 +1,5 @@
 import itertools
-from collections import defaultdict
+from collections import defaultdict, Counter
 from typing import Tuple, Union, FrozenSet, Dict, List, Optional
 from functools import singledispatch
 from itertools import accumulate
@@ -230,7 +230,7 @@ def _(expr: PermuteDims):
                 args_array[i] = mat_mul_lines.args[pos]
         return _a2m_tensor_product(*args_array)
     else:
-        raise NotImplementedError()
+        return expr
 
 
 @_array2matrix.register(ArrayAdd)
@@ -621,8 +621,6 @@ def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
                 arg_pos, rel_pos = mapping[j]
                 editor.args_with_ind[arg_pos].indices[rel_pos] = -1 - i
 
-    ret_diag = []
-
     map_contr_to_args: Dict[FrozenSet, List[_ArgE]] = defaultdict(list)
     map_ind_to_inds = defaultdict(int)
     for arg_with_ind in editor.args_with_ind:
@@ -632,6 +630,8 @@ def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
             continue
         map_contr_to_args[frozenset(arg_with_ind.indices)].append(arg_with_ind)
 
+    k: FrozenSet[int]
+    v: List[_ArgE]
     for k, v in map_contr_to_args.items():
         if len(k) != 2:
             # Hadamard product only defined for matrices:
@@ -644,6 +644,11 @@ def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
                 # There is no other contraction, skip:
                 continue
 
+        # Check if expression is a trace:
+        if all([map_ind_to_inds[j] == len(v) and j >= 0 for j in k]):
+            # This is a trace
+            continue
+
         # This is a Hadamard product:
 
         def check_transpose(x):
@@ -652,16 +657,32 @@ def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
 
         hp = hadamard_product(*[i.element if check_transpose(i.indices) else Transpose(i.element) for i in v])
         hp_indices = v[0].indices
-        # Mark diagonal indices for removal:
-        ret_diag.extend([i for i in k if i < 0])
+        if not check_transpose(v[0].indices):
+            hp_indices = list(reversed(hp_indices))
         editor.insert_after(v[0], _ArgE(hp, hp_indices))
         for i in v:
             editor.args_with_ind.remove(i)
 
     # Count the ranks of the arguments:
     counter = 0
-    diag_new_pos = {}
+    # Create a collector for the new diagonal indices:
     diag_indices = defaultdict(list)
+
+    count_index_freq = Counter()
+    for arg_with_ind in editor.args_with_ind:
+        count_index_freq.update(Counter(arg_with_ind.indices))
+
+    free_index_count = count_index_freq[None]
+
+    # Construct the inverse permutation:
+    inv_perm1 = []
+    inv_perm2 = []
+    # Keep track of which diagonal indices have already been processed:
+    done = set([])
+
+    # Counter for the diagonal indices:
+    counter4 = 0
+
     for arg_with_ind in editor.args_with_ind:
         # If some diagonalization axes have been removed, they should be
         # permuted in order to keep the permutation.
@@ -669,37 +690,35 @@ def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
         counter2 = 0  # counter for the indices
         for i in arg_with_ind.indices:
             if i is None:
+                inv_perm1.append(counter4)
                 counter2 += 1
+                counter4 += 1
                 continue
             if i >= 0:
                 continue
-            if i < 0:
-                # Reconstruct the diagonal indices:
-                diag_indices[-1 - i].append(counter + counter2)
-            if i < 0 and i in ret_diag:
-                diag_new_pos[-1-i] = counter + counter2
+            # Reconstruct the diagonal indices:
+            diag_indices[-1 - i].append(counter + counter2)
+            if count_index_freq[i] == 1 and i not in done:
+                inv_perm1.append(free_index_count - 1 - i)
+                done.add(i)
+            elif i not in done:
+                inv_perm2.append(free_index_count - 1 - i)
+                done.add(i)
             counter2 += 1
+        # Remove negative indices to restore a proper editor object:
         arg_with_ind.indices = [i if i is not None and i >= 0 else None for i in arg_with_ind.indices]
-        counter += len([i for i in arg_with_ind.indices if i is None])
+        counter += len([i for i in arg_with_ind.indices if i is None or i < 0])
 
-    # Get the diagonal indices after the detection of HadamardProduct in the expression:
-    diag_indices2 = [tuple(v) for v in diag_indices.values() if len(v) > 1]
+    inverse_permutation = inv_perm1 + inv_perm2
+    permutation = _af_invert(inverse_permutation)
 
     if isinstance(expr, ArrayContraction):
         return editor.to_array_contraction()
     else:
-        # This is an array diagonal, we need to find the permutation:
-        non_diag_rank = get_rank(expr) - len(expr.diagonal_indices)
-        # diag_new_pos maps the index of the diagonal_indices array to the new positions,
-        # they are no longer diagonalized because of the recognition of Hadamard products.
-        # They still need to undergo the same permutation as ArrayDiagonal was applying to them:
-        go_to = {j: non_diag_rank + i for i, j in diag_new_pos.items()}
-        inverse_permutation = list(range(get_rank(expr)))
-        for i, j in go_to.items():
-            inverse_permutation.remove(i)
-            inverse_permutation.insert(j, i)
-        permutation = _af_invert(inverse_permutation)
+        # Get the diagonal indices after the detection of HadamardProduct in the expression:
+        diag_indices_filtered = [tuple(v) for v in diag_indices.values() if len(v) > 1]
+
         expr1 = editor.to_array_contraction()
-        expr2 = ArrayDiagonal(expr1, *diag_indices2)
+        expr2 = ArrayDiagonal(expr1, *diag_indices_filtered)
         expr3 = PermuteDims(expr2, permutation)
         return expr3

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -483,7 +483,7 @@ def test_convert_array_to_hadamard_products():
     # ArrayDiagonal should be converted
     cg = ArrayDiagonal(ArrayTensorProduct(M, N, Q), (1, 3), (0, 2, 4))
     ret = convert_array_to_matrix(cg)
-    expected = PermuteDims(ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M, N), Q), (0, 2)), [1, 0, 2])
+    expected = PermuteDims(ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M.T, N.T), Q), (1, 2)), [1, 0, 2])
     assert expected == ret
 
     # Special case that should return the same expression:

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,5 +1,5 @@
 from sympy import (
-    symbols, Identity, cos, ZeroMatrix, OneMatrix, sqrt)
+    symbols, Identity, cos, ZeroMatrix, OneMatrix, sqrt, HadamardProduct)
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 from sympy.tensor.array.expressions.conv_array_to_matrix import _support_function_tp1_recognize, \
     _array_diag2contr_diagmatrix, convert_array_to_matrix, _remove_trivial_dims, _array2matrix
@@ -442,3 +442,47 @@ def test_arrayexpr_convert_array_to_matrix_support_function():
     assert _support_function_tp1_recognize([(0, 4), (1, 7), (2, 5), (3, 8)], [X, A, B, C, D]) == C*X.T*B*A*D
 
     assert _support_function_tp1_recognize([(0, 4), (1, 7), (2, 5), (3, 8)], [X, A, B, C, D]) == C*X.T*B*A*D
+
+
+def test_convert_array_to_hadamard_products():
+
+    expr = HadamardProduct(M, N)
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert ret == expr
+
+    expr = HadamardProduct(M, N)*P
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert ret == expr
+
+    expr = Q*HadamardProduct(M, N)*P
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert ret == expr
+
+    expr = Q*HadamardProduct(M, N.T)*P
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert ret == expr
+
+    expr = HadamardProduct(M, N)*HadamardProduct(Q, P)
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert expr == ret
+
+    expr = P.T*HadamardProduct(M, N)*HadamardProduct(Q, P)
+    cg = convert_matrix_to_array(expr)
+    ret = convert_array_to_matrix(cg)
+    assert expr == ret
+
+    # ArrayDiagonal should be converted
+    cg = ArrayDiagonal(ArrayTensorProduct(M, N, Q), (1, 3), (0, 2, 4))
+    ret = convert_array_to_matrix(cg)
+    expected = PermuteDims(ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M, N), Q), (0, 2)), [1, 0, 2])
+    assert expected == ret
+
+    # Special case that should return the same expression:
+    cg = ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M, N), Q), (0, 2))
+    ret = convert_array_to_matrix(cg)
+    assert ret == cg


### PR DESCRIPTION
Discussion in #21910 indicated that Rational goes through the Rational path even for int input. Now it doesn't.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
