### PR TITLE
import * as t* from typing to avoid clash

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -51,7 +51,7 @@ pi(C, Q)
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 import string
 
@@ -85,16 +85,16 @@ phi, chi, psi, omega = symbols('phi, chi, psi, omega')
 # This is mostly for diagnosing SymPy's namespace during SymPy development.
 
 _latin = list(string.ascii_letters)
-# OSINEQ should not be imported as they clash; gamma, pi and zeta clash, too
+# QOSINE should not be imported as they clash; gamma, pi and zeta clash, too
 _greek = list(greeks) # make a copy, so we can mutate it
 # Note: We import lamda since lambda is a reserved keyword in Python
 _greek.remove("lambda")
 _greek.append("lamda")
 
-ns: Dict[str, Any] = {}
+ns: tDict[str, Any] = {}
 exec('from sympy import *', ns)
-_clash1: Dict[str, Any] = {}
-_clash2: Dict[str, Any] = {}
+_clash1: tDict[str, Any] = {}
+_clash2: tDict[str, Any] = {}
 while ns:
     _k, _ = ns.popitem()
     if _k in _greek:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable
+from typing import Dict as tDict, Callable
 
 from sympy.core import S, Add, Expr, Basic, Mul, Pow, Rational
 from sympy.core.logic import fuzzy_not
@@ -401,4 +401,4 @@ handlers_dict = {
     'arg': refine_arg,
     'sign': refine_sign,
     'MatrixElement': refine_matrixelement
-}  # type: Dict[str, Callable[[Expr, Boolean], Expr]]
+}  # type: tDict[str, Callable[[Expr, Boolean], Expr]]

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -124,7 +124,7 @@ There is a function constructing a loop (or a complete function) like this in
 
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict as tDict, List
 
 from collections import defaultdict
 
@@ -177,7 +177,7 @@ class Token(Basic):
     """
 
     __slots__ = ()
-    defaults = {}  # type: Dict[str, Any]
+    defaults = {}  # type: tDict[str, Any]
     not_in_args = []  # type: List[str]
     indented_args = ['body']
 
@@ -931,7 +931,7 @@ class Node(Token):
 
     __slots__ = ('attrs',)
 
-    defaults = {'attrs': Tuple()}  # type: Dict[str, Any]
+    defaults = {'attrs': Tuple()}  # type: tDict[str, Any]
 
     _construct_attrs = staticmethod(_mk_Tuple)
 

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict as tDict, List
 
 from sympy.core import S
 from sympy.core.expr import Expr
@@ -109,7 +109,7 @@ def _parse_symbols(symbols):
 #                          FREE GROUP                                        #
 ##############################################################################
 
-_free_group_cache = {}  # type: Dict[int, FreeGroup]
+_free_group_cache = {}  # type: tDict[int, FreeGroup]
 
 class FreeGroup(DefaultPrinting):
     """

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -3,7 +3,7 @@ Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
 
-from typing import Tuple
+from typing import Tuple as tTuple
 
 import math
 
@@ -1428,7 +1428,7 @@ def evalf(x, prec, options):
 class EvalfMixin:
     """Mixin class adding evalf capabililty."""
 
-    __slots__ = ()  # type: Tuple[str, ...]
+    __slots__ = ()  # type: tTuple[str, ...]
 
     def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False):
         """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -30,7 +30,7 @@ There are three types of functions implemented in SymPy:
 
 """
 
-from typing import Any, Dict as tDict, Optional, Set as tSet, Tuple as tTuple, Union
+from typing import Any, Dict as tDict, Optional, Set as tSet, Tuple as tTuple, Union as tUnion
 from collections.abc import Iterable
 
 from .add import Add
@@ -632,7 +632,7 @@ class Function(Application, Expr):
 
         return fuzzy_not(type(self).is_singular(arg.subs(x, a)))
 
-    _singularities = None  # type: Union[FuzzyBool, tTuple[Expr, ...]]
+    _singularities = None  # type: tUnion[FuzzyBool, tTuple[Expr, ...]]
 
     @classmethod
     def is_singular(cls, a):

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -7,11 +7,11 @@ at present this is mainly needed for facts.py, feel free however to improve
 this stuff for general purpose.
 """
 
-from typing import Dict, Type, Union
+from typing import Dict as tDict, Type, Union as tUnion
 
 
 # Type of a fuzzy bool
-FuzzyBool = Union[bool, None]
+FuzzyBool = tUnion[bool, None]
 
 
 def _torf(args):
@@ -223,7 +223,7 @@ def fuzzy_nand(args):
 class Logic:
     """Logical expression"""
     # {} 'op' -> LogicClass
-    op_2class = {}  # type: Dict[str, Type[Logic]]
+    op_2class = {}  # type: tDict[str, Type[Logic]]
 
     def __new__(cls, *args):
         obj = object.__new__(cls)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -5,7 +5,7 @@ import math
 import re as regex
 import sys
 from functools import lru_cache
-from typing import Set
+from typing import Set as tSet
 
 from .containers import Tuple
 from .sympify import (SympifyError, converter, sympify, _convert_numpy_types, _sympify,
@@ -2516,7 +2516,7 @@ class AlgebraicNumber(Expr):
     # Optional alias symbol is not free.
     # Actually, alias should be a Str, but some methods
     # expect that it be an instance of Expr.
-    free_symbols: Set[Basic] = set()
+    free_symbols: tSet[Basic] = set()
 
     def __new__(cls, expr, coeffs=None, alias=None, **args):
         """Construct a new algebraic number. """

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -1,5 +1,5 @@
 from operator import attrgetter
-from typing import Tuple, Type
+from typing import Tuple as tTuple, Type
 from collections import defaultdict
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -39,7 +39,7 @@ class AssocOp(Basic):
 
     # for performance reason, we don't let is_commutative go to assumptions,
     # and keep it right here
-    __slots__ = ('is_commutative',)  # type: Tuple[str, ...]
+    __slots__ = ('is_commutative',)  # type: tTuple[str, ...]
 
     _args_type = None  # type: Type[Basic]
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Type
+from typing import Dict as tDict, Union as tUnion, Type
 
 from .basic import Atom, Basic
 from .sorting import ordered
@@ -85,7 +85,7 @@ class Relational(Boolean, EvalfMixin):
     """
     __slots__ = ()
 
