### PR TITLE
Added tests for different values of k for limit(x**n - x**(n - k), x, oo)  

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -607,13 +607,17 @@ def test_issue_8481():
     limit(lamda**k * exp(-lamda) / factorial(k), k, oo) == 0
 
 
-def test_issue_8635():
+def test_issue_8635_18176():
     x = Symbol('x', real=True)
     k = Symbol('k', positive=True)
     assert limit(x**n - x**(n - 0), x, oo) == 0
     assert limit(x**n - x**(n - 5), x, oo) == oo
     assert limit(x**n - x**(n - 2.5), x, oo) == oo
     assert limit(x**n - x**(n - k - 1), x, oo) == oo
+    x = Symbol('x', positive=True)
+    n = Symbol('n', integer=True, positive=True)
+    assert limit(x**n - x**(n - 1), x, oo) == oo
+    assert limit(x**n - x**(n + 2), x, oo) == -oo
 
 
 def test_issue_8730():
@@ -879,12 +883,6 @@ def test_issue_17792():
 def test_issue_18118():
     assert limit(sign(sin(x)), x, 0, "-") == -1
     assert limit(sign(sin(x)), x, 0, "+") == 1
-
-def test_issue_18176():
-    x = Symbol('x', real=True , positive= True)
-    n = Symbol('n', integer=True, positive=True)
-    assert limit(x**n - x**(n - 1), x, oo) == oo
-    assert limit(x**n - x**(n + 2), x, oo) == -oo
 
 
 def test_issue_18306():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -883,10 +883,8 @@ def test_issue_18118():
 def test_issue_18176():
     x = Symbol('x', real=True , positive= True)
     n = Symbol('n', integer=True, positive=True)
-    k = 1
-    assert limit(x**n-x**(n-k), x, oo) == oo
-    k = -2
-    assert limit(x**n-x**(n-k), x, oo) == -oo
+    assert limit(x**n - x**(n - 1), x, oo) == oo
+    assert limit(x**n - x**(n + 2), x, oo) == -oo
 
 
 def test_issue_18306():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -615,7 +615,6 @@ def test_issue_8635_18176():
     assert limit(x**n - x**(n - 2.5), x, oo) == oo
     assert limit(x**n - x**(n - k - 1), x, oo) == oo
     x = Symbol('x', positive=True)
-    n = Symbol('n', integer=True, positive=True)
     assert limit(x**n - x**(n - 1), x, oo) == oo
     assert limit(x**n - x**(n + 2), x, oo) == -oo
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -880,6 +880,14 @@ def test_issue_18118():
     assert limit(sign(sin(x)), x, 0, "-") == -1
     assert limit(sign(sin(x)), x, 0, "+") == 1
 
+def test_issue_18176():
+    x = Symbol('x', real=True , positive= True)
+    n = Symbol('n', integer=True, positive=True)
+    k = 1
+    assert limit(x**n-x**(n-k), x, oo) == oo
+    k = -2
+    assert limit(x**n-x**(n-k), x, oo) == -oo
+
 
 def test_issue_18306():
     assert limit(sin(sqrt(x))/sqrt(sin(x)), x, 0, '+') == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #18176

#### Brief description of what is fixed or changed

Added Appropriate tests . The following limit wasn't working properly( all cases except `k=0`) when the issue was reported ( we used to get `NotImplementedError: Result depends on the sign of sign(n - k)` which was wrong ). This has been addressed somewhere else and is working properly. It gives the correct `NotImplementedError` now which is `Result depends on the sign of sign(k)`
```
>>> x = Symbol('x', real=True , positive= True)
>>> n = Symbol('n', integer=True, positive=True)
>>> k = Symbol('k')
>>> limit(x**n-x**(n-k),x,oo)
NotImplementedError: Result depends on the sign of sign(k)
>>> k = 1
>>> limit(x**n-x**(n-k), x, oo)
oo
>>> k = -2
>>> limit(x**n-x**(n-k), x, oo)
-oo
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
