### PR TITLE
Removed doctest deprecation warning

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -670,6 +670,7 @@ def _get_doctest_blacklist():
         "sympy/integrals/rubi/rubi.py",
         "sympy/plotting/pygletplot/__init__.py", # crashes on some systems
         "sympy/plotting/pygletplot/plot.py", # crashes on some systems
+        "sympy/codegen/array_utils.py", # raises deprecation warning
     ])
     # autolev parser tests
     num = 12


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Remove the following:
```
/home/runner/work/sympy/sympy/sympy/codegen/array_utils.py:8: SymPyDeprecationWarning: 

Array expressions inside the codegen module has been deprecated since
SymPy 1.8. Use Experimental module in sympy.tensor.array.expressions
instead. See https://github.com/sympy/sympy/issues/20996 for more
info.

  SymPyDeprecationWarning(
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