-    ValidRelationOperator = {}  # type: Dict[Union[str, None], Type[Relational]]
+    ValidRelationOperator = {}  # type: tDict[tUnion[str, None], Type[Relational]]
 
     is_Relational = True
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -2,7 +2,7 @@
 
 import typing
 if typing.TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Type
+    from typing import Any, Callable, Dict as tDict, Type
 
 from inspect import getmro
 import string
@@ -26,7 +26,7 @@ class SympifyError(ValueError):
 
 
 # See sympify docstring.
-converter = {}  # type: Dict[Type[Any], Callable[[Any], Basic]]
+converter = {}  # type: tDict[Type[Any], Callable[[Any], Basic]]
 
 
 class CantSympify:

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1,4 +1,4 @@
-from typing import Any, Set
+from typing import Any, Set as tSet
 
 from functools import reduce
 from itertools import permutations
@@ -971,7 +971,7 @@ class BaseScalarField(Expr):
         return simplify(coords[self._index]).doit()
 
     # XXX Workaround for limitations on the content of args
-    free_symbols = set()  # type: Set[Any]
+    free_symbols = set()  # type: tSet[Any]
 
     def doit(self):
         return self

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -1,5 +1,5 @@
 import os
-from typing import Tuple, Type
+from typing import Tuple as tTuple, Type
 
 import mpmath.libmp as mlib
 
@@ -78,7 +78,7 @@ else:
 # unrecognised value). The two blocks below define the values exported by this
 # module in each case.
 #
-SYMPY_INTS: Tuple[Type, ...]
+SYMPY_INTS: tTuple[Type, ...]
 
 if gmpy is not None:
 

--- a/sympy/external/pythonmpq.py
+++ b/sympy/external/pythonmpq.py
@@ -35,7 +35,7 @@ from math import gcd
 from decimal import Decimal
 from fractions import Fraction
 import sys
-from typing import Tuple, Type
+from typing import Tuple as tTuple, Type
 
 
 # Used for __hash__
@@ -352,7 +352,7 @@ class PythonMPQ:
         else:
             return NotImplemented
 
-    _compatible_types: Tuple[Type, ...] = ()
+    _compatible_types: tTuple[Type, ...] = ()
 
 #
 # These are the types that PythonMPQ will interoperate with for operations

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -7,7 +7,7 @@ Factorials, binomial coefficients and related functions are located in
 the separate 'factorials' module.
 """
 
-from typing import Callable, Dict
+from typing import Callable, Dict as tDict
 
 from sympy.core import S, Symbol, Add, Dummy
 from sympy.core.cache import cacheit
@@ -817,7 +817,7 @@ class harmonic(Function):
 
     # Generate one memoized Harmonic number-generating function for each
     # order and store it in a dictionary
-    _functions = {}  # type: Dict[Integer, Callable[[int], Rational]]
+    _functions = {}  # type: tDict[Integer, Callable[[int], Rational]]
 
     @classmethod
     def eval(cls, n, m=None):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple as tTuple
 
 from sympy.core.add import Add
 from sympy.core.basic import sympify, cacheit
@@ -2049,7 +2049,7 @@ class sinc(Function):
 
 class InverseTrigonometricFunction(Function):
     """Base class for inverse trigonometric functions."""
-    _singularities = (S.One, S.NegativeOne, S.Zero, S.ComplexInfinity)  # type: Tuple[Expr, ...]
+    _singularities = (S.One, S.NegativeOne, S.Zero, S.ComplexInfinity)  # type: tTuple[Expr, ...]
 
     @staticmethod
     def _asin_table():

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict as tDict, List
 
 from itertools import permutations
 from functools import reduce
@@ -87,7 +87,7 @@ def components(f, x):
     return result
 
 # name -> [] of symbols
-_symbols_cache = {}  # type: Dict[str, List[Dummy]]
+_symbols_cache = {}  # type: tDict[str, List[Dummy]]
 
 
 # NB @cacheit is not convenient here

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -26,7 +26,7 @@ The main references for this are:
     Gordon and Breach Science Publisher
 """
 
