### PR TITLE
Documentation cleanup 7

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,7 +14,7 @@ PDFFILES = $(SVGFILES:%.svg=%.pdf)
 
 ALLSPHINXOPTS = -d _build/doctrees $(SPHINXOPTS) src
 ALLSPHINXOPTSapi = -d _build/doctrees-api $(SPHINXOPTS) api
-ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_element.papersize=$(PAPER) \
+ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_element.papersize=$(PAPER)paper \
                 $(SPHINXOPTS) src
 
 .PHONY: changes cheatsheet clean help html htmlapi htmlhelp info latex \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,7 +14,7 @@ PDFFILES = $(SVGFILES:%.svg=%.pdf)
 
 ALLSPHINXOPTS = -d _build/doctrees $(SPHINXOPTS) src
 ALLSPHINXOPTSapi = -d _build/doctrees-api $(SPHINXOPTS) api
-ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_paper_size=$(PAPER) \
+ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_element.papersize=$(PAPER) \
                 $(SPHINXOPTS) src
 
 .PHONY: changes cheatsheet clean help html htmlapi htmlhelp info latex \

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -22,7 +22,7 @@ issues
    * Multiple solutions: `x^2 = 1`
    * No Solution: `x^2 + 1 = 0 ; x \in \mathbb{R}`
    * Interval of solution: `\lfloor x \rfloor = 0`
-   * Infinitely many solutions: `sin(x) = 0`
+   * Infinitely many solutions: `\sin(x) = 0`
    * Multivariate functions with point solutions: `x^2 + y^2 = 0`
    * Multivariate functions with non-point solution: `x^2 + y^2 = 1`
    * System of equations: `x + y = 1` and `x - y = 0`
@@ -43,7 +43,7 @@ Why Solveset?
 
 * ``solveset`` has a cleaner input and output interface: ``solveset`` returns
   a set object and a set object takes care of all types of output. For
-  cases where it doesn't "know" all the solutions a ``ConditionSet`` with a partial
+  cases where it does not "know" all the solutions a ``ConditionSet`` with a partial
   solution is returned. For input it only takes the equation, the variables
   to solve for and the optional argument ``domain`` over which the equation is to
   be solved.

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -91,7 +91,7 @@ containers in Mathematics such as:
     >>> 4 in squares
     True
 
- * :class:`ComplexRegion`
+ * :class:`~.ComplexRegion`
 
    Represents the set of all complex numbers in a region in the Argand plane.
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -66,22 +66,22 @@ SymPy has a well developed sets module, which can represent most of the set
 containers in Mathematics such as:
 
 
- * ``FiniteSet``
+ * :class:`~.FiniteSet`
 
    Represents a finite set of discrete numbers.
 
 
- * ``Interval``
+ * :class:`~.Interval`
 
    Represents a real interval as a set.
 
 
- * ``ProductSet``
+ * :class:`~.ProductSet`
 
    Represents a Cartesian product of sets.
 
 
- * ``ImageSet``
+ * :class:`~.ImageSet`
 
    Represents the image of a set under a mathematical function
 
@@ -91,46 +91,46 @@ containers in Mathematics such as:
     >>> 4 in squares
     True
 
- * ``ComplexRegion``
+ * :class:`ComplexRegion`
 
    Represents the set of all complex numbers in a region in the Argand plane.
 
 
- * ``ConditionSet``
+ * :class:`~.ConditionSet`
 
    Represents the set of elements, which satisfies a given condition.
 
 
 Also, the predefined set classes such as:
 
- * ``Naturals`` `\mathbb{N}`
+ * :class:`~.Naturals`, $\mathbb{N}
 
    Represents the natural numbers (or counting numbers), which are all
    positive integers starting from 1.
 
 
- * ``Naturals0`` `\mathbb{N_0}`
+ * :class:`~.Naturals0`, $\mathbb{N_0}$
 
    Represents the whole numbers, which are all the non-negative integers,
    inclusive of 0.
 
 
- * ``Integers`` `\mathbb{Z}`
+ * :class:`~.Integers`, $\mathbb{Z}$
 
    Represents all integers: positive, negative and zero.
 
 
