### PR TITLE
LaTeX and pretty printing for symbolic statistics

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2471,16 +2471,16 @@ class LatexPrinter(Printer):
         return result
 
     def _print_Expectation(self, expr):
-        return r"E\left[{}\right]".format(self._print(expr.args[0]))
+        return r"\operatorname{{E}}\left[{}\right]".format(self._print(expr.args[0]))
 
     def _print_Variance(self, expr):
-        return r"\operatorname{{var}}\left({}\right)".format(self._print(expr.args[0]))
+        return r"\operatorname{{Var}}\left({}\right)".format(self._print(expr.args[0]))
 
     def _print_Covariance(self, expr):
-        return r"\operatorname{{cov}}\left({}\right)".format(", ".join(self._print(arg) for arg in expr.args))
+        return r"\operatorname{{Cov}}\left({}\right)".format(", ".join(self._print(arg) for arg in expr.args))
 
     def _print_Probability(self, expr):
-        return r"P\left({}\right)".format(self._print(expr.args[0]))
+        return r"\operatorname{{P}}\left({}\right)".format(self._print(expr.args[0]))
 
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2029,7 +2029,7 @@ class LatexPrinter(Printer):
         if hasattr(d, 'as_boolean'):
             return '\\text{Domain: }' + self._print(d.as_boolean())
         elif hasattr(d, 'set'):
-            return ('\\text{Domain: }' + self._print(d.symbols) + '\\text{ in }' +
+            return ('\\text{Domain: }' + self._print(d.symbols) + ' \\in ' +
                     self._print(d.set))
         elif hasattr(d, 'symbols'):
             return '\\text{Domain on }' + self._print(d.symbols)
@@ -2469,6 +2469,18 @@ class LatexPrinter(Printer):
             arg1 = self._print(expr.args[1])
             result = "W{0}_{{{1}}}\\left({2}\\right)".format(exp, arg1, arg0)
         return result
+
+    def _print_Expectation(self, expr):
+        return r"E\left[{}\right]".format(self._print(expr.args[0]))
+
+    def _print_Variance(self, expr):
+        return r"\operatorname{{var}}\left({}\right)".format(self._print(expr.args[0]))
+
+    def _print_Covariance(self, expr):
+        return r"\operatorname{{cov}}\left({}\right)".format(", ".join(self._print(arg) for arg in expr.args))
+
+    def _print_Probability(self, expr):
+        return r"P\left({}\right)".format(self._print(expr.args[0]))
 
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1682,10 +1682,10 @@ class PrettyPrinter(Printer):
         return self._print_Function(e, func_name="W")
 
     def _print_Covariance(self, e):
-        return self._print_Function(e, func_name="cov")
+        return self._print_Function(e, func_name="Cov")
 
     def _print_Variance(self, e):
-        return self._print_Function(e, func_name="var")
+        return self._print_Function(e, func_name="Var")
 
     def _print_Probability(self, e):
         return self._print_Function(e, func_name="P")

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -766,13 +766,19 @@ class PrettyPrinter(Printer):
 
     def _print_TensorProduct(self, expr):
         # This should somehow share the code with _print_WedgeProduct:
-        circled_times = "\u2297"
+        if self._use_unicode:
+            circled_times = "\u2297"
+        else:
+            circled_times = ".*"
         return self._print_seq(expr.args, None, None, circled_times,
             parenthesize=lambda x: precedence_traditional(x) <= PRECEDENCE["Mul"])
 
     def _print_WedgeProduct(self, expr):
         # This should somehow share the code with _print_TensorProduct:
-        wedge_symbol = "\u2227"
+        if self._use_unicode:
+            wedge_symbol = "\u2227"
+        else:
+            wedge_symbol = '/\\'
         return self._print_seq(expr.args, None, None, wedge_symbol,
             parenthesize=lambda x: precedence_traditional(x) <= PRECEDENCE["Mul"])
 
@@ -1546,10 +1552,11 @@ class PrettyPrinter(Printer):
     def _print_Exp1(self, e):
         return prettyForm(pretty_atom('Exp1', 'e'))
 
-    def _print_Function(self, e, sort=False, func_name=None):
+    def _print_Function(self, e, sort=False, func_name=None, left='(',
+                        right=')'):
         # optional argument func_name for supplying custom names
         # XXX works only for applied functions
-        return self._helper_print_function(e.func, e.args, sort=sort, func_name=func_name)
+        return self._helper_print_function(e.func, e.args, sort=sort, func_name=func_name, left=left, right=right)
 
     def _print_mathieuc(self, e):
         return self._print_Function(e, func_name='C')
@@ -1563,7 +1570,9 @@ class PrettyPrinter(Printer):
     def _print_mathieusprime(self, e):
         return self._print_Function(e, func_name="S'")
 
-    def _helper_print_function(self, func, args, sort=False, func_name=None, delimiter=', ', elementwise=False):
+    def _helper_print_function(self, func, args, sort=False, func_name=None,
+                               delimiter=', ', elementwise=False, left='(',
+                               right=')'):
         if sort:
             args = sorted(args, key=default_sort_key)
 
@@ -1586,7 +1595,8 @@ class PrettyPrinter(Printer):
                 *stringPict.next(prettyFunc, circ)
             )
 
