### PR TITLE
utilities/matchpy_connector: Wildcard.__eq__ now works without matchpy

### DIFF
--- a/sympy/integrals/rubi/symbol.py
+++ b/sympy/integrals/rubi/symbol.py
@@ -2,14 +2,8 @@ from sympy.external import import_module
 matchpy = import_module("matchpy")
 from sympy.utilities.decorator import doctest_depends_on
 
-if matchpy:
-    from matchpy import Wildcard
-else:
-    class Wildcard:
-        def __init__(self, min_length, fixed_size, variable_name, optional):
-            pass
-
 from sympy.core.symbol import Symbol
+from sympy.utilities.matchpy_connector import Wildcard
 
 @doctest_depends_on(modules=('matchpy',))
 class matchpyWC(Wildcard, Symbol):

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -109,7 +109,10 @@ if matchpy:
 else:
     class Wildcard: # type: ignore
         def __init__(self, min_length, fixed_size, variable_name, optional):
-            pass
+            self.min_count = min_length
+            self.fixed_size = fixed_size
+            self.variable_name = variable_name
+            self.optional = optional
 
 
 @doctest_depends_on(modules=('matchpy',))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See also https://github.com/sympy/sympy/issues/22310

#### Brief description of what is fixed or changed
The `Wildcard` class has an interface for when matchpy is not available,
but a comparsion with `==` results in an error because `__init__` does
not correctly initialize the class.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
