### PR TITLE
core/containers: Dict now stores arguments as `Basic`

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -11,7 +11,7 @@ from collections.abc import MutableSet
 from typing import Any, Callable
 
 from .basic import Basic
-from .sorting import default_sort_key
+from .sorting import default_sort_key, ordered
 from .sympify import _sympify, sympify, converter, SympifyError
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import as_int
@@ -233,7 +233,7 @@ class Dict(Basic):
         else:
             raise TypeError('Pass Dict args as Dict((k1, v1), ...) or Dict({k1: v1, ...})')
         elements = frozenset(items)
-        obj = Basic.__new__(cls, elements)
+        obj = Basic.__new__(cls, *ordered(items))
         obj.elements = elements
         obj._dict = dict(items)  # In case Tuple decides it wants to sympify
         return obj
@@ -249,17 +249,6 @@ class Dict(Basic):
 
     def __setitem__(self, key, value):
         raise NotImplementedError("SymPy Dicts are Immutable")
-
-    @property
-    def args(self):
-        """Returns a tuple of arguments of 'self'.
-
-        See Also
-        ========
-
-        sympy.core.basic.Basic.args
-        """
-        return tuple(self.elements)
 
     def items(self):
         '''Returns a set-like object providing a view on dict's items.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22579 

#### Brief description of what is fixed or changed
Currently `Dict` stores its `key,value` pairs inside a `frozenset` which is not a `Basic`, so should not be stored in `_args`. Note that `args` already provides the correct interface, so this behaviour might be acceptable. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
