### PR TITLE
Cleanup in utilities.iterables including no more usage of cartes

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -9,12 +9,13 @@ from .function import FunctionClass
 from .kind import NumberKind, UndefinedKind
 from sympy.core.logic import fuzzy_bool
 from sympy.logic.boolalg import Boolean
-from sympy.utilities.iterables import cartes, sift
+from sympy.utilities.iterables import sift
 from sympy.core.containers import Tuple
 
 import string
 import re as _re
 import random
+from itertools import product
 
 class Str(Atom):
     """
@@ -741,7 +742,7 @@ def symbols(names, *, cls=Symbol, **args):
                 if len(split) == 1:
                     names = split[0]
                 else:
-                    names = [''.join(s) for s in cartes(*split)]
+                    names = [''.join(s) for s in product(*split)]
                 if literals:
                     result.extend([cls(literal(s), **args) for s in names])
                 else:

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -21,9 +21,8 @@ from sympy.logic.boolalg import (
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
-from sympy.utilities.iterables import cartes
 
-from itertools import combinations, permutations
+from itertools import combinations, permutations, product
 
 A, B, C, D = symbols('A:D')
 a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
@@ -760,7 +759,7 @@ def test_true_false():
     assert ~true is false
     assert ~false is true
 
-    for T, F in cartes([True, true], [False, false]):
+    for T, F in product((True, true), (False, false)):
         assert And(T, F) is false
         assert And(F, T) is false
         assert And(F, F) is false

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,6 +1,5 @@
 from sympy.core.compatibility import as_int
 from sympy.core.function import Function
-from sympy.utilities.iterables import cartes
 from sympy.core.numbers import igcd, igcdex, mod_inverse
 from sympy.core.power import isqrt
 from sympy.core.singleton import S
@@ -8,7 +7,7 @@ from .primetest import isprime
 from .factor_ import factorint, trailing, totient, multiplicity
 from random import randint, Random
 
-
+from itertools import product
 
 def n_order(a, n):
     """Returns the order of ``a`` modulo ``n``.
@@ -795,7 +794,7 @@ def _help(m, prime_modulo_method, diff_method, expr_val):
     for x, y in dd.items():
         m.append(x)
         a.append(list(y))
