### PR TITLE
use Pow.combines to limit subs

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -823,32 +823,14 @@ class Pow(Expr):
         return self.base.is_polar
 
     def combines(self, x):
-        """return +/-1 if ``(b**e)**x == +/-b**(e*x)`` else None"""
+        """return True if ``(b**e)**x == b**(e*x)`` else False"""
         try:
             as_int(x, strict=False)
-            return S.One
+            return True
         except ValueError:
             b, e = self.as_base_exp()
-            p = Pow._eval_power(
-                Pow(b, e, evaluate=False), x)
-            if p is None:
-                return
-            c = S.One
-            # we might get Pow or -Pow
-            if p.is_Mul:
-                if p.args[0] == -1 and len(p.args) == 2:
-                    p = p.args[1]
-                    c = -c
-                else:
-                    return
-            # trickier input involving numbers could collapse;
-            # leave that out unless it is needed, e.g.
-            # Pow(1, x)**y -> 1 or nan and the result will
-            # match the result of 1**(x*y) unless x,y=0,oo
-            # >>> (1*oo)**0,1**(0*oo)
-            # (1, nan)
-            if p.as_base_exp()[0] == b:
-                return c
+            # These conditions ensure that (b**e)**f == b**(e*f) for any f
+            return b.is_positive and e.is_real or b.is_nonnegative and e.is_nonnegative
 
     def _eval_subs(self, old, new):
         from sympy.calculus.accumulationbounds import AccumBounds
@@ -885,7 +867,7 @@ class Pow(Expr):
                 if old.is_commutative:
                     # Allow fractional powers for commutative objects
                     pow = coeff1/coeff2
-                    return bool(old.combines(pow)), pow, None
+                    return old.combines(pow), pow, None
                 else:
                     # With noncommutative symbols, substitute only integer powers
                     if not isinstance(terms1, tuple):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -895,3 +895,13 @@ def test_guard_against_indeterminate_evaluation():
     assert eq.subs([(y, oo), (x, 1)]) is S.NaN
     assert eq.subs({x: 1, y: oo}) is S.NaN
     assert eq.subs([(x, 1), (y, oo)], simultaneous=True) is S.NaN
+
+
+def test_issue_22529():
+    R = Rational
+    assert [(x**(i*S.Half)).subs(x**2, y) for i in range(2, 7)] == [
+        x, x**R(3, 2), y, x**R(5, 2), x**3]
+    r = Symbol('r', positive=True)
+    assert [(r**(i*S.Half)).subs(r**2, y) for i in range(2, 7)] == [
+        sqrt(y), y**R(3, 4), y, y**R(5, 4), y**R(3, 2)]
+    assert sqrt(exp(x*I)).subs(x, 5) == -exp(5*I/2)

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -904,4 +904,5 @@ def test_issue_22529():
     r = Symbol('r', positive=True)
     assert [(r**(i*S.Half)).subs(r**2, y) for i in range(2, 7)] == [
         sqrt(y), y**R(3, 4), y, y**R(5, 4), y**R(3, 2)]
-    assert sqrt(exp(x*I)).subs(x, 5) == -exp(5*I/2)
+    # XXX how can this be made -exp(5*I/2)
+    assert sqrt(exp(x*I)).subs(x, 5) == sqrt(exp(5*I))

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -904,5 +904,3 @@ def test_issue_22529():
     r = Symbol('r', positive=True)
     assert [(r**(i*S.Half)).subs(r**2, y) for i in range(2, 7)] == [
         sqrt(y), y**R(3, 4), y, y**R(5, 4), y**R(3, 2)]
-    # XXX how can this be made -exp(5*I/2)
-    assert sqrt(exp(x*I)).subs(x, 5) == sqrt(exp(5*I))

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -128,6 +128,9 @@ class ExpBase(Function):
         """
         if self.combines(other):
             return self.func(self.args[0]*other)
+        # allow for more general combining, e.g.
+        # sqrt(exp(5*I)) = -exp(5*I/2)
+        return Pow._eval_power(Pow(*self.as_base_exp()), other)
 
     def _eval_expand_power_exp(self, **hints):
         from sympy.concrete.products import Product

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -119,18 +119,15 @@ class ExpBase(Function):
     def combines(self, pow):
         try:
             as_int(pow, strict=False)
-            return S.One
+            return True
         except ValueError:
-            # treat like Pow
-            b, e = self.as_base_exp()
-            return Pow(b, e, evaluate=False).combines(pow)
+            return self.args[0].is_real
 
     def _eval_power(self, other):
         """exp(arg)**e -> exp(arg*e) if assumptions allow it.
         """
-        c = self.combines(other)
-        if c:
-            return c*self.func(self.args[0]*other)
+        if self.combines(other):
+            return self.func(self.args[0]*other)
 
     def _eval_expand_power_exp(self, **hints):
         from sympy.concrete.products import Product
@@ -205,7 +202,7 @@ class exp_polar(ExpBase):
         return res
 
     def combines(self, other):
-        return S.One
+        return True
 
     def _eval_is_extended_real(self):
         if self.args[0].is_extended_real:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fizes #22529 which gives examples of subs doing algebraic substitutions that are not always valid

It also does not break anything that was committed in #22052.

#### Brief description of what is fixed or changed

The conditions for `(b**e)**x -> b**(e*x)` were, near SymPy's beginning, spread out and applied inconsistently in the code base. Now they are all localized in the logic of the `Pow._eval_power` routine (or should be). 

But in the code base one might want to know if a combination should be made or not. The canonical way to do that now is to see if `self.combines(x) == True` where `self = b**e`.


#### Other comments

- [x] add tests from #22529 to demonstrate that less surprising (and correct) algebraic substitutions are taking place.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Pow and ExpBase now have `combines` method that should return True if self's exponent can combine with other
<!-- END RELEASE NOTES -->
