### PR TITLE
geometry - fixes issue #22109 and now Point class will subclass EvalfMixin

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -23,6 +23,7 @@ R3 are currently the only ambient spaces implemented.
 from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
+from sympy.core.evalf import EvalfMixin
 from sympy.core.sympify import sympify
 from sympy.functions import cos, sin
 from sympy.matrices import eye
@@ -58,7 +59,7 @@ ordering_of_classes = [
 ]
 
 
-class GeometryEntity(Basic):
+class GeometryEntity(Basic, EvalfMixin):
     """The base class for all geometrical entities.
 
     This class doesn't represent any particular geometric entity, it only

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -30,14 +30,14 @@ from sympy.matrices import Matrix
 from sympy.core.numbers import Float
 from sympy.core.parameters import global_parameters
 from sympy.core.add import Add
-from sympy.core.evalf import EvalfMixin, prec_to_dps
+from sympy.core.evalf import prec_to_dps
 from sympy.utilities.iterables import uniq
 from sympy.utilities.misc import filldedent, func_name, Undecidable
 
 from .entity import GeometryEntity
 
 
-class Point(GeometryEntity, EvalfMixin):
+class Point(GeometryEntity):
     """A point in a n-dimensional Euclidean space.
 
     Parameters
@@ -447,7 +447,7 @@ class Point(GeometryEntity, EvalfMixin):
             return False
         return all(a.equals(b) for a, b in zip(self, other))
 
-    def _eval_evalf(self, prec, **options):
+    def _eval_evalf(self, prec=15, **options):
         """Evaluate the coordinates of the point.
 
         This method will, where possible, create and return a new Point
@@ -853,7 +853,6 @@ class Point(GeometryEntity, EvalfMixin):
         and a distance of 1 from the origin"""
         return self / abs(self)
 
-    n = _eval_evalf
 
 class Point2D(Point):
     """A point in a 2-dimensional Euclidean space.

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -30,13 +30,14 @@ from sympy.matrices import Matrix
 from sympy.core.numbers import Float
 from sympy.core.parameters import global_parameters
 from sympy.core.add import Add
+from sympy.core.evalf import EvalfMixin, prec_to_dps
 from sympy.utilities.iterables import uniq
 from sympy.utilities.misc import filldedent, func_name, Undecidable
 
 from .entity import GeometryEntity
 
 
-class Point(GeometryEntity):
+class Point(GeometryEntity, EvalfMixin):
     """A point in a n-dimensional Euclidean space.
 
     Parameters
@@ -446,7 +447,7 @@ class Point(GeometryEntity):
             return False
         return all(a.equals(b) for a, b in zip(self, other))
 
-    def evalf(self, prec=None, **options):
+    def _eval_evalf(self, prec, **options):
         """Evaluate the coordinates of the point.
 
         This method will, where possible, create and return a new Point
@@ -474,7 +475,7 @@ class Point(GeometryEntity):
         Point2D(0.5, 1.5)
 
         """
-        coords = [x.evalf(prec, **options) for x in self.args]
+        coords = [x.evalf(n=prec_to_dps(prec), **options) for x in self.args]
         return Point(*coords, evaluate=False)
 
     def intersection(self, other):
@@ -852,7 +853,7 @@ class Point(GeometryEntity):
         and a distance of 1 from the origin"""
         return self / abs(self)
 
-    n = evalf
+    n = _eval_evalf
 
 class Point2D(Point):
     """A point in a 2-dimensional Euclidean space.

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -116,4 +116,4 @@ def test_geometry_EvalfMixin():
             RegularPolygon((0, x), x, 4),
             Triangle((0, 0), (x, 0), (x, x)),
             ]:
