### PR TITLE
ArraySymbol shape parameter is now a tuple

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4440,7 +4440,7 @@ def test_sympy__tensor__array__array_derivatives__ArrayDerivative():
 def test_sympy__tensor__array__expressions__array_expressions__ArraySymbol():
     from sympy.tensor.array.expressions.array_expressions import ArraySymbol
     m, n, k = symbols("m n k")
-    array = ArraySymbol("A", m, n, k, 2)
+    array = ArraySymbol("A", (m, n, k, 2))
     assert _test_args(array)
 
 def test_sympy__tensor__array__expressions__array_expressions__ArrayElement():
@@ -4949,7 +4949,7 @@ def test_sympy__tensor__array__expressions__array_expressions__PermuteDims():
 
 def test_sympy__tensor__array__expressions__array_expressions__ArrayElementwiseApplyFunc():
     from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayElementwiseApplyFunc
-    A = ArraySymbol("A", 4)
+    A = ArraySymbol("A", (4,))
     assert _test_args(ArrayElementwiseApplyFunc(exp, A))
 
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2808,7 +2808,7 @@ def test_pickleable():
     assert pickle.loads(pickle.dumps(latex)) is latex
 
 def test_printing_latex_array_expressions():
-    assert latex(ArraySymbol("A", 2, 3, 4)) == "A"
+    assert latex(ArraySymbol("A", (2, 3, 4))) == "A"
     assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1125,7 +1125,7 @@ def test_AppliedPredicate():
     assert sstr(Q.even(x)) == 'Q.even(x)'
 
 def test_printing_str_array_expressions():
-    assert sstr(ArraySymbol("A", 2, 3, 4)) == "A"
+    assert sstr(ArraySymbol("A", (2, 3, 4))) == "A"
     assert sstr(ArrayElement("A", (2, 1/(1-x), 0))) == "A[2, 1/(1 - x), 0]"
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -28,7 +28,7 @@ class ArraySymbol(_ArrayExpr):
     Symbol representing an array expression
     """
 
-    def __new__(cls, symbol, shape):
+    def __new__(cls, symbol, shape: typing.Iterable) -> "ArraySymbol":
         if isinstance(symbol, str):
             symbol = Symbol(symbol)
         # symbol = _sympify(symbol)
@@ -41,7 +41,7 @@ class ArraySymbol(_ArrayExpr):
         return self._args[0]
 
     @property
-    def shape(self):
+    def shape(self) -> Tuple:
         return self._args[1]
 
     def __getitem__(self, item):

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -28,12 +28,12 @@ class ArraySymbol(_ArrayExpr):
     Symbol representing an array expression
     """
 
-    def __new__(cls, symbol, *shape):
+    def __new__(cls, symbol, shape):
         if isinstance(symbol, str):
             symbol = Symbol(symbol)
         # symbol = _sympify(symbol)
-        shape = map(_sympify, shape)
-        obj = Expr.__new__(cls, symbol, *shape)
+        shape = Tuple(*map(_sympify, shape))
+        obj = Expr.__new__(cls, symbol, shape)
         return obj
 
     @property
@@ -42,7 +42,7 @@ class ArraySymbol(_ArrayExpr):
 
     @property
     def shape(self):
-        return self._args[1:]
+        return self._args[1]
 
     def __getitem__(self, item):
         return ArrayElement(self, item)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -41,7 +41,7 @@ class ArraySymbol(_ArrayExpr):
         return self._args[0]
 
     @property
-    def shape(self) -> Tuple:
+    def shape(self):
         return self._args[1]
 
     def __getitem__(self, item):

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -11,27 +11,27 @@ from sympy.testing.pytest import raises
 i, j, k, l, m, n = symbols("i j k l m n")
 
 
-M = ArraySymbol("M", k, k)
-N = ArraySymbol("N", k, k)
-P = ArraySymbol("P", k, k)
-Q = ArraySymbol("Q", k, k)
+M = ArraySymbol("M", (k, k))
+N = ArraySymbol("N", (k, k))
+P = ArraySymbol("P", (k, k))
+Q = ArraySymbol("Q", (k, k))
 
