### PR TITLE
maint(core): undeprecate expr_free_symbols

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -509,10 +509,6 @@ class Basic(Printable, metaclass=ManagedProperties):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-        SymPyDeprecationWarning(feature="expr_free_symbols method",
-                                issue=21494,
-                                deprecated_since_version="1.9").warn()
         return set()
 
     def as_dummy(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2430,9 +2430,6 @@ class Expr(Basic, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy.utilities.exceptions import SymPyDeprecationWarning
-        >>> import warnings
-        >>> warnings.simplefilter("ignore", SymPyDeprecationWarning)
         >>> from sympy.abc import x, y
         >>> (x + y).expr_free_symbols
         {x, y}
@@ -2447,10 +2444,6 @@ class Expr(Basic, EvalfMixin):
         >>> t.free_symbols
         {x, y}
         """
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-        SymPyDeprecationWarning(feature="expr_free_symbols method",
-                                issue=21494,
-                                deprecated_since_version="1.9").warn()
         return {j for i in self.args for j in i.expr_free_symbols}
 
     def could_extract_minus_sign(self):
@@ -3945,10 +3938,6 @@ class AtomicExpr(Atom, Expr):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-        SymPyDeprecationWarning(feature="expr_free_symbols method",
-                                issue=21494,
-                                deprecated_since_version="1.9").warn()
         return {self}
 
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2321,10 +2321,6 @@ class Subs(Expr):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-        SymPyDeprecationWarning(feature="expr_free_symbols method",
-                                issue=21494,
-                                deprecated_since_version="1.9").warn()
         return (self.expr.expr_free_symbols - set(self.variables) |
             set(self.point.expr_free_symbols))
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2133,9 +2133,3 @@ def test_non_string_equality():
 
     assert (x == BadRepr()) is False
     assert (x != BadRepr()) is True
-
-
-def test_21494():
-    from sympy.testing.pytest import warns_deprecated_sympy
-    with warns_deprecated_sympy():
-        assert x.expr_free_symbols == {x}

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -350,10 +350,6 @@ class Indexed(Expr):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-        SymPyDeprecationWarning(feature="expr_free_symbols method",
-                                issue=21494,
-                                deprecated_since_version="1.9").warn()
         return {self}
 
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -34,7 +34,6 @@ excluded_attrs = {
     '_assumptions',  # This is a local cache that isn't automatically filled on creation
     '_mhash',   # Cached after __hash__ is called but set to None after creation
     'is_EmptySet',  # Deprecated from SymPy 1.5. This can be removed when is_EmptySet is removed.
-    'expr_free_symbols',  # Deprecated from SymPy 1.9. This can be removed when exr_free_symbols is removed.
     '_mat', # Deprecated from SymPy 1.9. This can be removed when Matrix._mat is removed
     '_smat', # Deprecated from SymPy 1.9. This can be removed when SparseMatrix._smat is removed
     }


### PR DESCRIPTION
The expr_free_symbols property was deprecated in GH-21485 but as
discussed in GH-21494 was being used by pycalphad because of the bug
reported there. It is too late in the release process to fix the
underlying issues so this commit undeprecates expr_free_symbols in the
1.9 branch while a broader fix is worked out for the SymPy 1.10 release.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
