### PR TITLE
Add back `sympy` module reST directive

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -4,6 +4,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. module:: sympy
+
 Welcome to SymPy's documentation!
 ----------------------------------
 


### PR DESCRIPTION
In https://github.com/sympy/sympy/commit/551c16facb2081c7b7a085aeaf20316244a1da01#diff-c914444a6f552b38ff8975af7c7c7e92a5a9f7e9dc780148bf43c7c8566e4578L6, the sphinx `.. module:: sympy` directive was removed. This causes `:mod:\`sympy\`` intersphinx references to fail. This PR adds it back. I'm suggesting this because the removal caused a doc build to fail for me: https://github.com/inducer/pymbolic/runs/4361946013?check_suite_focus=true

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
