### PR TITLE
allow for economical specification of `parse_expr` transformations

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -76,7 +76,7 @@ class MatrixRequired:
         """Implementations of __getitem__ should accept ints, in which
         case the matrix is indexed as a flat list, tuples (i,j) in which
         case the (i,j) entry is returned, slices, or mixed tuples (a,b)
-        where a and b are any combintion of slices and integers."""
+        where a and b are any combination of slices and integers."""
         raise NotImplementedError("Subclasses must implement this.")
 
     def __len__(self):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -914,7 +914,7 @@ def eval_expr(code, local_dict, global_dict):
 
 
 def parse_expr(s, local_dict=None, transformations=standard_transformations,
-               global_dict=None, evaluate=True, all=None, implicit=None):
+               global_dict=None, evaluate=True):
     """Converts the string ``s`` to a SymPy expression, in ``local_dict``
 
     Parameters
@@ -931,12 +931,13 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
         with ``from sympy import *``; provide this parameter to override
         this behavior (for instance, to parse ``"Q & S"``).
 
-    transformations : tuple, optional
+    transformations : tuple or str, optional
         A tuple of transformation functions used to modify the tokens of the
         parsed expression before evaluation. The default transformations
         convert numeric literals into their SymPy equivalents, convert
         undefined variables into SymPy symbols, and allow the use of standard
-        mathematical factorial notation (e.g. ``x!``).
+        mathematical factorial notation (e.g. ``x!``). Selection via
+        string is available (see below).
 
     evaluate : bool, optional
         When False, the order of the arguments will remain as they were in the
@@ -1025,10 +1026,10 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     >>> parse_expr('.3x', transformations=T[:])
     3*x/10
 
-    As a further convenience, keywords `implicit` and `all`, when set
-    to True, will select 0-5 and all the transformations, respectively.
+    As a further convenience, strings 'implicit' and 'all' can be used
+    to select 0-5 and all the transformations, respectively.
 
-    >>> parse_expr('.3x', all=True)
+    >>> parse_expr('.3x', transformations='all')
     3*x/10
 
     See Also
@@ -1050,18 +1051,14 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     elif not isinstance(global_dict, dict):
         raise TypeError('expecting global_dict to be a dict')
 
