### PR TITLE
improve Expr.coeff for noncommutative sums

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1630,7 +1630,7 @@ class Expr(Basic, EvalfMixin):
                         if right:
                             np = n[:ii]
                         else:
-                            np = n[ii+len(nx):]
+                            np = n[ii + len(nx):]
                     else:
                         if right:
                             if n[:ii] != np:
@@ -1639,11 +1639,11 @@ class Expr(Basic, EvalfMixin):
                             if n[ii+len(nx):] != np:
                                 break
                     if right:
-                        hit.append(({},n[ii+len(nx):]))
+                        hit.append(({}, n[ii + len(nx):]))
                     else:
                         hit.append((r, n[:ii]))
             else:
-                if hit is not None:
+                if hit:
                     return Add(*[Mul(*(list(r) + n)) for r, n in hit])
 
             return S.Zero

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1620,22 +1620,31 @@ class Expr(Basic, EvalfMixin):
                         return Add(*[Mul(*(list(r) + n[:-len(end) + ii])) for r, n in co])
                     else:
                         return Mul(*end[ii + len(nx):])
-            # look for single match
-            hit = None
+            # look for a single hit but allow a sum of terms if each have the
+            # same remaining expression after removing coefficient
+            hit = []
             for i, (r, n) in enumerate(co):
                 ii = find(n, nx, right)
                 if ii is not None:
                     if not hit:
-                        hit = ii, r, n
+                        if not right:
+                            np = n[ii+len(nx):]
+                        else:
+                            np = n[:ii]
                     else:
-                        break
-            else:
-                if hit:
-                    ii, r, n = hit
+                        if not right:
+                            if n[ii+len(nx):] != np:
+                              break
+                        else:
+                            if n[:ii] != np:
+                                break
                     if not right:
-                        return Mul(*(list(r) + n[:ii]))
+                        hit.append((r, n[:ii]))
                     else:
-                        return Mul(*n[ii + len(nx):])
+                        hit.append(({},n[ii+len(nx):]))
+            else:
+                if hit is not None:
+                    return Add(*[Mul(*(list(r) + n)) for r, n in hit])
 
             return S.Zero
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1627,21 +1627,21 @@ class Expr(Basic, EvalfMixin):
                 ii = find(n, nx, right)
                 if ii is not None:
                     if not hit:
-                        if not right:
-                            np = n[ii+len(nx):]
-                        else:
+                        if right:
                             np = n[:ii]
-                    else:
-                        if not right:
-                            if n[ii+len(nx):] != np:
-                              break
                         else:
+                            np = n[ii+len(nx):]
+                    else:
+                        if right:
                             if n[:ii] != np:
                                 break
-                    if not right:
-                        hit.append((r, n[:ii]))
-                    else:
+                        else:
+                            if n[ii+len(nx):] != np:
+                                break
+                    if right:
                         hit.append(({},n[ii+len(nx):]))
+                    else:
+                        hit.append((r, n[:ii]))
             else:
                 if hit is not None:
                     return Add(*[Mul(*(list(r) + n)) for r, n in hit])

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,6 +1414,8 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
+    assert (x*n + y*n + z*m).coeff(n) == x+y
+    assert (n*m +n*o + o*l).coeff(n,right=1) == m+o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1412,13 +1412,17 @@ def test_coeff():
     assert (n*m + m*n*m).coeff(n, right=True) == m  # = (1 + m)*n*m
     assert (n*m + m*n).coeff(n) == 0
     assert (n*m + o*m*n).coeff(m*n) == o
-    assert (n*m + o*m*n).coeff(m*n, right=1) == 1
-    assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
-    assert (x*n + y*n + z*m).coeff(n) == x + y #i issue #16752
-    assert (n*m + n*o + o*l).coeff(n, right=1) == m + o
-    assert (x*n*m*n + y*n*m*o + z*l).coeff(m, right=1) == x*n + y*o
+    assert (n*m + o*m*n).coeff(m*n, right=True) == 1
+    assert (n*m + n*m*n).coeff(n*m, right=True) == 1 + n  # = n*m*(n + 1)
 
     assert (x*y).coeff(z, 0) == x*y
