### PR TITLE
Better `srepr` for vectors and some LaTeX improvements

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4327,9 +4327,9 @@ class Catalan(NumberSymbol, metaclass=Singleton):
     Explanation
     ===========
 
-    `K = 0.91596559\ldots` is given by the infinite series
+    $G = 0.91596559\ldots$ is given by the infinite series
 
-    .. math:: K = \sum_{k=0}^{\infty} \frac{(-1)^k}{(2k+1)^2}
+    .. math:: G = \sum_{k=0}^{\infty} \frac{(-1)^k}{(2k+1)^2}
 
     Catalan is a singleton, and can be accessed by ``S.Catalan``.
 
@@ -4379,6 +4379,9 @@ class Catalan(NumberSymbol, metaclass=Singleton):
         from sympy.concrete.summations import Sum
         k = Dummy('k', integer=True, nonnegative=True)
         return Sum(S.NegativeOne**k / (2*k+1)**2, (k, 0, S.Infinity))
+
+    def _latex(self, printer):
+        return "G"
 
 
 class ImaginaryUnit(AtomicExpr, metaclass=Singleton):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2557,6 +2557,10 @@ class LatexPrinter(Printer):
         mat = self._print(expr._expr_mat)
         return r"%s_\tau" % mat
 
+    def _print_DFT(self, expr):
+        return r"\text{{{}}}_{{{}}}".format(expr.__class__.__name__, expr.n)
+    _print_IDFT = _print_DFT
+
     def _print_NamedMorphism(self, morphism):
         pretty_name = self._print(Symbol(morphism.name))
         pretty_morphism = self._print_Morphism(morphism)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1855,6 +1855,9 @@ class PrettyPrinter(Printer):
             return prettyForm(pretty_symbol('gamma'))
         return self._print(Symbol("EulerGamma"))
 
+    def _print_Catalan(self, expr):
+        return self._print(Symbol("G"))
+
     def _print_Mod(self, expr):
         pform = self._print(expr.args[0])
         if pform.binding > prettyForm.MUL:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6,7 +6,7 @@ from sympy.core.basic import Basic
 from sympy.core.containers import (Dict, Tuple)
 from sympy.core.function import (Derivative, Function, Lambda, Subs)
 from sympy.core.mul import Mul
-from sympy.core import (EulerGamma, GoldenRatio)
+from sympy.core import (EulerGamma, GoldenRatio, Catalan)
 from sympy.core.numbers import (I, Rational, oo, pi)
 from sympy.core.power import Pow
 from sympy.core.relational import (Eq, Ge, Gt, Le, Lt, Ne)
@@ -1134,6 +1134,11 @@ def test_EulerGamma():
 def test_GoldenRatio():
     assert pretty(GoldenRatio) == str(GoldenRatio) == "GoldenRatio"
     assert upretty(GoldenRatio) == "φ"
+
+
+def test_Catalan():
+    assert pretty(Catalan) == upretty(Catalan) == "G"
+
 
 def test_pretty_relational():
     expr = Eq(x, y)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1279,6 +1279,15 @@ def test_latex_list():
     assert latex(ll) == r'\left[ \omega_{1}, \  a, \  \alpha\right]'
 
 
+def test_latex_NumberSymbols():
+    assert latex(S.Catalan) == "G"
+    assert latex(S.EulerGamma) == r"\gamma"
+    assert latex(S.Exp1) == "e"
+    assert latex(S.GoldenRatio) == r"\phi"
+    assert latex(S.Pi) == r"\pi"
+    assert latex(S.TribonacciConstant) == r"\text{TribonacciConstant}"
+
+
 def test_latex_rational():
     # tests issue 3973
     assert latex(-Rational(1, 2)) == r"- \frac{1}{2}"
@@ -1975,6 +1984,12 @@ def test_Identity():
     from sympy.matrices.expressions.special import Identity
     assert latex(Identity(1), mat_symbol_style='plain') == r"\mathbb{I}"
     assert latex(Identity(1), mat_symbol_style='bold') == r"\mathbf{I}"
