### PR TITLE
`_nodes` gives answer for symbolic order derivative

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -495,7 +495,8 @@ def _nodes(e):
 
     if isinstance(e, Basic):
         if isinstance(e, Derivative):
-            return _nodes(e.expr) + len(e.variables)
+            return _nodes(e.expr) + sum(i[1] if i[1].is_Number else
+                _nodes(i[1]) for i in e.variable_count)
         return _node_count(e)
     elif iterable(e):
         return 1 + sum(_nodes(ei) for ei in e)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -7,7 +7,7 @@ from sympy import (
     Matrix, MatrixSymbol, Mul, nsimplify, oo, pi, Piecewise, Poly, posify, rad,
     Rational, S, separatevars, signsimp, simplify, sign, sin,
     sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan,
-    zoo, And, Gt, Ge, Le, Or, eye)
+    zoo, And, Gt, Ge, Le, Or, eye, Derivative)
 from sympy.core.mul import _keep_coeff
 from sympy.core.expr import unchanged
 from sympy.simplify.simplify import nthroot, inversecombine
@@ -1007,6 +1007,13 @@ def test_issue_19484():
     e = x + sign(x + f(x)**3)
     assert simplify(Abs(x + f(x)**3) * e) == x*Abs(x + f(x)**3) + x + f(x)**3
 
+
 def test_issue_19161():
     polynomial = Poly('x**2').simplify()
     assert (polynomial-x**2).simplify() == 0
+
+
+def test_issue_22210():
+    d = Symbol('d', integer=True)
+    expr = 2*Derivative(sin(x), (x, d))
+    assert expr.simplify() == expr


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #22210
#### Brief description of what is fixed or changed


#### Other comments

An operation is counted for each derivative wrt a variable (so `(x, 2)` is counted twice) and symbolic orders are attributed with the count of the order, similar to what `count_ops` does:
```python
>>> Derivative(f(x), (x,y+1)).count_ops()
3
>>> Derivative(f(x), (x,y)).count_ops()
2
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
