### PR TITLE
`perfect_power` handles all Rationals

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -435,9 +435,9 @@ def perfect_power(n, candidates=None, big=True, factor=True):
 
     Rationals are also recognized:
 
-    >>> perfect_power(Rational(1/2)**3)
+    >>> perfect_power(Rational(1, 2)**3)
     (1/2, 3)
-    >>> perfect_power(Rational(-3/2)**3)
+    >>> perfect_power(Rational(-3, 2)**3)
     (-3/2, 3)
 
     Notes

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -399,9 +399,9 @@ def multiplicity_in_factorial(p, n):
 
 def perfect_power(n, candidates=None, big=True, factor=True):
     """
-    Return ``(b, e)`` such that ``n`` == ``b**e`` if ``n`` is a
-    perfect power with ``e > 1``, else ``False``. A ValueError is
-    raised if ``n`` is not an integer or is not positive.
+    Return ``(b, e)`` such that ``n`` == ``b**e`` if ``n`` is a unique
+    perfect power with ``e > 1``, else ``False`` (e.g. 1 is not a
+    perfect power). A ValueError is raised if ``n`` is not Rational.
 
     By default, the base is recursively decomposed and the exponents
     collected so the largest possible ``e`` is sought. If ``big=False``
@@ -420,11 +420,25 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     Examples
     ========
 
-    >>> from sympy import perfect_power
+    >>> from sympy import perfect_power, Rational
     >>> perfect_power(16)
     (2, 4)
     >>> perfect_power(16, big=False)
     (4, 2)
+
+    Negative numbers can only have odd perfect powers:
+
+    >>> perfect_power(-4)
+    False
+    >>> perfect_power(-8)
+    (-2, 3)
+
+    Rationals are also recognized:
+
+    >>> perfect_power(Rational(1/2)**3)
+    (1/2, 3)
+    >>> perfect_power(Rational(-3/2)**3)
+    (-3/2, 3)
 
     Notes
     =====
@@ -452,10 +466,34 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     sympy.core.power.integer_nthroot
     sympy.ntheory.primetest.is_square
     """
+    if isinstance(n, Rational) and not n.is_Integer:
+        p, q = n.as_numer_denom()
+        if p is S.One:
+            pp = perfect_power(q)
+            if pp:
+                pp = (n.func(1, pp[0]), pp[1])
+        else:
+            pp = perfect_power(p)
+            if pp:
+                num, e = pp
+                pq = perfect_power(q, [e])
+                if pq:
+                    den, _ = pq
+                    pp = n.func(num, den), e
+        return pp
+
     n = as_int(n)
-    if n < 3:
-        if n < 1:
-            raise ValueError('expecting positive n')
+    if n < 0:
+        pp = perfect_power(-n)
+        if pp:
+            b, e = pp
+            if e % 2:
+                return -b, e
+        return False
+
+    if n <= 3:
+        # no unique exponent for 0, 1
+        # 2 and 3 have exponents of 1
         return False
     logn = math.log(n, 2)
     max_possible = int(logn) + 2  # only check values less than this

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -160,8 +160,8 @@ def test_perfect_power():
     # negatives and non-integer rationals
     assert perfect_power(-4) is False
     assert perfect_power(-8) == (-2, 3)
-    assert perfect_power(Rational(1/2)**3) == (S.Half, 3)
-    assert perfect_power(Rational(-3/2)**3) == (-3*S.Half, 3)
+    assert perfect_power(Rational(1, 2)**3) == (S.Half, 3)
+    assert perfect_power(Rational(-3, 2)**3) == (-3*S.Half, 3)
 
 
 @slow

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -116,8 +116,8 @@ def test_multiplicity_in_factorial():
 
 
 def test_perfect_power():
-    raises(ValueError, lambda: perfect_power(0))
-    raises(ValueError, lambda: perfect_power(Rational(25, 4)))
+    raises(ValueError, lambda: perfect_power(0.1))
+    assert perfect_power(0) is False
     assert perfect_power(1) is False
     assert perfect_power(2) is False
     assert perfect_power(3) is False
@@ -156,6 +156,12 @@ def test_perfect_power():
         assert m and m[1] == d or d == 1
         m = perfect_power(t*3**d, big=False)
         assert m and m[1] == 2 or d == 1 or d == 3, (d, m)
+
+    # negatives and non-integer rationals
+    assert perfect_power(-4) is False
+    assert perfect_power(-8) == (-2, 3)
+    assert perfect_power(Rational(1/2)**3) == (S.Half, 3)
+    assert perfect_power(Rational(-3/2)**3) == (-3*S.Half, 3)
 
 
 @slow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The following used to raise a ValueError:
```python
>>> perfect_power(0)
False
>>> perfect_power(-9)
False
>>> perfect_power(-27)
(-3, 2)
>>> perfect_power(S.Half**3)
(1/2, 3)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
    * `perfect_power` now only raises a ValueError for non-Rational input
<!-- END RELEASE NOTES -->
