### PR TITLE
Better `is_zero` for LambertW, hyperbolic, and trigonometric functions

### DIFF
--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -443,12 +443,12 @@ def test_Add_Mul_is_finite():
     x = Symbol('x', extended_real=True, finite=False)
 
     assert sin(x).is_finite is True
-    assert (x*sin(x)).is_finite is None
+    assert (x*sin(x)).is_finite is False
     assert (x*atan(x)).is_finite is False
     assert (1024*sin(x)).is_finite is True
     assert (sin(x)*exp(x)).is_finite is None
     assert (sin(x)*cos(x)).is_finite is True
-    assert (x*sin(x)*exp(x)).is_finite is None
+    assert (x*sin(x)*exp(x)).is_finite is False
 
     assert (sin(x) - 67).is_finite is True
     assert (sin(x) + exp(x)).is_finite is not True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -443,12 +443,12 @@ def test_Add_Mul_is_finite():
     x = Symbol('x', extended_real=True, finite=False)
 
     assert sin(x).is_finite is True
-    assert (x*sin(x)).is_finite is False
+    assert (x*sin(x)).is_finite is None
     assert (x*atan(x)).is_finite is False
     assert (1024*sin(x)).is_finite is True
     assert (sin(x)*exp(x)).is_finite is None
     assert (sin(x)*cos(x)).is_finite is True
-    assert (x*sin(x)*exp(x)).is_finite is False
+    assert (x*sin(x)*exp(x)).is_finite is None
 
     assert (sin(x) - 67).is_finite is True
     assert (sin(x) + exp(x)).is_finite is not True

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1202,8 +1202,6 @@ class LambertW(Function):
     def _eval_is_zero(self):
         x = self.args[0]
         if len(self.args) == 1:
-            k = S.Zero
+            return x.is_zero
         else:
-            k = self.args[1]
-        if x.is_zero and k.is_zero:
-            return True
+            return fuzzy_and(x.is_zero, self.args[1].is_zero)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1204,4 +1204,4 @@ class LambertW(Function):
         if len(self.args) == 1:
             return x.is_zero
         else:
-            return fuzzy_and(x.is_zero, self.args[1].is_zero)
+            return fuzzy_and([x.is_zero, self.args[1].is_zero])

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -272,8 +272,8 @@ class sinh(HyperbolicFunction):
 
     def _eval_is_zero(self):
         rest, ipi_mult = _peeloff_ipi(self.args[0])
-        return fuzzy_and([ipi_mult.is_integer,
-                          rest.is_zero])
+        if rest.is_zero:
+            return ipi_mult.is_integer
 
 
 class cosh(HyperbolicFunction):
@@ -512,11 +512,8 @@ class cosh(HyperbolicFunction):
 
     def _eval_is_zero(self):
         rest, ipi_mult = _peeloff_ipi(self.args[0])
-        if ipi_mult:
-            return fuzzy_and([(ipi_mult - S.Half).is_integer,
-                              rest.is_zero])
-        else:
-            return rest.is_zero
+        if ipi_mult and rest.is_zero:
+            (ipi_mult - S.Half).is_integer
 
 
 class tanh(HyperbolicFunction):
@@ -1369,7 +1366,8 @@ class acosh(InverseHyperbolicFunction):
         return cosh
 
     def _eval_is_zero(self):
-        return (self.args[0] - 1).is_zero
+        if (self.args[0] - 1).is_zero:
+            return True
 
 
 class atanh(InverseHyperbolicFunction):
@@ -1470,7 +1468,8 @@ class atanh(InverseHyperbolicFunction):
         return (log(1 + x) - log(1 - x)) / 2
 
     def _eval_is_zero(self):
-        return self.args[0].is_zero
+        if self.args[0].is_zero:
+            return True
 
     def _eval_is_imaginary(self):
         return self.args[0].is_imaginary

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -269,9 +269,7 @@ class sinh(HyperbolicFunction):
         return arg.is_finite
 
     def _eval_is_zero(self):
