### PR TITLE
Iterable

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -141,7 +141,7 @@ def _process_limits(*symbols, discrete=None):
                     raise NotImplementedError(
                         'expecting Range' if discrete else
                         'Relational or single Interval' )
-            V = sympify(flatten(V))  # a list of sympified elements
+            V = sympify(flatten(V))  # list of sympified elements/None
             if isinstance(V[0], (Symbol, Idx)) or getattr(V[0], '_diff_wrt', False):
                 newsymbol = V[0]
                 if len(V) == 3:

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -8,7 +8,8 @@ here for easy import.
 from .sorting import ordered as _ordered, _nodes as __nodes, default_sort_key as _default_sort_key
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.misc import as_int as _as_int
-from sympy.utilities.iterables import iterable as _iterable, is_sequence as _is_sequence
+from sympy.utilities.iterables import (iterable as _iterable,
+    is_sequence as _is_sequence, NotIterable as _notiterable)
 
 
 default_sort_key = deprecated(useinstead="sympy.core.sorting.default_sort_key",
@@ -33,3 +34,6 @@ is_sequence = deprecated(useinstead="sympy.utilities.iterables.is_sequence",
 
 iterable = deprecated(useinstead="sympy.utilities.iterables.iterable",
     deprecated_since_version="1.10", issue=22352)(_iterable)
+
+NotIterable = deprecated(useinstead="sympy.utilities.iterables.NotIterable",
+    deprecated_since_version="1.10", issue=22352)(_notiterable)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -155,7 +155,7 @@ class Expr(Basic, EvalfMixin):
             try:
                 other = _sympify(other)
             except (SympifyError, SyntaxError):
-                return False
+                return NotImplemented
         if not isinstance(other, Expr):
             return False
         # check for pure number expr

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -146,11 +146,11 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
-        assert not iterable(self), 'needs __eq__ definition'
         if not isinstance(other, Basic):
-            if iterable(other):
-                # XXX assume that an iterable with a _sympy_
-                # method will not sympify to a non-iterable
+            if iterable(other) and not hasattr(other, '_sympy_'):
+                # XXX iterable self should have it's own __eq__
+                # method if the path gives a false negative
+                # comparison
                 return False
             try:
                 other = _sympify(other)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -12,7 +12,7 @@ from .sorting import default_sort_key
 from .kind import NumberKind
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import as_int, func_name, filldedent
-from sympy.utilities.iterables import has_variety, sift, iterable
+from sympy.utilities.iterables import has_variety, sift, iterable, NotIterable
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
@@ -147,7 +147,8 @@ class Expr(Basic, EvalfMixin):
 
     def __eq__(self, other):
         if not isinstance(other, Basic):
-            if iterable(other) and not hasattr(other, '_sympy_'):
+            if iterable(other, exclude=(str, NotIterable)
+                    ) and not hasattr(other, '_sympy_'):
                 # XXX iterable self should have it's own __eq__
                 # method if the path gives a false negative
                 # comparison

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -12,7 +12,7 @@ from .sorting import default_sort_key
 from .kind import NumberKind
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import as_int, func_name, filldedent
-from sympy.utilities.iterables import has_variety, sift
+from sympy.utilities.iterables import has_variety, sift, iterable
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
@@ -146,11 +146,15 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
-        try:
-            other = _sympify(other)
-            if not isinstance(other, Expr):
+        if not isinstance(other, Basic):
+            if iterable(other):
+                # no expression is iterable
                 return False
-        except (SympifyError, SyntaxError):
+            try:
+                other = _sympify(other)
+            except (SympifyError, SyntaxError):
+                return False
+        if not isinstance(other, Expr):
             return False
         # check for pure number expr
         if  not (self.is_Number and other.is_Number) and (

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -146,9 +146,11 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
+        assert not iterable(self), 'needs __eq__ definition'
         if not isinstance(other, Basic):
             if iterable(other):
-                # no expression is iterable
+                # XXX assume that an iterable with a _sympy_
+                # method will not sympify to a non-iterable
                 return False
             try:
                 other = _sympify(other)

--- a/sympy/core/random.py
+++ b/sympy/core/random.py
@@ -72,10 +72,13 @@ def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     True
     """
     from sympy.core.symbol import Symbol
+    from sympy.core.sympify import sympify
     from sympy.core.numbers import comp
-    from sympy.core.containers import Tuple
-    f, g, z = Tuple(f, g, z)
-    z = [z] if isinstance(z, Symbol) else (f.free_symbols | g.free_symbols)
+    f, g = (sympify(i) for i in (f, g))
+    if z is None:
+        z = f.free_symbols | g.free_symbols
+    elif isinstance(z, Symbol):
+        z = [z]
     reps = list(zip(z, [random_complex_number(a, b, c, d) for _ in z]))
     z1 = f.subs(reps).n()
     z2 = g.subs(reps).n()

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2171,3 +2171,7 @@ def test_21494():
     from sympy.testing.pytest import warns_deprecated_sympy
     with warns_deprecated_sympy():
         assert x.expr_free_symbols == {x}
+
+
+def test_Expr__eq__iterable_handling():
+    assert x != range(3)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -808,7 +808,7 @@ class Integral(AddWithLimits):
             u = Dummy('u')
             arg = f.subs(x, u).diff(sym).subs(u, x)
             if arg:
-                rv += self.func(arg, Tuple(x, a, b))
+                rv += self.func(arg, (x, a, b))
         return rv
 
     def _eval_integral(self, f, x, meijerg=None, risch=None, manual=None,

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1184,8 +1184,25 @@ def test_rmul_pr19860():
     assert isinstance(c, Foo)
     assert c == Matrix([[7, 10], [15, 22]])
 
+
 def test_issue_18956():
     A = Array([[1, 2], [3, 4]])
     B = Matrix([[1,2],[3,4]])
     raises(TypeError, lambda: B + A)
     raises(TypeError, lambda: A + B)
+
+
+def test__eq__():
+    class My(object):
+        def __iter__(self):
+            yield 1
+            yield 2
+            return
+        def __getitem__(self, i):
+            return list(self)[i]
+    a = Matrix(2, 1, [1, 2])
+    assert a != My()
+    class My_sympy(My):
+        def _sympy_(self):
+            return Matrix(self)
+    assert a == My_sympy()

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -323,12 +323,12 @@ class Indexed(Expr):
 
         """
         ranges = []
+        sentinel = object()
         for i in self.indices:
-            sentinel = object()
             upper = getattr(i, 'upper', sentinel)
             lower = getattr(i, 'lower', sentinel)
             if sentinel not in (upper, lower):
-                ranges.append(Tuple(lower, upper))
+                ranges.append((lower, upper))
             else:
                 ranges.append(None)
         return ranges


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

spinoff from #22582 with some additional changes

#### Brief description of what is fixed or changed

1. `Expr.__eq__` automatically rejects as unequal anything that is iterable (and also saves time by not having to sympify anything in the iterable
2. The default arg z=None is handled without putting it into a Tuple
3. it looked like NotIterable was in campatibililty at one time -- the tests for compatibility wanted to import it from there -- so it was added along with the others that are deprecated in favor of importing them from iterables.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