+
+
+def test_latex_DFT_IDFT():
+    from sympy.matrices.expressions.fourier import DFT, IDFT
+    assert latex(DFT(13)) == r"\text{DFT}_{13}"
+    assert latex(IDFT(x)) == r"\text{IDFT}_{x}"
 
 
 def test_boolean_args_order():

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -225,6 +225,10 @@ class BaseDyadic(Dyadic, AtomicExpr):
         return "({}|{})".format(
             printer._print(self.args[0]), printer._print(self.args[1]))
 
+    def _sympyrepr(self, printer):
+        return "BaseDyadic({}, {})".format(
+            printer._print(self.args[0]), printer._print(self.args[1]))
+
 
 class DyadicMul(BasisDependentMul, Dyadic):
     """ Products of scalars and BaseDyadics """

--- a/sympy/vector/tests/test_dyadic.py
+++ b/sympy/vector/tests/test_dyadic.py
@@ -118,3 +118,17 @@ def test_dyadic_simplify():
     test4 = ((-4 * x * y**2 - 2 * y**3 - 2 * x**2 * y) / (x + y)**2) * dy
     test4 = test4.simplify()
     assert (N.i & test4 & N.i) == -2 * y
+
+
+def test_dyadic_srepr():
+    from sympy.printing.repr import srepr
+    N = CoordSys3D('N')
+
+    dy = N.i | N.j
+    res = "BaseDyadic(CoordSys3D(Str('N'), Tuple(ImmutableDenseMatrix([["\
+        "Integer(1), Integer(0), Integer(0)], [Integer(0), Integer(1), "\
+        "Integer(0)], [Integer(0), Integer(0), Integer(1)]]), "\
+        "VectorZero())).i, CoordSys3D(Str('N'), Tuple(ImmutableDenseMatrix("\
+        "[[Integer(1), Integer(0), Integer(0)], [Integer(0), Integer(1), "\
+        "Integer(0)], [Integer(0), Integer(0), Integer(1)]]), VectorZero())).j)"
+    assert srepr(dy) == res

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -245,3 +245,11 @@ def test_vector_diff_integrate():
 def test_vector_args():
     raises(ValueError, lambda: BaseVector(3, C))
     raises(TypeError, lambda: BaseVector(0, Vector.zero))
+
+
+def test_srepr():
+    from sympy.printing.repr import srepr
+    res = "CoordSys3D(Str('C'), Tuple(ImmutableDenseMatrix([[Integer(1), "\
+            "Integer(0), Integer(0)], [Integer(0), Integer(1), Integer(0)], "\
+            "[Integer(0), Integer(0), Integer(1)]]), VectorZero())).i"
+    assert srepr(C.i) == res

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -395,6 +395,10 @@ class BaseVector(Vector, AtomicExpr):
     def _sympystr(self, printer):
         return self._name
 
+    def _sympyrepr(self, printer):
+        index, system = self._id
+        return printer._print(system) + '.' + system._vector_names[index]
+
     @property
     def free_symbols(self):
         return {self}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Builds on #22661 so that should be merged first.
Related to #22654 

#### Brief description of what is fixed or changed
`srepr` for `BaseVector` and `BaseDyadic` did not return correct code (in the same way as other `srepr` does).

`DFT` and `IDFT` now have better LaTeX-printing.

`S.Catalan` is now printed as `G` (as per the Wiki-link provided as reference and many pther sources).

#### Other comments

Tests added for LaTeX-printing of all(?) NumberSymbols in `S`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * `S.Catalan` is now printed as `G` in LaTeX and pretty printers. 
   * Improved LaTeX-printing of `DFT` and `IDFT`. 
* vector
   * Improved `srepr` for `BaseVector` and `BaseDyadic`. 
<!-- END RELEASE NOTES -->