-from typing import Dict, Tuple as tTuple
+from typing import Dict as tDict, Tuple as tTuple
 
 from sympy import SYMPY_DEBUG
 from sympy.core import S, Expr
@@ -571,7 +571,7 @@ def _inflate_fox_h(g, a):
     bs = [(n + 1)/p for n in range(p)]
     return D, meijerg(g.an, g.aother, g.bm, list(g.bother) + bs, z)
 
-_dummies = {}  # type: Dict[tTuple[str, str], Dummy]
+_dummies = {}  # type: tDict[tTuple[str, str], Dummy]
 
 
 def _dummy(name, token, expr, **kwargs):

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -2,7 +2,7 @@
     be displayed in the sphinx documentation. """
 
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any, Dict as tDict, List, Tuple as tTuple, Type
 
 from sympy.integrals.meijerint import _create_lookup_table
 from sympy.core.add import Add
@@ -10,7 +10,7 @@ from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
 from sympy.printing.latex import latex
 
-t = {}  # type: Dict[Tuple[Type, ...], List[Any]]
+t = {}  # type: tDict[tTuple[Type, ...], List[Any]]
 _create_lookup_table(t)
 
 doc = ""

--- a/sympy/multipledispatch/core.py
+++ b/sympy/multipledispatch/core.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict as tDict, Any
 
 import inspect
 
@@ -6,7 +6,7 @@ from .dispatcher import Dispatcher, MethodDispatcher, ambiguity_warn
 
 # XXX: This parameter to dispatch isn't documented and isn't used anywhere in
 # sympy. Maybe it should just be removed.
-global_namespace = dict()  # type: Dict[str, Any]
+global_namespace = dict()  # type: tDict[str, Any]
 
 
 def dispatch(*types, namespace=global_namespace, on_ambiguity=ambiguity_warn):

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Set as tSet
 
 from warnings import warn
 import inspect
@@ -71,7 +71,7 @@ def ambiguity_register_error_ignore_dup(dispatcher, ambiguities):
 ###
 
 
-_unresolved_dispatchers = set() # type: Set[Dispatcher]
+_unresolved_dispatchers = set() # type: tSet[Dispatcher]
 _resolve = [True]
 
 

--- a/sympy/multipledispatch/tests/test_core.py
+++ b/sympy/multipledispatch/tests/test_core.py
@@ -1,11 +1,11 @@
-from typing import Dict, Any
+from typing import Dict as tDict, Any
 
 from sympy.multipledispatch import dispatch
 from sympy.multipledispatch.conflict import AmbiguityWarning
 from sympy.testing.pytest import raises, warns
 from functools import partial
 
-test_namespace = dict()  # type: Dict[str, Any]
+test_namespace = dict()  # type: tDict[str, Any]
 
 orig_dispatch = dispatch
 dispatch = partial(dispatch, namespace=test_namespace)

--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict as tDict, Tuple as tTuple
 
 from sympy.ntheory import qs
 from sympy.ntheory.qs import SievePolynomial, \
@@ -50,7 +50,7 @@ assert _check_smoothness(9645, factor_base) == (5, False)
 assert _check_smoothness(210313, factor_base)[0][0:15] == [0, 0, 0, 0, 0, 0, 0,\
                         0, 0, 1, 0, 0, 1, 0, 1]
 assert _check_smoothness(210313, factor_base)[1] == True
-partial_relations = {} # type: Dict[int, Tuple[int, int]]
+partial_relations = {} # type: tDict[int, tTuple[int, int]]
 smooth_relation, partial_relation = _trial_division_stage(n, M, factor_base,\
                                                           sieve_array, sieve_poly,\
                                                           partial_relations, ERROR_TERM=25*2**10)

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict as tDict, Tuple as tTuple
 
 from itertools import product
 import re
@@ -142,13 +142,13 @@ class MathematicaParser:
                 '''
 
     # will contain transformed CORRESPONDENCES dictionary
-    TRANSLATIONS = {}  # type: Dict[Tuple[str, int], Dict[str, Any]]
+    TRANSLATIONS = {}  # type: tDict[tTuple[str, int], tDict[str, Any]]
 
     # cache for a raw users' translation dictionary
-    cache_original = {}  # type: Dict[Tuple[str, int], Dict[str, Any]]
+    cache_original = {}  # type: tDict[tTuple[str, int], tDict[str, Any]]
 
     # cache for a compiled users' translation dictionary
-    cache_compiled = {}  # type: Dict[Tuple[str, int], Dict[str, Any]]
+    cache_compiled = {}  # type: tDict[tTuple[str, int], tDict[str, Any]]
 
     @classmethod
     def _initialize_class(cls):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -14,7 +14,7 @@ Todo:
 * Write some tests/examples!
 """
 
-from typing import List, Dict
+from typing import List, Dict as tDict
 
 from sympy.core.mul import Mul
 from sympy.external import import_module
@@ -56,7 +56,7 @@ class CircuitPlot:
     not_radius = 0.15
     swap_delta = 0.05
     labels = []  # type: List[str]
