### PR TITLE
use EmptySet like singleton; check/correct singleton printing

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -162,7 +162,7 @@ from .simplify import (simplify, hypersimp, hypersimilar, logcombine,
 
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
         Intersection, DisjointUnion, imageset, Complement, SymmetricDifference, ImageSet,
-        Range, ComplexRegion, Reals, Contains, ConditionSet, Ordinal,
+        Range, ComplexRegion, Complexes, Reals, Contains, ConditionSet, Ordinal,
         OmegaPower, ord0, PowerSet, Naturals, Naturals0, UniversalSet,
         Integers, Rationals)
 
@@ -175,8 +175,7 @@ from .solvers import (solve, solve_linear_system, solve_linear_system_LU,
         pdsolve, classify_pde, checkpdesol, ode_order, reduce_inequalities,
         reduce_abs_inequality, reduce_abs_inequalities, solve_poly_inequality,
         solve_rational_inequalities, solve_univariate_inequality, decompogen,
-        solveset, linsolve, linear_eq_to_matrix, nonlinsolve, substitution,
-        Complexes)
+        solveset, linsolve, linear_eq_to_matrix, nonlinsolve, substitution)
 
 from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         casoratian, diag, eye, hessian, jordan_cell, list2numpy, matrix2numpy,
@@ -390,8 +389,8 @@ __all__ = [
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
     'Intersection', 'imageset', 'DisjointUnion', 'Complement', 'SymmetricDifference',
     'ImageSet', 'Range', 'ComplexRegion', 'Reals', 'Contains', 'ConditionSet',
-    'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Reals', 'Naturals',
-    'Naturals0', 'UniversalSet', 'Integers', 'Rationals',
+    'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Naturals',
+    'Naturals0', 'UniversalSet', 'Integers', 'Rationals', 'Complexes',
 
     # sympy.solvers
     'solve', 'solve_linear_system', 'solve_linear_system_LU',
@@ -405,7 +404,7 @@ __all__ = [
     'reduce_abs_inequality', 'reduce_abs_inequalities',
     'solve_poly_inequality', 'solve_rational_inequalities',
     'solve_univariate_inequality', 'decompogen', 'solveset', 'linsolve',
-    'linear_eq_to_matrix', 'nonlinsolve', 'substitution', 'Complexes',
+    'linear_eq_to_matrix', 'nonlinsolve', 'substitution',
 
     # sympy.matrices
     'ShapeError', 'NonSquareMatrixError', 'GramSchmidt', 'casoratian', 'diag',
@@ -436,8 +435,8 @@ __all__ = [
     'cartes', 'capture', 'dict_merge', 'prefixes', 'postfixes', 'sift',
     'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
     'default_sort_key', 'ordered', 'rotations', 'filldedent', 'lambdify',
-    'source', 'threaded', 'xthreaded', 'public', 'memoize_property', 'test',
-    'doctest', 'timed',
+    'source', 'threaded', 'xthreaded', 'public', 'memoize_property',
+    'timed',
 
     # sympy.integrals
     'integrate', 'Integral', 'line_integrate', 'mellin_transform',

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -14,7 +14,7 @@ from sympy.calculus.util import (function_range, continuous_domain, not_empty_in
                                  stationary_points, minimum, maximum)
 from sympy.core import Add, Mul, Pow
 from sympy.core.expr import unchanged
-from sympy.sets.sets import (EmptySet, Interval, FiniteSet, Complement, Union)
+from sympy.sets.sets import (Interval, FiniteSet, Complement, Union)
 from sympy.testing.pytest import raises, _both_exp_pow, XFAIL
 from sympy.abc import x
 
@@ -225,9 +225,9 @@ def test_stationary_points():
     assert stationary_points(sin(x), x, Interval(-pi/2, pi/2)
         ) == {-pi/2, pi/2}
     assert  stationary_points(sin(x), x, Interval.Ropen(0, pi/4)
-        ) == EmptySet()
+        ) is S.EmptySet
     assert stationary_points(tan(x), x,
-        ) == EmptySet()
+        ) is S.EmptySet
     assert stationary_points(sin(x)*cos(x), x, Interval(0, pi)
         ) == {pi/4, pi*Rational(3, 4)}
     assert stationary_points(sec(x), x, Interval(0, pi)
@@ -235,7 +235,7 @@ def test_stationary_points():
     assert stationary_points((x+3)*(x-2), x
         ) == FiniteSet(Rational(-1, 2))
     assert stationary_points((x + 3)/(x - 2), x, Interval(-5, 5)
-        ) == EmptySet()
+        ) is S.EmptySet
     assert stationary_points((x**2+3)/(x-2), x
         ) == {2 - sqrt(7), 2 + sqrt(7)}
     assert stationary_points((x**2+3)/(x-2), x, Interval(0, 5)
@@ -243,7 +243,7 @@ def test_stationary_points():
     assert stationary_points(x**4 + x**3 - 5*x**2, x, S.Reals
         ) == FiniteSet(-2, 0, Rational(5, 4))
     assert stationary_points(exp(x), x
-        ) == EmptySet()
+        ) is S.EmptySet
     assert stationary_points(log(x) - x, x, S.Reals
         ) == {1}
     assert stationary_points(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -20,7 +20,7 @@ from sympy.functions.elementary.trigonometric import (
 from sympy.logic.boolalg import And
 from sympy.polys.polytools import degree
 from sympy.sets.sets import (Interval, Intersection, FiniteSet, Union,
-                             Complement, EmptySet)
+                             Complement)
 from sympy.sets.fancysets import ImageSet
 from sympy.simplify.simplify import simplify
 from sympy.solvers.decompogen import compogen, decompogen
@@ -152,7 +152,7 @@ def function_range(f, symbol, domain):
     """
     from sympy.solvers.solveset import solveset
 
-    if isinstance(domain, EmptySet):
+    if domain is S.EmptySet:
         return S.EmptySet
 
     period = periodicity(f, symbol)
@@ -745,7 +745,7 @@ def stationary_points(f, symbol, domain=S.Reals):
     """
     from sympy.solvers.solveset import solveset
 
-    if isinstance(domain, EmptySet):
+    if domain is S.EmptySet:
         return S.EmptySet
 
     domain = continuous_domain(f, symbol, domain)
@@ -794,7 +794,7 @@ def maximum(f, symbol, domain=S.Reals):
 
     """
     if isinstance(symbol, Symbol):
-        if isinstance(domain, EmptySet):
+        if domain is S.EmptySet:
             raise ValueError("Maximum value not defined for empty domain.")
 
         return function_range(f, symbol, domain).sup
@@ -842,7 +842,7 @@ def minimum(f, symbol, domain=S.Reals):
 
     """
     if isinstance(symbol, Symbol):
-        if isinstance(domain, EmptySet):
+        if domain is S.EmptySet:
             raise ValueError("Minimum value not defined for empty domain.")
 
         return function_range(f, symbol, domain).inf

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -34,8 +34,8 @@ from sympy.concrete.summations import (
 from sympy.concrete.expr_with_intlimits import ReorderError
 from sympy.core.facts import InconsistentAssumptions
 from sympy.testing.pytest import XFAIL, raises, slow
-from sympy.matrices import \
-    Matrix, SparseMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
+from sympy.matrices import (Matrix, SparseMatrix,
+    ImmutableDenseMatrix, ImmutableSparseMatrix)
 from sympy.core.mod import Mod
 
 n = Symbol('n', integer=True)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -6,7 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.sets.sets import (EmptySet, Interval, Union)
+from sympy.sets.sets import (Interval, Union)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or,
@@ -869,7 +869,7 @@ def test_bool_as_set():
     assert Not(And(x > 2, x < 3)).as_set() == \
         Union(Interval(-oo, 2), Interval(3, oo))
     assert true.as_set() == S.UniversalSet
-    assert false.as_set() == EmptySet()
+    assert false.as_set() is S.EmptySet
     assert x.as_set() == S.UniversalSet
     assert And(Or(x < 1, x > 3), x < 2).as_set() == Interval.open(-oo, 1)
     assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -8,7 +8,7 @@ from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.repmatrix import RepMatrix
-from sympy.matrices.sparse import SparseMatrix
+from sympy.matrices.sparse import SparseRepMatrix
 from sympy.multipledispatch import dispatch
 
 
@@ -72,7 +72,7 @@ class ImmutableRepMatrix(RepMatrix, MatrixExpr): # type: ignore
         return super().is_diagonalizable(
             reals_only=reals_only, **kwargs)
 
-    is_diagonalizable.__doc__ = SparseMatrix.is_diagonalizable.__doc__
+    is_diagonalizable.__doc__ = SparseRepMatrix.is_diagonalizable.__doc__
     is_diagonalizable = cacheit(is_diagonalizable)
 
 
@@ -136,7 +136,7 @@ class ImmutableDenseMatrix(DenseMatrix, ImmutableRepMatrix):  # type: ignore
 ImmutableMatrix = ImmutableDenseMatrix
 
 
-class ImmutableSparseMatrix(SparseMatrix, ImmutableRepMatrix):  # type:ignore
+class ImmutableSparseMatrix(SparseRepMatrix, ImmutableRepMatrix):  # type:ignore
     """Create an immutable version of a sparse matrix.
 
     Examples

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -18,7 +18,7 @@ from .solvers import (
     _lower_triangular_solve_sparse, _upper_triangular_solve_sparse)
 
 
-class SparseMatrix(RepMatrix):
+class SparseRepMatrix(RepMatrix):
     """
     A sparse matrix (a matrix with a large number of zero elements).
 
@@ -456,7 +456,7 @@ class SparseMatrix(RepMatrix):
     upper_triangular_solve.__doc__          = upper_triangular_solve.__doc__
 
 
-class MutableSparseMatrix(SparseMatrix, MutableRepMatrix):
+class MutableSparseMatrix(SparseRepMatrix, MutableRepMatrix):
 
     @classmethod
     def _new(cls, *args, **kwargs):
@@ -465,3 +465,6 @@ class MutableSparseMatrix(SparseMatrix, MutableRepMatrix):
         rep = cls._smat_to_DomainMatrix(rows, cols, smat)
 
         return cls._fromrep(rep)
+
+
+SparseMatrix = MutableSparseMatrix

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -151,7 +151,7 @@ class GLSLPrinter(CodePrinter):
                 A.table(self,rowsep=mat_separator,rowstart='float[](',rowend=')')
             )
 
-    def _print_SparseMatrix(self, mat):
+    def _print_SparseRepMatrix(self, mat):
         # do not allow sparse matrices to be made dense
         return self._print_not_supported(mat)
 

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -345,7 +345,7 @@ class JuliaCodePrinter(CodePrinter):
                                 rowsep=';\n', colsep=' ')
 
 
-    def _print_SparseMatrix(self, A):
+    def _print_SparseRepMatrix(self, A):
         from sympy.matrices import Matrix
         L = A.col_list();
         # make row vectors of the indices and entries

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -162,7 +162,7 @@ class NumExprPrinter(LambdaPrinter):
                         expr.__class__.__name__)
 
     # blacklist all Matrix printing
