### PR TITLE
Test error raised when result depends on symbol

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -901,6 +901,10 @@ def test_issue_18508():
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
 
 
+def test_issue_18521():
+    raises(NotImplementedError, lambda: limit(exp((2 - n) * x), x, oo))
+
+
 def test_issue_18969():
     a, b = symbols('a b', positive=True)
     assert limit(LambertW(a), a, b) == LambertW(b)


### PR DESCRIPTION
Fixes #18521. 

#### Brief description of what is fixed or changed

The result of `limit(exp((2-n)*x), x, oo)` depends on n, how to address this [is an open issue](https://github.com/sympy/sympy/issues/13312) and for this reason a `NotImplementedError` is raised. This PR adds a unit test to ensure this behavior 

#### Other comments
Let me know if I misunderstood/made a bad assumption (such as where the test should be placed).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
