### PR TITLE
better is_integer for 1/expr

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1333,6 +1333,7 @@ class Mul(Expr, AssocOp):
     #    (a.is_integer for a in self.args), quick_exit=True)
     def _eval_is_integer(self):
         from sympy import trailing
+        from sympy.core.relational import is_gt
         is_rational = self._eval_is_rational()
         if is_rational is False:
             return False
@@ -1356,13 +1357,14 @@ class Mul(Expr, AssocOp):
                 if not b.is_integer or not e.is_integer:
                     hit = unknown = True
                 if e.is_negative:
-                    denominators.append(2 if a is S.Half else Pow(a, S.NegativeOne))
+                    denominators.append(2 if a is S.Half else
+                        Pow(a, S.NegativeOne))
                 elif not hit:
-                    # for integer b and positive integer e: a = b**e would be integer
+                    # int b and pos int e: a = b**e is integer
                     assert not e.is_positive
-                    # for self being rational and e equal to zero: a = b**e would be 1
+                    # for rational self and e equal to zero: a = b**e is 1
                     assert not e.is_zero
-                    return # sign of e unknown -> self.is_integer cannot be decided
+                    return # sign of e unknown -> self.is_integer unknown
             else:
                 return
 
@@ -1373,7 +1375,7 @@ class Mul(Expr, AssocOp):
         alleven = lambda x: all(i.is_even for i in x)
         anyeven = lambda x: any(i.is_even for i in x)
 
-        if not numerators and denominators and all((_ - 1).is_extended_positive
+        if not numerators and denominators and all(is_gt(_, 1)
                 for _ in denominators):
             return False
         elif unknown:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1375,7 +1375,7 @@ class Mul(Expr, AssocOp):
         alleven = lambda x: all(i.is_even for i in x)
         anyeven = lambda x: any(i.is_even for i in x)
 
-        if not numerators and denominators and all(is_gt(_, 1)
+        if not numerators and denominators and all(is_gt(_, S.One)
                 for _ in denominators):
             return False
         elif unknown:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1056,6 +1056,7 @@ def test_Pow_is_integer():
     x = Symbol('x', positive=True)
     assert (1/(x + 1)).is_integer is False
     assert (1/(-x - 1)).is_integer is False
+    assert (-1/(x + 1)).is_integer is False
 
     # issue 8648-like
     k = Symbol('k', even=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

```python
>>> (1/(Dummy(positive=True) + 1)).is_integer
False  <-- formerly None
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
