### PR TITLE
series - added fix for sympifying expr in Order.contains

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -371,6 +371,7 @@ class Order(Expr):
         (e.g. when self and expr have different symbols).
         """
         from sympy import powsimp
+        expr = sympify(expr)
         if expr.is_zero:
             return True
         if expr is S.NaN:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -446,3 +446,7 @@ def test_issue_15539():
 
 def test_issue_18606():
     assert unchanged(Order, 0)
+
+
+def test_issue_22165():
+    assert O(log(x)).contains(2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #22165 by sympifying `expr` in the contains method and now `O(log(x)).contains(2)` returns `True` instead of error. Also added a test case function `test_issue_22165()` .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
   * fixed bug in Order.contains
<!-- END RELEASE NOTES -->
