### PR TITLE
Added special case for _integer_basis with two-term polynomials (fixes #20913)

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -695,6 +695,14 @@ def _integer_basis(poly):
     monoms = monoms[:-1]
     coeffs = coeffs[:-1]
 
+    # Special case for two-term polynominals
+    if len(monoms) == 1:
+        r = Pow(coeffs[0], S.One/monoms[0])
+        if r.is_Integer:
+            return int(r)
+        else:
+            return None
+
     divs = reversed(divisors(gcd_list(coeffs))[1:])
 
     try:

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -715,3 +715,8 @@ def test_issue_19113():
 
 def test_issue_17454():
     assert roots([1, -3*(-4 - 4*I)**2/8 + 12*I, 0], multiple=True) == [0, 0]
+
+
+def test_issue_20913():
+    assert Poly(x + 9671406556917067856609794, x).real_roots() == [-9671406556917067856609794]
+    assert Poly(x**3 + 4, x).real_roots() == [-2**(S(2)/3)]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20913

#### Brief description of what is fixed or changed
Added special case when solving roots of polynomials only containing two terms which avoids prime-factorization.

#### Other comments
Not sure if it is indeed valid for all orders, but so far the tests I have tried work.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Faster root computation for two-term polynomials with large integer constant.
<!-- END RELEASE NOTES -->
