### PR TITLE
OneArray and ZeroArray shape parameter is now a tuple

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4476,13 +4476,13 @@ def test_sympy__tensor__array__expressions__array_expressions__ArrayElement():
 def test_sympy__tensor__array__expressions__array_expressions__ZeroArray():
     from sympy.tensor.array.expressions.array_expressions import ZeroArray
     m, n, k = symbols("m n k")
-    za = ZeroArray(m, n, k, 2)
+    za = ZeroArray(shape=(m, n, k, 2))
     assert _test_args(za)
 
 def test_sympy__tensor__array__expressions__array_expressions__OneArray():
     from sympy.tensor.array.expressions.array_expressions import OneArray
     m, n, k = symbols("m n k")
-    za = OneArray(m, n, k, 2)
+    za = OneArray(shape=(m, n, k, 2))
     assert _test_args(za)
 
 def test_sympy__tensor__functions__TensorProduct():

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -23,7 +23,7 @@ def array_derive(expr, x):
 
 @array_derive.register(Expr) # type: ignore
 def _(expr: Expr, x: Expr):
-    return ZeroArray(*x.shape)
+    return ZeroArray(x.shape)
 
 
 @array_derive.register(ArrayTensorProduct) # type: ignore
@@ -63,7 +63,7 @@ def _(expr: ArraySymbol, x: Expr):
             ArrayTensorProduct.fromiter(Identity(i) for i in expr.shape),
             [2*i for i in range(len(expr.shape))] + [2*i+1 for i in range(len(expr.shape))]
         )
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(shape=(x.shape + expr.shape))
 
 
 @array_derive.register(MatrixSymbol) # type: ignore
@@ -74,12 +74,12 @@ def _(expr: MatrixSymbol, x: Expr):
             ArrayTensorProduct(Identity(m), Identity(n)),
             [0, 2, 1, 3]
         )
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(shape=(x.shape + expr.shape))
 
 
 @array_derive.register(Identity) # type: ignore
 def _(expr: Identity, x: Expr):
-    return ZeroArray(*(x.shape + expr.shape))
+    return ZeroArray(shape=(x.shape + expr.shape))
 
 
 @array_derive.register(Transpose) # type: ignore

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -568,7 +568,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                 contr_indices.append(((pos2_outer, pos2_inner), (len(args)-1, pos1_inner)))
                 total_rank += 1
                 diag_indices[i] = None
-                args[pos1_outer] = OneArray(arg1.shape[pos1_in2])
+                args[pos1_outer] = OneArray(shape=[arg1.shape[pos1_in2]])
                 replaced[pos1_outer] = True
             elif arg2.shape[pos2_in2] == 1:
                 if arg2.shape[pos2_inner] != 1:
@@ -579,7 +579,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                 contr_indices.append(((pos1_outer, pos1_inner), (len(args)-1, pos2_inner)))
                 total_rank += 1
                 diag_indices[i] = None
-                args[pos2_outer] = OneArray(arg2.shape[pos2_in2])
+                args[pos2_outer] = OneArray(shape=[arg2.shape[pos2_in2]])
                 replaced[pos2_outer] = True
         diag_indices_new = [i for i in diag_indices if i is not None]
         cumul = list(accumulate([0] + [get_rank(arg) for arg in args]))
@@ -728,8 +728,8 @@ def identify_removable_identity_matrices(expr):
                     counted = editor.count_args_with_index(ind)
                     if counted == 1:
                         # Identity matrix contracted only on one index with itself,
-                        # transform to a OneArray(k) element:
-                        editor.insert_after(arg_with_ind, OneArray(k))
+                        # transform to a OneArray(shape=[k]) element:
+                        editor.insert_after(arg_with_ind, OneArray(shape=[k]))
                         editor.args_with_ind.remove(arg_with_ind)
                         flag = True
                         break

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -60,31 +60,31 @@ def test_array_symbol_and_element():
 
 
 def test_zero_array():
