### PR TITLE
Fixed limit(1/asin(x) , x, 0) which was returning wrong outputs along both directions .

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -273,7 +273,9 @@ class Limit(Expr):
 
         if e.is_meromorphic(z, z0):
             if abs(z0) is S.Infinity:
-                newe = e.subs(z, -1/z)
+                newe = e.subs(z, 1/z)
+                # cdir changes sign as oo- should become 0+
+                cdir = -cdir
             else:
                 newe = e.subs(z, z + z0)
             try:
@@ -329,7 +331,7 @@ class Limit(Expr):
                         if cdir == 1:
                             return S.Infinity*sign(coeff)
                         elif cdir == -1:
-                            return S.NegativeInfinity*sign(coeff)*S.NegativeOne**(S.One + ex)
+                            return S.Infinity*sign(coeff)*S.NegativeOne**ex
                         else:
                             return S.ComplexInfinity
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -270,6 +270,7 @@ class Limit(Expr):
             e = nsimplify(e)
         e = set_signs(e)
 
+
         if e.is_meromorphic(z, z0):
             if abs(z0) is S.Infinity:
                 newe = e.subs(z, -1/z)
@@ -284,9 +285,9 @@ class Limit(Expr):
                     return S.Zero
                 elif ex == 0:
                     return coeff
-                if str(dir) == "+" or not(int(ex) & 1):
+                if cdir == 1 or not(int(ex) & 1):
                     return S.Infinity*sign(coeff)
-                elif str(dir) == "-":
+                elif cdir == -1:
                     return S.NegativeInfinity*sign(coeff)
                 else:
                     return S.ComplexInfinity
@@ -318,16 +319,16 @@ class Limit(Expr):
                     return coeff
                 elif ex.is_negative:
                     if ex.is_integer:
-                        if str(dir) == "-" or ex.is_even:
+                        if cdir == 1 or ex.is_even:
                             return S.Infinity*sign(coeff)
-                        elif str(dir) == "+":
+                        elif cdir == -1:
                             return S.NegativeInfinity*sign(coeff)
                         else:
                             return S.ComplexInfinity
                     else:
-                        if str(dir) == "+":
+                        if cdir == 1:
                             return S.Infinity*sign(coeff)
-                        elif str(dir) == "-":
+                        elif cdir == -1:
                             return S.NegativeInfinity*sign(coeff)*S.NegativeOne**(S.One + ex)
                         else:
                             return S.ComplexInfinity

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -308,6 +308,15 @@ def test_series_AccumBounds():
     assert limit(e, x, oo) == AccumBounds(0, oo)
 
 
+def test_pull_request_22491():
+    assert limit(1/asin(x), x, 0, dir = '+') == oo
+    assert limit(1/asin(x), x, 0, dir = '-') == -oo
+    assert limit(1/sinh(x), x, 0, dir = '+') == oo
+    assert limit(1/sinh(x), x, 0, dir = '-') == -oo
+    assert limit(log(1/x) + 1/sin(x), x, 0, dir = '+') == oo
+    assert limit(log(1/x) + 1/x, x, 0, dir = '+') == oo
+
+
 @XFAIL
 def test_doit2():
     f = Integral(2 * x, x)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -85,7 +85,7 @@ def test_basic1():
     assert limit(1/sqrt(x), x, 0, dir='-') == (-oo)*I
     assert limit(x**2, x, 0, dir='-') == 0
     assert limit(sqrt(x), x, 0, dir='-') == 0
-    assert limit(x**-pi, x, 0, dir='-') == -oo*(-1)**(1 - pi)
+    assert limit(x**-pi, x, 0, dir='-') == oo/(-1)**pi
     assert limit((1 + cos(x))**oo, x, 0) == Limit((cos(x) + 1)**oo, x, 0)
 
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -88,6 +88,14 @@ def test_basic1():
     assert limit(x**-pi, x, 0, dir='-') == oo/(-1)**pi
     assert limit((1 + cos(x))**oo, x, 0) == Limit((cos(x) + 1)**oo, x, 0)
 
+    # test pull request 22491
+    assert limit(1/asin(x), x, 0, dir = '+') == oo
+    assert limit(1/asin(x), x, 0, dir = '-') == -oo
+    assert limit(1/sinh(x), x, 0, dir = '+') == oo
+    assert limit(1/sinh(x), x, 0, dir = '-') == -oo
+    assert limit(log(1/x) + 1/sin(x), x, 0, dir = '+') == oo
+    assert limit(log(1/x) + 1/x, x, 0, dir = '+') == oo
+
 
 def test_basic2():
     assert limit(x**x, x, 0, dir="+") == 1
@@ -306,15 +314,6 @@ def test_series_AccumBounds():
     # https://github.com/sympy/sympy/issues/12312
     e = 2**(-x)*(sin(x) + 1)**x
     assert limit(e, x, oo) == AccumBounds(0, oo)
-
-
-def test_pull_request_22491():
-    assert limit(1/asin(x), x, 0, dir = '+') == oo
-    assert limit(1/asin(x), x, 0, dir = '-') == -oo
-    assert limit(1/sinh(x), x, 0, dir = '+') == oo
-    assert limit(1/sinh(x), x, 0, dir = '-') == -oo
-    assert limit(log(1/x) + 1/sin(x), x, 0, dir = '+') == oo
-    assert limit(log(1/x) + 1/x, x, 0, dir = '+') == oo
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I discovered this when I was debugging one of my other Prs
On Master
```
>>> limit(1/asin(x), x, 0, dir = '+')
-oo
>>> limit(1/asin(x), x, 0, dir = '-')
oo
```
But this is clearly wrong !

![image](https://user-images.githubusercontent.com/87052487/141668463-7d689cf9-71cc-4445-835e-b34a5cc9da18.png)


And it won't be that hard to find more like these . When I went through the code , there weren't any obvious errors in `limits.py`. The workflow was straightforward in returning the above results but then I realized that we should be using ` cdir` rather than `str(dir)` in the final checks which are in the lines(320 -333) 
```
                    if ex.is_integer:
                        if str(dir) == "-" or ex.is_even:
                            return S.Infinity*sign(coeff)
                        elif str(dir) == "+":
                            return S.NegativeInfinity*sign(coeff)
                        else:
                            return S.ComplexInfinity
                    else:
                        if str(dir) == "+":
                            return S.Infinity*sign(coeff)
                        elif str(dir) == "-":
                            return S.NegativeInfinity*sign(coeff)*S.NegativeOne**(S.One + ex)
                        else:
                            return S.ComplexInfinity
```
This would help us generally and also for the above reported cases . This is because any expression of the form 
`limit( f(x), x, +-oo)` is converted into something like `limit( f(1/x), x, 0)` followed by a change in `cdir` which is done by line 299
```
            # cdir changes sign as oo- should become 0+
            cdir = -cdir
```
But we haven't used the changed `cdir` anywhere after the change( nothing but switching signs) . Now that we have made the above explained transformation , we should be dealing with the changed `cdir` rather than the original direction ! This would also solve the above problem and also deal with all general cases better . 

```
>>> limit(1/asin(x), x, 0, dir = '+')
oo
>>> limit(1/asin(x), x, 0, dir = '-')
-oo
```
As I said it won't be that tough to come across this on master . Some basic examples could be something as follows
```
>>> limit(1/sinh(x), x, 0, dir = '+') # Both should be returning oo
-oo
>>> limit(ln(1/x) + 1/sin(x), x, 0, dir = '+')
-oo
>>> limit(ln(1/x) + 1/x, x, 0, dir = '+')
-oo
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
