### PR TITLE
Getting rid of inkscape critical warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
             - librsvg2-bin
             - imagemagick
             - docbook2x
+            - dbus
 
     - python: 3.8
       dist: xenial

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -88,7 +88,7 @@ latex: $(PDFFILES)
 	@echo "And run \`make all' in that directory to run these through xelatex."
 
 .svg.pdf:
-	inkscape --file=$< --export-area-drawing --without-gui --export-pdf=$@
+	dbus-run-session inkscape --file=$< --export-area-drawing --without-gui --export-pdf=$@
 
 changes:
 	mkdir -p _build/changes _build/doctrees

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -3,7 +3,7 @@ FROM continuumio/anaconda3
 WORKDIR /root
 
 RUN apt-get update \
-    && apt-get install -y libc6-i386 libc6 linux-headers-amd64 git make zip graphviz inkscape texlive-xetex texlive-fonts-recommended texlive-latex-extra librsvg2-bin docbook2x latexmk libatlas-dev libatlas-base-dev liblapack-dev gfortran gcc \
+    && apt-get install -y libc6-i386 libc6 linux-headers-amd64 git make zip graphviz inkscape texlive-xetex texlive-fonts-recommended texlive-latex-extra librsvg2-bin docbook2x latexmk libatlas-dev libatlas-base-dev liblapack-dev gfortran gcc dbus \
     && apt-get -y clean
 
 RUN conda config --add channels conda-forge

--- a/release/aptinstall.sh
+++ b/release/aptinstall.sh
@@ -24,6 +24,7 @@ sudo apt install\
        	docbook2x\
 	graphviz\
 	gfortran\
+	dbus\
 	#
 
 sudo apt install\

--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -139,7 +139,7 @@ def prepare_apt():
     # Be sure to use the Python 2 pip
     sudo("/usr/bin/pip install twine")
     # Needed to build the docs
-    sudo("apt-get -y install graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra librsvg2-bin docbook2x")
+    sudo("apt-get -y install graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra librsvg2-bin docbook2x dbus")
     # Our Ubuntu is too old to include Python 3.3
     sudo("apt-get -y install python-software-properties")
     sudo("add-apt-repository -y ppa:fkrull/deadsnakes")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Seeing if I can get rid of these warnings in the CI:
```
inkscape --file=src/modules/physics/vector/kin_1.svg --export-area-drawing --without-gui --export-pdf=src/modules/physics/vector/kin_1.pdf
Failed to get connection
** (inkscape:11360): CRITICAL **: 10:50:46.143: dbus_g_proxy_new_for_name: assertion 'connection != NULL' failed

** (inkscape:11360): CRITICAL **: 10:50:46.143: dbus_g_proxy_call: assertion 'DBUS_IS_G_PROXY (proxy)' failed

** (inkscape:11360): CRITICAL **: 10:50:46.143: dbus_g_connection_register_g_object: assertion 'connection != NULL' failed
```


#### Other comments

Here is the Inkscape bug report: https://gitlab.com/inkscape/inkscape/-/issues/294

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
