### PR TITLE
Array expression objects are not evaluated by default anymore

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -160,12 +160,12 @@ def tensorcontraction(array, *contraction_axes):
     [a*e + b*g, a*f + b*h],
     [c*e + d*g, c*f + d*h]])
     """
-    from sympy.tensor.array.expressions.array_expressions import ArrayContraction
+    from sympy.tensor.array.expressions.array_expressions import _array_contraction
     from sympy.tensor.array.expressions.array_expressions import _CodegenArrayAbstract
     from sympy.tensor.array.expressions.array_expressions import _ArrayExpr
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     if isinstance(array, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
-        return ArrayContraction(array, *contraction_axes)
+        return _array_contraction(array, *contraction_axes)
 
     array, remaining_indices, remaining_shape, summed_deltas = _util_contraction_diagonal(array, *contraction_axes)
 
@@ -237,10 +237,10 @@ def tensordiagonal(array, *diagonal_axes):
 
     from sympy.tensor.array.expressions.array_expressions import _ArrayExpr
     from sympy.tensor.array.expressions.array_expressions import _CodegenArrayAbstract
-    from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal
+    from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal, _array_diagonal
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     if isinstance(array, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
-        return ArrayDiagonal(array, *diagonal_axes)
+        return _array_diagonal(array, *diagonal_axes)
 
     ArrayDiagonal._validate(array, *diagonal_axes)
 
@@ -374,10 +374,10 @@ def permutedims(expr, perm):
 
     from sympy.tensor.array.expressions.array_expressions import _ArrayExpr
     from sympy.tensor.array.expressions.array_expressions import _CodegenArrayAbstract
-    from sympy.tensor.array.expressions.array_expressions import PermuteDims
+    from sympy.tensor.array.expressions.array_expressions import _permute_dims
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     if isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
-        return PermuteDims(expr, perm)
+        return _permute_dims(expr, perm)
 
     if not isinstance(expr, NDimArray):
         expr = ImmutableDenseNDimArray(expr)

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -12,7 +12,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, ArraySymbol, ArrayTensorProduct, \
     ArrayAdd, PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_rank, \
-    get_shape, ArrayContraction
+    get_shape, ArrayContraction, _array_tensor_product, _array_contraction, _array_diagonal, _array_add, _permute_dims
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 
 
@@ -38,7 +38,7 @@ def _(expr: ArrayTensorProduct, x: Expr):
         args_succ = args[i+1:]
         shape_prev = reduce(operator.add, map(get_shape, args_prev), ())
         shape_succ = reduce(operator.add, map(get_shape, args_succ), ())
-        addend = ArrayTensorProduct(*args_prev, darg, *args_succ)
+        addend = _array_tensor_product(*args_prev, darg, *args_succ)
         tot1 = len(get_shape(x))
         tot2 = tot1 + len(shape_prev)
         tot3 = tot2 + len(get_shape(arg))
@@ -46,20 +46,20 @@ def _(expr: ArrayTensorProduct, x: Expr):
         perm = [i for i in range(tot1, tot2)] + \
                [i for i in range(tot1)] + [i for i in range(tot2, tot3)] + \
                [i for i in range(tot3, tot4)]
-        addend = PermuteDims(addend, _af_invert(perm))
+        addend = _permute_dims(addend, _af_invert(perm))
         addend_list.append(addend)
     if len(addend_list) == 1:
         return addend_list[0]
     elif len(addend_list) == 0:
         return S.Zero
     else:
-        return ArrayAdd(*addend_list)
+        return _array_add(*addend_list)
 
 
 @array_derive.register(ArraySymbol) # type: ignore
 def _(expr: ArraySymbol, x: Expr):
     if expr == x:
-        return PermuteDims(
+        return _permute_dims(
             ArrayTensorProduct.fromiter(Identity(i) for i in expr.shape),
             [2*i for i in range(len(expr.shape))] + [2*i+1 for i in range(len(expr.shape))]
         )
@@ -70,8 +70,8 @@ def _(expr: ArraySymbol, x: Expr):
 def _(expr: MatrixSymbol, x: Expr):
     m, n = expr.shape
     if expr == x:
-        return PermuteDims(
-            ArrayTensorProduct(Identity(m), Identity(n)),
+        return _permute_dims(
+            _array_tensor_product(Identity(m), Identity(n)),
             [0, 2, 1, 3]
         )
     return ZeroArray(*(x.shape + expr.shape))
@@ -87,16 +87,16 @@ def _(expr: Transpose, x: Expr):
     # D(A.T, A) ==> (m,n,i,j) ==> D(A_ji, A_mn) = d_mj d_ni
     # D(B.T, A) ==> (m,n,i,j) ==> D(B_ji, A_mn)
     fd = array_derive(expr.arg, x)
-    return PermuteDims(fd, [0, 1, 3, 2])
+    return _permute_dims(fd, [0, 1, 3, 2])
 
 
 @array_derive.register(Inverse) # type: ignore
 def _(expr: Inverse, x: Expr):
     mat = expr.I
     dexpr = array_derive(mat, x)
-    tp = ArrayTensorProduct(-expr, dexpr, expr)
-    mp = ArrayContraction(tp, (1, 4), (5, 6))
-    pp = PermuteDims(mp, [1, 2, 0, 3])
+    tp = _array_tensor_product(-expr, dexpr, expr)
+    mp = _array_contraction(tp, (1, 4), (5, 6))
+    pp = _permute_dims(mp, [1, 2, 0, 3])
     return pp
 
 
@@ -106,11 +106,11 @@ def _(expr: ElementwiseApplyFunction, x: Expr):
     assert get_rank(x) == 2
     fdiff = expr._get_function_fdiff()
     dexpr = array_derive(expr.expr, x)
-    tp = ArrayTensorProduct(
+    tp = _array_tensor_product(
         ElementwiseApplyFunction(fdiff, expr.expr),
         dexpr
     )
-    td = ArrayDiagonal(
+    td = _array_diagonal(
         tp, (0, 4), (1, 5)
     )
     return td
@@ -121,14 +121,14 @@ def _(expr: ArrayElementwiseApplyFunc, x: Expr):
     fdiff = expr._get_function_fdiff()
     subexpr = expr.expr
     dsubexpr = array_derive(subexpr, x)
-    tp = ArrayTensorProduct(
+    tp = _array_tensor_product(
         dsubexpr,
         ArrayElementwiseApplyFunc(fdiff, subexpr)
     )
     b = get_rank(x)
     c = get_rank(expr)
     diag_indices = [(b + i, b + c + i) for i in range(c)]
-    return ArrayDiagonal(tp, *diag_indices)
+    return _array_diagonal(tp, *diag_indices)
 
 
 @array_derive.register(MatrixExpr) # type: ignore
@@ -148,7 +148,7 @@ def _(expr: ArrayContraction, x: Expr):
     rank_x = len(get_shape(x))
     contraction_indices = expr.contraction_indices
     new_contraction_indices = [tuple(j + rank_x for j in i) for i in contraction_indices]
-    return ArrayContraction(fd, *new_contraction_indices)
+    return _array_contraction(fd, *new_contraction_indices)
 
 
 @array_derive.register(ArrayDiagonal) # type: ignore
@@ -156,19 +156,19 @@ def _(expr: ArrayDiagonal, x: Expr):
     dsubexpr = array_derive(expr.expr, x)
     rank_x = len(get_shape(x))
     diag_indices = [[j + rank_x for j in i] for i in expr.diagonal_indices]
-    return ArrayDiagonal(dsubexpr, *diag_indices)
+    return _array_diagonal(dsubexpr, *diag_indices)
 
 
 @array_derive.register(ArrayAdd) # type: ignore
 def _(expr: ArrayAdd, x: Expr):
-    return ArrayAdd(*[array_derive(arg, x) for arg in expr.args])
+    return _array_add(*[array_derive(arg, x) for arg in expr.args])
 
 
 @array_derive.register(PermuteDims) # type: ignore
 def _(expr: PermuteDims, x: Expr):
     de = array_derive(expr.expr, x)
     perm = [0, 1] + [i + 2 for i in expr.permutation.array_form]
-    return PermuteDims(de, perm)
+    return _permute_dims(de, perm)
 
 
 def matrix_derive(expr, x):

--- a/sympy/tensor/array/expressions/conv_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/conv_array_to_matrix.py
@@ -21,7 +21,7 @@ from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayDiagonal, \
     ArrayTensorProduct, OneArray, get_rank, _get_subrank, ZeroArray, ArrayContraction, \
     ArrayAdd, _CodegenArrayAbstract, get_shape, ArrayElementwiseApplyFunc, _ArrayExpr, _EditArrayContraction, _ArgE, \
-    ArrayElement
+    ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, _array_add, _permute_dims
 from sympy.tensor.array.expressions.utils import _get_mapping_from_subranks
 
 
@@ -76,7 +76,7 @@ def _support_function_tp1_recognize(contraction_indices, args):
     if len(contraction_indices) == 0:
         return _a2m_tensor_product(*args)
 
-    ac = ArrayContraction(ArrayTensorProduct(*args), *contraction_indices)
+    ac = _array_contraction(_array_tensor_product(*args), *contraction_indices)
     editor = _EditArrayContraction(ac)
     editor.track_permutation_start()
 
@@ -136,7 +136,7 @@ def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
     # expression can be inserted.
 
     # For example, if "a" has shape (1, 1) and "b" has shape (k, 1), the
-    # expressions "ArrayTensorProduct(a, b*b.T)" can be rewritten as
+    # expressions "_array_tensor_product(a, b*b.T)" can be rewritten as
     # "b*a*b.T"
 
     trivial_matrices = []
@@ -164,7 +164,7 @@ def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
     if pos is None:
         return expr, []
     args[pos] = (first*MatMul.fromiter(i for i in trivial_matrices)*second).doit()
-    return ArrayTensorProduct(*[i for i in args if i is not None]), removed
+    return _array_tensor_product(*[i for i in args if i is not None]), removed
 
 
 @singledispatch
@@ -205,12 +205,12 @@ def _(expr: ArrayContraction):
         if isinstance(subexpr, MatrixExpr):
             return OneMatrix(1, shape[0])*subexpr*OneMatrix(shape[1], 1)
     if isinstance(subexpr, ArrayTensorProduct):
-        newexpr = ArrayContraction(_array2matrix(subexpr), *contraction_indices)
+        newexpr = _array_contraction(_array2matrix(subexpr), *contraction_indices)
         contraction_indices = newexpr.contraction_indices
         if any(i > 2 for i in newexpr.subranks):
-            addends = ArrayAdd(*[_a2m_tensor_product(*j) for j in itertools.product(*[i.args if isinstance(i,
+            addends = _array_add(*[_a2m_tensor_product(*j) for j in itertools.product(*[i.args if isinstance(i,
                                                                                                                              ArrayAdd) else [i] for i in expr.expr.args])])
-            newexpr = ArrayContraction(addends, *contraction_indices)
+            newexpr = _array_contraction(addends, *contraction_indices)
         if isinstance(newexpr, ArrayAdd):
             ret = _array2matrix(newexpr)
             return ret
@@ -223,12 +223,12 @@ def _(expr: ArrayContraction):
             assert expr.contraction_indices == ((0, 1),)
             return _a2m_trace(ret)
         else:
-            return ArrayContraction(ret, *expr.contraction_indices)
+            return _array_contraction(ret, *expr.contraction_indices)
 
 
 @_array2matrix.register(ArrayDiagonal) # type: ignore
 def _(expr: ArrayDiagonal):
-    pexpr = ArrayDiagonal(_array2matrix(expr.expr), *expr.diagonal_indices)
+    pexpr = _array_diagonal(_array2matrix(expr.expr), *expr.diagonal_indices)
     pexpr = identify_hadamard_products(pexpr)
     if isinstance(pexpr, ArrayDiagonal):
         pexpr = _array_diag2contr_diagmatrix(pexpr)
@@ -265,7 +265,7 @@ def _(expr: PermuteDims):
             else:
                 raise NotImplementedError()
         newargs = [i[0] for i in newargs]
-        return PermuteDims(_a2m_tensor_product(*scalars, *newargs), _af_invert(newperm))
+        return _permute_dims(_a2m_tensor_product(*scalars, *newargs), _af_invert(newperm))
     elif isinstance(expr.expr, ArrayContraction):
         mat_mul_lines = _array2matrix(expr.expr)
         if not isinstance(mat_mul_lines, ArrayTensorProduct):
@@ -282,7 +282,7 @@ def _(expr: PermuteDims):
             p1 = permuted[2*i]
             p2 = permuted[2*i+1]
             if p1 // 2 != p2 // 2:
-                return PermuteDims(mat_mul_lines, permutation)
+                return _permute_dims(mat_mul_lines, permutation)
             pos = p1 // 2
             if p1 > p2:
                 args_array[i] = _a2m_transpose(mat_mul_lines.args[pos])
@@ -421,7 +421,7 @@ def _(expr: PermuteDims):
     premoved = [pinv[i] for i in subremoved]
     p2 = [e - shift[e] for i, e in enumerate(p) if e not in subremoved]
     # TODO: check if subremoved should be permuted as well...
-    newexpr = PermuteDims(subexpr, p2)
+    newexpr = _permute_dims(subexpr, p2)
     premoved = sorted(premoved)
     if newexpr != expr:
         newexpr, removed2 = _remove_trivial_dims(_array2matrix(newexpr))
@@ -452,7 +452,7 @@ def _(expr: ArrayContraction):
     # Shift removed2:
     removed2 = ArrayContraction._push_indices_up(expr.contraction_indices, removed2)
     removed = _combine_removed(rank1, removed1, removed2)
-    return ArrayContraction(newexpr, *new_contraction_indices), list(removed)
+    return _array_contraction(newexpr, *new_contraction_indices), list(removed)
 
 
 def _remove_diagonalized_identity_matrices(expr: ArrayDiagonal):
@@ -499,7 +499,7 @@ def _(expr: ArrayDiagonal):
     # corresponding dimension has been removed, they no longer need diagonalization:
     new_diag_indices = [i for i in new_diag_indices if len(i) > 0]
     if len(new_diag_indices) > 0:
-        newexpr2 = ArrayDiagonal(newexpr, *new_diag_indices, allow_trivial_diags=True)
+        newexpr2 = _array_diagonal(newexpr, *new_diag_indices, allow_trivial_diags=True)
     else:
         newexpr2 = newexpr
     if isinstance(newexpr2, ArrayDiagonal):
@@ -536,10 +536,9 @@ def convert_array_to_matrix(expr):
     ========
 
     >>> from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array
-    >>> from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
+    >>> from sympy.tensor.array import tensorcontraction, tensorproduct
     >>> from sympy import MatrixSymbol, Sum
     >>> from sympy.abc import i, j, k, l, N
-    >>> from sympy.tensor.array.expressions.array_expressions import ArrayContraction
     >>> from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
     >>> from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
     >>> A = MatrixSymbol("A", N, N)
@@ -597,7 +596,7 @@ def convert_array_to_matrix(expr):
     If more than one line of matrix multiplications is detected, return
     separate matrix multiplication factors embedded in a tensor product object:
 
-    >>> cg = ArrayContraction(ArrayTensorProduct(A, B, C, D), (1, 2), (5, 6))
+    >>> cg = tensorcontraction(tensorproduct(A, B, C, D), (1, 2), (5, 6))
     >>> convert_array_to_matrix(cg)
     ArrayTensorProduct(A*B, C*D)
 
@@ -656,10 +655,10 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
         diag_indices_new = [i for i in diag_indices if i is not None]
         cumul = list(accumulate([0] + [get_rank(arg) for arg in args]))
         contr_indices2 = [tuple(cumul[a] + b for a, b in i) for i in contr_indices]
-        tc = ArrayContraction(
-            ArrayTensorProduct(*args), *contr_indices2
+        tc = _array_contraction(
+            _array_tensor_product(*args), *contr_indices2
         )
-        td = ArrayDiagonal(tc, *diag_indices_new)
+        td = _array_diagonal(tc, *diag_indices_new)
         return td
     return expr
 
@@ -669,8 +668,8 @@ def _a2m_mul(*args):
         from sympy.matrices.expressions.matmul import MatMul
         return MatMul(*args).doit()
     else:
-        return ArrayContraction(
-            ArrayTensorProduct(*args),
+        return _array_contraction(
+            _array_tensor_product(*args),
             *[(2*i-1, 2*i) for i in range(1, len(args))]
         )
 
@@ -691,7 +690,7 @@ def _a2m_tensor_product(*args):
             arrays = [scalar] + arrays
         else:
             arrays[0] *= scalar
-    return ArrayTensorProduct(*arrays)
+    return _array_tensor_product(*arrays)
 
 
 def _a2m_add(*args):
@@ -699,12 +698,12 @@ def _a2m_add(*args):
         from sympy.matrices.expressions.matadd import MatAdd
         return MatAdd(*args).doit()
     else:
-        return ArrayAdd(*args)
+        return _array_add(*args)
 
 
 def _a2m_trace(arg):
     if isinstance(arg, _CodegenArrayAbstract):
-        return ArrayContraction(arg, (0, 1))
+        return _array_contraction(arg, (0, 1))
     else:
         from sympy.matrices.expressions.trace import Trace
         return Trace(arg)
@@ -712,7 +711,7 @@ def _a2m_trace(arg):
 
 def _a2m_transpose(arg):
     if isinstance(arg, _CodegenArrayAbstract):
-        return PermuteDims(arg, [1, 0])
+        return _permute_dims(arg, [1, 0])
     else:
         from sympy.matrices.expressions.transpose import Transpose
         return Transpose(arg).doit()
@@ -902,7 +901,7 @@ def remove_identity_matrices(expr: ArrayContraction):
             permutation.append(counter)
             counter += 1
             counter2 += 1
-    ret_expr2 = PermuteDims(ret_expr, _af_invert(permutation))
+    ret_expr2 = _permute_dims(ret_expr, _af_invert(permutation))
     return ret_expr2, removed
 
 

--- a/sympy/tensor/array/expressions/conv_matrix_to_array.py
+++ b/sympy/tensor/array/expressions/conv_matrix_to_array.py
@@ -12,8 +12,9 @@ from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.expressions.trace import Trace
 from sympy.matrices.expressions.transpose import Transpose
 from sympy.matrices.expressions.matexpr import MatrixExpr
-from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal, ArrayTensorProduct, \
-    PermuteDims, ArrayAdd, ArrayContraction, ArrayElementwiseApplyFunc
+from sympy.tensor.array.expressions.array_expressions import \
+    ArrayElementwiseApplyFunc, _array_tensor_product, _array_contraction, \
+    _array_diagonal, _array_add, _permute_dims
 
 
 def convert_matrix_to_array(expr: Basic) -> Basic:
@@ -26,35 +27,35 @@ def convert_matrix_to_array(expr: Basic) -> Basic:
             else:
                 args_nonmat.append(convert_matrix_to_array(arg))
         contractions = [(2*i+1, 2*i+2) for i in range(len(args)-1)]
-        scalar = ArrayTensorProduct.fromiter(args_nonmat) if args_nonmat else S.One
+        scalar = _array_tensor_product(*args_nonmat) if args_nonmat else S.One
         if scalar == 1:
-            tprod = ArrayTensorProduct(
+            tprod = _array_tensor_product(
                 *[convert_matrix_to_array(arg) for arg in args])
         else:
-            tprod = ArrayTensorProduct(
+            tprod = _array_tensor_product(
                 scalar,
                 *[convert_matrix_to_array(arg) for arg in args])
-        return ArrayContraction(
+        return _array_contraction(
                 tprod,
                 *contractions
         )
     elif isinstance(expr, MatAdd):
-        return ArrayAdd(
+        return _array_add(
                 *[convert_matrix_to_array(arg) for arg in expr.args]
         )
     elif isinstance(expr, Transpose):
-        return PermuteDims(
+        return _permute_dims(
                 convert_matrix_to_array(expr.args[0]), [1, 0]
         )
     elif isinstance(expr, Trace):
         inner_expr: MatrixExpr = convert_matrix_to_array(expr.arg) # type: ignore
-        return ArrayContraction(inner_expr, (0, len(inner_expr.shape) - 1))
+        return _array_contraction(inner_expr, (0, len(inner_expr.shape) - 1))
     elif isinstance(expr, Mul):
-        return ArrayTensorProduct.fromiter(convert_matrix_to_array(i) for i in expr.args)
+        return _array_tensor_product(*[convert_matrix_to_array(i) for i in expr.args])
     elif isinstance(expr, Pow):
         base = convert_matrix_to_array(expr.base)
         if (expr.exp > 0) == True:
-            return ArrayTensorProduct.fromiter(base for i in range(expr.exp))
+            return _array_tensor_product(*[base for i in range(expr.exp)])
         else:
             return expr
     elif isinstance(expr, MatPow):
@@ -67,9 +68,9 @@ def convert_matrix_to_array(expr: Basic) -> Basic:
         else:
             return expr
     elif isinstance(expr, HadamardProduct):
-        tp = ArrayTensorProduct.fromiter([convert_matrix_to_array(arg) for arg in expr.args])
+        tp = _array_tensor_product(*[convert_matrix_to_array(arg) for arg in expr.args])
         diag = [[2*i for i in range(len(expr.args))], [2*i+1 for i in range(len(expr.args))]]
-        return ArrayDiagonal(tp, *diag)
+        return _array_diagonal(tp, *diag)
     elif isinstance(expr, HadamardPower):
         base, exp = expr.args
         if isinstance(exp, Integer) and exp > 0:

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -1,5 +1,6 @@
 import random
 
+from sympy import tensordiagonal, eye
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.expressions.diagonal import DiagMatrix
@@ -10,7 +11,8 @@ from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, ArraySymbol, ArrayElement, \
     PermuteDims, ArrayContraction, ArrayTensorProduct, ArrayDiagonal, \
-    ArrayAdd, nest_permutation, ArrayElementwiseApplyFunc, _EditArrayContraction, _ArgE
+    ArrayAdd, nest_permutation, ArrayElementwiseApplyFunc, _EditArrayContraction, _ArgE, _array_tensor_product, \
+    _array_contraction, _array_diagonal, _array_add, _permute_dims
 from sympy.testing.pytest import raises
 
 i, j, k, l, m, n = symbols("i j k l m n")
@@ -55,7 +57,7 @@ def test_array_symbol_and_element():
     assert Ae == ImmutableDenseNDimArray(
         [[[ArrayElement(A, (i, j, k)) for k in range(4)] for j in range(3)] for i in range(2)])
 
-    p = permutedims(A, Permutation(0, 2, 1))
+    p = _permute_dims(A, Permutation(0, 2, 1))
     assert isinstance(p, PermuteDims)
 
 
@@ -91,184 +93,184 @@ def test_one_array():
 
 def test_arrayexpr_contraction_construction():
 
-    cg = ArrayContraction(A)
+    cg = _array_contraction(A)
     assert cg == A
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B), (1, 0))
-    assert cg == ArrayContraction(ArrayTensorProduct(A, B), (0, 1))
+    cg = _array_contraction(_array_tensor_product(A, B), (1, 0))
+    assert cg == _array_contraction(_array_tensor_product(A, B), (0, 1))
 
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (0, 1))
+    cg = _array_contraction(_array_tensor_product(M, N), (0, 1))
     indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 0), (0, 1)]]
     assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(0, 1)]
 
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (1, 2))
+    cg = _array_contraction(_array_tensor_product(M, N), (1, 2))
     indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 1), (1, 0)]]
     assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(1, 2)]
 
-    cg = ArrayContraction(ArrayTensorProduct(M, M, N), (1, 4), (2, 5))
+    cg = _array_contraction(_array_tensor_product(M, M, N), (1, 4), (2, 5))
     indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 0), (1, 1)], [(0, 1), (2, 0)]]
     assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(0, 3), (1, 4)]
 
     # Test removal of trivial contraction:
-    assert ArrayContraction(a, (1,)) == a
-    assert ArrayContraction(
-        ArrayTensorProduct(a, b), (0, 2), (1,), (3,)) == ArrayContraction(
-        ArrayTensorProduct(a, b), (0, 2))
+    assert _array_contraction(a, (1,)) == a
+    assert _array_contraction(
+        _array_tensor_product(a, b), (0, 2), (1,), (3,)) == _array_contraction(
+        _array_tensor_product(a, b), (0, 2))
 
 
 def test_arrayexpr_array_flatten():
 
     # Flatten nested ArrayTensorProduct objects:
-    expr1 = ArrayTensorProduct(M, N)
-    expr2 = ArrayTensorProduct(P, Q)
-    expr = ArrayTensorProduct(expr1, expr2)
-    assert expr == ArrayTensorProduct(M, N, P, Q)
+    expr1 = _array_tensor_product(M, N)
+    expr2 = _array_tensor_product(P, Q)
+    expr = _array_tensor_product(expr1, expr2)
+    assert expr == _array_tensor_product(M, N, P, Q)
     assert expr.args == (M, N, P, Q)
 
     # Flatten mixed ArrayTensorProduct and ArrayContraction objects:
-    cg1 = ArrayContraction(expr1, (1, 2))
-    cg2 = ArrayContraction(expr2, (0, 3))
+    cg1 = _array_contraction(expr1, (1, 2))
+    cg2 = _array_contraction(expr2, (0, 3))
 
-    expr = ArrayTensorProduct(cg1, cg2)
-    assert expr == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (1, 2), (4, 7))
+    expr = _array_tensor_product(cg1, cg2)
+    assert expr == _array_contraction(_array_tensor_product(M, N, P, Q), (1, 2), (4, 7))
 
-    expr = ArrayTensorProduct(M, cg1)
-    assert expr == ArrayContraction(ArrayTensorProduct(M, M, N), (3, 4))
+    expr = _array_tensor_product(M, cg1)
+    assert expr == _array_contraction(_array_tensor_product(M, M, N), (3, 4))
 
     # Flatten nested ArrayContraction objects:
-    cgnested = ArrayContraction(cg1, (0, 1))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N), (0, 3), (1, 2))
+    cgnested = _array_contraction(cg1, (0, 1))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N), (0, 3), (1, 2))
 
-    cgnested = ArrayContraction(ArrayTensorProduct(cg1, cg2), (0, 3))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 6), (1, 2), (4, 7))
+    cgnested = _array_contraction(_array_tensor_product(cg1, cg2), (0, 3))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N, P, Q), (0, 6), (1, 2), (4, 7))
 
-    cg3 = ArrayContraction(ArrayTensorProduct(M, N, P, Q), (1, 3), (2, 4))
-    cgnested = ArrayContraction(cg3, (0, 1))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 5), (1, 3), (2, 4))
+    cg3 = _array_contraction(_array_tensor_product(M, N, P, Q), (1, 3), (2, 4))
+    cgnested = _array_contraction(cg3, (0, 1))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N, P, Q), (0, 5), (1, 3), (2, 4))
 
-    cgnested = ArrayContraction(cg3, (0, 3), (1, 2))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 7), (1, 3), (2, 4), (5, 6))
+    cgnested = _array_contraction(cg3, (0, 3), (1, 2))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N, P, Q), (0, 7), (1, 3), (2, 4), (5, 6))
 
-    cg4 = ArrayContraction(ArrayTensorProduct(M, N, P, Q), (1, 5), (3, 7))
-    cgnested = ArrayContraction(cg4, (0, 1))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 2), (1, 5), (3, 7))
+    cg4 = _array_contraction(_array_tensor_product(M, N, P, Q), (1, 5), (3, 7))
+    cgnested = _array_contraction(cg4, (0, 1))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N, P, Q), (0, 2), (1, 5), (3, 7))
 
-    cgnested = ArrayContraction(cg4, (0, 1), (2, 3))
-    assert cgnested == ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 2), (1, 5), (3, 7), (4, 6))
+    cgnested = _array_contraction(cg4, (0, 1), (2, 3))
+    assert cgnested == _array_contraction(_array_tensor_product(M, N, P, Q), (0, 2), (1, 5), (3, 7), (4, 6))
 
-    cg = ArrayDiagonal(cg4)
+    cg = _array_diagonal(cg4)
     assert cg == cg4
     assert isinstance(cg, type(cg4))
 
     # Flatten nested ArrayDiagonal objects:
-    cg1 = ArrayDiagonal(expr1, (1, 2))
-    cg2 = ArrayDiagonal(expr2, (0, 3))
-    cg3 = ArrayDiagonal(ArrayTensorProduct(M, N, P, Q), (1, 3), (2, 4))
-    cg4 = ArrayDiagonal(ArrayTensorProduct(M, N, P, Q), (1, 5), (3, 7))
+    cg1 = _array_diagonal(expr1, (1, 2))
+    cg2 = _array_diagonal(expr2, (0, 3))
+    cg3 = _array_diagonal(_array_tensor_product(M, N, P, Q), (1, 3), (2, 4))
+    cg4 = _array_diagonal(_array_tensor_product(M, N, P, Q), (1, 5), (3, 7))
 
-    cgnested = ArrayDiagonal(cg1, (0, 1))
-    assert cgnested == ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2), (0, 3))
+    cgnested = _array_diagonal(cg1, (0, 1))
+    assert cgnested == _array_diagonal(_array_tensor_product(M, N), (1, 2), (0, 3))
 
-    cgnested = ArrayDiagonal(cg3, (1, 2))
-    assert cgnested == ArrayDiagonal(ArrayTensorProduct(M, N, P, Q), (1, 3), (2, 4), (5, 6))
+    cgnested = _array_diagonal(cg3, (1, 2))
+    assert cgnested == _array_diagonal(_array_tensor_product(M, N, P, Q), (1, 3), (2, 4), (5, 6))
 
-    cgnested = ArrayDiagonal(cg4, (1, 2))
-    assert cgnested == ArrayDiagonal(ArrayTensorProduct(M, N, P, Q), (1, 5), (3, 7), (2, 4))
+    cgnested = _array_diagonal(cg4, (1, 2))
+    assert cgnested == _array_diagonal(_array_tensor_product(M, N, P, Q), (1, 5), (3, 7), (2, 4))
 
-    cg = ArrayAdd(M, N)
-    cg2 = ArrayAdd(cg, P)
+    cg = _array_add(M, N)
+    cg2 = _array_add(cg, P)
     assert isinstance(cg2, ArrayAdd)
     assert cg2.args == (M, N, P)
     assert cg2.shape == (k, k)
 
-    expr = ArrayTensorProduct(ArrayDiagonal(X, (0, 1)), ArrayDiagonal(A, (0, 1)))
-    assert expr == ArrayDiagonal(ArrayTensorProduct(X, A), (0, 1), (2, 3))
+    expr = _array_tensor_product(_array_diagonal(X, (0, 1)), _array_diagonal(A, (0, 1)))
+    assert expr == _array_diagonal(_array_tensor_product(X, A), (0, 1), (2, 3))
 
-    expr1 = ArrayDiagonal(ArrayTensorProduct(X, A), (1, 2))
-    expr2 = ArrayTensorProduct(expr1, a)
-    assert expr2 == PermuteDims(ArrayDiagonal(ArrayTensorProduct(X, A, a), (1, 2)), [0, 1, 4, 2, 3])
+    expr1 = _array_diagonal(_array_tensor_product(X, A), (1, 2))
+    expr2 = _array_tensor_product(expr1, a)
+    assert expr2 == _permute_dims(_array_diagonal(_array_tensor_product(X, A, a), (1, 2)), [0, 1, 4, 2, 3])
 
-    expr1 = ArrayContraction(ArrayTensorProduct(X, A), (1, 2))
-    expr2 = ArrayTensorProduct(expr1, a)
+    expr1 = _array_contraction(_array_tensor_product(X, A), (1, 2))
+    expr2 = _array_tensor_product(expr1, a)
     assert isinstance(expr2, ArrayContraction)
     assert isinstance(expr2.expr, ArrayTensorProduct)
 
-    cg = ArrayTensorProduct(ArrayDiagonal(ArrayTensorProduct(A, X, Y), (0, 3), (1, 5)), a, b)
-    assert cg == PermuteDims(ArrayDiagonal(ArrayTensorProduct(A, X, Y, a, b), (0, 3), (1, 5)), [0, 1, 6, 7, 2, 3, 4, 5])
+    cg = _array_tensor_product(_array_diagonal(_array_tensor_product(A, X, Y), (0, 3), (1, 5)), a, b)
+    assert cg == _permute_dims(_array_diagonal(_array_tensor_product(A, X, Y, a, b), (0, 3), (1, 5)), [0, 1, 6, 7, 2, 3, 4, 5])
 
 
 def test_arrayexpr_array_diagonal():
-    cg = ArrayDiagonal(M, (1, 0))
-    assert cg == ArrayDiagonal(M, (0, 1))
+    cg = _array_diagonal(M, (1, 0))
+    assert cg == _array_diagonal(M, (0, 1))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N, P), (4, 1), (2, 0))
-    assert cg == ArrayDiagonal(ArrayTensorProduct(M, N, P), (1, 4), (0, 2))
+    cg = _array_diagonal(_array_tensor_product(M, N, P), (4, 1), (2, 0))
+    assert cg == _array_diagonal(_array_tensor_product(M, N, P), (1, 4), (0, 2))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2), (3,), allow_trivial_diags=True)
-    assert cg == PermuteDims(ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2)), [0, 2, 1])
+    cg = _array_diagonal(_array_tensor_product(M, N), (1, 2), (3,), allow_trivial_diags=True)
+    assert cg == _permute_dims(_array_diagonal(_array_tensor_product(M, N), (1, 2)), [0, 2, 1])
 
     Ax = ArraySymbol("Ax", shape=(1, 2, 3, 4, 3, 5, 6, 2, 7))
-    cg = ArrayDiagonal(Ax, (1, 7), (3,), (2, 4), (6,), allow_trivial_diags=True)
-    assert cg == PermuteDims(ArrayDiagonal(Ax, (1, 7), (2, 4)), [0, 2, 4, 5, 1, 6, 3])
+    cg = _array_diagonal(Ax, (1, 7), (3,), (2, 4), (6,), allow_trivial_diags=True)
+    assert cg == _permute_dims(_array_diagonal(Ax, (1, 7), (2, 4)), [0, 2, 4, 5, 1, 6, 3])
 
-    cg = ArrayDiagonal(M, (0,), allow_trivial_diags=True)
-    assert cg == PermuteDims(M, [1, 0])
+    cg = _array_diagonal(M, (0,), allow_trivial_diags=True)
+    assert cg == _permute_dims(M, [1, 0])
 
-    raises(ValueError, lambda: ArrayDiagonal(M, (0, 0)))
+    raises(ValueError, lambda: _array_diagonal(M, (0, 0)))
 
 
 def test_arrayexpr_array_shape():
-    expr = ArrayTensorProduct(M, N, P, Q)
+    expr = _array_tensor_product(M, N, P, Q)
     assert expr.shape == (k, k, k, k, k, k, k, k)
     Z = MatrixSymbol("Z", m, n)
-    expr = ArrayTensorProduct(M, Z)
+    expr = _array_tensor_product(M, Z)
     assert expr.shape == (k, k, m, n)
-    expr2 = ArrayContraction(expr, (0, 1))
+    expr2 = _array_contraction(expr, (0, 1))
     assert expr2.shape == (m, n)
-    expr2 = ArrayDiagonal(expr, (0, 1))
+    expr2 = _array_diagonal(expr, (0, 1))
     assert expr2.shape == (m, n, k)
-    exprp = PermuteDims(expr, [2, 1, 3, 0])
+    exprp = _permute_dims(expr, [2, 1, 3, 0])
     assert exprp.shape == (m, k, n, k)
-    expr3 = ArrayTensorProduct(N, Z)
-    expr2 = ArrayAdd(expr, expr3)
+    expr3 = _array_tensor_product(N, Z)
+    expr2 = _array_add(expr, expr3)
     assert expr2.shape == (k, k, m, n)
 
     # Contraction along axes with discordant dimensions:
-    raises(ValueError, lambda: ArrayContraction(expr, (1, 2)))
+    raises(ValueError, lambda: _array_contraction(expr, (1, 2)))
     # Also diagonal needs the same dimensions:
-    raises(ValueError, lambda: ArrayDiagonal(expr, (1, 2)))
+    raises(ValueError, lambda: _array_diagonal(expr, (1, 2)))
     # Diagonal requires at least to axes to compute the diagonal:
-    raises(ValueError, lambda: ArrayDiagonal(expr, (1,)))
+    raises(ValueError, lambda: _array_diagonal(expr, (1,)))
 
 
 def test_arrayexpr_permutedims_sink():
 
-    cg = PermuteDims(ArrayTensorProduct(M, N), [0, 1, 3, 2], nest_permutation=False)
+    cg = _permute_dims(_array_tensor_product(M, N), [0, 1, 3, 2], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayTensorProduct(M, PermuteDims(N, [1, 0]))
+    assert sunk == _array_tensor_product(M, _permute_dims(N, [1, 0]))
 
-    cg = PermuteDims(ArrayTensorProduct(M, N), [1, 0, 3, 2], nest_permutation=False)
+    cg = _permute_dims(_array_tensor_product(M, N), [1, 0, 3, 2], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayTensorProduct(PermuteDims(M, [1, 0]), PermuteDims(N, [1, 0]))
+    assert sunk == _array_tensor_product(_permute_dims(M, [1, 0]), _permute_dims(N, [1, 0]))
 
-    cg = PermuteDims(ArrayTensorProduct(M, N), [3, 2, 1, 0], nest_permutation=False)
+    cg = _permute_dims(_array_tensor_product(M, N), [3, 2, 1, 0], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayTensorProduct(PermuteDims(N, [1, 0]), PermuteDims(M, [1, 0]))
+    assert sunk == _array_tensor_product(_permute_dims(N, [1, 0]), _permute_dims(M, [1, 0]))
 
-    cg = PermuteDims(ArrayContraction(ArrayTensorProduct(M, N), (1, 2)), [1, 0], nest_permutation=False)
+    cg = _permute_dims(_array_contraction(_array_tensor_product(M, N), (1, 2)), [1, 0], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayContraction(PermuteDims(ArrayTensorProduct(M, N), [[0, 3]]), (1, 2))
+    assert sunk == _array_contraction(_permute_dims(_array_tensor_product(M, N), [[0, 3]]), (1, 2))
 
-    cg = PermuteDims(ArrayTensorProduct(M, N), [1, 0, 3, 2], nest_permutation=False)
+    cg = _permute_dims(_array_tensor_product(M, N), [1, 0, 3, 2], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayTensorProduct(PermuteDims(M, [1, 0]), PermuteDims(N, [1, 0]))
+    assert sunk == _array_tensor_product(_permute_dims(M, [1, 0]), _permute_dims(N, [1, 0]))
 
-    cg = PermuteDims(ArrayContraction(ArrayTensorProduct(M, N, P), (1, 2), (3, 4)), [1, 0], nest_permutation=False)
+    cg = _permute_dims(_array_contraction(_array_tensor_product(M, N, P), (1, 2), (3, 4)), [1, 0], nest_permutation=False)
     sunk = nest_permutation(cg)
-    assert sunk == ArrayContraction(PermuteDims(ArrayTensorProduct(M, N, P), [[0, 5]]), (1, 2), (3, 4))
+    assert sunk == _array_contraction(_permute_dims(_array_tensor_product(M, N, P), [[0, 5]]), (1, 2), (3, 4))
 
 
 def test_arrayexpr_push_indices_up_and_down():
@@ -298,22 +300,22 @@ def test_arrayexpr_split_multiple_contractions():
     C = MatrixSymbol("C", k, k)
     X = MatrixSymbol("X", k, k)
 
-    cg = ArrayContraction(ArrayTensorProduct(A.T, a, b, b.T, (A*X*b).applyfunc(cos)), (1, 2, 8), (5, 6, 9))
-    expected = ArrayContraction(ArrayTensorProduct(A.T, DiagMatrix(a), OneArray(1), b, b.T, (A*X*b).applyfunc(cos)), (1, 3), (2, 9), (6, 7, 10))
+    cg = _array_contraction(_array_tensor_product(A.T, a, b, b.T, (A*X*b).applyfunc(cos)), (1, 2, 8), (5, 6, 9))
+    expected = _array_contraction(_array_tensor_product(A.T, DiagMatrix(a), OneArray(1), b, b.T, (A*X*b).applyfunc(cos)), (1, 3), (2, 9), (6, 7, 10))
     assert cg.split_multiple_contractions().dummy_eq(expected)
 
     # Check no overlap of lines:
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a, C, a, B), (1, 2, 4), (5, 6, 8), (3, 7))
+    cg = _array_contraction(_array_tensor_product(A, a, C, a, B), (1, 2, 4), (5, 6, 8), (3, 7))
     assert cg.split_multiple_contractions() == cg
 
-    cg = ArrayContraction(ArrayTensorProduct(a, b, A), (0, 2, 4), (1, 3))
+    cg = _array_contraction(_array_tensor_product(a, b, A), (0, 2, 4), (1, 3))
     assert cg.split_multiple_contractions() == cg
 
 
 def test_arrayexpr_nested_permutations():
 
-    cg = PermuteDims(PermuteDims(M, (1, 0)), (1, 0))
+    cg = _permute_dims(_permute_dims(M, (1, 0)), (1, 0))
     assert cg == M
 
     times = 3
@@ -342,21 +344,21 @@ def test_arrayexpr_nested_permutations():
         p1 = Permutation(permutation_array1)
         p2 = Permutation(permutation_array2)
 
-        cg = PermuteDims(
-            PermuteDims(
-                ArrayTensorProduct(M, N, P),
+        cg = _permute_dims(
+            _permute_dims(
+                _array_tensor_product(M, N, P),
                 p1),
             p2
         )
-        result = PermuteDims(
-            ArrayTensorProduct(M, N, P),
+        result = _permute_dims(
+            _array_tensor_product(M, N, P),
             p2*p1
         )
         assert cg == result
 
         # Check that `permutedims` behaves the same way with explicit-component arrays:
-        result1 = permutedims(permutedims(cge, p1), p2)
-        result2 = permutedims(cge, p2*p1)
+        result1 = _permute_dims(_permute_dims(cge, p1), p2)
+        result2 = _permute_dims(cge, p2*p1)
         assert result1 == result2
 
 
@@ -365,49 +367,49 @@ def test_arrayexpr_contraction_permutation_mix():
     Me = M.subs(k, 3).as_explicit()
     Ne = N.subs(k, 3).as_explicit()
 
-    cg1 = ArrayContraction(PermuteDims(ArrayTensorProduct(M, N), Permutation([0, 2, 1, 3])), (2, 3))
-    cg2 = ArrayContraction(ArrayTensorProduct(M, N), (1, 3))
+    cg1 = _array_contraction(PermuteDims(_array_tensor_product(M, N), Permutation([0, 2, 1, 3])), (2, 3))
+    cg2 = _array_contraction(_array_tensor_product(M, N), (1, 3))
     assert cg1 == cg2
     cge1 = tensorcontraction(permutedims(tensorproduct(Me, Ne), Permutation([0, 2, 1, 3])), (2, 3))
     cge2 = tensorcontraction(tensorproduct(Me, Ne), (1, 3))
     assert cge1 == cge2
 
-    cg1 = PermuteDims(ArrayTensorProduct(M, N), Permutation([0, 1, 3, 2]))
-    cg2 = ArrayTensorProduct(M, PermuteDims(N, Permutation([1, 0])))
+    cg1 = _permute_dims(_array_tensor_product(M, N), Permutation([0, 1, 3, 2]))
+    cg2 = _array_tensor_product(M, _permute_dims(N, Permutation([1, 0])))
     assert cg1 == cg2
 
-    cg1 = ArrayContraction(
-        PermuteDims(
-            ArrayTensorProduct(M, N, P, Q), Permutation([0, 2, 3, 1, 4, 5, 7, 6])),
+    cg1 = _array_contraction(
+        _permute_dims(
+            _array_tensor_product(M, N, P, Q), Permutation([0, 2, 3, 1, 4, 5, 7, 6])),
         (1, 2), (3, 5)
     )
-    cg2 = ArrayContraction(
-        ArrayTensorProduct(M, N, P, PermuteDims(Q, Permutation([1, 0]))),
+    cg2 = _array_contraction(
+        _array_tensor_product(M, N, P, _permute_dims(Q, Permutation([1, 0]))),
         (1, 5), (2, 3)
     )
     assert cg1 == cg2
 
-    cg1 = ArrayContraction(
-        PermuteDims(
-            ArrayTensorProduct(M, N, P, Q), Permutation([1, 0, 4, 6, 2, 7, 5, 3])),
+    cg1 = _array_contraction(
+        _permute_dims(
+            _array_tensor_product(M, N, P, Q), Permutation([1, 0, 4, 6, 2, 7, 5, 3])),
         (0, 1), (2, 6), (3, 7)
     )
-    cg2 = PermuteDims(
-        ArrayContraction(
-            ArrayTensorProduct(M, P, Q, N),
+    cg2 = _permute_dims(
+        _array_contraction(
+            _array_tensor_product(M, P, Q, N),
             (0, 1), (2, 3), (4, 7)),
         [1, 0]
     )
     assert cg1 == cg2
 
-    cg1 = ArrayContraction(
-        PermuteDims(
-            ArrayTensorProduct(M, N, P, Q), Permutation([1, 0, 4, 6, 7, 2, 5, 3])),
+    cg1 = _array_contraction(
+        _permute_dims(
+            _array_tensor_product(M, N, P, Q), Permutation([1, 0, 4, 6, 7, 2, 5, 3])),
         (0, 1), (2, 6), (3, 7)
     )
-    cg2 = PermuteDims(
-        ArrayContraction(
-            ArrayTensorProduct(PermuteDims(M, [1, 0]), N, P, Q),
+    cg2 = _permute_dims(
+        _array_contraction(
+            _array_tensor_product(_permute_dims(M, [1, 0]), N, P, Q),
             (0, 1), (3, 6), (4, 5)
         ),
         Permutation([1, 0])
@@ -416,101 +418,101 @@ def test_arrayexpr_contraction_permutation_mix():
 
 
 def test_arrayexpr_permute_tensor_product():
-    cg1 = PermuteDims(ArrayTensorProduct(M, N, P, Q), Permutation([2, 3, 1, 0, 5, 4, 6, 7]))
-    cg2 = ArrayTensorProduct(N, PermuteDims(M, [1, 0]),
-                                    PermuteDims(P, [1, 0]), Q)
+    cg1 = _permute_dims(_array_tensor_product(M, N, P, Q), Permutation([2, 3, 1, 0, 5, 4, 6, 7]))
+    cg2 = _array_tensor_product(N, _permute_dims(M, [1, 0]),
+                                    _permute_dims(P, [1, 0]), Q)
     assert cg1 == cg2
 
     # TODO: reverse operation starting with `PermuteDims` and getting down to `bb`...
-    cg1 = PermuteDims(ArrayTensorProduct(M, N, P, Q), Permutation([2, 3, 4, 5, 0, 1, 6, 7]))
-    cg2 = ArrayTensorProduct(N, P, M, Q)
+    cg1 = _permute_dims(_array_tensor_product(M, N, P, Q), Permutation([2, 3, 4, 5, 0, 1, 6, 7]))
+    cg2 = _array_tensor_product(N, P, M, Q)
     assert cg1 == cg2
 
-    cg1 = PermuteDims(ArrayTensorProduct(M, N, P, Q), Permutation([2, 3, 4, 6, 5, 7, 0, 1]))
-    assert cg1.expr == ArrayTensorProduct(N, P, Q, M)
+    cg1 = _permute_dims(_array_tensor_product(M, N, P, Q), Permutation([2, 3, 4, 6, 5, 7, 0, 1]))
+    assert cg1.expr == _array_tensor_product(N, P, Q, M)
     assert cg1.permutation == Permutation([0, 1, 2, 4, 3, 5, 6, 7])
 
-    cg1 = ArrayContraction(
-        PermuteDims(
-            ArrayTensorProduct(N, Q, Q, M),
+    cg1 = _array_contraction(
+        _permute_dims(
+            _array_tensor_product(N, Q, Q, M),
             [2, 1, 5, 4, 0, 3, 6, 7]),
         [1, 2, 6])
-    cg2 = PermuteDims(ArrayContraction(ArrayTensorProduct(Q, Q, N, M), (3, 5, 6)), [0, 2, 3, 1, 4])
+    cg2 = _permute_dims(_array_contraction(_array_tensor_product(Q, Q, N, M), (3, 5, 6)), [0, 2, 3, 1, 4])
     assert cg1 == cg2
 
-    cg1 = ArrayContraction(
-        ArrayContraction(
-            ArrayContraction(
-                ArrayContraction(
-                    PermuteDims(
-                        ArrayTensorProduct(N, Q, Q, M),
+    cg1 = _array_contraction(
+        _array_contraction(
+            _array_contraction(
+                _array_contraction(
+                    _permute_dims(
+                        _array_tensor_product(N, Q, Q, M),
                         [2, 1, 5, 4, 0, 3, 6, 7]),
                     [1, 2, 6]),
                 [1, 3, 4]),
             [1]),
         [0])
-    cg2 = ArrayContraction(ArrayTensorProduct(M, N, Q, Q), (0, 3, 5), (1, 4, 7), (2,), (6,))
+    cg2 = _array_contraction(_array_tensor_product(M, N, Q, Q), (0, 3, 5), (1, 4, 7), (2,), (6,))
     assert cg1 == cg2
 
 
-def test_arrayexpr_normalize_diagonal_permutedims():
-    tp = ArrayTensorProduct(M, Q, N, P)
-    expr = ArrayDiagonal(
-        PermuteDims(tp, [0, 1, 2, 4, 7, 6, 3, 5]), (2, 4, 5), (6, 7),
+def test_arrayexpr_normalize_diagonal__permute_dims():
+    tp = _array_tensor_product(M, Q, N, P)
+    expr = _array_diagonal(
+        _permute_dims(tp, [0, 1, 2, 4, 7, 6, 3, 5]), (2, 4, 5), (6, 7),
         (0, 3))
-    result = ArrayDiagonal(tp, (2, 6, 7), (3, 5), (0, 4))
+    result = _array_diagonal(tp, (2, 6, 7), (3, 5), (0, 4))
     assert expr == result
 
-    tp = ArrayTensorProduct(M, N, P, Q)
-    expr = ArrayDiagonal(PermuteDims(tp, [0, 5, 2, 4, 1, 6, 3, 7]), (1, 2, 6), (3, 4))
-    result = ArrayDiagonal(ArrayTensorProduct(M, P, N, Q), (3, 4, 5), (1, 2))
+    tp = _array_tensor_product(M, N, P, Q)
+    expr = _array_diagonal(_permute_dims(tp, [0, 5, 2, 4, 1, 6, 3, 7]), (1, 2, 6), (3, 4))
+    result = _array_diagonal(_array_tensor_product(M, P, N, Q), (3, 4, 5), (1, 2))
     assert expr == result
 
 
 def test_arrayexpr_normalize_diagonal_contraction():
-    tp = ArrayTensorProduct(M, N, P, Q)
-    expr = ArrayContraction(ArrayDiagonal(tp, (1, 3, 4)), (0, 3))
-    result = ArrayDiagonal(ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 6)), (0, 2, 3))
+    tp = _array_tensor_product(M, N, P, Q)
+    expr = _array_contraction(_array_diagonal(tp, (1, 3, 4)), (0, 3))
+    result = _array_diagonal(_array_contraction(_array_tensor_product(M, N, P, Q), (0, 6)), (0, 2, 3))
     assert expr == result
 
-    expr = ArrayContraction(ArrayDiagonal(tp, (0, 1, 2, 3, 7)), (1, 2, 3))
-    result = ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 1, 2, 3, 5, 6, 7))
+    expr = _array_contraction(_array_diagonal(tp, (0, 1, 2, 3, 7)), (1, 2, 3))
+    result = _array_contraction(_array_tensor_product(M, N, P, Q), (0, 1, 2, 3, 5, 6, 7))
     assert expr == result
 
-    expr = ArrayContraction(ArrayDiagonal(tp, (0, 2, 6, 7)), (1, 2, 3))
-    result = ArrayDiagonal(ArrayContraction(tp, (3, 4, 5)), (0, 2, 3, 4))
+    expr = _array_contraction(_array_diagonal(tp, (0, 2, 6, 7)), (1, 2, 3))
+    result = _array_diagonal(_array_contraction(tp, (3, 4, 5)), (0, 2, 3, 4))
     assert expr == result
 
-    td = ArrayDiagonal(ArrayTensorProduct(M, N, P, Q), (0, 3))
-    expr = ArrayContraction(td, (2, 1), (0, 4, 6, 5, 3))
-    result = ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 1, 3, 5, 6, 7), (2, 4))
+    td = _array_diagonal(_array_tensor_product(M, N, P, Q), (0, 3))
+    expr = _array_contraction(td, (2, 1), (0, 4, 6, 5, 3))
+    result = _array_contraction(_array_tensor_product(M, N, P, Q), (0, 1, 3, 5, 6, 7), (2, 4))
     assert expr == result
 
 
 def test_arrayexpr_array_wrong_permutation_size():
-    cg = ArrayTensorProduct(M, N)
-    raises(ValueError, lambda: PermuteDims(cg, [1, 0]))
-    raises(ValueError, lambda: PermuteDims(cg, [1, 0, 2, 3, 5, 4]))
+    cg = _array_tensor_product(M, N)
+    raises(ValueError, lambda: _permute_dims(cg, [1, 0]))
+    raises(ValueError, lambda: _permute_dims(cg, [1, 0, 2, 3, 5, 4]))
 
 
 def test_arrayexpr_nested_array_elementwise_add():
-    cg = ArrayContraction(ArrayAdd(
-        ArrayTensorProduct(M, N),
-        ArrayTensorProduct(N, M)
+    cg = _array_contraction(_array_add(
+        _array_tensor_product(M, N),
+        _array_tensor_product(N, M)
     ), (1, 2))
-    result = ArrayAdd(
-        ArrayContraction(ArrayTensorProduct(M, N), (1, 2)),
-        ArrayContraction(ArrayTensorProduct(N, M), (1, 2))
+    result = _array_add(
+        _array_contraction(_array_tensor_product(M, N), (1, 2)),
+        _array_contraction(_array_tensor_product(N, M), (1, 2))
     )
     assert cg == result
 
-    cg = ArrayDiagonal(ArrayAdd(
-        ArrayTensorProduct(M, N),
-        ArrayTensorProduct(N, M)
+    cg = _array_diagonal(_array_add(
+        _array_tensor_product(M, N),
+        _array_tensor_product(N, M)
     ), (1, 2))
-    result = ArrayAdd(
-        ArrayDiagonal(ArrayTensorProduct(M, N), (1, 2)),
-        ArrayDiagonal(ArrayTensorProduct(N, M), (1, 2))
+    result = _array_add(
+        _array_diagonal(_array_tensor_product(M, N), (1, 2)),
+        _array_diagonal(_array_tensor_product(N, M), (1, 2))
     )
     assert cg == result
 
@@ -523,28 +525,28 @@ def test_arrayexpr_array_expr_zero_array():
     zm2 = ZeroMatrix(m, m)
     zm3 = ZeroMatrix(k, k)
 
-    assert ArrayTensorProduct(M, N, za1) == ZeroArray(k, k, k, k, k, l, m, n)
-    assert ArrayTensorProduct(M, N, zm1) == ZeroArray(k, k, k, k, m, n)
+    assert _array_tensor_product(M, N, za1) == ZeroArray(k, k, k, k, k, l, m, n)
+    assert _array_tensor_product(M, N, zm1) == ZeroArray(k, k, k, k, m, n)
 
-    assert ArrayContraction(za1, (3,)) == ZeroArray(k, l, m)
-    assert ArrayContraction(zm1, (1,)) == ZeroArray(m)
-    assert ArrayContraction(za2, (1, 2)) == ZeroArray(k, n)
-    assert ArrayContraction(zm2, (0, 1)) == 0
+    assert _array_contraction(za1, (3,)) == ZeroArray(k, l, m)
+    assert _array_contraction(zm1, (1,)) == ZeroArray(m)
+    assert _array_contraction(za2, (1, 2)) == ZeroArray(k, n)
+    assert _array_contraction(zm2, (0, 1)) == 0
 
-    assert ArrayDiagonal(za2, (1, 2)) == ZeroArray(k, n, m)
-    assert ArrayDiagonal(zm2, (0, 1)) == ZeroArray(m)
+    assert _array_diagonal(za2, (1, 2)) == ZeroArray(k, n, m)
+    assert _array_diagonal(zm2, (0, 1)) == ZeroArray(m)
 
-    assert PermuteDims(za1, [2, 1, 3, 0]) == ZeroArray(m, l, n, k)
-    assert PermuteDims(zm1, [1, 0]) == ZeroArray(n, m)
+    assert _permute_dims(za1, [2, 1, 3, 0]) == ZeroArray(m, l, n, k)
+    assert _permute_dims(zm1, [1, 0]) == ZeroArray(n, m)
 
-    assert ArrayAdd(za1) == za1
-    assert ArrayAdd(zm1) == ZeroArray(m, n)
-    tp1 = ArrayTensorProduct(MatrixSymbol("A", k, l), MatrixSymbol("B", m, n))
-    assert ArrayAdd(tp1, za1) == tp1
-    tp2 = ArrayTensorProduct(MatrixSymbol("C", k, l), MatrixSymbol("D", m, n))
-    assert ArrayAdd(tp1, za1, tp2) == ArrayAdd(tp1, tp2)
-    assert ArrayAdd(M, zm3) == M
-    assert ArrayAdd(M, N, zm3) == ArrayAdd(M, N)
+    assert _array_add(za1) == za1
+    assert _array_add(zm1) == ZeroArray(m, n)
+    tp1 = _array_tensor_product(MatrixSymbol("A", k, l), MatrixSymbol("B", m, n))
+    assert _array_add(tp1, za1) == tp1
+    tp2 = _array_tensor_product(MatrixSymbol("C", k, l), MatrixSymbol("D", m, n))
+    assert _array_add(tp1, za1, tp2) == _array_add(tp1, tp2)
+    assert _array_add(M, zm3) == M
+    assert _array_add(M, N, zm3) == _array_add(M, N)
 
 
 def test_arrayexpr_array_expr_applyfunc():
@@ -555,18 +557,18 @@ def test_arrayexpr_array_expr_applyfunc():
 
 
 def test_edit_array_contraction():
-    cg = ArrayContraction(ArrayTensorProduct(A, B, C, D), (1, 2, 5))
+    cg = _array_contraction(_array_tensor_product(A, B, C, D), (1, 2, 5))
     ecg = _EditArrayContraction(cg)
     assert ecg.to_array_contraction() == cg
 
     ecg.args_with_ind[1], ecg.args_with_ind[2] = ecg.args_with_ind[2], ecg.args_with_ind[1]
-    assert ecg.to_array_contraction() == ArrayContraction(ArrayTensorProduct(A, C, B, D), (1, 3, 4))
+    assert ecg.to_array_contraction() == _array_contraction(_array_tensor_product(A, C, B, D), (1, 3, 4))
 
     ci = ecg.get_new_contraction_index()
     new_arg = _ArgE(X)
     new_arg.indices = [ci, ci]
     ecg.args_with_ind.insert(2, new_arg)
-    assert ecg.to_array_contraction() == ArrayContraction(ArrayTensorProduct(A, C, X, B, D), (1, 3, 6), (4, 5))
+    assert ecg.to_array_contraction() == _array_contraction(_array_tensor_product(A, C, X, B, D), (1, 3, 6), (4, 5))
 
     assert ecg.get_contraction_indices() == [[1, 3, 6], [4, 5]]
     assert [[tuple(j) for j in i] for i in ecg.get_contraction_indices_to_ind_rel_pos()] == [[(0, 1), (1, 1), (3, 0)], [(2, 0), (2, 1)]]
@@ -575,67 +577,103 @@ def test_edit_array_contraction():
     raises(ValueError, lambda: ecg.get_mapping_for_index(2))
 
     ecg.args_with_ind.pop(1)
-    assert ecg.to_array_contraction() == ArrayContraction(ArrayTensorProduct(A, X, B, D), (1, 4), (2, 3))
+    assert ecg.to_array_contraction() == _array_contraction(_array_tensor_product(A, X, B, D), (1, 4), (2, 3))
 
     ecg.args_with_ind[0].indices[1] = ecg.args_with_ind[1].indices[0]
     ecg.args_with_ind[1].indices[1] = ecg.args_with_ind[2].indices[0]
-    assert ecg.to_array_contraction() == ArrayContraction(ArrayTensorProduct(A, X, B, D), (1, 2), (3, 4))
+    assert ecg.to_array_contraction() == _array_contraction(_array_tensor_product(A, X, B, D), (1, 2), (3, 4))
 
     ecg.insert_after(ecg.args_with_ind[1], _ArgE(C))
-    assert ecg.to_array_contraction() == ArrayContraction(ArrayTensorProduct(A, X, C, B, D), (1, 2), (3, 6))
+    assert ecg.to_array_contraction() == _array_contraction(_array_tensor_product(A, X, C, B, D), (1, 2), (3, 6))
 
 
 def test_array_expressions_no_normalization():
 
-    tp = ArrayTensorProduct(M, N, P)
+    tp = _array_tensor_product(M, N, P)
 
     # ArrayTensorProduct:
 
-    expr = ArrayTensorProduct(tp, N, normalize=False)
+    expr = ArrayTensorProduct(tp, N)
     assert str(expr) == "ArrayTensorProduct(ArrayTensorProduct(M, N, P), N)"
 
-    expr = ArrayTensorProduct(ArrayContraction(M, (0, 1)), N, normalize=False)
+    expr = ArrayTensorProduct(ArrayContraction(M, (0, 1)), N)
     assert str(expr) == "ArrayTensorProduct(ArrayContraction(M, (0, 1)), N)"
 
-    expr = ArrayTensorProduct(ArrayDiagonal(M, (0, 1)), N, normalize=False)
+    expr = ArrayTensorProduct(ArrayDiagonal(M, (0, 1)), N)
     assert str(expr) == "ArrayTensorProduct(ArrayDiagonal(M, (0, 1)), N)"
 
-    expr = ArrayTensorProduct(PermuteDims(M, [1, 0]), N, normalize=False)
+    expr = ArrayTensorProduct(PermuteDims(M, [1, 0]), N)
     assert str(expr) == "ArrayTensorProduct(PermuteDims(M, (0 1)), N)"
 
     # ArrayContraction:
 
-    expr = ArrayContraction(ArrayContraction(tp, (0, 2)), (0, 1), normalize=False)
+    expr = ArrayContraction(_array_contraction(tp, (0, 2)), (0, 1))
     assert isinstance(expr, ArrayContraction)
     assert isinstance(expr.expr, ArrayContraction)
     assert str(expr) == "ArrayContraction(ArrayContraction(ArrayTensorProduct(M, N, P), (0, 2)), (0, 1))"
 
-    expr = ArrayContraction(ArrayDiagonal(tp, (0, 1)), (0, 1), normalize=False)
+    expr = ArrayContraction(ArrayDiagonal(tp, (0, 1)), (0, 1))
     assert str(expr) == "ArrayContraction(ArrayDiagonal(ArrayTensorProduct(M, N, P), (0, 1)), (0, 1))"
 
-    expr = ArrayContraction(PermuteDims(M, [1, 0]), (0, 1), normalize=False)
+    expr = ArrayContraction(PermuteDims(M, [1, 0]), (0, 1))
     assert str(expr) == "ArrayContraction(PermuteDims(M, (0 1)), (0, 1))"
 
     # ArrayDiagonal:
 
-    expr = ArrayDiagonal(ArrayDiagonal(tp, (0, 2)), (0, 1), normalize=False)
+    expr = ArrayDiagonal(ArrayDiagonal(tp, (0, 2)), (0, 1))
     assert str(expr) == "ArrayDiagonal(ArrayDiagonal(ArrayTensorProduct(M, N, P), (0, 2)), (0, 1))"
 
-    expr = ArrayDiagonal(ArrayContraction(tp, (0, 1)), (0, 1), normalize=False)
+    expr = ArrayDiagonal(ArrayContraction(tp, (0, 1)), (0, 1))
     assert str(expr) == "ArrayDiagonal(ArrayContraction(ArrayTensorProduct(M, N, P), (0, 1)), (0, 1))"
 
-    expr = ArrayDiagonal(PermuteDims(M, [1, 0]), (0, 1), normalize=False)
+    expr = ArrayDiagonal(PermuteDims(M, [1, 0]), (0, 1))
     assert str(expr) == "ArrayDiagonal(PermuteDims(M, (0 1)), (0, 1))"
 
     # ArrayAdd:
 
-    expr = ArrayAdd(ArrayAdd(M, N), P, normalize=False)
+    expr = ArrayAdd(ArrayAdd(M, N), P)
     assert str(expr) == "ArrayAdd(ArrayAdd(M, N), P)"
 
-    expr = ArrayAdd(M, ZeroArray(k, k), N, normalize=False)
+    expr = ArrayAdd(M, ZeroArray(k, k), N)
     assert str(expr) == "ArrayAdd(M, ZeroArray(k, k), N)"
 
     # PermuteDims:
 
-    expr = PermuteDims(PermuteDims(M, [1, 0]), [1, 0], normalize=False)
+    expr = PermuteDims(PermuteDims(M, [1, 0]), [1, 0])
     assert str(expr) == "PermuteDims(PermuteDims(M, (0 1)), (0 1))"
+
+
+def test_array_expr_construction_with_functions():
+
+    tp = tensorproduct(M, N)
+    assert tp == ArrayTensorProduct(M, N)
+
+    expr = tensorproduct(A, eye(2))
+    assert expr == ArrayTensorProduct(A, eye(2))
+
+    # Contraction:
+
+    expr = tensorcontraction(M, (0, 1))
+    assert expr == ArrayContraction(M, (0, 1))
+
+    expr = tensorcontraction(tp, (1, 2))
+    assert expr == ArrayContraction(tp, (1, 2))
+
+    expr = tensorcontraction(tensorcontraction(tp, (1, 2)), (0, 1))
+    assert expr == ArrayContraction(tp, (0, 3), (1, 2))
+
+    # Diagonalization:
+
+    expr = tensordiagonal(M, (0, 1))
+    assert expr == ArrayDiagonal(M, (0, 1))
+
+    expr = tensordiagonal(tensordiagonal(tp, (0, 1)), (0, 1))
+    assert expr == ArrayDiagonal(tp, (0, 1), (2, 3))
+
+    # Permutation of dimensions:
+
+    expr = permutedims(M, [1, 0])
+    assert expr == PermuteDims(M, [1, 0])
+
+    expr = permutedims(PermuteDims(tp, [1, 0, 2, 3]), [0, 1, 3, 2])
+    assert expr == PermuteDims(tp, [1, 0, 3, 2])

--- a/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
@@ -4,7 +4,7 @@ from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayTensorProduct, \
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, ArrayContraction
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, ArrayContraction, _permute_dims
 from sympy.tensor.array.expressions.arrayexpr_derivatives import array_derive
 
 k = symbols("k")
@@ -28,7 +28,7 @@ def test_arrayexpr_derivatives1():
 
     cg = ArrayTensorProduct(A, X, B)
     res = array_derive(cg, X)
-    assert res == PermuteDims(
+    assert res == _permute_dims(
         ArrayTensorProduct(I, A, I, B),
         [0, 4, 2, 3, 1, 5, 6, 7])
 

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -14,8 +14,8 @@ from sympy.combinatorics import Permutation
 from sympy.matrices.expressions.diagonal import DiagMatrix, DiagonalMatrix
 from sympy.matrices import Trace, MatMul, Transpose
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, \
-    ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
-    ArrayContraction, ArrayElement, ArraySymbol, ArrayElementwiseApplyFunc
+    ArrayElement, ArraySymbol, ArrayElementwiseApplyFunc, _array_tensor_product, _array_contraction, \
+    _array_diagonal, _permute_dims, PermuteDims, ArrayAdd, ArrayDiagonal
 from sympy.testing.pytest import raises
 
 
@@ -48,16 +48,16 @@ y = MatrixSymbol("y", k, 1)
 
 def test_arrayexpr_convert_array_to_matrix():
 
-    cg = ArrayContraction(ArrayTensorProduct(M), (0, 1))
+    cg = _array_contraction(_array_tensor_product(M), (0, 1))
     assert convert_array_to_matrix(cg) == Trace(M)
 
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (0, 1), (2, 3))
+    cg = _array_contraction(_array_tensor_product(M, N), (0, 1), (2, 3))
     assert convert_array_to_matrix(cg) == Trace(M) * Trace(N)
 
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (0, 3), (1, 2))
+    cg = _array_contraction(_array_tensor_product(M, N), (0, 3), (1, 2))
     assert convert_array_to_matrix(cg) == Trace(M * N)
 
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (0, 2), (1, 3))
+    cg = _array_contraction(_array_tensor_product(M, N), (0, 2), (1, 3))
     assert convert_array_to_matrix(cg) == Trace(M * N.T)
 
     cg = convert_matrix_to_array(M * N * P)
@@ -66,22 +66,22 @@ def test_arrayexpr_convert_array_to_matrix():
     cg = convert_matrix_to_array(M * N.T * P)
     assert convert_array_to_matrix(cg) == M * N.T * P
 
-    cg = ArrayContraction(ArrayTensorProduct(M,N,P,Q), (1, 2), (5, 6))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M * N, P * Q)
+    cg = _array_contraction(_array_tensor_product(M,N,P,Q), (1, 2), (5, 6))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M * N, P * Q)
 
-    cg = ArrayContraction(ArrayTensorProduct(-2, M, N), (1, 2))
+    cg = _array_contraction(_array_tensor_product(-2, M, N), (1, 2))
     assert convert_array_to_matrix(cg) == -2 * M * N
 
     a = MatrixSymbol("a", k, 1)
     b = MatrixSymbol("b", k, 1)
     c = MatrixSymbol("c", k, 1)
     cg = PermuteDims(
-        ArrayContraction(
-            ArrayTensorProduct(
+        _array_contraction(
+            _array_tensor_product(
                 a,
                 ArrayAdd(
-                    ArrayTensorProduct(b, c),
-                    ArrayTensorProduct(c, b),
+                    _array_tensor_product(b, c),
+                    _array_tensor_product(c, b),
                 )
             ), (2, 4)), [0, 1, 3, 2])
     assert convert_array_to_matrix(cg) == a * (b.T * c + c.T * b)
@@ -89,16 +89,16 @@ def test_arrayexpr_convert_array_to_matrix():
     za = ZeroArray(m, n)
     assert convert_array_to_matrix(za) == ZeroMatrix(m, n)
 
-    cg = ArrayTensorProduct(3, M)
+    cg = _array_tensor_product(3, M)
     assert convert_array_to_matrix(cg) == 3 * M
 
     # Partial conversion to matrix multiplication:
-    expr = ArrayContraction(ArrayTensorProduct(M, N, P, Q), (0, 2), (1, 4, 6))
-    assert convert_array_to_matrix(expr) == ArrayContraction(ArrayTensorProduct(M.T*N, P, Q), (0, 2, 4))
+    expr = _array_contraction(_array_tensor_product(M, N, P, Q), (0, 2), (1, 4, 6))
+    assert convert_array_to_matrix(expr) == _array_contraction(_array_tensor_product(M.T*N, P, Q), (0, 2, 4))
 
     x = MatrixSymbol("x", k, 1)
     cg = PermuteDims(
-        ArrayContraction(ArrayTensorProduct(OneArray(1), x, OneArray(1), DiagMatrix(Identity(1))),
+        _array_contraction(_array_tensor_product(OneArray(1), x, OneArray(1), DiagMatrix(Identity(1))),
                                 (0, 5)), Permutation(1, 2, 3))
     assert convert_array_to_matrix(cg) == x
 
@@ -107,45 +107,45 @@ def test_arrayexpr_convert_array_to_matrix():
 
 
 def test_arrayexpr_convert_array_to_matrix2():
-    cg = ArrayContraction(ArrayTensorProduct(M, N), (1, 3))
+    cg = _array_contraction(_array_tensor_product(M, N), (1, 3))
     assert convert_array_to_matrix(cg) == M * N.T
 
-    cg = PermuteDims(ArrayTensorProduct(M, N), Permutation([0, 1, 3, 2]))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M, N.T)
+    cg = PermuteDims(_array_tensor_product(M, N), Permutation([0, 1, 3, 2]))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M, N.T)
 
-    cg = ArrayTensorProduct(M, PermuteDims(N, Permutation([1, 0])))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M, N.T)
+    cg = _array_tensor_product(M, PermuteDims(N, Permutation([1, 0])))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M, N.T)
 
-    cg = ArrayContraction(
+    cg = _array_contraction(
         PermuteDims(
-            ArrayTensorProduct(M, N, P, Q), Permutation([0, 2, 3, 1, 4, 5, 7, 6])),
+            _array_tensor_product(M, N, P, Q), Permutation([0, 2, 3, 1, 4, 5, 7, 6])),
         (1, 2), (3, 5)
     )
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M * P.T * Trace(N), Q.T)
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M * P.T * Trace(N), Q.T)
 
-    cg = ArrayContraction(
-        ArrayTensorProduct(M, N, P, PermuteDims(Q, Permutation([1, 0]))),
+    cg = _array_contraction(
+        _array_tensor_product(M, N, P, PermuteDims(Q, Permutation([1, 0]))),
         (1, 5), (2, 3)
     )
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M * P.T * Trace(N), Q.T)
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M * P.T * Trace(N), Q.T)
 
-    cg = ArrayTensorProduct(M, PermuteDims(N, [1, 0]))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M, N.T)
+    cg = _array_tensor_product(M, PermuteDims(N, [1, 0]))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M, N.T)
 
-    cg = ArrayTensorProduct(PermuteDims(M, [1, 0]), PermuteDims(N, [1, 0]))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(M.T, N.T)
+    cg = _array_tensor_product(PermuteDims(M, [1, 0]), PermuteDims(N, [1, 0]))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(M.T, N.T)
 
-    cg = ArrayTensorProduct(PermuteDims(N, [1, 0]), PermuteDims(M, [1, 0]))
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(N.T, M.T)
+    cg = _array_tensor_product(PermuteDims(N, [1, 0]), PermuteDims(M, [1, 0]))
+    assert convert_array_to_matrix(cg) == _array_tensor_product(N.T, M.T)
 
-    cg = ArrayContraction(M, (0,), (1,))
+    cg = _array_contraction(M, (0,), (1,))
     assert convert_array_to_matrix(cg) == OneMatrix(1, k)*M*OneMatrix(k, 1)
 
-    cg = ArrayContraction(x, (0,), (1,))
+    cg = _array_contraction(x, (0,), (1,))
     assert convert_array_to_matrix(cg) == OneMatrix(1, k)*x
 
     Xm = MatrixSymbol("Xm", m, n)
-    cg = ArrayContraction(Xm, (0,), (1,))
+    cg = _array_contraction(Xm, (0,), (1,))
     assert convert_array_to_matrix(cg) == OneMatrix(1, m)*Xm*OneMatrix(n, 1)
 
 
@@ -153,104 +153,104 @@ def test_arrayexpr_convert_array_to_diagonalized_vector():
 
     # Check matrix recognition over trivial dimensions:
 
-    cg = ArrayTensorProduct(a, b)
+    cg = _array_tensor_product(a, b)
     assert convert_array_to_matrix(cg) == a * b.T
 
-    cg = ArrayTensorProduct(I1, a, b)
+    cg = _array_tensor_product(I1, a, b)
     assert convert_array_to_matrix(cg) == a * b.T
 
     # Recognize trace inside a tensor product:
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, C), (0, 3), (1, 2))
+    cg = _array_contraction(_array_tensor_product(A, B, C), (0, 3), (1, 2))
     assert convert_array_to_matrix(cg) == Trace(A * B) * C
 
     # Transform diagonal operator to contraction:
 
-    cg = ArrayDiagonal(ArrayTensorProduct(A, a), (1, 2))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(A, OneArray(1), DiagMatrix(a)), (1, 3))
+    cg = _array_diagonal(_array_tensor_product(A, a), (1, 2))
+    assert _array_diag2contr_diagmatrix(cg) == _array_contraction(_array_tensor_product(A, OneArray(1), DiagMatrix(a)), (1, 3))
     assert convert_array_to_matrix(cg) == A * DiagMatrix(a)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(a, b), (0, 2))
-    assert _array_diag2contr_diagmatrix(cg) == PermuteDims(
-        ArrayContraction(ArrayTensorProduct(DiagMatrix(a), OneArray(1), b), (0, 3)), [1, 2, 0]
+    cg = _array_diagonal(_array_tensor_product(a, b), (0, 2))
+    assert _array_diag2contr_diagmatrix(cg) == _permute_dims(
+        _array_contraction(_array_tensor_product(DiagMatrix(a), OneArray(1), b), (0, 3)), [1, 2, 0]
     )
     assert convert_array_to_matrix(cg) == b.T * DiagMatrix(a)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(A, a), (0, 2))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(A, OneArray(1), DiagMatrix(a)), (0, 3))
+    cg = _array_diagonal(_array_tensor_product(A, a), (0, 2))
+    assert _array_diag2contr_diagmatrix(cg) == _array_contraction(_array_tensor_product(A, OneArray(1), DiagMatrix(a)), (0, 3))
     assert convert_array_to_matrix(cg) == A.T * DiagMatrix(a)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I, x, I1), (0, 2), (3, 5))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(I, OneArray(1), I1, DiagMatrix(x)), (0, 5))
+    cg = _array_diagonal(_array_tensor_product(I, x, I1), (0, 2), (3, 5))
+    assert _array_diag2contr_diagmatrix(cg) == _array_contraction(_array_tensor_product(I, OneArray(1), I1, DiagMatrix(x)), (0, 5))
     assert convert_array_to_matrix(cg) == DiagMatrix(x)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I, x, A, B), (1, 2), (5, 6))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayDiagonal(ArrayContraction(ArrayTensorProduct(I, OneArray(1), A, B, DiagMatrix(x)), (1, 7)), (5, 6))
+    cg = _array_diagonal(_array_tensor_product(I, x, A, B), (1, 2), (5, 6))
+    assert _array_diag2contr_diagmatrix(cg) == _array_diagonal(_array_contraction(_array_tensor_product(I, OneArray(1), A, B, DiagMatrix(x)), (1, 7)), (5, 6))
     # TODO: this is returning a wrong result:
     # convert_array_to_matrix(cg)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I1, a, b), (1, 3, 5))
+    cg = _array_diagonal(_array_tensor_product(I1, a, b), (1, 3, 5))
     assert convert_array_to_matrix(cg) == a*b.T
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I1, a, b), (1, 3))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(OneArray(1), a, b, I1), (2, 6))
+    cg = _array_diagonal(_array_tensor_product(I1, a, b), (1, 3))
+    assert _array_diag2contr_diagmatrix(cg) == _array_contraction(_array_tensor_product(OneArray(1), a, b, I1), (2, 6))
     assert convert_array_to_matrix(cg) == a*b.T
 
-    cg = ArrayDiagonal(ArrayTensorProduct(x, I1), (1, 2))
+    cg = _array_diagonal(_array_tensor_product(x, I1), (1, 2))
     assert isinstance(cg, ArrayDiagonal)
     assert cg.diagonal_indices == ((1, 2),)
     assert convert_array_to_matrix(cg) == x
 
-    cg = ArrayDiagonal(ArrayTensorProduct(x, I), (0, 2))
-    assert _array_diag2contr_diagmatrix(cg) == ArrayContraction(ArrayTensorProduct(OneArray(1), I, DiagMatrix(x)), (1, 3))
+    cg = _array_diagonal(_array_tensor_product(x, I), (0, 2))
+    assert _array_diag2contr_diagmatrix(cg) == _array_contraction(_array_tensor_product(OneArray(1), I, DiagMatrix(x)), (1, 3))
     assert convert_array_to_matrix(cg).doit() == DiagMatrix(x)
 
-    raises(ValueError, lambda: ArrayDiagonal(x, (1,)))
+    raises(ValueError, lambda: _array_diagonal(x, (1,)))
 
     # Ignore identity matrices with contractions:
 
-    cg = ArrayContraction(ArrayTensorProduct(I, A, I, I), (0, 2), (1, 3), (5, 7))
+    cg = _array_contraction(_array_tensor_product(I, A, I, I), (0, 2), (1, 3), (5, 7))
     assert cg.split_multiple_contractions() == cg
     assert convert_array_to_matrix(cg) == Trace(A) * I
 
-    cg = ArrayContraction(ArrayTensorProduct(Trace(A) * I, I, I), (1, 5), (3, 4))
+    cg = _array_contraction(_array_tensor_product(Trace(A) * I, I, I), (1, 5), (3, 4))
     assert cg.split_multiple_contractions() == cg
     assert convert_array_to_matrix(cg).doit() == Trace(A) * I
 
     # Add DiagMatrix when required:
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a), (1, 2))
+    cg = _array_contraction(_array_tensor_product(A, a), (1, 2))
     assert cg.split_multiple_contractions() == cg
     assert convert_array_to_matrix(cg) == A * a
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a, B), (1, 2, 4))
-    assert cg.split_multiple_contractions() == ArrayContraction(ArrayTensorProduct(A, DiagMatrix(a), OneArray(1), B), (1, 2), (3, 5))
+    cg = _array_contraction(_array_tensor_product(A, a, B), (1, 2, 4))
+    assert cg.split_multiple_contractions() == _array_contraction(_array_tensor_product(A, DiagMatrix(a), OneArray(1), B), (1, 2), (3, 5))
     assert convert_array_to_matrix(cg) == A * DiagMatrix(a) * B
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a, B), (0, 2, 4))
-    assert cg.split_multiple_contractions() == ArrayContraction(ArrayTensorProduct(A, DiagMatrix(a), OneArray(1), B), (0, 2), (3, 5))
+    cg = _array_contraction(_array_tensor_product(A, a, B), (0, 2, 4))
+    assert cg.split_multiple_contractions() == _array_contraction(_array_tensor_product(A, DiagMatrix(a), OneArray(1), B), (0, 2), (3, 5))
     assert convert_array_to_matrix(cg) == A.T * DiagMatrix(a) * B
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a, b, a.T, B), (0, 2, 4, 7, 9))
-    assert cg.split_multiple_contractions() == ArrayContraction(ArrayTensorProduct(A, DiagMatrix(a), OneArray(1),
+    cg = _array_contraction(_array_tensor_product(A, a, b, a.T, B), (0, 2, 4, 7, 9))
+    assert cg.split_multiple_contractions() == _array_contraction(_array_tensor_product(A, DiagMatrix(a), OneArray(1),
                                                 DiagMatrix(b), OneArray(1), DiagMatrix(a), OneArray(1), B),
                                                (0, 2), (3, 5), (6, 9), (8, 12))
     assert convert_array_to_matrix(cg) == A.T * DiagMatrix(a) * DiagMatrix(b) * DiagMatrix(a) * B.T
 
-    cg = ArrayContraction(ArrayTensorProduct(I1, I1, I1), (1, 2, 4))
-    assert cg.split_multiple_contractions() == ArrayContraction(ArrayTensorProduct(I1, I1, OneArray(1), I1), (1, 2), (3, 5))
+    cg = _array_contraction(_array_tensor_product(I1, I1, I1), (1, 2, 4))
+    assert cg.split_multiple_contractions() == _array_contraction(_array_tensor_product(I1, I1, OneArray(1), I1), (1, 2), (3, 5))
     assert convert_array_to_matrix(cg) == 1
 
-    cg = ArrayContraction(ArrayTensorProduct(I, I, I, I, A), (1, 2, 8), (5, 6, 9))
+    cg = _array_contraction(_array_tensor_product(I, I, I, I, A), (1, 2, 8), (5, 6, 9))
     assert convert_array_to_matrix(cg.split_multiple_contractions()).doit() == A
 
-    cg = ArrayContraction(ArrayTensorProduct(A, a, C, a, B), (1, 2, 4), (5, 6, 8))
-    expected = ArrayContraction(ArrayTensorProduct(A, DiagMatrix(a), OneArray(1), C, DiagMatrix(a), OneArray(1), B), (1, 3), (2, 5), (6, 7), (8, 10))
+    cg = _array_contraction(_array_tensor_product(A, a, C, a, B), (1, 2, 4), (5, 6, 8))
+    expected = _array_contraction(_array_tensor_product(A, DiagMatrix(a), OneArray(1), C, DiagMatrix(a), OneArray(1), B), (1, 3), (2, 5), (6, 7), (8, 10))
     assert cg.split_multiple_contractions() == expected
     assert convert_array_to_matrix(cg) == A * DiagMatrix(a) * C * DiagMatrix(a) * B
 
-    cg = ArrayContraction(ArrayTensorProduct(a, I1, b, I1, (a.T*b).applyfunc(cos)), (1, 2, 8), (5, 6, 9))
-    expected = ArrayContraction(ArrayTensorProduct(a, I1, OneArray(1), b, I1, OneArray(1), (a.T*b).applyfunc(cos)),
+    cg = _array_contraction(_array_tensor_product(a, I1, b, I1, (a.T*b).applyfunc(cos)), (1, 2, 8), (5, 6, 9))
+    expected = _array_contraction(_array_tensor_product(a, I1, OneArray(1), b, I1, OneArray(1), (a.T*b).applyfunc(cos)),
                                 (1, 3), (2, 10), (6, 8), (7, 11))
     assert cg.split_multiple_contractions().dummy_eq(expected)
     assert convert_array_to_matrix(cg).doit().dummy_eq(MatMul(a, (a.T * b).applyfunc(cos), b.T))
@@ -258,29 +258,29 @@ def test_arrayexpr_convert_array_to_diagonalized_vector():
 
 def test_arrayexpr_convert_array_contraction_tp_additions():
     a = ArrayAdd(
-        ArrayTensorProduct(M, N),
-        ArrayTensorProduct(N, M)
+        _array_tensor_product(M, N),
+        _array_tensor_product(N, M)
     )
-    tp = ArrayTensorProduct(P, a, Q)
-    expr = ArrayContraction(tp, (3, 4))
-    expected = ArrayTensorProduct(
+    tp = _array_tensor_product(P, a, Q)
+    expr = _array_contraction(tp, (3, 4))
+    expected = _array_tensor_product(
         P,
         ArrayAdd(
-            ArrayContraction(ArrayTensorProduct(M, N), (1, 2)),
-            ArrayContraction(ArrayTensorProduct(N, M), (1, 2)),
+            _array_contraction(_array_tensor_product(M, N), (1, 2)),
+            _array_contraction(_array_tensor_product(N, M), (1, 2)),
         ),
         Q
     )
     assert expr == expected
-    assert convert_array_to_matrix(expr) == ArrayTensorProduct(P, M * N + N * M, Q)
+    assert convert_array_to_matrix(expr) == _array_tensor_product(P, M * N + N * M, Q)
 
-    expr = ArrayContraction(tp, (1, 2), (3, 4), (5, 6))
-    result = ArrayContraction(
-        ArrayTensorProduct(
+    expr = _array_contraction(tp, (1, 2), (3, 4), (5, 6))
+    result = _array_contraction(
+        _array_tensor_product(
             P,
             ArrayAdd(
-                ArrayContraction(ArrayTensorProduct(M, N), (1, 2)),
-                ArrayContraction(ArrayTensorProduct(N, M), (1, 2)),
+                _array_contraction(_array_tensor_product(M, N), (1, 2)),
+                _array_contraction(_array_tensor_product(N, M), (1, 2)),
             ),
             Q
         ), (1, 2), (3, 4))
@@ -291,73 +291,73 @@ def test_arrayexpr_convert_array_contraction_tp_additions():
 def test_arrayexpr_convert_array_to_implicit_matmul():
     # Trivial dimensions are suppressed, so the result can be expressed in matrix form:
 
-    cg = ArrayTensorProduct(a, b)
+    cg = _array_tensor_product(a, b)
     assert convert_array_to_matrix(cg) == a * b.T
 
-    cg = ArrayTensorProduct(a, b, I)
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(a*b.T, I)
+    cg = _array_tensor_product(a, b, I)
+    assert convert_array_to_matrix(cg) == _array_tensor_product(a*b.T, I)
 
-    cg = ArrayTensorProduct(I, a, b)
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(I, a*b.T)
+    cg = _array_tensor_product(I, a, b)
+    assert convert_array_to_matrix(cg) == _array_tensor_product(I, a*b.T)
 
-    cg = ArrayTensorProduct(a, I, b)
-    assert convert_array_to_matrix(cg) == ArrayTensorProduct(a, I, b)
+    cg = _array_tensor_product(a, I, b)
+    assert convert_array_to_matrix(cg) == _array_tensor_product(a, I, b)
 
-    cg = ArrayContraction(ArrayTensorProduct(I, I), (1, 2))
+    cg = _array_contraction(_array_tensor_product(I, I), (1, 2))
     assert convert_array_to_matrix(cg) == I
 
-    cg = PermuteDims(ArrayTensorProduct(I, Identity(1)), [0, 2, 1, 3])
+    cg = PermuteDims(_array_tensor_product(I, Identity(1)), [0, 2, 1, 3])
     assert convert_array_to_matrix(cg) == I
 
 
 def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
 
     # Tensor Product:
-    assert _remove_trivial_dims(ArrayTensorProduct(a, b)) == (a * b.T, [1, 3])
-    assert _remove_trivial_dims(ArrayTensorProduct(a.T, b)) == (a * b.T, [0, 3])
-    assert _remove_trivial_dims(ArrayTensorProduct(a, b.T)) == (a * b.T, [1, 2])
-    assert _remove_trivial_dims(ArrayTensorProduct(a.T, b.T)) == (a * b.T, [0, 2])
+    assert _remove_trivial_dims(_array_tensor_product(a, b)) == (a * b.T, [1, 3])
+    assert _remove_trivial_dims(_array_tensor_product(a.T, b)) == (a * b.T, [0, 3])
+    assert _remove_trivial_dims(_array_tensor_product(a, b.T)) == (a * b.T, [1, 2])
+    assert _remove_trivial_dims(_array_tensor_product(a.T, b.T)) == (a * b.T, [0, 2])
 
-    assert _remove_trivial_dims(ArrayTensorProduct(I, a.T, b.T)) == (ArrayTensorProduct(I, a * b.T), [2, 4])
-    assert _remove_trivial_dims(ArrayTensorProduct(a.T, I, b.T)) == (ArrayTensorProduct(a.T, I, b.T), [])
+    assert _remove_trivial_dims(_array_tensor_product(I, a.T, b.T)) == (_array_tensor_product(I, a * b.T), [2, 4])
+    assert _remove_trivial_dims(_array_tensor_product(a.T, I, b.T)) == (_array_tensor_product(a.T, I, b.T), [])
 
-    assert _remove_trivial_dims(ArrayTensorProduct(a, I)) == (ArrayTensorProduct(a, I), [])
-    assert _remove_trivial_dims(ArrayTensorProduct(I, a)) == (ArrayTensorProduct(I, a), [])
+    assert _remove_trivial_dims(_array_tensor_product(a, I)) == (_array_tensor_product(a, I), [])
+    assert _remove_trivial_dims(_array_tensor_product(I, a)) == (_array_tensor_product(I, a), [])
 
-    assert _remove_trivial_dims(ArrayTensorProduct(a.T, b.T, c, d)) == (
-        ArrayTensorProduct(a * b.T, c * d.T), [0, 2, 5, 7])
-    assert _remove_trivial_dims(ArrayTensorProduct(a.T, I, b.T, c, d, I)) == (
-        ArrayTensorProduct(a.T, I, b*c.T, d, I), [4, 7])
+    assert _remove_trivial_dims(_array_tensor_product(a.T, b.T, c, d)) == (
+        _array_tensor_product(a * b.T, c * d.T), [0, 2, 5, 7])
+    assert _remove_trivial_dims(_array_tensor_product(a.T, I, b.T, c, d, I)) == (
+        _array_tensor_product(a.T, I, b*c.T, d, I), [4, 7])
 
     # Addition:
 
-    cg = ArrayAdd(ArrayTensorProduct(a, b), ArrayTensorProduct(c, d))
+    cg = ArrayAdd(_array_tensor_product(a, b), _array_tensor_product(c, d))
     assert _remove_trivial_dims(cg) == (a * b.T + c * d.T, [1, 3])
 
     # Permute Dims:
 
-    cg = PermuteDims(ArrayTensorProduct(a, b), Permutation(3)(1, 2))
+    cg = PermuteDims(_array_tensor_product(a, b), Permutation(3)(1, 2))
     assert _remove_trivial_dims(cg) == (a * b.T, [2, 3])
 
-    cg = PermuteDims(ArrayTensorProduct(a, I, b), Permutation(5)(1, 2, 3, 4))
+    cg = PermuteDims(_array_tensor_product(a, I, b), Permutation(5)(1, 2, 3, 4))
     assert _remove_trivial_dims(cg) == (cg, [])
 
-    cg = PermuteDims(ArrayTensorProduct(I, b, a), Permutation(5)(1, 2, 4, 5, 3))
-    assert _remove_trivial_dims(cg) == (PermuteDims(ArrayTensorProduct(I, b * a.T), [0, 2, 3, 1]), [4, 5])
+    cg = PermuteDims(_array_tensor_product(I, b, a), Permutation(5)(1, 2, 4, 5, 3))
+    assert _remove_trivial_dims(cg) == (PermuteDims(_array_tensor_product(I, b * a.T), [0, 2, 3, 1]), [4, 5])
 
     # Diagonal:
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, a), (1, 2))
+    cg = _array_diagonal(_array_tensor_product(M, a), (1, 2))
     assert _remove_trivial_dims(cg) == (cg, [])
 
     # Contraction:
 
-    cg = ArrayContraction(ArrayTensorProduct(M, a), (1, 2))
+    cg = _array_contraction(_array_tensor_product(M, a), (1, 2))
     assert _remove_trivial_dims(cg) == (cg, [])
 
     # A few more cases to test the removal and shift of nested removed axes
     # with array contractions and array diagonals:
-    tp = ArrayTensorProduct(
+    tp = _array_tensor_product(
         OneMatrix(1, 1),
         M,
         x,
@@ -365,100 +365,100 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
         Identity(1),
     )
 
-    expr = ArrayContraction(tp, (1, 8))
+    expr = _array_contraction(tp, (1, 8))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 5, 6, 7]
 
-    expr = ArrayContraction(tp, (1, 8), (3, 4))
+    expr = _array_contraction(tp, (1, 8), (3, 4))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 3, 4, 5]
 
-    expr = ArrayDiagonal(tp, (1, 8))
+    expr = _array_diagonal(tp, (1, 8))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 5, 6, 7, 8]
 
-    expr = ArrayDiagonal(tp, (1, 8), (3, 4))
+    expr = _array_diagonal(tp, (1, 8), (3, 4))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [0, 3, 4, 5, 6]
 
-    expr = ArrayDiagonal(ArrayContraction(ArrayTensorProduct(A, x, I, I1), (1, 2, 5)), (1, 4))
+    expr = _array_diagonal(_array_contraction(_array_tensor_product(A, x, I, I1), (1, 2, 5)), (1, 4))
     rexpr, removed = _remove_trivial_dims(expr)
     assert removed == [2, 3]
 
-    cg = ArrayDiagonal(ArrayTensorProduct(PermuteDims(ArrayTensorProduct(x, I1), Permutation(1, 2, 3)), (x.T*x).applyfunc(sqrt)), (2, 4), (3, 5))
+    cg = _array_diagonal(_array_tensor_product(PermuteDims(_array_tensor_product(x, I1), Permutation(1, 2, 3)), (x.T*x).applyfunc(sqrt)), (2, 4), (3, 5))
     rexpr, removed = _remove_trivial_dims(cg)
     assert removed == [1, 2]
 
     # Contractions with identity matrices need to be followed by a permutation
     # in order
-    cg = ArrayContraction(ArrayTensorProduct(A, B, C, M, I), (1, 8))
+    cg = _array_contraction(_array_tensor_product(A, B, C, M, I), (1, 8))
     ret, removed = _remove_trivial_dims(cg)
-    assert ret == PermuteDims(ArrayTensorProduct(A, B, C, M), [0, 2, 3, 4, 5, 6, 7, 1])
+    assert ret == PermuteDims(_array_tensor_product(A, B, C, M), [0, 2, 3, 4, 5, 6, 7, 1])
     assert removed == []
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, C, M, I), (1, 8), (3, 4))
+    cg = _array_contraction(_array_tensor_product(A, B, C, M, I), (1, 8), (3, 4))
     ret, removed = _remove_trivial_dims(cg)
-    assert ret == PermuteDims(ArrayContraction(ArrayTensorProduct(A, B, C, M), (3, 4)), [0, 2, 3, 4, 5, 1])
+    assert ret == PermuteDims(_array_contraction(_array_tensor_product(A, B, C, M), (3, 4)), [0, 2, 3, 4, 5, 1])
     assert removed == []
 
     # Trivial matrices are sometimes inserted into MatMul expressions:
 
-    cg = ArrayTensorProduct(b*b.T, a.T*a)
+    cg = _array_tensor_product(b*b.T, a.T*a)
     ret, removed = _remove_trivial_dims(cg)
     assert ret == b*a.T*a*b.T
     assert removed == [2, 3]
 
     Xs = ArraySymbol("X", (3, 2, k))
-    cg = ArrayTensorProduct(M, Xs, b.T*c, a*a.T, b*b.T, c.T*d)
+    cg = _array_tensor_product(M, Xs, b.T*c, a*a.T, b*b.T, c.T*d)
     ret, removed = _remove_trivial_dims(cg)
-    assert ret == ArrayTensorProduct(M, Xs, a*b.T*c*c.T*d*a.T, b*b.T)
+    assert ret == _array_tensor_product(M, Xs, a*b.T*c*c.T*d*a.T, b*b.T)
     assert removed == [5, 6, 11, 12]
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I, I1, x), (1, 4), (3, 5))
-    assert _remove_trivial_dims(cg) == (PermuteDims(ArrayDiagonal(ArrayTensorProduct(I, x), (1, 2)), Permutation(1, 2)), [1])
+    cg = _array_diagonal(_array_tensor_product(I, I1, x), (1, 4), (3, 5))
+    assert _remove_trivial_dims(cg) == (PermuteDims(_array_diagonal(_array_tensor_product(I, x), (1, 2)), Permutation(1, 2)), [1])
 
-    expr = ArrayDiagonal(ArrayTensorProduct(x, I, y), (0, 2))
-    assert _remove_trivial_dims(expr) == (PermuteDims(ArrayTensorProduct(DiagMatrix(x), y), [1, 2, 3, 0]), [0])
+    expr = _array_diagonal(_array_tensor_product(x, I, y), (0, 2))
+    assert _remove_trivial_dims(expr) == (PermuteDims(_array_tensor_product(DiagMatrix(x), y), [1, 2, 3, 0]), [0])
 
-    expr = ArrayDiagonal(ArrayTensorProduct(x, I, y), (0, 2), (3, 4))
+    expr = _array_diagonal(_array_tensor_product(x, I, y), (0, 2), (3, 4))
     assert _remove_trivial_dims(expr) == (expr, [])
 
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():
-    cg = ArrayDiagonal(ArrayTensorProduct(M, a), (1, 2))
+    cg = _array_diagonal(_array_tensor_product(M, a), (1, 2))
     res = _array_diag2contr_diagmatrix(cg)
     assert res.shape == cg.shape
-    assert res == ArrayContraction(ArrayTensorProduct(M, OneArray(1), DiagMatrix(a)), (1, 3))
+    assert res == _array_contraction(_array_tensor_product(M, OneArray(1), DiagMatrix(a)), (1, 3))
 
-    raises(ValueError, lambda: ArrayDiagonal(ArrayTensorProduct(a, M), (1, 2)))
+    raises(ValueError, lambda: _array_diagonal(_array_tensor_product(a, M), (1, 2)))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(a.T, M), (1, 2))
+    cg = _array_diagonal(_array_tensor_product(a.T, M), (1, 2))
     res = _array_diag2contr_diagmatrix(cg)
     assert res.shape == cg.shape
-    assert res == ArrayContraction(ArrayTensorProduct(OneArray(1), M, DiagMatrix(a.T)), (1, 4))
+    assert res == _array_contraction(_array_tensor_product(OneArray(1), M, DiagMatrix(a.T)), (1, 4))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(a.T, M, N, b.T), (1, 2), (4, 7))
+    cg = _array_diagonal(_array_tensor_product(a.T, M, N, b.T), (1, 2), (4, 7))
     res = _array_diag2contr_diagmatrix(cg)
     assert res.shape == cg.shape
-    assert res == ArrayContraction(
-        ArrayTensorProduct(OneArray(1), M, N, OneArray(1), DiagMatrix(a.T), DiagMatrix(b.T)), (1, 7), (3, 9))
+    assert res == _array_contraction(
+        _array_tensor_product(OneArray(1), M, N, OneArray(1), DiagMatrix(a.T), DiagMatrix(b.T)), (1, 7), (3, 9))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(a, M, N, b.T), (0, 2), (4, 7))
+    cg = _array_diagonal(_array_tensor_product(a, M, N, b.T), (0, 2), (4, 7))
     res = _array_diag2contr_diagmatrix(cg)
     assert res.shape == cg.shape
-    assert res == ArrayContraction(
-        ArrayTensorProduct(OneArray(1), M, N, OneArray(1), DiagMatrix(a), DiagMatrix(b.T)), (1, 6), (3, 9))
+    assert res == _array_contraction(
+        _array_tensor_product(OneArray(1), M, N, OneArray(1), DiagMatrix(a), DiagMatrix(b.T)), (1, 6), (3, 9))
 
-    cg = ArrayDiagonal(ArrayTensorProduct(a, M, N, b.T), (0, 4), (3, 7))
+    cg = _array_diagonal(_array_tensor_product(a, M, N, b.T), (0, 4), (3, 7))
     res = _array_diag2contr_diagmatrix(cg)
     assert res.shape == cg.shape
-    assert res == ArrayContraction(
-        ArrayTensorProduct(OneArray(1), M, N, OneArray(1), DiagMatrix(a), DiagMatrix(b.T)), (3, 6), (2, 9))
+    assert res == _array_contraction(
+        _array_tensor_product(OneArray(1), M, N, OneArray(1), DiagMatrix(a), DiagMatrix(b.T)), (3, 6), (2, 9))
 
     I1 = Identity(1)
     x = MatrixSymbol("x", k, 1)
     A = MatrixSymbol("A", k, k)
-    cg = ArrayDiagonal(ArrayTensorProduct(x, A.T, I1), (0, 2))
+    cg = _array_diagonal(_array_tensor_product(x, A.T, I1), (0, 2))
     assert _array_diag2contr_diagmatrix(cg).shape == cg.shape
     assert _array2matrix(cg).shape == cg.shape
 
@@ -476,9 +476,9 @@ def test_arrayexpr_convert_array_to_matrix_support_function():
     assert _support_function_tp1_recognize([(1, 3)], [A, B]) == A * B.T
     assert _support_function_tp1_recognize([(0, 3)], [A, B]) == A.T * B.T
 
-    assert _support_function_tp1_recognize([(1, 2), (5, 6)], [A, B, C, D]) == ArrayTensorProduct(A * B, C * D)
+    assert _support_function_tp1_recognize([(1, 2), (5, 6)], [A, B, C, D]) == _array_tensor_product(A * B, C * D)
     assert _support_function_tp1_recognize([(1, 4), (3, 6)], [A, B, C, D]) == PermuteDims(
-        ArrayTensorProduct(A * C, B * D), [0, 2, 1, 3])
+        _array_tensor_product(A * C, B * D), [0, 2, 1, 3])
 
     assert _support_function_tp1_recognize([(0, 3), (1, 4)], [A, B, C]) == B * A * C
 
@@ -486,24 +486,24 @@ def test_arrayexpr_convert_array_to_matrix_support_function():
                                            [X, Y, A, B, C, D]) == X * Y * A * B * C * D
 
     assert _support_function_tp1_recognize([(9, 10), (1, 2), (5, 6), (3, 4)],
-                                           [X, Y, A, B, C, D]) == ArrayTensorProduct(X * Y * A * B, C * D)
+                                           [X, Y, A, B, C, D]) == _array_tensor_product(X * Y * A * B, C * D)
 
     assert _support_function_tp1_recognize([(1, 7), (3, 8), (4, 11)], [X, Y, A, B, C, D]) == PermuteDims(
-        ArrayTensorProduct(X * B.T, Y * C, A.T * D.T), [0, 2, 4, 1, 3, 5]
+        _array_tensor_product(X * B.T, Y * C, A.T * D.T), [0, 2, 4, 1, 3, 5]
     )
 
     assert _support_function_tp1_recognize([(0, 1), (3, 6), (5, 8)], [X, A, B, C, D]) == PermuteDims(
-        ArrayTensorProduct(Trace(X) * A * C, B * D), [0, 2, 1, 3])
+        _array_tensor_product(Trace(X) * A * C, B * D), [0, 2, 1, 3])
 
     assert _support_function_tp1_recognize([(1, 2), (3, 4), (5, 6), (7, 8)], [A, A, B, C, D]) == A ** 2 * B * C * D
     assert _support_function_tp1_recognize([(1, 2), (3, 4), (5, 6), (7, 8)], [X, A, B, C, D]) == X * A * B * C * D
 
     assert _support_function_tp1_recognize([(1, 6), (3, 8), (5, 10)], [X, Y, A, B, C, D]) == PermuteDims(
-        ArrayTensorProduct(X * B, Y * C, A * D), [0, 2, 4, 1, 3, 5]
+        _array_tensor_product(X * B, Y * C, A * D), [0, 2, 4, 1, 3, 5]
     )
 
     assert _support_function_tp1_recognize([(1, 4), (3, 6)], [A, B, C, D]) == PermuteDims(
-        ArrayTensorProduct(A * C, B * D), [0, 2, 1, 3])
+        _array_tensor_product(A * C, B * D), [0, 2, 1, 3])
 
     assert _support_function_tp1_recognize([(0, 4), (1, 7), (2, 5), (3, 8)], [X, A, B, C, D]) == C*X.T*B*A*D
 
@@ -543,13 +543,13 @@ def test_convert_array_to_hadamard_products():
     assert expr == ret
 
     # ArrayDiagonal should be converted
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N, Q), (1, 3), (0, 2, 4))
+    cg = _array_diagonal(_array_tensor_product(M, N, Q), (1, 3), (0, 2, 4))
     ret = convert_array_to_matrix(cg)
-    expected = PermuteDims(ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M.T, N.T), Q), (1, 2)), [1, 0, 2])
+    expected = PermuteDims(_array_diagonal(_array_tensor_product(HadamardProduct(M.T, N.T), Q), (1, 2)), [1, 0, 2])
     assert expected == ret
 
     # Special case that should return the same expression:
-    cg = ArrayDiagonal(ArrayTensorProduct(HadamardProduct(M, N), Q), (0, 2))
+    cg = _array_diagonal(_array_tensor_product(HadamardProduct(M, N), Q), (0, 2))
     ret = convert_array_to_matrix(cg)
     assert ret == cg
 
@@ -572,21 +572,21 @@ def test_convert_array_to_hadamard_products():
 
     # These should not be converted into Hadamard products:
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N), (0, 1, 2, 3))
+    cg = _array_diagonal(_array_tensor_product(M, N), (0, 1, 2, 3))
     ret = convert_array_to_matrix(cg)
     assert ret == cg
 
-    cg = ArrayDiagonal(ArrayTensorProduct(A), (0, 1))
+    cg = _array_diagonal(_array_tensor_product(A), (0, 1))
     ret = convert_array_to_matrix(cg)
     assert ret == cg
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N, P), (0, 2, 4), (1, 3, 5))
+    cg = _array_diagonal(_array_tensor_product(M, N, P), (0, 2, 4), (1, 3, 5))
     assert convert_array_to_matrix(cg) == HadamardProduct(M, N, P)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(M, N, P), (0, 3, 4), (1, 2, 5))
+    cg = _array_diagonal(_array_tensor_product(M, N, P), (0, 3, 4), (1, 2, 5))
     assert convert_array_to_matrix(cg) == HadamardProduct(M, P, N.T)
 
-    cg = ArrayDiagonal(ArrayTensorProduct(I, I1, x), (1, 4), (3, 5))
+    cg = _array_diagonal(_array_tensor_product(I, I1, x), (1, 4), (3, 5))
     assert convert_array_to_matrix(cg) == DiagMatrix(x)
 
 
@@ -594,22 +594,22 @@ def test_identify_removable_identity_matrices():
 
     D = DiagonalMatrix(MatrixSymbol("D", k, k))
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, I), (1, 2, 4, 5))
-    expected = ArrayContraction(ArrayTensorProduct(A, B), (1, 2))
+    cg = _array_contraction(_array_tensor_product(A, B, I), (1, 2, 4, 5))
+    expected = _array_contraction(_array_tensor_product(A, B), (1, 2))
     assert identify_removable_identity_matrices(cg) == expected
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, C, I), (1, 3, 5, 6, 7))
-    expected = ArrayContraction(ArrayTensorProduct(A, B, C), (1, 3, 5))
+    cg = _array_contraction(_array_tensor_product(A, B, C, I), (1, 3, 5, 6, 7))
+    expected = _array_contraction(_array_tensor_product(A, B, C), (1, 3, 5))
     assert identify_removable_identity_matrices(cg) == expected
 
     # Tests with diagonal matrices:
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, D), (1, 2, 4, 5))
+    cg = _array_contraction(_array_tensor_product(A, B, D), (1, 2, 4, 5))
     ret = identify_removable_identity_matrices(cg)
-    expected = ArrayContraction(ArrayTensorProduct(A, B, D), (1, 4), (2, 5))
+    expected = _array_contraction(_array_tensor_product(A, B, D), (1, 4), (2, 5))
     assert ret == expected
 
-    cg = ArrayContraction(ArrayTensorProduct(A, B, D, M, N), (1, 2, 4, 5, 6, 8))
+    cg = _array_contraction(_array_tensor_product(A, B, D, M, N), (1, 2, 4, 5, 6, 8))
     ret = identify_removable_identity_matrices(cg)
     assert ret == cg
 
@@ -623,18 +623,18 @@ def test_combine_removed():
 
 def test_array_contraction_to_diagonal_multiple_identities():
 
-    expr = ArrayContraction(ArrayTensorProduct(A, B, I, C), (1, 2, 4), (5, 6))
+    expr = _array_contraction(_array_tensor_product(A, B, I, C), (1, 2, 4), (5, 6))
     assert _array_contraction_to_diagonal_multiple_identity(expr) == (expr, [])
-    assert convert_array_to_matrix(expr) == ArrayContraction(ArrayTensorProduct(A, B, C), (1, 2, 4))
+    assert convert_array_to_matrix(expr) == _array_contraction(_array_tensor_product(A, B, C), (1, 2, 4))
 
-    expr = ArrayContraction(ArrayTensorProduct(A, I, I), (1, 2, 4))
+    expr = _array_contraction(_array_tensor_product(A, I, I), (1, 2, 4))
     assert _array_contraction_to_diagonal_multiple_identity(expr) == (A, [2])
     assert convert_array_to_matrix(expr) == A
 
-    expr = ArrayContraction(ArrayTensorProduct(A, I, I, B), (1, 2, 4), (3, 6))
+    expr = _array_contraction(_array_tensor_product(A, I, I, B), (1, 2, 4), (3, 6))
     assert _array_contraction_to_diagonal_multiple_identity(expr) == (expr, [])
 
-    expr = ArrayContraction(ArrayTensorProduct(A, I, I, B), (1, 2, 3, 4, 6))
+    expr = _array_contraction(_array_tensor_product(A, I, I, B), (1, 2, 3, 4, 6))
     assert _array_contraction_to_diagonal_multiple_identity(expr) == (expr, [])
 
 
@@ -643,10 +643,10 @@ def test_convert_array_element_to_matrix():
     expr = ArrayElement(M, (i, j))
     assert convert_array_to_matrix(expr) == MatrixElement(M, i, j)
 
-    expr = ArrayElement(ArrayContraction(ArrayTensorProduct(M, N), (1, 3)), (i, j))
+    expr = ArrayElement(_array_contraction(_array_tensor_product(M, N), (1, 3)), (i, j))
     assert convert_array_to_matrix(expr) == MatrixElement(M*N.T, i, j)
 
-    expr = ArrayElement(ArrayTensorProduct(M, N), (i, j, m, n))
+    expr = ArrayElement(_array_tensor_product(M, N), (i, j, m, n))
     assert convert_array_to_matrix(expr) == expr
 
 

--- a/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
@@ -6,7 +6,8 @@ from sympy.matrices.expressions.special import Identity
 from sympy.tensor.indexed import IndexedBase
 from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ArrayContraction, ArrayTensorProduct, \
-    ArrayDiagonal, ArrayAdd, PermuteDims, ArrayElement
+    ArrayDiagonal, ArrayAdd, PermuteDims, ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, \
+    _array_add, _permute_dims
 from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array, _convert_indexed_to_array
 from sympy.testing.pytest import raises
@@ -44,7 +45,7 @@ def test_arrayexpr_convert_index_to_array_support_function():
     expr = M[i, j] + M[j, i]
     assert _convert_indexed_to_array(expr) == (ArrayAdd(M, PermuteDims(M, Permutation([1, 0]))), (i, j))
     expr = (M*N*P)[i, j]
-    assert _convert_indexed_to_array(expr) == (ArrayContraction(ArrayTensorProduct(M, N, P), (1, 2), (3, 4)), (i, j))
+    assert _convert_indexed_to_array(expr) == (_array_contraction(ArrayTensorProduct(M, N, P), (1, 2), (3, 4)), (i, j))
     expr = expr.function  # Disregard summation in previous expression
     ret1, ret2 = _convert_indexed_to_array(expr)
     assert ret1 == ArrayDiagonal(ArrayTensorProduct(M, N, P), (1, 2), (3, 4))
@@ -54,14 +55,14 @@ def test_arrayexpr_convert_index_to_array_support_function():
     expr = KroneckerDelta(i, j)*KroneckerDelta(j, k)*M[i, l]
     assert _convert_indexed_to_array(expr) == (M, ({i, j, k}, l))
     expr = KroneckerDelta(j, k)*(M[i, j]*N[k, l] + N[i, j]*M[k, l])
-    assert _convert_indexed_to_array(expr) == (ArrayDiagonal(ArrayAdd(
+    assert _convert_indexed_to_array(expr) == (_array_diagonal(_array_add(
             ArrayTensorProduct(M, N),
-            PermuteDims(ArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
+            _permute_dims(ArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
         ), (1, 2)), (i, l, frozenset({j, k})))
     expr = KroneckerDelta(j, m)*KroneckerDelta(m, k)*(M[i, j]*N[k, l] + N[i, j]*M[k, l])
-    assert _convert_indexed_to_array(expr) == (ArrayDiagonal(ArrayAdd(
+    assert _convert_indexed_to_array(expr) == (_array_diagonal(_array_add(
             ArrayTensorProduct(M, N),
-            PermuteDims(ArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
+            _permute_dims(ArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
         ), (1, 2)), (i, l, frozenset({j, m, k})))
     expr = KroneckerDelta(i, j)*KroneckerDelta(j, k)*KroneckerDelta(k,m)*M[i, 0]*KroneckerDelta(m, n)
     assert _convert_indexed_to_array(expr) == (M, ({i, j, k, m, n}, 0))
@@ -82,15 +83,15 @@ def test_arrayexpr_convert_indexed_to_array_expression():
 
     expr = M*N*M
     elem = expr[i, j]
-    result = ArrayContraction(ArrayTensorProduct(M, M, N), (1, 4), (2, 5))
+    result = _array_contraction(_array_tensor_product(M, M, N), (1, 4), (2, 5))
     cg = convert_indexed_to_array(elem)
     assert cg == result
 
     cg = convert_indexed_to_array((M * N * P)[i, j])
-    assert cg == ArrayContraction(ArrayTensorProduct(M, N, P), (1, 2), (3, 4))
+    assert cg == _array_contraction(ArrayTensorProduct(M, N, P), (1, 2), (3, 4))
 
     cg = convert_indexed_to_array((M * N.T * P)[i, j])
-    assert cg == ArrayContraction(ArrayTensorProduct(M, N, P), (1, 3), (2, 4))
+    assert cg == _array_contraction(ArrayTensorProduct(M, N, P), (1, 3), (2, 4))
 
     expr = -2*M*N
     elem = expr[i, j]

--- a/sympy/tensor/array/expressions/tests/test_convert_matrix_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_matrix_to_array.py
@@ -8,7 +8,7 @@ from sympy.matrices.expressions.special import Identity
 from sympy.matrices.expressions.trace import Trace
 from sympy.matrices.expressions.transpose import Transpose
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayContraction, \
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, _array_contraction, _array_tensor_product
 from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
 
@@ -42,14 +42,14 @@ def test_arrayexpr_convert_matrix_to_array():
     assert convert_matrix_to_array(expr) == result
 
     expr = M*N*M
-    result = ArrayContraction(ArrayTensorProduct(M, N, M), (1, 2), (3, 4))
+    result = _array_contraction(ArrayTensorProduct(M, N, M), (1, 2), (3, 4))
     assert convert_matrix_to_array(expr) == result
 
     expr = Transpose(M)
     assert convert_matrix_to_array(expr) == PermuteDims(M, [1, 0])
 
     expr = M*Transpose(N)
-    assert convert_matrix_to_array(expr) == ArrayContraction(ArrayTensorProduct(M, PermuteDims(N, [1, 0])), (1, 2))
+    assert convert_matrix_to_array(expr) == _array_contraction(_array_tensor_product(M, PermuteDims(N, [1, 0])), (1, 2))
 
     expr = 3*M*N
     res = convert_matrix_to_array(expr)


### PR DESCRIPTION
This PR makes are classes in `sympy.tensor.array.expressions` unevaluated by default. That is, the class constructor will not perform any transformation or simplification. They will indeed be abstract syntax trees (AST) for array expressions.

Use functions like `tensorproduct( ... )`, `tensordiagonal( ... )`, `tensorcontraction( ... )`, and `permutedims( ... )` to perform automatic simplifications of array expressions.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

## Examples

### Previous behaviour:
```python
In [1]: from sympy.tensor.array.expressions.array_expressions import *

In [2]: A = ArraySymbol("A", shape=(2, 2, 2, 2))

In [4]: ArrayContraction(PermuteDims(A, [3, 2, 1, 0]), (1, 2))
Out[4]: PermuteDims(ArrayContraction(A, (1, 2)), (0 1))
```

_PermuteDims_ and _ArrayContraction_ are swapped, as the current normal form for array expressions reorders the operations so that the array-operations that decrease dimensions are applied before array-operations that do not decrease (or decrease less) the number of dimensions.

### New behaviour:
```python
>>> ArrayContraction(PermuteDims(A, [3, 2, 1, 0]), (1, 2))
ArrayContraction(PermuteDims(A, (0 3)(1 2)), (1, 2))
```
That is, no reordering takes place.

To achieve the same behaviour as before, use the functions instead of the classes:
```python
>>> tensorcontraction(permutedims(A, [3, 2, 1, 0]), (1, 2))
PermuteDims(ArrayContraction(A, (1, 2)), (0 1))
```