### PR TITLE
Removed a manual file handler pitfall

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,7 +35,8 @@ else:
     veryslow_group, slow_group = [], []
 
 if os.path.exists(blacklist_path):
-    blacklist_group = _mk_group(json.loads(open(blacklist_path, 'rt').read()))
+    with open(blacklist_path, 'rt') as stream:
+        blacklist_group = _mk_group(json.loads(stream.read()))
 else:
     warnings.warn("conftest.py:28: Could not find %s, no tests will be skipped due to blacklisting\n" % blacklist_path)
     blacklist_group = []


### PR DESCRIPTION
**The problem**
There was a case where the code was using a manual file handler pitfall, where a file stream was being opened and closed manually. But since Python supports automatic stream closing using the block 'with', its better to use it instead of the manual close in order to remove a bug vector.

**Solution**
Refactored the code to remove the manual file handler

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* other
    * manual file-hander pitfall was removed
<!-- END RELEASE NOTES -->
