### PR TITLE
Better return values and used S.Half

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -74,27 +74,27 @@ def _monotonic_sign(self):
         s = self
         if s.is_prime:
             if s.is_odd:
-                return S(3)
+                return Integer(3)
             else:
-                return S(2)
+                return Integer(2)
         elif s.is_composite:
             if s.is_odd:
-                return S(9)
+                return Integer(9)
             else:
-                return S(4)
+                return Integer(4)
         elif s.is_positive:
             if s.is_even:
                 if s.is_prime is False:
-                    return S(4)
+                    return Integer(4)
                 else:
-                    return S(2)
+                    return Integer(2)
             elif s.is_integer:
                 return S.One
             else:
                 return _eps
         elif s.is_extended_negative:
             if s.is_even:
-                return S(-2)
+                return Integer(-2)
             elif s.is_integer:
                 return S.NegativeOne
             else:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -561,7 +561,7 @@ class Pow(Expr):
                 return log(self.base).is_imaginary
 
     def _eval_is_extended_negative(self):
-        if self.exp is S(1)/2:
+        if self.exp is S.Half:
             if self.base.is_complex or self.base.is_extended_real:
                 return False
         if self.base.is_extended_negative:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -442,7 +442,7 @@ def test_issue_3982():
 
 
 def test_S_sympify():
-    assert S(1)/2 == sympify(1)/2
+    assert S(1)/2 == sympify(1)/2 == S.Half
     assert (-2)**(S(1)/2) == sqrt(2)*I
 
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -219,7 +219,7 @@ class factorial(CombinatorialFunction):
                     # its inverse (if n > 4 is a composite number, then
                     # (n-1)! = 0 mod n)
                     if isprime:
-                        return S(-1 % q)
+                        return -1 % q
                     elif isprime is False and (aq - 6).is_nonnegative:
                         return S.Zero
                 elif n.is_Integer and q.is_Integer:
@@ -232,7 +232,7 @@ class factorial(CombinatorialFunction):
                     else:
                         fc = self._facmod(n, aq)
 
-                    return S(fc % q)
+                    return fc % q
 
     def _eval_rewrite_as_gamma(self, n, piecewise=True, **kwargs):
         from sympy import gamma

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -5,7 +5,7 @@ from sympy.core.basic import sympify, cacheit
 from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool
-from sympy.core.numbers import igcdex, Rational, pi
+from sympy.core.numbers import igcdex, Rational, pi, Integer
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
@@ -198,7 +198,7 @@ def _pi_coeff(arg, cycles=1):
                 elif not c2:
                     if x.is_even is not None:  # known parity
                         return S.Zero
-                    return S(2)
+                    return Integer(2)
                 else:
                     return c2*x
             return cx

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -649,7 +649,7 @@ class Heaviside(Function):
                 ((sign(arg) + 1)/2, Ne(arg, 0)),
                 (Heaviside(0, H0=H0), True))
             pw2 = Piecewise(
-                ((sign(arg) + 1)/2, Eq(Heaviside(0, H0=H0), S(1)/2)),
+                ((sign(arg) + 1)/2, Eq(Heaviside(0, H0=H0), S.Half)),
                 (pw1, True))
             return pw2
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -384,7 +384,7 @@ class erfc(Function):
 
         # Try to pull out factors of -1
         if arg.could_extract_minus_sign():
-            return S(2) - cls(-arg)
+            return 2 - cls(-arg)
 
     @staticmethod
     @cacheit

--- a/sympy/geometry/parabola.py
+++ b/sympy/geometry/parabola.py
@@ -96,7 +96,7 @@ class Parabola(GeometrySet):
         2
 
         """
-        return S(2)
+        return 2
 
     @property
     def axis_of_symmetry(self):

--- a/sympy/physics/units/systems/cgs.py
+++ b/sympy/physics/units/systems/cgs.py
@@ -34,7 +34,7 @@ cgs_gauss = UnitSystem(
 cgs_gauss.set_quantity_scale_factor(coulombs_constant, 1)
 
 cgs_gauss.set_quantity_dimension(statcoulomb, charge)
-cgs_gauss.set_quantity_scale_factor(statcoulomb, centimeter**(S(3)/2)*gram**(S(1)/2)/second)
+cgs_gauss.set_quantity_scale_factor(statcoulomb, centimeter**(S(3)/2)*gram**(S.Half)/second)
 
 cgs_gauss.set_quantity_dimension(coulomb, charge)
 

--- a/sympy/solvers/ode/riccati.py
+++ b/sympy/solvers/ode/riccati.py
@@ -409,7 +409,7 @@ def construct_c_case_1(num, den, x, pole):
     # in the c-vector is c = (1 +- sqrt(1 + 4*r))/2
     if r != -S(1)/4:
         return [[(1 + sqrt(1 + 4*r))/2], [(1 - sqrt(1 + 4*r))/2]]
-    return [[S(1)/2]]
+    return [[S.Half]]
 
 
 def construct_c_case_2(num, den, x, pole, mul):
@@ -540,7 +540,7 @@ def construct_d_case_6(num, den, x):
     # d_(-1) = (1 +- sqrt(1 + 4*s_oo))/2
     if s_inf != -S(1)/4:
         return [[(1 + sqrt(1 + 4*s_inf))/2], [(1 - sqrt(1 + 4*s_inf))/2]]
-    return [[S(1)/2]]
+    return [[S.Half]]
 
 
 def construct_d(num, den, x, val_inf):

--- a/sympy/solvers/ode/riccati.py
+++ b/sympy/solvers/ode/riccati.py
@@ -698,7 +698,7 @@ def solve_aux_eq(numa, dena, numy, deny, x, m):
         return psol, linsolve_dict(auxeq.all_coeffs(), psyms), True
     else:
         # m == 0 . Check if 1 (x**0) is a solution to the auxiliary equation
-        return S(1), auxeq, auxeq == 0
+        return S.One, auxeq, auxeq == 0
 
 
 def remove_redundant_sols(sol1, sol2, x):

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -259,9 +259,10 @@ class MultivariateLaplaceDistribution(JointDistribution):
         x = (mu_T*sigma_inv*mu)[0]
         y = (args_T*sigma_inv*args)[0]
         v = 1 - k/2
-        return S(2)/((2*pi)**(S(k)/2)*sqrt(det(sigma)))\
-        *(y/(2 + x))**(S(v)/2)*besselk(v, sqrt((2 + x)*(y)))\
-        *exp((args_T*sigma_inv*mu)[0])
+        return (2 * (y/(2 + x))**(v/2) * besselk(v, sqrt((2 + x)*y)) *
+                exp((args_T * sigma_inv * mu)[0]) /
+                ((2 * pi)**(k/2) * sqrt(det(sigma))))
+
 
 def MultivariateLaplace(name, mu, sigma):
     """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Follow-up on useful parts from #22171 not present in #22199.

* Used `S.Half` in library code instead of `S(1)/2` (still many tests using the latter).
* Removed some not required `S` in return values
* Used `Integer` instead of `S` for constant integer returns. (Or `S.One` etc...)

#### Other comments
The removed `S` in ambient dimension is for most similar functions returns a plain `int`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
