### PR TITLE
codegen/ast: references to statement class removed

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -54,7 +54,6 @@ AST Type Tree
        |        |--->NoneToken
        |
        |--->Statement
-       |--->Return
 
 
 Predefined types

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -53,7 +53,7 @@ AST Type Tree
        |        |--->ContinueToken
        |        |--->NoneToken
        |
-       |--->Statement
+       |--->Return
 
 
 Predefined types

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -391,10 +391,6 @@ class CodePrinter(StrPrinter):
     def _print_Variable(self, expr):
         return self._print(expr.symbol)
 
-    def _print_Statement(self, expr):
-        arg, = expr.args
-        return self._get_statement(self._print(arg))
-
     def _print_Symbol(self, expr):
 
         name = super()._print_Symbol(expr)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes  #22375

#### Brief description of what is fixed or changed
The codegen/ast module docstring describes the `Statement class`,
but it is not implemented. This is removed together with the
`_print_Statement` method of the codeprinters considering the class
does not exist.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
