### PR TITLE
Improved LaTeX printing of symbolic Range

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2057,13 +2057,8 @@ class LatexPrinter(Printer):
             it = iter(s)
             printset = next(it), next(it), dots
         else:
-            try:
-                if (s.size < 4) == True:
-                    printset = tuple(s)
-                else:
-                    it = iter(s)
-                    printset = next(it), next(it), dots, s[-1]
-            except (TypeError, ValueError):
+            def _print_symbolic_range():
+                # Symbolic Range that cannot be resolved
                 if s.args[0] == 0:
                     if s.args[2] == 1:
                         cont = self._print(s.args[1])
@@ -2075,11 +2070,23 @@ class LatexPrinter(Printer):
                     else:
                         cont = ", ".join(self._print(arg) for arg in s.args)
 
-                return(f"\\operatorname{{Range}}\\left({cont}\\right)")
+                return(f"\\text{{Range}}\\left({cont}\\right)")
 
+            if s.is_empty is not None:
+                if (s.size < 4) == True:
+                    printset = tuple(s)
+                else:
+                    try:
+                        it = iter(s)
+                        printset = next(it), next(it), dots, s[-1]
+                    except TypeError:
+                        return _print_symbolic_range()
+            else:
+                return _print_symbolic_range()
         return (r"\left\{" +
                 r", ".join(self._print(el) if el is not dots else r'\ldots' for el in printset) +
                 r"\right\}")
+
 
     def __print_number_polynomial(self, expr, letter, exp=None):
         if len(expr.args) == 2:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2046,9 +2046,6 @@ class LatexPrinter(Printer):
     def _print_Range(self, s):
         dots = object()
 
-        if s.has(Symbol):
-            return self._print_Basic(s)
-
         if s.start.is_infinite and s.stop.is_infinite:
             if s.step.is_positive:
                 printset = dots, -1, 0, 1, dots
@@ -2059,11 +2056,26 @@ class LatexPrinter(Printer):
         elif s.stop.is_infinite:
             it = iter(s)
             printset = next(it), next(it), dots
-        elif len(s) > 4:
-            it = iter(s)
-            printset = next(it), next(it), dots, s[-1]
         else:
