### PR TITLE
Add support for .doit() to array expressions

### DIFF
--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -107,7 +107,7 @@ class ArrayElement(_ArrayExpr):
         if s.name != self.name:
             return S.Zero
 
-        return KroneckerDelta(s.indices[0], self.indices[0])*KroneckerDelta(s.indices[1], self.indices[1])
+        return Mul.fromiter(KroneckerDelta(i, j) for i, j in zip(self.indices, s.indices))
 
 
 class ZeroArray(_ArrayExpr):

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -722,3 +722,9 @@ def test_array_element_expressions():
     assert M[0, 0].diff(N[0, 0]) == 0
     assert M[0, 1].diff(M[i, j]) == KroneckerDelta(i, 0)*KroneckerDelta(j, 1)
     assert M[0, 1].diff(N[i, j]) == 0
+
+    K4 = ArraySymbol("K4", shape=(k, k, k, k))
+
+    assert K4[i, j, k, l].diff(K4[1, 2, 3, 4]) == (
+        KroneckerDelta(i, 1)*KroneckerDelta(j, 2)*KroneckerDelta(k, 3)*KroneckerDelta(l, 4)
+    )


### PR DESCRIPTION
- Add support for .doit() to array expressions
- Using the correct term `canonicalize` for canonicalization of expressions (previous term _normalize_ was not quite proper)
- ArrayElement is now commutative and differentiatable

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