-    inits = {}  # type: Dict[str, str]
+    inits = {}  # type: tDict[str, str]
     label_buffer = 0.5
 
     def __init__(self, c, nqubits, **kwargs):

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -3,7 +3,7 @@
 TODO:
 * Address Issue 2251, printing of spin states
 """
-from typing import Dict, Any
+from typing import Dict as tDict, Any
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.cg import CG, Wigner3j, Wigner6j, Wigner9j
@@ -40,7 +40,7 @@ from sympy.printing.latex import latex
 MutableDenseMatrix = Matrix
 
 
-ENV = {}  # type: Dict[str, Any]
+ENV = {}  # type: tDict[str, Any]
 exec('from sympy import *', ENV)
 exec('from sympy.physics.quantum import *', ENV)
 exec('from sympy.physics.quantum.cg import *', ENV)

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -2,7 +2,7 @@
 Unit system for physical quantities; include definition of constants.
 """
 
-from typing import Dict
+from typing import Dict as tDict
 
 from sympy.core.add import Add
 from sympy.core.function import (Derivative, Function)
@@ -26,7 +26,7 @@ class UnitSystem(_QuantityMapper):
     It is much better if all base units have a symbol.
     """
 
-    _unit_systems = {}  # type: Dict[str, UnitSystem]
+    _unit_systems = {}  # type: tDict[str, UnitSystem]
 
     def __init__(self, base_units, units=(), name="", descr="", dimension_system=None):
 

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -1,7 +1,7 @@
 """Implementation of :class:`ModularInteger` class. """
 
 
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict as tDict, Tuple as tTuple, Type
 
 import operator
 
@@ -172,7 +172,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
     def invert(self):
         return self.__class__(self._invert(self.val))
 
-_modular_integer_cache = {}  # type: Dict[Tuple[Any, Any, Any], Type[ModularInteger]]
+_modular_integer_cache = {}  # type: tDict[tTuple[Any, Any, Any], Type[ModularInteger]]
 
 def ModularIntegerFactory(_mod, _dom, _sym, parent):
     """Create custom class for specific integer modulus."""

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -1,7 +1,7 @@
 """Sparse rational function fields. """
 
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 from functools import reduce
 
 from operator import add, mul, lt, le, gt, ge
@@ -99,7 +99,7 @@ def sfield(exprs, *symbols, **options):
     else:
         return (_field, fracs)
 
-_field_cache = {}  # type: Dict[Any, Any]
+_field_cache = {}  # type: tDict[Any, Any]
 
 class FracField(DefaultPrinting):
     """Multivariate distributed rational function field. """

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -10,7 +10,7 @@ as unifying matrices with different domains.
 
 """
 from functools import reduce
-from typing import Union, Tuple
+from typing import Union as tUnion, Tuple as tTuple
 
 from sympy.core.sympify import _sympify
 
@@ -99,8 +99,8 @@ class DomainMatrix:
     Poly
 
     """
-    rep: Union[SDM, DDM]
-    shape: Tuple[int, int]
+    rep: tUnion[SDM, DDM]
+    shape: tTuple[int, int]
     domain: Domain
 
     def __new__(cls, rows, shape, domain, *, fmt=None):

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -3,7 +3,7 @@
 
 __all__ = ["Options"]
 
-from typing import Dict, Type
+from typing import Dict as tDict, Type
 from typing import List, Optional
 
 from sympy.core import Basic, sympify
@@ -123,7 +123,7 @@ class Options(dict):
     """
 
     __order__ = None
-    __options__ = {}  # type: Dict[str, Type[Option]]
+    __options__ = {}  # type: tDict[str, Type[Option]]
 
     def __init__(self, gens, args, flags=None, strict=False):
         dict.__init__(self)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1,7 +1,7 @@
 """Sparse polynomial rings. """
 
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from operator import add, mul, lt, le, gt, ge
 from functools import reduce
@@ -191,7 +191,7 @@ def _parse_symbols(symbols):
 
     raise GeneratorsError("expected a string, Symbol or expression or a non-empty sequence of strings, Symbols or expressions")
 
-_ring_cache = {}  # type: Dict[Any, Any]
+_ring_cache = {}  # type: tDict[Any, Any]
 
 class PolyRing(DefaultPrinting, IPolys):
     """Multivariate distributed polynomial ring. """

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.external import import_module
 from sympy.printing.printer import Printer
@@ -306,7 +306,7 @@ class AesaraPrinter(Printer):
         return self._print(expr, dtypes=dtypes, broadcastables=broadcastables)
 
 
-global_cache = {}  # type: Dict[Any, Any]
+global_cache = {}  # type: tDict[Any, Any]
 
 
 def aesara_code(expr, cache=None, **kwargs):

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -11,7 +11,7 @@ source code files that are compilable without further modifications.
 
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict as tDict, Tuple as tTuple
 
 from functools import wraps
 from itertools import chain
