### PR TITLE
fix(multipledispatch): use OrderedDict for deterministic behaviour

### DIFF
--- a/sympy/multipledispatch/utils.py
+++ b/sympy/multipledispatch/utils.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 def expand_tuples(L):
     """
     >>> from sympy.multipledispatch.utils import expand_tuples
@@ -39,17 +42,17 @@ def _toposort(edges):
     """
     incoming_edges = reverse_dict(edges)
     incoming_edges = {k: set(val) for k, val in incoming_edges.items()}
-    S = {v for v in edges if v not in incoming_edges}
+    S = OrderedDict.fromkeys(v for v in edges if v not in incoming_edges)
     L = []
 
     while S:
-        n = S.pop()
+        n, _ = S.popitem()
         L.append(n)
         for m in edges.get(n, ()):
             assert n in incoming_edges[m]
             incoming_edges[m].remove(n)
             if not incoming_edges[m]:
-                S.add(m)
+                S[m] = None
     if any(incoming_edges.get(v, None) for v in edges):
         raise ValueError("Input has cycles")
     return L


### PR DESCRIPTION
Without OrderedDict the following is non-deterministic:
```python
from sympy.multipledispatch import dispatch

class A: pass

class B: pass

class C(A, B): pass

class D(B, A): pass

@dispatch(A)
def f(a):
    print('A method')

@dispatch(B)
def f(B):
    print('B method')

c = C()
d = D()

f(c)
f(d)
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21968

#### Other comments

It would be better to remove multipledispatch from sympy and use the PyPI version.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
