### PR TITLE
combinatorics: Subset no longer subclasses from Basic

### DIFF
--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,10 +1,10 @@
 from itertools import combinations
 
 from sympy.combinatorics.graycode import GrayCode
-from sympy.core import Basic
+from sympy.core import Atom
 
 
-class Subset(Basic):
+class Subset(Atom):
     """
     Represents a basic subset object.
 
@@ -59,7 +59,7 @@ class Subset(Basic):
             if elem not in superset:
                 raise ValueError('The superset provided is invalid as it does '
                                  'not contain the element {}'.format(elem))
-        obj = Basic.__new__(cls)
+        obj = Atom.__new__(cls)
         obj._subset = subset
         obj._superset = superset
         return obj

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,10 +1,9 @@
 from itertools import combinations
 
 from sympy.combinatorics.graycode import GrayCode
-from sympy.core import Atom
 
 
-class Subset(Atom):
+class Subset():
     """
     Represents a basic subset object.
 
@@ -59,10 +58,25 @@ class Subset(Atom):
             if elem not in superset:
                 raise ValueError('The superset provided is invalid as it does '
                                  'not contain the element {}'.format(elem))
-        obj = Atom.__new__(cls)
+        obj = object.__new__(cls)
         obj._subset = subset
         obj._superset = superset
         return obj
+
+    def __eq__(self, other):
+        """Return a boolean indicating whether a == b on the basis of
+        whether both objects are of the class Subset and if the values 
+        of the subset and superset attributes are the same.
+        """
+        if not isinstance(self, Subset):
+            return False
+        if not isinstance(other, Subset):
+            return False
+        if not self.superset == other.superset:
+            return False
+        if not self.subset == other.subset:
+            return False
+        return True
 
     def iterate_binary(self, k):
         """

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -65,18 +65,12 @@ class Subset():
 
     def __eq__(self, other):
         """Return a boolean indicating whether a == b on the basis of
-        whether both objects are of the class Subset and if the values 
+        whether both objects are of the class Subset and if the values
         of the subset and superset attributes are the same.
         """
-        if not isinstance(self, Subset):
-            return False
         if not isinstance(other, Subset):
-            return False
-        if not self.superset == other.superset:
-            return False
-        if not self.subset == other.subset:
-            return False
-        return True
+            return NotImplemented
+        return self.subset == other.subset and self.superset == other.superset
 
     def iterate_binary(self, k):
         """

--- a/sympy/combinatorics/tests/test_subsets.py
+++ b/sympy/combinatorics/tests/test_subsets.py
@@ -54,6 +54,8 @@ def test_subset():
     raises(ValueError, lambda: Subset(['a'], ['b', 'c']))
     raises(ValueError, lambda: Subset.subset_from_bitlist(['a', 'b'], '010'))
 
+    assert Subset(['a'], ['a', 'b']) != Subset(['b'], ['a', 'b'])
+    assert Subset(['a'], ['a', 'b']) != Subset(['a'], ['a', 'c'])
 
 def test_ksubsets():
     assert list(ksubsets([1, 2, 3], 2)) == [(1, 2), (1, 3), (2, 3)]

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -500,12 +500,6 @@ def test_sympy__combinatorics__graycode__GrayCode():
     assert _test_args(GrayCode(3, rank=1))
 
 
-def test_sympy__combinatorics__subsets__Subset():
-    from sympy.combinatorics.subsets import Subset
-    assert _test_args(Subset([0, 1], [0, 1, 2, 3]))
-    assert _test_args(Subset(['c', 'd'], ['a', 'b', 'c', 'd']))
-
-
 def test_sympy__combinatorics__permutations__Permutation():
     from sympy.combinatorics.permutations import Permutation
     assert _test_args(Permutation([0, 1, 2, 3]))


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22420 
Related to https://github.com/sympy/sympy/issues/22310

#### Brief description of what is fixed or changed
Subset does not correctly behave as a `Basic` since its arguments are not stored in the args attribute.
Additionally, comparisons between `Subset` instances would return `True` even when their `subset` and `superset` arguments are not.
Subset is now no longer a subclass of `Basic` and a `__eq__` method was added in addition to inequality tests.


#### Other comments

Is the release note needed in this case?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * `Subset` is now no longer a subclass of `Basic`.
  * bug fix: comparisons between `Subset`s no longer always return `True`.
<!-- END RELEASE NOTES -->
