### PR TITLE
meijerg indefinite_1 bug eliminated

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1045,11 +1045,16 @@ class Piecewise(Function):
             return result
 
 
-def piecewise_fold(expr):
+def piecewise_fold(expr, evaluate=True):
     """
     Takes an expression containing a piecewise function and returns the
     expression in piecewise form. In addition, any ITE conditions are
     rewritten in negation normal form and simplified.
+
+    The final Piecewise is evaluated (default) but if the raw form
+    is desired, send ``evaluate=False``; if trivial evaluation is
+    desired, send ``evaluate=None`` and duplicate conditions and
+    processing of True and False will be handled.
 
     Examples
     ========
@@ -1139,7 +1144,14 @@ def piecewise_fold(expr):
             e, c = zip(*ec)
             new_args.append((expr.func(*e), And(*c)))
 
-    return Piecewise(*new_args)
+    if evaluate is None:
+        # don't return duplicate conditions, otherwise don't evaluate
+        new_args = list(reversed([(e, c) for c, e in {
+            c: e for e, c in reversed(new_args)}.items()]))
+    rv = Piecewise(*new_args, evaluate=evaluate)
+    if evaluate is None and len(rv.args) == 1 and rv.args[0].cond == True:
+        return rv.args[0].expr
+    return rv
 
 
 def _clip(A, B, k):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -592,8 +592,17 @@ def test_piecewise_fold_expand():
     p1 = Piecewise((1, Interval(0, 1, False, True).contains(x)), (0, True))
 
     p2 = piecewise_fold(expand((1 - x)*p1))
-    assert p2 == Piecewise((1 - x, (x >= 0) & (x < 1)), (0, True))
+    cond = ((x >= 0) & (x < 1))
+    assert piecewise_fold(expand((1 - x)*p1), evaluate=False
+        ) == Piecewise((1 - x, cond), (-x, cond), (1, cond), (0, True), evaluate=False)
+    assert piecewise_fold(expand((1 - x)*p1), evaluate=None
+        ) == Piecewise((1 - x, cond), (0, True))
+    assert p2 == Piecewise((1 - x, cond), (0, True))
     assert p2 == expand(piecewise_fold((1 - x)*p1))
+    p3 = Piecewise((1, True), evaluate=False)
+    assert p3 != 1
+    assert piecewise_fold(p3, evaluate=None) == 1
+    assert piecewise_fold(p3, evaluate=False) == p3
 
 
 def test_piecewise_duplicate():

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -468,6 +468,13 @@ class Integral(AddWithLimits):
         reps = {}
         for xab in self.limits:
             if len(xab) != 3:
+                # it makes sense to just make
+                # all x real but in practice with the
+                # current state of integration...this
+                # doesn't work out well
+                # x = xab[0]
+                # if x not in reps and not x.is_real:
+                #     reps[x] = Dummy(real=True)
                 continue
             x, a, b = xab
             l = (a, b)
@@ -559,10 +566,8 @@ class Integral(AddWithLimits):
                         if res is not None:
                             f, cond = res
                             if conds == 'piecewise':
-                                ret = Piecewise(
-                                    (f, cond),
-                                    (self.func(
-                                    function, (x, a, b)), True))
+                                u = self.func(function, (x, a, b))
+                                return Piecewise((f, cond), (u, True))
                             elif conds == 'separate':
                                 if len(self.limits) != 1:
                                     raise ValueError(filldedent('''

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1748,13 +1748,13 @@ def _meijerint_indefinite_1(f, x):
         res = expand_mul(cancel(res), deep=False)
         return Add._from_args(res.as_coeff_add(x)[1])
 
-    res = piecewise_fold(res)
+    res = piecewise_fold(res, evaluate=None)
     if res.is_Piecewise:
         newargs = []
-        for expr, cond in res.args:
-            expr = _my_unpolarify(_clean(expr))
-            newargs += [(expr, cond)]
-        res = Piecewise(*newargs)
+        for e, c in res.args:
+            e = _my_unpolarify(_clean(e))
+            newargs += [(e, c)]
+        res = Piecewise(*newargs, evaluate=False)
     else:
         res = _my_unpolarify(_clean(res))
     return Piecewise((res, _my_unpolarify(cond)), (Integral(f, x), True))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -724,3 +724,9 @@ def test_issue_6462():
     # exception
     assert integrate(cos(x**n)/x**n, x, meijerg=True).subs(n, 2).equals(
             integrate(cos(x**2)/x**2, x, meijerg=True))
+
+
+def test_indefinite_1_bug():
+    assert integrate((b + t)**(-a), t, meijerg=True
+        ) == -b/(b**a*(1 + t/b)**a*(a - 1)
+        ) - t/(b**a*(1 + t/b)**a*(a - 1))

--- a/sympy/matrices/expressions/tests/test_companion.py
+++ b/sympy/matrices/expressions/tests/test_companion.py
@@ -13,7 +13,7 @@ def test_creation():
     raises(ValueError, lambda: CompanionMatrix(Poly([1], x)))
     raises(ValueError, lambda: CompanionMatrix(Poly([2, 1], x)))
     raises(ValueError, lambda: CompanionMatrix(Poly(x*y, [x, y])))
-    unchanged(CompanionMatrix, Poly([1, 2, 3], x))
+    assert unchanged(CompanionMatrix, Poly([1, 2, 3], x))
 
 
 def test_shape():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The loop over expr, cond overwrote the previously defined cond. A test was added to show that this will fail if it is not changed: an unevaluated integral results. The result that is there is confirmed for this case:

```python
>>> integrate((b + t)**(-a), (t),meijerg=True).subs(b,1).subs(a,2)
-t/(t + 1)**2 - 1/(t + 1)**2
>>> simplify(_)
1/(-t - 1)
>>> signsimp(_)
-1/(t + 1)
>>> integrate(((b + t)**(-a)).subs(b,1).subs(a,2), t)
-1/(t + 1)
```
#### Other comments

An evaluate option was given to `piecewise_fold`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `piecewise_fold` has the option to avoid evaluation
* integrals
    * a bug in indefinite meijerg integration was fixed
<!-- END RELEASE NOTES -->
