### PR TITLE
Fixed #22020 by checking for oo in numerical equals

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -666,7 +666,8 @@ class Expr(Basic, EvalfMixin):
                     a = expr._random(None, 0, 0, 0, 0)
             except ZeroDivisionError:
                 a = None
-            if a is not None and a not in (S.NaN, S.Infinity, S.NegativeInfinity):
+            from sympy.polys.polyutils import illegal
+            if a is not None and a not in illegal:
                 try:
                     b = expr.subs(list(zip(free, [1]*len(free))),
                         simultaneous=True)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -666,7 +666,7 @@ class Expr(Basic, EvalfMixin):
                     a = expr._random(None, 0, 0, 0, 0)
             except ZeroDivisionError:
                 a = None
-            if a is not None and a is not S.NaN:
+            if a is not None and a not in (S.NaN, S.Infinity, S.NegativeInfinity):
                 try:
                     b = expr.subs(list(zip(free, [1]*len(free))),
                         simultaneous=True)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2135,6 +2135,13 @@ def test_non_string_equality():
     assert (x != BadRepr()) is True
 
 
+def test_issue_22020():
+    from sympy.parsing.sympy_parser import parse_expr
+    x = parse_expr("log((2*V/3-V)/C)/-(R+r)*C")
+    y = parse_expr("log((2*V/3-V)/C)/-(R+r)*2")
+    assert x.equals(y) is None
+
+
 def test_21494():
     from sympy.testing.pytest import warns_deprecated_sympy
     with warns_deprecated_sympy():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2077,7 +2077,7 @@ def test_issue_10651():
     assert e1.is_constant() is None
     assert e3.is_constant() is None
     assert e4.is_constant() is None
-    assert e5.is_constant() is False
+    assert e5.is_constant() is None
 
 
 def test_issue_10161():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #22020

#### Brief description of what is fixed or changed
It seems like `evalf` now returns `oo`  instead of throwing `ZeroDivisionError` for some cases. This breaks equals resulting in an error that `oo` cannot be turned into an `int`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Fixed issue when performing `is_constant()` on certain expressions which may result in division by zero.
<!-- END RELEASE NOTES -->
