### PR TITLE
Moved iterable, is_sequence, and NotIterable to utilities.iterables

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -521,14 +521,6 @@ compatibility
 -------------
 .. module:: sympy.core.compatibility
 
-iterable
-^^^^^^^^
-.. autofunction:: iterable
-
-is_sequence
-^^^^^^^^^^^
-.. autofunction:: is_sequence
-
 as_int
 ^^^^^^
 .. autofunction:: as_int

--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -2,17 +2,6 @@
 Iterables
 =========
 
-cartes
-------
-
-Returns the cartesian product of sequences as a generator.
-
-Examples::
-    >>> from sympy.utilities.iterables import cartes
-    >>> list(cartes([1,2,3], 'ab'))
-    [(1, 'a'), (1, 'b'), (2, 'a'), (2, 'b'), (3, 'a'), (3, 'b')]
-
-
 
 variations
 ----------

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -4,7 +4,7 @@ Euler-Lagrange Equations for given Lagrangian.
 """
 from itertools import combinations_with_replacement
 from sympy import Function, sympify, diff, Eq, S, Symbol, Derivative
-from sympy.core.compatibility import iterable
+from sympy.utilities.iterables import iterable
 
 
 def euler_equations(L, funcs=(), vars=()):

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -18,11 +18,12 @@ for:
 """
 
 from sympy import Derivative, S
-from sympy.core.compatibility import iterable
 from sympy.core.decorators import deprecated
 from sympy.core.function import Subs
 from sympy.core.traversal import preorder_traversal
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import iterable
+
 
 
 def finite_diff_weights(order, x_list, x0=S.One):

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1,7 +1,6 @@
 from sympy import Order, limit, lcm_list, Piecewise
 from sympy.core import Add, Mul, Pow, S
 from sympy.core.basic import Basic
-from sympy.core.compatibility import iterable
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.function import diff, expand_mul
 from sympy.core.kind import NumberKind
@@ -24,6 +23,7 @@ from sympy.simplify.simplify import simplify
 from sympy.solvers.decompogen import compogen, decompogen
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
+from sympy.utilities.iterables import iterable
 from sympy.multipledispatch import dispatch
 
 

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -1,7 +1,7 @@
 from sympy.core import S, Basic, Dict, Symbol, Tuple, sympify
-from sympy.core.compatibility import iterable
 from sympy.core.symbol import Str
 from sympy.sets import Set, FiniteSet, EmptySet
+from sympy.utilities.iterables import iterable
 
 
 class Class(Set):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -85,10 +85,10 @@ References
 from sympy.categories import (CompositeMorphism, IdentityMorphism,
                               NamedMorphism, Diagram)
 from sympy.core import Dict, Symbol
-from sympy.core.compatibility import iterable
 from sympy.printing import latex
 from sympy.sets import FiniteSet
 from sympy.utilities import default_sort_key
+from sympy.utilities.iterables import iterable
 from sympy.utilities.decorator import doctest_depends_on
 
 from itertools import chain

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -1,13 +1,13 @@
 from typing import Dict, List
 
 from sympy.core import S
-from sympy.core.compatibility import is_sequence, as_int
+from sympy.core.compatibility import as_int
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.sympify import CantSympify
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
-from sympy.utilities.iterables import flatten
+from sympy.utilities.iterables import flatten, is_sequence
 from sympy.utilities.magic import pollute
 
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -6,14 +6,13 @@ from functools import reduce
 from sympy.core.parameters import global_parameters
 from sympy.core.basic import Atom
 from sympy.core.expr import Expr
-from sympy.core.compatibility import \
-    is_sequence, as_int
+from sympy.core.compatibility import as_int
 from sympy.core.numbers import Integer
 from sympy.core.sympify import _sympify
 from sympy.matrices import zeros
 from sympy.polys.polytools import lcm
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
-    has_dups, runs)
+    has_dups, runs, is_sequence)
 from mpmath.libmp.libintmath import ifac
 from sympy.multipledispatch import dispatch
 

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -1,6 +1,6 @@
 from sympy.core import Basic
-from sympy.core.compatibility import iterable, as_int
-from sympy.utilities.iterables import flatten
+from sympy.core.compatibility import as_int
+from sympy.utilities.iterables import flatten, iterable
 
 from collections import defaultdict
 

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -1,5 +1,4 @@
 from sympy.core.add import Add
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
@@ -14,7 +13,7 @@ from sympy.tensor.indexed import Idx
 from sympy.sets.sets import Interval
 from sympy.sets.fancysets import Range
 from sympy.utilities import flatten
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, is_sequence
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -1,10 +1,10 @@
 """Gosper's algorithm for hypergeometric summation. """
 
 from sympy.core import S, Dummy, symbols
-from sympy.core.compatibility import is_sequence
 from sympy.polys import Poly, parallel_poly_from_expr, factor
 from sympy.solvers import solve
 from sympy.simplify import hypersimp
+from sympy.utilities.iterables import is_sequence
 
 
 def gosper_normal(f, g, n, polys=True):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from functools import cmp_to_key, reduce
 from operator import attrgetter
 from .basic import Basic
-from .compatibility import is_sequence
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
@@ -11,6 +10,7 @@ from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
 from .kind import UndefinedKind
+from sympy.utilities.iterables import is_sequence
 
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,9 +8,10 @@ from .assumptions import BasicMeta, ManagedProperties
 from .decorators import deprecated
 from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
-from .compatibility import iterable, ordered
+from .compatibility import ordered
 from .kind import Kind, UndefinedKind
 from ._print_helpers import Printable
+
 
 from inspect import getmro
 
@@ -882,10 +883,12 @@ class Basic(Printable, metaclass=ManagedProperties):
         """
         from .containers import Dict
         from .symbol import Dummy, Symbol
+        from sympy.utilities.iterables import iterable
         from sympy.utilities.misc import filldedent
 
         unordered = False
         if len(args) == 1:
+
             sequence = args[0]
             if isinstance(sequence, set):
                 unordered = True
@@ -1806,6 +1809,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             method = "_eval_rewrite_as_%s" % clsname
 
         if pattern:
+            from sympy.utilities.iterables import iterable
             if iterable(pattern[0]):
                 pattern = pattern[0]
             pattern = tuple(p for p in pattern if self.has(p))

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -38,7 +38,7 @@ CACHE = _cache()
 print_cache = CACHE.print_cache
 clear_cache = CACHE.clear_cache
 
-from functools import lru_cache
+from functools import lru_cache, wraps
 
 def __cacheit(maxsize):
     """caching decorator.
