### PR TITLE
liealgebras: subclass from atom instead of basic where appropriate

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2895,52 +2895,42 @@ def test_sympy__liealgebras__cartan_type__CartanType_generator():
     from sympy.liealgebras.cartan_type import CartanType_generator
     assert _test_args(CartanType_generator("A2"))
 
-@XFAIL
 def test_sympy__liealgebras__cartan_type__Standard_Cartan():
     from sympy.liealgebras.cartan_type import Standard_Cartan
     assert _test_args(Standard_Cartan("A", 2))
 
-@XFAIL
 def test_sympy__liealgebras__weyl_group__WeylGroup():
     from sympy.liealgebras.weyl_group import WeylGroup
     assert _test_args(WeylGroup("B4"))
 
-@XFAIL
 def test_sympy__liealgebras__root_system__RootSystem():
     from sympy.liealgebras.root_system import RootSystem
     assert _test_args(RootSystem("A2"))
 
-@XFAIL
 def test_sympy__liealgebras__type_a__TypeA():
     from sympy.liealgebras.type_a import TypeA
     assert _test_args(TypeA(2))
 
-@XFAIL
 def test_sympy__liealgebras__type_b__TypeB():
     from sympy.liealgebras.type_b import TypeB
     assert _test_args(TypeB(4))
 
-@XFAIL
 def test_sympy__liealgebras__type_c__TypeC():
     from sympy.liealgebras.type_c import TypeC
     assert _test_args(TypeC(4))
 
-@XFAIL
 def test_sympy__liealgebras__type_d__TypeD():
     from sympy.liealgebras.type_d import TypeD
     assert _test_args(TypeD(4))
 
-@XFAIL
 def test_sympy__liealgebras__type_e__TypeE():
     from sympy.liealgebras.type_e import TypeE
     assert _test_args(TypeE(6))
 
-@XFAIL
 def test_sympy__liealgebras__type_f__TypeF():
     from sympy.liealgebras.type_f import TypeF
     assert _test_args(TypeF(4))
 
-@XFAIL
 def test_sympy__liealgebras__type_g__TypeG():
     from sympy.liealgebras.type_g import TypeG
     assert _test_args(TypeG(2))

--- a/sympy/liealgebras/cartan_type.py
+++ b/sympy/liealgebras/cartan_type.py
@@ -1,4 +1,4 @@
-from sympy.core import Basic
+from sympy.core import Atom, Basic
 
 
 class CartanType_generator(Basic):
@@ -49,13 +49,13 @@ class CartanType_generator(Basic):
 CartanType = CartanType_generator()
 
 
-class Standard_Cartan(Basic):
+class Standard_Cartan(Atom):
     """
     Concrete base class for Cartan types such as A4, etc
     """
 
     def __new__(cls, series, n):
-        obj = Basic.__new__(cls, series, n)
+        obj = Basic.__new__(cls)
         obj.n = n
         obj.series = series
         return obj

--- a/sympy/liealgebras/root_system.py
+++ b/sympy/liealgebras/root_system.py
@@ -1,5 +1,4 @@
 from .cartan_type import CartanType
-from sympy.core.backend import Basic
 from sympy.core.basic import Atom
 
 class RootSystem(Atom):
@@ -45,7 +44,7 @@ class RootSystem(Atom):
         cartan_type attribute of the RootSystem instance.
 
         """
-        obj = Basic.__new__(cls)
+        obj = Atom.__new__(cls)
         obj.cartan_type = CartanType(cartantype)
         return obj
 

--- a/sympy/liealgebras/root_system.py
+++ b/sympy/liealgebras/root_system.py
@@ -1,7 +1,8 @@
 from .cartan_type import CartanType
 from sympy.core.backend import Basic
+from sympy.core.basic import Atom
 
-class RootSystem(Basic):
+class RootSystem(Atom):
     """Represent the root system of a simple Lie algebra
 
     Every simple Lie algebra has a unique root system.  To find the root
@@ -44,7 +45,7 @@ class RootSystem(Basic):
         cartan_type attribute of the RootSystem instance.
 
         """
-        obj = Basic.__new__(cls, cartantype)
+        obj = Basic.__new__(cls)
         obj.cartan_type = CartanType(cartantype)
         return obj
 

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -2,7 +2,7 @@
 
 from .cartan_type import CartanType
 from mpmath import fac
-from sympy.core.backend import Matrix, eye, Rational, Basic, igcd
+from sympy.core.backend import Matrix, eye, Rational, igcd
 from sympy.core.basic import Atom
 
 class WeylGroup(Atom):
@@ -17,7 +17,7 @@ class WeylGroup(Atom):
     """
 
     def __new__(cls, cartantype):
-        obj = Basic.__new__(cls)
+        obj = Atom.__new__(cls)
         obj.cartan_type = CartanType(cartantype)
         return obj
 

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -3,8 +3,9 @@
 from .cartan_type import CartanType
 from mpmath import fac
 from sympy.core.backend import Matrix, eye, Rational, Basic, igcd
+from sympy.core.basic import Atom
 
-class WeylGroup(Basic):
+class WeylGroup(Atom):
 
     """
     For each semisimple Lie group, we have a Weyl group.  It is a subgroup of
@@ -16,7 +17,7 @@ class WeylGroup(Basic):
     """
 
     def __new__(cls, cartantype):
-        obj = Basic.__new__(cls, cartantype)
+        obj = Basic.__new__(cls)
         obj.cartan_type = CartanType(cartantype)
         return obj
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves part of the issues reported in https://github.com/sympy/sympy/pull/22445

#### Brief description of what is fixed or changed
The changed objects make sense as an `Atom` rather than a `Basic`
since their arguments should not be substitutable. Currently they
also store non-`Basic` arguments in `_args`, which should not be
allowed. Finally the changes also make the instances of these
classes pass the arg invariance test which was previously skipped
with `@XFAIL`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
