### PR TITLE
do not add free symbols of bound objects

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -312,18 +312,24 @@ class ExprWithLimits(Expr):
         # should be returned, e.g. don't return set() if the
         # function is zero -- treat it like an unevaluated expression.
         function, limits = self.function, self.limits
+        # mask off non-symbol integration variables
+        reps = {i[0]: i[0] if isinstance(i[0], Symbol) else Dummy()
+            for i in self.limits}
+        function = function.xreplace(reps)
         isyms = function.free_symbols
         for xab in limits:
+            v = reps[xab[0]]
             if len(xab) == 1:
-                isyms.add(xab[0])
+                isyms.add(v)
                 continue
             # take out the target symbol
-            if xab[0] in isyms:
-                isyms.remove(xab[0])
+            if v in isyms:
+                isyms.remove(v)
             # add in the new symbols
             for i in xab[1:]:
                 isyms.update(i.free_symbols)
-        return isyms
+        reps = {v: k for k, v in reps.items()}
+        return set([reps.get(_, _) for _ in isyms])
 
     @property
     def is_number(self):

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -312,8 +312,9 @@ class ExprWithLimits(Expr):
         # should be returned, e.g. don't return set() if the
         # function is zero -- treat it like an unevaluated expression.
         function, limits = self.function, self.limits
-        # mask off non-symbol integration variables
-        reps = {i[0]: i[0] if isinstance(i[0], Symbol) else Dummy()
+        # mask off non-symbol integration variables that have
+        # more than themself as a free symbol
+        reps = {i[0]: i[0] if i[0].free_symbols == {i[0]} else Dummy()
             for i in self.limits}
         function = function.xreplace(reps)
         isyms = function.free_symbols

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -470,15 +470,15 @@ def test_as_leading_term():
     raises(ValueError, lambda: (x + 1).as_leading_term(1))
 
     # https://github.com/sympy/sympy/issues/21177
-    f = -3*x + (x + Rational(3, 2) - sqrt(3)*S.ImaginaryUnit/2)**2\
+    e = -3*x + (x + Rational(3, 2) - sqrt(3)*S.ImaginaryUnit/2)**2\
         - Rational(3, 2) + 3*sqrt(3)*S.ImaginaryUnit/2
-    assert f.as_leading_term(x) == \
+    assert e.as_leading_term(x) == \
         (12*sqrt(3)*x - 12*S.ImaginaryUnit*x)/(4*sqrt(3) + 12*S.ImaginaryUnit)
 
     # https://github.com/sympy/sympy/issues/21245
-    f = 1 - x - x**2
-    fi = (1 + sqrt(5))/2
-    assert f.subs(x, y + 1/fi).as_leading_term(y) == \
+    e = 1 - x - x**2
+    d = (1 + sqrt(5))/2
+    assert e.subs(x, y + 1/d).as_leading_term(y) == \
         (-576*sqrt(5)*y - 1280*y)/(256*sqrt(5) + 576)
 
 
@@ -1735,15 +1735,16 @@ def test_as_ordered_terms():
     assert ( 4 - 3*I).as_ordered_terms() == [4, -3*I]
     assert (-4 - 3*I).as_ordered_terms() == [-4, -3*I]
 
-    f = x**2*y**2 + x*y**4 + y + 2
+    e = x**2*y**2 + x*y**4 + y + 2
 
-    assert f.as_ordered_terms(order="lex") == [x**2*y**2, x*y**4, y, 2]
-    assert f.as_ordered_terms(order="grlex") == [x*y**4, x**2*y**2, y, 2]
-    assert f.as_ordered_terms(order="rev-lex") == [2, y, x*y**4, x**2*y**2]
-    assert f.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
+    assert e.as_ordered_terms(order="lex") == [x**2*y**2, x*y**4, y, 2]
+    assert e.as_ordered_terms(order="grlex") == [x*y**4, x**2*y**2, y, 2]
+    assert e.as_ordered_terms(order="rev-lex") == [2, y, x*y**4, x**2*y**2]
+    assert e.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
 
     k = symbols('k')
     assert k.as_ordered_terms(data=True) == ([(k, ((1.0, 0.0), (1,), ()))], [k])
+
 
 def test_sort_key_atomic_expr():
     from sympy.physics.units import m, s

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -964,7 +964,7 @@ def test_is_number():
     assert Integral(f(x), (x, 0, 1)).is_number is True
 
 
-def test_symbols():
+def test_free_symbols():
     from sympy.abc import x, y, z
     assert Integral(0, x).free_symbols == {x}
     assert Integral(x).free_symbols == {x}
@@ -978,12 +978,18 @@ def test_symbols():
     assert Integral(x, (y, 1, 2)).free_symbols == {x}
     # pseudo-free in this case
     assert Integral(x, (y, z, z)).free_symbols == {x, z}
-    assert Integral(x, (y, 1, 2), (y, None, None)).free_symbols == {x, y}
-    assert Integral(x, (y, 1, 2), (x, 1, y)).free_symbols == {y}
-    assert Integral(2, (y, 1, 2), (y, 1, x), (x, 1, 2)).free_symbols == set()
-    assert Integral(2, (y, x, 2), (y, 1, x), (x, 1, 2)).free_symbols == set()
-    assert Integral(2, (x, 1, 2), (y, x, 2), (y, 1, 2)).free_symbols == \
-        {x}
+    assert Integral(x, (y, 1, 2), (y, None, None)
+        ).free_symbols == {x, y}
+    assert Integral(x, (y, 1, 2), (x, 1, y)
+        ).free_symbols == {y}
+    assert Integral(2, (y, 1, 2), (y, 1, x), (x, 1, 2)
+        ).free_symbols == set()
+    assert Integral(2, (y, x, 2), (y, 1, x), (x, 1, 2)
+        ).free_symbols == set()
+    assert Integral(2, (x, 1, 2), (y, x, 2), (y, 1, 2)
+        ).free_symbols == {x}
+    assert Integral(f(x), (f(x), 1, y)).free_symbols == {y}
+    assert Integral(f(x), (f(x), 1, x)).free_symbols == {x}
 
 
 def test_is_zero():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
    * free symbols appearing only in expressions of variables of integration, summation, ... no longer reported as free symbols
<!-- END RELEASE NOTES -->