-        arg = self.args[0]
-        if arg.is_zero:
-            return True
+        return (self.args[0]/(S.Pi*I)).is_integer
 
 
 class cosh(HyperbolicFunction):
@@ -506,6 +504,9 @@ class cosh(HyperbolicFunction):
     def _eval_is_finite(self):
         arg = self.args[0]
         return arg.is_finite
+
+    def _eval_is_zero(self):
+        return (self.args[0]/(S.Pi*I) - S.Half).is_integer
 
 
 class tanh(HyperbolicFunction):
@@ -1211,9 +1212,7 @@ class asinh(InverseHyperbolicFunction):
         return sinh
 
     def _eval_is_zero(self):
-        arg = self.args[0]
-        if arg.is_zero:
-            return True
+        return self.args[0].is_zero
 
 
 class acosh(InverseHyperbolicFunction):
@@ -1359,6 +1358,9 @@ class acosh(InverseHyperbolicFunction):
         """
         return cosh
 
+    def _eval_is_zero(self):
+        return (self.args[0] - 1).is_zero
+
 
 class atanh(InverseHyperbolicFunction):
     """
@@ -1458,10 +1460,7 @@ class atanh(InverseHyperbolicFunction):
         return (log(1 + x) - log(1 - x)) / 2
 
     def _eval_is_zero(self):
-        arg = self.args[0]
-        if arg.is_zero:
-            return True
-
+        return self.args[0].is_zero
 
     def inverse(self, argindex=1):
         """

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -36,7 +36,7 @@ class HyperbolicFunction(Function):
 
 def _peeloff_ipi(arg):
     """
-    Split ARG into two parts, a "rest" and a multiple of I*pi/2.
+    Split ARG into two parts, a "rest" and a multiple of I*pi.
     This assumes ARG to be an Add.
     The multiple of I*pi returned in the second position is always a Rational.
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1462,6 +1462,9 @@ class atanh(InverseHyperbolicFunction):
     def _eval_is_zero(self):
         return self.args[0].is_zero
 