-    if all:
-        if not (implicit is None and
-                transformations == standard_transformations):
-            raise ValueError('give transformations or use single selector keyword')
-        transformations =  T[:]
-    elif implicit:
-        if not (all is None and
-                transformations == standard_transformations):
-            raise ValueError('give transformations or use single selector keyword')
-        transformations = T[:6]
-    elif not transformations:
-        transformations = ()
+    transformations = transformations or ()
+    if type(transformations) is str:
+        if transformations == 'all':
+            transformations = T[:]
+        elif transformations == 'implicit':
+            transformations = T[:6]
+        else:
+            raise ValueError('unknown transformation group name')
     if transformations:
         if not iterable(transformations):
             raise TypeError(

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -914,7 +914,7 @@ def eval_expr(code, local_dict, global_dict):
 
 
 def parse_expr(s, local_dict=None, transformations=standard_transformations,
-               global_dict=None, evaluate=True):
+               global_dict=None, evaluate=True, all=None, implicit=None):
     """Converts the string ``s`` to a SymPy expression, in ``local_dict``
 
     Parameters
@@ -1025,6 +1025,12 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     >>> parse_expr('.3x', transformations=T[:])
     3*x/10
 
+    As a further convenience, keywords `implicit` and `all`, when set
+    to True, will select 0-5 and all the transformations, respectively.
+
+    >>> parse_expr('.3x', all=True)
+    3*x/10
+
     See Also
     ========
 
@@ -1044,7 +1050,18 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     elif not isinstance(global_dict, dict):
         raise TypeError('expecting global_dict to be a dict')
 
-    transformations = transformations or ()
+    if all:
+        if not (implicit is None and
+                transformations == standard_transformations):
+            raise ValueError('give transformations or use single selector keyword')
+        transformations =  T[:]
+    elif implicit:
+        if not (all is None and
+                transformations == standard_transformations):
+            raise ValueError('give transformations or use single selector keyword')
+        transformations = T[:6]
+    elif not transformations:
+        transformations = ()
     if transformations:
         if not iterable(transformations):
             raise TypeError(

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -975,6 +975,56 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     >>> b.args
     (x, 1)
 
+    Note, however, that when these expressions are printed they will
+    appear the same:
+
+    >>> assert str(a) == str(b)
+
+    As a convenience, transformations can be seen by printing ``transformations``:
+
+    >>> from sympy.parsing.sympy_parser import transformations
+
+    >>> print(transformations)
+    0: lambda_notation
+    1: auto_symbol
+    2: repeated_decimals
+    3: auto_number
+    4: factorial_notation
+    5: implicit_multiplication_application
+    6: convert_xor
+    7: implicit_application
+    8: implicit_multiplication
+    9: convert_equals_signs
+    10: function_exponentiation
+    11: rationalize
+
+    The ``T`` object provides a way to select these transformations:
+
+    >>> from sympy.parsing.sympy_parser import T
+
+    If you print it, you will see the same list as shown above.
+
+    >>> str(T) == str(transformations)
+    True
+
+    Standard slicing will return a tuple of transformations:
+
+    >>> T[:5] == standard_transformations
+    True
+
+    So ``T`` can be used to specify the parsing transformations:
+
+    >>> parse_expr("2x", transformations=T[:5])
+    Traceback (most recent call last):
+    ...
+    SyntaxError: invalid syntax
+    >>> parse_expr("2x", transformations=T[:6])
+    2*x
+    >>> parse_expr('.3', transformations=T[3, 11])
+    3/10
+    >>> parse_expr('.3x', transformations=T[:])
+    3*x/10
+
     See Also
     ========
 
@@ -1130,3 +1180,51 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         if isinstance(node.func, ast.Name) and node.func.id in self.functions:
             new_node.keywords.append(ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load())))
         return new_node
+
+
+_transformation = {  # items can be added but never re-ordered
+0: lambda_notation,
+1: auto_symbol,
+2: repeated_decimals,
+3: auto_number,
+4: factorial_notation,
+5: implicit_multiplication_application,
+6: convert_xor,
+7: implicit_application,
+8: implicit_multiplication,
+9: convert_equals_signs,
+10: function_exponentiation,
+11: rationalize}
+
+transformations = '\n'.join('%s: %s' % (i, func_name(f)) for i, f in _transformation.items())
+
+
+class _T():
+    """class to retrieve transformations from a given slice
+
+    EXAMPLES
+    ========
+
+    >>> from sympy.parsing.sympy_parser import T, standard_transformations
+    >>> assert T[:5] == standard_transformations
+    """
+    def __init__(self):
+        self.N = len(_transformation)
+
+    def __str__(self):
+        return transformations
+
+    def __getitem__(self, t):
+        if not type(t) is tuple:
+            t = (t,)
+        i = []
+        for ti in t:
+            if type(ti) is int:
+                i.append(range(self.N)[ti])
+            elif type(ti) is slice:
+                i.extend(list(range(*ti.indices(self.N))))
+            else:
+                raise TypeError('unexpected slice arg')
+        return tuple([_transformation[_] for _ in i])
+
+T = _T()

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -297,7 +297,8 @@ def test_issue_19501():
     assert eq.free_symbols == {x}
 
 
-def test_definitions():
+def test_parsing_definitions():
+    from sympy.abc import x
     assert len(_transformation) == 12  # if this changes, extend below
     assert _transformation[0] == lambda_notation
     assert _transformation[1] == auto_symbol
@@ -315,3 +316,5 @@ def test_definitions():
     t = _transformation
     assert T[-1, 0] == (t[len(t) - 1], t[0])
     assert T[:5, 8] == standard_transformations + (t[8],)
+    assert parse_expr('0.3x^2', all=True) == 3*x**2/10
+    assert parse_expr('sin 3x', implicit=True) == sin(3*x)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -316,5 +316,5 @@ def test_parsing_definitions():
     t = _transformation
     assert T[-1, 0] == (t[len(t) - 1], t[0])
     assert T[:5, 8] == standard_transformations + (t[8],)
-    assert parse_expr('0.3x^2', all=True) == 3*x**2/10
-    assert parse_expr('sin 3x', implicit=True) == sin(3*x)
+    assert parse_expr('0.3x^2', transformations='all') == 3*x**2/10
+    assert parse_expr('sin 3x', transformations='implicit') == sin(3*x)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -13,8 +13,10 @@ from sympy.testing.pytest import raises, skip
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
     split_symbols, implicit_multiplication, convert_equals_signs,
-    convert_xor, function_exponentiation,
-    implicit_multiplication_application,
+    convert_xor, function_exponentiation, lambda_notation, auto_symbol,
+    repeated_decimals, implicit_multiplication_application,
+    auto_number, factorial_notation, implicit_application,
+    _transformation, T
     )
 
 
@@ -293,3 +295,23 @@ def test_issue_19501():
         standard_transformations +
         (implicit_multiplication_application,)))
     assert eq.free_symbols == {x}
+
+
+def test_definitions():
+    assert len(_transformation) == 12  # if this changes, extend below
+    assert _transformation[0] == lambda_notation
+    assert _transformation[1] == auto_symbol
+    assert _transformation[2] == repeated_decimals
+    assert _transformation[3] == auto_number
+    assert _transformation[4] == factorial_notation
+    assert _transformation[5] == implicit_multiplication_application
+    assert _transformation[6] == convert_xor
+    assert _transformation[7] == implicit_application
+    assert _transformation[8] == implicit_multiplication
+    assert _transformation[9] == convert_equals_signs
+    assert _transformation[10] == function_exponentiation
+    assert _transformation[11] == rationalize
+    assert T[:5] == T[0,1,2,3,4] == standard_transformations
+    t = _transformation
+    assert T[-1, 0] == (t[len(t) - 1], t[0])
+    assert T[:5, 8] == standard_transformations + (t[8],)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

fixes #21226

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
    * strings 'all' and 'implicit' can be passed to select commonly used transformations; `T` can be sliced to give desired transformations for `parse_expr`
<!-- END RELEASE NOTES -->
