### PR TITLE
stats/rv: Density can no longer have None as its argument

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -852,11 +852,11 @@ def probability(condition, given_condition=None, numsamples=None,
 class Density(Basic):
     expr = property(lambda self: self.args[0])
 
-    def __new__(self, expr, condition = None):
+    def __new__(cls, expr, condition = None):
         if condition is None:
-            obj = Basic.__new__(expr)
+            obj = Basic.__new__(cls, expr)
         else:
-            obj = Basic.__new__(expr, condition)
+            obj = Basic.__new__(cls, expr, condition)
         return obj
 
     @property

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -852,6 +852,13 @@ def probability(condition, given_condition=None, numsamples=None,
 class Density(Basic):
     expr = property(lambda self: self.args[0])
 
+    def __new__(self, expr, condition = None):
+        if condition is None:
+            obj = Basic.__new__(expr)
+        else:
+            obj = Basic.__new__(expr, condition)
+        return obj
+
     @property
     def condition(self):
         if len(self.args) > 1:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22507
See also: https://github.com/sympy/sympy/pull/22445
#### Brief description of what is fixed or changed
Previously, `Density` would take `None` as its argument for `condition`.
This has been changed such that it only takes a single argument if
`condition` is `None`. Having one argument less rather than a `None`
value was already supported elsewhere in the class.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
