### PR TITLE
added quaternion matrix and vector properties

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -74,17 +74,17 @@ class Quaternion(Expr):
     @property
     def d(self):
         return self._d
-    
+
     # vector/imaginary part as 3x1 Matrix
     @property
     def v(self):
         return Matrix([self._b,self._c,self._d])
-    
+
     # whole quaternion as 4x1 Matrix
     @property
     def v4(self):
         return Matrix([self._a,self._b,self._c,self._d])
-    
+
     @property
     def LM(self):
         return Matrix([
@@ -92,7 +92,7 @@ class Quaternion(Expr):
                 [+self.b,+self.a,-self.d,+self.c],
                 [+self.c,+self.d,+self.a,-self.b],
                 [+self.d,-self.c,+self.b,+self.a]])
-    
+
     @property
     def RM(self):
         return Matrix([

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -74,6 +74,32 @@ class Quaternion(Expr):
     @property
     def d(self):
         return self._d
+    
+    # vector/imaginary part as 3x1 Matrix
+    @property
+    def v(self):
+        return Matrix([self._b,self._c,self._d])
+    
+    # whole quaternion as 4x1 Matrix
+    @property
+    def v4(self):
+        return Matrix([self._a,self._b,self._c,self._d])
+    
+    @property
+    def LM(self):
+        return Matrix([
+                [+self.a,-self.b,-self.c,-self.d],
+                [+self.b,+self.a,-self.d,+self.c],
+                [+self.c,+self.d,+self.a,-self.b],
+                [+self.d,-self.c,+self.b,+self.a]])
+    
+    @property
+    def RM(self):
+        return Matrix([
+                [+self.a,-self.b,-self.c,-self.d],
+                [+self.b,+self.a,+self.d,-self.c],
+                [+self.c,-self.d,+self.a,+self.b],
+                [+self.d,+self.c,-self.b,+self.a]])
 
     @property
     def real_field(self):


### PR DESCRIPTION
Added vector and matrix properties to the Quaternion class

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Sometimes it is useful to get the imaginary part of a quaternion as a vector (3x1 Matrix), and sometimes it is useful to have the whole quaternion as a 4-vector.
I propose adding two properties to get exactly this: 
- Quaternion.v = returns the imaginary part as a 3x1 Matrix / vector
- Quaternion.v4 = returns the real+imaginary parts as a 4x1 Matrix / 4-vector

Moreover, treating the quaternion as a 4-vector, we can easily define the Hamilton product between two quaternions as the product between a 4x4 matrix and quaternion (more can be read about this on Wikipedia).
I propose the addition of two more properties: one that gives a matrix representing the product by a quaternion on the left, and another one representing the product of the quaternion on the right:
- Quaternion.LM = matrix representing the multiplication by the quaternion on the left
- Quaternion.RM = matrix representing the multiplication by the quaternion on the right

To check that the implementations are correct, we can easily compare these three expressions:
q = Quaternion(qa,qb,qc,qd)
p = Quaternion(pa,pb,pc,pd)
expr1 = (p * q).v4
expr2 = p.LM * q.v4
expr3 = q.RM * p.v4

#### Other comments

It would also be useful to define the multiplication between 3x1 matrices and 4x1 matrices with quaternions. Mathutils from Blender, for example, defines the operation q @ v between a unit quaternion q and a 3x1 vector v as the rotation of vector v by quaternion q.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * added Quaternion.v property, returns imaginary part as 3x1 Matrix
  * added Quaternion.v4 property, returns all values as 4x1 Matrix
  * added Quaternion.LM property, returns 4x4 matrix representing the product with the Quaternion from the left
  * added Quaternion.RM property, returns 4x4 matrix representing the product with the Quaternion from the right

<!-- END RELEASE NOTES -->
