### PR TITLE
MatrixElement gets enhanced free symbols

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1308,7 +1308,10 @@ def eval_sum_hyper(f, i_a_b):
                 return Piecewise(res, (old_sum, True))
         else:
             res1 = _eval_sum_hyper(f, i, a)
-            res2 = _eval_sum_hyper(f, i, b + 1)
+            try:
+                res2 = _eval_sum_hyper(f, i, b + 1)
+            except IndexError:  # for f = Trace (or other matexpr?)
+                res2 = None
             if res1 is None or res2 is None:
                 return None
             (res1, cond1), (res2, cond2) = res1, res2

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -6,6 +6,7 @@ from sympy.core.assumptions import check_assumptions
 from sympy.core.decorators import call_highest_priority
 from sympy.core.expr import Expr, ExprBuilder
 from sympy.core.logic import FuzzyBool
+from sympy.core.relational import is_le
 from sympy.core.symbol import Str, Dummy, symbols, Symbol
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.external.gmpy import SYMPY_INTS
@@ -589,10 +590,14 @@ class MatrixElement(Expr):
     def __new__(cls, name, n, m):
         n, m = map(_sympify, (n, m))
         from sympy.matrices.matrices import MatrixBase
-        if isinstance(name, (MatrixBase,)):
+        if isinstance(name, MatrixBase):
             if n.is_Integer and m.is_Integer:
                 return name[n, m]
-        if isinstance(name, str):
+        elif isinstance(name, MatrixSymbol):
+            r, c = name.shape
+            if is_le(r, n) or is_le(c, m):
+                raise IndexError('indices out of bounds')
+        elif isinstance(name, str):
             name = Symbol(name)
         else:
             name = _sympify(name)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -627,6 +627,10 @@ class MatrixElement(Expr):
     def indices(self):
         return self.args[1:]
 
+    @property
+    def free_symbols(self):
+        return {self}.union(*[i.free_symbols for i in self.args])
+
     def _eval_derivative(self, v):
 
         if not isinstance(v, MatrixElement):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -601,6 +601,14 @@ class MatrixElement(Expr):
         obj = Expr.__new__(cls, name, n, m)
         return obj
 
+    @property
+    def name(self):
+        return str(self)
+
+    @property
+    def symbol(self):
+        return self.args[0]
+
     def doit(self, **kwargs):
         deep = kwargs.get('deep', True)
         if deep:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -593,6 +593,7 @@ class MatrixElement(Expr):
         if isinstance(name, MatrixBase):
             if n.is_Integer and m.is_Integer:
                 return name[n, m]
+            name = _sympify(name)  # change mutable into immutable
         elif isinstance(name, MatrixSymbol):
             r, c = name.shape
             if is_le(r, n) or is_le(c, m):

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -184,8 +184,9 @@ def test_dense_conversion():
     assert Matrix(X) == Matrix(2, 2, lambda i, j: X[i, j])
 
 
-def test_free_symbols():
+def test_matexpr_free_symbols():
     assert (C*D).free_symbols == {C, D}
+    assert C[x, 0].free_symbols == {C, x, C[x, 0]}
 
 
 def test_zero_matmul():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -48,10 +48,14 @@ def test_matrix_symbol_creation():
     raises(ValueError, lambda: MatrixSymbol('A', n, n))
 
 
-def test_shape():
+def test_matexpr_properties():
     assert A.shape == (n, m)
     assert (A*B).shape == (n, l)
     raises(ShapeError, lambda: B*A)
+    assert A[0, 1].indices == (0, 1)
+    assert A[0, 1].name == 'A[0, 1]'
+    assert A[0, 0].symbol == A
+    assert A[0, 0].symbol.name == 'A'
 
 
 def test_matexpr():

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -23,7 +23,7 @@ def array_derive(expr, x):
 
 @array_derive.register(Expr) # type: ignore
 def _(expr: Expr, x: Expr):
