### PR TITLE
added function for limiting numerator

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1714,25 +1714,23 @@ class Rational(Number):
         elif self < 0:
             return -(-self).limit_num_denom(a, b)
 
-        if b is not None:
-            if b < 0:
-                raise AssertionError("Value should be greater than 0")
-            if self*b < 1:
+        if b is None:
+            return self.limit_denominator(a)
+        if b < 0:
+            raise AssertionError("Value should be greater than 0")
+        if self.p*b < self.q:
                 return self.limit_denominator(b)
-            if b == 1:
-                return Integer(min(a, max(1, int(self))))
-            if a == 1:
-                if self >=1:
-                    return self.limit_num_denom(1, 1)
-                return self.limit_num_denom(1, int(1/self))
-            if self >=1:
-                b = min(a, b)
-            else:
-                a = min(a, b)
-            d_use = min(int(a/self), b)
+        if b == 1:
+            return Integer(min(a, max(1, int(self))))
+        if a == 1:
+            if self.p >= self.q:
+                return self.limit_num_denom(1, 1)
+            return self.limit_num_denom(1, self.q//self.p)
+        if self.p >= self.q:
+            b = min(a, b)
         else:
-            d_use = a
-        return self.limit_denominator(d_use)
+            a = min(a, b)
+        return self.limit_denominator(min(int(a*self.q/self.p), b))
 
     def __getnewargs__(self):
         return (self.p, self.q)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1691,6 +1691,49 @@ class Rational(Number):
         f = fractions.Fraction(self.p, self.q)
         return Rational(f.limit_denominator(fractions.Fraction(int(max_denominator))))
 
+    def limit_num_denom(self, a, b = None):
+        """Closest Rational to self with numerator at most a
+           and denominator at most b if not None else Closest
+           Rational to self with denominator at most a.
+
+        Examples
+        ========
+
+        >>> from sympy import Rational
+        >>> Rational(1819831678027117, 9007199254740992).limit_num_denom(10**5)
+        11003/54459
+        >>> Rational(1819831678027117, 9007199254740992).limit_num_denom(10**3, 10**5)
+        376/1861
+
+        """
+        if a < 0:
+            raise AssertionError("Value should be greater than 0")
+
+        if self == 0:
+            return self
+        elif self < 0:
+            return -(-self).limit_num_denom(a, b)
+
+        if b is not None:
+            if b < 0:
+                raise AssertionError("Value should be greater than 0")
+            if self*b < 1:
+                return self.limit_denominator(b)
+            if b == 1:
+                return Integer(min(a, max(1, int(self))))
+            if a == 1:
+                if self >=1:
+                    return self.limit_num_denom(1, 1)
+                return self.limit_num_denom(1, int(1/self))
+            if self >=1:
+                b = min(a, b)
+            else:
+                a = min(a, b)
+            d_use = min(int(a/self), b)
+        else:
+            d_use = a
+        return self.limit_denominator(d_use)
+
     def __getnewargs__(self):
         return (self.p, self.q)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1691,7 +1691,7 @@ class Rational(Number):
         f = fractions.Fraction(self.p, self.q)
         return Rational(f.limit_denominator(fractions.Fraction(int(max_denominator))))
 
-    def limit_num_denom(self, a, b = None):
+    def limit_div(self, a, b = None):
         """Closest Rational to self with numerator at most a
            and denominator at most b if not None else Closest
            Rational to self with denominator at most a.

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1700,9 +1700,9 @@ class Rational(Number):
         ========
 
         >>> from sympy import Rational
-        >>> Rational(1819831678027117, 9007199254740992).limit_num_denom(10**5)
+        >>> Rational(1819831678027117, 9007199254740992).limit_div(10**5)
         11003/54459
-        >>> Rational(1819831678027117, 9007199254740992).limit_num_denom(10**3, 10**5)
+        >>> Rational(1819831678027117, 9007199254740992).limit_div(10**3, 10**5)
         376/1861
 
         """
@@ -1712,7 +1712,7 @@ class Rational(Number):
         if self == 0:
             return self
         elif self < 0:
-            return -(-self).limit_num_denom(a, b)
+            return -(-self).limit_div(a, b)
 
         if b is None:
             return self.limit_denominator(a)
@@ -1724,8 +1724,8 @@ class Rational(Number):
             return Integer(min(a, max(1, int(self))))
         if a == 1:
             if self.p >= self.q:
-                return self.limit_num_denom(1, 1)
-            return self.limit_num_denom(1, self.q//self.p)
+                return self.limit_div(1, 1)
+            return self.limit_div(1, self.q//self.p)
         if self.p >= self.q:
             b = min(a, b)
         else:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -321,16 +321,15 @@ def test_Rational_new():
     assert Rational(19, 25).limit_denominator(4) == n3_4
     assert Rational('19/25').limit_denominator(4) == n3_4
     n2_3 = Rational(2, 3)
-    assert Rational('2/3') == n2_3
-    assert -Rational('-2/3') == n2_3
     assert Rational('.68').limit_num_denom(3, 5) == n2_3
-    assert Rational(-17, 25).limit_num_denom(3, 5) == -n2_3
     assert Rational('17/25').limit_num_denom(5) == Rational('17/25').limit_denominator(5)
+    assert S.Zero.limit_num_denom(3, 5) == S.Zero
+    assert Rational(-17, 25).limit_num_denom(3, 5) == -n2_3
     assert Rational(7, 25).limit_num_denom(2, 3) == Rational(7, 25).limit_denominator(3)
     assert Rational(17, 25).limit_num_denom(3, 1) == 1
     assert Rational(17, 25).limit_num_denom(1, 5) == 1
     assert Rational(25, 17).limit_num_denom(1, 5) == 1
-    assert Rational(25, 17).limit_num_denom(3, 5) == Rational(1, n2_3)
+    assert Rational(25, 17).limit_num_denom(3, 5) == Rational(3, 2)
     raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-5))
     raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(3, -5))
     assert Rational(1.0, 3) == Rational(1, 3)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -321,17 +321,17 @@ def test_Rational_new():
     assert Rational(19, 25).limit_denominator(4) == n3_4
     assert Rational('19/25').limit_denominator(4) == n3_4
     n2_3 = Rational(2, 3)
