### PR TITLE
[proof of concept] only use _sympify in __eq__ when required 

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -341,26 +341,11 @@ class Basic(Printable, metaclass=ManagedProperties):
         if self is other:
             return True
 
-        tself = type(self)
-        tother = type(other)
-        if tself is not tother:
-            try:
-                other = _sympify(other)
-                tother = type(other)
-            except SympifyError:
-                return NotImplemented
-
-            # As long as we have the ordering of classes (sympy.core),
-            # comparing types will be slow in Python 2, because it uses
-            # __cmp__. Until we can remove it
-            # (https://github.com/sympy/sympy/issues/4269), we only compare
-            # types in Python 2 directly if they actually have __ne__.
-            if type(tself).__ne__ is not type.__ne__:
-                if tself != tother:
-                    return False
-            elif tself is not tother:
-                return False
-
+        if not isinstance(other, Basic) and hasattr(other, '_sympy_'):
+            return self == _sympify(other)
+        if type(self) is not type(other):
+            #print("not implemented:", type(self), type(other))
+            return NotImplemented
         return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -345,7 +345,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             return self == _sympify(other)
         if type(self) is not type(other):
             #print("not implemented:", type(self), type(other))
-            return NotImplemented
+            return False
         return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -343,9 +343,9 @@ class Basic(Printable, metaclass=ManagedProperties):
 
         if not isinstance(other, Basic) and hasattr(other, '_sympy_'):
             return self == _sympify(other)
-        if type(self) is not type(other):
+        if type(self) != type(other):
             #print("not implemented:", type(self), type(other))
-            return False
+            return NotImplemented
         return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -341,12 +341,26 @@ class Basic(Printable, metaclass=ManagedProperties):
         if self is other:
             return True
 
-        if not isinstance(other, Basic) and hasattr(other, '_sympy_'):
-            return self == _sympify(other)
-        if type(self) != type(other):
-            #print("not implemented:", type(self), type(other))
-            return NotImplemented
-        return self._hashable_content() == other._hashable_content()
+        if not isinstance(other, Basic):
+            if hasattr(other, '_sympy_'):
+                return self == _sympify(other)
+            else:
+                return NotImplemented
+
+        if  not (self.is_Number and other.is_Number) and (
+                type(self) != type(other)):
+            return False
+
+        a, b = self._hashable_content(), other._hashable_content()
+        if a != b:
+            return False
+        # check number *in* an expression
+        for a, b in zip(a, b):
+            if not isinstance(a, Basic):
+                continue
+            if a.is_Number and type(a) != type(b):
+                return False
+        return True
 
     def __ne__(self, other):
         """``a != b``  -> Compare two symbolic trees and see whether they are different

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -304,6 +304,13 @@ class Dict(Basic):
     def _sorted_args(self):
         return tuple(sorted(self.args, key=default_sort_key))
 
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            return self == _sympify(other)
+        else:
+            return super().__eq__(other)
+
+    __hash__ = Tuple.__hash__
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -310,7 +310,8 @@ class Dict(Basic):
         else:
             return super().__eq__(other)
 
-    __hash__ = Tuple.__hash__
+    def __hash__(self):
+        return Tuple.__hash__()
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -311,7 +311,7 @@ class Dict(Basic):
             return super().__eq__(other)
 
     def __hash__(self):
-        return Tuple.__hash__()
+        return Tuple.__hash__(self)
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -145,26 +145,27 @@ class Expr(Basic, EvalfMixin):
         been defined by a class. See note about this in Basic.__eq__."""
         return self._args
 
