### PR TITLE
DOC: replace ** -> ^ in LaTeX equation for atan2()

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3331,7 +3331,7 @@ class atan2(InverseTrigonometricFunction):
     .. math::
 
         \operatorname{atan2}(y, x) =
-            -i\log\left(\frac{x + iy}{\sqrt{x**2 + y**2}}\right)
+            -i\log\left(\frac{x + iy}{\sqrt{x^2 + y^2}}\right)
 
     Examples
     ========


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`**` is used in Python for exponentiation, but LaTeX equations need to use `^` instead.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->