### PR TITLE
tests: tests no longer create instances of Basic with non-Basic args

### DIFF
--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -29,7 +29,7 @@ b21 = Basic(b2, b1)
 def test__aresame():
     assert not _aresame(Basic([]), Basic())
     assert not _aresame(Basic([]), Basic(()))
-    assert not _aresame(Basic(2), Basic(2.))
+    assert not _aresame(Basic(S(2)), Basic(S(2.)))
 
 
 def test_structure():
@@ -255,7 +255,7 @@ def test_atomic():
     assert _atomic(g(x + h(x))) == {g(x + h(x))}
     assert _atomic(g(x + h(x)), recursive=True) == {h(x), x, g(x + h(x))}
     assert _atomic(1) == set()
-    assert _atomic(Basic(1,2)) == {Basic(1, 2)}
+    assert _atomic(Basic(S(1), S(2))) == set()
 
 
 def test_as_dummy():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -208,11 +208,11 @@ def test_gcd_terms():
     assert gcd_terms(set(args)) == newf
     # but a Basic sequence is treated as a container
     assert gcd_terms(Tuple(*args)) != newf
-    assert gcd_terms(Basic(Tuple(1, 3*y + 3*x*y), Tuple(1, 3))) == \
-        Basic((1, 3*y*(x + 1)), (1, 3))
+    assert gcd_terms(Basic(Tuple(S(1), 3*y + 3*x*y), Tuple(S(1), S(3)))) == \
+        Basic((S(1), 3*y*(x + 1)), (S(1), S(3)))
     # but we shouldn't change keys of a dictionary or some may be lost
-    assert gcd_terms(Dict((x*(1 + y), 2), (x + x*y, y + x*y))) == \
-        Dict({x*(y + 1): 2, x + x*y: y*(1 + x)})
+    assert gcd_terms(Dict((x*(1 + y), S(2)), (x + x*y, y + x*y))) == \
+        Dict({x*(y + 1): S(2), x + x*y: y*(1 + x)})
 
     assert gcd_terms((2*x + 2)**3 + (2*x + 2)**2) == 4*(x + 1)**2*(2*x + 3)
 

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -626,7 +626,7 @@ def test_issue_6079():
     assert _aresame((x + 2.0).subs(2, 3), x + 2.0)
     assert _aresame((x + 2.0).subs(2.0, 3), x + 3)
     assert not _aresame(x + 2, x + 2.0)