-    def __eq__(self, other):
-        if not isinstance(other, Expr):
-            return super().__eq__(other)
-        # check for pure number expr
-        result = True
-        if  not (self.is_Number and other.is_Number) and (
-                type(self) != type(other)):
-            result = False
-        a, b = self._hashable_content(), other._hashable_content()
-        if a != b:
-            result = False
-        # check number *in* an expression
-        for a, b in zip(a, b):
-            if not isinstance(a, Expr):
-                continue
-            if a.is_Number and type(a) != type(b):
-                result = False
-        if not result is Basic.__eq__(self, other):
-            raise TypeError(result, Basic.__eq__(self, other), type(self), type(other), self.__repr__(), other.__repr__())
-        return result
+    #def __eq__(self, other):
+    #    if not isinstance(other, Expr):
+    #        return super().__eq__(other)
+    #    # check for pure number expr
+    #    result = True
+    #    if  not (self.is_Number and other.is_Number) and (
+    #            type(self) != type(other)):
+    #        result = False
+    #    a, b = self._hashable_content(), other._hashable_content()
+    #    if a != b:
+    #        result = False
+    #    # check number *in* an expression
+    #    for a, b in zip(a, b):
+    #        if not isinstance(a, Expr):
+    #            continue
+    #        if a.is_Number and type(a) != type(b):
+    #            result = False
+    #    if not result is Basic.__eq__(self, other):
+    #        raise TypeError(result, Basic.__eq__(self, other), type(self), type(other), self.__repr__(), other.__repr__(),
+    #                type(self) is type(other))
+    #    return result
 
     # ***************
     # * Arithmetics *

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2,7 +2,7 @@ from typing import Tuple as tTuple
 from collections.abc import Iterable
 from functools import reduce
 
-from .sympify import sympify, _sympify, SympifyError
+from .sympify import sympify, _sympify
 from .basic import Basic, Atom
 from .singleton import S
 from .evalf import EvalfMixin, pure_complex, DEFAULT_MAXPREC
@@ -12,7 +12,7 @@ from .sorting import default_sort_key
 from .kind import NumberKind
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import as_int, func_name, filldedent
-from sympy.utilities.iterables import has_variety, sift, iterable, NotIterable
+from sympy.utilities.iterables import has_variety, sift
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -127,7 +127,7 @@ class Expr(Basic, EvalfMixin):
 
         return expr.class_key(), args, exp, coeff
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # hash cannot be cached using cache_it because infinite recurrence
         # occurs as hash is needed for setting cache dictionary keys
         h = self._mhash
@@ -146,7 +146,22 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
-        return super().__eq__(other)
+        if not isinstance(other, Expr):
+            return super().__eq__(other)
+        # check for pure number expr
+        if  not (self.is_Number and other.is_Number) and (
+                type(self) != type(other)):
+            return False
+        a, b = self._hashable_content(), other._hashable_content()
+        if a != b:
+            return False
+        # check number *in* an expression
+        for a, b in zip(a, b):
+            if not isinstance(a, Expr):
+                continue
+            if a.is_Number and type(a) != type(b):
+                return False
+        return True
 
     # ***************
     # * Arithmetics *

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -162,8 +162,8 @@ class Expr(Basic, EvalfMixin):
                 continue
             if a.is_Number and type(a) != type(b):
                 result = False
-        if not result == super().__eq__(other):
-            print(self, other, type(self), type(other))
+        if not result is super().__eq__(other):
+            print(result, super().__eq__(other))
         return result
 
     # ***************

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -145,25 +145,6 @@ class Expr(Basic, EvalfMixin):
         been defined by a class. See note about this in Basic.__eq__."""
         return self._args
 
-    def __eq__(self, other):
-        # This is not responsible for comparisons with non Expr
-        if not isinstance(other, Expr):
-            return super().__eq__(other)
-        # check for pure number expr
-        if  not (self.is_Number and other.is_Number) and (
-                type(self) != type(other)):
-            return False
-        a, b = self._hashable_content(), other._hashable_content()
-        if a != b:
-            return False
-        # check number *in* an expression
-        for a, b in zip(a, b):
-            if not isinstance(a, Expr):
-                continue
-            if a.is_Number and type(a) != type(b):
-                return False
-        return True
-
     # ***************
     # * Arithmetics *
     # ***************

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -127,6 +127,15 @@ class Expr(Basic, EvalfMixin):
 
         return expr.class_key(), args, exp, coeff
 
+    def __hash__(self):
+        # hash cannot be cached using cache_it because infinite recurrence
+        # occurs as hash is needed for setting cache dictionary keys
+        h = self._mhash
+        if h is None:
+            h = hash((type(self).__name__,) + self._hashable_content())
+            self._mhash = h
+        return h
+
     def _hashable_content(self):
         """Return a tuple of information about self that can be used to
         compute the hash. If a class defines additional attributes,
