### PR TITLE
cleanup of Float handling and evaluate of powers

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1277,6 +1277,8 @@ class Float(Number):
         return self._mpf_ != fzero
 
     def __neg__(self):
+        if not self:
+            return self
         return Float._new(mlib.mpf_neg(self._mpf_), self._prec)
 
     @_sympifyit('other', NotImplemented)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1339,10 +1339,10 @@ class Float(Number):
                   -> p**r*(sin(Pi*r) + cos(Pi*r)*I)
         """
         if self == 0:
-            if expt.is_positive:
-                return S.Zero
-            if expt.is_negative:
-                return S.Infinity
+            if expt.is_extended_positive:
+                return self
+            if expt.is_extended_negative:
+                return S.ComplexInfinity
         if isinstance(expt, Number):
             if isinstance(expt, Integer):
                 prec = self._prec
@@ -2697,9 +2697,9 @@ class Zero(IntegerConstant, metaclass=Singleton):
         return S.Zero
 
     def _eval_power(self, expt):
-        if expt.is_positive:
+        if expt.is_extended_positive:
             return self
-        if expt.is_negative:
+        if expt.is_extended_negative:
             return S.ComplexInfinity
         if expt.is_extended_real is False:
             return S.NaN
@@ -3184,7 +3184,14 @@ class NegativeInfinity(Number, metaclass=Singleton):
                 else:
                     return S.Infinity
 
-            return S.NegativeOne**expt*S.Infinity**expt
+            inf_part = S.Infinity**expt
+            s_part = S.NegativeOne**expt
+            if inf_part == 0 and s_part.is_finite:
+                return inf_part
+            if (inf_part is S.ComplexInfinity and
+                    s_part.is_finite and not s_part.is_zero):
+                return S.ComplexInfinity
+            return s_part*inf_part
 
     def _as_mpf_val(self, prec):
         return mlib.fninf
@@ -3478,6 +3485,7 @@ class NumberSymbol(AtomicExpr):
 
     def __hash__(self):
         return super().__hash__()
+
 
 class Exp1(NumberSymbol, metaclass=Singleton):
     r"""The `e` constant.

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2721,10 +2721,6 @@ class Zero(IntegerConstant, metaclass=Singleton):
     def __bool__(self):
         return False
 
