### PR TITLE
Fix: abs for numexpr, not Abs

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -95,7 +95,7 @@ class NumExprPrinter(LambdaPrinter):
         'log': 'log',
         'exp': 'exp',
         'sqrt' : 'sqrt',
-        'Abs' : 'abs',
+        'abs' : 'abs',
         'conjugate' : 'conj',
         'im' : 'imag',
         're' : 'real',


### PR DESCRIPTION
#### Brief description of what is fixed or changed

NumexprPrinter has an invalid entry, it's "abs", not "Abs". The name of the function "abs" is "abs" not "Abs".

#### Other comments


#### Release Notes

Fix bug in numexpr lambdify that used the invalid identifier Abs instead of abs

<!-- BEGIN RELEASE NOTES -->
 * printing
 	* Fix invalid NumExprPrinter identifier "Abs" to "abs"
<!-- END RELEASE NOTES -->
