### PR TITLE
Make the core assumptions fully deterministic

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -715,10 +715,11 @@ class Add(Expr, AssocOp):
             else:
                 return
         b = self.func(*nz)
-        if b.is_zero:
-            return fuzzy_not(self.func(*im_I).is_zero)
-        elif b.is_zero is False:
-            return False
+        if b != self:
+            if b.is_zero:
+                return fuzzy_not(self.func(*im_I).is_zero)
+            elif b.is_zero is False:
+                return False
 
     def _eval_is_zero(self):
         if self.is_commutative is False:

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -210,7 +210,7 @@ References
 
 """
 
-from .facts import FactRules, FactKB, InconsistentAssumptions
+from .facts import FactRules, FactKB
 from .core import BasicMeta
 from .sympify import sympify
 
@@ -510,57 +510,84 @@ def _ask(fact, obj):
     In all cases, when we settle on some fact value, its implications are
     deduced, and the result is cached in ._assumptions.
     """
+    # FactKB which is dict-like and maps facts to their known values:
     assumptions = obj._assumptions
+
+    # A dict that maps facts to their handlers:
     handler_map = obj._prop_handler
 
-    # Store None into the assumptions so that recursive attempts at
-    # evaluating the same fact don't trigger infinite recursion.
-    #
-    # Potentially in a multithreaded context it is possible that the
-    # assumptions query for fact was already resolved in another thread. If
-    # that happens and the query was resolved as True or False then
-    # assumptions._tell will raise InconsistentAssumptions because of the
-    # attempt to replace True/False with None. In that case it should be safe
-    # to catch the exception and return the result that was computed in the
-    # other thread.
-    #
-    # XXX: Ideally this call to assumptions._tell would be removed. Its purpose
-    # is to guard against infinite recursion if a query for one fact attempts
-    # to evaluate a related fact for the same object. However really this is
-    # just masking bugs because a query for a fact about obj should only query
-    # the properties of obj.args and not obj itself. This is not easy to change
-    # though because it requires fixing all of the buggy _eval_is_* handlers.
-    try:
-        assumptions._tell(fact, None)
-    except InconsistentAssumptions:
+    # This is our queue of facts to check:
+    facts_to_check = [fact]
+    facts_queued = {fact}
+
+    # Loop over the queue as it extends
+    for fact_i in facts_to_check:
+
+        # If fact_i has already been determined then we don't need to rerun the
+        # handler. There is a potential race condition for multithreaded code
+        # though because it's possible that fact_i was checked in another
+        # thread. The main logic of the loop below would potentially skip
+        # checking assumptions[fact] in this case so we check it once after the
+        # loop to be sure.
+        if fact_i in assumptions:
+            continue
+
+        # Now we call the associated handler for fact_i if it exists.
+        fact_i_value = None
+        handler_i = handler_map.get(fact_i)
+        if handler_i is not None:
+            fact_i_value = handler_i(obj)
+
+        # If we get a new value for fact_i then we should update our knowledge
+        # of fact_i as well as any related facts that can be inferred using the
+        # inference rules connecting the fact_i and any other fact values that
+        # are already known.
+        if fact_i_value is not None:
+            assumptions.deduce_all_facts(((fact_i, fact_i_value),))
+
+        # Usually if assumptions[fact] is now not None then that is because of
+        # the call to deduce_all_facts above. The handler for fact_i returned
+        # True or False and knowing fact_i (which is equal to fact in the first
+        # iteration) implies knowing a value for fact. It is also possible
+        # though that independent code e.g. called indirectly by the handler or
+        # called in another thread in a multithreaded context might have
+        # resulted in assumptions[fact] being set. Either way we return it.
+        fact_value = assumptions.get(fact)
+        if fact_value is not None:
+            return fact_value
+
+        # Extend the queue with other facts that might determine fact_i. Here
+        # we randomise the order of the facts that are checked. This should not
+        # lead to any non-determinism if all handlers are logically consistent
+        # with the inference rules for the facts. Non-deterministic assumptions
+        # queries can result from bugs in the handlers that are exposed by this
+        # call to shuffle. These are pushed to the back of the queue meaning
+        # that the inference graph is traversed in breadth-first order.
+        new_facts_to_check = list(_assume_rules.prereq[fact_i] - facts_queued)
+        shuffle(new_facts_to_check)
+        facts_to_check.extend(new_facts_to_check)
+        facts_queued.update(new_facts_to_check)
+
+    # The above loop should be able to handle everything fine in a
+    # single-threaded context but in multithreaded code it is possible that
+    # this thread skipped computing a particular fact that was computed in
+    # another thread (due to the continue). In that case it is possible that
+    # fact was inferred and is now stored in the assumptions dict but it wasn't
+    # checked for in the body of the loop. This is an obscure case but to make
+    # sure we catch it we check once here at the end of the loop.
+    if fact in assumptions:
         return assumptions[fact]
 
