### PR TITLE
nfloat does not affect AppliedUndef args; dsolve terms defaults to 5

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2244,7 +2244,7 @@ def test_check_old_assumption():
     assert ask(Q.real(x)) is None
     assert ask(Q.complex(x)) is True
 
-    x = symbols('x', positive=True, finite=True)
+    x = symbols('x', positive=True)
     assert ask(Q.positive(x)) is True
     assert ask(Q.negative(x)) is False
     assert ask(Q.real(x)) is True

--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -27,7 +27,7 @@ negk = Symbol('k', negative=True)
 mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, finite=True)
 sigma1, sigma2 = symbols('sigma1 sigma2', real=True, nonzero=True,
                          finite=True, positive=True)
-rate = Symbol('lambda', real=True, positive=True, finite=True)
+rate = Symbol('lambda', positive=True)
 
 
 def normal(x, mu, sigma):

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -12,7 +12,7 @@ def test_expm1():
     # Eval
     assert expm1(0) == 0
 
-    x = Symbol('x', real=True, finite=True)
+    x = Symbol('x', real=True)
 
     # Expand and rewrite
     assert expm1(x).expand(func=True) - exp(x) == -1
@@ -38,7 +38,7 @@ def test_log1p():
     d = S(10)
     assert expand_log(log1p(d**-1000) - log(d**1000 + 1) + log(d**1000)) == 0
 
-    x = Symbol('x', real=True, finite=True)
+    x = Symbol('x', real=True)
 
     # Expand and rewrite
     assert log1p(x).expand(func=True) - log(x + 1) == 0
@@ -73,7 +73,7 @@ def test_exp2():
     # Eval
     assert exp2(2) == 4
 
-    x = Symbol('x', real=True, finite=True)
+    x = Symbol('x', real=True)
 
     # Expand
     assert exp2(x).expand(func=True) - 2**x == 0
@@ -88,7 +88,7 @@ def test_log2():
     assert log2(8) == 3
     assert log2(pi) != log(pi)/log(2)  # log2 should *save* (CPU) instructions
 
-    x = Symbol('x', real=True, finite=True)
+    x = Symbol('x', real=True)
     assert log2(x) != log(x)/log(2)
     assert log2(2**x) == x
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -346,7 +346,7 @@ def failing_assumptions(expr, **assumptions):
     >>> x = Symbol('x', positive=True)
     >>> y = Symbol('y')
     >>> failing_assumptions(6*x + y, positive=True)
-    {'positive': None, 'real': None}
+    {'positive': None}
 
     >>> failing_assumptions(x**2 - 1, positive=True)
     {'positive': None}

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -343,9 +343,9 @@ def failing_assumptions(expr, **assumptions):
 
     >>> from sympy import failing_assumptions, Symbol
 
-    >>> x = Symbol('x', real=True, positive=True)
+    >>> x = Symbol('x', positive=True)
     >>> y = Symbol('y')
-    >>> failing_assumptions(6*x + y, real=True, positive=True)
+    >>> failing_assumptions(6*x + y, positive=True)
     {'positive': None, 'real': None}
 
     >>> failing_assumptions(x**2 - 1, positive=True)
@@ -386,14 +386,14 @@ def check_assumptions(expr, against=None, **assume):
     True
     >>> check_assumptions(pi, real=True, integer=False)
     True
-    >>> check_assumptions(pi, real=True, negative=True)
+    >>> check_assumptions(pi, negative=True)
     False
     >>> check_assumptions(exp(I*pi/7), real=False)
     True
-    >>> x = Symbol('x', real=True, positive=True)
-    >>> check_assumptions(2*x + 1, real=True, positive=True)
+    >>> x = Symbol('x', positive=True)
+    >>> check_assumptions(2*x + 1, positive=True)
     True
-    >>> check_assumptions(-2*x - 5, real=True, positive=True)
+    >>> check_assumptions(-2*x - 5, positive=True)
     False
 
     To check assumptions of *expr* against another variable or expression,

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3002,7 +3002,7 @@ class Expr(Basic, EvalfMixin):
 
         if x.is_positive is x.is_negative is None or x.is_Symbol is not True:
             # replace x with an x that has a positive assumption
