### PR TITLE
fix(core): support unpickling older pickles (1.9 branch)

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -303,6 +303,15 @@ class Symbol(AtomicExpr, Boolean):
     def __getnewargs_ex__(self):
         return ((self.name,), self.assumptions0)
 
+    # NOTE: __setstate__ is not needed for pickles created by __getnewargs_ex__
+    # but was used before Symbol was changed to use __getnewargs_ex__ in v1.9.
+    # Pickles created in previous SymPy versions will still need __setstate__
+    # so that they can be unpickled in SymPy > v1.9.
+
+    def __setstate__(self, state):
+        for name, value in state.items():
+            setattr(self, name, value)
+
     def _hashable_content(self):
         # Note: user-specified assumptions not hashed, just derived ones
         return (self.name,) + tuple(sorted(self.assumptions0.items()))


### PR DESCRIPTION
The changes to pickling in 6a1c295c70cae386ac4aa4fb499e18ba58062de9 means that
in sympy>=1.9 Symbols are pickled using `__getnewargs_ex__` rather than
`__getstate__/__setstate__`. This breaks unpickling of pickles created with
`sympy<1.9` because those pickle files still need to use `__setstate__` when being
unpickled.

This commit adds back the `__setstate__` method to Symbol although it should only
be used when unpickling pickles created in older SymPy versions.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22241 (on the 1.9 branch)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed unpickling of pickles created using older versions (<1.9) of SymPy.
<!-- END RELEASE NOTES -->