@@ -62,8 +62,6 @@ def __cacheit(maxsize):
         set environment variable SYMPY_USE_CACHE to 'debug'
     """
     def func_wrapper(func):
-        from .decorators import wraps
-
         cfunc = lru_cache(maxsize, typed=True)(func)
 
         @wraps(func)
@@ -93,8 +91,6 @@ def __cacheit_nocache(func):
 def __cacheit_debug(maxsize):
     """cacheit + code to check cache consistency"""
     def func_wrapper(func):
-        from .decorators import wraps
-
         cfunc = __cacheit(maxsize)(func)
 
         @wraps(func)

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -12,122 +12,8 @@ Some utility functions originating from Python 2 and Python 3 compatible imports
 """
 
 __all__ = [
-    'NotIterable', 'iterable', 'is_sequence',
     'as_int', 'default_sort_key', 'ordered',
 ]
-
-
-
-# These are in here because telling if something is an iterable just by calling
-# hasattr(obj, "__iter__") behaves differently in Python 2 and Python 3.  In
-# particular, hasattr(str, "__iter__") is False in Python 2 and True in Python 3.
-# I think putting them here also makes it easier to use them in the core.
-
-class NotIterable:
-    """
-    Use this as mixin when creating a class which is not supposed to
-    return true when iterable() is called on its instances because
-    calling list() on the instance, for example, would result in
-    an infinite loop.
-    """
-    pass
-
-def iterable(i, exclude=(str, dict, NotIterable)):
-    """
-    Return a boolean indicating whether ``i`` is SymPy iterable.
-    True also indicates that the iterator is finite, e.g. you can
-    call list(...) on the instance.
-
-    When SymPy is working with iterables, it is almost always assuming
-    that the iterable is not a string or a mapping, so those are excluded
-    by default. If you want a pure Python definition, make exclude=None. To
-    exclude multiple items, pass them as a tuple.
-
-    You can also set the _iterable attribute to True or False on your class,
-    which will override the checks here, including the exclude test.
-
-    As a rule of thumb, some SymPy functions use this to check if they should
-    recursively map over an object. If an object is technically iterable in
-    the Python sense but does not desire this behavior (e.g., because its
-    iteration is not finite, or because iteration might induce an unwanted
-    computation), it should disable it by setting the _iterable attribute to False.
-
-    See also: is_sequence
-
-    Examples
-    ========
-
-    >>> from sympy.utilities.iterables import iterable
-    >>> from sympy import Tuple
-    >>> things = [[1], (1,), set([1]), Tuple(1), (j for j in [1, 2]), {1:2}, '1', 1]
-    >>> for i in things:
-    ...     print('%s %s' % (iterable(i), type(i)))
-    True <... 'list'>
-    True <... 'tuple'>
-    True <... 'set'>
-    True <class 'sympy.core.containers.Tuple'>
-    True <... 'generator'>
-    False <... 'dict'>
-    False <... 'str'>
-    False <... 'int'>
-
-    >>> iterable({}, exclude=None)
-    True
-    >>> iterable({}, exclude=str)
-    True
-    >>> iterable("no", exclude=str)
-    False
-
-    """
-    if hasattr(i, '_iterable'):
-        return i._iterable
-    try:
-        iter(i)
-    except TypeError:
-        return False
-    if exclude:
-        return not isinstance(i, exclude)
-    return True
-
-
-def is_sequence(i, include=None):
-    """
-    Return a boolean indicating whether ``i`` is a sequence in the SymPy
-    sense. If anything that fails the test below should be included as
-    being a sequence for your application, set 'include' to that object's
-    type; multiple types should be passed as a tuple of types.
-
-    Note: although generators can generate a sequence, they often need special
-    handling to make sure their elements are captured before the generator is
-    exhausted, so these are not included by default in the definition of a
-    sequence.
-
-    See also: iterable
-
-    Examples
-    ========
-
-    >>> from sympy.utilities.iterables import is_sequence
-    >>> from types import GeneratorType
-    >>> is_sequence([])
-    True
-    >>> is_sequence(set())
-    False
-    >>> is_sequence('abc')
-    False
-    >>> is_sequence('abc', include=str)
-    True
-    >>> generator = (c for c in 'abc')
-    >>> is_sequence(generator)
-    False
-    >>> is_sequence(generator, include=(str, GeneratorType))
-    True
-
-    """
-    return (hasattr(i, '__getitem__') and
-            iterable(i) or
-            bool(include) and
-            isinstance(i, include))
 
 
 def as_int(n, strict=True):
@@ -315,7 +201,7 @@ def default_sort_key(item, order=None):
     from .singleton import S
     from .basic import Basic
     from .sympify import sympify, SympifyError
-    from .compatibility import iterable
+    from sympy.utilities.iterables import iterable
 
     if isinstance(item, Basic):
         return item.sort_key(order=order)
@@ -377,6 +263,7 @@ def _nodes(e):
     """
     from .basic import Basic
     from .function import Derivative
+    from sympy.utilities.iterables import iterable
 
     if isinstance(e, Basic):
         if isinstance(e, Derivative):

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -4,7 +4,7 @@ Provides functionality for multidimensional usage of scalar-functions.
 Read the vectorize docstring for more details.
 """
 
-from .decorators import wraps
+from functools import wraps
 
 
 def apply_on_element(f, args, kwargs, n):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4,6 +4,7 @@ import fractions
 import math
 import re as regex
 import sys
+from functools import lru_cache
 from typing import Set
 
 from .containers import Tuple
@@ -13,7 +14,7 @@ from .singleton import S, Singleton
 from .basic import Basic
 from .expr import Expr, AtomicExpr
 from .evalf import pure_complex
-from .cache import cacheit, clear_cache, lru_cache
+from .cache import cacheit, clear_cache
 from .compatibility import as_int
 from .decorators import _sympifyit
 from .logic import fuzzy_not

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,7 +1,7 @@
 from .assumptions import StdFactKB, _assume_defined
 from .basic import Basic, Atom
 from .cache import cacheit
-from .compatibility import is_sequence, ordered
+from .compatibility import ordered
 from .containers import Tuple
 from .expr import Expr, AtomicExpr
 from .function import AppliedUndef, FunctionClass
@@ -10,7 +10,7 @@ from .logic import fuzzy_bool
 from .singleton import S
 from .sympify import sympify
 from sympy.logic.boolalg import Boolean
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, is_sequence
 
 import string
 import re as _re

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,7 +8,6 @@ from inspect import getmro
 import string
 from random import choice
 
-from .compatibility import iterable
 from .parameters import global_parameters
 
 
@@ -433,6 +432,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     if strict:
         raise SympifyError(a)
+
+    from sympy.utilities.iterables import iterable
 
     if iterable(a):
         try:

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,5 +1,4 @@
-from sympy.core.compatibility import (default_sort_key, as_int, ordered,
-    iterable, NotIterable)
+from sympy.core.compatibility import default_sort_key, as_int, ordered
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises
 