-    return sorted({crt(m, list(i))[0] for i in cartes(*a)})
+    return sorted({crt(m, list(i))[0] for i in product(*a)})
 
 def _nthroot_mod_composite(a, n, m):
     """

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -3,7 +3,6 @@
 from sympy import I, S, sqrt, sin, oo, Poly, Float, Integer, Rational, pi, exp, E
 from sympy.abc import x, y, z
 
-from sympy.utilities.iterables import cartes
 from sympy.core.compatibility import HAS_GMPY
 
 from sympy.polys.domains import (ZZ, QQ, RR, CC, FF, GF, EX, EXRAW, ZZ_gmpy,
@@ -27,6 +26,9 @@ from sympy.polys.polyerrors import (
 from sympy.polys.polyutils import illegal
 
 from sympy.testing.pytest import raises
+
+from itertools import product
+
 
 ALG = QQ.algebraic_field(sqrt(2), sqrt(3))
 
@@ -616,7 +618,7 @@ def test_Domain_convert():
     K3 = QQ[x]
     K4 = ZZ[x]
     Ks = [K1, K2, K3, K4]
-    for Ka, Kb in cartes(Ks, Ks):
+    for Ka, Kb in product(Ks, Ks):
         assert Ka.convert_from(Kb.from_sympy(x), Kb) == Ka.from_sympy(x)
 
     assert K2.convert_from(QQ(1, 2), QQ) == K2(QQ(1, 2))

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -14,10 +14,11 @@ from sympy.polys.orthopolys import legendre_poly
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polyutils import _nsort
 
-from sympy.utilities.iterables import cartes
 from sympy.testing.pytest import raises, slow
 from sympy.testing.randtest import verify_numerically
 import mpmath
+from itertools import product
+
 
 
 a, b, c, d, e, q, t, x, y, z = symbols('a,b,c,d,e,q,t,x,y,z')
@@ -69,7 +70,7 @@ def test_roots_quadratic():
     f = Poly(-24*x**2 - 180*x + 264)
     assert [w.n(2) for w in f.all_roots(radicals=True)] == \
            [w.n(2) for w in f.all_roots(radicals=False)]
-    for _a, _b, _c in cartes((-2, 2), (-2, 2), (0, -1)):
+    for _a, _b, _c in product((-2, 2), (-2, 2), (0, -1)):
         f = Poly(_a*x**2 + _b*x + _c)
         roots = roots_quadratic(f)
         assert roots == _nsort(roots)
@@ -307,7 +308,7 @@ def test_roots_binomial():
 
     assert powsimp(r0[0]) == powsimp(r1[0])
     assert powsimp(r0[1]) == powsimp(r1[1])
-    for a, b, s, n in cartes((1, 2), (1, 2), (-1, 1), (2, 3, 4, 5)):
+    for a, b, s, n in product((1, 2), (1, 2), (-1, 1), (2, 3, 4, 5)):
         if a == b and a != 1:  # a == b == 1 is sufficient
             continue
         p = Poly(a*x**n + s*b)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,4 +1,4 @@
-from itertools import product as cartes
+from itertools import product
 
 from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling, sinh,
@@ -341,10 +341,10 @@ def test_issue_14793():
 
 def test_issue_5183():
     # using list(...) so py.test can recalculate values
-    tests = list(cartes([x, -x],
-                        [-1, 1],
-                        [2, 3, S.Half, Rational(2, 3)],
-                        ['-', '+']))
+    tests = list(product([x, -x],
+                         [-1, 1],
+                         [2, 3, S.Half, Rational(2, 3)],
+                         ['-', '+']))
     results = (oo, oo, -oo, oo, -oo*I, oo, -oo*(-1)**Rational(1, 3), oo,
                0, 0, 0, 0, 0, 0, 0, 0,
                oo, oo, oo, -oo, oo, -oo*I, oo, -oo*(-1)**Rational(1, 3),
@@ -380,9 +380,9 @@ def test_issue_5229():
 
 def test_issue_4546():
     # using list(...) so py.test can recalculate values
-    tests = list(cartes([cot, tan],
-                        [-pi/2, 0, pi/2, pi, pi*Rational(3, 2)],
-                        ['-', '+']))
+    tests = list(product([cot, tan],
+                         [-pi/2, 0, pi/2, pi, pi*Rational(3, 2)],
+                         ['-', '+']))
     results = (0, 0, -oo, oo, 0, 0, -oo, oo, 0, 0,
                oo, -oo, 0, 0, oo, -oo, 0, 0, oo, -oo)
     assert len(tests) == len(results)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from itertools import product
 
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -14,7 +15,6 @@ from sympy.logic.boolalg import And, Or
 from sympy.sets.sets import (Set, Interval, Union, FiniteSet,
     ProductSet)
 from sympy.utilities.misc import filldedent
-from sympy.utilities.iterables import cartes
 
 
 class Rationals(Set, metaclass=Singleton):
@@ -500,7 +500,7 @@ class ImageSet(Set):
             base_set = self.base_sets[0]
             return SetExpr(base_set)._eval_func(f).set
         if all(s.is_FiniteSet for s in self.base_sets):
-            return FiniteSet(*(f(*a) for a in cartes(*self.base_sets)))
+            return FiniteSet(*(f(*a) for a in product(*self.base_sets)))
         return self
 
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -9,7 +9,6 @@ from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, exp, Abs, I, Tuple, eye,
                    Dummy, floor, And, Eq)
-from sympy.utilities.iterables import cartes
 from sympy.testing.pytest import XFAIL, raises
 from sympy.abc import x, y, t, z
 from sympy.core.mod import Mod
@@ -304,7 +303,7 @@ def test_Range_set():
             Range(1, 10, 2),
         ]:
         r = list(R)
-        for a, b, c in cartes(AB, AB, [-3, -1, None, 1, 3]):
+        for a, b, c in itertools.product(AB, AB, [-3, -1, None, 1, 3]):
             for reverse in range(2):
                 r = list(reversed(r))
                 R = R.reversed

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -50,7 +50,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent
-from sympy.utilities.iterables import (cartes, connected_components,
+from sympy.utilities.iterables import (connected_components,
     generate_bell, uniq)
 from sympy.utilities.decorator import conserve_mpmath_dps
 
@@ -61,6 +61,8 @@ from sympy.solvers.inequalities import reduce_inequalities
 
 from types import GeneratorType
 from collections import defaultdict
+from itertools import product
+
 import warnings
 
 
@@ -1765,7 +1767,7 @@ def _solve_system(exprs, symbols, **flags):
                 subsols.append(subsol)
             # Full solution is cartesion product of subsystems
             sols = []
-            for soldicts in cartes(*subsols):
+            for soldicts in product(*subsols):
                 sols.append(dict(item for sd in soldicts
                     for item in sd.items()))
             # Return a list with one dict as just the dict

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,8 +1,9 @@
 from collections import defaultdict, OrderedDict
 from itertools import (
     combinations, combinations_with_replacement, permutations,
-    product, product as cartes
+    product
 )
+from itertools import product as cartes # noqa: F401
 import random
 from operator import gt
 
@@ -11,8 +12,6 @@ from sympy.core import Basic
 # this is the logical location of these functions
 from sympy.core.compatibility import (as_int, is_sequence, iterable, ordered)
 from sympy.core.compatibility import default_sort_key  # noqa: F401
-
-import sympy
 
 from sympy.utilities.enumerative import (
     multiset_partitions_taocp, list_visitor, MultisetPartitionTraverser)
@@ -525,7 +524,7 @@ def ibin(n, bits=None, str=False):
         bits = 0
     else:
         try:
-             bits = as_int(bits)
+            bits = as_int(bits)
         except ValueError:
             bits = -1
         else:
@@ -664,7 +663,7 @@ def filter_symbols(iterator, exclude):
         if s not in exclude:
             yield s
 
-def numbered_symbols(prefix='x', cls=None, start=0, exclude=[], *args, **assumptions):
+def numbered_symbols(prefix='x', cls=None, start=0, exclude=(), *args, **assumptions):
     """
     Generate an infinite stream of Symbols consisting of a prefix and
     increasing subscripts provided that they do not occur in ``exclude``.
