### PR TITLE
Deprecate the use of non-Basic 

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,14 @@ SymPy deprecation warnings.
 
 ## Version 1.11
 
+(non_basic_arguments_to_basic)=
+### non-``Basic`` arguments for ``Basic`` is no longer allowed.
+
+All arguments stored in ``Basic._args`` should be instances of ``Basic``.
+Many algorithms in SymPy assume this is the case and any violation should
+be considered a bug. This deprecation explicitly disallows any `Basic` to
+be instantiated with non-Basic arguments.
+
 (mathematica-parser-additional-translations)=
 ### Mathematica parser: removed ``additional_translations`` parameter
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -122,6 +122,23 @@ class Basic(Printable, metaclass=ManagedProperties):
         obj = object.__new__(cls)
         obj._assumptions = cls.default_assumptions
         obj._mhash = None  # will be set by __hash__ method.
+        types = set(map(type,args))
+        if not all(issubclass(typ, Basic, ManagedProperties) for typ in types ):
+            # XXX: ManagedProperties should be remove eventually,
+            # but this is currently (SymPy 1.9) not possible due to
+            # how Functions work.
+            offending_args = [type(arg) for arg in args if not isinstance(arg,
+                    (Basic, ManagedProperties))]
+            msgargs = "non-Basic arguments of types {offending_args} found for\n"
+            msgargs = msgargs.format(offending_args = offending_args)
+            msgtype = "Basic of type {objtype}".format(objtype = cls)
+            msg = msgargs+msgtype
+            sympy_deprecation_warning(
+                message = msg,
+                deprecated_since_version = "1.11",
+                active_deprecations_target = "non_basic_arguments_to_basic"
+
+            )
 
         obj._args = args  # all items in args must be Basic objects
         return obj

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -123,7 +123,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         obj._assumptions = cls.default_assumptions
         obj._mhash = None  # will be set by __hash__ method.
         types = set(map(type,args))
-        if not all(issubclass(typ, Basic, ManagedProperties) for typ in types ):
+        if not all(issubclass(typ, (Basic, ManagedProperties)) for typ in types ):
             # XXX: ManagedProperties should be remove eventually,
             # but this is currently (SymPy 1.9) not possible due to
             # how Functions work.

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -14,7 +14,8 @@ from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry,
     riemann_cyclic_replace, riemann_cyclic, TensMul, tensor_heads, \
     TensorManager, TensExpr, TensorHead, canon_bp, \
     tensorhead, tensorsymmetry, TensorType, substitute_indices
-from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy, warns, \
+        SymPyDeprecationWarning
 from sympy.matrices import diag
 
 def _is_equal(arg1, arg2):
@@ -1962,7 +1963,8 @@ def test_rewrite_tensor_to_Indexed():
 
 
 def test_tensorsymmetry():
-    with warns_deprecated_sympy():
+    #XXX: this deprecated class makes use of another deprecation, so stack level can't be tested
+    with warns(SymPyDeprecationWarning, test_stacklevel = False):
         tensorsymmetry([1]*2)
 
 def test_tensorhead():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/22310#issuecomment-962291545

#### Brief description of what is fixed or changed
Basic now forces args to be an instance or subclass of `Basic`. Eventually subclasses of `Basic` should also be disallowed, but this is currently not possible due to how `Function`s currently work in SymPy.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Basic now forces args to be an instance or subclass of `Basic`.
<!-- END RELEASE NOTES -->
