### PR TITLE
Reordered imports and moved to top level

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -7,11 +7,15 @@ References
 .. [1] http://mathworld.wolfram.com/KroneckerDelta.html
 
 """
+from .products import product
+from .summations import Sum, summation
 from sympy.core import Add, Mul, S, Dummy
 from sympy.core.cache import cacheit
 from sympy.core.sorting import default_sort_key
 from sympy.functions import KroneckerDelta, Piecewise, piecewise_fold
-from sympy.sets import Interval
+from sympy.polys.polytools import factor
+from sympy.sets.sets import Interval
+from sympy.solvers.solvers import solve
 
 
 @cacheit
@@ -120,7 +124,6 @@ def _remove_multiple_delta(expr):
     """
     Evaluate products of KroneckerDelta's.
     """
-    from sympy.solvers import solve
     if expr.is_Add:
         return expr.func(*list(map(_remove_multiple_delta, expr.args)))
     if not expr.is_Mul:
@@ -151,7 +154,6 @@ def _simplify_delta(expr):
     """
     Rewrite a KroneckerDelta's indices in its simplest form.
     """
-    from sympy.solvers import solve
     if isinstance(expr, KroneckerDelta):
         try:
             slns = solve(expr.args[0] - expr.args[1], dict=True)
@@ -175,8 +177,6 @@ def deltaproduct(f, limit):
     sympy.functions.special.tensor_functions.KroneckerDelta
     sympy.concrete.products.product
     """
-    from sympy.concrete.products import product
-
     if ((limit[2] - limit[1]) < 0) == True:
         return S.One
 
@@ -215,7 +215,6 @@ def deltaproduct(f, limit):
     if not delta:
         g = _expand_delta(f, limit[0])
         if f != g:
-            from sympy.polys.polytools import factor
             try:
                 return factor(deltaproduct(g, limit))
             except AssertionError:
@@ -294,9 +293,6 @@ def deltasummation(f, limit, no_piecewise=False):
     sympy.functions.special.tensor_functions.KroneckerDelta
     sympy.concrete.sums.summation
     """
-    from sympy.concrete.summations import summation
-    from sympy.solvers import solve
-
     if ((limit[2] - limit[1]) < 0) == True:
         return S.Zero
 
@@ -325,7 +321,6 @@ def deltasummation(f, limit, no_piecewise=False):
     if len(solns) == 0:
         return S.Zero
     elif len(solns) != 1:
-        from sympy.concrete.summations import Sum
         return Sum(f, limit)
     value = solns[0]
     if no_piecewise:

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -10,9 +10,10 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.piecewise import (piecewise_fold,
     Piecewise)
 from sympy.logic.boolalg import BooleanFunction
-from sympy.tensor.indexed import Idx
+from sympy.matrices.matrices import MatrixBase
 from sympy.sets.sets import Interval, Set
 from sympy.sets.fancysets import Range
+from sympy.tensor.indexed import Idx
 from sympy.utilities import flatten
 from sympy.utilities.iterables import sift, is_sequence
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -573,8 +574,6 @@ class AddWithLimits(ExprWithLimits):
         return self
 
     def _eval_expand_basic(self, **hints):
-        from sympy.matrices.matrices import MatrixBase
-
         summand = self.function.expand(**hints)
         if summand.is_Add and summand.is_commutative:
             return Add(*[self.func(i, *self.limits) for i in summand.args])

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -1,15 +1,19 @@
 from typing import Tuple as tTuple
 
+from .expr_with_intlimits import ExprWithIntLimits
+from .summations import Sum, summation, _dummy_with_inherited_properties_concrete
 from sympy.core.expr import Expr
+from sympy.core.exprtools import factor_terms
+from sympy.core.function import Derivative
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
-from sympy.concrete.expr_with_intlimits import ExprWithIntLimits
-from sympy.core.exprtools import factor_terms
-from sympy.functions.elementary.exponential import exp, log
-from sympy.polys import quo, roots
-from sympy.simplify import powsimp
-from sympy.core.function import Derivative
 from sympy.core.symbol import Dummy, Symbol
+from sympy.functions.combinatorial.factorials import RisingFactorial
+from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.special.tensor_functions import KroneckerDelta
+from sympy.polys import quo, roots
+from sympy.simplify.powsimp import powsimp
+from sympy.simplify.simplify import product_simplify
 
 
 class Product(ExprWithIntLimits):
@@ -196,7 +200,6 @@ class Product(ExprWithIntLimits):
         return obj
 
     def _eval_rewrite_as_Sum(self, *args, **kwargs):
-        from sympy.concrete.summations import Sum
         return exp(Sum(log(self.function), *self.limits))
 
     @property
@@ -252,8 +255,6 @@ class Product(ExprWithIntLimits):
         # variables with matching assumptions
         reps = {}
         for xab in self.limits:
-            # Must be imported here to avoid circular imports
-            from .summations import _dummy_with_inherited_properties_concrete
             d = _dummy_with_inherited_properties_concrete(xab)
             if d:
                 reps[xab[0]] = d
@@ -294,9 +295,6 @@ class Product(ExprWithIntLimits):
         return self.func(self.function.conjugate(), *self.limits)
 
     def _eval_product(self, term, limits):
-        from sympy.concrete.delta import deltaproduct, _has_simple_delta
-        from sympy.concrete.summations import summation
-        from sympy.functions import KroneckerDelta, RisingFactorial
 
         (k, a, n) = limits
 
@@ -308,6 +306,7 @@ class Product(ExprWithIntLimits):
         if a == n:
             return term.subs(k, a)
 
+        from .delta import deltaproduct, _has_simple_delta
         if term.has(KroneckerDelta) and _has_simple_delta(term, limits[0]):
             return deltaproduct(term, limits)
 
@@ -393,7 +392,6 @@ class Product(ExprWithIntLimits):
             return self._eval_product_direct(term, limits)
 
     def _eval_simplify(self, **kwargs):
-        from sympy.simplify.simplify import product_simplify
         rv = product_simplify(self)
         return rv.doit() if kwargs['doit'] else rv
 
@@ -407,7 +405,6 @@ class Product(ExprWithIntLimits):
         return Mul(*[term.subs(k, a + i) for i in range(n - a + 1)])
 
     def _eval_derivative(self, x):
-        from sympy.concrete.summations import Sum
         if isinstance(x, Symbol) and x not in self.free_symbols:
             return S.Zero
         f, limits = self.function, list(self.limits)
@@ -469,8 +466,6 @@ class Product(ExprWithIntLimits):
 
         .. [1] https://en.wikipedia.org/wiki/Infinite_product
         """
-        from sympy.concrete.summations import Sum
-
         sequence_term = self.function
         log_sum = log(sequence_term)
         lim = self.limits

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -1,7 +1,9 @@
-from sympy.core import Mul
-from sympy.functions import DiracDelta, Heaviside
+from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
+from sympy.functions import DiracDelta, Heaviside
+from .integrals import Integral, integrate
+from sympy.solvers import solve
 
 
 def change_mul(node, x):
@@ -135,9 +137,6 @@ def deltaintegrate(f, x):
     """
     if not f.has(DiracDelta):
         return None
-
-    from sympy.integrals import Integral, integrate
-    from sympy.solvers import solve
 
     # g(x) = DiracDelta(h(x))
     if f.func == DiracDelta:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -19,12 +19,7 @@ from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.complexes import Abs, sign
 from sympy.functions.elementary.miscellaneous import Min, Max
-from sympy.integrals.manualintegrate import manualintegrate
-from sympy.integrals.trigonometry import trigintegrate
-from sympy.integrals.meijerint import (meijerint_definite, meijerint_indefinite,
-                                       _debug)
-from sympy.integrals.deltafunctions import deltaintegrate
-from sympy.integrals.rationaltools import ratint
+from .rationaltools import ratint
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
 from sympy.series.formal import FormalPowerSeries
@@ -32,6 +27,7 @@ from sympy.series.limits import limit
 from sympy.series.order import Order
 from sympy.simplify.fu import sincos_to_sum
 from sympy.simplify.simplify import simplify
+from sympy.solvers.solvers import solve, posify
 from sympy.tensor.functions import shape
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import is_sequence
@@ -266,7 +262,6 @@ class Integral(AddWithLimits):
         sympy.concrete.expr_with_limits.ExprWithLimits.variables : Lists the integration variables
         as_dummy : Replace integration variables with dummy ones
         """
