### PR TITLE
Allow single axis diagonalizations in ArrayDiagonal

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -242,6 +242,8 @@ def tensordiagonal(array, *diagonal_axes):
     if isinstance(array, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
         return ArrayDiagonal(array, *diagonal_axes)
 
+    ArrayDiagonal._validate(array, *diagonal_axes)
+
     array, remaining_indices, remaining_shape, diagonal_deltas = _util_contraction_diagonal(array, *diagonal_axes)
 
     # Compute the diagonalized array:

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -207,6 +207,18 @@ def test_arrayexpr_array_diagonal():
     cg = ArrayDiagonal(ArrayTensorProduct(M, N, P), (4, 1), (2, 0))
     assert cg == ArrayDiagonal(ArrayTensorProduct(M, N, P), (1, 4), (0, 2))
 
+    cg = ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2), (3,), allow_trivial_diags=True)
+    assert cg == PermuteDims(ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2)), [0, 2, 1])
+
+    Ax = ArraySymbol("Ax", shape=(1, 2, 3, 4, 3, 5, 6, 2, 7))
+    cg = ArrayDiagonal(Ax, (1, 7), (3,), (2, 4), (6,), allow_trivial_diags=True)
+    assert cg == PermuteDims(ArrayDiagonal(Ax, (1, 7), (2, 4)), [0, 2, 4, 5, 1, 6, 3])
+
+    cg = ArrayDiagonal(M, (0,), allow_trivial_diags=True)
+    assert cg == PermuteDims(M, [1, 0])
+
+    raises(ValueError, lambda: ArrayDiagonal(M, (0, 0)))
+
 
 def test_arrayexpr_array_shape():
     expr = ArrayTensorProduct(M, N, P, Q)

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -315,6 +315,7 @@ def test_tensordiagonal():
     from sympy.matrices.dense import eye
     expr = Array(range(9)).reshape(3, 3)
     raises(ValueError, lambda: tensordiagonal(expr, [0], [1]))
+    raises(ValueError, lambda: tensordiagonal(expr, [0, 0]))
     assert tensordiagonal(eye(3), [0, 1]) == Array([1, 1, 1])
     assert tensordiagonal(expr, [0, 1]) == Array([0, 4, 8])
     x, y, z = symbols("x y z")


### PR DESCRIPTION
Changes in this PR:

- allow single axis diagonalizations in ArrayDiagonal,
- disallow diagonalizations with the same axes repeated in both `ArrayDiagonal` and `tensordiagonal`.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
