### PR TITLE
Fixed issue with simplifying oo + imaginary

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2112,7 +2112,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
         if not clear and coeff.is_Rational and coeff.q != 1:
             args = [i.as_coeff_Mul() for i in factors.args]
             args = [(_keep_coeff(c, coeff), m) for c, m in args]
-            if any(not c.is_infinite and c == int(c) for c, _ in args):
+            if any(c.is_Integer for c, _ in args):
                 return Add._from_args([Mul._from_args(
                     i[1:] if i[0] == 1 else i) for i in args])
         return Mul(coeff, factors, evaluate=False)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2112,7 +2112,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
         if not clear and coeff.is_Rational and coeff.q != 1:
             args = [i.as_coeff_Mul() for i in factors.args]
             args = [(_keep_coeff(c, coeff), m) for c, m in args]
-            if any(c == int(c) for c, _ in args):
+            if any(not c.is_infinite and c == int(c) for c, _ in args):
                 return Add._from_args([Mul._from_args(
                     i[1:] if i[0] == 1 else i) for i in args])
         return Mul(coeff, factors, evaluate=False)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2113,6 +2113,13 @@ def test_ExprBuilder():
     assert eb.build() == x**2
 
 
+def test_issue_22020():
+    from sympy.parsing.sympy_parser import parse_expr
+    x = parse_expr("log((2*V/3-V)/C)/-(R+r)*C")
+    y = parse_expr("log((2*V/3-V)/C)/-(R+r)*2")
+    assert x.equals(y) is False
+
+
 def test_non_string_equality():
     # Expressions should not compare equal to strings
     x = symbols('x')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -984,6 +984,13 @@ def test_issue_7950():
     expr = And(Eq(x, 1), Eq(x, 2))
     assert simplify(expr) == S.false
 
+
+def test_issue_22020():
+    expr = I*pi/2 -oo
+    assert simplify(expr) == expr
+    # Used to throw an error
+
+
 def test_issue_19484():
     assert simplify(sign(x) * Abs(x)) == x
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #22020

#### Brief description of what is fixed or changed
Simplifying expressions of the type `oo + I/2` used to throw an error. Not anymore.

#### Other comments
To be honest, I do not fully understand the logic behind the code I added, but it seems to work and avoids the `int(c)` that was the cause of all evil here.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
     * Fixed issue with simplifying infinity plus rational imaginary.
<!-- END RELEASE NOTES -->
