### PR TITLE
Code printing improvements for Boolean functions

### DIFF
--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -51,8 +51,10 @@ if aesara:
             sympy.StrictLessThan: aet.lt,
             sympy.LessThan: aet.le,
             sympy.GreaterThan: aet.ge,
-            sympy.And: aet.and_,
-            sympy.Or: aet.or_,
+            sympy.And: aet.and_,  # bitwise
+            sympy.Or: aet.or_,  # bitwise
+            sympy.Not: aet.invert,  # bitwise
+            sympy.Xor: aet.xor,  # bitwise
             sympy.Max: aet.maximum,  # Sympy accept >2 inputs, Aesara only 2
             sympy.Min: aet.minimum,  # Sympy accept >2 inputs, Aesara only 2
             sympy.conjugate: aet.conj,

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -382,8 +382,7 @@ class C89CodePrinter(CodePrinter):
 
     def _print_ITE(self, expr):
         from sympy.functions import Piecewise
-        _piecewise = Piecewise((expr.args[1], expr.args[0]), (expr.args[2], True))
-        return self._print(_piecewise)
+        return self._print(expr.rewrite(Piecewise))
 
     def _print_MatrixElement(self, expr):
         return "{}[{}]".format(self.parenthesize(expr.parent, PRECEDENCE["Atom"],
@@ -401,14 +400,6 @@ class C89CodePrinter(CodePrinter):
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
         return "{} {} {}".format(lhs_code, op, rhs_code)
-
-    def _print_sinc(self, expr):
-        from sympy.functions.elementary.trigonometric import sin
-        from sympy.core.relational import Ne
-        from sympy.functions import Piecewise
-        _piecewise = Piecewise(
-            (sin(expr.args[0]) / expr.args[0], Ne(expr.args[0], 0)), (1, True))
-        return self._print(_piecewise)
 
     def _print_For(self, expr):
         target = self._print(expr.target)

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -383,7 +383,7 @@ class C89CodePrinter(CodePrinter):
 
     def _print_ITE(self, expr):
         from sympy.functions import Piecewise
-        return self._print(expr.rewrite(Piecewise))
+        return self._print(expr.rewrite(Piecewise, deep=False))
 
     def _print_MatrixElement(self, expr):
         return "{}[{}]".format(self.parenthesize(expr.parent, PRECEDENCE["Atom"],

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -50,6 +50,7 @@ known_functions_C89 = {
     "tanh": "tanh",
     "floor": "floor",
     "ceiling": "ceil",
+    "sqrt": "sqrt", # To enable automatic rewrites
 }
 
 known_functions_C99 = dict(known_functions_C89, **{

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -68,7 +68,10 @@ class CodePrinter(StrPrinter):
     _rewriteable_functions = {
             'erf2': 'erf',
             'Li': 'li',
-            'beta': 'gamma'
+            'beta': 'gamma',
+            'sinc': 'sin',
+            'fibonacci': 'sqrt',
+            'lucas': 'sqrt',
     }
 
     def __init__(self, settings=None):
@@ -455,14 +458,14 @@ class CodePrinter(StrPrinter):
 
     def _print_Xor(self, expr):
         if self._operators.get('xor') is None:
-            return self._print_not_supported(expr)
+            return self._print(expr.to_nnf())
         PREC = precedence(expr)
         return (" %s " % self._operators['xor']).join(self.parenthesize(a, PREC)
                 for a in expr.args)
 
     def _print_Equivalent(self, expr):
         if self._operators.get('equivalent') is None:
-            return self._print_not_supported(expr)
+            return self._print(expr.to_nnf())
         PREC = precedence(expr)
         return (" %s " % self._operators['equivalent']).join(self.parenthesize(a, PREC)
                 for a in expr.args)
@@ -470,6 +473,9 @@ class CodePrinter(StrPrinter):
     def _print_Not(self, expr):
         PREC = precedence(expr)
         return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
+
+    def _print_BooleanFunction(self, expr):
+        return self._print(expr.to_nnf())
 
     def _print_Mul(self, expr):
 

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -45,6 +45,7 @@ known_functions = {
     "digamma": "digamma",
     "trigamma": "trigamma",
     "beta": "beta",
+    "sqrt": "sqrt",  # To enable automatic rewrite
 }
 
 # These are the core reserved words in the R language. Taken from:
@@ -228,8 +229,7 @@ class RCodePrinter(CodePrinter):
 
     def _print_ITE(self, expr):
         from sympy.functions import Piecewise
-        _piecewise = Piecewise((expr.args[1], expr.args[0]), (expr.args[2], True))
-        return self._print(_piecewise)
+        return self._print(expr.rewrite(Piecewise))
 
     def _print_MatrixElement(self, expr):
         return "{}[{}]".format(self.parenthesize(expr.parent, PRECEDENCE["Atom"],
@@ -247,14 +247,6 @@ class RCodePrinter(CodePrinter):
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
         return "{} {} {}".format(lhs_code, op, rhs_code)
-
-    def _print_sinc(self, expr):
-        from sympy.functions.elementary.trigonometric import sin
-        from sympy.core.relational import Ne
-        from sympy.functions import Piecewise
-        _piecewise = Piecewise(
-            (sin(expr.args[0]) / expr.args[0], Ne(expr.args[0], 0)), (1, True))
-        return self._print(_piecewise)
 
     def _print_AugmentedAssignment(self, expr):
         lhs_code = self._print(expr.lhs)

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -432,7 +432,7 @@ class RustCodePrinter(CodePrinter):
 
     def _print_ITE(self, expr):
         from sympy.functions import Piecewise
-        return self._print(expr.rewrite(Piecewise))
+        return self._print(expr.rewrite(Piecewise, deep=False))
 
     def _print_MatrixBase(self, A):
         if A.cols == 1:

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -432,8 +432,7 @@ class RustCodePrinter(CodePrinter):
 
     def _print_ITE(self, expr):
         from sympy.functions import Piecewise
-        _piecewise = Piecewise((expr.args[1], expr.args[0]), (expr.args[2], True))
-        return self._print(_piecewise)
+        return self._print(expr.rewrite(Piecewise))
 
     def _print_MatrixBase(self, A):
         if A.cols == 1:

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -5,10 +5,10 @@ from sympy.core import (
 from sympy.functions import (
     Abs, acos, acosh, asin, asinh, atan, atanh, atan2, ceiling, cos, cosh, erf,
     erfc, exp, floor, gamma, log, loggamma, Max, Min, Piecewise, sign, sin, sinh,
-    sqrt, tan, tanh
+    sqrt, tan, tanh, fibonacci, lucas
 )
 from sympy.sets import Range
-from sympy.logic import ITE
+from sympy.logic import ITE, Implies, Equivalent
 from sympy.codegen import For, aug_assign, Assignment
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 from sympy.printing.c import C89CodePrinter, C99CodePrinter, get_math_macros
@@ -164,6 +164,8 @@ def test_ccode_functions2():
     assert ccode(Mod(p1, p2)**s) == 'pow(p1 % p2, s)'
     n = symbols('n', integer=True, negative=True)
     assert ccode(Mod(-n, p2)) == '(-n) % p2'
+    assert ccode(fibonacci(n)) == '(1.0/5.0)*pow(2, -n)*sqrt(5)*(-pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n))'
+    assert ccode(lucas(n)) == 'pow(2, -n)*(pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n))'
 
 
 def test_ccode_user_functions():
@@ -190,6 +192,11 @@ def test_ccode_boolean():
     assert ccode(x | y | z) == "x || y || z"
     assert ccode((x & y) | z) == "z || x && y"
     assert ccode((x | y) & z) == "z && (x || y)"
+    # Automatic rewrites
+    assert ccode(x ^ y) == '(x || y) && (!x || !y)'
+    assert ccode((x ^ y) ^ z) == '(x || y || z) && (x || !y || !z) && (y || !x || !z) && (z || !x || !y)'
+    assert ccode(Implies(x, y)) == 'y || !x'
+    assert ccode(Equivalent(x, z ^ y, Implies(z, x))) == '(x || (y || !z) && (z || !y)) && (z && !x || (y || z) && (!y || !z))'
 
 
 def test_ccode_Relational():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added rewriting of BooleanFunction to NNF to enable printing of all Boolean Functions, even though only And, Or and Not are supported.

Added rewriting support for `sinc`, so corresponding code can be removed.

#### Other comments

Changed some explicit rewrites to use `.rewrite`.

Added support for printing Xor and Not in aesara, but do not really understand how the tests work. (But better to have it and not to...)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Better support for Boolean functions (`Xor`, `Implies`, etc) in code generation through rewriting.
<!-- END RELEASE NOTES -->
