### PR TITLE
22453a: (oo + I*oo)**(not 0 or 1) -> nan

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -480,10 +480,14 @@ class Add(Expr, AssocOp):
     def _eval_power(self, e):
         from .evalf import pure_complex
         from .relational import is_eq
-        if e.is_zero is False and is_eq(e, S.One
-                    ) is False and all(_.is_infinite for _
-                    in self.as_real_imag()):
-            return S.NaN
+        if len(self.args) == 2 and all(_.is_infinite for _ in self.args):
+            if e.is_zero is False and is_eq(e, S.One) is False:
+                a, b = self.args
+                if not a.coeff(S.ImaginaryUnit):
+                    a, b = b, a
+                ico = a.coeff(S.ImaginaryUnit)
+                if ico and ico.is_extended_real and b.is_extended_real:
+                    return S.NaN
         if e.is_Rational and self.is_number:
             ri = pure_complex(self)
             if ri:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -478,8 +478,13 @@ class Add(Expr, AssocOp):
     # issue 5524.
 
     def _eval_power(self, e):
+        from .evalf import pure_complex
+        from .relational import is_eq
+        if e.is_zero is False and is_eq(e, S.One
+                    ) is False and all(_.is_infinite for _
+                    in self.as_real_imag()):
+            return S.NaN
         if e.is_Rational and self.is_number:
-            from .evalf import pure_complex
             ri = pure_complex(self)
             if ri:
                 r, i = ri

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -480,7 +480,7 @@ class Add(Expr, AssocOp):
     def _eval_power(self, e):
         from .evalf import pure_complex
         from .relational import is_eq
-        if len(self.args) == 2 and all(_.is_infinite for _ in self.args):
+        if len(self.args) == 2 and any(_.is_infinite for _ in self.args):
             if e.is_zero is False and is_eq(e, S.One) is False:
                 a, b = self.args
                 if not a.coeff(S.ImaginaryUnit):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -489,7 +489,7 @@ class Add(Expr, AssocOp):
                 ico = b.coeff(S.ImaginaryUnit)
                 if ico and ico.is_extended_real and a.is_extended_real:
                     if e.is_extended_negative:
-                        return S.NaN
+                        return S.Zero
                     if e.is_extended_positive:
                         return S.ComplexInfinity
             return

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -482,12 +482,17 @@ class Add(Expr, AssocOp):
         from .relational import is_eq
         if len(self.args) == 2 and any(_.is_infinite for _ in self.args):
             if e.is_zero is False and is_eq(e, S.One) is False:
+                # looking for literal a + I*b
                 a, b = self.args
-                if not a.coeff(S.ImaginaryUnit):
+                if a.coeff(S.ImaginaryUnit):
                     a, b = b, a
-                ico = a.coeff(S.ImaginaryUnit)
-                if ico and ico.is_extended_real and b.is_extended_real:
-                    return S.NaN
+                ico = b.coeff(S.ImaginaryUnit)
+                if ico and ico.is_extended_real and a.is_extended_real:
+                    if e.is_extended_negative:
+                        return S.NaN
+                    if e.is_extended_positive:
+                        return S.ComplexInfinity
+            return
         if e.is_Rational and self.is_number:
             ri = pure_complex(self)
             if ri:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2404,10 +2404,16 @@ def test_issue_22244():
 
 
 def test_issue_22453():
+    from sympy.utilities.iterables import cartes
     e = Symbol('e', positive=True)
-    for i in (oo + I*oo, oo - I*oo, -oo + I*oo, -oo - I*oo):
+    for a, b in cartes(*[[oo, -oo, 3]]*2):
+        if a == b == 3:
+            continue
+        i = a + I*b
         assert i**(1 + e) is S.NaN
         assert unchanged(Pow, i, e)
     assert 1/(oo + I*oo) is S.NaN
     r, i = [Dummy(infinite=True, extended_real=True) for _ in range(2)]
     assert 1/(r + I*i) is S.NaN
+    assert 1/(3 + I*i) is S.NaN
+    assert 1/(r + I*3) is S.NaN

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2411,10 +2411,10 @@ def test_issue_22453():
             continue
         i = a + I*b
         assert i**(1 + e) is S.ComplexInfinity
-        assert i**-e is S.NaN
+        assert i**-e is S.Zero
         assert unchanged(Pow, i, e)
-    assert 1/(oo + I*oo) is S.NaN
+    assert 1/(oo + I*oo) is S.Zero
     r, i = [Dummy(infinite=True, extended_real=True) for _ in range(2)]
-    assert 1/(r + I*i) is S.NaN
-    assert 1/(3 + I*i) is S.NaN
-    assert 1/(r + I*3) is S.NaN
+    assert 1/(r + I*i) is S.Zero
+    assert 1/(3 + I*i) is S.Zero
+    assert 1/(r + I*3) is S.Zero

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2401,3 +2401,13 @@ def test_issue_22021():
 
 def test_issue_22244():
     assert -(zoo*x) == zoo*x
+
+
+def test_issue_22453():
+    e = Symbol('e', positive=True)
+    for i in (oo + I*oo, oo - I*oo, -oo + I*oo, -oo - I*oo):
+        assert i**(1 + e) is S.NaN
+        assert unchanged(Pow, i, e)
+    assert 1/(oo + I*oo) is S.NaN
+    r, i = [Dummy(infinite=True, extended_real=True) for _ in range(2)]
+    assert 1/(r + I*i) is S.NaN

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2405,12 +2405,13 @@ def test_issue_22244():
 
 def test_issue_22453():
     from sympy.utilities.iterables import cartes
-    e = Symbol('e', positive=True)
+    e = Symbol('e', extended_positive=True)
     for a, b in cartes(*[[oo, -oo, 3]]*2):
         if a == b == 3:
             continue
         i = a + I*b
-        assert i**(1 + e) is S.NaN
+        assert i**(1 + e) is S.ComplexInfinity
+        assert i**-e is S.NaN
         assert unchanged(Pow, i, e)
     assert 1/(oo + I*oo) is S.NaN
     r, i = [Dummy(infinite=True, extended_real=True) for _ in range(2)]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments

This is in response to an inline comment in `test_add_flatten` which noted that `1/(oo + I*oo) -> 0*(oo - I*oo)`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * nan is returned for any power (with exponent not 0 or 1) with infinite real and imaginary portions, e.g. 1/(oo + I*oo)->nan
<!-- END RELEASE NOTES -->
