### PR TITLE
Moved imports to top level

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,6 +1,7 @@
 from typing import Dict, Callable
 
-from sympy.core import S, Add, Expr, Basic, Mul
+from sympy.core import S, Add, Expr, Basic, Mul, Pow, Rational
+from sympy.core.logic import fuzzy_not
 from sympy.logic.boolalg import Boolean
 
 from sympy.assumptions import ask, Q  # type: ignore
@@ -83,7 +84,6 @@ def refine_abs(expr, assumptions):
     -x
 
     """
-    from sympy.core.logic import fuzzy_not
     from sympy.functions.elementary.complexes import Abs
     arg = expr.args[0]
     if ask(Q.real(arg), assumptions) and \
@@ -133,7 +133,6 @@ def refine_Pow(expr, assumptions):
     (-1)**(x + 1)
 
     """
-    from sympy.core import Pow, Rational
     from sympy.functions.elementary.complexes import Abs
     from sympy.functions import sign
     if isinstance(expr.base, Abs):

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -134,7 +134,8 @@ from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.numbers import Float, Integer, oo
 from sympy.core.sympify import _sympify, sympify, SympifyError
-from sympy.utilities.iterables import iterable
+from sympy.utilities.iterables import (iterable, topological_sort,
+                                       numbered_symbols, filter_symbols)
 
 
 def _mk_Tuple(args):
@@ -688,7 +689,6 @@ class CodeBlock(Basic):
         )
 
         """
-        from sympy.utilities.iterables import topological_sort
 
         if not all(isinstance(i, Assignment) for i in assignments):
             # Will support more things later
@@ -771,7 +771,6 @@ class CodeBlock(Basic):
 
         """
         from sympy.simplify.cse_main import cse
-        from sympy.utilities.iterables import numbered_symbols, filter_symbols
 
         # Check that the CodeBlock only contains assignments to unique variables
         if not all(isinstance(i, Assignment) for i in self.args):

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -1,6 +1,7 @@
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
+from sympy.core.function import AppliedUndef, UndefinedFunction
 from sympy.core.mul import Mul
 from sympy.core.relational import Equality, Relational
 from sympy.core.singleton import S
@@ -360,7 +361,6 @@ class ExprWithLimits(Expr):
         change_index : Perform mapping on the sum and product dummy variables
 
         """
-        from sympy.core.function import AppliedUndef, UndefinedFunction
         func, limits = self.function, list(self.limits)
 
         # If one of the expressions we are replacing is used as a func index

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -10,7 +10,7 @@ from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
 from .kind import UndefinedKind
-from sympy.utilities.iterables import is_sequence
+from sympy.utilities.iterables import is_sequence, sift
 
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)
@@ -453,7 +453,6 @@ class Add(Expr, AssocOp):
         (0, (7*x,))
         """
         if deps:
-            from sympy.utilities.iterables import sift
             l1, l2 = sift(self.args, lambda x: x.has(*deps), binary=True)
             return self._new_rawargs(*l2), tuple(l1)
         coeff, notrat = self.args[0].as_coeff_add()

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -12,6 +12,9 @@ from .sorting import ordered
 from .kind import Kind, UndefinedKind
 from ._print_helpers import Printable
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import iterable, numbered_symbols
+from sympy.utilities.misc import filldedent, func_name
 
 from inspect import getmro
 
@@ -20,7 +23,6 @@ def as_Basic(expr):
     """Return expr as a Basic instance using strict sympify
     or raise a TypeError; this is just a wrapper to _sympify,
     raising a TypeError instead of a SympifyError."""
-    from sympy.utilities.misc import func_name
     try:
         return _sympify(expr)
     except SympifyError:
@@ -515,7 +517,6 @@ class Basic(Printable, metaclass=ManagedProperties):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
         SymPyDeprecationWarning(feature="expr_free_symbols method",
                                 issue=21494,
                                 deprecated_since_version="1.9").warn()
@@ -581,7 +582,6 @@ class Basic(Printable, metaclass=ManagedProperties):
         >>> Lambda(x, 2*x).canonical_variables
         {x: _0}
         """
-        from sympy.utilities.iterables import numbered_symbols
         if not hasattr(self, 'bound_symbols'):
             return {}
         dums = numbered_symbols('_')
@@ -883,8 +883,6 @@ class Basic(Printable, metaclass=ManagedProperties):
         """
         from .containers import Dict
         from .symbol import Dummy, Symbol
-        from sympy.utilities.iterables import iterable
-        from sympy.utilities.misc import filldedent
 
         unordered = False
         if len(args) == 1:
@@ -1623,8 +1621,6 @@ class Basic(Printable, metaclass=ManagedProperties):
         {p_: 2/x**2}
 
         """
-        from sympy.utilities.misc import filldedent
-
         pattern = sympify(pattern)
         # match non-bound symbols
         canonical = lambda x: x if x.is_Symbol else x.as_dummy()
@@ -1809,7 +1805,6 @@ class Basic(Printable, metaclass=ManagedProperties):
             method = "_eval_rewrite_as_%s" % clsname
 
         if pattern:
-            from sympy.utilities.iterables import iterable
             if iterable(pattern[0]):
                 pattern = pattern[0]
             pattern = tuple(p for p in pattern if self.has(p))

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -26,6 +26,7 @@ from .sympify import sympify
 from .singleton import S
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.utilities.iterables import is_sequence
+from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import as_int
 
 LG10 = math.log(10, 2)
@@ -1132,7 +1133,6 @@ def hypsum(expr, n, start, prec):
     """
     from .numbers import Float
     from sympy.simplify.simplify import hypersimp
-    from sympy.utilities.lambdify import lambdify
 
     if prec == float('inf'):
         raise NotImplementedError('does not support inf prec')

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -10,8 +10,9 @@ from .decorators import call_highest_priority, sympify_method_args, sympify_retu
 from .cache import cacheit
 from .sorting import default_sort_key
 from .kind import NumberKind
-from sympy.utilities.misc import as_int, func_name
-from sympy.utilities.iterables import has_variety
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.misc import as_int, func_name, filldedent
+from sympy.utilities.iterables import has_variety, sift
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
@@ -1872,7 +1873,6 @@ class Expr(Basic, EvalfMixin):
         from .symbol import Symbol
         from .add import _unevaluated_Add
         from .mul import _unevaluated_Mul
-        from sympy.utilities.iterables import sift
 
         if self.is_zero:
             return S.Zero, S.Zero
@@ -2459,7 +2459,6 @@ class Expr(Basic, EvalfMixin):
         >>> t.free_symbols
         {x, y}
         """
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
         SymPyDeprecationWarning(feature="expr_free_symbols method",
                                 issue=21494,
                                 deprecated_since_version="1.9").warn()
@@ -3383,7 +3382,6 @@ class Expr(Basic, EvalfMixin):
         never call this method directly (use .nseries() instead), so you do not
         have to write docstrings for _eval_nseries().
         """