- * ``Reals`` `\mathbb{R}`
+ * :class:`~.Reals`, $\mathbb{R}$
 
    Represents the set of all real numbers.
 
 
- * ``Complexes`` `\mathbb{C}`
+ * :class:`~.Complexes`, $\mathbb{C}$
 
    Represents the set of all complex numbers.
 
 
- * ``EmptySet`` `\phi`
+ * :class:`~.EmptySet`, $\emptyset$
 
    Represents the empty set.
 

--- a/sympy/assumptions/predicates/matrices.py
+++ b/sympy/assumptions/predicates/matrices.py
@@ -218,9 +218,9 @@ class PositiveDefinitePredicate(Predicate):
     Explanation
     ===========
 
-    If ``M`` is a :math:``n \times n`` symmetric real matrix, it is said
+    If $M$ is a :math:`n \times n` symmetric real matrix, it is said
     to be positive definite if :math:`Z^TMZ` is positive for
-    every non-zero column vector ``Z`` of ``n`` real numbers.
+    every non-zero column vector $Z$ of $n$ real numbers.
 
     Examples
     ========
@@ -254,7 +254,7 @@ class UpperTriangularPredicate(Predicate):
     Explanation
     ===========
 
-    A matrix ``M`` is called upper triangular matrix if :math:`M_{ij}=0`
+    A matrix $M$ is called upper triangular matrix if :math:`M_{ij}=0`
     for :math:`i<j`.
 
     Examples
@@ -283,7 +283,7 @@ class LowerTriangularPredicate(Predicate):
     Explanation
     ===========
 
-    A matrix ``M`` is called lower triangular matrix if :math:`a_{ij}=0`
+    A matrix $M$ is called lower triangular matrix if :math:`M_{ij}=0`
     for :math:`i>j`.
 
     Examples

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2916,7 +2916,7 @@ def _random_coprime_stream(n, seed=None):
 
 
 def gm_private_key(p, q, a=None):
-    """
+    r"""
     Check if ``p`` and ``q`` can be used as private keys for
     the Goldwasser-Micali encryption. The method works
     roughly as follows.
@@ -2924,38 +2924,34 @@ def gm_private_key(p, q, a=None):
     Explanation
     ===========
 
-    $\\cdot$ Pick two large primes $p$ and $q$.
-
-    $\\cdot$ Call their product $N$.
-
-    $\\cdot$ Given a message as an integer $i$, write $i$ in its
-    bit representation $b_0, \\dots, b_n$ .
-
-    $\\cdot$ For each $k$ ,
+    #. Pick two large primes $p$ and $q$.
+    #. Call their product $N$.
+    #. Given a message as an integer $i$, write $i$ in its bit representation $b_0, \dots, b_n$.
+    #. For each $k$,
 
      if $b_k = 0$:
         let $a_k$ be a random square
         (quadratic residue) modulo $p q$
-        such that $jacobi \\_symbol(a, p q) = 1$
+        such that ``jacobi_symbol(a, p*q) = 1``
      if $b_k = 1$:
         let $a_k$ be a random non-square
         (non-quadratic residue) modulo $p q$
-        such that $jacobi \\_ symbol(a, p q) = 1$
+        such that ``jacobi_symbol(a, p*q) = 1``
 
-    returns $[a_1, a_2, \\dots]$
+    returns $\left[a_1, a_2, \dots\right]$
 
     $b_k$ can be recovered by checking whether or not
-    $a_k$ is a residue. And from the $b_k$ 's, the message
+    $a_k$ is a residue. And from the $b_k$'s, the message
     can be reconstructed.
 
-    The idea is that, while $jacobi \\_ symbol(a, p q)$
+    The idea is that, while ``jacobi_symbol(a, p*q)``
     can be easily computed (and when it is equal to $-1$ will
-    tell you that $a$ is not a square mod $p q$ ), quadratic
+    tell you that $a$ is not a square mod $p q$), quadratic
     residuosity modulo a composite number is hard to compute
     without knowing its factorization.
 
     Moreover, approximately half the numbers coprime to $p q$ have
