### PR TITLE
POC: Short-circuit int objects in Basic.__eq__ and Expr.__eq__

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -334,6 +334,9 @@ class Basic(Printable, metaclass=ManagedProperties):
         if self is other:
             return True
 
+        if isinstance(other, int):
+            return False
+
         tself = type(self)
         tother = type(other)
         if tself is not tother:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -143,6 +143,8 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
+        if isinstance(other, int):
+            return False
         try:
             other = _sympify(other)
             if not isinstance(other, Expr):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -339,6 +339,9 @@ class BooleanTrue(BooleanAtom, metaclass=Singleton):
     def __hash__(self):
         return hash(True)
 
+    def __eq__(self, other):
+        return other is True or other is true
+
     @property
     def negated(self):
         return S.false
@@ -406,6 +409,9 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
 
     def __hash__(self):
         return hash(False)
+
+    def __eq__(self, other):
+        return other is False or other is false
 
     @property
     def negated(self):


### PR DESCRIPTION
This is a proof-of-concept of an idea described at https://github.com/sympy/sympy/pull/22157#discussion_r718043707. `Basic.__eq__` and `Expr.__eq__` return False when given an `int` object. `Integer.__eq__` then overrides this to do the actual comparison (this is [already implemented](https://github.com/sympy/sympy/blob/fe125868e480747aedc14f65b8fcbeb5e3eb8089/sympy/core/numbers.py#L2251-L2253)). This also adds `BooleanTrue.__eq__` and `BooleanFalse.__eq__` since `bool` is a subtype of `int`.

What remains to be seen is if this actually provides enough of a performance gain to be worth the extra complexity. In theory, it is faster, because comparisons like `x == 1` do not need to go through sympify to create `Integer(1)` just to do the check. Indeed, `x == 1` is about 2x faster in this branch, where `x = Symbol('x')`. However, I did a preliminary check on the benchmark suite and didn't see a huge difference, so it's possible this isn't actually worth it. If it is, we should generalize this to all non-SymPy types that are known to be sympifiable, so that `__eq__` only calls `sympify` as a last resort on unknown types.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Improve the performance of == on native Python types.
<!-- END RELEASE NOTES -->