-        from sympy.solvers.solvers import solve, posify
         d = Dummy('d')
 
         xfree = x.free_symbols.intersection(self.variables)
@@ -403,7 +398,6 @@ class Integral(AddWithLimits):
         sympy.integrals.rationaltools.ratint
         as_sum : Approximate the integral using a sum
         """
-        from sympy.concrete.summations import Sum
         if not hints.get('integrals', True):
             return self
 
@@ -439,6 +433,7 @@ class Integral(AddWithLimits):
 
         # hacks to handle integrals of
         # nested summations
+        from sympy.concrete.summations import Sum
         if isinstance(self.function, Sum):
             if any(v in self.function.limits[0] for v in self.variables):
                 raise ValueError('Limit of the sum cannot be an integration variable.')
@@ -909,6 +904,7 @@ class Integral(AddWithLimits):
         """
 
         from sympy.integrals.risch import risch_integrate, NonElementaryIntegral
+        from sympy.integrals.manualintegrate import manualintegrate
 
         if risch:
             try:
@@ -1058,8 +1054,8 @@ class Integral(AddWithLimits):
                     parts.append(coeff * h)
                     continue
 
+                from .singularityfunctions import singularityintegrate
                 # g(x) has at least a Singularity Function term
-                from sympy.integrals.singularityfunctions import singularityintegrate
                 h = singularityintegrate(g, x)
                 if h is not None:
                     parts.append(coeff * h)
@@ -1624,3 +1620,8 @@ def line_integrate(field, curve, vars):
 @shape.register(Integral)
 def _(expr):
     return shape(expr.function)
+
+# Delayed imports
+from .deltafunctions import deltaintegrate
+from .meijerint import meijerint_definite, meijerint_indefinite, _debug
+from .trigonometry import trigintegrate

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -51,11 +51,13 @@ from sympy.functions.special.polynomials import (chebyshevt, chebyshevu,
     legendre, hermite, laguerre, assoc_laguerre, gegenbauer, jacobi,
     OrthogonalPolynomial)
 from sympy.functions.special.zeta_functions import polylog
+from .integrals import Integral
 from sympy.logic.boolalg import And
 from sympy.ntheory.factor_ import divisors
 from sympy.polys.polytools import degree
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
+from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
@@ -637,8 +639,6 @@ def parts_rule(integral):
         u, dv, v, du, v_step = result
         debug("u : {}, dv : {}, v : {}, du : {}, v_step: {}".format(u, dv, v, du, v_step))
         steps.append(result)
-
-        from .integrals import Integral
 
         if isinstance(v, Integral):
             return
