### PR TITLE
Fixed issue with matching

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1556,7 +1556,13 @@ class Basic(Printable, metaclass=ManagedProperties):
         for arg, other_arg in zip(self.args, expr.args):
             if arg == other_arg:
                 continue
-            d = arg.xreplace(d).matches(other_arg, d, old=old)
+            if arg.is_Relational:
+                try:
+                    d = arg.xreplace(d).matches(other_arg, d, old=old)
+                except TypeError: # Should be InvalidCompatisonError when introduced
+                    d = None
+            else:
+                    d = arg.xreplace(d).matches(other_arg, d, old=old)
             if d is None:
                 return None
         return d

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1559,7 +1559,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             if arg.is_Relational:
                 try:
                     d = arg.xreplace(d).matches(other_arg, d, old=old)
-                except TypeError: # Should be InvalidCompatisonError when introduced
+                except TypeError: # Should be InvalidComparisonError when introduced
                     d = None
             else:
                     d = arg.xreplace(d).matches(other_arg, d, old=old)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -691,6 +691,14 @@ def test_gh_issue_2711():
         {meijerg(((), ()), ((S.Zero,), ()), x), x, S.Zero}
     assert f.find(a**2) == {meijerg(((), ()), ((S.Zero,), ()), x), x}
 
+
+def test_issue_17354():
+    from sympy import symbols, Wild
+    x, y = symbols("x y", real=True)
+    a, b = symbols("a b", cls=Wild)
+    assert ((0 <= x).reversed | (y <= x)).match((1/a <= b) | (a <= b)) is None
+
+
 def test_match_issue_17397():
     f = Function("f")
     x = Symbol("x")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracted a part of #17443 that doesn't have to wait for the rest of the code.
Solves parts of #17354 (the matching issue, not the original one).

#### Brief description of what is fixed or changed
`match` with some expressions now work without throwing an error.

#### Other comments
Yes, catching `ValueError` is bad, but that is what we have to live with for now.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `match` no longer throws are exception for certain relationals.  
<!-- END RELEASE NOTES -->
