### PR TITLE
Convert array to matrix: recognize applyfunc as hadamard power

### DIFF
--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -4,12 +4,12 @@ from typing import Tuple as tTuple, Union as tUnion, FrozenSet, Dict as tDict, L
 from functools import singledispatch
 from itertools import accumulate
 
-from sympy import MatMul, Basic
+from sympy import MatMul, Basic, Wild
 from sympy.assumptions.ask import (Q, ask)
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.matrices.expressions.diagonal import DiagMatrix
-from sympy.matrices.expressions.hadamard import hadamard_product
+from sympy.matrices.expressions.hadamard import hadamard_product, HadamardPower
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.expressions.special import (Identity, ZeroMatrix, OneMatrix)
 from sympy.matrices.expressions.trace import Trace
@@ -303,6 +303,12 @@ def _(expr: ArrayAdd):
 def _(expr: ArrayElementwiseApplyFunc):
     subexpr = _array2matrix(expr.expr)
     if isinstance(subexpr, MatrixExpr):
+        d = expr.function.bound_symbols[0]
+        w = Wild("w", exclude=[d])
+        p = Wild("p", exclude=[d])
+        m = expr.function.expr.match(w*d**p)
+        if m is not None:
+            return m[w]*HadamardPower(subexpr, m[p])
         return ElementwiseApplyFunction(expr.function, subexpr)
     else:
         return ArrayElementwiseApplyFunc(expr.function, subexpr)
@@ -509,7 +515,7 @@ def _(expr: ElementwiseApplyFunction):
     if subexpr.shape == (1, 1):
         # TODO: move this to ElementwiseApplyFunction
         return expr.function(subexpr), removed + [0, 1]
-    return ElementwiseApplyFunction(expr.function, subexpr)
+    return ElementwiseApplyFunction(expr.function, subexpr), []
 
 
 @_remove_trivial_dims.register(ArrayElementwiseApplyFunc) # type: ignore

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -303,12 +303,13 @@ def _(expr: ArrayAdd):
 def _(expr: ArrayElementwiseApplyFunc):
     subexpr = _array2matrix(expr.expr)
     if isinstance(subexpr, MatrixExpr):
-        d = expr.function.bound_symbols[0]
-        w = Wild("w", exclude=[d])
-        p = Wild("p", exclude=[d])
-        m = expr.function.expr.match(w*d**p)
-        if m is not None:
-            return m[w]*HadamardPower(subexpr, m[p])
+        if subexpr.shape != (1, 1):
+            d = expr.function.bound_symbols[0]
+            w = Wild("w", exclude=[d])
+            p = Wild("p", exclude=[d])
+            m = expr.function.expr.match(w*d**p)
+            if m is not None:
+                return m[w]*HadamardPower(subexpr, m[p])
         return ElementwiseApplyFunction(expr.function, subexpr)
     else:
         return ArrayElementwiseApplyFunc(expr.function, subexpr)

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,7 +1,8 @@
+from sympy import Lambda, S, Dummy
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import cos
-from sympy.matrices.expressions.hadamard import HadamardProduct
+from sympy.functions.elementary.trigonometric import cos, sin
+from sympy.matrices.expressions.hadamard import HadamardProduct, HadamardPower
 from sympy.matrices.expressions.special import (Identity, OneMatrix, ZeroMatrix)
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
@@ -14,7 +15,7 @@ from sympy.matrices.expressions.diagonal import DiagMatrix, DiagonalMatrix
 from sympy.matrices import Trace, MatMul, Transpose
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, \
     ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
-    ArrayContraction, ArrayElement, ArraySymbol
+    ArrayContraction, ArrayElement, ArraySymbol, ArrayElementwiseApplyFunc
 from sympy.testing.pytest import raises
 
 
@@ -647,3 +648,14 @@ def test_convert_array_element_to_matrix():
 
     expr = ArrayElement(ArrayTensorProduct(M, N), (i, j, m, n))
     assert convert_array_to_matrix(expr) == expr
+
+
+def test_convert_array_elementwise_function_to_matrix():
+
+    d = Dummy("d")
+
+    expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x)
+    assert convert_array_to_matrix(expr).dummy_eq(x.applyfunc(sin))
+
+    expr = ArrayElementwiseApplyFunc(Lambda(d, 1 / (2 * sqrt(d))), x)
+    assert convert_array_to_matrix(expr) == S.Half * HadamardPower(x, -S.Half)

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -654,6 +654,12 @@ def test_convert_array_elementwise_function_to_matrix():
 
     d = Dummy("d")
 
+    expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x.T*y)
+    assert convert_array_to_matrix(expr) == sin(x.T*y)
+
+    expr = ArrayElementwiseApplyFunc(Lambda(d, d**2), x.T*y)
+    assert convert_array_to_matrix(expr) == (x.T*y)**2
+
     expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x)
     assert convert_array_to_matrix(expr).dummy_eq(x.applyfunc(sin))
 


### PR DESCRIPTION
Sometimes `ArrayElementwiseApplyFunc` contains a lambda that applied to a matrix is equivalent to Hadamard power. This PR adds support to the function `convert_array_to_matrix( ... )` for the recognition of Hadamard powers expressed as elementwise function applications to matrices using the array expression module.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
