### PR TITLE
Fix typo: Explnation to Explanation

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -924,8 +924,8 @@ class Pow(Expr):
     def as_base_exp(self):
         """Return base and exp of self.
 
-        Explnation
-        ==========
+        Explanation
+        ===========
 
         If base is 1/Integer, then return Integer, -exp. If this extra
         processing is not needed, the base and exp properties will


### PR DESCRIPTION
Fix small typo in docstring of sympy.core.power.Pow

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
