### PR TITLE
Add 'make latexpdf' to build the PDF documentation in one step

### DIFF
--- a/bin/test_sphinx.sh
+++ b/bin/test_sphinx.sh
@@ -6,12 +6,9 @@ echo "Testing SPHINX"
 cd doc
 make html
 make man
-make latex
-cd _build/latex
-export LATEXMKOPTS="-halt-on-error -xelatex -silent"
-make all || {
+make pdflatex LATEXMKOPTS="-halt-on-error -xelatex -silent" || {
     echo "An error had occured during the LaTeX build";
-    tail -n 1000 *.log;
+    tail -n 1000 ./*.log;
     sleep 1; # A guard against travis running tail concurrently.
-    exit -1;
+    exit 1;
 }

--- a/bin/test_sphinx.sh
+++ b/bin/test_sphinx.sh
@@ -8,7 +8,7 @@ make html
 make man
 make pdflatex LATEXMKOPTS="-halt-on-error -xelatex -silent" || {
     echo "An error had occured during the LaTeX build";
-    tail -n 1000 ./*.log;
+    tail -n 1000 _build/latex/*.log;
     sleep 1; # A guard against travis running tail concurrently.
     exit 1;
 }

--- a/bin/test_sphinx.sh
+++ b/bin/test_sphinx.sh
@@ -6,7 +6,7 @@ echo "Testing SPHINX"
 cd doc
 make html
 make man
-make pdflatex LATEXMKOPTS="-halt-on-error -xelatex -silent" || {
+make latexpdf LATEXMKOPTS="-halt-on-error -xelatex -silent" || {
     echo "An error had occured during the LaTeX build";
     tail -n 1000 _build/latex/*.log;
     sleep 1; # A guard against travis running tail concurrently.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,12 +12,15 @@ PAPER        =
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)
 PDFFILES = $(SVGFILES:%.svg=%.pdf)
 
+# This must be set for the recursive make pdf build to work in make latexpdf
+export LATEXMKOPTS = -halt-on-error -xelatex
+
 ALLSPHINXOPTS = -d _build/doctrees $(SPHINXOPTS) src
 ALLSPHINXOPTSapi = -d _build/doctrees-api $(SPHINXOPTS) api
 ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_element.papersize=$(PAPER)paper \
                 $(SPHINXOPTS) src
 
-.PHONY: changes cheatsheet clean help html htmlapi htmlhelp info latex \
+.PHONY: changes cheatsheet clean help html htmlapi htmlhelp info latex latexpdf \
         linkcheck livehtml texinfo web logo man
 
 .SUFFIXES: .pdf .svg
@@ -86,6 +89,9 @@ latex: $(PDFFILES)
 	@echo "Build finished; the LaTeX files are in _build/latex."
 	@echo "Set the environment variable LATEXMKOPTS='-xelatex -silent'"
 	@echo "And run \`make all' in that directory to run these through xelatex."
+
+latexpdf: latex
+	$(MAKE) -C _build/latex
 
 .svg.pdf:
 	dbus-run-session inkscape --file=$< --export-area-drawing --without-gui --export-pdf=$@


### PR DESCRIPTION
I have several fixes I am making to the docs build. However, some of them may more controversial or require some more review than others, so I am going to make separate PRs, as they are mostly independent fixes. 

Previously to build the pdf docs you had to run

```
make latex
export LATEXMKOPTS='-halt-on-error -xelatex'
cd _build/latex
make
```

now you can just run

```
make latexpdf
```

This was also something the output of `make latex` said you could do but didn't actually work.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
