### PR TITLE
Allow taking a single index from ArraySymbol

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1909,9 +1909,9 @@ class LatexPrinter(Printer):
         return self._print(expr.name)
 
     def _print_ArrayElement(self, expr):
-        return "{{%s}_{%s}}" % (
-            self.parenthesize(expr.name, PRECEDENCE["Func"], True),
-            ", ".join([f"{self._print(i)}" for i in expr.indices]))
+        name = self.parenthesize(expr.name, PRECEDENCE["Func"], True)
+        indices = ", ".join([f"{self._print(i)}" for i in expr.indices])
+        return "{{%s}_{%s}}" % (name, indices)
 
     def _print_UniversalSet(self, expr):
         return r"\mathbb{U}"

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -491,8 +491,9 @@ class StrPrinter(Printer):
         return self._print(expr.name)
 
     def _print_ArrayElement(self, expr):
-        return "%s[%s]" % (
-            self.parenthesize(expr.name, PRECEDENCE["Func"], True), ", ".join([self._print(i) for i in expr.indices]))
+        name = self.parenthesize(expr.name, PRECEDENCE["Func"], True)
+        indices = ", ".join([f"{self._print(i)}" for i in expr.indices])
+        return "%s[%s]" % (name, indices)
 
     def _print_PermutationGroup(self, expr):
         p = ['    %s' % self._print(a) for a in expr.args]

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2834,9 +2834,17 @@ def test_pickleable():
     import pickle
     assert pickle.loads(pickle.dumps(latex)) is latex
 
-def test_printing_latex_array_expressions():
-    assert latex(ArraySymbol("A", (2, 3, 4))) == "A"
-    assert latex(ArrayElement("A", (2, 1/(1-x), 0))) == "{{A}_{2, \\frac{1}{1 - x}, 0}}"
+
+def test_printing_ArraySymbol():
+    A = ArraySymbol("A", shape=(2, 3, 4))
+    assert latex(A) == "A"
+
+
+def test_printing_ArrayElement():
+    element = ArrayElement("A", indices=(2, 1 / (1 - x), 0))
+    assert latex(element) == R"{{A}_{2, \frac{1}{1 - x}, 0}}"
+
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)
-    assert latex(ArrayElement(M*N, [x, 0])) == "{{\\left(M N\\right)}_{x, 0}}"
+    element = ArrayElement(M * N, indices=(x, 0))
+    assert latex(element) == R"{{\left(M N\right)}_{x, 0}}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2841,8 +2841,8 @@ def test_printing_ArraySymbol():
 
 
 def test_printing_ArrayElement():
-    element = ArrayElement("A", indices=(2, 1 / (1 - x), 0))
-    assert latex(element) == R"{{A}_{2, \frac{1}{1 - x}, 0}}"
+    element = ArrayElement("A", indices=(2, 2 * m + 1, 0))
+    assert latex(element) == "{{A}_{2, 2 m + 1, 0}}"
 
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -48,6 +48,7 @@ from sympy.printing import sstr, sstrrepr, StrPrinter
 from sympy.physics.quantum.trace import Tr
 
 x, y, z, w, t = symbols('x,y,z,w,t')
+k, m, n = symbols("k m n", integer=True)
 d = Dummy('d')
 
 
@@ -1154,8 +1155,8 @@ def test_printing_ArraySymbol():
 
 
 def test_printing_ArrayElement():
-    element = ArrayElement("A", indices=(2, 1 / (1 - x), 0))
-    assert sstr(element) == "A[2, 1/(1 - x), 0]"
+    element = ArrayElement("A", indices=(2, 2 * m + 1, 0))
+    assert sstr(element) == "A[2, 2*m + 1, 0]"
 
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1147,9 +1147,17 @@ def test_Predicate():
 def test_AppliedPredicate():
     assert sstr(Q.even(x)) == 'Q.even(x)'
 
