### PR TITLE
maint(ci): run symengine tests in CI (USE_SYMENGINE=1)

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -134,6 +134,24 @@ jobs:
       # Test modules that can use tensorflow
       - run: bin/test_tensorflow.py
 
+  # -------------------- SymEngine tests --------------------------- #
+
+  symengine:
+    needs: code-quality
+
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - run: python -m pip install --upgrade pip
+      - run: pip install mpmath symengine
+      # Test modules that can use tensorflow
+      - run: bin/test_symengine.py
+        env:
+          USE_SYMENGINE: '1'
+
   # -------------------- Slow test split 1/2 ----------------------- #
 
   slow1:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           python-version: '3.9'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath symengine
+      - run: pip install mpmath numpy symengine
       # Test modules that can use tensorflow
       - run: bin/test_symengine.py
         env:

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -127,11 +127,3 @@ import sympy
 if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitplot.py',
     subprocess=False) and sympy.doctest('sympy/plotting', subprocess=False)):
     raise TestsFailedError('Tests failed')
-
-
-print('Testing SYMENGINE')
-import sympy
-if not sympy.test('sympy/physics/mechanics'):
-    raise TestsFailedError('Tests failed')
-if not sympy.test('sympy/liealgebras'):
-    raise TestsFailedError('Tests failed')

--- a/bin/test_symengine.py
+++ b/bin/test_symengine.py
@@ -21,7 +21,7 @@ class TestsFailedError(Exception):
     pass
 
 
