### PR TITLE
Ne written in terms of Complement

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -709,6 +709,10 @@ class Unequality(Relational):
             return self.func(*eq.args)
         return eq.negated  # result of Ne is the negated Eq
 
+    def _eval_as_set(self):
+        from sympy.sets.sets import Complement
+        return Complement(S.UniversalSet, Eq(*self.args).as_set())
+
 
 Ne = Unequality
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -10,7 +10,7 @@ from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
                                    Gt, Ge, Ne, is_le, is_gt, is_ge, is_lt, is_eq, is_neq)
-from sympy.sets.sets import Interval, FiniteSet
+from sympy.sets.sets import Interval, FiniteSet, Complement
 
 from itertools import combinations
 
@@ -433,8 +433,7 @@ def test_univariate_relational_as_set():
     assert (x < 0).as_set() == Interval(-oo, 0, True, True)
     assert (x <= 0).as_set() == Interval(-oo, 0)
     assert Eq(x, 0).as_set() == FiniteSet(0)
-    assert Ne(x, 0).as_set() == Interval(-oo, 0, True, True) + \
-        Interval(0, oo, True, True)
+    assert Ne(x, 0).as_set() == Complement(S.UniversalSet, {0})
 
     assert (x**2 >= 4).as_set() == Interval(-oo, -2) + Interval(2, oo)
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -624,11 +624,11 @@ def test_messy():
                        fourier_transform)
     assert laplace_transform(Si(x), x, s) == ((-atan(s) + pi/2)/s, 0, True)
 
-    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, s > 1)
+    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, True)
 
     # where should the logs be simplified?
     assert laplace_transform(Chi(x), x, s) == \
-        ((log(s**(-2)) - log(1 - 1/s**2))/(2*s), 1, s > 1)
+        ((log(s**(-2)) - log(1 - 1/s**2))/(2*s), 1, True)
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
@@ -638,8 +638,8 @@ def test_messy():
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \
         (Piecewise((0, 4*abs(pi**2*s**2) > 1),
                    (2*sqrt(-4*pi**2*s**2 + 1), True)), s > 0)
-    # TODO FT(besselj(0,x)) - conditions are messy (but for acceptable reasons)
-    #                       - folding could be better
+    assert fourier_transform(besselj(0, x), x, s) == Piecewise(
+        (0, 4*pi**2*abs(s**2) > 1), (2/sqrt(-4*pi**2*s**2 + 1), True))
 
     assert integrate(E1(x)*besselj(0, x), (x, 0, oo), meijerg=True) == \
         log(1 + sqrt(2))

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -562,7 +562,7 @@ def test_laplace_transform_matrix():
 def test_issue_8368_7173():
     # hyperbolic
     assert LT(sinh(x), x, s) == (1/(s**2 - 1), 1, True)
-    assert LT(cosh(x), x, s) == (s/(s**2 - 1), 1, s > 1)
+    assert LT(cosh(x), x, s) == (s/(s**2 - 1), 1, True)
     assert LT(sinh(x + 3), x, s) == (
         (-s + (s + 1)*exp(6) + 1)*exp(-3)/(s - 1)/(s + 1)/2, 1, True)
     assert LT(sinh(x)*cosh(x), x, s) == (

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -169,7 +169,11 @@ class Boolean(Basic):
                             as_set is not implemented for relationals
                             with periodic solutions
                             '''))
-                return self.subs(reps)._eval_as_set()
+                new = self.subs(reps)
+                if new.func != self.func:
+                    return new.as_set()
+                else:
+                    return new._eval_as_set()
             return self._eval_as_set()
         else:
             raise NotImplementedError("Sorry, as_set has not yet been"

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -998,7 +998,9 @@ class Not(BooleanFunction):
         >>> Not(x > 0).as_set()
         Interval(-oo, 0)
         """
-        return self.args[0].as_set().complement(S.Reals)
+        # if we have Not(x) then the universe is the limit,
+        # not only Reals
+        return self.args[0].as_set().complement(S.UniversalSet)
 
     def to_nnf(self, simplify=True):
         if is_literal(self):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -5,7 +5,7 @@ from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
-from sympy.functions.elementary.trigonometric import sin
+from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.sets.sets import (EmptySet, Interval, Union)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
@@ -874,6 +874,8 @@ def test_bool_as_set():
     assert And(Or(x < 1, x > 3), x < 2).as_set() == Interval.open(-oo, 1)
     assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()
     raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
+    # watch for object morph in as_set
+    assert Eq(-1, cos(2*x)**2/sin(2*x)**2).as_set() is S.EmptySet
 
 
 @XFAIL

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -6,7 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
 from sympy.functions.elementary.trigonometric import sin, cos
-from sympy.sets.sets import (EmptySet, Interval, Union)
+from sympy.sets.sets import (EmptySet, Interval, Complement)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or,
@@ -866,8 +866,8 @@ def test_bool_as_set():
     assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
     assert Not(x > 2).as_set() == Interval(-oo, 2)
     # issue 10240
-    assert Not(And(x > 2, x < 3)).as_set() == \
-        Union(Interval(-oo, 2), Interval(3, oo))
+    assert Not(And(x > 2, x < 3)).as_set() == Complement(
+        S.UniversalSet, Interval.open(2, 3))
     assert true.as_set() == S.UniversalSet
     assert false.as_set() == EmptySet()
     assert x.as_set() == S.UniversalSet
@@ -876,6 +876,10 @@ def test_bool_as_set():
     raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
     # watch for object morph in as_set
     assert Eq(-1, cos(2*x)**2/sin(2*x)**2).as_set() is S.EmptySet
+    # Not is differenced with UniversalSet, not Reals
+    neset = And(Ne(x, 1), Ne(x, 2)).as_set()
+    assert neset == Complement(S.UniversalSet, {1, 2})
+    assert neset == neset.as_relational(x).as_set()
 
 
 @XFAIL

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1563,6 +1563,7 @@ class Complement(Set):
     is_Complement = True
 
     def __new__(cls, a, b, evaluate=True):
+        a, b = map(_sympify, (a, b))
         if evaluate:
             return Complement.reduce(a, b)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -371,6 +371,7 @@ def test_set_operations_nonsets():
 
 
 def test_complement():
+    assert Complement({1, 2}, {1}) == {2}
     assert Interval(0, 1).complement(S.Reals) == \
         Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
     assert Interval(0, 1, True, False).complement(S.Reals) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -937,6 +937,7 @@ def test_Complement_as_relational():
     expr = Complement(Interval(0, 1), FiniteSet(2), evaluate=False)
     assert expr.as_relational(x) == \
         And(Le(0, x), Le(x, 1), Ne(x, 2))
+    assert Complement(S.UniversalSet, {1}).as_relational(x) == Ne(x, 1)
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Whereas inequalities require arguments to be real (and are rewritten as sets under that assumption), `Ne` is more general -- even `Ne(nan, 1)` is True. So now rewriting of `Ne` is done in terms of UniversalSet in a Complement (and that set round-trips back to an instance of Ne).

Complement also sympies args, now, so sets will be converted to FiniteSet.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
