### PR TITLE
Added possibility to rewrite error functions as integrals

### DIFF
--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -513,6 +513,21 @@ def tn_arg(func):
         test(exp_polar(-I*pi), -1, -I)
 
 
+def test_rewrite_integral():
+    # Rewrite to Integral, integrate and get the same function back
+    # (maybe with simplification and rewrite to same function)
+    funcs1arg = [erf, erfi, li, Li, Ei, fresnelc, fresnels, Si, Shi, Chi, erfc]
+    for func in funcs1arg:
+        assert func(x).rewrite(Integral).doit().simplify().rewrite(func) == func(x), func
+
+    # Must be positive for log-terms to cancel
+    xp = Symbol('xp', positive=True)
+    assert Ci(xp).rewrite(Integral).doit().simplify() == Ci(xp)
+
+    # Will lead to erf(y) - erf(x) which is not possible to get back to erf2
+    assert erf2(x, y).rewrite(Integral).doit().simplify() == erf2(x, y).rewrite(erf)
+
+
 def test_li():
     z = Symbol("z")
     zr = Symbol("z", real=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

It is now possible to rewrite error functions as integrals (and in one case as a Sum). 

This was inspired by #19691 where it in some similar cases may help to rewrite the erf:s as an integral, perform the summation and then integrate (although probably all steps are not yet supported anyway).

#### Other comments
Some things are not so obvious.
* For expint, the rewrite is only valid when z has a positive real part. Probably a Piecewise should be returned.
* For Ci, there are two possible integrals to return

More tests will be added.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * It is now possible to rewrite error functions as integrals (and `Ei` as a `Sum`). 
<!-- END RELEASE NOTES -->
