### PR TITLE
MatrixExpr.from_index_summation now uses array expressions module

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1908,7 +1908,9 @@ class LatexPrinter(Printer):
         return self._print(expr.name)
 
     def _print_ArrayElement(self, expr):
-        return "{{%s}_{%s}}" % (expr.name, ", ".join([f"{self._print(i)}" for i in expr.indices]))
+        return "{{%s}_{%s}}" % (
+            self.parenthesize(expr.name, PRECEDENCE["Func"], True),
+            ", ".join([f"{self._print(i)}" for i in expr.indices]))
 
     def _print_UniversalSet(self, expr):
         return r"\mathbb{U}"

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -490,7 +490,8 @@ class StrPrinter(Printer):
         return self._print(expr.name)
 
     def _print_ArrayElement(self, expr):
-        return "%s[%s]" % (expr.name, ", ".join([self._print(i) for i in expr.indices]))
+        return "%s[%s]" % (
+            self.parenthesize(expr.name, PRECEDENCE["Func"], True), ", ".join([self._print(i) for i in expr.indices]))
 
     def _print_PermutationGroup(self, expr):
         p = ['    %s' % self._print(a) for a in expr.args]

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2810,3 +2810,6 @@ def test_pickleable():
 def test_printing_latex_array_expressions():
     assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+    M = MatrixSymbol("M", 3, 3)
+    N = MatrixSymbol("N", 3, 3)
+    assert latex(ArrayElement(M*N, [x, 0])) == "{{\\left(M N\\right)}_{x, 0}}"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1127,3 +1127,6 @@ def test_AppliedPredicate():
 def test_printing_str_array_expressions():
     assert sstr(ArraySymbol("A", 2, 3, 4)) == "A"
     assert sstr(ArrayElement("A", (2, 1/(1-x), 0))) == "A[2, 1/(1 - x), 0]"
+    M = MatrixSymbol("M", 3, 3)
+    N = MatrixSymbol("N", 3, 3)
+    assert sstr(ArrayElement(M*N, [x, 0])) == "(M*N)[x, 0]"

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -62,7 +62,7 @@ class ArrayElement(_ArrayExpr):
         if isinstance(name, str):
             name = Symbol(name)
         name = _sympify(name)
-        indices = _sympify(indices)
+        indices = _sympify(tuple(indices))
         if hasattr(name, "shape"):
             if any((i >= s) == True for i, s in zip(indices, name.shape)):
                 raise ValueError("shape is out of bounds")

--- a/sympy/tensor/array/expressions/conv_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/conv_indexed_to_array.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 
-from sympy import Sum, Mul, KroneckerDelta, Indexed, IndexedBase, Add
+from sympy import Sum, Mul, KroneckerDelta, Indexed, IndexedBase, Add, Pow, Integer, default_sort_key
 from sympy.combinatorics import Permutation
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayDiagonal, \
-    ArrayContraction, ArrayTensorProduct, ArrayAdd
+    ArrayContraction, ArrayTensorProduct, ArrayAdd, get_shape, ArrayElement
 from sympy.tensor.array.expressions.utils import _get_argindex, _get_diagonal_indices
 
 
