### PR TITLE
Improved and corrected LaTeX printing of Mod

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1712,13 +1712,18 @@ class LatexPrinter(Printer):
 
     def _print_Mod(self, expr, exp=None):
         if exp is not None:
-            return r'\left(%s\bmod{%s}\right)^{%s}' % \
+            return r'\left(%s \bmod %s\right)^{%s}' % \
                 (self.parenthesize(expr.args[0], PRECEDENCE['Mul'],
-                                   strict=True), self._print(expr.args[1]),
+                                   strict=True),
+                 self.parenthesize(expr.args[1], PRECEDENCE['Mul'],
+                                   strict=True),
                  exp)
-        return r'%s\bmod{%s}' % (self.parenthesize(expr.args[0],
-                                 PRECEDENCE['Mul'], strict=True),
-                                 self._print(expr.args[1]))
+        return r'%s \bmod %s' % (self.parenthesize(expr.args[0],
+                                                   PRECEDENCE['Mul'],
+                                                   strict=True),
+                                 self.parenthesize(expr.args[1],
+                                                   PRECEDENCE['Mul'],
+                                                   strict=True))
 
     def _print_HadamardProduct(self, expr):
         args = expr.args

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -142,16 +142,16 @@ This is done by overriding the method ``_latex`` of ``Mod``.
 >>> class ModOp(Mod):
 ...     def _latex(self, printer):
 ...         a, b = [printer._print(i) for i in self.args]
-...         return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+...         return r"\\operatorname{Mod}{\\left(%s, %s\\right)}" % (a, b)
 
 Comparing the output of our custom operator to the builtin one:
 
 >>> x = Symbol('x')
 >>> m = Symbol('m')
 >>> print_latex(Mod(x, m))
-x\\bmod{m}
+x \\bmod m
 >>> print_latex(ModOp(x, m))
-\\operatorname{Mod}{\\left( x,m \\right)}
+\\operatorname{Mod}{\\left(x, m\\right)}
 
 Common mistakes
 ~~~~~~~~~~~~~~~
@@ -165,29 +165,29 @@ an expression when customizing a printer. Mistakes include:
     >>> class ModOpModeWrong(Mod):
     ...     def _latex(self, printer):
     ...         a, b = [printer.doprint(i) for i in self.args]
-    ...         return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+    ...         return r"\\operatorname{Mod}{\\left(%s, %s\\right)}" % (a, b)
 
     This fails when the `mode` argument is passed to the printer:
 
     >>> print_latex(ModOp(x, m), mode='inline')  # ok
-    $\\operatorname{Mod}{\\left( x,m \\right)}$
+    $\\operatorname{Mod}{\\left(x, m\\right)}$
     >>> print_latex(ModOpModeWrong(x, m), mode='inline')  # bad
-    $\\operatorname{Mod}{\\left( $x$,$m$ \\right)}$
+    $\\operatorname{Mod}{\\left($x$, $m$\\right)}$
 
 2.  Using ``str(obj)`` instead:
 
     >>> class ModOpNestedWrong(Mod):
     ...     def _latex(self, printer):
     ...         a, b = [str(i) for i in self.args]
-    ...         return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+    ...         return r"\\operatorname{Mod}{\\left(%s, %s\\right)}" % (a, b)
 
     This fails on nested objects:
 
     >>> # Nested modulo.
     >>> print_latex(ModOp(ModOp(x, m), Integer(7)))  # ok
-    \\operatorname{Mod}{\\left( \\operatorname{Mod}{\\left( x,m \\right)},7 \\right)}
+    \\operatorname{Mod}{\\left(\\operatorname{Mod}{\\left(x, m\\right)}, 7\\right)}
     >>> print_latex(ModOpNestedWrong(ModOpNestedWrong(x, m), Integer(7)))  # bad
-    \\operatorname{Mod}{\\left( ModOpNestedWrong(x, m),7 \\right)}
+    \\operatorname{Mod}{\\left(ModOpNestedWrong(x, m), 7\\right)}
 
 3.  Using ``LatexPrinter()._print(obj)`` instead.
 
@@ -195,7 +195,7 @@ an expression when customizing a printer. Mistakes include:
     >>> class ModOpSettingsWrong(Mod):
     ...     def _latex(self, printer):
     ...         a, b = [LatexPrinter()._print(i) for i in self.args]
-    ...         return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+    ...         return r"\\operatorname{Mod}{\\left(%s, %s\\right)}" % (a, b)
 
     This causes all the settings to be discarded in the subobjects. As an
     example, the ``full_prec`` setting which shows floats to full precision is
@@ -203,9 +203,9 @@ an expression when customizing a printer. Mistakes include:
 
     >>> from sympy import Float
     >>> print_latex(ModOp(Float(1) * x, m), full_prec=True)  # ok
-    \\operatorname{Mod}{\\left( 1.00000000000000 x,m \\right)}
+    \\operatorname{Mod}{\\left(1.00000000000000 x, m\\right)}
     >>> print_latex(ModOpSettingsWrong(Float(1) * x, m), full_prec=True)  # bad
-    \\operatorname{Mod}{\\left( 1.0 x,m \\right)}
+    \\operatorname{Mod}{\\left(1.0 x, m\\right)}
 
 """
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -603,11 +603,14 @@ def test_latex_functions():
     assert latex(LambertW(n)**k) == r"W^{k}\left(n\right)"
     assert latex(LambertW(n, k)**p) == r"W^{p}_{k}\left(n\right)"
 
-    assert latex(Mod(x, 7)) == r'x\bmod{7}'
-    assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'
-    assert latex(Mod(2 * x, 7)) == r'2 x\bmod{7}'
-    assert latex(Mod(x, 7) + 1) == r'\left(x\bmod{7}\right) + 1'
-    assert latex(2 * Mod(x, 7)) == r'2 \left(x\bmod{7}\right)'
+    assert latex(Mod(x, 7)) == r'x \bmod 7'
+    assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right) \bmod 7'
+    assert latex(Mod(7, x + 1)) == r'7 \bmod \left(x + 1\right)'
+    assert latex(Mod(2 * x, 7)) == r'2 x \bmod 7'
+    assert latex(Mod(7, 2 * x)) == r'7 \bmod 2 x'
+    assert latex(Mod(x, 7) + 1) == r'\left(x \bmod 7\right) + 1'
+    assert latex(2 * Mod(x, 7)) == r'2 \left(x \bmod 7\right)'
+    assert latex(Mod(7, 2 * x)**n) == r'\left(7 \bmod 2 x\right)^{n}'
 
     # some unknown function name should get rendered with \operatorname
     fjlkd = Function('fjlkd')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier `Mod(x, y + 1)` was printed as
![image](https://user-images.githubusercontent.com/8114497/133048450-177d27fe-8720-45e9-b9a6-c39831e4f412.png)

Now it is printed as
![image](https://user-images.githubusercontent.com/8114497/133048044-d0e232b3-a1b2-48ad-b7ac-8c840f9be838.png)

Also, the LaTeX used `\bmod{7}` which is incorrect. It should just be `\bmod 7` as `\bmod` is not a command. (Probably a confusion with `\pmod` which is used like that.)

#### Other comments
Still an issue with unary -, where both `-Mod(x, y)` and `Mod(-x, y)` ends up with the same output.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
     * Improved and corrected LaTeX-printing of `Mod`. 
<!-- END RELEASE NOTES -->