-    $jacobi \\_ symbol$ equal to $1$ . And among those, approximately half
+    :func:`~.jacobi_symbol` equal to $1$ . And among those, approximately half
     are residues and approximately half are not. This maximizes the
     entropy of the code.
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -310,14 +310,12 @@ def factor_in_front(mul):
     return mul
 
 def combine_powers(mul):
-    """Combine consecutive powers with the same base into one
-
-    e.g. A*A**2 -> A**3
+    r"""Combine consecutive powers with the same base into one, e.g.
+    $$A \times A^2 \Rightarrow A^3$$
 
     This also cancels out the possible matrix inverses using the
-    knowledgebase of ``Inverse``.
-
-    e.g. Y * X * X.I -> Y
+    knowledgebase of :class:`~.Inverse`, e.g.,
+    $$ Y \times X \times X^{-1} \Rightarrow Y $$
     """
     factor, args = mul.as_coeff_matrices()
     new_args = [args[0]]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -286,9 +286,9 @@ class MatrixReductions(MatrixDeterminant):
 
         `op` may be one of
 
-            * "n->kn" (column n goes to k*n)
-            * "n<->m" (swap column n and column m)
-            * "n->n+km" (column n goes to column n + k*column m)
+            * ``"n->kn"`` (column n goes to k*n)
+            * ``"n<->m"`` (swap column n and column m)
+            * ``"n->n+km"`` (column n goes to column n + k*column m)
 
         Parameters
         ==========
@@ -316,9 +316,9 @@ class MatrixReductions(MatrixDeterminant):
 
         `op` may be one of
 
-            * "n->kn" (row n goes to k*n)
-            * "n<->m" (swap row n and row m)
-            * "n->n+km" (row n goes to row n + k*row m)
+            * ``"n->kn"`` (row n goes to k*n)
+            * ``"n<->m"`` (swap row n and row m)
+            * ``"n->n+km"`` (row n goes to row n + k*row m)
 
         Parameters
         ==========

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2087,8 +2087,8 @@ def solveset(f, symbol=None, domain=S.Complexes):
 
     Set
         A set of values for `symbol` for which `f` is True or is equal to
-        zero. An :func:`~.EmptySet` is returned if `f` is False or nonzero.
-        A :func:`~.ConditionSet` is returned as unsolved object if algorithms
+        zero. An :class:`~.EmptySet` is returned if `f` is False or nonzero.
+        A :class:`~.ConditionSet` is returned as unsolved object if algorithms
         to evaluate complete solution are not yet implemented.
 
     ``solveset`` claims to be complete in the solution set that it returns.
@@ -2156,7 +2156,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
     >>> pprint(solveset(p**2 - 4))
     {-2, 2}
 
-    When a :func:`~.ConditionSet` is returned, symbols with assumptions that
+    When a :class:`~.ConditionSet` is returned, symbols with assumptions that
     would alter the set are replaced with more generic symbols:
 
     >>> i = Symbol('i', imaginary=True)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -118,7 +118,7 @@ def _invert(f_x, y, x, domain=S.Complexes):
 
     $\mathrm{set}_h$ contains the functions, along with the information
     about the domain in which they are valid, through set
-    operations. For instance, if $y = |x| - n$ is inverted
+    operations. For instance, if :math:`y = |x| - n` is inverted
     in the real domain, then $\mathrm{set}_h$ is not simply
     $\{-n, n\}$ as the nature of `n` is unknown; rather, it is:
 
@@ -3613,7 +3613,7 @@ def nonlinsolve(system, *symbols):
     use :func:`~.solveset` to get the value of $x$.
 
     How nonlinsolve is better than old solver ``_solve_system`` :
-    ===========================================================
+    =============================================================
 
     1. A positive dimensional system solver: nonlinsolve can return
     solution for positive dimensional system. It finds the

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2628,7 +2628,7 @@ def linsolve(system, *symbols):
 
         system  =  [3x + 2y - z - 1, 2x - 2y + 4z + 2, 2x - y + 2z]
 
-    * Input $A$ and $b$ in matrix form (from $Ax = b$) are given as below:
+    * Input $A$ and $b$ in matrix form (from $Ax = b$) are given as:
 
     $$ A = \left[\begin{array}{ccc}
         3 &  2 & -1 \\
@@ -3490,9 +3490,9 @@ def nonlinsolve(system, *symbols):
     Solve system of $N$ nonlinear equations with $M$ variables, which means both
     under and overdetermined systems are supported. Positive dimensional
     system is also supported (A system with infinitely many solutions is said
-    to be positive-dimensional). In positive dimensional system solution will
+    to be positive-dimensional). In a positive dimensional system the solution will
     be dependent on at least one symbol. Returns both real solution
-    and complex solution(If system have). The possible number of solutions
+    and complex solution (if they exist). The possible number of solutions
     is zero, one or infinite.
 
     Parameters

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -107,29 +107,33 @@ def _masked(f, *atoms):
 
 def _invert(f_x, y, x, domain=S.Complexes):
     r"""
