### PR TITLE
unigen; as_set and non-Symbols; as_relational and +/-oo

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -184,7 +184,8 @@ def _monotonic_sign(self):
                     except (PolynomialError, NotImplementedError):
                         currentroots = [r for r in roots(d, x) if r.is_extended_real]
                 y = self.subs(x, x0)
-                if x.is_nonnegative and all(r <= x0 for r in currentroots):
+                if x.is_nonnegative and all(
+                        (r - x0).is_nonpositive for r in currentroots):
                     if y.is_nonnegative and d.is_positive:
                         if y:
                             return y if y.is_positive else Dummy('pos', positive=True)
@@ -195,7 +196,8 @@ def _monotonic_sign(self):
                             return y if y.is_negative else Dummy('neg', negative=True)
                         else:
                             return Dummy('npos', nonpositive=True)
-                elif x.is_nonpositive and all(r >= x0 for r in currentroots):
+                elif x.is_nonpositive and all(
+                        (r - x0).is_nonnegative for r in currentroots):
                     if y.is_nonnegative and d.is_negative:
                         if y:
                             return Dummy('pos', positive=True)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -406,6 +406,11 @@ class Relational(Boolean, EvalfMixin):
         x = syms.pop()
         try:
             xset = solve_univariate_inequality(self, x, relational=False)
+            # check infinities
+            if self.xreplace({x: S.Infinity}) == True:
+                xset |= {S.Infinity}
+            if self.xreplace({x: S.NegativeInfinity}) == True:
+                xset |= {S.NegativeInfinity}
         except NotImplementedError:
             # solve_univariate_inequality raises NotImplementedError for
             # unsolvable equations/inequalities.

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -477,8 +477,8 @@ def test_unigen():
     from sympy import IndexedBase, Function, MatrixSymbol
     from sympy.core.exprtools import unigen
     f = Function('f')
-    for x in [a, IndexedBase("X")[a], f(a, b),
+    for i in [a, IndexedBase("X")[a], f(a, b),
             MatrixSymbol("M", 1, 1)[0, 0]]:
-        assert unigen(x + 1) == x, x
+        assert unigen(i + 1) == i, i
     assert unigen(a + b) is None
     assert unigen(f(a) + b) is None

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -448,6 +448,7 @@ def test_monotonic_sign():
     assert F((p - 1)*q + 1).is_positive
     assert F(-(p - 1)*q - 1).is_negative
 
+
 def test_issue_17256():
     from sympy import Range
     x = Symbol('x')
@@ -465,7 +466,19 @@ def test_issue_17256():
     r2 = s2.xreplace({x:a})
     assert r1 == r2
 
+
 def test_issue_21623():
     from sympy import MatrixSymbol
     M = MatrixSymbol('X', 2, 2)
     assert gcd_terms(M[0,0], 1) == M[0,0]
+
+
+def test_unigen():
+    from sympy import IndexedBase, Function, MatrixSymbol
+    from sympy.core.exprtools import unigen
+    f = Function('f')
+    for x in [a, IndexedBase("X")[a], f(a, b),
+            MatrixSymbol("M", 1, 1)[0, 0]]:
+        assert unigen(x + 1) == x, x
+    assert unigen(a + b) is None
+    assert unigen(f(a) + b) is None

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -428,15 +428,16 @@ def test_relational_logic_symbols():
 
 
 def test_univariate_relational_as_set():
-    assert (x > 0).as_set() == Interval(0, oo, True, True)
-    assert (x >= 0).as_set() == Interval(0, oo)
-    assert (x < 0).as_set() == Interval(-oo, 0, True, True)
-    assert (x <= 0).as_set() == Interval(-oo, 0)
+    from sympy import Union
+    assert (x > 0).as_set() == Union({oo}, Interval.open(0, oo))
+    assert (x >= 0).as_set() == Union({oo}, Interval(0, oo))
+    assert (x < 0).as_set() == Union({-oo}, Interval.open(-oo, 0))
+    assert (x <= 0).as_set() == Union({-oo}, Interval(-oo, 0))
     assert Eq(x, 0).as_set() == FiniteSet(0)
-    assert Ne(x, 0).as_set() == Interval(-oo, 0, True, True) + \
-        Interval(0, oo, True, True)
-
-    assert (x**2 >= 4).as_set() == Interval(-oo, -2) + Interval(2, oo)
+    assert Ne(x, 0).as_set() == Union({-oo, oo}, Interval.open(-oo, 0),
+        Interval.open(0, oo))
+    assert (x**2 >= 4).as_set() == Union({-oo, oo},
+        Interval(-oo, -2), Interval(2, oo))
 
 
 @XFAIL

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -172,17 +172,9 @@ class Piecewise(Function):
         args = []
         for e, c in _args:
             if (not c.is_Atom and not isinstance(c, Relational) and
-                not c.has(im, re)):
+                    not c.has(im, re)):
                 x = unigen(c)
                 if x is not None:
-                    funcs = [i for i in c.atoms(Function)
-                             if not isinstance(i, Boolean)]
-                    if len(funcs) == 1 and len(
-                            c.xreplace({list(funcs)[0]: Dummy()}
-                            ).free_symbols) == 1:
-                        # we can treat function like a symbol
-                        free = funcs
-                    _c = c
                     try:
                         c = c.as_set().as_relational(x)
                     except NotImplementedError:

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1149,8 +1149,9 @@ def test_unevaluated_integrals():
     # this is a test of using _solve_inequality when
     # solve_univariate_inequality fails
     assert p.integrate(y) == Piecewise(
-        (y, Eq(f(x), 1) | ((x < 10) & Eq(f(x), 1))),
-        (2*y, (x >= -oo) & (x < 10)), (0, True))
+         (y, ((x > -oo) & (x < 10) & Eq(f(x), 1)) |
+             ((x > -oo) & (x < oo) & Eq(f(x), 1))),
+         (2*y, (x > -oo) & (x < 10)), (0, True))
 
 
 def test_conditions_as_alternate_booleans():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -858,17 +858,19 @@ def test_true_false():
 
 
 def test_bool_as_set():
