### PR TITLE
Fixed syntax error

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -336,7 +336,7 @@ class Relational(Boolean, EvalfMixin):
                         else:
                             r = r.func(x, -b / m)
                     else:
-                        r = r.func(b, S.zero)
+                        r = r.func(b, S.Zero)
                 except ValueError:
                     # maybe not a linear function, try polynomial
                     from sympy.polys import Poly, poly, PolynomialError, gcd
@@ -375,7 +375,7 @@ class Relational(Boolean, EvalfMixin):
                             r = r.func(lhsterm, -newexpr)
 
                     else:
-                        r = r.func(constant, S.zero)
+                        r = r.func(constant, S.Zero)
                 except ValueError:
                     pass
         # Did we get a simplified result?

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
                    Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
                    log, cos, sin, Add, Mul, Pow, floor, ceiling, trigsimp, Reals,
-                   Basic, Expr, Q)
+                   Basic, Expr, Q, exp, exp_polar)
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -786,6 +786,13 @@ def test_simplify_relational():
     assert Lt(-x, -2).simplify() == Gt(x, 2)
     assert Lt(x, 2).simplify() == Lt(x, 2)
     assert Lt(-x, 2).simplify() == Gt(x, -2)
+
+    # Test particulat branches of _eval_simplify
+    m = exp(1) - exp_polar(1)
+    assert simplify(m*x > 1) is S.false
+    # These two tests the same branch
+    assert simplify(m*x + 2*m*y > 1) is S.false
+    assert simplify(m*x + y > 1 + y) is S.false
 
 
 def test_equals():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -1,4 +1,4 @@
-from sympy.core import Rational
+from sympy.core import Rational, S
 from sympy.simplify import simplify, trigsimp
 from sympy import pi, sqrt, symbols, ImmutableMatrix as Matrix, \
      sin, cos, Function, Integral, Derivative, diff
@@ -220,9 +220,10 @@ def test_projection():
     v3 = 0*i + 0*j
     assert v1.projection(v1) == i + j + k
     assert v1.projection(v2) == Rational(7, 3)*C.i + Rational(7, 3)*C.j + Rational(7, 3)*C.k
-    assert v1.projection(v1, scalar=True) == 1
+    assert v1.projection(v1, scalar=True) == S.One
     assert v1.projection(v2, scalar=True) == Rational(7, 3)
     assert v3.projection(v1) == Vector.zero
+    assert v3.projection(v1, scalar=True) == S.Zero
 
 
 def test_vector_diff_integrate():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -234,7 +234,7 @@ class Vector(BasisDependent):
 
         """
         if self.equals(Vector.zero):
-            return S.zero if scalar else Vector.zero
+            return S.Zero if scalar else Vector.zero
 
         if scalar:
             return self.dot(other) / self.dot(self)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Three instances of `S.zero` changed to `S.Zero`.

#### Other comments
I cannot figure out tests for the relational. What I would need is an expression which returns `True` for `.is_zero`, but does not evaluate or simplify to 0. (Using `evaluate=False` is not really an option, unless running the whole test part with it.)

Will backport to 1.9 if this seems OK.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
