### PR TITLE
remove domain arg from invert_real

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1085,7 +1085,9 @@ class Interval(Set):
 
     def _contains(self, other):
         if (not isinstance(other, Expr) or other is S.NaN
-            or other.is_real is False):
+            or other.is_real is False or other.has(S.ComplexInfinity)):
+                # if an expression has zoo it will be zoo or nan
+                # and neither of those is real
                 return false
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -584,6 +584,9 @@ def test_Reals():
     assert S.Reals != Interval(0, oo)
     assert S.Reals.is_subset(Interval(-oo, oo))
     assert S.Reals.intersect(Range(-oo, oo)) == Range(-oo, oo)
+    assert S.ComplexInfinity not in S.Reals
+    assert S.NaN not in S.Reals
+    assert x + S.ComplexInfinity not in S.Reals
 
 
 def test_Complex():

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -186,12 +186,12 @@ def _invert(f_x, y, x, domain=S.Complexes):
 invert_complex = _invert
 
 
-def invert_real(f_x, y, x, domain=S.Reals):
+def invert_real(f_x, y, x):
     """
-    Inverts a real-valued function. Same as _invert, but sets
+    Inverts a real-valued function. Same as ``_invert``, but sets
     the domain to ``S.Reals`` before inverting.
     """
-    return _invert(f_x, y, x, domain)
+    return _invert(f_x, y, x, S.Reals)
 
 
 def _invert_real(f, g_ys, symbol):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -62,9 +62,6 @@ def test_invert_real():
     def ireal(x, s=S.Reals):
         return Intersection(s, x)
 
-    # issue 14223
-    assert invert_real(x, 0, x, Interval(1, 2)) == (x, S.EmptySet)
-
     assert invert_real(exp(x), z, x) == (x, ireal(FiniteSet(log(z))))
 
     y = Symbol('y', positive=True)
@@ -2216,6 +2213,7 @@ def test_issue_14223():
         S.Reals) == FiniteSet(-1, 1)
     assert solveset((Abs(x + Min(x, 2)) - 2).rewrite(Piecewise), x,
         Interval(0, 2)) == FiniteSet(1)
+    assert solveset(x, x, FiniteSet(1, 2)) is S.EmptySet
 
 
 def test_issue_10158():
@@ -2247,8 +2245,8 @@ def test_issue_14300():
 
 def test_issue_14454():
     number = CRootOf(x**4 + x - 1, 2)
-    raises(ValueError, lambda: invert_real(number, 0, x, S.Reals))
-    assert invert_real(x**2, number, x, S.Reals)  # no error
+    raises(ValueError, lambda: invert_real(number, 0, x))
+    assert invert_real(x**2, number, x)  # no error
 
 
 def test_issue_17882():


### PR DESCRIPTION
This private function does not need the domain
argument. All the domain handling happens at a
higher level. This function just assures the caller
that the result will be real.

Also, expressions like `x + zoo` were not filtered from FiniteSet when intersected with Reals
but since the only possible values are nan and zoo (when x is infinity or finite, respectively) and
neither of those are currently  in Reals then the sum can be excluded, too.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