-        prettyArgs = prettyForm(*self._print_seq(args, delimiter=delimiter).parens())
+        prettyArgs = prettyForm(*self._print_seq(args, delimiter=delimiter).parens(
+                                                 left=left, right=right))
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -1670,6 +1680,18 @@ class PrettyPrinter(Printer):
 
     def _print_LambertW(self, e):
         return self._print_Function(e, func_name="W")
+
+    def _print_Covariance(self, e):
+        return self._print_Function(e, func_name="cov")
+
+    def _print_Variance(self, e):
+        return self._print_Function(e, func_name="var")
+
+    def _print_Probability(self, e):
+        return self._print_Function(e, func_name="P")
+
+    def _print_Expectation(self, e):
+        return self._print_Function(e, func_name="E", left='[', right=']')
 
     def _print_Lambda(self, e):
         expr = e.expr
@@ -2749,14 +2771,18 @@ class PrettyPrinter(Printer):
         return self._print(pretty_symbol(s))
 
     def _print_Differential(self, diff):
+        if self._use_unicode:
+            d = '\N{DOUBLE-STRUCK ITALIC SMALL D}'
+        else:
+            d = 'd'
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys.symbols[field._index].name
-            return self._print('\N{DOUBLE-STRUCK ITALIC SMALL D} ' + pretty_symbol(string))
+            return self._print(d + ' ' + pretty_symbol(string))
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())
-            return prettyForm(*pform.left("\N{DOUBLE-STRUCK ITALIC SMALL D}"))
+            return prettyForm(*pform.left(d))
 
     def _print_Tr(self, p):
         #TODO: Handle indices

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -66,6 +66,9 @@ from sympy.sets.conditionset import ConditionSet
 
 from sympy.sets import ImageSet, ProductSet
 from sympy.sets.setexpr import SetExpr
+from sympy.stats.crv_types import Normal
+from sympy.stats.symbolic_probability import (Covariance, Expectation,
+                                              Probability, Variance)
 from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
                                 MutableDenseNDimArray, MutableSparseNDimArray, tensorproduct)
 from sympy.tensor.functions import TensorProduct
@@ -3608,6 +3611,7 @@ def test_diffgeom_print_WedgeProduct():
     from sympy.diffgeom import WedgeProduct
     wp = WedgeProduct(R2.dx, R2.dy)
     assert upretty(wp) == "ⅆ x∧ⅆ y"
+    assert pretty(wp) == r"d x/\d y"
 
 
 def test_Adjoint():
@@ -7628,6 +7632,7 @@ def test_issue_17857():
     assert pretty(Range(-oo, oo)) == '{..., -1, 0, 1, ...}'
     assert pretty(Range(oo, -oo, -1)) == '{..., 1, 0, -1, ...}'
 
+
 def test_issue_18272():
     x = Symbol('x')
     n = Symbol('n')
@@ -7657,6 +7662,19 @@ def test_issue_18272():
 def test_Str():
     from sympy.core.symbol import Str
     assert pretty(Str('x')) == 'x'
+
+
+
+def test_symbolic_probability():
+    mu = symbols("mu")
+    sigma = symbols("sigma", positive=True)
+    X = Normal("X", mu, sigma)
+    assert pretty(Expectation(X)) == r'E[X]'
+    assert pretty(Variance(X)) == r'var(X)'
+    assert pretty(Probability(X > 0)) == r'P(X > 0)'
+    Y = Normal("Y", mu, sigma)
+    assert pretty(Covariance(X, Y)) == 'cov(X, Y)'
+
 
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7670,10 +7670,10 @@ def test_symbolic_probability():
     sigma = symbols("sigma", positive=True)
     X = Normal("X", mu, sigma)
     assert pretty(Expectation(X)) == r'E[X]'
