### PR TITLE
core - fixes issue#22244 and now -(zoo*x) return zoo*x

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -164,6 +164,8 @@ class Mul(Expr, AssocOp):
     def __neg__(self):
         c, args = self.as_coeff_mul()
         c = -c
+        if args[0] is S.ComplexInfinity:
+            c = -c
         if c is not S.One:
             if args[0].is_Number:
                 args = list(args)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -163,8 +163,7 @@ class Mul(Expr, AssocOp):
 
     def __neg__(self):
         c, args = self.as_coeff_mul()
-        c = -c
-        if args[0] is S.ComplexInfinity:
+        if args[0] is not S.ComplexInfinity:
             c = -c
         if c is not S.One:
             if args[0].is_Number:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2375,3 +2375,9 @@ def test_issue_22021():
         e = Add(*args, evaluate=False)
         assert -e == -1*e
     assert 2*Add(1, x, x, evaluate=False) == 4*x + 2
+
+
+def test_issue_22244():
+    assert -(zoo*x) == zoo*x
+    assert -(x*zoo) == zoo*x
+    assert -(zoo*x + zoo*y) == zoo*x + zoo*y

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2379,5 +2379,3 @@ def test_issue_22021():
 
 def test_issue_22244():
     assert -(zoo*x) == zoo*x
-    assert -(x*zoo) == zoo*x
-    assert -(zoo*x + zoo*y) == zoo*x + zoo*y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #22244 and now `-(zoo*x)` returns `zoo*x` and also added regression tests in test_arit.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * fixed bug in mul.py related to sign of `zoo`.
<!-- END RELEASE NOTES -->
