### PR TITLE
`_is_connected` is aware of invalid comparisons

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -604,14 +604,6 @@ class MinMaxBase(Expr, LatticeOp):
     def _is_connected(cls, x, y):
         """
         Check if x and y are connected somehow.
-
-        EXAMPLES
-        ========
-
-        >>> from sympy import nonlinsolve, exp
-        >>> from sympy.abc import x, y
-        >>> nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x],x,y)
-        >>> nonlinsolve([(1 - 4*x**2)*exp(-2*x**2 - 2*y**2), -4*x*y*exp(-2*x**2)*exp(-2*y**2)], x,y)
         """
         for i in range(2):
             if x == y:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -604,15 +604,23 @@ class MinMaxBase(Expr, LatticeOp):
     def _is_connected(cls, x, y):
         """
         Check if x and y are connected somehow.
+
+        EXAMPLES
+        ========
+
+        >>> from sympy import nonlinsolve, exp
+        >>> from sympy.abc import x, y
+        >>> nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x],x,y)
+        >>> nonlinsolve([(1 - 4*x**2)*exp(-2*x**2 - 2*y**2), -4*x*y*exp(-2*x**2)*exp(-2*y**2)], x,y)
         """
         for i in range(2):
             if x == y:
                 return True
             t, f = Max, Min
-            for op in range(2):
+            for op in "><":
                 for j in range(2):
                     try:
-                        if op == 0:
+                        if op == ">":
                             v = x >= y
                         else:
                             v = x <= y
@@ -622,7 +630,7 @@ class MinMaxBase(Expr, LatticeOp):
                         return t if v else f
                     t, f = f, t
                     x, y = y, x