-    Reduce the complex valued equation ``f(x) = y`` to a set of equations
-    ``{g(x) = h_1(y), g(x) = h_2(y), ..., g(x) = h_n(y) }`` where ``g(x)`` is
-    a simpler function than ``f(x)``.  The return value is a tuple ``(g(x),
-    set_h)``, where ``g(x)`` is a function of ``x`` and ``set_h`` is
-    the set of function ``{h_1(y), h_2(y), ..., h_n(y)}``.
-    Here, ``y`` is not necessarily a symbol.
+    Reduce the complex valued equation $f(x) = y$ to a set of equations
 
-    The ``set_h`` contains the functions, along with the information
+    $$\left\{g(x) = h_1(y),\  g(x) = h_2(y),\ \dots,\  g(x) = h_n(y) \right\}$$
+
+    where $g(x)$ is a simpler function than $f(x)$.  The return value is a tuple
+    $(g(x), \mathrm{set}_h)$, where $g(x)$ is a function of $x$ and $\mathrm{set}_h$ is
+    the set of function $\left\{h_1(y), h_2(y), \dots, h_n(y)\right\}$.
+    Here, $y$ is not necessarily a symbol.
+
+    $\mathrm{set}_h$ contains the functions, along with the information
     about the domain in which they are valid, through set
-    operations. For instance, if ``y = Abs(x) - n`` is inverted
-    in the real domain, then ``set_h`` is not simply
-    `{-n, n}` as the nature of `n` is unknown; rather, it is:
-    `Intersection([0, oo) {n}) U Intersection((-oo, 0], {-n})`
+    operations. For instance, if $y = |x| - n$ is inverted
+    in the real domain, then $\mathrm{set}_h$ is not simply
+    $\{-n, n\}$ as the nature of `n` is unknown; rather, it is:
+
+    $$ \left(\left[0, \infty\right) \cap \left\{n\right\}\right) \cup
+                       \left(\left(-\infty, 0\right] \cap \left\{- n\right\}\right)$$
 
     By default, the complex domain is used which means that inverting even
-    seemingly simple functions like ``exp(x)`` will give very different
+    seemingly simple functions like $\exp(x)$ will give very different
     results from those obtained in the real domain.