-    _print_SparseMatrix = \
+    _print_SparseRepMatrix = \
     _print_MutableSparseMatrix = \
     _print_ImmutableSparseMatrix = \
     _print_Matrix = \

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -202,7 +202,7 @@ class MapleCodePrinter(CodePrinter):
     def _print_MatrixBase(self, expr):
         return self._get_matrix(expr, sparse=False)
 
-    def _print_SparseMatrix(self, expr):
+    def _print_SparseRepMatrix(self, expr):
         return self._get_matrix(expr, sparse=True)
 
     def _print_Identity(self, expr):

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -354,7 +354,7 @@ class SciPyPrinter(NumPyPrinter):
         super().__init__(settings=settings)
         self.language = "Python with SciPy and NumPy"
 
-    def _print_SparseMatrix(self, expr):
+    def _print_SparseRepMatrix(self, expr):
         i, j, data = [], [], []
         for (r, c), v in expr.todok().items():
             i.append(r)
@@ -366,7 +366,7 @@ class SciPyPrinter(NumPyPrinter):
             data=data, i=i, j=j, shape=expr.shape
         )
 
-    _print_ImmutableSparseMatrix = _print_SparseMatrix
+    _print_ImmutableSparseMatrix = _print_SparseRepMatrix
 
     # SciPy's lpmv has a different order of arguments from assoc_legendre
     def _print_assoc_legendre(self, expr):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -339,7 +339,7 @@ class OctaveCodePrinter(CodePrinter):
                                   for r in range(A.rows))
 
 