-    # First try the assumption evaluation function if it exists
-    try:
-        evaluate = handler_map[fact]
-    except KeyError:
-        pass
-    else:
-        a = evaluate(obj)
-        if a is not None:
-            assumptions.deduce_all_facts(((fact, a),))
-            return a
-
-    # Try assumption's prerequisites
-    prereq = list(_assume_rules.prereq[fact])
-    shuffle(prereq)
-    for pk in prereq:
-        if pk in assumptions:
-            continue
-        if pk in handler_map:
-            _ask(pk, obj)
-
-            # we might have found the value of fact
-            ret_val = assumptions.get(fact)
-            if ret_val is not None:
-                return ret_val
-
-    # Note: the result has already been cached
+    # This query can not be answered. It's possible that e.g. another thread
+    # has already stored None for fact but assumptions._tell does not mind if
+    # we call _tell twice setting the same value. If this raises
+    # InconsistentAssumptions then it probably means that another thread
+    # attempted to compute this and got a value of True or False rather than
+    # None. In that case there must be a bug in at least one of the handlers.
+    # If the handlers are all deterministic and are consistent with the
+    # inference rules then the same value should be computed for fact in all
+    # threads.
+    assumptions._tell(fact, None)
     return None
 
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -832,33 +832,10 @@ class Expr(Basic, EvalfMixin):
             return diff
         return None
 
-    def _eval_is_positive(self):
-        finite = self.is_finite
-        if finite is False:
-            return False
-        extended_positive = self.is_extended_positive
-        if finite is True:
-            return extended_positive
-        if extended_positive is False:
-            return False
-
-    def _eval_is_negative(self):
-        finite = self.is_finite
-        if finite is False:
-            return False
-        extended_negative = self.is_extended_negative
-        if finite is True:
-            return extended_negative
-        if extended_negative is False:
-            return False
-
     def _eval_is_extended_positive_negative(self, positive):
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
-            if self.is_extended_real is False:
-                return False
-
             # check to see that we can get a value
             try:
                 n2 = self._eval_evalf(2)
@@ -887,7 +864,7 @@ class Expr(Basic, EvalfMixin):
             if r._prec != 1 and i._prec != 1:
                 return bool(not i and ((r > 0) if positive else (r < 0)))
             elif r._prec == 1 and (not i or i._prec == 1) and \
-                    self.is_algebraic and not self.has(Function):
+                    self._eval_is_algebraic() and not self.has(Function):
                 try:
                     if minimal_polynomial(self).is_Symbol:
                         return False
@@ -1862,8 +1839,8 @@ class Expr(Basic, EvalfMixin):
         from .add import _unevaluated_Add
         from .mul import _unevaluated_Mul
 
-        if self.is_zero:
-            return S.Zero, S.Zero
+        if self is S.Zero:
+            return (self, self)
 
         func = self.func
         if hint.get('as_Add', isinstance(self, Add) ):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1324,14 +1324,18 @@ class Mul(Expr, AssocOp):
         if r:
             return r
         elif r is False:
-            return self.is_zero
+            # All args except one are rational
+            if all(a.is_zero is False for a in self.args):
+                return False
 
     def _eval_is_algebraic(self):
         r = _fuzzy_group((a.is_algebraic for a in self.args), quick_exit=True)
         if r:
             return r
         elif r is False:
-            return self.is_zero
+            # All args except one are algebraic
+            if all(a.is_zero is False for a in self.args):
+                return False
 
     def _eval_is_zero(self):
         zero = infinite = False
@@ -1480,56 +1484,34 @@ class Mul(Expr, AssocOp):
             return real  # doesn't matter what zero is
 
     def _eval_is_imaginary(self):
-        z = self.is_zero
-        if z:
-            return False
-        if self.is_finite is False:
-            return False
-        elif z is False and self.is_finite is True:
+        if all(a.is_zero is False and a.is_finite for a in self.args):
             return self._eval_real_imag(False)
 
     def _eval_is_hermitian(self):
         return self._eval_herm_antiherm(True)
 
-    def _eval_herm_antiherm(self, real):
-        one_nc = zero = one_neither = False
+    def _eval_is_antihermitian(self):
+        return self._eval_herm_antiherm(False)
 
+    def _eval_herm_antiherm(self, herm):
         for t in self.args:
-            if not t.is_commutative:
-                if one_nc:
-                    return
-                one_nc = True
-
-            if t.is_antihermitian:
-                real = not real
-            elif t.is_hermitian:
-                if not zero:
-                    z = t.is_zero
-                    if not z and zero is False:
-                        zero = z
-                    elif z:
-                        if all(a.is_finite for a in self.args):
-                            return True
-                        return
-            elif t.is_hermitian is False:
-                if one_neither:
-                    return
-                one_neither = True
+            if t.is_hermitian is None or t.is_antihermitian is None:
+                return
+            if t.is_hermitian:
+                continue
+            elif t.is_antihermitian:
+                herm = not herm
             else:
                 return
 
-        if one_neither:
-            if real:
-                return zero
-        elif zero is False or real:
-            return real
+        if herm is not False:
+            return herm
 
-    def _eval_is_antihermitian(self):
-        z = self.is_zero
-        if z:
-            return False
-        elif z is False:
-            return self._eval_herm_antiherm(False)
+        is_zero = self._eval_is_zero()
+        if is_zero:
+            return True
+        elif is_zero is False:
+            return herm
 
     def _eval_is_irrational(self):
         for t in self.args:
@@ -1602,44 +1584,37 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(-1)
 
     def _eval_is_odd(self):
-        is_integer = self.is_integer
-        if is_integer:
-            if self.is_zero:
+        is_integer = self._eval_is_integer()
+        if is_integer is not True:
+            return is_integer
+
+        from sympy.simplify.radsimp import fraction
+        n, d = fraction(self)
+        if d.is_Integer and d.is_even:
+            from sympy.ntheory.factor_ import trailing
+            # if minimal power of 2 in num vs den is
+            # positive then we have an even number
+            if (Add(*[i.as_base_exp()[1] for i in
+                    Mul.make_args(n) if i.is_even]) - trailing(d.p)
+                    ).is_positive:
                 return False
-            from sympy.simplify.radsimp import fraction
-            n, d = fraction(self)
-            if d.is_Integer and d.is_even:
-                from sympy.ntheory.factor_ import trailing
-                # if minimal power of 2 in num vs den is
-                # positive then we have an even number
-                if (Add(*[i.as_base_exp()[1] for i in
-                        Mul.make_args(n) if i.is_even]) - trailing(d.p)
-                        ).is_positive:
-                    return False
-                return
-            r, acc = True, 1
-            for t in self.args:
-                if abs(t) is S.One:
-                    continue
-                assert t.is_integer
-                if t.is_even:
-                    return False
-                if r is False:
-                    pass
-                elif acc != 1 and (acc + t).is_odd:
-                    r = False
-                elif t.is_even is None:
-                    r = None
-                acc = t
-            return r
-        return is_integer # !integer -> !odd
+            return
+        r, acc = True, 1
+        for t in self.args:
+            if abs(t) is S.One:
+                continue
+            if t.is_even:
+                return False
+            if r is False:
+                pass
+            elif acc != 1 and (acc + t).is_odd:
+                r = False
+            elif t.is_even is None:
+                r = None
+            acc = t
+        return r
 
     def _eval_is_even(self):
