### PR TITLE
Matrix power now fully supports .as_explicit()

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -312,6 +312,10 @@ class MatrixExpr(Expr):
                 with a single index.'''))
         raise IndexError("Invalid index, wanted %s[i,j]" % self)
 
+    def _is_shape_symbolic(self) -> bool:
+        return (not isinstance(self.rows, (SYMPY_INTS, Integer))
+            or not isinstance(self.cols, (SYMPY_INTS, Integer)))
+
     def as_explicit(self):
         """
         Returns a dense Matrix with elements represented explicitly
@@ -336,8 +340,7 @@ class MatrixExpr(Expr):
         as_mutable: returns mutable Matrix type
 
         """
-        if (not isinstance(self.rows, (SYMPY_INTS, Integer))
-            or not isinstance(self.cols, (SYMPY_INTS, Integer))):
+        if self._is_shape_symbolic():
             raise ValueError(
                 'Matrix with symbolic shape '
                 'cannot be represented explicitly.')

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -4,8 +4,7 @@ from .special import Identity
 from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from ... import cacheit, Integer
-from ...external.gmpy import SYMPY_INTS
+from ... import cacheit
 
 
 class MatPow(MatrixExpr):
@@ -48,7 +47,7 @@ class MatPow(MatrixExpr):
             # We still have a MatPow, make an explicit MatMul out of it.
             if A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
-            elif isinstance(self.rows, (SYMPY_INTS, Integer)) and isinstance(self.cols, (SYMPY_INTS, Integer)):
+            elif not self._is_shape_symbolic():
                 return A._get_explicit_matrix()[i, j]
             else:
                 # Leave the expression unevaluated:

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -4,7 +4,8 @@ from .special import Identity
 from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from ... import cacheit
+from ... import cacheit, Integer
+from ...external.gmpy import SYMPY_INTS
 
 
 class MatPow(MatrixExpr):
@@ -47,7 +48,7 @@ class MatPow(MatrixExpr):
             # We still have a MatPow, make an explicit MatMul out of it.
             if A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
-            elif A.exp.is_number:
+            elif isinstance(self.rows, (SYMPY_INTS, Integer)) and isinstance(self.cols, (SYMPY_INTS, Integer)):
                 return A._get_explicit_matrix()[i, j]
             else:
                 # Leave the expression unevaluated:

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -4,6 +4,7 @@ from .special import Identity
 from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
+from ... import cacheit
 
 
 class MatPow(MatrixExpr):
@@ -35,6 +36,10 @@ class MatPow(MatrixExpr):
     def shape(self):
         return self.base.shape
 
+    @cacheit
+    def _get_explicit_matrix(self):
+        return self.base.as_explicit()**self.exp
+
     def _entry(self, i, j, **kwargs):
         from sympy.matrices.expressions import MatMul
         A = self.doit()
@@ -42,12 +47,8 @@ class MatPow(MatrixExpr):
             # We still have a MatPow, make an explicit MatMul out of it.
             if A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
-            #elif A.exp.is_Integer and self.exp.is_negative:
-            # Note: possible future improvement: in principle we can take
-            # positive powers of the inverse, but carefully avoid recursion,
-            # perhaps by adding `_entry` to Inverse (as it is our subclass).
-            # T = A.base.as_explicit().inverse()
-            # A = MatMul(*[T for k in range(-A.exp)])
+            elif A.exp.is_number:
+                return A._get_explicit_matrix()[i, j]
             else:
                 # Leave the expression unevaluated:
                 from sympy.matrices.expressions.matexpr import MatrixElement

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, MatrixSymbol, MatPow, BlockMatrix, KroneckerDelta,
         Identity, ZeroMatrix, ImmutableMatrix, eye, Sum, Dummy, trace,
-        Symbol)
+        Symbol, sqrt)
 from sympy.testing.pytest import raises, XFAIL
 from sympy.matrices.expressions.matexpr import MatrixElement, MatrixExpr
 
@@ -51,7 +51,22 @@ def test_pow_index():
     assert Q[0, 0] == A[0, 0]**2 + A[0, 1]*A[1, 0]
     n = symbols("n")
     Q2 = A**n
-    assert Q2[0, 0] == MatrixElement(Q2, 0, 0)
+    assert Q2[0, 0] == 2*(
+            -sqrt((A[0, 0] + A[1, 1])**2 - 4*A[0, 0]*A[1, 1] +
+            4*A[0, 1]*A[1, 0])/2 + A[0, 0]/2 + A[1, 1]/2
+        )**n * \
+        A[0, 1]*A[1, 0]/(
+            (sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] +
+                  A[1, 1]**2) + A[0, 0] - A[1, 1])*
+            sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] + A[1, 1]**2)
+        ) - 2*(
+            sqrt((A[0, 0] + A[1, 1])**2 - 4*A[0, 0]*A[1, 1] +
+            4*A[0, 1]*A[1, 0])/2 + A[0, 0]/2 + A[1, 1]/2
+        )**n * A[0, 1]*A[1, 0]/(
+            (-sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] +
+            A[1, 1]**2) + A[0, 0] - A[1, 1])*
+            sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] + A[1, 1]**2)
+        )
 
 
 def test_transpose_index():

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,8 +1,9 @@
+from sympy import sqrt
 from sympy.simplify.powsimp import powsimp
 from sympy.testing.pytest import raises
 from sympy.core.expr import unchanged
 from sympy.core import symbols, S
-from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix, OneMatrix
+from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix, OneMatrix, Matrix
 from sympy.matrices.common import NonSquareMatrixError
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
 from sympy.matrices.expressions.inverse import Inverse
@@ -43,6 +44,27 @@ def test_as_explicit_symbol():
         [(X ** n)[0, 0], (X ** n)[0, 1]],
         [(X ** n)[1, 0], (X ** n)[1, 1]],
     ])
+
+    a = MatrixSymbol("a", 3, 1)
+    b = MatrixSymbol("b", 3, 1)
+    c = MatrixSymbol("c", 3, 1)
+
+    expr = (a.T*b)**S.Half
+    assert expr.as_explicit() == Matrix([[sqrt(a[0, 0]*b[0, 0] + a[1, 0]*b[1, 0] + a[2, 0]*b[2, 0])]])
+
+    expr = c*(a.T*b)**S.Half
+    m = sqrt(a[0, 0]*b[0, 0] + a[1, 0]*b[1, 0] + a[2, 0]*b[2, 0])
+    assert expr.as_explicit() == Matrix([[c[0, 0]*m], [c[1, 0]*m], [c[2, 0]*m]])
+
+    expr = (a*b.T)**S.Half
+    denom = sqrt(a[0, 0]*b[0, 0] + a[1, 0]*b[1, 0] + a[2, 0]*b[2, 0])
+    expected = (a*b.T).as_explicit()/denom
+    assert expr.as_explicit() == expected
+
+    expr = X**-1
+    det = X[0, 0]*X[1, 1] - X[1, 0]*X[0, 1]
+    expected = Matrix([[X[1, 1], -X[0, 1]], [-X[1, 0], X[0, 0]]])/det
+    assert expr.as_explicit() == expected
 
 
 def test_as_explicit_matrix():

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -66,6 +66,9 @@ def test_as_explicit_symbol():
     expected = Matrix([[X[1, 1], -X[0, 1]], [-X[1, 0], X[0, 0]]])/det
     assert expr.as_explicit() == expected
 
+    expr = X**m
+    assert expr.as_explicit() == X.as_explicit()**m
+
 
 def test_as_explicit_matrix():
     A = ImmutableMatrix([[1, 2], [3, 4]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Method `.as_explicit()` applied on `MatPow` objects was returning the full explicit matrix only when the exponent was a positive integer. In all other cases, a fake explicit matrix was returned (i.e. the matrix expression in the base of the `MatPow` object was not made explicit).

This PR fixes this issue and extends the explicit matrix to all exponents. Only matrices with symbolic shapes won't get an explicit form.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