-            printset = tuple(s)
+            try:
+                if (s.size < 4) == True:
+                    printset = tuple(s)
+                else:
+                    it = iter(s)
+                    printset = next(it), next(it), dots, s[-1]
+            except (TypeError, ValueError):
+                if s.args[0] == 0:
+                    if s.args[2] == 1:
+                        cont = self._print(s.args[1])
+                    else:
+                        cont = ", ".join(self._print(arg) for arg in s.args)
+                else:
+                    if s.args[2] == 1:
+                        cont = ", ".join(self._print(arg) for arg in s.args[:2])
+                    else:
+                        cont = ", ".join(self._print(arg) for arg in s.args)
+
+                return(f"\\operatorname{{Range}}\\left({cont}\\right)")
 
         return (r"\left\{" +
                 r", ".join(self._print(el) if el is not dots else r'\ldots' for el in printset) +

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -826,10 +826,20 @@ def test_latex_Range():
     assert latex(Range(oo, -oo, -1)) == r'\left\{\ldots, 1, 0, -1, \ldots\right\}'
 
     a, b, c = symbols('a:c')
-    assert latex(Range(a, b, c)) == r'Range\left(a, b, c\right)'
-    assert latex(Range(a, 10, 1)) == r'Range\left(a, 10, 1\right)'
-    assert latex(Range(0, b, 1)) == r'Range\left(0, b, 1\right)'
-    assert latex(Range(0, 10, c)) == r'Range\left(0, 10, c\right)'
+    assert latex(Range(a, b, c)) == r'\operatorname{Range}\left(a, b, c\right)'
+    assert latex(Range(a, 10, 1)) == r'\operatorname{Range}\left(a, 10\right)'
+    assert latex(Range(0, b, 1)) == r'\operatorname{Range}\left(b\right)'
+    assert latex(Range(0, 10, c)) == r'\operatorname{Range}\left(0, 10, c\right)'
+
+    i = Symbol('i', integer=True)
+    n = Symbol('n', negative=True, integer=True)
+    p = Symbol('p', positive=True, integer=True)
+
+    assert latex(Range(i, i + 3)) == r'\left\{i, i + 1, i + 2\right\}'
+    assert latex(Range(-oo, n, 2)) == r'\left\{\ldots, n - 4, n - 2\right\}'
+    assert latex(Range(p, oo)) == r'\left\{p, p + 1, \ldots\right\}'
+    # Must have integer assumptions
+    assert latex(Range(a, a + 3)) == r'\operatorname{Range}\left(a, a + 3\right)'
 
 
 def test_latex_sequences():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -826,10 +826,10 @@ def test_latex_Range():
     assert latex(Range(oo, -oo, -1)) == r'\left\{\ldots, 1, 0, -1, \ldots\right\}'
 
     a, b, c = symbols('a:c')
-    assert latex(Range(a, b, c)) == r'\operatorname{Range}\left(a, b, c\right)'
-    assert latex(Range(a, 10, 1)) == r'\operatorname{Range}\left(a, 10\right)'
-    assert latex(Range(0, b, 1)) == r'\operatorname{Range}\left(b\right)'
-    assert latex(Range(0, 10, c)) == r'\operatorname{Range}\left(0, 10, c\right)'
+    assert latex(Range(a, b, c)) == r'\text{Range}\left(a, b, c\right)'
+    assert latex(Range(a, 10, 1)) == r'\text{Range}\left(a, 10\right)'
+    assert latex(Range(0, b, 1)) == r'\text{Range}\left(b\right)'
+    assert latex(Range(0, 10, c)) == r'\text{Range}\left(0, 10, c\right)'
 
     i = Symbol('i', integer=True)
     n = Symbol('n', negative=True, integer=True)
@@ -839,7 +839,7 @@ def test_latex_Range():
     assert latex(Range(-oo, n, 2)) == r'\left\{\ldots, n - 4, n - 2\right\}'
     assert latex(Range(p, oo)) == r'\left\{p, p + 1, \ldots\right\}'
     # Must have integer assumptions
-    assert latex(Range(a, a + 3)) == r'\operatorname{Range}\left(a, a + 3\right)'
+    assert latex(Range(a, a + 3)) == r'\text{Range}\left(a, a + 3\right)'
 
 
 def test_latex_sequences():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -838,6 +838,8 @@ def test_latex_Range():
     assert latex(Range(i, i + 3)) == r'\left\{i, i + 1, i + 2\right\}'
     assert latex(Range(-oo, n, 2)) == r'\left\{\ldots, n - 4, n - 2\right\}'
     assert latex(Range(p, oo)) == r'\left\{p, p + 1, \ldots\right\}'
+    # The following will work if __iter__ is improved
+    # assert latex(Range(-3, p + 7)) == r'\left\{-3, -2,  \ldots, p + 6\right\}'
     # Must have integer assumptions
     assert latex(Range(a, a + 3)) == r'\text{Range}\left(a, a + 3\right)'
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -587,8 +587,6 @@ class Range(Set):
         {n, n + 3, ..., n + 18}
     """
 
-    is_iterable = True
-
     def __new__(cls, *args):
         from sympy.functions.elementary.integers import ceiling
         if len(args) == 1:
@@ -744,6 +742,19 @@ class Range(Set):
                 for j in range(n):
                     yield i
                     i += self.step
+
+    @property
+    def is_iterable(self):
+        # Check that size can be determined, used by __iter__
+        dif = self.stop - self.start
+        n = dif/self.step
+        if not (n.has(S.Infinity) or n.has(S.NegativeInfinity) or n.is_Integer):
+            return False
+        if self.start in [S.NegativeInfinity, S.Infinity]:
+            return False
+        if not (n.is_extended_nonnegative and all(i.is_integer for i in self.args)):
+            return False
+        return True
 
     def __len__(self):
         rv = self.size

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -509,6 +509,7 @@ def test_range_interval_intersection():
     assert Range(0).intersect(Interval(0.2, 0.8)) is S.EmptySet
     assert Range(0).intersect(Interval(-oo, oo)) is S.EmptySet
 
+
 def test_range_is_finite_set():
     assert Range(-100, 100).is_finite_set is True
     assert Range(2, oo).is_finite_set is False
@@ -531,6 +532,39 @@ def test_range_is_finite_set():
     # assert Range(n, -oo).is_finite_set is True
     # assert Range(oo, n).is_finite_set is True
     # Above tests fail due to a (potential) bug in sympy.sets.fancysets.Range.size (See issue #18999)
+
+
+def test_Range_is_iterable():
+    assert Range(-100, 100).is_iterable is True
+    assert Range(2, oo).is_iterable is False
+    assert Range(-oo, 50).is_iterable is False
+    assert Range(-oo, oo).is_iterable is False
+    assert Range(oo, -oo).is_iterable is True
+    assert Range(0, 0).is_iterable is True
+    assert Range(oo, oo).is_iterable is True
+    assert Range(-oo, -oo).is_iterable is True
+    n = Symbol('n', integer=True)
+    m = Symbol('m', integer=True)
+    p = Symbol('p', integer=True, positive=True)
+    assert Range(n, n + 49).is_iterable is True
+    assert Range(n, 0).is_iterable is False
+    assert Range(-3, n + 7).is_iterable is False
+    assert Range(-3, p + 7).is_iterable is False # Should work with better __iter__
+    assert Range(n, m).is_iterable is False
+    assert Range(n + m, m - n).is_iterable is False
+    assert Range(n, n + m + n).is_iterable is False
+    assert Range(n, oo).is_iterable is False
+    assert Range(-oo, n).is_iterable is False
+    x = Symbol('x')
+    assert Range(x, x + 49).is_iterable is False
+    assert Range(x, 0).is_iterable is False
+    assert Range(-3, x + 7).is_iterable is False
+    assert Range(x, m).is_iterable is False
+    assert Range(x + m, m - x).is_iterable is False
+    assert Range(x, x + m + x).is_iterable is False
+    assert Range(x, oo).is_iterable is False
+    assert Range(-oo, x).is_iterable is False
+
 
 def test_Integers_eval_imageset():
     ans = ImageSet(Lambda(x, 2*x + Rational(3, 7)), S.Integers)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Better printing of symbolic ranges.
a) Use `\operatorname` for `Range`
![image](https://user-images.githubusercontent.com/8114497/133000825-75698456-7180-4a91-a30e-87e353f3edb5.png)

b) Only print required arguments
![image](https://user-images.githubusercontent.com/8114497/133000836-6546fe43-ac42-4b4c-95a2-ba7d525c6062.png)

c) Print as set when possible.
![image](https://user-images.githubusercontent.com/8114497/133000851-78d645b1-9443-4d72-9051-1a1eb9af9f60.png)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Better LaTeX printing of symbolic `Range`. 
<!-- END RELEASE NOTES -->