-test_list = doctest_list = [
+test_list = [
     'sympy/physics/mechanics',
     'sympy/liealgebras',
 ]
@@ -29,7 +29,10 @@ test_list = doctest_list = [
 
 print('Testing optional dependencies')
 
-
+#
+# XXX: The doctests are not tested here but there are many failures when
+# running them with symengine.
+#
 import sympy
-if not (sympy.test(*test_list, verbose=True) and sympy.doctest(*doctest_list)):
+if not sympy.test(*test_list, verbose=True):
     raise TestsFailedError('Tests failed')

--- a/bin/test_symengine.py
+++ b/bin/test_symengine.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+Run tests involving symengine
+
+These are separate from the other optional dependency tests because they need
+to be run with the USE_SYMENGINE=1 environment variable set. This script does
+not set the environment variable by default so that the same tests can be run
+with and without symengine.
+
+Run this as:
+
+    $ USE_SYMENGINE=1 bin/test_symengine.py
+"""
+
+# Add the local sympy to sys.path (needed for CI)
+from get_sympy import path_hack
+path_hack()
+
+
+class TestsFailedError(Exception):
+    pass
+
+
+test_list = doctest_list = [
+    'sympy/physics/mechanics',
+    'sympy/liealgebras',
+]
+
+
+print('Testing optional dependencies')
+
+
+import sympy
+if not (sympy.test(*test_list, verbose=True) and sympy.doctest(*doctest_list)):
+    raise TestsFailedError('Tests failed')

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -12,6 +12,17 @@ if USE_SYMENGINE:
         ImmutableMatrix, MatrixBase, Rational, Basic)
     from symengine.lib.symengine_wrapper import gcd as igcd
     from symengine import AppliedUndef
+
+    class Matrix(Matrix):
+        def simplify(self):
+            super().simplify()
+            return self
+    class ImmutableMatrix(ImmutableMatrix):
+        def simplify(self):
+            super().simplify()
+            return self
+    old_eye, eye = eye, lambda *args: Matrix(old_eye(*args))
+    old_zeros, zeros = zeros, lambda *args: Matrix(old_zeros(*args))
 else:
     from sympy import (Symbol, Integer, sympify, S,
         SympifyError, exp, log, gamma, sqrt, I, E, pi, Matrix,

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -12,17 +12,6 @@ if USE_SYMENGINE:
         ImmutableMatrix, MatrixBase, Rational, Basic)
     from symengine.lib.symengine_wrapper import gcd as igcd
     from symengine import AppliedUndef
-
-    class Matrix(Matrix):
-        def simplify(self):
-            super().simplify()
-            return self
-    class ImmutableMatrix(ImmutableMatrix):
-        def simplify(self):
-            super().simplify()
-            return self
-    old_eye, eye = eye, lambda *args: Matrix(old_eye(*args))
-    old_zeros, zeros = zeros, lambda *args: Matrix(old_zeros(*args))
 else:
     from sympy import (Symbol, Integer, sympify, S,
         SympifyError, exp, log, gamma, sqrt, I, E, pi, Matrix,
@@ -32,6 +21,42 @@ else:
         expand, Function, symbols, var, Add, Mul, Derivative,
         ImmutableMatrix, MatrixBase, Rational, Basic, igcd)
     from sympy.core.function import AppliedUndef
+
+
+#
+# XXX: Handling of immutable and mutable matrices in SymEngine is inconsistent
+# with SymPy's matrix classes in at least SymEngine version 0.7.0. Until that
+# is fixed the function below is needed for consistent behaviour when
+# attempting to simplify a matrix.
+#
+# Expected behaviour of a SymPy mutable/immutable matrix .simplify() method:
+#
+#   Matrix.simplify() : works in place, returns None
+#   ImmutableMatrix.simplify() : returns a simplified copy
+#
+# In SymEngine both mutable and immutable matrices simplify in place and return
+# None. This is inconsistent with the matrix being "immutable" and also the
+# returned None leads to problems in the mechanics module.
+#
+# The simplify function should not be used because simplify(M) sympifies the
+# matrix M and the SymEngine matrices all sympify to SymPy matrices. If we want
+# to work with SymEngine matrices then we need to use their .simplify() method
+# but that method does not work correctly with immutable matrices.
+#
+# The _simplify_matrix function can be removed when the SymEngine bug is fixed.
+# Since this should be a temporary problem we do not make this function part of
+# the public API.
+#
+
+def _simplify_matrix(M):
+    """Return a simplified copy of the matrix M"""
+    assert isinstance(M, (Matrix, ImmutableMatrix))
+    Mnew = M.as_mutable() # makes a copy if mutable
+    Mnew.simplify()
+    if isinstance(M, ImmutableMatrix):
+        Mnew = Mnew.as_immutable()
+    return Mnew
+
 
 __all__ = [
     'Symbol', 'Integer', 'sympify', 'S', 'SympifyError', 'exp', 'log',

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -47,6 +47,8 @@ else:
 # Since this should be a temporary problem we do not make this function part of
 # the public API.
 #
+#   SymEngine issue: https://github.com/symengine/symengine.py/issues/363
+#
 
 def _simplify_matrix(M):
     """Return a simplified copy of the matrix M"""

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -1,4 +1,5 @@
 from sympy import sin, cos, Matrix, sqrt, pi, expand_mul, S
+from sympy.core.backend import _simplify_matrix
 from sympy.core.symbol import symbols
 from sympy.physics.mechanics import dynamicsymbols, Body, PinJoint, PrismaticJoint
 from sympy.physics.mechanics.joint import Joint
@@ -78,9 +79,9 @@ def test_pin_joint_double_pendulum():
                                [sin(q1), cos(q1), 0], [0, 0, 1]])
     assert A.dcm(B) == Matrix([[cos(q2), -sin(q2), 0],
                                [sin(q2), cos(q2), 0], [0, 0, 1]])
-    assert N.dcm(B).simplify() == Matrix([[cos(q1 + q2), -sin(q1 + q2), 0],
-                                          [sin(q1 + q2), cos(q1 + q2), 0],
-                                          [0, 0, 1]])
+    assert _simplify_matrix(N.dcm(B)) == Matrix([[cos(q1 + q2), -sin(q1 + q2), 0],
+                                                 [sin(q1 + q2), cos(q1 + q2), 0],
+                                                 [0, 0, 1]])
 
     # Check Angular Velocity
     assert A.ang_vel_in(N) == u1 * N.z
@@ -206,7 +207,7 @@ def test_pinjoint_arbitrary_axis():
              child_axis=A.x+A.y)
     assert expand_mul(N.x.angle_between(A.x + A.y)) == 0  # Axis are aligned
     assert (A.x + A.y).express(N).simplify() == sqrt(2)*N.x
-    assert A.dcm(N).simplify() == Matrix([
+    assert _simplify_matrix(A.dcm(N)) == Matrix([
         [sqrt(2)/2, -sqrt(2)*cos(theta)/2, -sqrt(2)*sin(theta)/2],
         [sqrt(2)/2, sqrt(2)*cos(theta)/2, sqrt(2)*sin(theta)/2],
         [0, -sin(theta), cos(theta)]])
@@ -230,7 +231,7 @@ def test_pinjoint_arbitrary_axis():
              child_axis=A.x+A.y-A.z)
     assert expand_mul(N.x.angle_between(A.x + A.y - A.z)) == 0  # Axis aligned
     assert (A.x + A.y - A.z).express(N).simplify() == sqrt(3)*N.x
-    assert A.dcm(N).simplify() == Matrix([
+    assert _simplify_matrix(A.dcm(N)) == Matrix([
         [sqrt(3)/3, -sqrt(6)*sin(theta + pi/4)/3,
          sqrt(6)*cos(theta + pi/4)/3],
         [sqrt(3)/3, sqrt(6)*cos(theta + pi/12)/3,
@@ -262,7 +263,7 @@ def test_pinjoint_arbitrary_axis():
     assert ((A.x-A.y+A.z).express(N).simplify() ==
             (-4*cos(theta)/3 - S(1)/3)*N.x + (S(1)/3 - 4*sin(theta + pi/6)/3)*N.y +
             (4*cos(theta + pi/3)/3 - S(1)/3)*N.z)
-    assert A.dcm(N).simplify() == Matrix([
+    assert _simplify_matrix(A.dcm(N)) == Matrix([
         [S(1)/3 - 2*cos(theta)/3, -2*sin(theta + pi/6)/3 - S(1)/3,
          2*cos(theta + pi/3)/3 + S(1)/3],
         [2*cos(theta + pi/3)/3 + S(1)/3, 2*cos(theta)/3 - S(1)/3,
@@ -428,9 +429,9 @@ def test_slidingjoint_arbitrary_axis():
     PrismaticJoint('S', P, C, parent_joint_pos=N.x, child_joint_pos=A.x, child_axis=A.x+A.y-A.z)
     assert N.x.angle_between(A.x + A.y - A.z) == 0 #Axis are aligned
     assert (A.x + A.y - A.z).express(N) == sqrt(3)*N.x
-    assert A.dcm(N).simplify() == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
-                                          [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
-                                          [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
+    assert _simplify_matrix(A.dcm(N)) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
+                                                 [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
+                                                 [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
     assert C.masscenter.pos_from(P.masscenter) == (x + 1)*N.x - A.x
     assert C.masscenter.pos_from(P.masscenter).express(N) == \
         (x - sqrt(3)/3 + 1)*N.x + sqrt(3)/3*N.y - sqrt(3)/3*N.z
@@ -445,9 +446,9 @@ def test_slidingjoint_arbitrary_axis():
                     child_axis=A.x+A.y-A.z, parent_axis=N.x-N.y+N.z)
     assert (N.x-N.y+N.z).angle_between(A.x+A.y-A.z) == 0 #Axis are aligned
     assert (A.x+A.y-A.z).express(N) == N.x - N.y + N.z
-    assert A.dcm(N).simplify() == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
-                                          [S(2)/3, S(1)/3, S(2)/3],
-                                          [-S(2)/3, S(2)/3, S(1)/3]])
+    assert _simplify_matrix(A.dcm(N)) == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
+                                                 [S(2)/3, S(1)/3, S(2)/3],
+                                                 [-S(2)/3, S(2)/3, S(1)/3]])
     assert C.masscenter.pos_from(P.masscenter) == \
         (m + sqrt(3)*x/3)*N.x - sqrt(3)*x/3*N.y + sqrt(3)*x/3*N.z - n*A.x
     assert C.masscenter.pos_from(P.masscenter).express(N) == \

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -176,7 +176,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N).express(A) == omega * A.y
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.y)
-    assert expand_mul(angle).xreplace({omega: 1}) == 0
+    assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N) == omega*A.z
     assert C.masscenter.pos_from(P.masscenter) == -A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==
@@ -196,7 +196,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N).express(A) == omega*A.x
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.x)
-    assert expand_mul(angle).xreplace({omega: 1}) == 0
+    assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == - omega*N.z
     assert C.masscenter.pos_from(P.masscenter) == N.x
 
@@ -215,7 +215,7 @@ def test_pinjoint_arbitrary_axis():
             (omega*A.x + omega*A.y)/sqrt(2))
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.x + A.y)
-    assert expand_mul(angle).xreplace({omega: 1}) == 0
+    assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == (omega * A.z)/sqrt(2)
     assert C.masscenter.pos_from(P.masscenter) == N.x - A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==
@@ -242,7 +242,7 @@ def test_pinjoint_arbitrary_axis():
                                                      omega*A.z)/sqrt(3)
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.x + A.y-A.z)
-    assert expand_mul(angle).xreplace({omega: 1}) == 0
+    assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == (omega*A.y + omega*A.z)/sqrt(3)
     assert C.masscenter.pos_from(P.masscenter) == N.x - A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==
@@ -260,8 +260,8 @@ def test_pinjoint_arbitrary_axis():
     angle = (N.x-N.y+N.z).angle_between(A.x+A.y-A.z)
     assert expand_mul(angle) == 0  # Axis are aligned
     assert ((A.x-A.y+A.z).express(N).simplify() ==
-            (-4*cos(theta)/3 - 1/3)*N.x + (1/3 - 4*sin(theta + pi/6)/3)*N.y +
-            (4*cos(theta + pi/3)/3 - 1/3)*N.z)
+            (-4*cos(theta)/3 - S(1)/3)*N.x + (S(1)/3 - 4*sin(theta + pi/6)/3)*N.y +
+            (4*cos(theta + pi/3)/3 - S(1)/3)*N.z)
     assert A.dcm(N).simplify() == Matrix([
         [S(1)/3 - 2*cos(theta)/3, -2*sin(theta + pi/6)/3 - S(1)/3,
          2*cos(theta + pi/3)/3 + S(1)/3],
@@ -274,7 +274,7 @@ def test_pinjoint_arbitrary_axis():
                                                      omega*A.z)/sqrt(3)
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.x+A.y-A.z)
-    assert expand_mul(angle).xreplace({omega: 1}) == 0
+    assert angle.xreplace({omega: 1}) == 0
     assert (C.masscenter.vel(N).simplify() ==
             (m*omega*N.y + m*omega*N.z + n*omega*A.y + n*omega*A.z)/sqrt(3))
     assert C.masscenter.pos_from(P.masscenter) == m*N.x - n*A.x
@@ -428,9 +428,9 @@ def test_slidingjoint_arbitrary_axis():
     PrismaticJoint('S', P, C, parent_joint_pos=N.x, child_joint_pos=A.x, child_axis=A.x+A.y-A.z)
     assert N.x.angle_between(A.x + A.y - A.z) == 0 #Axis are aligned
     assert (A.x + A.y - A.z).express(N) == sqrt(3)*N.x
-    assert A.dcm(N) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
-                                [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
-                                [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
+    assert A.dcm(N).simplify() == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
+                                          [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
+                                          [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
     assert C.masscenter.pos_from(P.masscenter) == (x + 1)*N.x - A.x
     assert C.masscenter.pos_from(P.masscenter).express(N) == \
         (x - sqrt(3)/3 + 1)*N.x + sqrt(3)/3*N.y - sqrt(3)/3*N.z
@@ -445,9 +445,9 @@ def test_slidingjoint_arbitrary_axis():
                     child_axis=A.x+A.y-A.z, parent_axis=N.x-N.y+N.z)
     assert (N.x-N.y+N.z).angle_between(A.x+A.y-A.z) == 0 #Axis are aligned
     assert (A.x+A.y-A.z).express(N) == N.x - N.y + N.z
-    assert A.dcm(N) == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
-                                [S(2)/3, S(1)/3, S(2)/3],
-                                [-S(2)/3, S(2)/3, S(1)/3]])
+    assert A.dcm(N).simplify() == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
+                                          [S(2)/3, S(1)/3, S(2)/3],
+                                          [-S(2)/3, S(2)/3, S(1)/3]])
     assert C.masscenter.pos_from(P.masscenter) == \
         (m + sqrt(3)*x/3)*N.x - sqrt(3)*x/3*N.y + sqrt(3)*x/3*N.z - n*A.x
     assert C.masscenter.pos_from(P.masscenter).express(N) == \

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -121,7 +121,7 @@ def test_nonminimal_pendulum():
     assert LM.eom == eom_sol
     # Check multiplier solution
     lam_sol = Matrix([(19.6*q1 + 2*q1d**2 + 2*q2d**2)/(4*q1**2/m + 4*q2**2/m)])
-    assert LM.solve_multipliers(sol_type='Matrix') == lam_sol
+    assert simplify(LM.solve_multipliers(sol_type='Matrix')) == simplify(lam_sol)
 
 
 def test_dub_pen():

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,4 +1,5 @@
-from sympy.core.backend import symbols, Matrix, cos, sin, atan, sqrt, Rational
+from sympy.core.backend import (symbols, Matrix, cos, sin, atan, sqrt,
+    Rational, _simplify_matrix)
 from sympy import solve, simplify, sympify
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\
@@ -257,9 +258,7 @@ def test_linearize_pendulum_lagrange_minimal():
     # Linearize
     A, B, inp_vec = LM.linearize([q1], [q1d], A_and_B=True)
 
-    A.simplify()
-
-    assert A == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
+    assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
     assert B == Matrix([])
 
 def test_linearize_pendulum_lagrange_nonminimal():
@@ -292,8 +291,7 @@ def test_linearize_pendulum_lagrange_nonminimal():
     # Perform the Linearization
     A, B, inp_vec = LM.linearize([q2], [q2d], [q1], [q1d],
             op_point=op_point, A_and_B=True)
-    A.simplify()
-    assert A == Matrix([[0, 1], [-9.8/L, 0]])
+    assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])
 
 def test_linearize_rolling_disc_lagrange():

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -257,6 +257,8 @@ def test_linearize_pendulum_lagrange_minimal():
     # Linearize
     A, B, inp_vec = LM.linearize([q1], [q1d], A_and_B=True)
 
+    A.simplify()
+
     assert A == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
     assert B == Matrix([])
 
@@ -290,6 +292,7 @@ def test_linearize_pendulum_lagrange_nonminimal():
     # Perform the Linearization
     A, B, inp_vec = LM.linearize([q2], [q2d], [q1], [q1d],
             op_point=op_point, A_and_B=True)
+    A.simplify()
     assert A == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros, acos,
-    ImmutableMatrix as Matrix)
+    ImmutableMatrix as Matrix, _simplify_matrix)
 from sympy import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -653,7 +653,7 @@ class Vector(Printable, EvalfMixin):
         """Returns a simplified Vector."""
         d = {}
         for v in self.args:
-            d[v[1]] = v[0].simplify()
+            d[v[1]] = _simplify_matrix(v[0])
         return Vector(d)
 
     def subs(self, *args, **kwargs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#20374

#### Brief description of what is fixed or changed

Although symengine was being installed in the optional dependency job `USE_SYMENGINE=1` was not set so the tests did not actually use symengine. This adds a new `bin/test_symengine.py` script that can be used with or without `USE_SYMENGINE=1` to run the tests that can involve symengine wither with or without symengine.

This also ensures that symengine is actually being tested in CI

#### Other comments

There are already failures with symengine in mechanics. It seems to be to do with a change in symengine rather than in sympy.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
