### PR TITLE
Modified coeff() to give correct value for a sum

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1629,7 +1629,7 @@ class Expr(Basic, EvalfMixin):
                         if right:
                             np = n[:ii]
                         else:
-                            np = n[ii+len(nx):]
+                            np = n[ii + len(nx):]
                     else:
                         if right:
                             if n[:ii] != np:
@@ -1638,11 +1638,11 @@ class Expr(Basic, EvalfMixin):
                             if n[ii+len(nx):] != np:
                                 break
                     if right:
-                        hit.append(({},n[ii+len(nx):]))
+                        hit.append(({}, n[ii + len(nx):]))
                     else:
                         hit.append((r, n[:ii]))
             else:
-                if hit is not None:
+                if hit:
                     return Add(*[Mul(*(list(r) + n)) for r, n in hit])
 
             return S.Zero

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1619,22 +1619,31 @@ class Expr(Basic, EvalfMixin):
                         return Add(*[Mul(*(list(r) + n[:-len(end) + ii])) for r, n in co])
                     else:
                         return Mul(*end[ii + len(nx):])
-            # look for single match
-            hit = None
+            # look for a single hit but allow a sum of terms if each have the
+            # same remaining expression after removing coefficient
+            hit = []
             for i, (r, n) in enumerate(co):
                 ii = find(n, nx, right)
                 if ii is not None:
                     if not hit:
-                        hit = ii, r, n
+                        if not right:
+                            np = n[ii+len(nx):]
+                        else:
+                            np = n[:ii]
                     else:
-                        break
-            else:
-                if hit:
-                    ii, r, n = hit
+                        if not right:
+                            if n[ii+len(nx):] != np:
+                              break
+                        else:
+                            if n[:ii] != np:
+                                break
                     if not right:
-                        return Mul(*(list(r) + n[:ii]))
+                        hit.append((r, n[:ii]))
                     else:
-                        return Mul(*n[ii + len(nx):])
+                        hit.append(({},n[ii+len(nx):]))
+            else:
+                if hit is not None:
+                    return Add(*[Mul(*(list(r) + n)) for r, n in hit])
 
             return S.Zero
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1558,6 +1558,39 @@ class Expr(Basic, EvalfMixin):
                 i = len(l) - (i + n)
             return i
 
+        def special_cases(co, nx, right):
+            if all(n == co[0][1] for r, n in co):
+                ii = find(co[0][1], nx, right)
+                if ii is not None:
+                    if right:
+                        return Mul(*co[0][1][ii + len(nx):])
+                    else:
+                        return Mul(Add(*[Mul(*r) for r, c in co]), Mul(*co[0][1][:ii]))
+            beg = reduce(incommon, (n[1] for n in co))
+            if beg:
+                ii = find(beg, nx, right)
+                if ii is not None:
+                    if right:
+                        m = ii + len(nx)
+                        return Add(*[Mul(*(list(r) + n[m:])) for r, n in co])
+                    else:
+                        gcdc = co[0][0]
+                        for i in range(1, len(co)):
+                            gcdc = gcdc.intersection(co[i][0])
+                            if not gcdc:
+                                break
+                        return Mul(*(list(gcdc) + beg[:ii]))
+            end = list(reversed(
+                reduce(incommon, (list(reversed(n[1])) for n in co))))
+            if end:
+                ii = find(end, nx, right)
+                if ii is not None:
+                    if right:
+                        return Mul(*end[ii + len(nx):])
+                    else:
+                        return Add(*[Mul(*(list(r) + n[:-len(end) + ii])) for r, n in co])
+            return None
+
         co = []
         args = Add.make_args(self)
         self_c = self.is_commutative
@@ -1589,61 +1622,32 @@ class Expr(Basic, EvalfMixin):
             # now check the non-comm parts
             if not co:
                 return S.Zero
-            if all(n == co[0][1] for r, n in co):
-                ii = find(co[0][1], nx, right)
-                if ii is not None:
-                    if not right:
-                        return Mul(Add(*[Mul(*r) for r, c in co]), Mul(*co[0][1][:ii]))
-                    else:
-                        return Mul(*co[0][1][ii + len(nx):])
-            beg = reduce(incommon, (n[1] for n in co))
-            if beg:
-                ii = find(beg, nx, right)
-                if ii is not None:
-                    if not right:
-                        gcdc = co[0][0]
-                        for i in range(1, len(co)):
-                            gcdc = gcdc.intersection(co[i][0])
-                            if not gcdc:
-                                break
-                        return Mul(*(list(gcdc) + beg[:ii]))
-                    else:
-                        m = ii + len(nx)
-                        return Add(*[Mul(*(list(r) + n[m:])) for r, n in co])
-            end = list(reversed(
-                reduce(incommon, (list(reversed(n[1])) for n in co))))
-            if end:
-                ii = find(end, nx, right)
-                if ii is not None:
-                    if not right:
-                        return Add(*[Mul(*(list(r) + n[:-len(end) + ii])) for r, n in co])
-                    else:
-                        return Mul(*end[ii + len(nx):])
-            # look for a single hit but allow a sum of terms if each have the
-            # same remaining expression after removing coefficient
-            hit = []
+            hit = special_cases(co, nx, right)
+            if hit is None:
+                # Slow for large expressions so only use if necessary
+                co = [t for t in co if find(t[1], nx, right) is not None]
+                if not co:
+                    return S.Zero
+                hit = special_cases(co, nx, right)
+            else:
+                return hit
+            if hit is not None:
+                return hit
+            # look for single match
             for i, (r, n) in enumerate(co):
                 ii = find(n, nx, right)
                 if ii is not None:
-                    if not hit:
-                        if right:
-                            np = n[:ii]
-                        else:
-                            np = n[ii + len(nx):]
+                    if hit:
+                        break
                     else:
-                        if right:
-                            if n[:ii] != np:
-                                break
-                        else:
-                            if n[ii+len(nx):] != np:
-                                break
-                    if right:
-                        hit.append(({}, n[ii + len(nx):]))
-                    else:
-                        hit.append((r, n[:ii]))
+                        hit = ii, r, n
             else:
                 if hit:
-                    return Add(*[Mul(*(list(r) + n)) for r, n in hit])
+                    ii, r, n = hit
+                    if right:
+                        return Mul(*n[ii + len(nx):])
+                    else:
+                        return Mul(*(list(r) + n[:ii]))
 
             return S.Zero
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1626,21 +1626,21 @@ class Expr(Basic, EvalfMixin):
                 ii = find(n, nx, right)
                 if ii is not None:
                     if not hit:
-                        if not right:
-                            np = n[ii+len(nx):]
-                        else:
+                        if right:
                             np = n[:ii]
-                    else:
-                        if not right:
-                            if n[ii+len(nx):] != np:
-                              break
                         else:
+                            np = n[ii+len(nx):]
+                    else:
+                        if right:
                             if n[:ii] != np:
                                 break
-                    if not right:
-                        hit.append((r, n[:ii]))
-                    else:
+                        else:
+                            if n[ii+len(nx):] != np:
+                                break
+                    if right:
                         hit.append(({},n[ii+len(nx):]))
+                    else:
+                        hit.append((r, n[:ii]))
             else:
                 if hit is not None:
                     return Add(*[Mul(*(list(r) + n)) for r, n in hit])

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,6 +1414,8 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
+    assert (x*n + y*n + z*m).coeff(n) == x+y
+    assert (n*m +n*o + o*l).coeff(n,right=1) == m+o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,8 +1414,8 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
-    assert (x*n + y*n + z*m).coeff(n) == x+y
-    assert (n*m +n*o + o*l).coeff(n,right=1) == m+o
+    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (n*m + n*o + o*l).coeff(n,right=1) == m + o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1415,7 +1415,7 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
     assert (x*n + y*n + z*m).coeff(n) == x + y
-    assert (n*m + n*o + o*l).coeff(n,right=1) == m + o
+    assert (n*m + n*o + o*l).coeff(n, right=1) == m + o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,8 +1414,9 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
-    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (x*n + y*n + z*m).coeff(n) == x + y #i issue #16752
     assert (n*m + n*o + o*l).coeff(n, right=1) == m + o
+    assert (x*n*m*n + y*n*m*o + z*l).coeff(m, right=1) == x*n + y*o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -204,6 +204,11 @@ def test_lie_derivative():
     assert LieDerivative(
         R2.e_x, TensorProduct(R2.dx, R2.dy))(R2.e_x, R2.e_y) == 0
 
+def test_issue_17917():
+    X = R2.x*R2.e_x - R2.y*R2.e_y
+    Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
+    assert simplify(LieDerivative(X, Y)) == R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y
+
 
 @nocache_fail
 def test_covar_deriv():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #16752 
Fixes #17917

#### Brief description of what is fixed or changed
Given expressions e and n which are both noncommutative when computing e.coeff(n) instead of immediately returning 0 if n is found in more than one summand of e it now only returns 0 when finding n in a new summand if, after removing n from both summands, the remaining noncommutative part of the new summand  and previous summand are not equal.  Added tests for this behaviour as well.

#### Other comments
Before if everything was commutative then for example `(x*a+y*a+z*b).coeff(a)` returned `x+y` and even if `a,b` were not commutative `(x*a+y*a).coeff(a)` returned `x+y` however for `a,b` not commutative `(x*a+y*a+z*b).coeff(a)` returned `0`.  With this change now `(x*a+y*a+z*b).coeff(a)` returns `x+y` in all cases. This fixes the incorrect answers given by `LieDerivative` and `Commutator` from the diffgeom submodule referenced above however it is slower so there is a performance hit.

<!-- BEGIN RELEASE NOTES -->

* core
  * Extended coeff() to return nonzero value for some sums with noncommutative variables
 
<!-- END RELEASE NOTES -->
