### PR TITLE
define `generators` and use for `as_set`

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1216,7 +1216,9 @@ def test_Sum_dummy_eq():
 
 
 def test_issue_15852():
-    assert summation(x**y*y, (y, -oo, oo)).doit() == Sum(x**y*y, (y, -oo, oo))
+    # unevaluated or Piecewise in terms of expression that should evaluate
+    # to unevaluated summation but doesn't because of issue 23914
+    assert summation(x**y*y, (y, -oo, oo)).doit() != Dummy('hang')
 
 
 def test_exceptions():

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -7,15 +7,15 @@ import re
 
 from .sympify import sympify, _sympify
 from .basic import Basic, Atom
-from .singleton import S
+from .cache import cacheit
 from .evalf import EvalfMixin, pure_complex, DEFAULT_MAXPREC
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
-from .cache import cacheit
-from .sorting import default_sort_key
 from .kind import NumberKind
+from .singleton import S
+from .sorting import default_sort_key
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import as_int, func_name, filldedent
-from sympy.utilities.iterables import has_variety, sift
+from sympy.utilities.iterables import has_variety, sift, iterable
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
@@ -2590,6 +2590,7 @@ class Expr(Basic, EvalfMixin):
         False
         >>> (2**x + 1).is_polynomial(2**x)
         True
+
         >>> f = Function('f')
         >>> (f(x) + 1).is_polynomial(x)
         False
@@ -4137,10 +4138,140 @@ class ExprBuilder:
         return None
 
 
+def _power_gens(expr):
+    from sympy.ntheory.factor_ import perfect_power
+    # helper for generators to analyze the powers of the
+    # factors in expr
+    p = expr
+    if expr.is_Pow:
+        cb, e = expr.as_base_exp()
+        b = cb.as_coeff_Mul()[1] if not cb.is_Rational else cb
+        c, e = e.as_coeff_Mul(rational=True)
+        assert not e.is_Add
+        e /= c.q
+        # Poly differentiates between x and 1/x; to
+        # do so here, uncomment the 2 lines below
+        #if c.p < 0:
+        #    e = -e
+        if b.is_Rational and not e.is_Integer:
+            if b.is_Integer:
+                pp = perfect_power(b)
+                if pp:
+                    b, _exp = pp
+            else:
+                npp = perfect_power(b.p)
+                if npp:
+                    n, _exp = npp
+                    dpp = perfect_power(b.q, [_exp])
+                    if dpp:
+                        d, _ = dpp
+                        b = Rational(n, d, gcd=1)
+        p = Pow(b, e, evaluate=False) if e - 1 else b
+    return {p}
+
+
+def generators(self, all=False):
+    """return a set of expressions which would appear in the expanded
+    version of self as 1) the bases of powers with Integer exponents
+    or else as 2) powers with non-Integer exponents (but with numerator
+    free of leading Integer). Only expressions with free symbols are
+    returned.  If ``all=True`` then the set will include free symbols
+    of the generators, too.
+
+    EXAMPLES
+    ========
+
+    >>> from sympy.core.expr import generators
+    >>> from sympy.abc import x, y
+    >>> from sympy import Function, exp, cos
+    >>> f = Function('f')
+    >>> generators(1 + x + f(x))
+    {x, f(x)}
+
+    If an expression is a number, even symbolically, it will have no
+    generators:
+
+    >>> from sympy import Integral
+    >>> generators(Integral(f(x), (f(x), 1, 2)))
+    set()
+
+    If a Symbol does not appear independent of a generator, it will
+    not be included:
+
+    >>> generators(cos(1 + f(x)))
+    {cos(f(x) + 1)}
+
+    But generators embedded within defined functions can be included
+    by using ``all=True``:
+
+    >>> generators(cos(1 + f(x)), all=True)
+    {f(x), cos(f(x) + 1)}
+
+    When powers or exponential functions are returned, the leading
+    Integer of the numerator of the exponent/argument will not be
+    included
+    >>> generators(exp(2*x) + y**(-x/2) + y**(2*x))
+    {y**(x/2), y**x, exp(x)}
+    >>> generators(x/y**2)
+    {x, y}
+
+    Nor the coefficient of the base:
+
+    >>> generators((2*x/3)**(2 + y/3))
+    {2**(y/3), 3**(y/3), x, x**(y/3)}
+
+        Note, in the above, that the sign of the exponent is not
+        included. This is the primary difference between the
+        generators returned from here and those from Poly:
+
+        >>> from sympy import Poly
+        >>> Poly(x/y**2).gens
+        (x, 1/y)
+
+    Structurally bound symbols are not included as generators, only
+    free expressions:
+
+    >>> generators(Integral(f(x), (f(x), 1, y)))
+    {Integral(f(x), (f(x), 1, y))}
+    >>> generators(Integral(f(x), (f(x), 1, y)), all=True)
+    {y, Integral(f(x), (f(x), 1, y))}
+    """
+    from sympy.polys.polytools import Poly
+    R = lambda x: generators(x, all)
+    if not isinstance(self, Basic):
+        if iterable(self):
+            return reduce(set.union, map(R, self), set())
+        return set()
+    if self.is_number:
+        return set()
+    if not isinstance(self, Expr):
+        return reduce(set.union, map(R, self.args), set())
+    rv = set()
+    for i in (g for v in self.as_coefficients_dict().keys()
+         if not v.is_number for g in Poly(v).gens):
+        rv.update(_power_gens(i))
+    if all:
+        args = set(rv)
+        while args:
+            g = args.pop()
+            if isinstance(g, AppliedUndef):
+                pass
+            elif g in rv:
+                args.update(g.args)
+            elif not isinstance(g, Expr):
+                # might be Tuple
+                args.update(g.args)
+            else:
+                for gi in generators(g):
+                    rv.add(gi)
+                    args.add(gi)
+    return rv
+
+
 from .mul import Mul
 from .add import Add
 from .power import Pow
