### PR TITLE
Use MathJax version 3 in the docs

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -54,17 +54,12 @@ nitpick_ignore = [
 # To stop docstrings inheritance.
 autodoc_inherit_docstrings = False
 
-# MathJax file, which is free to use.  See https://www.mathjax.org/#gettingstarted
-# As explained in the link using latest.js will get the latest version even
-# though it says 2.7.5.
-mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML-full'
-
 # See https://www.sympy.org/sphinx-math-dollar/
-mathjax_config = {
-    'tex2jax': {
-        'inlineMath': [ ["\\(","\\)"] ],
-        'displayMath': [["\\[","\\]"] ],
-    },
+mathjax3_config = {
+  "tex": {
+    "inlineMath": [['\\(', '\\)']],
+    "displayMath": [["\\[", "\\]"]],
+  }
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

I have several fixes I am making to the docs build. However, some of them may more controversial or require some more review than others, so I am going to make separate PRs, as they are mostly independent fixes. 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

MathJax 3 is now the default in Sphinx, so simply removing our manual use of MathJax 2 will use it. We also have to update the config as the config format has changed (see https://www.sphinx-doc.org/en/master/usage/extensions/math.html).

MathJax 3 is faster than MathJax 2 and also has several other features https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html. For the most part, this shouldn't really affect anything. I noticed some formulas render slightly differently with MathJax 3 due to some minor font differences. I primarily need this for a future PR I plan to make that was not working properly without this change. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* other
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Use MathJax version 3 in the docs
<!-- END RELEASE NOTES -->
