### PR TITLE
Fix check whether _sage_ method has been replaced by Sage

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1864,7 +1864,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         old_method = self._sage_
         from sage.interfaces.sympy import sympy_init
         sympy_init()  # may monkey-patch _sage_ method into self's class or superclasses
-        if old_method is self._sage_:
+        if old_method == self._sage_:
             raise NotImplementedError('conversion to SageMath is not implemented')
         else:
             # call the freshly monkey-patched method


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

For SymPy classes for which Sage does not provide a `_sage_` method, code added in #21958 leads to:
```
sage: import sympy.physics
....: from sympy.physics.units import meter
sage: meter._sage_()
~/s/sage/sympy/sympy/core/basic.py in _sage_(self)
   1869         else:
   1870             # call the freshly monkey-patched method
-> 1871             return self._sage_()
   1872 
   1873 

RecursionError: maximum recursion depth exceeded
```

Fixed in this PR so it correctly says:
```
NotImplementedError: conversion to SageMath is not implemented
```

Sorry @oscarbenjamin for not noticing this earlier.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
