### PR TITLE
simplify `Or(x?=y,And(x?y, z))` as `x?=y`

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -196,6 +196,36 @@ class Relational(Boolean, EvalfMixin):
         #      b, evaluate=evaluate)))(*self.args, evaluate=False)
         return Relational.__new__(ops.get(self.func), *self.args)
 
+    @property
+    def weak(self):
+        """return the non-strict version of the inequality or self
+
+        EXAMPLES
+        ========
+
+        >>> from sympy.abc import x
+        >>> (x < 1).weak
+        x <= 1
+        >>> _.weak
+        x <= 1
+        """
+        return self
+
+    @property
+    def strict(self):
+        """return the strict version of the inequality or self
+
+        EXAMPLES
+        ========
+
+        >>> from sympy.abc import x
+        >>> (x <= 1).strict
+        x < 1
+        >>> _.strict
+        x < 1
+        """
+        return self
+
     def _eval_evalf(self, prec):
         return self.func(*[s._evalf(prec) for s in self.args])
 
@@ -997,6 +1027,9 @@ class GreaterThan(_Greater):
     def _eval_fuzzy_relation(cls, lhs, rhs):
         return is_ge(lhs, rhs)
 
+    @property
+    def strict(self):
+        return Gt(*self.args)
 
 Ge = GreaterThan
 
@@ -1011,6 +1044,9 @@ class LessThan(_Less):
     def _eval_fuzzy_relation(cls, lhs, rhs):
         return is_le(lhs, rhs)
 
+    @property
+    def strict(self):
+        return Lt(*self.args)
 
 Le = LessThan
 
@@ -1024,6 +1060,10 @@ class StrictGreaterThan(_Greater):
     @classmethod
     def _eval_fuzzy_relation(cls, lhs, rhs):
         return is_gt(lhs, rhs)
+
+    @property
+    def weak(self):
+        return Ge(*self.args)
 
 
 Gt = StrictGreaterThan
@@ -1039,6 +1079,9 @@ class StrictLessThan(_Less):
     def _eval_fuzzy_relation(cls, lhs, rhs):
         return is_lt(lhs, rhs)
 
+    @property
+    def weak(self):
+        return Le(*self.args)
 
 Lt = StrictLessThan
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1218,3 +1218,21 @@ def test_is_ge_le():
     assert is_gt(PowTest(3, 9), PowTest(3,2))
     assert is_le(PowTest(3, 2), PowTest(3,9))
     assert is_lt(PowTest(3, 2), PowTest(3,9))
+
+
+def test_weak_strict():
+    for func in (Eq, Ne):
+        eq = func(x, 1)
+        assert eq.strict == eq.weak == eq
+    eq = Gt(x, 1)
+    assert eq.weak == Ge(x, 1)
+    assert eq.strict == eq
+    eq = Lt(x, 1)
+    assert eq.weak == Le(x, 1)
+    assert eq.strict == eq
+    eq = Ge(x, 1)
+    assert eq.strict == Gt(x, 1)
+    assert eq.weak == eq
+    eq = Le(x, 1)
+    assert eq.strict == Lt(x, 1)
+    assert eq.weak == eq

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -51,6 +51,8 @@ def test_piecewise1():
 
     assert Piecewise((1, x > 0), (2, And(x <= 0, x > -1))
         ) == Piecewise((1, x > 0), (2, x > -1))
+    assert Piecewise((1, x <= 0), (2, (x < 0) & (x > -1))
+        ) == Piecewise((1, x <= 0))
 
     # test for supporting Contains in Piecewise
     pwise = Piecewise(

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -153,6 +153,7 @@ class Boolean(Basic):
         """
         from sympy.calculus.util import periodicity
         from sympy.core.relational import Relational
+
         free = self.free_symbols
         if len(free) == 1:
             x = free.pop()
@@ -899,6 +900,12 @@ class Or(LatticeOp, BooleanFunction):
         return Nand(*[Not(arg) for arg in self.args])
 
     def _eval_simplify(self, **kwargs):
+        from sympy.core.relational import Le, Ge, Eq
+        lege = self.atoms(Le, Ge)
+        if lege:
+            reps = {i: self.func(
+                Eq(i.lhs, i.rhs), i.strict) for i in lege}
+            return self.xreplace(reps)._eval_simplify(**kwargs)
         # standard simplify
         rv = super()._eval_simplify(**kwargs)
         if not isinstance(rv, Or):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -241,7 +241,7 @@ def test_equals():
     raises(NotImplementedError, lambda: (A & B).equals(A > B))
 
 
-def test_simplification():
+def test_simplification_boolalg():
     """
     Test working of simplification methods.
     """
@@ -311,6 +311,9 @@ def test_simplification():
     e = And(A, b)
     assert simplify_logic(e) == A & ~x & ~y
     raises(ValueError, lambda: simplify_logic(A & (B | C), form='blabla'))
+    assert simplify(Or(x <= y, And(x < y, z))) == (x <= y)
+    assert simplify(Or(x <= y, And(y > x, z))) == (x <= y)
+    assert simplify(Or(x >= y, And(y < x, z))) == (x >= y)
 
     # Check that expressions with nine variables or more are not simplified
     # (without the force-flag)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #22300

#### Brief description of what is fixed or changed

`Piecewise` and `Or._eval_simplify` now recognize this condition.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
