### PR TITLE
Limit handling in _process_limits

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -17,7 +17,7 @@ from sympy.utilities.iterables import sift, is_sequence
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
-def _common_new(cls, function, *symbols, **assumptions):
+def _common_new(cls, function, *symbols, discrete, **assumptions):
     """Return either a special return value or the tuple,
     (function, limits, orientation). This code is common to
     both ExprWithLimits and AddWithLimits."""
@@ -26,7 +26,7 @@ def _common_new(cls, function, *symbols, **assumptions):
     if isinstance(function, Equality):
         # This transforms e.g. Integral(Eq(x, y)) to Eq(Integral(x), Integral(y))
         # but that is only valid for definite integrals.
-        limits, orientation = _process_limits(*symbols)
+        limits, orientation = _process_limits(*symbols, discrete=discrete)
         if not (limits and all(len(limit) == 3 for limit in limits)):
             SymPyDeprecationWarning(
                 feature='Integral(Eq(x, y))',
@@ -44,7 +44,7 @@ def _common_new(cls, function, *symbols, **assumptions):
         return S.NaN
 
     if symbols:
-        limits, orientation = _process_limits(*symbols)
+        limits, orientation = _process_limits(*symbols, discrete=discrete)
         for i, li in enumerate(limits):
             if len(li) == 4:
                 function = function.subs(li[0], li[-1])
@@ -80,7 +80,7 @@ def _common_new(cls, function, *symbols, **assumptions):
     return function, limits, orientation
 
 
-def _process_limits(*symbols):
+def _process_limits(*symbols, discrete=None):
     """Process the list of symbols and convert them to canonical limits,
     storing them as Tuple(symbol, lower, upper). The orientation of
     the function is also returned when the upper limit is missing
@@ -92,8 +92,16 @@ def _process_limits(*symbols):
     """
     limits = []
     orientation = 1
+    if discrete is None:
+        err_msg = 'discrete must be True or False'
+    elif discrete:
+        err_msg = 'use Range, not Interval or Relational'
+    else:
+        err_msg = 'use Interval or Relational, not Range'
     for V in symbols:
         if isinstance(V, (Relational, BooleanFunction)):
+            if discrete:
+                raise TypeError(err_msg)
             variable = V.atoms(Symbol).pop()
             V = (variable, V.as_set())
         elif isinstance(V, Symbol) or getattr(V, '_diff_wrt', False):
@@ -108,9 +116,13 @@ def _process_limits(*symbols):
         if is_sequence(V) and not isinstance(V, Set):
             if len(V) == 2 and isinstance(V[1], Set):
                 V = list(V)
-                if isinstance(V[1], Interval):
-                    V[1:] = i.args[:2]
+                if isinstance(V[1], Interval):  # includes Reals
+                    if discrete:
+                        raise TypeError(err_msg)
+                    V[1:] = V[1].inf, V[1].sup
                 elif isinstance(V[1], Range):
+                    if not discrete:
+                        raise TypeError(err_msg)
                     lo = V[1].inf
                     hi = V[1].sup
                     dx = abs(V[1].step)  # direction doesn't matter
@@ -124,7 +136,9 @@ def _process_limits(*symbols):
                 else:
                     # more complicated sets would require splitting, e.g.
                     # Union(Interval(1, 3), interval(6,10))
-                    raise NotImplementedError('expecting Range or Interval')
+                    raise NotImplementedError(
+                        'expecting Range' if discrete else
+                        'Relational or single Interval' )
             V = sympify(flatten(V))  # a list of sympified elements
             if isinstance(V[0], (Symbol, Idx)) or getattr(V[0], '_diff_wrt', False):
                 newsymbol = V[0]
@@ -176,7 +190,9 @@ class ExprWithLimits(Expr):
     __slots__ = ('is_commutative',)
 
     def __new__(cls, function, *symbols, **assumptions):
-        pre = _common_new(cls, function, *symbols, **assumptions)
+        from sympy.concrete.products import Product
+        pre = _common_new(cls, function, *symbols,
+            discrete=issubclass(cls, Product), **assumptions)
         if isinstance(pre, tuple):
             function, limits, _ = pre
         else:
@@ -509,7 +525,9 @@ class AddWithLimits(ExprWithLimits):
     """
 
     def __new__(cls, function, *symbols, **assumptions):
-        pre = _common_new(cls, function, *symbols, **assumptions)
+        from sympy.concrete.summations import Sum
+        pre = _common_new(cls, function, *symbols,
+            discrete=issubclass(cls, Sum), **assumptions)
         if isinstance(pre, tuple):
             function, limits, orientation = pre
         else:

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -10,7 +10,7 @@ from sympy.functions.elementary.piecewise import (piecewise_fold,
     Piecewise)
 from sympy.logic.boolalg import BooleanFunction
 from sympy.tensor.indexed import Idx
-from sympy.sets.sets import Interval
+from sympy.sets.sets import Interval, Set
 from sympy.sets.fancysets import Range
 from sympy.utilities import flatten
 from sympy.utilities.iterables import sift, is_sequence
@@ -85,6 +85,10 @@ def _process_limits(*symbols):
     storing them as Tuple(symbol, lower, upper). The orientation of
     the function is also returned when the upper limit is missing
     so (x, 1, None) becomes (x, None, 1) and the orientation is changed.
+    In the case that a limit is specified as (symbol, Range), a list of
+    length 4 may be returned if a change of variables is needed; the
+    expression that should replace the symbol in the expression is
+    the fourth element in the list.
     """
     limits = []
     orientation = 1
@@ -101,19 +105,30 @@ def _process_limits(*symbols):
             else:
                 limits.append(Tuple(V))
             continue
-        if is_sequence(V, (tuple, Tuple)):
-            if len(V) == 2 and isinstance(V[1], Range):
-                lo = V[1].inf
-                hi = V[1].sup
-                dx = abs(V[1].step)
-                V = [V[0]] + [0, (hi - lo)//dx, dx*V[0] + lo]
+        if is_sequence(V) and not isinstance(V, Set):
+            if len(V) == 2 and isinstance(V[1], Set):
+                V = list(V)
+                if isinstance(V[1], Interval):
+                    V[1:] = i.args[:2]
+                elif isinstance(V[1], Range):
+                    lo = V[1].inf
+                    hi = V[1].sup
+                    dx = abs(V[1].step)  # direction doesn't matter
+                    if dx == 1:
+                        V[1:] = [lo, hi]
+                    else:
+                        if lo is not S.NegativeInfinity:
+                            V = [V[0]] + [0, (hi - lo)//dx, dx*V[0] + lo]
+                        else:
+                            V = [V[0]] + [0, S.Infinity, -dx*V[0] + hi]
+                else:
+                    # more complicated sets would require splitting, e.g.
+                    # Union(Interval(1, 3), interval(6,10))
+                    raise NotImplementedError('expecting Range or Interval')
             V = sympify(flatten(V))  # a list of sympified elements
             if isinstance(V[0], (Symbol, Idx)) or getattr(V[0], '_diff_wrt', False):
                 newsymbol = V[0]
-                if len(V) == 2 and isinstance(V[1], Interval):  # 2 -> 3
-                    # Interval
-                    V[1:] = [V[1].start, V[1].end]
-                elif len(V) == 3:
+                if len(V) == 3:
                     # general case
                     if V[2] is None and not V[1] is None:
                         orientation *= -1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

While Integral, Sum, Product allow non-standard specification of limit ranges via Range, Interval and Relational (see tests), there is no safety in terms of what is accepted according to whether the process is discrete (Sum, Product) or continuous (Integral). Disrete processes should accept only Range and Continuous, not Range but Relational or Interval.

Also, the handling of `Range(-oo, 1)`  gave an unfavorable expanded limit:
```python
>>> Sum(x, (x, Range(-oo,3)))
Sum(x - oo, (x, 0, oo))  --> now gives `Sum(x, (x, -oo, 2))`
```

#### Other comments

It's possible to interpret Relational/Interval as discrete for the user, but it is probably better to make them be aware of the difference and do it themselves, e.g. `(x > 3).as_set().interrsection(Integers)` or `Interval(2, 3).intersection(Integers)`. But given the work to do that it is perhaps better to just write `(x, 3, oo)` and `(x, 2, 3)`; even `Range` is clunky as `(x, Range(lo, hi + 1))` instead of `(x, lo, hi)`. BUT...range allows you to specify a step (and then automatically change variable accordingly as shown in the tests that were added).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
    * fixed an issue with the use of Range (with an argument of -oo) as s Sum/Product variable range
<!-- END RELEASE NOTES -->
