### PR TITLE
fix(printing): suppress printing default Heaviside arg

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -493,6 +493,14 @@ class Heaviside(Function):
             H0 = S.Half
         return super(cls, cls).__new__(cls, arg, H0, **options)
 
+    @property
+    def pargs(self):
+        """Args without default S.Half"""
+        args = self.args
+        if args[1] is S.Half:
+            args = args[:1]
+        return args
+
     @classmethod
     def eval(cls, arg, H0=S.Half):
         """

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -523,7 +523,7 @@ class Heaviside(Function):
         >>> from sympy.abc import x
 
         >>> Heaviside(x)
-        Heaviside(x, 1/2)
+        Heaviside(x)
 
         >>> Heaviside(19)
         1
@@ -633,10 +633,10 @@ class Heaviside(Function):
         sign(x**2 - 2*x + 1)/2 + 1/2
 
         >>> Heaviside(y).rewrite(sign)
-        Heaviside(y, 1/2)
+        Heaviside(y)
 
         >>> Heaviside(y**2 - 2*y + 1).rewrite(sign)
-        Heaviside(y**2 - 2*y + 1, 1/2)
+        Heaviside(y**2 - 2*y + 1)
 
         See Also
         ========

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -65,11 +65,11 @@ class SingularityFunction(Function):
 
     >>> expr = SingularityFunction(x, 4, 5) + SingularityFunction(x, -3, -1) - SingularityFunction(x, 0, -2)
     >>> expr.rewrite(Heaviside)
-    (x - 4)**5*Heaviside(x - 4, 1/2) + DiracDelta(x + 3) - DiracDelta(x, 1)
+    (x - 4)**5*Heaviside(x - 4) + DiracDelta(x + 3) - DiracDelta(x, 1)
     >>> expr.rewrite(DiracDelta)
-    (x - 4)**5*Heaviside(x - 4, 1/2) + DiracDelta(x + 3) - DiracDelta(x, 1)
+    (x - 4)**5*Heaviside(x - 4) + DiracDelta(x + 3) - DiracDelta(x, 1)
     >>> expr.rewrite('HeavisideDiracDelta')
-    (x - 4)**5*Heaviside(x - 4, 1/2) + DiracDelta(x + 3) - DiracDelta(x, 1)
+    (x - 4)**5*Heaviside(x - 4) + DiracDelta(x + 3) - DiracDelta(x, 1)
 
     See Also
     ========

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -90,6 +90,15 @@ def test_heaviside():
     assert unchanged(Heaviside,x, nan)
     assert Heaviside(0, nan) == nan
 
+    h0  = Heaviside(x, 0)
+    h12 = Heaviside(x, S.Half)
+    h1  = Heaviside(x, 1)
+
+    assert h0.args == h0.pargs == (x, 0)
+    assert h1.args == h1.pargs == (x, 1)
+    assert h12.args == (x, S.Half)
+    assert h12.pargs == (x,) # default 1/2 suppressed
+
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)
     assert conjugate(Heaviside(x)) == Heaviside(x)

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -123,9 +123,9 @@ def deltaintegrate(f, x):
         >>> from sympy.integrals.deltafunctions import deltaintegrate
         >>> from sympy import sin, cos, DiracDelta
         >>> deltaintegrate(x*sin(x)*cos(x)*DiracDelta(x - 1), x)
-        sin(1)*cos(1)*Heaviside(x - 1, 1/2)
+        sin(1)*cos(1)*Heaviside(x - 1)
         >>> deltaintegrate(y**2*DiracDelta(x - z)*DiracDelta(y - z), y)
-        z**2*DiracDelta(x - z)*Heaviside(y - z, 1/2)
+        z**2*DiracDelta(x - z)*Heaviside(y - z)
 
     See Also
     ========

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -2087,7 +2087,7 @@ def meijerint_inversion(f, x, t):
     >>> from sympy.abc import x, t
     >>> from sympy.integrals.meijerint import meijerint_inversion
     >>> meijerint_inversion(1/x, x, t)
-    Heaviside(t, 1/2)
+    Heaviside(t)
     """
     from sympy import exp, expand, log, Add, Mul, Heaviside
     f_ = f

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -899,11 +899,11 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     >>> f = 1/(s**2 - 1)
     >>> inverse_mellin_transform(f, s, x, (-oo, -1))