@@ -33,43 +32,6 @@ def test_as_int():
     raises(ValueError, lambda : as_int(1e23))
     raises(ValueError, lambda : as_int(S('1.'+'0'*20+'1')))
     assert as_int(True, strict=False) == 1
-
-
-def test_iterable():
-    assert iterable(0) is False
-    assert iterable(1) is False
-    assert iterable(None) is False
-
-    class Test1(NotIterable):
-        pass
-
-    assert iterable(Test1()) is False
-
-    class Test2(NotIterable):
-        _iterable = True
-
-    assert iterable(Test2()) is True
-
-    class Test3:
-        pass
-
-    assert iterable(Test3()) is False
-
-    class Test4:
-        _iterable = True
-
-    assert iterable(Test4()) is True
-
-    class Test5:
-        def __iter__(self):
-            yield 1
-
-    assert iterable(Test5()) is True
-
-    class Test6(Test5):
-        _iterable = False
-
-    assert iterable(Test6()) is False
 
 
 def test_ordered():

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,12 +1,12 @@
 from collections import defaultdict
 
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
-from sympy.core.compatibility import is_sequence, iterable
 from sympy.core.containers import tuple_wrapper
 from sympy.core.expr import unchanged
 from sympy.core.function import Function, Lambda
 from sympy.core.relational import Eq
 from sympy.testing.pytest import raises
+from sympy.utilities.iterables import is_sequence, iterable
 
 from sympy.abc import x, y
 

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -1,6 +1,8 @@
 from .basic import Basic
-from .compatibility import iterable, ordered
+from .compatibility import ordered
 from .sympify import sympify
+from sympy.utilities.iterables import iterable
+
 
 
 class preorder_traversal:

--- a/sympy/discrete/convolutions.py
+++ b/sympy/discrete/convolutions.py
@@ -4,11 +4,12 @@ Covering Product, Intersecting Product
 """
 
 from sympy.core import S, sympify
-from sympy.core.compatibility import as_int, iterable
+from sympy.core.compatibility import as_int
 from sympy.core.function import expand_mul
 from sympy.discrete.transforms import (
     fft, ifft, ntt, intt, fwht, ifwht,
     mobius_transform, inverse_mobius_transform)
+from sympy.utilities.iterables import iterable
 
 
 def convolution(a, b, cycle=0, dps=None, prime=None, dyadic=None, subset=None):

--- a/sympy/discrete/recurrences.py
+++ b/sympy/discrete/recurrences.py
@@ -3,7 +3,9 @@ Recurrences
 """
 
 from sympy.core import S, sympify
-from sympy.core.compatibility import as_int, iterable
+from sympy.core.compatibility import as_int
+from sympy.utilities.iterables import iterable
+
 
 def linrec(coeffs, init, n):
     r"""

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -4,12 +4,12 @@ Walsh Hadamard Transform, Mobius Transform
 """
 
 from sympy.core import S, Symbol, sympify
-from sympy.core.compatibility import as_int, iterable
+from sympy.core.compatibility import as_int
 from sympy.core.function import expand_mul
 from sympy.core.numbers import pi, I
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.ntheory import isprime, primitive_root
-from sympy.utilities.iterables import ibin
+from sympy.utilities.iterables import ibin, iterable
 
 
 #----------------------------------------------------------------------------#

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -2,7 +2,7 @@ from sympy.core import S, sympify
 from sympy.functions import Piecewise, piecewise_fold
 from sympy.sets.sets import Interval
 
-from sympy.core.cache import lru_cache
+from functools import lru_cache
 
 
 def _ivl(cond, x):

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -8,13 +8,13 @@ Curve
 
 from sympy import sqrt
 from sympy.core import sympify, diff
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.evalf import prec_to_dps
 from sympy.core.symbol import _symbol
 from sympy.geometry.entity import GeometryEntity, GeometrySet
 from sympy.geometry.point import Point
 from sympy.integrals import integrate
+from sympy.utilities.iterables import is_sequence
 
 
 class Curve(GeometrySet):

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -21,7 +21,6 @@ R3 are currently the only ambient spaces implemented.
 """
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.evalf import EvalfMixin
 from sympy.core.sympify import sympify
@@ -32,6 +31,7 @@ from sympy.sets import Set
 from sympy.sets.handlers.intersection import intersection_sets
 from sympy.sets.handlers.union import union_sets
 from sympy.utilities.misc import func_name
+from sympy.utilities.iterables import is_sequence
 
 
 # How entities are ordered; used by __cmp__ in GeometryEntity

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -9,7 +9,6 @@ Plane
 from sympy.core import Dummy, Rational, S, Symbol
 from sympy.core.evalf import prec_to_dps
 from sympy.core.symbol import _symbol
-from sympy.core.compatibility import is_sequence
 from sympy.functions.elementary.trigonometric import cos, sin, acos, asin, sqrt
 from .entity import GeometryEntity
 from .line import (Line, Ray, Segment, Line3D, LinearEntity, LinearEntity3D,
@@ -19,7 +18,7 @@ from sympy.matrices import Matrix
 from sympy.polys.polytools import cancel
 from sympy.simplify.simplify import simplify
 from sympy.solvers import solve, linsolve
-from sympy.utilities.iterables import uniq
+from sympy.utilities.iterables import uniq, is_sequence
 from sympy.utilities.misc import filldedent, func_name, Undecidable
 
 import random

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -20,7 +20,6 @@ False
 import warnings
 
 from sympy.core import S, sympify, Expr
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.simplify import nsimplify, simplify
 from sympy.geometry.exceptions import GeometryError
@@ -31,7 +30,7 @@ from sympy.core.numbers import Float
 from sympy.core.parameters import global_parameters
 from sympy.core.add import Add
 from sympy.core.evalf import prec_to_dps
-from sympy.utilities.iterables import uniq
+from sympy.utilities.iterables import uniq, is_sequence
 from sympy.utilities.misc import filldedent, func_name, Undecidable
 
 from .entity import GeometryEntity

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -12,10 +12,10 @@ are_similar
 """
 
 from sympy import Function, Symbol, solve, sqrt
-from sympy.core.compatibility import (
-    is_sequence, ordered)
+from sympy.core.compatibility import ordered
 from sympy.core.containers import OrderedSet
 from .point import Point, Point2D
+from sympy.utilities.iterables import is_sequence
 
 
 def find(x, equation):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1,7 +1,6 @@
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import diff
@@ -27,8 +26,9 @@ from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
 from sympy.simplify.fu import sincos_to_sum
 from sympy.tensor.functions import shape