-    def as_coeff_Mul(self, rational=False):  # XXX this routine should be deleted
-        """Efficiently extract the coefficient of a summation. """
-        return S.One, self
-
 
 class One(IntegerConstant, metaclass=Singleton):
     """The number one.

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,6 +11,7 @@ from .function import (expand_complex, expand_multinomial,
     expand_mul, _mexpand, PoleError)
 from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .parameters import global_parameters
+from .relational import is_ge, is_gt, is_lt
 from .kind import NumberKind, UndefinedKind
 from sympy.external.gmpy import HAS_GMPY, gmpy
 from sympy.utilities.iterables import sift
@@ -293,10 +294,20 @@ class Pow(Expr):
             ).warn()
 
         if evaluate:
-            if b is S.Zero and e is S.NegativeInfinity:
-                return S.ComplexInfinity
             if e is S.ComplexInfinity:
                 return S.NaN
+            if e is S.Infinity:
+                if is_gt(b, S.One):
+                    return S.Infinity
+                if is_ge(b, S.Zero) and is_lt(b, S.One):
+                    return S.Zero
+                if is_gt(b, S.NegativeOne) and is_lt(b, S.Zero):
+                    return S.Zero
+                if is_lt(b, S.NegativeOne):
+                    if b.is_finite:
+                        return S.ComplexInfinity
+                    if b.is_finite is False:
+                        return S.NaN
             if e is S.Zero:
                 return S.One
             elif e is S.One:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,7 +11,7 @@ from .function import (expand_complex, expand_multinomial,
     expand_mul, _mexpand, PoleError)
 from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .parameters import global_parameters
-from .relational import is_ge, is_gt, is_lt
+from .relational import is_gt, is_lt
 from .kind import NumberKind, UndefinedKind
 from sympy.external.gmpy import HAS_GMPY, gmpy
 from sympy.utilities.iterables import sift
@@ -299,9 +299,7 @@ class Pow(Expr):
             if e is S.Infinity:
                 if is_gt(b, S.One):
                     return S.Infinity
-                if is_ge(b, S.Zero) and is_lt(b, S.One):
-                    return S.Zero
-                if is_gt(b, S.NegativeOne) and is_lt(b, S.Zero):
+                if is_gt(b, S.NegativeOne) and is_lt(b, S.One):
                     return S.Zero
                 if is_lt(b, S.NegativeOne):
                     if b.is_finite:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -245,7 +245,7 @@ class Pow(Expr):
     | -oo**(-1+I)  |         | limit is 0.                                   |
     +--------------+---------+-----------------------------------------------+
 
-    Because symbolic computations are more flexible that floating point
+    Because symbolic computations are more flexible than floating point
     calculations and we prefer to never return an incorrect answer,
     we choose not to conform to all IEEE 754 conventions.  This helps
     us avoid extra test-case code in the calculation of limits.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1610,7 +1610,6 @@ def test_floordiv():
 
 
 def test_as_coeff_Mul():
-    assert S.Zero.as_coeff_Mul() == (S.One, S.Zero)
     assert Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
     assert Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
     assert Float(5.0).as_coeff_Mul() == (Float(5.0), Integer(1))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2204,5 +2204,11 @@ def test_abc():
     assert(isinstance(z, numbers.Rational))
     assert(isinstance(z, nums.Integral))
 
+
 def test_floordiv():
     assert S(2)//S.Half == 4
+
+
+def test_negation():
+    assert -S.Zero is S.Zero
+    assert -Float(0) is not S.Zero and -Float(0) == 0

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -38,6 +38,7 @@ t = Symbol('t', real=False)
 _ninf = float(-oo)
 _inf = float(oo)
 
+
 def same_and_same_prec(a, b):
     # stricter matching for Floats
     return a == b and a._prec == b._prec
@@ -247,12 +248,14 @@ def test_igcd_lehmer():
     # swapping argmument
     assert igcd_lehmer(1, 2) == igcd_lehmer(2, 1)
 
+
 def test_igcd2():
     # short loop
     assert igcd2(2**100 - 1, 2**99 - 1) == 1
     # Lehmer's algorithm
     a, b = int(fibonacci(10001)), int(fibonacci(10000))
     assert igcd2(a, b) == 1
+
 
 def test_ilcm():
     assert ilcm(0, 0) == 0
@@ -603,12 +606,14 @@ def test_Float():
     for i, a in zip(u, v):
         assert Float(i) is a
 
+
 def test_zero_not_false():
     # https://github.com/sympy/sympy/issues/20796
     assert (S(0.0) == S.false) is False
     assert (S.false == S(0.0)) is False
     assert (S(0) == S.false) is False
     assert (S.false == S(0)) is False
+
 
 @conserve_mpmath_dps
 def test_float_mpf():
@@ -622,11 +627,13 @@ def test_float_mpf():
 
     assert Float(mp_pi, 100) == Float(mp_pi._mpf_, 100) == pi.evalf(100)
 
+
 def test_Float_RealElement():
     repi = RealField(dps=100)(pi.evalf(100))
     # We still have to pass the precision because Float doesn't know what
     # RealElement is, but make sure it keeps full precision from the result.
     assert Float(repi, 100) == pi.evalf(100)
+
 
 def test_Float_default_to_highprec_from_str():
     s = str(pi.evalf(128))
@@ -1092,7 +1099,7 @@ def test_powers_Integer():
     assert S.One ** S.Infinity is S.NaN
     assert S.NegativeOne** S.Infinity is S.NaN
     assert S(2) ** S.Infinity is S.Infinity
-    assert S(-2)** S.Infinity == S.Infinity + S.Infinity * S.ImaginaryUnit
+    assert S(-2)** S.Infinity == zoo
     assert S(0) ** S.Infinity is S.Zero
 
     # check Nan
@@ -1199,8 +1206,7 @@ def test_powers_Rational():
     assert S.Half ** S.Infinity == 0
     assert Rational(3, 2) ** S.Infinity is S.Infinity
     assert Rational(-1, 2) ** S.Infinity == 0
-    assert Rational(-3, 2) ** S.Infinity == \
-        S.Infinity + S.Infinity * S.ImaginaryUnit
+    assert Rational(-3, 2) ** S.Infinity == zoo
 
     # check Nan
     assert Rational(3, 4) ** S.NaN is S.NaN
@@ -1640,6 +1646,7 @@ def test_conversion_to_mpmath():
     assert mpmath.mpmathify(pi.evalf(100) + pi.evalf(100)*I) == mpmath.pi + mpmath.pi*mpmath.j
     assert mpmath.mpmathify(pi.evalf(100)*I) == mpmath.pi*mpmath.j
 
+
 def test_relational():
     # real
     x = S(.1)
@@ -1820,11 +1827,13 @@ def test_Catalan_EulerGamma_prec():
     assert f._prec == 20
     assert n._as_mpf_val(20) == f._mpf_
 
+
 def test_Catalan_rewrite():
     k = Dummy('k', integer=True, nonnegative=True)
     assert Catalan.rewrite(Sum).dummy_eq(
             Sum((-1)**k/(2*k + 1)**2, (k, 0, oo)))
     assert Catalan.rewrite() == Catalan
+
 
 def test_bool_eq():
     assert 0 == False
@@ -1888,9 +1897,11 @@ def test_issue_6349():
     assert Float('23000', '')._prec == 20
     assert Float('-23000', '')._prec == 20
 
+
 def test_mpf_norm():
     assert mpf_norm((1, 0, 1, 0), 10) == mpf('0')._mpf_
     assert Float._new((1, 0, 1, 0), 10)._mpf_ == mpf('0')._mpf_
+
 
 def test_latex():
     assert latex(pi) == r"\pi"
@@ -2093,11 +2104,13 @@ def test_comparisons_with_unknown_type():
         raises(TypeError, lambda: n >= bar)
         raises(TypeError, lambda: bar <= n)
 
+
 def test_NumberSymbol_comparison():
     from sympy.core.tests.test_relational import rel_check
     rpi = Rational('905502432259640373/288230376151711744')
     fpi = Float(float(pi))
     assert rel_check(rpi, fpi)
+
 
 def test_Integer_precision():
     # Make sure Integer inputs for keyword args work
@@ -2105,6 +2118,7 @@ def test_Integer_precision():
     assert Float('1.0', precision=Integer(15))._prec == 15
     assert type(Float('1.0', precision=Integer(15))._prec) == int
     assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)
+
 
 def test_numpy_to_float():
     from sympy.testing.pytest import skip
@@ -2132,16 +2146,19 @@ def test_numpy_to_float():
     raises(TypeError, lambda: Float(np.complex64(1+2j)))
     raises(TypeError, lambda: Float(np.complex128(1+2j)))
 
+
 def test_Integer_ceiling_floor():
     a = Integer(4)
 
     assert a.floor() == a
     assert a.ceiling() == a
 
+
 def test_ComplexInfinity():
     assert zoo.floor() is zoo
     assert zoo.ceiling() is zoo
     assert zoo**zoo is S.NaN
+
 
 def test_Infinity_floor_ceiling_power():
     assert oo.floor() is oo
@@ -2149,9 +2166,11 @@ def test_Infinity_floor_ceiling_power():
     assert oo**S.NaN is S.NaN
     assert oo**zoo is S.NaN
 
+
 def test_One_power():
     assert S.One**12 is S.One
     assert S.NegativeOne**S.NaN is S.NaN
+
 
 def test_NegativeInfinity():
     assert (-oo).floor() is -oo
@@ -2159,12 +2178,14 @@ def test_NegativeInfinity():
     assert (-oo)**11 is -oo
     assert (-oo)**12 is oo
 
+
 def test_issue_6133():
     raises(TypeError, lambda: (-oo < None))
     raises(TypeError, lambda: (S(-2) < None))
     raises(TypeError, lambda: (oo < None))
     raises(TypeError, lambda: (oo > None))
     raises(TypeError, lambda: (S(2) < None))
+
 
 def test_abc():
     x = numbers.Float(5)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -12,7 +12,6 @@ from sympy.functions.elementary.trigonometric import (
 from sympy.polys import Poly
 from sympy.series.order import O
 from sympy.sets import FiniteSet
-from sympy.core.expr import unchanged
 from sympy.core.power import power
 from sympy.testing.pytest import warns_deprecated_sympy, _both_exp_pow
 
@@ -270,10 +269,15 @@ def test_zero():
     assert 0**(x - 2) != S.Infinity**(2 - x)
     assert 0**(2*x*y) == 0**(x*y)
     assert 0**(-2*x*y) == S.ComplexInfinity**(x*y)
+    assert Float(0)**2 is not S.Zero
+    assert Float(0)**2 == 0.0
+    assert Float(0)**-2 is zoo
+    assert Float(0)**oo is S.Zero
 
     #Test issue 19572
     assert 0 ** -oo is zoo
     assert power(0, -oo) is zoo
+    assert Float(0)**-oo is zoo
 
 def test_pow_as_base_exp():
     x = Symbol('x')
@@ -555,8 +559,15 @@ def test_issue_14815():
 
 
 def test_issue_18509():
-    assert unchanged(Mul, oo, 1/pi**oo)
-    assert (1/pi**oo).is_extended_positive == False
+    x = Symbol('x', prime=True)
+    assert x**oo is oo
+    assert (1/x)**oo is S.Zero
+    assert (-1/x)**oo is S.Zero
+    assert (-x)**oo is zoo
+    assert (-oo)**(-1 + I) is S.Zero
+    assert (-oo)**(1 + I) is zoo
+    assert (oo)**(-1 + I) is S.Zero
+    assert (oo)**(1 + I) is zoo
 
 
 def test_issue_18762():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -870,9 +870,18 @@ def test_issue_19326():
     x, y = [i(t) for i in map(Function, 'xy')]
     assert (x*y).subs({x: 1 + x, y: x}) == (1 + x)*x
 
+
 def test_issue_19558():
     e = (7*x*cos(x) - 12*log(x)**3)*(-log(x)**4 + 2*sin(x) + 1)**2/ \
     (2*(x*cos(x) - 2*log(x)**3)*(3*log(x)**4 - 7*sin(x) + 3)**2)
 
     assert e.subs(x, oo) == AccumBounds(-oo, oo)
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
+
+
+def test_guard_against_indeterminate_evaluation():
+    eq = x**y
+    assert eq.subs([(x, 1), (y, oo)]) == 1  # because 1**y == 1
+    assert eq.subs([(y, oo), (x, 1)]) is S.NaN
+    assert eq.subs({x: 1, y: oo}) is S.NaN
+    assert eq.subs([(x, 1), (y, oo)],simultaneous=True) is S.NaN

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -593,7 +593,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         doit=kwargs.get('doit', doit))
     # no routine for Expr needs to check for is_zero
     if isinstance(expr, Expr) and expr.is_zero:
-        return S.Zero
+        return S.Zero if not expr.is_Number else expr
 
     _eval_simplify = getattr(expr, '_eval_simplify', None)
     if _eval_simplify is not None:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -33,6 +33,7 @@ from sympy.solvers.solvers import solve
 from sympy.testing.pytest import XFAIL, slow, _both_exp_pow
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, n
 
+
 def test_issue_7263():
     assert abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf() - \
             673.447451402970) < 1e-12
@@ -912,10 +913,13 @@ def test_issue_21869():
     assert expr.simplify() == S.false
 
 
-def test_issue_7971():
+def test_issue_7971_21740():
     z = Integral(x, (x, 1, 1))
     assert z != 0
     assert simplify(z) is S.Zero
+    assert simplify(S.Zero) is S.Zero
+    z = simplify(Float(0))
+    assert z is not S.Zero and z == 0
 
 
 @slow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * a Float(0) is retained during negation and simplification
   * Float(0)**-oo is now zoo instead of oo
   * there is better detection of small (|x| < 1) and large numbers raised to oo or -oo
   * subs will handle +/-oo and zoo before other replacements to help guard against evaluating indeterminate forms
<!-- END RELEASE NOTES -->