@@ -135,6 +144,9 @@ class Expr(Basic, EvalfMixin):
         Defining more than _hashable_content is necessary if __eq__ has
         been defined by a class. See note about this in Basic.__eq__."""
         return self._args
+
+    def __eq__(self, other):
+        return super().__eq__(other)
 
     # ***************
     # * Arithmetics *

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -149,19 +149,22 @@ class Expr(Basic, EvalfMixin):
         if not isinstance(other, Expr):
             return super().__eq__(other)
         # check for pure number expr
+        result = True
         if  not (self.is_Number and other.is_Number) and (
                 type(self) != type(other)):
-            return False
+            result = False
         a, b = self._hashable_content(), other._hashable_content()
         if a != b:
-            return False
+            result = False
         # check number *in* an expression
         for a, b in zip(a, b):
             if not isinstance(a, Expr):
                 continue
             if a.is_Number and type(a) != type(b):
-                return False
-        return True
+                result = False
+        if not result == super().__eq__(other):
+            print(self, other, type(self), type(other))
+        return result
 
     # ***************
     # * Arithmetics *

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -146,19 +146,9 @@ class Expr(Basic, EvalfMixin):
         return self._args
 
     def __eq__(self, other):
-        if not isinstance(other, Basic):
-            if iterable(other, exclude=(str, NotIterable)
-                    ) and not hasattr(other, '_sympy_'):
-                # XXX iterable self should have it's own __eq__
-                # method if the path gives a false negative
-                # comparison
-                return False
-            try:
-                other = _sympify(other)
-            except (SympifyError, SyntaxError):
-                return NotImplemented
+        # This is not responsible for comparisons with non Expr
         if not isinstance(other, Expr):
-            return False
+            return super().__eq__(other)
         # check for pure number expr
         if  not (self.is_Number and other.is_Number) and (
                 type(self) != type(other)):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -162,8 +162,8 @@ class Expr(Basic, EvalfMixin):
                 continue
             if a.is_Number and type(a) != type(b):
                 result = False
-        if not result is super().__eq__(other):
-            print(result, super().__eq__(other))
+        if not result is Basic.__eq__(self, other):
+            raise TypeError(result, Basic.__eq__(self, other), type(self), type(other), self.__repr__(), other.__repr__())
         return result
 
     # ***************

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -127,15 +127,6 @@ class Expr(Basic, EvalfMixin):
 
         return expr.class_key(), args, exp, coeff
 
-    def __hash__(self) -> int:
-        # hash cannot be cached using cache_it because infinite recurrence
-        # occurs as hash is needed for setting cache dictionary keys
-        h = self._mhash
-        if h is None:
-            h = hash((type(self).__name__,) + self._hashable_content())
-            self._mhash = h
-        return h
-
     def _hashable_content(self):
         """Return a tuple of information about self that can be used to
         compute the hash. If a class defines additional attributes,

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -38,7 +38,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 _LOG2 = math.log(2)
 