-    assert ITE(y <= 0, False, y >= 1).as_set() == Interval(1, oo)
+    assert ITE(y <= 0, False, y >= 1).as_set() == Union({oo}, Interval(1, oo))
     assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
-    assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
-    assert Not(x > 2).as_set() == Interval(-oo, 2)
+    assert Or(x >= 2, x <= -2).as_set() == Union(
+        {-oo, oo}, Interval(-oo, -2) + Interval(2, oo))
+    assert Not(x > 2).as_set() == Union({-oo}, Interval(-oo, 2))
     # issue 10240
     assert Not(And(x > 2, x < 3)).as_set() == \
         Union(Interval(-oo, 2), Interval(3, oo))
     assert true.as_set() == S.UniversalSet
     assert false.as_set() == EmptySet()
     assert x.as_set() == S.UniversalSet
-    assert And(Or(x < 1, x > 3), x < 2).as_set() == Interval.open(-oo, 1)
+    assert And(Or(x < 1, x > 3), x < 2).as_set() == Union(
+        {-oo}, Interval.open(-oo, 1))
     assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()
     raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1296,7 +1296,6 @@ class Union(Set, LatticeOp):
 
     def as_relational(self, symbol):
         """Rewrite a Union in terms of equalities and logic operators. """
-        from sympy.core.relational import Relational
         # make Interval(-oo, oo) -> Reals
         args = [S.Reals if i == S.Reals else i for i in self.args]
         if self == Union({S.NegativeInfinity, S.Infinity}, S.Reals):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -918,10 +918,40 @@ def test_Union_as_relational():
         Or(And(Le(0, x), Le(x, 1)), Eq(x, 2))
     assert (Interval(0, 1, True, True) + FiniteSet(1)).as_relational(x) == \
         And(Lt(0, x), Le(x, 1))
-    assert Or(x < 0, x > 0).as_set().as_relational(x) == \
-        And((x > -oo), (x < oo), Ne(x, 0))
+    assert Or(x < 0, x > 0).as_set().as_relational(x) == (x > 0) | (x < 0)
     assert (Interval.Ropen(1, 3) + Interval.Lopen(3, 5)
         ).as_relational(x) == And((x > 1), (x < 5), Ne(x, 3))
+    for r in (S.Reals, Interval(-oo, oo)):
+        assert Union({-oo, oo}, r).as_relational(x) == (x <= oo)
+        assert Union({-oo}, r).as_relational(x) == (x < oo)
+        assert Union({oo}, r).as_relational(x) == (x > -oo)
+    # these Ands generate a Union with +/-oo
+    assert And(Ne(x, 1), x < 0).as_set().as_relational(x
+        ) == (x < 0)
+    assert And(Ne(x, 1), x < 1).as_set().as_relational(x
+        ) == (x < 1)
+    assert And(Ne(x, 1), x < 2).as_set().as_relational(x
+        ) == ((x < 1) | ((S(1) < x) & (x < 2)))
+    assert And(Ne(x, 1), x <= 0).as_set().as_relational(x
+        ) == (x <= 0)
+    assert And(Ne(x, 1), x <= 1).as_set().as_relational(x
+        ) == (x < 1)
+    assert And(Ne(x, 1), x <= 2).as_set().as_relational(x
+        ) == ((x < 1) | ((x <= 2) & (S(1) < x)))
+    assert And(Ne(x, 1), x >= 0).as_set().as_relational(x
+        ) == ((x > 1) | ((S(0) <= x) & (x < 1)))
+    assert And(Ne(x, 1), x >= 1).as_set().as_relational(x
+        ) == (x > 1)
+    assert And(Ne(x, 1), x >= 2).as_set().as_relational(x
+        ) == (x >= 2)
+    assert And(Ne(x, 1), x > 0).as_set().as_relational(x
+        ) == ((x > 1) | ((S(0) < x) & (x < 1)))
+    assert And(Ne(x, 1), x > 1).as_set().as_relational(x
+        ) == (x > 1)
+    assert And(Ne(x, 1), x > 2).as_set().as_relational(x
+        ) == (x > 2)
+    assert Union({oo}, Interval(1, 2)).as_relational(x
+        ) == Eq(x, oo) | ((S(1) <= x) & (x <= 2))
 
 
 def test_Intersection_as_relational():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

fixes #22175 by introducing `unigen` which looks for the smallest symbol-like univariate generator for an expression.

fixes #22073 by returning a union to show inclusion of infinity, Relationals are unbounded and hold in extended real whereas `Interval(-oo,oo) == Reals`
```python
>>> (x>9).as_set()
Union({oo}, Interval.open(9, oo))
>>> _.as_relational(x)
x > 9
```
To maintain economy when dealing with such sets being conveted to Relationals, special tests are done to return something similar to the starting Relational. So instead of `Eq(x, oo) | (x > 9) & (x < oo)` for the above, `x > 9` is returned.


With this in place, the corner-case introduction of `=` to relationships expressed without equality in Piecewise conditions has been fixed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
