### PR TITLE
maint: add version_tuple instead of LooseVersion

### DIFF
--- a/bin/authors_update.py
+++ b/bin/authors_update.py
@@ -19,7 +19,7 @@ if sys.version_info < (3, 6):
     sys.exit("This script requires Python 3.6 or newer")
 
 from subprocess import run, PIPE
-from distutils.version import LooseVersion
+from sympy.external.importtools import version_tuple
 from collections import OrderedDict
 
 def red(text):
@@ -44,7 +44,7 @@ from sympy.utilities.misc import filldedent
 # check git version
 minimal = '1.8.4.2'
 git_ver = run(['git', '--version'], stdout=PIPE, encoding='utf-8').stdout[12:]
-if LooseVersion(git_ver) < LooseVersion(minimal):
+if version_tuple(git_ver) < version_tuple(minimal):
     print(yellow("Please use a git version >= %s" % minimal))
 
 def author_name(line):

--- a/bin/mailmap_update.py
+++ b/bin/mailmap_update.py
@@ -15,7 +15,7 @@ if sys.version_info < (3, 6):
     sys.exit("This script requires Python 3.6 or newer")
 
 from subprocess import run, PIPE
-from distutils.version import LooseVersion
+from sympy.external.importtools import version_tuple
 from collections import defaultdict, OrderedDict
 
 def red(text):
@@ -41,7 +41,7 @@ from sympy.utilities.iterables import sift
 # check git version
 minimal = '1.8.4.2'
 git_ver = run(['git', '--version'], stdout=PIPE, encoding='utf-8').stdout[12:]
-if LooseVersion(git_ver) < LooseVersion(minimal):
+if version_tuple(git_ver) < version_tuple(minimal):
     print(yellow("Please use a git version >= %s" % minimal))
 
 def author_name(line):

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,10 @@ except ImportError:
     extra_kwargs['scripts'] = ['bin/isympy']
 
     # handle mpmath deps in the hard way:
-    from distutils.version import LooseVersion
+    from sympy.external.importtools import version_tuple
     try:
         import mpmath
