### PR TITLE
CodeParsers to preprocess expressions for CodePrinters

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1840,7 +1840,7 @@ class Return(Token):
     >>> print(pycode(Return(x)))
     return x
     >>> print(pycode(Return(x,x)))
-    return (x,x)
+    return (x, x)
 
     """
     __slots__ = ('return',)

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -10,6 +10,10 @@ AST Type Tree
 ::
 
   *Basic*
+       |
+       |
+   CodegenAST
+       |
        |--->AssignmentBase
        |             |--->Assignment
        |             |--->AugmentedAssignment
@@ -156,8 +160,10 @@ def _mk_Tuple(args):
     args = [String(arg) if isinstance(arg, str) else arg for arg in args]
     return Tuple(*args)
 
+class CodegenAST(Basic): pass
 
-class Token(Basic):
+
+class Token(CodegenAST):
     """ Base class for the AST types.
 
     Explanation
@@ -239,7 +245,7 @@ class Token(Basic):
             val for attr, val in zip(cls.__slots__, attrvals)
             if attr not in cls.not_in_args
         ]
-        obj = Basic.__new__(cls, *basic_args)
+        obj = CodegenAST.__new__(cls, *basic_args)
 
         # Set attributes
         for attr, arg in zip(cls.__slots__, attrvals):
@@ -393,7 +399,7 @@ class NoneToken(Token):
 none = NoneToken()
 
 
-class AssignmentBase(Basic):
+class AssignmentBase(CodegenAST):
     """ Abstract base class for Assignment and AugmentedAssignment.
 
     Attributes:
@@ -580,7 +586,7 @@ def aug_assign(lhs, op, rhs):
     return augassign_classes[op](lhs, rhs)
 
 
-class CodeBlock(Basic):
+class CodeBlock(CodegenAST):
     """
     Represents a block of code.
 
@@ -630,7 +636,7 @@ class CodeBlock(Basic):
                 left_hand_sides.append(lhs)
                 right_hand_sides.append(rhs)
 
-        obj = Basic.__new__(cls, *args)
+        obj = CodegenAST.__new__(cls, *args)
 
         obj.left_hand_sides = Tuple(*left_hand_sides)
         obj.right_hand_sides = Tuple(*right_hand_sides)
@@ -1811,7 +1817,7 @@ class FunctionDefinition(FunctionPrototype):
         return cls(body=body, **func_proto.kwargs())
 
 
-class Return(Basic):
+class Return(CodegenAST):
     """ Represents a return command in the code. """
 
 

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -56,9 +56,9 @@ AST Type Tree
        |        |--->BreakToken
        |        |--->ContinueToken
        |        |--->NoneToken
+       |        |--->Return
        |
-       |--->Statement
-       |--->Return
+      #|--->Statement  #Currently not yet defined.
 
 
 Predefined types
@@ -160,7 +160,9 @@ def _mk_Tuple(args):
     args = [String(arg) if isinstance(arg, str) else arg for arg in args]
     return Tuple(*args)
 
-class CodegenAST(Basic): pass
+
+class CodegenAST(Basic):
+    pass
 
 
 class Token(CodegenAST):
@@ -1817,8 +1819,39 @@ class FunctionDefinition(FunctionPrototype):
         return cls(body=body, **func_proto.kwargs())
 
 
-class Return(CodegenAST):
-    """ Represents a return command in the code. """
+class Return(Token):
+    """ Represents a return command in the code.
+
+    When multiple arguments are provided, they
+    are interpreted as a Tuple.
+
+    Parameters
+    ==========
+
+    return : Tuple
+
+    Examples
+    ========
+
+    >>> from sympy.codegen.ast import Return
+    >>> from sympy.printing.pycode import pycode
+    >>> from sympy import Symbol
+    >>> x = Symbol('x')
+    >>> print(pycode(Return(x)))
+    return x
+    >>> print(pycode(Return(x,x)))
+    return (x,x)
+
+    """
+    __slots__ = ('return',)
+    #Return has to support multiple arguments
+    #for backwards competability, these are now
+    #interpreted as a single tuple
+    def __new__(cls,*args,**kwargs):
+        if len(args)>1:
+            return super().__new__(cls,args,**kwargs)
+        return super().__new__(cls,*args,**kwargs)
+    _construct_return=staticmethod(_sympify)
 
 
 class FunctionCall(Token, Expr):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -126,6 +126,10 @@ def test_sympy__assumptions__wrapper__AssumptionsWrapper():
     from sympy.assumptions.wrapper import AssumptionsWrapper
     assert _test_args(AssumptionsWrapper(x, Q.positive(x)))
 
+@SKIP("abstract Class")
+def test_sympy__codegen__ast__CodegenAST():
+    from sympy.codegen.ast import CodegenAST
+    assert _test_args(CodegenAST())
 
 @SKIP("abstract Class")
 def test_sympy__codegen__ast__AssignmentBase():

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -66,7 +66,9 @@ class MathMLPrinterBase(Printer):
         """
         Prints the expression as MathML.
         """
