### PR TITLE
simplify/powsimp: check for isinstance with instance not class

### DIFF
--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -615,7 +615,7 @@ def _denest_pow(eq):
     from sympy.simplify.simplify import logcombine
 
     b, e = eq.as_base_exp()
-    if b.is_Pow or isinstance(b.func, exp) and e != 1:
+    if b.is_Pow or isinstance(b, exp) and e != 1:
         new = b._eval_power(e)
         if new is not None:
             eq = new


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes  #22542

#### Brief description of what is fixed or changed
Line 618 in sympy/simplify/powersimp.py reads `if b.is_Pow or isinstance(b.func, exp) and e != 1:`. There should not be a case when `b.func` is an instance of `exp` (and if it was, it would be an incorrect use of `.func`).

`isinstance(b.func, exp)` was changed to  `isinstance(b, exp)`.

#### Other comments
Considering this did not influence any tests, I suspect that this line could also be changed to `if b.is_Pow and e != 1:` (previously `isinstance(b.func, exp)` was always `False`)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
