### PR TITLE
Piecewise handling of evaluate modified

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,6 +1,7 @@
 from sympy.core import S, Function, diff, Tuple, Dummy
 from sympy.core.basic import Basic, as_Basic
 from sympy.core.numbers import Rational, NumberSymbol
+from sympy.core.parameters import global_parameters
 from sympy.core.relational import Eq, Ne, Relational, _canonical
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or, Not,
@@ -65,11 +66,14 @@ class Piecewise(Function):
       Piecewise( (expr,cond), (expr,cond), ... )
         - Each argument is a 2-tuple defining an expression and condition
         - The conds are evaluated in turn returning the first that is True.
-          If any of the evaluated conds are not determined explicitly False,
-          e.g. x < 1, the function is returned in symbolic form.
+          If any of the evaluated conds are not explicitly False,
+          e.g. ``x < 1``, the function is returned in symbolic form.
         - If the function is evaluated at a place where all conditions are False,
           nan will be returned.
-        - Pairs where the cond is explicitly False, will be removed.
+        - Pairs where the cond is explicitly False, will be removed and no pair
+          appearing after a True condition will ever be retained. If a single
+          pair with a True condition remains, it will be returned, even when
+          evaluation is False.
 
     Examples
     ========
@@ -131,15 +135,15 @@ class Piecewise(Function):
             if cond is true:
                 break
 
-        if options.pop('evaluate', True):
+        eval = options.pop('evaluate', global_parameters.evaluate)
+        if eval:
             r = cls.eval(*newargs)
-        else:
-            r = None
+            if r is not None:
+                return r
+        elif len(newargs) == 1 and newargs[0].cond == True:
+            return newargs[0].expr
 
-        if r is None:
-            return Basic.__new__(cls, *newargs, **options)
-        else:
-            return r
+        return Basic.__new__(cls, *newargs, **options)
 
     @classmethod
     def eval(cls, *_args):
@@ -155,9 +159,20 @@ class Piecewise(Function):
         If there are no args left, nan will be returned.
         If there is a single arg with a True condition, its
         corresponding expression will be returned.
