### PR TITLE
Add new err classes for DomainMatrix.

### DIFF
--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -38,8 +38,8 @@ from operator import mul
 
 from .exceptions import (
     DMShapeError,
-    NonInvertibleMatrixError,
-    NonSquareMatrixError,
+    DMNonInvertibleMatrixError,
+    DMNonSquareMatrixError,
     )
 
 
@@ -197,13 +197,13 @@ def ddm_iinv(ainv, a, K):
         return
     n = len(a[0])
     if m != n:
-        raise NonSquareMatrixError
+        raise DMNonSquareMatrixError
 
     eye = [[K.one if i==j else K.zero for j in range(n)] for i in range(n)]
     Aaug = [row + eyerow for row, eyerow in zip(a, eye)]
     pivots = ddm_irref(Aaug)
     if pivots != list(range(n)):
-        raise NonInvertibleMatrixError('Matrix det == 0; not invertible.')
+        raise DMNonInvertibleMatrixError('Matrix det == 0; not invertible.')
     ainv[:] = [row[n:] for row in Aaug]
 
 
@@ -288,13 +288,13 @@ def ddm_ilu_solve(x, L, U, swaps, b):
         for i in range(n, m):
             for j in range(o):
                 if y[i][j]:
-                    raise NonInvertibleMatrixError
+                    raise DMNonInvertibleMatrixError
 
     # Solve Ux = y
     for k in range(o):
         for i in reversed(range(n)):
             if not U[i][i]:
-                raise NonInvertibleMatrixError
+                raise DMNonInvertibleMatrixError
             rhs = y[i][k]
             for j in range(i+1, n):
                 rhs -= U[i][j] * x[j][k]

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -14,7 +14,7 @@ from sympy.core.sympify import _sympify
 
 from ..constructor import construct_domain
 
