### PR TITLE
Use autosummary in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ sample.tex
 
 # pytest related data file for slow tests
 .ci/durations.log
+
+# Stub .rst files generated from sphinx autosummary.
+_generated

--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,4 @@ sample.tex
 .ci/durations.log
 
 # Stub .rst files generated from sphinx autosummary.
-_generated
+doc/src/**/ref/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,7 @@ SOURCEDIR    = src
 
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)
 PDFFILES = $(SVGFILES:%.svg=%.pdf)
+RSTSTUBFILES := $(shell find . -name "_generated")
 
 # This must be set for the recursive make pdf build to work in make latexpdf
 export LATEXMKOPTS = -halt-on-error -xelatex
@@ -49,6 +50,7 @@ clean:
 	-rm -rf $(BUILDDIR)
 	-rm -rf sphinx
 	-rm -f $(PDFFILES)
+	-rm -rf $(RSTSTUBFILES)
 
 html: $(BUILDDIR)/html/pics/*.png
 html: SPHINXOPTS += -W --keep-going

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,7 +13,7 @@ SOURCEDIR    = src
 
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)
 PDFFILES = $(SVGFILES:%.svg=%.pdf)
-RSTSTUBFILES := $(shell find . -name "_generated")
+RSTSTUBFILES := $(shell find . -name "ref")
 
 # This must be set for the recursive make pdf build to work in make latexpdf
 export LATEXMKOPTS = -halt-on-error -xelatex
@@ -118,8 +118,9 @@ linkcheck:
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-livehtml: html
-	sphinx-autobuild --open-browser --watch .. --port 0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+livehtml: $(BUILDDIR)/html/pics/*.png
+livehtml: $(BUILDDIR)/logo/sympy-notailtext-favicon.ico
+	sphinx-autobuild --open-browser --watch .. --re-ignore 'src/modules/.*/ref/' --ignore '_build/*' --port 0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 
 cheatsheet: $(BUILDDIR)/cheatsheet/cheatsheet.pdf $(BUILDDIR)/cheatsheet/combinatoric_cheatsheet.pdf
 

--- a/doc/src/_templates/autosummary/class.rst
+++ b/doc/src/_templates/autosummary/class.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline}}
+
+{# Ideally we would be able to use the autosummary for class methods as well,
+but unfortunately, autosummary does not allow just documenting :members:
+using the same methodology as autodoc, so if we were to use autosummary, we
+would get documentation for a bunch of methods that we don't want to include.
+#}
+
+.. autoclass:: {{ fullname }}
+   :members:

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -29,9 +29,11 @@ sys.path = ['ext'] + sys.path
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.addons.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode', 'sphinx_math_dollar',
-              'sphinx.ext.mathjax', 'numpydoc', 'sympylive', 'sphinx_reredirects',
-              'sphinx.ext.graphviz', 'matplotlib.sphinxext.plot_directive']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+              'sphinx.ext.linkcode', 'sphinx_math_dollar',
+              'sphinx.ext.mathjax', 'numpydoc', 'sympylive',
+              'sphinx_reredirects', 'sphinx.ext.graphviz',
+              'matplotlib.sphinxext.plot_directive']
 
 redirects = {
     "install.rst": "guides/getting_started/install.html",
@@ -47,6 +49,8 @@ redirects = {
 
 # Use this to use pngmath instead
 #extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.pngmath', ]
+
+autosummary_generate = True
 
 # Enable warnings for all bad cross references. These are turned into errors
 # with the -W flag in the Makefile.

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -1,8 +1,6 @@
 Matrices (linear algebra)
 =========================
 
-.. module:: sympy.matrices.matrices
-
 Creating Matrices
 -----------------
 
@@ -523,87 +521,57 @@ So there is quite a bit that can be done with the module including eigenvalues,
 eigenvectors, nullspace calculation, cofactor expansion tools, and so on. From
 here one might want to look over the ``matrices.py`` file for all functionality.
 
-MatrixDeterminant Class Reference
----------------------------------
-.. autoclass:: MatrixDeterminant
-   :members:
+Matrix Baseclasses Reference
+----------------------------
 
-MatrixReductions Class Reference
---------------------------------
-.. autoclass:: MatrixReductions
-   :members:
+.. autosummary::
+   :toctree: ref
 
-MatrixSubspaces Class Reference
--------------------------------
-.. autoclass:: MatrixSubspaces
-   :members:
-
-MatrixEigen Class Reference
----------------------------
-.. autoclass:: MatrixEigen
-   :members:
-
-MatrixCalculus Class Reference
-------------------------------
-.. autoclass:: MatrixCalculus
-   :members:
-
-MatrixBase Class Reference
---------------------------
-.. autoclass:: MatrixBase
-   :members:
+   sympy.matrices.matrices.MatrixBase
+   sympy.matrices.matrices.MatrixCalculus
+   sympy.matrices.matrices.MatrixDeterminant
+   sympy.matrices.matrices.MatrixEigen
+   sympy.matrices.matrices.MatrixReductions
+   sympy.matrices.matrices.MatrixSubspaces
 
 Matrix Exceptions Reference
 ---------------------------
 
-.. autoclass:: MatrixError
-   :members:
+.. autosummary::
+   :toctree: ref
 
-.. autoclass:: ShapeError
-   :members:
-
-.. autoclass:: NonSquareMatrixError
-   :members:
-
+   sympy.matrices.matrices.MatrixError
+   ~sympy.matrices.matrices.NonSquareMatrixError
+   ~sympy.matrices.matrices.ShapeError
 
 Matrix Functions Reference
 --------------------------
 
-.. autofunction:: sympy.matrices.dense::matrix_multiply_elementwise
+.. autosummary::
+   :toctree: ref
 
-.. autofunction:: sympy.matrices.dense::zeros
-
-.. autofunction:: sympy.matrices.dense::ones
-
-.. autofunction:: sympy.matrices.dense::eye
-
-.. autofunction:: sympy.matrices.dense::diag
-
-.. autofunction:: sympy.matrices.dense::jordan_cell
-
-.. autofunction:: sympy.matrices.dense::hessian
-
-.. autofunction:: sympy.matrices.dense::GramSchmidt
-
-.. autofunction:: sympy.matrices.dense::wronskian
-
-.. autofunction:: sympy.matrices.dense::casoratian
-
-.. autofunction:: sympy.matrices.dense::randMatrix
+   ~sympy.matrices.dense.GramSchmidt
+   ~sympy.matrices.dense.casoratian
+   ~sympy.matrices.dense.diag
+   ~sympy.matrices.dense.eye
+   ~sympy.matrices.dense.hessian
+   ~sympy.matrices.dense.jordan_cell
+   ~sympy.matrices.dense.matrix_multiply_elementwise
+   ~sympy.matrices.dense.ones
+   ~sympy.matrices.dense.randMatrix
+   ~sympy.matrices.dense.wronskian
+   ~sympy.matrices.dense.zeros
 
 Numpy Utility Functions Reference
 ---------------------------------
 
-.. autofunction:: sympy.matrices.dense::list2numpy
+.. autosummary::
+   :toctree: ref
 
-.. autofunction:: sympy.matrices.dense::matrix2numpy
-
-.. autofunction:: sympy.matrices.dense::symarray
-
-.. autofunction:: sympy.matrices.dense::rot_axis1
-
-.. autofunction:: sympy.matrices.dense::rot_axis2
-
-.. autofunction:: sympy.matrices.dense::rot_axis3
-
-.. autofunction:: a2idx
+   sympy.matrices.matrices.a2idx
+   ~sympy.matrices.dense.list2numpy
+   ~sympy.matrices.dense.matrix2numpy
+   ~sympy.matrices.dense.rot_axis1
+   ~sympy.matrices.dense.rot_axis2
+   ~sympy.matrices.dense.rot_axis3
+   ~sympy.matrices.dense.symarray


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is a redux of the work that was started in https://github.com/sympy/sympy/pull/18594. 

#### Brief description of what is fixed or changed

Our [documentation poll](
https://forms.gle/EjkFEdnLXaYxjvfn6) is still ongoing, but one thing that is already becoming clear from some of the responses is that our documentation would benefit from splitting the documentation of each function into separate pages. This is achieved with the autosummary Sphinx extension. 

Not only does this make each page of the documentation more manageable, but it also makes it easier for Google search results to return the exact function in question, rather than just a large page that contains the function somewhere on it. 

For now, I have only modified the matrices.rst file. Please review what this looks like, both in the RST and the generated HTML. If we like how this looks, we can add it to other pages.

#### Other comments


- You have to manually add `:toctree: ref` to each autosummary to tell it where
  to put the autogenerated files. You should always use the name "ref" for
  this for consistency, but you can use something like `:toctree: ../ref` to put
  it on level up. The word "ref" is part in the URL for each generated page.

- The classes I have documented here really need to be organized in a better
  way. However, I have not done that in this PR. An advantage of autosummary
  is that we can move where a class is documented in the organization without
  breaking the URL to it, since it lives on a separate page.

- This will break any existing links to specific anchors on this page.

- The class template hardcodes :members:. However, it would be easy to use
  other combinations by adding additional templates, although each autosummary
  list can only use one template at a time.

- The docs for classes still list each method on the same page. This is
  because autosummary is not really capable of doing recursive autosummary on
  class members in a way that only includes the members we want to include.
  See the commit message of a0e955bfc56267877442ab318e9ec92f29a806d6.

- Autosummary is very particular about how you spell the name of the function
  so that it can find it. I recommend avoiding `.. module::` or `..
  currentmodule::`and just spelling everything explicitly, using `~` before the
  name to truncate the module name for public names (eventually, we will have
  *only* public names in this part of documentation, see
  #22105, but this is a separate issue to
  clean this up).

- When building, be aware that files for the autosummary are generated
  automatically, but are only cleaned when you do a `make clean`. Thus if you
  add something to an autosummary and then delete it, you will get warnings in
  the build from the generated file that no longer is referenced anywhere.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- other
  - Start using the autosummary extension in the docs, which puts documentation for each function and class on a separate page. 
<!-- END RELEASE NOTES -->

#### Screenshots

Here is what the matrices page looks like
<img width="838" alt="Screen Shot 2021-12-02 at 7 38 34 PM" src="https://user-images.githubusercontent.com/71486/144535550-40ee9895-6a1e-4b94-974b-c1085003d51a.png">

and here is what a page for one of the clases looks like

<img width="1072" alt="Screen Shot 2021-12-02 at 7 38 59 PM" src="https://user-images.githubusercontent.com/71486/144535579-8e1f3105-84bf-4d11-ad5e-38f5a64f6761.png">


