### PR TITLE
ZeroMatrix and OneMatrix print as 0 and 1 in LaTeX mat_symbol_style='…

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1762,11 +1762,11 @@ class LatexPrinter(Printer):
             'mat_symbol_style'])
 
     def _print_ZeroMatrix(self, Z):
-        return r"\mathbb{0}" if self._settings[
+        return "0" if self._settings[
             'mat_symbol_style'] == 'plain' else r"\mathbf{0}"
 
     def _print_OneMatrix(self, O):
-        return r"\mathbb{1}" if self._settings[
+        return "1" if self._settings[
             'mat_symbol_style'] == 'plain' else r"\mathbf{1}"
 
     def _print_Identity(self, I):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1922,13 +1922,13 @@ def test_ElementwiseApplyFunction():
 
 def test_ZeroMatrix():
     from sympy import ZeroMatrix
-    assert latex(ZeroMatrix(1, 1), mat_symbol_style='plain') == r"\mathbb{0}"
+    assert latex(ZeroMatrix(1, 1), mat_symbol_style='plain') == r"0"
     assert latex(ZeroMatrix(1, 1), mat_symbol_style='bold') == r"\mathbf{0}"
 
 
 def test_OneMatrix():
     from sympy import OneMatrix
-    assert latex(OneMatrix(3, 4), mat_symbol_style='plain') == r"\mathbb{1}"
+    assert latex(OneMatrix(3, 4), mat_symbol_style='plain') == r"1"
     assert latex(OneMatrix(3, 4), mat_symbol_style='bold') == r"\mathbf{1}"
 
 


### PR DESCRIPTION
…plain'

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier `ZeroMatrix` and `OneMatrix` printed as `\mathbb{0}` and `\mathbb{1}` which one could think gives 
![mathematical_doublestruck_digit_zero](https://user-images.githubusercontent.com/8114497/133893206-acb3ef9c-1f48-4a14-adf9-1bd8377f5628.png)
and 
![mathematical_doublestruck_digit_one](https://user-images.githubusercontent.com/8114497/133893216-6ff5c08e-818f-4abb-9f0f-f4473df3bd31.png)

However, they do give (without any additional packages): 
![image](https://user-images.githubusercontent.com/8114497/133893227-25044028-3d46-44f3-b1df-fb8c63f4efc3.png)
and 
![image](https://user-images.githubusercontent.com/8114497/133893230-703b06b1-61f7-4b36-8f0f-a9ec0ce364e3.png)

Here, I have changed them to just give 0 and 1, unless `mat_symbol_style = 'bold'`, then, as before, `\mathbf{0}` and `\mathbf{1}`.

CC: @smichr @Upabjojr 

#### Other comments
Maybe we should just use `\mathbf{0}` and `\mathbf{1}` all the time?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Fixed LaTeX printing of `ZeroMatrix` and `OneMatrix` 
<!-- END RELEASE NOTES -->
