### PR TITLE
Reverted useless fix of solveset domain handling and removed useless code

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1106,28 +1106,17 @@ def _solveset(f, symbol, domain, _check=False):
     if isinstance(result, ConditionSet):
         if isinstance(f, Expr):
             num, den = f.as_numer_denom()
-        else:
-            num, den = f, S.One
-        if den.has(symbol):
-            _result = _solveset(num, symbol, domain)
-            if not isinstance(_result, ConditionSet):
-                singularities = _solveset(den, symbol, domain)
-                result = _result - singularities
+            if den.has(symbol):
+                _result = _solveset(num, symbol, domain)
+                if not isinstance(_result, ConditionSet):
+                    singularities = _solveset(den, symbol, domain)
+                    result = _result - singularities
 
     if _check:
         if isinstance(result, ConditionSet):
             # it wasn't solved or has enumerated all conditions
             # -- leave it alone
-            if domain is S.Complexes:
-                return result
-            # Add domain
-            new_res = Intersection(result, domain)
-            # Check if the domain is really contributing
-            if new_res.is_subset(result):
-                return new_res
-            else:
-                return result
-
+            return result
 
         # whittle away all but the symbol-containing core
         # to use this for testing


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removes the useless fix attempt from #21925.

The only potential benefit of the "new and improved" fix I tried out is that `solveset(sin(log(x)), x, Interval(0,1, True, False))` from #17579 returns an intersection with the original domain, so the solution is not incorrect, but also not what is really expected, so I do not suggest that. (Simply `result = Intersection(result, domain)` before line 1106 if domain is not S.Complexes.)

I also found a bit of useless code. If den is S.One (the second case), it will never contain symbol, so no need to assign and test in that case.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
