### PR TITLE
mods for `has_free`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1271,11 +1271,11 @@ class Basic(Printable, metaclass=ManagedProperties):
                     continue  # Basic won't have this in it
             p_set.add(p)  # fails if object defines __eq__ but
                           # doesn't define __hash__
-                                  #
+        types = tuple(type_set)   #
         for i in iterargs(self):  #
             if i in p_set:        # <--- here, too
                 return True
-            if type(i) in type_set or any(isinstance(i, t) for t in type_set):
+            if isinstance(i, types):
                 return True
 
         # use matcher if defined, e.g. operations defines

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -132,13 +132,14 @@ def uniquely_named_symbol(xname, exprs=(), compare=str, modify=None, **assumptio
     Parameters
     ==========
 
-        xname : a string or a Symbol (when symbol xname <- str(xname))
+        xname : a string or a Symbol
 
         compare : a single arg function that takes a symbol and returns
             a string to be compared with xname (the default is the str
             function which indicates how the name will look when it
             is printed, e.g. this includes underscores that appear on
-            Dummy symbols)
+            Dummy symbols). When ``xname`` is a Symbol, ``compare`` will
+            be used to supply the value for ``xname``.
 
         modify : a single arg function that changes its string argument
             in some way (the default is to append numbers)
@@ -165,7 +166,7 @@ def uniquely_named_symbol(xname, exprs=(), compare=str, modify=None, **assumptio
     default = None
     if is_sequence(xname):
         xname, default = xname
-    x = str(xname)
+    x = compare(xname)
     if not exprs:
         return _symbol(x, default, **assumptions)
     if not is_sequence(exprs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

* modifications from review comments in #22539
* minor update to how `uniquely_named_symbol` handles a passed Symbol

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `uniquely_named_symbol` uses `compare` (default `str`) to get the string name of the passed `xname`
<!-- END RELEASE NOTES -->