-    return ZeroArray(*x.shape)
+    return ZeroArray(*x.shape)  # type: ignore
 
 
 @array_derive.register(ArrayTensorProduct) # type: ignore
@@ -63,7 +63,7 @@ def _(expr: ArraySymbol, x: Expr):
             ArrayTensorProduct.fromiter(Identity(i) for i in expr.shape),
             [2*i for i in range(len(expr.shape))] + [2*i+1 for i in range(len(expr.shape))]
         )
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(*(x.shape + expr.shape))  # type: ignore
 
 
 @array_derive.register(MatrixSymbol) # type: ignore
@@ -74,12 +74,12 @@ def _(expr: MatrixSymbol, x: Expr):
             _array_tensor_product(Identity(m), Identity(n)),
             [0, 2, 1, 3]
         )
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(*(x.shape + expr.shape))  # type: ignore
 
 
 @array_derive.register(Identity) # type: ignore
 def _(expr: Identity, x: Expr):
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(*(x.shape + expr.shape))  # type: ignore
 
 
 @array_derive.register(Transpose) # type: ignore

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -285,9 +285,9 @@ def _(expr: PermuteDims):
                 return _permute_dims(mat_mul_lines, permutation)
             pos = p1 // 2
             if p1 > p2:
-                args_array[i] = _a2m_transpose(mat_mul_lines.args[pos])
+                args_array[i] = _a2m_transpose(mat_mul_lines.args[pos])  # type: ignore
             else:
-                args_array[i] = mat_mul_lines.args[pos]
+                args_array[i] = mat_mul_lines.args[pos]  # type: ignore
         return _a2m_tensor_product(*args_array)
     else:
         return expr
@@ -491,13 +491,13 @@ def _(expr: ArrayDiagonal):
     for old_diag_tuple, new_diag_tuple in new_diag_indices.items():
         if len(new_diag_tuple) == 1:
             removed = [i for i in removed if i not in old_diag_tuple]
-    new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices.values()]
+    new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices.values()]  # type: ignore
     rank = get_rank(expr.expr)
     removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, rank)
     removed = sorted({i for i in removed})
     # If there are single axes to diagonalize remaining, it means that their
     # corresponding dimension has been removed, they no longer need diagonalization:
-    new_diag_indices = [i for i in new_diag_indices if len(i) > 0]
+    new_diag_indices = [i for i in new_diag_indices if len(i) > 0]  # type: ignore
     if len(new_diag_indices) > 0:
         newexpr2 = _array_diagonal(newexpr, *new_diag_indices, allow_trivial_diags=True)
     else:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -94,6 +94,7 @@ from sympy.printing.rust import RustCodePrinter
 from sympy.tensor import Idx, Indexed, IndexedBase
 from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
                             MatrixExpr, MatrixSlice)
+from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.utilities.iterables import is_sequence
 
 
@@ -185,7 +186,9 @@ class Routine:
             else:
                 local_symbols.add(r)
 
-        symbols = {s.label if isinstance(s, Idx) else s for s in symbols}
+        symbols = {s.label if isinstance(s, Idx) else
+            (s.symbol if isinstance(s, MatrixElement) else
+            s) for s in symbols}
 
         # Check that all symbols in the expressions are covered by
         # InputArguments/InOutArguments---subset because user could
@@ -646,6 +649,8 @@ class CodeGen:
                 new_symbols.remove(symbol)
                 new_symbols.update(symbol.args[1].free_symbols)
             if isinstance(symbol, Indexed):
+                new_symbols.remove(symbol)
+            if isinstance(symbol, MatrixElement):
                 new_symbols.remove(symbol)
         symbols = new_symbols
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This makes MatrixElement more like Indexed in that
it returns itself as well as free symbols of the object.
In addition,

```python
>>> IndexedBase('x')[0].free_symbols
{x[0], x}
>>> MatrixSymbol('x',2,2)[0,0].free_symbols
{x, x[0, 0]}
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * MatrixElement now lists symbolic indices and the MatrixSymbol as free symbols
<!-- END RELEASE NOTES -->