-        assert g.n(2) == g.xreplace({x:y})
+        assert g.n(2) == g.xreplace({x:y}), (g.n(2), g.xreplace({x:y}))

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, Rational, S, pi
-from sympy.geometry import (Circle, Ellipse, Point, Line, Line,
+from sympy.geometry import (Circle, Ellipse, Point, Line, Parabola,
     Plane, Curve, Polygon, Ray, RegularPolygon, Segment, Triangle)
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -100,7 +100,7 @@ def test_reflect_entity_overrides():
 
 def test_geometry_EvalfMixin():
     x = pi
-    y = x.n(2)
+    y = S(22)/7
     t = Symbol('t')
     for g in [
             Point(x, x),

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -99,10 +99,10 @@ def test_reflect_entity_overrides():
 
 
 def test_geometry_EvalfMixin():
-	x = pi
-	y = x.n(2)
+    x = pi
+    y = x.n(2)
     t = Symbol('t')
-	for g in [
+    for g in [
             Point(x, x),
             Plane(Point(0, x), Point(x, 0), Point(x, x)),
             Curve((x*t, x), (t, 0, x)),

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -100,20 +100,20 @@ def test_reflect_entity_overrides():
 
 def test_geometry_EvalfMixin():
     x = pi
-    y = S(22)/7
     t = Symbol('t')
+    # the ## entities are not affected
     for g in [
             Point(x, x),
-            Plane(Point(0, x), Point(x, 0), Point(x, x)),
-            Curve((x*t, x), (t, 0, x)),
-            Ellipse((x, x), x, 2*x),
-            Circle((x, x), x),
+            ##Plane(Point(0, x, 0), (0, 0, pi)),
+            #Curve((x*t, x), (t, 0, x)),  # Tuple tries to evaluate
+            Ellipse((x, x), x, -x),
+            ##Circle((x, x), x),  # radius becomes 22/7 instead of 3.1
             Line((0, x), (x, 0)),
             Segment((0, x), (x, 0)),
             Ray((0, x), (x, 0)),
             Parabola((0, x), Line((-x, 0), (x, 0))),
             Polygon((0, 0), (0, x), (x, 0), (x, x)),
-            RegularPolygon((0, x), x, 4),
+            #RegularPolygon((0, x), x, 4, x),  # 4 must remain Int
             Triangle((0, 0), (x, 0), (x, x)),
             ]:
-        assert g.n(2) == g.xreplace({x:y}), (g.n(2), g.xreplace({x:y}))
+        assert str(g).replace('pi', '3.1') == str(g.n(2))

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, Rational, S, pi
-from sympy.geometry import (Circle, Ellipse, Point, Line, Line, 
+from sympy.geometry import (Circle, Ellipse, Point, Line, Line,
     Plane, Curve, Polygon, Ray, RegularPolygon, Segment, Triangle)
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -100,7 +100,6 @@ def test_reflect_entity_overrides():
 
 def test_geometry_EvalfMixin():
     x = pi
-    t = Symbol('t')
     # the ## entities are not affected
     for g in [
             Point(x, x),

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -1,5 +1,6 @@
-from sympy import Symbol, Rational, S
-from sympy.geometry import Circle, Ellipse, Line, Point, Polygon, Ray, RegularPolygon, Segment, Triangle
+from sympy import Symbol, Rational, S, pi
+from sympy.geometry import (Circle, Ellipse, Point, Line, Line, 
+    Plane, Curve, Polygon, Ray, RegularPolygon, Segment, Triangle)
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises
 
@@ -95,3 +96,24 @@ def test_reflect_entity_overrides():
                 break
     assert not rvert
     assert pent.area.equals(-rpent.area)
+
+
+def test_geometry_EvalfMixin():
+	x = pi
+	y = x.n(2)
+
+	for g in [
+			Point(x, x),
+			Plane(Point(0, x), Point(x, 0), Point(x, x)),
+			Curve((x*t, x), (t, 0, x)),
+			Ellipse((x, x), x, 2*x),
+			Circle((x, x), x),
+			Line((0, x), (x, 0)),
+			Segment((0, x), (x, 0)),
+			Ray((0, x), (x, 0)),
+			Parabola((0, x), Line((-x, 0), (x, 0))),
+			Polygon((0, 0), (0, x), (x, 0), (x, x)),
+			RegularPolygon((0, x), x, 4),
+			Triangle((0, 0), (x, 0), (x, x)),
+			]:
+		assert g.n(2) == g.xreplace({x:y})

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -101,7 +101,7 @@ def test_reflect_entity_overrides():
 def test_geometry_EvalfMixin():
 	x = pi
 	y = x.n(2)
-
+    t = Symbol('t')
 	for g in [
 			Point(x, x),
 			Plane(Point(0, x), Point(x, 0), Point(x, x)),

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, Rational, S, pi
 from sympy.geometry import (Circle, Ellipse, Point, Line, Parabola,
-    Plane, Curve, Polygon, Ray, RegularPolygon, Segment, Triangle)
+    Polygon, Ray, RegularPolygon, Segment, Triangle)
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises
 

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -103,17 +103,17 @@ def test_geometry_EvalfMixin():
 	y = x.n(2)
     t = Symbol('t')
 	for g in [
-			Point(x, x),
-			Plane(Point(0, x), Point(x, 0), Point(x, x)),
-			Curve((x*t, x), (t, 0, x)),
-			Ellipse((x, x), x, 2*x),
-			Circle((x, x), x),
-			Line((0, x), (x, 0)),
-			Segment((0, x), (x, 0)),
-			Ray((0, x), (x, 0)),
-			Parabola((0, x), Line((-x, 0), (x, 0))),
-			Polygon((0, 0), (0, x), (x, 0), (x, x)),
-			RegularPolygon((0, x), x, 4),
-			Triangle((0, 0), (x, 0), (x, x)),
-			]:
-		assert g.n(2) == g.xreplace({x:y})
+            Point(x, x),
+            Plane(Point(0, x), Point(x, 0), Point(x, x)),
+            Curve((x*t, x), (t, 0, x)),
+            Ellipse((x, x), x, 2*x),
+            Circle((x, x), x),
+            Line((0, x), (x, 0)),
+            Segment((0, x), (x, 0)),
+            Ray((0, x), (x, 0)),
+            Parabola((0, x), Line((-x, 0), (x, 0))),
+            Polygon((0, 0), (0, x), (x, 0), (x, x)),
+            RegularPolygon((0, x), x, 4),
+            Triangle((0, 0), (x, 0), (x, x)),
+            ]:
+        assert g.n(2) == g.xreplace({x:y})


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes #22109 , https://github.com/sympy/sympy/issues/22109#issuecomment-921785187 and now Point2D will subclass `EvalfMixin` .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