-from .exceptions import (NonSquareMatrixError, ShapeError, DMShapeError,
+from .exceptions import (DMNonSquareMatrixError, DMShapeError,
                          DMDomainError, DMFormatError, DMBadInputError,
                          DMNotAField)
 
@@ -854,7 +854,7 @@ class DomainMatrix:
         Raises
         ======
 
-        ShapeError
+        DMShapeError
             If the dimensions of the two DomainMatrix are not equal
 
         ValueError
@@ -904,7 +904,7 @@ class DomainMatrix:
         Raises
         ======
 
-        ShapeError
+        DMShapeError
             If the dimensions of the two DomainMatrix are not equal
 
         ValueError
@@ -1131,7 +1131,7 @@ class DomainMatrix:
         """
         nrows, ncols = A.shape
         if nrows != ncols:
-            raise NonSquareMatrixError('Power of a nonsquare matrix')
+            raise DMNonSquareMatrixError('Power of a nonsquare matrix')
         if n < 0:
             raise NotImplementedError('Negative powers')
         elif n == 0:
@@ -1360,7 +1360,7 @@ class DomainMatrix:
         ValueError
             If the domain of DomainMatrix not a Field
 
-        NonSquareMatrixError
+        DMNonSquareMatrixError
             If the DomainMatrix is not a not Square DomainMatrix
 
         Examples
@@ -1385,7 +1385,7 @@ class DomainMatrix:
             raise DMNotAField('Not a field')
         m, n = self.shape
         if m != n:
-            raise NonSquareMatrixError
+            raise DMNonSquareMatrixError
         inv = self.rep.inv()
         return self.from_rep(inv)
 
@@ -1420,7 +1420,7 @@ class DomainMatrix:
         """
         m, n = self.shape
         if m != n:
-            raise NonSquareMatrixError
+            raise DMNonSquareMatrixError
         return self.rep.det()
 
     def lu(self):
@@ -1480,7 +1480,7 @@ class DomainMatrix:
         Raises
         ======
 
-        ShapeError
+        DMShapeError
             If the DomainMatrix A and rhs have different number of rows
 
         ValueError
@@ -1508,7 +1508,7 @@ class DomainMatrix:
 
         """
         if self.shape[0] != rhs.shape[0]:
-            raise ShapeError("Shape")
+            raise DMShapeError("Shape")
         if not self.domain.is_Field:
             raise DMNotAField('Not a field')
         sol = self.rep.lu_solve(rhs.rep)
@@ -1518,7 +1518,7 @@ class DomainMatrix:
         # XXX: Not sure about this method or its signature. It is just created
         # because it is needed by the holonomic module.
         if A.shape[0] != b.shape[0]:
-            raise ShapeError("Shape")
+            raise DMShapeError("Shape")
         if A.domain != b.domain or not A.domain.is_Field:
             raise DMNotAField('Not a field')
         Aaug = A.hstack(b)
@@ -1543,7 +1543,7 @@ class DomainMatrix:
         Raises
         ======
 
-        NonSquareMatrixError
+        DMNonSquareMatrixError
             If the DomainMatrix is not a not Square DomainMatrix
 
         Examples
@@ -1561,7 +1561,7 @@ class DomainMatrix:
         """
         m, n = self.shape
         if m != n:
-            raise NonSquareMatrixError("not square")
+            raise DMNonSquareMatrixError("not square")
         return self.rep.charpoly()
 
     @classmethod

--- a/sympy/polys/matrices/exceptions.py
+++ b/sympy/polys/matrices/exceptions.py
@@ -9,12 +9,9 @@ ValueError/TypeError would not be raised anywhere.
 
 """
 
-from sympy.matrices.common import (NonInvertibleMatrixError,
-    NonSquareMatrixError, ShapeError)
-
 
 class DMError(Exception):
-    """Base class for errors raised by DDM"""
+    """Base class for errors raised by DomainMatrix"""
     pass
 
 
@@ -38,6 +35,11 @@ class DMFormatError(DMError):
     pass
 
 
+class DMNonInvertibleMatrixError(DMError):
+    """The matrix in not invertible"""
+    pass
+
+
 class DMRankError(DMError):
     """matrix does not have expected rank"""
     pass
@@ -48,9 +50,13 @@ class DMShapeError(DMError):
     pass
 
 
+class DMNonSquareMatrixError(DMShapeError):
+    """The matrix is not square"""
+    pass
+
+
 __all__ = [
     'DMError', 'DMBadInputError', 'DMDomainError', 'DMFormatError',
     'DMRankError', 'DMShapeError', 'DMNotAField',
-
-    'NonSquareMatrixError', 'NonInvertibleMatrixError', 'ShapeError',
+    'DMNonInvertibleMatrixError', 'DMNonSquareMatrixError',
 ]

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -5,7 +5,7 @@ from sympy.polys import ZZ, QQ
 
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.exceptions import (
-    DMShapeError, NonInvertibleMatrixError, DMDomainError,
+    DMShapeError, DMNonInvertibleMatrixError, DMDomainError,
     DMBadInputError)
 
 
@@ -340,7 +340,7 @@ def test_DDM_inv():
     assert A.inv() == A
 
     A = DDM([[QQ(1), QQ(2)], [QQ(2), QQ(4)]], (2, 2), QQ)
-    raises(NonInvertibleMatrixError, lambda: A.inv())
+    raises(DMNonInvertibleMatrixError, lambda: A.inv())
 
 
 def test_DDM_lu():
@@ -381,12 +381,12 @@ def test_DDM_lu_solve():
 
     # Overdetermined, inconsistent
     b = DDM([[QQ(1)], [QQ(2)], [QQ(4)]], (3, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: A.lu_solve(b))
+    raises(DMNonInvertibleMatrixError, lambda: A.lu_solve(b))
 
     # Square, noninvertible
     A = DDM([[QQ(1), QQ(2)], [QQ(1), QQ(2)]], (2, 2), QQ)
     b = DDM([[QQ(1)], [QQ(2)]], (2, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: A.lu_solve(b))
+    raises(DMNonInvertibleMatrixError, lambda: A.lu_solve(b))
 
     # Underdetermined
     A = DDM([[QQ(1), QQ(2)]], (1, 2), QQ)

--- a/sympy/polys/matrices/tests/test_dense.py
+++ b/sympy/polys/matrices/tests/test_dense.py
@@ -8,7 +8,7 @@ from sympy.polys.matrices.dense import (
         ddm_iadd, ddm_isub, ddm_ineg, ddm_imatmul, ddm_imul, ddm_irref,
         ddm_idet, ddm_iinv, ddm_ilu, ddm_ilu_split, ddm_ilu_solve, ddm_berk)
 from sympy.polys.matrices.exceptions import (
-    DMShapeError, NonInvertibleMatrixError, NonSquareMatrixError)
+    DMShapeError, DMNonInvertibleMatrixError, DMNonSquareMatrixError)
 
 
 def test_ddm_transpose():
@@ -147,7 +147,7 @@ def test_ddm_inv():
 
     A = [[QQ(1), QQ(2)]]
     Ainv = [[QQ(0), QQ(0)]]
-    raises(NonSquareMatrixError, lambda: ddm_iinv(Ainv, A, QQ))
+    raises(DMNonSquareMatrixError, lambda: ddm_iinv(Ainv, A, QQ))
 
     A = [[QQ(1, 1), QQ(2, 1)], [QQ(3, 1), QQ(4, 1)]]
     Ainv = [[QQ(0), QQ(0)], [QQ(0), QQ(0)]]
@@ -157,7 +157,7 @@ def test_ddm_inv():
 
     A = [[QQ(1, 1), QQ(2, 1)], [QQ(2, 1), QQ(4, 1)]]
     Ainv = [[QQ(0), QQ(0)], [QQ(0), QQ(0)]]
-    raises(NonInvertibleMatrixError, lambda: ddm_iinv(Ainv, A, QQ))
+    raises(DMNonInvertibleMatrixError, lambda: ddm_iinv(Ainv, A, QQ))
 
 
 def test_ddm_ilu():
@@ -293,7 +293,7 @@ def test_ddm_ilu_solve():
 
     # Overdetermined, inconsistent
     b = DDM([[QQ(1)], [QQ(2)], [QQ(4)]], (3, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: ddm_ilu_solve(x, L, U, swaps, b))
+    raises(DMNonInvertibleMatrixError, lambda: ddm_ilu_solve(x, L, U, swaps, b))
 
     # Square, noninvertible
     # A = DDM([[QQ(1), QQ(2)], [QQ(1), QQ(2)]], (2, 2), QQ)
@@ -301,7 +301,7 @@ def test_ddm_ilu_solve():
     L = [[QQ(1), QQ(0)], [QQ(1), QQ(1)]]
     swaps = []
     b = DDM([[QQ(1)], [QQ(2)]], (2, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: ddm_ilu_solve(x, L, U, swaps, b))
+    raises(DMNonInvertibleMatrixError, lambda: ddm_ilu_solve(x, L, U, swaps, b))
 
     # Underdetermined
     # A = DDM([[QQ(1), QQ(2)]], (1, 2), QQ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -4,14 +4,14 @@ from sympy.core.numbers import Integer, Rational
 from sympy.core.singleton import S
 from sympy.functions import sqrt
 
-from sympy.matrices.common import (NonInvertibleMatrixError,
-    NonSquareMatrixError, ShapeError)
 from sympy.matrices.dense import Matrix
 from sympy.polys.domains import FF, ZZ, QQ, EXRAW
 
 from sympy.polys.matrices.domainmatrix import DomainMatrix, DomainScalar, DM
 from sympy.polys.matrices.exceptions import (
-    DMBadInputError, DMDomainError, DMShapeError, DMFormatError, DMNotAField)
+    DMBadInputError, DMDomainError, DMShapeError, DMFormatError, DMNotAField,
+    DMNonSquareMatrixError, DMNonInvertibleMatrixError,
+)
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.sdm import SDM
 
@@ -450,7 +450,7 @@ def test_DomainMatrix_pow():
     raises(NotImplementedError, lambda: A.pow(-1))
 
     A = DomainMatrix.zeros((2, 1), ZZ)
-    raises(NonSquareMatrixError, lambda: A ** 1)
+    raises(DMNonSquareMatrixError, lambda: A ** 1)
 
 
 def test_DomainMatrix_scc():
@@ -535,7 +535,7 @@ def test_DomainMatrix_solve():
     assert A._solve(b) == (particular, nullspace)
 
     b3 = DomainMatrix([[QQ(1)], [QQ(1)], [QQ(1)]], (3, 1), QQ)
-    raises(ShapeError, lambda: A._solve(b3))
+    raises(DMShapeError, lambda: A._solve(b3))
 
     bz = DomainMatrix([[ZZ(1)], [ZZ(1)]], (2, 1), ZZ)
     raises(DMNotAField, lambda: A._solve(bz))
@@ -553,10 +553,10 @@ def test_DomainMatrix_inv():
     raises(DMNotAField, lambda: Az.inv())
 
     Ans = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
-    raises(NonSquareMatrixError, lambda: Ans.inv())
+    raises(DMNonSquareMatrixError, lambda: Ans.inv())
 
     Aninv = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(6)]], (2, 2), QQ)
-    raises(NonInvertibleMatrixError, lambda: Aninv.inv())
+    raises(DMNonInvertibleMatrixError, lambda: Aninv.inv())
 
 
 def test_DomainMatrix_det():
@@ -576,7 +576,7 @@ def test_DomainMatrix_det():
     assert A.det() == ZZ(0)
 
     Ans = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
-    raises(NonSquareMatrixError, lambda: Ans.det())
+    raises(DMNonSquareMatrixError, lambda: Ans.det())
 
     A = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
     assert A.det() == QQ(-2)
@@ -658,7 +658,7 @@ def test_DomainMatrix_lu_solve():
     # Non-invertible
     A = DomainMatrix([[QQ(1), QQ(2)], [QQ(2), QQ(4)]], (2, 2), QQ)
     b = DomainMatrix([[QQ(1)], [QQ(2)]], (2, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: A.lu_solve(b))
+    raises(DMNonInvertibleMatrixError, lambda: A.lu_solve(b))
 
     # Overdetermined, consistent
     A = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)], [QQ(5), QQ(6)]], (3, 2), QQ)
@@ -669,7 +669,7 @@ def test_DomainMatrix_lu_solve():
     # Overdetermined, inconsistent
     A = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)], [QQ(5), QQ(6)]], (3, 2), QQ)
     b = DomainMatrix([[QQ(1)], [QQ(2)], [QQ(4)]], (3, 1), QQ)
-    raises(NonInvertibleMatrixError, lambda: A.lu_solve(b))
+    raises(DMNonInvertibleMatrixError, lambda: A.lu_solve(b))
 
     # Underdetermined
     A = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
@@ -684,7 +684,7 @@ def test_DomainMatrix_lu_solve():
     # Shape mismatch
     A = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
     b = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
-    raises(ShapeError, lambda: A.lu_solve(b))
+    raises(DMShapeError, lambda: A.lu_solve(b))
 
 
 def test_DomainMatrix_charpoly():
@@ -701,7 +701,7 @@ def test_DomainMatrix_charpoly():
     assert A.charpoly() == [ZZ(1), ZZ(-15), ZZ(-18), ZZ(0)]
 
     Ans = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
-    raises(NonSquareMatrixError, lambda: Ans.charpoly())
+    raises(DMNonSquareMatrixError, lambda: Ans.charpoly())
 
 
 def test_DomainMatrix_eye():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

We introduce `DM....` counterparts for error classes that were formerly imported from `sympy.matrices`, so that the latter need not be imported here.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
