### PR TITLE
More fixes on conversion from array expressions to matrix expressions

### DIFF
--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -530,7 +530,10 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
             pos1_in2 = 1 - pos1_inner
             pos2_in2 = 1 - pos2_inner
             if arg1.shape[pos1_in2] == 1:
-                darg1 = DiagMatrix(arg1)
+                if arg1.shape[pos1_inner] != 1:
+                    darg1 = DiagMatrix(arg1)
+                else:
+                    darg1 = arg1
                 args.append(darg1)
                 contr_indices.append(((pos2_outer, pos2_inner), (len(args)-1, pos1_inner)))
                 total_rank += 1
@@ -538,7 +541,10 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                 args[pos1_outer] = OneArray(arg1.shape[pos1_in2])
                 replaced[pos1_outer] = True
             elif arg2.shape[pos2_in2] == 1:
-                darg2 = DiagMatrix(arg2)
+                if arg2.shape[pos2_inner] != 1:
+                    darg2 = DiagMatrix(arg2)
+                else:
+                    darg2 = arg2
                 args.append(darg2)
                 contr_indices.append(((pos1_outer, pos1_inner), (len(args)-1, pos2_inner)))
                 total_rank += 1

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -178,12 +178,15 @@ def test_arrayexpr_array_flatten():
 
     expr1 = ArrayDiagonal(ArrayTensorProduct(X, A), (1, 2))
     expr2 = ArrayTensorProduct(expr1, a)
-    assert expr2 == PermuteDims(ArrayDiagonal(ArrayTensorProduct(X, A, a), (1, 2)), [0, 1, 3, 4, 2])
+    assert expr2 == PermuteDims(ArrayDiagonal(ArrayTensorProduct(X, A, a), (1, 2)), [0, 1, 4, 2, 3])
 
     expr1 = ArrayContraction(ArrayTensorProduct(X, A), (1, 2))
     expr2 = ArrayTensorProduct(expr1, a)
     assert isinstance(expr2, ArrayContraction)
     assert isinstance(expr2.expr, ArrayTensorProduct)
+
+    cg = ArrayTensorProduct(ArrayDiagonal(ArrayTensorProduct(A, X, Y), (0, 3), (1, 5)), a, b)
+    assert cg == PermuteDims(ArrayDiagonal(ArrayTensorProduct(A, X, Y, a, b), (0, 3), (1, 5)), [0, 1, 6, 7, 2, 3, 4, 5])
 
 
 def test_arrayexpr_array_diagonal():

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -173,6 +173,13 @@ def test_arrayexpr_convert_array_to_diagonalized_vector():
     # TODO: this is returning a wrong result:
     # convert_array_to_matrix(cg)
 
+    cg = ArrayDiagonal(ArrayTensorProduct(I1, a, b), (1, 3, 5))
+    assert convert_array_to_matrix(cg) == a*b.T
+
+    cg = ArrayDiagonal(ArrayTensorProduct(I1, a, b), (1, 3))
+    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(OneArray(1), a, b, I1), (2, 6))
+    assert convert_array_to_matrix(cg) == a*b.T
+
     cg = ArrayDiagonal(ArrayTensorProduct(x, I1), (1, 2))
     assert isinstance(cg, ArrayDiagonal)
     assert cg.diagonal_indices == ((1, 2),)


### PR DESCRIPTION
- Fixing normalization of ArrayDiagonal nested in ArrayTensorProduct.
- No diagonalization of trivial vectors (i.e. with only one axis).


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
