### PR TITLE
coeff update for nc terms

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1471,25 +1471,6 @@ class Expr(Basic, EvalfMixin):
         >>> (n*m + x*m*n).coeff(m*n, right=1)
         1
 
-        >>> n, m, o, l = symbols('n m o l', commutative=False)
-        >>> (x*n + y*n + z*m).coeff(n)
-        x + y
-        >>> (n*m + n*o + o*l).coeff(n, right=1)
-        m + o
-        >>> (x*n*m*n + y*n*m*o + z*l).coeff(m, right=1)
-        x*n + y*o
-        >>> (x*n*m*n + x*n*m*o + z*l).coeff(m, right=1)
-        n + o
-        >>> (x*n*m*n + x*n*m*o + z*l).coeff(m)
-        x*n
-
-        >>> from sympy.diffgeom.rn import R2
-        >>> from sympy.diffgeom import LieDerivative
-        >>> X = R2.x*R2.e_x - R2.y*R2.e_y
-        >>> Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
-        >>> set(LieDerivative(X, Y).expand().args) == set([R2.x**2*R2.e_x, - R2.x*R2.y*R2.e_y, - 3*R2.y**2*R2.e_x])
-        True
-
         See Also
         ========
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1586,7 +1586,7 @@ class Expr(Basic, EvalfMixin):
             return S.Zero
         if self.is_Add and not self_c and not x_c:
             # get the part that depends on x exactly
-            d = Add(*[i for i in self.as_independent(x)[1] if x in Mul.make_args(i)])
+            d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if x in Mul.make_args(i)])
             rv = d.coeff(x, right=right)
             if not rv.is_Add or not right:
                 return rv

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1369,7 +1369,7 @@ class Expr(Basic, EvalfMixin):
                                  [ci for ci in c if list(self.args).count(ci) > 1])
         return [c, nc]
 
-    def coeff(self, x, n=1, right=False):
+    def coeff(self, x, n=1, right=False, _first=True):
         """
         Returns the coefficient from the term(s) containing ``x**n``. If ``n``
         is zero then all terms independent of ``x`` will be returned.
@@ -1584,10 +1584,10 @@ class Expr(Basic, EvalfMixin):
         x_c = x.is_commutative
         if self_c and not x_c:
             return S.Zero
-        if self.is_Add and not self_c and not x_c:
+        if _first and self.is_Add and not self_c and not x_c:
             # get the part that depends on x exactly
             d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if x in Mul.make_args(i)])
-            rv = d.coeff(x, right=right)
+            rv = d.coeff(x, right=right, _first=False)
             if not rv.is_Add or not right:
                 return rv
             from sympy.utilities.iterables import has_variety

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1471,6 +1471,7 @@ class Expr(Basic, EvalfMixin):
         >>> (n*m + x*m*n).coeff(m*n, right=1)
         1
 
+        >>> n, m, o, l = symbols('n m o l', commutative=False)
         >>> (x*n + y*n + z*m).coeff(n)
         x + y
         >>> (n*m + n*o + o*l).coeff(n, right=1)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1586,7 +1586,8 @@ class Expr(Basic, EvalfMixin):
             return S.Zero
         if _first and self.is_Add and not self_c and not x_c:
             # get the part that depends on x exactly
-            d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if x in Mul.make_args(i)])
+            xargs = Mul.make_args(x)
+            d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if all(xi in Mul.make_args(i) for xi in xargs)])
             rv = d.coeff(x, right=right, _first=False)
             if not rv.is_Add or not right:
                 return rv

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1412,10 +1412,17 @@ def test_coeff():
     assert (n*m + m*n*m).coeff(n, right=True) == m  # = (1 + m)*n*m
     assert (n*m + m*n).coeff(n) == 0
     assert (n*m + o*m*n).coeff(m*n) == o
-    assert (n*m + o*m*n).coeff(m*n, right=1) == 1
-    assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
+    assert (n*m + o*m*n).coeff(m*n, right=True) == 1
+    assert (n*m + n*m*n).coeff(n*m, right=True) == 1 + n  # = n*m*(n + 1)
 
     assert (x*y).coeff(z, 0) == x*y
+
+    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (n*m + n*o + o*l).coeff(n, right=True) == m + o
+    assert (x*n*m*n + y*n*m*o + z*l).coeff(m, right=True) == x*n + y*o
+    assert (x*n*m*n + x*n*m*o + z*l).coeff(m, right=True) == n + o
+    assert (x*n*m*n + x*n*m*o + z*l).coeff(m) == x*n
+
 
 def test_coeff2():
     r, kappa = symbols('r, kappa')

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -318,3 +318,11 @@ def test_simplify():
     assert simplify(dx*dy) == dx*dy
     assert simplify(ex*ey) == ex*ey
     assert ((1-x)*dx)/(1-x)**2 == dx/(1-x)
+
+
+def test_issue_17917():
+    X = R2.x*R2.e_x - R2.y*R2.e_y
+    Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
+    assert LieDerivative(X, Y).expand() == (
+        R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y)
+

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -325,4 +325,3 @@ def test_issue_17917():
     Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
     assert LieDerivative(X, Y).expand() == (
         R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y)
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16752
closes #21986 as alternative

TODO
- [x] check that `(x*n + x*n*m).coeff(x*n)` works as expected

#### Brief description of what is fixed or changed

Sums of non-commutative terms are now handled correctly when extracting a coefficient.

#### Other comments

The commutative coefficient is only included as a right-coefficient of a non-commutative term when multiple terms have different commutative factors. If the commutative factors are the same then they will only be extracted as a left-coefficient so
```python
(x*n + x*n*m).coeff(n, right=1) -> 1 + m
(x*n + x*n*m).coeff(n) -> x
factor_nc(x*n + x*n*m) -> x*n*(1 + m)

(y*n + x*n*m).coeff(n, right=1) -> y + x*m
(y*n + x*n*m).coeff(n) -> 1
factor_nc(y*n + x*n*m) -> n*(y + x*m)
```

If #22138 were fixed then the simplest fix for this issue would be
```python
if self.is_Add and not self_c and not x_c:
            xargs = Mul.make_args(x)
            d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if all(xi in Mul.make_args(i) for xi in xargs)])
            f = factor_nc(d)
            if f.is_Add:
                return S.Zero
            return f.coeff(x, right=right)
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Expr.coeff improved in handling of non-commutative sums
<!-- END RELEASE NOTES -->