-number_types=[]
+number_types:list[type] = []
 
 def comp(z1, z2, tol=None):
     """Return a bool indicating whether the error between z1 and z2
@@ -1484,7 +1484,7 @@ class Float(Number):
 # Add sympify converters
 converter[float] = converter[decimal.Decimal] = Float
 number_types.append(float)
-nubmer_types.append(decimal.Decimal)
+number_types.append(decimal.Decimal)
 # this is here to work nicely in Sage
 RealNumber = Float
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1,3 +1,4 @@
+#pinging this file so it can be used in the review
 import numbers
 import decimal
 import fractions

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -766,7 +766,7 @@ class Number(AtomicExpr):
             elif other in (S.Infinity, S.NegativeInfinity):
                 return S.Zero
         return AtomicExpr.__truediv__(self, other)
-
+#ping
     def __eq__(self, other):
         raise NotImplementedError('%s needs .__eq__() method' %
             (self.__class__.__name__))
@@ -1375,7 +1375,7 @@ class Float(Number):
         if self._mpf_ == fzero:
             return 0
         return int(mlib.to_int(self._mpf_))  # uses round_fast = round_down
-
+#ping
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
         try:
@@ -1873,7 +1873,7 @@ class Rational(Number):
 
     def __ceil__(self):
         return self.ceiling()
-
+#ping
     def __eq__(self, other):
         try:
             other = _sympify(other)
@@ -2244,7 +2244,7 @@ class Integer(Rational):
                 return Integer(other.p % self.p)
             return Rational.__rmod__(self, other)
         return Rational.__rmod__(self, other)
-
+#ping
     def __eq__(self, other):
         if isinstance(other, int):
             return (self.p == other)
@@ -3036,7 +3036,7 @@ class Infinity(Number, metaclass=Singleton):
 
     def __hash__(self):
         return super().__hash__()
-
+#ping
     def __eq__(self, other):
         return other is S.Infinity or other == float('inf')
 
@@ -3202,7 +3202,7 @@ class NegativeInfinity(Number, metaclass=Singleton):
 
     def __hash__(self):
         return super().__hash__()
-
+#ping
     def __eq__(self, other):
         return other is S.NegativeInfinity or other == float('-inf')
 
@@ -3333,7 +3333,7 @@ class NaN(Number, metaclass=Singleton):
 
     def __hash__(self):
         return super().__hash__()
-
+#ping
     def __eq__(self, other):
         # NaN is structurally equal to another NaN
         return other is S.NaN
@@ -3457,7 +3457,7 @@ class NumberSymbol(AtomicExpr):
 
     def _eval_evalf(self, prec):
         return Float._new(self._as_mpf_val(prec), prec)
-
+#ping
     def __eq__(self, other):
         try:
             other = _sympify(other)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -38,6 +38,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 _LOG2 = math.log(2)
 
+number_types=[]
 
 def comp(z1, z2, tol=None):
     """Return a bool indicating whether the error between z1 and z2
@@ -1378,9 +1379,9 @@ class Float(Number):
 #ping
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
-        try:
+        if type(other) in number_types:
             other = _sympify(other)
-        except SympifyError:
+        if not isinstance(other, Basic):
             return NotImplemented
         if isinstance(other, Boolean):
             return False
@@ -1482,7 +1483,8 @@ class Float(Number):
 
 # Add sympify converters
 converter[float] = converter[decimal.Decimal] = Float
-
+number_types.append(float)
+nubmer_types.append(decimal.Decimal)
 # this is here to work nicely in Sage
 RealNumber = Float
 
@@ -1875,9 +1877,9 @@ class Rational(Number):
         return self.ceiling()
 #ping
     def __eq__(self, other):
-        try:
+        if type(other) in number_types:
             other = _sympify(other)
-        except SympifyError:
+        if not isinstance(other, Basic):
             return NotImplemented
         if not isinstance(other, Number):
             # S(0) == S.false is False
@@ -2507,7 +2509,7 @@ class Integer(Rational):
 
 # Add sympify converters
 converter[int] = Integer
-
+number_types.append(int)
 
 class AlgebraicNumber(Expr):
     """Class for representing algebraic numbers in SymPy. """
@@ -3459,9 +3461,9 @@ class NumberSymbol(AtomicExpr):
         return Float._new(self._as_mpf_val(prec), prec)
 #ping
     def __eq__(self, other):
-        try:
+        if type(other) in number_types:
             other = _sympify(other)
-        except SympifyError:
+        if not isinstance(other, Basic):
             return NotImplemented
         if self is other:
             return True
@@ -4059,6 +4061,7 @@ def sympify_fractions(f):
     return Rational(f.numerator, f.denominator, 1)
 
 converter[fractions.Fraction] = sympify_fractions