-    assert ZeroArray() == 0
-    assert ZeroArray().is_Integer
+    assert ZeroArray(shape=()) == 0
+    assert ZeroArray(shape=()).is_Integer
 
-    za = ZeroArray(3, 2, 4)
+    za = ZeroArray(shape=(3, 2, 4))
     assert za.shape == (3, 2, 4)
     za_e = za.as_explicit()
     assert za_e.shape == (3, 2, 4)
 
     m, n, k = symbols("m n k")
-    za = ZeroArray(m, n, k, 2)
+    za = ZeroArray(shape=(m, n, k, 2))
     assert za.shape == (m, n, k, 2)
     raises(ValueError, lambda: za.as_explicit())
 
 
 def test_one_array():
-    assert OneArray() == 1
-    assert OneArray().is_Integer
+    assert OneArray(shape=()) == 1
+    assert OneArray(shape=()).is_Integer
 
-    oa = OneArray(3, 2, 4)
+    oa = OneArray(shape=(3, 2, 4))
     assert oa.shape == (3, 2, 4)
     oa_e = oa.as_explicit()
     assert oa_e.shape == (3, 2, 4)
 
     m, n, k = symbols("m n k")
-    oa = OneArray(m, n, k, 2)
+    oa = OneArray(shape=(m, n, k, 2))
     assert oa.shape == (m, n, k, 2)
     raises(ValueError, lambda: oa.as_explicit())
 
@@ -281,7 +281,7 @@ def test_arrayexpr_split_multiple_contractions():
     X = MatrixSymbol("X", k, k)
 
     cg = ArrayContraction(ArrayTensorProduct(A.T, a, b, b.T, (A*X*b).applyfunc(cos)), (1, 2, 8), (5, 6, 9))
-    expected = ArrayContraction(ArrayTensorProduct(A.T, DiagMatrix(a), OneArray(1), b, b.T, (A*X*b).applyfunc(cos)), (1, 3), (2, 9), (6, 7, 10))
+    expected = ArrayContraction(ArrayTensorProduct(A.T, DiagMatrix(a), OneArray(shape=[1]), b, b.T, (A*X*b).applyfunc(cos)), (1, 3), (2, 9), (6, 7, 10))
     assert cg.split_multiple_contractions().dummy_eq(expected)
 
     # Check no overlap of lines:
@@ -498,29 +498,29 @@ def test_arrayexpr_nested_array_elementwise_add():
 
 
 def test_arrayexpr_array_expr_zero_array():
-    za1 = ZeroArray(k, l, m, n)
+    za1 = ZeroArray(shape=(k, l, m, n))
     zm1 = ZeroMatrix(m, n)
 
-    za2 = ZeroArray(k, m, m, n)
+    za2 = ZeroArray(shape=(k, m, m, n))
     zm2 = ZeroMatrix(m, m)
     zm3 = ZeroMatrix(k, k)
 
-    assert ArrayTensorProduct(M, N, za1) == ZeroArray(k, k, k, k, k, l, m, n)
-    assert ArrayTensorProduct(M, N, zm1) == ZeroArray(k, k, k, k, m, n)
+    assert ArrayTensorProduct(M, N, za1) == ZeroArray(shape=(k, k, k, k, k, l, m, n))
+    assert ArrayTensorProduct(M, N, zm1) == ZeroArray(shape=(k, k, k, k, m, n))
 
-    assert ArrayContraction(za1, (3,)) == ZeroArray(k, l, m)
-    assert ArrayContraction(zm1, (1,)) == ZeroArray(m)
-    assert ArrayContraction(za2, (1, 2)) == ZeroArray(k, n)
+    assert ArrayContraction(za1, (3,)) == ZeroArray(shape=(k, l, m))
+    assert ArrayContraction(zm1, (1,)) == ZeroArray(shape=(m,))
+    assert ArrayContraction(za2, (1, 2)) == ZeroArray(shape=(k, n))
     assert ArrayContraction(zm2, (0, 1)) == 0
 
