### PR TITLE
Min/Max now supports sets as argument

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -405,7 +405,9 @@ class MinMaxBase(Expr, LatticeOp):
         if not args:
             return cls.identity
 
-        if len(args) == 1:
+        from sympy.sets.sets import Set
+
+        if len(args) == 1 and not isinstance(list(args).pop(), Set):
             return list(args).pop()
 
         # base creation
@@ -558,9 +560,10 @@ class MinMaxBase(Expr, LatticeOp):
         Also reshape Max(a, Max(b, c)) to Max(a, b, c),
         and check arguments for comparability
         """
+        from sympy.sets.sets import Set
         for arg in arg_sequence:
             # pre-filter, checking comparability of arguments
-            if not isinstance(arg, Expr) or arg.is_extended_real is False or (
+            if not isinstance(arg, (Expr, Set)) or arg.is_extended_real is False or (
                     arg.is_number and
                     not arg.is_comparable):
                 raise ValueError("The argument '%s' is not comparable." % arg)
@@ -571,6 +574,11 @@ class MinMaxBase(Expr, LatticeOp):
                 continue
             elif arg.func == cls:
                 yield from arg.args
+            elif isinstance(arg, Set):
+                try:
+                    yield cls.setfunc(arg)
+                except NotImplementedError:
+                    yield arg
             else:
                 yield arg
 
@@ -773,6 +781,7 @@ class Max(MinMaxBase, Application):
     """
     zero = S.Infinity
     identity = S.NegativeInfinity
+    setfunc = lambda x : x.sup
 
     def fdiff( self, argindex ):
         from sympy.functions.special.delta_functions import Heaviside
@@ -836,6 +845,7 @@ class Min(MinMaxBase, Application):
     """
     zero = S.NegativeInfinity
     identity = S.Infinity
+    setfunc = lambda x : x.inf
 
     def fdiff( self, argindex ):
         from sympy.functions.special.delta_functions import Heaviside

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -14,6 +14,9 @@ from sympy.functions.elementary.miscellaneous import (sqrt, cbrt, root, Min,
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.delta_functions import Heaviside
 
+from sympy.sets.sets import FiniteSet
+from sympy.sets.fancysets import Range
+
 from sympy.utilities.lambdify import lambdify
 from sympy.testing.pytest import raises, skip, ignore_warnings
 
@@ -449,6 +452,7 @@ def test_rewrite_as_Abs():
     test(Min(x, y, z))
     test(Min(Max(w, x), Max(y, z)))
 
+
 def test_issue_14000():
     assert isinstance(sqrt(4, evaluate=False), Pow) == True
     assert isinstance(cbrt(3.5, evaluate=False), Pow) == True
@@ -461,11 +465,26 @@ def test_issue_14000():
     assert root(16, 4, 2, evaluate=False).has(Pow) == True
     assert real_root(-8, 3, evaluate=False).has(Pow) == True
 
+
 def test_issue_6899():
     from sympy.core.function import Lambda
     x = Symbol('x')
     eqn = Lambda(x, x)
     assert eqn.func(*eqn.args) == eqn
+
+
+def test_MinMax_with_Sets():
+    assert Max(Range(3)) == 2
+    assert Max(FiniteSet(-1, 1, 2)) == 2
+    assert Max(Range(3), FiniteSet(-1, 1, 2)) == 2
+    assert Max(Range(3), FiniteSet(-1, 1, 2), 3) == 3
+    assert Min(Range(3)) == 0
+    assert Min(FiniteSet(-1, 1, 2)) == -1
+    assert Min(Range(3), FiniteSet(-1, 1, 2)) == -1
+    assert Min(Range(3), FiniteSet(-1, 1, 2), -2) == -2
+    J = Symbol('J', integer=True, positive=True)
+    assert Max(Range(J)) == J - 1
+
 
 def test_Rem():
     from sympy.abc import x, y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #22568

#### Brief description of what is fixed or changed
It is now possible to use sets as arguments to `Max` and `Min`. I needed a way to write something like

`Max(imageset(Lambda(x, f(x), Range(J))`

and later on replace J with an integer.

Although this is not yet supported as it doesn't seem possible to convert `Range` to `FiniteSet` at will, see #22571, it is a step in the right direction.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `Max` and `Min` now accept `Set` arguments. 
<!-- END RELEASE NOTES -->