@@ -160,7 +160,7 @@ class C89CodePrinter(CodePrinter):
         'dereference': set(),
         'error_on_reserved': False,
         'reserved_word_suffix': '_',
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     type_aliases = {
         real: float64,
@@ -183,7 +183,7 @@ class C89CodePrinter(CodePrinter):
         uint16: 'int16_t',
         uint32: 'int32_t',
         uint64: 'int64_t',
-    }  # type: Dict[Type, Any]
+    }  # type: tDict[Type, Any]
 
     type_headers = {
         bool_: {'stdbool.h'},
@@ -198,7 +198,7 @@ class C89CodePrinter(CodePrinter):
     }
 
     # Macros needed to be defined when using a Type
-    type_macros = {}  # type: Dict[Type, Tuple[str, ...]]
+    type_macros = {}  # type: tDict[Type, tTuple[str, ...]]
 
     type_func_suffixes = {
         float32: 'f',
@@ -220,7 +220,7 @@ class C89CodePrinter(CodePrinter):
 
     _ns = ''  # namespace, C++ uses 'std::'
     # known_functions-dict to copy
-    _kf = known_functions_C89  # type: Dict[str, Any]
+    _kf = known_functions_C89  # type: tDict[str, Any]
 
     def __init__(self, settings=None):
         settings = settings or {}
@@ -645,7 +645,7 @@ class C99CodePrinter(C89CodePrinter):
     }.items()))
 
     # known_functions-dict to copy
-    _kf = known_functions_C99  # type: Dict[str, Any]
+    _kf = known_functions_C99  # type: tDict[str, Any]
 
     # functions with versions with 'f' and 'l' suffixes:
     _prec_funcs = ('fabs fmod remainder remquo fma fmax fmin fdim nan exp exp2'

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict as tDict, Set as tSet, Tuple as tTuple
 
 from functools import wraps
 
@@ -61,7 +61,7 @@ class CodePrinter(StrPrinter):
         'human': True,
         'inline': False,
         'allow_unknown_functions': False,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     # Functions which are "simple" to rewrite to other functions that
     # may be supported
@@ -142,7 +142,7 @@ class CodePrinter(StrPrinter):
         # keep a set of expressions that are not strictly translatable to Code
         # and number constants that must be declared and initialized
         self._not_supported = set()
-        self._number_symbols = set()  # type: Set[Tuple[Expr, Float]]
+        self._number_symbols = set()  # type: tSet[tTuple[Expr, Float]]
 
         lines = self._print(expr).splitlines()
 

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -17,7 +17,7 @@ SymPy is case sensitive. So, fcode adds underscores to variable names when
 it is necessary to make them different for Fortran.
 """
 
-from typing import Dict, Any
+from typing import Dict as tDict, Any
 
 from collections import defaultdict
 from itertools import chain
@@ -105,7 +105,7 @@ class FCodePrinter(CodePrinter):
         'contract': True,
         'standard': 77,
         'name_mangling' : True,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     _operators = {
         'and': '.and.',

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Set as tSet
 
 from sympy.core import Basic, S
 from sympy.core.function import Lambda
@@ -33,7 +33,7 @@ class GLSLPrinter(CodePrinter):
     Additional settings:
     'use_operators': Boolean (should the printer use operators for +,-,*, or functions?)
     """
-    _not_supported = set()  # type: Set[Basic]
+    _not_supported = set()  # type: tSet[Basic]
     printmethod = "_glsl"
     language = "GLSL"
 

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -7,7 +7,7 @@ Math object where possible.
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core import S
 from sympy.printing.codeprinter import CodePrinter
@@ -55,7 +55,7 @@ class JavascriptCodePrinter(CodePrinter):
         'human': True,
         'allow_unknown_functions': False,
         'contract': True,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -9,7 +9,7 @@ complete source code files.
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core import Mul, Pow, S, Rational
 from sympy.core.mul import _keep_coeff
@@ -65,7 +65,7 @@ class JuliaCodePrinter(CodePrinter):
         'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
     # Note: contract is for expressing tensors as loops (if True), or just
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Julia.

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2,7 +2,7 @@
 A Printer which converts an expression into its LaTeX equivalent.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 import itertools
 
@@ -161,7 +161,7 @@ class LatexPrinter(Printer):
         "parenthesize_super": True,
         "min": None,
         "max": None,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -2,7 +2,7 @@
 Mathematica code printer
 """
 
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict as tDict, Set as tSet, Tuple as tTuple
 
 from sympy.core import Basic, Expr, Float
 from sympy.core.sorting import default_sort_key
@@ -133,10 +133,10 @@ class MCodePrinter(CodePrinter):
         'user_functions': {},
         'human': True,
         'allow_unknown_functions': False,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
-    _number_symbols = set()  # type: Set[Tuple[Expr, Float]]
-    _not_supported = set()  # type: Set[Basic]
+    _number_symbols = set()  # type: tSet[tTuple[Expr, Float]]
+    _not_supported = set()  # type: tSet[Basic]
 
     def __init__(self, settings={}):
         """Register function mappings supplied by user"""

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -2,7 +2,7 @@
 A MathML printer.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
@@ -37,7 +37,7 @@ class MathMLPrinterBase(Printer):
         "root_notation": True,
         "symbol_names": {},
         "mul_symbol_mathml_numbers": '&#xB7;',
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -10,7 +10,7 @@ complete source code files.
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core import Mul, Pow, S, Rational
 from sympy.core.mul import _keep_coeff
@@ -82,7 +82,7 @@ class OctaveCodePrinter(CodePrinter):
         'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
     # Note: contract is for expressing tensors as loops (if True), or just
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Octave.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -210,7 +210,7 @@ an expression when customizing a printer. Mistakes include:
 """
 
 import sys
-from typing import Any, Dict, Type
+from typing import Any, Dict as tDict, Type
 import inspect
 from contextlib import contextmanager
 from functools import cmp_to_key, update_wrapper
@@ -242,9 +242,9 @@ class Printer:
     for your custom class then see the example above: printer_example_ .
     """
 
-    _global_settings = {}  # type: Dict[str, Any]
+    _global_settings = {}  # type: tDict[str, Any]
 
-    _default_settings = {}  # type: Dict[str, Any]
+    _default_settings = {}  # type: tDict[str, Any]
 
     printmethod = None  # type: str
 

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -8,7 +8,7 @@ using the functions defined in math.h where possible.
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
@@ -88,7 +88,7 @@ class RCodePrinter(CodePrinter):
         'dereference': set(),
         'error_on_reserved': False,
         'reserved_word_suffix': '_',
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
     _operators = {
        'and': '&',
         'or': '|',
@@ -96,7 +96,7 @@ class RCodePrinter(CodePrinter):
     }
 
     _relationals = {
-    }  # type: Dict[str, str]
+    }  # type: tDict[str, str]
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -5,7 +5,7 @@ The most important function here is srepr that returns a string so that the
 relation eval(srepr(expr))=expr holds in an appropriate environment.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core.function import AppliedUndef
 from sympy.core.mul import Mul
@@ -20,7 +20,7 @@ class ReprPrinter(Printer):
     _default_settings = {
         "order": None,
         "perm_cyclic" : True,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     def reprify(self, args, sep):
         """

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -31,7 +31,7 @@ complete source code files.
 # .. _Rational64: http://rust-num.github.io/num/num/rational/type.Rational64.html
 # .. _BigRational: http://rust-num.github.io/num/num/rational/type.BigRational.html
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core import S, Rational, Float, Lambda
 from sympy.printing.codeprinter import CodePrinter
@@ -230,7 +230,7 @@ class RustCodePrinter(CodePrinter):
         'error_on_reserved': False,
         'reserved_word_suffix': '_',
         'inline': False,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -2,7 +2,7 @@
 A Printer for generating readable representation of most SymPy classes.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
@@ -28,9 +28,9 @@ class StrPrinter(Printer):
         "perm_cyclic": True,
         "min": None,
         "max": None,
-    }  # type: Dict[str, Any]
+    }  # type: tDict[str, Any]
 