-    assert pretty(Variance(X)) == r'var(X)'
+    assert pretty(Variance(X)) == r'Var(X)'
     assert pretty(Probability(X > 0)) == r'P(X > 0)'
     Y = Normal("Y", mu, sigma)
-    assert pretty(Covariance(X, Y)) == 'cov(X, Y)'
+    assert pretty(Covariance(X, Y)) == 'Cov(X, Y)'
 
 
 def test_diffgeom():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2621,11 +2621,11 @@ def test_latex_symbolic_probability():
     mu = symbols("mu")
     sigma = symbols("sigma", positive=True)
     X = Normal("X", mu, sigma)
-    assert latex(Expectation(X)) == r'E\left[X\right]'
-    assert latex(Variance(X)) == r'\operatorname{var}\left(X\right)'
-    assert latex(Probability(X > 0)) == r'P\left(X > 0\right)'
+    assert latex(Expectation(X)) == r'\operatorname{E}\left[X\right]'
+    assert latex(Variance(X)) == r'\operatorname{Var}\left(X\right)'
+    assert latex(Probability(X > 0)) == r'\operatorname{P}\left(X > 0\right)'
     Y = Normal("Y", mu, sigma)
-    assert latex(Covariance(X, Y)) == r'\operatorname{cov}\left(X, Y\right)'
+    assert latex(Covariance(X, Y)) == r'\operatorname{Cov}\left(X, Y\right)'
 
 
 def test_trace():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -63,6 +63,9 @@ from sympy.sets.contains import Contains
 from sympy.sets.fancysets import (ComplexRegion, ImageSet, Range)
 from sympy.sets.sets import (FiniteSet, Interval, Union, Intersection, Complement, SymmetricDifference, ProductSet)
 from sympy.sets.setexpr import SetExpr
+from sympy.stats.crv_types import Normal
+from sympy.stats.symbolic_probability import (Covariance, Expectation,
+                                              Probability, Variance)
 from sympy.tensor.array import (ImmutableDenseNDimArray,
                                 ImmutableSparseNDimArray,
                                 MutableSparseNDimArray,
@@ -1735,7 +1738,7 @@ def test_latex_RandomDomain():
         r"\text{Domain: }0 \leq a \wedge 0 \leq b \wedge a < \infty \wedge b < \infty"
 
     assert latex(RandomDomain(FiniteSet(x), FiniteSet(1, 2))) == \
-        r'\text{Domain: }\left\{x\right\}\text{ in }\left\{1, 2\right\}'
+        r'\text{Domain: }\left\{x\right\} \in \left\{1, 2\right\}'
 
 def test_PrettyPoly():
     from sympy.polys.domains import QQ
@@ -2612,6 +2615,17 @@ def test_issue_15353():
         r'\left\{\left( x, \  a\right)\; \middle|\; \left( x, \  a\right) \in ' \
         r'\mathbb{C}^{2} \wedge \sin{\left(a x \right)} = 0 \wedge ' \
         r'\cos{\left(a x \right)} = 0 \right\}'
+
+
+def test_latex_symbolic_probability():
+    mu = symbols("mu")
+    sigma = symbols("sigma", positive=True)
+    X = Normal("X", mu, sigma)
+    assert latex(Expectation(X)) == r'E\left[X\right]'
+    assert latex(Variance(X)) == r'\operatorname{var}\left(X\right)'
+    assert latex(Probability(X > 0)) == r'P\left(X > 0\right)'
+    Y = Normal("Y", mu, sigma)
+    assert latex(Covariance(X, Y)) == r'\operatorname{cov}\left(X, Y\right)'
 
 
 def test_trace():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #22654 

#### Brief description of what is fixed or changed
`Covariance`, `Expectation`, `Probability` and `Variance` now have dedicated LaTex and pretty printing.
![image](https://user-images.githubusercontent.com/8114497/145788669-61a5c6d1-2bf7-40ed-bdc1-d57a7da0ada0.png)
![image](https://user-images.githubusercontent.com/8114497/145788709-f1505c41-568c-4e93-a309-70345bd2ae38.png)

#### Other comments
Also changed so that a random domain prints using the `\in` symbol rather than the text `in`.

Added some rudimentary ASCII pretty-printing option for `Differential` (`d`), `WedgeProduct` (`/\`), and `TensorProduct` (`.*`). The last is a bit doubtful, but probably better than an error...

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Dedicated LaTeX and pretty printing for `Covariance`, `Expectation`, `Probability` and `Variance`.
<!-- END RELEASE NOTES -->