+number_types.append(fractions.Fraction)
 
 if HAS_GMPY:
     def sympify_mpz(x):
@@ -4072,26 +4075,28 @@ if HAS_GMPY:
 
     converter[type(gmpy.mpz(1))] = sympify_mpz
     converter[type(gmpy.mpq(1, 2))] = sympify_mpq
-
+    number_types.append(type(gmpy.mpz(1)))
+    number_types.append(type(gmpy.mpq(1, 2)))
 
 def sympify_mpmath_mpq(x):
     p, q = x._mpq_
     return Rational(p, q, 1)
 
 converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
-
+number_types.append(type(mpmath.rational.mpq(1, 2)))
 
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 
 converter[mpnumeric] = sympify_mpmath
-
+number_types.append(mpnumeric)
 
 def sympify_complex(a):
     real, imag = list(map(sympify, (a.real, a.imag)))
     return real + S.ImaginaryUnit*imag
 
 converter[complex] = sympify_complex
+number_types.append(complex)
 
 from .power import Pow, integer_nthroot
 from .mul import Mul

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -204,7 +204,7 @@ class Boolean(Basic):
             return super().__eq__(other)
 
     def __hash__(self):
-        return Basic.__hash__()
+        return Basic.__hash__(self)
 
 
 class BooleanAtom(Boolean):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -197,6 +197,14 @@ class Boolean(Basic):
             return false
         return None
 
+    def __eq__(self, other):
+        if isinstance(other, bool):
+            return self == _sympify(other)
+        else:
+            return super().__eq__(other)
+
+    __hash__ = Basic.__hash__
+
 
 class BooleanAtom(Boolean):
     """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -203,7 +203,8 @@ class Boolean(Basic):
         else:
             return super().__eq__(other)
 
-    __hash__ = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__()
 
 
 class BooleanAtom(Boolean):

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -46,7 +46,7 @@ class RepMatrix(MatrixBase):
     #
 
     _rep: DomainMatrix
-
+#ping
     def __eq__(self, other):
         # Skip sympify for mutable matrices...
         if not isinstance(other, RepMatrix):

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1641,7 +1641,7 @@ class DomainMatrix:
 
         """
         return cls.from_rep(DDM.ones(shape, domain))
-
+#ping
     def __eq__(A, B):
         r"""
         Checks for two DomainMatrix matrices to be equal or not

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -186,7 +186,7 @@ class MutablePolyDenseMatrix:
             return to_poly(dm[i, j].element)
         else:
             return self.from_dm(dm[i, j])
-
+#ping
     def __eq__(self, other):
         if not isinstance(self, type(other)):
             return NotImplemented

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -701,7 +701,8 @@ class Set(Basic, EvalfMixin):
             return self == _sympify(other)
         return super().__eq__(other)
 
-    __hash__ = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__()
 
 
 class ProductSet(Set):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -702,7 +702,7 @@ class Set(Basic, EvalfMixin):
         return super().__eq__(other)
 
     def __hash__(self):
-        return Basic.__hash__()
+        return Basic.__hash__(self)
 
 
 class ProductSet(Set):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -696,6 +696,13 @@ class Set(Basic, EvalfMixin):
             raise TypeError('did not evaluate to a bool: %r' % c)
         return b
 
+    def __eq__(self, other):
+        if isinstance(other, (set, frozenset)):
+            return self == _sympify(other)
+        return super().__eq__(other)
+
+    __hash__ = Basic.__hash__
+
 
 class ProductSet(Set):
     """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Currently `__eq__` almost always tries to apply `_symplify` to `other`.
While this does follow the ideas of "pythonic duck-typing", it is also
somewhat inefficient. It also seems to sometimes cause the creation of
invalid SymPy objects (that are only used for comparison) which results
in the need for non-pythonic instance checking anyways. Instead, it
was suggested in sympy#22580 (comment) to have any class that 
wants to compare with non-`Basic` classes to perform `_sympify` only 
for those classes it knows that it can compare against. This PR 
implements this, except for `Number` and `Matrix` subclasses, which 
already have their own `__eq__` logic.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