-    _relationals = dict()  # type: Dict[str, str]
+    _relationals = dict()  # type: tDict[str, str]
 
     def parenthesize(self, item, level, strict=False):
         if (precedence(item) < level) or ((not strict) and precedence(item) <= level):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.testing.pytest import raises
 from sympy.assumptions.ask import Q
@@ -27,7 +27,7 @@ x, y = symbols('x,y')
 
 # eval(srepr(expr)) == expr has to succeed in the right environment. The right
 # environment is the scope of "from sympy import *" for most cases.
-ENV = {"Str": Str}  # type: Dict[str, Any]
+ENV = {"Str": Str}  # type: tDict[str, Any]
 exec("from sympy import *", ENV)
 
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.external import import_module
 from sympy.printing.printer import Printer
@@ -305,7 +305,7 @@ class TheanoPrinter(Printer):
         return self._print(expr, dtypes=dtypes, broadcastables=broadcastables)
 
 
-global_cache = {}  # type: Dict[Any, Any]
+global_cache = {}  # type: tDict[Any, Any]
 
 
 def theano_code(expr, cache=None, **kwargs):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -5,7 +5,7 @@
 import typing
 if typing.TYPE_CHECKING:
     from typing import ClassVar
-from typing import Dict, Type, Iterator, List, Optional
+from typing import Dict as tDict, Type, Iterator, List, Optional
 
 from .riccati import match_riccati, solve_riccati
 from sympy.core import Add, S, Pow, Rational
@@ -433,7 +433,7 @@ class NthAlgebraic(SingleODESolver):
     # be stored in cached results we need to ensure that we always get the
     # same class back for each particular integration variable so we store these
     # classes in a global dict:
-    _diffx_stored = {}  # type: Dict[Symbol, Type[Function]]
+    _diffx_stored = {}  # type: tDict[Symbol, Type[Function]]
 
     @staticmethod
     def _get_diffx(var):

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -3,7 +3,7 @@ from collections import defaultdict, Counter
 from functools import reduce
 import itertools
 from itertools import accumulate
-from typing import Optional, List, Dict, Tuple as tTuple
+from typing import Optional, List, Dict as tDict, Tuple as tTuple
 
 import typing
 
@@ -1024,8 +1024,8 @@ class ArrayContraction(_CodegenArrayAbstract):
             # Also consider the case of diagonal matrices being contracted:
             current_dimension = self.expr.shape[links[0]]
 
