### PR TITLE
maint(release): don't guess previous version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
 env:
   release_branch: 1.9
   release_version: 1.9rc1
+  previous_version: 1.8
 
 jobs:
 
@@ -37,7 +38,7 @@ jobs:
           python-version: 3.9
 
       - name: Build release files
-        run: release/ci_release_script.sh ${{ env.release_version }}
+        run: release/ci_release_script.sh ${{ env.release_version }} ${{ env.previous_version }}
 
       - name: Store release files
         uses: actions/upload-artifact@v2

--- a/release/ci_release_script.sh
+++ b/release/ci_release_script.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# Run
+#
+#   $ release/ci_release_script.sh version prevversion releasedir
+#
+# Example:
+#
+#   $ release/ci_release_script.sh 1.9rc1 1.8 release-1.9rc1
 
 release/aptinstall.sh
 
@@ -9,4 +17,4 @@ pip install -U pip wheel
 pip install -r release/requirements.txt
 pip install -e .
 
-python release/releasecheck.py $1 release-$1
+python release/releasecheck.py $1 $2 release-$1

--- a/release/releasecheck.py
+++ b/release/releasecheck.py
@@ -3,7 +3,7 @@
 from os.path import join, basename, normpath
 from subprocess import check_call
 
-def main(version, outdir):
+def main(version, prevversion, outdir):
     check_version(version, outdir)
     run_stage(['bin/mailmap_update.py'])
     run_stage(['bin/authors_update.py'])
@@ -14,7 +14,7 @@ def main(version, outdir):
     run_stage(['release/test_install.py', version, outdir])
     run_stage(['release/build_docs.py', version, outdir])
     run_stage(['release/sha256.py', version, outdir])
-    run_stage(['release/authors.py', version, outdir])
+    run_stage(['release/authors.py', version, prevversion, outdir])
 
 
 def green(text):


### PR DESCRIPTION
The release script attempts to identify new authors by guessing the
correct tag for the previous SymPy release but this fails under a number
of scenarios such as if the current release tag is for a merge commit or
if the previous release tag has not ultimately been merged into master.
This commit prevents trying to guess the tag and instead requires the
previous version to be provided explicitly.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Issue tracking the release of SymPy 1.9: #22008

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
