### PR TITLE
Added _eval_nseries , _eval_as_leading_term  methods for asech and acsch functions

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -681,13 +681,17 @@ class tanh(HyperbolicFunction):
         return 1/coth(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return arg
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_is_real(self):
         arg = self.args[0]
@@ -883,13 +887,17 @@ class coth(HyperbolicFunction):
             return self.args[0].is_negative
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return 1/arg
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
@@ -1201,13 +1209,17 @@ class asinh(InverseHyperbolicFunction):
                 return S.NegativeOne**k * R / F * x**n / n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return arg
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x**2 + 1))
@@ -1348,13 +1360,17 @@ class acosh(InverseHyperbolicFunction):
                 return -R / F * S.ImaginaryUnit * x**n / n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return S.ImaginaryUnit*S.Pi/2
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x + 1) * sqrt(x - 1))
@@ -1456,13 +1472,17 @@ class atanh(InverseHyperbolicFunction):
             return x**n / n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return arg
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + x) - log(1 - x)) / 2
@@ -1554,13 +1574,17 @@ class acoth(InverseHyperbolicFunction):
             return x**n / n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
             return S.ImaginaryUnit*S.Pi/2
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + 1/x) - log(1 - 1/x)) / 2
@@ -1694,13 +1718,18 @@ class asech(InverseHyperbolicFunction):
                 return -1 * R / F * x**n / 4
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
-            return -1*log(arg)
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
+            c, e = arg.as_coeff_exponent(x)
+            return log(2) - log(c) - e*log(x)
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def inverse(self, argindex=1):
         """
@@ -1823,13 +1852,18 @@ class acsch(InverseHyperbolicFunction):
                 return S.NegativeOne**(k +1) * R / F * x**n / 4
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.series.order import Order
         arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
 
-        if x in arg.free_symbols and Order(1, x).contains(arg):
-            return -1*log(arg)
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if cdir.is_negative else '+')
+        if arg0.is_zero:
+            c, e = arg.as_coeff_exponent(x)
+            return log(2) - log(c) - e*log(x)
+        elif arg0.is_finite:
+            return self.func(arg0)
         else:
-            return self.func(arg)
+            return self
 
     def inverse(self, argindex=1):
         """

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1677,7 +1677,7 @@ class asech(InverseHyperbolicFunction):
 
     @staticmethod
     @cacheit
-    def expansion_term(n, x, *previous_terms):
+    def taylor_term(n, x, *previous_terms):
         if n == 0:
             return log(2 / x)
         elif n < 0 or n % 2 == 1:
@@ -1692,6 +1692,15 @@ class asech(InverseHyperbolicFunction):
                 R = RisingFactorial(S.Half, k) *  n
                 F = factorial(k) * n // 2 * n // 2
                 return -1 * R / F * x**n / 4
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.series.order import Order
+        arg = self.args[0].as_leading_term(x)
+
+        if x in arg.free_symbols and Order(1, x).contains(arg):
+            return -1*log(arg)
+        else:
+            return self.func(arg)
 
     def inverse(self, argindex=1):
         """
@@ -1794,6 +1803,33 @@ class acsch(InverseHyperbolicFunction):
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)
+
+    @staticmethod
+    @cacheit
+    def taylor_term(n, x, *previous_terms):
+        if n == 0:
+            return log(2 / x)
+        elif n < 0 or n % 2 == 1:
+            return S.Zero
+        else:
+            x = sympify(x)
+            if len(previous_terms) > 2 and n > 2:
+                p = previous_terms[-2]
+                return p * (n - 1)**2 // (n // 2)**2 * x**2 / 4
+            else:
+                k = n // 2
+                R = RisingFactorial(S.Half, k) *  n
+                F = factorial(k) * n // 2 * n // 2
+                return S.NegativeOne**(k +1) * R / F * x**n / 4
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.series.order import Order
+        arg = self.args[0].as_leading_term(x)
+
+        if x in arg.free_symbols and Order(1, x).contains(arg):
+            return -1*log(arg)
+        else:
+            return self.func(arg)
 
     def inverse(self, argindex=1):
         """

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -713,9 +713,11 @@ def test_asech():
 
 def test_asech_series():
     x = Symbol('x')
-    t6 = asech(x).expansion_term(6, x)
+    assert asech(x).series(x, 0, 8) == \
+        log(2) - log(x) - x**2/4 - 3*x**4/32 - 5*x**6/96 + O(x**8)
+    t6 = asech(x).taylor_term(6, x)
     assert t6 == -5*x**6/96
-    assert asech(x).expansion_term(8, x, t6, 0) == -35*x**8/1024
+    assert asech(x).taylor_term(8, x, t6, 0) == -35*x**8/1024
 
 
 def test_asech_rewrite():
@@ -791,6 +793,15 @@ def test_acsch_infinities():
     assert acsch(oo) == 0
     assert acsch(-oo) == 0
     assert acsch(zoo) == 0
+
+
+def test_acsch_series():
+    x = Symbol('x')
+    assert acsch(x).series(x, 0, 8) == \
+        log(2) - log(x) + x**2/4 - 3*x**4/32 + 5*x**6/96 + O(x**8)
+    t6 = acsch(x).taylor_term(6, x)
+    assert t6 == 5*x**6/96
+    assert acsch(x).taylor_term(10, x, t6, 0) == 63*x**10/2560
 
 
 def test_acsch_rewrite():
