### PR TITLE
Removed distutil since it is deprecated in Python 3.10

### DIFF
--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -5,8 +5,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
-from distutils.errors import CompileError
-from distutils.sysconfig import get_config_var, get_config_vars
+from sysconfig import get_config_var, get_config_vars, get_path
 
 from .runners import (
     CCompilerRunner,
@@ -16,10 +15,8 @@ from .runners import (
 from .util import (
     get_abspath, make_dirs, copy, Glob, ArbitraryDepthGlob,
     glob_at_depth, import_module_from_file, pyx_is_cplus,
-    sha256_of_string, sha256_of_file
+    sha256_of_string, sha256_of_file, CompileError
 )
-
-sharedext = get_config_var('EXT_SUFFIX')
 
 if os.name == 'posix':
     objext = '.o'
@@ -149,7 +146,7 @@ def link(obj_files, out_file=None, shared=False, Runner=None,
     if out_file is None:
         out_file, ext = os.path.splitext(os.path.basename(obj_files[-1]))
         if shared:
-            out_file += sharedext
+            out_file += get_config_var('EXT_SUFFIX')
 
     if not Runner:
         if fort:
@@ -228,8 +225,7 @@ def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
         # Don't use the default code below
         pass
     else:
-        from distutils import sysconfig
-        if sysconfig.get_config_var('Py_ENABLE_SHARED'):
+        if get_config_var('Py_ENABLE_SHARED'):
             cfgDict = get_config_vars()
             kwargs['linkline'] = kwargs.get('linkline', []) + [cfgDict['PY_LDFLAGS']] # PY_LDFLAGS or just LDFLAGS?
             library_dirs += [cfgDict['LIBDIR']]
@@ -350,8 +346,7 @@ def src2obj(srcpath, Runner=None, objpath=None, cwd=None, inc_py=False, **kwargs
 
     include_dirs = kwargs.pop('include_dirs', [])
     if inc_py:
-        from distutils.sysconfig import get_python_inc
-        py_inc_dir = get_python_inc()
+        py_inc_dir = get_path('include')
         if py_inc_dir not in include_dirs:
             include_dirs.append(py_inc_dir)
 

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -1,13 +1,12 @@
 from typing import Callable, Dict as tDict, Optional, Tuple as tTuple, Union as tUnion
 
 from collections import OrderedDict
-from distutils.errors import CompileError
 import os
 import re
 import subprocess
 
 from .util import (
-    find_binary_of_command, unique_list
+    find_binary_of_command, unique_list, CompileError
 )
 
 

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -22,6 +22,10 @@ class CompilerNotFoundError(FileNotFoundError):
     pass
 
 
+class CompileError (Exception):
+    """Failure to compile one or more C/C++ source files."""
+
+
 def get_abspath(path, cwd='.'):
     """ Returns the aboslute path.
 
@@ -250,7 +254,7 @@ def import_module_from_file(filename, only_if_newer_than=None):
 def find_binary_of_command(candidates):
     """ Finds binary first matching name among candidates.
 
-    Calls `find_executable` from distuils for provided candidates and returns
+    Calls ``which`` from shutils for provided candidates and returns
     first hit.
 
     Parameters
@@ -264,11 +268,12 @@ def find_binary_of_command(candidates):
 
     CompilerNotFoundError if no candidates match.
     """
-    from distutils.spawn import find_executable
+    from shutil import which
     for c in candidates:
-        binary_path = find_executable(c)
+        binary_path = which(c)
         if c and binary_path:
             return c, binary_path
+
     raise CompilerNotFoundError('No binary located for candidates: {}'.format(candidates))
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`distutils` is deprecated in Python 3.10, so removed all use.

```
/home/runner/work/sympy/sympy/sympy/utilities/_compilation/compilation.py:8: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.errors import CompileError
/home/runner/work/sympy/sympy/sympy/utilities/_compilation/compilation.py:9: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  from distutils.sysconfig import get_config_var, get_config_vars
```
#### Other comments

There is a template code in autowrap that imports distutils as a backup to setuptools. It may be a bit early to remove that part yet(?).
https://github.com/sympy/sympy/blob/c62bb34279944303f9d34748e9ff51f75e346f04/sympy/utilities/autowrap.py#L236-L255

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