-        is_integer = self.is_integer
-
-        if is_integer:
-            return fuzzy_not(self.is_odd)
-
         from sympy.simplify.radsimp import fraction
         n, d = fraction(self)
         if n.is_Integer and n.is_even:
@@ -1651,7 +1626,6 @@ class Mul(Expr, AssocOp):
                     Mul.make_args(d) if i.is_even]) - trailing(n.p)
                     ).is_nonnegative:
                 return False
-        return is_integer
 
     def _eval_is_composite(self):
         """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -704,9 +704,6 @@ class Number(AtomicExpr):
             return -new
         return self  # there is no other possibility
 
-    def _eval_is_finite(self):
-        return True
-
     @classmethod
     def class_key(cls):
         return 1, 0, 'Number'

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -562,12 +562,6 @@ class Pow(Expr):
             return self.is_finite
         return ext_neg
 
-    def _eval_is_positive(self):
-        ext_pos = Pow._eval_is_extended_positive(self)
-        if ext_pos is True:
-            return self.is_finite
-        return ext_pos
-
     def _eval_is_extended_positive(self):
         if self.base == self.exp:
             if self.base.is_extended_nonnegative:
@@ -668,7 +662,6 @@ class Pow(Expr):
             return False
 
     def _eval_is_extended_real(self):
-
         if self.base is S.Exp1:
             if self.exp.is_extended_real:
                 return True
@@ -730,7 +723,7 @@ class Pow(Expr):
                 if ok is not None:
                     return ok
 
-        if real_b is False:  # we already know it's not imag
+        if real_b is False and real_e: # we already know it's not imag
             from sympy.functions.elementary.complexes import arg
             i = arg(self.base)*self.exp/S.Pi
             if i.is_complex: # finite
@@ -745,6 +738,9 @@ class Pow(Expr):
             return True
 
     def _eval_is_imaginary(self):
+        if self.base.is_commutative is False:
+            return False
+
         if self.base.is_imaginary:
             if self.exp.is_integer:
                 odd = self.exp.is_odd

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -395,6 +395,7 @@ def test_Mul_is_integer():
     k = Symbol('k', integer=True)
     n = Symbol('n', integer=True)
     nr = Symbol('nr', rational=False)
+    ir = Symbol('ir', irrational=True)
     nz = Symbol('nz', integer=True, zero=False)
     e = Symbol('e', even=True)
     o = Symbol('o', odd=True)
@@ -403,6 +404,7 @@ def test_Mul_is_integer():
     assert (k/3).is_integer is None
     assert (nz/3).is_integer is None
     assert (nr/3).is_integer is False
+    assert (ir/3).is_integer is False
     assert (x*k*n).is_integer is None
     assert (e/2).is_integer is True
     assert (e**2/2).is_integer is True
@@ -1535,6 +1537,23 @@ def test_Mul_is_imaginary_real():
 
 
 def test_Mul_hermitian_antihermitian():
+    xz, yz = symbols('xz, yz', zero=True, antihermitian=True)
+    xf, yf = symbols('xf, yf', hermitian=False, antihermitian=False, finite=True)
+    xh, yh = symbols('xh, yh', hermitian=True, antihermitian=False, nonzero=True)
+    xa, ya = symbols('xa, ya', hermitian=False, antihermitian=True, zero=False, finite=True)
+    assert (xz*xh).is_hermitian is True
+    assert (xz*xh).is_antihermitian is True
+    assert (xz*xa).is_hermitian is True
+    assert (xz*xa).is_antihermitian is True
+    assert (xf*yf).is_hermitian is None
+    assert (xf*yf).is_antihermitian is None
+    assert (xh*yh).is_hermitian is True
+    assert (xh*yh).is_antihermitian is False
+    assert (xh*ya).is_hermitian is False
+    assert (xh*ya).is_antihermitian is True
+    assert (xa*ya).is_hermitian is True
+    assert (xa*ya).is_antihermitian is False
+
     a = Symbol('a', hermitian=True, zero=False)
     b = Symbol('b', hermitian=True)
     c = Symbol('c', hermitian=False)

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -631,9 +631,7 @@ class Abs(Function):
         return self._args[0].is_zero
 
     def _eval_is_extended_positive(self):
-        is_z = self.is_zero
-        if is_z is not None:
-            return not is_z
+        return fuzzy_not(self._args[0].is_zero)
 
     def _eval_is_rational(self):
         if self.args[0].is_extended_real:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -259,7 +259,14 @@ class Order(Expr):
                                 e = expr.exp
                                 b = expr.base
                                 expr = exp(e * log(b))
-                    expr = expr.as_independent(*args, as_Add=False)[1]
+
+                    # It would probably be better to handle this somewhere
+                    # else. This is needed for a testcase in which there is a
+                    # symbol with the assumptions zero=True.
+                    if expr.is_zero:
+                        expr = S.Zero
+                    else:
+                        expr = expr.as_independent(*args, as_Add=False)[1]
 
                     expr = expand_power_base(expr)
                     expr = expand_log(expr)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See e.g. here: https://github.com/sympy/sympy/issues/22537#issuecomment-975485692

#### Brief description of what is fixed or changed

Rework the `_ask` function in the core assumptions module.

The core assumptions system could be non-deterministic in some cases due
to the storing a key value of None in the _assumptions dict while
handling an assumptions query. For example in a query like e.is_zero the
assumptions system would:

1. Store None in self._assumptions['zero']
2. Look for and evaluate _eval_is_zero
3. If _eval_is_zero then other facts (is_integer, is_real, etc) are
checked.
4. While checking the other facts zero=None is still stored in the
_assumptions dict so any code that checks e.is_zero receives a None
value.
5. Possibly later the value of is_zero becomes known e.g. if is_real
turns out to be False than is_zero must be False.

The problem here is that in step 4 is_zero gives None even though a
fully resolved is_zero query should give e.g. False. Since the different
facts attempted in step 3 are tried in a random order this can lead to
non-deterministic behaviour.

The reason None is stored in self._assumptions['zero'] is that without
then a query like e.is_zero that occurs recursively while trying to
evaluate e.is_zero leads to infinite recursion. The None is stored there
to prevent the infinite recursion but that is really just masking bugs
and replacing the infinite recursion with non-deterministic behaviour.

With the change in this commit it is now necessary that no assumptions
query ever recursively queries an assumption on self. Mostly there is no
reason for assumptions queries to do that and in many cases the change
here just deletes a redundant `_eval_is_*` method that isn't actually
needed because the resolver in the assumptions system can figure out the
result itself.

The other situation where this could be problematic is where an
assumptions query calls higher-level code that should not really be used
within the assumptions system because it makes things circular. The
higher-level code should be free to query assumptions on e and so should
not be called as part of an assumptions query on e.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * A bug resulting in the core assumptions system being sometimes unreliable was fixed meaning that the assumptions system should now be fully reliable and deterministic including under multithreaded usage. The fix has a side effect that any code that is used as part of an `_eval_is_*` handler for an assumptions predicate (e.g. `_eval_is_real`) must not recursively query another assumption on the same object (e.g. by checking something like `self.is_positive`) or it will lead to infinite recursion. Any downstream code that implements such assumption handlers will need to be reviewed for bugs of this kind. Note that it isn't necessary to query something like `x.is_positive`` in a handler for `x.is_real` because the assumptions system already understands the relationship between these so if `x_eval_is_positive()` returns True then the system will conclude that `x.is_real` should be true.
<!-- END RELEASE NOTES -->
