### PR TITLE
Fixed printing of all(?) quantum states and more

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -914,6 +914,9 @@ class String(Atom, Token):
     def func(self):
         return lambda: self
 
+    def _latex(self, printer):
+        return r'\texttt{{"{}"}}'.format(self.text)
+
 class QuotedString(String):
     """ Represents a string which should be printed with quotes. """
 
@@ -1128,6 +1131,10 @@ class Type(Token):
             raise ValueError("Casting gives a significantly different value.")
 
         return new_val
+
+    def _latex(self, printer):
+        return r"\text{{{}}}\left(\texttt{{{}}}\right)".format(self.__class__.__name__,
+                                                               self.name.text)
 
 
 class IntBaseType(Type):

--- a/sympy/codegen/fnodes.py
+++ b/sympy/codegen/fnodes.py
@@ -282,7 +282,7 @@ class Extent(Basic):
     def _sympystr(self, printer):
         if len(self.args) == 0:
             return ':'
-        return '%d:%d' % self.args
+        return ":".join(str(arg) for arg in self.args)
 
 assumed_extent = Extent() # or Extent(':'), Extent(None)
 

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -874,7 +874,7 @@ class CNotGate(HermitianOperator, CGate, TwoQubitGate):
 
     """
     gate_name = 'CNOT'
-    gate_name_latex = 'CNOT'
+    gate_name_latex = r'\text{CNOT}'
     simplify_cgate = True
 
     #-------------------------------------------------------------------------
@@ -980,7 +980,7 @@ class SwapGate(TwoQubitGate):
 
     """
     gate_name = 'SWAP'
-    gate_name_latex = 'SWAP'
+    gate_name_latex = r'\text{SWAP}'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('SWAP', format)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -139,12 +139,12 @@ class StateBase(QExpr):
 
         # Setup for unicode vs ascii
         if use_unicode:
-            lbracket, rbracket = self.lbracket_ucode, self.rbracket_ucode
+            lbracket, rbracket = getattr(self, 'lbracket_ucode', ""), getattr(self, 'rbracket_ucode', "")
             slash, bslash, vert = '\N{BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT}', \
                                   '\N{BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT}', \
                                   '\N{BOX DRAWINGS LIGHT VERTICAL}'
         else:
-            lbracket, rbracket = self.lbracket, self.rbracket
+            lbracket, rbracket = getattr(self, 'lbracket', ""), getattr(self, 'rbracket', "")
             slash, bslash, vert = '/', '\\', '|'
 
         # If height is 1, just return brackets
@@ -177,7 +177,7 @@ class StateBase(QExpr):
 
     def _sympystr(self, printer, *args):
         contents = self._print_contents(printer, *args)
-        return '%s%s%s' % (self.lbracket, contents, self.rbracket)
+        return '%s%s%s' % (getattr(self, 'lbracket', ""), contents, getattr(self, 'rbracket', ""))
 
     def _pretty(self, printer, *args):
         from sympy.printing.pretty.stringpict import prettyForm
@@ -194,7 +194,7 @@ class StateBase(QExpr):
         contents = self._print_contents_latex(printer, *args)
         # The extra {} brackets are needed to get matplotlib's latex
         # rendered to render this properly.
-        return '{%s%s%s}' % (self.lbracket_latex, contents, self.rbracket_latex)
+        return '{%s%s%s}' % (getattr(self, 'lbracket_latex', ""), contents, getattr(self, 'rbracket_latex', ""))
 
 
 class KetBase(StateBase):

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -302,7 +302,7 @@ CNOT   \n\
 """
     assert pretty(g3) == ascii_str
     assert upretty(g3) == ucode_str
-    assert latex(g3) == r'CNOT_{1,0}'
+    assert latex(g3) == r'\text{CNOT}_{1,0}'
     sT(g3, "CNotGate(Integer(1),Integer(0))")
     ascii_str = \
 """\

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -451,8 +451,10 @@ class AnnihilateBoson(BosonicOperator, Annihilator):
         return "AnnihilateBoson(%s)" % self.state
 
     def _latex(self, printer):