-from sympy.utilities.misc import filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import is_sequence
+from sympy.utilities.misc import filldedent
 
 
 class Integral(AddWithLimits):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -24,7 +24,6 @@ from functools import reduce
 
 import sympy
 
-from sympy.core.compatibility import iterable
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
 from sympy.core.logic import fuzzy_not
@@ -35,6 +34,7 @@ from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
 from sympy.ntheory.factor_ import divisors
+from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
 ZERO = sympy.S.Zero

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1,5 +1,5 @@
 """ Integral Transforms """
-from functools import reduce
+from functools import reduce, wraps
 from itertools import repeat
 
 from sympy.core import S, pi
@@ -233,8 +233,6 @@ def _noconds_(default):
     argument of this function).
     """
     def make_wrapper(func):
-        from sympy.core.decorators import wraps
-
         @wraps(func)
         def wrapper(*args, noconds=default, **kwargs):
             res = func(*args, **kwargs)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -4,7 +4,7 @@ from itertools import repeat
 
 from sympy.core import S, pi
 from sympy.core.add import Add
-from sympy.core.compatibility import iterable, ordered
+from sympy.core.compatibility import ordered
 from sympy.core.function import (AppliedUndef, count_ops, expand,
                                  expand_complex, expand_mul, Function, Lambda)
 from sympy.core.mul import Mul
@@ -39,6 +39,7 @@ from sympy.simplify.powsimp import powdenest
 from sympy.solvers.inequalities import _solve_inequality
 from sympy.utilities import default_sort_key
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import iterable
 
 
 ##########################################################################

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -13,7 +13,7 @@ from sympy.core.logic import FuzzyBool
 from sympy.assumptions.refine import refine
 from sympy.core import SympifyError, Add
 from sympy.core.basic import Atom
-from sympy.core.compatibility import as_int, is_sequence
+from sympy.core.compatibility import as_int
 from sympy.core.decorators import call_highest_priority
 from sympy.core.kind import Kind, NumberKind
 from sympy.core.logic import fuzzy_and
@@ -25,7 +25,7 @@ from sympy.polys.polytools import Poly
 from sympy.simplify import simplify as _simplify
 from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import flatten
+from sympy.utilities.iterables import flatten, is_sequence
 from sympy.utilities.misc import filldedent
 from sympy.tensor.array import NDimArray
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,7 +1,6 @@
 import random
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import is_sequence
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
@@ -9,6 +8,7 @@ from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.simplify.simplify import simplify as _simplify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import is_sequence
 
 from .common import ShapeError
 from .decompositions import _cholesky, _LDLdecomposition

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -54,7 +54,7 @@ class MatrixExpr(Expr):
     """
 
     # Should not be considered iterable by the
-    # sympy.core.compatibility.iterable function. Subclass that actually are
+    # sympy.utilities.iterables.iterable function. Subclass that actually are
     # iterable (i.e., explicit matrices) should set this to True.
     _iterable = False
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.compatibility import NotIterable, as_int, is_sequence
+from sympy.core.compatibility import as_int
 from sympy.core.decorators import deprecated
 from sympy.core.expr import Expr
 from sympy.core.kind import _NumberKind, UndefinedKind
