### PR TITLE
use ibin for redundant function

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2136,7 +2136,7 @@ def truth_table(expr, variables, input=True):
     In this case, the corresponding input values of variables can be
     deduced from the index of a given output.
 
-    >>> from sympy.logic.boolalg import ibin
+    >>> from sympy.utilities.iterables import ibin
     >>> vars = [y, x]
     >>> values = truth_table(x >> y, vars, input=False)
     >>> values = list(values)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -7,7 +7,7 @@ from itertools import chain, combinations, product
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import ordered, as_int
+from sympy.core.compatibility import ordered
 from sympy.core.decorators import sympify_method_args, sympify_return
 from sympy.core.function import Application, Derivative
 from sympy.core.kind import NumberKind
@@ -2099,31 +2099,7 @@ def term_to_integer(term):
     return int(''.join(list(map(str, list(term)))), 2)
 
 
-def integer_to_term(k, n_bits=None):
-    """
-    Return a list of the base-2 digits in the integer, ``k``.
-
-    Parameters
-    ==========
-
-    k : int
-    n_bits : int
-        If ``n_bits`` is given and the number of digits in the binary
-        representation of ``k`` is smaller than ``n_bits`` then left-pad the
-        list with 0s.
-
-    Examples
-    ========
-
-    >>> from sympy.logic.boolalg import integer_to_term
-    >>> integer_to_term(4)
-    [1, 0, 0]
-    >>> integer_to_term(4, 6)
-    [0, 0, 0, 1, 0, 0]
-    """
-
-    s = '{0:0{1}b}'.format(abs(as_int(k)), as_int(abs(n_bits or 0)))
-    return list(map(int, s))
+integer_to_term = ibin  # XXX could delete?
 
 
 def truth_table(expr, variables, input=True):
@@ -2160,7 +2136,7 @@ def truth_table(expr, variables, input=True):
     In this case, the corresponding input values of variables can be
     deduced from the index of a given output.
 
-    >>> from sympy.logic.boolalg import integer_to_term
+    >>> from sympy.logic.boolalg import ibin
     >>> vars = [y, x]
     >>> values = truth_table(x >> y, vars, input=False)
     >>> values = list(values)
@@ -2169,7 +2145,7 @@ def truth_table(expr, variables, input=True):
 
     >>> for i, value in enumerate(values):
     ...     print('{0} -> {1}'.format(list(zip(
-    ...     vars, integer_to_term(i, len(vars)))), value))
+    ...     vars, ibin(i, len(vars)))), value))
     [(y, 0), (x, 0)] -> True
     [(y, 0), (x, 1)] -> False
     [(y, 1), (x, 0)] -> True
@@ -2731,7 +2707,7 @@ def bool_minterm(k, variables):
 
     """
     if isinstance(k, int):
-        k = integer_to_term(k, len(variables))
+        k = ibin(k, len(variables))
     variables = tuple(map(sympify, variables))
     return _convert_to_varsSOP(k, variables)
 
@@ -2767,7 +2743,7 @@ def bool_maxterm(k, variables):
 
     """
     if isinstance(k, int):
-        k = integer_to_term(k, len(variables))
+        k = ibin(k, len(variables))
     variables = tuple(map(sympify, variables))
     return _convert_to_varsPOS(k, variables)
 
@@ -2808,7 +2784,7 @@ def bool_monomial(k, variables):
 
     """
     if isinstance(k, int):
-        k = integer_to_term(k, len(variables))
+        k = ibin(k, len(variables))
     variables = tuple(map(sympify, variables))
     return _convert_to_varsANF(k, variables)
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -14,7 +14,7 @@ from sympy.logic.boolalg import (
     distribute_or_over_and, distribute_and_over_or,
     eliminate_implications, is_nnf, is_cnf, is_dnf, simplify_logic,
     to_nnf, to_cnf, to_dnf, to_int_repr, bool_map, true, false,
-    BooleanAtom, is_literal, term_to_integer, integer_to_term,
+    BooleanAtom, is_literal, term_to_integer,
     truth_table, as_Boolean, to_anf, is_anf, distribute_xor_over_and,
     anf_coeffs, ANFform, bool_minterm, bool_maxterm, bool_monomial,
     _check_pair, _convert_to_varsSOP, _convert_to_varsPOS, Exclusive,)
@@ -923,12 +923,6 @@ def test_term_to_integer():
     assert term_to_integer([1, 0, 1, 0, 0, 1, 0]) == 82
     assert term_to_integer('0010101000111001') == 10809
 
-
-def test_integer_to_term():
-    assert integer_to_term(777) == [1, 1, 0, 0, 0, 0, 1, 0, 0, 1]
-    assert integer_to_term(123, 3) == [1, 1, 1, 1, 0, 1, 1]
-    assert integer_to_term(456, 16) == [0, 0, 0, 0, 0, 0, 0, 1,
-                                        1, 1, 0, 0, 1, 0, 0, 0]
 
 def test_issue_21971():
     a, b, c, d = symbols('a b c d')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The `integer_to_term` function allowed errors in logic to "pass silently", allowing negative ints and size requests that were too small to hold the integer being converted to binary representation. I left it in the `boolalg` namespace but it should probably just be removed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
    * `integer_to_term` will now raise an error for negative args or when the requested size is too small; use of `ibin` is recommended
<!-- END RELEASE NOTES -->