-                x, y = y, x
+                x, y = y, x  # run next pass with reversed order relative to start
             # simplification can be expensive, so be conservative
             # in what is attempted
             x = factor_terms(x - y)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -558,7 +558,6 @@ class MinMaxBase(Expr, LatticeOp):
         and check arguments for comparability
         """
         for arg in arg_sequence:
-
             # pre-filter, checking comparability of arguments
             if not isinstance(arg, Expr) or arg.is_extended_real is False or (
                     arg.is_number and
@@ -606,24 +605,24 @@ class MinMaxBase(Expr, LatticeOp):
         """
         Check if x and y are connected somehow.
         """
-        def hit(v, t, f):
-            if not v.is_Relational:
-                return t if v else f
         for i in range(2):
             if x == y:
                 return True
-            r = hit(x >= y, Max, Min)
-            if r is not None:
-                return r
-            r = hit(y <= x, Max, Min)
-            if r is not None:
-                return r
-            r = hit(x <= y, Min, Max)
-            if r is not None:
-                return r
-            r = hit(y >= x, Min, Max)
-            if r is not None:
-                return r
+            t, f = Max, Min
+            for op in range(2):
+                for j in range(2):
+                    try:
+                        if op == 0:
+                            v = x >= y
+                        else:
+                            v = x <= y
+                    except TypeError:
+                        return False  # non-real arg
+                    if not v.is_Relational:
+                        return t if v else f
+                    t, f = f, t
+                    x, y = y, x
+                x, y = y, x
             # simplification can be expensive, so be conservative
             # in what is attempted
             x = factor_terms(x - y)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3274,9 +3274,9 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # one symbol's real soln, another symbol may have
                             # corresponding complex soln.
                             if not isinstance(soln, (ImageSet, ConditionSet)):
-                                soln += solveset_complex(eq2, sym)
-                    except NotImplementedError:
-                        # If sovleset is not able to solve equation `eq2`. Next
+                                soln += solveset_complex(eq2, sym)  # might give ValueError with Abs
+                    except (NotImplementedError, ValueError):
+                        # If solveset is not able to solve equation `eq2`. Next
                         # time we may get soln using next equation `eq2`
                         continue
                     if isinstance(soln, ConditionSet):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3086,9 +3086,9 @@ def test_issue_21890():
         ((-2**e/4 + 2**e*sqrt(3)*I/4)/y, y)}
     assert nonlinsolve([(1 - 4*x**2)*exp(-2*x**2 - 2*y**2),
         -4*x*y*exp(-2*x**2)*exp(-2*y**2)], x, y) == {(-S(1)/2, 0), (S(1)/2, 0)}
-    x, y = symbols('x y', real=True)
-    sol = nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x], x, y)
-    ans = {(2**(S(2)/3)/(2*y), y),
-        ((-2**(S(2)/3)/4 - 2**(S(2)/3)*sqrt(3)*I/4)/y, y),
-        ((-2**(S(2)/3)/4 + 2**(S(2)/3)*sqrt(3)*I/4)/y, y)}
+    rx, ry = symbols('x y', real=True)
+    sol = nonlinsolve([4*rx**3*ry**4 - 2*ry, 4*rx**4*ry**3 - 2*rx], rx, ry)
+    ans = {(2**(S(2)/3)/(2*ry), ry),
+        ((-2**(S(2)/3)/4 - 2**(S(2)/3)*sqrt(3)*I/4)/ry, ry),
+        ((-2**(S(2)/3)/4 + 2**(S(2)/3)*sqrt(3)*I/4)/ry, ry)}
     assert sol == ans

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3077,3 +3077,12 @@ def test_issue_22058():
 
 def test_issue_11184():
     assert solveset(20*sqrt(y**2 + (sqrt(-(y - 10)*(y + 10)) + 10)**2) - 60, y, S.Reals) is S.EmptySet
+
+
+def test_issue_21890():
+    x, y = symbols('x y', real=True)
+    sol = nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x], x, y)
+    ans = {(2**(S(2)/3)/(2*y), y),
+        ((-2**(S(2)/3)/4 - 2**(S(2)/3)*sqrt(3)*I/4)/y, y),
+        ((-2**(S(2)/3)/4 + 2**(S(2)/3)*sqrt(3)*I/4)/y, y)}
+    assert sol == ans

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3080,6 +3080,12 @@ def test_issue_11184():
 
 
 def test_issue_21890():
+    e = S(2)/3
+    assert nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x], x, y) == {
+        (2*e/(2*y), y), ((-2**e/4 - 2**e*sqrt(3)*I/4)/y, y),
+        ((-2**e/4 + 2**e*sqrt(3)*I/4)/y, y)}
+    assert nonlinsolve([(1 - 4*x**2)*exp(-2*x**2 - 2*y**2),
+        -4*x*y*exp(-2*x**2)*exp(-2*y**2)], x, y) == {(-S(1)/2, 0), (S(1)/2, 0)}
     x, y = symbols('x y', real=True)
     sol = nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x], x, y)
     ans = {(2**(S(2)/3)/(2*y), y),

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3082,7 +3082,7 @@ def test_issue_11184():
 def test_issue_21890():
     e = S(2)/3
     assert nonlinsolve([4*x**3*y**4 - 2*y, 4*x**4*y**3 - 2*x], x, y) == {
-        (2*e/(2*y), y), ((-2**e/4 - 2**e*sqrt(3)*I/4)/y, y),
+        (2**e/(2*y), y), ((-2**e/4 - 2**e*sqrt(3)*I/4)/y, y),
         ((-2**e/4 + 2**e*sqrt(3)*I/4)/y, y)}
     assert nonlinsolve([(1 - 4*x**2)*exp(-2*x**2 - 2*y**2),
         -4*x*y*exp(-2*x**2)*exp(-2*y**2)], x, y) == {(-S(1)/2, 0), (S(1)/2, 0)}


### PR DESCRIPTION
The equation that is solved ends up sending an expression which
simplifies to basically I/x with x real so it fails to compare.
So the _is_connected routine now returns False immediately when
that is detected.

Curiously, Relational(floor(x), x, '<=') does not evaluate,
nor does is_le(floor(x), x), even when x is real, but the
expression floor(x) <= x does evaluate, so that sort of literal
expression is retained in the _is_connected routine.
```python
>>> Relational(floor(x),x,'<=')
floor(x) <= x
>>> is_le(floor(x),x)
>>> floor(x) <= x
True
>>> x >= floor(x)
x >= floor(x)
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #22424 as alternate
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
