### PR TITLE
do not sort args during 2-arg mul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -275,14 +275,8 @@ class Mul(Expr, AssocOp):
                             arb = cls(a*r, b, evaluate=False)
                         rv = [arb], [], None
                     elif global_parameters.distribute and b.is_commutative:
-                        r, b = b.as_coeff_Add()
-                        bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
-                        _addsort(bargs)
-                        ar = a*r
-                        if ar:
-                            bargs.insert(0, ar)
-                        bargs = [Add._from_args(bargs)]
-                        rv = bargs, [], None
+                        newb = Add(*[_keep_coeff(a, bi) for bi in b.args])
+                        rv = [newb], [], None
             if rv:
                 return rv
 
@@ -2144,4 +2138,4 @@ def expand_2arg(e):
 
 from .numbers import Rational
 from .power import Pow
-from .add import Add, _addsort, _unevaluated_Add
+from .add import Add, _unevaluated_Add

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2354,3 +2354,24 @@ def test_issue_17130():
 def test_issue_21034():
     e = -I*log((re(asin(5)) + I*im(asin(5)))/sqrt(re(asin(5))**2 + im(asin(5))**2))/pi
     assert e.round(2)
+
+
+def test_issue_22021():
+    from sympy.calculus.util import AccumBounds
+    from sympy.utilities.iterables import permutations
+    # these objects are special cases in Mul
+    from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensor_heads
+    L = TensorIndexType("L")
+    i = tensor_indices("i", L)
+    A, B = tensor_heads("A B", [L])
+    e = A(i) + B(i)
+    assert -e == -1*e
+    e = zoo + x
+    assert -e == -1*e
+    a = AccumBounds(1, 2)
+    e = a + x
+    assert -e == -1*e
+    for args in permutations((zoo, a, x)):
+        e = Add(*args, evaluate=False)
+        assert -e == -1*e
+    assert 2*Add(1, x, x, evaluate=False) == 4*x + 2


### PR DESCRIPTION
Since this should be an evaluate=True operation
(and Add ordered TensExpr, AccumBounds, and zoo
independently of the sort key) we no longer
avoid the evaluation step after distributing the
Rational.

This has the benefit that the 2-arg multiplication result is now fully evaluated, e.g.
```python
>>> 2*Add(1,x,x,evaluate=False)
2*x + 2*x + 2
```
is now
```python
4*x + 2
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
closes #22021

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * multiplying an Add by a Rational will now yield a fully evaluated expression
<!-- END RELEASE NOTES -->