-A = ArraySymbol("A", k, k)
-B = ArraySymbol("B", k, k)
-C = ArraySymbol("C", k, k)
-D = ArraySymbol("D", k, k)
+A = ArraySymbol("A", (k, k))
+B = ArraySymbol("B", (k, k))
+C = ArraySymbol("C", (k, k))
+D = ArraySymbol("D", (k, k))
 
-X = ArraySymbol("X", k, k)
-Y = ArraySymbol("Y", k, k)
+X = ArraySymbol("X", (k, k))
+Y = ArraySymbol("Y", (k, k))
 
-a = ArraySymbol("a", k, 1)
-b = ArraySymbol("b", k, 1)
-c = ArraySymbol("c", k, 1)
-d = ArraySymbol("d", k, 1)
+a = ArraySymbol("a", (k, 1))
+b = ArraySymbol("b", (k, 1))
+c = ArraySymbol("c", (k, 1))
+d = ArraySymbol("d", (k, 1))
 
 
 def test_array_symbol_and_element():
-    A = ArraySymbol("A", 2)
+    A = ArraySymbol("A", (2,))
     A0 = ArrayElement(A, (0,))
     A1 = ArrayElement(A, (1,))
     assert A.as_explicit() == ImmutableDenseNDimArray([A0, A1])
@@ -45,7 +45,7 @@ def test_array_symbol_and_element():
     # TODO: not yet supported:
     # assert A3.as_explicit() == Array([])
 
-    A = ArraySymbol("A", 2, 3, 4)
+    A = ArraySymbol("A", (2, 3, 4))
     Ae = A.as_explicit()
     assert Ae == ImmutableDenseNDimArray(
         [[[ArrayElement(A, (i, j, k)) for k in range(4)] for j in range(3)] for i in range(2)])
@@ -526,7 +526,7 @@ def test_arrayexpr_array_expr_zero_array():
 
 def test_arrayexpr_array_expr_applyfunc():
 
-    A = ArraySymbol("A", 3, k, 2)
+    A = ArraySymbol("A", (3, k, 2))
     aaf = ArrayElementwiseApplyFunc(sin, A)
     assert aaf.shape == (3, k, 2)
 

--- a/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
@@ -15,7 +15,7 @@ B = MatrixSymbol("B", k, k)
 C = MatrixSymbol("C", k, k)
 D = MatrixSymbol("D", k, k)
 
-A1 = ArraySymbol("A", 3, 2, k)
+A1 = ArraySymbol("A", (3, 2, k))
 
 
 def test_arrayexpr_derivatives1():

--- a/sympy/tensor/array/expressions/tests/test_as_explicit.py
+++ b/sympy/tensor/array/expressions/tests/test_as_explicit.py
@@ -11,13 +11,13 @@ def test_array_as_explicit_call():
     assert OneArray(3, 2, 4).as_explicit() == ImmutableDenseNDimArray([1 for i in range(3*2*4)]).reshape(3, 2, 4)
 
     k = Symbol("k")
-    X = ArraySymbol("X", k, 3, 2)
+    X = ArraySymbol("X", (k, 3, 2))
     raises(ValueError, lambda: X.as_explicit())
     raises(ValueError, lambda: ZeroArray(k, 2, 3).as_explicit())
     raises(ValueError, lambda: OneArray(2, k, 2).as_explicit())
 
-    A = ArraySymbol("A", 3, 3)
-    B = ArraySymbol("B", 3, 3)
+    A = ArraySymbol("A", (3, 3))
+    B = ArraySymbol("B", (3, 3))
 
     texpr = tensorproduct(A, B)
     assert isinstance(texpr, ArrayTensorProduct)


### PR DESCRIPTION
Making the parameter _shape_ of _ArraySymbol_ a tuple, so that it is possible to avoid defining the shape.

<!-- BEGIN RELEASE NOTES -->
- tensor
  - Change the signature of `ArraySymbol` from `ArraySymbol(name, *shape)` to `ArraySymbol(name, shape)`.
<!-- END RELEASE NOTES -->
