### PR TITLE
Moved postorder_traversal and interactive_traversal

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -577,6 +577,10 @@ bottom_up
 ^^^^^^^^^
 .. autofunction:: bottom_up
 
+postorder_traversal
+^^^^^^^^^^^^^^^^^^^
+.. autofunction:: postorder_traversal
+
 preorder_traversal
 ^^^^^^^^^^^^^^^^^^
 .. autofunction:: preorder_traversal

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -200,11 +200,10 @@ from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         GeometryError, Curve, Parabola)
 
 from .utilities import (flatten, group, take, subsets, variations,
-        numbered_symbols, cartes, capture, dict_merge,
-        interactive_traversal, prefixes, postfixes, sift, topological_sort,
-        unflatten, has_dups, has_variety, reshape, default_sort_key, ordered,
-        rotations, filldedent, lambdify, source, threaded, xthreaded, public,
-        memoize_property, timed)
+        numbered_symbols, cartes, capture, dict_merge, prefixes, postfixes,
+        sift, topological_sort, unflatten, has_dups, has_variety, reshape,
+        default_sort_key, ordered, rotations, filldedent, lambdify, source,
+        threaded, xthreaded, public, memoize_property, timed)
 
 from .integrals import (integrate, Integral, line_integrate, mellin_transform,
         inverse_mellin_transform, MellinTransform, InverseMellinTransform,
@@ -250,7 +249,7 @@ from .testing import test, doctest
 # This module is slow to import:
 #from physics import units
 from .plotting import plot, textplot, plot_backends, plot_implicit, plot_parametric
-from .interactive import init_session, init_printing
+from .interactive import init_session, init_printing, interactive_traversal
 
 evalf._create_evalf_table()
 
@@ -271,6 +270,7 @@ __all__ = [
     'expand_power_exp', 'arity', 'PrecisionExhausted', 'N', 'evalf', 'Tuple',
     'Dict', 'gcd_terms', 'factor_terms', 'factor_nc', 'evaluate', 'Catalan',
     'EulerGamma', 'GoldenRatio', 'TribonacciConstant', 'bottom_up', 'use',
+    'postorder_traversal',
 
     # sympy.logic
     'to_cnf', 'to_dnf', 'to_nnf', 'And', 'Or', 'Not', 'Xor', 'Nand', 'Nor',
@@ -433,8 +433,7 @@ __all__ = [
 
     # sympy.utilities
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
-    'cartes', 'capture', 'dict_merge', 'postorder_traversal',
-    'interactive_traversal', 'prefixes', 'postfixes', 'sift',
+    'cartes', 'capture', 'dict_merge', 'prefixes', 'postfixes', 'sift',
     'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
     'default_sort_key', 'ordered', 'rotations', 'filldedent', 'lambdify',
     'source', 'threaded', 'xthreaded', 'public', 'memoize_property', 'test',
@@ -486,7 +485,7 @@ __all__ = [
     'plot', 'textplot', 'plot_backends', 'plot_implicit', 'plot_parametric',
 
     # sympy.interactive
-    'init_session', 'init_printing',
+    'init_session', 'init_printing', 'interactive_traversal',
 
     # sympy.testing
     'test', 'doctest',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -60,7 +60,8 @@ from .core import (sympify, SympifyError, cacheit, Basic, Atom,
         expand_func, expand_trig, expand_complex, expand_multinomial, nfloat,
         expand_power_base, expand_power_exp, arity, PrecisionExhausted, N,
         evalf, Tuple, Dict, gcd_terms, factor_terms, factor_nc, evaluate,
-        Catalan, EulerGamma, GoldenRatio, TribonacciConstant, bottom_up, use)
+        Catalan, EulerGamma, GoldenRatio, TribonacciConstant, bottom_up, use,
+        postorder_traversal)
 
 from .logic import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor,
         Implies, Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map,
@@ -199,7 +200,7 @@ from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         GeometryError, Curve, Parabola)
 
 from .utilities import (flatten, group, take, subsets, variations,
-        numbered_symbols, cartes, capture, dict_merge, postorder_traversal,
+        numbered_symbols, cartes, capture, dict_merge,
         interactive_traversal, prefixes, postfixes, sift, topological_sort,
         unflatten, has_dups, has_variety, reshape, default_sort_key, ordered,
         rotations, filldedent, lambdify, source, threaded, xthreaded, public,

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -29,7 +29,7 @@ from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc
 from .parameters import evaluate
 from .kind import UndefinedKind, NumberKind, BooleanKind
-from .traversal import preorder_traversal, bottom_up, use
+from .traversal import preorder_traversal, bottom_up, use, postorder_traversal
 
 # expose singletons
 Catalan = S.Catalan
@@ -93,5 +93,5 @@ __all__ = [
 
     'UndefinedKind', 'NumberKind', 'BooleanKind',
 
-    'preorder_traversal', 'bottom_up', 'use',
+    'preorder_traversal', 'bottom_up', 'use', 'postorder_traversal',
 ]

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2295,7 +2295,7 @@ class Subs(Expr):
     def evalf(self, prec=None, **options):
         return self.doit().evalf(prec, **options)
 
-    n = evalf
+    n = evalf  # type:ignore
 
     @property
     def variables(self):

--- a/sympy/core/tests/test_traversal.py
+++ b/sympy/core/tests/test_traversal.py
@@ -1,9 +1,9 @@
 from sympy.core.basic import Basic
 from sympy.core.compatibility import default_sort_key
 from sympy.core.symbol import symbols
-from sympy.core.traversal import preorder_traversal, use
-from sympy import expand, factor, I
-
+from sympy.core.traversal import preorder_traversal, use, postorder_traversal
+from sympy import expand, factor, I, Piecewise, S, Integral, Tuple
+from sympy.functions.elementary.piecewise import ExprCondPair
 
 b1 = Basic()
 b2 = Basic(b1)
@@ -53,3 +53,29 @@ def test_use():
     assert use(f, factor, level=1, kwargs=kwargs) == (x + I)**2*(x - I)**2 - 1
     assert use(f, factor, level=2, kwargs=kwargs) == (x + I)**2*(x - I)**2 - 1
     assert use(f, factor, level=3, kwargs=kwargs) == (x**2 + 1)**2 - 1
+
+
+def test_postorder_traversal():
+    x, y, z, w = symbols('x y z w')
+    expr = z + w*(x + y)
+    expected = [z, w, x, y, x + y, w*(x + y), w*(x + y) + z]
+    assert list(postorder_traversal(expr, keys=default_sort_key)) == expected
+    assert list(postorder_traversal(expr, keys=True)) == expected
+
+    expr = Piecewise((x, x < 1), (x**2, True))
+    expected = [
+        x, 1, x, x < 1, ExprCondPair(x, x < 1),
+        2, x, x**2, S.true,
+        ExprCondPair(x**2, True), Piecewise((x, x < 1), (x**2, True))
+    ]
+    assert list(postorder_traversal(expr, keys=default_sort_key)) == expected
+    assert list(postorder_traversal(
+        [expr], keys=default_sort_key)) == expected + [[expr]]
+
+    assert list(postorder_traversal(Integral(x**2, (x, 0, 1)),
+        keys=default_sort_key)) == [
+            2, x, x**2, 0, 1, x, Tuple(x, 0, 1),
+            Integral(x**2, Tuple(x, 0, 1))
+        ]
+    assert list(postorder_traversal(('abc', ('d', 'ef')))) == [
+        'abc', 'd', 'ef', ('d', 'ef'), ('abc', ('d', 'ef'))]

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -189,3 +189,60 @@ def bottom_up(rv, F, atoms=False, nonbasic=False):
                 pass
 
     return rv
+
+
+def postorder_traversal(node, keys=None):
+    """
+    Do a postorder traversal of a tree.
+
+    This generator recursively yields nodes that it has visited in a postorder
+    fashion. That is, it descends through the tree depth-first to yield all of
+    a node's children's postorder traversal before yielding the node itself.
+
+    Parameters
+    ==========
+
+    node : sympy expression
+        The expression to traverse.
+    keys : (default None) sort key(s)
+        The key(s) used to sort args of Basic objects. When None, args of Basic
+        objects are processed in arbitrary order. If key is defined, it will
+        be passed along to ordered() as the only key(s) to use to sort the
+        arguments; if ``key`` is simply True then the default keys of
+        ``ordered`` will be used (node count and default_sort_key).
+
+    Yields
+    ======
+    subtree : sympy expression
+        All of the subtrees in the tree.
+
+    Examples
+    ========
+
+    >>> from sympy.core.traversal import postorder_traversal
+    >>> from sympy.abc import w, x, y, z
+
+    The nodes are returned in the order that they are encountered unless key
+    is given; simply passing key=True will guarantee that the traversal is
+    unique.
+
+    >>> list(postorder_traversal(w + (x + y)*z)) # doctest: +SKIP
+    [z, y, x, x + y, z*(x + y), w, w + z*(x + y)]
+    >>> list(postorder_traversal(w + (x + y)*z, keys=True))
+    [w, z, x, y, x + y, z*(x + y), w + z*(x + y)]
+
+
+    """
+    if isinstance(node, Basic):
+        args = node.args
+        if keys:
+            if keys != True:
+                args = ordered(args, keys, default=False)
+            else:
+                args = ordered(args)
+        for arg in args:
+            yield from postorder_traversal(arg, keys)
+    elif iterable(node):
+        for item in node:
+            yield from postorder_traversal(item, keys)
+    yield node

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -13,6 +13,7 @@ from sympy import (Basic, E, polylog, N, Wild, WildFunction, factor, gcd, Sum,
     powdenest, PolynomialDivisionFailed, discriminant, UnificationFailed, appellf1)
 from sympy.core.exprtools import factor_terms
 from sympy.core.sympify import sympify
+from sympy.core.traversal import postorder_traversal
 from sympy.functions import (log as sym_log, sin, cos, tan, cot, csc, sec,
                              sqrt, erf, gamma, uppergamma, polygamma, digamma,
                              loggamma, factorial, zeta, LambertW)
@@ -27,7 +28,7 @@ from sympy.logic.boolalg import Or
 from sympy.polys.polytools import Poly, quo, rem, total_degree, degree
 from sympy.simplify.simplify import fraction, simplify, cancel, powsimp
 from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.iterables import flatten, postorder_traversal
+from sympy.utilities.iterables import flatten
 from random import randint
 
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -11,6 +11,7 @@ from sympy.core.mul import Mul
 from sympy.core.numbers import igcd, ilcm
 from sympy.core.relational import _canonical, Ge, Gt, Lt, Unequality
 from sympy.core.symbol import Dummy, symbols, Wild
+from sympy.core.traversal import postorder_traversal
 from sympy.functions.combinatorial.factorials import factorial, rf
 from sympy.functions.elementary.complexes import (re, arg, Abs, polar_lift,
                                                   periodic_argument)
@@ -841,7 +842,6 @@ class InverseMellinTransform(IntegralTransform):
         return a, b
 
     def _compute_transform(self, F, s, x, **hints):
-        from sympy.utilities.iterables import postorder_traversal
         global _allowed
         if _allowed is None:
             _allowed = {

--- a/sympy/interactive/__init__.py
+++ b/sympy/interactive/__init__.py
@@ -2,5 +2,7 @@
 
 from .printing import init_printing
 from .session import init_session
+from .traversal import interactive_traversal
 
-__all__ = ['init_printing', 'init_session']
+
+__all__ = ['init_printing', 'init_session', 'interactive_traversal']

--- a/sympy/interactive/traversal.py
+++ b/sympy/interactive/traversal.py
@@ -1,0 +1,95 @@
+from sympy.core.basic import Basic
+from sympy.printing import pprint
+
+import random
+
+def interactive_traversal(expr):
+    """Traverse a tree asking a user which branch to choose. """
+
+    RED, BRED = '\033[0;31m', '\033[1;31m'
+    GREEN, BGREEN = '\033[0;32m', '\033[1;32m'
+    YELLOW, BYELLOW = '\033[0;33m', '\033[1;33m'  # noqa
+    BLUE, BBLUE = '\033[0;34m', '\033[1;34m'      # noqa
+    MAGENTA, BMAGENTA = '\033[0;35m', '\033[1;35m'# noqa
+    CYAN, BCYAN = '\033[0;36m', '\033[1;36m'      # noqa
+    END = '\033[0m'
+
+    def cprint(*args):
+        print("".join(map(str, args)) + END)
+
+    def _interactive_traversal(expr, stage):
+        if stage > 0:
+            print()
+
+        cprint("Current expression (stage ", BYELLOW, stage, END, "):")
+        print(BCYAN)
+        pprint(expr)
+        print(END)
+
+        if isinstance(expr, Basic):
+            if expr.is_Add:
+                args = expr.as_ordered_terms()
+            elif expr.is_Mul:
+                args = expr.as_ordered_factors()
+            else:
+                args = expr.args
+        elif hasattr(expr, "__iter__"):
+            args = list(expr)
+        else:
+            return expr
+
+        n_args = len(args)
+
+        if not n_args:
+            return expr
+
+        for i, arg in enumerate(args):
+            cprint(GREEN, "[", BGREEN, i, GREEN, "] ", BLUE, type(arg), END)
+            pprint(arg)
+            print()
+
+        if n_args == 1:
+            choices = '0'
+        else:
+            choices = '0-%d' % (n_args - 1)
+
+        try:
+            choice = input("Your choice [%s,f,l,r,d,?]: " % choices)
+        except EOFError:
+            result = expr
+            print()
+        else:
+            if choice == '?':
+                cprint(RED, "%s - select subexpression with the given index" %
+                       choices)
+                cprint(RED, "f - select the first subexpression")
+                cprint(RED, "l - select the last subexpression")
+                cprint(RED, "r - select a random subexpression")
+                cprint(RED, "d - done\n")
+
+                result = _interactive_traversal(expr, stage)
+            elif choice in ('d', ''):
+                result = expr
+            elif choice == 'f':
+                result = _interactive_traversal(args[0], stage + 1)
+            elif choice == 'l':
+                result = _interactive_traversal(args[-1], stage + 1)
+            elif choice == 'r':
+                result = _interactive_traversal(random.choice(args), stage + 1)
+            else:
+                try:
+                    choice = int(choice)
+                except ValueError:
+                    cprint(BRED,
+                           "Choice must be a number in %s range\n" % choices)
+                    result = _interactive_traversal(expr, stage)
+                else:
+                    if choice < 0 or choice >= n_args:
+                        cprint(BRED, "Choice must be in %s range\n" % choices)
+                        result = _interactive_traversal(expr, stage)
+                    else:
+                        result = _interactive_traversal(args[choice], stage + 1)
+
+        return result
+
+    return _interactive_traversal(expr, 0)

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -3,7 +3,6 @@ SymPy.
 """
 from .iterables import (flatten, group, take, subsets,
     variations, numbered_symbols, cartes, capture, dict_merge,
-    interactive_traversal,
     prefixes, postfixes, sift, topological_sort, unflatten,
     has_dups, has_variety, reshape, default_sort_key, ordered,
     rotations)
@@ -20,8 +19,7 @@ from .timeutils import timed
 
 __all__ = [
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
-    'cartes', 'capture', 'dict_merge',
-    'interactive_traversal', 'prefixes', 'postfixes', 'sift',
+    'cartes', 'capture', 'dict_merge', 'prefixes', 'postfixes', 'sift',
     'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
     'default_sort_key', 'ordered', 'rotations',
 

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -3,7 +3,7 @@ SymPy.
 """
 from .iterables import (flatten, group, take, subsets,
     variations, numbered_symbols, cartes, capture, dict_merge,
-    postorder_traversal, interactive_traversal,
+    interactive_traversal,
     prefixes, postfixes, sift, topological_sort, unflatten,
     has_dups, has_variety, reshape, default_sort_key, ordered,
     rotations)
@@ -20,7 +20,7 @@ from .timeutils import timed
 
 __all__ = [
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
-    'cartes', 'capture', 'dict_merge', 'postorder_traversal',
+    'cartes', 'capture', 'dict_merge',
     'interactive_traversal', 'prefixes', 'postfixes', 'sift',
     'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
     'default_sort_key', 'ordered', 'rotations',

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -4,13 +4,10 @@ from itertools import (
     product
 )
 from itertools import product as cartes # noqa: F401
-import random
 from operator import gt
 
-from sympy.core.basic import Basic
 from sympy.core.decorators import deprecated
 from sympy.core.traversal import postorder_traversal as _postorder_traversal
-
 
 # this is the logical location of these functions
 from sympy.core.compatibility import as_int, is_sequence, ordered
@@ -325,98 +322,6 @@ def multiset(seq):
     return dict(rv)
 
 
-
-def interactive_traversal(expr):
-    """Traverse a tree asking a user which branch to choose. """
-    from sympy.printing import pprint
-
-    RED, BRED = '\033[0;31m', '\033[1;31m'
-    GREEN, BGREEN = '\033[0;32m', '\033[1;32m'
-    YELLOW, BYELLOW = '\033[0;33m', '\033[1;33m'  # noqa
-    BLUE, BBLUE = '\033[0;34m', '\033[1;34m'      # noqa
-    MAGENTA, BMAGENTA = '\033[0;35m', '\033[1;35m'# noqa
-    CYAN, BCYAN = '\033[0;36m', '\033[1;36m'      # noqa
-    END = '\033[0m'
-
-    def cprint(*args):
-        print("".join(map(str, args)) + END)
-
-    def _interactive_traversal(expr, stage):
-        if stage > 0:
-            print()
-
-        cprint("Current expression (stage ", BYELLOW, stage, END, "):")
-        print(BCYAN)
-        pprint(expr)
-        print(END)
-
-        if isinstance(expr, Basic):
-            if expr.is_Add:
-                args = expr.as_ordered_terms()
-            elif expr.is_Mul:
-                args = expr.as_ordered_factors()
-            else:
-                args = expr.args
-        elif hasattr(expr, "__iter__"):
-            args = list(expr)
-        else:
-            return expr
-
-        n_args = len(args)
-
-        if not n_args:
-            return expr
-
-        for i, arg in enumerate(args):
-            cprint(GREEN, "[", BGREEN, i, GREEN, "] ", BLUE, type(arg), END)
-            pprint(arg)
-            print()
-
-        if n_args == 1:
-            choices = '0'
-        else:
-            choices = '0-%d' % (n_args - 1)
-
-        try:
-            choice = input("Your choice [%s,f,l,r,d,?]: " % choices)
-        except EOFError:
-            result = expr
-            print()
-        else:
-            if choice == '?':
-                cprint(RED, "%s - select subexpression with the given index" %
-                       choices)
-                cprint(RED, "f - select the first subexpression")
-                cprint(RED, "l - select the last subexpression")
-                cprint(RED, "r - select a random subexpression")
-                cprint(RED, "d - done\n")
-
-                result = _interactive_traversal(expr, stage)
-            elif choice in ('d', ''):
-                result = expr
-            elif choice == 'f':
-                result = _interactive_traversal(args[0], stage + 1)
-            elif choice == 'l':
-                result = _interactive_traversal(args[-1], stage + 1)
-            elif choice == 'r':
-                result = _interactive_traversal(random.choice(args), stage + 1)
-            else:
-                try:
-                    choice = int(choice)
-                except ValueError:
-                    cprint(BRED,
-                           "Choice must be a number in %s range\n" % choices)
-                    result = _interactive_traversal(expr, stage)
-                else:
-                    if choice < 0 or choice >= n_args:
-                        cprint(BRED, "Choice must be in %s range\n" % choices)
-                        result = _interactive_traversal(expr, stage)
-                    else:
-                        result = _interactive_traversal(args[choice], stage + 1)
-
-        return result
-
-    return _interactive_traversal(expr, 0)
 
 
 def ibin(n, bits=None, str=False):
@@ -2675,3 +2580,10 @@ def roundrobin(*iterables):
 postorder_traversal = deprecated(
     useinstead="sympy.core.traversal.postorder_traversal",
     deprecated_since_version="1.10", issue=22288)(_postorder_traversal)
+
+
+@deprecated(useinstead="sympy.interactive.traversal.interactive_traversal",
+            issue=22288, deprecated_since_version="1.10")
+def interactive_traversal(expr):
+    from sympy.interactive.traversal import interactive_traversal as _interactive_traversal
+    return _interactive_traversal(expr)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -7,11 +7,14 @@ from itertools import product as cartes # noqa: F401
 import random
 from operator import gt
 
-from sympy.core import Basic
+from sympy.core.basic import Basic
+from sympy.core.decorators import deprecated
+from sympy.core.traversal import postorder_traversal as _postorder_traversal
+
 
 # this is the logical location of these functions
-from sympy.core.compatibility import (as_int, is_sequence, iterable, ordered)
-from sympy.core.compatibility import default_sort_key  # noqa: F401
+from sympy.core.compatibility import as_int, is_sequence, ordered
+from sympy.core.compatibility import iterable, default_sort_key  # noqa: F401
 
 from sympy.utilities.enumerative import (
     multiset_partitions_taocp, list_visitor, MultisetPartitionTraverser)
@@ -53,7 +56,7 @@ def is_palindromic(s, i=0, j=None):
     return all(s[i + k] == s[j - 1 - k] for k in range(m))
 
 
-def flatten(iterable, levels=None, cls=None):
+def flatten(iterable, levels=None, cls=None):  # noqa: F811
     """
     Recursively denest iterable containers.
 
@@ -321,62 +324,6 @@ def multiset(seq):
         rv[s] += 1
     return dict(rv)
 
-
-def postorder_traversal(node, keys=None):
-    """
-    Do a postorder traversal of a tree.
-
-    This generator recursively yields nodes that it has visited in a postorder
-    fashion. That is, it descends through the tree depth-first to yield all of
-    a node's children's postorder traversal before yielding the node itself.
-
-    Parameters
-    ==========
-
-    node : sympy expression
-        The expression to traverse.
-    keys : (default None) sort key(s)
-        The key(s) used to sort args of Basic objects. When None, args of Basic
-        objects are processed in arbitrary order. If key is defined, it will
-        be passed along to ordered() as the only key(s) to use to sort the
-        arguments; if ``key`` is simply True then the default keys of
-        ``ordered`` will be used (node count and default_sort_key).
-
-    Yields
-    ======
-    subtree : sympy expression
-        All of the subtrees in the tree.
-
-    Examples
-    ========
-
-    >>> from sympy.utilities.iterables import postorder_traversal
-    >>> from sympy.abc import w, x, y, z
-
-    The nodes are returned in the order that they are encountered unless key
-    is given; simply passing key=True will guarantee that the traversal is
-    unique.
-
-    >>> list(postorder_traversal(w + (x + y)*z)) # doctest: +SKIP
-    [z, y, x, x + y, z*(x + y), w, w + z*(x + y)]
-    >>> list(postorder_traversal(w + (x + y)*z, keys=True))
-    [w, z, x, y, x + y, z*(x + y), w + z*(x + y)]
-
-
-    """
-    if isinstance(node, Basic):
-        args = node.args
-        if keys:
-            if keys != True:
-                args = ordered(args, keys, default=False)
-            else:
-                args = ordered(args)
-        for arg in args:
-            yield from postorder_traversal(arg, keys)
-    elif iterable(node):
-        for item in node:
-            yield from postorder_traversal(item, keys)
-    yield node
 
 
 def interactive_traversal(expr):
@@ -2723,3 +2670,8 @@ def roundrobin(*iterables):
         except StopIteration:
             pending -= 1
             nexts = itertools.cycle(itertools.islice(nexts, pending))
+
+
+postorder_traversal = deprecated(
+    useinstead="sympy.core.traversal.postorder_traversal",
+    deprecated_since_version="1.10", issue=22288)(_postorder_traversal)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,9 +1,7 @@
 from textwrap import dedent
 from itertools import islice, product
 
-from sympy import (
-    symbols, Integer, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
-    factorial, true)
+from sympy import symbols, Integer, Dummy, Basic, Matrix, factorial
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
 from sympy.core.compatibility import iterable
 from sympy.utilities.iterables import (
@@ -13,7 +11,7 @@ from sympy.utilities.iterables import (
     generate_involutions, generate_oriented_forest, group, has_dups, ibin,
     iproduct, kbins, minlex, multiset, multiset_combinations,
     multiset_partitions, multiset_permutations, necklaces, numbered_symbols,
-    ordered, partitions, permutations, postfixes, postorder_traversal,
+    ordered, partitions, permutations, postfixes,
     prefixes, reshape, rotate_left, rotate_right, runs, sift,
     strongly_connected_components, subsets, take, topological_sort, unflatten,
     uniq, variations, ordered_partitions, rotations, is_palindromic)
@@ -21,7 +19,6 @@ from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
 from sympy.core.singleton import S
-from sympy.functions.elementary.piecewise import Piecewise, ExprCondPair
 from sympy.testing.pytest import raises
 
 w, x, y, z = symbols('w,x,y,z')
@@ -41,31 +38,6 @@ def test_is_palindromic():
     assert is_palindromic('xxyzyx', 1)
     assert not is_palindromic('xxyzyx', 2)
     assert is_palindromic('xxyzyx', 2, 2 + 3)
-
-
-def test_postorder_traversal():
-    expr = z + w*(x + y)
-    expected = [z, w, x, y, x + y, w*(x + y), w*(x + y) + z]
-    assert list(postorder_traversal(expr, keys=default_sort_key)) == expected
-    assert list(postorder_traversal(expr, keys=True)) == expected
-
-    expr = Piecewise((x, x < 1), (x**2, True))
-    expected = [
-        x, 1, x, x < 1, ExprCondPair(x, x < 1),
-        2, x, x**2, true,
-        ExprCondPair(x**2, True), Piecewise((x, x < 1), (x**2, True))
-    ]
-    assert list(postorder_traversal(expr, keys=default_sort_key)) == expected
-    assert list(postorder_traversal(
-        [expr], keys=default_sort_key)) == expected + [[expr]]
-
-    assert list(postorder_traversal(Integral(x**2, (x, 0, 1)),
-        keys=default_sort_key)) == [
-            2, x, x**2, 0, 1, x, Tuple(x, 0, 1),
-            Integral(x**2, Tuple(x, 0, 1))
-        ]
-    assert list(postorder_traversal(('abc', ('d', 'ef')))) == [
-        'abc', 'd', 'ef', ('d', 'ef'), ('abc', ('d', 'ef'))]
 
 
 def test_flatten():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Moved `postorder_traversal` and `preorder_traversal` in accordance with the previous moves, see #22288 

#### Other comments
Should `interactive_traversal` also move? This would get rid of the `Basic` import (but there will still be `deprecated` imports and imports of the deprecated function).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
   * `postorder_traversal` is moved from `utilities.iterables` to `core.traversal`.
   * `interactive_traversal` is moved from `utilities.iterables` to `interactive.traversal`.
<!-- END RELEASE NOTES -->
