### PR TITLE
Restructured the imports in simplify with related changes

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -968,7 +968,6 @@ class BaseScalarField(Expr):
         coords = point.coords(self._coord_sys)
         # XXX Calling doit  is necessary with all the Subs expressions
         # XXX Calling simplify is necessary with all the trig expressions
-        from sympy.simplify.simplify import simplify
         return simplify(coords[self._index]).doit()
 
     # XXX Workaround for limitations on the content of args
@@ -1856,8 +1855,6 @@ def intcurve_diffequ(vector_field, param, start_point, coord_sys=None):
     intcurve_series
 
     """
-    from sympy.simplify import simplify
-
     if contravariant_order(vector_field) != 1 or covariant_order(vector_field):
         raise ValueError('The supplied field was not a vector field.')
     coord_sys = coord_sys if coord_sys else start_point._coord_sys
@@ -2246,8 +2243,14 @@ class _deprecated_container:
         self.warn()
         return super().__contains__(key)
 
+
 class _deprecated_list(_deprecated_container, list):
     pass
 
+
 class _deprecated_dict(_deprecated_container, dict):
     pass
+
+
+# Import at end to avoid cyclic imports
+from sympy.simplify.simplify import simplify

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -15,7 +15,6 @@ from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.functions import factorial
 from sympy.matrices import ImmutableDenseMatrix as Matrix
-from sympy.simplify import simplify
 from sympy.solvers import solve
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -969,6 +968,7 @@ class BaseScalarField(Expr):
         coords = point.coords(self._coord_sys)
         # XXX Calling doit  is necessary with all the Subs expressions
         # XXX Calling simplify is necessary with all the trig expressions
+        from sympy.simplify.simplify import simplify
         return simplify(coords[self._index]).doit()
 
     # XXX Workaround for limitations on the content of args
@@ -1856,6 +1856,8 @@ def intcurve_diffequ(vector_field, param, start_point, coord_sys=None):
     intcurve_series
 
     """
+    from sympy.simplify import simplify
+
     if contravariant_order(vector_field) != 1 or covariant_order(vector_field):
         raise ValueError('The supplied field was not a vector field.')
     coord_sys = coord_sys if coord_sys else start_point._coord_sys

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -121,7 +121,7 @@ from functools import reduce
 from sympy import cacheit
 from sympy.core import Basic, S, oo, I, Dummy, Wild, Mul, PoleError
 
-from sympy.functions import log, exp
+from sympy.functions import log, exp, sign as _sign
 from sympy.series.order import Order
 from sympy.simplify import logcombine
 from sympy.simplify.powsimp import powsimp, powdenest
@@ -378,7 +378,6 @@ def sign(e, x):
     for x sufficiently large. [If e is constant, of course, this is just
     the same thing as the sign of e.]
     """
-    from sympy import sign as _sign
     if not isinstance(e, Basic):
         raise TypeError("e should be an instance of Basic")
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -74,8 +74,6 @@ from sympy.functions.special.hyper import (hyper, HyperRep_atanh,
         HyperRep_asin2, HyperRep_sqrts1, HyperRep_sqrts2, HyperRep_log2,
         HyperRep_cosasin, HyperRep_sinasin, meijerg)
 from sympy.polys import poly, Poly
-from sympy.series import residue
-from sympy.simplify import simplify  # type: ignore
 from sympy.simplify.powsimp import powdenest
 from sympy.utilities.iterables import sift
 
@@ -1948,6 +1946,7 @@ def hyperexpand_special(ap, bq, z):
     z = unpolarify(z)
     if z == 0:
         return S.One
+    from sympy.simplify.simplify import simplify
     if p == 2 and q == 1:
         # 2F1
         a, b, c = ap + bq
@@ -1986,6 +1985,8 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
 
     if z.is_zero:
         return S.One
+
+    from sympy.simplify.simplify import simplify
 
     z = polarify(z, subs=False)
     if rewrite == 'default':
@@ -2283,6 +2284,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
     def do_slater(an, bm, ap, bq, z, zfinal):
         # zfinal is the value that will eventually be substituted for z.
         # We pass it to _hyperexpand to improve performance.
+        from sympy.series import residue
         func = G_Function(an, bm, ap, bq)
         _, pbm, pap, _ = func.compute_buckets()
         if not can_do(pbm, pap):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
"Better" import order in simplify and a bit less top level dependencies. As much as possible is moved to the top level imports and the remaining are distributed to where they are needed (as there are returns earlier and so on).

The changes in `hyperexpand.py` are primarily to be able to top-level import that in `simplify.py`, which I think make sense as `simplify` should be the top level.

Change in `gruntz.py` is a "left-over" from a non-successful attempt to make it not import from simplify, but no harm in keeping it. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
