### PR TITLE
fix _eval_transpose for matrices

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2017,9 +2017,9 @@ class MatrixOperations(MatrixRequired):
 
     def _eval_transpose(self):
         def func(i, j):
-            if hasattr(U[j, i], "transpose"):
-                return U[j, i].transpose()
-            return U[j, i]
+            if hasattr(self[j, i], "transpose"):
+                return self[j, i].transpose()
+            return self[j, i]
 
         return self._new(self.cols, self.rows, func)
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2020,7 +2020,7 @@ class MatrixOperations(MatrixRequired):
             if hasattr(U[j, i], "transpose"):
                 return U[j, i].transpose()
             return U[j, i]
-            
+
         return self._new(self.cols, self.rows, func)
 
     def adjoint(self):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2016,7 +2016,12 @@ class MatrixOperations(MatrixRequired):
         return sum(self[i, i] for i in range(self.rows))
 
     def _eval_transpose(self):
-        return self._new(self.cols, self.rows, lambda i, j: self[j, i])
+        def func(i, j):
+            if hasattr(U[j, i], "transpose"):
+                return U[j, i].transpose()
+            return U[j, i]
+            
+        return self._new(self.cols, self.rows, func)
 
     def adjoint(self):
         """Conjugate transpose or Hermitian conjugation."""

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -915,6 +915,8 @@ def sdm_transpose(M):
     MT = {}
     for i, Mi in M.items():
         for j, Mij in Mi.items():
+            if hasattr(Mij, "transpose"):
+                Mij =  Mij.transpose()
             try:
                 MT[j][i] = Mij
             except KeyError:


### PR DESCRIPTION
Fix for _eval_transpose for Matrices, so that the transposition is applied recursievely.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed
If you want to transpose a Matrix with quantum operators inside you would expect the following behavior:
<img src="https://render.githubusercontent.com/render/math?math=A = [[0,U],[0,0]]">
<img src="https://render.githubusercontent.com/render/math?math=A^T = [[0,0],[U^T,0]]">
but currently this is the behaviour:
<img src="https://render.githubusercontent.com/render/math?math=A^T = [[0,0],[U,0]]">

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Transposition is now applied recursievely.
<!-- END RELEASE NOTES -->
