### PR TITLE
fix bottom_up for Dict/Tuple

### DIFF
--- a/sympy/core/tests/test_traversal.py
+++ b/sympy/core/tests/test_traversal.py
@@ -1,13 +1,15 @@
 from sympy.core.basic import Basic
-from sympy.core.containers import Tuple
+from sympy.core.expr import Expr
+from sympy.core.containers import Tuple, Dict
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import symbols
 from sympy.core.singleton import S
 from sympy.core.function import expand
 from sympy.core.numbers import I
 from sympy.integrals.integrals import Integral
-from sympy.polys.polytools import factor
-from sympy.core.traversal import preorder_traversal, use, postorder_traversal
+from sympy.polys.polytools import factor, cancel
+from sympy.core.traversal import (preorder_traversal, use,
+    postorder_traversal, bottom_up)
 from sympy.functions.elementary.piecewise import ExprCondPair, Piecewise
 
 b1 = Basic()
@@ -84,3 +86,12 @@ def test_postorder_traversal():
         ]
     assert list(postorder_traversal(('abc', ('d', 'ef')))) == [
         'abc', 'd', 'ef', ('d', 'ef'), ('abc', ('d', 'ef'))]
+
+
+def test_Dict_Tuple():
+    x = symbols('x')
+    n1 = (x - 1)/(1 - x)
+    assert bottom_up(Dict({1: n1}), cancel,
+        lambda x: isinstance(x, Expr)) == Dict({1: -1})
+    assert bottom_up(Tuple(n1), cancel,
+        lambda x: isinstance(x, Expr)) == Tuple(-1)

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -167,27 +167,18 @@ def walk(e, *target):
             yield from walk(i, *target)
 
 
-def bottom_up(rv, F, atoms=False, nonbasic=False):
-    """Apply ``F`` to all expressions in an expression tree from the
-    bottom up. If ``atoms`` is True, apply ``F`` even if there are no args;
-    if ``nonbasic`` is True, try to apply ``F`` to non-Basic objects.
+def bottom_up(rv, F, predicate=None):
+    """Apply ``F`` to all nodes in an expression tree from the
+    bottom up (default when ``predicate`` is None) else only those for
+    which `predicate(node)` is True.
     """
     args = getattr(rv, 'args', None)
-    if args is not None:
-        if args:
-            args = tuple([bottom_up(a, F, atoms, nonbasic) for a in args])
-            if args != rv.args:
-                rv = rv.func(*args)
-            rv = F(rv)
-        elif atoms:
-            rv = F(rv)
-    else:
-        if nonbasic:
-            try:
-                rv = F(rv)
-            except TypeError:
-                pass
-
+    if args:
+        args = tuple([bottom_up(a, F, predicate) for a in args])
+        if args != rv.args:
+            rv = rv.func(*args)
+    if predicate is not None and predicate(rv):
+        rv = F(rv)
     return rv
 
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -347,6 +347,7 @@ def test_cse_MatrixSymbol():
     B = MatrixSymbol("B", n, n)
     assert cse(B) == ([], [B])
 
+
 def test_cse_MatrixExpr():
     A = MatrixSymbol('A', 3, 3)
     y = MatrixSymbol('y', 3, 1)
@@ -519,6 +520,7 @@ def test_cse_ignore():
     assert not any(y in sub.free_symbols for _, sub in subst2), "Sub-expressions containing y must be ignored"
     assert any(sub - sqrt(x + 1) == 0 for _, sub in subst2), "cse failed to identify sqrt(x + 1) as sub-expression"
 
+
 def test_cse_ignore_issue_15002():
     l = [
         w*exp(x)*exp(-z),
@@ -527,6 +529,7 @@ def test_cse_ignore_issue_15002():
     substs, reduced = cse(l, ignore=(x,))
     rl = [e.subs(reversed(substs)) for e in reduced]
     assert rl == l
+
 
 def test_cse__performance():
     nexprs, nterms = 3, 20
@@ -564,6 +567,7 @@ def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
 
+
 def test_cse_release_variables():
     from sympy.simplify.cse_main import cse_release_variables
     _0, _1, _2, _3, _4 = symbols('_:5')
@@ -579,6 +583,7 @@ def test_cse_release_variables():
     r.reverse()
     assert eqs == [i.subs(r) for i in e]
 
+
 def test_cse_list():
     _cse = lambda x: cse(x, list=False)
     assert _cse(x) == ([], x)
@@ -590,6 +595,7 @@ def test_cse_list():
     assert _cse(Tuple(*it)) == ([], Tuple(*it))
     d = {x: 1}
     assert _cse(d) == ([], d)
+
 
 def test_issue_18991():
     A = MatrixSymbol('A', 2, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

It was ackward to make `bottom_up` work for non-Expr.
```python
>>> d = Dict({1: (x-1)/(1-x)})
>>> bottom_up(d, cancel)
Dict({1: (x-1)/(1-x)})
>>> bottom_up(d, lambda a: a if not isinstance(a, Expr) else cancel(a))
{1: -1}
```
now
```python
>>> bottom_up(d, cancel, lambda x: isinstance(x, Expr))
{1: -1}
```

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * bottom_up now uses `predicate` instead of `atoms` and `nonbasic` directives
<!-- END RELEASE NOTES -->
