### PR TITLE
Convert array to matrix expr: squash trivial matrices into MatMul

### DIFF
--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -4,7 +4,7 @@ from typing import Tuple as tTuple, Union as tUnion, FrozenSet, Dict as tDict, L
 from functools import singledispatch
 from itertools import accumulate
 
-from sympy import MatMul
+from sympy import MatMul, Basic
 from sympy.assumptions.ask import (Q, ask)
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
@@ -145,7 +145,7 @@ def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
     second: Optional[MatrixExpr] = None
     removed: List[int] = []
     counter: int = 0
-    args = list(expr.args)
+    args: List[Optional[Basic]] = [i for i in expr.args]
     for i, arg in enumerate(expr.args):
         if isinstance(arg, MatrixExpr):
             if arg.shape == (1, 1):

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -4,6 +4,7 @@ from typing import Tuple as tTuple, Union as tUnion, FrozenSet, Dict as tDict, L
 from functools import singledispatch
 from itertools import accumulate
 
+from sympy import MatMul
 from sympy.assumptions.ask import (Q, ask)
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
@@ -127,6 +128,43 @@ def _support_function_tp1_recognize(contraction_indices, args):
 
     editor.refresh_indices()
     return editor.to_array_contraction()
+
+
+def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
+    # If there are matrices of trivial shape in the tensor product (i.e. shape
+    # (1, 1)), try to check if there is a suitable non-trivial MatMul where the
+    # expression can be inserted.
+
+    # For example, if "a" has shape (1, 1) and "b" has shape (k, 1), the
+    # expressions "ArrayTensorProduct(a, b*b.T)" can be rewritten as
+    # "b*a*b.T"
+
+    trivial_matrices = []
+    pos: Optional[int] = None
+    first: Optional[MatrixExpr] = None
+    second: Optional[MatrixExpr] = None
+    removed: List[int] = []
+    counter: int = 0
+    args = list(expr.args)
+    for i, arg in enumerate(expr.args):
+        if isinstance(arg, MatrixExpr):
+            if arg.shape == (1, 1):
+                trivial_matrices.append(arg)
+                args[i] = None
+                removed.extend([counter, counter+1])
+            elif pos is None and isinstance(arg, MatMul):
+                margs = arg.args
+                for j, e in enumerate(margs):
+                    if isinstance(e, MatrixExpr) and e.shape[1] == 1:
+                        pos = i
+                        first = MatMul.fromiter(margs[:j+1])
+                        second = MatMul.fromiter(margs[j+1:])
+                        break
+        counter += get_rank(arg)
+    if pos is None:
+        return expr, []
+    args[pos] = (first*MatMul.fromiter(i for i in trivial_matrices)*second).doit()
+    return ArrayTensorProduct(*[i for i in args if i is not None]), removed
 
 
 @singledispatch
@@ -369,7 +407,11 @@ def _(expr: ArrayTensorProduct):
         else:
             newargs.append(arg)
             pending = None
-    return _a2m_tensor_product(*newargs), sorted(removed)
+    newexpr, newremoved = _a2m_tensor_product(*newargs), sorted(removed)
+    if isinstance(newexpr, ArrayTensorProduct):
+        newexpr, newremoved2 = _find_trivial_matrices_rewrite(newexpr)
+        newremoved = _combine_removed(-1, newremoved, newremoved2)
+    return newexpr, newremoved
 
 
 @_remove_trivial_dims.register(ArrayAdd) # type: ignore

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -14,7 +14,7 @@ from sympy.matrices.expressions.diagonal import DiagMatrix, DiagonalMatrix
 from sympy.matrices import Trace, MatMul, Transpose
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, \
     ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
-    ArrayContraction, ArrayElement
+    ArrayContraction, ArrayElement, ArraySymbol
 from sympy.testing.pytest import raises
 
 
@@ -392,6 +392,19 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     ret, removed = _remove_trivial_dims(cg)
     assert ret == PermuteDims(ArrayContraction(ArrayTensorProduct(A, B, C, M), (3, 4)), [0, 2, 3, 4, 5, 1])
     assert removed == []
+
+    # Trivial matrices are sometimes inserted into MatMul expressions:
+
+    cg = ArrayTensorProduct(b*b.T, a.T*a)
+    ret, removed = _remove_trivial_dims(cg)
+    assert ret == b*a.T*a*b.T
+    assert removed == [2, 3]
+
+    Xs = ArraySymbol("X", (3, 2, k))
+    cg = ArrayTensorProduct(M, Xs, b.T*c, a*a.T, b*b.T, c.T*d)
+    ret, removed = _remove_trivial_dims(cg)
+    assert ret == ArrayTensorProduct(M, Xs, a*b.T*c*c.T*d*a.T, b*b.T)
+    assert removed == [5, 6, 11, 12]
 
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():


### PR DESCRIPTION
Convert array to matrix expression: trivial matrices in tensor product can now be inserted into another MatMul expression argument of the tensor product.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
