### PR TITLE
powsimp recognizes non-symbolic negated exponents

### DIFF
--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -4,7 +4,6 @@ from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import (binomial, factorial)
-from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys.polytools import Poly
@@ -54,7 +53,7 @@ def test_gosper_sum():
     # issue 6033:
     assert gosper_sum(
         n*(n + a + b)*a**n*b**n/(factorial(n + a)*factorial(n + b)), \
-        (n, 0, m)).simplify() == -exp(m*log(a) + m*log(b))*gamma(a + 1) \
+        (n, 0, m)).simplify() == -(a*b)**m*gamma(a + 1) \
         *gamma(b + 1)/(gamma(a)*gamma(b)*gamma(a + m + 1)*gamma(b + m + 1)) \
         + 1/(gamma(a)*gamma(b))
 

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -238,7 +238,7 @@ def test__eval_product():
     a = Function('a')
     assert product(2*a(i), (i, 1, n)) == 2**n * Product(a(i), (i, 1, n))
     # issue 4810
-    assert product(2**i, (i, 1, n)) == 2**(n/2 + n**2/2)
+    assert product(2**i, (i, 1, n)) == 2**(n*(n + 1)/2)
     k, m = symbols('k m', integer=True)
     assert product(2**i, (i, k, m)) == 2**(-k**2/2 + k/2 + m**2/2 + m/2)
     n = Symbol('n', negative=True, integer=True)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from functools import reduce
 
-from sympy.core.function import expand_log, count_ops
+from sympy.core.function import expand_log, count_ops, _coeff_isneg
 from sympy.core import sympify, Basic, Dummy, S, Add, Mul, Pow, expand_mul, factor_terms
 from sympy.core.sorting import ordered, default_sort_key
 from sympy.core.numbers import Integer, Rational
@@ -402,6 +402,11 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         for b, e in c_powers:
             if deep:
                 e = recurse(e)
+            if e.is_Add and (b.is_positive or e.is_integer):
+                e = factor_terms(e)
+                if _coeff_isneg(e):
+                    e = -e
+                    b = 1/b
             c_exp[e].append(b)
         del c_powers
 

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -349,3 +349,18 @@ def test_issue_19627():
     expr = (exp(z/e)*x**(b/e)*y**((1 - b)/e))**e
     assert powdenest(expand_power_base(expr, force=True), force=True
         ) == x**b*y**(1 - b)*exp(z)
+
+
+def test_issue_22546():
+    p1, p2 = symbols('p1, p2', positive=True)
+    ref = powsimp(p1**z/p2**z)
+    e = z + 1
+    ans = ref.subs(z, e)
+    assert ans.is_Pow
+    assert powsimp(p1**e/p2**e) == ans
+    i = symbols('i', integer=True)
+    ref = powsimp(x**i/y**i)
+    e = i + 1
+    ans = ref.subs(i, e)
+    assert ans.is_Pow
+    assert powsimp(x**e/y**e) == ans

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -2479,13 +2479,13 @@ def _get_examples_ode_sol_nth_linear_constant_coeff_homogeneous():
 
     'lin_const_coeff_hom_06': {
         'eq': Eq(f(x).diff(x, 2) + 2*f(x).diff(x) - f(x), 0),
-        'sol': [Eq(f(x), C1*exp(x*(-1 + sqrt(2))) + C2*exp(x*(-sqrt(2) - 1)))],
+        'sol': [Eq(f(x), C1*exp(x*(-1 + sqrt(2))) + C2*exp(-x*(sqrt(2) + 1)))],
         'slow': True,
     },
 
     'lin_const_coeff_hom_07': {
         'eq': diff(f(x), x, 3) + diff(f(x), x, 2) - 10*diff(f(x), x) - 6*f(x),
-        'sol': [Eq(f(x), C1*exp(3*x) + C2*exp(x*(-2 - sqrt(2))) + C3*exp(x*(-2 + sqrt(2))))],
+        'sol': [Eq(f(x), C1*exp(3*x) + C3*exp(-x*(2 + sqrt(2))) + C2*exp(x*(-2 + sqrt(2))))],
         'slow': True,
     },
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1632,15 +1632,15 @@ def _get_examples_ode_sol_nth_linear_undetermined_coefficients():
     # https://github.com/sympy/sympy/issues/12623
     'undet_38': {
         'eq': Eq( u(t).diff(t,t) + R /L*u(t).diff(t) + 1/(L*C)*u(t), alpha),
-        'sol': [Eq(u(t), C*L*alpha + C1*exp(t*(-R - sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
-        + C2*exp(t*(-R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L)))],
+        'sol': [Eq(u(t), C*L*alpha + C2*exp(-t*(R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
+        + C1*exp(t*(-R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L)))],
         'func': u(t)
     },
 
     'undet_39': {
         'eq': Eq( L*C*u(t).diff(t,t) + R*C*u(t).diff(t) + u(t), E_0*exp(I*omega*t) ),
-        'sol': [Eq(u(t), C1*exp(t*(-R - sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
-        + C2*exp(t*(-R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
+        'sol': [Eq(u(t), C2*exp(-t*(R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
+        + C1*exp(t*(-R + sqrt(C*R**2 - 4*L)/sqrt(C))/(2*L))
         - E_0*exp(I*omega*t)/(C*L*omega**2 - I*C*R*omega - 1))],
         'func': u(t),
     },


### PR DESCRIPTION
If an exponent in powsimp is a sum from which a -1 can be
factored then if that exponent is an integer or the base on which
it occurs is positive, then `b**e == (1/b)**-e` and this can be used to combine
bases that were previously not combined, so now
```python
>>> i = Symbol('i', integer=True)
>>> powsimp(x**(i + 1)/y**(i + 1))
(x/y)**(i + 1)

>>> x, y = symbols('x y', positive=True)
>>> from sympy.abc import z
>>> powsimp(x**(z + 1)/y**(z + 1))
(x/y)**(z + 1)
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * `powsimp` now recognizes any negated exponent that is an integer or that occurs on positive bases
<!-- END RELEASE NOTES -->
