### PR TITLE
Added gateinputcount method for Boolean functions

### DIFF
--- a/doc/src/modules/logic.rst
+++ b/doc/src/modules/logic.rst
@@ -112,6 +112,8 @@ Disjunctive, and Negated Normal forms:
 
 .. autofunction:: sympy.logic.boolalg::is_nnf
 
+.. autofunction:: sympy.logic.boolalg::gateinputcount
+
 Simplification and equivalence-testing
 --------------------------------------
 

--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,11 +1,12 @@
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
-    Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false)
+    Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false,
+    gateinputcount)
 from .inference import satisfiable
 
 __all__ = [
     'to_cnf', 'to_dnf', 'to_nnf', 'And', 'Or', 'Not', 'Xor', 'Nand', 'Nor',
     'Implies', 'Equivalent', 'ITE', 'POSform', 'SOPform', 'simplify_logic',
-    'bool_map', 'true', 'false',
+    'bool_map', 'true', 'false', 'gateinputcount',
 
     'satisfiable',
 ]

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3449,7 +3449,7 @@ def gateinputcount(expr):
     Not all Boolean functions count as gate here, only those that are
     considered to be standard gates. These are: ``And``, ``Or``, ``Xor``,
     ``Not``, and ``ITE`` (multiplexer). ``Nand``, ``Nor``, and ``Xnor`` will
-    be evalutated to ``Not(And())`` etc.
+    be evaluated to ``Not(And())`` etc.
 
     Examples
     ========

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -17,7 +17,8 @@ from sympy.logic.boolalg import (
     BooleanAtom, is_literal, term_to_integer,
     truth_table, as_Boolean, to_anf, is_anf, distribute_xor_over_and,
     anf_coeffs, ANFform, bool_minterm, bool_maxterm, bool_monomial,
-    _check_pair, _convert_to_varsSOP, _convert_to_varsPOS, Exclusive,)
+    _check_pair, _convert_to_varsSOP, _convert_to_varsPOS, Exclusive,
+    gateinputcount)
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
@@ -1264,6 +1265,14 @@ def test_convert_to_varsSOP():
 def test_convert_to_varsPOS():
     assert _convert_to_varsPOS([0, 1, 0], [x, y, z]) == Or(x, Not(y), z)
     assert _convert_to_varsPOS([3, 1, 0], [x, y, z]) ==  Or(Not(y), z)
+
+
+def test_gateinputcount():
+    a, b, c, d, e = symbols('a:e')
+    assert gateinputcount(And(a, b)) == 2
+    assert gateinputcount(a | b & c & d ^ (e | a)) == 9
+    assert gateinputcount(And(a, True)) == 0
+    raises(TypeError, lambda: gateinputcount(a*b))
 
 
 def test_refine():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18982

#### Brief description of what is fixed or changed
A function `gateinputcount()` is added to `boolalg.py` and works for the boolean functions corresponding to gates. This is quite handy as the complexity of a digital circuit is often measures/estimated based on this.

#### Other comments
Ideally one should not rewrite `Nand` and `Not(And())` and correspondingly for `Nor` for this to really make sense. However, it is explicitly mentioned in the documentation.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
   * Function `gateinputcount` added to returns the total number of inputs for all classes corresponding to gates in the expression.  
<!-- END RELEASE NOTES -->
