### PR TITLE
core/basic: argument invariance for all Atom classes - class

### DIFF
--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -174,6 +174,7 @@ class Singleton(ManagedProperties):
         cls.__new__ = lambda cls: obj
         cls.__getnewargs__ = lambda obj: ()
         cls.__getstate__ = lambda obj: None
+        cls.func = property(lambda obj: cls)
         S.register(cls)
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -96,9 +96,7 @@ def test_all_classes_are_tested():
 
 def _test_args(obj):
     all_basic = all(isinstance(arg, Basic) for arg in obj.args)
-    # Ideally obj.func(*obj.args) would always recreate the object, but for
-    # now, we only require it for objects with non-empty .args
-    recreatable = not obj.args or obj.func(*obj.args) == obj
+    recreatable = obj.func(*obj.args) == obj
     return all_basic and recreatable
 
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -225,7 +225,7 @@ class CoordSystem(Basic):
     2
     >>> Car2D.symbols
     (x, y)
-    >>> _[0].func
+    >>> type(_[0])
     <class 'sympy.diffgeom.diffgeom.CoordinateSymbol'>
 
     ``transformation()`` method returns the transformation function from

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -232,3 +232,11 @@ class Quantity(AtomicExpr):
     def free_symbols(self):
         """Return free symbols from quantity."""
         return set()
+
+# XXX: This method is only needed because Quantity is a subclass of
+# AtomicExpr even though it is not really an AtomicExpr. If Quantity
+# was fixed to not subclass AtomicExpr then this func method could be
+# deleted.
+    @property
+    def func(self):
+        return self.__class__

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -225,6 +225,15 @@ class BaseDyadic(Dyadic, AtomicExpr):
         return "({}|{})".format(
             printer._print(self.args[0]), printer._print(self.args[1]))
 
+# XXX: This method is only needed because BaseDyadic is a subclass
+# of AtomicExpr even though it is not really an AtomicExpr. If BaseDyadic
+# was fixed to not subclass AtomicExpr then this func method could be
+# deleted.
+    @property
+    def func(self):
+        return self.__class__
+
+
     def _sympyrepr(self, printer):
         return "BaseDyadic({}, {})".format(
             printer._print(self.args[0]), printer._print(self.args[1]))

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -67,3 +67,11 @@ class BaseScalar(AtomicExpr):
 
     def _sympystr(self, printer):
         return self._name
+
+# XXX: This method is only needed because BaseScalar is a subclass
+# of AtomicExpr even though it is not really an AtomicExpr. If BaseScalar
+# was fixed to not subclass AtomicExpr then this func method could be
+# deleted.
+    @property
+    def func(self):
+        return self.__class__

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -402,6 +402,12 @@ class BaseVector(Vector, AtomicExpr):
     def free_symbols(self):
         return {self}
 
+# XXX: This method is only needed because Vector is a subclass of
+# AtomicExpr even though it is not really an AtomicExpr. If Vector was
+# fixed to not subclass AtomicExpr then this func method could be deleted.
+    @property
+    def func(self):
+        return self.__class__
 
 class VectorAdd(BasisDependentAdd, Vector):
     """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The following identities now hold for `Atom` classes:
```python
assert obj.func == AtomSubClass
assert AtomSubClass == obj.func
assert hash(AtomSubClass) == hash(obj.func)
assert {AtomSubClass: True}[obj.func]
assert {obj.func: True}[AtomSubClass]
assert obj.func() == obj
assert obj.func(*obj.args) == obj
assert str(obj.func) == str(AtomSubClass)
```
These seem to all be needed since several parts of SymPy
assumes that `obj.func` returns `obj.__class__`, although it
is not needed for every class.

Several classes still behave as previously, these are:

`Quantity`
`BaseVector`
`BaseDyadic`
`BaseScalar`

It seems that these classes need a redesign rather than
a fix to their argument invariance, hence the previous
behaviour was maintained.

#### Other comments
It might be the case that some "solutions" provided to issues I encountered are actually not needed as the issues were only introduced due to changes I made (and reverted).

```python
@property
def func(self):
    return lambda: self
```
Has several intertwined issues and I expanded from that. In particular:
* printing of `obj.func`
* `Singleton`s and their "create once" behaviour
* comparisons of `obj.func == obj.class`
* use of `obj.__class__` hash for comparison with `obj.func` hash (e.g. in `dict` lookups)

were use cases in SymPy that were assumed to work as if `obj.func` always returns
`obj.__class__`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Atom classes now correctly implement the invariance `obj.func(*obj.args)`
<!-- END RELEASE NOTES -->
