### PR TITLE
adding module sympy.matrices.random

### DIFF
--- a/doc/src/modules/matrices/index.rst
+++ b/doc/src/modules/matrices/index.rst
@@ -18,3 +18,4 @@ Contents:
    sparsetools.rst
    immutablematrices.rst
    expressions.rst
+   random.rst

--- a/doc/src/modules/matrices/random.rst
+++ b/doc/src/modules/matrices/random.rst
@@ -13,7 +13,8 @@ In order to setup distinct mathematical problems, like
  - non-standard geometries by non-standard scalar products
  - orthogonal basis of vector space,
 
-require specific types of matrices.
+specific types of matrices are required.
+
 A purely random generation of matrix entries does not grant any
 specific shape or property of the matrix.
 So, those matrices have to be created carefully using
@@ -25,20 +26,22 @@ Generators on different types of matrices are presented below.
 
    Even for carefully sampled matrices which are elements in topological matrix groups,
    the sample distribution does not claim to meet any uniform distribution
-   (with respect to the groups haar measure). The sample procedures focuses
-   mainly on educational and academic problems than a proper pre-defined
-   distribution.
+   (with respect to the groups Haar measure).
+   So the sampling procedures may be used to produce educational or academic problems
+   but do not generate proper pre-defined distribution.
 
 There are three different types of matrix generators:
 
-   - the *base matrices* which from the atomic building block of the later
+   - the *base matrices* which form the atomic building block of the later
    - the *compound matrices* which are simply products of base matrices of given types
-   - the *conjugate matrices* which are usually given as base or compound matrix $A$
-     conjugate by another compound matrix $S$, i.e.
+   - the *conjugate matrices* which are usually given as base or compound matrix $\mathbf{A}$
+     conjugate by another compound matrix $\mathbf{S}$,  i.e.
 
       .. math::
 
-         B = S \cdot A \cdot S^{-1} \text{ or } C = S \cdot A \cdot S^{t}
+         \mathbf{B} = \mathbf{S} \cdot \mathbf{A} \cdot \mathbf{S}^{-1}
+         \text{ or }
+         \mathbf{C} = \mathbf{S} \cdot \mathbf{A} \cdot \mathbf{S}^{T}
 
 
  1. *base matrices* are simple matrix types with only a few non trivial entries.
@@ -79,9 +82,10 @@ There are three different types of matrix generators:
     - :py:func:`triangular <sympy.matrices.random.triangular>` as product of *triangular*
       :py:func:`elementary <sympy.matrices.random.elementary>` matrices
 
- 3. *conjugate matrices* that arise as a product $SAS^{-1}$ of specific matrices $A$
+ 3. *conjugate matrices* that arise as a product $\mathbf{SAS}^{-1}$
+    of specific matrices $\mathbf{A}$
     - usually given as a *normal form* - conjugate by an
-    :py:func:`invertible <sympy.matrices.random.invertible>` $S$
+    :py:func:`invertible <sympy.matrices.random.invertible>` $\mathbf{S}$
     such as
 
     - :py:func:`diagonalizable <sympy.matrices.random.diagonalizable>` with
@@ -96,8 +100,9 @@ There are three different types of matrix generators:
     - :py:func:`nilpotent <sympy.matrices.random.nilpotent>` with
       :py:func:`jordan_normal <sympy.matrices.random.jordan_normal>` (with zero eigenvalues)
 
-    *isometry conjugate matrices* that arise as a product $OAO^{-1} = OAO^{t}$ of specific matrices $A$
-    where $A$ sets the (complex) eigenvalue spectrum.
+    *isometry conjugate matrices* that arise as a product $\mathbf{OAO}^{-1} = \mathbf{OAO}^{T}$
+    of specific matrices $A$
+    where $\mathbf{A}$ sets the (complex) eigenvalue spectrum.
 
     - :py:func:`orthogonal <sympy.matrices.random.orthogonal>`
       can be a conjugate of
@@ -119,13 +124,14 @@ There are three different types of matrix generators:
       or
       :py:func:`unitary <sympy.matrices.random.unitary>`
 
-    finally *symmetric matrices* given as a as product $SS^t$ resp. $S\bar{S}^t$ of $S$, such as
+    finally *symmetric matrices* given as a as product $\mathbf{MM}^T$
+    resp. $\mathbf{MM}^H$ of $\mathbf{M}$, such as
 
-    - :py:func:`symmetric <sympy.matrices.random.symmetric>` $SS^t$ with
-      :py:func:`invertible <sympy.matrices.random.invertible>` $S$
+    - :py:func:`symmetric <sympy.matrices.random.symmetric>` $\mathbf{MM}^T$ with
+      :py:func:`invertible <sympy.matrices.random.invertible>` $\mathbf{M}$
 
-    - :py:func:`hermite <sympy.matrices.random.hermite>` $S\bar{S}^t$ with
-      :py:func:`invertible <sympy.matrices.random.orthogonal>` $S$
+    - :py:func:`hermite <sympy.matrices.random.hermite>` $\mathbf{MM}^H$ with
+      :py:func:`invertible <sympy.matrices.random.orthogonal>` $\mathbf{M}$
 
 
 In addition to the type of matrix, also the type of entries (as a commutative ring with one)
@@ -163,7 +169,7 @@ The product of *elementary* matrices
     [-1, 1, 0],
     [ 0, 0, 1]])
 
-gives an *invertible* matrix ``M``
+gives an *invertible* matrix $\mathbf{M}$
 
     >>> M = A*B*C
     >>> M
@@ -177,6 +183,35 @@ gives an *invertible* matrix ``M``
     [1, 0, 2],
     [1, 1, 1],
     [0, 0, 1]])
+
+
+Random Generator
+----------------
+
+The module uses its own random generator ``rand`` which is a instance of ``random.Random()``.
+Hence, the state can be set by invoking ``rand.seed()``.
+
+
+    >>> from sympy.matrices.random import rand, orthogonal
+    >>> rand.seed(1)
+    >>> orthogonal(3)
+    Matrix([
+    [-1,          0,          0],
+    [ 0,  sqrt(2)/2, -sqrt(2)/2],
+    [ 0, -sqrt(2)/2, -sqrt(2)/2]])
+
+    >>> orthogonal(3)
+    Matrix([
+    [sqrt(2)/2,          0, -sqrt(2)/2],
+    [      1/2, -sqrt(2)/2,        1/2],
+    [     -1/2, -sqrt(2)/2,       -1/2]])
+
+    >>> rand.seed(1)
+    >>> orthogonal(3)
+    Matrix([
+    [-1,          0,          0],
+    [ 0,  sqrt(2)/2, -sqrt(2)/2],
+    [ 0, -sqrt(2)/2, -sqrt(2)/2]])
 
 
 Matrix Functions Reference

--- a/doc/src/modules/matrices/random.rst
+++ b/doc/src/modules/matrices/random.rst
@@ -1,0 +1,187 @@
+.. _matrices-random:
+
+Generate Specific Random Matrices
+=================================
+
+In order to setup distinct mathematical problems, like
+
+ - systems of linear equations,
+ - invertible matrices,
+ - triangular matrices
+ - differential equations with given eigenvalues
+ - linear isometries
+ - non-standard geometries by non-standard scalar products
+ - orthogonal basis of vector space,
+
+require specific types of matrices.
+A purely random generation of matrix entries does not grant any
+specific shape or property of the matrix.
+So, those matrices have to be created carefully using
+classical classification theorems of linear algebra.
+
+Generators on different types of matrices are presented below.
+
+.. note::
+
+   Even for carefully sampled matrices which are elements in topological matrix groups,
+   the sample distribution does not claim to meet any uniform distribution
+   (with respect to the groups haar measure). The sample procedures focuses
+   mainly on educational and academic problems than a proper pre-defined
+   distribution.
+
+There are three different types of matrix generators:
+
+   - the *base matrices* which from the atomic building block of the later
+   - the *compound matrices* which are simply products of base matrices of given types
+   - the *conjugate matrices* which are usually given as base or compound matrix $A$
+     conjugate by another compound matrix $S$, i.e.
+
+      .. math::
+
+         B = S \cdot A \cdot S^{-1} \text{ or } C = S \cdot A \cdot S^{t}
+
+
+ 1. *base matrices* are simple matrix types with only a few non trivial entries.
+    Those entries can set explicit by arguments or, if not given, are chosen randomly.
+
+    - :py:func:`jordan <sympy.matrices.random.jordan>`
+    - :py:func:`elementary <sympy.matrices.random.elementary>`
+
+    - :py:func:`transposition <sympy.matrices.random.transposition>`
+    - :py:func:`permutation <sympy.matrices.random.permutation>`
+
+    - :py:func:`projection <sympy.matrices.random.projection>`
+
+    - :py:func:`rotation <sympy.matrices.random.rotation>`
+    - :py:func:`reflection <sympy.matrices.random.reflection>`
+
+    as well as specific *normal form* matrices defined by their spectrum of eigenvalues
+    given via the **spec** argument.
+
+    - :py:func:`diagonal_normal <sympy.matrices.random.diagonal_normal>`
+    - :py:func:`jordan_normal <sympy.matrices.random.jordan_normal>`
+    - :py:func:`isometry_normal <sympy.matrices.random.isometry_normal>`
+
+ 2. *compound matrices* are build as a multiplication of several base matrices.
+    Since by this the entries of the base matrices are chosen randomly
+    but can be controlled by **scalar_set** arguments.
+
+    - :py:func:`permutation <sympy.matrices.random.permutation>` as product of
+      :py:func:`transposition <sympy.matrices.random.transposition>` matrices
+
+    - :py:func:`orthogonal <sympy.matrices.random.orthogonal>` as product of
+      :py:func:`rotation <sympy.matrices.random.rotation>` and
+      :py:func:`reflection <sympy.matrices.random.reflection>` matrices
+
+    - :py:func:`invertible <sympy.matrices.random.invertible>` as product of
+      :py:func:`elementary <sympy.matrices.random.elementary>` matrices
+
+    - :py:func:`triangular <sympy.matrices.random.triangular>` as product of *triangular*
+      :py:func:`elementary <sympy.matrices.random.elementary>` matrices
+
+ 3. *conjugate matrices* that arise as a product $SAS^{-1}$ of specific matrices $A$
+    - usually given as a *normal form* - conjugate by an
+    :py:func:`invertible <sympy.matrices.random.invertible>` $S$
+    such as
+
+    - :py:func:`diagonalizable <sympy.matrices.random.diagonalizable>` with
+      :py:func:`diagonal_normal <sympy.matrices.random.diagonal_normal>`
+
+    - :py:func:`idempotent <sympy.matrices.random.idempotent>` with
+      :py:func:`projection <sympy.matrices.random.projection>` (with only zero and one entries)
+
+    - :py:func:`trigonalizable <sympy.matrices.random.trigonalizable>` with
+      :py:func:`jordan_normal <sympy.matrices.random.jordan_normal>`
+
+    - :py:func:`nilpotent <sympy.matrices.random.nilpotent>` with
+      :py:func:`jordan_normal <sympy.matrices.random.jordan_normal>` (with zero eigenvalues)
+
+    *isometry conjugate matrices* that arise as a product $OAO^{-1} = OAO^{t}$ of specific matrices $A$
+    where $A$ sets the (complex) eigenvalue spectrum.
+
+    - :py:func:`orthogonal <sympy.matrices.random.orthogonal>`
+      can be a conjugate of
+      :py:func:`isometry_normal <sympy.matrices.random.isometry_normal>`
+      by
+      :py:func:`orthogonal <sympy.matrices.random.orthogonal>`
+
+    - same holds for :py:func:`unitary <sympy.matrices.random.unitary>`
+      which can be a conjugate of
+      :py:func:`isometry_normal <sympy.matrices.random.isometry_normal>`
+      by
+      :py:func:`unitary <sympy.matrices.random.unitary>`
+
+    - :py:func:`normal <sympy.matrices.random.normal>`
+      is a conjugate of
+      :py:func:`diagonal_normal <sympy.matrices.random.diagonal_normal>`
+      by either
+      :py:func:`orthogonal <sympy.matrices.random.orthogonal>`
+      or
+      :py:func:`unitary <sympy.matrices.random.unitary>`
+
+    finally *symmetric matrices* given as a as product $SS^t$ resp. $S\bar{S}^t$ of $S$, such as
+
+    - :py:func:`symmetric <sympy.matrices.random.symmetric>` $SS^t$ with
+      :py:func:`invertible <sympy.matrices.random.invertible>` $S$
+
+    - :py:func:`hermite <sympy.matrices.random.hermite>` $S\bar{S}^t$ with
+      :py:func:`invertible <sympy.matrices.random.orthogonal>` $S$
+
+
+In addition to the type of matrix, also the type of entries (as a commutative ring with one)
+to be able to define values (**scalar_set**) can be specified,
+from which the value entries (**scalar**) of the basic matrices are randomly generated.
+
+Because the complexity and amount of entries in the generated compound matrices
+in addition to the **scalar_set**, also by the number of base matrices multiplied for generation
+This can be set using the argument **length**.
+
+Normal forms as well as conjugate types have the arg **spec** to provide a spectrum of eigenvalues.
+
+The product of *elementary* matrices
+
+    >>> from sympy.matrices.random import elementary
+
+    >>> A = elementary(3, (0, 2), -2)
+    >>> A
+    Matrix([
+    [1, 0, -2],
+    [0, 1,  0],
+    [0, 0,  1]])
+
+    >>> B = elementary(3, (1, 2), 1)
+    >>> B
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 1],
+    [0, 0, 1]])
+
+    >>> C = elementary(3, (1, 0), -1)
+    >>> C
+    Matrix([
+    [ 1, 0, 0],
+    [-1, 1, 0],
+    [ 0, 0, 1]])
+
+gives an *invertible* matrix ``M``
+
+    >>> M = A*B*C
+    >>> M
+    Matrix([
+    [ 1, 0, -2],
+    [-1, 1,  1],
+    [ 0, 0,  1]])
+
+    >>> M.inv()
+    Matrix([
+    [1, 0, 2],
+    [1, 1, 1],
+    [0, 0, 1]])
+
+
+Matrix Functions Reference
+--------------------------
+
+.. automodule:: sympy.matrices.random
+   :members:
+   :member-order: bysource

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -231,6 +231,163 @@ filled with `0`\ s.
     ⎢           ⎥
     ⎣0   0  0  5⎦
 
