### PR TITLE
Partial fix for `matches` being unable to match

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -253,10 +253,12 @@ class AssocOp(Basic):
                 # the matching continue
                 return None
             newexpr = self._combine_inverse(expr, exact)
+            from sympy import signsimp
+            expr = signsimp(expr)
             if not old and (expr.is_Add or expr.is_Mul):
                 if newexpr.count_ops() > expr.count_ops():
                     return None
-            newpattern = self._new_rawargs(*wild_part)
+            newpattern = signsimp(self._new_rawargs(*wild_part))
             return newpattern.matches(newexpr, repl_dict)
 
         # now to real work ;)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -710,15 +710,12 @@ def test_match_issue_17397():
 
 
 def test_match_issue_21942_1():
-    a, r, w = symbols('a, r, w', nonnegative=True)
+    a, x, r, w = symbols('a, x, r, w', nonnegative=True)
     p = symbols('p', positive=True)
     g_ = Wild('g')
-    pattern = g_ ** (1 / (1 - p))
-    eq = (a * r ** (1 - p) + w ** (1 - p) * (1 - a)) ** (1 / (1 - p))
-    assert pattern.matches(eq) == {g_: a * r ** (1 - p) + w ** (1 - p) * (1 - a)}
-
-    eq = signsimp(eq)
-    assert pattern.matches(eq) is None
+    pattern = x - g_ ** (1 / (1 - p))
+    eq = x - (a * r ** (1 - p) + w ** (1 - p) * (1 - a)) ** (1 / (1 - p))
+    assert pattern.matches(eq) == {g_: a * r ** (1 - p) - w ** (1 - p) * (a - 1)}
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #21942
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A central idea about symbolic mathematics is pattern matching. 

A common question is something like: "what does `W` have to be so that `2*x*W` is the same as `2*x*exp(y)`"? In this case, `W` maps to `exp(y)`. `W` is a Wild while everything else is a symbol. I'm not sure what they are supposed to be called, but I will call `2*x*W` the "pattern" and I will call `2*x*exp(y)` the "expression". 

SymPy's pattern matching is very complex (and possibly overly convoluted compared to JuliaLang's SymbolicUtils.jl), but it does seem to work for the most part. However, there is a problem that #21942 picked up: in the process of matching, the expression mutates and information is lost. 

In the very first example above, the way SymPy goes about finding what `W` is, is by going step by step: it sees that the 2 is common and drops that. That leaves a new pattern of `x*W` and a new expression of `x*exp(y)`. It then applies the same process recursively. It drops the `x` and it is left with `W` and `exp(y)`. It is then obvious that it should take `W` to be `exp(y)`. 

Extending this further, let us consider the pattern to be `-W**(1/(1-p))` and the expression to be `-x**(1/(1-p))`. SymPy begins by dropping the -1 in the front of both expressions. It does this through a function called `Mul._combine_inverse` on the expression to get rid of the -1. However, in the last step, it performs a signsimp on the resulting expression. So after it has dropped the -1, it is left with a pattern of `W**(1/(1-p))` but a mutated expression of `x**(-1/(p-1))`. It cannot match this and it says that a match is not possible. 

What would be first prize is to not simplify the expression but instead just divide it straight to get `x**(1/(1-p))` instead. However, there was a unit test that explicitly checked that it would simplify. I fear that it may have longer reaching effects further down in the code base. This is probably the simplest and most correct way to go though.

However, for some reason, I chose to do it another way: to simplify the pattern as well. That way we get the pattern of `W**(-1/(p-1))` with a mutated expression of `x**(-1/(p-1))` which SymPy can then match. In the end SymPy says that `W` maps to `x`. This is fine. But if we started with a different expression that would simplify into the same one we had in the last step, then we would have a problem. 

Consider if we had a pattern of `-W**(1/(1-p))` but an expression of `-x**(-1/(p-1))`. Since these expressions are not exactly the same, it should not find a match. But this is not the case. The signsimp on the expression will do nothing but the signsimp on the pattern will result in `W**(-1/(p-1))` which means SymPy is then able to identify a match when none exists.

I'm open to suggestions. (I'm not sure why I didn't remove the simplification in the first place).

Edit:
It may have been because there is a `_combine_inverse` for every function such as `Add`, `Mul` and `Pow` and all of them perform a signsimp before returning. If we change all of them, there will be dozens of unit test failures. But the problem may extend to all of these classes and not just the `Mul` class. This is possibly why I chose a more universal but slightly incorrect fix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
