### PR TITLE
add `limit_numerator` to Rational

### DIFF
--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -348,6 +348,22 @@ def test_Rational_new():
     assert n.q == 4
     assert n.p == -2
 
+    p = Rational(884279719003555, 281474976710656)
+    assert S.Zero.limit_numerator(1) == S.Zero
+    assert S.One.limit_numerator(0) == S.Zero
+    assert p.limit_numerator(400) == Rational(355, 113)
+    assert p.limit_numerator(100) == Rational(22, 7)
+    assert p.limit_numerator(100, proper=True) == Rational(355, 113)
+    assert S(2).limit_numerator(1) == S.One
+    assert S(2).limit_numerator(1, proper=True) == S(2)
+    p = -p
+    assert S.NegativeOne.limit_numerator(0) == S.Zero
+    assert p.limit_numerator(400) == -Rational(355, 113)
+    assert p.limit_numerator(100) == -Rational(22, 7)
+    assert p.limit_numerator(100, proper=True) == -Rational(355, 113)
+    assert S(-2).limit_numerator(1) == -S.One
+    assert S(-2).limit_numerator(1, proper=True) == -S(2)
+
 
 def test_Number_new():
     """"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

close #22094 as alternate
fixes #21681

#### Brief description of what is fixed or changed


#### Other comments

I'm not sure that the flag has the right name but it is to allow one to choose between limiting the numerator of the improper fraction or only the proper fractional part of an improper fraction. See docstring for examples of the distinction.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Rational now has a `limit_numerator` method.
<!-- END RELEASE NOTES -->