-        return "b_{%s}" % self.state.name
-
+        if self.state is S.Zero:
+            return "b_{0}"
+        else:
+            return "b_{%s}" % self.state.name
 
 class CreateBoson(BosonicOperator, Creator):
     """
@@ -490,7 +492,10 @@ class CreateBoson(BosonicOperator, Creator):
         return "CreateBoson(%s)" % self.state
 
     def _latex(self, printer):
-        return "{b^\\dagger_{%s}}" % self.state.name
+        if self.state is S.Zero:
+            return "{b^\\dagger_{0}}"
+        else:
+            return "{b^\\dagger_{%s}}" % self.state.name
 
 B = AnnihilateBoson
 Bd = CreateBoson
@@ -805,7 +810,10 @@ class AnnihilateFermion(FermionicOperator, Annihilator):
         return "AnnihilateFermion(%s)" % self.state
 
     def _latex(self, printer):
-        return "a_{%s}" % self.state.name
+        if self.state is S.Zero:
+            return "a_{0}"
+        else:
+            return "a_{%s}" % self.state.name
 
 
 class CreateFermion(FermionicOperator, Creator):
@@ -951,7 +959,10 @@ class CreateFermion(FermionicOperator, Creator):
         return "CreateFermion(%s)" % self.state
 
     def _latex(self, printer):
-        return "{a^\\dagger_{%s}}" % self.state.name
+        if self.state is S.Zero:
+            return "{a^\\dagger_{0}}"
+        else:
+            return "{a^\\dagger_{%s}}" % self.state.name
 
 Fd = CreateFermion
 F = AnnihilateFermion
@@ -991,13 +1002,16 @@ class FockState(Expr):
         return ("FockState(%r)") % (self.args)
 
     def __str__(self):
-        return "%s%r%s" % (self.lbracket, self._labels(), self.rbracket)
+        return "%s%r%s" % (getattr(self, 'lbracket', ""), self._labels(), getattr(self, 'rbracket', ""))
 
     def _labels(self):
         return self.args[0]
 
     def __len__(self):
         return len(self.args[0])
+
+    def _latex(self, printer):
+        return "%s%s%s" % (getattr(self, 'lbracket_latex', ""), printer._print(self._labels()), getattr(self, 'rbracket_latex', ""))
 
 
 class BosonState(FockState):
@@ -1254,6 +1268,8 @@ class FockStateKet(FockState):
     """
     lbracket = '|'
     rbracket = '>'
+    lbracket_latex = r'\left|'
+    rbracket_latex = r'\right\rangle'
 
 
 class FockStateBra(FockState):
@@ -1262,6 +1278,8 @@ class FockStateBra(FockState):
     """
     lbracket = '<'
     rbracket = '|'
+    lbracket_latex = r'\left\langle'
+    rbracket_latex = r'\right|'
 
     def __mul__(self, other):
         if isinstance(other, FockStateKet):

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -216,8 +216,8 @@ class BaseDyadic(Dyadic, AtomicExpr):
         obj._sys = vector1._sys
         obj._pretty_form = ('(' + vector1._pretty_form + '|' +
                              vector2._pretty_form + ')')
-        obj._latex_form = ('(' + vector1._latex_form + "{|}" +
-                           vector2._latex_form + ')')
+        obj._latex_form = (r'\left(' + vector1._latex_form + r"{\middle|}" +
+                           vector2._latex_form + r'\right)')
 
         return obj
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -148,15 +148,17 @@ def test_latex_printing():
                            ' db)\\mathbf{\\hat{k}_{N}}')
     assert latex(s) == '3 \\mathbf{{y}_{C}} \\mathbf{{x}_{N}}^{2}'
     assert latex(d[0]) == '(\\mathbf{\\hat{0}}|\\mathbf{\\hat{0}})'
-    assert latex(d[4]) == ('(a)(\\mathbf{\\hat{i}_{N}}{|}\\mathbf' +
-                           '{\\hat{k}_{N}})')
-    assert latex(d[9]) == ('(\\mathbf{\\hat{k}_{C}}{|}\\mathbf{\\' +
-                           'hat{k}_{N}}) + (\\mathbf{\\hat{i}_{N}}{|' +
-                           '}\\mathbf{\\hat{k}_{N}})')
-    assert latex(d[11]) == ('(a^{2} + b)(\\mathbf{\\hat{i}_{N}}{|}\\' +
-                            'mathbf{\\hat{k}_{N}}) + (\\int f{\\left(' +
-                            'b \\right)}\\, db)(\\mathbf{\\hat{k}_{N}' +
-                            '}{|}\\mathbf{\\hat{k}_{N}})')
+    assert latex(d[4]) == ('(a)\\left(\\mathbf{\\hat{i}_{N}}{\\middle|}' +
+                           '\\mathbf{\\hat{k}_{N}}\\right)')
+    assert latex(d[9]) == ('\\left(\\mathbf{\\hat{k}_{C}}{\\middle|}' +
+                           '\\mathbf{\\hat{k}_{N}}\\right) + \\left(' +
+                           '\\mathbf{\\hat{i}_{N}}{\\middle|}\\mathbf{' +
+                           '\\hat{k}_{N}}\\right)')
+    assert latex(d[11]) == ('(a^{2} + b)\\left(\\mathbf{\\hat{i}_{N}}' +
+                            '{\\middle|}\\mathbf{\\hat{k}_{N}}\\right) + ' +
+                            '(\\int f{\\left(b \\right)}\\, db)\\left(' +
+                            '\\mathbf{\\hat{k}_{N}}{\\middle|}\\mathbf{' +
+                            '\\hat{k}_{N}}\\right)')
 
 
 def test_custom_names():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Builds on #22661 and #22663 so should be merged in order
Related to #22654 

#### Brief description of what is fixed or changed
All states in both `physics.secondquant` and `physics.quantum` can now be printed without errors.

#### Other comments
`String` and `Type` from `sympy.codegen.ast` now has a reasonable LaTeX-printing. Not that it is really required, but at least nice if something proper shows up in case one happens to try it...

`Extent` from  `sympy.codegen.ast` can be printed using symbolic arguments, which seems to be supported based on `test_args`.

Improved the printing of `BaseDyadic`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