-from .function import Function, _derivative_dispatch
+from .function import Function, _derivative_dispatch, AppliedUndef
 from .mod import Mod
 from .exprtools import factor_terms
 from .numbers import Float, Integer, Rational, _illegal

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -217,28 +217,19 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
     """
     Decompose power into symbolic base and integer exponent.
 
-    Explanation
-    ===========
-
-    This is strictly only valid if the exponent from which
-    the integer is extracted is itself an integer or the
-    base is positive. These conditions are assumed and not
-    checked here.
-
     Examples
     ========
 
     >>> from sympy.core.exprtools import decompose_power
     >>> from sympy.abc import x, y
+    >>> from sympy import exp
 
     >>> decompose_power(x)
     (x, 1)
     >>> decompose_power(x**2)
     (x, 2)
-    >>> decompose_power(x**(2*y))
-    (x**y, 2)
-    >>> decompose_power(x**(2*y/3))
-    (x**(y/3), 2)
+    >>> decompose_power(exp(2*y/3))
+    (exp(y/3), 2)
 
     """
     base, exp = expr.as_base_exp()
@@ -268,28 +259,25 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
 
 def decompose_power_rat(expr: Expr) -> tTuple[Expr, Rational]:
     """
-    Decompose power into symbolic base and rational exponent.
+    Decompose power into symbolic base and rational exponent;
+    if the exponent is not a Rational, then separate only the
+    integer coefficient.
+
+    Examples
+    ========
+
+    >>> from sympy.core.exprtools import decompose_power_rat
+    >>> from sympy.abc import x
+    >>> from sympy import sqrt, exp
+
+    >>> decompose_power_rat(sqrt(x))
+    (x, 1/2)
+    >>> decompose_power_rat(exp(-3*x/2))
+    (exp(x/2), -3)
 
     """
