### PR TITLE
codegen/ast: references to statement class removed

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -53,7 +53,6 @@ AST Type Tree
        |        |--->ContinueToken
        |        |--->NoneToken
        |
-       |--->Statement
        |--->Return
 
 

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -250,10 +250,6 @@ class C89CodePrinter(CodePrinter):
     def _rate_index_position(self, p):
         return p*5
 
-    def _get_statement(self, codestring):
-        """ Get code string as a statement - i.e. ending with a semicolon. """
-        return codestring if codestring.endswith(';') else codestring + ';'
-
     def _get_comment(self, text):
         return "// {}".format(text)
 


### PR DESCRIPTION
The codegen/ast module docstring describes the `Statement class`,
but it is not implemented. This is removed together with the
`_print_Statement` method of the codeprinters considering the class
does not exist.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes  #22375

#### Brief description of what is fixed or changed
The codegen/ast module docstring describes the `Statement class`,
but it is not implemented. This is removed together with the
`_print_Statement` method of the codeprinters considering the class
does not exist.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
