### PR TITLE
polys/numberfields: Support conversions `ANP` --> `AlgebraicNumber`

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2835,6 +2835,50 @@ class AlgebraicNumber(Expr):
                     return AlgebraicNumber(r)
         return self
 
+    def field_element(self, coeffs):
+        r"""
+        Form another element of the same number field.
+
+        Explanation
+        ===========
+
+        If we represent $\alpha \in \mathbb{Q}(\theta)$, form another element
+        $\beta \in \mathbb{Q}(\theta)$ of the same number field.
+
+        Parameters
+        ==========
+
+        coeffs : list, :py:class:`~.ANP`
+            Like the *coeffs* arg to the class
+            :py:meth:`constructor<.AlgebraicNumber.__new__>`, defines the
+            new element as a polynomial in the primitive element.
+
+            If a list, the elements should be integers or rational numbers.
+            If an :py:class:`~.ANP`, we take its coefficients (using its
+            :py:meth:`~.ANP.to_list()` method).
+
+        Examples
+        ========
+
+        >>> from sympy import AlgebraicNumber, sqrt
+        >>> a = AlgebraicNumber(sqrt(5), [-1, 1])
+        >>> b = a.field_element([3, 2])
+        >>> print(a)
+        1 - sqrt(5)
+        >>> print(b)
+        2 + 3*sqrt(5)
+        >>> print(b.primitive_element() == a.primitive_element())
+        True
+
+        See Also
+        ========
+
+        .AlgebraicNumber.__new__()
+
+        """
+        return AlgebraicNumber(
+            (self.minpoly, self.root), coeffs=coeffs, alias=self.alias)
+
     @property
     def is_primitive_element(self):
         r"""
@@ -2858,7 +2902,7 @@ class AlgebraicNumber(Expr):
         """
         if self.is_primitive_element:
             return self
-        return AlgebraicNumber((self.minpoly, self.root), coeffs=[1, 0])
+        return self.field_element([1, 0])
 
     def to_primitive_element(self, radicals=True):
         r"""

--- a/sympy/polys/numberfields/basis.py
+++ b/sympy/polys/numberfields/basis.py
@@ -122,7 +122,7 @@ def round_two(T, radicals=None):
     Submodule[[2, 0, 0], [0, 2, 0], [0, 1, 1]]/2
     >>> print(K.discriminant())
     -503
-    >>> print([K.to_sympy(a) for a in K.integral_basis()])
+    >>> print(K.integral_basis(fmt='sympy'))
     [1, theta, theta**2/2 + theta/2]
 
     Calling directly:

--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -279,7 +279,7 @@ class PrimeIdeal(IntegerPowerable):
         >>> k = QQ.algebraic_field((Phi, zeta))
         >>> P = k.primes_above(11)
         >>> frp = P[0]
-        >>> B = [k.to_sympy(a) for a in k.integral_basis()]
+        >>> B = k.integral_basis(fmt='sympy')
         >>> print([frp.reduce_poly(b, zeta) for b in B])
         [1, zeta, zeta**2, -5*zeta**2 - 4*zeta + 1, -zeta**2 - zeta - 5,
          4*zeta**2 - zeta - 1]

--- a/sympy/polys/numberfields/tests/test_basis.py
+++ b/sympy/polys/numberfields/tests/test_basis.py
@@ -1,6 +1,9 @@
-from sympy import QQ
 from sympy.abc import theta, x
+from sympy.core import S
+from sympy.core.numbers import AlgebraicNumber
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.polys import Poly, cyclotomic_poly
+from sympy.polys.domains import QQ
 from sympy.polys.matrices import DomainMatrix, DM
 from sympy.polys.numberfields.basis import round_two
 from sympy.testing.pytest import raises
@@ -65,3 +68,15 @@ def test_round_two():
         # The computed basis need not equal the expected one, but their quotient
         # must be unimodular:
         assert (B.inv()*B_exp).det()**2 == 1
+
+
+def test_AlgebraicField_integral_basis():
+    alpha = AlgebraicNumber(sqrt(5), alias='alpha')
+    k = QQ.algebraic_field(alpha)
+    B0 = k.integral_basis()
+    B1 = k.integral_basis(fmt='sympy')
+    B2 = k.integral_basis(fmt='alg')
+    assert B0 == [k([1]), k([S.Half, S.Half])]
+    assert B1 == [1, S.Half + alpha/2]
+    assert B2 == [alpha.field_element([1]),
+                  alpha.field_element([S.Half, S.Half])]

--- a/sympy/polys/numberfields/tests/test_primes.py
+++ b/sympy/polys/numberfields/tests/test_primes.py
@@ -255,7 +255,7 @@ def test_PrimeIdeal_reduce_poly():
     k = QQ.algebraic_field((T, x))
     P = k.primes_above(11)
     frp = P[0]
-    B = [k.to_sympy(a) for a in k.integral_basis()]
+    B = k.integral_basis(fmt='sympy')
     assert [frp.reduce_poly(b, x) for b in B] == [
         1, x, x ** 2, -5 * x ** 2 - 4 * x + 1, -x ** 2 - x - 5,
         4 * x ** 2 - x - 1]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

* Give the `AlgebraicField` class a `to_alg_num(a)` method, which converts an `ANP` to an `AlgebraicNumber`.

* This is supported by a new method, `AlgebraicNumber.field_element()`, which is useful on its own.

* Make `AlgebraicField.integral_basis()` accept a `fmt` arg, so user can define the
  desired format for the returned basis elements.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Add support for conversions `ANP` --> `AlgebraicNumber`.
<!-- END RELEASE NOTES -->
