### PR TITLE
sympy/core: Basic and Expr __eq__ are merged

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -274,9 +274,13 @@ def is_decreasing(expression, interval=S.Reals, symbol=None):
     >>> from sympy import S, Interval, oo
     >>> is_decreasing(1/(x**2 - 3*x), Interval.open(S(3)/2, 3))
     True
+    >>> is_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
+    True
     >>> is_decreasing(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     True
     >>> is_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, S(3)/2))
+    False
+    >>> is_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, 1.5))
     False
     >>> is_decreasing(-x**2, Interval(-oo, 0))
     False
@@ -318,6 +322,8 @@ def is_strictly_decreasing(expression, interval=S.Reals, symbol=None):
     >>> is_strictly_decreasing(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     True
     >>> is_strictly_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, S(3)/2))
+    False
+    >>> is_strictly_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, 1.5))
     False
     >>> is_strictly_decreasing(-x**2, Interval(-oo, 0))
     False
@@ -362,6 +368,8 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
     >>> from sympy import is_monotonic
     >>> from sympy.abc import x, y
     >>> from sympy import S, Interval, oo
+    >>> is_monotonic(1/(x**2 - 3*x), Interval.open(S(3)/2, 3))
+    True
     >>> is_monotonic(1/(x**2 - 3*x), Interval.open(1.5, 3))
     True
     >>> is_monotonic(1/(x**2 - 3*x), Interval.Lopen(3, oo))

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -272,7 +272,7 @@ def is_decreasing(expression, interval=S.Reals, symbol=None):
     >>> from sympy import is_decreasing
     >>> from sympy.abc import x, y
     >>> from sympy import S, Interval, oo
-    >>> is_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
+    >>> is_decreasing(1/(x**2 - 3*x), Interval.open(S(3)/2, 3))
     True
     >>> is_decreasing(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     True

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -67,6 +67,7 @@ def test_is_decreasing():
     b = Symbol('b', positive=True)
 
     assert is_decreasing(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
+    assert is_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
     assert is_decreasing(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     assert not is_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, Rational(3, 2)))
     assert not is_decreasing(-x**2, Interval(-oo, 0))

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -81,13 +81,12 @@ def test_is_strictly_decreasing():
     assert not is_strictly_decreasing(-x**2, Interval(-oo, 0))
     assert not is_strictly_decreasing(1)
     assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
-    print(is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3)))
     assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