+    def _eval_is_imaginary(self):
+        return self.args[0].is_imaginary
+
     def inverse(self, argindex=1):
         """
         Returns the inverse of this function.
@@ -1791,3 +1794,6 @@ class acsch(InverseHyperbolicFunction):
 
     def _eval_rewrite_as_log(self, arg, **kwargs):
         return log(1/arg + sqrt(1/arg**2 + 1))
+
+    def _eval_is_zero(self):
+        return self.args[0].is_infinite

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -513,7 +513,7 @@ class cosh(HyperbolicFunction):
     def _eval_is_zero(self):
         rest, ipi_mult = _peeloff_ipi(self.args[0])
         if ipi_mult and rest.is_zero:
-            (ipi_mult - S.Half).is_integer
+            return (ipi_mult - S.Half).is_integer
 
 
 class tanh(HyperbolicFunction):

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -567,6 +567,9 @@ def test_lambertw():
     assert LambertW(0, evaluate=False).is_algebraic
     na = Symbol('na', nonzero=True, algebraic=True)
     assert LambertW(na).is_algebraic is False
+    assert LambertW(p).is_zero is False
+    n = Symbol('n', negative=True)
+    assert LambertW(n).is_zero is False
 
 
 def test_issue_5673():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -81,8 +81,8 @@ def test_sinh():
     assert sinh(I).is_real is False
     p = Symbol('p', positive=True)
     assert sinh(p).is_zero is False
-    assert sinh(0, evaluate=False).is_zero
-    assert sinh(2*pi*I, evaluate=False).is_zero
+    assert sinh(0, evaluate=False).is_zero is True
+    assert sinh(2*pi*I, evaluate=False).is_zero is True
 
 
 def test_sinh_series():
@@ -165,7 +165,7 @@ def test_cosh():
     assert cosh(I*x).is_finite is True
     assert cosh(I*x).is_real is True
     assert cosh(I*2 + 1).is_real is False
-    assert cosh(5*I*S.Pi/2, evaluate=False).is_zero
+    assert cosh(5*I*S.Pi/2, evaluate=False).is_zero is True
     assert cosh(x).is_zero is False
 
 
@@ -545,7 +545,7 @@ def test_asinh():
     assert asinh(sinh(13 - 3*I)) == -13 - I*pi + 3*I
     p = Symbol('p', positive=True)
     assert asinh(p).is_zero is False
-    assert asinh(sinh(0, evaluate=False), evaluate=False).is_zero
+    assert asinh(sinh(0, evaluate=False), evaluate=False).is_zero is True
 
 
 def test_asinh_rewrite():
@@ -624,7 +624,7 @@ def test_acosh():
     assert acosh(cosh(-5 - 17*I)) == 5 - 6*I*pi + 17*I
     assert acosh(cosh(-21 + 11*I)) == 21 - 11*I + 4*I*pi
     assert acosh(cosh(cosh(1) + I)) == cosh(1) + I
-    assert acosh(1, evaluate=False).is_zero
+    assert acosh(1, evaluate=False).is_zero is True
 
 
 def test_acosh_rewrite():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -79,6 +79,10 @@ def test_sinh():
     assert sinh(I*x).is_finite is True
     assert sinh(x).is_real is True
     assert sinh(I).is_real is False
+    p = Symbol('p', positive=True)
+    assert sinh(p).is_zero is False
+    assert sinh(0, evaluate=False).is_zero
+    assert sinh(2*pi*I, evaluate=False).is_zero
 
 
 def test_sinh_series():
@@ -161,6 +165,8 @@ def test_cosh():
     assert cosh(I*x).is_finite is True
     assert cosh(I*x).is_real is True
     assert cosh(I*2 + 1).is_real is False
+    assert cosh(5*I*S.Pi/2, evaluate=False).is_zero
+    assert cosh(x).is_zero is False
 
 
 def test_cosh_series():
@@ -537,6 +543,9 @@ def test_asinh():
     assert asinh(sinh(-73 + 97*I)) == 73 - 97*I + 31*I*pi
     assert asinh(sinh(-7 - 23*I)) == 7 - 7*I*pi + 23*I
     assert asinh(sinh(13 - 3*I)) == -13 - I*pi + 3*I
+    p = Symbol('p', positive=True)
+    assert asinh(p).is_zero is False
+    assert asinh(sinh(0, evaluate=False), evaluate=False).is_zero
 
 
 def test_asinh_rewrite():
@@ -615,6 +624,7 @@ def test_acosh():
     assert acosh(cosh(-5 - 17*I)) == 5 - 6*I*pi + 17*I
     assert acosh(cosh(-21 + 11*I)) == 21 - 11*I + 4*I*pi
     assert acosh(cosh(cosh(1) + I)) == cosh(1) + I
+    assert acosh(1, evaluate=False).is_zero
 
 
 def test_acosh_rewrite():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -149,7 +149,7 @@ def test_sin():
             assert e < 1e-12
 
     assert sin(0, evaluate=False).is_zero is True
-    assert sin(k*pi, evaluate=False).is_zero is None
+    assert sin(k*pi, evaluate=False).is_zero is True
 
     assert sin(Add(1, -1, evaluate=False), evaluate=False).is_zero is True
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -834,17 +834,17 @@ def test_sinc():
 
     assert sinc(x).rewrite(jn) == jn(0, x)
     assert sinc(x).rewrite(sin) == Piecewise((sin(x)/x, Ne(x, 0)), (1, True))
-    assert sinc(pi, evaluate=False).is_zero
+    assert sinc(pi, evaluate=False).is_zero is True
     assert sinc(0, evaluate=False).is_zero is False
-    assert sinc(n*pi, evaluate=False).is_zero
+    assert sinc(n*pi, evaluate=False).is_zero is True
     assert sinc(x).is_zero is None
     xr = Symbol('xr', real=True, nonzero=True)
     assert sinc(x).is_real is None
-    assert sinc(xr).is_real
-    assert sinc(I*xr).is_real
-    assert sinc(I*100).is_real
+    assert sinc(xr).is_real is True
+    assert sinc(I*xr).is_real is True
+    assert sinc(I*100).is_real is True
     assert sinc(x).is_finite is None
-    assert sinc(xr).is_finite
+    assert sinc(xr).is_finite is True
 
 
 def test_asin():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -872,7 +872,7 @@ def test_asin():
     assert asin(x).diff(x) == 1/sqrt(1 - x**2)
     assert asin(1/x).as_leading_term(x) == I*log(1/x)
 
-    assert asin(0.2).is_real is True
+    assert asin(0.2, evaluate=False).is_real is True
     assert asin(-2).is_real is False
     assert asin(r).is_real is None
 
@@ -1581,9 +1581,9 @@ def test_sec():
 
     assert sec(x).as_leading_term() == sec(x)
 
-    assert sec(0).is_finite == True
+    assert sec(0, evaluate=False).is_finite == True
     assert sec(x).is_finite == None
-    assert sec(pi/2).is_finite == False
+    assert sec(pi/2, evaluate=False).is_finite == False
 
     assert series(sec(x), x, x0=0, n=6) == 1 + x**2/2 + 5*x**4/24 + O(x**6)
 
@@ -1668,9 +1668,9 @@ def test_csc():
 
     assert csc(x).as_leading_term() == csc(x)
 
-    assert csc(0).is_finite == False
+    assert csc(0, evaluate=False).is_finite == False
     assert csc(x).is_finite == None
-    assert csc(pi/2).is_finite == True
+    assert csc(pi/2, evaluate=False).is_finite == True
 
     assert series(csc(x), x, x0=pi/2, n=6) == \
         1 + (x - pi/2)**2/2 + 5*(x - pi/2)**4/24 + O((x - pi/2)**6, (x, pi/2))

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -834,6 +834,17 @@ def test_sinc():
 
     assert sinc(x).rewrite(jn) == jn(0, x)
     assert sinc(x).rewrite(sin) == Piecewise((sin(x)/x, Ne(x, 0)), (1, True))
+    assert sinc(pi, evaluate=False).is_zero
+    assert sinc(0, evaluate=False).is_zero is False
+    assert sinc(n*pi, evaluate=False).is_zero
+    assert sinc(x).is_zero is None
+    xr = Symbol('xr', real=True, nonzero=True)
+    assert sinc(x).is_real is None
+    assert sinc(xr).is_real
+    assert sinc(I*xr).is_real
+    assert sinc(I*100).is_real
+    assert sinc(x).is_finite is None
+    assert sinc(xr).is_finite
 
 
 def test_asin():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -501,9 +501,7 @@ class sin(TrigonometricFunction):
             return True
 
     def _eval_is_zero(self):
-        arg = self.args[0]
-        if arg.is_zero:
-            return True
+        return (self.args[0]/S.Pi).is_integer
 
     def _eval_is_complex(self):
         if self.args[0].is_extended_real \
@@ -963,6 +961,9 @@ class cos(TrigonometricFunction):
             or self.args[0].is_complex:
             return True
 
+    def _eval_is_zero(self):
+        return (self.args[0]/S.Pi - S.Half).is_integer
+
 
 class tan(TrigonometricFunction):
     """
