### PR TITLE
Fixed partial subs in Boolean expressions

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -728,8 +728,10 @@ class And(LatticeOp, BooleanFunction):
         # If old is And, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, And):
-            if all(a in args for a in old.args):
-                args = [new] + [a for a in args if a not in old.args]
+            old_args = set(old.args)
+            sd = old_args.symmetric_difference(set(args))
+            if not sd & old_args:
+                args = [new] + list(sd)
 
         return self.func(*args)
 
@@ -881,8 +883,10 @@ class Or(LatticeOp, BooleanFunction):
         # If old is Or, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, Or):
-            if all(a in args for a in old.args):
-                args = [new] + [a for a in args if a not in old.args]
+            old_args = set(old.args)
+            sd = old_args.symmetric_difference(set(args))
+            if not sd & old_args:
+                args = [new] + list(sd)
 
         return self.func(*args)
 
@@ -1152,9 +1156,11 @@ class Xor(BooleanFunction):
         # If old is Xor, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, Xor):
-            if all(a in self.args for a in old.args):
-                args = [new] + [a for a in self.args  if a not in old.args]
-                return self.func(*args)
+            old_args = set(old.args)
+            sd = old_args.symmetric_difference(set(self.args))
+            if not sd & old_args:
+                sd.add(new)
+                return self.func(*sd)
 
 
 class Nand(BooleanFunction):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -728,10 +728,10 @@ class And(LatticeOp, BooleanFunction):
         # If old is And, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, And):
-            old_args = set(old.args)
-            sd = old_args.symmetric_difference(set(args))
-            if not sd & old_args:
-                args = [new] + list(sd)
+            old_set = set(old.args)
+            if old_set.issubset(args):
+                args = set(args) - old_set
+                args.update(new)
 
         return self.func(*args)
 
@@ -883,10 +883,10 @@ class Or(LatticeOp, BooleanFunction):
         # If old is Or, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, Or):
-            old_args = set(old.args)
-            sd = old_args.symmetric_difference(set(args))
-            if not sd & old_args:
-                args = [new] + list(sd)
+            old_set = set(old.args)
+            if old_set.issubset(args):
+                args = set(args) - old_set
+                args.update(new)
 
         return self.func(*args)
 
@@ -1156,11 +1156,11 @@ class Xor(BooleanFunction):
         # If old is Xor, replace the parts of the arguments with new if all
         # are there
         if isinstance(old, Xor):
-            old_args = set(old.args)
-            sd = old_args.symmetric_difference(set(self.args))
-            if not sd & old_args:
-                sd.add(new)
-                return self.func(*sd)
+            old_set = set(old.args)
+            if old_set.issubset(args):
+                args = set(args) - old_set
+                args.update(new)
+                return self.func(*args)
 
 
 class Nand(BooleanFunction):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -731,7 +731,7 @@ class And(LatticeOp, BooleanFunction):
             old_set = set(old.args)
             if old_set.issubset(args):
                 args = set(args) - old_set
-                args.update(new)
+                args.add(new)
 
         return self.func(*args)
 
@@ -886,7 +886,7 @@ class Or(LatticeOp, BooleanFunction):
             old_set = set(old.args)
             if old_set.issubset(args):
                 args = set(args) - old_set
-                args.update(new)
+                args.add(new)
 
         return self.func(*args)
 
@@ -1157,9 +1157,9 @@ class Xor(BooleanFunction):
         # are there
         if isinstance(old, Xor):
             old_set = set(old.args)
-            if old_set.issubset(args):
-                args = set(args) - old_set
-                args.update(new)
+            if old_set.issubset(self.args):
+                args = set(self.args) - old_set
+                args.add(new)
                 return self.func(*args)
 
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -725,6 +725,12 @@ class And(LatticeOp, BooleanFunction):
         if bad is not None:
             # let it raise
             bad.subs(old, new)
+        # If old is And, replace the parts of the arguments with new if all
+        # are there
+        if isinstance(old, And):
+            if all(a in args for a in old.args):
+                args = [new] + [a for a in args if a not in old.args]
+
         return self.func(*args)
 
     def _eval_simplify(self, **kwargs):
@@ -872,6 +878,12 @@ class Or(LatticeOp, BooleanFunction):
         if bad is not None:
             # let it raise
             bad.subs(old, new)
+        # If old is Or, replace the parts of the arguments with new if all
+        # are there
+        if isinstance(old, Or):
+            if all(a in args for a in old.args):
+                args = [new] + [a for a in args if a not in old.args]
+
         return self.func(*args)
 
     def _eval_as_set(self):
@@ -1135,6 +1147,14 @@ class Xor(BooleanFunction):
         patterns = simplify_patterns_xor()
         return self._apply_patternbased_simplification(rv, patterns,
             kwargs['measure'], None)
+
+    def _eval_subs(self, old, new):
+        # If old is Xor, replace the parts of the arguments with new if all
+        # are there
+        if isinstance(old, Xor):
+            if all(a in self.args for a in old.args):
+                args = [new] + [a for a in self.args  if a not in old.args]
+                return self.func(*args)
 
 
 class Nand(BooleanFunction):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -931,6 +931,16 @@ def test_integer_to_term():
     assert integer_to_term(456, 16) == [0, 0, 0, 0, 0, 0, 0, 1,
                                         1, 1, 0, 0, 1, 0, 0, 0]
 
+def test_issue_21971():
+    a, b, c, d = symbols('a b c d')
+    f = a & b & c | a & c
+    assert f.subs(a & c, d) == b & d | d
+
+    f = (a | b | c) & (a | c)
+    assert f.subs(a | c, d) == (b | d) & d
+
+    f = (a ^ b ^ c) & (a ^ c)
+    assert f.subs(a ^ c, d) == (b ^ d) & d
 
 def test_truth_table():
     assert list(truth_table(And(x, y), [x, y], input=False)) == \

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -935,12 +935,16 @@ def test_issue_21971():
     a, b, c, d = symbols('a b c d')
     f = a & b & c | a & c
     assert f.subs(a & c, d) == b & d | d
+    assert f.subs(a & b & c, d) == a & c | d
 
     f = (a | b | c) & (a | c)
     assert f.subs(a | c, d) == (b | d) & d
+    assert f.subs(a | b | c, d) == (a | c) & d
 
     f = (a ^ b ^ c) & (a ^ c)
     assert f.subs(a ^ c, d) == (b ^ d) & d
+    assert f.subs(a ^ b ^ c, d) == (a ^ c) & d
+
 
 def test_truth_table():
     assert list(truth_table(And(x, y), [x, y], input=False)) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21971

#### Brief description of what is fixed or changed
It is now possible to use `subs` where the expression to be replaced is part of a Boolean function.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
    * `subs` works better when replacing parts of a Boolean expression.
<!-- END RELEASE NOTES -->