-
 
 def test_is_monotonic():
     """Test whether is_monotonic returns correct value."""
     assert is_monotonic(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
+    assert is_monotonic(1/(x**2 - 3*x), Interval.open(1.5, 3))
     assert is_monotonic(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     assert is_monotonic(x**3 - 3*x**2 + 4*x, S.Reals)
     assert not is_monotonic(-x**2, S.Reals)

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -66,7 +66,7 @@ def test_is_decreasing():
     """Test whether is_decreasing returns correct value."""
     b = Symbol('b', positive=True)
 
-    assert is_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
+    assert is_decreasing(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
     assert is_decreasing(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     assert not is_decreasing(1/(x**2 - 3*x), Interval.Ropen(-oo, Rational(3, 2)))
     assert not is_decreasing(-x**2, Interval(-oo, 0))
@@ -80,12 +80,14 @@ def test_is_strictly_decreasing():
         1/(x**2 - 3*x), Interval.Ropen(-oo, Rational(3, 2)))
     assert not is_strictly_decreasing(-x**2, Interval(-oo, 0))
     assert not is_strictly_decreasing(1)
+    assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
+    print(is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3)))
     assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
 
 
 def test_is_monotonic():
     """Test whether is_monotonic returns correct value."""
-    assert is_monotonic(1/(x**2 - 3*x), Interval.open(1.5, 3))
+    assert is_monotonic(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
     assert is_monotonic(1/(x**2 - 3*x), Interval.Lopen(3, oo))
     assert is_monotonic(x**3 - 3*x**2 + 4*x, S.Reals)
     assert not is_monotonic(-x**2, S.Reals)

--- a/sympy/core/sorting.py
+++ b/sympy/core/sorting.py
@@ -172,6 +172,8 @@ def _node_count(e):
     # some object has a non-Basic arg, it needs to be
     # fixed since it is intended that all Basic args
     # are of Basic type (though this is not easy to enforce).
+    if e.is_Float:
+        return 0.5
     return 1 + sum(map(_node_count, e.args))
 
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -124,7 +124,7 @@ def test_piecewise1():
     assert p6.subs(x, n) == Undefined
 
     # Test evalf
-    assert p.evalf() == p
+    assert p.evalf() == Piecewise((-1.0, x < -1), (x**2, x < 0), (log(x), True))
     assert p.evalf(subs={x: -2}) == -1
     assert p.evalf(subs={x: -1}) == 1
     assert p.evalf(subs={x: 1}) == log(1)

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -4,6 +4,7 @@ from sympy.core.numbers import ilcm
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
+from sympy.core.sorting import ordered
 from sympy.sets.fancysets import ComplexRegion
 from sympy.sets.sets import (FiniteSet, Intersection, Interval, Set, Union)
 from sympy.multipledispatch import dispatch
@@ -426,7 +427,10 @@ def intersection_sets(a, b): # noqa:F811
             start = a.start
             left_open = a.left_open
         else:
-            start = a.start
+            #this is to ensure that if Eq(a.start,b.start) but
+            #type(a.start) != type(b.start) the order of a and b
+            #does not matter for the result
+            start = list(ordered([a,b]))[0].start
             left_open = a.left_open or b.left_open
 
         if a.end < b.end:
@@ -436,7 +440,7 @@ def intersection_sets(a, b): # noqa:F811
             end = b.end
             right_open = b.right_open
         else:
-            end = a.end
+            end = list(ordered([a,b]))[0].end
             right_open = a.right_open or b.right_open
 
         if end - start == 0 and (left_open or right_open):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -396,7 +396,8 @@ class Set(Basic, EvalfMixin):
         # XXX: We shouldn't do this. A query like this should be handled
         # without evaluating new Set objects. It should be the other way round
         # so that the intersect method uses is_subset for evaluation.
-        if self.intersect(other) == self:
+        intersect = self.intersect(other)
+        if intersect == self:
             return True
 
     def _eval_is_subset(self, other):
@@ -1154,6 +1155,13 @@ class Interval(Set):
                 return None
             return false
 
+    def is_subset(self, other):
+        is_subset = super().is_subset(other)
+        if isinstance(other, Interval) and is_subset is None:
+            intersect = self.intersect(other)
+            if Eq(intersect.right, self.right) == True and Eq(intersect.left, self.left) == True:
+                return True
+        return subset
 
 class Union(Set, LatticeOp):
     """
@@ -1364,7 +1372,6 @@ class Intersection(Set, LatticeOp):
         if evaluate:
             args = list(cls._new_args_filter(args))
             return simplify_intersection(args)
-
         args = list(ordered(args, Set._infimum_key))
 
         obj = Basic.__new__(cls, *args)
@@ -2445,7 +2452,6 @@ def simplify_intersection(args):
             args.remove(s)
             other_sets = args + [s.args[0]]
             return Complement(Intersection(*other_sets), s.args[1])
-
 
     from sympy.sets.handlers.intersection import intersection_sets
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1364,6 +1364,7 @@ class Intersection(Set, LatticeOp):
         if evaluate:
             args = list(cls._new_args_filter(args))
             return simplify_intersection(args)
+
         args = list(ordered(args, Set._infimum_key))
 
         obj = Basic.__new__(cls, *args)
@@ -2444,6 +2445,7 @@ def simplify_intersection(args):
             args.remove(s)
             other_sets = args + [s.args[0]]
             return Complement(Intersection(*other_sets), s.args[1])
+
 
     from sympy.sets.handlers.intersection import intersection_sets
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -396,8 +396,7 @@ class Set(Basic, EvalfMixin):
         # XXX: We shouldn't do this. A query like this should be handled
         # without evaluating new Set objects. It should be the other way round
         # so that the intersect method uses is_subset for evaluation.
-        intersect = self.intersect(other)
-        if intersect == self:
+        if self.intersect(other) == self:
             return True
 
     def _eval_is_subset(self, other):
@@ -1155,13 +1154,6 @@ class Interval(Set):
                 return None
             return false
 
-    def is_subset(self, other):
-        is_subset = super().is_subset(other)
-        if isinstance(other, Interval) and is_subset is None:
-            intersect = self.intersect(other)
-            if Eq(intersect.right, self.right) == True and Eq(intersect.left, self.left) == True:
-                return True
-        return is_subset
 
 class Union(Set, LatticeOp):
     """

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1161,7 +1161,7 @@ class Interval(Set):
             intersect = self.intersect(other)
             if Eq(intersect.right, self.right) == True and Eq(intersect.left, self.left) == True:
                 return True
-        return subset
+        return is_subset
 
 class Union(Set, LatticeOp):
     """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1006,8 +1006,6 @@ def test_finite_basic():
     assert A >= AandB and B >= AandB
     assert A > AandB and B > AandB
 
-    assert FiniteSet(1.0) == FiniteSet(1)
-
 
 def test_product_basic():
     H, T = 'H', 'T'

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -389,7 +389,7 @@ def test_issue_8974():
 
 def test_issue_10198():
     assert reduce_inequalities(
-        -1 + 1/abs(1/x - 1) < 0) == (x > -oo) & (x < 1/2) & Ne(x, 0)
+        -1 + 1/abs(1/x - 1) < 0) == (x > -oo) & (x < S(1)/2) & Ne(x, 0)
 
     assert reduce_inequalities(abs(1/sqrt(x)) - 1, x) == Eq(x, 1)
     assert reduce_abs_inequality(-3 + 1/abs(1 - 1/x), '<', x) == \

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1550,8 +1550,8 @@ def test_ContinuousDistributionHandmade():
         (S.Half, (x>=2)&(x<3)), (0, True)))
     dens = ContinuousDistributionHandmade(dens, set=Interval(0, 3))
     space = SingleContinuousPSpace(z, dens)
-    assert dens.pdf == Lambda(x, Piecewise((1/2, (x >= 0) & (x < 1)),
-        (0, (x >= 1) & (x < 2)), (1/2, (x >= 2) & (x < 3)), (0, True)))
+    assert dens.pdf == Lambda(x, Piecewise((S(1)/2, (x >= 0) & (x < 1)),
+        (0, (x >= 1) & (x < 2)), (S(1)/2, (x >= 2) & (x < 3)), (0, True)))
     assert median(space.value) == Interval(1, 2)
     assert E(space.value) == Rational(3, 2)
     assert variance(space.value) == Rational(13, 12)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Helps with https://github.com/sympy/sympy/pull/22607

#### Brief description of what is fixed or changed
Currently, `Expr` ensures that `Expr(S(1)) != Expr(S(1.0))`. However, this does not work for
`Basic` : `Basic(S(1)) == Basic(S(1.0))`. Since this is the only difference currently between
`Basic` and `Expr`'s `__eq__` method, this PR attempts to merge these two so that
`__eq__` only has to be defined in `Basic`.

This causes backwards compatibility issues, but I believe `Basic(S(1)) == Basic(S(1.0))`
should be considered a bug.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `Basic` now behaves the same as `Expr` when comparing structural equality with `==`.
<!-- END RELEASE NOTES -->