-    def _print_SparseMatrix(self, A):
+    def _print_SparseRepMatrix(self, A):
         from sympy.matrices import Matrix
         L = A.col_list();
         # make row vectors of the indices and entries

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -306,7 +306,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         func = self.known_functions.get(name, name)
         return "%s(%s)" % (func, self._print(expr.tolist()))
 
-    _print_SparseMatrix = \
+    _print_SparseRepMatrix = \
         _print_MutableSparseMatrix = \
         _print_ImmutableSparseMatrix = \
         _print_Matrix = \

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -128,6 +128,9 @@ class ReprPrinter(Printer):
     def _print_Integer(self, expr):
         return 'Integer(%i)' % expr.p
 
+    def _print_Complexes(self, expr):
+        return 'Complexes'
+
     def _print_Integers(self, expr):
         return 'Integers'
 
@@ -137,11 +140,17 @@ class ReprPrinter(Printer):
     def _print_Naturals0(self, expr):
         return 'Naturals0'
 
+    def _print_Rationals(self, expr):
+        return 'Rationals'
+
     def _print_Reals(self, expr):
         return 'Reals'
 
     def _print_EmptySet(self, expr):
         return 'EmptySet'
+
+    def _print_UniversalSet(self, expr):
+        return 'UniversalSet'
 
     def _print_EmptySequence(self, expr):
         return 'EmptySequence'

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -440,7 +440,7 @@ class RustCodePrinter(CodePrinter):
         else:
             raise ValueError("Full Matrix Support in Rust need Crates (https://crates.io/keywords/matrix).")
 
-    def _print_SparseMatrix(self, mat):
+    def _print_SparseRepMatrix(self, mat):
         # do not allow sparse matrices to be made dense
         return self._print_not_supported(mat)
 

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,57 +1,63 @@
+from sympy.calculus.util import AccumBounds
 from sympy.concrete.summations import Sum
 from sympy.core.basic import Basic
-from sympy.core.function import (Derivative, Function, Lambda, diff)
-from sympy.core import (EulerGamma, GoldenRatio, TribonacciConstant)
-from sympy.core.numbers import (E, Float, I, Integer, Rational, oo, pi, zoo)
-from sympy.core.relational import (Eq, Ge, Lt, Ne)
+from sympy.core.containers import Tuple
+from sympy.core.function import Derivative, Lambda, diff, Function
+from sympy.core.numbers import (zoo, Float, Integer, I, oo, pi, E,
+    Rational)
+from sympy.core.relational import Lt, Ge, Ne, Eq
 from sympy.core.singleton import S
-from sympy.core.symbol import (Symbol, symbols)
-from sympy.functions.combinatorial.numbers import euler
-from sympy.functions.elementary.exponential import (LambertW, log)
-from sympy.functions.elementary.hyperbolic import (acosh, acoth, acsch, asech, asinh, atanh, cosh, coth, csch, sech, sinh, tanh)
-from sympy.functions.elementary.miscellaneous import (Max, Min)
-from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, csc, sec, sin, tan)
-from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f, elliptic_pi)
-from sympy.functions.special.error_functions import (Ei, expint)
-from sympy.functions.special.mathieu_functions import (mathieuc, mathieucprime, mathieus, mathieusprime)
-from sympy.functions.special.polynomials import (assoc_laguerre, assoc_legendre, chebyshevt, chebyshevu, gegenbauer, hermite, jacobi, laguerre, legendre)
-from sympy.functions.special.zeta_functions import stieltjes
+from sympy.core.symbol import symbols, Symbol
+from sympy.core.sympify import sympify
+from sympy.functions.combinatorial.factorials import (factorial2,
+    binomial, factorial)
+from sympy.functions.combinatorial.numbers import (lucas, bell,
+    catalan, euler, tribonacci, fibonacci, bernoulli)
+from sympy.functions.elementary.complexes import re, im, conjugate, Abs
+from sympy.functions.elementary.exponential import exp, LambertW, log
+from sympy.functions.elementary.hyperbolic import (tanh, acoth, atanh,
+    coth, asinh, acsch, asech, acosh, csch, sinh, cosh, sech)
+from sympy.functions.elementary.integers import ceiling, floor
+from sympy.functions.elementary.miscellaneous import Max, Min
+from sympy.functions.elementary.trigonometric import (csc, sec, tan,
+    atan, sin, asec, cot, cos, acot, acsc, asin, acos)
+from sympy.functions.special.delta_functions import Heaviside
+from sympy.functions.special.elliptic_integrals import (elliptic_pi,
+    elliptic_f, elliptic_k, elliptic_e)
+from sympy.functions.special.error_functions import (fresnelc,
+    fresnels, Ei, expint)
+from sympy.functions.special.gamma_functions import (gamma, uppergamma,
+    lowergamma)
+from sympy.functions.special.mathieu_functions import (mathieusprime,
+    mathieus, mathieucprime, mathieuc)
+from sympy.functions.special.polynomials import (jacobi, chebyshevu,
+    chebyshevt, hermite, assoc_legendre, gegenbauer, assoc_laguerre,
+    legendre, laguerre)
+from sympy.functions.special.singularity_functions import SingularityFunction
+from sympy.functions.special.zeta_functions import (polylog, stieltjes,
+    lerchphi, dirichlet_eta, zeta)
 from sympy.integrals.integrals import Integral
-from sympy.logic.boolalg import (false, true)
+from sympy.logic.boolalg import (Xor, Or, false, true, And, Equivalent,
+    Implies, Not)
 from sympy.matrices.dense import Matrix
