### PR TITLE
Fixed incorrect answer when adding an identity matrix to a block matrix

### DIFF
--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -118,6 +118,13 @@ def test_issue_18618():
     A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert A == Matrix(BlockDiagMatrix(A))
 
+def test_issue_22034():
+    I_10, I_20 = Identity(10), Identity(20)
+    O_10, O_20 = ZeroMatrix(10, 10), ZeroMatrix(20, 20)
+    A = BlockMatrix([[I_10, O_10], [O_10, I_10]])
+    assert block_collapse(A - I_20) == O_20
+    assert block_collapse(A + I_20) == 2*I_20
+
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']
     X = BlockMatrix([[A, B], [C, D]])


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #22034 

#### Brief description of what is fixed or changed
Previously `bc_block_plus_ident(expr)` added any block identity matrix in `expr` to both the list of block matrices and the list of identity matrices so that when everything is summed together in the end any block identity matrix was added twice. I fixed this and added a test.

#### Other comments
As suggested in issue #22034 I am treating every block identity matrix  the same regardless of internal block structure. If there is at least one non-identity block matrices and all non-identity block matrices have the same internal block structure then every identity matrix is converted to a matrix with this same block structure as well. However if the only block matrices in `expr` are also identity matrices then I chose to forget the internal block structure and just treat it as a usual identity matrix rather than a block matrix so in this case the result of `bc_block_plus_ident(expr)` no longer contains any block matrices in it at all.  In the original code the function returned `expr` unchanged if any two block matrices in `expr` had a different internal block structure, even if only an identity matrix was different whereas now the block structure of the identity matrices is ignored. This change does not seem to cause any problems and the tests pass however if this is a problem or just not the behaviour `bc_block_plus_ident` was intended to have I will modify it.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed a bug when adding identity matrix to block matrix.
<!-- END RELEASE NOTES -->
