### PR TITLE
Internal API reference: sympy.algebras

### DIFF
--- a/doc/src/_templates/custom-class-template.rst
+++ b/doc/src/_templates/custom-class-template.rst
@@ -1,0 +1,35 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      {%- if not item.startswith('_') %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+   

--- a/doc/src/_templates/custom-module-template.rst
+++ b/doc/src/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module attributes
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -20,6 +20,7 @@ import sympy
 
 # If your extensions are in another directory, add it here.
 sys.path = ['ext'] + sys.path
+sys.path.insert(0, os.path.abspath('../..'))
 
 # General configuration
 # ---------------------
@@ -28,7 +29,8 @@ sys.path = ['ext'] + sys.path
 # coming with Sphinx (named 'sphinx.addons.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode', 'sphinx_math_dollar',
               'sphinx.ext.mathjax', 'numpydoc', 'sympylive', 'sphinx_reredirects',
-              'sphinx.ext.graphviz', 'matplotlib.sphinxext.plot_directive']
+              'sphinx.ext.graphviz', 'matplotlib.sphinxext.plot_directive',
+              'sphinx.ext.autosummary']
 
 redirects = {
     "install.rst": "guides/getting_started/install.html",
@@ -69,6 +71,9 @@ mathjax_config = {
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+exclude_patterns = ['_build', '_templates']
+autosummary_generate = True
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -50,6 +50,13 @@ This is the central page for all of SymPy's documentation.
 
 ..  rst-class:: clearfix row custom-headings
 
+.. autosummary::
+   :toctree: reference/private
+   :template: custom-module-template.rst
+   :recursive:
+
+   sympy.abc
+
 .. toctree::
    :hidden:
 

--- a/doc/src/modules/abc.rst
+++ b/doc/src/modules/abc.rst
@@ -3,3 +3,4 @@
 =====
 
 .. automodule:: sympy.abc
+   :noindex:

--- a/doc/src/reference/index.rst
+++ b/doc/src/reference/index.rst
@@ -8,3 +8,4 @@
    :maxdepth: 2
 
    ../modules/index.rst
+   private/index.rst

--- a/doc/src/reference/private/index.rst
+++ b/doc/src/reference/private/index.rst
@@ -13,3 +13,4 @@ subpackage.
    :maxdepth: 2
 
    sympy.abc.rst
+   sympy.algebras.rst

--- a/doc/src/reference/private/index.rst
+++ b/doc/src/reference/private/index.rst
@@ -1,0 +1,15 @@
+.. _private_reference:
+
+Private API reference
+=====================
+
+This section contains a description of the internal SymPy modules. The functions,methods and modules
+are detailed following the implemetantion structure in the  ``sympy``.
+subpackage.
+
+**Content**
+
+.. toctree::
+   :maxdepth: 2
+
+   sympy.abc.rst

--- a/doc/src/reference/private/sympy.abc.rst
+++ b/doc/src/reference/private/sympy.abc.rst
@@ -1,0 +1,4 @@
+﻿sympy.abc
+=========
+
+.. automodule:: sympy.abc

--- a/doc/src/reference/private/sympy.algebras.quaternion.Quaternion.rst
+++ b/doc/src/reference/private/sympy.algebras.quaternion.Quaternion.rst
@@ -1,0 +1,212 @@
+﻿sympy.algebras.quaternion.Quaternion
+====================================
+
+.. currentmodule:: sympy.algebras.quaternion
+
+.. autoclass:: Quaternion
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+   
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+      :nosignatures:
+   
+      ~Quaternion.add
+      ~Quaternion.adjoint
+      ~Quaternion.apart
+      ~Quaternion.args_cnc
+      ~Quaternion.as_base_exp
+      ~Quaternion.as_coeff_Add
+      ~Quaternion.as_coeff_Mul
+      ~Quaternion.as_coeff_add
+      ~Quaternion.as_coeff_exponent
+      ~Quaternion.as_coeff_mul
+      ~Quaternion.as_coefficient
+      ~Quaternion.as_coefficients_dict
+      ~Quaternion.as_content_primitive
+      ~Quaternion.as_dummy
+      ~Quaternion.as_expr
+      ~Quaternion.as_independent
+      ~Quaternion.as_leading_term
+      ~Quaternion.as_numer_denom
+      ~Quaternion.as_ordered_factors
+      ~Quaternion.as_ordered_terms
+      ~Quaternion.as_poly
+      ~Quaternion.as_powers_dict
+      ~Quaternion.as_real_imag
+      ~Quaternion.as_terms
+      ~Quaternion.aseries
+      ~Quaternion.atoms
+      ~Quaternion.cancel
+      ~Quaternion.class_key
+      ~Quaternion.coeff
+      ~Quaternion.collect
+      ~Quaternion.combsimp
+      ~Quaternion.compare
+      ~Quaternion.compute_leading_term
+      ~Quaternion.conjugate
+      ~Quaternion.copy
+      ~Quaternion.could_extract_minus_sign
+      ~Quaternion.count
+      ~Quaternion.count_ops
+      ~Quaternion.diff
+      ~Quaternion.dir
+      ~Quaternion.doit
+      ~Quaternion.dummy_eq
+      ~Quaternion.equals
+      ~Quaternion.evalf
+      ~Quaternion.exp
+      ~Quaternion.expand
+      ~Quaternion.extract_additively
+      ~Quaternion.extract_branch_factor
+      ~Quaternion.extract_multiplicatively
+      ~Quaternion.factor
+      ~Quaternion.find
+      ~Quaternion.fourier_series
+      ~Quaternion.fps
+      ~Quaternion.from_axis_angle
+      ~Quaternion.from_rotation_matrix
+      ~Quaternion.fromiter
+      ~Quaternion.gammasimp
+      ~Quaternion.getO
+      ~Quaternion.getn
+      ~Quaternion.has
+      ~Quaternion.integrate
+      ~Quaternion.inverse
+      ~Quaternion.invert
+      ~Quaternion.is_algebraic_expr
+      ~Quaternion.is_constant
+      ~Quaternion.is_hypergeometric
+      ~Quaternion.is_meromorphic
+      ~Quaternion.is_polynomial
+      ~Quaternion.is_rational_function
+      ~Quaternion.leadterm
+      ~Quaternion.limit
+      ~Quaternion.lseries
+      ~Quaternion.match
+      ~Quaternion.matches
+      ~Quaternion.mul
+      ~Quaternion.n
+      ~Quaternion.norm
+      ~Quaternion.normal
+      ~Quaternion.normalize
+      ~Quaternion.nseries
+      ~Quaternion.nsimplify
+      ~Quaternion.pow
+      ~Quaternion.pow_cos_sin
+      ~Quaternion.powsimp
+      ~Quaternion.primitive
+      ~Quaternion.radsimp
+      ~Quaternion.ratsimp
+      ~Quaternion.rcall
+      ~Quaternion.refine
+      ~Quaternion.removeO
+      ~Quaternion.replace
+      ~Quaternion.rewrite
+      ~Quaternion.rotate_point
+      ~Quaternion.round
+      ~Quaternion.separate
+      ~Quaternion.series
+      ~Quaternion.simplify
+      ~Quaternion.sort_key
+      ~Quaternion.subs
+      ~Quaternion.taylor_term
+      ~Quaternion.to_axis_angle
+      ~Quaternion.to_rotation_matrix
+      ~Quaternion.together
+      ~Quaternion.transpose
+      ~Quaternion.trigsimp
+      ~Quaternion.xreplace
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Quaternion.a
+      ~Quaternion.args
+      ~Quaternion.assumptions0
+      ~Quaternion.b
+      ~Quaternion.c
+      ~Quaternion.canonical_variables
+      ~Quaternion.d
+      ~Quaternion.default_assumptions
+      ~Quaternion.expr_free_symbols
+      ~Quaternion.free_symbols
+      ~Quaternion.func
+      ~Quaternion.is_Add
+      ~Quaternion.is_AlgebraicNumber
+      ~Quaternion.is_Atom
+      ~Quaternion.is_Boolean
+      ~Quaternion.is_Derivative
+      ~Quaternion.is_Dummy
+      ~Quaternion.is_Equality
+      ~Quaternion.is_Float
+      ~Quaternion.is_Function
+      ~Quaternion.is_Indexed
+      ~Quaternion.is_Integer
+      ~Quaternion.is_MatAdd
+      ~Quaternion.is_MatMul
+      ~Quaternion.is_Matrix
+      ~Quaternion.is_Mul
+      ~Quaternion.is_Not
+      ~Quaternion.is_Number
+      ~Quaternion.is_NumberSymbol
+      ~Quaternion.is_Order
+      ~Quaternion.is_Piecewise
+      ~Quaternion.is_Point
+      ~Quaternion.is_Poly
+      ~Quaternion.is_Pow
+      ~Quaternion.is_Rational
+      ~Quaternion.is_Relational
+      ~Quaternion.is_Symbol
+      ~Quaternion.is_Vector
+      ~Quaternion.is_Wild
+      ~Quaternion.is_algebraic
+      ~Quaternion.is_antihermitian
+      ~Quaternion.is_commutative
+      ~Quaternion.is_comparable
+      ~Quaternion.is_complex
+      ~Quaternion.is_composite
+      ~Quaternion.is_even
+      ~Quaternion.is_extended_negative
+      ~Quaternion.is_extended_nonnegative
+      ~Quaternion.is_extended_nonpositive
+      ~Quaternion.is_extended_nonzero
+      ~Quaternion.is_extended_positive
+      ~Quaternion.is_extended_real
+      ~Quaternion.is_finite
+      ~Quaternion.is_hermitian
+      ~Quaternion.is_imaginary
+      ~Quaternion.is_infinite
+      ~Quaternion.is_integer
+      ~Quaternion.is_irrational
+      ~Quaternion.is_negative
+      ~Quaternion.is_noninteger
+      ~Quaternion.is_nonnegative
+      ~Quaternion.is_nonpositive
+      ~Quaternion.is_nonzero
+      ~Quaternion.is_number
+      ~Quaternion.is_odd
+      ~Quaternion.is_polar
+      ~Quaternion.is_positive
+      ~Quaternion.is_prime
+      ~Quaternion.is_rational
+      ~Quaternion.is_real
+      ~Quaternion.is_scalar
+      ~Quaternion.is_symbol
+      ~Quaternion.is_transcendental
+      ~Quaternion.is_zero
+      ~Quaternion.kind
+      ~Quaternion.real_field
+   
+   
+   

--- a/doc/src/reference/private/sympy.algebras.quaternion.rst
+++ b/doc/src/reference/private/sympy.algebras.quaternion.rst
@@ -1,0 +1,32 @@
+sympy.algebras.quaternion
+=========================
+
+.. automodule:: sympy.algebras.quaternion
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+   
+      Quaternion
+   
+   
+
+   
+   
+   
+
+
+

--- a/doc/src/reference/private/sympy.algebras.rst
+++ b/doc/src/reference/private/sympy.algebras.rst
@@ -1,0 +1,13 @@
+sympy.algebras
+==============
+
+.. automodule:: sympy.algebras
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+
+   sympy.algebras.quaternion
+   sympy.algebras.tests
+

--- a/doc/src/reference/private/sympy.algebras.tests.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.rst
@@ -1,0 +1,30 @@
+﻿sympy.algebras.tests
+====================
+
+.. automodule:: sympy.algebras.tests
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+
+   sympy.algebras.tests.test_quaternion
+

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.rst
@@ -1,0 +1,40 @@
+sympy.algebras.tests.test\_quaternion
+=====================================
+
+.. automodule:: sympy.algebras.tests.test_quaternion
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   
+      test_issue_16318
+      test_quaternion_axis_angle
+      test_quaternion_axis_angle_simplification
+      test_quaternion_complex_real_addition
+      test_quaternion_construction
+      test_quaternion_conversions
+      test_quaternion_evalf
+      test_quaternion_functions
+      test_quaternion_multiplication
+      test_quaternion_rotation_iss1593
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_issue_16318.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_issue_16318.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_issue\_16318
+========================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_issue_16318

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_axis_angle.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_axis_angle.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_axis\_angle
+===================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_axis_angle

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_axis_angle_simplification.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_axis_angle_simplification.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_axis\_angle\_simplification
+===================================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_axis_angle_simplification

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_complex_real_addition.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_complex_real_addition.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_complex\_real\_addition
+===============================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_complex_real_addition

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_construction.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_construction.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_construction
+====================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_construction

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_conversions.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_conversions.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_conversions
+===================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_conversions

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_evalf.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_evalf.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_evalf
+=============================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_evalf

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_functions.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_functions.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_functions
+=================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_functions

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_multiplication.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_multiplication.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_multiplication
+======================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_multiplication

--- a/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_rotation_iss1593.rst
+++ b/doc/src/reference/private/sympy.algebras.tests.test_quaternion.test_quaternion_rotation_iss1593.rst
@@ -1,0 +1,6 @@
+sympy.algebras.tests.test\_quaternion.test\_quaternion\_rotation\_iss1593
+=========================================================================
+
+.. currentmodule:: sympy.algebras.tests.test_quaternion
+
+.. autofunction:: test_quaternion_rotation_iss1593


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This PR adds docs for the ``Private API reference `` section and specifically the ``sympy.algebras`` module.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/22105

#### Builds on PRs

https://github.com/sympy/sympy/pull/22214

#### Brief description of what is fixed or changed

The docs in the directories ``modules`` have been re-categorized, see [Categorize SymPy Modules](https://github.com/sympy/sympy/issues/22006)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
