### PR TITLE
Speed up is_square

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -88,13 +88,27 @@ def is_square(n, prep=True):
             return False
         if n in (0, 1):
             return True
-    m = n & 127
-    if not ((m*0x8bc40d7d) & (m*0xa1e2f5d1) & 0x14020a):
-        m = n % 63
-        if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
-            return integer_nthroot(n, 2)[1]
-    return False
-
+    # def magic(n):
+    #     s = {x**2 % n for x in range(n)}
+    #     return sum(1 << bit for bit in s)
+    # >>> print(hex(magic(128)))
+    # 0x2020212020202130202021202030213
+    # >>> print(hex(magic(99)))
+    # 0x209060049048220348a410213
+    # >>> print(hex(magic(91)))
+    # 0x102e403012a0c9862c14213
+    # >>> print(hex(magic(85)))
+    # 0x121065188e001c46298213
+    if not 0x2020212020202130202021202030213 & (1 << (n & 127)):
+        return False
+    m = n % (99 * 91 * 85)
+    if not 0x209060049048220348a410213 & (1 << (m % 99)):
+        return False
+    if not 0x102e403012a0c9862c14213 & (1 << (m % 91)):
+        return False
+    if not 0x121065188e001c46298213 & (1 << (m % 85)):
+        return False
+    return integer_nthroot(n, 2)[1]
 
 def _test(n, base, s, t):
     """Miller-Rabin strong pseudoprime test for one base.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

With Python's big boxed integers, using one "<<" and one "&" is faster than two multiplications and two "&"s. Also added stronger filters, letting only 0.425% of cases get to the integer_nthroot computation.

#### Other comments

Benchmarks:
```python
from timeit import timeit
R = range(2_000_000)
x = timeit(lambda: sum(my_is_square(x, False) for x in R), number=3)
y = timeit(lambda: sum(sympy_is_square(x, False) for x in R), number=3)
print(x) # 1.632436300162226
print(y) # 2.681206800043583
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Improved the performance of the `is_square(n)` function.
<!-- END RELEASE NOTES -->
