### PR TITLE
limit nested arg to depth of 3

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -747,7 +747,7 @@ class arg(Function):
             if isinstance(a, cls):
                 a = a.args[0]
             else:
-                if i == 2 and a.is_real:
+                if i == 2 and a.is_extended_real:
                     return S.NaN
                 break
         else:

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -689,15 +689,20 @@ class Abs(Function):
 
 class arg(Function):
     """
-    returns the argument (in radians) of a complex number.  The argument is
+    returns the argument (in radians) of a complex number. The argument is
     evaluated in consistent convention with atan2 where the branch-cut is
     taken along the negative real axis and arg(z) is in the interval
-    (-pi,pi].  For a positive number, the argument is always 0.
+    (-pi,pi]. For a positive number, the argument is always 0; the
+    argument of a negative number is pi; and the argument of 0
+    is undefined and returns nan. So the ``arg`` function will never nest
+    greater than 3 levels since at the 4th application, the result must be
+    nan; for a real number, nan is returned on the 3rd application.
 
     Examples
     ========
 
-    >>> from sympy import arg, I, sqrt
+    >>> from sympy import arg, I, sqrt, Dummy
+    >>> from sympy.abc import x
     >>> arg(2.0)
     0
     >>> arg(I)
@@ -710,6 +715,11 @@ class arg(Function):
     atan(3/4)
     >>> arg(0.8 + 0.6*I)
     0.643501108793284
+    >>> arg(arg(arg(arg(x))))
+    nan
+    >>> real = Dummy(real=True)
+    >>> arg(arg(arg(real)))
+    nan
 
     Parameters
     ==========
@@ -732,6 +742,16 @@ class arg(Function):
 
     @classmethod
     def eval(cls, arg):
+        a = arg
+        for i in range(3):
+            if isinstance(a, cls):
+                a = a.args[0]
+            else:
+                if i == 2 and a.is_real:
+                    return S.NaN
+                break
+        else:
+            return S.NaN
         if isinstance(arg, exp_polar):
             return periodic_argument(arg, oo)
         if not arg.is_Atom:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -608,16 +608,25 @@ def test_arg():
     f = Function('f')
     assert not arg(f(0) + I*f(1)).atoms(re)
 
+    # check nesting
     x = Symbol('x')
+    assert arg(arg(arg(x))) is not S.NaN
+    assert arg(arg(arg(arg(x)))) is S.NaN
+    r = Symbol('r', real=True)
+    assert arg(arg(r)) is not S.NaN
+    assert arg(arg(arg(r))) is S.NaN
+
     p = Function('p', extended_positive=True)
     assert arg(p(x)) == 0
     assert arg((3 + I)*p(x)) == arg(3  + I)
 
     p = Symbol('p', positive=True)
     assert arg(p) == 0
+    assert arg(p*I) == pi/2
 
     n = Symbol('n', negative=True)
     assert arg(n) == pi
+    assert arg(n*I) == -pi/2
 
     x = Symbol('x')
     assert conjugate(arg(x)) == arg(x)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -612,7 +612,7 @@ def test_arg():
     x = Symbol('x')
     assert arg(arg(arg(x))) is not S.NaN
     assert arg(arg(arg(arg(x)))) is S.NaN
-    r = Symbol('r', real=True)
+    r = Symbol('r', extended_real=True)
     assert arg(arg(r)) is not S.NaN
     assert arg(arg(arg(r))) is S.NaN
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #22185

#### Brief description of what is fixed or changed

`arg(arg(arg(arg(x)))) -> nan (no further nesting possible -- see added code comments)`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * arg will no longer nest past 3 levels for generic arg; 2 level for real arg
<!-- END RELEASE NOTES -->
