### PR TITLE
Added powsimp simplification to limits tending to `oo`

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -175,20 +175,20 @@ class Limit(Expr):
         return isyms
 
 
-    def pow_heuristics(self):
+    def pow_heuristics(self, e):
         from sympy import exp, log
-        expr, z, z0, _ = self.args
-        b, e = expr.base, expr.exp
-        if not b.has(z):
-            res = limit(e*log(b), z, z0)
+        _, z, z0, _ = self.args
+        b1, e1 = e.base, e.exp
+        if not b1.has(z):
+            res = limit(e1*log(b1), z, z0)
             return exp(res)
 
-        ex_lim = limit(e, z, z0)
-        base_lim = limit(b, z, z0)
+        ex_lim = limit(e1, z, z0)
+        base_lim = limit(b1, z, z0)
 
         if base_lim is S.One:
             if ex_lim in (S.Infinity, S.NegativeInfinity):
-                res = limit(e*(b - 1), z, z0)
+                res = limit(e1*(b1 - 1), z, z0)
                 return exp(res)
         if base_lim is S.NegativeInfinity and ex_lim is S.Infinity:
             return S.ComplexInfinity
@@ -207,7 +207,7 @@ class Limit(Expr):
         hints : optional keyword arguments
             To be passed to ``doit`` methods; only used if deep is True.
         """
-        from sympy import Abs, sign
+        from sympy import Abs, powsimp, sign
 
         e, z, z0, dir = self.args
 
@@ -295,8 +295,9 @@ class Limit(Expr):
             coeff, ex = newe.leadterm(z, cdir=cdir)
         except (ValueError, NotImplementedError, PoleError):
             # The NotImplementedError catching is for custom functions
+            e = powsimp(e)
             if e.is_Pow:
-                r = self.pow_heuristics()
+                r = self.pow_heuristics(e)
                 if r is not None:
                     return r
         else:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1010,3 +1010,7 @@ def test_issue_21756():
 def test_issue_21785():
     a = Symbol('a')
     assert sqrt((-a**2 + x**2)/(1 - x**2)).limit(a, 1, '-') == I
+
+
+def test_issue_22181():
+    assert limit((-1)**x * 2**(-x), x, oo) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22181 

#### Brief description of what is fixed or changed
Previously, `(-1)**(1/n)` (1/n as sympy substitutes to bring n->0) is rewritten as `exp(I*pi/n)` and `2**(1/n)` is rewritten as `exp(log(2)/n)` which leads to the `NotImplementedError` with `(-log(2) + I*pi)`.
Now the expression is first `powsimp`lified in case it is a `Mul` with `z0` as infinite.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed a bug due to insufficient power simplification in limits
<!-- END RELEASE NOTES -->