@@ -24,7 +24,7 @@ from sympy.printing import sstr
 from sympy.printing.defaults import Printable
 from sympy.simplify import simplify as _simplify
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import flatten
+from sympy.utilities.iterables import flatten, NotIterable, is_sequence
 from sympy.utilities.misc import filldedent
 
 from .common import (

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 from operator import index as index_
 
-from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.kind import Kind, NumberKind, UndefinedKind
 from sympy.core.numbers import Integer, Rational
@@ -10,8 +9,9 @@ from sympy.core.sympify import _sympify, SympifyError
 from sympy.core.singleton import S
 from sympy.polys.domains import ZZ, QQ, EXRAW
 from sympy.polys.matrices import DomainMatrix
-from sympy.utilities.misc import filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import is_sequence
+from sympy.utilities.misc import filldedent
 
 from .common import classof
 from .matrices import MatrixBase, MatrixKind, ShapeError

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1,8 +1,9 @@
 from collections.abc import Callable
 
-from sympy.core.compatibility import as_int, is_sequence
+from sympy.core.compatibility import as_int
 from sympy.core.containers import Dict
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import is_sequence
 
 from .matrices import MatrixBase
 from .repmatrix import MutableRepMatrix, RepMatrix

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -16,10 +16,9 @@ from sympy.matrices import (
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
     MatrixSymbol, dotprodsimp)
 from sympy.matrices.utilities import _dotprodsimp_state
-from sympy.core.compatibility import iterable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
-from sympy.utilities.iterables import flatten, capture
+from sympy.utilities.iterables import flatten, capture, iterable
 from sympy.testing.pytest import raises, XFAIL, slow, skip, warns_deprecated_sympy
 from sympy.assumptions import Q
 from sympy.tensor.array import Array

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -1,9 +1,10 @@
-from sympy.core.compatibility import as_int, is_sequence
+from sympy.core.compatibility import as_int
 from sympy.core.numbers import oo
 from sympy.core.relational import Eq
 from sympy.core.symbol import symbols
 from sympy.polys.domains import FiniteField, QQ, RationalField, FF
 from sympy.solvers.solvers import solve
+from sympy.utilities.iterables import is_sequence
 from .factor_ import divisors
 from .residue_ntheory import polynomial_congruence
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -10,10 +10,10 @@ import unicodedata
 from io import StringIO
 
 from sympy.assumptions.ask import AssumptionKeys
-from sympy.core.compatibility import iterable
 from sympy.core.basic import Basic
 from sympy.core import Symbol
 from sympy.core.function import arity, Function
+from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import filldedent, func_name
 
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -14,8 +14,8 @@ from sympy.plotting import plot, PlotGrid
 from sympy.geometry.entity import GeometryEntity
 from sympy.external import import_module
 from sympy import lambdify, Add
-from sympy.core.compatibility import iterable
 from sympy.utilities.decorator import doctest_depends_on
+from sympy.utilities.iterables import iterable
 
 numpy = import_module('numpy', import_kwargs={'fromlist':['arange']})
 

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -27,10 +27,10 @@ __all__ = ['refraction_angle',
 
 from sympy import Symbol, sympify, sqrt, Matrix, acos, oo, Limit, atan2, asin,\
 cos, sin, tan, I, cancel, pi, Float, S, zoo
-from sympy.core.compatibility import is_sequence
 from sympy.geometry.line import Ray3D
 from sympy.geometry.util import intersection
 from sympy.geometry.plane import Plane
+from sympy.utilities.iterables import is_sequence
 from .medium import Medium
 
 

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -18,7 +18,6 @@ import random
 
 from sympy import Add, I, Integer, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -33,6 +32,7 @@ from sympy.physics.quantum.matrixcache import matrix_cache
 from sympy.matrices.matrices import MatrixBase
 
 from sympy.utilities import default_sort_key
+from sympy.utilities.iterables import is_sequence
 
 __all__ = [
     'Gate',

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -1,7 +1,7 @@
 from sympy import Expr, sympify, Symbol, Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import is_sequence
+from sympy.utilities.iterables import is_sequence
 
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.matrixutils import (

--- a/sympy/plotting/pygletplot/plot.py
+++ b/sympy/plotting/pygletplot/plot.py
@@ -7,7 +7,6 @@ except ImportError:
     raise ImportError("pyglet is required for plotting.\n "
                       "visit http://www.pyglet.org/")
 
-from sympy.core.compatibility import is_sequence
 from sympy.core.numbers import Integer
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.geometry.entity import GeometryEntity
@@ -17,6 +16,7 @@ from sympy.plotting.pygletplot.plot_object import PlotObject
 from sympy.plotting.pygletplot.plot_window import PlotWindow
 from sympy.plotting.pygletplot.util import parse_option_string
 from sympy.utilities.decorator import doctest_depends_on
+from sympy.utilities.iterables import is_sequence
 
 from time import sleep
 from os import getcwd, listdir

--- a/sympy/plotting/pygletplot/plot_axes.py
+++ b/sympy/plotting/pygletplot/plot_axes.py
@@ -2,10 +2,10 @@ import pyglet.gl as pgl
 from pyglet import font
 
 from sympy.core import S
-from sympy.core.compatibility import is_sequence
 from sympy.plotting.pygletplot.plot_object import PlotObject
 from sympy.plotting.pygletplot.util import billboard_matrix, dot_product, \
         get_direction_vectors, strided_range, vec_mag, vec_sub
+from sympy.utilities.iterables import is_sequence
 
 
 class PlotAxes(PlotObject):

--- a/sympy/plotting/pygletplot/plot_mode.py
+++ b/sympy/plotting/pygletplot/plot_mode.py
@@ -1,9 +1,9 @@
 from sympy import Symbol, sympify
-from sympy.core.compatibility import is_sequence
 from sympy.geometry.entity import GeometryEntity
 from .plot_interval import PlotInterval
 from .plot_object import PlotObject
 from .util import parse_option_string
+from sympy.utilities.iterables import is_sequence
 
 
 class PlotMode(PlotObject):

--- a/sympy/plotting/pygletplot/plot_mode_base.py
+++ b/sympy/plotting/pygletplot/plot_mode_base.py
@@ -1,8 +1,8 @@
 import pyglet.gl as pgl
 from sympy.core import S
-from sympy.core.compatibility import is_sequence
 from sympy.plotting.pygletplot.color_scheme import ColorScheme
 from sympy.plotting.pygletplot.plot_mode import PlotMode
+from sympy.utilities.iterables import is_sequence
 from time import sleep
 from threading import Thread, Event, RLock
 import warnings

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -21,12 +21,12 @@ convenience methods, for example if there are faster algorithms available.
 from copy import copy
 from functools import reduce
 
-from sympy.core.compatibility import iterable
 from sympy.polys.agca.ideals import Ideal
 from sympy.polys.domains.field import Field
 from sympy.polys.orderings import ProductOrder, monomial_key
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.core.basic import _aresame
+from sympy.utilities.iterables import iterable
 
 # TODO
 # - module saturation

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -4,7 +4,7 @@
 from typing import Any, Optional, Type
 
 from sympy.core import Basic, sympify
-from sympy.core.compatibility import is_sequence, ordered
+from sympy.core.compatibility import ordered
 from sympy.core.decorators import deprecated
 from sympy.external.gmpy import HAS_GMPY
 from sympy.polys.domains.domainelement import DomainElement
@@ -12,6 +12,8 @@ from sympy.polys.orderings import lex
 from sympy.polys.polyerrors import UnificationFailed, CoercionFailed, DomainError
 from sympy.polys.polyutils import _unify_gens, _not_a_coeff
 from sympy.utilities import default_sort_key, public
+from sympy.utilities.iterables import is_sequence
+
 
 @public
 class Domain:

--- a/sympy/polys/domains/old_polynomialring.py
+++ b/sympy/polys/domains/old_polynomialring.py
@@ -1,7 +1,6 @@
 """Implementation of :class:`PolynomialRing` class. """
 
 
-from sympy.core.compatibility import iterable
 from sympy.polys.agca.modules import FreeModulePolyRing
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.compositedomain import CompositeDomain
@@ -13,6 +12,7 @@ from sympy.polys.polyerrors import (GeneratorsNeeded, PolynomialError,
         CoercionFailed, ExactQuotientFailed, NotReversible)
 from sympy.polys.polyutils import dict_from_basic, basic_from_dict, _dict_reorder
 from sympy.utilities import public
+from sympy.utilities.iterables import iterable
 
 # XXX why does this derive from CharacteristicZero???
 

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -6,7 +6,6 @@ from functools import reduce
 
 from operator import add, mul, lt, le, gt, ge
 
-from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.mod import Mod
 from sympy.core.numbers import Exp1
@@ -25,6 +24,7 @@ from sympy.polys.polyutils import _parallel_dict_from_expr
 from sympy.polys.rings import PolyElement
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
+from sympy.utilities.iterables import is_sequence
 from sympy.utilities.magic import pollute
 
 @public

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -5,11 +5,10 @@ from itertools import combinations_with_replacement, product
 from textwrap import dedent
 
 from sympy.core import Mul, S, Tuple, sympify
-from sympy.core.compatibility import iterable
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.utilities import public
-from sympy.core.compatibility import is_sequence
+from sympy.utilities.iterables import is_sequence, iterable
 
 @public
 def itermonomials(variables, max_degrees, min_degrees=None):

--- a/sympy/polys/orderings.py
+++ b/sympy/polys/orderings.py
@@ -6,7 +6,7 @@ from typing import Optional
 __all__ = ["lex", "grlex", "grevlex", "ilex", "igrlex", "igrevlex"]
 
 from sympy.core import Symbol
-from sympy.core.compatibility import iterable
+from sympy.utilities.iterables import iterable
 
 class MonomialOrder:
     """Base class for monomial orderings. """

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -9,8 +9,7 @@ from typing import List, Optional
 from sympy.core import Basic, sympify
 from sympy.polys.polyerrors import GeneratorsError, OptionError, FlagError
 from sympy.utilities import numbered_symbols, topological_sort, public
-from sympy.utilities.iterables import has_dups
-from sympy.core.compatibility import is_sequence
+from sympy.utilities.iterables import has_dups, is_sequence
 
 import sympy.polys
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -8,7 +8,7 @@ from sympy.core import (
     S, Expr, I, Integer, Add, Tuple
 )
 from sympy.core.basic import Basic
-from sympy.core.compatibility import iterable, ordered
+from sympy.core.compatibility import ordered
 from sympy.core.decorators import _sympifyit
 from sympy.core.evalf import pure_complex
 from sympy.core.function import Derivative
@@ -47,8 +47,9 @@ from sympy.polys.polyutils import (
 )
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import dup_isolate_real_roots_list
-from sympy.utilities import group, sift, public, filldedent
+from sympy.utilities import group, public, filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import iterable, sift
 
 
 # Required to avoid errors

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -2,9 +2,10 @@
 
 
 from sympy.core import Basic, Add, sympify
-from sympy.core.compatibility import iterable
 from sympy.core.exprtools import gcd_terms
 from sympy.utilities import public
+from sympy.utilities.iterables import iterable
+
 
 @public
 def together(expr, deep=False, fraction=True):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -7,7 +7,6 @@ from operator import add, mul, lt, le, gt, ge
 from functools import reduce
 from types import GeneratorType
 
-from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.numbers import igcd, oo
 from sympy.core.symbol import Symbol, symbols as _symbols
@@ -30,6 +29,7 @@ from sympy.polys.polyutils import (expr_from_dict, _dict_reorder,
                                    _parallel_dict_from_expr)
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
+from sympy.utilities.iterables import is_sequence
 from sympy.utilities.magic import pollute
 
 @public

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -60,9 +60,9 @@ from sympy import (
 
 from sympy.core.add import Add
 from sympy.core.basic import _aresame
-from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
 from sympy.core.power import Pow
+from sympy.utilities.iterables import iterable
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 from sympy.abc import a, b, c, d, p, q, t, w, x, y, z

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
 
-from sympy.core.compatibility import is_sequence
 from sympy.external import import_module
 from sympy.printing.printer import Printer
+from sympy.utilities.iterables import is_sequence
 import sympy
 from functools import partial
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
 
-from sympy.core.compatibility import is_sequence
 from sympy.external import import_module
 from sympy.printing.printer import Printer
+from sympy.utilities.iterables import is_sequence
 import sympy
 from functools import partial
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 from sympy import oo, zoo, nan
 from sympy.core.add import Add
-from sympy.core.compatibility import iterable
 from sympy.core.expr import Expr
 from sympy.core.function import Derivative, Function, expand
 from sympy.core.mul import Mul
@@ -25,6 +24,8 @@ from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
+from sympy.utilities.iterables import iterable
+
 
 
 def rational_algorithm(f, x, k, order=4, full=False):

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -3,7 +3,6 @@
 from sympy import pi, oo, Wild
 from sympy.core.expr import Expr
 from sympy.core.add import Add
-from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol
@@ -13,6 +12,7 @@ from sympy.series.series_class import SeriesBase
 from sympy.series.sequences import SeqFormula
 from sympy.sets.sets import Interval
 from sympy.simplify.fu import TR2, TR1, TR10, sincos_to_sum
+from sympy.utilities.iterables import is_sequence
 
 
 def fourier_cos_seq(func, limits, n):

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -1,10 +1,10 @@
 from sympy.core import S, sympify, Expr, Dummy
 from sympy.core import Add, Mul, expand_power_base, expand_log
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import default_sort_key, is_sequence
+from sympy.core.compatibility import default_sort_key
 from sympy.core.containers import Tuple
 from sympy.sets.sets import Complement
-from sympy.utilities.iterables import uniq
+from sympy.utilities.iterables import uniq, is_sequence
 
 
 class Order(Expr):

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -1,6 +1,6 @@
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import is_sequence, iterable, ordered
+from sympy.core.compatibility import ordered
 from sympy.core.containers import Tuple
 from sympy.core.decorators import call_highest_priority
 from sympy.core.parameters import global_parameters
@@ -15,7 +15,7 @@ from sympy.polys import lcm, factor
 from sympy.sets.sets import Interval, Intersection
 from sympy.simplify import simplify
 from sympy.tensor.indexed import Idx
-from sympy.utilities.iterables import flatten
+from sympy.utilities.iterables import flatten, is_sequence, iterable
 from sympy import expand
 
 

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -2,7 +2,7 @@ from sympy import (symbols, pi, Piecewise, sin, cos, sinc, Rational, S,
                    oo, fourier_series, Add, log, exp, tan)
 from sympy.series.fourier import FourierSeries
 from sympy.testing.pytest import raises
-from sympy.core.cache import lru_cache
+from functools import lru_cache
 
 x, y, z = symbols('x y z')
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import inspect
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import iterable, ordered
+from sympy.core.compatibility import ordered
 from sympy.core.containers import Tuple
 from sympy.core.decorators import (deprecated, sympify_method_args,
     sympify_return)
@@ -23,7 +23,7 @@ from sympy.logic.boolalg import And, Or, Not, Xor, true, false
 from sympy.sets.contains import Contains
 from sympy.utilities import subsets
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import iproduct, sift, roundrobin
+from sympy.utilities.iterables import iproduct, sift, roundrobin, iterable
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -1,12 +1,11 @@
 """ Tools for doing common subexpression elimination.
 """
 from sympy.core import Basic, Mul, Add, Pow, sympify, Symbol
-from sympy.core.compatibility import iterable
 from sympy.core.containers import Tuple, OrderedSet
 from sympy.core.exprtools import factor_terms
 from sympy.core.singleton import S
 from sympy.utilities.iterables import numbered_symbols, sift, \
-        topological_sort, ordered
+        topological_sort, ordered, iterable
 
 from . import cse_opts
 

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -4,7 +4,7 @@ from sympy import SYMPY_DEBUG
 
 from sympy.core import expand_power_base, sympify, Add, S, Mul, Derivative, Pow, symbols, expand_mul
 from sympy.core.add import _unevaluated_Add
-from sympy.core.compatibility import iterable, ordered, default_sort_key
+from sympy.core.compatibility import ordered, default_sort_key
 from sympy.core.parameters import global_parameters
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.function import _mexpand
@@ -14,6 +14,7 @@ from sympy.functions import exp, sqrt, log
 from sympy.functions.elementary.complexes import Abs
 from sympy.polys import gcd
 from sympy.simplify.sqrtdenest import sqrtdenest
+from sympy.utilities.iterables import iterable
 
 
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from sympy.core import (Basic, S, Add, Mul, Pow, Symbol, sympify,
                         expand_func, Function, Dummy, Expr, factor_terms,
                         expand_power_exp, Eq)
-from sympy.core.compatibility import iterable, ordered, as_int
+from sympy.core.compatibility import ordered, as_int
 from sympy.core.decorators import deprecated
 from sympy.core.exprtools import factor_nc
 from sympy.core.parameters import global_parameters
@@ -33,7 +33,7 @@ from sympy.simplify.powsimp import powsimp
 from sympy.simplify.radsimp import radsimp, fraction, collect_abs
 from sympy.simplify.sqrtdenest import sqrtdenest
 from sympy.simplify.trigsimp import trigsimp, exptrigsimp
-from sympy.utilities.iterables import has_variety, sift, subsets
+from sympy.utilities.iterables import has_variety, sift, subsets, iterable
 
 import mpmath
 

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -4,7 +4,6 @@ from functools import reduce
 from sympy.core import (sympify, Basic, S, Expr, expand_mul, factor_terms,
     Mul, Dummy, igcd, FunctionClass, Add, symbols, Wild, expand, bottom_up)
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import iterable
 from sympy.core.function import count_ops, _mexpand
 from sympy.core.numbers import I, Integer
 from sympy.external.gmpy import SYMPY_INTS
@@ -18,6 +17,7 @@ from sympy.polys.polytools import groebner
 from sympy.simplify.cse_main import cse
 from sympy.strategies.core import identity
 from sympy.strategies.tree import greedy
+from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1,7 +1,7 @@
 from sympy.core.add import Add
 from sympy.core.assumptions import check_assumptions
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import as_int, is_sequence, ordered
+from sympy.core.compatibility import as_int, ordered
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import _mexpand
 from sympy.core.mul import Mul
@@ -27,6 +27,7 @@ from sympy.simplify.simplify import signsimp
 from sympy.solvers.solveset import solveset_real
 from sympy.utilities import default_sort_key, numbered_symbols
 from sympy.utilities.misc import filldedent
+from sympy.utilities.iterables import is_sequence
 
 
 # these are imported with 'from sympy.solvers.diophantine import *

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -1,7 +1,6 @@
 """Tools for solving inequalities and systems of inequalities. """
 
 from sympy.core import Symbol, Dummy, sympify
-from sympy.core.compatibility import iterable
 from sympy.core.exprtools import factor_terms
 from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.sets import Interval
@@ -13,7 +12,7 @@ from sympy.functions import Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, iterable
 from sympy.utilities.misc import filldedent
 
 

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -229,7 +229,7 @@ of those tests will surely fail.
 """
 
 from sympy.core import Add, S, Mul, Pow, oo
-from sympy.core.compatibility import ordered, iterable
+from sympy.core.compatibility import ordered
 from sympy.core.containers import Tuple
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
@@ -255,8 +255,8 @@ from sympy.simplify import (collect, logcombine, powsimp,  # type: ignore
 from sympy.simplify.radsimp import collect_const
 from sympy.solvers import checksol, solve
 
-from sympy.utilities import numbered_symbols, default_sort_key, sift
-from sympy.utilities.iterables import uniq
+from sympy.utilities import numbered_symbols, default_sort_key
+from sympy.utilities.iterables import uniq, sift, iterable
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 
 

--- a/sympy/solvers/ode/subscheck.py
+++ b/sympy/solvers/ode/subscheck.py
@@ -1,5 +1,4 @@
 from sympy.core import S, Pow
-from sympy.core.compatibility import iterable, is_sequence
 from sympy.core.function import (Derivative, AppliedUndef, diff)
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Dummy
@@ -12,8 +11,8 @@ from sympy.simplify.simplify import simplify, posify, besselsimp
 from sympy.simplify.trigsimp import trigsimp
 from sympy.simplify.sqrtdenest import sqrtdenest
 from sympy.solvers import solve
-
 from sympy.solvers.deutils import _preprocess, ode_order
+from sympy.utilities.iterables import iterable, is_sequence
 
 
 def sub_func_doit(eq, func, new):

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1,6 +1,5 @@
 from sympy.core import Add, Mul, S
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import iterable
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import I
 from sympy.core.relational import Eq, Equality
@@ -20,7 +19,7 @@ from sympy.sets.sets import FiniteSet
 from sympy.solvers.deutils import ode_order
 from sympy.solvers.solveset import NonlinearError, solveset
 from sympy.utilities import default_sort_key
-from sympy.utilities.iterables import ordered
+from sympy.utilities.iterables import ordered, iterable
 from sympy.utilities.misc import filldedent
 from sympy.integrals.integrals import Integral, integrate
 

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -37,13 +37,12 @@ from functools import reduce
 from itertools import combinations_with_replacement
 from sympy.simplify import simplify  # type: ignore
 from sympy.core import Add, S
-from sympy.core.compatibility import is_sequence
 from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, symbols
 from sympy.functions import exp
 from sympy.integrals.integrals import Integral
-from sympy.utilities.iterables import has_dups
+from sympy.utilities.iterables import has_dups, is_sequence
 from sympy.utilities.misc import filldedent
 
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -14,8 +14,7 @@ This module contain solvers for all kinds of equations:
 
 from sympy import divisors, binomial, expand_func
 from sympy.core.assumptions import check_assumptions
-from sympy.core.compatibility import (iterable, is_sequence, ordered,
-    default_sort_key)
+from sympy.core.compatibility import ordered, default_sort_key
 from sympy.core.sympify import sympify
 from sympy.core import (S, Add, Symbol, Equality, Dummy, Expr, Mul,
     Pow, Unequality)
@@ -51,7 +50,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent
 from sympy.utilities.iterables import (connected_components,
-    generate_bell, uniq)
+    generate_bell, uniq, iterable, is_sequence)
 from sympy.utilities.decorator import conserve_mpmath_dps
 
 from mpmath import findroot

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -50,9 +50,10 @@ from sympy.solvers.solvers import (checksol, denoms, unrad,
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
-from sympy.utilities.iterables import numbered_symbols, has_dups
+from sympy.utilities.iterables import (numbered_symbols, has_dups,
+                                       default_sort_key, is_sequence)
 from sympy.calculus.util import periodicity, continuous_domain
-from sympy.core.compatibility import ordered, default_sort_key, is_sequence
+from sympy.core.compatibility import ordered
 
 from types import GeneratorType
 from collections import defaultdict

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -14,7 +14,6 @@ from sympy import (Basic, Lambda, sympify, Indexed, Symbol, ProductSet, S,
                    Dummy, prod)
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum, summation
-from sympy.core.compatibility import iterable
 from sympy.core.containers import Tuple
 from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices import ImmutableMatrix, matrix2numpy, list2numpy
@@ -23,6 +22,7 @@ from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin, Distribution,
                             ProductDomain, RandomSymbol, random_symbols,
                             SingleDomain, _symbol_converter)
+from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import filldedent
 from sympy.external import import_module
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -28,6 +28,7 @@ from sympy.external import import_module
 from sympy.utilities.misc import filldedent
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import iterable
 import warnings
 
 
@@ -1666,7 +1667,6 @@ def _value_check(condition, message):
     >>> _value_check(And(a < 0, b < 0, c < 0), '')
     False
     """
-    from sympy.core.compatibility import iterable
     from sympy.core.logic import fuzzy_and
     if not iterable(condition):
         condition = [condition]

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -109,11 +109,11 @@ from sympy import Number
 from sympy.core.assumptions import StdFactKB
 from sympy.core import Expr, Tuple, sympify, S
 from sympy.core.symbol import _filter_assumptions, Symbol
-from sympy.core.compatibility import (is_sequence, NotIterable)
 from sympy.core.logic import fuzzy_bool, fuzzy_not
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.multipledispatch import dispatch
+from sympy.utilities.iterables import is_sequence, NotIterable
 
 
 class IndexException(Exception):

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -1,7 +1,7 @@
 from sympy.core import symbols, Symbol, Tuple, oo, Dummy
-from sympy.core.compatibility import iterable
 from sympy.tensor.indexed import IndexException
 from sympy.testing.pytest import raises, XFAIL
+from sympy.utilities.iterables import iterable
 
 # import test:
 from sympy import (IndexedBase, Idx, Indexed, S, sin, cos, exp, log, Sum,

--- a/sympy/testing/randtest.py
+++ b/sympy/testing/randtest.py
@@ -2,11 +2,12 @@
 
 from random import uniform, Random, randrange, randint
 
-from sympy.core.compatibility import is_sequence, as_int
+from sympy.core.compatibility import as_int
 from sympy.core.containers import Tuple
 from sympy.core.numbers import comp, I
 from sympy.core.symbol import Symbol
 from sympy.simplify.simplify import nsimplify
+from sympy.utilities.iterables import is_sequence
 
 
 def random_complex_number(a=2, b=-1, c=3, d=1, rational=False, tolerance=None):

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -89,7 +89,6 @@ from string import Template
 from warnings import warn
 
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import iterable
 from sympy.core.function import Lambda
 from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy, Symbol
@@ -98,6 +97,7 @@ from sympy.utilities.codegen import (make_routine, get_code_generator,
                                      OutputArgument, InOutArgument,
                                      InputArgument, CodeGenArgumentListError,
                                      Result, ResultBase, C99CodeGen)
+from sympy.utilities.iterables import iterable
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.decorator import doctest_depends_on
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -85,7 +85,6 @@ from io import StringIO
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Tuple, Equality, Function, Basic
-from sympy.core.compatibility import is_sequence
 from sympy.printing.c import c_code_printers
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.fortran import FCodePrinter
@@ -95,6 +94,7 @@ from sympy.printing.rust import RustCodePrinter
 from sympy.tensor import Idx, Indexed, IndexedBase
 from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
                             MatrixExpr, MatrixSlice)
+from sympy.utilities.iterables import is_sequence
 
 
 __all__ = [

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -3,8 +3,8 @@
 import sys
 import types
 import inspect
+from functools import wraps
 
-from sympy.core.decorators import wraps
 from sympy.testing.runtests import DependencyError, SymPyDocTests, PyTestReporter
 from sympy.utilities.iterables import iterable
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -5,8 +5,8 @@ import types
 import inspect
 
 from sympy.core.decorators import wraps
-from sympy.core.compatibility import iterable
 from sympy.testing.runtests import DependencyError, SymPyDocTests, PyTestReporter
+from sympy.utilities.iterables import iterable
 
 def threaded_factory(func, use_add):
     """A factory for ``threaded`` decorators. """

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -13,10 +13,11 @@ import linecache
 
 from sympy.core.basic import Basic
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.core.compatibility import (is_sequence, iterable,
+from sympy.utilities.decorator import doctest_depends_on
+from sympy.utilities.iterables import (is_sequence, iterable,
     NotIterable)
 from sympy.utilities.misc import filldedent
-from sympy.utilities.decorator import doctest_depends_on
+
 
 __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,4 +1,4 @@
-from sympy.core.decorators import wraps
+from functools import wraps
 
 
 def recurrence_memo(initial):

--- a/sympy/utilities/tests/test_decorator.py
+++ b/sympy/utilities/tests/test_decorator.py
@@ -1,9 +1,10 @@
+from functools import wraps
+
 from sympy.utilities.decorator import threaded, xthreaded, memoize_property
 
 from sympy import Eq, Matrix, Basic
 
 from sympy.abc import x, y
-from sympy.core.decorators import wraps
 
 
 def test_threaded():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -3,7 +3,6 @@ from itertools import islice, product
 
 from sympy import symbols, Integer, Dummy, Basic, Matrix, factorial
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
-from sympy.core.compatibility import iterable
 from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
     cartes, common_prefix, common_suffix, connected_components, dict_merge,
@@ -14,7 +13,8 @@ from sympy.utilities.iterables import (
     ordered, partitions, permutations, postfixes,
     prefixes, reshape, rotate_left, rotate_right, runs, sift,
     strongly_connected_components, subsets, take, topological_sort, unflatten,
-    uniq, variations, ordered_partitions, rotations, is_palindromic)
+    uniq, variations, ordered_partitions, rotations, is_palindromic, iterable,
+    NotIterable)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -815,3 +815,40 @@ def test_ibin():
     assert list(ibin(2, '', str=True)) == ['00', '01', '10', '11']
     raises(ValueError, lambda: ibin(-.5))
     raises(ValueError, lambda: ibin(2, 1))
+
+
+def test_iterable():
+    assert iterable(0) is False
+    assert iterable(1) is False
+    assert iterable(None) is False
+
+    class Test1(NotIterable):
+        pass
+
+    assert iterable(Test1()) is False
+
+    class Test2(NotIterable):
+        _iterable = True
+
+    assert iterable(Test2()) is True
+
+    class Test3:
+        pass
+
+    assert iterable(Test3()) is False
+
+    class Test4:
+        _iterable = True
+
+    assert iterable(Test4()) is True
+
+    class Test5:
+        def __iter__(self):
+            yield 1
+
+    assert iterable(Test5()) is True
+
+    class Test6(Test5):
+        _iterable = False
+
+    assert iterable(Test6()) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The three should obviously be in utilities (and the doctests already state that as they were imported through that file).

Had to change about half of the is_sequence imports and 30% of the iterable imports, so many were already pointing to the right location.

#### Other comments

Importing inside `sympify` is not ideal, but it should be possible to move it back to the top-level once the import cleanup is (enough) finished.

There will be a single text in release note outlining this and other moves.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