+from sympy.matrices.expressions.determinant import Determinant
 from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy.ntheory.factor_ import (totient, reduced_totient, primenu,
+    primeomega)
+from sympy.physics.quantum import (ComplexSpace, FockSpace, hbar,
+    HilbertSpace, Dagger)
+from sympy.printing.mathml import (MathMLPresentationPrinter,
+    MathMLPrinter, MathMLContentPrinter, mathml)
 from sympy.series.limits import Limit
 from sympy.sets.contains import Contains
 from sympy.sets.fancysets import Range
-from sympy.tensor.indexed import IndexedBase
-
-from sympy.functions.special.delta_functions import Heaviside
-from sympy.functions.special.elliptic_integrals import elliptic_k
-from sympy.functions.special.error_functions import (fresnelc, fresnels)
-from sympy.ntheory.factor_ import (primenu, primeomega, reduced_totient, totient)
-from sympy.calculus.util import AccumBounds
-from sympy.core.containers import Tuple
-from sympy.functions.combinatorial.factorials import factorial, factorial2, \
-    binomial
-from sympy.functions.combinatorial.numbers import bernoulli, bell, lucas, \
-    fibonacci, tribonacci, catalan
-from sympy.functions.elementary.complexes import re, im, Abs, conjugate
-from sympy.functions.elementary.exponential import exp
-from sympy.functions.elementary.integers import floor, ceiling
-from sympy.functions.special.gamma_functions import gamma, lowergamma, uppergamma
-from sympy.functions.special.singularity_functions import SingularityFunction
-from sympy.functions.special.zeta_functions import polylog, lerchphi, zeta, dirichlet_eta
-from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
-from sympy.matrices.expressions.determinant import Determinant
-from sympy.physics.quantum import ComplexSpace, HilbertSpace, FockSpace, hbar, Dagger
-from sympy.printing.mathml import mathml, MathMLContentPrinter, \
-    MathMLPresentationPrinter, MathMLPrinter
-from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
-    SymmetricDifference, Interval, EmptySet, ProductSet
+from sympy.sets.sets import (Interval, Union, SymmetricDifference,
+    Complement, FiniteSet, Intersection, ProductSet)
 from sympy.stats.rv import RandomSymbol
+from sympy.tensor.indexed import IndexedBase
+from sympy.vector import (Divergence, CoordSys3D, Cross, Curl, Dot,
+    Laplacian, Gradient)
 from sympy.testing.pytest import raises
-from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Laplacian
-from sympy.core.sympify import sympify
 
 x, y, z, a, b, c, d, e, n = symbols('x:z a:e n')
 mp = MathMLContentPrinter()
@@ -234,12 +240,13 @@ def test_content_mathml_constants():
     mml = mp._print(pi)
     assert mml.nodeName == 'pi'
 
-    assert mathml(GoldenRatio) == '<cn>&#966;</cn>'
-
-    mml = mathml(EulerGamma)
+    assert mathml(hbar) == '<hbar/>'
+    assert mathml(S.TribonacciConstant) == '<tribonacciconstant/>'
+    assert mathml(S.GoldenRatio) == '<cn>&#966;</cn>'
+    mml = mathml(S.EulerGamma)
     assert mml == '<eulergamma/>'
 
-    mml = mathml(EmptySet())
+    mml = mathml(S.EmptySet)
     assert mml == '<emptyset/>'
 
     mml = mathml(S.true)
@@ -880,7 +887,13 @@ def test_presentation_mathml_constants():
     mml = mpp._print(pi)
     assert mml.childNodes[0].nodeValue == '&pi;'
 
-    assert mathml(GoldenRatio, printer='presentation') == '<mi>&#x3A6;</mi>'
+    assert mathml(hbar, printer='presentation') == '<mi>&#x210F;</mi>'
+    assert mathml(S.TribonacciConstant, printer='presentation'
+        ) == '<mi>TribonacciConstant</mi>'
+    assert mathml(S.EulerGamma, printer='presentation'
+        ) == '<mi>&#x3B3;</mi>'
+    assert mathml(S.GoldenRatio, printer='presentation'
+        ) == '<mi>&#x3A6;</mi>'
 
     assert mathml(zoo, printer='presentation') == \
         '<mover><mo>&#x221E;</mo><mo>~</mo></mover>'
@@ -1211,8 +1224,7 @@ def test_toprettyxml_hooking():
 
 
 def test_print_domains():
-    from sympy import Complexes
-    from sympy.sets import Integers, Naturals, Naturals0, Reals
+    from sympy.sets import Integers, Naturals, Naturals0, Reals, Complexes
 
     assert mpp.doprint(Complexes) == '<mi mathvariant="normal">&#x2102;</mi>'
     assert mpp.doprint(Integers) == '<mi mathvariant="normal">&#x2124;</mi>'
@@ -1319,7 +1331,7 @@ def test_print_LambertW():
 
 
 def test_print_EmptySet():
-    assert mpp.doprint(EmptySet()) == '<mo>&#x2205;</mo>'
+    assert mpp.doprint(S.EmptySet) == '<mo>&#x2205;</mo>'
 
 
 def test_print_UniversalSet():
@@ -1334,8 +1346,9 @@ def test_print_spaces():
 
 def test_print_constants():
     assert mpp.doprint(hbar) == '<mi>&#x210F;</mi>'
-    assert mpp.doprint(TribonacciConstant) == '<mi>TribonacciConstant</mi>'
-    assert mpp.doprint(EulerGamma) == '<mi>&#x3B3;</mi>'
+    assert mpp.doprint(S.TribonacciConstant) == '<mi>TribonacciConstant</mi>'
+    assert mpp.doprint(S.GoldenRatio) == '<mi>&#x3A6;</mi>'
+    assert mpp.doprint(S.EulerGamma) == '<mi>&#x3B3;</mi>'
 
 
 def test_print_Contains():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -107,6 +107,15 @@ def test_Singletons():
     sT(S.One, 'Integer(1)')
     sT(S.Pi, 'pi')
     sT(S.Zero, 'Integer(0)')
+    sT(S.Complexes, 'Complexes')
+    sT(S.EmptySequence, 'EmptySequence')
+    sT(S.EmptySet, 'EmptySet')
+    # sT(S.IdentityFunction, 'Lambda(_x, _x)')
+    sT(S.Naturals, 'Naturals')
+    sT(S.Naturals0, 'Naturals0')
+    sT(S.Rationals, 'Rationals')
+    sT(S.Reals, 'Reals')
+    sT(S.UniversalSet, 'UniversalSet')
 
 
 def test_Integer():

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -9,13 +9,14 @@ from .ordinals import Ordinal, OmegaPower, ord0
 from .powerset import PowerSet
 from ..core.singleton import S
 from .handlers.comparison import _eval_is_eq  # noqa:F401
