### PR TITLE
Make SymPy PEP 561 compatible

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -915,7 +915,9 @@ Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuy.(none)>
 Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr.(none)>
 Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr>
 Rehas Sachdeva <aquannie@gmail.com>
+Remco de Boer <29308176+redeboer@users.noreply.github.com>
 Remco de Boer <redeboer@gmx.com>
+Remco de Boer <redeboer@outlook.com>
 Renato Coutinho <renato.coutinho@gmail.com>
 Renato Orsino <renato.orsino@gmail.com>
 Rhea Parekh <rheaparekh12@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -446,6 +446,7 @@ if __name__ == '__main__':
               'sympy.parsing.latex': ['*.txt', '*.g4'],
               'sympy.integrals.rubi.parsetools': ['header.py.txt'],
               'sympy.plotting.tests': ['test_region_*.png'],
+              'sympy': ['py.typed']
               },
           data_files=[('share/man/man1', ['doc/man/isympy.1'])],
           cmdclass={'test': test_sympy,


### PR DESCRIPTION
#### References to other Issues or PRs

Follow-up to #22212 and and #22320


#### Brief description of what is fixed or changed

Now that SymPy is type-checked with mypy, it should signal to downstream packages that it is typed (even if partially). This is achieved by installing a `py.typed` file:
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* other
  * SymPy is now [PEP 561](https://www.python.org/dev/peps/pep-0561) compatible
<!-- END RELEASE NOTES -->