-        if mpmath.__version__ < LooseVersion(min_mpmath_version):
+        if version_tuple(mpmath.__version__) < version_tuple(min_mpmath_version):
             raise ImportError
     except ImportError:
         print("Please install the mpmath package with a version >= %s"

--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -1,6 +1,6 @@
 import sys
 sys._running_pytest = True  # type: ignore
-from distutils.version import LooseVersion as V
+from sympy.external.importtools import version_tuple
 
 import pytest
 from sympy.core.cache import clear_cache
@@ -70,6 +70,6 @@ def check_disabled(request):
         pytest.skip("test requirements not met.")
     elif getattr(request.module, 'ipython', False):
         # need to check version and options for ipython tests
-        if (V(pytest.__version__) < '2.6.3' and
+        if (version_tuple(pytest.__version__) < version_tuple('2.6.3') and
             pytest.config.getvalue('-s') != 'no'):
             pytest.skip("run py.test with -s or upgrade to newer version.")

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -4,8 +4,7 @@
 # Always write regular SymPy tests for anything, that can be tested in pure
 # Python (without numpy). Here we test everything, that a user may need when
 # using SymPy with NumPy
-from distutils.version import LooseVersion
-
+from sympy.external.importtools import version_tuple
 from sympy.external import import_module
 
 numpy = import_module('numpy')
@@ -235,7 +234,7 @@ def test_lambdify():
 
     # if this succeeds, it can't be a numpy function
 
-    if LooseVersion(numpy.__version__) >= LooseVersion('1.17'):
+    if version_tuples(numpy.__version__) >= version_tuples('1.17'):
         with raises(TypeError):
             f(x)
     else:

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -234,7 +234,7 @@ def test_lambdify():
 
     # if this succeeds, it can't be a numpy function
 
-    if version_tuples(numpy.__version__) >= version_tuples('1.17'):
+    if version_tuple(numpy.__version__) >= version_tuple('1.17'):
         with raises(TypeError):
             f(x)
     else:

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -1,7 +1,7 @@
 """Tools for setting up printing in interactive sessions. """
 
 import sys
-from distutils.version import LooseVersion as V
+from sympy.external.importtools import version_tuple
 from io import BytesIO
 
 from sympy import latex as default_latex
@@ -247,7 +247,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             print(repr(arg))
 
     import IPython
-    if V(IPython.__version__) >= '0.11':
+    if version_tuple(IPython.__version__) >= version_tuple('0.11'):
 
         # Printable is our own type, so we handle it with methods instead of
         # the approach required by builtin types. This allows downstream
@@ -524,7 +524,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
             # IPython 1.0 deprecates the frontend module, so we import directly
             # from the terminal module to prevent a deprecation message from being
             # shown.
-            if V(IPython.__version__) >= '1.0':
+            if version_tuple(IPython.__version__) >= version_tuple('1.0'):
                 from IPython.terminal.interactiveshell import TerminalInteractiveShell
             else:
                 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -1,6 +1,6 @@
 """Tools for setting up interactive sessions. """
 
-from distutils.version import LooseVersion as V
+from sympy.external.importtools import version_tuple
 
 from sympy.interactive.printing import init_printing
 
@@ -234,13 +234,13 @@ def init_ipython_session(shell=None, argv=[], auto_symbols=False, auto_int_to_In
     """Construct new IPython session. """
     import IPython
 
-    if V(IPython.__version__) >= '0.11':
+    if version_tuple(IPython.__version__) >= version_tuple('0.11'):
         if not shell:
             # use an app to parse the command line, and init config
             # IPython 1.0 deprecates the frontend module, so we import directly
             # from the terminal module to prevent a deprecation message from being
             # shown.
-            if V(IPython.__version__) >= '1.0':
+            if version_tuple(IPython.__version__) >= version_tuple('1.0'):
                 from IPython.terminal import ipapp
             else:
                 from IPython.frontend.terminal import ipapp
@@ -421,7 +421,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
         ip = init_ipython_session(ip, argv=argv, auto_symbols=auto_symbols,
                                   auto_int_to_Integer=auto_int_to_Integer)
 
-        if V(IPython.__version__) >= '0.11':
+        if version_tuple(IPython.__version__) >= version_tuple('0.11'):
             # runsource is gone, use run_cell instead, which doesn't
             # take a symbol arg.  The second arg is `store_history`,
             # and False means don't add the line to IPython's history.
@@ -439,9 +439,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
         if not in_ipython:
             mainloop = ip.mainloop
 
-    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11'):
+    if auto_symbols and (not ipython or version_tuple(IPython.__version__) < version_tuple('0.11')):
         raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")
-    if auto_int_to_Integer and (not ipython or V(IPython.__version__) < '0.11'):
+    if auto_int_to_Integer and (not ipython or version_tuple(IPython.__version__) < version_tuple('0.11')):
         raise RuntimeError("automatic int to Integer transformation is possible only in IPython 0.11 or above")
 
     _preexec_source = preexec_source

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion as V
+from sympy.external.importtools import version_tuple
 from collections.abc import Iterable
 
 from sympy import Mul, S
@@ -116,7 +116,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
 
     def _print_Transpose(self, expr):
         version = self.tensorflow_version
-        if version and V(version) < V('1.14'):
+        if version and version_tuple(version) < version_tuple('1.14'):
             op = self._module_format('tensorflow.matrix_transpose')
         else:
             op = self._module_format('tensorflow.linalg.matrix_transpose')
@@ -138,7 +138,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
 
     def _print_Piecewise(self, expr):
         version = self.tensorflow_version
-        if version and V(version) < V('1.0'):
+        if version and version_tuple(version) < version_tuple('1.0'):
             tensorflow_piecewise = "tensorflow.select"
         else:
             tensorflow_piecewise = "tensorflow.where"


### PR DESCRIPTION
Previously sympy used the LooseVersion class from distutils.versions. As
of Python 3.10 distutils is deprecated and shows a warning on import.
This commit extracts the basic algorithm of LooseVersion into a simple
function version_tuple to be used for comparing versions.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22026 on the 1.9 branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- external
    - No longer use deprecated distutils. Previously a deprecation warning was seen when importing sympy on Python 3.10.
<!-- END RELEASE NOTES -->
