### PR TITLE
core/basic: __eq__ ignores iterables like Expr.__eq__

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -13,7 +13,7 @@ from ._print_helpers import Printable
 
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import iterable, numbered_symbols
+from sympy.utilities.iterables import iterable, numbered_symbols, NotIterable
 from sympy.utilities.misc import filldedent, func_name
 
 from inspect import getmro
@@ -342,9 +342,15 @@ class Basic(Printable, metaclass=ManagedProperties):
             return True
 
         if not isinstance(other, Basic):
+            if iterable(other, exclude=(str, NotIterable)
+                    ) and not hasattr(other, '_sympy_'):
+                # XXX iterable self should have it's own __eq__
+                # method if the path gives a false negative
+                # comparison
+                return False
             try:
                 other = _sympify(other)
-            except SympifyError:
+            except (SympifyError, SyntaxError):
                 return NotImplemented
 
         if type(self) != type(other):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -328,10 +328,10 @@ class Basic(Printable, metaclass=ManagedProperties):
 
         If a class that overrides __eq__() needs to retain the
         implementation of __hash__() from a parent class, the
-        interpreter must be told this explicitly by setting __hash__ =
-        <ParentClass>.__hash__. Otherwise the inheritance of __hash__()
-        will be blocked, just as if __hash__ had been explicitly set to
-        None.
+        interpreter must be told this explicitly by setting 
+        __hash__ : Callable[[object], int] = <ParentClass>.__hash__. 
+        Otherwise the inheritance of __hash__() will be blocked, 
+        just as if __hash__ had been explicitly set to None.
 
         References
         ==========

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -328,9 +328,9 @@ class Basic(Printable, metaclass=ManagedProperties):
 
         If a class that overrides __eq__() needs to retain the
         implementation of __hash__() from a parent class, the
-        interpreter must be told this explicitly by setting 
-        __hash__ : Callable[[object], int] = <ParentClass>.__hash__. 
-        Otherwise the inheritance of __hash__() will be blocked, 
+        interpreter must be told this explicitly by setting
+        __hash__ : Callable[[object], int] = <ParentClass>.__hash__.
+        Otherwise the inheritance of __hash__() will be blocked,
         just as if __hash__ had been explicitly set to None.
 
         References

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,6 +8,7 @@
 
 from collections import OrderedDict
 from collections.abc import MutableSet
+from typing import Callable
 
 from .basic import Basic
 from .sorting import default_sort_key
@@ -309,8 +310,7 @@ class Dict(Basic):
             return self == Dict(other)
         return super().__eq__(other)
 
-    def __hash__(self):
-        return Basic.__hash__(self)
+    __hash__ : Callable[[object], int] = Basic.__hash___
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,7 @@
 
 from collections import OrderedDict
 from collections.abc import MutableSet
-from typing import Callable
+from typing import Any, Callable
 
 from .basic import Basic
 from .sorting import default_sort_key
@@ -310,7 +310,7 @@ class Dict(Basic):
             return self == Dict(other)
         return super().__eq__(other)
 
-    __hash__ : Callable[[object], int] = Basic.__hash___
+    __hash__ : Callable[[Basic], Any] = Basic.__hash__
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -304,6 +304,13 @@ class Dict(Basic):
     def _sorted_args(self):
         return tuple(sorted(self.args, key=default_sort_key))
 
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            return self == Dict(other)
+        return super().__eq__(other)
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
 # this handles dict, defaultdict, OrderedDict
 converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Callable
 from functools import reduce
 from collections import defaultdict
 import inspect
@@ -1973,8 +1973,7 @@ class FiniteSet(Set):
             return self._args_set == other
         return super().__eq__(other)
 
-    def __hash__(self):
-        return Basic.__hash__(self)
+    __hash__ : Callable[[object], int] = Basic.__hash___
 
 converter[set] = lambda x: FiniteSet(*x)
 converter[frozenset] = lambda x: FiniteSet(*x)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1968,6 +1968,13 @@ class FiniteSet(Set):
             raise TypeError("Invalid comparison of set with %s" % func_name(other))
         return self.is_proper_subset(other)
 
+    def __eq__(self, other):
+        if isinstance(other, (set, frozenset)):
+            return self._args_set == other
+        return super().__eq__(other)
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
 converter[set] = lambda x: FiniteSet(*x)
 converter[frozenset] = lambda x: FiniteSet(*x)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable
+from typing import Any, Callable, Optional
 from functools import reduce
 from collections import defaultdict
 import inspect
@@ -1973,7 +1973,7 @@ class FiniteSet(Set):
             return self._args_set == other
         return super().__eq__(other)
 
-    __hash__ : Callable[[object], int] = Basic.__hash___
+    __hash__ : Callable[[Basic], Any] = Basic.__hash__
 
 converter[set] = lambda x: FiniteSet(*x)
 converter[frozenset] = lambda x: FiniteSet(*x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
follow-up from #22593
See also https://github.com/sympy/sympy/pull/22607

#### Brief description of what is fixed or changed
Recently `Expr.__eq__` was updated to not convert iterables with
`_sympify`. This is now also added to `Basic.__eq__`.

`FiniteSet` and `Dict` now have explicit checks.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