-    assert not _aresame(Basic(cos, 1), Basic(cos, 1.))
+    assert not _aresame(Basic(cos(x), S(1)), Basic(cos(x), S(1.)))
     assert _aresame(cos, cos)
     assert not _aresame(1, S.One)
     assert not _aresame(x, symbols('x', positive=True))

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -3,6 +3,7 @@ from sympy.printing.dot import (purestr, styleof, attrprint, dotnode,
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.numbers import (Float, Integer)
+from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.printing.repr import srepr
 from sympy.abc import x
@@ -10,11 +11,12 @@ from sympy.abc import x
 
 def test_purestr():
     assert purestr(Symbol('x')) == "Symbol('x')"
-    assert purestr(Basic(1, 2)) == "Basic(1, 2)"
+    assert purestr(Basic(S(1), S(2))) == "Basic(Integer(1), Integer(2))"
     assert purestr(Float(2)) == "Float('2.0', precision=53)"
 
     assert purestr(Symbol('x'), with_args=True) == ("Symbol('x')", ())
-    assert purestr(Basic(1, 2), with_args=True) == ('Basic(1, 2)', ('1', '2'))
+    assert purestr(Basic(S(1), S(2)), with_args=True) == \
+            ('Basic(Integer(1), Integer(2))', ('Integer(1)', 'Integer(2)'))
     assert purestr(Float(2), with_args=True) == \
         ("Float('2.0', precision=53)", ())
 
@@ -22,7 +24,7 @@ def test_purestr():
 def test_styleof():
     styles = [(Basic, {'color': 'blue', 'shape': 'ellipse'}),
               (Expr,  {'color': 'black'})]
-    assert styleof(Basic(1), styles) == {'color': 'blue', 'shape': 'ellipse'}
+    assert styleof(Basic(S(1)), styles) == {'color': 'blue', 'shape': 'ellipse'}
 
     assert styleof(x + 1, styles) == {'color': 'black', 'shape': 'ellipse'}
 

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1254,7 +1254,7 @@ def test_print_AssocOp():
 
 
 def test_print_basic():
-    expr = Basic(1, 2)
+    expr = Basic(S(1), S(2))
     assert mpp.doprint(expr) == \
         '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
     assert mp.doprint(expr) == '<basic><cn>1</cn><cn>2</cn></basic>'

--- a/sympy/strategies/branch/tests/test_tools.py
+++ b/sympy/strategies/branch/tests/test_tools.py
@@ -1,15 +1,16 @@
 from sympy.strategies.branch.tools import canon
 from sympy.core.basic import Basic
-
+from sympy.core.numbers import Integer
+from sympy.core.singleton import S
 
 def posdec(x):
-    if isinstance(x, int) and x > 0:
+    if isinstance(x, Integer) and x > 0:
         yield x-1
     else:
         yield x
 
 def branch5(x):
-    if isinstance(x, int):
+    if isinstance(x, Integer):
         if 0 < x < 5:
             yield x-1
         elif 5 < x < 10:
@@ -21,16 +22,16 @@ def branch5(x):
             yield x
 
 def test_zero_ints():
-    expr = Basic(2, Basic(5, 3), 8)
-    expected = {Basic(0, Basic(0, 0), 0)}
+    expr = Basic(S(2), Basic(S(5), S(3)), S(8))
+    expected = {Basic(S(0), Basic(S(0), S(0)), S(0))}
 
     brl = canon(posdec)
     assert set(brl(expr)) == expected
 
 def test_split5():
-    expr = Basic(2, Basic(5,  3), 8)
-    expected = {Basic(0, Basic(0,  0), 10),
-                 Basic(0, Basic(10, 0), 10)}
+    expr = Basic(S(2), Basic(S(5),  S(3)), S(8))
+    expected = {Basic(S(0), Basic(S(0),  S(0)), S(10)),
+                 Basic(S(0), Basic(S(10), S(0)), S(10))}
 
     brl = canon(branch5)
     assert set(brl(expr)) == expected

--- a/sympy/strategies/branch/tests/test_traverse.py
+++ b/sympy/strategies/branch/tests/test_traverse.py
@@ -1,21 +1,23 @@
 from sympy.core.basic import Basic
+from sympy.core.numbers import Integer
+from sympy.core.singleton import S
 from sympy.strategies.branch.traverse import top_down, sall
 from sympy.strategies.branch.core import do_one, identity
 
 def inc(x):
-    if isinstance(x, int):
+    if isinstance(x, Integer):
         yield x + 1
 
 def test_top_down_easy():
-    expr     = Basic(1, 2)
-    expected = Basic(2, 3)
+    expr     = Basic(S(1), S(2))
+    expected = Basic(S(2), S(3))
     brl = top_down(inc)
 
     assert set(brl(expr)) == {expected}
 
 def test_top_down_big_tree():
-    expr     = Basic(1, Basic(2), Basic(3, Basic(4), 5))
-    expected = Basic(2, Basic(3), Basic(4, Basic(5), 6))
+    expr     = Basic(S(1), Basic(S(2)), Basic(S(3), Basic(S(4)), S(5)))
+    expected = Basic(S(2), Basic(S(3)), Basic(S(4), Basic(S(5)), S(6)))
     brl = top_down(inc)
 
     assert set(brl(expr)) == {expected}
@@ -26,21 +28,21 @@ def test_top_down_harder_function():
             yield x - 1
             yield x + 1
 
-    expr     = Basic(Basic(5, 6), 1)
-    expected = {Basic(Basic(4, 6), 1), Basic(Basic(6, 6), 1)}
+    expr     = Basic(Basic(S(5), S(6)), S(1))
+    expected = {Basic(Basic(S(4), S(6)), S(1)), Basic(Basic(S(6), S(6)), S(1))}
     brl = top_down(split5)
 
     assert set(brl(expr)) == expected
 
 def test_sall():
-    expr     = Basic(1, 2)
-    expected = Basic(2, 3)
+    expr     = Basic(S(1), S(2))
+    expected = Basic(S(2), S(3))
     brl = sall(inc)
 
     assert list(brl(expr)) == [expected]
 
-    expr     = Basic(1, 2, Basic(3, 4))
-    expected = Basic(2, 3, Basic(3, 4))
+    expr     = Basic(S(1), S(2), Basic(S(3), S(4)))
+    expected = Basic(S(2), S(3), Basic(S(3), S(4)))
     brl = sall(do_one(inc, identity))
 
     assert list(brl(expr)) == [expected]

--- a/sympy/strategies/tests/test_rl.py
+++ b/sympy/strategies/tests/test_rl.py
@@ -5,9 +5,9 @@ from sympy.core.basic import Basic
 
 def test_rm_id():
     rmzeros = rm_id(lambda x: x == 0)
-    assert rmzeros(Basic(0, 1)) == Basic(1)
-    assert rmzeros(Basic(0, 0)) == Basic(0)
-    assert rmzeros(Basic(2, 1)) == Basic(2, 1)
+    assert rmzeros(Basic(S(0), S(1))) == Basic(S(1))
+    assert rmzeros(Basic(S(0), S(0))) == Basic(S(0))
+    assert rmzeros(Basic(S(2), S(1))) == Basic(S(2), S(1))
 
 def test_glom():
     from sympy.core.add import Add
@@ -22,24 +22,24 @@ def test_glom():
     assert  set(result.args) == set(expected.args)
 
 def test_flatten():
-    assert flatten(Basic(1, 2, Basic(3, 4))) == Basic(1, 2, 3, 4)
+    assert flatten(Basic(S(1), S(2), Basic(S(3), S(4)))) == \
+            Basic(S(1), S(2), S(3), S(4))
 
 def test_unpack():
-    assert unpack(Basic(2)) == 2
-    assert unpack(Basic(2, 3)) == Basic(2, 3)
+    assert unpack(Basic(S(2))) == 2
+    assert unpack(Basic(S(2), S(3))) == Basic(S(2), S(3))
 
 def test_sort():
-    assert sort(str)(Basic(3,1,2)) == Basic(1,2,3)
+    assert sort(str)(Basic(S(3),S(1),S(2))) == Basic(S(1),S(2),S(3))
 
 def test_distribute():
     class T1(Basic):        pass
     class T2(Basic):        pass
 
     distribute_t12 = distribute(T1, T2)
-    assert distribute_t12(T1(1, 2, T2(3, 4), 5)) == \
-            T2(T1(1, 2, 3, 5),
-               T1(1, 2, 4, 5))
-    assert distribute_t12(T1(1, 2, 3)) == T1(1, 2, 3)
+    assert distribute_t12(T1(S(1), S(2), T2(S(3), S(4)), S(5))) == \
+            T2(T1(S(1), S(2), S(3), S(5)), T1(S(1), S(2), S(4), S(5)))
+    assert distribute_t12(T1(S(1), S(2), S(3))) == T1(S(1), S(2), S(3))
 
 def test_distribute_add_mul():
     from sympy.core.add import Add

--- a/sympy/strategies/tests/test_tools.py
+++ b/sympy/strategies/tests/test_tools.py
@@ -1,6 +1,7 @@
 from sympy.strategies.tools import subs, typed
 from sympy.strategies.rl import rm_id
 from sympy.core.basic import Basic
+from sympy.core.singleton import S
 
 def test_subs():
     from sympy.core.symbol import symbols
@@ -11,16 +12,16 @@ def test_subs():
     assert subs(mapping)(expr) == result
 
 def test_subs_empty():
-    assert subs({})(Basic(1, 2)) == Basic(1, 2)
+    assert subs({})(Basic(S(1), S(2))) == Basic(S(1), S(2))
 
 def test_typed():
     class A(Basic):
         pass
     class B(Basic):
         pass
-    rmzeros = rm_id(lambda x: x == 0)
-    rmones  = rm_id(lambda x: x == 1)
+    rmzeros = rm_id(lambda x: x == S(0))
+    rmones  = rm_id(lambda x: x == S(1))
     remove_something = typed({A: rmzeros, B: rmones})
 
-    assert remove_something(A(0, 1)) == A(1)
-    assert remove_something(B(0, 1)) == B(0)
+    assert remove_something(A(S(0), S(1))) == A(S(1))
+    assert remove_something(B(S(0), S(1))) == B(S(0))

--- a/sympy/strategies/tests/test_traverse.py
+++ b/sympy/strategies/tests/test_traverse.py
@@ -4,8 +4,9 @@ from sympy.strategies.rl import rebuild
 from sympy.strategies.util import expr_fns
 from sympy.core.add import Add
 from sympy.core.basic import Basic
+from sympy.core.numbers import Integer
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Str, Symbol
 from sympy.abc import x, y, z
 
 
@@ -16,7 +17,7 @@ def zero_symbols(expression):
 def test_sall():
     zero_onelevel = sall(zero_symbols)
 
-    assert zero_onelevel(Basic(x, y, Basic(x, z))) == Basic(0, 0, Basic(x, z))
+    assert zero_onelevel(Basic(x, y, Basic(x, z))) == Basic(S(0), S(0), Basic(x, z))
 
 
 def test_bottom_up():
@@ -33,7 +34,7 @@ def _test_global_traversal(trav):
     zero_all_symbols = trav(zero_symbols)
 
     assert zero_all_symbols(Basic(x, y, Basic(x, z))) == \
-        Basic(0, 0, Basic(0, 0))
+        Basic(S(0), S(0), Basic(S(0), S(0)))
 
 
 def _test_stop_on_non_basics(trav):
@@ -43,8 +44,8 @@ def _test_stop_on_non_basics(trav):
         except TypeError:
             return expr
 
-    expr = Basic(1, 'a', Basic(2, 'b'))
-    expected = Basic(2, 'a', Basic(3, 'b'))
+    expr = Basic(S(1), Str('a'), Basic(S(2), Str('b')))
+    expected = Basic(S(2), Str('a'), Basic(S(3), Str('b')))
     rl = trav(add_one_if_can)
 
     assert rl(expr) == expected
@@ -54,19 +55,19 @@ class Basic2(Basic):
     pass
 
 
-rl = lambda x: Basic2(*x.args) if isinstance(x, Basic) else x
+rl = lambda x: Basic2(*x.args) if x.args and not isinstance(x.args[0], Integer) else x
 
 
 def test_top_down_once():
     top_rl = top_down_once(rl)
 
-    assert top_rl(Basic(1, 2, Basic(3, 4))) == Basic2(1, 2, Basic(3, 4))
+    assert top_rl(Basic(S(1.0), S(2.0), Basic(S(3), S(4)))) == Basic2(S(1.0), S(2.0), Basic(S(3), S(4)))
 
 
 def test_bottom_up_once():
     bottom_rl = bottom_up_once(rl)
 
-    assert bottom_rl(Basic(1, 2, Basic(3, 4))) == Basic(1, 2, Basic2(3, 4))
+    assert bottom_rl(Basic(S(1), S(2), Basic(S(3.0), S(4.0)))) == Basic(S(1), S(2), Basic2(S(3.0), S(4.0)))
 
 
 def test_expr_fns():

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -10,8 +10,8 @@ from sympy.assumptions import Q
 p, q = Symbol('p'), Symbol('q')
 
 def test_simple():
-    rl = rewriterule(Basic(p, 1), Basic(p, 2), variables=(p,))
-    assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
+    rl = rewriterule(Basic(p, S(1)), Basic(p, S(2)), variables=(p,))
+    assert list(rl(Basic(S(3), S(1)))) == [Basic(S(3), S(2))]
 
     p1 = p**2
     p2 = p**3
@@ -21,8 +21,8 @@ def test_simple():
     assert list(rl(expr)) == [x**3]
 
 def test_simple_variables():
-    rl = rewriterule(Basic(x, 1), Basic(x, 2), variables=(x,))
-    assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
+    rl = rewriterule(Basic(x, S(1)), Basic(x, S(2)), variables=(x,))
+    assert list(rl(Basic(S(3), S(1)))) == [Basic(S(3), S(2))]
 
     rl = rewriterule(x**2, x**3, variables=(x,))
     assert list(rl(y**2)) == [y**3]

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -10,7 +10,7 @@ from sympy.unify.usympy import (deconstruct, construct, unify, is_associative,
 from sympy.abc import x, y, z, n
 
 def test_deconstruct():
-    expr     = Basic(1, 2, 3)
+    expr     = Basic(S(1), S(2), S(3))
     expected = Compound(Basic, (1, 2, 3))
     assert deconstruct(expr) == expected
 
@@ -23,17 +23,17 @@ def test_deconstruct():
 
 def test_construct():
     expr     = Compound(Basic, (1, 2, 3))
-    expected = Basic(1, 2, 3)
+    expected = Basic(S(1), S(2), S(3))
     assert construct(expr) == expected
 
 def test_nested():
-    expr = Basic(1, Basic(2), 3)
+    expr = Basic(S(1), Basic(S(2)), S(3))
     cmpd = Compound(Basic, (1, Compound(Basic, (2,)), 3))
     assert deconstruct(expr) == cmpd
     assert construct(cmpd) == expr
 
 def test_unify():
-    expr = Basic(1, 2, 3)
+    expr = Basic(S(1), S(2), S(3))
     a, b, c = map(Symbol, 'abc')
     pattern = Basic(a, b, c)
     assert list(unify(expr, pattern, {}, (a, b, c))) == [{a: 1, b: 2, c: 3}]
@@ -41,10 +41,10 @@ def test_unify():
             [{a: 1, b: 2, c: 3}]
 
 def test_unify_variables():
-    assert list(unify(Basic(1, 2), Basic(1, x), {}, variables=(x,))) == [{x: 2}]
+    assert list(unify(Basic(S(1), S(2)), Basic(S(1), x), {}, variables=(x,))) == [{x: 2}]
 
 def test_s_input():
-    expr = Basic(1, 2)
+    expr = Basic(S(1), S(2))
     a, b = map(Symbol, 'ab')
     pattern = Basic(a, b)
     assert list(unify(expr, pattern, {}, (a, b))) == [{a: 1, b: 2}]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22549

#### Brief description of what is fixed or changed
There were several uses of e.g. `Basic(1)` in the tests. This should
not be allowed, since it creates a `Basic` with non-`Basic` arguments.
This PR fixes all such uses that are directly in the tests. However,
it appears that for some tests, there are places in SymPy where
such invalid instances of `Basic` are still created.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