+
+Random Matrices
+---------------
+
+To create Matrices with specific properties use one of
+the random matrix generation functions, e.g.
+``invertible``, ``triangular``, ``orthogonal``.
+Find a :ref:`full list of random matrices <matrices-random>`.
+
+    >>> import random
+    >>> random.seed(1)
+
+    >>> from sympy.matrices.random import invertible, triangular, orthogonal
+    >>> from sympy import simplify
+
+    >>> M = invertible(3)  # only integer entries
+    >>> M
+    ⎡-1  -1  -1⎤
+    ⎢          ⎥
+    ⎢-2  -1  -1⎥
+    ⎢          ⎥
+    ⎣0   0   1 ⎦
+    >>> M.inv()
+    ⎡1   -1  0 ⎤
+    ⎢          ⎥
+    ⎢-2  1   -1⎥
+    ⎢          ⎥
+    ⎣0   0   1 ⎦
+
+    >>> M = invertible(3, scalar_set=(sqrt(2),))  # entries as sums and products of sqrt(2) and 1
+    >>> M
+    ⎡1   0    √2  ⎤
+    ⎢             ⎥
+    ⎢√2  1  √2 + 2⎥
+    ⎢             ⎥
+    ⎣0   0    1   ⎦
+    >>> simplify(M.inv()*M)
+    ⎡1  0  0⎤
+    ⎢       ⎥
+    ⎢0  1  0⎥
+    ⎢       ⎥
+    ⎣0  0  1⎦
+
+
+    >>> random.seed(1)
+    >>> M = triangular(3, rank=3)
+    >>> M
+    ⎡-1  1  2 ⎤
+    ⎢         ⎥
+    ⎢0   1  1 ⎥
+    ⎢         ⎥
+    ⎣0   0  -1⎦
+    >>> M.inv()
+    ⎡-1  1  -1⎤
+    ⎢         ⎥
+    ⎢0   1  1 ⎥
+    ⎢         ⎥
+    ⎣0   0  -1⎦
+
+    >>> random.seed(1)
+    >>> M = orthogonal(3)
+    >>> M
+    ⎡      -√2      ⎤
+    ⎢1/2   ────  1/2⎥
+    ⎢       2       ⎥
+    ⎢               ⎥
+    ⎢       √2      ⎥
+    ⎢1/2    ──   1/2⎥
+    ⎢       2       ⎥
+    ⎢               ⎥
+    ⎢-√2         √2 ⎥
+    ⎢────   0    ── ⎥
+    ⎣ 2          2  ⎦
+    >>> M.T*M
+    ⎡1  0  0⎤
+    ⎢       ⎥
+    ⎢0  1  0⎥
+    ⎢       ⎥
+    ⎣0  0  1⎦
+
+And symbolic matrices work, too.
+
+    >>> from sympy import symbols, cos, sin
+
+    >>> phi = symbols('phi')
+    >>> scalar_set = cos(phi), sin(phi)
+    >>> random.seed(1)
+    >>> M = orthogonal(3, scalar_set=scalar_set, length=1)
+    >>> M
+    ⎡                         _____________⎤
+    ⎢                        ╱        2    ⎥
+    ⎢     cos(φ)       0  -╲╱  1 - cos (φ) ⎥
+    ⎢                                      ⎥
+    ⎢       0          1          0        ⎥
+    ⎢                                      ⎥
+    ⎢   _____________                      ⎥
+    ⎢  ╱        2                          ⎥
+    ⎣╲╱  1 - cos (φ)   0       cos(φ)      ⎦
+    >>> M.T*M
+    ⎡1  0  0⎤
+    ⎢       ⎥
+    ⎢0  1  0⎥
+    ⎢       ⎥
+    ⎣0  0  1⎦
+
+Using matrices to construct a matrix with integer entries
+which has an inverse with integer entries, too.
+
+    >>> from sympy.matrices.random import invertible
+    >>> random.seed(1)
+    >>> A = invertible(4, scalar_set=(1,-1))
+    >>> A
+    ⎡-1  0   0   0 ⎤
+    ⎢              ⎥
+    ⎢0   1   0   0 ⎥
+    ⎢              ⎥
+    ⎢0   1   1   0 ⎥
+    ⎢              ⎥
+    ⎣-2  -1  -1  -1⎦
+    >>> A.inv()
+    ⎡-1  0   0   0 ⎤
+    ⎢              ⎥
+    ⎢0   1   0   0 ⎥
+    ⎢              ⎥
+    ⎢0   -1  1   0 ⎥
+    ⎢              ⎥
+    ⎣2   0   -1  -1⎦
+
+Using matrices to construct a quadric,
+a quadratic equation in multiple variables
+
+    >>> from sympy import diag
+    >>> from sympy.abc import x, y, z
+    >>> from sympy.matrices.random import orthogonal
+    >>> random.seed(1)
+    >>> xyz = Matrix([x, y, z])
+    >>> D = diag(1, 2, 3)
+    >>> S = orthogonal(3)
+    >>> S.T * D * S
+    ⎡      √2       ⎤
+    ⎢9/4   ──   -3/4⎥
+    ⎢      4        ⎥
+    ⎢               ⎥
+    ⎢ √2         √2 ⎥
+    ⎢ ──   3/2   ── ⎥
+    ⎢ 4          4  ⎥
+    ⎢               ⎥
+    ⎢      √2       ⎥
+    ⎢-3/4  ──   9/4 ⎥
+    ⎣      4        ⎦
+    >>> q = expand(xyz.T * S.T * D * S * xyz)[0, 0].as_expr()
+    >>> q
+       2                       2               2
+    9⋅x    √2⋅x⋅y   3⋅x⋅z   3⋅y    √2⋅y⋅z   9⋅z
+    ──── + ────── - ───── + ──── + ────── + ────
+     4       2        2      2       2       4
+
 Advanced Methods
 ================
 

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -240,8 +240,8 @@ the random matrix generation functions, e.g.
 ``invertible``, ``triangular``, ``orthogonal``.
 Find a :ref:`full list of random matrices <matrices-random>`.
 
-    >>> import random
-    >>> random.seed(1)
+    >>> from sympy.matrices.random import rand
+    >>> rand.seed(1)
 
     >>> from sympy.matrices.random import invertible, triangular, orthogonal
     >>> from sympy import simplify
@@ -275,35 +275,33 @@ Find a :ref:`full list of random matrices <matrices-random>`.
     ⎣0  0  1⎦
 
 
-    >>> random.seed(1)
-    >>> M = triangular(3, rank=3)
+    >>> M = triangular(3, scalar_set=(1, sqrt(2)))
     >>> M
-    ⎡-1  1  2 ⎤
-    ⎢         ⎥
-    ⎢0   1  1 ⎥
-    ⎢         ⎥
-    ⎣0   0  -1⎦
+    ⎡1  1 + √2  0 ⎤
+    ⎢             ⎥
+    ⎢0    1     0 ⎥
+    ⎢             ⎥
+    ⎣0    0     -1⎦
     >>> M.inv()
-    ⎡-1  1  -1⎤
-    ⎢         ⎥
-    ⎢0   1  1 ⎥
-    ⎢         ⎥
-    ⎣0   0  -1⎦
+    ⎡1  -√2 - 1  0 ⎤
+    ⎢              ⎥
+    ⎢0     1     0 ⎥
+    ⎢              ⎥
+    ⎣0     0     -1⎦
 
-    >>> random.seed(1)
-    >>> M = orthogonal(3)
+    >>> M = orthogonal(3, length=6)
     >>> M
-    ⎡      -√2      ⎤
-    ⎢1/2   ────  1/2⎥
-    ⎢       2       ⎥
+    ⎡ √2   √2       ⎤
+    ⎢ ──   ──    0  ⎥
+    ⎢ 2    2        ⎥
     ⎢               ⎥
-    ⎢       √2      ⎥
-    ⎢1/2    ──   1/2⎥
-    ⎢       2       ⎥
+    ⎢           -√2 ⎥
+    ⎢-1/2  1/2  ────⎥
+    ⎢            2  ⎥
     ⎢               ⎥
-    ⎢-√2         √2 ⎥
-    ⎢────   0    ── ⎥
-    ⎣ 2          2  ⎦
+    ⎢            √2 ⎥
+    ⎢-1/2  1/2   ── ⎥
+    ⎣            2  ⎦
     >>> M.T*M
     ⎡1  0  0⎤
     ⎢       ⎥
@@ -314,21 +312,19 @@ Find a :ref:`full list of random matrices <matrices-random>`.
 And symbolic matrices work, too.
 
     >>> from sympy import symbols, cos, sin
-
     >>> phi = symbols('phi')
     >>> scalar_set = cos(phi), sin(phi)
-    >>> random.seed(1)
     >>> M = orthogonal(3, scalar_set=scalar_set, length=1)
     >>> M
-    ⎡                         _____________⎤
-    ⎢                        ╱        2    ⎥
-    ⎢     cos(φ)       0  -╲╱  1 - cos (φ) ⎥
-    ⎢                                      ⎥
-    ⎢       0          1          0        ⎥
+    ⎡                      _____________   ⎤
+    ⎢                     ╱        2       ⎥
+    ⎢     sin(φ)       -╲╱  1 - sin (φ)   0⎥
     ⎢                                      ⎥
     ⎢   _____________                      ⎥
     ⎢  ╱        2                          ⎥
-    ⎣╲╱  1 - cos (φ)   0       cos(φ)      ⎦
+    ⎢╲╱  1 - sin (φ)        sin(φ)        0⎥
+    ⎢                                      ⎥
+    ⎣       0                  0          1⎦
     >>> M.T*M
     ⎡1  0  0⎤
     ⎢       ⎥
@@ -340,24 +336,23 @@ Using matrices to construct a matrix with integer entries
 which has an inverse with integer entries, too.
 
     >>> from sympy.matrices.random import invertible
-    >>> random.seed(1)
     >>> A = invertible(4, scalar_set=(1,-1))
     >>> A
-    ⎡-1  0   0   0 ⎤
-    ⎢              ⎥
-    ⎢0   1   0   0 ⎥
-    ⎢              ⎥
-    ⎢0   1   1   0 ⎥
-    ⎢              ⎥
-    ⎣-2  -1  -1  -1⎦
+    ⎡1  0  0  1⎤
+    ⎢          ⎥
+    ⎢1  1  0  1⎥
+    ⎢          ⎥
+    ⎢0  0  1  0⎥
+    ⎢          ⎥
+    ⎣0  0  0  1⎦
     >>> A.inv()
-    ⎡-1  0   0   0 ⎤
-    ⎢              ⎥
-    ⎢0   1   0   0 ⎥
-    ⎢              ⎥
-    ⎢0   -1  1   0 ⎥
-    ⎢              ⎥
-    ⎣2   0   -1  -1⎦
+    ⎡1   0  0  -1⎤
+    ⎢            ⎥
+    ⎢-1  1  0  0 ⎥
+    ⎢            ⎥
+    ⎢0   0  1  0 ⎥
+    ⎢            ⎥
+    ⎣0   0  0  1 ⎦
 
 Using matrices to construct a quadric,
 a quadratic equation in multiple variables
@@ -365,28 +360,19 @@ a quadratic equation in multiple variables
     >>> from sympy import diag
     >>> from sympy.abc import x, y, z
     >>> from sympy.matrices.random import orthogonal
-    >>> random.seed(1)
     >>> xyz = Matrix([x, y, z])
     >>> D = diag(1, 2, 3)
-    >>> S = orthogonal(3)
+    >>> S = orthogonal(3, length=6)
     >>> S.T * D * S
-    ⎡      √2       ⎤
-    ⎢9/4   ──   -3/4⎥
-    ⎢      4        ⎥
-    ⎢               ⎥
-    ⎢ √2         √2 ⎥
-    ⎢ ──   3/2   ── ⎥
-    ⎢ 4          4  ⎥
-    ⎢               ⎥
-    ⎢      √2       ⎥
-    ⎢-3/4  ──   9/4 ⎥
-    ⎣      4        ⎦
+    ⎡2  0  1⎤
+    ⎢       ⎥
+    ⎢0  2  0⎥
+    ⎢       ⎥
+    ⎣1  0  2⎦
     >>> q = expand(xyz.T * S.T * D * S * xyz)[0, 0].as_expr()
     >>> q
-       2                       2               2
-    9⋅x    √2⋅x⋅y   3⋅x⋅z   3⋅y    √2⋅y⋅z   9⋅z
-    ──── + ────── - ───── + ──── + ────── + ────
-     4       2        2      2       2       4
+       2              2      2
+    2⋅x  + 2⋅x⋅z + 2⋅y  + 2⋅z
 
 Advanced Methods
 ================

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -7,8 +7,8 @@ from ..functions import sqrt as _sqrt, re as _re, im as _im, \
 from ..tensor import shape as _shape
 from .dense import eye as _eye
 
-__all__ = 'identity', 'projection', 'jordan', 'transposition', 'permutation', \
-          'elementary', 'rotation', 'reflection', \
+__all__ = 'identity_matrix', 'projection', 'jordan', 'transposition', \
+          'permutation', 'elementary', 'rotation', 'reflection', \
           'diagonal_normal', 'jordan_normal', 'isometry_normal', \
           'triangular', 'invertible', 'singular', \
           'idempotent', 'nilpotent', 'diagonalizable', 'trigonalizable', \
@@ -60,7 +60,7 @@ def super_elementary_matrix(dim,
                             index=None,
                             value=None,
                             *scalar_set):
-    r"""super elementary matrix n x n, i.e. identity with on 2 x 2 block
+    r"""super elementary matrix n x n, i.e. identity_matrix with on 2 x 2 block
 
     Explanation
     ===========
