### PR TITLE
line - added fix to define horizontal and vertical lines using Eq instead of Point

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -24,7 +24,7 @@ from sympy.core.decorators import deprecated
 from sympy.core.evalf import N
 from sympy.core.numbers import Rational, oo
 from sympy.core.relational import Eq
-from sympy.core.symbol import _symbol, Dummy
+from sympy.core.symbol import _symbol, Dummy, uniquely_named_symbol
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (_pi_coeff as pi_coeff, acos, tan, atan2)
 from .entity import GeometryEntity, GeometrySet
@@ -1154,7 +1154,6 @@ class Line(LinearEntity):
     Line2D(Point2D(0, -18), Point2D(1, -21))
     """
     def __new__(cls, *args, **kwargs):
-        from sympy.core.symbol import uniquely_named_symbol
         if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
             x = kwargs.get('x', 'x')
             y = kwargs.get('y', 'y')

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1155,8 +1155,6 @@ class Line(LinearEntity):
     """
     def __new__(cls, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
-            x = kwargs.get('x', 'x')
-            y = kwargs.get('y', 'y')
             missing = uniquely_named_symbol('?', args).name
             if not kwargs:
                 x = 'x'

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1154,15 +1154,31 @@ class Line(LinearEntity):
     Line2D(Point2D(0, -18), Point2D(1, -21))
     """
     def __new__(cls, *args, **kwargs):
+        from sympy.core.symbol import uniquely_named_symbol
         if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
             x = kwargs.get('x', 'x')
             y = kwargs.get('y', 'y')
+            missing = uniquely_named_symbol('?', args).name
+            if not kwargs:
+                x = 'x'
+                y = 'y'
+            else:
+                x = kwargs.pop('x', missing)
+                y = kwargs.pop('y', missing)
+            if kwargs:
+                raise ValueError('expecting only x and y as keywords')
+
             equation = args[0]
             if isinstance(equation, Eq):
                 equation = equation.lhs - equation.rhs
-            xin, yin = x, y
-            x = find(x, equation) or Dummy()
-            y = find(y, equation) or Dummy()
+
+            def find_or_missing(x):
+                try:
+                    return find(x, equation)
+                except ValueError:
+                    return missing
+            x = find_or_missing(x)
+            y = find_or_missing(y)
 
             a, b, c = linear_coeffs(equation, x, y)
 
@@ -1170,7 +1186,8 @@ class Line(LinearEntity):
                 return Line((0, -c/b), slope=-a/b)
             if a:
                 return Line((-c/a, 0), slope=oo)
-            raise ValueError('neither %s nor %s were found in the equation' % (xin, yin))
+
+            raise ValueError('not found in equation: %s' % (set('xy') - {x, y}))
 
         else:
             if len(args) > 0:

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -24,17 +24,24 @@ m = symbols('m', real=True)
 def test_object_from_equation():
     from sympy.abc import x, y, a, b
     assert Line(3*x + y + 18) == Line2D(Point2D(0, -18), Point2D(1, -21))
-    assert Line(3*x + 5 * y + 1) == Line2D(Point2D(0, Rational(-1, 5)), Point2D(1, Rational(-4, 5)))
-    assert Line(3*a + b + 18, x='a', y='b') == Line2D(Point2D(0, -18), Point2D(1, -21))
+    assert Line(3*x + 5 * y + 1) == Line2D(
+        Point2D(0, Rational(-1, 5)), Point2D(1, Rational(-4, 5)))
+    assert Line(3*a + b + 18, x="a", y="b") == Line2D(
+        Point2D(0, -18), Point2D(1, -21))
     assert Line(3*x + y) == Line2D(Point2D(0, 0), Point2D(1, -3))
     assert Line(x + y) == Line2D(Point2D(0, 0), Point2D(1, -1))
-    assert Line(Eq(3*a + b, -18), x='a', y=b) == Line2D(Point2D(0, -18), Point2D(1, -21))
-    raises(ValueError, lambda: Line(x))
-    raises(ValueError, lambda: Line(y))
-    raises(ValueError, lambda: Line(x/y))
-    raises(ValueError, lambda: Line(a/b, x='a', y='b'))
-    raises(ValueError, lambda: Line(y/x))
-    raises(ValueError, lambda: Line(b/a, x='a', y='b'))
+    assert Line(Eq(3*a + b, -18), x="a", y=b) == Line2D(
+        Point2D(0, -18), Point2D(1, -21))
+    # issue 22361
+    assert Line(x - 1) == Line2D(Point2D(1, 0), Point2D(1, 1))
+    assert Line(2*x - 2, y=x) == Line2D(Point2D(0, 1), Point2D(1, 1))
+    assert Line(y) == Line2D(Point2D(0, 0), Point2D(1, 0))
+    assert Line(2*y, x=y) == Line2D(Point2D(0, 0), Point2D(0, 1))
+    assert Line(y, x=y) == Line2D(Point2D(0, 0), Point2D(0, 1))
+    raises(ValueError, lambda: Line(x / y))
+    raises(ValueError, lambda: Line(a / b, x='a', y='b'))
+    raises(ValueError, lambda: Line(y / x))
+    raises(ValueError, lambda: Line(b / a, x='a', y='b'))
     raises(ValueError, lambda: Line((x + 1)**2 + y))
 
 
@@ -802,8 +809,3 @@ def test_issue_8615():
     a = Line3D(Point3D(6, 5, 0), Point3D(6, -6, 0))
     b = Line3D(Point3D(6, -1, 19/10), Point3D(6, -1, 0))
     assert a.intersection(b) == [Point3D(6, -1, 0)]
-
-
-def test_issue_22361():
-    assert Line(Eq(x, 1)) == Line2D(Point2D(1, 0), Point2D(1, 1))
-    assert Line(Eq(y, 1)) == Line2D(Point2D(0, 1), Point2D(1, 1))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -805,5 +805,5 @@ def test_issue_8615():
 
 
 def test_issue_22361():
-    assert Line(Eq(x, 1)) == Line2D(Point2D(0, 1), Point2D(1, 1))
-    assert Line(Eq(y, 1)) == Line2D(Point2D(1, 0), Point2D(1, 1))
+    assert Line(Eq(x, 1)) == Line2D(Point2D(1, 0), Point2D(1, 1))
+    assert Line(Eq(y, 1)) == Line2D(Point2D(0, 1), Point2D(1, 1))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -802,3 +802,8 @@ def test_issue_8615():
     a = Line3D(Point3D(6, 5, 0), Point3D(6, -6, 0))
     b = Line3D(Point3D(6, -1, 19/10), Point3D(6, -1, 0))
     assert a.intersection(b) == [Point3D(6, -1, 0)]
+
+
+def test_issue_22361():
+    assert Line(Eq(x, 1)) == Line2D(Point2D(0, 1), Point2D(1, 1))
+    assert Line(Eq(y, 1)) == Line2D(Point2D(1, 0), Point2D(1, 1))

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -27,7 +27,9 @@ def find(x, equation):
 
     free = equation.free_symbols
     xs = [i for i in free if (i.name if isinstance(x, str) else i) == x]
-    if not xs:
+    if not xs and (str(equation) != x):
+        return 1
+    if str(equation) == x:
         raise ValueError('could not find %s' % x)
     if len(xs) != 1:
         raise ValueError('ambiguous %s' % x)

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -27,9 +27,7 @@ def find(x, equation):
 
     free = equation.free_symbols
     xs = [i for i in free if (i.name if isinstance(x, str) else i) == x]
-    if not xs and (str(equation) != x):
-        return 1
-    if str(equation) == x:
+    if not xs:
         raise ValueError('could not find %s' % x)
     if len(xs) != 1:
         raise ValueError('ambiguous %s' % x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #22361 and now we can define horizontal and vertical lines using `Eq`. `Line(Eq(x, 1))` now returns `Line2D(Point2D(1, 0), Point2D(1, 1))` instead of `ValueError: could not find y` .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
   * `Line` class can now define horizontal and vertical lines using `Eq`
<!-- END RELEASE NOTES -->
