### PR TITLE
Fix inconsistent number substitution

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -696,7 +696,7 @@ class Number(AtomicExpr):
         return Order(S.One, *symbols)
 
     def _eval_subs(self, old, new):
-        if old == -self:
+        if old == -self and old.__class__ == self.__class__:
             return -new
         return self  # there is no other possibility
 


### PR DESCRIPTION
Currently number substitutions accross number types (Float vs Integer) behave inconsistently.
```
e = sympy.Integer(9)
e.subs(sympy.Float(9.0000),0)
```
will result in `9` (nothing gets substituted) but:
```
e = sympy.Integer(9)
e.subs(-sympy.Float(9.0000),0)
```
will result in `0` (the substitution is applied).

This is because in the first case, the decision to not substitute is made by `_aresame` https://github.com/sympy/sympy/blob/master/sympy/core/basic.py#L1959 which checks for the class of the number, whereas in the second case the decision is made in `Number._eval_subs` which does not.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Changed `Number._eval_subs` to perform a substitution only if the two number are of the same class.

#### Other comments

I guess another option to fix the inconsistency would be to use `_aresame` inside `Number._eval_subs` though `_aresame` is supposed to be private:
```
if _aresame(old, -self):
```
This way the two behaviors won't diverge again.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
    * Fix bug in substitution of different classes of numbers

<!-- END RELEASE NOTES -->