-    assert ArrayDiagonal(za2, (1, 2)) == ZeroArray(k, n, m)
-    assert ArrayDiagonal(zm2, (0, 1)) == ZeroArray(m)
+    assert ArrayDiagonal(za2, (1, 2)) == ZeroArray(shape=(k, n, m))
+    assert ArrayDiagonal(zm2, (0, 1)) == ZeroArray(shape=(m,))
 
-    assert PermuteDims(za1, [2, 1, 3, 0]) == ZeroArray(m, l, n, k)
-    assert PermuteDims(zm1, [1, 0]) == ZeroArray(n, m)
+    assert PermuteDims(za1, [2, 1, 3, 0]) == ZeroArray(shape=(m, l, n, k))
+    assert PermuteDims(zm1, [1, 0]) == ZeroArray(shape=(n, m))
 
     assert ArrayAdd(za1) == za1
-    assert ArrayAdd(zm1) == ZeroArray(m, n)
+    assert ArrayAdd(zm1) == ZeroArray(shape=(m, n))
     tp1 = ArrayTensorProduct(MatrixSymbol("A", k, l), MatrixSymbol("B", m, n))
     assert ArrayAdd(tp1, za1) == tp1
     tp2 = ArrayTensorProduct(MatrixSymbol("C", k, l), MatrixSymbol("D", m, n))
@@ -614,8 +614,8 @@ def test_array_expressions_no_normalization():
     expr = ArrayAdd(ArrayAdd(M, N), P, normalize=False)
     assert str(expr) == "ArrayAdd(ArrayAdd(M, N), P)"
 
-    expr = ArrayAdd(M, ZeroArray(k, k), N, normalize=False)
-    assert str(expr) == "ArrayAdd(M, ZeroArray(k, k), N)"
+    expr = ArrayAdd(M, ZeroArray(shape=(k, k)), N, normalize=False)
+    assert str(expr) == "ArrayAdd(M, ZeroArray((k, k)), N)"
 
     # PermuteDims:
 

--- a/sympy/tensor/array/expressions/tests/test_as_explicit.py
+++ b/sympy/tensor/array/expressions/tests/test_as_explicit.py
@@ -9,14 +9,14 @@ from sympy.testing.pytest import raises
 
 def test_array_as_explicit_call():
 
-    assert ZeroArray(3, 2, 4).as_explicit() == ImmutableDenseNDimArray.zeros(3, 2, 4)
-    assert OneArray(3, 2, 4).as_explicit() == ImmutableDenseNDimArray([1 for i in range(3*2*4)]).reshape(3, 2, 4)
+    assert ZeroArray(shape=(3, 2, 4)).as_explicit() == ImmutableDenseNDimArray.zeros(3, 2, 4)
+    assert OneArray(shape=(3, 2, 4)).as_explicit() == ImmutableDenseNDimArray([1 for i in range(3*2*4)]).reshape(3, 2, 4)
 
     k = Symbol("k")
     X = ArraySymbol("X", (k, 3, 2))
     raises(ValueError, lambda: X.as_explicit())
-    raises(ValueError, lambda: ZeroArray(k, 2, 3).as_explicit())
-    raises(ValueError, lambda: OneArray(2, k, 2).as_explicit())
+    raises(ValueError, lambda: ZeroArray(shape=(k, 2, 3)).as_explicit())
+    raises(ValueError, lambda: OneArray(shape=(2, k, 2)).as_explicit())
 
     A = ArraySymbol("A", (3, 3))
     B = ArraySymbol("B", (3, 3))


### PR DESCRIPTION
The `shape` parameter of `OneArray` and `ZeroArray` is now a single positional argument, as to match the new interface of `ArraySymbol` (#22324). Note that this matches the signature of e.g. [`numpy.ones()`](https://numpy.org/doc/stable/reference/generated/numpy.ones.html).

See also #22321.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Changed the signature of `OneArray` and `ZeroArray` from `OneArray(*shape)` to `OneArray(shape)`.

<!-- END RELEASE NOTES -->