-    x*(1 - 1/x**2)*Heaviside(x - 1, 1/2)/2
+    x*(1 - 1/x**2)*Heaviside(x - 1)/2
     >>> inverse_mellin_transform(f, s, x, (-1, 1))
-    -x*Heaviside(1 - x, 1/2)/2 - Heaviside(x - 1, 1/2)/(2*x)
+    -x*Heaviside(1 - x)/2 - Heaviside(x - 1)/(2*x)
     >>> inverse_mellin_transform(f, s, x, (1, oo))
-    (1/2 - x**2/2)*Heaviside(1 - x, 1/2)/x
+    (1/2 - x**2/2)*Heaviside(1 - x)/x
 
     See Also
     ========
@@ -1409,7 +1409,7 @@ def inverse_laplace_transform(F, s, t, plane=None, **hints):
     >>> from sympy.abc import s, t
     >>> a = Symbol('a', positive=True)
     >>> inverse_laplace_transform(exp(-a*s)/s, s, t)
-    Heaviside(-a + t, 1/2)
+    Heaviside(-a + t)
 
     See Also
     ========

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -417,6 +417,9 @@ class CodePrinter(StrPrinter):
 
     _print_Expr = _print_Function
 
+    # Don't inherit the str-printer method for Heaviside to the code printers
+    _print_Heaviside = None
+
     def _print_NumberSymbol(self, expr):
         if self._settings.get("inline", False):
             return self._print(Float(expr.evalf(self._settings["precision"])))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1989,7 +1989,8 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_Heaviside(self, expr, exp=None):
-        tex = r"\theta\left(%s\right)" % self._print(expr.args[0])
+        pargs = ', '.join(self._print(arg) for arg in expr.pargs)
+        tex = r"\theta\left(%s\right)" % pargs
         if exp:
             tex = r"\left(%s\right)^{%s}" % (tex, exp)
         return tex

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -408,6 +408,9 @@ class OctaveCodePrinter(CodePrinter):
         s = ", ".join(self._print(n) for n in shape)
         return "eye(" + s + ")"
 
+    def _print_Heaviside(self, expr):
+        pargs = ', '.join(self._print(arg) for arg in expr.pargs)
+        return "heaviside(%s)" % (pargs,)
 
     def _print_lowergamma(self, expr):
         # Octave implements regularized incomplete gamma function

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -408,10 +408,6 @@ class OctaveCodePrinter(CodePrinter):
         s = ", ".join(self._print(n) for n in shape)
         return "eye(" + s + ")"
 
-    def _print_Heaviside(self, expr):
-        pargs = ', '.join(self._print(arg) for arg in expr.pargs)
-        return "heaviside(%s)" % (pargs,)
-
     def _print_lowergamma(self, expr):
         # Octave implements regularized incomplete gamma function
         return "(gammainc({1}, {0}).*gamma({0}))".format(

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -325,9 +325,10 @@ class Printer:
                     c.__name__ == classes[0].__name__ or \
                     c.__name__.endswith("Base")) + classes[i:]
             for cls in classes:
-                printmethod = '_print_' + cls.__name__
-                if hasattr(self, printmethod):
-                    return getattr(self, printmethod)(expr, **kwargs)
+                printmethodname = '_print_' + cls.__name__
+                printmethod = getattr(self, printmethodname, None)
+                if printmethod is not None:
+                    return printmethod(expr, **kwargs)
             # Unknown object, fall back to the emptyPrinter.
             return self.emptyPrinter(expr)
         finally:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -100,6 +100,13 @@ class ReprPrinter(Printer):
         r += '(%s)' % ', '.join([self._print(a) for a in expr.args])
         return r
 
+    def _print_Heaviside(self, expr):
+        # Same as _print_Function but uses pargs to suppress default value for
+        # 2nd arg.
+        r = self._print(expr.func)
+        r += '(%s)' % ', '.join([self._print(a) for a in expr.pargs])
+        return r
+
     def _print_FunctionClass(self, expr):
         if issubclass(expr, AppliedUndef):
             return 'Function(%r)' % (expr.__name__)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -157,6 +157,11 @@ class StrPrinter(Printer):
     def _print_GoldenRatio(self, expr):
         return 'GoldenRatio'
 