-        mathML = Printer._print(self, expr)
+        #mathML = Printer._print(self, expr)
+        #
+        mathML=self._print(expr)
         unistr = mathML.toxml()
         xmlbstr = unistr.encode('ascii', 'xmlcharrefreplace')
         res = xmlbstr.decode()

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -217,8 +217,6 @@ from functools import cmp_to_key, update_wrapper
 
 from sympy import Basic, Add
 
-from sympy.core.core import BasicMeta
-from sympy.core.function import AppliedUndef, UndefinedFunction, Function
 from sympy.utilities.parser import Parser
 
 

--- a/sympy/utilities/parser.py
+++ b/sympy/utilities/parser.py
@@ -1,7 +1,7 @@
 from types import MethodType
 
 class Parser():
-    groups={}
+    groups: = {} # type: Dict[str,Tuple(str)]
 
     def __init__(self,*args,**kwargs):
         self.namestack=[]

--- a/sympy/utilities/parser.py
+++ b/sympy/utilities/parser.py
@@ -28,7 +28,6 @@ class Parser():
             return parsed
         run_parser.__doc__=parser.__doc__
         decorated=MethodType(run_parser,self)
-        
         return decorated
 
     def setup_parser(self,name):
@@ -59,7 +58,7 @@ class Parser():
             return self.generic_parser
         #this can happen if Parser._<parse> or Parser._<parse>_<Class>
         #is used directly, but a Parser._<parse> is not explicitly defined:
-        #in that case, we replace the first Parser._<parse> with a 
+        #in that case, we replace the first Parser._<parse> with a
         #generic do to set it up properly:
         if len(attr[1:].split('_'))==1:
             self.setup_parser(attr[1:])
@@ -117,16 +116,16 @@ class Parser():
                     c == classes[0] or \
                     c.endswith("Base")) + classes[i:]
             #If a class is inside any group, add the group Class right after
-            #the class which is part of the group          
+            #the class which is part of the group
             for group_class,group in self.groups.items():
                 idx=0
                 for i,cls in enumerate(classes):
                     if cls in group:
                         idx=i+1
-                if idx:        
+                if idx:
                     classes=classes[:idx] +(group_class,) + classes[idx:]
             for cls in classes:
-                parsemethodname = '_'+name+'_' + cls #               
+                parsemethodname = '_'+name+'_' + cls
                 parsemethod = getattr(self, parsemethodname, None)
                 if parsemethod is not None:
                     return parsemethod(expr, **kwargs)
@@ -135,4 +134,3 @@ class Parser():
             return empty(expr, **kwargs)
         finally:
             setattr(self,'_'+name+'_level',getattr(self,'_'+name+'_level')-1)
-