-Reals = S.Reals
-Naturals = S.Naturals
-Naturals0 = S.Naturals0
-UniversalSet = S.UniversalSet
+Complexes = S.Complexes
 EmptySet = S.EmptySet
 Integers = S.Integers
+Naturals = S.Naturals
+Naturals0 = S.Naturals0
 Rationals = S.Rationals
+Reals = S.Reals
+UniversalSet = S.UniversalSet
 
 __all__ = [
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -11,7 +11,7 @@ from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .contains import Contains
-from .sets import Set, EmptySet, Union, FiniteSet
+from .sets import Set, Union, FiniteSet
 
 
 adummy = Dummy('conditionset')
@@ -118,8 +118,8 @@ class ConditionSet(Set):
         if condition is S.false:
             return S.EmptySet
 
-        if isinstance(base_set, EmptySet):
-            return base_set
+        if base_set is S.EmptySet:
+            return S.EmptySet
 
         # no simple answers, so now check syms
         for i in flat:

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1513,9 +1513,3 @@ class Complexes(CartesianComplexRegion, metaclass=Singleton):
 
     def __new__(cls):
         return Set.__new__(cls)
-
-    def __str__(self):
-        return "S.Complexes"
-
-    def __repr__(self):
-        return "S.Complexes"

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -10,7 +10,8 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.logic.boolalg import true
 from sympy.multipledispatch import dispatch
 from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
-                        EmptySet, Intersection, Range)
+    Intersection, Range)
+from sympy.sets.sets import EmptySet
 from sympy.sets.fancysets import Integers, Naturals, Reals
 from sympy.functions.elementary.exponential import match_real_imag
 
@@ -88,7 +89,8 @@ def _set_function(f, x): # noqa:F811
 
     if len(sing) == 0:
         soln_expr = solveset(diff(expr, var), var)
-        if not (isinstance(soln_expr, FiniteSet) or soln_expr is EmptySet):
+        if not (isinstance(soln_expr, FiniteSet)
+                or soln_expr is S.EmptySet):
             return
         solns = list(soln_expr)
 
@@ -140,7 +142,7 @@ def _set_function(f, x): # noqa:F811
     else:
         return ImageSet(Lambda(_x, f(_x)), x)
 
-@dispatch(FunctionUnion, type(EmptySet))  # type: ignore # noqa:F811
+@dispatch(FunctionUnion, EmptySet)  # type: ignore # noqa:F811
 def _set_function(f, x): # noqa:F811
     return x
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -8,11 +8,9 @@ from sympy.multipledispatch import dispatch
 from sympy.sets.conditionset import ConditionSet
 from sympy.sets.fancysets import (Integers, Naturals, Reals, Range,
     ImageSet, Rationals)
-from sympy.sets.sets import UniversalSet, imageset, ProductSet
+from sympy.sets.sets import EmptySet, UniversalSet, imageset, ProductSet
 from sympy.simplify.radsimp import numer
 
-
-EmptySet = S.EmptySet
 
 @dispatch(ConditionSet, ConditionSet)  # type: ignore # noqa:F811
 def intersection_sets(a, b): # noqa:F811
@@ -275,7 +273,7 @@ def intersection_sets(self, other): # noqa:F811
             # Among those, there is one type of solution set that is
             # not helpful here: multiple parametric solutions.
             if len(solns) == 0:
-                return EmptySet
+                return S.EmptySet
             elif any(s.free_symbols for tupl in solns for s in tupl):
                 if len(solns) == 1:
                     soln, solm = solns[0]
@@ -452,7 +450,7 @@ def intersection_sets(a, b): # noqa:F811
 
     return Interval(start, end, left_open, right_open)
 
-@dispatch(type(EmptySet), Set)  # type: ignore # noqa:F811
+@dispatch(EmptySet, Set)  # type: ignore # noqa:F811
 def intersection_sets(a, b): # noqa:F811
     return S.EmptySet
 

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -1,12 +1,11 @@
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
-from sympy.sets.sets import (FiniteSet, Intersection, Interval, ProductSet, Set, Union, UniversalSet)
-from sympy.sets.fancysets import ComplexRegion
-from sympy.sets.fancysets import (Naturals, Naturals0, Integers, Rationals, Reals)
+from sympy.sets.sets import (EmptySet, FiniteSet, Intersection,
+    Interval, ProductSet, Set, Union, UniversalSet)
+from sympy.sets.fancysets import (ComplexRegion, Naturals, Naturals0,
+    Integers, Rationals, Reals)
 from sympy.multipledispatch import dispatch
 
-
-EmptySet = S.EmptySet
 
 @dispatch(Naturals0, Naturals)  # type: ignore # noqa:F811
 def union_sets(a, b): # noqa:F811
@@ -55,7 +54,7 @@ def union_sets(a, b): # noqa:F811
             return ComplexRegion(Union(a.sets, b.sets), polar=True)
     return None
 
-@dispatch(type(EmptySet), Set)  # type: ignore # noqa:F811
+@dispatch(EmptySet, Set)  # type: ignore # noqa:F811
 def union_sets(a, b): # noqa:F811
     return b
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -210,7 +210,7 @@ class Set(Basic, EvalfMixin):
         elif isinstance(other, Complement):
             return Complement(other.args[0], Union(other.args[1], self), evaluate=False)
 
-        elif isinstance(other, EmptySet):
+        elif other is S.EmptySet:
             return S.EmptySet
 
         elif isinstance(other, FiniteSet):