-    (In the case of ``exp(x)``, the inversion via ``log`` is multi-valued
+    (In the case of $\exp(x)$, the inversion via $\log$ is multi-valued
     in the complex domain, having infinitely many branches.)
 
     If you are working with real values only (or you are not sure which
     function to use) you should probably set the domain to
-    ``S.Reals`` (or use `invert\_real` which does that automatically).
+    ``S.Reals`` (or use ``invert_real`` which does that automatically).
 
 
     Examples
@@ -188,7 +192,7 @@ invert_complex = _invert
 
 def invert_real(f_x, y, x):
     """
-    Inverts a real-valued function. Same as ``_invert``, but sets
+    Inverts a real-valued function. Same as :func:`invert_complex`, but sets
     the domain to ``S.Reals`` before inverting.
     """
     return _invert(f_x, y, x, S.Reals)
@@ -381,11 +385,11 @@ def _invert_abs(f, g_ys, symbol):
     Returns the complete result of inverting an absolute value
     function along with the conditions which must also be satisfied.
 
-    If it is certain that all these conditions are met, a `FiniteSet`
+    If it is certain that all these conditions are met, a :class:`~.FiniteSet`
     of all possible solutions is returned. If any condition cannot be
-    satisfied, an `EmptySet` is returned. Otherwise, a `ConditionSet`
-    of the solutions, with all the required conditions specified, is
-    returned.
+    satisfied, an :class:`~.EmptySet` is returned. Otherwise, a
+    :class:`~.ConditionSet` of the solutions, with all the required conditions
+    specified, is returned.
 
     """
     if not g_ys.is_FiniteSet:
@@ -2083,11 +2087,11 @@ def solveset(f, symbol=None, domain=S.Complexes):
 
     Set
         A set of values for `symbol` for which `f` is True or is equal to
-        zero. An `EmptySet` is returned if `f` is False or nonzero.
-        A `ConditionSet` is returned as unsolved object if algorithms
+        zero. An :func:`~.EmptySet` is returned if `f` is False or nonzero.
+        A :func:`~.ConditionSet` is returned as unsolved object if algorithms
         to evaluate complete solution are not yet implemented.
 
-    `solveset` claims to be complete in the solution set that it returns.
+    ``solveset`` claims to be complete in the solution set that it returns.
 
     Raises
     ======
@@ -2106,7 +2110,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
 
     Python interprets 0 and 1 as False and True, respectively, but
     in this function they refer to solutions of an expression. So 0 and 1
-    return the Domain and EmptySet, respectively, while True and False
+    return the domain and EmptySet, respectively, while True and False
     return the opposite (as they are assumed to be solutions of relational
     expressions).
 
@@ -2135,7 +2139,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
     >>> pprint(solveset(exp(x) - 1, x), use_unicode=False)
     {2*n*I*pi | n in Integers}
 
-    * If you want to use `solveset` to solve the equation in the
+    * If you want to use ``solveset`` to solve the equation in the
       real domain, provide a real domain. (Using ``solveset_real``
       does this automatically.)
 
@@ -2152,7 +2156,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
     >>> pprint(solveset(p**2 - 4))
     {-2, 2}
 
-    When a conditionSet is returned, symbols with assumptions that
+    When a :func:`~.ConditionSet` is returned, symbols with assumptions that
     would alter the set are replaced with more generic symbols:
 
     >>> i = Symbol('i', imaginary=True)
@@ -2486,13 +2490,13 @@ def linear_eq_to_matrix(equations, *symbols):
 
     This system will return $A$ and $b$ as:
 
-    $$ A = \begin{bmatrix}
+    $$ A = \left[\begin{array}{ccc}
         4 & 2 & 3 \\
         3 & 1 & 1 \\
         2 & 4 & 9
-        \end{bmatrix} \ \  b = \begin{bmatrix}
+        \end{array}\right] \ \  b = \left[\begin{array}{c}
         1 \\ -6 \\ 2
-        \end{bmatrix} $$
+        \end{array}\right] $$
 
     The only simplification performed is to convert
     ``Eq(a, b)`` $\Rightarrow a - b$.
@@ -2608,11 +2612,11 @@ def linsolve(system, *symbols):
 
     * Augmented matrix form, ``system`` given below:
 
-    $$ \text{system} = \begin{bmatrix}
+    $$ \text{system} = \left[{array}{cccc}
         3 &  2 & -1 &  1\\
         2 & -2 &  4 & -2\\
         2 & -1 &  2 &  0
-        \end{bmatrix} $$
+        \end{array}\right] $$
 
     ::
 
@@ -2626,13 +2630,13 @@ def linsolve(system, *symbols):
 
     * Input $A$ and $b$ in matrix form (from $Ax = b$) are given as below:
 
-    $$ A = \begin{bmatrix}
+    $$ A = \left[\begin{array}{ccc}
         3 &  2 & -1 \\
         2 & -2 &  4 \\
         2 & -1 &  2
-        \end{bmatrix} \ \  b = \begin{bmatrix}
+        \end{array}\right] \ \  b = \left[\begin{array}{c}
         1 \\ -2 \\ 0
-        \end{bmatrix} $$
+        \end{array}\right] $$
 
     ::
 
@@ -3486,7 +3490,7 @@ def nonlinsolve(system, *symbols):
     Solve system of $N$ nonlinear equations with $M$ variables, which means both
     under and overdetermined systems are supported. Positive dimensional
     system is also supported (A system with infinitely many solutions is said
-    to be positive-dimensional). In Positive dimensional system solution will
+    to be positive-dimensional). In positive dimensional system solution will
     be dependent on at least one symbol. Returns both real solution
     and complex solution(If system have). The possible number of solutions
     is zero, one or infinite.
@@ -3502,27 +3506,29 @@ def nonlinsolve(system, *symbols):
     Returns
     =======
 
-    A FiniteSet of ordered tuple of values of `symbols` for which the `system`
+    A :class:`~.FiniteSet` of ordered tuple of values of `symbols` for which the `system`
     has solution. Order of values in the tuple is same as symbols present in
     the parameter `symbols`.
 
-    Please note that general FiniteSet is unordered, the solution returned
-    here is not simply a FiniteSet of solutions, rather it is a FiniteSet of
-    ordered tuple, i.e. the first & only argument to FiniteSet is a tuple of
-    solutions, which is ordered, & hence the returned solution is ordered.
+    Please note that general :class:`~.FiniteSet` is unordered, the solution
+    returned here is not simply a :class:`~.FiniteSet` of solutions, rather it
+    is a :class:`~.FiniteSet` of ordered tuple, i.e. the first and only
+    argument to :class:`~.FiniteSet` is a tuple of solutions, which is
+    ordered, and, hence ,the returned solution is ordered.
 
     Also note that solution could also have been returned as an ordered tuple,
-    FiniteSet is just a wrapper `{}` around the tuple. It has no other
+    FiniteSet is just a wrapper ``{}`` around the tuple. It has no other
     significance except for the fact it is just used to maintain a consistent
     output format throughout the solveset.
 
     For the given set of equations, the respective input types
     are given below:
 
-    .. math:: x*y - 1 = 0
-    .. math:: 4*x**2 + y**2 - 5 = 0
+    .. math:: xy - 1 = 0
+    .. math:: 4x^2 + y^2 - 5 = 0
 
     ::
+
        system  = [x*y - 1, 4*x**2 + y**2 - 5]
        symbols = [x, y]
 
@@ -3574,7 +3580,7 @@ def nonlinsolve(system, *symbols):
 
     3. If system is non-linear polynomial and zero-dimensional then it
     returns both solution (real and complex solutions, if present) using
-    `solve_poly_system`:
+    :func:`~.solve_poly_system`:
 
     >>> from sympy import sqrt
     >>> nonlinsolve([x**2 - 2*y**2 -2, x*y - 2], [x, y])
@@ -3606,7 +3612,7 @@ def nonlinsolve(system, *symbols):
     $f(x)$ with a symbol and so on. Get a solution from ``nonlinsolve`` and then
     use :func:`~.solveset` to get the value of $x$.
 
-    How nonlinsolve is better than old solver `_solve_system` :
+    How nonlinsolve is better than old solver ``_solve_system`` :
     ===========================================================
 
     1. A positive dimensional system solver: nonlinsolve can return


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Follow up as it turned out that combining $$ and bmatrix didn't work well for the HTML docs. https://github.com/sympy/sympy_doc/issues/51

Also, a bit more cleanups for solveset and crypto.

In addition, I fixed(?) the following warning:
```
PYTHONPATH=..: sphinx-build -b latex -d _build/doctrees-latex -D latex_paper_size=  src _build/latex
Running Sphinx v4.1.2
WARNING: unknown config value 'latex_paper_size' in override, ignoring
```

The warning does not show up, but I have not been able to confirm that the paper size is actually correct. However, at least now we follow the Sphinx documentation how to do it.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