-def test_printing_str_array_expressions():
-    assert sstr(ArraySymbol("A", (2, 3, 4))) == "A"
-    assert sstr(ArrayElement("A", (2, 1/(1-x), 0))) == "A[2, 1/(1 - x), 0]"
+
+def test_printing_ArraySymbol():
+    A = ArraySymbol("A", shape=(2, 3, 4))
+    assert sstr(A) == "A"
+
+
+def test_printing_ArrayElement():
+    element = ArrayElement("A", indices=(2, 1 / (1 - x), 0))
+    assert sstr(element) == "A[2, 1/(1 - x), 0]"
+
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)
-    assert sstr(ArrayElement(M*N, [x, 0])) == "(M*N)[x, 0]"
+    element = ArrayElement(M * N, indices=(x, 0))
+    assert sstr(element) == "(M*N)[x, 0]"

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -94,6 +94,8 @@ class ArrayElement(_ArrayExpr):
         if hasattr(name, "shape"):
             if any((i >= s) == True for i, s in zip(indices, name.shape)):
                 raise IndexError("Some of the indices are out of bounds of the shape")
+        if any((i.is_integer) == False for i in indices):
+            raise IndexError("Not all indices are integer")
         if any((i < 0) == True for i in indices):
             raise IndexError("Some of the indices are negative")
         obj = Expr.__new__(cls, name, indices)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -67,6 +67,11 @@ class ArraySymbol(_ArrayExpr):
             indices = key
         else:
             indices = (key,)
+        if len(indices) != len(self.shape):
+            raise ValueError(
+                f"Number of indices ({len(indices)}) is not the same"
+                f" as shape size ({len(self.shape)})."
+            )
         return ArrayElement(self, indices)
 
     def as_explicit(self):

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -3,9 +3,7 @@ from collections import defaultdict, Counter
 from functools import reduce
 import itertools
 from itertools import accumulate
-from typing import Optional, List, Dict as tDict, Tuple as tTuple
-
-import typing
+from typing import Iterable, Optional, List, Dict as tDict, Tuple as tTuple, Union as tUnion
 
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -40,7 +38,7 @@ class ArraySymbol(_ArrayExpr):
     Symbol representing an array expression
     """
 
-    def __new__(cls, symbol, shape: typing.Iterable) -> "ArraySymbol":
+    def __new__(cls, symbol, shape: Iterable) -> "ArraySymbol":
         if isinstance(symbol, str):
             symbol = Symbol(symbol)
         # symbol = _sympify(symbol)
@@ -1447,7 +1445,7 @@ class _EditArrayContraction:
     by calling the ``.to_array_contraction()`` method.
     """
 
-    def __init__(self, base_array: typing.Union[ArrayContraction, ArrayDiagonal, ArrayTensorProduct]):
+    def __init__(self, base_array: tUnion[ArrayContraction, ArrayDiagonal, ArrayTensorProduct]):
 
         expr: Basic
         diagonalized: tTuple[tTuple[int, ...], ...]
@@ -1681,7 +1679,7 @@ class _EditArrayContraction:
         self._track_permutation[index_destination].extend(self._track_permutation[index_element]) # type: ignore
         self._track_permutation.pop(index_element) # type: ignore
 
-    def get_absolute_free_range(self, arg: _ArgE) -> typing.Tuple[int, int]:
+    def get_absolute_free_range(self, arg: _ArgE) -> tTuple[int, int]:
         """
         Return the range of the free indices of the arg as absolute positions
         among all free indices.
@@ -1694,7 +1692,7 @@ class _EditArrayContraction:
             counter += number_free_indices
         raise IndexError("argument not found")
 
-    def get_absolute_range(self, arg: _ArgE) -> typing.Tuple[int, int]:
+    def get_absolute_range(self, arg: _ArgE) -> tTuple[int, int]:
         """
         Return the absolute range of indices for arg, disregarding dummy
         indices.

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -93,9 +93,9 @@ class ArrayElement(_ArrayExpr):
         indices = _sympify(tuple(indices))
         if hasattr(name, "shape"):
             if any((i >= s) == True for i, s in zip(indices, name.shape)):
-                raise ValueError("shape is out of bounds")
+                raise IndexError("Some of the indices are out of bounds of the shape")
         if any((i < 0) == True for i in indices):