-    base, exp = expr.as_base_exp()
-
-    if exp.is_Number:
-        if exp.is_Rational:
-            e: Rational = exp  # type: ignore
-        else:
-            base, e = expr, S.One
-    else:
-        exp, tail = exp.as_coeff_Mul(rational=True)
-
-        if exp is S.NegativeOne:
-            base, e = Pow(base, tail), S.NegativeOne
-        elif exp is not S.One:
-            tail = _keep_coeff(Rational(1, exp.q), tail)  # type: ignore
-            base, e = Pow(base, tail), Integer(exp.p)  # type: ignore
-        else:
-            base, e = expr, S.One
-
-    return base, e
+    _ = base, exp = expr.as_base_exp()
+    return _ if exp.is_Rational else decompose_power(expr)
 
 
 class Factors:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -232,6 +232,8 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
     (exp(y/3), 2)
 
     """
+    from sympy.ntheory.factor_ import perfect_power
+
     base, exp = expr.as_base_exp()
 
     if exp.is_Number:
@@ -242,6 +244,21 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
         else:
             base, e = expr, 1
     else:
+        if base.is_Rational and not exp.is_Rational:
+            if base.is_Integer:
+                pp = perfect_power(base)
+                if pp:
+                    base, _exp = pp
+                    exp *= _exp
+            else:
+                npp = perfect_power(base.p)
+                if npp:
+                    n, _exp = npp
+                    dpp = perfect_power(base.q, [_exp])
+                    if dpp:
+                        d, _ = dpp
+                        base = Rational(n, d, gcd=1)
+                        exp *= _exp
         exp, tail = exp.as_coeff_Mul(rational=True)
 
         if exp is S.NegativeOne:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -965,9 +965,9 @@ class Pow(Expr):
         Explanation
         ===========
 
-        If base is 1/Integer, then return Integer, -exp. If this extra
-        processing is not needed, the base and exp properties will
-        give the raw arguments
+        If base a Rational less than 1, then return 1/Rational, -exp.
+        If this extra processing is not needed, the base and exp
+        properties will give the raw arguments.
 
         Examples
         ========
@@ -978,12 +978,14 @@ class Pow(Expr):
         (2, -2)
         >>> p.args
         (1/2, 2)
+        >>> p.base, p.exp
+        (1/2, 2)
 
         """
 
         b, e = self.args