@@ -1289,9 +1290,7 @@ class tan(TrigonometricFunction):
             return True
 
     def _eval_is_zero(self):
-        arg = self.args[0]
-        if arg.is_zero:
-            return True
+        return (self.args[0]/S.Pi).is_integer
 
     def _eval_is_complex(self):
         arg = self.args[0]
@@ -1599,6 +1598,9 @@ class cot(TrigonometricFunction):
         arg = self.args[0]
         if arg.is_real and (arg/pi).is_integer is False:
             return True
+
+    def _eval_is_zero(self):
+        return (self.args[0]/S.Pi - S.Half).is_integer
 
     def _eval_subs(self, old, new):
         arg = self.args[0]

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -94,7 +94,7 @@ class TrigonometricFunction(Function):
 
 def _peeloff_pi(arg):
     """
-    Split ARG into two parts, a "rest" and a multiple of pi/2.
+    Split ARG into two parts, a "rest" and a multiple of pi.
     This assumes ARG to be an Add.
     The multiple of pi returned in the second position is always a Rational.
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -501,7 +501,8 @@ class sin(TrigonometricFunction):
             return True
 
     def _eval_is_zero(self):
-        return (self.args[0]/S.Pi).is_integer
+        return fuzzy_or([self.args[0].is_zero,
+                         (self.args[0]/S.Pi).is_integer])
 
     def _eval_is_complex(self):
         if self.args[0].is_extended_real \
@@ -1290,7 +1291,8 @@ class tan(TrigonometricFunction):
             return True
 
     def _eval_is_zero(self):
-        return (self.args[0]/S.Pi).is_integer
+        return fuzzy_or([self.args[0].is_zero,
+                         (self.args[0]/S.Pi).is_integer])
 
     def _eval_is_complex(self):
         arg = self.args[0]

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -496,12 +496,13 @@ class sin(TrigonometricFunction):
 
     def _eval_is_finite(self):
         arg = self.args[0]
-        if arg.is_finite:
+        if arg.is_extended_real:
             return True
 
     def _eval_is_zero(self):
         rest, pi_mult = _peeloff_pi(self.args[0])
-        return fuzzy_and([pi_mult.is_integer, rest.is_zero])
+        if rest.is_zero:
+            return pi_mult.is_integer
 
     def _eval_is_complex(self):
         if self.args[0].is_extended_real \
@@ -1296,7 +1297,8 @@ class tan(TrigonometricFunction):
 
     def _eval_is_zero(self):
         rest, pi_mult = _peeloff_pi(self.args[0])
-        return fuzzy_and([pi_mult.is_integer, rest.is_zero])
+        if rest.is_zero:
+            return pi_mult.is_integer
 
     def _eval_is_complex(self):
         arg = self.args[0]
@@ -1607,11 +1609,8 @@ class cot(TrigonometricFunction):
 
     def _eval_is_zero(self):
         rest, pimult = _peeloff_pi(self.args[0])
-        if pimult:
-            return fuzzy_and([(pimult - S.Half).is_integer,
-                              rest.is_zero])
-        else:
-            return rest.is_zero
+        if pimult and rest.is_zero:
+            return (pimult - S.Half).is_integer
 
     def _eval_subs(self, old, new):
         arg = self.args[0]

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2026,6 +2026,21 @@ class sinc(Function):
     def _eval_rewrite_as_sin(self, arg, **kwargs):
         return Piecewise((sin(arg)/arg, Ne(arg, S.Zero)), (S.One, S.true))
 
+    def _eval_is_zero(self):
+        if self.args[0].is_infinite:
+            return True
+        rest, pi_mult = _peeloff_pi(self.args[0])
+        if rest.is_zero:
+            return fuzzy_and([pi_mult.is_integer, pi_mult.is_nonzero])
+        if rest.is_Number and pi_mult.is_integer:
+            return False
+
+    def _eval_is_real(self):
+        if self.args[0].is_extended_real or self.args[0].is_imaginary:
+            return True
+
+    _eval_is_finite = _eval_is_real
+
 
 ###############################################################################
 ########################### TRIGONOMETRIC INVERSES ############################


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Improved zero detection. Sometimes it reported incorrectly earlier, e.g. `cosh(5*I*S.Pi/2, evaluate=False).is_zero` returned `False` while the correct is `True`.

#### Other comments
Primarily pushed to see if it breaks anything else. Not sure if I tested everything...

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Better zero detection for `LambertW` and some hyperbolic and trigonometric functions.
<!-- END RELEASE NOTES -->
