### PR TITLE
[WIP] CodeParsers for preprocessing expressions given to CodePrinters

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -62,7 +62,7 @@ class VectorLatexPrinter(LatexPrinter):
                 base = self.parenthesize_super(base)
                 return r"%s^{%s}" % (base, exp)
             else:
-                return super()._print(expr)
+                return self._print(expr)
         else:
             return super()._print_Function(expr, exp)
 

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -67,7 +67,7 @@ class MathMLPrinterBase(Printer):
         """
         Prints the expression as MathML.
         """
-        mathML = Printer._print(self, expr)
+        mathML = self._print(expr)
         unistr = mathML.toxml()
         xmlbstr = unistr.encode('ascii', 'xmlcharrefreplace')
         res = xmlbstr.decode()

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -218,9 +218,7 @@ from functools import cmp_to_key, update_wrapper
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 
-from sympy.core.core import BasicMeta
-from sympy.core.function import AppliedUndef, UndefinedFunction, Function
-
+from sympy.utilities.parser import Parser
 
 
 @contextmanager
@@ -233,7 +231,7 @@ def printer_context(printer, **kwargs):
         printer._context = original
 
 
-class Printer:
+class Printer(Parser):
     """ Generic printer
 
     Its job is to provide infrastructure for implementing new printers easily.
@@ -288,52 +286,7 @@ class Printer:
         else:
             raise AttributeError("No order defined.")
 
-    def doprint(self, expr):
-        """Returns printer's representation for expr (as a string)"""
-        return self._str(self._print(expr))
-
-    def _print(self, expr, **kwargs):
-        """Internal dispatcher
-
-        Tries the following concepts to print an expression:
-            1. Let the object print itself if it knows how.
-            2. Take the best fitting method defined in the printer.
-            3. As fall-back use the emptyPrinter method for the printer.
-        """
-        self._print_level += 1
-        try:
-            # If the printer defines a name for a printing method
-            # (Printer.printmethod) and the object knows for itself how it
-            # should be printed, use that method.
-            if (self.printmethod and hasattr(expr, self.printmethod)
-                    and not isinstance(expr, BasicMeta)):
-                return getattr(expr, self.printmethod)(self, **kwargs)
-
-            # See if the class of expr is known, or if one of its super
-            # classes is known, and use that print function
-            # Exception: ignore the subclasses of Undefined, so that, e.g.,
-            # Function('gamma') does not get dispatched to _print_gamma
-            classes = type(expr).__mro__
-            if AppliedUndef in classes:
-                classes = classes[classes.index(AppliedUndef):]
-            if UndefinedFunction in classes:
-                classes = classes[classes.index(UndefinedFunction):]
-            # Another exception: if someone subclasses a known function, e.g.,
-            # gamma, and changes the name, then ignore _print_gamma
-            if Function in classes:
-                i = classes.index(Function)
-                classes = tuple(c for c in classes[:i] if \
-                    c.__name__ == classes[0].__name__ or \
-                    c.__name__.endswith("Base")) + classes[i:]
-            for cls in classes:
-                printmethodname = '_print_' + cls.__name__
-                printmethod = getattr(self, printmethodname, None)
-                if printmethod is not None:
-                    return printmethod(expr, **kwargs)
-            # Unknown object, fall back to the emptyPrinter.
-            return self.emptyPrinter(expr)
-        finally:
-            self._print_level -= 1
+    _printempty='emptyPrinter'
 
     def emptyPrinter(self, expr):
         return str(expr)

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -271,6 +271,7 @@ class Printer(Parser):
         # _print_level is the number of times self._print() was recursively
         # called. See StrPrinter._print_Float() for an example of usage
         self._print_level = 0
+        super().__init__()
 
     @classmethod
     def set_global_settings(cls, **settings):
@@ -285,6 +286,10 @@ class Printer(Parser):
             return self._settings['order']
         else:
             raise AttributeError("No order defined.")
+
+    def doprint(self, expr):
+        """Returns printer's representation for expr (as a string)"""
+        return self._str(self._print(expr))
 
     _printempty='emptyPrinter'
 

