### PR TITLE
Matrix expression derivatives are now computed with the array expressions module

### DIFF
--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -3,6 +3,7 @@ Some examples have been taken from:
 
 http://www.math.uwaterloo.ca/~hwolkowi//matrixcookbook.pdf
 """
+from sympy.combinatorics import Permutation
 from sympy.concrete.summations import Sum
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
@@ -23,6 +24,7 @@ from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.special import (Identity, ZeroMatrix)
 from sympy.tensor.array.array_derivatives import ArrayDerivative
 from sympy.matrices.expressions import hadamard_power
+from sympy.tensor.array.expressions.array_expressions import ArrayAdd, ArrayTensorProduct, PermuteDims
 
 k = symbols("k")
 i, j = symbols("i j")
@@ -85,11 +87,13 @@ def test_matrix_derivative_by_scalar():
 
 def test_matrix_derivative_non_matrix_result():
     # This is a 4-dimensional array:
-    assert A.diff(A) == ArrayDerivative(A, A)
-    assert A.T.diff(A) == ArrayDerivative(A.T, A)
-    assert (2*A).diff(A) == ArrayDerivative(2*A, A)
-    assert MatAdd(A, A).diff(A) == ArrayDerivative(MatAdd(A, A), A)
-    assert (A + B).diff(A) == ArrayDerivative(A + B, A)  # TODO: `B` can be removed.
+    I = Identity(k)
+    AdA = PermuteDims(ArrayTensorProduct(I, I), Permutation(3)(1, 2))
+    assert A.diff(A) == AdA
+    assert A.T.diff(A) == PermuteDims(ArrayTensorProduct(I, I), Permutation(3)(1, 2, 3))
+    assert (2*A).diff(A) == PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
+    assert MatAdd(A, A).diff(A) == ArrayAdd(AdA, AdA)
+    assert (A + B).diff(A) == AdA
 
 
 def test_matrix_derivative_trivial_cases():
@@ -172,7 +176,8 @@ def test_matrix_derivative_vectors_and_scalars():
 def test_matrix_derivatives_of_traces():
 
     expr = Trace(A)*A
-    assert expr.diff(A) == ArrayDerivative(Trace(A)*A, A)
+    I = Identity(k)
+    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A)*I, I), Permutation(3)(1, 2)))
     assert expr[i, j].diff(A[m, n]).doit() == (
         KDelta(i, m)*KDelta(j, n)*Trace(A) +
         KDelta(m, n)*A[i, j]
@@ -317,7 +322,7 @@ def test_matrix_derivatives_of_traces():
 
 def test_derivatives_of_complicated_matrix_expr():
     expr = a.T*(A*X*(X.T*B + X*A) + B.T*X.T*(a*b.T*(X*D*X.T + X*(X.T*B + A*X)*D*B - X.T*C.T*A)*B + B*(X*D.T + B*A*X*A.T - 3*X*D))*B + 42*X*B*X.T*A.T*(X + X.T))*b
-    result = (B*(B*A*X*A.T - 3*X*D + X*D.T) + a*b.T*(X*(A*X + X.T*B)*D*B + X*D*X.T - X.T*C.T*A)*B)*B*b*a.T*B.T + B**2*b*a.T*B.T*X.T*a*b.T*X*D + 42*A*X*B.T*X.T*a*b.T + B*D*B**3*b*a.T*B.T*X.T*a*b.T*X + B*b*a.T*A*X + 42*a*b.T*(X + X.T)*A*X*B.T + b*a.T*X*B*a*b.T*B.T**2*X*D.T + b*a.T*X*B*a*b.T*B.T**3*D.T*(B.T*X + X.T*A.T) + 42*b*a.T*X*B*X.T*A.T + 42*A.T*(X + X.T)*b*a.T*X*B + A.T*B.T**2*X*B*a*b.T*B.T*A + A.T*a*b.T*(A.T*X.T + B.T*X) + A.T*X.T*b*a.T*X*B*a*b.T*B.T**3*D.T + B.T*X*B*a*b.T*B.T*D - 3*B.T*X*B*a*b.T*B.T*D.T - C.T*A*B**2*b*a.T*B.T*X.T*a*b.T + X.T*A.T*a*b.T*A.T
+    result = (B*(B*A*X*A.T - 3*X*D + X*D.T) + a*b.T*(X*(A*X + X.T*B)*D*B + X*D*X.T - X.T*C.T*A)*B)*B*b*a.T*B.T + B**2*b*a.T*B.T*X.T*a*b.T*X*D + 42*A*X*B.T*X.T*a*b.T + B*D*B**3*b*a.T*B.T*X.T*a*b.T*X + B*b*a.T*A*X + a*b.T*(42*X + 42*X.T)*A*X*B.T + b*a.T*X*B*a*b.T*B.T**2*X*D.T + b*a.T*X*B*a*b.T*B.T**3*D.T*(B.T*X + X.T*A.T) + 42*b*a.T*X*B*X.T*A.T + A.T*(42*X + 42*X.T)*b*a.T*X*B + A.T*B.T**2*X*B*a*b.T*B.T*A + A.T*a*b.T*(A.T*X.T + B.T*X) + A.T*X.T*b*a.T*X*B*a*b.T*B.T**3*D.T + B.T*X*B*a*b.T*B.T*D - 3*B.T*X*B*a*b.T*B.T*D.T - C.T*A*B**2*b*a.T*B.T*X.T*a*b.T + X.T*A.T*a*b.T*A.T
     assert expr.diff(X) == result
 
 
@@ -335,8 +340,8 @@ def test_mixed_deriv_mixed_expressions():
     assert expr.diff(A) == (2*Trace(A))*Identity(k)
 
     expr = Trace(A)*A
-    # TODO: this is not yet supported:
-    assert expr.diff(A) == ArrayDerivative(expr, A)
+    I = Identity(k)
+    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A)*I, I), Permutation(3)(1, 2)))
 
     expr = Trace(Trace(A)*A)
     assert expr.diff(A) == (2*Trace(A))*Identity(k)
@@ -358,16 +363,16 @@ def test_derivatives_matrix_norms():
     assert expr.diff(x) == x*(x.T*x)**Rational(-1, 2)
 
     expr = (c.T*a*x.T*b)**S.Half
-    assert expr.diff(x) == b/(2*sqrt(c.T*a*x.T*b))*c.T*a
+    assert expr.diff(x) == b*a.T*c/sqrt(c.T*a*x.T*b)/2
 
     expr = (c.T*a*x.T*b)**Rational(1, 3)
-    assert expr.diff(x) == b*(c.T*a*x.T*b)**Rational(-2, 3)*c.T*a/3
+    assert expr.diff(x) == b*a.T*c*(c.T*a*x.T*b)**Rational(-2, 3)/3
 
     expr = (a.T*X*b)**S.Half
     assert expr.diff(X) == a/(2*sqrt(a.T*X*b))*b.T
 
     expr = d.T*x*(a.T*X*b)**S.Half*y.T*c
-    assert expr.diff(X) == a*d.T*x/(2*sqrt(a.T*X*b))*y.T*c*b.T
+    assert expr.diff(X) == a/(2*sqrt(a.T*X*b))*x.T*d*y.T*c*b.T
 
 
 def test_derivatives_elementwise_applyfunc():
@@ -424,7 +429,7 @@ def test_derivatives_elementwise_applyfunc():
 
     expr = a.T*A*X.applyfunc(sin)*B*b
     assert expr.diff(X).dummy_eq(
-        DiagMatrix(A.T*a)*X.applyfunc(cos)*DiagMatrix(B*b))
+        HadamardProduct(A.T * a * b.T * B.T, X.applyfunc(cos)))
 
     expr = a.T * (A*X.applyfunc(sin)*B).applyfunc(log) * b
     # TODO: wrong
@@ -443,7 +448,7 @@ def test_derivatives_of_hadamard_expressions():
     assert expr.diff(x) == DiagMatrix(hadamard_product(b, a))
 
     expr = a.T*hadamard_product(A, X, B)*b
-    assert expr.diff(X) == DiagMatrix(a)*hadamard_product(B, A)*DiagMatrix(b)
+    assert expr.diff(X) == HadamardProduct(a*b.T, A, B)
 
     # Hadamard Power
 
@@ -460,4 +465,4 @@ def test_derivatives_of_hadamard_expressions():
     assert expr.diff(X) == 2*a*a.T*X*b*b.T
 
     expr = hadamard_power(a.T*X*b, S.Half)
-    assert expr.diff(X) == a/2*hadamard_power(a.T*X*b, Rational(-1, 2))*b.T
+    assert expr.diff(X) == a/(2*sqrt(a.T*X*b))*b.T


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
- matrices
  - Derivatives of matrix expressions are now computed in the array expressions module. The result is therefore able to represent higher dimensional arrays. If trivial dimensions are present, an attempt is made at converting the resulting array expression back to matrix expression.
<!-- END RELEASE NOTES -->