-            not_vectors: Tuple[_ArgE, int] = []
-            vectors: Tuple[_ArgE, int] = []
+            not_vectors: tTuple[_ArgE, int] = []
+            vectors: tTuple[_ArgE, int] = []
             for arg_ind, rel_ind in positions:
                 arg = editor.args_with_ind[arg_ind]
                 mat = arg.element
@@ -1508,7 +1508,7 @@ class _EditArrayContraction:
         return self.number_of_contraction_indices - 1
 
     def refresh_indices(self):
-        updates: Dict[int, int] = {}
+        updates: tDict[int, int] = {}
         for arg_with_ind in self.args_with_ind:
             updates.update({i: -1 for i in arg_with_ind.indices if i is not None})
         for i, e in enumerate(sorted(updates)):

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -1,6 +1,6 @@
 import itertools
 from collections import defaultdict
-from typing import Tuple, Union, FrozenSet, Dict, List, Optional
+from typing import Tuple as tTuple, Union as tUnion, FrozenSet, Dict as tDict, List, Optional
 from functools import singledispatch
 from itertools import accumulate
 
@@ -24,7 +24,7 @@ from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayD
 from sympy.tensor.array.expressions.utils import _get_mapping_from_subranks
 
 
-def _get_candidate_for_matmul_from_contraction(scan_indices: List[Optional[int]], remaining_args: List[_ArgE]) -> Tuple[Optional[_ArgE], bool, int]:
+def _get_candidate_for_matmul_from_contraction(scan_indices: List[Optional[int]], remaining_args: List[_ArgE]) -> tTuple[Optional[_ArgE], bool, int]:
 
     scan_indices_int: List[int] = [i for i in scan_indices if i is not None]
     if len(scan_indices_int) == 0:
@@ -156,7 +156,7 @@ def _(expr: ArrayContraction):
     if not isinstance(expr, ArrayContraction):
         return _array2matrix(expr)
     subexpr = expr.expr
-    contraction_indices: Tuple[Tuple[int]] = expr.contraction_indices
+    contraction_indices: tTuple[tTuple[int]] = expr.contraction_indices
     if contraction_indices == ((0,), (1,)):
         shape = subexpr.shape
         subexpr = _array2matrix(subexpr)
@@ -646,12 +646,12 @@ def _a2m_transpose(arg):
         return Transpose(arg).doit()
 
 
-def identify_hadamard_products(expr: Union[ArrayContraction, ArrayDiagonal]):
+def identify_hadamard_products(expr: tUnion[ArrayContraction, ArrayDiagonal]):
 
     editor: _EditArrayContraction = _EditArrayContraction(expr)
 
-    map_contr_to_args: Dict[FrozenSet, List[_ArgE]] = defaultdict(list)
-    map_ind_to_inds: Dict[Optional[int], int] = defaultdict(int)
+    map_contr_to_args: tDict[FrozenSet, List[_ArgE]] = defaultdict(list)
+    map_ind_to_inds: tDict[Optional[int], int] = defaultdict(int)
     for arg_with_ind in editor.args_with_ind:
         for ind in arg_with_ind.indices:
             map_ind_to_inds[ind] += 1

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -29,7 +29,7 @@ If there is a (anti)symmetric metric, the indices can be raised and
 lowered when the tensor is put in canonical form.
 """
 
-from typing import Any, Dict as tDict, List, Set, Tuple as tTuple
+from typing import Any, Dict as tDict, List, Set as tSet, Tuple as tTuple
 from functools import reduce
 
 from abc import abstractmethod, ABCMeta
@@ -2468,13 +2468,13 @@ class TensAdd(TensExpr, AssocOp):
     def _tensAdd_check(args):
         # check that all addends have the same free indices
 
-        def get_indices_set(x):  # type: (Expr) -> Set[TensorIndex]
+        def get_indices_set(x):  # type: (Expr) -> tSet[TensorIndex]
             if isinstance(x, TensExpr):
                 return set(x.get_free_indices())
             return set()
 
-        indices0 = get_indices_set(args[0])  # type: Set[TensorIndex]
-        list_indices = [get_indices_set(arg) for arg in args[1:]]  # type: List[Set[TensorIndex]]
+        indices0 = get_indices_set(args[0])  # type: tSet[TensorIndex]
+        list_indices = [get_indices_set(arg) for arg in args[1:]]  # type: List[tSet[TensorIndex]]
         if not all(x == indices0 for x in list_indices):
             raise ValueError('all tensors must have the same indices')
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -4,7 +4,7 @@
 Import diagnostics. Run bin/diagnose_imports.py --help for details.
 """
 
-from typing import Dict
+from typing import Dict as tDict
 
 if __name__ == "__main__":
 
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                 repr(self.name), repr(self.definer))
 
     # Maps each function/variable to name of module to define it
-    symbol_definers = {}  # type: Dict[Definition, str]
+    symbol_definers = {}  # type: tDict[Definition, str]
 
     def in_module(a, b):
         """Is a the same module as or a submodule of b?"""

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Dict as tDict, Optional, Tuple as tTuple, Union as tUnion
 
 from collections import OrderedDict
 from distutils.errors import CompileError
