### PR TITLE
fix #22606: gammasimp (y|func(y)) + gamma(x))

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1558,7 +1558,7 @@ def test_issue_15285():
 def test_issue_15432():
     assert integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp() == Piecewise(
         (gamma(n + 1)*polygamma(0, n) + gamma(n + 1)/n, re(n) + 1 > 0),
-        (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True)),integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp()
+        (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True))
 
 
 def test_issue_15124():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1558,7 +1558,7 @@ def test_issue_15285():
 def test_issue_15432():
     assert integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp() == Piecewise(
         (gamma(n + 1)*polygamma(0, n) + gamma(n + 1)/n, re(n) + 1 > 0),
-        (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True))
+        (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True)),integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp()
 
 
 def test_issue_15124():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -265,7 +265,7 @@ def test_mellin_transform_bessel():
 
     mt = MT(exp(-x/2)*besselk(a, x/2), x, s)
     mt0 = gammasimp(trigsimp(gammasimp(mt[0].expand(func=True))))
-    assert mt0 == 2*pi**Rational(3, 2)*cos(pi*s)*gamma(-s + S.Half)/(
+    assert mt0 == 2*pi**Rational(3, 2)*cos(pi*s)*gamma(S.Half - s)/(
         (cos(2*pi*a) - cos(2*pi*s))*gamma(-a - s + 1)*gamma(a - s + 1))
     assert mt[1:] == ((Max(-re(a), re(a)), oo), True)
     # TODO exp(x/2)*besselk(a, x/2) [etc] cannot currently be done

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -119,7 +119,7 @@ def test_mellin_transform():
 
     assert MT(abs(1 - x)**(-rho), x, s) == (
         2*sin(pi*rho/2)*gamma(1 - rho)*
-        cos(pi*(rho/2 - s))*gamma(s)*gamma(rho-s)/pi,
+        cos(pi*(s - rho/2))*gamma(s)*gamma(rho-s)/pi,
         (0, re(rho)), re(rho) < 1)
     mt = MT((1 - x)**(beta - 1)*Heaviside(1 - x)
             + a*(x - 1)**(beta - 1)*Heaviside(x - 1), x, s)

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -97,7 +97,10 @@ def dominant(expr, n):
     term0 = terms[-1]
     comp = [term0]  # comparable terms
     for t in terms[:-1]:
-        e = (term0 / t).gammasimp()
+        r = term0/t
+        e = r.gammasimp()
+        if e == r:
+            e = r.factor()
         l = limit_seq(e, n)
         if l is None:
             return None

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -1,8 +1,7 @@
 from sympy.core import Function, S, Mul, Pow, Add
 from sympy.core.sorting import ordered, default_sort_key
-from sympy.core.function import count_ops, expand_func
+from sympy.core.function import expand_func
 from sympy.core.symbol import Dummy
-from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions import gamma, sqrt, sin
 from sympy.polys import factor, cancel
 from sympy.utilities.iterables import sift, uniq
@@ -99,35 +98,6 @@ def _gammasimp(expr, as_comb):
     else:
         expr = expr.replace(_rf,
             lambda a, b: gamma(a + b)/gamma(a))
-
-    def rule(n, k):
-        coeff, rewrite = S.One, False
-
-        cn, _n = n.as_coeff_Add()
-
-        if _n and cn.is_Integer and cn:
-            coeff *= _rf(_n + 1, cn)/_rf(_n - k + 1, cn)
-            rewrite = True
-            n = _n
-
-        # this sort of binomial has already been removed by
-        # rising factorials but is left here in case the order
-        # of rule application is changed
-        if k.is_Add:
-            ck, _k = k.as_coeff_Add()
-            if _k and ck.is_Integer and ck:
-                coeff *= _rf(n - ck - _k + 1, ck)/_rf(_k + 1, ck)
-                rewrite = True
-                k = _k
-
-        if count_ops(k) > count_ops(n - k):
-            rewrite = True
-            k = n - k
-
-        if rewrite:
-            return coeff*binomial(n, k)
-
-    expr = expr.replace(binomial, rule)
 
     def rule_gamma(expr, level=0):
         """ Simplify products of gamma functions further. """

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -74,9 +74,7 @@ def gammasimp(expr):
             for fi in f])
         d = expr.xreplace(dict(zip(fun, dum)))
         if not d.has(gamma):
