### PR TITLE
Print with parenthesis around UnevaluatedExpr in CodePrinter

### DIFF
--- a/doc/src/tutorial/manipulation.rst
+++ b/doc/src/tutorial/manipulation.rst
@@ -546,7 +546,7 @@ expression. Combine both of the methods to prevent both inside and outside
 evaluations:
 
     >>> UnevaluatedExpr(sympify("x + x", evaluate=False)) + y
-    y + x + x
+    y + (x + x)
 
 ``UnevalutedExpr`` is supported by SymPy printers and can be used to print the
 result in different output forms. For example

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -502,9 +502,6 @@ class CodePrinter(StrPrinter):
         else:
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
-    def _print_UnevaluatedExpr(self, arg):
-        return "(%s)" % super()._print_UnevaluatedExpr(arg)
-
     def _print_not_supported(self, expr):
         try:
             self._not_supported.add(expr)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -502,6 +502,9 @@ class CodePrinter(StrPrinter):
         else:
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
+    def _print_UnevaluatedExpr(self, arg):
+        return "(%s)" % super()._print_UnevaluatedExpr(arg)
+
     def _print_not_supported(self, expr):
         try:
             self._not_supported.add(expr)

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -101,7 +101,7 @@ def precedence_FracElement(item):
 
 
 def precedence_UnevaluatedExpr(item):
-    return precedence(item.args[0])
+    return precedence(item.args[0]) - 0.5
 
 
 PRECEDENCE_FUNCTIONS = {

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -1,6 +1,6 @@
 from sympy.core import (
     S, pi, oo, symbols, Rational, Integer, Float, Mod, GoldenRatio, EulerGamma, Catalan,
-    Lambda, Dummy, Eq, nan, Mul, Pow
+    Lambda, Dummy, Eq, nan, Mul, Pow, UnevaluatedExpr
 )
 from sympy.functions import (
     Abs, acos, acosh, asin, asinh, atan, atanh, atan2, ceiling, cos, cosh, erf,
@@ -840,3 +840,7 @@ def test_ccode_submodule():
     # Test the compatibility sympy.printing.ccode module imports
     with warns_deprecated_sympy():
         import sympy.printing.ccode # noqa:F401
+
+
+def test_ccode_UnevaluatedExpr():
+    assert ccode(UnevaluatedExpr(y + x) + z) == "z + (x + y)"  # gh-21955

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -843,4 +843,7 @@ def test_ccode_submodule():
 
 
 def test_ccode_UnevaluatedExpr():
+    assert ccode(UnevaluatedExpr(y * x) + z) == "z + x*y"
     assert ccode(UnevaluatedExpr(y + x) + z) == "z + (x + y)"  # gh-21955
+    w = symbols('w')
+    assert ccode(UnevaluatedExpr(y + x) + UnevaluatedExpr(z + w)) == "(w + z) + (x + y)"


### PR DESCRIPTION


#### References to other Issues or PRs
Fixes #21955

#### Brief description of what is fixed or changed
Floating point add is not associative, it would be nice if we can use UnevaluatedExpr to represent this in the subclasses of CodePrinter.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
