### PR TITLE
Fixed mat_str=array-LaTeX-printing of Array

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1798,9 +1798,6 @@ class LatexPrinter(Printer):
             block_str = r'\left' + left_delim + block_str + \
                         r'\right' + right_delim
 
-        if expr.rank() == 0:
-            return block_str % ""
-
         if mat_str == 'array':
             block_str = block_str.replace('%s', '%s%s')
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1778,7 +1778,6 @@ class LatexPrinter(Printer):
         return "P_{%s}" % perm_str
 
     def _print_NDimArray(self, expr):
-
         if expr.rank() == 0:
             return self._print(expr[()])
 
@@ -1802,6 +1801,9 @@ class LatexPrinter(Printer):
         if expr.rank() == 0:
             return block_str % ""
 
+        if mat_str == 'array':
+            block_str = block_str.replace('%s', '%s%s')
+
         level_str = [[]] + [[] for i in range(expr.rank())]
         shape_ranges = [list(range(i)) for i in expr.shape]
         for outer_i in itertools.product(*shape_ranges):
@@ -1814,8 +1816,12 @@ class LatexPrinter(Printer):
                     level_str[back_outer_i].append(
                         r" & ".join(level_str[back_outer_i+1]))
                 else:
-                    level_str[back_outer_i].append(
-                        block_str % (r"\\".join(level_str[back_outer_i+1])))
+                    str2 = r"\\".join(level_str[back_outer_i+1])
+                    if mat_str == 'array':
+                        str1 = '{' + 'c'*expr.shape[back_outer_i+1] + '}'
+                        level_str[back_outer_i].append(block_str % (str1, str2))
+                    else:
+                        level_str[back_outer_i].append(block_str % str2)
                     if len(level_str[back_outer_i+1]) == 1:
                         level_str[back_outer_i][-1] = r"\left[" + \
                             level_str[back_outer_i][-1] + r"\right]"
@@ -1825,8 +1831,10 @@ class LatexPrinter(Printer):
         out_str = level_str[0][0]
 
         if expr.rank() % 2 == 1:
-            out_str = block_str % out_str
-
+            if mat_str == 'array':
+                out_str = block_str % ('{' + 'c'*expr.shape[0] + '}', out_str)
+            else:
+                out_str = block_str % out_str
         return out_str
 
     def _printer_tensor_indices(self, name, indices, index_map={}):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -29,7 +29,8 @@ from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary, multiline_latex,
                                   latex_escape, LatexPrinter)
-from sympy.tensor.array import (ImmutableDenseNDimArray,
+from sympy.tensor.array import (Array,
+                                ImmutableDenseNDimArray,
                                 ImmutableSparseNDimArray,
                                 MutableSparseNDimArray,
                                 MutableDenseNDimArray,
@@ -1418,6 +1419,17 @@ def test_latex_NDimArray():
             r"\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]"
         assert latex(Mcol2) == \
             r'\left[\begin{matrix}\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]\end{matrix}\right]'
+    # Issue 19381
+    assert latex(Array([[[1]]]), mat_str='array') == \
+        r'\left[\begin{array}{c}\left[\left[\begin{array}{c}1\end{array}\right]\right]\end{array}\right]'
+    assert latex(Array([[[1, 2], [3, 4], [5, 6]],
+                        [[7, 8], [9, 10], [11, 12]]]),
+                 mat_str='array') == \
+        r'\left[\begin{array}{cc}\left[\begin{array}{cc}1 & 2\\3 & 4\\5 & 6\end{array}\right] & \left[\begin{array}{cc}7 & 8\\9 & 10\\11 & 12\end{array}\right]\end{array}\right]'
+    assert latex(Array([[[1, 2], [3, 4], [5, 6]],
+                        [[7, 8], [9, 10], [11, 12]],
+                        [[1, 2], [3, 4], [5, 6]]]), mat_str='array') == \
+        r'\left[\begin{array}{ccc}\left[\begin{array}{cc}1 & 2\\3 & 4\\5 & 6\end{array}\right] & \left[\begin{array}{cc}7 & 8\\9 & 10\\11 & 12\end{array}\right] & \left[\begin{array}{cc}1 & 2\\3 & 4\\5 & 6\end{array}\right]\end{array}\right]'
 
 
 def test_latex_mul_symbol():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19381

#### Brief description of what is fixed or changed
Added correct(?) number of `c` arguments for printing `Array` using `array`.

#### Other comments
@eric-wieser do you have time to take a look?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Correct LaTeX-printing of `Array` when using `mat_str='array'`.
<!-- END RELEASE NOTES -->
