### PR TITLE
physics/quantum: ensure arguments are Basic

### DIFF
--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -24,6 +24,7 @@ from sympy.core.power import Pow
 from sympy.core.numbers import Number
 from sympy.core.singleton import S as _S
 from sympy.core.sorting import default_sort_key
+from sympy.core.sympify import _sympify
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
@@ -520,6 +521,8 @@ class UGate(Gate):
         mat = args[1]
         if not isinstance(mat, MatrixBase):
             raise TypeError('Matrix expected, got: %r' % mat)
+        #make sure this matrix is of a Basic type
+        mat = _sympify(mat)
         dim = 2**len(targets)
         if not all(dim == shape for shape in mat.shape):
             raise IndexError(

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -323,7 +323,7 @@ U((0,),Matrix([\n\
     assert pretty(g4) == ascii_str
     assert upretty(g4) == ucode_str
     assert latex(g4) == r'U_{0}'
-    sT(g4, "UGate(Tuple(Integer(0)),MutableDenseMatrix([[Symbol('a'), Symbol('b')], [Symbol('c'), Symbol('d')]]))")
+    sT(g4, "UGate(Tuple(Integer(0)),ImmutableDenseMatrix([[Symbol('a'), Symbol('b')], [Symbol('c'), Symbol('d')]]))")
 
 
 def test_hilbert():

--- a/sympy/physics/quantum/tests/test_qexpr.py
+++ b/sympy/physics/quantum/tests/test_qexpr.py
@@ -29,7 +29,7 @@ def test_qexpr_commutative():
     assert q2.is_commutative is False
     assert q1*q2 != q2*q1
 
-    q = QExpr._new_rawargs(0, 1, HilbertSpace())
+    q = QExpr._new_rawargs(Integer(0), Integer(1), HilbertSpace())
     assert q.is_commutative is False
 
 def test_qexpr_commutative_free_symbols():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Would help with https://github.com/sympy/sympy/pull/22445

#### Brief description of what is fixed or changed
A test used `int` in `._raw_args`, this is replaced with `Integer`.
`UGate` did not convert its matrix argument to a `Basic` (allowing
`MutableDenseMatrix`). This is now converted with `_sympify` and
the respective print test is updated.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
