### PR TITLE
Fixed incorrect behaviour of _minpoly_cos for pi/9

### DIFF
--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -437,7 +437,7 @@ def _minpoly_cos(ex, x):
                 if c.q == 7:
                     return 8*x**3 - 4*x**2 - 4*x + 1
                 if c.q == 9:
-                    return 8*x**3 - 6*x + 1
+                    return 8*x**3 - 6*x - 1
             elif c.p == 2:
                 q = sympify(c.q)
                 if q.is_prime:

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -273,7 +273,7 @@ def test_minpoly_compose():
             2816*x**6 - 1232*x**4 + 220*x**2 - 11
     assert minimal_polynomial(sin(pi/21), x) == 4096*x**12 - 11264*x**10 + \
            11264*x**8 - 4992*x**6 + 960*x**4 - 64*x**2 + 1
-    assert minimal_polynomial(cos(pi/9), x) == 8*x**3 - 6*x + 1
+    assert minimal_polynomial(cos(pi/9), x) == 8*x**3 - 6*x - 1
 
     ex = 2**Rational(1, 3)*exp(2*I*pi/3)
     assert minimal_polynomial(ex, x) == x**3 - 2


### PR DESCRIPTION
minpoly(cos(pi/9)) returned `8*x**3 - 6*x + 1`, the correct result is `8*x**3 - 6*x - 1`. This commit fixes that error.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22605 


#### Brief description of what is fixed or changed

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug in minpoly
<!-- END RELEASE NOTES -->
