### PR TITLE
Various fixes to the Makefile for the docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ RST2HTML     = rst2html
 # You can set these variables from the command line.
 SPHINXOPTS   =
 SPHINXVER    = 0.5
-SPHINXBUILD  = PYTHONPATH=..:$(PYTHONPATH) sphinx-build
+SPHINXBUILD  = sphinx-build
 PAPER        =
 
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -116,8 +116,8 @@ linkcheck:
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-livehtml:
-	livereload _build/html
+livehtml: html
+	sphinx-autobuild --open-browser --watch .. --port 0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 
 cheatsheet: $(BUILDDIR)/cheatsheet/cheatsheet.pdf $(BUILDDIR)/cheatsheet/combinatoric_cheatsheet.pdf
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,6 +50,7 @@ clean:
 	-rm -rf sphinx
 	-rm -f $(PDFFILES)
 
+html: $(BUILDDIR)/html/pics/*.png
 html: SPHINXOPTS += -W --keep-going
 html: $(BUILDDIR)/logo/sympy-notailtext-favicon.ico
 	mkdir -p $(SOURCEDIR)/.static
@@ -57,9 +58,12 @@ html: $(BUILDDIR)/logo/sympy-notailtext-favicon.ico
 	mkdir -p $(BUILDDIR)/doctrees
 	mkdir -p $(SOURCEDIR)/modules
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
-	cp -r src/pics _build/html/
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+$(BUILDDIR)/html/pics/*.png: $(SOURCEDIR)/pics/*.png
+	mkdir -p $(BUILDDIR)/html
+	cp -r $(SOURCEDIR)/pics $(BUILDDIR)/html/
 
 htmlapi:
 	mkdir -p api/.static

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,6 +8,8 @@ SPHINXOPTS   =
 SPHINXVER    = 0.5
 SPHINXBUILD  = sphinx-build
 PAPER        =
+BUILDDIR     = _build
+SOURCEDIR    = src
 
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)
 PDFFILES = $(SVGFILES:%.svg=%.pdf)
@@ -15,9 +17,10 @@ PDFFILES = $(SVGFILES:%.svg=%.pdf)
 # This must be set for the recursive make pdf build to work in make latexpdf
 export LATEXMKOPTS = -halt-on-error -xelatex
 
-ALLSPHINXOPTS = -d _build/doctrees $(SPHINXOPTS) src
-ALLSPHINXOPTSapi = -d _build/doctrees-api $(SPHINXOPTS) api
-ALLSPHINXOPTSlatex = -d _build/doctrees-latex -D latex_element.papersize=$(PAPER)paper \
+
+ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS)
+ALLSPHINXOPTSapi = -d $(BUILDDIR)/doctrees-api $(SPHINXOPTS) api
+ALLSPHINXOPTSlatex = -d $(BUILDDIR)/doctrees-latex -D latex_element.papersize=$(PAPER)paper \
                 $(SPHINXOPTS) src
 
 .PHONY: changes cheatsheet clean help html htmlapi htmlhelp info latex latexpdf \
@@ -43,101 +46,101 @@ help:
 	@echo "  man         build manpage"
 
 clean:
-	-rm -rf _build
+	-rm -rf $(BUILDDIR)
 	-rm -rf sphinx
 	-rm -f $(PDFFILES)
 
 html: SPHINXOPTS += -W --keep-going
-html: _build/logo/sympy-notailtext-favicon.ico
-	mkdir -p src/.static
-	mkdir -p _build/html
-	mkdir -p _build/doctrees
-	mkdir -p src/modules
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html
+html: $(BUILDDIR)/logo/sympy-notailtext-favicon.ico
+	mkdir -p $(SOURCEDIR)/.static
+	mkdir -p $(BUILDDIR)/html
+	mkdir -p $(BUILDDIR)/doctrees
+	mkdir -p $(SOURCEDIR)/modules
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 	cp -r src/pics _build/html/
 	@echo
-	@echo "Build finished. The HTML pages are in _build/html."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 htmlapi:
 	mkdir -p api/.static
 	mkdir -p api/modules
-	mkdir -p _build/api _build/doctreesapi
+	mkdir -p $(BUILDDIR)/api $(BUILDDIR)/doctreesapi
 	rm -f api/modules/sympy*.rst
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTSapi) _build/api
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTSapi) $(BUILDDIR)/api
 	@echo
-	@echo "Build finished. The API docs pages are in _build/api."
+	@echo "Build finished. The API docs pages are in $(BUILDDIR)/api."
 
 web:
-	mkdir -p _build/web _build/doctrees
-	$(SPHINXBUILD) -b web $(ALLSPHINXOPTS) _build/web
+	mkdir -p $(BUILDDIR)/web $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b web $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/web
 	@echo
 	@echo "Build finished; now you can run"
-	@echo "  python -m sphinx.web _build/web"
+	@echo "  python -m sphinx.web $(BUILDDIR)/web"
 	@echo "to start the server."
 
 htmlhelp:
-	mkdir -p _build/htmlhelp _build/doctrees
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) _build/htmlhelp
+	mkdir -p $(BUILDDIR)/htmlhelp $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) %(SOURCEDIR) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in _build/htmlhelp."
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 latex: $(PDFFILES)
-	mkdir -p _build/latex _build/doctrees
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) _build/latex
+	mkdir -p $(BUILDDIR)/latex $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) $(BUILDDIR)/latex
 	@echo
-	@echo "Build finished; the LaTeX files are in _build/latex."
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Set the environment variable LATEXMKOPTS='-xelatex -silent'"
 	@echo "And run \`make all' in that directory to run these through xelatex."
 
 latexpdf: latex
-	$(MAKE) -C _build/latex
+	$(MAKE) -C $(BUILDDIR)/latex
 
 .svg.pdf:
 	dbus-run-session inkscape --file=$< --export-area-drawing --without-gui --export-pdf=$@
 
 changes:
-	mkdir -p _build/changes _build/doctrees
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) _build/changes
+	mkdir -p $(BUILDDIR)/changes $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/changes
 	@echo
-	@echo "The overview file is in _build/changes."
+	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	mkdir -p _build/linkcheck _build/doctrees
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) _build/linkcheck
+	mkdir -p $(BUILDDIR)/linkcheck $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
-	      "or in _build/linkcheck/output.txt."
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 livehtml:
 	livereload _build/html
 
-cheatsheet: _build/cheatsheet/cheatsheet.pdf _build/cheatsheet/combinatoric_cheatsheet.pdf
+cheatsheet: $(BUILDDIR)/cheatsheet/cheatsheet.pdf $(BUILDDIR)/cheatsheet/combinatoric_cheatsheet.pdf
 
-_build/cheatsheet/cheatsheet.pdf: cheatsheet/cheatsheet.tex
-	mkdir -p _build/cheatsheet
-	pdflatex -output-directory=_build/cheatsheet cheatsheet/cheatsheet.tex
-	pdflatex -output-directory=_build/cheatsheet cheatsheet/cheatsheet.tex
+$(BUILDDIR)/cheatsheet/cheatsheet.pdf: cheatsheet/cheatsheet.tex
+	mkdir -p $(BUILDDIR)/cheatsheet
+	pdflatex -output-directory=$(BUILDDIR)/cheatsheet cheatsheet/cheatsheet.tex
+	pdflatex -output-directory=$(BUILDDIR)/cheatsheet cheatsheet/cheatsheet.tex
 
-_build/cheatsheet/combinatoric_cheatsheet.pdf: cheatsheet/combinatoric_cheatsheet.tex
-	mkdir -p _build/cheatsheet
-	pdflatex -output-directory=_build/cheatsheet cheatsheet/combinatoric_cheatsheet.tex
-	pdflatex -output-directory=_build/cheatsheet cheatsheet/combinatoric_cheatsheet.tex
+$(BUILDDIR)/cheatsheet/combinatoric_cheatsheet.pdf: cheatsheet/combinatoric_cheatsheet.tex
+	mkdir -p $(BUILDDIR)/cheatsheet
+	pdflatex -output-directory=$(BUILDDIR)/cheatsheet cheatsheet/combinatoric_cheatsheet.tex
+	pdflatex -output-directory=$(BUILDDIR)/cheatsheet cheatsheet/combinatoric_cheatsheet.tex
 
 texinfo:
-	mkdir -p _build/texinfo
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	mkdir -p $(BUILDDIR)/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/texinfo
 	@echo
-	@echo "Build finished. The Texinfo files are in _build/texinfo."
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
 info:
-	mkdir -p _build/texinfo
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	mkdir -p $(BUILDDIR)/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
-	make -C _build/texinfo info
-	@echo "makeinfo finished; the Info files are in _build/texinfo."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
 man: man/isympy.xml
 	docbook2x-man --to-stdout $< > man/isympy.1

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -149,11 +149,12 @@ info:
 man: man/isympy.xml
 	docbook2x-man --to-stdout $< > man/isympy.1
 
-_build/logo/sympy-notailtext-favicon.ico: logo
+logo: $(BUILDDIR)/logo/*.png
 
-logo: src/logo/sympy.svg
-	rm -rf _build/logo
-	mkdir -p _build/logo
+$(BUILDDIR)/logo/sympy-notailtext-favicon.ico: logo
+
+$(BUILDDIR)/logo/*.png: $(SOURCEDIR)/logo/sympy.svg
+	mkdir -p $(BUILDDIR)/logo
 	$(PYTHON) ./generate_logos.py -d
 	@echo
 	@echo "Logo generated."

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -16,6 +16,9 @@ import os
 import subprocess
 from datetime import datetime
 
+# Make sure we import sympy from git
+sys.path.insert(0, os.path.abspath('../..'))
+
 import sympy
 
 # If your extensions are in another directory, add it here.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

The most notable changes here are:

- The logo files are no longer rebuilt on every build, which makes rebuilds faster.
- Update `make livehtml` to use sphinx-autobuild, which works better than livereload.

Also includes

- Refactor some things in the Makefile into variables.
- Add `..` to the path in conf.py instead of in the Makefile. This fixes running sphinx commands from outside the Makefile to not pick up the system installed SymPy. 
 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes https://github.com/sympy/sympy/pull/11735
Fixes https://github.com/sympy/sympy/issues/11715

I did not address this issue https://github.com/sympy/sympy/issues/17817, because I'm not sure if there are actual benefits to it. 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
