### PR TITLE
basic: use type instead of func for dictionary keys

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -458,7 +458,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if isinstance(proposition, AppliedPredicate):
         key, args = proposition.function, proposition.arguments
     elif proposition.func in binrelpreds:
-        key, args = binrelpreds[proposition.func], proposition.args
+        key, args = binrelpreds[type(proposition)], proposition.args
     else:
         key, args = Q.is_true, (proposition,)
 

--- a/sympy/assumptions/predicates/common.py
+++ b/sympy/assumptions/predicates/common.py
@@ -76,6 +76,6 @@ class IsTruePredicate(Predicate):
             return arg
         # Convert relational predicates instead of wrapping them
         if getattr(arg, "is_Relational", False):
-            pred = binrelpreds[arg.func]
+            pred = binrelpreds[type(arg)]
             return pred(*arg.args)
         return super().__call__(arg)

--- a/sympy/assumptions/relation/binrel.py
+++ b/sympy/assumptions/relation/binrel.py
@@ -183,7 +183,7 @@ class AppliedBinaryRelation(AppliedPredicate):
         binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}
         for a in conjuncts(assumptions):
             if a.func in binrelpreds:
-                conj_assumps.add(binrelpreds[a.func](*a.args))
+                conj_assumps.add(binrelpreds[type(a)](*a.args))
             else:
                 conj_assumps.add(a)
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -182,7 +182,7 @@ class ClassFactRegistry:
     def __call__(self, expr):
         ret = set()
 
-        handlers1, handlers2 = self[expr.func]
+        handlers1, handlers2 = self[type(expr)]
 
         for h in handlers1:
             ret.add(h(expr))

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1488,7 +1488,7 @@ def evalf(x: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
     """
     from sympy.functions.elementary.complexes import re as re_, im as im_
     try:
-        rf = evalf_table[x.func]
+        rf = evalf_table[type(x)]
         r = rf(x, prec, options)
     except KeyError:
         # Fall back to ordinary evalf if possible

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -243,7 +243,7 @@ def TR3(rv):
             return rv
         if (rv.args[0] - S.Pi/4).is_positive is (S.Pi/2 - rv.args[0]).is_positive is True:
             fmap = {cos: sin, sin: cos, tan: cot, cot: tan, sec: csc, csc: sec}
-            rv = fmap[rv.func](S.Pi/2 - rv.args[0])
+            rv = fmap[type(rv)](S.Pi/2 - rv.args[0])
         return rv
 
     return bottom_up(rv, f)
@@ -445,12 +445,12 @@ def TR8(rv, first=True):
         args = {cos: [], sin: [], None: []}
         for a in ordered(Mul.make_args(rv)):
             if a.func in (cos, sin):
-                args[a.func].append(a.args[0])
+                args[type(a)].append(a.args[0])
             elif (a.is_Pow and a.exp.is_Integer and a.exp > 0 and \
                     a.base.func in (cos, sin)):
                 # XXX this is ok but pathological expression could be handled
                 # more efficiently as in TRmorrie
-                args[a.base.func].extend([a.base.args[0]]*a.exp)
+                args[type(a.base)].extend([a.base.args[0]]*a.exp)
             else:
                 args[None].append(a)
         c = args[cos]
@@ -869,7 +869,7 @@ def _TR11(rv):
                 b, e = fi.as_base_exp()
                 if e.is_Integer and e > 0:
                     if b.func in (cos, sin):
-                        args[b.func].add(b.args[0])
+                        args[type(b)].add(b.args[0])
             return args
         num_args, den_args = map(sincos_args, rv.as_numer_denom())
         def handle_match(rv, num_args, den_args):
@@ -1076,7 +1076,7 @@ def TR13(rv):
         args = {tan: [], cot: [], None: []}
         for a in ordered(Mul.make_args(rv)):
             if a.func in (tan, cot):
-                args[a.func].append(a.args[0])
+                args[type(a)].append(a.args[0])
             else:
                 args[None].append(a)
         t = args[tan]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2666,7 +2666,7 @@ def _tsolve(eq, sym, **flags):
             if lhs.func in multi_inverses:
                 # sin(x) = 1/3 -> x - asin(1/3) & x - (pi - asin(1/3))
                 soln = []
-                for i in multi_inverses[lhs.func](rhs):
+                for i in multi_inverses[type(lhs)](rhs):
                     soln.extend(_solve(lhs.args[0] - i, sym, **flags))
                 return list(ordered(soln))
             elif lhs.func == LambertW:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This would make https://github.com/sympy/sympy/pull/22535 safer to use.

#### Brief description of what is fixed or changed
Currently SymPy uses `obj.func` to obtain the classes of expressions
to use as keys in dictionaries. This might not be safe to do when
`obj.func` does not return `obj.__class__`. Instead, `type(obj)` can
be used safely. It is also more efficient.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