+    def _print_Heaviside(self, expr):
+        # Same as _print_Function but uses pargs to suppress default 1/2 for
+        # 2nd args
+        return expr.func.__name__ + "(%s)" % self.stringify(expr.pargs, ", ")
+
     def _print_TribonacciConstant(self, expr):
         return 'TribonacciConstant'
 

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -90,7 +90,7 @@ def test_Function_change_name():
     assert mcode(RisingFactorial(x, y)) == "pochhammer(x, y)"
     assert mcode(DiracDelta(x)) == "dirac(x)"
     assert mcode(DiracDelta(x, 3)) == "dirac(3, x)"
-    assert mcode(Heaviside(x)) == "heaviside(x)"
+    assert mcode(Heaviside(x)) == "heaviside(x, 1/2)"
     assert mcode(Heaviside(x, y)) == "heaviside(x, y)"
     assert mcode(binomial(x, y)) == "bincoeff(x, y)"
     assert mcode(Mod(x, y)) == "mod(x, y)"

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -90,7 +90,7 @@ def test_Function_change_name():
     assert mcode(RisingFactorial(x, y)) == "pochhammer(x, y)"
     assert mcode(DiracDelta(x)) == "dirac(x)"
     assert mcode(DiracDelta(x, 3)) == "dirac(3, x)"
-    assert mcode(Heaviside(x)) == "heaviside(x, 1/2)"
+    assert mcode(Heaviside(x)) == "heaviside(x)"
     assert mcode(Heaviside(x, y)) == "heaviside(x, y)"
     assert mcode(binomial(x, y)) == "bincoeff(x, y)"
     assert mcode(Mod(x, y)) == "mod(x, y)"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from sympy.testing.pytest import raises
-from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
+from sympy import (symbols, sympify, Function, Integer, Matrix, Abs, Heaviside,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
     sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol, Q)
 from sympy.combinatorics import Cycle, Permutation
@@ -65,6 +65,11 @@ def test_Function():
 
     sT(sin(x), "sin(Symbol('x'))")
     sT(sin, "sin")
+
+
+def test_Heaviside():
+    sT(Heaviside(x), "Heaviside(Symbol('x'))")
+    sT(Heaviside(x, 1), "Heaviside(Symbol('x'), Integer(1))")
 
 
 def test_Geometry():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,11 +1,11 @@
 from sympy import (Add, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
-    factorial, factorial2, Function, GoldenRatio, TribonacciConstant, I,
-    Integer, Integral, Interval, Lambda, Limit, Matrix, nan, O, oo, pi, Pow,
-    Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
-    symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
-    subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice,
-    Q,)
+    factorial, factorial2, Function, GoldenRatio, Heaviside,
+    TribonacciConstant, I, Integer, Integral, Interval, Lambda, Limit, Matrix,
+    nan, O, oo, pi, Pow, Rational, Float, Rel, S, sin, SparseMatrix, sqrt,
+    summation, Sum, Symbol, symbols, Wild, WildFunction, zeta, zoo, Dummy,
+    Dict, Tuple, FiniteSet, factor, subfactorial, true, false, Equivalent, Xor,
+    Complement, SymmetricDifference, AccumBounds, UnevaluatedExpr, Eq, Ne,
+    Quaternion, Subs, MatrixSymbol, MatrixSlice, Q,)
 from sympy.combinatorics.partitions import Partition
 from sympy.core import Expr, Mul
 from sympy.core.parameters import _exp_is_pow
@@ -149,6 +149,11 @@ def test_Geometry():
 
 def test_GoldenRatio():
     assert str(GoldenRatio) == "GoldenRatio"
+
+
+def test_Heaviside():
+    assert str(Heaviside(x)) == str(Heaviside(x, S.Half)) == "Heaviside(x)"
+    assert str(Heaviside(x, 1)) == "Heaviside(x, 1)"
 
 
 def test_TribonacciConstant():


### PR DESCRIPTION
Heaviside(x) was changed to have a default value of 1/2 for the second
argument rather than leaving it undefined. This changed the args from
(x,) to (x, 1/2) which then changed the output of several printers. This
commit restores the previous printing behaviour so that if the second
arg for Heaviside(x, y) is equal to the default 1/2 then it is
suppressed from printing in the str/repr/latex printers.

Fixes the printing issue from #21945 on the master branch.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