-        from sympy.utilities.misc import filldedent
         raise NotImplementedError(filldedent("""
                      The _eval_nseries method should be added to
                      %s to give terms up to O(x**n) at x=0
@@ -3496,7 +3494,6 @@ class Expr(Basic, EvalfMixin):
             l = l.subs(log(x), d)
         c, e = l.as_coeff_exponent(x)
         if x in c.free_symbols:
-            from sympy.utilities.misc import filldedent
             raise ValueError(filldedent("""
                 cannot compute leadterm(%s, %s). The coefficient
                 should have been free of %s but got %s""" % (self, x, x, c)))
@@ -3963,7 +3960,6 @@ class AtomicExpr(Atom, Expr):
 
     @property
     def expr_free_symbols(self):
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
         SymPyDeprecationWarning(feature="expr_free_symbols method",
                                 issue=21494,
                                 deprecated_since_version="1.9").warn()

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -52,8 +52,9 @@ from .sympify import sympify
 from .sorting import default_sort_key, ordered
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import (has_dups, sift, iterable,
-    is_sequence)
-from sympy.utilities.misc import as_int, filldedent
+    is_sequence, uniq, topological_sort)
+from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
+from sympy.utilities.misc import as_int, filldedent, func_name
 
 import mpmath
 import mpmath.libmp as mlib
@@ -543,7 +544,6 @@ class Function(Application, Expr):
                 return None
 
             if not hasattr(mpmath, fname):
-                from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
                 fname = MPMATH_TRANSLATIONS.get(fname, None)
                 if fname is None:
                     return None
@@ -1541,7 +1541,6 @@ class Derivative(Expr):
         >>> assert vsort0(dfx, y) == [y, dfx]
         >>> assert vsort0(dfx, x) == [dfx, x]
         """
-        from sympy.utilities.iterables import uniq, topological_sort
         if not vc:
             return []
         vc = list(vc)
@@ -3134,7 +3133,6 @@ def count_ops(expr, visual=False):
     from sympy.integrals.integrals import Integral
     from sympy.logic.boolalg import BooleanFunction
     from sympy.simplify.radsimp import fraction
-    from sympy.utilities.misc import func_name
 
     expr = sympify(expr)
     if isinstance(expr, Expr) and not expr.is_Relational:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -14,6 +14,7 @@ from .parameters import global_parameters
 from .kind import KindDispatcher
 from .traversal import bottom_up
 
+from sympy.utilities.iterables import sift
 
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
@@ -831,7 +832,6 @@ class Mul(Expr, AssocOp):
     @cacheit
     def as_coeff_mul(self, *deps, rational=True, **kwargs):
         if deps:
-            from sympy.utilities.iterables import sift
             l1, l2 = sift(self.args, lambda x: x.has(*deps), binary=True)
             return self._new_rawargs(*l2), tuple(l1)
         args = self.args

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,6 +1,5 @@
 from typing import Dict, Union, Type
 
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from .basic import Atom, Basic
 from .sorting import ordered
 from .evalf import EvalfMixin
@@ -10,6 +9,9 @@ from .sympify import _sympify, SympifyError
 from .parameters import global_parameters
 from .logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
 from sympy.logic.boolalg import Boolean, BooleanAtom
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import sift
+from sympy.utilities.misc import filldedent
 
 __all__ = (
     'Rel', 'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge',
@@ -110,7 +112,6 @@ class Relational(Boolean, EvalfMixin):
             # Note: Symbol is a subclass of Boolean but is considered
             # acceptable here.
             if any(map(_nontrivBool, (lhs, rhs))):
-                from sympy.utilities.misc import filldedent
                 raise TypeError(filldedent('''
                     A Boolean argument can only be used in
                     Eq and Ne; all other relationals expect
@@ -1448,7 +1449,6 @@ def is_eq(lhs, rhs, assumptions=None):
         # Try to split real/imaginary parts and equate them
         I = S.ImaginaryUnit
 
-        from sympy.utilities.iterables import sift
         def split_real_imag(expr):
             real_imag = lambda t: (
                 'real' if is_extended_real(t, assumptions) else

--- a/sympy/core/sorting.py
+++ b/sympy/core/sorting.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from .sympify import sympify, SympifyError
+from sympy.utilities.iterables import iterable, uniq
 
 
 __all__ = ['default_sort_key', 'ordered']
@@ -122,7 +123,6 @@ def default_sort_key(item, order=None):
     """
     from .basic import Basic
     from .singleton import S
-    from sympy.utilities.iterables import iterable
 
     if isinstance(item, Basic):
         return item.sort_key(order=order)
@@ -184,7 +184,6 @@ def _nodes(e):
     """
     from .basic import Basic
     from .function import Derivative
-    from sympy.utilities.iterables import iterable
 
     if isinstance(e, Basic):
         if isinstance(e, Derivative):
@@ -278,7 +277,6 @@ def ordered(seq, keys=None, default=True, warn=False):
     of candidates is small relative to the number of items being processed.
 
     """
-    from sympy.utilities.iterables import uniq
 
     d = defaultdict(list)
     if keys:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -11,6 +11,7 @@ from .sorting import ordered
 from .sympify import sympify
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.iterables import sift, is_sequence
+from sympy.utilities.misc import filldedent
 
 import string
 import re as _re
@@ -251,7 +252,6 @@ class Symbol(AtomicExpr, Boolean):
         base = self.assumptions0
         for k in set(assumptions) & set(base):
             if assumptions[k] != base[k]:
-                from sympy.utilities.misc import filldedent
                 raise ValueError(filldedent('''
                     non-matching assumptions for %s: existing value
                     is %s and new value is %s''' % (

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -5,7 +5,7 @@ from sympy.core import S, sympify, Dummy, Mod
 from sympy.core.cache import cacheit
 from sympy.core.function import Function, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and
-from sympy.core.numbers import Integer, pi
+from sympy.core.numbers import Integer, pi, I
 from sympy.core.relational import Eq
 from sympy.external.gmpy import HAS_GMPY
 from sympy.ntheory import sieve
@@ -361,7 +361,6 @@ class subfactorial(CombinatorialFunction):
         return factorial(arg) * summation(f, (i, 0, arg))
 
     def _eval_rewrite_as_gamma(self, arg, piecewise=True, **kwargs):
-        from sympy.core.numbers import I
         from sympy.functions.elementary.exponential import exp
         from sympy.functions.special.gamma_functions import (gamma, lowergamma)
         return ((-1)**(arg + 1)*exp(-I*pi*arg)*lowergamma(arg + 1, -1) + gamma(arg + 1))*exp(-1)

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -26,6 +26,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.trigonometric import sin, cos, cot
 from sympy.ntheory import isprime
 from sympy.ntheory.primetest import is_square
+from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.memoization import recurrence_memo
 from sympy.utilities.misc import as_int
 
@@ -1988,7 +1989,6 @@ def nT(n, k=None):
     .. [1] http://undergraduate.csse.uwa.edu.au/units/CITS7209/partition.pdf
 
     """
-    from sympy.utilities.enumerative import MultisetPartitionTraverser
 
     if isinstance(n, SYMPY_INTS):
         # n identical items

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -1092,7 +1092,6 @@ def jn_zeros(n, k, method="sympy", dps=15):
     if method == "sympy":
         from mpmath import besseljzero
         from mpmath.libmp.libmpf import dps_to_prec
-        from sympy.core.expr import Expr
         prec = dps_to_prec(dps)
         return [Expr._from_mpmath(besseljzero(S(n + 0.5)._to_mpmath(prec),
                                               int(l)), prec)

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -1,7 +1,9 @@
-from sympy.core.numbers import (I, pi)
-from sympy.core import Dummy, sympify
+from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.numbers import I, pi
 from sympy.core.singleton import S
+from sympy.core.symbol import Dummy
+from sympy.core.sympify import sympify
 from sympy.functions import assoc_legendre
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import Abs
@@ -213,7 +215,6 @@ class Ynm(Function):
         #       mpmath for Legendre polynomials. But using
         #       the dedicated function directly is cleaner.
         from mpmath import mp, workprec
-        from sympy.core.expr import Expr
         n = self.args[0]._to_mpmath(prec)
         m = self.args[1]._to_mpmath(prec)
         theta = self.args[2]._to_mpmath(prec)

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -2,6 +2,7 @@ from sympy.core import S, Integer
 from sympy.core.function import Function
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import prod
+from sympy.core.relational import Ne
 from sympy.core.sorting import default_sort_key
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.utilities.iterables import has_dups
@@ -468,6 +469,5 @@ class KroneckerDelta(Function):
 
     def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         from sympy.functions.elementary.piecewise import Piecewise
-        from sympy.core.relational import Ne
         i, j = args
         return Piecewise((0, Ne(i, j)), (1, True))

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -22,7 +22,7 @@ R3 are currently the only ambient spaces implemented.
 
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
-from sympy.core.evalf import EvalfMixin
+from sympy.core.evalf import EvalfMixin, N
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
@@ -164,8 +164,6 @@ class GeometryEntity(Basic, EvalfMixin):
 
     def _repr_svg_(self):
         """SVG representation of a GeometryEntity suitable for IPython"""
-
-        from sympy.core.evalf import N
 
         try:
             bounds = self.bounds

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -3,15 +3,19 @@ This module implements Holonomic Functions and
 various operations on them.
 """
 
-from sympy.core.numbers import NaN, Infinity, NegativeInfinity, Float, I
+from sympy.core import Add, Mul, Pow
+from sympy.core.numbers import NaN, Infinity, NegativeInfinity, Float, I, pi
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
-from sympy.functions.combinatorial.factorials import rf
+from sympy.functions.combinatorial.factorials import binomial, factorial, rf
+from sympy.functions.elementary.exponential import exp_polar, exp, log
+from sympy.functions.elementary.hyperbolic import (cosh, sinh)
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
+from sympy.functions.special.error_functions import (Ci, Shi, Si, erf, erfc, erfi)
 from sympy.functions.special.gamma_functions import gamma
-from sympy.functions.combinatorial.factorials import binomial, factorial
-from sympy.functions.elementary.exponential import exp_polar, exp
 from sympy.functions.special.hyper import hyper, meijerg
 from sympy.integrals import meijerint
 from sympy.matrices import Matrix
@@ -2440,7 +2444,6 @@ def expr_to_holonomic(func, x=None, x0=0, y0=None, lenics=None, domain=None, ini
     # iterate through the expression recursively
     args = func.args
     f = func.func
-    from sympy.core import Add, Mul, Pow
     sol = expr_to_holonomic(args[0], x=x, initcond=False, domain=domain)
 
     if f is Add:
@@ -2861,13 +2864,6 @@ def _create_table(table, domain=QQ):
 
     R = domain.old_poly_ring(x_1)
     _, Dx = DifferentialOperators(R, 'Dx')
-
-    from sympy.core.numbers import pi
-    from sympy.functions.elementary.exponential import log
-    from sympy.functions.elementary.hyperbolic import (cosh, sinh)
-    from sympy.functions.elementary.miscellaneous import sqrt
-    from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
-    from sympy.functions.special.error_functions import (Ci, Shi, Si, erf, erfc, erfi)
 
     # add some basic functions
     add(sin(x_1), Dx**2 + 1, x_1, 0, [0, 1])

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -28,7 +28,8 @@ The main references for this are:
 
 from typing import Dict, Tuple as tTuple
 
-from sympy.core import S, pi, Expr
+from sympy import SYMPY_DEBUG
+from sympy.core import S, Expr
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
@@ -36,8 +37,8 @@ from sympy.core.exprtools import factor_terms
 from sympy.core.function import (expand, expand_mul, expand_power_base,
                                  expand_trig, Function)
 from sympy.core.mul import Mul
-from sympy.core.numbers import ilcm, Rational
-from sympy.core.relational import Eq, Ne
+from sympy.core.numbers import ilcm, Rational, pi
+from sympy.core.relational import Eq, Ne, _canonical_coeff
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.functions.combinatorial.factorials import factorial
@@ -621,8 +622,6 @@ def _condsimp(cond, first=True):
     >>> simp(Or(x < y, Eq(x, y)))
     x <= y
     """
-    from sympy import SYMPY_DEBUG
-    from sympy.core.relational import _canonical_coeff
     if first:
         cond = cond.replace(lambda _: _.is_Relational, _canonical_coeff)
         first = False

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -1,6 +1,6 @@
 """Inference in propositional logic"""
 
-from sympy.logic.boolalg import And, Not, conjuncts, to_cnf
+from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
@@ -173,7 +173,7 @@ def pl_true(expr, model=None, deep=False):
     """
 
     from sympy.core.symbol import Symbol
-    from sympy.logic.boolalg import BooleanFunction
+
     boolean = (True, False)
 
     def _validate(expr):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -15,6 +15,7 @@ from sympy.core.basic import Atom
 from sympy.core.decorators import call_highest_priority
 from sympy.core.kind import Kind, NumberKind
 from sympy.core.logic import fuzzy_and, FuzzyBool
+from sympy.core.mod import Mod
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
@@ -2679,7 +2680,6 @@ class MatrixArithmetic(MatrixRequired):
         return self._new(self.rows, self.cols, lambda i, j: other*self[i,j])
 
     def _eval_Mod(self, other):
-        from sympy.core.mod import Mod
         return self._new(self.rows, self.cols, lambda i, j: Mod(self[i, j], other))
 
     # Python arithmetic functions

--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -1,8 +1,9 @@
-from sympy.matrices.expressions import MatrixExpr
+from sympy.core.expr import ExprBuilder
 from sympy.core.function import (Function, FunctionClass, Lambda)
 from sympy.core.symbol import Dummy
-from sympy.matrices.matrices import MatrixBase
 from sympy.core.sympify import sympify, _sympify
+from sympy.matrices.expressions import MatrixExpr
+from sympy.matrices.matrices import MatrixBase
 
 
 class ElementwiseApplyFunction(MatrixExpr):
@@ -137,7 +138,6 @@ class ElementwiseApplyFunction(MatrixExpr):
         from sympy.tensor.array.expressions.array_expressions import ArrayContraction
         from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
-        from sympy.core.expr import ExprBuilder
 
         fdiff = self._get_function_fdiff()
         lr = self.expr._eval_derivative_matrix_lines(x)

--- a/sympy/matrices/expressions/diagonal.py
+++ b/sympy/matrices/expressions/diagonal.py
@@ -2,6 +2,7 @@ from sympy.core.sympify import _sympify
 
 from sympy.matrices.expressions import MatrixExpr
 from sympy.core import S, Eq, Ge
+from sympy.core.mul import Mul
 from sympy.functions.special.tensor_functions import KroneckerDelta
 
 
@@ -192,7 +193,6 @@ class DiagMatrix(MatrixExpr):
 
     def doit(self, **hints):
         from sympy.assumptions import ask, Q
-        from sympy.core.mul import Mul
         from sympy.matrices.expressions.matmul import MatMul
         from sympy.matrices.expressions.transpose import Transpose
         from sympy.matrices.dense import eye

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,4 +1,6 @@
 from sympy.core import Mul, sympify
+from sympy.core.add import Add
+from sympy.core.expr import ExprBuilder
 from sympy.core.sorting import default_sort_key
 from sympy.matrices.common import ShapeError
 from sympy.matrices.expressions.matexpr import MatrixExpr
@@ -96,7 +98,6 @@ class HadamardProduct(MatrixExpr):
         return canonicalize(expr)
 
     def _eval_derivative(self, x):
-        from sympy.core.add import Add
         terms = []
         args = list(self.args)
         for i in range(len(args)):
@@ -105,7 +106,6 @@ class HadamardProduct(MatrixExpr):
         return Add.fromiter(terms)
 
     def _eval_derivative_matrix_lines(self, x):
-        from sympy.core.expr import ExprBuilder
         from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
         from sympy.matrices.expressions.matexpr import _make_matrix
@@ -431,7 +431,6 @@ class HadamardPower(MatrixExpr):
     def _eval_derivative_matrix_lines(self, x):
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
         from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal
-        from sympy.core.expr import ExprBuilder
         from sympy.matrices.expressions.matexpr import _make_matrix
 
         lr = self.base._eval_derivative_matrix_lines(x)

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -1,8 +1,8 @@
 from functools import reduce
 import operator
 
-from sympy.core import Add, Basic, sympify
-from sympy.core.add import add
+from sympy.core import Basic, sympify
+from sympy.core.add import add, Add, _could_extract_minus_sign
 from sympy.core.sorting import default_sort_key
 from sympy.functions import adjoint
 from sympy.matrices.common import ShapeError
@@ -63,8 +63,7 @@ class MatAdd(MatrixExpr, Add):
         return self.args[0].shape
 
     def could_extract_minus_sign(self):
-        from sympy.core.add import _could_extract_minus_sign as f
-        return f(self)
+        return _could_extract_minus_sign(self)
 
     def _entry(self, i, j, **kwargs):
         return Add(*[arg._entry(i, j, **kwargs) for arg in self.args])

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,11 +1,12 @@
 from typing import Tuple as tTuple
 from functools import wraps
 
-from sympy.core import S, Symbol, Integer, Basic, Expr, Mul, Add
+from sympy.core import S, Integer, Basic, Mul, Add
 from sympy.core.assumptions import check_assumptions
 from sympy.core.decorators import call_highest_priority
+from sympy.core.expr import Expr, ExprBuilder
 from sympy.core.logic import FuzzyBool
-from sympy.core.symbol import Str
+from sympy.core.symbol import Str, Dummy, symbols, Symbol
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.functions import conjugate, adjoint
@@ -594,8 +595,6 @@ class MatrixElement(Expr):
         return self.args[1:]
 
     def _eval_derivative(self, v):
-        from sympy.concrete.summations import Sum
-        from sympy.core.symbol import (Dummy, symbols)
 
         if not isinstance(v, MatrixElement):
             from sympy.matrices.matrices import MatrixBase
@@ -612,6 +611,7 @@ class MatrixElement(Expr):
                    KroneckerDelta(self.args[2], v.args[2], (0, n-1))
 
         if isinstance(M, Inverse):
+            from sympy.concrete.summations import Sum
             i, j = self.args[1:]
             i1, i2 = symbols("z1, z2", cls=Dummy)
             Y = M.args[0]
@@ -752,7 +752,6 @@ class _LeftRightArgs:
 
     @staticmethod
     def _build(expr):
-        from sympy.core.expr import ExprBuilder
         if isinstance(expr, ExprBuilder):
             return expr.build()
         if isinstance(expr, list):
@@ -807,7 +806,6 @@ class _LeftRightArgs:
         return rank
 
     def _multiply_pointer(self, pointer, other):
-        from sympy.core.expr import ExprBuilder
         from ...tensor.array.expressions.array_expressions import ArrayTensorProduct
         from ...tensor.array.expressions.array_expressions import ArrayContraction
 

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -2,9 +2,11 @@ from sympy.matrices.common import NonSquareMatrixError
 from .matexpr import MatrixExpr
 from .special import Identity
 from sympy.core import S
+from sympy.core.expr import ExprBuilder
+from sympy.core.cache import cacheit
+from sympy.core.power import Pow
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from ... import cacheit
 
 
 class MatPow(MatrixExpr):
@@ -90,11 +92,9 @@ class MatPow(MatrixExpr):
         return MatPow(base.T, exp)
 
     def _eval_derivative(self, x):
-        from sympy.core.power import Pow
         return Pow._eval_derivative(self, x)
 
     def _eval_derivative_matrix_lines(self, x):
-        from sympy.core.expr import ExprBuilder
         from sympy.tensor.array.expressions.array_expressions import ArrayContraction
         from ...tensor.array.expressions.array_expressions import ArrayTensorProduct
         from .matmul import MatMul

--- a/sympy/matrices/expressions/sets.py
+++ b/sympy/matrices/expressions/sets.py
@@ -1,3 +1,4 @@
+from sympy.core.assumptions import check_assumptions
 from sympy.core.logic import fuzzy_and
 from sympy.core.sympify import _sympify
 from sympy.sets.sets import Set
@@ -54,7 +55,6 @@ class MatrixSet(Set):
     @classmethod
     def _check_dim(cls, dim):
         """Helper function to check invalid matrix dimensions"""
-        from sympy.core.assumptions import check_assumptions
         ok = check_assumptions(dim, integer=True, nonnegative=True)
         if ok is False:
             raise ValueError(

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -1,7 +1,8 @@
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, ExprBuilder
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
+from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.common import NonSquareMatrixError
@@ -57,7 +58,6 @@ class Trace(Expr):
 
     def _eval_derivative_matrix_lines(self, x):
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayContraction
-        from sympy.core.expr import ExprBuilder
         r = self.args[0]._eval_derivative_matrix_lines(x)
         for lr in r:
             if lr.higher == 1:
@@ -144,7 +144,6 @@ class Trace(Expr):
 
     def _eval_rewrite_as_Sum(self, expr, **kwargs):
         from sympy.concrete.summations import Sum
-        from sympy.core.symbol import Dummy
         i = Dummy('i')
         return Sum(self.arg[i, i], (i, 0, self.arg.rows-1)).doit()
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.decorators import deprecated
+from sympy.core.function import diff
 from sympy.core.expr import Expr
 from sympy.core.kind import _NumberKind, UndefinedKind
 from sympy.core.mul import Mul
@@ -1552,7 +1553,6 @@ class MatrixBase(MatrixDeprecated,
             parameter of f
 
         """
-        from sympy.core.function import diff
 
         f, x = _sympify(f), _sympify(x)
         if not self.is_square:

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,3 +1,5 @@
+from sympy.core.containers import Dict
+from sympy.core.symbol import Dummy
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import as_int, filldedent
 
@@ -193,8 +195,6 @@ def banded(*args, **kwargs):
     [0, 0, 0, 0, 2, 1, 1],
     [0, 0, 0, 0, 0, 0, 1]])
     """
-    from sympy.core.containers import Dict
-    from sympy.core.symbol import Dummy
     try:
         if len(args) not in (1, 2, 3):
             raise TypeError

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -1,4 +1,5 @@
 from sympy.ntheory import sieve, isprime
+from sympy.core.numbers import mod_inverse
 from sympy.core.power import integer_log
 from sympy.utilities.misc import as_int
 import random
@@ -50,7 +51,6 @@ class Point:
     def __eq__(self, other):
         """Two points are equal if X/Z of both points are equal
         """
-        from sympy.core.numbers import mod_inverse
         if self.a_24 != other.a_24 or self.mod != other.mod:
             return False
         return self.x_cord * mod_inverse(self.z_cord, self.mod) % self.mod ==\
@@ -193,7 +193,6 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     .. [1]  Carl Pomerance and Richard Crandall "Prime Numbers:
         A Computational Perspective" (2nd Ed.), page 344
     """
-    from sympy.core.numbers import mod_inverse
     from sympy.functions.elementary.miscellaneous import sqrt
     from sympy.polys.polytools import gcd
     n = as_int(n)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -14,12 +14,13 @@ from sympy.core.function import Function
 from sympy.core.logic import fuzzy_and
 from sympy.core.mul import Mul, prod
 from sympy.core.numbers import igcd, ilcm, Rational, Integer
-from sympy.core.power import integer_nthroot, Pow
+from sympy.core.power import integer_nthroot, Pow, integer_log
 from sympy.core.singleton import S
 from sympy.external.gmpy import SYMPY_INTS
 from .primetest import isprime
 from .generate import sieve, primerange, nextprime
 from .digits import digits
+from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
 
@@ -151,7 +152,6 @@ def smoothness_p(n, m=-1, power=0, visual=None):
 
     factorint, smoothness
     """
-    from sympy.utilities import flatten
 
     # visual must be True, False or other (stored as None)
     if visual in (1, 0):
@@ -2363,7 +2363,6 @@ def is_perfect(n):
     .. [2] https://en.wikipedia.org/wiki/Perfect_number
 
     """
-    from sympy.core.power import integer_log
 
     n = as_int(n)
     if _isperfect(n):
@@ -2440,7 +2439,6 @@ def is_mersenne_prime(n):
     .. [1] http://mathworld.wolfram.com/MersennePrime.html
 
     """
-    from sympy.core.power import integer_log
 
     n = as_int(n)
     if _ismersenneprime(n):

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -3,6 +3,9 @@ Primality testing
 
 """
 
+from sympy.core.numbers import igcd
+from sympy.core.power import integer_nthroot
+from sympy.core.sympify import sympify
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -89,7 +92,6 @@ def is_square(n, prep=True):
     if not ((m*0x8bc40d7d) & (m*0xa1e2f5d1) & 0x14020a):
         m = n % 63
         if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
-            from sympy.core.power import integer_nthroot
             return integer_nthroot(n, 2)[1]
     return False
 
@@ -251,7 +253,6 @@ def _lucas_selfridge_params(n):
     .. [1] "Lucas Pseudoprimes", Baillie and Wagstaff, 1980.
            http://mpqs.free.fr/LucasPseudoprimes.pdf
     """
-    from sympy.core import igcd
     from sympy.ntheory.residue_ntheory import jacobi_symbol
     D = 5
     while True:
@@ -276,7 +277,6 @@ def _lucas_extrastrong_params(n):
            https://oeis.org/A217719
     .. [1] https://en.wikipedia.org/wiki/Lucas_pseudoprime
     """
-    from sympy.core import igcd
     from sympy.ntheory.residue_ntheory import jacobi_symbol
     P, Q, D = 3, 1, 5
     while True:
@@ -650,7 +650,6 @@ def is_gaussian_prime(num):
     .. [1] https://oeis.org/wiki/Gaussian_primes
     """
 
-    from sympy.core.sympify import sympify
     num = sympify(num)
     a, b = num.as_real_imag()
     a = as_int(a, strict=False)

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -1,4 +1,5 @@
 from sympy.core.numbers import igcd, mod_inverse
+from sympy.core.power import integer_nthroot
 from sympy.ntheory.residue_ntheory import _sqrt_mod_prime_power
 from sympy.ntheory import isprime
 from math import log, sqrt
@@ -412,7 +413,6 @@ def _find_factor(dependent_rows, mark, gauss_matrix, index, smooth_relations, N)
     smooth_relations : Smooth relations vectors matrix
     N : Number to be factored
     """
-    from sympy.core.power import integer_nthroot
     idx_in_smooth = dependent_rows[index][1]
     independent_u = [smooth_relations[idx_in_smooth][0]]
     independent_v = [smooth_relations[idx_in_smooth][1]]

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -4,16 +4,23 @@ singularity functions in mechanics.
 """
 
 from sympy.core import S, Symbol, diff, symbols
+from sympy.core.add import Add
+from sympy.core.expr import Expr
+from sympy.core.function import (Derivative, Function)
+from sympy.core.mul import Mul
+from sympy.core.relational import Eq
+from sympy.core.sympify import sympify
 from sympy.solvers import linsolve
+from sympy.solvers.ode.ode import dsolve
+from sympy.solvers.solvers import solve
 from sympy.printing import sstr
 from sympy.functions import SingularityFunction, Piecewise, factorial
-from sympy.core import sympify
 from sympy.integrals import integrate
 from sympy.series import limit
 from sympy.plotting import plot, PlotGrid
 from sympy.geometry.entity import GeometryEntity
 from sympy.external import import_module
-from sympy.core.add import Add
+from sympy.sets.sets import Interval
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import iterable
@@ -880,9 +887,6 @@ class Beam:
     def max_shear_force(self):
         """Returns maximum Shear force and its coordinate
         in the Beam object."""
-        from sympy.core.mul import Mul
-        from sympy.sets.sets import Interval
-        from sympy.solvers.solvers import solve
         shear_curve = self.shear_force()
         x = self.variable
 
@@ -967,9 +971,6 @@ class Beam:
     def max_bmoment(self):
         """Returns maximum Shear force and its coordinate
         in the Beam object."""
-        from sympy.core.mul import Mul
-        from sympy.sets.sets import Interval
-        from sympy.solvers.solvers import solve
         bending_curve = self.bending_moment()
         x = self.variable
 
@@ -1048,7 +1049,6 @@ class Beam:
         >>> b.point_cflexure()
         [10/3]
         """
-        from sympy.solvers.solvers import solve
 
         # To restrict the range within length of the Beam
         moment_curve = Piecewise((float("nan"), self.variable<=0),
@@ -1263,7 +1263,6 @@ class Beam:
         Returns point of max deflection and its corresponding deflection value
         in a Beam object.
         """
-        from sympy.solvers.solvers import solve
 
         # To restrict the range within length of the Beam
         slope_curve = Piecewise((float("nan"), self.variable<=0),
@@ -2135,7 +2134,6 @@ class Beam:
         x = self.variable
 
         # checking whether length is an expression in terms of any Symbol.
-        from sympy.core.expr import Expr
         if isinstance(self.length, Expr):
             l = list(self.length.atoms(Symbol))
             # assigning every Symbol a default value of 10
@@ -2675,9 +2673,6 @@ class Beam3D(Beam):
         return self.bending_moment()[0]
 
     def solve_slope_deflection(self):
-        from sympy.core.function import (Derivative, Function)
-        from sympy.core.relational import Eq
-        from sympy.solvers.ode.ode import dsolve
         x = self.variable
         l = self.length
         E = self.elastic_modulus
@@ -3356,7 +3351,6 @@ class Beam3D(Beam):
 
         elif dir == 'z':
             dir_num = 2
-        from sympy.solvers.solvers import solve
 
         if not self.shear_force()[dir_num]:
             return (0,0)
@@ -3432,8 +3426,6 @@ class Beam3D(Beam):
 
         elif dir == 'z':
             dir_num = 2
-
-        from sympy.solvers.solvers import solve
 
         if not self.bending_moment()[dir_num]:
             return (0,0)
@@ -3511,7 +3503,6 @@ class Beam3D(Beam):
 
         elif dir == 'z':
             dir_num = 2
-        from sympy.solvers.solvers import solve
 
         if not self.deflection()[dir_num]:
             return (0,0)

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -8,14 +8,15 @@ This module has all the classes and functions related to waves in optics.
 
 __all__ = ['TWave']
 
-from sympy.core.function import Derivative
-from sympy.core.numbers import (Number, pi)
+from sympy.core.expr import Expr
+from sympy.core.function import Derivative, Function
+from sympy.core.numbers import (Number, pi, I)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (atan2, cos, sin)
-from sympy.core.expr import Expr
 from sympy.physics.units import speed_of_light, meter, second
 
 
@@ -319,13 +320,10 @@ class TWave(Expr):
             - self.angular_velocity*Symbol('t') + self._phase)
 
     def _eval_rewrite_as_pde(self, *args, **kwargs):
-        from sympy.core.function import Function
         mu, epsilon, x, t = symbols('mu, epsilon, x, t')
         E = Function('E')
         return Derivative(E(x, t), x, 2) + mu*epsilon*Derivative(E(x, t), t, 2)
 
     def _eval_rewrite_as_exp(self, *args, **kwargs):
-        from sympy.core.numbers import I
-        from sympy.functions.elementary.exponential import exp
         return self._amplitude*exp(I*(self.wavenumber*Symbol('x')
             - self.angular_velocity*Symbol('t') + self._phase))

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -1,6 +1,9 @@
 """Implementation of :class:`AlgebraicField` class. """
 
 
+from sympy.core.add import Add
+from sympy.core.mul import Mul
+from sympy.core.singleton import S
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -370,8 +373,6 @@ def _make_converter(K):
     # conversion from K to Expr is slow. Here we compute the expansions for
     # each power of the generator and collect together the resulting algebraic
     # terms and the rational coefficients into a matrix.
-    from sympy.core.add import Add
-    from sympy.core.singleton import S
 
     gen = K.ext.as_expr()
     todom = K.dom.from_sympy
@@ -394,8 +395,6 @@ def _make_converter(K):
 
     def converter(a):
         """Convert a to Expr using converter"""
-        from sympy.core.add import Add
-        from sympy.core.mul import Mul
         ai = a.rep[::-1]
         tosympy = K.dom.to_sympy
         coeffs_dom = [sum(mij*aj for mij, aj in zip(mi, ai)) for mi in matrix]

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -3,7 +3,7 @@
 from functools import reduce
 
 from sympy.core.add import Add
-from sympy.core.function import expand_mul
+from sympy.core.function import expand_mul, expand_multinomial
 from sympy.core.mul import Mul
 from sympy.core import (GoldenRatio, TribonacciConstant)
 from sympy.core.numbers import (I, Rational, pi)
@@ -22,7 +22,7 @@ from sympy.ntheory.factor_ import divisors
 from sympy.utilities.iterables import subsets
 
 from sympy.polys.densetools import dup_eval
-from sympy.polys.domains import ZZ, QQ
+from sympy.polys.domains import ZZ, QQ, FractionField
 from sympy.polys.orthopolys import dup_chebyshevt
 from sympy.polys.polyerrors import (
     NotAlgebraic,
@@ -32,7 +32,7 @@ from sympy.polys.polytools import (
     Poly, PurePoly, invert, factor_list, groebner, resultant,
     degree, poly_from_expr, parallel_poly_from_expr, lcm
 )
-from sympy.polys.polyutils import dict_from_expr, expr_from_dict
+from sympy.polys.polyutils import dict_from_expr, expr_from_dict, illegal
 from sympy.polys.ring_series import rs_compose_add
 from sympy.polys.rings import ring
 from sympy.polys.rootoftools import CRootOf
@@ -49,7 +49,6 @@ def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
     Return a factor having root ``v``
     It is assumed that one of the factors has root ``v``.
     """
-    from sympy.polys.polyutils import illegal
 
     if isinstance(factors[0], tuple):
         factors = [f[0] for f in factors]
@@ -675,7 +674,6 @@ def minimal_polynomial(ex, x=None, compose=True, polys=False, domain=None):
     x**2 - y
 
     """
-    from sympy.polys.domains import FractionField
 
     ex = sympify(ex)
     if ex.is_number:
@@ -729,7 +727,6 @@ def _minpoly_groebner(ex, x, cls):
     x**2 - 2*x - 1
 
     """
-    from sympy.core.function import expand_multinomial
 
     generator = numbered_symbols('a', cls=Dummy)
     mapping, symbols = {}, {}

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5,14 +5,16 @@ from functools import wraps, reduce
 from operator import mul
 
 from sympy.core import (
-    S, Expr, I, Integer, Add, Tuple
+    S, Expr, Add, Tuple
 )
 from sympy.core.basic import Basic
 from sympy.core.decorators import _sympifyit
+from sympy.core.exprtools import Factors, factor_nc, factor_terms
 from sympy.core.evalf import pure_complex
 from sympy.core.function import Derivative
 from sympy.core.mul import Mul, _keep_coeff
-from sympy.core.relational import Relational
+from sympy.core.numbers import ilcm, I, Integer
+from sympy.core.relational import Relational, Equality
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify, _sympify
@@ -3664,7 +3666,6 @@ class Poly(Basic):
             coeffs = [int(coeff) for coeff in f.all_coeffs()]
         elif f.rep.dom is QQ:
             denoms = [coeff.q for coeff in f.all_coeffs()]
-            from sympy.core.numbers import ilcm
             fac = ilcm(*denoms)
             coeffs = [int(coeff*fac) for coeff in f.all_coeffs()]
         else:
@@ -5533,7 +5534,6 @@ def terms_gcd(f, *gens, **args):
     sympy.core.exprtools.gcd_terms, sympy.core.exprtools.factor_terms
 
     """
-    from sympy.core.relational import Equality
 
     orig = sympify(f)
 
@@ -6171,7 +6171,6 @@ def to_rational_coeffs(f):
         """
         Return True if ``f`` is a sum with square roots but no other root
         """
-        from sympy.core.exprtools import Factors
         coeffs = p.coeffs()
         has_sq = False
         for y in coeffs:
@@ -6391,7 +6390,6 @@ def factor(f, *gens, deep=False, **args):
         return _generic_factor(f, gens, args, method='factor')
     except PolynomialError as msg:
         if not f.is_commutative:
-            from sympy.core.exprtools import factor_nc
             return factor_nc(f)
         else:
             raise PolynomialError(msg)
@@ -6673,7 +6671,6 @@ def cancel(f, *gens, **args):
     >>> together(_)
     (x + 2)/2
     """
-    from sympy.core.exprtools import factor_terms
     from sympy.functions.elementary.piecewise import Piecewise
     from sympy.polys.rings import sring
     options.allowed_flags(args, ['polys'])

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -11,6 +11,7 @@ from sympy.core.alphabets import greeks
 from sympy.core.containers import Tuple
 from sympy.core.function import AppliedUndef, Derivative
 from sympy.core.operations import AssocOp
+from sympy.core.power import Pow
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
 from sympy.logic.boolalg import true
@@ -498,7 +499,6 @@ class LatexPrinter(Printer):
         return r"\triangle %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
     def _print_Mul(self, expr):
-        from sympy.core.power import Pow
         from sympy.physics.units import Quantity
         from sympy.simplify import fraction
         separator = self._settings['mul_symbol_latex']

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1,7 +1,9 @@
 import itertools
 
 from sympy.core import S
+from sympy.core.add import Add
 from sympy.core.containers import Tuple
+from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import Number, Rational
 from sympy.core.power import Pow
@@ -874,7 +876,6 @@ class PrettyPrinter(Printer):
 
     def _print_MatMul(self, expr):
         args = list(expr.args)
-        from sympy.core.add import Add
         from sympy.matrices.expressions.hadamard import HadamardProduct
         from sympy.matrices.expressions.kronecker import KroneckerProduct
         from sympy.matrices.expressions.matadd import MatAdd
@@ -1763,7 +1764,6 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_expint(self, e):
-        from sympy.core.function import Function
         if e.args[0].is_Integer and self._use_unicode:
             return self._print_Function(Function('E_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -8,13 +8,14 @@ from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
 from sympy.core.relational import Relational
 from sympy.core.sorting import default_sort_key
+from sympy.core.sympify import SympifyError
 from sympy.sets.sets import FiniteSet
+from sympy.utilities.iterables import sift
+from .precedence import precedence, PRECEDENCE
 from .printer import Printer, print_function
-from sympy.printing.precedence import precedence, PRECEDENCE
 
 from mpmath.libmp import prec_to_dps, to_str as mlib_to_str
 
-from sympy.utilities import sift
 
 
 class StrPrinter(Printer):
@@ -909,7 +910,6 @@ class StrPrinter(Printer):
         return "0"
 
     def _print_DMP(self, p):
-        from sympy.core.sympify import SympifyError
         try:
             if p.ring is not None:
                 # TODO incorporate order

--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -1,4 +1,7 @@
 from sympy.core.containers import Tuple
+from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import SympifyError
 
 from types import FunctionType
 
@@ -112,10 +115,7 @@ class TableForm:
          .. . ..
         ... . ...
         """
-        from sympy.core.singleton import S
-        from sympy.core.symbol import Symbol
         from sympy.matrices.dense import Matrix
-        from sympy.core.sympify import SympifyError
 
         # We only support 2D data. Check the consistency:
         if isinstance(data, Matrix):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -118,8 +118,11 @@ debug this function to figure out the exact problem.
 """
 from functools import reduce
 
+from sympy.core import Basic, S, Mul, PoleError
 from sympy.core.cache import cacheit
-from sympy.core import Basic, S, oo, I, Dummy, Wild, Mul, PoleError, bottom_up
+from sympy.core.numbers import ilcm, I, oo
+from sympy.core.symbol import Dummy, Wild
+from sympy.core.traversal import bottom_up
 
 from sympy.functions import log, exp, sign as _sign
 from sympy.series.order import Order
@@ -598,7 +601,6 @@ def rewrite(e, Omega, x, wsym):
     Returns the rewritten e in terms of w and log(w). See test_rewrite1()
     for examples and correct results.
     """
-    from sympy.core.numbers import ilcm
     if not isinstance(Omega, SubsSet):
         raise TypeError("Omega should be an instance of SubsSet")
     if len(Omega) == 0:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,11 +1,15 @@
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
+from sympy.core.numbers import Float
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.elementary.complexes import (Abs, sign)
+from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys import PolynomialError, factor
 from sympy.series.order import Order
+from sympy.simplify.powsimp import powsimp
 from sympy.simplify.ratsimp import ratsimp
-from sympy.simplify.simplify import together
+from sympy.simplify.simplify import nsimplify, together
 from .gruntz import gruntz
 
 def limit(e, z, z0, dir="+"):
@@ -176,7 +180,6 @@ class Limit(Expr):
 
 
     def pow_heuristics(self, e):
-        from sympy.functions.elementary.exponential import (exp, log)
         _, z, z0, _ = self.args
         b1, e1 = e.base, e.exp
         if not b1.has(z):
@@ -207,10 +210,6 @@ class Limit(Expr):
         hints : optional keyword arguments
             To be passed to ``doit`` methods; only used if deep is True.
         """
-        from sympy.core.numbers import Float
-        from sympy.functions.elementary.complexes import (Abs, sign)
-        from sympy.simplify.powsimp import powsimp
-        from sympy.simplify.simplify import nsimplify
 
         e, z, z0, dir = self.args
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -1,7 +1,7 @@
-from sympy.core import S, sympify, Expr, Dummy
-from sympy.core import Add, Mul, expand_power_base, expand_log
+from sympy.core import S, sympify, Expr, Dummy, Add, Mul
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
+from sympy.core.function import Function, PoleError, expand_power_base, expand_log
 from sympy.core.sorting import default_sort_key
 from sympy.sets.sets import Complement
 from sympy.utilities.iterables import uniq, is_sequence
@@ -225,7 +225,6 @@ class Order(Expr):
                     expr = Add(*[f.expr for (e, f) in lst])
 
                 elif expr:
-                    from sympy.core.function import (Function, PoleError)
                     try:
                         expr = expr.as_leading_term(*args)
                     except PoleError:

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -3,6 +3,8 @@ This module implements the Residue function and related tools for working
 with residues.
 """
 
+from sympy.core.mul import Mul
+from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
 
@@ -46,8 +48,6 @@ def residue(expr, x, x0):
     # For the definition of a resultant, see section 1.4 (and any
     # previous sections for more review).
 
-    from sympy.core.mul import Mul
-    from sympy.core.singleton import S
     from sympy.series.order import Order
     from sympy.simplify.radsimp import collect
     expr = sympify(expr)

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -1,15 +1,14 @@
 from sympy.core.singleton import S
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
-from sympy.core.function import Lambda
+from sympy.core.function import Lambda, BadSignatureError
 from sympy.core.logic import fuzzy_bool
 from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import And, as_Boolean
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, flatten, has_dups
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-
 from .contains import Contains
 from .sets import Set, Union, FiniteSet
 
@@ -87,8 +86,6 @@ class ConditionSet(Set):
 
     """
     def __new__(cls, sym, condition, base_set=S.UniversalSet):
-        from sympy.core.function import BadSignatureError
-        from sympy.utilities.iterables import flatten, has_dups
         sym = _sympify(sym)
         flat = flatten([sym])
         if has_dups(flat):
@@ -178,7 +175,6 @@ class ConditionSet(Set):
 
     @property
     def bound_symbols(self):
-        from sympy.utilities.iterables import flatten
         return flatten([self.sym])
 
     def _contains(self, other):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -6,7 +6,8 @@ from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_not, fuzzy_or, fuzzy_and
-from sympy.core.numbers import oo
+from sympy.core.mod import Mod
+from sympy.core.numbers import oo, igcd, Rational
 from sympy.core.relational import Eq, is_eq
 from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Dummy, symbols, Symbol
@@ -45,7 +46,6 @@ class Rationals(Set, metaclass=Singleton):
         return other.is_rational
 
     def __iter__(self):
-        from sympy.core.numbers import igcd, Rational
         yield S.Zero
         yield S.One
         yield S.NegativeOne
@@ -978,7 +978,6 @@ class Range(Set):
 
     def as_relational(self, x):
         """Rewrite a Range in terms of equalities and logic operators. """
-        from sympy.core.mod import Mod
         if self.start.is_infinite:
             assert not self.stop.is_infinite  # by instantiation
             a = self.reversed.start

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -2,7 +2,7 @@ from sympy.core.singleton import S
 from sympy.sets.sets import Set
 from sympy.calculus.singularities import singularities
 from sympy.core import Expr, Add
-from sympy.core.function import Lambda, FunctionClass, diff
+from sympy.core.function import Lambda, FunctionClass, diff, expand_mul
 from sympy.core.numbers import Float, oo
 from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.functions.elementary.exponential import exp, log
@@ -152,7 +152,6 @@ def _set_function(f, x): # noqa:F811
 
 @dispatch(FunctionUnion, Range)  # type: ignore # noqa:F811
 def _set_function(f, self): # noqa:F811
-    from sympy.core.function import expand_mul
     if not self:
         return S.EmptySet
     if not isinstance(f.expr, Expr):

--- a/sympy/sets/handlers/mul.py
+++ b/sympy/sets/handlers/mul.py
@@ -1,8 +1,8 @@
-from sympy.core.symbol import symbols
-from sympy.sets.sets import Set
 from sympy.core import Basic, Expr
+from sympy.core.numbers import oo
+from sympy.core.symbol import symbols
 from sympy.multipledispatch import dispatch
-from sympy.sets import Interval
+from sympy.sets.sets import Interval, Set
 
 _x, _y = symbols("x y")
 
@@ -61,7 +61,6 @@ def _set_div(x, y): # noqa:F811
     https://en.wikipedia.org/wiki/Interval_arithmetic
     """
     from sympy.sets.setexpr import set_mul
-    from sympy.core.numbers import oo
     if (y.start*y.end).is_negative:
         return Interval(-oo, oo)
     if y.start == 0:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -12,7 +12,7 @@ from sympy.core.expr import Expr
 from sympy.core.function import Lambda
 from sympy.core.logic import (FuzzyBool, fuzzy_bool, fuzzy_or, fuzzy_and,
     fuzzy_not)
-from sympy.core.numbers import Float
+from sympy.core.numbers import Float, Integer
 from sympy.core.operations import LatticeOp
 from sympy.core.parameters import global_parameters
 from sympy.core.relational import Eq, Ne, is_lt
@@ -2151,7 +2151,6 @@ class DisjointUnion(Set):
 
     def __iter__(self):
         if self.is_iterable:
-            from sympy.core.numbers import Integer
 
             iters = []
             for i, s in enumerate(self.sets):

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -7,7 +7,7 @@ from sympy.core.add import _unevaluated_Add, Add
 from sympy.core.assumptions import assumptions
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.function import _mexpand, expand_mul, expand_power_base
-from sympy.core.mul import _keep_coeff, _unevaluated_Mul
+from sympy.core.mul import _keep_coeff, _unevaluated_Mul, _mulsort
 from sympy.core.numbers import Rational, zoo, nan
 from sympy.core.parameters import global_parameters
 from sympy.core.sorting import ordered, default_sort_key
@@ -576,7 +576,6 @@ def collect_abs(expr):
     Abs(1/x)
     """
     def _abs(mul):
-      from sympy.core.mul import _mulsort
       c, nc = mul.args_cnc()
       a = []
       o = []

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1,11 +1,14 @@
 from collections import defaultdict
 from functools import reduce
 
-from sympy.core import (sympify, Basic, S, Expr, expand_mul, factor_terms,
-    Mul, Dummy, igcd, FunctionClass, Add, symbols, Wild, expand, bottom_up)
+from sympy.core import (sympify, Basic, S, Expr, factor_terms,
+                        Mul, Add, bottom_up)
 from sympy.core.cache import cacheit
-from sympy.core.function import count_ops, _mexpand
-from sympy.core.numbers import I, Integer
+from sympy.core.function import (count_ops, _mexpand, FunctionClass, expand,
+                                 expand_mul, Derivative)
+from sympy.core.numbers import I, Integer, igcd
+from sympy.core.sorting import _nodes
+from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.functions import sin, cos, exp, cosh, tanh, sinh, tan, cot, coth
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -1115,7 +1118,6 @@ def _futrig(e):
         TR1, TR2, TR3, TR2i, TR10, L, TR10i,
         TR8, TR6, TR15, TR16, TR111, TR5, TRmorrie, TR11, _TR11, TR14, TR22,
         TR12)
-    from sympy.core.sorting import _nodes
 
     if not e.has(TrigonometricFunction):
         return e
@@ -1176,7 +1178,6 @@ def _futrig(e):
 def _is_Expr(e):
     """_eapply helper to tell whether ``e`` and all its args
     are Exprs."""
-    from sympy.core.function import Derivative
     if isinstance(e, Derivative):
         return _is_Expr(e.expr)
     if not isinstance(e, Expr):

--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -1,5 +1,6 @@
 from sympy.core.add import Add
-from sympy.core.function import expand_log
+from sympy.core.exprtools import factor_terms
+from sympy.core.function import expand_log, _mexpand
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
@@ -8,7 +9,6 @@ from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.miscellaneous import root
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import Poly, factor
-from sympy.core.function import _mexpand
 from sympy.simplify.simplify import separatevars
 from sympy.simplify.radsimp import collect
 from sympy.simplify.simplify import powsimp
@@ -99,7 +99,6 @@ def _linab(arg, symbol):
     >>> _linab(3 + 2*exp(x), x)
     (2, 3, exp(x))
     """
-    from sympy.core.exprtools import factor_terms
     arg = factor_terms(arg.expand())
     ind, dep = arg.as_independent(symbol)
     if arg.is_Mul and dep.is_Add:

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -1,5 +1,6 @@
 from sympy.core import (Function, Pow, sympify, Expr)
 from sympy.core.relational import Relational
+from sympy.core.singleton import S
 from sympy.polys import Poly, decompose
 from sympy.utilities.misc import func_name
 
@@ -42,7 +43,6 @@ def decompogen(f, symbol):
 
     # ===== Simple Functions ===== #
     if isinstance(f, (Function, Pow)):
-        from sympy.core.singleton import S
         if f.is_Pow and f.base == S.Exp1:
             arg = f.exp
         else:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -27,7 +27,8 @@ from sympy.simplify.simplify import signsimp
 from sympy.solvers.solveset import solveset_real
 from sympy.utilities import numbered_symbols
 from sympy.utilities.misc import as_int, filldedent
-from sympy.utilities.iterables import is_sequence
+from sympy.utilities.iterables import (is_sequence, subsets, permute_signs,
+                                       signed_permutations, ordered_partitions)
 
 
 # these are imported with 'from sympy.solvers.diophantine import *
@@ -1341,9 +1342,6 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     sympy.utilities.iterables.permute_signs
     sympy.utilities.iterables.signed_permutations
     """
-
-    from sympy.utilities.iterables import (
-        subsets, permute_signs, signed_permutations)
 
     eq = _sympify(eq)
 
@@ -3594,7 +3592,6 @@ def partition(n, k=None, zeros=False):
     (0, 0, 5)
 
     """
-    from sympy.utilities.iterables import ordered_partitions
     if not zeros or k is None:
         for i in ordered_partitions(n, k):
             yield tuple(i)

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -19,7 +19,8 @@ from sympy.simplify.simplify import simplify
 from sympy.sets.sets import FiniteSet
 from sympy.solvers.deutils import ode_order
 from sympy.solvers.solveset import NonlinearError, solveset
-from sympy.utilities.iterables import iterable
+from sympy.utilities.iterables import (connected_components, iterable,
+                                       strongly_connected_components)
 from sympy.utilities.misc import filldedent
 from sympy.integrals.integrals import Integral, integrate
 
@@ -1577,7 +1578,6 @@ def _combine_type1_subsystems(subsystem, funcs, t):
 
 
 def _component_division(eqs, funcs, t):
-    from sympy.utilities.iterables import connected_components, strongly_connected_components
 
     # Assuming that each eq in eqs is in canonical form,
     # that is, [f(x).diff(x) = .., g(x).diff(x) = .., etc]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -12,33 +12,33 @@ This module contain solvers for all kinds of equations:
 
 """
 
-from sympy.core.function import expand_func
-from sympy.functions.combinatorial.factorials import binomial
-from sympy.ntheory.factor_ import divisors
+from sympy.core import (S, Add, Symbol, Dummy, Expr, Mul)
 from sympy.core.assumptions import check_assumptions
+from sympy.core.exprtools import factor_terms
+from sympy.core.function import (expand_mul, expand_log, Derivative,
+                                 AppliedUndef, UndefinedFunction, nfloat,
+                                 Function, expand_power_exp, _mexpand, expand,
+                                 expand_func)
+from sympy.core.logic import fuzzy_not
+from sympy.core.numbers import ilcm, Float, Rational
+from sympy.core.power import integer_log, Pow
+from sympy.core.relational import Relational, Eq, Ne
 from sympy.core.sorting import ordered, default_sort_key
 from sympy.core.sympify import sympify
-from sympy.core import (S, Add, Symbol, Equality, Dummy, Expr, Mul,
-    Pow, Unequality)
-from sympy.core.exprtools import factor_terms
-from sympy.core.function import (expand_mul, expand_log,
-                          Derivative, AppliedUndef, UndefinedFunction, nfloat,
-                          Function, expand_power_exp, _mexpand, expand)
-from sympy.integrals.integrals import Integral
-from sympy.core.numbers import ilcm, Float, Rational
-from sympy.core.relational import Relational
-from sympy.core.logic import fuzzy_not
-from sympy.core.power import integer_log
 from sympy.core.traversal import preorder_traversal
 from sympy.logic.boolalg import And, Or, BooleanAtom
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, acos, asin, atan,
                              Abs, re, im, arg, sqrt, atan2)
+from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
+from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
+from sympy.ntheory.factor_ import divisors
 from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
     separatevars)
+from sympy.integrals.integrals import Integral
 from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1, TR2i
 from sympy.matrices.common import NonInvertibleMatrixError
@@ -47,12 +47,11 @@ from sympy.polys import roots, cancel, factor, Poly
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
-from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
 from sympy.utilities.lambdify import lambdify
-from sympy.utilities.misc import filldedent
+from sympy.utilities.misc import filldedent, debug
 from sympy.utilities.iterables import (connected_components,
-    generate_bell, uniq, iterable, is_sequence)
+    generate_bell, uniq, iterable, is_sequence, subsets)
 from sympy.utilities.decorator import conserve_mpmath_dps
 
 from mpmath import findroot
@@ -264,7 +263,7 @@ def checksol(f, symbol, sol=None, **flags):
 
     if isinstance(f, Poly):
         f = f.as_expr()
-    elif isinstance(f, (Equality, Unequality)):
+    elif isinstance(f, (Eq, Ne)):
         if f.rhs in (S.true, S.false):
             f = f.reversed
         B, E = f.args
@@ -884,7 +883,7 @@ def solve(f, *symbols, **flags):
     # preprocess equation(s)
     ###########################################################################
     for i, fi in enumerate(f):
-        if isinstance(fi, (Equality, Unequality)):
+        if isinstance(fi, (Eq, Ne)):
             if 'ImmutableDenseMatrix' in [type(a).__name__ for a in fi.args]:
                 fi = fi.lhs - fi.rhs
             else:
@@ -892,7 +891,7 @@ def solve(f, *symbols, **flags):
                 if isinstance(R, BooleanAtom):
                     L, R = R, L
                 if isinstance(L, BooleanAtom):
-                    if isinstance(fi, Unequality):
+                    if isinstance(fi, Ne):
                         L = ~L
                     if R.is_Relational:
                         fi = ~R if L is S.false else R
@@ -1826,7 +1825,6 @@ def _solve_system(exprs, symbols, **flags):
 
         else:
             if len(symbols) > len(polys):
-                from sympy.utilities.iterables import subsets
 
                 free = set().union(*[p.free_symbols for p in polys])
                 free = list(ordered(free.intersection(symbols)))
@@ -2098,7 +2096,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     solution.)
 
     """
-    if isinstance(lhs, Equality):
+    if isinstance(lhs, Eq):
         if rhs:
             raise ValueError(filldedent('''
             If lhs is an Equality, rhs must be 0 but was %s''' % rhs))
@@ -2229,7 +2227,6 @@ def minsolve_linear_system(system, *symbols, **flags):
         # We speed up slightly by starting at one less than the number of
         # variables the quick method manages.
         from itertools import combinations
-        from sympy.utilities.misc import debug
         N = len(symbols)
         bestsol = minsolve_linear_system(system, *symbols, quick=True)
         n0 = len([x for x in bestsol.values() if x != 0])
@@ -2344,7 +2341,7 @@ def solve_undetermined_coeffs(equ, coeffs, sym, **flags):
     {a: 1/c, b: -1/c}
 
     """
-    if isinstance(equ, Equality):
+    if isinstance(equ, Eq):
         # got equation, so move all the
         # terms to the left hand side
         equ = equ.lhs - equ.rhs
@@ -2913,14 +2910,14 @@ def nsolve(*args, dict=False, **kwargs):
     if iterable(f):
         f = list(f)
         for i, fi in enumerate(f):
-            if isinstance(fi, Equality):
+            if isinstance(fi, Eq):
                 f[i] = fi.lhs - fi.rhs
         f = Matrix(f).T
     if iterable(x0):
         x0 = list(x0)
     if not isinstance(f, Matrix):
         # assume it's a SymPy expression
-        if isinstance(f, Equality):
+        if isinstance(f, Eq):
             f = f.lhs - f.rhs
         syms = f.free_symbols
         if fargs is None:
@@ -3218,7 +3215,6 @@ def unrad(eq, *syms, **flags):
     (_p**3 + _p**2 - 2, [_p, _p**6 - x])
 
     """
-    from sympy.core.relational import Equality as Eq
 
     uflags = dict(check=False, simplify=False)
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -22,6 +22,7 @@ from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import (Function, Lambda)
+from sympy.core.logic import fuzzy_and
 from sympy.core.mul import (Mul, prod)
 from sympy.core.relational import (Eq, Ne)
 from sympy.core.singleton import S
@@ -1680,7 +1681,6 @@ def _value_check(condition, message):
     >>> _value_check(And(a < 0, b < 0, c < 0), '')
     False
     """
-    from sympy.core.logic import fuzzy_and
     if not iterable(condition):
         condition = [condition]
     truth = fuzzy_and(condition)

--- a/sympy/stats/sampling/sample_scipy.py
+++ b/sympy/stats/sampling/sample_scipy.py
@@ -103,7 +103,6 @@ def _(dist: CauchyDistribution, size, seed):
 @do_sample_scipy.register(DiscreteDistributionHandmade) # type: ignore
 def _(dist: DiscreteDistributionHandmade, size, seed):
     from scipy.stats import rv_discrete
-    from sympy.utilities.lambdify import lambdify
 
     z = Dummy('z')
     handmade_pmf = lambdify(z, dist.pdf(z), ['numpy', 'scipy'])

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -5,9 +5,10 @@ from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.singleton import S
 from sympy.core.sympify import _sympify
+from sympy.simplify.simplify import simplify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray, ArrayKind
-from sympy.simplify.simplify import simplify
+from sympy.utilities.iterables import flatten
 
 
 class DenseNDimArray(NDimArray):
@@ -138,8 +139,6 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray): # type: ignor
 
     @classmethod
     def _new(cls, iterable, shape, **kwargs):
-        from sympy.utilities.iterables import flatten
-
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         shape = Tuple(*map(_sympify, shape))
         cls._check_special_bounds(flat_list, shape)
@@ -168,8 +167,6 @@ class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
 
     @classmethod
     def _new(cls, iterable, shape, **kwargs):
-        from sympy.utilities.iterables import flatten
-
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         flat_list = flatten(flat_list)
         self = object.__new__(cls)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,9 +1,10 @@
 from sympy.core.basic import Basic
-from sympy.core.singleton import S
+from sympy.core.containers import (Dict, Tuple)
 from sympy.core.expr import Expr
-from sympy.core.numbers import Integer
-from sympy.core.sympify import sympify
 from sympy.core.kind import Kind, NumberKind, UndefinedKind
+from sympy.core.numbers import Integer
+from sympy.core.singleton import S
+from sympy.core.sympify import sympify
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.printing.defaults import Printable
 
@@ -207,7 +208,6 @@ class NDimArray(Printable):
     def _handle_ndarray_creation_inputs(cls, iterable=None, shape=None, **kwargs):
         from sympy.matrices.matrices import MatrixBase
         from sympy.tensor.array import SparseNDimArray
-        from sympy.core.containers import (Dict, Tuple)
 
         if shape is None:
             if iterable is None:

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -4,6 +4,7 @@ from sympy.core.singleton import S
 from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
+from sympy.utilities.iterables import flatten
 
 import functools
 
@@ -103,8 +104,6 @@ class SparseNDimArray(NDimArray):
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray): # type: ignore
 
     def __new__(cls, iterable=None, shape=None, **kwargs):
-        from sympy.utilities.iterables import flatten
-
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         shape = Tuple(*map(_sympify, shape))
         cls._check_special_bounds(flat_list, shape)
@@ -139,8 +138,6 @@ class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray): # type: ign
 class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
 
     def __new__(cls, iterable=None, shape=None, **kwargs):
-        from sympy.utilities.iterables import flatten
-
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         self = object.__new__(cls)
         self._shape = shape

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -114,6 +114,7 @@ from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.multipledispatch import dispatch
 from sympy.utilities.iterables import is_sequence, NotIterable
+from sympy.utilities.misc import filldedent
 
 
 class IndexException(Exception):
@@ -144,7 +145,6 @@ class Indexed(Expr):
     is_Atom = True
 
     def __new__(cls, base, *args, **kw_args):
-        from sympy.utilities.misc import filldedent
         from sympy.tensor.array.ndim_array import NDimArray
         from sympy.matrices.matrices import MatrixBase
 
@@ -283,7 +283,6 @@ class Indexed(Expr):
         >>> B[i, j].shape
         (m, m)
         """
-        from sympy.utilities.misc import filldedent
 
         if self.base.shape:
             return self.base.shape
@@ -641,7 +640,6 @@ class Idx(Expr):
     _diff_wrt = True
 
     def __new__(cls, label, range=None, **kw_args):
-        from sympy.utilities.misc import filldedent
 
         if isinstance(label, str):
             label = Symbol(label, integer=True)

--- a/sympy/testing/randtest.py
+++ b/sympy/testing/randtest.py
@@ -3,6 +3,7 @@
 from random import uniform, Random, randrange, randint
 
 from sympy.core.containers import Tuple
+from sympy.core.function import Derivative
 from sympy.core.numbers import comp, I
 from sympy.core.symbol import Symbol
 from sympy.simplify.simplify import nsimplify
@@ -71,7 +72,6 @@ def test_derivative_numerically(f, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     >>> td(sin(x), x)
     True
     """
-    from sympy.core.function import Derivative
     z0 = random_complex_number(a, b, c, d)
     f1 = f.diff(z).subs(z, z0)
     f2 = Derivative(f, z).doit_numerically(z0)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -11,7 +11,6 @@ import keyword
 import textwrap
 import linecache
 
-from sympy.core.basic import Basic
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import (is_sequence, iterable,
@@ -944,6 +943,7 @@ def _recursive_to_string(doprint, arg):
     lists and tuples. This method ensures that we only call the doprint method of the
     printer with SymPy types (so that the printer safely can use SymPy-methods)."""
     from sympy.matrices.common import MatrixOperations
+    from sympy.core.basic import Basic
 
     if isinstance(arg, (Basic, MatrixOperations)):
         return doprint(arg)
@@ -984,6 +984,7 @@ def lambdastr(args, expr, printer=None, dummify=None):
     """
     # Transforming everything to strings.
     from sympy.matrices import DeferredVector
+    from sympy.core.basic import Basic
     from sympy.core.function import (Derivative, Function)
     from sympy.core.symbol import (Dummy, Symbol)
     from sympy.core.sympify import sympify


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Sort of an alternative solution to #22351 (both can still be merged, but lambdify is no longer directly importing from core).

#### Brief description of what is fixed or changed

Moved "all" core and utilities to the top level.

#### Other comments

It would make sense to move the `deprecated` decorator to `utilities` as this is the one causing cyclic imports at the moment. This will be in a later PR though as the current one really doesn't affect any functionality (just better importing).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