--- a/sympy/utilities/parser.py
+++ b/sympy/utilities/parser.py
@@ -1,0 +1,138 @@
+from types import MethodType
+
+class Parser():
+    groups={}
+
+    def __init__(self,*args,**kwargs):
+        self.namestack=[]
+        for cls in self.__class__.__mro__[::-1]:
+            for parser in cls.__dict__:
+                if "do" == parser[:2]:
+                    setattr(self,parser,self.decorate_parser(getattr(self,parser)))
+        super().__init__(*args,**kwargs)
+
+    def decorate_parser(self,parser):
+        def run_parser(self,*args,**kwargs):
+            name=parser.__name__[2:]
+
+            #setup parser attributes
+            self.setup_parser(name)
+
+            #update the stack so that we can nest different parsers
+            #(but not the same)
+            self.namestack.append(name)
+            #perform parsing
+            parsed=parser(*args,**kwargs)
+            #pop the stack to indicate we are done with parsing
+            self.namestack.pop()
+            return parsed
+        run_parser.__doc__=parser.__doc__
+        decorated=MethodType(run_parser,self)
+        
+        return decorated
+
+    def setup_parser(self,name):
+        #check if this parser is already being used
+        #if name in self.namestack:
+        #    error='You are not allowed to run {0} inside itself'
+        #    raise RecursionError(error.format(name))
+        level="_"+name+"_level"
+        if not hasattr(self,level):
+            setattr(self,"_"+name+"_level",0)
+        #setup the name of the method to use for parsing of a class
+        #that is being parsed has it.
+        method=name+"method"
+        if not hasattr(self,method):
+            setattr(self,method,"_"+method)
+        #setup the method name for when no parser is found
+        empty="_"+name+"empty"
+        if not hasattr(self,empty):
+            setattr(self,empty,"emptyParser")
+
+
+    def __getattr__(self,attr):
+        if attr[:2]=='do':
+            self.setup_parser(attr[2:])
+            self.namestack.append(attr[2:])
+            return self.generic_do
+        if attr[1:] in self.namestack:
+            return self.generic_parser
+        #this can happen if Parser._<parse> or Parser._<parse>_<Class>
+        #is used directly, but a Parser._<parse> is not explicitly defined:
+        #in that case, we replace the first Parser._<parse> with a 
+        #generic do to set it up properly:
+        if len(attr[1:].split('_'))==1:
+            self.setup_parser(attr[1:])
+            self.namestack.append(attr[1:])
+            return self.generic_do
+        raise AttributeError(attr)
+
+    def emptyParser(self,obj):
+        return obj
+
+
+    def generic_do(self,*args,**kwargs):
+        name=kwargs.get('name',None)
+        if name is None:
+            name=self.namestack[-1]
+        else:
+            self.namestack.append(name)
+        result= getattr(self,'_'+name)(*args,**kwargs)
+        self.namestack.pop()
+        return result
+
+    def generic_parser(self,expr,name=None,**kwargs):
+        if name is None:
+            name=self.namestack[-1]
+        """Internal dispatcher
+        Tries the following concepts to parse an expression:
+            1. Let the object parse itself if it knows how.
+            2. Take the best fitting method defined in the parser.
+            3. As fall-back use the _parse_Object method for the printer
+                    default is to .
+        """
+        setattr(self,'_'+name+'_level',getattr(self,'_'+name+'_level')+1)
+        try:
+            # If the printer defines a name for a printing method
+            # (Printer.printmethod) and the object knows for itself how it
+            # should be printed, use that method.
+            parsemethod=getattr(self,name+'method')
+            if (parsemethod and hasattr(expr, parsemethod) #
+                    and not 'BasicMeta' in expr.__class__.__mro__):
+                return getattr(expr, parsemethod)(self, **kwargs) #
+            # See if the class of expr is known, or if one of its super
+            # classes is known, and use that print function
+            # Exception: ignore the subclasses of Undefined, so that, e.g.,
+            # Function('gamma') does not get dispatched to _print_gamma
+            classes = tuple(mro.__name__ for mro in type(expr).__mro__)
+            if 'AppliedUndef' in classes:
+                classes = classes[classes.index('AppliedUndef'):]
+            if 'UndefinedFunction' in classes:
+                classes = classes[classes.index('UndefinedFunction'):]
+            # Another exception: if someone subclasses a known function, e.g.,
+            # gamma, and changes the name, then ignore _print_gamma
+            if 'Function' in classes:
+                i = classes.index('Function')
+                classes = tuple(c for c in classes[:i] if \
+                    c == classes[0] or \
+                    c.endswith("Base")) + classes[i:]
+            #If a class is inside any group, add the group Class right after
+            #the class which is part of the group          
+            for group_class,group in self.groups.items():
+                idx=0
+                for i,cls in enumerate(classes):
+                    if cls in group:
+                        idx=i+1
+                if idx:        
+                    classes=classes[:idx] +(group_class,) + classes[idx:]
+            for cls in classes:
+                parsemethodname = '_'+name+'_' + cls #               
+                parsemethod = getattr(self, parsemethodname, None)
+                if parsemethod is not None:
+                    return parsemethod(expr, **kwargs)
+            #use the empty parser as a last resort
+            empty=getattr(self,getattr(self,"_"+name+"empty"))
+            return empty(expr, **kwargs)
+        finally:
+            setattr(self,'_'+name+'_level',getattr(self,'_'+name+'_level')-1)
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
SymPy features a very extensive printing system. In this sytem, the `doprint`
method of an appropriate `Printer` is used to obtain a string. Internally,
doprint will use the `_print` method which looks for an appropriate 
`_print_<class>` based on the class (or its parent classes) of the object 
being printed. Additionally, an object can define its own printing method
by giving it the appropriate name (Printer dependent) such that users
can define the printing behaviour for their custom objects. These
`_print_<class>` methods will often call `_print` again. For example: `Mul`, 
the object in SymPy representing multiplication, might use `_print` on all
of its arguments and then join the obtained strings with a "*" character.

Here, the `Parser` class is introduced which generalises the above concepts.
The `Parser` class allows the use of not only `doprint`, `_print` and
`_print_<class>`, but now allows print to be replaced with any name (without
underscores "_") using `do<parsername>`, `_<parsername>` and 
`_<parsername>_<class>`. Multiple such parsers can be stored in the same
object since they should not conflict. Additionally, `do<parsername>` and
`_<parsername>`	are automatically constructed if they are not provided.

Currently, several parts of SymPy rely heavily on the code printers. For
example, `lambdify` and `autowrap` use the code printers to convert SymPy
expressions into code that can be run in several different languages.
However, both use their own code generation to obtain the code needed to
embed the printed expression in a form that is expected of a programming
language (e.g. function definitions, variable declarations etc.). Code 
parsers could be used to perform these tasks, such that new functionality
is immediately available in both `autowrap` and `lambdify` as well as to
the user simply wanting to obtain the code and reuse it in their own 
projects.

Recently, common subexpression extraction (CSE) was implemented in 
`lambdify`, which was also used to delete temporary variables to reduce
the memory usage. Automatic (de)allocation would also be useful for
`autowrap` but would now need to be implemented again. On top of that, 
putting new functionality in code parsers would stop bloating the already
lengthy lambdify and autowrap functions.

#### Other comments

Examples of how to use code parsers to follow.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
