### PR TITLE
Fixed issue when doing evalf on Sum

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -769,11 +769,14 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         for k in range(1, n + 2):
             ga, gb = fpoint(g)
             term = bernoulli(2*k)/factorial(2*k)*(gb - ga)
-            term_evalf = term.evalf(3)
-            if term_evalf is S.NaN:
-                return S.NaN, S.NaN
-            if (eps and term and abs(term_evalf) < eps) or (k > n):
+            if k > n:
                 break
+            if eps and term:
+                term_evalf = term.evalf(3)
+                if term_evalf is S.NaN:
+                    return S.NaN, S.NaN
+                if abs(term_evalf) < eps:
+                    break
             s += term
             g = g.diff(i, 2, simplify=False)
         return s + iterm, abs(term)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -769,7 +769,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         for k in range(1, n + 2):
             ga, gb = fpoint(g)
             term = bernoulli(2*k)/factorial(2*k)*(gb - ga)
-            if (eps and term and abs(term.evalf(3)) < eps) or (k > n):
+            term_evalf = term.evalf(3)
+            if term_evalf is S.NaN:
+                return S.NaN, S.NaN
+            if (eps and term and abs(term_evalf) < eps) or (k > n):
                 break
             s += term
             g = g.diff(i, 2, simplify=False)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -388,6 +388,15 @@ def test_evalf_slow_series():
     assert NS(Sum((-1)**n / (2*n + 1)**3, (n, 0, oo)), 50) == NS(pi**3/32, 50)
 
 
+def test_evalf_oo_to_oo():
+    # There used to be an error in certain cases
+    # Does not evaluate, but at least do not throw an error
+    # Evaluates symbolically to 0, which is not correct
+    assert Sum(1/(n**2+1), (n, -oo, oo)).evalf() == Sum(1/(n**2+1), (n, -oo, oo))
+    # This evaluates if from 1 to oo and symbolically
+    assert Sum(1/(factorial(abs(n))), (n, -oo, -1)).evalf() == Sum(1/(factorial(abs(n))), (n, -oo, -1))
+
+
 def test_euler_maclaurin():
     # Exact polynomial sums with E-M
     def check_exact(f, a, b, m, n):

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1217,7 +1217,7 @@ def evalf_sum(expr, prec, options):
     prec2 = prec + 10
     try:
         n, a, b = limits[0]
-        if b != S.Infinity or a != int(a):
+        if b is not S.Infinity or a is S.NegativeInfinity or a != int(a):
             raise NotImplementedError
         # Use fast hypergeometric summation if possible
         v = hypsum(func, n, int(a), prec2)
@@ -1233,6 +1233,8 @@ def evalf_sum(expr, prec, options):
             s, err = expr.euler_maclaurin(m=m, n=n, eps=eps,
                 eval_integral=False)
             err = err.evalf()
+            if err is S.NaN:
+                raise NotImplementedError
             if err <= eps:
                 break
         err = fastlog(evalf(abs(err), 20, options)[0])
@@ -1529,6 +1531,8 @@ class EvalfMixin:
                 # Probably contains symbols or unknown functions
                 return v
         re, im, re_acc, im_acc = result
+        if re is S.NaN or im is S.NaN:
+            return S.NaN
         if re:
             p = max(min(prec, re_acc), 1)
             re = Float._new(re, p)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
On current master:
```
In [6]: Sum(1/(factorial(abs(n))), (n, -oo, -1)).n()
Traceback (most recent call last):

  File "C:\Users\Oscar\AppData\Local\Temp/ipykernel_30316/3418860033.py", line 1, in <module>
    Sum(1/(factorial(abs(n))), (n, -oo, -1)).n()

  File "C:\Users\Oscar\sympy\sympy\core\evalf.py", line 1535, in evalf
    p = max(min(prec, re_acc), 1)

  File "C:\Users\Oscar\sympy\sympy\core\decorators.py", line 266, in _func
    return func(self, other)

  File "C:\Users\Oscar\sympy\sympy\core\expr.py", line 385, in __lt__
    return StrictLessThan(self, other)

  File "C:\Users\Oscar\sympy\sympy\core\relational.py", line 708, in __new__
    raise TypeError("Invalid NaN comparison")

TypeError: Invalid NaN comparison
```

```
In [3]: Sum(1/(n**2+1), (n, -oo, oo)).evalf()
Traceback (most recent call last):

  File "C:\Users\Oscar\AppData\Local\Temp/ipykernel_23872/3268128940.py", line 1, in <module>
    Sum(1/(n**2+1), (n, -oo, oo)).evalf()

  File "C:\Users\Oscar\sympy\sympy\core\evalf.py", line 1514, in evalf
    result = evalf(self, prec + 4, options)

  File "C:\Users\Oscar\sympy\sympy\core\evalf.py", line 1366, in evalf
    r = rf(x, prec, options)

  File "C:\Users\Oscar\sympy\sympy\core\evalf.py", line 1220, in evalf_sum
    if b != S.Infinity or a != int(a):

  File "C:\Users\Oscar\sympy\sympy\core\expr.py", line 334, in __int__
    raise TypeError("Cannot convert %s to int" % r)

TypeError: Cannot convert -oo to int
```
At least avoids the errors, although there are other issues leading to that the values are not computed.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
    * Performing `evalf` on some `Sum` no longer leads to comparison errors. 
<!-- END RELEASE NOTES -->