--- a/sympy/utilities/parser.py
+++ b/sympy/utilities/parser.py
@@ -2,6 +2,7 @@ from types import MethodType
 
 class Parser():
     groups = {} # type: dict[str,tuple]
+    namestack = [] #type: list[str]
 
     def __init__(self,*args,**kwargs):
         self.namestack=[]

--- a/sympy/utilities/parser.py
+++ b/sympy/utilities/parser.py
@@ -1,0 +1,136 @@
+from types import MethodType
+
+class Parser():
+    groups = {} # type: dict[str,tuple]
+
+    def __init__(self,*args,**kwargs):
+        self.namestack=[]
+        for cls in self.__class__.__mro__[::-1]:
+            for parser in cls.__dict__:
+                if "do" == parser[:2]:
+                    setattr(self,parser,self.decorate_parser(getattr(self,parser)))
+        super().__init__(*args,**kwargs)
+
+    def decorate_parser(self,parser):
+        def run_parser(self,*args,**kwargs):
+            name=parser.__name__[2:]
+
+            #setup parser attributes
+            self.setup_parser(name)
+
+            #update the stack so that we can nest different parsers
+            #(but not the same)
+            self.namestack.append(name)
+            #perform parsing
+            parsed=parser(*args,**kwargs)
+            #pop the stack to indicate we are done with parsing
+            self.namestack.pop()
+            return parsed
+        run_parser.__doc__=parser.__doc__
+        decorated=MethodType(run_parser,self)
+        return decorated
+
+    def setup_parser(self,name):
+        #check if this parser is already being used
+        #if name in self.namestack:
+        #    error='You are not allowed to run {0} inside itself'
+        #    raise RecursionError(error.format(name))
+        level="_"+name+"_level"
+        if not hasattr(self,level):
+            setattr(self,"_"+name+"_level",0)
+        #setup the name of the method to use for parsing of a class
+        #that is being parsed has it.
+        method=name+"method"
+        if not hasattr(self,method):
+            setattr(self,method,"_"+method)
+        #setup the method name for when no parser is found
+        empty="_"+name+"empty"
+        if not hasattr(self,empty):
+            setattr(self,empty,"emptyParser")
+
+
+    def __getattr__(self,attr):
+        if attr[:2]=='do':
+            self.setup_parser(attr[2:])
+            self.namestack.append(attr[2:])
+            return self.generic_do
+        if attr[1:] in self.namestack:
+            return self.generic_parser
+        #this can happen if Parser._<parse> or Parser._<parse>_<Class>
+        #is used directly, but a Parser._<parse> is not explicitly defined:
+        #in that case, we replace the first Parser._<parse> with a
+        #generic do to set it up properly:
+        if len(attr[1:].split('_'))==1:
+            self.setup_parser(attr[1:])
+            self.namestack.append(attr[1:])
+            return self.generic_do
+        raise AttributeError(attr)
+
+    def emptyParser(self,obj):
+        return obj
+
+
+    def generic_do(self,*args,**kwargs):
+        name=kwargs.get('name',None)
+        if name is None:
+            name=self.namestack[-1]
+        else:
+            self.namestack.append(name)
+        result= getattr(self,'_'+name)(*args,**kwargs)
+        self.namestack.pop()
+        return result
+
+    def generic_parser(self,expr,name=None,**kwargs):
+        if name is None:
+            name=self.namestack[-1]
+        """Internal dispatcher
+        Tries the following concepts to parse an expression:
+            1. Let the object parse itself if it knows how.
+            2. Take the best fitting method defined in the parser.
+            3. As fall-back use the _parse_Object method for the printer
+                    default is to .
+        """
+        setattr(self,'_'+name+'_level',getattr(self,'_'+name+'_level')+1)
+        try:
+            # If the printer defines a name for a printing method
+            # (Printer.printmethod) and the object knows for itself how it
+            # should be printed, use that method.
+            parsemethod=getattr(self,name+'method')
+            if (parsemethod and hasattr(expr, parsemethod) #
+                    and not 'BasicMeta' in expr.__class__.__mro__):
+                return getattr(expr, parsemethod)(self, **kwargs) #
+            # See if the class of expr is known, or if one of its super
+            # classes is known, and use that print function
+            # Exception: ignore the subclasses of Undefined, so that, e.g.,
+            # Function('gamma') does not get dispatched to _print_gamma
+            classes = tuple(mro.__name__ for mro in type(expr).__mro__)
+            if 'AppliedUndef' in classes:
+                classes = classes[classes.index('AppliedUndef'):]
+            if 'UndefinedFunction' in classes:
+                classes = classes[classes.index('UndefinedFunction'):]
+            # Another exception: if someone subclasses a known function, e.g.,
+            # gamma, and changes the name, then ignore _print_gamma
+            if 'Function' in classes:
+                i = classes.index('Function')
+                classes = tuple(c for c in classes[:i] if \
+                    c == classes[0] or \
+                    c.endswith("Base")) + classes[i:]
+            #If a class is inside any group, add the group Class right after
+            #the class which is part of the group
+            for group_class,group in self.groups.items():
+                idx=0
+                for i,cls in enumerate(classes):
+                    if cls in group:
+                        idx=i+1
+                if idx:
+                    classes=classes[:idx] +(group_class,) + classes[idx:]
+            for cls in classes:
+                parsemethodname = '_'+name+'_' + cls
+                parsemethod = getattr(self, parsemethodname, None)
+                if parsemethod is not None:
+                    return parsemethod(expr, **kwargs)
+            #use the empty parser as a last resort
+            empty=getattr(self,getattr(self,"_"+name+"empty"))
+            return empty(expr, **kwargs)
+        finally:
+            setattr(self,'_'+name+'_level',getattr(self,'_'+name+'_level')-1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
SymPy features a very extensive printing system. In this sytem, the `doprint`
method of an appropriate `Printer` is used to obtain a string. Internally,
doprint will use the `_print` method which looks for an appropriate
`_print_<class>` based on the class (or its parent classes) of the object
being printed. Additionally, an object can define its own printing method
by giving it the appropriate name (Printer dependent) such that users
can define the printing behaviour for their custom objects. These
`_print_<class>` methods will often call `_print` again. For example: `Mul`,
the object in SymPy representing multiplication, might use `_print` on all
of its arguments and then join the obtained strings with a "*" character.

Here, the `Parser` class is introduced which generalises the above concepts.
The `Parser` class allows the use of not only `doprint`, `_print` and
`_print_<class>`, but now allows print to be replaced with any name (without
underscores "_") using `do<parsername>`, `_<parsername>` and
`_<parsername>_<class>`. Multiple such parsers can be stored in the same
object since they should not conflict. Additionally, `do<parsername>` and
`_<parsername>`	are automatically constructed if they are not provided.

Currently, several parts of SymPy rely heavily on the code printers. For
example, `lambdify` and `autowrap` use the code printers to convert SymPy
expressions into code that can be run in several different languages.
However, both use their own code generation to obtain the code needed to
embed the printed expression in a form that is expected of a programming
language (e.g. function definitions, variable declarations etc.). Code
parsers could be used to perform these tasks, such that new functionality
is immediately available in both `autowrap` and `lambdify` as well as to
the user simply wanting to obtain the code and reuse it in their own
projects.

Recently, common subexpression extraction (CSE) was implemented in
`lambdify`, which was also used to delete temporary variables to reduce
the memory usage. Automatic (de)allocation would also be useful for
`autowrap` but would now need to be implemented again. On top of that,
putting new functionality in code parsers would stop bloating the already
lengthy lambdify and autowrap functions.


#### Other comments

Examples:

This google colab contains a simple example of how to use code parsers (more to follow)
https://colab.research.google.com/drive/1ugRSYuA6fdvNpZlHss7aLx3r3YSLJ7tB?usp=sharing
- Creating a function definition around a SymPy `Expr` with `Parser`
- Creating a (simplified version of) `lambdify` with `Parser`


Known issues:

- [ ] Currently pickling does not work for the new Parser class
- [x] Some doc tests are still failing.  

To do:

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
