### PR TITLE
core - fixes 21532 and count_ops will now distinguish user-defined functions from other types of objects

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3217,7 +3217,10 @@ def count_ops(expr, visual=False):
                 # if it's not in the list above we don't
                 # consider a.func something to count, e.g.
                 # Tuple, MatrixSymbol, etc...
-                o = Symbol(a.func.__name__.upper())
+                if isinstance(a.func,UndefinedFunction):
+                    o = Symbol("FUNC_" + a.func.__name__.upper())
+                else:
+                    o = Symbol(a.func.__name__.upper())
                 ops.append(o)
 
             if not a.is_Symbol:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3217,7 +3217,7 @@ def count_ops(expr, visual=False):
                 # if it's not in the list above we don't
                 # consider a.func something to count, e.g.
                 # Tuple, MatrixSymbol, etc...
-                if isinstance(a.func,UndefinedFunction):
+                if isinstance(a.func, UndefinedFunction):
                     o = Symbol("FUNC_" + a.func.__name__.upper())
                 else:
                     o = Symbol(a.func.__name__.upper())

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,6 +1,6 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor, Nand, Nor, Implies, \
-    Equivalent, MatrixSymbol, Symbol, ITE, Rel, Rational, Sum
+    Equivalent, MatrixSymbol, Symbol, ITE, Rel, Rational, Sum, Function
 from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
@@ -135,3 +135,11 @@ def test_issue_9324():
     n = Symbol('n', integer=True)
     M = MatrixSymbol('M', m + n, m * m)
     assert count(M[0, 1]) == 2
+
+
+def test_issue_21532():
+    f = Function('f')
+    g = Function('g')
+    FUNC_F, FUNC_G = symbols('FUNC_F, FUNC_G')
+    assert f(x).count_ops(visual=True) == FUNC_F
+    assert g(x).count_ops(visual=True) == FUNC_G


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21532 and now count_ops will distinguish user-defined functions from other types of objects, for example - 
```
f = Function('f')
f(x).count_ops(visual=True)
```
gives `FUNC_F` instead of `F` as output.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * added a functionality for count_ops to distinguish user-defined functions from other types of objects.
<!-- END RELEASE NOTES -->
