### PR TITLE
tensor/array: Flatten is no longer a subclass of Basic

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4440,12 +4440,6 @@ def test_sympy__tensor__array__array_comprehension__ArrayComprehensionMap():
     arrcomma = ArrayComprehensionMap(lambda: 0, (x, 1, 5))
     assert _test_args(arrcomma)
 
-def test_sympy__tensor__array__arrayop__Flatten():
-    from sympy.tensor.array.arrayop import Flatten
-    from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
-    fla = Flatten(ImmutableDenseNDimArray(range(24)).reshape(2, 3, 4))
-    assert _test_args(fla)
-
 
 def test_sympy__tensor__array__array_derivatives__ArrayDerivative():
     from sympy.tensor.array.array_derivatives import ArrayDerivative

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -477,4 +477,4 @@ class Flatten(Printable):
         return self.__next__()
 
     def _sympystr(self, printer):
-        return 'Flatten(' + printer._print(self._iter) + ')'
+        return self.__name__ + '(' + printer._print(self._iter) + ')'

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,7 +1,6 @@
 import itertools
 from collections.abc import Iterable
 
-from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.function import diff
 from sympy.core.singleton import S
@@ -407,7 +406,7 @@ def permutedims(expr, perm):
     return type(expr)(new_array, new_shape)
 
 
-class Flatten(Basic):
+class Flatten():
     '''
     Flatten an iterable object to a list in a lazy-evaluation way.
 

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -477,4 +477,4 @@ class Flatten(Printable):
         return self.__next__()
 
     def _sympystr(self, printer):
-        return self.__name__ + '(' + printer._print(self._iter) + ')'
+        return type(self).__name__ + '(' + printer._print(self._iter) + ')'

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,6 +1,7 @@
 import itertools
 from collections.abc import Iterable
 
+from sympy.core._print_helpers import Printable
 from sympy.core.containers import Tuple
 from sympy.core.function import diff
 from sympy.core.singleton import S
@@ -406,7 +407,7 @@ def permutedims(expr, perm):
     return type(expr)(new_array, new_shape)
 
 
-class Flatten():
+class Flatten(Printable):
     '''
     Flatten an iterable object to a list in a lazy-evaluation way.
 
@@ -474,3 +475,6 @@ class Flatten():
 
     def next(self):
         return self.__next__()
+
+    def _sympystr(self, printer):
+        return 'Flatten(' + printer._print(self._iter) + ')'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
See https://github.com/sympy/sympy/pull/22445

#### Brief description of what is fixed or changed
Currently `Flatten` is a subclass of `Basic`. It is meant to avoid
evaluating its argument for as long as possible, thus it can't make
sure that its arguments are a `Basic` (e.g. this is meant to work
with mutable arrays, which can not be a `Basic`. Moreover, currently
this class seems to not use any of the properties of a `Basic`.
I realise this module is currently under development, so I would
like to know if `Basic` can savely be removed considering future
plans for this module.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
