### PR TITLE
polys/domains: Improve `ANP.__init__()`.

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1512,7 +1512,9 @@ class ANP(PicklableWithSlots, CantSympify):
         if type(rep) is dict:
             self.rep = dup_from_dict(rep, dom)
         else:
-            if type(rep) is not list:
+            if type(rep) is list:
+                rep = [dom.convert(a) for a in rep]
+            else:
                 rep = [dom.convert(rep)]
 
             self.rep = dup_strip(rep)

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -1,8 +1,10 @@
 """Tests for OO layer of several polynomial representations. """
 
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.polyclasses import DMP, DMF, ANP
-from sympy.polys.polyerrors import ExactQuotientFailed, NotInvertible
+from sympy.polys.polyerrors import (CoercionFailed, ExactQuotientFailed,
+                                    NotInvertible)
 from sympy.polys.specialpolys import f_polys
 from sympy.testing.pytest import raises
 
@@ -430,6 +432,12 @@ def test_ANP___init__():
     assert f.rep == [QQ(1)]
     assert f.mod == [QQ(1), QQ(0), QQ(1)]
     assert f.dom == QQ
+
+    f = ANP([1, 0.5], mod, QQ)
+
+    assert all(QQ.of_type(a) for a in f.rep)
+
+    raises(CoercionFailed, lambda: ANP([sqrt(2)], mod, QQ))
 
 
 def test_ANP___eq__():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In `ANP.__init__()`, ensure that the elements of the incoming `rep` are converted to the underlying domain whether
or not `rep` is a list.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