-            raise ValueError("shape contains negative values")
+            raise IndexError("Some of the indices are negative")
         obj = Expr.__new__(cls, name, indices)
         return obj
 

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -84,19 +84,20 @@ class TestArraySymbol:
 
     def test_getitem(self):
         A = ArraySymbol("A", shape=(m, n))
-        assert A[0] == ArrayElement(A, indices=(0,))
-        assert A[k] == ArrayElement(A, indices=(k,))
         assert A[i, j] == ArrayElement(A, indices=(i, j))
         assert A[9, 7] == ArrayElement(A, indices=(9, 7))
         A = ArraySymbol("A", shape=(3, 2, 4))
-        assert A[i, j] == ArrayElement(A, indices=(i, j))
         assert A[i, j, k] == ArrayElement(A, indices=(i, j, k))
-        assert A[2, 1] == ArrayElement(A, indices=(2, 1))
         assert A[2, 1, 3] == ArrayElement(A, indices=(2, 1, 3))
         with raises(ValueError, match="shape is out of bounds"):
             A[4, 1, 3]
         with raises(ValueError, match="shape contains negative values"):
-            A[0, -1]
+            A[0, -1, 0]
+
+    def test_getitem_exception(self):
+        A = ArraySymbol("A", shape=(m, n))
+        with raises(ValueError, match=r"Number of indices .* not the same as shape"):
+            A[0]
 
 
 def test_array_symbol_and_element():

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -57,6 +57,7 @@ class TestArrayElement:
         test_cases = (  # @pytest.mark.parametrize
             ((7, 0), r"Some of the indices are out of bounds of the shape"),
             ((-1, 0), r"Some of the indices are negative"),
+            ((3.14, 0), r"Not all indices are integer"),
         )
         for indices, match in test_cases:
             A = ArraySymbol("A", shape=(4, 4))

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -53,13 +53,14 @@ class TestArrayElement:
             assert element.name is A
             assert element.indices == expected
 
-    def test_construction_errors_from_array_symbol(self):
+    def test_construct_errors_from_array_symbol(self):
         test_cases = (  # @pytest.mark.parametrize
-            ([4, 4], (7, 0), ValueError, r"shape is out of bounds"),
+            ((7, 0), r"Some of the indices are out of bounds of the shape"),
+            ((-1, 0), r"Some of the indices are negative"),
         )
-        for shape, indices, exception, match in test_cases:
-            A = ArraySymbol("A", shape)
-            with raises(exception, match=match):
+        for indices, match in test_cases:
+            A = ArraySymbol("A", shape=(4, 4))
+            with raises(IndexError, match=match):
                 ArrayElement(A, indices=indices)
 
 

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -39,6 +39,7 @@ class TestArrayElement:
     def test_construct_from_array_symbol(self):
         test_cases = (  # @pytest.mark.parametrize
             # shapeless
+            ([], (0,), (0,)),
             ([], (1, 2), (1, 2)),
             ([], (i, j), (i, j)),
             # specific shape
@@ -83,6 +84,8 @@ class TestArraySymbol:
 
     def test_getitem(self):
         A = ArraySymbol("A", shape=(m, n))
+        assert A[0] == ArrayElement(A, indices=(0,))
+        assert A[k] == ArrayElement(A, indices=(k,))
         assert A[i, j] == ArrayElement(A, indices=(i, j))
         assert A[9, 7] == ArrayElement(A, indices=(9, 7))
         A = ArraySymbol("A", shape=(3, 2, 4))


### PR DESCRIPTION
_Extracted from #22265_

#### Brief description of what is fixed or changed

It's now possible to take a single index from an `ArraySymbol`:

```python
>>> from sympy import ArraySymbol, symbols
>>> m, n = symbols("m n")
>>> A = ArraySymbol("A", shape=(m, n))
>>> A[0]
A[0]
```

See also #22321.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `ArraySymbol` now accepts a single index.
  * Number of indices in an `ArraySymbol` has to be the same as its dimension.
<!-- END RELEASE NOTES -->