+
+        EXAMPLES
+        ========
+
+        >>> from sympy import Piecewise
+        >>> from sympy.abc import x
+        >>> cond = -x < -1
+        >>> args = [(1, cond), (4, cond), (3, False), (2, True), (5, x < 1)]
+        >>> Piecewise(*args, evaluate=False)
+        Piecewise((1, -x < -1), (4, -x < -1), (2, True))
+        >>> Piecewise(*args)
+        Piecewise((1, x > 1), (2, True))
         """
         from sympy.functions.elementary.complexes import im, re
-
         if not _args:
             return Undefined
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -599,10 +599,6 @@ def test_piecewise_fold_expand():
         ) == Piecewise((1 - x, cond), (0, True))
     assert p2 == Piecewise((1 - x, cond), (0, True))
     assert p2 == expand(piecewise_fold((1 - x)*p1))
-    p3 = Piecewise((1, True), evaluate=False)
-    assert p3 != 1
-    assert piecewise_fold(p3, evaluate=None) == 1
-    assert piecewise_fold(p3, evaluate=False) == p3
 
 
 def test_piecewise_duplicate():
@@ -752,13 +748,13 @@ def test_conjugate_transpose():
 def test_piecewise_evaluate():
     assert Piecewise((x, True)) == x
     assert Piecewise((x, True), evaluate=True) == x
-    p = Piecewise((x, True), evaluate=False)
-    assert p != x
-    assert p.is_Piecewise
-    assert all(isinstance(i, Basic) for i in p.args)
     assert Piecewise((1, Eq(1, x))).args == ((1, Eq(x, 1)),)
     assert Piecewise((1, Eq(1, x)), evaluate=False).args == (
         (1, Eq(1, x)),)
+    # like the additive and multiplicative identities that
+    # cannot be kept in Add/Mul, we also do not keep a single True
+    p = Piecewise((x, True), evaluate=False)
+    assert p == x
 
 
 def test_as_expr_set_pairs():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,4 +1,4 @@
-from sympy import (symbols, sin, Interval, Piecewise, Sum, lambdify,
+from sympy import (symbols, sin, Matrix, Interval, Piecewise, Sum, lambdify,
     Expr, sqrt)
 from sympy.testing.pytest import raises
 

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -17,6 +17,14 @@ def test_basic():
     assert lambdarepr(x**y) == "x**y"
 
 
+def test_matrix():
+    # Test printing a Matrix that has an element that is printed differently
+    # with the LambdaPrinter than with the StrPrinter.
+    e = x % 2
+    assert lambdarepr(e) != str(e)
+    assert lambdarepr(Matrix([e])) == 'ImmutableDenseMatrix([[x % 2]])'
+
+
 def test_piecewise():
     # In each case, test eval() the lambdarepr() to make sure there are a
     # correct number of parentheses. It will give a SyntaxError if there aren't.

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,5 +1,5 @@
-from sympy import symbols, sin, Matrix, Interval, Piecewise, Sum, lambdify, \
-                  Expr, sqrt
+from sympy import (symbols, sin, Interval, Piecewise, Sum, lambdify,
+    Expr, sqrt)
 from sympy.testing.pytest import raises
 
 from sympy.printing.tensorflow import TensorflowPrinter
@@ -17,26 +17,11 @@ def test_basic():
     assert lambdarepr(x**y) == "x**y"
 
 
-def test_matrix():
-    A = Matrix([[x, y], [y*x, z**2]])
-    # assert lambdarepr(A) == "ImmutableDenseMatrix([[x, y], [x*y, z**2]])"
-    # Test printing a Matrix that has an element that is printed differently
-    # with the LambdaPrinter than in the StrPrinter.
-    p = Piecewise((x, True), evaluate=False)
-    A = Matrix([p])
-    assert lambdarepr(A) == "ImmutableDenseMatrix([[((x))]])"
-
-
 def test_piecewise():
     # In each case, test eval() the lambdarepr() to make sure there are a
     # correct number of parentheses. It will give a SyntaxError if there aren't.
 
     h = "lambda x: "
-
-    p = Piecewise((x, True), evaluate=False)
-    l = lambdarepr(p)
-    eval(h + l)
-    assert l == "((x))"
 
     p = Piecewise((x, x < 0))
     l = lambdarepr(p)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -208,7 +208,7 @@ def MultivariateNormal(name, mu, sigma):
     The example below shows that it is also possible to use
     symbolic parameters to define the MultivariateNormal class.
 
-    >>> n = symbols('n', natural=True)
+    >>> n = symbols('n', integer=True, positive=True)
     >>> Sg = MatrixSymbol('Sg', n, n)
     >>> mu = MatrixSymbol('mu', n, 1)
     >>> obs = MatrixSymbol('obs', n, 1)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -36,7 +36,7 @@ def test_Normal():
 
     raises (ValueError, lambda: Normal('M', [1, 2], [[1, 1], [1, -1]]))
     # symbolic
-    n = symbols('n', natural=True)
+    n = symbols('n', integer=True, positive=True)
     mu = MatrixSymbol('mu', n, 1)
     sigma = MatrixSymbol('sigma', n, n)
     X = Normal('X', mu, sigma)
@@ -63,7 +63,7 @@ def test_Normal():
     assert eval_a == sqrt(2)/(4*pi**Rational(3/2))
     assert eval_b == sqrt(2)/(4*pi**Rational(3/2))
 
-    n = symbols('n', natural=True)
+    n = symbols('n', integer=True, positive=True)
 
     Sg = MatrixSymbol('Sg', n, n)
     mu = MatrixSymbol('mu', n, 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracted from #22286 

#### Brief description of what is fixed or changed

Piecewise will always handle True and False conditions regardless of `evaluate` setting (and if you don't want this you can use Symbols("True") and Symbols("False") as conditions to simulate it.

Piecewise now uses the global `evaluate` setting if available.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Piecewise will always process True/False conditions, even if `evaluate=False`
  * Piecewise will use global `evaluate` setting if present
<!-- END RELEASE NOTES -->