@@ -51,17 +51,17 @@ class CompilerRunner:
     """
 
     # Subclass to vendor/binary dict
-    compiler_dict = None  # type: Dict[str, str]
+    compiler_dict = None  # type: tDict[str, str]
 
     # Standards should be a tuple of supported standards
     # (first one will be the default)
-    standards = None  # type: Tuple[Union[None, str], ...]
+    standards = None  # type: tTuple[tUnion[None, str], ...]
 
     # Subclass to dict of binary/formater-callback
-    std_formater = None  # type: Dict[str, Callable[[Optional[str]], str]]
+    std_formater = None  # type: tDict[str, Callable[[Optional[str]], str]]
 
     # subclass to be e.g. {'gcc': 'gnu', ...}
-    compiler_name_vendor_mapping = None  # type: Dict[str, str]
+    compiler_name_vendor_mapping = None  # type: tDict[str, str]
 
     def __init__(self, sources, out, flags=None, run_linker=True, compiler=None, cwd='.',
                  include_dirs=None, libraries=None, library_dirs=None, std=None, define=None,

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -3,7 +3,7 @@ This module provides convenient functions to transform SymPy expressions to
 lambda functions which can be used to calculate numerical values very fast.
 """
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict as tDict, Iterable
 
 import builtins
 import inspect
@@ -22,14 +22,14 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 
 # Default namespaces, letting us define translations that can't be defined
 # by simple variable maps, like I => 1j
-MATH_DEFAULT = {}  # type: Dict[str, Any]
-MPMATH_DEFAULT = {}  # type: Dict[str, Any]
-NUMPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
-SCIPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
-CUPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
-TENSORFLOW_DEFAULT = {}  # type: Dict[str, Any]
-SYMPY_DEFAULT = {}  # type: Dict[str, Any]
-NUMEXPR_DEFAULT = {}  # type: Dict[str, Any]
+MATH_DEFAULT = {}  # type: tDict[str, Any]
+MPMATH_DEFAULT = {}  # type: tDict[str, Any]
+NUMPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
+SCIPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
+CUPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
+TENSORFLOW_DEFAULT = {}  # type: tDict[str, Any]
+SYMPY_DEFAULT = {}  # type: tDict[str, Any]
+NUMEXPR_DEFAULT = {}  # type: tDict[str, Any]
 
 # These are the namespaces the lambda functions will use.
 # These are separate from the names above because they are modified
@@ -86,13 +86,13 @@ MPMATH_TRANSLATIONS = {
 
 NUMPY_TRANSLATIONS = {
     "Heaviside": "heaviside",
-    }  # type: Dict[str, str]
-SCIPY_TRANSLATIONS = {}  # type: Dict[str, str]
-CUPY_TRANSLATIONS = {}  # type: Dict[str, str]
+    }  # type: tDict[str, str]
+SCIPY_TRANSLATIONS = {}  # type: tDict[str, str]
+CUPY_TRANSLATIONS = {}  # type: tDict[str, str]
 
-TENSORFLOW_TRANSLATIONS = {}  # type: Dict[str, str]
+TENSORFLOW_TRANSLATIONS = {}  # type: tDict[str, str]
 
-NUMEXPR_TRANSLATIONS = {}  # type: Dict[str, str]
+NUMEXPR_TRANSLATIONS = {}  # type: tDict[str, str]
 
 # Available modules:
 MODULES = {
@@ -785,7 +785,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
             raise TypeError("numexpr must be the only item in 'modules'")
         namespaces += list(modules)
     # fill namespace with first having highest priority
-    namespace = {} # type: Dict[str, Any]
+    namespace = {} # type: tDict[str, Any]
     for m in namespaces[::-1]:
         buf = _get_namespace(m)
         namespace.update(buf)
@@ -886,7 +886,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     # Provide lambda expression with builtins, and compatible implementation of range
     namespace.update({'builtins':builtins, 'range':range})
 
-    funclocals = {} # type: Dict[str, Any]
+    funclocals = {} # type: tDict[str, Any]
     global _lambdify_generated_counter
     filename = '<lambdifygenerated-%s>' % _lambdify_generated_counter
     _lambdify_generated_counter += 1

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict as tDict
 
 from sympy.simplify import simplify as simp, trigsimp as tsimp
 from sympy.core.decorators import call_highest_priority, _sympifyit
@@ -301,7 +301,7 @@ class BasisDependentZero(BasisDependent):
     """
     # XXX: Can't type the keys as BaseVector because of cyclic import
     # problems.
-    components = {}  # type: Dict[Any, Expr]
+    components = {}  # type: tDict[Any, Expr]
 
     def __new__(cls):
         obj = super().__new__(cls)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
import clashing types as tTypes
```python
>>> from sympy import *
>>> Set, Union, Tuple, Dict  # also used from typing
(<class 'sympy.sets.sets.Set'>, <class 'sympy.sets.sets.Union'>, <class 'sympy.core.containers.Tuple'>, <class 'sympy.core.containers.Dict'>)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
