### PR TITLE
codegen/ast: argument invariance is now supported for String

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -335,6 +335,12 @@ class Token(CodegenAST):
         else:
             return kwargs
 
+    @property
+    def func(self):
+        if self.is_Atom:
+            return lambda: self
+        else:
+            return super().func
 
 class BreakToken(Token):
     """ Represents 'break' in C/Python ('exit' in Fortran).

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -335,12 +335,11 @@ class Token(CodegenAST):
         else:
             return kwargs
 
-    @property
-    def func(self):
-        if self.is_Atom:
-            return lambda: self
+    def func(self, *args, **kwargs):
+        if self.is_Atom and not kwargs:
+            return self
         else:
-            return super().func
+            return super().func(*args, **kwargs)
 
 class BreakToken(Token):
     """ Represents 'break' in C/Python ('exit' in Fortran).

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -133,7 +133,7 @@ from collections import defaultdict
 from sympy.core.relational import (Ge, Gt, Le, Lt)
 from sympy.core import Symbol, Tuple, Dummy
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, Atom
 from sympy.core.numbers import Float, Integer, oo
 from sympy.core.sympify import _sympify, sympify, SympifyError
 from sympy.utilities.iterables import (iterable, topological_sort,
@@ -334,12 +334,6 @@ class Token(CodegenAST):
             return {k: apply(v) for k, v in kwargs.items()}
         else:
             return kwargs
-
-    def func(self, *args, **kwargs):
-        if self.is_Atom and not kwargs:
-            return self
-        else:
-            return super().func(*args, **kwargs)
 
 class BreakToken(Token):
     """ Represents 'break' in C/Python ('exit' in Fortran).
@@ -874,7 +868,7 @@ class For(Token):
         return _sympify(itr)
 
 
-class String(Token):
+class String(Atom, Token):
     """ SymPy object representing a string.
 
     Atomic object which is not an expression (as opposed to Symbol).
@@ -912,6 +906,13 @@ class String(Token):
     def _sympystr(self, printer, *args, **kwargs):
         return self.text
 
+    def kwargs(self, exclude = (), apply = None):
+        return {}
+
+    #to be removed when Atom is given a suitable func
+    @property
+    def func(self):
+        return lambda: self
 
 class QuotedString(String):
     """ Represents a string which should be printed with quotes. """

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -267,6 +267,7 @@ def test_String():
     assert st == String('foobar')
     assert st.text == 'foobar'
     assert st.func(**st.kwargs()) == st
+    assert st.func(*st.args) == st
 
 
     class Signifier(String):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22455
See also https://github.com/sympy/sympy/issues/22310

#### Brief description of what is fixed or changed
Previously, `String` and its subclasses only supported the
invariance `string.func(**string.kwargs()) == string`. Now
also `string.func(string.args) == string` is supported as is
required for all `Basic` subclasses.


#### Other comments
**Now the proposed solution since it would allow the class to function as it currently does in addition to preserving the argument invariance**
Currently this would mean that `string.func(**string.kwargs()) == string` does not work, since no arguments are allowed. Instead, it acts as an `Atom` and does not allow modification of its non-`expr.arg` arguments.
This does not generally solve the issue for `Token` classes with mixed `expr.arg` and non-`expr.arg` arguments, however, it does not appear that such a class currently exists.

This could be a possible solution for supporting this invariance:
```python

    def func(self, *args, **kwargs):
        if self.is_Atom and not kwargs:
            return self
        else:
            return super().func(*args, **kwargs)
```

Alternatively,
`lambda *args, **kwargs: self` could simply be returned

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
