### PR TITLE
Added pretty printing for transforms

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -20,7 +20,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import hobj, vobj, xobj, \
     xsym, pretty_symbol, pretty_atom, pretty_use_unicode, greek_unicode, U, \
-    pretty_try_use_unicode,  annotated
+    pretty_try_use_unicode,  annotated, capital_script
 
 # rename for usage from outside
 pprint_use_unicode = pretty_use_unicode
@@ -2039,7 +2039,7 @@ class PrettyPrinter(Printer):
         return s
 
     def _print_Pow(self, power):
-        from sympy.simplify.simplify import fraction
+        from sympy.simplify.radsimp import fraction
         b, e = power.as_base_exp()
         if power.is_commutative:
             if e is S.NegativeOne:
@@ -2820,6 +2820,55 @@ class PrettyPrinter(Printer):
 
     def _print_Str(self, s):
         return self._print(s.name)
+
+    def _print_unified_transform(self, expr, s, inverse=False):
+        if self._use_unicode:
+            name = "".join(capital_script(c) for c in s)
+        else:
+            name = s
+        tvar = self._print(expr.args[1])
+        f = self._print(expr.args[0])
+        var = self._print(expr.args[2])
+        prettyFunc = prettyForm(name)
+        pform_arg = prettyForm(" "*tvar.width())
+        pform_arg = prettyForm(*pform_arg.below(tvar))
+        prettyFunc = prettyForm(*prettyFunc.right(pform_arg))
+        prettyArgs = prettyForm(*f.parens('[', ']'))
+        prettyArgs2 = prettyForm(*var.parens())
+        pform = prettyForm(
+            binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs, prettyArgs2))
+        return pform
+
+    def _print_MellinTransform(self, expr):
+        return self._print_unified_transform(expr, 'M')
+
+    def _print_InverseMellinTransform(self, expr):
+        return self._print_unified_transform(expr, 'M', True)
+
+    def _print_LaplaceTransform(self, expr):
+        return self._print_unified_transform(expr, 'L')
+
+    def _print_InverseLaplaceTransform(self, expr):
+        return self._print_unified_transform(expr, 'L', True)
+
+    def _print_FourierTransform(self, expr):
+        return self._print_unified_transform(expr, 'F')
+
+    def _print_InverseFourierTransform(self, expr):
+        return self._print_unified_transform(expr, 'F', True)
+
+    def _print_SineTransform(self, expr):
+        return self._print_unified_transform(expr, 'SIN')
+
+    def _print_InverseSineTransform(self, expr):
+        return self._print_UnifiedTransform(expr, 'SIN', True)
+
+    def _print_CosineTransform(self, expr):
+        return self._print_UnifiedTransform(expr, 'COS')
+
+    def _print_InverseCosineTransform(self, expr):
+        return self._print_UnifiedTransform(expr, 'COS', True)
+
 
 
 @print_function(PrettyPrinter)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -637,3 +637,15 @@ def line_width(line):
     separate symbols and thus shouldn't be counted
     """
     return len(line.translate(_remove_combining))
+
+
+def capital_script(c):
+    if c in 'BEFHILMPR':
+        return U('SCRIPT CAPITAL {}'.format(c))
+    return U('MATHEMATICAL SCRIPT CAPITAL {}'.format(c))
+
+
+def small_script(c):
+    if c in 'eglo':
+        return U('SCRIPT SMALL {}'.format(c))
+    return U('MATHEMATICAL SCRIPT SMALL {}'.format(c))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -21,6 +21,7 @@ from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import dirichlet_eta
 from sympy.geometry.line import (Ray, Segment)
 from sympy.integrals.integrals import Integral
+from sympy.integrals.transforms import LaplaceTransform, SineTransform
 from sympy.logic.boolalg import (And, Equivalent, ITE, Implies, Nand, Nor, Not, Or, Xor)
 from sympy.matrices.dense import (Matrix, diag)
 from sympy.matrices.expressions.slice import MatrixSlice
@@ -7631,6 +7632,25 @@ def test_issue_18272():
 def test_Str():
     from sympy.core.symbol import Str
     assert pretty(Str('x')) == 'x'
+
+
+def test_transforms():
+    e = LaplaceTransform(a, b, c)
+    assert pretty(e) == \
+    'L [a](c)\n'\
+    ' b      '
+    assert upretty(e) == \
+    'ℒ [a](c)\n'\
+    ' b      '
+
+    e = SineTransform(a, b, c)
+    assert pretty(e) == \
+    'SIN [a](c)\n'\
+    '   b      '
+    assert upretty(e) == \
+    '𝒮ℐ𝒩 [a](c)\n'\
+    '   b      '
+
 
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

https://github.com/sympy/sympy/pull/22376#issuecomment-971448533

Now, transforms are printed like:
```
In [13]: LaplaceTransform(s, t, x)
Out[13]: 
ℒ [s](x)
 t      
In [14]: LaplaceTransform(Integral(s, s), t, x)
Out[14]: 
  ⎡⌠     ⎤   
ℒ ⎢⎮ s ds⎥(x)
 t⎣⌡     ⎦   
```

It remains to add tests and support for inverse transforms.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Pretty printing for transforms (Laplace etc). 
<!-- END RELEASE NOTES -->