@@ -53,13 +53,39 @@ def convert_indexed_to_array(expr, first_indices=None):
     """
 
     result, indices = _convert_indexed_to_array(expr)
+
+    if any(isinstance(i, (int, Integer)) for i in indices):
+        result = ArrayElement(result, indices)
+        indices = []
+
     if not first_indices:
         return result
+
+    def _check_is_in(elem, indices):
+        if elem in indices:
+            return True
+        if any(elem in i for i in indices if isinstance(i, frozenset)):
+            return True
+        return False
+
+    repl = {j: i for i in indices if isinstance(i, frozenset) for j in i}
+    first_indices = [repl.get(i, i) for i in first_indices]
     for i in first_indices:
-        if i not in indices:
+        if not _check_is_in(i, indices):
             first_indices.remove(i)
-    first_indices.extend([i for i in indices if i not in first_indices])
-    permutation = [first_indices.index(i) for i in indices]
+    first_indices.extend([i for i in indices if not _check_is_in(i, first_indices)])
+
+    def _get_pos(elem, indices):
+        if elem in indices:
+            return indices.index(elem)
+        for i, e in enumerate(indices):
+            if not isinstance(e, frozenset):
+                continue
+            if elem in e:
+                return i
+        raise ValueError("not found")
+
+    permutation = [_get_pos(i, first_indices) for i in indices]
     return PermuteDims(result, permutation)
 
 
@@ -68,8 +94,20 @@ def _convert_indexed_to_array(expr):
         function = expr.function
         summation_indices = expr.variables
         subexpr, subindices = _convert_indexed_to_array(function)
+        subindicessets = {j: i for i in subindices if isinstance(i, frozenset) for j in i}
+        summation_indices = sorted(set([subindicessets.get(i, i) for i in summation_indices]), key=default_sort_key)
+        # TODO: check that Kronecker delta is only contracted to one other element:
+        kronecker_indices = set([])
+        if isinstance(function, Mul):
+            for arg in function.args:
+                if not isinstance(arg, KroneckerDelta):
+                    continue
+                arg_indices = sorted(set(arg.indices), key=default_sort_key)
+                if len(arg_indices) == 2:
+                    kronecker_indices.update(arg_indices)
+        kronecker_indices = sorted(kronecker_indices, key=default_sort_key)
         # Check dimensional consistency:
-        shape = subexpr.shape
+        shape = get_shape(subexpr)
         if shape:
             for ind, istart, iend in expr.limits:
                 i = _get_argindex(subindices, ind)
@@ -97,10 +135,13 @@ def _convert_indexed_to_array(expr):
 
         axes_contraction = defaultdict(list)
         for i, ind in enumerate(subindices):
-            if ind in summation_indices:
+            include = all(j not in kronecker_indices for j in ind) if isinstance(ind, frozenset) else ind not in kronecker_indices
+            if ind in summation_indices and include:
                 axes_contraction[ind].append(i)
                 subindices[i] = None
         for k, v in axes_contraction.items():
+            if any(i in kronecker_indices for i in k) if isinstance(k, frozenset) else k in kronecker_indices:
+                continue
             contraction_indices.append(tuple(v))
         free_indices = [i for i in subindices if i is not None]
         indices_ret = list(free_indices)
@@ -174,4 +215,10 @@ def _convert_indexed_to_array(expr):
             # Perform index permutations:
             args[i] = PermuteDims(args[i], permutation)
         return ArrayAdd(*args), index0
+    if isinstance(expr, Pow):
+        subexpr, subindices = _convert_indexed_to_array(expr.base)
+        if isinstance(expr.exp, (int, Integer)):
+            diags = zip(*[(2*i, 2*i + 1) for i in range(expr.exp)])
+            arr = ArrayDiagonal(ArrayTensorProduct(*[subexpr for i in range(expr.exp)]), *diags)
+            return arr, subindices
     return expr, ()

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,5 +1,6 @@
 from sympy import (
     symbols, Identity, cos, ZeroMatrix, OneMatrix, sqrt, HadamardProduct)
+from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 from sympy.tensor.array.expressions.conv_array_to_matrix import _support_function_tp1_recognize, \
     _array_diag2contr_diagmatrix, convert_array_to_matrix, _remove_trivial_dims, _array2matrix, \
@@ -10,7 +11,7 @@ from sympy.matrices.expressions.diagonal import DiagMatrix, DiagonalMatrix
 from sympy.matrices import Trace, MatMul, Transpose
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, \
     ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
-    ArrayContraction
+    ArrayContraction, ArrayElement
 from sympy.testing.pytest import raises
 
 
@@ -131,6 +132,16 @@ def test_arrayexpr_convert_array_to_matrix2():
 
     cg = ArrayTensorProduct(PermuteDims(N, [1, 0]), PermuteDims(M, [1, 0]))
     assert convert_array_to_matrix(cg) == ArrayTensorProduct(N.T, M.T)
+
+    cg = ArrayContraction(M, (0,), (1,))
+    assert convert_array_to_matrix(cg) == OneMatrix(1, k)*M*OneMatrix(k, 1)
+
+    cg = ArrayContraction(x, (0,), (1,))
+    assert convert_array_to_matrix(cg) == OneMatrix(1, k)*x
+
+    Xm = MatrixSymbol("Xm", m, n)
+    cg = ArrayContraction(Xm, (0,), (1,))
+    assert convert_array_to_matrix(cg) == OneMatrix(1, m)*Xm*OneMatrix(n, 1)
 
 
 def test_arrayexpr_convert_array_to_diagonalized_vector():
@@ -589,3 +600,15 @@ def test_array_contraction_to_diagonal_multiple_identities():
 
     expr = ArrayContraction(ArrayTensorProduct(A, I, I, B), (1, 2, 3, 4, 6))
     assert _array_contraction_to_diagonal_multiple_identity(expr) == (expr, [])
+
+
+def test_convert_array_element_to_matrix():
+
+    expr = ArrayElement(M, (i, j))
+    assert convert_array_to_matrix(expr) == MatrixElement(M, i, j)
+
+    expr = ArrayElement(ArrayContraction(ArrayTensorProduct(M, N), (1, 3)), (i, j))
+    assert convert_array_to_matrix(expr) == MatrixElement(M*N.T, i, j)
+
+    expr = ArrayElement(ArrayTensorProduct(M, N), (i, j, m, n))
+    assert convert_array_to_matrix(expr) == expr

--- a/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
@@ -1,7 +1,7 @@
 from sympy import Sum, MatrixSymbol, Identity, symbols, IndexedBase, KroneckerDelta
 from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ArrayContraction, ArrayTensorProduct, \
-    ArrayDiagonal, ArrayAdd, PermuteDims
+    ArrayDiagonal, ArrayAdd, PermuteDims, ArrayElement
 from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array, _convert_indexed_to_array
 from sympy.testing.pytest import raises
@@ -98,7 +98,7 @@ def test_arrayexpr_convert_indexed_to_array_and_back_to_matrix():
     expr = a.T*b
     elem = expr[0, 0]
     cg = convert_indexed_to_array(elem)
-    assert cg == ArrayContraction(ArrayTensorProduct(a, b), (0, 2))
+    assert cg == ArrayElement(ArrayContraction(ArrayTensorProduct(a, b), (0, 2)), [0, 0])
 
     expr = M[i,j] + N[i,j]
     p1, p2 = _convert_indexed_to_array(expr)


### PR DESCRIPTION
`MatrixExpr.from_index_summation` used to have its own parser of `Sum` and `MatrixElement` objects in order to transform expressions with summations of matrices with indices into index-implicit matrix expression objects.

This PR removes the old algorithm and delegates the transformation to the array expressions module. The parsing is now in two-steps:
1. the indexed summations are transformed into array expression,
2. the array expression is transformed into matrix expression (if possible).

The array expressions module is indeed able to parse summations of matrix indices even if they cannot be expressed in matrix form.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