-    assert Rational('.68').limit_num_denom(3, 5) == n2_3
-    assert Rational('17/25').limit_num_denom(5) == Rational('17/25').limit_denominator(5)
-    assert S.Zero.limit_num_denom(3, 5) == S.Zero
-    assert Rational(-17, 25).limit_num_denom(3, 5) == -n2_3
-    assert Rational(7, 25).limit_num_denom(2, 3) == Rational(7, 25).limit_denominator(3)
-    assert Rational(17, 25).limit_num_denom(3, 1) == 1
-    assert Rational(17, 25).limit_num_denom(1, 5) == 1
-    assert Rational(25, 17).limit_num_denom(1, 5) == 1
-    assert Rational(25, 17).limit_num_denom(3, 5) == Rational(3, 2)
-    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-5))
-    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(3, -5))
+    assert Rational('.68').limit_div(3, 5) == n2_3
+    assert Rational('17/25').limit_div(5) == Rational('17/25').limit_denominator(5)
+    assert S.Zero.limit_div(3, 5) == S.Zero
+    assert Rational(-17, 25).limit_div(3, 5) == -n2_3
+    assert Rational(7, 25).limit_div(2, 3) == Rational(7, 25).limit_denominator(3)
+    assert Rational(17, 25).limit_div(3, 1) == 1
+    assert Rational(17, 25).limit_div(1, 5) == 1
+    assert Rational(25, 17).limit_div(1, 5) == 1
+    assert Rational(25, 17).limit_div(3, 5) == Rational(3, 2)
+    raises(AssertionError, lambda: Rational(17, 25).limit_div(-5))
+    raises(AssertionError, lambda: Rational(17, 25).limit_div(3, -5))
     assert Rational(1.0, 3) == Rational(1, 3)
     assert Rational(1, 3.0) == Rational(1, 3)
     assert Rational(Float(0.5)) == S.Half

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -323,13 +323,16 @@ def test_Rational_new():
     n2_3 = Rational(2, 3)
     assert Rational('2/3') == n2_3
     assert -Rational('-2/3') == n2_3
-    assert Rational('.68').limit_num_denom(5) == n2_3
+    assert Rational('.68').limit_num_denom(3, 5) == n2_3
+    assert Rational(-17, 25).limit_num_denom(3, 5) == -n2_3
     assert Rational('17/25').limit_num_denom(5) == Rational('17/25').limit_denominator(5)
-    assert Rational(17, 25).limit_num_denom(3, 5) == n2_3
-    raises(AssertionError, lambda: Rational('17/25').limit_num_denom(-5))
-    raises(AssertionError, lambda: Rational('17/25').limit_num_denom(3, -5))
-    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-3, 5))
-    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-3, -5))
+    assert Rational(7, 25).limit_num_denom(2, 3) == Rational(7, 25).limit_denominator(3)
+    assert Rational(17, 25).limit_num_denom(3, 1) == 1
+    assert Rational(17, 25).limit_num_denom(1, 5) == 1
+    assert Rational(25, 17).limit_num_denom(1, 5) == 1
+    assert Rational(25, 17).limit_num_denom(3, 5) == Rational(1, n2_3)
+    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-5))
+    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(3, -5))
     assert Rational(1.0, 3) == Rational(1, 3)
     assert Rational(1, 3.0) == Rational(1, 3)
     assert Rational(Float(0.5)) == S.Half

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -320,6 +320,16 @@ def test_Rational_new():
     assert Rational('.76').limit_denominator(4) == n3_4
     assert Rational(19, 25).limit_denominator(4) == n3_4
     assert Rational('19/25').limit_denominator(4) == n3_4
+    n2_3 = Rational(2, 3)
+    assert Rational('2/3') == n2_3
+    assert -Rational('-2/3') == n2_3
+    assert Rational('.68').limit_num_denom(5) == n2_3
+    assert Rational('17/25').limit_num_denom(5) == Rational('17/25').limit_denominator(5)
+    assert Rational(17, 25).limit_num_denom(3, 5) == n2_3
+    raises(AssertionError, lambda: Rational('17/25').limit_num_denom(-5))
+    raises(AssertionError, lambda: Rational('17/25').limit_num_denom(3, -5))
+    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-3, 5))
+    raises(AssertionError, lambda: Rational(17, 25).limit_num_denom(-3, -5))
     assert Rational(1.0, 3) == Rational(1, 3)
     assert Rational(1, 3.0) == Rational(1, 3)
     assert Rational(Float(0.5)) == S.Half


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes issue #21681 and now we can request that the numerator of the result have a value less than a limit too using limit_num_denom() function.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * added method limit_num_denom() for limiting numerator in Rational class.
<!-- END RELEASE NOTES -->
