### PR TITLE
closes #8357: test against bare expressions

### DIFF
--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -168,7 +168,7 @@ def line_with_bare_expr(code):
         assert msg.args
         msg = msg.args[0]
         assert msg.startswith(message_bare_expr.split(':', 1)[0])
-        return int(msg.rsplit(' ', 1)[1])  # the line numbers
+        return int(msg.rsplit(' ', 1)[1].rstrip('.'))  # the line numbers
 
 
 def test_files():

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -157,7 +157,8 @@ def line_with_bare_expr(code):
     >>> f('a == 1')
     0
     >>> f('if a == 1:\n b = 1')
-    >>> f('if a == 1:\n b == 1')  # XXX need to figure this out
+
+        >> f('if a == 1:\n b == 1')  # XXX need to figure this out
     1
     """
     tree = ast.parse(code)

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -164,7 +164,7 @@ def line_with_bare_expr(code):
     tree = ast.parse(code)
     try:
         BareExpr.visit(tree)
-    except Assertionerror as msg:
+    except AssertionError as msg:
         assert msg.startswith(message_bare_expr.split(':', 1))
         return msg.rsplit(' ', 1)  # the line numbers
 

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -170,8 +170,8 @@ def test_files():
             _test_this_file_encoding(fname, test_file)
 
     def test_this_file(fname, test_file):
-        bare = line_with_bare_expr(test_file.read())
-        if bare is not None:
+        idx = line_with_bare_expr(test_file.read())
+        if idx is not None:
             assert False, message_bare_expr % (fname, idx + 1)
         test_file.seek(0)  # restore reader to head
 

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -165,6 +165,8 @@ def line_with_bare_expr(code):
     try:
         BareExpr.visit(tree)
     except AssertionError as msg:
+        assert msg.args
+        msg = msg.args[0]
         assert msg.startswith(message_bare_expr.split(':', 1))
         return msg.rsplit(' ', 1)  # the line numbers
 

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -170,9 +170,10 @@ def test_files():
             _test_this_file_encoding(fname, test_file)
 
     def test_this_file(fname, test_file):
-        bare = line_with_bare_expr(test_file)
+        bare = line_with_bare_expr(test_file.read())
         if bare is not None:
             assert False, message_bare_expr % (fname, idx + 1)
+        test_file.seek(0)  # restore reader to head
 
         line = None  # to flag the case where there were no lines in file
         tests = 0

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -167,8 +167,8 @@ def line_with_bare_expr(code):
     except AssertionError as msg:
         assert msg.args
         msg = msg.args[0]
-        assert msg.startswith(message_bare_expr.split(':', 1))
-        return msg.rsplit(' ', 1)  # the line numbers
+        assert msg.startswith(message_bare_expr.split(':', 1)[0])
+        return int(msg.rsplit(' ', 1)[1])  # the line numbers
 
 
 def test_files():

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -164,7 +164,7 @@ def line_with_bare_expr(code):
     tree = ast.parse(code)
     try:
         BareExpr.visit(tree)
-    except Assertion error as msg:
+    except Assertionerror as msg:
         assert msg.startswith(message_bare_expr.split(':', 1))
         return msg.rsplit(' ', 1)  # the line numbers
 


### PR DESCRIPTION
Bare expressions can represent a logical error that passes silently. e.g.
```
x + 1 instead of x += 1
x == 1 instead of x = 1
```
This PR adds checking for such expressions using ast.

It increases code-quality checking from 6 seconds to 32 seconds (based on observation of run-times of this and another PR).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments

Got a tutorial on [ast here](https://www.mattlayman.com/blog/2018/decipher-python-ast/) and made this attempt at checking for relationals and binary ops that appear alone as an expression.

- [ ] add tests

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
    * bare Relational (x == 1) and binary operations (x + 1) will raise a code-quality error
<!-- END RELEASE NOTES -->