@@ -692,7 +691,7 @@ def numbered_symbols(prefix='x', cls=None, start=0, exclude=[], *args, **assumpt
     if cls is None:
         # We can't just make the default cls=Symbol because it isn't
         # imported yet.
-        from sympy import Symbol
+        from sympy.core import Symbol
         cls = Symbol
 
     while True:
@@ -1317,7 +1316,8 @@ def least_rotation(x, key=None):
     .. [1] https://en.wikipedia.org/wiki/Lexicographically_minimal_string_rotation
 
     '''
-    if key is None: key = sympy.Id
+    from sympy import Id
+    if key is None: key = Id
     S = x + x      # Concatenate string to it self to avoid modular arithmetic
     f = [-1] * len(S)     # Failure function
     k = 0       # Least rotation of string found so far
@@ -2018,14 +2018,14 @@ def binary_partitions(n):
 
     """
     from math import ceil, log
-    pow = int(2**(ceil(log(n, 2))))
-    sum = 0
+    power = int(2**(ceil(log(n, 2))))
+    acc = 0
     partition = []
-    while pow:
-        if sum + pow <= n:
-            partition.append(pow)
-            sum += pow
-        pow >>= 1
+    while power:
+        if acc + power <= n:
+            partition.append(power)
+            acc += power
+        power >>= 1
 
     last_num = len(partition) - 1 - (n & 1)
     while last_num >= 0:
@@ -2069,8 +2069,8 @@ def has_dups(seq):
     from sympy.sets.sets import Set
     if isinstance(seq, (dict, set, Dict, Set)):
         return False
-    uniq = set()
-    return any(True for s in seq if s in uniq or uniq.add(s))
+    unique = set()
+    return any(True for s in seq if s in unique or unique.add(s))
 
 
 def has_variety(seq):
@@ -2456,8 +2456,8 @@ def minlex(seq, directed=True, key=None):
     ('c', 'a', 'bb', 'aaa')
 
     """
-
-    if key is None: key = sympy.Id
+    from sympy import Id
+    if key is None: key = Id
     best = rotate_left(seq, least_rotation(seq, key=key))
     if not directed:
         rseq = seq[::-1]
@@ -2642,7 +2642,7 @@ def permute_signs(t):
     >>> list(permute_signs((0, 1, 2)))
     [(0, 1, 2), (0, -1, 2), (0, 1, -2), (0, -1, -2)]
     """
-    for signs in cartes(*[(1, -1)]*(len(t) - t.count(0))):
+    for signs in product(*[(1, -1)]*(len(t) - t.count(0))):
         signs = list(signs)
         yield type(t)([i*signs.pop() if i else i for i in t])
 
@@ -2701,8 +2701,8 @@ def roundrobin(*iterables):
     pending = len(iterables)
     while pending:
         try:
-            for next in nexts:
-                yield next()
+            for nxt in nexts:
+                yield nxt()
         except StopIteration:
             pending -= 1
             nexts = itertools.cycle(itertools.islice(nexts, pending))

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -193,13 +193,13 @@ def debug_decorator(func):
         _debug_iter += 1
 
         def tree(subtrees):
-            def indent(s, type=1):
+            def indent(s, variant=1):
                 x = s.split("\n")
                 r = "+-%s\n" % x[0]
                 for a in x[1:]:
                     if a == "":
                         continue
-                    if type == 1:
+                    if variant == 1:
                         r += "| %s\n" % a
                     else:
                         r += "  %s\n" % a


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #22028

#### Brief description of what is fixed or changed
Some general cleanup of `utilities.iterables` to improve the imports (not import sympy at top level).

As `cartes` is now supported as `itertools.product` it is not use in the code base anymore. However, I kept it here, but probably it should be deprecated before removal?

#### Other comments
Some of the imports can probably be made more "directed".

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