+
+    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (n*m + n*o + o*l).coeff(n, right=True) == m + o
+    assert (x*n*m*n + y*n*m*o + z*l).coeff(m, right=True) == x*n + y*o
+    assert (x*n*m*n + x*n*m*o + z*l).coeff(m, right=True) == n + o
+    assert (x*n*m*n + x*n*m*o + z*l).coeff(m) == x*n
+
 
 def test_coeff2():
     r, kappa = symbols('r, kappa')

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,8 +1414,8 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
-    assert (x*n + y*n + z*m).coeff(n) == x+y
-    assert (n*m +n*o + o*l).coeff(n,right=1) == m+o
+    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (n*m + n*o + o*l).coeff(n,right=1) == m + o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1415,7 +1415,7 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
     assert (x*n + y*n + z*m).coeff(n) == x + y
-    assert (n*m + n*o + o*l).coeff(n,right=1) == m + o
+    assert (n*m + n*o + o*l).coeff(n, right=1) == m + o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1414,8 +1414,9 @@ def test_coeff():
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n  # = n*m*(n + 1)
-    assert (x*n + y*n + z*m).coeff(n) == x + y
+    assert (x*n + y*n + z*m).coeff(n) == x + y #i issue #16752
     assert (n*m + n*o + o*l).coeff(n, right=1) == m + o
+    assert (x*n*m*n + y*n*m*o + z*l).coeff(m, right=1) == x*n + y*o
 
     assert (x*y).coeff(z, 0) == x*y
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -204,11 +204,6 @@ def test_lie_derivative():
     assert LieDerivative(
         R2.e_x, TensorProduct(R2.dx, R2.dy))(R2.e_x, R2.e_y) == 0
 
-def test_issue_17917():
-    X = R2.x*R2.e_x - R2.y*R2.e_y
-    Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
-    assert simplify(LieDerivative(X, Y)) == R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y
-
 
 @nocache_fail
 def test_covar_deriv():
@@ -323,3 +318,10 @@ def test_simplify():
     assert simplify(dx*dy) == dx*dy
     assert simplify(ex*ey) == ex*ey
     assert ((1-x)*dx)/(1-x)**2 == dx/(1-x)
+
+
+def test_issue_17917():
+    X = R2.x*R2.e_x - R2.y*R2.e_y
+    Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
+    assert LieDerivative(X, Y).expand() == (
+        R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y)

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -204,6 +204,11 @@ def test_lie_derivative():
     assert LieDerivative(
         R2.e_x, TensorProduct(R2.dx, R2.dy))(R2.e_x, R2.e_y) == 0
 
+def test_issue_17917():
+    X = R2.x*R2.e_x - R2.y*R2.e_y
+    Y = (R2.x**2 + R2.y**2)*R2.e_x - R2.x*R2.y*R2.e_y
+    assert simplify(LieDerivative(X, Y)) == R2.x**2*R2.e_x - 3*R2.y**2*R2.e_x - R2.x*R2.y*R2.e_y
+
 
 @nocache_fail
 def test_covar_deriv():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16752
closes #21986 as alternative

TODO
- [x] check that `(x*n + x*n*m).coeff(x*n)` works as expected

#### Brief description of what is fixed or changed

Sums of non-commutative terms are now handled correctly when extracting a coefficient.

#### Other comments

The commutative coefficient is only included as a right-coefficient of a non-commutative term when multiple terms have different commutative factors. If the commutative factors are the same then they will only be extracted as a left-coefficient so
```python
(x*n + x*n*m).coeff(n, right=1) -> 1 + m
(x*n + x*n*m).coeff(n) -> x
factor_nc(x*n + x*n*m) -> x*n*(1 + m)

(y*n + x*n*m).coeff(n, right=1) -> y + x*m
(y*n + x*n*m).coeff(n) -> 1
factor_nc(y*n + x*n*m) -> n*(y + x*m)
```

If #22138 were fixed then the simplest fix for this issue would be
```python
if self.is_Add and not self_c and not x_c:
            xargs = Mul.make_args(x)
            d = Add(*[i for i in Add.make_args(self.as_independent(x)[1]) if all(xi in Mul.make_args(i) for xi in xargs)])
            f = factor_nc(d)
            if f.is_Add:
                return S.Zero
            return f.coeff(x, right=right)
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Expr.coeff improved in handling of non-commutative sums
<!-- END RELEASE NOTES -->
