### PR TITLE
Array expressions: fix bug in conversion to matrix

### DIFF
--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -641,6 +641,8 @@ class ArrayDiagonal(_CodegenArrayAbstract):
         # dimensions:
         shape = get_shape(expr)
         for i in diagonal_indices:
+            if any(j >= len(shape) for j in i):
+                raise ValueError("index is larger than expression shape")
             if len({shape[j] for j in i}) != 1:
                 raise ValueError("diagonalizing indices of different dimensions")
             if len(i) <= 1:

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -394,8 +394,11 @@ def _(expr: ArrayContraction):
 def _(expr: ArrayDiagonal):
     newexpr, removed = _remove_trivial_dims(expr.expr)
     shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_rank(expr.expr))]))
-    new_diag_indices = [tuple(j for j in i if j not in removed) for i in expr.diagonal_indices]
-    new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices]
+    new_diag_indices = {i: tuple(j for j in i if j not in removed) for i in expr.diagonal_indices}
+    for old_diag_tuple, new_diag_tuple in new_diag_indices.items():
+        if len(new_diag_tuple) == 1:
+            removed = [i for i in removed if i not in old_diag_tuple]
+    new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices.values()]
     rank = get_rank(expr.expr)
     removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, rank)
     removed = sorted({i for i in removed})

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -835,7 +835,7 @@ def remove_identity_matrices(expr: ArrayContraction):
         for i in identity_matrices:
             i.element = None
             removed.extend(range(free_map[i], free_map[i] + len([j for j in i.indices if j is None])))
-        last_removed = removed.pop(-1)  # [-1]  # .pop(-1)
+        last_removed = removed.pop(-1)
         update_pairs[last_removed, ind] = non_identity.indices[:]
         # Remove the indices from the non-identity matrix, as the contraction
         # no longer exists:

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -350,9 +350,13 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 3, 4, 5, 6]
 
+    expr = ArrayDiagonal(ArrayContraction(ArrayTensorProduct(A, x, I, I1), (1, 2, 5)), (1, 4))
+    rexpr, removed = _remove_trivial_dims(expr)
+    assert removed == [1, 2]
+
     cg = ArrayDiagonal(ArrayTensorProduct(PermuteDims(ArrayTensorProduct(x, I1), Permutation(1, 2, 3)), (x.T*x).applyfunc(sqrt)), (2, 4), (3, 5))
     rexpr, removed = _remove_trivial_dims(cg)
-    assert removed == [1, 2, 3]
+    assert removed == [1, 2]
 
     # Contractions with identity matrices need to be followed by a permutation
     # in order


### PR DESCRIPTION
- Fixing bug returning more removed dimensions in _remove_trivial_dims( ) for ArrayDiagonal objects.
- Remove unnecessary comment.
- Add better exceptions in case of failed validation for ArrayDiagonal.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