-            # match side-effect of _gammasimp since this is
-            # the expected state in the calling routine
-            return factor(expr)
+            return expr  # avoid side effects like factoring
         return _gammasimp(d, as_comb=False).xreplace(dict(zip(dum, simp)))
     return _gammasimp(expr, as_comb=False)
 

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -58,13 +58,16 @@ def gammasimp(expr):
     """
 
     expr = expr.rewrite(gamma)
+
     # compute_ST will be looking for Functions and we don't want
-    # it looking for non-gamma/binomial functions: issue 22606
-    # NOTE: functions should not be replaced with dummies if they
-    # have bound symbols
+    # it looking for non-gamma functions: issue 22606
+    # so we mask free, non-gamma functions
     f = expr.atoms(Function)
     # take out gammas
-    f -= {i for i in f if isinstance(i, gamma)}
+    gammas = {i for i in f if isinstance(i, gamma)}
+    if not gammas:
+        return expr  # avoid side effects like factoring
+    f -= gammas
     # keep only those without bound symbols
     f = f & expr.as_dummy().atoms(Function)
     if f:
@@ -73,9 +76,8 @@ def gammasimp(expr):
                 _gammasimp(a, as_comb=False) for a in fi.args]))
             for fi in f])
         d = expr.xreplace(dict(zip(fun, dum)))
-        if not d.has(gamma):
-            return expr  # avoid side effects like factoring
         return _gammasimp(d, as_comb=False).xreplace(dict(zip(dum, simp)))
+
     return _gammasimp(expr, as_comb=False)
 
 

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -72,8 +72,12 @@ def gammasimp(expr):
             (Dummy(), fi, fi.func(*[
                 _gammasimp(a, as_comb=False) for a in fi.args]))
             for fi in f])
-        s = _gammasimp(expr.xreplace(dict(zip(fun, dum))), as_comb=False)
-        return s.xreplace(dict(zip(dum, simp)))
+        d = expr.xreplace(dict(zip(fun, dum)))
+        if not d.has(gamma):
+            # match side-effect of _gammasimp since this is
+            # the expected state in the calling routine
+            return factor(expr)
+        return _gammasimp(d, as_comb=False).xreplace(dict(zip(dum, simp)))
     return _gammasimp(expr, as_comb=False)
 
 

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -1,11 +1,10 @@
 from sympy.core import Function, S, Mul, Pow, Add
 from sympy.core.sorting import ordered, default_sort_key
-from sympy.core.function import count_ops, expand_func, AppliedUndef
+from sympy.core.function import count_ops, expand_func
 from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions import gamma, sqrt, sin
 from sympy.polys import factor, cancel
-from sympy.simplify.radsimp import fraction
 from sympy.utilities.iterables import sift, uniq
 
 
@@ -76,8 +75,9 @@ def _gammasimp(expr, as_comb):
     combsimp() in combsimp.py.
     """
     # compute_ST will be looking for Functions and we don't want