@@ -74,7 +74,7 @@ def super_elementary_matrix(dim,
        A = \left[\begin{array}{cc}a & b \\ -c & d\end{array}\right]
 
     is super elementary, i.e. $ad+bc \neq 0$. In higher dimensions,
-    any matrix $A$ looking like identity matrix but with entries
+    any matrix $A$ looking like identity_matrix matrix but with entries
 
     .. math::
 
@@ -148,7 +148,7 @@ def super_elementary_matrix(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     diagonal
     elementary
     transposition
@@ -168,7 +168,7 @@ def super_elementary_matrix(dim,
             "index argument must be tuple of two matrix index integer.")
 
     if row == col:
-        # identity or _multiply by scalar
+        # identity_matrix or _multiply by scalar
         _set_value(obj, row, col, value or 1)
         if scalar_set:
             raise ValueError(
@@ -253,7 +253,7 @@ def complex_to_real(mat=None):
 
     """
     dim = _shape(mat)[0]
-    mat = mat or identity(dim)
+    mat = mat or identity_matrix(dim)
     obj = super_elementary_matrix(2 * dim)
     for i in range(dim):
         for j in range(dim):
@@ -271,7 +271,7 @@ def regular_to_singular(mat, rank=None):
 
     Explanation
     ===========
-    Let $I$ be the $n \times n$ identity matrix
+    Let $I$ be the $n \times n$ identity_matrix matrix
     and $D$ an diagonal matrix with only zero and one entries
     of rank $r$ (i.e. all entries but $n-r$ diagonal entries are zero).
 
@@ -284,7 +284,8 @@ def regular_to_singular(mat, rank=None):
 
     If $A$ is an upper triangular matrix $B$ as well $A*B$ is one, too.
 
-    Here, $A*B$ is returned. Note, if $n=r$ the matrix $B$ is the identity.
+    Here, $A*B$ is returned.
+    Note, if $n=r$ the matrix $B$ is the identity_matrix.
 
     Examples
     ========
@@ -315,7 +316,7 @@ def regular_to_singular(mat, rank=None):
     dim = _shape(mat)[0]
     if rank == dim:
         return mat
-    i = identity(dim)
+    i = identity_matrix(dim)
     p = permutation(dim)
     d = projection(dim, (0, rank))
     d = _multiply(p.inv(), d, p)
@@ -326,21 +327,21 @@ def regular_to_singular(mat, rank=None):
 # === base matrices ===
 
 
-def identity(dim):
-    r"""identity matrix n x n
+def identity_matrix(dim):
+    r"""identity_matrix matrix n x n
 
     Explanation
     ===========
 
-    Creates identity matrix with only ones on the diagonal
+    Creates identity_matrix matrix with only ones on the diagonal
     and zeros anywhere else.
 
     Examples
     ========
 
-    >>> from sympy.matrices.random import identity
+    >>> from sympy.matrices.random import identity_matrix
 
-    >>> identity(3)
+    >>> identity_matrix(3)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -367,7 +368,7 @@ def projection(dim,
 
     Explanation
     ===========
-    A projection is a identity like matrix
+    A projection is a identity_matrix like matrix
     but with zero diagonal entiries off **index**.
 
     Examples
@@ -398,13 +399,13 @@ def projection(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     diagonal
 
     """
 
     index = index or random.sample(range(dim + 1), 2)
-    obj = identity(dim)
+    obj = identity_matrix(dim)
     start, end = sorted(index)
     for i in range(dim):
         v = 1 if start <= i < end else 0
@@ -474,7 +475,7 @@ def jordan(dim,
     """
     index = index or random.sample(range(dim), 2)
     scalar = random.choice(_elementary_scalar_set) if scalar is None else scalar
-    obj = identity(dim)
+    obj = identity_matrix(dim)
     start, end = sorted(index)
     _set_value(obj, start, start, scalar)
     for i in range(start + 1, end):
@@ -489,7 +490,7 @@ def transposition(dim,
 
     Explamation
     ===========
-    A transposition matrix is an identity matrix where two columns (or rows)
+    A transposition matrix is an identity_matrix where two columns (or rows)
     are swapped. It is a special permutation matrix.
     Moreover, any permutaion matrix is a product of transposition matrices.
 
@@ -530,7 +531,7 @@ def transposition(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     elementary
     permutation
 
@@ -551,7 +552,7 @@ def permutation(dim,
 
     Such a matrix can be obtained by shuffeling the rows
     of an identiy matrix .i.e ``permutation(dim, perm)`` is eqivalent to
-    ``identity(dim).permute(perm)``.
+    ``identity_matrix(dim).permute(perm)``.
 
     Examples
     ========
@@ -581,16 +582,16 @@ def permutation(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     transposition
 
     """
     perm = perm or random.sample(range(dim), dim)
-    obj = identity(dim)
+    obj = identity_matrix(dim)
     for i, j in enumerate(perm):
         _set_value(obj, i, i, 0)  # aka zeros(dim)
         _set_value(obj, i, j, 1)
-    return obj  # aka identity(dim).permute(perm)
+    return obj  # aka identity_matrix(dim).permute(perm)
 
 
 def elementary(dim,
@@ -612,7 +613,7 @@ def elementary(dim,
 
        A = \left[\begin{array}{cc}1 & \mu \\ 0 & 1\end{array}\right] \\
 
-    In higher dimensions, any matrix $A$ looking like identity matrix
+    In higher dimensions, any matrix $A$ looking like identity_matrix matrix
     but with entries
 
     .. math::
@@ -677,7 +678,7 @@ def elementary(dim,
         value of elementary entry,
         defaults to values -1 or 1
         if **scalar** is **None** the *elementary matrix*
-        will be a transposition $T$ or identity
+        will be a transposition $T$ or identity_matrix
 
     See Also
     ========
@@ -920,7 +921,7 @@ def diagonal_normal(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     sympy.matrices.dense.diag
 
     """
@@ -939,7 +940,7 @@ def diagonal_normal(dim,
         return _multiply(*items)
 
     else:
-        obj = identity(dim)
+        obj = identity_matrix(dim)
         for start, scalar in enumerate(spec):
             _set_value(obj, start, start, scalar)
         return obj  # eq. to gauss_jordan(dim, rank, eigenvalue_set, dim)
@@ -1093,7 +1094,7 @@ def jordan_normal(dim,
         return _multiply(*items)
 
     else:
-        obj = identity(dim)
+        obj = identity_matrix(dim)
         start = 0
         for scalar, size in spec:
             end = min(dim, start + size)
@@ -1258,7 +1259,7 @@ def isometry_normal(dim,
         return _multiply(*items)
 
     else:
-        obj = identity(dim)
+        obj = identity_matrix(dim)
         start = 0
         for s in spec:
             end = start + len(s)
@@ -1328,13 +1329,13 @@ def triangular(dim,
 
     See Also
     ========
-    identity
+    identity_matrix
     elementary
     square
 
     """
     if length == 0:
-        return regular_to_singular(identity(dim), rank)
+        return regular_to_singular(identity_matrix(dim), rank)
     scalar_set = scalar_set or (0,)
     unit_set = unit_set or (1,)
     length = length or 2 * dim
@@ -1401,7 +1402,7 @@ def square(dim,
 
     """
     if length == 0:
-        return regular_to_singular(identity(dim), rank)
+        return regular_to_singular(identity_matrix(dim), rank)
 
     length = length or 2 * dim
     lwr = triangular(dim, None, scalar_set, unit_set, int(length / 2))
@@ -1901,7 +1902,7 @@ def orthogonal(dim,
     """
     if spec is None:
         if length == 0:
-            return identity(dim)
+            return identity_matrix(dim)
         length = length or dim
         scalars = [random.choice(scalar_set) for _ in range(length)]
         items = [rotation(dim, scalar=s) for s in scalars]
@@ -2023,7 +2024,7 @@ def unitary(dim,
     """
     if spec is None:
         if length == 0:
-            return identity(dim)
+            return identity_matrix(dim)
         length = length or dim
 
         real_scalar_set = tuple(_cs(x) for x in scalar_set)

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import random
 
 from ..core import I as _i

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -18,21 +18,6 @@ __all__ = 'identity', 'projection', 'jordan', 'transposition', 'permutation', \
 
 _TEST = False
 
-
-'''
-USEFUL STUFF
-============
-
-# build and show docs with
-make html; open ./_build/html/modules/matrices/random.html
-
-# pretty print with sympy
-from sympy.matrices.random import *
-from sympy import init_printing, pprint
-init_printing()
-pprint(invertible(3))
-'''
-
 _eps = 1e-13
 
 

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -1438,7 +1438,7 @@ def invertible(dim,
 
     Examples
     ========
-    >>> from sympy import symbols, pprint
+    >>> from sympy import symbols
     >>> from sympy.matrices.random import invertible
     >>> import random
     >>> random.seed(1)
@@ -1943,7 +1943,7 @@ def unitary(dim,
 
     Examples
     ========
-    >>> from sympy import sqrt, I, simplify, eye, expand, re
+    >>> from sympy import sqrt, I, simplify, re
     >>> from sympy.matrices.random import unitary
     >>> import random
     >>> random.seed(1)
@@ -2080,7 +2080,7 @@ def normal(dim,
 
     Examples
     ========
-    >>> from sympy import sqrt, I
+    >>> from sympy import sqrt
     >>> from sympy.matrices.random import normal
     >>> import random
     >>> random.seed(1)

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import random
 
 from ..core import I as _i
@@ -1939,7 +1938,7 @@ def unitary(dim,
 
         B = \bar{A}^t D' A = \bar{V}^t \bar{D}^t \bar{U}^t D' UDV
 
-    (see Führ/Rzeszotnik, "A note on factoring unitary matrices", 2018
+    (see Fuehr/Rzeszotnik, "A note on factoring unitary matrices", 2018
     https://doi.org/10.1016%2Fj.laa.2018.02.017)
 
     Examples

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -2097,7 +2097,7 @@ def normal(dim,
     Examples
     ========
 
-    >>> from sympy import sqrt, I, zeros, expand
+    >>> from sympy import I, zeros, expand
     >>> from sympy.matrices.random import rand, normal
     >>> rand.seed(44)
 

--- a/sympy/matrices/random.py
+++ b/sympy/matrices/random.py
@@ -1,0 +1,2262 @@
+import random
+
+from ..core import I as _i
+from ..core.mul import Mul as _multiply
+from ..functions import sqrt as _sqrt, re as _re, im as _im, \
+    transpose as _t, adjoint as _c
+from ..tensor import shape as _shape
+from .dense import eye as _eye
+
+__all__ = 'identity', 'projection', 'jordan', 'transposition', 'permutation', \
+          'elementary', 'rotation', 'reflection', \
+          'diagonal_normal', 'jordan_normal', 'isometry_normal', \
+          'triangular', 'invertible', 'singular', \
+          'idempotent', 'nilpotent', 'diagonalizable', 'trigonalizable', \
+          'orthogonal', 'unitary', 'normal', \
+          'symmetric', 'hermite', \
+          'regular_to_singular', 'complex_to_real'
+
+_TEST = False
+
+
+'''
+USEFUL STUFF
+============
+
+# build and show docs with
+make html; open ./_build/html/modules/matrices/random.html
+
+# pretty print with sympy
+from sympy.matrices.random import *
+from sympy import init_printing, pprint
+init_printing()
+pprint(invertible(3))
+'''
+
+_eps = 1e-13
+
+
+def _get_value(o, i, j):
+    return o[i, j]
+
+
+def _set_value(o, i, j, v):
+    o[i, j] = v
+
+
+def _inv(o):
+    return o.inv()
+
+
+def _cs(scalar):
+    sgn = random.choice((-1, 1))
+    if isinstance(scalar, (tuple, list)) and len(scalar) == 2:
+        return scalar
+    if isinstance(scalar, complex) or getattr(scalar, 'is_real', True) is False:
+        return _re(scalar), _im(scalar)
+    c = scalar
+    s = sgn * _sqrt(1 - c * c)
+    return c, s
+
+    # msg = "rotation scalar argument must have norm equal to 1"
+    # msg += " or norm less than 1 and real"
+    # msg += " not abs(%s)=%s" % (str(scalar), str(abs(scalar)))
+    # raise ValueError(msg)
+
+
+_elementary_scalar_set = -1, 1
+_rotation_scalar_set = (_sqrt(2) / 2, _sqrt(2) / 2), (0, -1),
+_unitary_scalar_set = tuple(c * 1 + s * _i for c, s in _rotation_scalar_set)
+
+
+# === fundamental constructor ===
+
+def super_elementary_matrix(dim,
+                            index=None,
+                            value=None,
+                            *scalar_set):
+    r"""super elementary matrix n x n, i.e. identity with on 2 x 2 block
+
+    Explanation
+    ===========
+    The super elementary matrix $A$ is a gerealization of elementary matrices
+    as well as of a rotation matrices that rotate only a single plane.
+
+    In two dimensions any invertible matrix
+
+    .. math::
+
+       A = \left[\begin{array}{cc}a & b \\ -c & d\end{array}\right]
+
+    is super elementary, i.e. $ad+bc \neq 0$. In higher dimensions,
+    any matrix $A$ looking like identity matrix but with entries
+
+    .. math::
+
+        A[i,i] = a, \quad A[i,j] = b, \quad A[j,i] = -c, \quad A[j,j] = d
+
+    and $ad - bc \neq 0$.
+
+    This inculdes elementary matrices of matrix operation for Gauss elimination.
+    So multiplication with $A$ gives for
+
+    * $a=0=d$ and $b=1=-c$ a *transposition*, i.e. swapping rows $i$ and $j$
+    * $a=1$, $d=\lambda$ and $b=0=-c$ this matrix describes scaling the
+      row $j$ by $\lambda$
+    * $a=1=d$, $b=\lambda$, $-c=0$ adding the $\lambda$ multiple
+      of the row $i$ to row $j$.
+
+    Moreover, a simple rotation by $\phi$ in $(i,j)$ plane is super elementary,
+    given by $a=\cos \phi = d$ and $b = \sin \phi = c$. Hence,
+
+    .. math::
+
+       \left[\begin{array}{cc}a & b \\ -c & d\end{array}\right]
+       =
+       \left[\begin{array}{cc}
+        \cos \phi & \sin \phi \\ -\sin \phi & \cos \phi \end{array}\right]
+
+    In this module the super elementary matrix serves as the base class to
+    create futher matrices of given type.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import super_elementary_matrix
+    >>> import random
+    >>> random.seed(1)
+
+    >>> super_elementary_matrix(3, (0,1))
+    Matrix([
+    [0, 1, 0],
+    [1, 0, 0],
+    [0, 0, 1]])
+
+    >>> super_elementary_matrix(3, (0,2), value=5)
+    Matrix([
+    [1, 0, 5],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    >>> super_elementary_matrix(3, (2,2), value=5)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 5]])
+
+    >>> super_elementary_matrix(3, (1,2), 1,2,3,4)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 2],
+    [0, -3, 4]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    index : tuple(int, int)
+        coordinates (i,j) of super elementary square
+    value : symbol (optional)
+        value as elementary entry
+    *scalar_set : symbols (optional)
+        up to three additional values as additional super elementry entries
+
+    See Also
+    ========
+    identity
+    diagonal
+    elementary
+    transposition
+    rotation
+
+    """
+    obj = _eye(dim)
+    if index is None:
+        return obj
+
+    if not isinstance(index, (list, tuple, set)) or not len(index) == 2:
+        raise ValueError(
+            "index argument must be tuple of two matrix index integer.")
+    row, col = index
+    if not isinstance(row, int) or not isinstance(col, int):
+        raise ValueError(
+            "index argument must be tuple of two matrix index integer.")
+
+    if row == col:
+        # identity or _multiply by scalar
+        _set_value(obj, row, col, value or 1)
+        if scalar_set:
+            raise ValueError(
+                "if row==col no further args than value may be supplied.")
+    elif not scalar_set:
+        # elementary
+        if value is None:
+            # transposition
+            _set_value(obj, row, row, 0)
+            _set_value(obj, row, col, 1)
+            _set_value(obj, col, row, 1)
+            _set_value(obj, col, col, 0)
+        else:
+            # add scalar multiple to another
+            _set_value(obj, row, col, value)
+    elif len(scalar_set) == 3:
+        _set_value(obj, row, row, value)
+        y, v, u = scalar_set
+        _set_value(obj, row, col, y)
+        _set_value(obj, col, row, -v)
+        _set_value(obj, col, col, u)
+    else:
+        msg = "either no, one or three additional scalar_set arguments " \
+              "may be supplied, but not %i"
+        raise ValueError(msg % len(scalar_set))
+    return obj
+
+
+# === fundamental matrix functions ===
+
+
+def complex_to_real(mat=None):
+    r""" returns real version of a complex matrix
+
+    Explanation
+    ===========
+    Any complex vector space $V$ with basis $(b_1, \dots, b_n)$
+    can be seen as a real vector space $V^{prime}$ with basis
+    $(b_1, b_1 \ i, \dots, b_n, b_n \ i)$
+    of dimension $2 \ n$.
+
+    Since multiplication with complex number is linear on $V$
+    resp. $V^{\prime}$,
+    any complex homomorphism (i.e. complex matrix $A$) on $V$
+    becomes a real homomorphism (i.e. matrix $A^{\prime}$) on $V^{\prime}$.
+
+    This transforms a complex matrix $A$
+    to the corresponding real matrix $A^{\prime}$.
+
+    Examples
+    ========
+    >>> from sympy import Matrix, I
+    >>> from sympy.abc import a, b
+    >>> from sympy.matrices.random import complex_to_real
+
+    >>> z = a + b * I
+    >>> A = Matrix([[z]])
+    >>> A
+    Matrix([[a + I*b]])
+
+    >>> complex_to_real(A)
+    Matrix([
+    [ re(a) - im(b), re(b) + im(a)],
+    [-re(b) - im(a), re(a) - im(b)]])
+
+    >>> A = Matrix([[z, 0],[1, I]])
+    >>> A
+    Matrix([
+    [a + I*b, 0],
+    [      1, I]])
+    >>> complex_to_real(A)
+    Matrix([
+    [ re(a) - im(b), re(b) + im(a),  0, 0],
+    [-re(b) - im(a), re(a) - im(b),  0, 0],
+    [             1,             0,  0, 1],
+    [             0,             1, -1, 0]])
+
+    Parameters
+    ==========
+    mat : Matrix
+        a complex matrix
+
+    """
+    dim = _shape(mat)[0]
+    mat = mat or identity(dim)
+    obj = super_elementary_matrix(2 * dim)
+    for i in range(dim):
+        for j in range(dim):
+            z_value = _get_value(mat, i, j)
+            a, b = _re(z_value), _im(z_value)
+            _set_value(obj, 2 * i, 2 * j, a)
+            _set_value(obj, 2 * i, 2 * j + 1, b)
+            _set_value(obj, 2 * i + 1, 2 * j, -b)
+            _set_value(obj, 2 * i + 1, 2 * j + 1, a)
+    return obj
+
+
+def regular_to_singular(mat, rank=None):
+    r""" build matrix with linear combination of matrix columns to meet rank
+
+    Explanation
+    ===========
+    Let $I$ be the $n \times n$ identity matrix
+    and $D$ an diagonal matrix with only zero and one entries
+    of rank $r$ (i.e. all entries but $n-r$ diagonal entries are zero).
+
+    If a full rank matrix $A$ is given, then
+
+    .. math::
+        B = D * (I + A * (I-D)) = D + D * A * (I-D)
+
+    is of rank $r$, too.  Some for $A*B$ which contains $r$ columns with $A$.
+
+    If $A$ is an upper triangular matrix $B$ as well $A*B$ is one, too.
+
+    Here, $A*B$ is returned. Note, if $n=r$ the matrix $B$ is the identity.
+
+    Examples
+    ========
+    >>> from sympy import Matrix
+    >>> from sympy.matrices.random import regular_to_singular
+    >>> m = Matrix([[1, 2, 3],[4, 5, 6], [7, 8 ,0]])
+    >>> m.rank()
+    3
+    >>> n = regular_to_singular(m, 2)
+    >>> n
+    Matrix([
+    [1, 2, 15],
+    [4, 5, 42],
+    [7, 8, 69]])
+    >>> n.rank()
+    2
+
+    Parameters
+    ==========
+    mat : Matrix
+        a complex matrix
+    rank : integer
+        rank of matrix
+
+    """
+    if rank is None:
+        return mat
+    dim = _shape(mat)[0]
+    if rank == dim:
+        return mat
+    i = identity(dim)
+    p = permutation(dim)
+    d = projection(dim, (0, rank))
+    d = _multiply(p.inv(), d, p)
+    md = _multiply(mat, d)
+    return md + _multiply(md, mat, i - d)
+
+
+# === base matrices ===
+
+
+def identity(dim):
+    r"""identity matrix n x n
+
+    Explanation
+    ===========
+
+    Creates identity matrix with only ones on the diagonal
+    and zeros anywhere else.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import identity
+
+    >>> identity(3)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+
+    See Also
+    ========
+    diagonal
+    sympy.matrices.dense.eye
+
+    """
+
+    return super_elementary_matrix(dim)
+
+
+def projection(dim,
+               index=None):
+    r"""a projection matrix n x n
+
+    Explanation
+    ===========
+    A projection is a identity like matrix
+    but with zero diagonal entiries off **index**.
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import projection
+    >>> import random
+    >>> random.seed(1)
+
+    >>> projection(3)
+    Matrix([
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0]])
+
+    >>> projection(3, index=(1,3))
+    Matrix([
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates ``(i,j)`` for start (included) and end (excluded)
+        to project onto
+
+    See Also
+    ========
+    identity
+    diagonal
+
+    """
+
+    index = index or random.sample(range(dim + 1), 2)
+    obj = identity(dim)
+    start, end = sorted(index)
+    for i in range(dim):
+        v = 1 if start <= i < end else 0
+        _set_value(obj, i, i, v)
+    return obj
+
+
+def jordan(dim,
+           index=None,
+           scalar=None):
+    r"""n x n matrix with a single Jordan block of given eigenvalue
+
+    Explanation
+    ===========
+    A matrix with a single Jordan block matrix
+    with only non-zero blocks on the diagonal
+    which have the form of an Jordan block $J$ which is
+
+    .. math::
+
+        J = \left[\begin{array}{cccccc}
+            \lambda  & 1       & 0         & \dots     &         & 0     \\
+             0       & \lambda & 1         & 0         & \dots   & 0     \\
+             0       & \ddots  & \ddots    & \ddots    & \ddots  & 0     \\
+             0       & \dots   & 0         & 0         & \lambda & 1     \\
+             0       & \dots   &           &           & 0       & \lambda
+             \end{array}\right]
+
+    Finally, each $\lambda$ of each Jordan block will be an eigenvalue.
+
+    >>> from sympy.matrices.random import jordan
+    >>> import random
+    >>> random.seed(1)
+
+    >>> jordan(3)
+    Matrix([
+    [1, 1, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+    >>> jordan(3, scalar=2)
+    Matrix([
+    [2, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+    >>> jordan(4, index=(1,4), scalar=2)
+    Matrix([
+    [1, 0, 0, 0],
+    [0, 2, 1, 0],
+    [0, 0, 2, 1],
+    [0, 0, 0, 2]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates ``(i,j)`` for start (included) and end (excluded)
+        of the Jordan square
+    scalar : symbol (optional)
+        eigenvalue used for the Jordan block
+        defaults to values -1 or 1
+
+    See Also
+    ========
+    jordan_normal
+
+    """
+    index = index or random.sample(range(dim), 2)
+    scalar = random.choice(_elementary_scalar_set) if scalar is None else scalar
+    obj = identity(dim)
+    start, end = sorted(index)
+    _set_value(obj, start, start, scalar)
+    for i in range(start + 1, end):
+        _set_value(obj, i - 1, i, 1)
+        _set_value(obj, i, i, scalar)
+    return obj
+
+
+def transposition(dim,
+                  index=None):
+    r"""n x n transposition matrix
+
+    Explamation
+    ===========
+    A transposition matrix is an identity matrix where two columns (or rows)
+    are swapped. It is a special permutation matrix.
+    Moreover, any permutaion matrix is a product of transposition matrices.
+
+    In two dimensions it is
+
+    .. math::
+
+       T = \left[\begin{array}{cc}0 & 1 \\ 1 & 0\end{array}\right] \\
+
+    If index is given, it sets which column or row will be swapped.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import transposition
+    >>> import random
+    >>> random.seed(1)
+
+    >>> transposition(4)
+    Matrix([
+    [1, 0, 0, 0],
+    [0, 0, 1, 0],
+    [0, 1, 0, 0],
+    [0, 0, 0, 1]])
+
+    >>> transposition(3, (0,1))
+    Matrix([
+    [0, 1, 0],
+    [1, 0, 0],
+    [0, 0, 1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates (i,j) of transposition
+
+    See Also
+    ========
+    identity
+    elementary
+    permutation
+
+    """
+    index = index or random.sample(range(dim), 2)
+    return super_elementary_matrix(dim, index)
+
+
+def permutation(dim,
+                perm=None):
+    r"""permutation matrix n x n
+
+    Explamation
+    ===========
+
+    A permutation matrix is a matrix with only 0 or 1 entries
+    and each column and each row consists of only one non-zero entry.
+
+    Such a matrix can be obtained by shuffeling the rows
+    of an identiy matrix .i.e ``permutation(dim, perm)`` is eqivalent to
+    ``identity(dim).permute(perm)``.
+
+    Examples
+    ========
+    >>> import random
+    >>> random.seed(1)
+    >>> from sympy.matrices.random import permutation
+
+    >>> permutation(3)
+    Matrix([
+    [1, 0, 0],
+    [0, 0, 1],
+    [0, 1, 0]])
+
+    >>> permutation(3, (2,0,1))
+    Matrix([
+    [0, 0, 1],
+    [1, 0, 0],
+    [0, 1, 0]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    perm : tuple or list of integer (optional)
+        permutation as list of n integers, e.g. ``[2,1,0,3]`` as a
+        permutation of ``[0,1,2,3]``
+
+    See Also
+    ========
+    identity
+    transposition
+
+    """
+    perm = perm or random.sample(range(dim), dim)
+    obj = identity(dim)
+    for i, j in enumerate(perm):
+        _set_value(obj, i, i, 0)  # aka zeros(dim)
+        _set_value(obj, i, j, 1)
+    return obj  # aka identity(dim).permute(perm)
+
+
+def elementary(dim,
+               index=None,
+               scalar=None):
+    r"""an elementary matrix n x n for Gauss elimination
+
+    Explanantion
+    ============
+    Elementary matrices are matrices for Gauss elimination operation.
+
+    In two dimensions any matrix of the following types are elemenarty
+
+    .. math::
+
+       T = \left[\begin{array}{cc}0 & 1 \\ 1 & 0\end{array}\right] \\
+
+       M = \left[\begin{array}{cc}\lambda & 0 \\ 0 & 1\end{array}\right] \\
+
+       A = \left[\begin{array}{cc}1 & \mu \\ 0 & 1\end{array}\right] \\
+
+    In higher dimensions, any matrix $A$ looking like identity matrix
+    but with entries
+
+    .. math::
+
+        A[i,i] = a, \quad A[i,j] = b, \quad A[j,i] = -c, \quad A[j,j] = d
+
+    and $ad - bc \neq 0$.
+    So multiplication with $A$ gives for
+
+    * $a=0=d$ and $b=1=-c$ a ``transposition``, i.e. swapping rows $i$ and $j$
+    * $a=1$, $d=\lambda$ and $b=0=-c$ this matrix describes scaling the
+        row $j$ by $\lambda$
+    * $a=1=d$, $b=\mu, $-c=0$ adding the $\mu multiple
+        of the row $i$ to row $j$.
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import elementary
+    >>> import random
+    >>> random.seed(1)
+
+    >>> elementary(3)
+    Matrix([
+    [0, 0, 1],
+    [0, 1, 0],
+    [1, 0, 0]])
+
+    >>> elementary(3, (0,2), scalar=5)
+    Matrix([
+    [1, 0, 5],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    >>> elementary(3, (2,2), scalar=5)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 5]])
+
+    >>> elementary(3, (2,1), 4)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 4, 1]])
+
+    >>> elementary(3, (0,1), None)
+    Matrix([
+    [0, 1, 0],
+    [1, 0, 0],
+    [0, 0, 1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates ``(i,j)`` of matrix operation
+        if ``i`` equals ``j`` the *elementary matrix*
+        will be of type $M$,
+        else of type $A$ or $T$
+    scalar : symbol (optional)
+        value of elementary entry,
+        defaults to values -1 or 1
+        if **scalar** is **None** the *elementary matrix*
+        will be a transposition $T$ or identity
+
+    See Also
+    ========
+    diagonal
+    transposition
+
+    """
+
+    index = index or random.sample(range(dim), 2)
+    # scalar = scalar or random.choice(_elementary_scalar_set + (None,))
+    return super_elementary_matrix(dim, index, scalar)
+
+
+def rotation(dim,
+             index=None,
+             scalar=None):
+    r"""a square matrix n x n of a plane rotation
+
+    Explanation
+    ===========
+    The matrix decribes in n dimensional Euclidian space
+    a rotation of $(i,j)$ plane given by a single rotation square
+
+    .. math::
+
+        \left[\begin{array}{cc} c & s \\ -s & c \end{array}\right]
+
+
+    Examples
+    ========
+    >>> from sympy import sqrt, cos, symbols, eye
+    >>> from sympy.matrices.random import rotation
+    >>> import random
+    >>> random.seed(1)
+
+    >>> rotation(3)
+    Matrix([
+    [0, 0, -1],
+    [0, 1,  0],
+    [1, 0,  0]])
+
+    >>> cos_a = sin_a = sqrt(2)/2
+    >>> rotation(3, scalar=cos_a)
+    Matrix([
+    [1,          0,         0],
+    [0,  sqrt(2)/2, sqrt(2)/2],
+    [0, -sqrt(2)/2, sqrt(2)/2]])
+
+    >>> r = rotation(3, scalar=(cos_a, sin_a))
+    >>> r
+    Matrix([
+    [1,         0,          0],
+    [0, sqrt(2)/2, -sqrt(2)/2],
+    [0, sqrt(2)/2,  sqrt(2)/2]])
+
+    >>> r.T * r == eye(3)
+    True
+
+    works with symbols too
+
+    >>> cos_phi = cos(symbols('phi'))
+    >>> random.seed(1)
+    >>> r =rotation(3, scalar=cos_phi)
+    >>> r
+    Matrix([
+    [              cos(phi), 0, sqrt(1 - cos(phi)**2)],
+    [                     0, 1,                     0],
+    [-sqrt(1 - cos(phi)**2), 0,              cos(phi)]])
+
+    >>> r.det()
+    1
+
+    >>> r.T * r == eye(3)
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates ``(i,j)`` of rotation plane
+    scalar : tuple(symbol, symbol) or symbol (optional)
+        either a tuple of cosine value $c$ and sine value $s$ of rotation square
+        or just cosine value $c$ of rotation square.
+
+        If given, the **scalar** $c$ is be between -1 and 1.
+        The resulting rotation square
+
+        .. math::
+
+            \left[\begin{array}{cc} c & \pm s \\ \mp s & c \end{array}\right]
+
+        takes **scalar** for $c$ and $\pm \sqrt{1-c^2}$ for $s$.
+
+    See Also
+    ========
+    reflection
+    isometry_normal
+    orthogonal
+
+    """
+    index = index or random.sample(range(dim), 2)
+    scalar = scalar or random.choice(_rotation_scalar_set)
+    c, s = _cs(scalar)
+    return super_elementary_matrix(dim, index, c, s, s, c)
+
+
+def reflection(dim,
+               index=None,
+               scalar=None):
+    r"""a square matrix n x n of a hyperplane reflection
+
+    Explanation
+    ===========
+    The matrix describes a reflaction in n dimensional Euclidian space.
+    Constructed as ``reflection =  rotation * transposition``, i.e.
+    there will be the reflection square
+
+    .. math::
+
+        \left[\begin{array}{cc} s & c \\ c & -s \end{array}\right]
+
+    Examples
+    ========
+    >>> from sympy import sqrt, eye
+    >>> from sympy.matrices.random import reflection
+    >>> import random
+    >>> random.seed(1)
+
+    >>> reflection(3)
+    Matrix([
+    [-1, 0, 0],
+    [ 0, 1, 0],
+    [ 0, 0, 1]])
+
+    >>> c = s = sqrt(2)/2
+    >>> reflection(3, scalar=c)
+    Matrix([
+    [1,         0,          0],
+    [0, sqrt(2)/2,  sqrt(2)/2],
+    [0, sqrt(2)/2, -sqrt(2)/2]])
+
+    >>> r = reflection(3, scalar=(c, s))
+    >>> r
+    Matrix([
+    [1,          0,         0],
+    [0, -sqrt(2)/2, sqrt(2)/2],
+    [0,  sqrt(2)/2, sqrt(2)/2]])
+
+    >>> r.det()
+    -1
+
+    >>> r.T * r == eye(3)
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    index : tuple(integer, integer) (optional)
+        coordinates ``(i,j)`` of transposition and rotation
+    scalar : tuple(symbol, symbol) or symbol (optional)
+        either a tuple of cosine value $c$ and sine value $s$ of rotation square
+        or just cosine value $c$ of rotation square.
+
+        If given, the **scalar** $c$ as be between -1 and 1.
+        The resulting rotation square
+
+        .. math::
+
+            \left[\begin{array}{cc} c & \pm s \\ \mp s & c \end{array}\right]
+
+        takes **scalar** for $c$ and $\pm \sqrt{1-c^2}$ for $s$.
+
+    See Also
+    ========
+    rotation
+
+    """
+
+    index = index or random.sample(range(dim), 2)
+    return rotation(dim, index, scalar) * transposition(dim, index)
+
+
+# === normal form matrices, i.e. defined by eigenvalues ===
+
+
+def diagonal_normal(dim,
+                    spec=None):
+    r"""n x n matrix with random values placed on the diagonal.
+
+    .. _matrices-random-diagonal:
+
+    Explanation
+    ===========
+    Creates a square diagonal matrix, i.e. matrix with only zero non-diagonal
+    entries.
+    The  diagonal values will be choose from **spec**,
+    the *spectrum* argument which is the set of eigenvalues.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import diagonal_normal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> diagonal_normal(3)
+    Matrix([
+    [-1,  0, 0],
+    [ 0, -1, 0],
+    [ 0,  0, 1]])
+
+    >>> diagonal_normal(3, (4,-3,2))
+    Matrix([
+    [4,  0, 0],
+    [0, -3, 0],
+    [0,  0, 2]])
+
+    >>> diagonal_normal(3, (-2,2))
+    Matrix([
+    [-2, 0, 0],
+    [ 0, 2, 0],
+    [ 0, 0, 2]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries) are choosen.
+
+        If **dim** meets the length of **spec**,
+        spec will be the eigenvalues (diagonal entries) as it is.
+
+        If **dim** and the length of **spec** differs,
+        the diagonal entries will be choosen randomly from **spec**.
+
+        If not given **spec** defaults to $\{ -1, 1 \}$.
+
+    See Also
+    ========
+    identity
+    sympy.matrices.dense.diag
+
+    """
+    spec = spec or _elementary_scalar_set
+
+    # choose spec randomly if dim and len(spec) does not meet
+    if not dim == len(spec):
+        spec = tuple(random.choice(spec) for _ in range(dim))
+
+    # set diagonal entries
+    if _TEST:
+        # multiplicative matrix construction (only for testing)
+        items = list()
+        for start, scalar in enumerate(spec):
+            items.append(elementary(dim, index=(start, start), scalar=scalar))
+        return _multiply(*items)
+
+    else:
+        obj = identity(dim)
+        for start, scalar in enumerate(spec):
+            _set_value(obj, start, start, scalar)
+        return obj  # eq. to gauss_jordan(dim, rank, eigenvalue_set, dim)
+
+
+def jordan_normal(dim,
+                  spec=None):
+    r"""n x n matrix in Jordan normal form
+
+    Explanation
+    ===========
+    A matrix in Jordan normal form is a block matrix
+    with only non-zero blocks on the diagonal
+    which have the form of an Jordan block $J$ which is
+
+    .. math::
+
+        J = \left[\begin{array}{cccccc}
+            \lambda  & 1       & 0         & \dots     &         & 0     \\
+             0       & \lambda & 1         & 0         & \dots   & 0     \\
+             0       & \ddots  & \ddots    & \ddots    & \ddots  & 0     \\
+             0       & \dots   & 0         & 0         & \lambda & 1     \\
+             0       & \dots   &           &           & 0       & \lambda
+             \end{array}\right]
+
+    Finally, each $\lambda$ of each Jordan block will be an eigenvalue.
+
+    To set the eigenvalues and block sizes use **spec**.
+
+    As long as an eigenvalue is repeated in **spec**
+    it mandates the same *Jordan* block.
+    Such a *Jordan* block is interrupted by **None** entries.
+
+    E.g. **spec** = (1,1,2, None, 2) would lead to
+
+    .. math::
+
+        J = \left[\begin{array}{cccc}
+            1 & 1 & 0 & 0 \\
+            0 & 1 & 0 & 0 \\
+            0 & 0 & 2 & 0 \\
+            0 & 0 & 0 & 2
+        \end{array}\right]
+
+    Alternativly, a sequence of pairs *(eigenvalue, block size)*,
+    i.e. tuple of length 2, can be provided.
+
+    So the above example is equivalent to
+    **spec** = [(1,2),(2,1),(2,1)].
+
+    .. math::
+
+    Note, if the length of **spec** (**None** entries excluded)
+    does not meet **dim**, blocks will be choosen randomly.
+
+    To meet **dim** the final block might be truncated.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import jordan_normal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> jordan_normal(3, spec=(2,2,2))
+    Matrix([
+    [2, 1, 0],
+    [0, 2, 1],
+    [0, 0, 2]])
+    >>> jordan_normal(6, spec=(2,None,2,2,2,2,0))
+    Matrix([
+    [2, 0, 0, 0, 0, 0],
+    [0, 2, 1, 0, 0, 0],
+    [0, 0, 2, 1, 0, 0],
+    [0, 0, 0, 2, 1, 0],
+    [0, 0, 0, 0, 2, 0],
+    [0, 0, 0, 0, 0, 0]])
+    >>> # equivalent to
+    >>> jordan_normal(6, spec=((2,1),(2,4),(0,1)))
+    Matrix([
+    [2, 0, 0, 0, 0, 0],
+    [0, 2, 1, 0, 0, 0],
+    [0, 0, 2, 1, 0, 0],
+    [0, 0, 0, 2, 1, 0],
+    [0, 0, 0, 0, 2, 0],
+    [0, 0, 0, 0, 0, 0]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries) are choosen.
+
+        If **dim** meets the length of **spec**,
+        spec will be the eigenvalues (diagonal entries) as it is.
+
+        If **dim** and the length of **spec** differs,
+        the diagonal entries will be choosen randomly from **spec**.
+
+        If not given **spec** defaults to $\{ -1, 1 \}$.
+
+    See Also
+    ========
+    diagonal_normal
+
+    """
+    spec = spec or _elementary_scalar_set
+
+    # make spec list of (scalar, size) tuples
+    if spec and spec[0] is None:
+        raise ValueError("spec argument must not start with None")
+
+    block_list = list()
+    val, cnt = None, 0
+    for s in spec:
+        if s == val:
+            cnt += 1
+            continue
+        elif s is None:
+            block_list.append((val, cnt))
+            val, cnt = None, 0
+            continue
+        elif cnt:
+            block_list.append((val, cnt))
+        if isinstance(s, (tuple, list)) and len(s) == 2:
+            block_list.append(s)
+            val, cnt = None, 0
+            continue
+        val, cnt = s, 1
+    if cnt:
+        block_list.append((val, cnt))
+    spec = block_list
+    del block_list
+
+    # choose block randomly if dim and len(spec) does not meet
+    if not dim == sum(cnt for val, cnt in spec):
+        spec = tuple(random.choice(spec) for _ in range(dim))
+
+    # set entries of jordan blocks
+    if _TEST:
+        # multiplicative matrix construction (only for testing)
+        items = list()
+        start = 0
+        for val, cnt in spec:
+            end = min(dim, start + cnt)
+            items.append(jordan(dim, index=(start, end), scalar=val))
+            if end == dim:
+                break
+            start = end
+        return _multiply(*items)
+
+    else:
+        obj = identity(dim)
+        start = 0
+        for scalar, size in spec:
+            end = min(dim, start + size)
+            _set_value(obj, start, start, scalar)
+            for i in range(start + 1, end):
+                _set_value(obj, i - 1, i, 1)
+                _set_value(obj, i, i, scalar)
+            if end == dim:
+                break
+            start = end
+        return obj
+
+
+def isometry_normal(dim,
+                    spec=None):
+    r""" isometry matrix n x n in normal form
+
+    Explanation
+    ===========
+
+    Isometries preserve the geometric structure of vectorspaces.
+    Let $<-,->$ be either the standard scalar product (over the reals)
+    or the standard *Herminte* form (for complex vectorspaces).
+
+    For vectors $x,y$ and a *isometry matrix* $A$ we have
+
+    .. math::
+
+        <Ax,Ay> = <x,y>
+
+    Hence, $A^tA = I$ for real $A$ which is called *orthogonal*
+    and $\bar{A}^tA = I$ for complex $A$ (called *unitary*).
+
+
+    In normal from complex isometries have only diagonal entries of
+    norm 1, i.e. for a diagonal element $z$ the following holds.
+
+    .. math::
+
+        |z| = z * \bar{z} = 1
+
+    As - in normal form - real isometry (othogonal) matrices
+    may have non diagonal entries but $2 \times 2$ rotation blocks
+
+    .. math::
+
+        \left[\begin{array}{cc} c & s \\ -s & c \end{array}\right]
+
+    with $c^2 + s^2 = 1$.
+
+    .. math::
+
+    So, **spec** is assumed to be a list of entries which are either
+    scalars $z$ with $|z| = z * \bar{z} = 1$
+    or
+    pairs $(c,s)$ with $c^2 + s^2 = 1$
+    to form the above rotaion square.
+
+    If a **spec** entry $c$ is neither such a pair nor $|c| = 1$
+    a corresponding $s = \pm \sqrt{1-c^2}$ is choosen randomly.
+
+    .. math::
+
+    Note: Testing $|c| = 1$ might be not exact.
+    To avoid such testing, provide $c$ as a 1-tuple in spec.
+
+    In stead of
+
+        **spec** = ( 1, -1, xi, (1/sqrt(2), 1/sqrt(2)) )
+
+    checking abs(xi) == 1,
+
+        **spec** = ((1,), (-1,), (xi,), (1/sqrt(2), 1/sqrt(2)))
+
+    will not check abs(x) == 1.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.random import isometry_normal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> isometry_normal(3)
+    Matrix([
+    [ sqrt(2)/2, sqrt(2)/2, 0],
+    [-sqrt(2)/2, sqrt(2)/2, 0],
+    [         0,         0, 1]])
+    >>> isometry_normal(3, spec=(0.5, -0.5))
+    Matrix([
+    [              -0.5, 0.866025403784439, 0],
+    [-0.866025403784439,              -0.5, 0],
+    [                 0,                 0, 1]])
+    >>> isometry_normal(3, spec=(-1, 1j, 1))
+    Matrix([
+    [-1,     0, 0],
+    [ 0, 1.0*I, 0],
+    [ 0,     0, 1]])
+    >>> z = 1+1j
+    >>> isometry_normal(3, spec=((-1,), (z/abs(z),), (1,)))
+    Matrix([
+    [-1,                                       0, 0],
+    [ 0, 0.707106781186547 + 0.707106781186547*I, 0],
+    [ 0,                                       0, 1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension n of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries) are choosen.
+
+        If **dim** meets the length of **spec**,
+        spec will be the eigenvalues (diagonal entries) as it is.
+
+        If **dim** and the length of **spec** differs,
+        the diagonal entries will be choosen randomly from **spec**.
+
+    See Also
+    ========
+    rotation
+    diagonal_normal
+
+    """
+    spec = spec or _rotation_scalar_set
+
+    # make spec list of (scalar,) or (scalar, +/-sqrt(1-scalar**2)) tuples
+    block_list = list()
+    for c in spec:
+        if isinstance(c, (tuple, list)):
+            block_list.append(c)
+        elif abs(c) == 1:
+            block_list.append((c,))
+        else:
+            block_list.append(_cs(c))
+    spec = block_list
+    del block_list
+
+    # choose spec randomly if dim and len(spec) does not meet
+    if not dim == sum(len(s) for s in spec):
+        spec = tuple(random.choice(spec) for _ in range(dim))
+
+    # set entries of rotation blocks
+
+    if _TEST:
+        # multiplicative matrix construction (only for testing)
+        items = list()
+        start = 0
+        for s in spec:
+            end = start + len(s)
+            if dim < end:
+                # leave the last diagonal entry one
+                break
+            if len(s) == 1:
+                scalar, = s
+                items.append(
+                    elementary(dim, index=(start, start), scalar=scalar))
+            else:
+                c, s = s
+                items.append(rotation(dim, (start, start + 1), (c, s)))
+            start = end
+        return _multiply(*items)
+
+    else:
+        obj = identity(dim)
+        start = 0
+        for s in spec:
+            end = start + len(s)
+            if dim < end:
+                # leave the last diagonal entry one
+                break
+            if len(s) == 1:
+                scalar, = s
+                _set_value(obj, start, start, scalar)
+            else:
+                c, s = s
+                _set_value(obj, start, start, c)
+                _set_value(obj, start, start + 1, s)
+                _set_value(obj, start + 1, start, -1 * s)
+                _set_value(obj, start + 1, start + 1, c)
+            start = end
+        return obj
+
+
+# === compound matrices, i.e. product of base matrices ===
+
+def triangular(dim,
+               rank=None,
+               scalar_set=_elementary_scalar_set,
+               unit_set=_elementary_scalar_set,
+               length=None):
+    r"""n x n upper triangular matrix with random entries.
+
+    Explanation
+    ===========
+    Matrix with values placed above and on the diagonal. Constructed as
+    product of random upper *triangular* :func:`elementary` matrices.
+
+    It is constructed from an invertible triangular matrix $S$
+    of which $r$ basis columns are randomly choosen
+    and the $n-r$ columes are build as linear combinations
+    of the basis colums.
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import triangular
+    >>> import random
+    >>> random.seed(1)
+
+    >>> triangular(3, scalar_set=(2, -2, 0))
+    Matrix([
+    [-1, -2,  2],
+    [ 0,  1, -2],
+    [ 0,  0, -1]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    rank : integer (optional with default dim)
+        rank of matrix
+    scalar_set : tuple or list of symbols (optional)
+        default values for random choosen scalars of
+        elementary matrices to build the invertible matrix
+    unit_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the invertible matrix
+        and non-zero diagonal entries
+        which are assumed to have a multiplicative inverse
+    length : integer (optional with default 2 * **dim**)
+        number of invertible matrices to build the resulting matrix.
+
+    See Also
+    ========
+    identity
+    elementary
+    square
+
+    """
+    if length == 0:
+        return regular_to_singular(identity(dim), rank)
+    scalar_set = scalar_set or (0,)
+    unit_set = unit_set or (1,)
+    length = length or 2 * dim
+    row_indicies = [random.choice(range(dim)) for _ in range(length)]
+    indicies = [(i, random.choice(range(i, dim))) for i in row_indicies]
+    scalars = [random.choice(unit_set) if i == j else random.choice(scalar_set)
+               for i, j in indicies]
+    items = [elementary(dim, ix, s) for ix, s in zip(indicies, scalars)]
+    return regular_to_singular(_multiply(*items), rank)
+
+
+def square(dim,
+           rank=None,
+           scalar_set=_elementary_scalar_set,
+           unit_set=_elementary_scalar_set,
+           length=None):
+    r"""a square matrix n x n
+
+    Explanation
+    ===========
+    A square matrix represents an endomorphism
+    in n dimensional vector space. It can be constructed as
+    product of :func:`elementary` matrices.
+
+    It is constructed from an :func:`invertible` matrix $S$
+    of which $r$ basis columns are randomly choosen
+    and the $n-r$ columes are build as linear combinations
+    of the basis colums.
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    rank : integer (optional with default dim)
+        rank of matrix
+    scalar_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the matrix
+    unit_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the matrix
+        which are assumed to have a multiplicative inverse
+    length : integer (optional with default 2 * **dim**)
+        number of invertible matrices
+        to build the resulting matrix.
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import square
+    >>> import random
+    >>> random.seed(1)
+
+    >>> square(3)
+    Matrix([
+    [-1, -1, -1],
+    [-2, -1, -1],
+    [ 0,  0,  1]])
+
+    See Also
+    ========
+    triangular
+    invertible
+    singular
+
+    """
+    if length == 0:
+        return regular_to_singular(identity(dim), rank)
+
+    length = length or 2 * dim
+    lwr = triangular(dim, None, scalar_set, unit_set, int(length / 2))
+    upr = triangular(dim, rank, scalar_set, unit_set, length - int(length / 2))
+    return _multiply(_t(lwr), upr)
+
+
+def invertible(dim,
+               scalar_set=_elementary_scalar_set,
+               unit_set=_elementary_scalar_set,
+               length=None):
+    r"""an invertible matrix n x n
+
+    Explanation
+    ===========
+    An invertible matrix represents an isomorphism
+    in n dimensional vector space. It can be constructed as
+    product of :func:`elementary` matrices.
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    scalar_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the matrix
+    unit_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the matrix
+        which are assumed to have a multiplicative inverse
+    length : integer (optional with default 2 * **dim**)
+        number of invertible matrices
+        to build the resulting matrix.
+
+    Examples
+    ========
+    >>> from sympy import symbols, pprint
+    >>> from sympy.matrices.random import invertible
+    >>> import random
+    >>> random.seed(1)
+
+    >>> invertible(3)
+    Matrix([
+    [-1, -1, -1],
+    [-2, -1, -1],
+    [ 0,  0,  1]])
+
+    >>> phi = symbols('phi')
+    >>> m = invertible(3, scalar_set=(1, -1, phi, -phi))
+    >>> m
+    Matrix([
+    [1, 0,     -phi],
+    [1, 1, -phi - 1],
+    [0, 0,        1]])
+    >>> m.det()
+    1
+    >>> m.inv()
+    Matrix([
+    [ 1, 0, phi],
+    [-1, 1,   1],
+    [ 0, 0,   1]])
+
+    """
+    return square(dim, None, scalar_set, unit_set, length)
+
+
+def singular(dim,
+             rank=None,
+             scalar_set=_elementary_scalar_set,
+             unit_set=_elementary_scalar_set,
+             length=None):
+    r"""a singular square matrix n x n of a given rank.
+
+    Explanation
+    ===========
+    A singular matrix is non-invertible and has determinant of zero.
+
+    A matrix of rank $r$ has $r$ linear independend rows
+    (i.e. a row space of dimension $r$).
+
+    It is constructed from an :func:`invertible` matrix $S$
+    of which $r$ basis columns are randomly choosen
+    and the $n-r$ columes are build as linear combinations
+    of the basis colums.
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import singular
+    >>> import random
+    >>> random.seed(1)
+
+    >>> m = singular(3, 2)
+    >>> m
+    Matrix([
+    [-1, 1, -1],
+    [-2, 2, -1],
+    [ 0, 0,  1]])
+    >>> m.rank()
+    2
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    rank : integer (optional with default dim-1)
+        rank of matrix
+    scalar_set : tuple or list of symbols (optional)
+        default values for random choosen scalars of
+        elementary matrices to build the matrix
+    unit_set : tuple or list of symbols (optional)
+        default values for random choosen scalar of
+        elementary matrices to build the matrix
+        which are assumed to have a multiplicative inverse
+    length : integer (optional with default 2 * **dim**)
+        number of invertible matrices to build the resulting matrix.
+
+    See Also
+    ========
+    invertible
+    triangular
+
+    """
+    rank = dim - 1 if rank is None else rank
+    return square(dim, rank, scalar_set, unit_set, length)
+
+
+# === conjugate matrices, i.e. defined by similarity to a normal from ==
+
+
+def idempotent(dim,
+               rank,
+               scalar_set=_elementary_scalar_set,
+               unit_set=_elementary_scalar_set,
+               length=None):
+    r"""an idempotent square matrix of a given rank s.th. $A*A=A$
+
+    Explanation
+    ===========
+    An idempotent matrix is a matrix $A$ such that $A^2 = A$.
+    It is constructed as product
+
+    .. math::
+
+        S \cdot P \cdot S^{-1}
+
+    of an :func:`invertible` matrices $S$
+    and a :func:`projection` matrix $P$ of given rank .
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import idempotent
+    >>> import random
+    >>> random.seed(1)
+
+    >>> A = idempotent(3, 2)
+    >>> A
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 1],
+    [0, 0, 0]])
+    >>> A.rank()
+    2
+    >>> A*A == A
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    rank : integer (optional with default ``dim``)
+        see :func:`projection`
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    See Also
+    ========
+    elementary
+    projection
+    invertible
+    nilpotent
+
+    References
+    ==========
+    .. [1] https://en.wikipedia.org/wiki/Idempotence#Idempotent_functions
+
+    """
+    normal_form = projection(dim, (0, rank))
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_inv(s), normal_form, s)
+
+
+def nilpotent(dim,
+              rank,
+              scalar_set=_elementary_scalar_set,
+              unit_set=_elementary_scalar_set,
+              length=None):
+    r"""a nilpotent matrix of dinemsion n x n.
+
+    Explanation
+    ===========
+    A *nilpotent* matrix is a matrix $A$ such that there is
+    an integer $n$ with $A^n = 0$.
+    It is build as the product
+
+    .. math::
+
+        S \cdot T \cdot S^{-1}
+
+    where $S$ is an :func:`invertible`,
+    $T$ a :func:`jordan_normal` matrix
+    with zero diagonal entries.
+
+    Examples
+    ========
+    >>> from sympy import zeros
+    >>> from sympy.matrices.random import nilpotent
+    >>> import random
+    >>> random.seed(1)
+
+    >>> A = nilpotent(3, 2)
+    >>> A
+    Matrix([
+    [-2, -1, -2],
+    [ 4,  2,  3],
+    [ 0,  0,  0]])
+    >>> A.rank()
+    2
+    >>> A*A*A == zeros(3)
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    rank : integer (optional with default dim)
+        rank of the matrix
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    See Also
+    ========
+    elementary
+    jordan_normal
+    invertible
+    idempotent
+
+    References
+    ==========
+    .. [1] Lang, S., Algebra, DOI 10.1007/978-1-4613-0041-0, (2002)
+    .. [2] https://en.wikipedia.org/wiki/nilpotent
+
+    """
+
+    def numbers_with_sum(n, k):
+        """n numbers with sum dim"""
+        if n == 1:
+            return [k]
+        num = random.choice(range(k - n)) + 1
+        return [num] + numbers_with_sum(n - 1, k - num)
+
+    index = numbers_with_sum(dim - rank, dim)
+    spec = tuple((0, i) for i in index)
+    normal_form = jordan_normal(dim, spec=spec)
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_inv(s), normal_form, s)
+
+
+def diagonalizable(dim,
+                   spec=_elementary_scalar_set,
+                   scalar_set=_elementary_scalar_set,
+                   unit_set=_elementary_scalar_set,
+                   length=None):
+    r"""a square matrix n x n of a given rank
+
+    Explanation
+    ===========
+    Creates a square matrix of a given rank
+    which is diagonalizable.
+
+    The matrix will be a product
+
+    .. math::
+
+        S^{-1}*D*S
+
+    of an :func:`invertible` matrix $S$ and
+    a :func:`diagonal_normal` matrix of given rank
+    and eigenvalues (diagonal entries) from **spec**.
+
+    To obtain a matrix with *complex* *eigenvalues*
+    but non-complex entries,
+    e.g. $\lambda_{1/2}=a \pm b \ i$,
+    you better may use a product of an invertible matrix $S$
+    with non-complex entries (**scalar_set**)
+    and where $D$ is a non-complex block diagonal matrix with a block $D_z$
+
+    .. math::
+
+        D_z = \left[\begin{array}{cc}a & b \\ -b & a\end{array}\right]
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import diagonalizable
+    >>> import random
+    >>> random.seed(1)
+
+    >>> diagonalizable(3)
+    Matrix([
+    [-1,  0, 0],
+    [-2, -3, 4],
+    [-2, -2, 3]])
+
+    >>> m = diagonalizable(3, spec=(1,2,2), scalar_set=(1,2,3), length=10)
+    >>> m
+    Matrix([
+    [ 4,  2, -6],
+    [-6, -4, 18],
+    [-1, -1,  5]])
+    >>> m.eigenvals(multiple=True)
+    [1, 2, 2]
+    >>> m.jordan_form(calc_transform=False)
+    Matrix([
+    [1, 0, 0],
+    [0, 2, 0],
+    [0, 0, 2]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries) are choosen
+        see :func:`diagonal_normal`
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    """
+    normal_form = diagonal_normal(dim, spec)
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_inv(s), normal_form, s)
+
+
+def trigonalizable(dim,
+                   spec=_elementary_scalar_set,
+                   scalar_set=_elementary_scalar_set,
+                   unit_set=_elementary_scalar_set,
+                   length=None):
+    r"""Creates a square matrix n x n of a given rank
+
+    Explanation
+    ===========
+    Creates a square matrix n x n of a given rank
+    which is trigonalizable (has echelon form)
+    and has eigenvalues from a given set.
+
+    The matrix will be a product
+
+    .. math::
+
+        S^{-1}*T*S
+
+    of an invertible matrix $S$ and a *Jordan* matrix $T$
+    and eigenvalues (diagonal entries) from **spec**.
+
+    Examples
+    ========
+    >>> from sympy import sqrt
+    >>> from sympy.matrices.random import trigonalizable
+    >>> import random
+    >>> random.seed(1)
+
+    >>> trigonalizable(3)
+    Matrix([
+    [-1,  0, 0],
+    [-2, -3, 4],
+    [-2, -2, 3]])
+
+    >>> m = trigonalizable(3, spec=(1, 1, 3), scalar_set=(1, sqrt(2), 2))
+    >>> m
+    Matrix([
+    [            1,           1, 0],
+    [            0,           1, 0],
+    [2*sqrt(2) + 4, sqrt(2) + 2, 3]])
+    >>> m.eigenvals(multiple=True)
+    [1, 1, 3]
+    >>> m.jordan_form(calc_transform=False)
+    Matrix([
+    [1, 1, 0],
+    [0, 1, 0],
+    [0, 0, 3]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries) are choosen
+        see :func:`jordan_normal`
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    See Also
+    ========
+    jordan_normal
+    invertible
+
+    """
+    normal_form = jordan_normal(dim, spec)
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_inv(s), normal_form, s)
+
+
+# === matrices conjugate by isometries ==
+
+def orthogonal(dim,
+               spec=None,
+               scalar_set=_rotation_scalar_set,
+               length=None):
+    r"""an orthogonal matrix n x n
+
+    Explanation
+    ===========
+    An orthogonal matrix is an isometry
+    in n dimensional Euclidian space. Constructed as
+    product of random :func:`rotation`
+    and a :func:`reflection` matrices.
+
+    The values for random choosen scalar of rotations
+    are from **scalar_set**.
+
+    If **spec** is given,
+
+    Examples
+    ========
+    >>> from sympy import sqrt, eye, expand
+    >>> from sympy.matrices.random import orthogonal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> orthogonal(3, scalar_set=(-1,1))
+    Matrix([
+    [-1, 0,  0],
+    [ 0, 1,  0],
+    [ 0, 0, -1]])
+
+    >>> s = sqrt(2)/2
+    >>> random.seed(1)
+    >>> orthogonal(3, scalar_set=(s,-s), length=2)
+    Matrix([
+    [sqrt(2)/2,       -1/2,      -1/2],
+    [sqrt(2)/2,        1/2,       1/2],
+    [        0, -sqrt(2)/2, sqrt(2)/2]])
+
+    >>> random.seed(1)
+    >>> o = orthogonal(3, spec=(-1, (s, s)), scalar_set=(s,), length=2)
+    >>> expand(o * o.T) == eye(3)
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    spec : tuple or list of symbols (optional),
+        set of values of which scalars (diagonal entries)
+        of :func:`isometry_normal` matrix
+        see :func:`isometry_normal` for details
+    scalar_set : tuple or list of symbols (optional),
+        default values for random choosen scalar of
+        rotations to build the orthogonal matrix
+        :func:`rotation`
+    length : integer (optional with default **dim**)
+        number rotations to build the matrix.
+
+    See Also
+    ========
+    rotation
+    reflection
+    isometry_normal
+    unitary
+
+    """
+    if spec is None:
+        if length == 0:
+            return identity(dim)
+        length = length or dim
+        scalars = [random.choice(scalar_set) for _ in range(length)]
+        items = [rotation(dim, scalar=s) for s in scalars]
+        return _multiply(*items)
+    normal_form = isometry_normal(dim, spec)
+    s = orthogonal(dim, scalar_set=scalar_set, length=length)
+    return _multiply(_t(s), normal_form, s)
+
+
+def unitary(dim,
+            spec=None,
+            scalar_set=_unitary_scalar_set,
+            length=None):
+    r"""an unitary matrix n x n
+
+    Explanation
+    ===========
+    An unitary matrix is an isometry
+    in n dimensional unitary space (complex vectorspace with Hermite form).
+    Constructed as product $A=UDV$ of two orthogonal matrices $U$ an $V$
+    and a diagonal unitary martix $D$ (see :func:`isometry_normal`.
+    All entries are taken from **scalar_set**.
+
+    But if **spec** is given, another diagonal unitary matrix $D'$ is
+    build with entries from **spec**.
+    Note, to give an *unitary* matrix,
+    **spec** must consist of roots of unity only.
+    A root of unity is a complex number $z$,
+    s.th. $|z| = z * \bar{z} = 1$.
+
+    Finally, the resulting unitar matrix $B$ is given as
+
+    .. math::
+
+        B = \bar{A}^t D' A = \bar{V}^t \bar{D}^t \bar{U}^t D' UDV
+
+    (see Führ/Rzeszotnik, "A note on factoring unitary matrices", 2018
+    https://doi.org/10.1016%2Fj.laa.2018.02.017)
+
+    Examples
+    ========
+    >>> from sympy import sqrt, I, simplify, eye, expand, re
+    >>> from sympy.matrices.random import unitary
+    >>> import random
+    >>> random.seed(1)
+    >>> u = unitary(3)
+
+    >>> random.seed(1)
+    >>> u = unitary(3)
+    >>> simplify(u)
+    Matrix([
+    [ 0, -sqrt(2)*I/2, -sqrt(2)*I/2],
+    [-I,            0,            0],
+    [ 0,    1/2 + I/2,   -1/2 - I/2]])
+
+    >>> u = unitary(3, scalar_set=(-1,))
+    >>> simplify(u) # doctest: +SKIP
+    Matrix([
+    [-1, 0, 0],
+    [ 0, 1, 0],
+    [ 0, 0, 1]])
+
+    >>> s = sqrt(2)/2
+    >>> z = simplify(s + s * I)
+    >>> z
+    sqrt(2)*(1 + I)/2
+    >>> abs(z)
+    1
+    >>> spec = [-1, z, 1]
+    >>> unitary(3, spec=spec, length=0)
+    Matrix([
+    [-1,                 0, 0],
+    [ 0, sqrt(2)*(1 + I)/2, 0],
+    [ 0,                 0, 1]])
+
+    >>> random.seed(1)
+    >>> u = unitary(3, spec=spec)
+    >>> simplify(u)
+    Matrix([
+    [sqrt(2)*(1 + I)/2,  0,  0],
+    [                0,  0, -1],
+    [                0, -1,  0]])
+    >>> simplify(u * u.C)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    >>> simplify(u.det()) == -z
+    True
+    >>> ev = [simplify(val) for val in u.eigenvals(multiple=True)]
+    >>> ev = sorted(ev, key=(lambda x: re(x.evalf())))
+    >>> ev
+    [-1, sqrt(2)*(1 + I)/2, 1]
+    >>> spec == ev
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    spec : tuple or list of symbols (optional),
+        set of values of which scalars (diagonal entries)
+        of :func:`isometry_normal` matrix.
+        see :func:`isometry_normal` for details
+    scalar_set : tuple or list of symbols (optional),
+        default values for random choosen scalar of
+        rotations to build the orthogonal matrix
+        see :func:`orthogonal`
+    length : integer (optional with default 2 * **dim**)
+        number rotations to build the matrix.
+        see :func:`orthogonal`
+
+    See Also
+    ========
+    isometry_normal
+    orthogonal
+
+    """
+    if spec is None:
+        if length == 0:
+            return identity(dim)
+        length = length or dim
+
+        real_scalar_set = tuple(_cs(x) for x in scalar_set)
+        complex_scalar_set = tuple(c * 1 + s * _i for c, s in real_scalar_set)
+        scalars = [random.choice(complex_scalar_set) for _ in range(dim)]
+
+        half = int(length/2)
+        u = orthogonal(dim, scalar_set=real_scalar_set, length=half)
+        d = diagonal_normal(dim, scalars)
+        v = orthogonal(dim, scalar_set=real_scalar_set, length=length-half)
+        return _multiply(u, d, v)
+
+    normal_form = isometry_normal(dim, spec)
+    s = unitary(dim, scalar_set=scalar_set, length=length)
+    return _multiply(_c(s), normal_form, s)
+
+
+def normal(dim,
+           spec=_elementary_scalar_set,
+           scalar_set=None,
+           length=None):
+    r""" normal n x n matrix
+
+    Explanation
+    ===========
+    By definition for a *normal* matrix $A$
+
+    .. math::
+
+        \bar{A}^t A = A \bar{A}^t
+
+    holds. Note, this extends the notion of an :func:`unitary` matrix $U$
+    since $\bar{U}^t U = I = U \bar{U}^t$.
+
+    A matrix $A$ is *normal* if and only if it is diagonalizable
+    by an *unitary* matrix $U$,
+    i.e. $\bar{U}^t A U = D$ with diagonal matrix $D$.
+
+    Hence, since $\bar{U}^t = U^{-1}$,
+
+    .. math::
+
+        A = U D \bar{U}^t
+
+    The entries of $D$ are taken from **spec**
+    and the entries to build $U$ are taken from **scalar_set**.
+
+    Since **orthogonal** matrices are **unitary**,
+    $U$ will be **orthogonal**
+    if **scalar_set** has only eal entries.
+
+    So the final *normal* matrix will be real
+    if **spec** consists only of real entries, too.
+
+    Examples
+    ========
+    >>> from sympy import sqrt, I
+    >>> from sympy.matrices.random import normal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> normal(3)
+    Matrix([
+    [ 0, -1,  0],
+    [-1,  0,  0],
+    [ 0,  0, -1]])
+
+    >>> z = complex(1, 1)
+    >>> random.seed(1)
+    >>> n = normal(2, spec=(2, 3),  scalar_set=(sqrt(2)/2,))
+    >>> n.T * n == n * n.T
+    True
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    spec : tuple or list of symbols (optional)
+        set of values of which scalars (diagonal entries)
+        see :func:`isometry_normal` for details
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`orthogonal` and :func:`unitary`
+    length : integer (optional with default **dim**)
+        see :func:`orthogonal` and :func:`unitary`
+
+    See Also
+    ========
+    isometry_normal
+    orthogonal
+    unitary
+
+    """
+    normal_form = diagonal_normal(dim, spec)
+    if any(isinstance(s, (list, tuple)) for s in spec):
+        scalar_set = scalar_set or _rotation_scalar_set
+        s = orthogonal(dim, None, scalar_set, length)
+    elif all(s == _c(s) for s in spec):
+        scalar_set = scalar_set or _rotation_scalar_set
+        s = orthogonal(dim, None, scalar_set, length)
+    else:
+        scalar_set = scalar_set or _unitary_scalar_set
+        s = unitary(dim, None, scalar_set, length)
+    return _multiply(_c(s), normal_form, s)
+
+
+# === symmetric or complex adjoined matrices ===
+
+def symmetric(dim,
+              scalar_set=_elementary_scalar_set,
+              unit_set=_elementary_scalar_set,
+              length=None):
+    r"""Creates a symmetric square matrix n x n of a given rank.
+
+    Explanation
+    ===========
+    A *symmetric* matrix is a matrix such that $A^t = A$
+    The matrix is simply constructed as
+
+    .. math::
+
+        S*D*S^t
+
+    by an ``invertible`` matrix $S$ and a ``diagonal`` matrix $D$ of given rank.
+
+    To obtain a matrix with given *eigenvalues*,
+    you better may use :func:`normal` matrix, which is a product
+
+    .. math::
+
+        O*D*O^t
+
+    by an *orthogonal* matrix $O$ and
+    a *diagonal* matrix $D$ with given eigenvalues (diagonal entries).
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import symmetric
+    >>> import random
+    >>> random.seed(1)
+
+    >>> symmetric(3)
+    Matrix([
+    [5, 3, 3],
+    [3, 2, 2],
+    [3, 2, 3]])
+
+    For a symmetric matrix with given eigenvalues
+    :func:`normal` works
+
+    >>> from sympy.matrices.random import normal
+    >>> import random
+    >>> random.seed(1)
+
+    >>> n = normal(3, spec=(1,2,3))
+    >>> sorted(n.eigenvals(multiple=True))
+    [1, 2, 3]
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    See Also
+    ========
+    invertible
+    normal
+    hermite
+
+    """
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_t(s), s)
+
+
+def hermite(dim,
+            scalar_set=_elementary_scalar_set,
+            unit_set=_elementary_scalar_set,
+            length=None):
+    r"""
+
+    Explanation
+    ===========
+
+    Examples
+    ========
+    >>> from sympy.matrices.random import hermite
+    >>> import random
+    >>> random.seed(1)
+
+    >>> z = complex(1,-1)
+    >>> hermite(3, (z, ), length=1)
+    Matrix([
+    [          1, 0,                     1.0 - 1.0*I],
+    [          0, 1,                               0],
+    [1.0 + 1.0*I, 0, 1 + (1.0 - 1.0*I)*(1.0 + 1.0*I)]])
+
+    Parameters
+    ==========
+    dim : integer
+        dimension of matrix
+    scalar_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    unit_set : tuple or list of symbols (optional)
+        see :func:`invertible`
+    length : integer (optional with default 2 * **dim**)
+        see :func:`invertible`
+
+    See Also
+    ========
+    invertible
+    normal
+    hermite
+
+    """
+    s = invertible(dim, scalar_set, unit_set, length)
+    return _multiply(_c(s), s)

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,7 +1,7 @@
 import random
 
 from sympy import Matrix, diag, eye, zeros, cartes, \
-    I, cos, simplify, symbols, sqrt, expand
+    I, cos, simplify, symbols, sqrt
 from sympy.matrices.random import super_elementary_matrix
 from sympy.matrices.random import jordan, jordan_normal, \
     complex_to_real, invertible, regular_to_singular, diagonal_normal, \

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,11 +1,16 @@
-# coding=utf-8
 import random
 
 from pytest import raises
 
 from sympy import Matrix, eye, zeros, cartes, I
 from sympy.matrices.random import super_elementary_matrix
-from sympy.matrices.random import *
+from sympy.matrices.random import identity, jordan, jordan_normal, \
+    complex_to_real, invertible, regular_to_singular, diagonal_normal, \
+    diagonalizable, transposition, triangular, trigonalizable, \
+    isometry_normal, permutation, projection, elementary, rotation, \
+    reflection, normal, nilpotent, idempotent, singular, orthogonal, unitary,\
+    hermite, symmetric
+
 from sympy.matrices import random as _random
 
 TEST_DIMS = dict((d, tuple(cartes(range(d), range(d)))) for d in range(2, 6))

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,28 +1,45 @@
 import random
 
-from sympy import Matrix, eye, zeros, cartes, I
+from sympy import Matrix, diag, eye, zeros, cartes, \
+    I, cos, simplify, symbols, sqrt, expand
 from sympy.matrices.random import super_elementary_matrix
-from sympy.matrices.random import identity_matrix, jordan, jordan_normal, \
+from sympy.matrices.random import jordan, jordan_normal, \
     complex_to_real, invertible, regular_to_singular, diagonal_normal, \
     diagonalizable, transposition, triangular, trigonalizable, \
     isometry_normal, permutation, projection, elementary, rotation, \
-    reflection, normal, nilpotent, idempotent, singular, orthogonal, unitary,\
-    hermite, symmetric
+    reflection, normal, nilpotent, idempotent, singular, orthogonal, unitary, \
+    hermite, symmetric, rand
 
 from sympy.matrices import random as _random
 from sympy.testing.pytest import raises
 
 TEST_DIMS = dict((d, tuple(cartes(range(d), range(d)))) for d in range(2, 6))
 TEST_PRECISION = 7
+TEST_EPSILON = 1e-7
 
-random.seed(1)
+phi, psi = symbols('phi psi')
+
+rand.seed(1)
 
 
-def _check_triangular(m):
+def _is_zeros(m, precision=None):
+    if precision is None:
+        return all(x == 0 for x in simplify(m))
+    else:
+        return all(abs(x) < precision for x in m.evalf())
+
+
+def _is_eye(m, precision=None):
+    return _is_zeros(m - eye(*m.shape), precision)
+
+
+def _is_triangular(m, precision=None):
     s, t = m.shape
-    for i in range(s):
-        for j in range(i):
-            assert m[i, j] == 0, m
+    if precision is None:
+        return all(m[i, j] == 0 for i in range(s) for j in range(i))
+    else:
+        n = m.evalf()
+        return all(abs(n[i, j]) < precision for i in range(s) for j in range(i))
 
 
 # === fundamental constructor ===
@@ -95,23 +112,14 @@ def test_singular_matrix():
 
 # === base matrices ===
 
-def test_identity_matrix():
-    for d in TEST_DIMS:
-        m = identity_matrix(d)
-        n = eye(d)
-        assert m == n
-
-
 def test_diagonal():
     for d in TEST_DIMS:
         m = diagonal_normal(d, (1,) * d)
-        n = eye(d)
-        assert m == n
+        assert _is_eye(m)
 
     for d in TEST_DIMS:
         m = diagonal_normal(d, (0,) * d)
-        n = zeros(d)
-        assert m == n
+        assert _is_zeros(m)
 
 
 def test_jordan():
@@ -129,7 +137,7 @@ def test_jordan():
 def test_transposition():
     for d in TEST_DIMS:
         m = transposition(d)
-        n = identity_matrix(d)
+        n = eye(d)
         assert m * m == n
 
     for d, coords in TEST_DIMS.items():
@@ -146,7 +154,7 @@ def test_permutation():
     for d in TEST_DIMS:
         perm = random.sample(range(d), d)
         m = permutation(d, perm)
-        n = identity_matrix(d).permute(perm)
+        n = eye(d).permute(perm)
         assert m == n
 
 
@@ -156,14 +164,14 @@ def test_projection():
             m = projection(d, (0, r))
             assert sum(m) == r
             assert m * m == m
-            _check_triangular(m)
-            _check_triangular(m.T)
+            assert _is_triangular(m)
+            assert _is_triangular(m.T)
 
 
 def test_elementary():
     for d in TEST_DIMS:
         m = elementary(d)
-        n = identity_matrix(d)
+        n = eye(d)
         for x, y in zip(m.inv() * m, n):
             assert round(x, TEST_PRECISION) == y
 
@@ -172,25 +180,51 @@ def test_elementary():
 
 
 def test_rotation():
+    z = 1 + 3 * I
     for d in TEST_DIMS:
         m = rotation(d)
-        n = identity_matrix(d)
-        for x, y in zip(m.T * m, n):
-            assert round(x, TEST_PRECISION) == y
-        assert round(m.det(), TEST_PRECISION) == 1
-    for d in TEST_DIMS:
+        assert _is_eye(m.T * m)
+        assert m.det() == 1
+
+        c = sqrt(2) / 2
+        m = rotation(d, scalar=c)
+        assert _is_eye(m.T * m, TEST_EPSILON), repr(m.T * m)
+        assert (m.det() - 1) < TEST_EPSILON, m.det()
+
+        z = complex(3, 1)
+        m = rotation(d, scalar=z / abs(z))
+        assert _is_eye(m.T * m, TEST_EPSILON), repr(m.T * m)
+        assert (m.det() - 1) < TEST_EPSILON, m.det()
+
+        z = 1 + 3 * I
+        m = rotation(d, scalar=z / abs(z))
+        assert _is_eye(m.T * m)
+        assert m.det() == 1
+
         m = rotation(d, scalar=(1, 0))
-        n = identity_matrix(d)
-        assert m == n, (m, n)
+        assert _is_eye(m)
 
 
 def test_reflection():
     for d in TEST_DIMS:
         m = reflection(d)
-        n = identity_matrix(d)
-        for x, y in zip(m.T * m, n):
-            assert round(x, TEST_PRECISION) == y
-        assert round(m.det(), TEST_PRECISION) == -1
+        assert _is_eye(m.T * m)
+        assert m.det() == -1
+
+        c = sqrt(2) / 2
+        m = reflection(d, scalar=c)
+        assert _is_eye(m.T * m)
+        assert m.det() == -1
+
+        z = complex(3, 1)
+        m = reflection(d, scalar=z / abs(z))
+        assert _is_eye(m.T * m, TEST_EPSILON), repr(m.T * m)
+        assert (m.det() + 1) < TEST_EPSILON, m.det()
+
+        z = 1 + 3 * I
+        m = reflection(d, scalar=z / abs(z))
+        assert _is_eye(m.T * m)
+        assert m.det() == -1
 
 
 # === normal form matrices, i.e. defined by eigenvalues ===
@@ -201,8 +235,8 @@ def test_diagonal_normal():
         rank = d - 1
         s = (0,) * (d - rank) + scalars[:rank]
         m = diagonal_normal(d, s)
-        _check_triangular(m)
-        _check_triangular(m.T)
+        assert _is_triangular(m)
+        assert _is_triangular(m.T)
         for x in m.diagonal():
             if x:
                 rank -= 1
@@ -210,8 +244,8 @@ def test_diagonal_normal():
         assert rank == 0
 
     spec = (1, 2, 3, 4)
-    _random._TEST = True
-    assert _random._TEST is True
+    _random._ALT = True
+    assert _random._ALT is True
     test = dict()
     specs = dict()
     for d in TEST_DIMS:
@@ -219,13 +253,13 @@ def test_diagonal_normal():
         specs[d] = s
         m = _random.diagonal_normal(d + 4, s)
         test[d] = m
-        _check_triangular(m)
-        _check_triangular(m.T)
+        assert _is_triangular(m)
+        assert _is_triangular(m.T)
         for ev in m.eigenvals(multiple=True):
             assert ev in spec
 
-    _random._TEST = False
-    assert _random._TEST is False
+    _random._ALT = False
+    assert _random._ALT is False
     for d in TEST_DIMS:
         m = _random.diagonal_normal(d + 4, specs[d])
         assert test[d] == m
@@ -237,7 +271,7 @@ def test_jordan_normal():
         rank = d - 1
         s = (0, None) * (d - rank) + scalars[:rank]
         m = jordan_normal(d, s)
-        _check_triangular(m)
+        assert _is_triangular(m)
         assert m.rank() == rank
 
         for v in (0, 1, 2):
@@ -249,13 +283,13 @@ def test_jordan_normal():
 
         s = ((3, 2), (3, 2))
         m = jordan_normal(d, s)
-        _check_triangular(m)
+        assert _is_triangular(m)
 
         with raises(AssertionError):
-            _check_triangular(m.T)
+            assert _is_triangular(m.T)
 
-    _random._TEST = True
-    assert _random._TEST is True
+    _random._ALT = True
+    assert _random._ALT is True
     test = dict()
     specs = dict()
     for d in TEST_DIMS:
@@ -264,31 +298,60 @@ def test_jordan_normal():
         m = _random.jordan_normal(d + 4, s)
         test[d] = m
 
-    _random._TEST = False
-    assert _random._TEST is False
+    _random._ALT = False
+    assert _random._ALT is False
     for d in TEST_DIMS:
         m = _random.jordan_normal(d + 4, specs[d])
         assert test[d] == m
 
 
 def test_isometry_normal():
-    z = complex(0, 1)
-    for d in TEST_DIMS:
-        m = isometry_normal(d, ((z,), (z,)))
-        assert abs(m.det()) == 1
+    spec = -1, 1, -1
+    m = isometry_normal(3, spec=spec)
+    assert _is_zeros(m - diag(*spec)), repr(m)
+    assert _is_eye(m * m), repr(m * m)
 
-    m = isometry_normal(3, ((0, -1), (0, 1)))
-    assert m[2, 2] == 1
+    m = isometry_normal(4, spec=(1,))
+    assert _is_eye(m), repr(m)
+
+    m = isometry_normal(4, spec=((1, 0), (1, 0)))
+    assert _is_eye(m), repr(m)
+
+    m = isometry_normal(3, spec=((0, -1), (0, 1)))
+    n = Matrix([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
+    assert _is_zeros(m - n), repr(m)
+
+    for d in TEST_DIMS:
+        m = isometry_normal(d, spec=(I,))
+        assert abs(m.det()) == 1, m.det()
+        m = isometry_normal(d, spec=(I,), real=False)
+        assert m.det() == I ** d, repr(m)
+
+        m = isometry_normal(d, spec=(sqrt(2) / 2,))
+        assert abs(m.det()) == 1, m.det()
+
+        z = 2 + 3 * I
+        m = isometry_normal(d, spec=(z / abs(z),))
+        assert abs(m.det()) == 1, m.det()
+        m = isometry_normal(d, spec=(z / abs(z),), real=False)
+        assert _is_zeros(m - diag(*(d * [z / abs(z)]))), repr(m)
+
+        m = isometry_normal(d, spec=(complex(0, 1),))
+        assert abs(m.det()) == 1, m.det()
+
+        z = complex(3, 2)
+        m = isometry_normal(d, spec=(z / abs(z),))
+        assert abs(abs(m.det()) - 1) < TEST_EPSILON, m.det()
 
     spec = (0, -1), (1,)
-    _random._TEST = True
-    assert _random._TEST is True
+    _random._ALT = True
+    assert _random._ALT is True
     test = dict()
     for d in TEST_DIMS:
         test[d] = _random.isometry_normal(2 * d, spec * d)
 
-    _random._TEST = False
-    assert _random._TEST is False
+    _random._ALT = False
+    assert _random._ALT is False
     for d in TEST_DIMS:
         m = _random.isometry_normal(2 * d, spec * d)
 
@@ -301,30 +364,31 @@ def test_isometry_normal():
 
 def test_invertible():
     for d in TEST_DIMS:
-        n = identity_matrix(d)
-        i = invertible(d, None, None)
-        assert n == i
+        i = invertible(d, length=0)
+        assert _is_eye(i)
 
-    for d in TEST_DIMS:
+        i = invertible(d, None, None)
+        assert _is_eye(i)
+
         m = invertible(d)
-        n = identity_matrix(d)
-        for x, y in zip(m.inv() * m, n):
-            assert round(x, TEST_PRECISION) == y
-        for x, y in zip(m.inv() * m, n):
-            assert round(x, TEST_PRECISION) == y
-        for x, y in zip(m.inv() * m, n):
-            assert round(x, TEST_PRECISION) == y
+        assert _is_eye(m.inv() * m, TEST_PRECISION)
+
+        m = invertible(d, scalar_set=(0.5, 2.), unit_set=(0.1, 1.))
+        assert _is_eye(m.inv() * m, TEST_PRECISION)
+
+        m = invertible(d, scalar_set=(1, phi))
+        assert _is_eye(m.inv() * m)
 
 
 def test_triangular():
     for d in TEST_DIMS:
-        _check_triangular(triangular(d))
+        assert _is_triangular(triangular(d))
         m = triangular(d, d)
-        n = identity_matrix(d)
+        n = eye(d)
         assert m.inv() * m == n
         for r in range(1, d):
             m = triangular(d, r)
-            _check_triangular(m)
+            assert _is_triangular(m)
             assert m.rank() == r
 
 
@@ -374,7 +438,7 @@ def test_nilpotent():
         for r in range(1, d):
             m = nilpotent(d, r)
             assert m.rank() == r
-            assert m ** d == zeros(d)
+            assert _is_zeros(m ** d)
 
 
 # === matrices conjugate by isometries ==
@@ -382,54 +446,61 @@ def test_nilpotent():
 
 def test_orthogonal():
     for d in TEST_DIMS:
-        n = identity_matrix(d)
         i = orthogonal(d, (1,), length=0)
-        assert n == i
+        assert _is_eye(i), repr(i)
 
         m = orthogonal(d).evalf()
-        for x in m.T * m - n:
-            assert abs(x) < TEST_PRECISION
+        assert _is_eye(m.T * m, TEST_PRECISION)
         assert abs(m.evalf().det()) - 1 < TEST_PRECISION
 
         m = orthogonal(d, spec=_random._rotation_scalar_set).evalf()
-        for x in m.T * m - n:
-            assert abs(x) < TEST_PRECISION
+        assert _is_eye(m.T * m, TEST_PRECISION)
         assert abs(m.evalf().det()) - 1 < TEST_PRECISION
+
+        m = orthogonal(d, spec=(cos(phi),))
+        assert _is_eye(m.T * m)
 
 
 def test_unitary():
-    # z = complex(1, 1) * _sqrt(2) / 2
-    for d in TEST_DIMS:
-        n = identity_matrix(d)
+    for d in list(TEST_DIMS)[1::3]:
         i = unitary(d, (1,), length=0)
-        assert n == i
-        m = unitary(d).evalf()
-        for x in (m.adjoint() * m - n).evalf():
-            assert abs(x) < TEST_PRECISION
-        det = m.evalf().det()
-        assert det * det.conjugate() - 1 < TEST_PRECISION
+        assert _is_eye(i), repr(i)
 
-        z = complex(0, 1)
-        m = unitary(d, spec=(z, z * z)).evalf()
-        for x in (m.adjoint() * m - n).evalf():
-            assert abs(x) < TEST_PRECISION
-        det = m.evalf().det()
-        assert det * det.conjugate() - 1 < TEST_PRECISION
+        m = unitary(d)
+        assert _is_eye(m.H * m, TEST_EPSILON), repr(simplify(m.H * m))
+        assert _is_eye(m.H * m), repr((m.H * m).evalf())
+        assert abs(abs(m.det()) - 1) < TEST_EPSILON
+
+        z = complex(1, 2)
+        m = unitary(d, spec=(z / abs(z),), length=d)
+        assert _is_eye(m.H * m, TEST_EPSILON), repr(simplify(m.H * m))
+        assert abs(m.evalf().det()) - 1 < TEST_PRECISION
+
+        z = 2 + 3 * I
+        m = unitary(d, spec=(z / abs(z),), length=d)
+        assert _is_eye(m.H * m), repr(simplify(m.H * m))
+
+        m = unitary(d, spec=(sqrt(2) / 2,), length=d)
+        assert _is_eye(m.H * m), repr(simplify(m.H * m))
 
 
 def test_normal():
-    spec = (2, 3, 4)
-    z = complex(0, 1)
-    for d in TEST_DIMS:
-        m = normal(d, spec).evalf()
-        for x in m:
-            assert x.is_real
-        for x in m.T * m - m * m.T:
-            assert abs(x) < TEST_PRECISION
+    for d in list(TEST_DIMS)[1::3]:
+        spec = (2, 3, 4)
+        m = normal(d, spec, length=d)
+        assert all(x.is_real for x in simplify(m)), repr(simplify(m))
+        assert _is_zeros(m.T * m - m * m.T), \
+            repr(simplify(m.T * m - m * m.T))
 
-        c = normal(d, spec, scalar_set=(z,)).evalf()
-        for x in c.adjoint() * c - c * c.adjoint():
-            assert abs(x) < TEST_PRECISION
+        z = 1 + 3 * I
+        c = normal(d, spec=(1, 2 * I, 3), scalar_set=(z/abs(z),), length=d)
+        assert _is_zeros(c.H * c - c * c.H), \
+            repr(simplify(m.H * m - m * m.H))
+
+        z = complex(3, 1)
+        c = normal(d, spec, scalar_set=(z/abs(z),), length=d)
+        assert _is_zeros(c.H * c - c * c.H, TEST_EPSILON), \
+            repr(simplify(m.H * m - m * m.H))
 
 
 # === symmetric or complex adjoined matrices ===
@@ -437,27 +508,28 @@ def test_normal():
 
 def test_symmetric():
     for d in TEST_DIMS:
+        m = symmetric(d,)
+        assert m.T == m
+
         m = symmetric(d, scalar_set=(4,))
         assert m.T == m
-        assert len(m.eigenvals(multiple=True)) == d
 
 
 def test_hermite():
     z = complex(1, 2)
     for d in TEST_DIMS:
         m = hermite(d, scalar_set=(z,))
-        assert m.adjoint() == m
-        assert len(m.eigenvals(multiple=True)) == d
+        assert m.H == m
 
 
 def test_raise():
-    # with raises(ValueError):
-    #    rotation(3, scalar=4)
+    with raises(ValueError):
+        rotation(3, scalar=4)
+    with raises(ValueError):
+        isometry_normal(3, spec=(4,))
+    with raises(ValueError):
+        orthogonal(3, spec=(4,))
+    with raises(ValueError):
+        unitary(3, spec=(complex(1, 1),))
     with raises(ValueError):
         jordan_normal(3, (None, 1, 2))
-
-
-if __name__ == '__main__':
-    import sympy
-
-    sympy.test(__file__, verbose=True, subprocess=False)

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -2,7 +2,7 @@ import random
 
 from sympy import Matrix, eye, zeros, cartes, I
 from sympy.matrices.random import super_elementary_matrix
-from sympy.matrices.random import identity, jordan, jordan_normal, \
+from sympy.matrices.random import identity_matrix, jordan, jordan_normal, \
     complex_to_real, invertible, regular_to_singular, diagonal_normal, \
     diagonalizable, transposition, triangular, trigonalizable, \
     isometry_normal, permutation, projection, elementary, rotation, \
@@ -95,9 +95,9 @@ def test_singular_matrix():
 
 # === base matrices ===
 
-def test_identity():
+def test_identity_matrix():
     for d in TEST_DIMS:
-        m = identity(d)
+        m = identity_matrix(d)
         n = eye(d)
         assert m == n
 
@@ -129,7 +129,7 @@ def test_jordan():
 def test_transposition():
     for d in TEST_DIMS:
         m = transposition(d)
-        n = identity(d)
+        n = identity_matrix(d)
         assert m * m == n
 
     for d, coords in TEST_DIMS.items():
@@ -146,7 +146,7 @@ def test_permutation():
     for d in TEST_DIMS:
         perm = random.sample(range(d), d)
         m = permutation(d, perm)
-        n = identity(d).permute(perm)
+        n = identity_matrix(d).permute(perm)
         assert m == n
 
 
@@ -163,7 +163,7 @@ def test_projection():
 def test_elementary():
     for d in TEST_DIMS:
         m = elementary(d)
-        n = identity(d)
+        n = identity_matrix(d)
         for x, y in zip(m.inv() * m, n):
             assert round(x, TEST_PRECISION) == y
 
@@ -174,20 +174,20 @@ def test_elementary():
 def test_rotation():
     for d in TEST_DIMS:
         m = rotation(d)
-        n = identity(d)
+        n = identity_matrix(d)
         for x, y in zip(m.T * m, n):
             assert round(x, TEST_PRECISION) == y
         assert round(m.det(), TEST_PRECISION) == 1
     for d in TEST_DIMS:
         m = rotation(d, scalar=(1, 0))
-        n = identity(d)
+        n = identity_matrix(d)
         assert m == n, (m, n)
 
 
 def test_reflection():
     for d in TEST_DIMS:
         m = reflection(d)
-        n = identity(d)
+        n = identity_matrix(d)
         for x, y in zip(m.T * m, n):
             assert round(x, TEST_PRECISION) == y
         assert round(m.det(), TEST_PRECISION) == -1
@@ -301,13 +301,13 @@ def test_isometry_normal():
 
 def test_invertible():
     for d in TEST_DIMS:
-        n = identity(d)
+        n = identity_matrix(d)
         i = invertible(d, None, None)
         assert n == i
 
     for d in TEST_DIMS:
         m = invertible(d)
-        n = identity(d)
+        n = identity_matrix(d)
         for x, y in zip(m.inv() * m, n):
             assert round(x, TEST_PRECISION) == y
         for x, y in zip(m.inv() * m, n):
@@ -320,7 +320,7 @@ def test_triangular():
     for d in TEST_DIMS:
         _check_triangular(triangular(d))
         m = triangular(d, d)
-        n = identity(d)
+        n = identity_matrix(d)
         assert m.inv() * m == n
         for r in range(1, d):
             m = triangular(d, r)
@@ -382,7 +382,7 @@ def test_nilpotent():
 
 def test_orthogonal():
     for d in TEST_DIMS:
-        n = identity(d)
+        n = identity_matrix(d)
         i = orthogonal(d, (1,), length=0)
         assert n == i
 
@@ -400,7 +400,7 @@ def test_orthogonal():
 def test_unitary():
     # z = complex(1, 1) * _sqrt(2) / 2
     for d in TEST_DIMS:
-        n = identity(d)
+        n = identity_matrix(d)
         i = unitary(d, (1,), length=0)
         assert n == i
         m = unitary(d).evalf()

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,0 +1,458 @@
+import random
+
+from pytest import raises
+
+from sympy import Matrix, eye, zeros, cartes, I
+from sympy.matrices.random import super_elementary_matrix
+from sympy.matrices.random import *
+from sympy.matrices import random as _random
+
+TEST_DIMS = dict((d, tuple(cartes(range(d), range(d)))) for d in range(2, 6))
+TEST_PRECISION = 7
+
+random.seed(1)
+
+
+def _check_triangular(m):
+    s, t = m.shape
+    for i in range(s):
+        for j in range(i):
+            assert m[i, j] == 0, m
+
+
+# === fundamental constructor ===
+
+def test_super_elementary_matrix():
+    m = super_elementary_matrix(3, (0, 1))
+    n = Matrix([
+        [0, 1, 0],
+        [1, 0, 0],
+        [0, 0, 1]])
+    assert m == n
+
+    m = super_elementary_matrix(3, (0, 2), value=5)
+    n = Matrix([
+        [1, 0, 5],
+        [0, 1, 0],
+        [0, 0, 1]])
+    assert m == n
+
+    m = super_elementary_matrix(3, (2, 2), value=5)
+    n = Matrix([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 5]])
+    assert m == n
+
+    m = super_elementary_matrix(3, (1, 2), 1, 2, 3, 4)
+    n = Matrix([
+        [1, 0, 0],
+        [0, 1, 2],
+        [0, -3, 4]])
+    assert m == n
+
+    for d, coords in TEST_DIMS.items():
+        for i, j in coords:
+            m = super_elementary_matrix(d, (i, j), value=d)
+            assert m[i, j] == d
+
+    # test ValueError
+    with raises(ValueError):
+        super_elementary_matrix(3, (1, 2, 3))
+    with raises(ValueError):
+        super_elementary_matrix(3, (1., 2.))
+    with raises(ValueError):
+        super_elementary_matrix(3, (1, 1), 1, 3)
+    with raises(ValueError):
+        super_elementary_matrix(3, (1, 2), 1, 3)
+
+
+# === fundamental functions ===
+
+def test_real_complex_matrix():
+    z = 4 + 2 * I
+    for d in TEST_DIMS:
+        c = jordan(d, (0, d - 1), scalar=z)
+        r = complex_to_real(c)
+        for x in r:
+            assert x.is_real
+        for v in r.eigenvals(multiple=True):
+            assert v in (z, z.conjugate(), 1)
+
+
+def test_singular_matrix():
+    for d in TEST_DIMS:
+        s = invertible(d)
+        assert regular_to_singular(s) == s
+        for r in range(1, d):
+            assert regular_to_singular(s, r).rank() == r
+
+
+# === base matrices ===
+
+def test_identity():
+    for d in TEST_DIMS:
+        m = identity(d)
+        n = eye(d)
+        assert m == n
+
+
+def test_diagonal():
+    for d in TEST_DIMS:
+        m = diagonal_normal(d, (1,) * d)
+        n = eye(d)
+        assert m == n
+
+    for d in TEST_DIMS:
+        m = diagonal_normal(d, (0,) * d)
+        n = zeros(d)
+        assert m == n
+
+
+def test_jordan():
+    for d in TEST_DIMS:
+        m = jordan(d, (0, d), (1,))
+        n = eye(d)
+        assert m.diagonal() == n.diagonal()
+
+    for d in TEST_DIMS:
+        m = jordan(d, (0, d), 0)
+        n = zeros(d)
+        assert m.diagonal() == n.diagonal()
+
+
+def test_transposition():
+    for d in TEST_DIMS:
+        m = transposition(d)
+        n = identity(d)
+        assert m * m == n
+
+    for d, coords in TEST_DIMS.items():
+        for i, j in coords:
+            m = transposition(d, (i, j))
+            assert m[j, i] == 1
+            assert m[i, j] == 1
+            if not i == j:
+                assert m[i, i] == 0
+                assert m[j, j] == 0
+
+
+def test_permutation():
+    for d in TEST_DIMS:
+        perm = random.sample(range(d), d)
+        m = permutation(d, perm)
+        n = identity(d).permute(perm)
+        assert m == n
+
+
+def test_projection():
+    for d in TEST_DIMS:
+        for r in range(1, d):
+            m = projection(d, (0, r))
+            assert sum(m) == r
+            assert m * m == m
+            _check_triangular(m)
+            _check_triangular(m.T)
+
+
+def test_elementary():
+    for d in TEST_DIMS:
+        m = elementary(d)
+        n = identity(d)
+        for x, y in zip(m.inv() * m, n):
+            assert round(x, TEST_PRECISION) == y
+
+        m = elementary(d, scalar=1)
+        assert round(m.det(), TEST_PRECISION) == 1
+
+
+def test_rotation():
+    for d in TEST_DIMS:
+        m = rotation(d)
+        n = identity(d)
+        for x, y in zip(m.T * m, n):
+            assert round(x, TEST_PRECISION) == y
+        assert round(m.det(), TEST_PRECISION) == 1
+    for d in TEST_DIMS:
+        m = rotation(d, scalar=(1, 0))
+        n = identity(d)
+        assert m == n, (m, n)
+
+
+def test_reflection():
+    for d in TEST_DIMS:
+        m = reflection(d)
+        n = identity(d)
+        for x, y in zip(m.T * m, n):
+            assert round(x, TEST_PRECISION) == y
+        assert round(m.det(), TEST_PRECISION) == -1
+
+
+# === normal form matrices, i.e. defined by eigenvalues ===
+
+def test_diagonal_normal():
+    scalars = 2, 3, 5, 7
+    for d in TEST_DIMS:
+        rank = d - 1
+        s = (0,) * (d - rank) + scalars[:rank]
+        m = diagonal_normal(d, s)
+        _check_triangular(m)
+        _check_triangular(m.T)
+        for x in m.diagonal():
+            if x:
+                rank -= 1
+                assert x in scalars
+        assert rank == 0
+
+    spec = (1, 2, 3, 4)
+    _random._TEST = True
+    assert _random._TEST is True
+    test = dict()
+    specs = dict()
+    for d in TEST_DIMS:
+        s = random.choices(spec, k=d + 4)
+        specs[d] = s
+        m = _random.diagonal_normal(d + 4, s)
+        test[d] = m
+        _check_triangular(m)
+        _check_triangular(m.T)
+        for ev in m.eigenvals(multiple=True):
+            assert ev in spec
+
+    _random._TEST = False
+    assert _random._TEST is False
+    for d in TEST_DIMS:
+        m = _random.diagonal_normal(d + 4, specs[d])
+        assert test[d] == m
+
+
+def test_jordan_normal():
+    scalars = 2, 3, 5, 7
+    for d in TEST_DIMS:
+        rank = d - 1
+        s = (0, None) * (d - rank) + scalars[:rank]
+        m = jordan_normal(d, s)
+        _check_triangular(m)
+        assert m.rank() == rank
+
+        for v in (0, 1, 2):
+            m = jordan_normal(d, ((v, d), (v, d)))
+            assert m[0, 0] == v
+            for i in range(1, d):
+                assert m[i, i] == v
+                assert m[i - 1, i] == 1
+
+        s = ((3, 2), (3, 2))
+        m = jordan_normal(d, s)
+        _check_triangular(m)
+
+        with raises(AssertionError):
+            _check_triangular(m.T)
+
+    _random._TEST = True
+    assert _random._TEST is True
+    test = dict()
+    specs = dict()
+    for d in TEST_DIMS:
+        s = random.choices(scalars, k=d + 4)
+        specs[d] = s
+        m = _random.jordan_normal(d + 4, s)
+        test[d] = m
+
+    _random._TEST = False
+    assert _random._TEST is False
+    for d in TEST_DIMS:
+        m = _random.jordan_normal(d + 4, specs[d])
+        assert test[d] == m
+
+
+def test_isometry_normal():
+    z = complex(0, 1)
+    for d in TEST_DIMS:
+        m = isometry_normal(d, ((z,), (z,)))
+        assert abs(m.det()) == 1
+
+    m = isometry_normal(3, ((0, -1), (0, 1)))
+    assert m[2, 2] == 1
+
+    spec = (0, -1), (1,)
+    _random._TEST = True
+    assert _random._TEST is True
+    test = dict()
+    for d in TEST_DIMS:
+        test[d] = _random.isometry_normal(2 * d, spec * d)
+
+    _random._TEST = False
+    assert _random._TEST is False
+    for d in TEST_DIMS:
+        m = _random.isometry_normal(2 * d, spec * d)
+
+        for x in (m - test[d]).evalf():
+            assert abs(x) < TEST_PRECISION
+
+
+# === compound matrices ===
+
+
+def test_invertible():
+    for d in TEST_DIMS:
+        n = identity(d)
+        i = invertible(d, None, None)
+        assert n == i
+
+    for d in TEST_DIMS:
+        m = invertible(d)
+        n = identity(d)
+        for x, y in zip(m.inv() * m, n):
+            assert round(x, TEST_PRECISION) == y
+        for x, y in zip(m.inv() * m, n):
+            assert round(x, TEST_PRECISION) == y
+        for x, y in zip(m.inv() * m, n):
+            assert round(x, TEST_PRECISION) == y
+
+
+def test_triangular():
+    for d in TEST_DIMS:
+        _check_triangular(triangular(d))
+        m = triangular(d, d)
+        n = identity(d)
+        assert m.inv() * m == n
+        for r in range(1, d):
+            m = triangular(d, r)
+            _check_triangular(m)
+            assert m.rank() == r
+
+
+def test_singular():
+    for d in TEST_DIMS:
+        for r in range(1, d):
+            assert singular(d, r).rank() == r
+
+
+def test_diagonalizable():
+    for d in TEST_DIMS:
+        m = diagonalizable(d, spec=(2,))
+        assert m.eigenvals(multiple=True) == [2] * d
+        for r in range(1, d):
+            s = (0,) * (d - r) + (2,) * r
+            m = diagonalizable(d, spec=s)
+            assert m.rank() == r
+            for ev in m.eigenvals(multiple=True):
+                assert ev in (0, 2), m.eigenvals(multiple=True)
+
+
+def test_trigonalizable():
+    for d in TEST_DIMS:
+        m = trigonalizable(d, spec=(2,))
+        assert m.eigenvals(multiple=True) == [2] * d
+        for r in range(1, d):
+            s = (0, None) * (d - r) + (2,) * r
+            m = trigonalizable(d, spec=s)
+            assert m.rank() == r, (m.rank(), r)
+            for ev in m.eigenvals(multiple=True):
+                assert ev in (0, 2), m.eigenvals(multiple=True)
+
+
+# === conjugate matrices, i.e. defined by similarity to a normal from ==
+
+
+def test_idempotent():
+    for d in TEST_DIMS:
+        for r in range(1, d):
+            m = idempotent(d, r)
+            assert m * m == m
+            assert m.rank() == r
+
+
+def test_nilpotent():
+    for d in TEST_DIMS:
+        for r in range(1, d):
+            m = nilpotent(d, r)
+            assert m.rank() == r
+            assert m ** d == zeros(d)
+
+
+# === matrices conjugate by isometries ==
+
+
+def test_orthogonal():
+    for d in TEST_DIMS:
+        n = identity(d)
+        i = orthogonal(d, (1,), length=0)
+        assert n == i
+
+        m = orthogonal(d).evalf()
+        for x in m.T * m - n:
+            assert abs(x) < TEST_PRECISION
+        assert abs(m.evalf().det()) - 1 < TEST_PRECISION
+
+        m = orthogonal(d, spec=_random._rotation_scalar_set).evalf()
+        for x in m.T * m - n:
+            assert abs(x) < TEST_PRECISION
+        assert abs(m.evalf().det()) - 1 < TEST_PRECISION
+
+
+def test_unitary():
+    # z = complex(1, 1) * _sqrt(2) / 2
+    for d in TEST_DIMS:
+        n = identity(d)
+        i = unitary(d, (1,), length=0)
+        assert n == i
+        m = unitary(d).evalf()
+        for x in (m.adjoint() * m - n).evalf():
+            assert abs(x) < TEST_PRECISION
+        det = m.evalf().det()
+        assert det * det.conjugate() - 1 < TEST_PRECISION
+
+        z = complex(0, 1)
+        m = unitary(d, spec=(z, z * z)).evalf()
+        for x in (m.adjoint() * m - n).evalf():
+            assert abs(x) < TEST_PRECISION
+        det = m.evalf().det()
+        assert det * det.conjugate() - 1 < TEST_PRECISION
+
+
+def test_normal():
+    spec = (2, 3, 4)
+    z = complex(0, 1)
+    for d in TEST_DIMS:
+        m = normal(d, spec).evalf()
+        for x in m:
+            assert x.is_real
+        for x in m.T * m - m * m.T:
+            assert abs(x) < TEST_PRECISION
+
+        c = normal(d, spec, scalar_set=(z,)).evalf()
+        for x in c.adjoint() * c - c * c.adjoint():
+            assert abs(x) < TEST_PRECISION
+
+
+# === symmetric or complex adjoined matrices ===
+
+
+def test_symmetric():
+    for d in TEST_DIMS:
+        m = symmetric(d, scalar_set=(4,))
+        assert m.T == m
+        assert len(m.eigenvals(multiple=True)) == d
+
+
+def test_hermite():
+    z = complex(1, 2)
+    for d in TEST_DIMS:
+        m = hermite(d, scalar_set=(z,))
+        assert m.adjoint() == m
+        assert len(m.eigenvals(multiple=True)) == d
+
+
+def test_raise():
+    # with raises(ValueError):
+    #    rotation(3, scalar=4)
+    with raises(ValueError):
+        jordan_normal(3, (None, 1, 2))
+
+
+if __name__ == '__main__':
+    import sympy
+
+    sympy.test(__file__, verbose=True, subprocess=False)

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import random
 
 from pytest import raises

--- a/sympy/matrices/tests/test_random.py
+++ b/sympy/matrices/tests/test_random.py
@@ -1,7 +1,5 @@
 import random
 
-from pytest import raises
-
 from sympy import Matrix, eye, zeros, cartes, I
 from sympy.matrices.random import super_elementary_matrix
 from sympy.matrices.random import identity, jordan, jordan_normal, \
@@ -12,6 +10,7 @@ from sympy.matrices.random import identity, jordan, jordan_normal, \
     hermite, symmetric
 
 from sympy.matrices import random as _random
+from sympy.testing.pytest import raises
 
 TEST_DIMS = dict((d, tuple(cartes(range(d), range(d)))) for d in range(2, 6))
 TEST_PRECISION = 7


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed

- generates random matrices of various types like
  - orthogonal
  - unitary
  - invertible
  - singular
  - symmetric
  - nilpotent
  - idempotent
  - normal
  - symmetric
  - hermite 
  - elementary
  - rotation
  - reflection

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Added random matrix generation, i.e. for orthogonal, unitary, invertible and more matrix types.

<!-- END RELEASE NOTES -->
