### PR TITLE
recursive canonical

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -111,8 +111,7 @@ class Relational(Boolean, EvalfMixin):
             # other than Eq/Ne;
             # Note: Symbol is a subclass of Boolean but is considered
             # acceptable here.
-            if any(map(_nontrivBool, (lhs, rhs))) or isinstance(lhs, Relational
-                    ) or isinstance(rhs, Relational)):
+            if any(map(_nontrivBool, (lhs, rhs))):
                 raise TypeError(filldedent('''
                     A Boolean argument can only be used in
                     Eq and Ne; all other relationals expect

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -111,7 +111,8 @@ class Relational(Boolean, EvalfMixin):
             # other than Eq/Ne;
             # Note: Symbol is a subclass of Boolean but is considered
             # acceptable here.
-            if any(map(_nontrivBool, (lhs, rhs))):
+            if any(map(_nontrivBool, (lhs, rhs))) or isinstance(lhs, Relational
+                    ) or isinstance(rhs, Relational)):
                 raise TypeError(filldedent('''
                     A Boolean argument can only be used in
                     Eq and Ne; all other relationals expect
@@ -266,7 +267,7 @@ class Relational(Boolean, EvalfMixin):
         >>> (-y < -x).canonical
         x < y
         """
-        args = self.args
+        args = [i.canonical if isinstance(i, Relational) else i for i in self.args]
         r = self
         if r.rhs.is_number:
             if r.rhs.is_Number and r.lhs.is_Number and r.lhs > r.rhs:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -265,9 +265,20 @@ class Relational(Boolean, EvalfMixin):
         x < -y
         >>> (-y < -x).canonical
         x < y
+
+        The canonicalization is recursively applied:
+
+        >>> from sympy import Eq
+        >>> Eq(x < y, y > x).canonical
+        True
         """
         args = tuple([i.canonical if isinstance(i, Relational) else i for i in self.args])
-        r = self
+        if args != self.args:
+            r = self.func(*args)
+            if not isinstance(r, Relational):
+                return r
+        else:
+            r = self
         if r.rhs.is_number:
             if r.rhs.is_Number and r.lhs.is_Number and r.lhs > r.rhs:
                 r = r.reversed

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -266,7 +266,7 @@ class Relational(Boolean, EvalfMixin):
         >>> (-y < -x).canonical
         x < y
         """
-        args = [i.canonical if isinstance(i, Relational) else i for i in self.args]
+        args = tuple([i.canonical if isinstance(i, Relational) else i for i in self.args])
         r = self
         if r.rhs.is_number:
             if r.rhs.is_Number and r.lhs.is_Number and r.lhs > r.rhs:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -854,6 +854,7 @@ def test_canonical():
     assert [i.canonical for i in c] == c
     assert [i.reversed.canonical for i in c] == c
     assert not any(i.lhs.is_Number and not i.rhs.is_Number for i in c)
+    assert Eq(y < x, x > y).canonical is S.true
 
 
 @XFAIL


### PR DESCRIPTION
This is for Eq and Ne which can have relational args.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #8243 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * canonical will recurse into Relational args in Eq and Ne so `Eq(y<x,x>y).canonical -> True`
<!-- END RELEASE NOTES -->
