### PR TITLE
Float: Fix use of MPZ constructor when unpickling

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1155,13 +1155,20 @@ class Float(Number):
         elif isinstance(num, tuple) and len(num) in (3, 4):
             if type(num[1]) is str:
                 # it's a hexadecimal (coming from a pickled object)
-                # assume that it is in standard form
                 num = list(num)
                 # If we're loading an object pickled in Python 2 into
                 # Python 3, we may need to strip a tailing 'L' because
                 # of a shim for int on Python 3, see issue #13470.
                 if num[1].endswith('L'):
                     num[1] = num[1][:-1]
+                # Strip leading '0x' - gmpy2 only documents such inputs
+                # with base prefix as valid when the 2nd argument (base) is 0.
+                # When mpmath uses Sage as the backend, however, it
+                # ends up including '0x' when preparing the picklable tuple.
+                # See issue #19690.
+                if num[1].startswith('0x'):
+                    num[1] = num[1][2:]
+                # Now we can assume that it is in standard form
                 num[1] = MPZ(num[1], 16)
                 _mpf_ = tuple(num)
             else:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -443,11 +443,12 @@ def test_Float():
     assert (S(.3) == S(.5)) is False
 
     mpf = (0, 5404319552844595, -52, 53)
-    x_str =  Float((0, '13333333333333', -52, 53))
+    x_str = Float((0, '13333333333333', -52, 53))
+    x_0xstr = Float((0, '0x13333333333333', -52, 53))
     x2_str = Float((0, '26666666666666', -53, 54))
     x_hex = Float((0, int(0x13333333333333), -52, 53))
     x_dec = Float(mpf)
-    assert x_str == x_hex == x_dec == Float(1.2)
+    assert x_str == x_0xstr == x_hex == x_dec == Float(1.2)
     # x2_str was entered slightly malformed in that the mantissa
     # was even -- it should be odd and the even part should be
     # included with the exponent, but this is resolved by normalization


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19690

#### Brief description of what is fixed or changed
Use `MPZ` constructor as documented.


#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
   * A bug that preventing `Float` from being unpickled in SageMath was fixed.
<!-- END RELEASE NOTES -->