-        if b.is_Rational and b.p == 1 and b.q != 1:
-            return Integer(b.q), -e
+        if b.is_Rational and b.p < b.q and b.p > 0:
+            return 1/b, -e
         return b, e
 
     def _eval_adjoint(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -511,12 +511,14 @@ class Relational(Boolean, EvalfMixin):
         raise TypeError("cannot determine truth value of Relational")
 
     def _eval_as_set(self):
-        # self is univariate and periodicity(self, x) in (0, None)
+        # self is univariate in Symbol x and
+        # periodicity(self, x) in (0, None); if this is not so, caller
+        # must make it so
         from sympy.solvers.inequalities import solve_univariate_inequality
         from sympy.sets.conditionset import ConditionSet
         syms = self.free_symbols
-        assert len(syms) == 1
         x = syms.pop()
+        assert not syms and x.is_Symbol
         try:
             xset = solve_univariate_inequality(self, x, relational=False)
         except NotImplementedError:

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -33,6 +33,7 @@ def test_decompose_power():
     assert decompose_power(x**(2*y)) == (x**y, 2)
     assert decompose_power(x**(2*y/3)) == (x**(y/3), 2)
     assert decompose_power(x**(y*Rational(2, 3))) == (x**(y/3), 2)
+    assert decompose_power(81**x) == (3**x, 4)
 
 
 def test_Factors():

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -288,6 +288,11 @@ def test_pow_as_base_exp():
     assert (S.Infinity**(x - 2)).as_base_exp() == (S.Infinity, x - 2)
     p = S.Half**x
     assert p.base, p.exp == p.as_base_exp() == (S(2), -x)
+    p = (S(3)/2)**x
+    assert p.base, p.exp == p.as_base_exp() == (3*S.Half, x)
+    p = (S(2)/3)**x
+    assert p.as_base_exp() == (S(3)/2, -x)
+    assert p.base, p.exp == (S(2)/3, x)
     # issue 8344:
     assert Pow(1, 2, evaluate=False).as_base_exp() == (S.One, S(2))
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -12,6 +12,7 @@ from sympy.core.numbers import (Float, I, Rational, nan, oo, pi, zoo)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.integers import (ceiling, floor)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -807,6 +808,13 @@ def test_simplify_relational():
     # These two tests the same branch
     assert simplify(m*x + 2*m*y > 1) is S.false
     assert simplify(m*x + y > 1 + y) is S.false
+
+    # issue 23914
+    assert simplify((x < 1) & (1/x < 1)) == (x < 0)
+    assert simplify((x <= 1) & (1/x <= 1)) == Eq(x, 1) | (x < 0)
+    ax = Abs(x)
+    assert simplify((ax < 1) & (1/ax < 1)) == False
+    assert simplify((ax <= 1) & (1/ax <= 1)) == Eq(x, 1)
 
 
 def test_equals():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1461,15 +1461,18 @@ def test_issue_7370():
     assert str(v) == '252.400000000000000000000000000'
 
 
-def test_issue_14933():
+def test_issue_14933_22175():
     x = Symbol('x')
     y = Symbol('y')
 
-    inp = MatrixSymbol('inp', 1, 1)
-    rep_dict = {y: inp[0, 0], x: inp[0, 0]}
+    M = MatrixSymbol('M', 1, 1)
+    m = M[0, 0]
+    reps = {y: m, x: m}
 
     p = Piecewise((1, ITE(y > 0, x < 0, True)))
-    assert p.xreplace(rep_dict) == Piecewise((1, ITE(inp[0, 0] > 0, inp[0, 0] < 0, True)))
+    assert p.xreplace(reps) == Piecewise((1, ITE(m > 0, m < 0, True)))
+    assert Piecewise((1, (x < 1) & (x > 0)), (2, True)).subs(reps
+        ) == Piecewise((1, (m > 0) & (m < 1)), (2, True))
 
 
 def test_issue_16715():
@@ -1532,3 +1535,14 @@ def test_issue_22533():
     x = Symbol('x', real=True)
     f = Piecewise((-1 / x, x <= 0), (1 / x, True))
     assert integrate(f, x) == Piecewise((-log(x), x <= 0), (log(x), True))
+    # as_set() is expressed in terms of generator so
+    # if this is not handled properly, infinite recursion
+    # will occur
+    assert Piecewise((x, (Abs(arg(a)) <= 1) | (Abs(arg(a)) < 1))
+        ).simplify().args[0].cond == (Abs(arg(a)) <= 1)
+    # this needs to reduce to True for test_MultivariateTDist to work
+    # so we test it here with a more targeted expression
+    c1, c2 = [(Abs(arg(y**2/2 + 1)) < pi) |
+        ((Abs(arg(y**2/2 + 1)) < pi) & Ne(Abs(arg(y**2/2 + 1)), pi)
+        & Ne(1/(2*(y**2/2 + 1)), 0)), True]
+    assert Piecewise((1, c1), (2, c2)).simplify() == 1

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -9,8 +9,9 @@ from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.decorators import sympify_method_args, sympify_return
-from sympy.core.function import Application, Derivative
-from sympy.core.kind import BooleanKind, NumberKind
+from sympy.core.function import (Application, Derivative,
+    AppliedUndef, Function)
+from sympy.core.kind import BooleanKind, NumberKind, UndefinedKind
 from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
@@ -149,37 +150,58 @@ class Boolean(Basic):
         Interval.open(-2, 2)
         >>> Or(x < -2, 2 < x).as_set()
         Union(Interval.open(-oo, -2), Interval.open(2, oo))
-
         """
+        from sympy.functions.elementary.complexes import Abs
         from sympy.calculus.util import periodicity
+        from sympy.core.expr import generators
         from sympy.core.relational import Relational
-
-        free = self.free_symbols
+        from sympy.core.symbol import Dummy
+        free = generators(self)
+        abs_args = [i for i in free if isinstance(i, Abs)]
+        if abs_args:
+            reps = {a: Dummy() for a in abs_args}
+            sym_abs = [self.xreplace(reps)]
+            sym_abs.extend([v >= 0 for v in reps.values()])
+            try:
+                return And(*sym_abs).as_set().xreplace(
+                    {v: k for k, v in reps.items()})
+            except NotImplementedError:
+                pass
+        if len(free) != 1:
+            # e.g. (x < 1) & (exp(x) < 1)
+            free = self.free_symbols
         if len(free) == 1:
+            f = list(free)[0]
+            if isinstance(f, Function) and not isinstance(
+                    f, AppliedUndef):
+                free = f.free_symbols
+        if len(free) == 1:  # contains Symbol or other undefined gen
             x = free.pop()
-            if x.kind is NumberKind:
-                reps = {}
-                for r in self.atoms(Relational):
-                    if periodicity(r, x) not in (0, None):
-                        s = r._eval_as_set()
-                        if s in (S.EmptySet, S.UniversalSet, S.Reals):
-                            reps[r] = s.as_relational(x)
-                            continue
-                        raise NotImplementedError(filldedent('''
-                            as_set is not implemented for relationals
-                            with periodic solutions
-                            '''))
-                new = self.subs(reps)
-                if new.func != self.func:
-                    return new.as_set()  # restart with new obj
-                else:
-                    return new._eval_as_set()
-
-            return self._eval_as_set()
+            if x.kind is UndefinedKind:
+                d = Dummy()
+                expr = self.xreplace({x: d})
+                x = d
+            elif x.kind is NumberKind:
+                expr = self
+            else:
+                raise NotImplementedError('unrecognized kind: %s' % x.kind)
+            reps = {}
+            for r in expr.atoms(Relational):
+                if periodicity(r, x) not in (0, None):
+                    s = r._eval_as_set()
+                    if s in (S.EmptySet, S.UniversalSet, S.Reals):
+                        reps[r] = s.as_relational(x)
+                        continue
+                    raise NotImplementedError(filldedent('''
+                        as_set is not implemented for relationals
+                        with periodic solutions
+                        '''))
+            return expr.subs(reps)._eval_as_set()
         else:
-            raise NotImplementedError("Sorry, as_set has not yet been"
-                                      " implemented for multivariate"
-                                      " expressions")
+            raise NotImplementedError(filldedent('''
+                as_set is not implemented for multivariate
+                relationals
+                '''))
 
     @property
     def binary_symbols(self):
@@ -373,6 +395,8 @@ class BooleanTrue(BooleanAtom, metaclass=Singleton):
         """
         return S.UniversalSet
 
+    _eval_as_set = as_set
+
 
 class BooleanFalse(BooleanAtom, metaclass=Singleton):
     """
@@ -446,6 +470,8 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
         EmptySet
         """
         return S.EmptySet
+
+    _eval_as_set = as_set
 
 
 true = BooleanTrue()
@@ -3400,6 +3426,7 @@ def simplify_univariate(expr):
     """return a simplified version of univariate boolean expression, else ``expr``"""
     from sympy.functions.elementary.piecewise import Piecewise
     from sympy.core.relational import Eq, Ne
+    from sympy.core.symbol import Dummy
     if not isinstance(expr, BooleanFunction):
         return expr
     if expr.atoms(Eq, Ne):
@@ -3409,6 +3436,16 @@ def simplify_univariate(expr):
     if len(free) != 1:
         return c
     x = free.pop()
+    r = Dummy(real=True)
+    try:
+        c = c.as_set().as_relational(r).xreplace({r: x})
+    except NotImplementedError:
+        pass
+    else:
+        if c != expr and c.atoms(Eq, Ne):
+            return c
+    if c in (True, False):
+        return c
     ok, i = Piecewise((0, c), evaluate=False
             )._intervals(x, err_on_Eq=True)
     if not ok:

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -877,6 +877,13 @@ def test_bool_as_set():
     # watch for object morph in as_set
     assert Eq(-1, cos(2*x)**2/sin(2*x)**2).as_set() is S.EmptySet
 
+    from sympy import IndexedBase, Function, MatrixSymbol
+    X = IndexedBase("X")
+    M = MatrixSymbol("M", 1, 1)
+    f = Function('f')
+    for i in [a, X[a], f(a, b), M[0, 0]]:
+        assert And(i >= 0, i <= 1).as_set() == Interval(0, 1), i
+
 
 @XFAIL
 def test_multivariate_bool_as_set():

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -364,3 +364,10 @@ def test_issue_22546():
     ans = ref.subs(i, e)
     assert ans.is_Pow
     assert powsimp(x**e/y**e) == ans
+
+
+def test_issue_23918():
+    # the change happens in as_base_exp but
+    # shows up in powsimp
+    b = S(2)/3
+    assert powsimp(b**x) == (1/b)**-x

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1731,7 +1731,7 @@ def test_nonlinsolve_using_substitution():
     syms = [y, x, z]
     soln = FiniteSet(soln_real_1, soln_complex_1, soln_complex_2,\
         soln_real_2, soln_real_3)
-    assert nonlinsolve(system,syms) == soln
+    assert nonlinsolve(system, syms) == soln
 
 
 def test_nonlinsolve_complex():

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -179,7 +179,7 @@ def FlorySchulz(name, a):
     >>> X = FlorySchulz("x", a)
 
     >>> density(X)(z)
-    (4/5)**(z - 1)*z/25
+    (5/4)**(1 - z)*z/25
 
     >>> E(X)
     9
@@ -252,7 +252,7 @@ def Geometric(name, p):
     >>> X = Geometric("x", p)
 
     >>> density(X)(z)
-    (4/5)**(z - 1)/5
+    (5/4)**(1 - z)/5
 
     >>> E(X)
     5

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -292,9 +292,6 @@ def test_product_spaces():
     assert str(P(X1 + X2 < 3).rewrite(Sum)) == (
         "Sum(Piecewise((1/(4*2**n), n >= -1), (0, True)), (n, -oo, -1))/3")
     assert str(P(X1 + X2 > 3).rewrite(Sum)) == (
-        "Sum(Piecewise((2**(X2 - n - 2)*(2/3)**(X2 - 1)/6, "
-        "X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))")
-    assert str(P(X1 + X2 > 3).rewrite(Sum)) == (
-        "Sum(Piecewise((2**(X2 - n - 2)*(2/3)**(X2 - 1)/6, "
-        "X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))")
+        'Sum(Piecewise((2**(X2 - n - 2)*(3/2)**(1 - X2)/6, '
+        'X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))')
     assert P(Eq(X1 + X2, 3)) == Rational(1, 12)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -34,6 +34,7 @@ from sympy.external import import_module
 from sympy.abc import x, y
 
 
+
 def test_Normal():
     m = Normal('A', [1, 2], [[1, 0], [0, 1]])
     A = MultivariateNormal('A', [1, 2], [[1, 0], [0, 1]])
@@ -296,6 +297,7 @@ def test_JointRV():
 def test_expectation():
     m = Normal('A', [x, y], [[1, 0], [0, 1]])
     assert simplify(E(m[1])) == y
+
 
 @XFAIL
 def test_joint_vector_expectation():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #22175
fixes #20809 
#### Brief description of what is fixed or changed

There is no method outside of Poly that can be used to identify the generators for an expression. A place where this is useful is when converting a relational like `f(x) < 1` to a set. We need to treat this like `y < 1`:
```python
>>> f=Function('f')
>>> f(x)<1
f(x) < 1
>>> _.as_set()
ConditionSet(x, f(x) < 1, Reals)
>>> x<1
x < 1
>>> _.as_set()
Interval.open(-oo, 1)
```
Now, `Relational` and `BooleanFunction` use the generators when trying to convert univariate (uni-generator) expressions to sets so both cases now give the Interval solution.

#### Other comments

- [x] add docstring
- [x] see how #22175 is affected

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * generators function added to identify the symbol and non-symbol generators in an object
<!-- END RELEASE NOTES -->
