### PR TITLE
Improved sign handling in signsimp (fixes #22189)

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -528,9 +528,6 @@ class Abs(Function):
             raise TypeError("Bad argument type for Abs(): %s" % type(arg))
 
         # handle what we can
-        if arg.could_extract_minus_sign():
-            return cls(-arg)
-
         arg = signsimp(arg, evaluate=False)
         n, d = arg.as_numer_denom()
         if d.free_symbols and not n.free_symbols:

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -528,6 +528,9 @@ class Abs(Function):
             raise TypeError("Bad argument type for Abs(): %s" % type(arg))
 
         # handle what we can
+        if arg.could_extract_minus_sign():
+            return cls(-arg)
+
         arg = signsimp(arg, evaluate=False)
         n, d = arg.as_numer_denom()
         if d.free_symbols and not n.free_symbols:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -866,6 +866,7 @@ def test_issue_11413():
     U.norm = sqrt(v0**2/(v0**2 + v1**2 + v2**2) + v1**2/(v0**2 + v1**2 + v2**2) + v2**2/(v0**2 + v1**2 + v2**2))
     assert simplify(U.norm) == 1
 
+
 def test_periodic_argument():
     from sympy import (periodic_argument, unbranched_argument,
                        principal_branch, polar_lift)
@@ -962,6 +963,14 @@ def test_issue_14238():
     # doesn't cause recursion error
     r = Symbol('r', real=True)
     assert Abs(r + Piecewise((0, r > 0), (1 - r, True)))
+
+
+def test_issue_22189():
+    x = Symbol('x')
+    a = Abs(sqrt(7 - 2*x) - 2)
+    b = Abs(2 - sqrt(7 - 2*x))
+    assert a - b == S.Zero
+
 
 def test_zero_assumptions():
     nr = Symbol('nonreal', real=False, finite=True)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -402,7 +402,15 @@ def signsimp(expr, evaluate=None):
     if not isinstance(e, (Expr, Relational)) or e.is_Atom:
         return e
     if e.is_Add:
-        return e.func(*[signsimp(a, evaluate) for a in e.args])
+        if e.could_extract_minus_sign():
+            neg = True
+            e = -e
+        else:
+            neg = False
+        rv = e.func(*[signsimp(a, evaluate) for a in e.args])
+        if evaluate:
+            return -rv if neg else rv
+        return Mul(-1, rv, evaluate=False) if neg else rv
     if evaluate:
         e = e.xreplace({m: -(-m) for m in e.atoms(Mul) if -(-m) != m})
     return e

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -402,15 +402,10 @@ def signsimp(expr, evaluate=None):
     if not isinstance(e, (Expr, Relational)) or e.is_Atom:
         return e
     if e.is_Add:
-        if e.could_extract_minus_sign():
-            neg = True
-            e = -e
-        else:
-            neg = False
-        rv = e.func(*[signsimp(a, evaluate) for a in e.args])
-        if evaluate:
-            return -rv if neg else rv
-        return Mul(-1, rv, evaluate=False) if neg else rv
+        rv = e.func(*[signsimp(a) for a in e.args])
+        if not evaluate and isinstance(rv, Add) and rv.could_extract_minus_sign():
+                return Mul(S.NegativeOne, -rv, evaluate=False)
+        return rv
     if evaluate:
         e = e.xreplace({m: -(-m) for m in e.atoms(Mul) if -(-m) != m})
     return e


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22189

#### Brief description of what is fixed or changed
Based on @asmeurer's insight, `could_extract_minus_sign` is used in `Abs` to make the argument canonical with respect to sign. 

#### Other comments
One may also consider making it canonical with respect to `I` (or `exp(I*x)`), but that is left.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `Abs` use canonical argument with respect to sign of argument.  
<!-- END RELEASE NOTES -->
