### PR TITLE
documentation tutorial: Append What's Next page

### DIFF
--- a/doc/src/tutorial/index.rst
+++ b/doc/src/tutorial/index.rst
@@ -58,3 +58,4 @@ write to our `mailing list
    intro.rst
    gotchas.rst
    features.rst
+   next.rst

--- a/doc/src/tutorial/next.rst
+++ b/doc/src/tutorial/next.rst
@@ -3,7 +3,7 @@ What’s Next
 
 Congratulations on finishing the SymPy tutorial!
 
-The next step to help you get started is to go to the :ref:`How-to Guides <guides>` for instructions on how to do different key developer tasks.
+If you are a developer interested in using SymPy in your code, please visit the :ref:`How-to Guides <guides>` which discuss key developer tasks.
 
 Intermediate SymPy users and developers might want to visit the :ref:`Explanation <explanation>` section for common pitfalls and advanced topics.
 

--- a/doc/src/tutorial/next.rst
+++ b/doc/src/tutorial/next.rst
@@ -1,24 +1,10 @@
 What’s Next
 ===========
 
-**Congratulations on finishing the SymPy tutorial!**
+Congratulations on finishing the SymPy tutorial!
 
-The next step to help you get started is to go to the
-`guides <https://docs.sympy.org/dev/guides/index.html#guides>`__ for
-instructions on how to do different key developer tasks:
+The next step to help you get started is to go to the :ref:`How-to Guides <guides>` for instructions on how to do different key developer tasks.
 
-.. toctree::
-   :maxdepth: 1
+Intermediate SymPy users and developers might want to visit the :ref:`Explanation <explanation>` section for common pitfalls and advanced topics.
 
-   ../guides/getting_started/index.rst
-   ../guides/assumptions.rst
-   ../guides/booleans.rst
-   ../guides/contributing/index.rst
-
-Intermediate SymPy users and developers might want to visit the
-`explanation <https://docs.sympy.org/dev/explanation/index.html#explanation>`__
-section for common pitfalls and advanced topics.
-
-The `SymPy API
-Reference <https://docs.sympy.org/dev/reference/index.html#reference>`__
-has a detailed description of the SymPy API.
+The :ref:`SymPy API Reference <reference>` has a detailed description of the SymPy API.

--- a/doc/src/tutorial/next.rst
+++ b/doc/src/tutorial/next.rst
@@ -1,0 +1,21 @@
+What’s Next
+===========
+
+**Congratulations on finishing the SymPy tutorial!**
+
+The next step to help you get started is to go to the
+`guides <https://docs.sympy.org/dev/guides/index.html#guides>`__ for
+instructions on how to do different key developer tasks:
+
++ `Getting Started <getting_started/index.html>`__ 
++ `Assumptions <assumptions.html>`__
++ `Symbolic and fuzzy booleans <booleans.html>`__
++ `Contributing to SymPy <contributing/index.html>`__ 
+
+Intermediate SymPy users and developers might want to visit the
+`explanation <https://docs.sympy.org/dev/explanation/index.html#explanation>`__
+section for common pitfalls and advanced topics.
+
+The `SymPy API
+Reference <https://docs.sympy.org/dev/reference/index.html#reference>`__
+has a detailed description of the SymPy API.

--- a/doc/src/tutorial/next.rst
+++ b/doc/src/tutorial/next.rst
@@ -7,10 +7,13 @@ The next step to help you get started is to go to the
 `guides <https://docs.sympy.org/dev/guides/index.html#guides>`__ for
 instructions on how to do different key developer tasks:
 
-+ `Getting Started <getting_started/index.html>`__ 
-+ `Assumptions <assumptions.html>`__
-+ `Symbolic and fuzzy booleans <booleans.html>`__
-+ `Contributing to SymPy <contributing/index.html>`__ 
+.. toctree::
+   :maxdepth: 1
+
+   ../guides/getting_started/index.rst
+   ../guides/assumptions.rst
+   ../guides/booleans.rst
+   ../guides/contributing/index.rst
 
 Intermediate SymPy users and developers might want to visit the
 `explanation <https://docs.sympy.org/dev/explanation/index.html#explanation>`__


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #22586

#### Brief description of what is fixed or changed
Added What's Next page with links to the three other Diataxis Framework sections:

- How-to Guides
- Explanation
- SymPy API Reference

#### Other comments
Tutorial index page lists What's Next page as the last (major) item.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->