@@ -2108,7 +2108,7 @@ class DisjointUnion(Set):
         where ``set`` is the element in ``sets`` at index = ``i``
         """
 
-        dj_union = EmptySet()
+        dj_union = S.EmptySet
         index = 0
         for set_i in sets:
             if isinstance(set_i, Set):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -663,8 +663,8 @@ def test_Complex():
     assert S.Complexes.union(S.Reals) == S.Complexes
     assert S.Complexes == ComplexRegion(S.Reals*S.Reals)
     assert (S.Complexes == ComplexRegion(Interval(1, 2)*Interval(3, 4))) == False
-    assert str(S.Complexes) == "S.Complexes"
-    assert repr(S.Complexes) == "S.Complexes"
+    assert str(S.Complexes) == "Complexes"
+    assert repr(S.Complexes) == "Complexes"
 
 
 def take(n, iterable):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -3,7 +3,7 @@
 from sympy.core import Symbol, Dummy, sympify
 from sympy.core.exprtools import factor_terms
 from sympy.core.relational import Relational, Eq, Ge, Lt
-from sympy.sets.sets import EmptySet, Interval, FiniteSet, Union, Intersection
+from sympy.sets.sets import Interval, FiniteSet, Union, Intersection
 from sympy.core.singleton import S
 from sympy.core.function import expand_mul
 
@@ -639,7 +639,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     im_sol = S.Reals
                     check = False
 
-                if isinstance(im_sol, EmptySet):
+                if im_sol is S.EmptySet:
                     raise ValueError(filldedent('''
                         %s contains imaginary parts which cannot be
                         made 0 for any value of %s satisfying the

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -235,7 +235,7 @@ from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
     expand, expand_mul, Subs)
 from sympy.core.multidimensional import vectorize
-from sympy.core.numbers import NaN, zoo, Number
+from sympy.core.numbers import nan, zoo, Number
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.core.sympify import sympify
@@ -1073,10 +1073,10 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             check = cancel(r[d]/r[e])
             check1 = check.subs({x: point, y: value})
             if not check1.has(oo) and not check1.has(zoo) and \
-                not check1.has(NaN) and not check1.has(-oo):
+                not check1.has(nan) and not check1.has(-oo):
                 check2 = (check1.diff(x)).subs({x: point, y: value})
                 if not check2.has(oo) and not check2.has(zoo) and \
-                    not check2.has(NaN) and not check2.has(-oo):
+                    not check2.has(nan) and not check2.has(-oo):
                     rseries = r.copy()
                     rseries.update({'terms': terms, 'f0': point, 'f0val': value})
                     matching_hints["1st_power_series"] = rseries
@@ -1101,9 +1101,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             q = cancel(r[c3]/r[a3])  # Used below
             point = kwargs.get('x0', 0)
             check = p.subs(x, point)
-            if not check.has(oo, NaN, zoo, -oo):
+            if not check.has(oo, nan, zoo, -oo):
                 check = q.subs(x, point)
-                if not check.has(oo, NaN, zoo, -oo):
+                if not check.has(oo, nan, zoo, -oo):
                     ordinary = True
                     r.update({'a3': a3, 'b3': b3, 'c3': c3, 'x0': point, 'terms': terms})
                     matching_hints["2nd_power_series_ordinary"] = r
@@ -1114,10 +1114,10 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             if not ordinary:
                 p = cancel((x - point)*p)
                 check = p.subs(x, point)
-                if not check.has(oo, NaN, zoo, -oo):
+                if not check.has(oo, nan, zoo, -oo):
                     q = cancel(((x - point)**2)*q)
                     check = q.subs(x, point)
-                    if not check.has(oo, NaN, zoo, -oo):
+                    if not check.has(oo, nan, zoo, -oo):
                         coeff_dict = {'p': p, 'q': q, 'x0': point, 'terms': terms}
                         matching_hints["2nd_power_series_regular"] = coeff_dict
 
@@ -2772,7 +2772,7 @@ def ode_1st_power_series(eq, func, order, match):
     series = value
     if terms > 1:
         hc = h.subs({x: point, y: value})
-        if hc.has(oo) or hc.has(NaN) or hc.has(zoo):
+        if hc.has(oo) or hc.has(nan) or hc.has(zoo):
             # Derivative does not exist, not analytic
             return Eq(f(x), oo)
         elif hc:
@@ -2782,7 +2782,7 @@ def ode_1st_power_series(eq, func, order, match):
         Fnew = F.diff(x) + F.diff(y)*h
         Fnewc = Fnew.subs({x: point, y: value})
         # Same logic as above
-        if Fnewc.has(oo) or Fnewc.has(NaN) or Fnewc.has(-oo) or Fnewc.has(zoo):
+        if Fnewc.has(oo) or Fnewc.has(nan) or Fnewc.has(-oo) or Fnewc.has(zoo):
             return Eq(f(x), oo)
         series += Fnewc*((x - point)**factcount)/factorial(factcount)
         F = Fnew

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -25,7 +25,7 @@ from sympy.polys.rootoftools import CRootOf
 from sympy.sets.contains import Contains
 from sympy.sets.conditionset import ConditionSet
 from sympy.sets.fancysets import ImageSet, Range
-from sympy.sets.sets import (Complement, EmptySet, FiniteSet,
+from sympy.sets.sets import (Complement, FiniteSet,
     Intersection, Interval, Union, imageset, ProductSet)
 from sympy.simplify import simplify
 from sympy.tensor.indexed import Indexed
@@ -91,7 +91,7 @@ def test_invert_real():
 
     # issue 21236
     assert invert_real(x**pi, y, x) == (x, FiniteSet(y**(1/pi)))
-    assert invert_real(x**pi, -E, x) == (x, EmptySet())
+    assert invert_real(x**pi, -E, x) == (x, S.EmptySet)
     assert invert_real(x**Rational(3/2), 1000, x) == (x, FiniteSet(100))
     assert invert_real(x**1.0, 1, x) == (x**1.0, FiniteSet(1))
 
@@ -307,7 +307,7 @@ def test_solve_mul():
     assert solveset_real((anz*x + bb)*(exp(x) - 3), x) == \
         FiniteSet(-bb/anz, log(3))
     assert solveset_real((2*x + 8)*(8 + exp(x)), x) == FiniteSet(S(-4))
-    assert solveset_real(x/log(x), x) == EmptySet()
+    assert solveset_real(x/log(x), x) is S.EmptySet
 
 
 def test_solve_invert():
@@ -546,20 +546,20 @@ def test_solve_rational():
 
 
 def test_solveset_real_gen_is_pow():
-    assert solveset_real(sqrt(1) + 1, x) == EmptySet()
+    assert solveset_real(sqrt(1) + 1, x) is S.EmptySet
 
 
 def test_no_sol():
-    assert solveset(1 - oo*x) == EmptySet()
-    assert solveset(oo*x, x) == EmptySet()
-    assert solveset(oo*x - oo, x) == EmptySet()
-    assert solveset_real(4, x) == EmptySet()
-    assert solveset_real(exp(x), x) == EmptySet()
-    assert solveset_real(x**2 + 1, x) == EmptySet()
-    assert solveset_real(-3*a/sqrt(x), x) == EmptySet()
-    assert solveset_real(1/x, x) == EmptySet()
-    assert solveset_real(-(1 + x)/(2 + x)**2 + 1/(2 + x), x) == \
-        EmptySet()
+    assert solveset(1 - oo*x) is S.EmptySet
+    assert solveset(oo*x, x) is S.EmptySet
+    assert solveset(oo*x - oo, x) is S.EmptySet
+    assert solveset_real(4, x) is S.EmptySet
+    assert solveset_real(exp(x), x) is S.EmptySet
+    assert solveset_real(x**2 + 1, x) is S.EmptySet
+    assert solveset_real(-3*a/sqrt(x), x) is S.EmptySet
+    assert solveset_real(1/x, x) is S.EmptySet
+    assert solveset_real(-(1 + x)/(2 + x)**2 + 1/(2 + x), x
+        ) is S.EmptySet
 
 
 def test_sol_zero_real():
@@ -569,8 +569,8 @@ def test_sol_zero_real():
 
 
 def test_no_sol_rational_extragenous():
-    assert solveset_real((x/(x + 1) + 3)**(-2), x) == EmptySet()
-    assert solveset_real((x - 1)/(1 + 1/(x - 1)), x) == EmptySet()
+    assert solveset_real((x/(x + 1) + 3)**(-2), x) is S.EmptySet
+    assert solveset_real((x - 1)/(1 + 1/(x - 1)), x) is S.EmptySet
 
 
 def test_solve_polynomial_cv_1a():
@@ -728,7 +728,7 @@ def test_solveset_complex_polynomial():
 
 
 def test_sol_zero_complex():
-    assert solveset_complex(0, x) == S.Complexes
+    assert solveset_complex(0, x) is S.Complexes
 
 
 def test_solveset_complex_rational():
@@ -1088,7 +1088,7 @@ def test_solve_lambert():
         FiniteSet(4*LambertW(sqrt(2)*sqrt(a)/4))
 
     # coverage test
-    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
+    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) is S.EmptySet
 
     assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
         FiniteSet(LambertW(3*S.Exp1)/3)
@@ -1298,8 +1298,8 @@ def test_issue_9522():
     expr1 = Eq(1/(x**2 - 4) + x, 1/(x**2 - 4) + 2)
     expr2 = Eq(1/x + x, 1/x)
 
-    assert solveset(expr1, x, S.Reals) == EmptySet()
-    assert solveset(expr2, x, S.Reals) == EmptySet()
+    assert solveset(expr1, x, S.Reals) is S.EmptySet
+    assert solveset(expr2, x, S.Reals) is S.EmptySet
 
 
 def test_solvify():
@@ -1425,7 +1425,7 @@ def test_linsolve():
     # No solution
     A = Matrix([[1, 2, 3], [2, 4, 6], [3, 6, 9]])
     B = Matrix([0, 0, 1])
-    assert linsolve((A, B), (x, y, z)) == EmptySet()
+    assert linsolve((A, B), (x, y, z)) is S.EmptySet
 
     # Issue #10056
     A, B, J1, J2 = symbols('A B J1 J2')
@@ -1485,7 +1485,7 @@ def test_linsolve():
     #
     # XXX: The case below should give the same as for [0]
     # assert linsolve([], [x]) == {(x,)}
-    assert linsolve([], [x]) == EmptySet()
+    assert linsolve([], [x]) is S.EmptySet
     assert linsolve([0], [x]) == {(x,)}
     assert linsolve([x], [x, y]) == {(0, y)}
     assert linsolve([x, 0], [x, y]) == {(0, y)}
@@ -1809,7 +1809,7 @@ def test_issue_13396():
     assert solveset(expr, y, domain=S.Reals) == sol
 
     # Related type of equation also solved here
-    assert solveset(atan(x**2 - y**2)-pi/2, y, S.Reals) == EmptySet()
+    assert solveset(atan(x**2 - y**2)-pi/2, y, S.Reals) is S.EmptySet
 
 
 def test_issue_12032():
@@ -2144,9 +2144,9 @@ def test_issue_14565():
 def test_issue_9556():
     b = Symbol('b', positive=True)
 
-    assert solveset(Abs(x) + 1, x, S.Reals) == EmptySet()
-    assert solveset(Abs(x) + b, x, S.Reals) == EmptySet()
-    assert solveset(Eq(b, -1), b, S.Reals) == EmptySet()
+    assert solveset(Abs(x) + 1, x, S.Reals) is S.EmptySet
+    assert solveset(Abs(x) + b, x, S.Reals) is S.EmptySet
+    assert solveset(Eq(b, -1), b, S.Reals) is S.EmptySet
 
 
 def test_issue_9611():
@@ -2354,7 +2354,7 @@ def test_issue_13550():
 
 
 def test_issue_13849():
-    assert nonlinsolve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t) == EmptySet()
+    assert nonlinsolve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t) is S.EmptySet
 
 
 def test_issue_14223():
@@ -2612,9 +2612,9 @@ def test_logarithmic():
 @XFAIL
 def test_uselogcombine_2():
     eq = log(exp(2*x) + 1) + log(-tanh(x) + 1) - log(2)
-    assert solveset_real(eq, x) == EmptySet()
+    assert solveset_real(eq, x) is S.EmptySet
     eq = log(8*x) - log(sqrt(x) + 1) - 2
-    assert solveset_real(eq, x) == EmptySet()
+    assert solveset_real(eq, x) is S.EmptySet
 
 
 def test_is_logarithmic():
@@ -2714,12 +2714,12 @@ def test_invert_modular():
             (Mod((x + 1)*(x + 2), 7), 5)
     # a.is_Pow
     assert invert_modular(Mod(x**4, 7), S(5), n, x) == \
-            (x, EmptySet())
+            (x, S.EmptySet)
     assert dumeq(invert_modular(Mod(3**x, 4), S(3), n, x),
             (x, ImageSet(Lambda(n, 2*n + 1), S.Naturals0)))
     assert dumeq(invert_modular(Mod(2**(x**2 + x + 1), 7), S(2), n, x),
             (x**2 + x + 1, ImageSet(Lambda(n, 3*n + 1), S.Naturals0)))
-    assert invert_modular(Mod(sin(x)**4, 7), S(5), n, x) == (x, EmptySet())
+    assert invert_modular(Mod(sin(x)**4, 7), S(5), n, x) == (x, S.EmptySet)
 
 
 def test_solve_modular():
@@ -2740,12 +2740,12 @@ def test_solve_modular():
         ).dummy_eq(ConditionSet(x, Eq(Mod(exp(x), 7) - 3, 0),
         S.Integers))
     # EmptySet solution definitely
-    assert solveset(7 - Mod(x, 5), x, S.Integers) == EmptySet()
-    assert solveset(5 - Mod(x, 5), x, S.Integers) == EmptySet()
+    assert solveset(7 - Mod(x, 5), x, S.Integers) is S.EmptySet
+    assert solveset(5 - Mod(x, 5), x, S.Integers) is S.EmptySet
     # Negative m
     assert dumeq(solveset(2 + Mod(x, -3), x, S.Integers),
             ImageSet(Lambda(n, -3*n - 2), S.Integers))
-    assert solveset(4 + Mod(x, -3), x, S.Integers) == EmptySet()
+    assert solveset(4 + Mod(x, -3), x, S.Integers) is S.EmptySet
     # linear expression in Mod
     assert dumeq(solveset(3 - Mod(x, 5), x, S.Integers),
         ImageSet(Lambda(n, 5*n + 3), S.Integers))
@@ -2763,7 +2763,7 @@ def test_solve_modular():
             ImageSet(Lambda(n, 160*n + 93), S.Integers),
             ImageSet(Lambda(n, 160*n + 147), S.Integers),
             ImageSet(Lambda(n, 160*n + 157), S.Integers)))
-    assert solveset(3 - Mod(x**4, 7), x, S.Integers) == EmptySet()
+    assert solveset(3 - Mod(x**4, 7), x, S.Integers) is S.EmptySet
     assert dumeq(solveset(Mod(x**4, 17) - 13, x, S.Integers),
             Union(ImageSet(Lambda(n, 17*n + 3), S.Integers),
             ImageSet(Lambda(n, 17*n + 5), S.Integers),
@@ -2782,7 +2782,7 @@ def test_solve_modular():
             Intersection(ImageSet(Lambda(n, Intersection({log(2*n + 1)/log(3)},
             S.Integers)), S.Naturals0), S.Integers))
     # Implemented for m without primitive root
-    assert solveset(Mod(x**3, 7) - 2, x, S.Integers) == EmptySet()
+    assert solveset(Mod(x**3, 7) - 2, x, S.Integers) is S.EmptySet
     assert dumeq(solveset(Mod(x**3, 8) - 1, x, S.Integers),
             ImageSet(Lambda(n, 8*n + 1), S.Integers))
     assert dumeq(solveset(Mod(x**4, 9) - 4, x, S.Integers),
@@ -2793,7 +2793,7 @@ def test_solve_modular():
             Intersection(ImageSet(Lambda(n, 7*n + 5), S.Integers), S.Naturals0))
     # Complex args
     assert solveset(Mod(x, 3) - I, x, S.Integers) == \
-            EmptySet()
+            S.EmptySet
     assert solveset(Mod(I*x, 3) - 2, x, S.Integers
         ).dummy_eq(
             ConditionSet(x, Eq(Mod(I*x, 3) - 2, 0), S.Integers))
@@ -2822,7 +2822,7 @@ def test_solve_modular():
     assert dumeq(solveset(c - Mod(a**(2*n)*b, m), n, S.Integers),
             Intersection(ImageSet(Lambda(n, 1073741823*n + 50), S.Naturals0),
             S.Integers))
-    assert solveset(c - Mod(a**(2*n + 7)*b, m), n, S.Integers) == EmptySet()
+    assert solveset(c - Mod(a**(2*n + 7)*b, m), n, S.Integers) is S.EmptySet
     assert dumeq(solveset(c - Mod(a**(n - 4)*b, m), n, S.Integers),
             Intersection(ImageSet(Lambda(n, 2147483646*n + 104), S.Naturals0),
             S.Integers))
@@ -2971,7 +2971,7 @@ def test_substitution_with_infeasible_solution():
 
 
 def test_issue_20097():
-    assert solveset(1/sqrt(x)) == EmptySet()
+    assert solveset(1/sqrt(x)) is S.EmptySet
 
 
 def test_issue_15350():
@@ -2995,7 +2995,7 @@ def test_issue_17604():
 
 
 def test_issue_17580():
-    assert solveset(1/(1 - x**3)**2, x, S.Reals) == EmptySet()
+    assert solveset(1/(1 - x**3)**2, x, S.Reals) is S.EmptySet
 
 
 def test_issue_17566_actual():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #22360
closes #22338

#### Brief description of what is fixed or changed

Not every Number defined in numbers.py has an alias by which to call it from `S`: `pi` is an alias for `S.Pi` but there is no alias for `Catalan`. The same is true with `EmptySet`.

Since I am not sure how to change the class name and get it to register by a different name in the `Singleton` collection, I just cleaned up the usage through the codebase.

I also removed the string printing of Complexes as `S.Complexes` and made sure that it could be imported the same was a Reals, etc...

SparseMatrix can now be imported from sparse.py; the former SparseMatrix there was renamed SparseRepMatrix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * `SparseMatrix` can now be imported from `sympy.matrices.sparse` like `Matrix` can be imported from `dense`; both can still be imported from `sympy.matrices`
<!-- END RELEASE NOTES -->