@@ -953,6 +964,8 @@ def test_leading_term():
     assert coth(x).as_leading_term(x) == 1/x
     assert acosh(x).as_leading_term(x) == I*pi/2
     assert acoth(x).as_leading_term(x) == I*pi/2
+    assert asech(x).as_leading_term(x) == -log(x)
+    assert acsch(x).as_leading_term(x) == -log(x)
     for func in [sinh, tanh, asinh, atanh]:
         assert func(x).as_leading_term(x) == x
     for func in [sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth]:

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -964,8 +964,8 @@ def test_leading_term():
     assert coth(x).as_leading_term(x) == 1/x
     assert acosh(x).as_leading_term(x) == I*pi/2
     assert acoth(x).as_leading_term(x) == I*pi/2
-    assert asech(x).as_leading_term(x) == -log(x)
-    assert acsch(x).as_leading_term(x) == -log(x)
+    assert asech(x).as_leading_term(x) == -log(x) + log(2)
+    assert acsch(x).as_leading_term(x) == -log(x) + log(2)
     for func in [sinh, tanh, asinh, atanh]:
         assert func(x).as_leading_term(x) == x
     for func in [sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth]:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -641,10 +641,9 @@ def test_issue_10801():
 
 
 def test_issue_10868():
-    assert limit(log(x)+asech(x),x,0, dir = '+') == log(2)
-    assert limit(log(x)+asech(x),x,0, dir = '-') == log(2) + 2*I*pi
-    assert limit(log(x)+acsch(x),x,0, dir = '+') == log(2)
-    assert limit(log(x)+acsch(x),x,0, dir = '-') == -oo
+    assert limit(log(x)+asech(x),x,0, dir = '+-') == log(2)
+    assert limit(log(x)+acsch(x),x,0, dir = '+-') == log(2)
+
 
 def test_issue_10976():
     s, x = symbols('s x', real=True)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -9,7 +9,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.combinatorial.factorials import (binomial, factorial, subfactorial)
 from sympy.functions.elementary.complexes import (Abs, re, sign)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
-from sympy.functions.elementary.hyperbolic import (acoth, atanh, sinh)
+from sympy.functions.elementary.hyperbolic import (acoth, atanh, sinh, asech, acsch)
 from sympy.functions.elementary.integers import (ceiling, floor, frac)
 from sympy.functions.elementary.miscellaneous import (cbrt, real_root, sqrt)
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, sec, sin, tan)
@@ -639,6 +639,12 @@ def test_issue_10801():
     # make sure limits work with binomial
     assert limit(16**k / (k * binomial(2*k, k)**2), k, oo) == pi
 
+
+def test_issue_10868():
+    assert limit(log(x)+asech(x),x,0, dir = '+') == log(2)
+    assert limit(log(x)+asech(x),x,0, dir = '-') == log(2) + 2*I*pi
+    assert limit(log(x)+acsch(x),x,0, dir = '+') == log(2)
+    assert limit(log(x)+acsch(x),x,0, dir = '-') == -oo
 
 def test_issue_10976():
     s, x = symbols('s x', real=True)


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #10868 

#### Brief description of what is fixed or changed
Currently on master , there was no series expansion(maclaurin or puiseux series including logarithm at `0`)  for `asech` and `acsch ` resulting into wrong output for limits etc which is shown as follows . So the `series` method didn't work because the `_eval_nseries` method didn't work which depends on the `taylor_term` method which has been added for the same . Similarly the `_eval_as_leading_term` method has been implemented for these.
```
>>> asech(x).series(x)
nan
>>> acsch(x).series(x)
nan
>>> limit(log(x)+asech(x),x,0, dir = '+') # This issue which has been addressed
oo
>>> limit(log(x)+asech(x),x,0, dir = '-')
oo + I*pi
>>> limit(log(x)+acsch(x),x,0, dir = '-')
zoo
>>> limit(log(x)+acsch(x),x,0, dir = '+')
zoo
```
Changes made 

```
>>> asech(x).series(x, 0, 8)
log(2) - log(x) - x**2/4 - 3*x**4/32 - 5*x**6/96 + O(x**8)

>>> acsch(x).series(x, 0, 8)
log(2) - log(x) + x**2/4 - 3*x**4/32 + 5*x**6/96 + O(x**8)

>>> limit(log(x)+asech(x),x,0, dir = '+')
log(2)
>>> limit(log(x)+asech(x),x,0, dir = '-')
log(2) + 2*I*pi
>>> limit(log(x)+acsch(x),x,0, dir = '-')
-oo
>>> limit(log(x)+acsch(x),x,0, dir = '+')
log(2)

>>> asech(x).as_leading_term(x)
-log(x)
>>> acsch(x).as_leading_term(x)
-log(x)
```

The issue originally also reported calculating `limit(log(x)+asech(x), x , oo)` which maybe ..... could return `oo` (as done by few other CAS libraries) as we would be computing something like `log(oo) + I*pi/2`  . But in this case sympy gives `oo + I*pi/2` which isn't wrong by any means . I guess in sympy as per convention , I don't think `oo + I*(some constant)` is mapped to `oo` hence this is not really an issue and we could maybe have a discussion over it .

#### Other comments
 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Added _eval_nseries , _eval_as_leading_term methods for some inverse hyperbolic functions.
<!-- END RELEASE NOTES -->
