### PR TITLE
break after getting solution

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1910,7 +1910,6 @@ def _solve_system(exprs, symbols, **flags):
             newresult = []
             bad_results = []
             got_s = set()
-            hit = False
             for r in result:
                 # update eq with everything that is known so far
                 eq2 = eq.subs(r)
@@ -1961,9 +1960,9 @@ def _solve_system(exprs, symbols, **flags):
                         else:
                             # keep it
                             newresult.append(rnew)
-                    hit = True
                     got_s.add(s)
-                if not hit:
+                    break
+                else:
                     raise NotImplementedError('could not solve %s' % eq2)
             else:
                 result = newresult

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1961,8 +1961,10 @@ def _solve_system(exprs, symbols, **flags):
                             # keep it
                             newresult.append(rnew)
                     got_s.add(s)
-                    break
-                else:
+                    hit = True
+                    if manual:
+                        break  # just take first solution
+                if not hit:
                     raise NotImplementedError('could not solve %s' % eq2)
             else:
                 result = newresult

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1405,6 +1405,10 @@ def test_issue_21882():
     ]
 
     assert solve(equations, unknowns, dict=True) == answer
+    assert solve([equations[i] for i in (0, 4, 5)], manual=True) == [
+        {a: c*(36*k**2 - 116*k + 79)/(12*k - 11)/3,
+         b: 2*c*(9*k - 17)/(12*k - 11)/9,
+         d: (216*c*k**3 - 984*c*k**2 + 1318*c*k - 520*c - 180*f*k + 165*f)/(12*k - 11)/15}]
 
 
 def test_issue_5901():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
When in manual/failed mode, the solver tries to solve each equation for all unknowns. It seems like it should stop after finding an unknown for which it can solve.

When no symbols are selected, there should be a prioritized selection of subset of symbols for which to solve. For these equations,
```
sub = [-a*k + 4*a/3 + b + 2*c/9 + 5*d/6 + 5*f/6, a + b/2 - c*k + 20*c/9, a/6 - b*k + b + c/18]
```
It should pick 3 symbols that appear in in all equations--and not pick k which always appears nonlinearly.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
