### PR TITLE
Added refine-support for Min and Max

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -7,7 +7,7 @@ from .function import AppliedUndef
 from .singleton import S
 from .sympify import _sympify, SympifyError
 from .parameters import global_parameters
-from .logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
+from .logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.logic.boolalg import Boolean, BooleanAtom
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import sift
@@ -1323,6 +1323,17 @@ def is_ge(lhs, rhs, assumptions=None):
                 rv = is_extended_nonnegative(diff, assumptions)
                 if rv is not None:
                     return rv
+        # Decomposition may help for certain assumptions
+        if assumptions is not None:
+            from sympy.assumptions import ask, Q
+            gt_retval = ask(Q.gt(lhs, rhs), assumptions)
+            if gt_retval:
+                return True
+            eq_retval = ask(Q.eq(lhs, rhs), assumptions)
+            if eq_retval:
+                return True
+            if fuzzy_or([gt_retval, eq_retval]) is False:
+                return False
 
 
 def is_neq(lhs, rhs, assumptions=None):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1318,22 +1318,23 @@ def is_ge(lhs, rhs, assumptions=None):
         if _lhs.is_extended_real and _rhs.is_extended_real:
             if (_lhs.is_infinite and _lhs.is_extended_positive) or (_rhs.is_infinite and _rhs.is_extended_negative):
                 return True
+            if _lhs.is_extended_nonnegative and _rhs.is_extended_nonpositive:
+                return True
             diff = lhs - rhs
             if diff is not S.NaN:
                 rv = is_extended_nonnegative(diff, assumptions)
                 if rv is not None:
                     return rv
         # Decomposition may help for certain assumptions
-        if assumptions is not None:
-            from sympy.assumptions import ask, Q
-            gt_retval = ask(Q.gt(lhs, rhs), assumptions)
-            if gt_retval:
-                return True
-            eq_retval = ask(Q.eq(lhs, rhs), assumptions)
-            if eq_retval:
-                return True
-            if fuzzy_or([gt_retval, eq_retval]) is False:
-                return False
+        # if assumptions is not None:
+            # eq_retval = is_eq(lhs, rhs, assumptions)
+            # if eq_retval:
+            #    return True
+            # gt_retval = is_gt(lhs, rhs, assumptions)
+            # if gt_retval:
+            #     return True
+            # if fuzzy_or([gt_retval, eq_retval]) is False:
+            #     return False
 
 
 def is_neq(lhs, rhs, assumptions=None):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -686,6 +686,7 @@ class MinMaxBase(Expr, LatticeOp):
     _eval_is_transcendental = lambda s: _torf(i.is_transcendental for i in s.args)
     _eval_is_zero = lambda s: _torf(i.is_zero for i in s.args)
 
+
 class Max(MinMaxBase, Application):
     """
     Return, if possible, the maximum value of the list.
@@ -803,6 +804,20 @@ class Max(MinMaxBase, Application):
     def _eval_is_negative(self):
         return fuzzy_and(a.is_negative for a in self.args)
 
+    def _eval_refine(self, assumptions):
+        from sympy.assumptions.ask import ask
+        to_remove = []
+        for i in self.args:
+            for j in self.args:
+                if i != j and i not in to_remove and j not in to_remove:
+                    if ask(i >= j, assumptions):
+                        to_remove.append(j)
+        new_args = []
+        for i in self.args:
+            if i not in to_remove:
+                new_args.append(i)
+        return Max(*new_args, evaluate=False)
+
 
 class Min(MinMaxBase, Application):
     """
@@ -865,6 +880,20 @@ class Min(MinMaxBase, Application):
 
     def _eval_is_negative(self):
         return fuzzy_or(a.is_negative for a in self.args)
+
+    def _eval_refine(self, assumptions):
+        from sympy.assumptions.ask import ask
+        to_remove = []
+        for i in self.args:
+            for j in self.args:
+                if i != j and i not in to_remove and j not in to_remove:
+                    if ask(i <= j, assumptions):
+                        to_remove.append(j)
+        new_args = []
+        for i in self.args:
+            if i not in to_remove:
+                new_args.append(i)
+        return Min(*new_args, evaluate=False)
 
 
 class Rem(Function):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -805,12 +805,12 @@ class Max(MinMaxBase, Application):
         return fuzzy_and(a.is_negative for a in self.args)
 
     def _eval_refine(self, assumptions):
-        from sympy.assumptions.ask import ask
+        from sympy.assumptions.ask import ask, Q
         to_remove = []
         for i in self.args:
             for j in self.args:
                 if i != j and i not in to_remove and j not in to_remove:
-                    if ask(i >= j, assumptions):
+                    if ask(Q.ge(i, j), assumptions):
                         to_remove.append(j)
         new_args = []
         for i in self.args:

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,11 +1,12 @@
 import itertools as it
 
+from sympy.assumptions import refine, Q
 from sympy.core.expr import unchanged
 from sympy.core.function import Function
 from sympy.core.numbers import I, oo, Rational
 from sympy.core.power import Pow
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol, symbols
 from sympy.external import import_module
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor, ceiling
@@ -461,11 +462,20 @@ def test_issue_14000():
     assert root(16, 4, 2, evaluate=False).has(Pow) == True
     assert real_root(-8, 3, evaluate=False).has(Pow) == True
 
+
+def test_refine_MinMax():
+    a, b, c = symbols('a b c')
+    assert refine(Max(a, b, c), Q.gt(a, c)) == Max(a, b)
+    assert refine(Min(a, b, c), Q.gt(a, c)) == Min(b, c)
+    # assert refine(Max(a, b, c), Q.positive(a) and Q.negative(c)) == Max(a, b)
+
+
 def test_issue_6899():
     from sympy.core.function import Lambda
     x = Symbol('x')
     eqn = Lambda(x, x)
     assert eqn.func(*eqn.args) == eqn
+
 
 def test_Rem():
     from sympy.abc import x, y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to https://github.com/sympy/sympy/discussions/22515

#### Brief description of what is fixed or changed
Just realized that there is a Discussions-tab... Found https://github.com/sympy/sympy/discussions/22515 and decided to make a stab at it.

Not really happy with the code, but can currently not figure out a better way of doing it... 

#### Other comments

I would have expected something else than an error here:
`refine(Max(a, b, c), Q.positive(a) & Q.negative(c))`

```
Traceback (most recent call last):

  File "C:\Users\Oscar\AppData\Local\Temp/ipykernel_22316/742831045.py", line 1, in <module>
    refine(Max(a, b, c), Q.positive(a) & Q.negative(c))

  File "C:\Users\Oscar\sympy\sympy\assumptions\refine.py", line 55, in refine
    ref_expr = expr._eval_refine(assumptions)

  File "C:\Users\Oscar\sympy\sympy\functions\elementary\miscellaneous.py", line 813, in _eval_refine
    if ask(i > j, assumptions):

  File "C:\Users\Oscar\sympy\sympy\assumptions\ask.py", line 480, in ask
    raise ValueError("inconsistent assumptions %s" % assumptions)

ValueError: inconsistent assumptions Q.negative(c) & Q.positive(a)
```

Not really clear why they are deemed inconsistent....


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
   * Basic support for `refine` of `Min` and `Max`. 
<!-- END RELEASE NOTES -->
