### PR TITLE
extract_multiplicatively handles exp

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2219,6 +2219,7 @@ class Expr(Basic, EvalfMixin):
            x/6
 
         """
+        from sympy.functions.elementary.exponential import exp
         from .add import _unevaluated_Add
         c = sympify(c)
         if self is S.NaN:
@@ -2316,15 +2317,17 @@ class Expr(Basic, EvalfMixin):
                 if newarg is not None:
                     args[i] = newarg
                     return Mul(*args)
-        elif self.is_Pow:
-            if c.is_Pow and c.base == self.base:
-                new_exp = self.exp.extract_additively(c.exp)
+        elif self.is_Pow or isinstance(self, exp):
+            sb, se = self.as_base_exp()
+            cb, ce = c.as_base_exp()
+            if cb == sb:
+                new_exp = se.extract_additively(ce)
                 if new_exp is not None:
-                    return self.base ** (new_exp)
-            elif c == self.base:
+                    return Pow(sb, new_exp)
+            elif c == sb:
                 new_exp = self.exp.extract_additively(1)
                 if new_exp is not None:
-                    return self.base ** (new_exp)
+                    return Pow(sb, new_exp)
 
     def extract_additively(self, c):
         """Return self - c if it's possible to subtract c from self and

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1250,6 +1250,11 @@ def test_as_coeff_exponent():
 
 
 def test_extractions():
+    for base in (2, S.Exp1):
+        assert Pow(base**x, 3, evaluate=False
+            ).extract_multiplicatively(base**x) == base**(2*x)
+        assert (base**(5*x)).extract_multiplicatively(
+            base**(3*x)) == base**(2*x)
     assert ((x*y)**3).extract_multiplicatively(x**2 * y) == x*y**2
     assert ((x*y)**3).extract_multiplicatively(x**4 * y) is None
     assert (2*x).extract_multiplicatively(2) == x


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Formerly, only Pow was recognized. Now `exp` is recognized, too:
```python
>>> (2**(5*x)).extract_multiplicatively(2**(2*x))
2**(3*x)
>>> exp(5*x).extract_multiplicatively(exp(2*x))
>>>  <-- now gives exp(3*x)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `exp` is handled the same as `Pow` wrt `extract_multiplicatively`
<!-- END RELEASE NOTES -->
