### PR TITLE
printing/latex: Support latex printing for `AlgebraicNumber`.

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -611,6 +611,12 @@ class LatexPrinter(Printer):
             tex += ")"
         return tex
 
+    def _print_AlgebraicNumber(self, expr):
+        if expr.is_aliased:
+            return self._print(expr.as_poly().as_expr())
+        else:
+            return self._print(expr.as_expr())
+
     def _print_Pow(self, expr):
         # Treat x**Rational(1,n) as special case
         if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -8,7 +8,7 @@ from sympy.core.expr import UnevaluatedExpr
 from sympy.core.function import (Derivative, Function, Lambda, Subs, diff)
 from sympy.core.mod import Mod
 from sympy.core.mul import Mul
-from sympy.core.numbers import (Float, I, Integer, Rational, oo, pi)
+from sympy.core.numbers import (AlgebraicNumber, Float, I, Integer, Rational, oo, pi)
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -187,6 +187,13 @@ def test_latex_basic():
         r"\left(x + 1\right)^{\frac{3}{4}}"
     assert latex((x + 1)**Rational(3, 4), fold_frac_powers=True) == \
         r"\left(x + 1\right)^{3/4}"
+    assert latex(AlgebraicNumber(sqrt(2))) == r"\sqrt{2}"
+    assert latex(AlgebraicNumber(sqrt(2), [3, -7])) == r"-7 + 3 \sqrt{2}"
+    assert latex(AlgebraicNumber(sqrt(2), alias='alpha')) == r"\alpha"
+    assert latex(AlgebraicNumber(sqrt(2), [3, -7], alias='alpha')) == \
+        r"3 \alpha - 7"
+    assert latex(AlgebraicNumber(2**(S(1)/3), [1, 3, -7], alias='beta')) == \
+           r"\beta^{2} + 3 \beta - 7"
 
     assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Added a `_print_AlgebraicNumber()` method to the `LatexPrinter` class, which didn't have one yet.


#### Other comments

I just copied the exact `_print_AlgebraicNumber()` method from the `StrPrinter` class, which does the right thing here as well.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Support latex printing for `AlgebraicNumber`
<!-- END RELEASE NOTES -->
