### PR TITLE
perf(functions): speed up MinMaxBase construction

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -605,31 +605,11 @@ class MinMaxBase(Expr, LatticeOp):
         """
         Check if x and y are connected somehow.
         """
-        from sympy.core.exprtools import factor_terms
         def hit(v, t, f):
             if not v.is_Relational:
                 return t if v else f
-        for i in range(2):
-            if x == y:
-                return True
-            r = hit(x >= y, Max, Min)
-            if r is not None:
-                return r
-            r = hit(y <= x, Max, Min)
-            if r is not None:
-                return r
-            r = hit(x <= y, Min, Max)
-            if r is not None:
-                return r
-            r = hit(y >= x, Min, Max)
-            if r is not None:
-                return r
-            # simplification can be expensive, so be conservative
-            # in what is attempted
-            x = factor_terms(x - y)
-            y = S.Zero
 
-        return False
+        return True if x == y else (hit(x >= y, Max, Min) or hit(x <= y, Min, Max) or False)
 
     def _eval_derivative(self, s):
         # f(x).diff(s) -> x.diff(s) * f.fdiff(1)(s)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #16249.

#### Brief description of what is fixed or changed

This change implements the findings from the discussions in #16249 (in particular https://github.com/sympy/sympy/issues/16249#issuecomment-473165810)

#### Other comments

The script

~~~ python
from sympy import Min, symbols

Min(*symbols('x:50'))
~~~

was used to test the improvements. Profiling data before:

![before](https://user-images.githubusercontent.com/20231758/135714108-047e05cc-918a-4c65-bfe6-d335e791f2f1.png)

and after:

![after](https://user-images.githubusercontent.com/20231758/135714125-5f795fd4-dce3-4923-94c8-d8d2cfb77907.png)

The flame graphs show that the cost of calling `factor_terms` disappears.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improved the performance of Min/Max expressions.
<!-- END RELEASE NOTES -->