-    # it looking for undefined functions: issue 22606
-    f = expr.atoms(AppliedUndef)
+    # it looking for non-gamma/binomial functions: issue 22606
+    f = expr.atoms(Function)
+    f = f - set([fi for fi in f if isinstance(fi, (gamma, binomial))])
     if f:
         dum, fun, simp = zip(*[
             (Dummy(), fi, fi.func(*[

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -74,7 +74,7 @@ def gammasimp(expr):
         dum, fun, simp = zip(*[
             (Dummy(), fi, fi.func(*[
                 _gammasimp(a, as_comb=False) for a in fi.args]))
-            for fi in f])
+            for fi in ordered(f)])
         d = expr.xreplace(dict(zip(fun, dum)))
         return _gammasimp(d, as_comb=False).xreplace(dict(zip(dum, simp)))
 

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -125,7 +125,7 @@ def _gammasimp(expr, as_comb):
 
     expr = expr.replace(binomial, rule)
 
-    def rule_gamma(expr, level=-1):
+    def rule_gamma(expr, level=0):
         """ Simplify products of gamma functions further. """
 
         if expr.is_Atom:
@@ -149,29 +149,6 @@ def _gammasimp(expr, as_comb):
             if x.is_Pow and (x.exp.is_integer or x.base.is_positive):
                 return gamma_factor(x.base)
             return False
-
-        # distribution pre-step
-        if level == -1:
-            n, d = fraction(expr, exact=True)
-            def distr(d, n):
-                # divide and Add arg in n by symbolic d and return
-                # else return None
-                if not d.is_number:
-                    n = list(Mul.make_args(n))
-                    for i, f in enumerate(n):
-                        if f.is_Add:
-                            n[i] = n[i].func(*[i/d for i in n[i].args])
-                            was = Mul(*n)
-                            return was
-            if not d.has(gamma):
-                did = distr(d, n)
-                if did is not None:
-                    return rule_gamma(did, level + 1)
-            elif not n.has(gamma):
-                did = distr(n, d)
-                if did is not None:
-                    return 1/rule_gamma(did, level + 1)
-            level += 1 # continue with level 0
 
         # recursion step
         if level == 0:

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -1,3 +1,4 @@
+from sympy.core.function import Function
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
@@ -112,4 +113,13 @@ def test_gammasimp():
     assert gammasimp(e) == e
 
     p = symbols("p", integer=True, positive=True)
-    assert gammasimp(gamma(-p+4)) == gamma(-p+4)
+    assert gammasimp(gamma(-p + 4)) == gamma(-p + 4)
+
+
+def test_issue_22606():
+    fx = Function('f')(x)
+    eq = x + gamma(y)
+    assert gammasimp(eq) == eq
+    assert eq == gammasimp(eq.subs(x, fx)).subs(fx, x)
+    assert 1/gammasimp(1/eq) == eq
+    assert gammasimp(fx.subs(x, eq)).args[0] == eq

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -122,5 +122,6 @@ def test_issue_22606():
     # seems like ans should be `eq`, not `(x*y + gamma(y + 1))/y`
     ans = gammasimp(eq)
     assert gammasimp(eq.subs(x, fx)).subs(fx, x) == ans
+    assert gammasimp(eq.subs(x, cos(x))).subs(cos(x), x) == ans
     assert 1/gammasimp(1/eq) == ans
     assert gammasimp(fx.subs(x, eq)).args[0] == ans

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -119,7 +119,8 @@ def test_gammasimp():
 def test_issue_22606():
     fx = Function('f')(x)
     eq = x + gamma(y)
-    assert gammasimp(eq) == eq
-    assert eq == gammasimp(eq.subs(x, fx)).subs(fx, x)
-    assert 1/gammasimp(1/eq) == eq
-    assert gammasimp(fx.subs(x, eq)).args[0] == eq
+    # seems like ans should be `eq`, not `(x*y + gamma(y + 1))/y`
+    ans = gammasimp(eq)
+    assert gammasimp(eq.subs(x, fx)).subs(fx, x) == ans
+    assert 1/gammasimp(1/eq) == ans
+    assert gammasimp(fx.subs(x, eq)).args[0] == ans

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -274,8 +274,9 @@ def test_NegativeMultinomial():
 
 def test_JointPSpace_marginal_distribution():
     T = MultivariateT('T', [0, 0], [[1, 0], [0, 1]], 2)
-    assert marginal_distribution(T, T[1])(x) == sqrt(2)*(x**2 + 2)/(
-        8*polar_lift(x**2/2 + 1)**Rational(5, 2))
+    got = marginal_distribution(T, T[1])(x)
+    ans = sqrt(2)*(x**2/2 + 1)/(4*polar_lift(x**2/2 + 1)**(S(5)/2))
+    assert got == ans, got
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
 
     t = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2915,7 +2915,7 @@ def test_Y2():
     w = symbols('w', real=True)
     s = symbols('s')
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
-    assert f == cos(t*w - t)
+    assert f == cos(t*(w - 1))
 
 
 def test_Y3():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#22606 

#### Brief description of what is fixed or changed

One~~Two~~ issue resolved:
1) divergence of behavior for `x + gamma(y)` vs `f(x) + gamma(y)`
~~2) returning of `(x + gamma(x + 1))/x` instead of `1 + gamma(x)` for `gammasimp(1 + gamma(x))`; the inverse expression is also handled~~

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * the presence of UndefinedFunction no longer affects how expressions with gamma functions are simplified
<!-- END RELEASE NOTES -->
