### PR TITLE
printing: Use sympify as a fall-back for unknown objects

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Set, Tuple
 
 from functools import wraps
 
-from sympy.core import Add, Expr, Mul, Pow, S, sympify, Float
+from sympy.core import Add, Expr, Mul, Pow, S, Float
 from sympy.core.basic import Basic
 from sympy.core.compatibility import default_sort_key
 from sympy.core.expr import UnevaluatedExpr

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -12,7 +12,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import re
 from sympy.printing.str import StrPrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
-
+from sympy.core.sympify import sympify, SympifyError
 
 class requires:
     """ Decorator for registering requirements on print methods. """
@@ -561,6 +561,20 @@ class CodePrinter(StrPrinter):
     _print_Wild = _print_not_supported
     _print_WildFunction = _print_not_supported
     _print_Relational = _print_not_supported
+
+    def _print_object(self, obj):
+        """
+        For classes that do not have any defined printing method
+        try to sympify the object. If a different class  emerges
+        try printing again, otherwise use the emtpyPrinter
+        """
+        try:
+            simp=sympify(obj)
+        except SympifyError:
+            return self.emptyPrinter(obj)
+        if (simp.__class__==obj.__class__):
+            return self.emptyPrinter(obj)
+        return self._print(simp)
 
 
 # Code printer functions. These are included in this file so that they can be

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -219,8 +219,7 @@ from sympy import Basic, Add
 
 from sympy.core.core import BasicMeta
 from sympy.core.function import AppliedUndef, UndefinedFunction, Function
-
-
+from sympy.core import sympify
 
 @contextmanager
 def printer_context(printer, **kwargs):
@@ -347,6 +346,21 @@ class Printer:
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)
+
+    def _print_object(self, obj):
+        """
+        For classes that do not have any defined printing method
+        try to sympify the object. If a different class  emerges
+        try printing again, otherwise use the emtpyPrinter
+        """
+        try:
+            simp=sympify(obj)
+            if (simp.__class__==obj.__class__):
+                raise
+        except:
+            return self.emptyPrinter(obj)
+        return self._print(simp)
+
 
 
 class _PrintFunction:

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -219,7 +219,8 @@ from sympy import Basic, Add
 
 from sympy.core.core import BasicMeta
 from sympy.core.function import AppliedUndef, UndefinedFunction, Function
-from sympy.core import sympify
+
+
 
 @contextmanager
 def printer_context(printer, **kwargs):
@@ -346,21 +347,6 @@ class Printer:
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)
-
-    def _print_object(self, obj):
-        """
-        For classes that do not have any defined printing method
-        try to sympify the object. If a different class  emerges
-        try printing again, otherwise use the emtpyPrinter
-        """
-        try:
-            simp=sympify(obj)
-            if (simp.__class__==obj.__class__):
-                raise
-        except:
-            return self.emptyPrinter(obj)
-        return self._print(simp)
-
 
 
 class _PrintFunction:


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22354

#### Brief description of what is fixed or changed
The following example failed previously:
```python
from sympy.codegen.ast import Return
from sympy.printing.pycode import MpmathPrinter
import mpmath
printer=MpmathPrinter()
mpmath.mp.dps = 50
print(printer.doprint(
  mpmath.mpf("0.19866933079506121545941262711838975037020672954020")))
print(printer.doprint(Return(
  mpmath.mpf("0.19866933079506121545941262711838975037020672954020"))))
```
with result:
```
mpmath.mpf((
  0, 594648170996565481936486824314862592256154935177875, -171, 169))
return 0.1986693307950612154594126271183897503702067295402
```
now the result for the second output will be:
```
return mpmath.mpf((
  0, 594648170996565481936486824314862592256154935177875, -171, 169))
```
#### Other comments
Does this require a release note?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
