### PR TITLE
Simplify function of Sum and Product on simplify

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -392,7 +392,7 @@ class Product(ExprWithIntLimits):
 
     def _eval_simplify(self, **kwargs):
         from sympy.simplify.simplify import product_simplify
-        rv = product_simplify(self)
+        rv = product_simplify(self, **kwargs)
         return rv.doit() if kwargs['doit'] else rv
 
     def _eval_transpose(self):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -332,8 +332,13 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
     def _eval_simplify(self, **kwargs):
 
+        function = self.function
+
+        if kwargs.get('deep', True):
+            function = function.simplify(**kwargs)
+
         # split the function into adds
-        terms = Add.make_args(expand(self.function))
+        terms = Add.make_args(expand(function))
         s_t = [] # Sum Terms
         o_t = [] # Other Terms
 
@@ -348,7 +353,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                     # go through each term
                     if isinstance(subterm, Sum):
                         # if it's a sum, simplify it
-                        out_terms.append(subterm._eval_simplify())
+                        out_terms.append(subterm._eval_simplify(**kwargs))
                     else:
                         # otherwise, add it as is
                         out_terms.append(subterm)

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -275,8 +275,9 @@ def test_conjugate_transpose():
     assert p.conjugate().doit() == p.doit().conjugate()
     assert p.transpose().doit() == p.doit().transpose()
 
+
 def test_simplify_prod():
-    y, t, b, c = symbols('y, t, b, c', integer = True)
+    y, t, b, c, v, d = symbols('y, t, b, c, v, d', integer = True)
 
     _simplify = lambda e: simplify(e, doit=False)
     assert _simplify(Product(x*y, (x, n, m), (y, a, k)) * \
@@ -294,6 +295,12 @@ def test_simplify_prod():
     assert _simplify(Product(x, (t, a, b)) * Product(x, (t, b+1, c)) * \
         Product(y, (t, a, b))) == Product(x*y, (t, a, b)) * \
             Product(x, (t, b+1, c))
+    assert _simplify(Product(sin(t)**2 + cos(t)**2 + 1, (t, a, b))) == \
+        Product(2, (t, a, b))
+    assert _simplify(Product(sin(t)**2 + cos(t)**2 - 1, (t, a, b))) == \
+           Product(0, (t, a, b))
+    assert _simplify(Product(v*Product(sin(t)**2 + cos(t)**2, (t, a, b)),
+                             (v, c, d))) == Product(v*Product(1, (t, a, b)), (v, c, d))
 
 
 def test_change_index():

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -714,7 +714,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
             i: factor_terms(i) for i in expr.atoms(Integral)})
 
     if expr.has(Product):
-        expr = product_simplify(expr)
+        expr = product_simplify(expr, **kwargs)
 
     from sympy.physics.units import Quantity
 
@@ -883,15 +883,20 @@ def sum_add(self, other, method=0):
     return Add(self, other)
 
 
-def product_simplify(s):
+def product_simplify(s, **kwargs):
     """Main function for Product simplification"""
     terms = Mul.make_args(s)
     p_t = [] # Product Terms
     o_t = [] # Other Terms
 
+    deep = kwargs.get('deep', True)
     for term in terms:
         if isinstance(term, Product):
-            p_t.append(term)
+            if deep:
+                p_t.append(Product(term.function.simplify(**kwargs),
+                                   *term.limits))
+            else:
+                p_t.append(term)
         else:
             o_t.append(term)
 
@@ -902,8 +907,9 @@ def product_simplify(s):
             if not used[i]:
                 for j, p_term2 in enumerate(p_t):
                     if not used[j] and i != j:
-                        if isinstance(product_mul(p_term1, p_term2, method), Product):
-                            p_t[i] = product_mul(p_term1, p_term2, method)
+                        tmp_prod = product_mul(p_term1, p_term2, method)
+                        if isinstance(tmp_prod, Product):
+                            p_t[i] = tmp_prod
                             used[j] = True
 
     result = Mul(*o_t)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Relates to #22260 (also see  #22264 which applies simplification as part of `doit` which also makes sense)
Closes #14219 (just adding test, fixed elsewhere)

#### Brief description of what is fixed or changed
The function in the `Sum` and `Product` is simplified when calling `simplify`.

Also, `product_simplify` is improved a bit, honoring simplify keyword arguments and using `sift`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
   * The function of `Sum` and `Product` is now simplified when calling `simplify`. 
<!-- END RELEASE NOTES -->