@@ -1468,7 +1468,6 @@ def eval_trigsubstitution(theta, func, rewritten, substep, restriction, integran
     trig_function = list(func.find(TrigonometricFunction))
     assert len(trig_function) == 1
     trig_function = trig_function[0]
-    from sympy.solvers.solvers import solve
     relation = solve(symbol - func, trig_function)
     assert len(relation) == 1
     numer, denom = fraction(relation[0])
@@ -1625,7 +1624,6 @@ def eval_elliptic_e(a, d, integrand, symbol):
 
 @evaluates(DontKnowRule)
 def eval_dontknowrule(integrand, symbol):
-    from .integrals import Integral
     return Integral(integrand, symbol)
 
 def _manualintegrate(rule):

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -61,6 +61,7 @@ from sympy.functions.special.error_functions import (erf, erfc, erfi, Ei,
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper, meijerg
 from sympy.functions.special.singularity_functions import SingularityFunction
+from .integrals import Integral
 from sympy.logic.boolalg import And, Or, BooleanAtom, Not, BooleanFunction
 from sympy.polys import cancel, factor
 from sympy.simplify.fu import sincos_to_sum
@@ -1565,8 +1566,6 @@ def _rewrite_single(f, x, recursive=True):
     # to avoid infinite recursion, we have to force the two g functions case
 
     def my_integrator(f, x):
-        from sympy.integrals.integrals import Integral
-
         r = _meijerint_definite_4(f, x, only_double=True)
         if r is not None:
             res, cond = r
@@ -1693,7 +1692,6 @@ def meijerint_indefinite(f, x):
 
 def _meijerint_indefinite_1(f, x):
     """ Helper that does not attempt any substitution. """
-    from sympy.integrals.integrals import Integral
     _debug('Trying to compute the indefinite integral of', f, 'wrt', x)
 
     gs = _rewrite1(f, x)

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -9,8 +9,9 @@ from sympy.functions.elementary.trigonometric import atan
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import cancel
 from sympy.polys.rootoftools import RootSum
-
 from sympy.polys import Poly, resultant, ZZ
+from sympy.solvers.solvers import solve
+
 
 def ratint(f, x, **flags):
     """
@@ -153,8 +154,6 @@ def ratint_ratpart(f, g, x):
 
     ratint, ratint_logpart
     """
-    from sympy.solvers.solvers import solve
-
     f = Poly(f, x)
     g = Poly(g, x)
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -202,7 +202,6 @@ def special_denom(a, ba, bd, ca, cd, DE, case='auto'):
 
     This constitutes step 2 of the outline given in the rde.py docstring.
     """
-    from sympy.integrals.prde import parametric_log_deriv
     # TODO: finish writing this and write tests
 
     if case == 'auto':
@@ -226,7 +225,7 @@ def special_denom(a, ba, bd, ca, cd, DE, case='auto'):
     n = min(0, nc - min(0, nb))
     if not nb:
         # Possible cancellation.
-
+        from .prde import parametric_log_deriv
         if case == 'exp':
             dcoeff = DE.d.quo(Poly(DE.t, DE.t))
             with DecrementLevel(DE):  # We are guaranteed to not have problems,
@@ -284,8 +283,6 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
 
     This constitutes step 3 of the outline given in the rde.py docstring.
     """
-    from sympy.integrals.prde import (parametric_log_deriv, limited_integrate,
-        is_log_deriv_k_t_radical_in_field)
     # TODO: finish writing this and write tests
 
     if case == 'auto':
@@ -320,6 +317,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
         with DecrementLevel(DE):
             alphaa, alphad = frac_in(alpha, DE.t)
             if db == da - 1:
+                from .prde import limited_integrate
                 # if alpha == m*Dt + Dz for z in k and m in ZZ:
                 try:
                     (za, zd), m = limited_integrate(alphaa, alphad, [(etaa, etad)],
@@ -336,6 +334,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                     # beta = -lc(a*Dz + b*z)/(z*lc(a))
                     # if beta == m*Dt + Dw for w in k and m in ZZ:
                         # n = max(n, m)
+                from .prde import is_log_deriv_k_t_radical_in_field
                 A = is_log_deriv_k_t_radical_in_field(alphaa, alphad, DE)
                 if A is not None:
                     aa, z = A
@@ -343,6 +342,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                         beta = -(a*derivation(z, DE).as_poly(t1) +
                             b*z.as_poly(t1)).LC()/(z.as_expr()*a.LC())
                         betaa, betad = frac_in(beta, DE.t)
+                        from .prde import limited_integrate
                         try:
                             (za, zd), m = limited_integrate(betaa, betad,
                                 [(etaa, etad)], DE)
@@ -354,6 +354,8 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                             n = max(n, m[0].as_expr())
 
     elif case == 'exp':
+        from .prde import parametric_log_deriv
+
         n = max(0, dc - max(db, da))
         if da == db:
             etaa, etad = frac_in(DE.d.quo(Poly(DE.t, DE.t)), DE.T[DE.level - 1])
@@ -566,8 +568,8 @@ def cancel_primitive(b, c, n, DE):
     has no solution of degree at most n in k[t], or a solution q in k[t] of
     this equation with deg(q) <= n.
     """
-    from sympy.integrals.prde import is_log_deriv_k_t_radical_in_field
-
+    # Delayed imports
+    from .prde import is_log_deriv_k_t_radical_in_field
     with DecrementLevel(DE):
         ba, bd = frac_in(b, DE.t)
         A = is_log_deriv_k_t_radical_in_field(ba, bd, DE)
@@ -616,8 +618,7 @@ def cancel_exp(b, c, n, DE):
     has no solution of degree at most n in k[t], or a solution q in k[t] of
     this equation with deg(q) <= n.
     """
-    from sympy.integrals.prde import parametric_log_deriv
-
+    from .prde import parametric_log_deriv
     eta = DE.d.quo(Poly(DE.t, DE.t)).as_expr()
 
     with DecrementLevel(DE):
@@ -673,14 +674,13 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
     For parametric=False, cQ is c, a Poly; for parametric=True, cQ is Q ==
     [q1, ..., qm], a list of Polys.
     """
-    from sympy.integrals.prde import (prde_no_cancel_b_large,
-        prde_no_cancel_b_small)
-
     # No cancellation
     if not b.is_zero and (DE.case == 'base' or
             b.degree(DE.t) > max(0, DE.d.degree(DE.t) - 1)):
 
         if parametric:
+            # Delayed imports
+            from .prde import prde_no_cancel_b_large
             return prde_no_cancel_b_large(b, cQ, n, DE)
         return no_cancel_b_large(b, cQ, n, DE)
 
@@ -688,6 +688,7 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
             (DE.case == 'base' or DE.d.degree(DE.t) >= 2):
 
         if parametric:
+            from .prde import prde_no_cancel_b_small
             return prde_no_cancel_b_small(b, cQ, n, DE)
 
         R = no_cancel_b_small(b, cQ, n, DE)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -40,8 +40,8 @@ from sympy.functions.elementary.hyperbolic import (cosh, coth, sinh,
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
-from sympy.integrals import integrate, Integral
-from sympy.integrals.heurisch import _symbols
+from .integrals import integrate, Integral
+from .heurisch import _symbols
 from sympy.polys.polyerrors import DomainError, PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
@@ -296,6 +296,8 @@ class DifferentialExtension:
         """
         Rewrite exps/pows for better processing.
         """
+        from .prde import is_deriv_k
+
         # Pre-preparsing.
         #################
         # Get all exp arguments, so we can avoid ahead of time doing
@@ -307,8 +309,6 @@ class DifferentialExtension:
         # to a**(Rational*b) before doing anything else.  Note that the
         # _exp_part code can generate terms of this form, so we do need to
         # do this at each pass (or else modify it to not do that).
-
-        from sympy.integrals.prde import is_deriv_k
 
         ratpows = [i for i in self.newf.atoms(Pow).union(self.newf.atoms(exp))
             if (i.base.is_Pow or isinstance(i.base, exp) and i.exp.is_Rational)]
@@ -461,8 +461,7 @@ class DifferentialExtension:
         way around an algebraic extension (e.g., exp(log(x)/2)), it will raise
         NotImplementedError.
         """
-        from sympy.integrals.prde import is_log_deriv_k_t_radical
-
+        from .prde import is_log_deriv_k_t_radical
         new_extension = False
         restart = False
         expargs = [i.exp for i in exps]
@@ -572,8 +571,7 @@ class DifferentialExtension:
         way, so this function does not ever return None or raise
         NotImplementedError.
         """
-        from sympy.integrals.prde import is_deriv_k
-
+        from .prde import is_deriv_k
         new_extension = False
         logargs = [i.args[0] for i in logs]
         for arg in ordered(logargs):
@@ -1389,14 +1387,13 @@ def integrate_primitive_polynomial(p, DE):
     True, or r = p - Dq does not have an elementary integral over k(t) if b is
     False.
     """
-    from sympy.integrals.prde import limited_integrate
-
     Zero = Poly(0, DE.t)
     q = Poly(0, DE.t)
 
     if not p.expr.has(DE.t):
         return (Zero, p, True)
 
+    from .prde import limited_integrate
     while True:
         if not p.expr.has(DE.t):
             return (q, p, True)
@@ -1484,8 +1481,6 @@ def integrate_hyperexponential_polynomial(p, DE, z):
     k[t, 1/t] and a bool b in {True, False} such that p - Dq in k if b is True,
     or p - Dq does not have an elementary integral over k(t) if b is False.
     """
-    from sympy.integrals.rde import rischDE
-
     t1 = DE.t
     dtt = DE.d.exquo(Poly(DE.t, DE.t))
     qa = Poly(0, DE.t)
@@ -1494,6 +1489,8 @@ def integrate_hyperexponential_polynomial(p, DE, z):
 
     if p.is_zero:
         return(qa, qd, b)
+
+    from sympy.integrals.rde import rischDE
 
     with DecrementLevel(DE):
         for i in range(-p.degree(z), p.degree(t1) + 1):

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -1,5 +1,6 @@
 from sympy.core import cacheit, Dummy, Ne, Integer, Rational, S, Wild
 from sympy.functions import binomial, sin, cos, Piecewise
+from .integrals import integrate
 
 # TODO sin(a*x)*cos(b*x) -> sin((a+b)x) + sin((a-b)x) ?
 
@@ -59,7 +60,6 @@ def trigintegrate(f, x, conds='piecewise'):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
-    from sympy.integrals.integrals import integrate
     pat, a, n, m = _pat_sincos(x)
 
     f = f.rewrite('sincos')

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -62,7 +62,6 @@ from sympy.solvers import solve, solve_undetermined_coeffs
 from sympy.polys import Poly, quo, gcd, lcm, roots, resultant
 from sympy.functions import binomial, factorial, FallingFactorial, RisingFactorial
 from sympy.matrices import Matrix, casoratian
-from sympy.concrete import product
 from sympy.utilities.iterables import numbered_symbols
 
 
@@ -510,6 +509,8 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
     .. [2] M. Petkovsek, H. S. Wilf, D. Zeilberger, A = B, 1996.
     """
+    from sympy.concrete import product
+
     coeffs = list(map(sympify, coeffs))
 
     f = sympify(f)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -38,16 +38,13 @@ from sympy.ntheory.factor_ import divisors
 from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
     separatevars)
-from sympy.integrals.integrals import Integral
 from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1, TR2i
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, factor, Poly
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
-
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
-
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent, debug
 from sympy.utilities.iterables import (connected_components,
@@ -2129,6 +2126,8 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     if not symbols:
         return S.Zero, S.One
 
+    from sympy.integrals.integrals import Integral
+
     # derivatives are easy to do but tricky to analyze to see if they
     # are going to disallow a linear solution, so for simplicity we
     # just evaluate the ones that have the symbols of interest
@@ -3514,5 +3513,7 @@ def unrad(eq, *syms, **flags):
     eq, cov = _canonical(eq, cov)
     return eq, cov
 
+
+# Delayed imports
 from sympy.solvers.bivariate import (
     bivariate_type, _solve_lambert, _filtered_gens)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Another stab in bringing some order among the imports. This time for integrals and concrete.

The general rationale is that the more general classes and functions should be imported at the top-level at the detailed classes. So `Integral` should be imported at top-level in e.g. manualintegrate rather than the other way around.

#### Other comments

This also affected the solvers module, where imports were moved into the methods. However, there was a clear benefit of moving in that direction (two imports in solvers, many more imports in the other modules)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
