### PR TITLE
parse_expr converts builtin abs, max, min, pow

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -8,6 +8,8 @@ from keyword import iskeyword
 import ast
 import unicodedata
 from io import StringIO
+import builtins
+import types
 
 from sympy.assumptions.ask import AssumptionKeys
 from sympy.core.basic import Basic
@@ -15,7 +17,7 @@ from sympy.core import Symbol
 from sympy.core.function import arity, Function
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import filldedent, func_name
-
+from sympy.functions.elementary.miscellaneous import Max, Min
 
 
 def _token_splittable(token):
@@ -1072,6 +1074,14 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
                 raise TypeError(filldedent('''
                     a transformation should be function that
                     takes 3 arguments'''))
+
+    builtins_dict = vars(builtins)
+    for name, obj in builtins_dict.items():
+        if isinstance(obj, types.BuiltinFunctionType):
+            global_dict[name] = obj
+    global_dict['max'] = Max
+    global_dict['min'] = Min
+
     code = stringify_expr(s, local_dict, global_dict, transformations)
 
     if not evaluate:

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -318,3 +318,15 @@ def test_parsing_definitions():
     assert T[:5, 8] == standard_transformations + (t[8],)
     assert parse_expr('0.3x^2', transformations='all') == 3*x**2/10
     assert parse_expr('sin 3x', transformations='implicit') == sin(3*x)
+
+
+def test_builtins():
+    cases = [
+        ('abs(x)', 'Abs(x)'),
+        ('max(x, y)', 'Max(x, y)'),
+        ('min(x, y)', 'Min(x, y)'),
+        ('pow(x, y)', 'Pow(x, y)'),
+    ]
+    for built_in_func_call, sympy_func_call in cases:
+        assert parse_expr(built_in_func_call) == parse_expr(sympy_func_call)
+    assert str(parse_expr('pow(38, -1, 97)')) == '23'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17811
#### Brief description of what is fixed or changed

See https://github.com/sympy/sympy/issues/17811#issuecomment-547191254
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * parse_expr converts builtin abs, max, min, pow to sympy functions
<!-- END RELEASE NOTES -->