-            xpos = Dummy('x', positive=True, finite=True)
+            xpos = Dummy('x', positive=True)
             rv = self.subs(x, xpos).series(xpos, x0, n, dir, logx=logx, cdir=cdir)
             if n is None:
                 return (s.subs(xpos, x) for s in rv)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3277,8 +3277,9 @@ def count_ops(expr, visual=False):
 
 def nfloat(expr, n=15, exponent=False, dkeys=False):
     """Make all Rationals in expr Floats except those in exponents
-    (unless the exponents flag is set to True). When processing
-    dictionaries, do not modify the keys unless ``dkeys=True``.
+    (unless the exponents flag is set to True) and those in undefined
+    functions. When processing dictionaries, do not modify the keys
+    unless ``dkeys=True``.
 
     Examples
     ========
@@ -3359,7 +3360,7 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
 
     return rv.xreplace(Transform(
         lambda x: x.func(*nfloat(x.args, n, exponent)),
-        lambda x: isinstance(x, Function)))
+        lambda x: isinstance(x, Function) and not isinstance(x, AppliedUndef)))
 
 
 from .symbol import Dummy, Symbol

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1091,7 +1091,7 @@ def test_Pow_is_integer():
 
 def test_Pow_is_real():
     x = Symbol('x', real=True)
-    y = Symbol('y', real=True, positive=True)
+    y = Symbol('y', positive=True)
 
     assert (x**2).is_real is True
     assert (x**3).is_real is True

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1267,7 +1267,7 @@ def test_check_assumptions():
 
 
 def test_failing_assumptions():
-    x = Symbol('x', real=True, positive=True)
+    x = Symbol('x', positive=True)
     y = Symbol('y')
     assert failing_assumptions(6*x + y, **x.assumptions0) == \
     {'real': None, 'imaginary': None, 'complex': None, 'hermitian': None,

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -968,6 +968,10 @@ def test_nfloat():
         [Float('3.0', precision=53), Float('4.0', precision=53)]])
     assert _aresame(nfloat(A), B)
 
+    # issue 22524
+    f = Function('f')
+    assert not nfloat(f(2)).atoms(Float)
+
 
 def test_issue_7068():
     from sympy.abc import a, b

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1684,8 +1684,8 @@ def test_zoo():
     n = Symbol('n', negative=True)
     im = Symbol('i', imaginary=True)
     c = Symbol('c', complex=True)
-    pb = Symbol('pb', positive=True, finite=True)
-    nb = Symbol('nb', negative=True, finite=True)
+    pb = Symbol('pb', positive=True)
+    nb = Symbol('nb', negative=True)
     imb = Symbol('ib', imaginary=True, finite=True)
     for i in [I, S.Infinity, S.NegativeInfinity, S.Zero, S.One, S.Pi, S.Half, S(3), log(3),
               b, nz, p, n, im, pb, nb, imb, c]:

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -425,8 +425,8 @@ def test_frac():
     n_i = Symbol('p_i', integer=True, negative=True)
     np_i = Symbol('np_i', integer=True, nonpositive=True)
     nn_i = Symbol('nn_i', integer=True, nonnegative=True)
-    p_r = Symbol('p_r', real=True, positive=True)
-    n_r = Symbol('n_r', real=True, negative=True)
+    p_r = Symbol('p_r', positive=True)
+    n_r = Symbol('n_r', negative=True)
     np_r = Symbol('np_r', real=True, nonpositive=True)
     nn_r = Symbol('nn_r', real=True, nonnegative=True)
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -192,7 +192,7 @@ def test_piecewise_free_symbols():
 
 
 def test_piecewise_integrate1():
-    x, y = symbols('x y', real=True, finite=True)
+    x, y = symbols('x y', real=True)
 
     f = Piecewise(((x - 2)**2, x >= 0), (1, True))
     assert integrate(f, (x, -2, 2)) == Rational(14, 3)
@@ -375,10 +375,10 @@ def test_piecewise_integrate3_inequality_conditions():
 
 @slow
 def test_piecewise_integrate4_symbolic_conditions():
-    a = Symbol('a', real=True, finite=True)
-    b = Symbol('b', real=True, finite=True)
-    x = Symbol('x', real=True, finite=True)
-    y = Symbol('y', real=True, finite=True)
+    a = Symbol('a', real=True)
+    b = Symbol('b', real=True)
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
     p0 = Piecewise((0, Or(x < a, x > b)), (1, True))
     p1 = Piecewise((0, x < a), (0, x > b), (1, True))
     p2 = Piecewise((0, x > b), (0, x < a), (1, True))
@@ -476,7 +476,7 @@ def test_piecewise_simplify():
     # issue 18634
     d = Symbol("d", integer=True)
     n = Symbol("n", integer=True)
-    t = Symbol("t", real=True, positive=True)
+    t = Symbol("t", positive=True)
     expr = Piecewise((-d + 2*n, Eq(1/t, 1)), (t**(1 - 4*n)*t**(4*n - 1)*(-d + 2*n), True))
     assert expr.simplify() == -d + 2*n
 
@@ -931,10 +931,10 @@ def test_issue_5227():
 
 
 def test_issue_10137():
-    a = Symbol('a', real=True, finite=True)
-    b = Symbol('b', real=True, finite=True)
-    x = Symbol('x', real=True, finite=True)
-    y = Symbol('y', real=True, finite=True)
+    a = Symbol('a', real=True)
+    b = Symbol('b', real=True)
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
     p0 = Piecewise((0, Or(x < a, x > b)), (1, True))
     p1 = Piecewise((0, Or(a > x, b < x)), (1, True))
     assert integrate(p0, (x, y, oo)) == integrate(p1, (x, y, oo))

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -439,7 +439,7 @@ def test_conjugate():
     n = Symbol('n')
     z = Symbol('z', extended_real=False)
     x = Symbol('x', extended_real=True)
-    y = Symbol('y', real=True, positive=True)
+    y = Symbol('y', positive=True)
     t = Symbol('t', negative=True)
 
     for f in [besseli, besselj, besselk, bessely, hankel1, hankel2]:

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -35,7 +35,7 @@ def test_K():
 
     zi = Symbol('z', real=False)
     assert K(zi).conjugate() == K(zi.conjugate())
-    zr = Symbol('z', real=True, negative=True)
+    zr = Symbol('z', negative=True)
     assert K(zr).conjugate() == K(zr)
 
     assert K(z).rewrite(hyper) == \
@@ -69,7 +69,7 @@ def test_F():
 
     mi = Symbol('m', real=False)
     assert F(z, mi).conjugate() == F(z.conjugate(), mi.conjugate())
-    mr = Symbol('m', real=True, negative=True)
+    mr = Symbol('m', negative=True)
     assert F(z, mr).conjugate() == F(z.conjugate(), mr)
 
     assert F(z, m).series(z) == \
@@ -103,7 +103,7 @@ def test_E():
     mi = Symbol('m', real=False)
     assert E(z, mi).conjugate() == E(z.conjugate(), mi.conjugate())
     assert E(mi).conjugate() == E(mi.conjugate())
-    mr = Symbol('m', real=True, negative=True)
+    mr = Symbol('m', negative=True)
     assert E(z, mr).conjugate() == E(z.conjugate(), mr)
     assert E(mr).conjugate() == E(mr)
 
@@ -146,8 +146,8 @@ def test_P():
     ni, mi = Symbol('n', real=False), Symbol('m', real=False)
     assert P(ni, z, mi).conjugate() == \
         P(ni.conjugate(), z.conjugate(), mi.conjugate())
-    nr, mr = Symbol('n', real=True, negative=True), \
-        Symbol('m', real=True, negative=True)
+    nr, mr = Symbol('n', negative=True), \
+        Symbol('m', negative=True)
     assert P(nr, z, mr).conjugate() == P(nr, z.conjugate(), mr)
     assert P(n, m).conjugate() == P(n.conjugate(), m.conjugate())
 

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -82,7 +82,7 @@ def test_point():
     assert p3.intersection(line) == []
     assert Point.intersection(Point(0, 0, 0), Point(0, 0)) == [Point(0, 0, 0)]
 
-    x_pos = Symbol('x', real=True, positive=True)
+    x_pos = Symbol('x', positive=True)
     p2_1 = Point(x_pos, 0)
     p2_2 = Point(0, x_pos)
     p2_3 = Point(-x_pos, 0)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1124,7 +1124,7 @@ def test_issue_4199():
 
 
 def test_issue_3940():
-    a, b, c, d = symbols('a:d', positive=True, finite=True)
+    a, b, c, d = symbols('a:d', positive=True)
     assert integrate(exp(-x**2 + I*c*x), x) == \
         -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
     assert integrate(exp(a*x**2 + b*x + c), x) == \
@@ -1632,7 +1632,7 @@ def test_issue_4311_fast():
 
 
 def test_integrate_with_complex_constants():
-    K = Symbol('K', real=True, positive=True)
+    K = Symbol('K', positive=True)
     x = Symbol('x', real=True)
     m = Symbol('m', real=True)
     t = Symbol('t', real=True)
@@ -1673,7 +1673,7 @@ def test_issue_8614():
 
 @slow
 def test_issue_15494():
-    s = symbols('s', real=True, positive=True)
+    s = symbols('s', positive=True)
 
     integrand = (exp(s/2) - 2*exp(1.6*s) + exp(s))*exp(s)
     solution = integrate(integrand, s)

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -743,7 +743,7 @@ def test_issue_10681():
 
 def test_issue_13536():
     from sympy.core.symbol import Symbol
-    a = Symbol('a', real=True, positive=True)
+    a = Symbol('a', positive=True)
     assert integrate(1/x**2, (x, oo, a)) == -1/a
 
 

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -142,7 +142,7 @@ def test_issue_5981():
     assert integrate(1/(u**2 + 1)) == atan(u)
 
 def test_issue_10488():
-    a,b,c,x = symbols('a b c x', real=True, positive=True)
+    a,b,c,x = symbols('a b c x', positive=True)
     assert integrate(x/(a*x+b),x) == x/a - b*log(a*x + b)/a**2
 
 

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -125,7 +125,7 @@ def Psi_nlm(n, l, m, r, phi, theta, Z=1):
 
     >>> from sympy.physics.hydrogen import Psi_nlm
     >>> from sympy import Symbol
-    >>> r=Symbol("r", real=True, positive=True)
+    >>> r=Symbol("r", positive=True)
     >>> phi=Symbol("phi", real=True)
     >>> theta=Symbol("theta", real=True)
     >>> Z=Symbol("Z", positive=True, integer=True, nonzero=True)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -534,7 +534,7 @@ def mrv_leadterm(e, x):
     # For limits of complex functions, the algorithm would have to be
     # improved, or just find limits of Re and Im components separately.
     #
-    w = Dummy("w", real=True, positive=True)
+    w = Dummy("w", positive=True)
     f, logw = rewrite(exps, Omega, x, w)
     series = calculate_series(f, w, logx=logw)
     try:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -603,7 +603,7 @@ def test_issue_8433():
 
 def test_issue_8481():
     k = Symbol('k', integer=True, nonnegative=True)
-    lamda = Symbol('lamda', real=True, positive=True)
+    lamda = Symbol('lamda', positive=True)
     assert limit(lamda**k * exp(-lamda) / factorial(k), k, oo) == 0
 
 
@@ -956,11 +956,11 @@ def test_issue_16708():
 
 
 def test_issue_19453():
-    beta = Symbol("beta", real=True, positive=True)
-    h = Symbol("h", real=True, positive=True)
-    m = Symbol("m", real=True, positive=True)
-    w = Symbol("omega", real=True, positive=True)
-    g = Symbol("g", real=True, positive=True)
+    beta = Symbol("beta", positive=True)
+    h = Symbol("h", positive=True)
+    m = Symbol("m", positive=True)
+    w = Symbol("omega", positive=True)
+    g = Symbol("g", positive=True)
 
     e = exp(1)
     q = 3*h**2*beta*g*e**(0.5*h*beta*w)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -223,7 +223,7 @@ def test_issue_12578():
 
 
 def test_issue_12791():
-    beta = symbols('beta', real=True, positive=True)
+    beta = symbols('beta', positive=True)
     theta, varphi = symbols('theta varphi', real=True)
 
     expr = (-beta**2*varphi*sin(theta) + beta**2*cos(theta) + \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -131,7 +131,7 @@ def test_interval_arguments():
 
 
     assert isinstance(Interval(0, Symbol('a')), Interval)
-    assert Interval(Symbol('a', real=True, positive=True), 0) == S.EmptySet
+    assert Interval(Symbol('a', positive=True), 0) == S.EmptySet
     raises(ValueError, lambda: Interval(0, S.ImaginaryUnit))
     raises(ValueError, lambda: Interval(0, Symbol('z', extended_real=False)))
     raises(ValueError, lambda: Interval(x, x + S.ImaginaryUnit))
@@ -1049,7 +1049,7 @@ def test_product_basic():
 
 
 def test_real():
-    x = Symbol('x', real=True, finite=True)
+    x = Symbol('x', real=True)
 
     I = Interval(0, 5)
     J = Interval(10, 20)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -956,7 +956,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
     x = func.args[0]
     f = func.func
     y = Dummy('y')
-    terms = n
+    terms = 5 if n is None else n
 
     order = ode_order(eq, f(x))
     # hint:matchdict or hint:(tuple of matchdicts)
@@ -2318,8 +2318,8 @@ def ode_2nd_power_series_ordinary(eq, func, order, match):
     n = Dummy("n", integer=True)
     s = Wild("s")
     k = Wild("k", exclude=[x])
-    x0 = match.get('x0')
-    terms = match.get('terms', 5)
+    x0 = match['x0']
+    terms = match['terms']
     p = match[match['a3']]
     q = match[match['b3']]
     r = match[match['c3']]
@@ -2479,8 +2479,8 @@ def ode_2nd_power_series_regular(eq, func, order, match):
     f = func.func
     C0, C1 = get_numbered_constants(eq, num=2)
     m = Dummy("m")  # for solving the indicial equation
-    x0 = match.get('x0')
-    terms = match.get('terms', 5)
+    x0 = match['x0']
+    terms = match['terms']
     p = match['p']
     q = match['q']
 
@@ -2759,9 +2759,9 @@ def ode_1st_power_series(eq, func, order, match):
     y = match['y']
     f = func.func
     h = -match[match['d']]/match[match['e']]
-    point = match.get('f0')
-    value = match.get('f0val')
-    terms = match.get('terms')
+    point = match['f0']
+    value = match['f0val']
+    terms = match['terms']
 
     # First term
     F = h

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1022,3 +1022,24 @@ def test_issue_13060():
     eq = [Eq(Derivative(A(t), t), A(t)*B(t)), Eq(Derivative(B(t), t), A(t)*B(t))]
     sol = dsolve(eq)
     assert checkodesol(eq, sol) == (True, [0, 0])
+
+
+def test_issue_22523():
+    N, s = symbols('N s')
+    rho = Function('rho')
+    # intentionally use 4.0 to confirm issue with nfloat
+    # works here
+    eqn = 4.0*N*sqrt(N - 1)*rho(s) + (4*s**2*(N - 1) + (N - 2*s*(N - 1))**2
+        )*Derivative(rho(s), (s, 2))
+    match = classify_ode(eqn, dict=True, hint='all')
+    assert match['2nd_power_series_ordinary']['terms'] == 5
+    C1, C2 = symbols('C1,C2')
+    sol = dsolve(eqn, hint='2nd_power_series_ordinary')
+    # there is no r(2.0) in this result
+    assert sol == Eq(rho(s), C2*(1 - 4.0*s**4*sqrt(N - 1.0)/N + 0.666666666666667*s**4/N
+        - 2.66666666666667*s**3*sqrt(N - 1.0)/N - 2.0*s**2*sqrt(N - 1.0)/N +
+        9.33333333333333*s**4*sqrt(N - 1.0)/N**2 - 0.666666666666667*s**4/N**2
+        + 2.66666666666667*s**3*sqrt(N - 1.0)/N**2 -
+        5.33333333333333*s**4*sqrt(N - 1.0)/N**3) + C1*s*(1.0 -
+        1.33333333333333*s**3*sqrt(N - 1.0)/N - 0.666666666666667*s**2*sqrt(N
+        - 1.0)/N + 1.33333333333333*s**3*sqrt(N - 1.0)/N**2) + O(s**6))

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -24,6 +24,7 @@ from sympy.solvers.ode.nonhomogeneous import _undetermined_coefficients_match
 from sympy.solvers.ode.single import LinearCoefficients
 from sympy.solvers.deutils import ode_order
 from sympy.testing.pytest import XFAIL, raises, slow
+from sympy.utilities.misc import filldedent
 
 
 C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C0:11')
@@ -1036,10 +1037,11 @@ def test_issue_22523():
     C1, C2 = symbols('C1,C2')
     sol = dsolve(eqn, hint='2nd_power_series_ordinary')
     # there is no r(2.0) in this result
-    assert sol == Eq(rho(s), C2*(1 - 4.0*s**4*sqrt(N - 1.0)/N + 0.666666666666667*s**4/N
+    assert filldedent(sol) == filldedent(str('''
+        Eq(rho(s), C2*(1 - 4.0*s**4*sqrt(N - 1.0)/N + 0.666666666666667*s**4/N
         - 2.66666666666667*s**3*sqrt(N - 1.0)/N - 2.0*s**2*sqrt(N - 1.0)/N +
         9.33333333333333*s**4*sqrt(N - 1.0)/N**2 - 0.666666666666667*s**4/N**2
         + 2.66666666666667*s**3*sqrt(N - 1.0)/N**2 -
         5.33333333333333*s**4*sqrt(N - 1.0)/N**3) + C1*s*(1.0 -
         1.33333333333333*s**3*sqrt(N - 1.0)/N - 0.666666666666667*s**2*sqrt(N
-        - 1.0)/N + 1.33333333333333*s**3*sqrt(N - 1.0)/N**2) + O(s**6))
+        - 1.0)/N + 1.33333333333333*s**3*sqrt(N - 1.0)/N**2) + O(s**6))'''))

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -216,7 +216,7 @@ def test_issue_6844():
 
 
 def test_issue_18751():
-    r = Symbol('r', real=True, positive=True)
+    r = Symbol('r', positive=True)
     theta = Symbol('theta', real=True)
     f = y(n) - 2 * r * cos(theta) * y(n - 1) + r**2 * y(n - 2)
     assert rsolve(f, y(n)) == \

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2587,8 +2587,8 @@ def LogLogistic(name, alpha, beta):
     >>> from sympy.stats import LogLogistic, density, cdf, quantile
     >>> from sympy import Symbol, pprint
 
-    >>> alpha = Symbol("alpha", real=True, positive=True)
-    >>> beta = Symbol("beta", real=True, positive=True)
+    >>> alpha = Symbol("alpha", positive=True)
+    >>> beta = Symbol("beta", positive=True)
     >>> p = Symbol("p")
     >>> z = Symbol("z", positive=True)
 

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -385,7 +385,7 @@ class MarginalDistribution(Distribution):
         marginalise_out = [i for i in random_symbols(expr) if i not in rvs]
         if isinstance(expr, JointDistribution):
             count = len(expr.domain.args)
-            x = Dummy('x', real=True, finite=True)
+            x = Dummy('x', real=True)
             syms = tuple(Indexed(x, i) for i in count)
             expr = expr.pdf(syms)
         else:

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -162,7 +162,7 @@ def covariance(X, Y, condition=None, **kwargs):
     >>> from sympy.stats import Exponential, covariance
     >>> from sympy import Symbol
 
-    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
+    >>> rate = Symbol('lambda', positive=True, real=True)
     >>> X = Exponential('X', rate)
     >>> Y = Exponential('Y', rate)
 
@@ -203,7 +203,7 @@ def correlation(X, Y, condition=None, **kwargs):
     >>> from sympy.stats import Exponential, correlation
     >>> from sympy import Symbol
 
-    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
+    >>> rate = Symbol('lambda', positive=True, real=True)
     >>> X = Exponential('X', rate)
     >>> Y = Exponential('Y', rate)
 
@@ -255,7 +255,7 @@ def smoment(X, n, condition=None, **kwargs):
 
     >>> from sympy.stats import skewness, Exponential, smoment
     >>> from sympy import Symbol
-    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
+    >>> rate = Symbol('lambda', positive=True, real=True)
     >>> Y = Exponential('Y', rate)
     >>> smoment(Y, 4)
     9
@@ -297,7 +297,7 @@ def skewness(X, condition=None, **kwargs):
     >>> skewness(X, X > 0) # find skewness given X > 0
     (-sqrt(2)/sqrt(pi) + 4*sqrt(2)/pi**(3/2))/(1 - 2/pi)**(3/2)
 
-    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
+    >>> rate = Symbol('lambda', positive=True, real=True)
     >>> Y = Exponential('Y', rate)
     >>> skewness(Y)
     2
@@ -335,7 +335,7 @@ def kurtosis(X, condition=None, **kwargs):
     >>> kurtosis(X, X > 0) # find kurtosis given X > 0
     (-4/pi - 12/pi**2 + 3)/(1 - 2/pi)**2
 
-    >>> rate = Symbol('lamda', positive=True, real=True, finite=True)
+    >>> rate = Symbol('lamda', positive=True, real=True)
     >>> Y = Exponential('Y', rate)
     >>> kurtosis(Y)
     9

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -581,7 +581,7 @@ class Moment(Expr):
     >>> from sympy import Symbol, Integral
     >>> from sympy.stats import Normal, Expectation, Probability, Moment
     >>> mu = Symbol('mu', real=True)
-    >>> sigma = Symbol('sigma', real=True, positive=True)
+    >>> sigma = Symbol('sigma', positive=True)
     >>> X = Normal('X', mu, sigma)
     >>> M = Moment(X, 3, 1)
 
@@ -639,7 +639,7 @@ class CentralMoment(Expr):
     >>> from sympy import Symbol, Integral
     >>> from sympy.stats import Normal, Expectation, Probability, CentralMoment
     >>> mu = Symbol('mu', real=True)
-    >>> sigma = Symbol('sigma', real=True, positive=True)
+    >>> sigma = Symbol('sigma', positive=True)
     >>> X = Normal('X', mu, sigma)
     >>> CM = CentralMoment(X, 4)
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -634,7 +634,7 @@ def test_exgaussian():
 def test_exponential():
     rate = Symbol('lambda', positive=True)
     X = Exponential('x', rate)
-    p = Symbol("p", positive=True, real=True, finite=True)
+    p = Symbol("p", positive=True, real=True)
 
     assert E(X) == 1/rate
     assert variance(X) == 1/rate**2
@@ -960,14 +960,14 @@ def test_maxwell():
 
 def test_Moyal():
     mu = Symbol('mu',real=False)
-    sigma = Symbol('sigma', real=True, positive=True)
+    sigma = Symbol('sigma', positive=True)
     raises(ValueError, lambda: Moyal('M',mu, sigma))
 
     mu = Symbol('mu', real=True)
-    sigma = Symbol('sigma', real=True, negative=True)
+    sigma = Symbol('sigma', negative=True)
     raises(ValueError, lambda: Moyal('M',mu, sigma))
 
-    sigma = Symbol('sigma', real=True, positive=True)
+    sigma = Symbol('sigma', positive=True)
     M = Moyal('M', mu, sigma)
     assert density(M)(z) == sqrt(2)*exp(-exp((mu - z)/sigma)/2
                         - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -295,8 +295,8 @@ def test_dependent_finite():
 
 def test_normality():
     X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
-    x = Symbol('x', real=True, finite=True)
-    z = Symbol('z', real=True, finite=True)
+    x = Symbol('x', real=True)
+    z = Symbol('z', real=True)
     dens = density(X - Y, Eq(X + Y, z))
 
     assert integrate(dens(x), (x, -oo, oo)) == 1

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -139,7 +139,7 @@ def test_probability_rewrite():
 
 def test_symbolic_Moment():
     mu = symbols('mu', real=True)
-    sigma = symbols('sigma', real=True, positive=True)
+    sigma = symbols('sigma', positive=True)
     x = symbols('x')
     X = Normal('X', mu, sigma)
     M = Moment(X, 4, 2)
@@ -158,7 +158,7 @@ def test_symbolic_Moment():
 
 def test_symbolic_CentralMoment():
     mu = symbols('mu', real=True)
-    sigma = symbols('sigma', real=True, positive=True)
+    sigma = symbols('sigma', positive=True)
     x = symbols('x')
     X = Normal('X', mu, sigma)
     CM = CentralMoment(X, 6)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -833,12 +833,12 @@ def test_K8():
 
 
 def test_K9():
-    z = symbols('z', real=True, positive=True)
+    z = symbols('z', positive=True)
     assert simplify(sqrt(1/z) - 1/sqrt(z)) == 0
 
 
 def test_K10():
-    z = symbols('z', real=True, negative=True)
+    z = symbols('z', negative=True)
     assert simplify(sqrt(1/z) + 1/sqrt(z)) == 0
 
 # This goes up to K25
@@ -2150,13 +2150,13 @@ def test_T7():
 
 
 def test_T8():
-    a, z = symbols('a z', real=True, positive=True)
+    a, z = symbols('a z', positive=True)
     assert limit(gamma(z + a)/gamma(z)*exp(-a*log(z)), z, oo) == 1
 
 
 @XFAIL
 def test_T9():
-    z, k = symbols('z k', real=True, positive=True)
+    z, k = symbols('z k', positive=True)
     # raises NotImplementedError:
     #           Don't know how to calculate the mrv of '(1, k)'
     assert limit(hyper((1, k), (1,), z/k), k, oo) == exp(z)
@@ -2482,7 +2482,7 @@ def test_W6():
 
 
 def test_W7():
-    a = symbols('a', real=True, positive=True)
+    a = symbols('a', positive=True)
     r1 = integrate(cos(x)/(x**2 + a**2), (x, -oo, oo))
     assert r1.simplify() == pi*exp(-a)/a
 
@@ -2525,7 +2525,7 @@ def test_W11():
 
 
 def test_W12():
-    p = symbols('p', real=True, positive=True)
+    p = symbols('p', positive=True)
     q = symbols('q', real=True)
     r1 = integrate(x*exp(-p*x**2 + 2*q*x), (x, -oo, oo))
     assert r1.simplify() == sqrt(pi)*q*exp(q**2/p)/p**R(3, 2)
@@ -2554,7 +2554,7 @@ def test_W16():
 
 
 def test_W17():
-    a, b = symbols('a b', real=True, positive=True)
+    a, b = symbols('a b', positive=True)
     assert integrate(exp(-a*x)*besselj(0, b*x),
                  (x, 0, oo)) == 1/(b*sqrt(a**2/b**2 + 1))
 
@@ -2593,14 +2593,14 @@ def test_W22():
 
 @slow
 def test_W23():
-    a, b = symbols('a b', real=True, positive=True)
+    a, b = symbols('a b', positive=True)
     r1 = integrate(integrate(x/(x**2 + y**2), (x, a, b)), (y, -oo, oo))
     assert r1.collect(pi).cancel() == -pi*a + pi*b
 
 
 def test_W23b():
     # like W23 but limits are reversed
-    a, b = symbols('a b', real=True, positive=True)
+    a, b = symbols('a b', positive=True)
     r2 = integrate(integrate(x/(x**2 + y**2), (y, -oo, oo)), (x, a, b))
     assert r2.collect(pi) == pi*(-a + b)
 
@@ -2903,7 +2903,7 @@ def test_X22():
 
 
 def test_Y1():
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     w = symbols('w', real=True)
     s = symbols('s')
     F, _, _ = laplace_transform(cos((w - 1)*t), t, s)
@@ -2911,7 +2911,7 @@ def test_Y1():
 
 
 def test_Y2():
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     w = symbols('w', real=True)
     s = symbols('s')
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
@@ -2919,7 +2919,7 @@ def test_Y2():
 
 
 def test_Y3():
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     w = symbols('w', real=True)
     s = symbols('s')
     F, _, _ = laplace_transform(sinh(w*t)*cosh(w*t), t, s)
@@ -2927,7 +2927,7 @@ def test_Y3():
 
 
 def test_Y4():
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     s = symbols('s')
     F, _, _ = laplace_transform(erf(3/sqrt(t)), t, s)
     assert F == (1 - exp(-6*sqrt(s)))/s
@@ -2942,7 +2942,7 @@ def test_Y5_Y6():
 # Company, 1983, p. 211.  First, take the Laplace transform of the ODE
 # => s^2 Y(s) - s + Y(s) = 4/s [e^(-s) - e^(-2 s)]
 # where Y(s) is the Laplace transform of y(t)
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     s = symbols('s')
     y = Function('y')
     F, _, _ = laplace_transform(diff(y(t), t, 2)
@@ -2964,7 +2964,7 @@ def test_Y7():
     # What is the Laplace transform of an infinite square wave?
     # => 1/s + 2 sum( (-1)^n e^(- s n a)/s, n = 1..infinity )
     #    [Sanchez, Allen and Kyner, p. 213]
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     a = symbols('a', real=True)
     s = symbols('s')
     F, _, _ = laplace_transform(1 + 2*Sum((-1)**n*Heaviside(t - n*a),
@@ -3090,7 +3090,7 @@ not supported')
 def test_Z6():
     # Second order ODE with initial conditions---solve  using Laplace
     # transform: f(t) = sin(2 t)/8 - t cos(2 t)/4
-    t = symbols('t', real=True, positive=True)
+    t = symbols('t', positive=True)
     s = symbols('s')
     eq = Derivative(f(t), t, 2) + 4*f(t) - sin(2*t)
     F, _, _ = laplace_transform(eq, t, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `nfloat` will no longer change args of user-defined functions to Float; solutions from solve may differ
<!-- END RELEASE NOTES -->
