### PR TITLE
maint: add all names from commits to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -601,7 +601,6 @@ Aman Thakur <thakuraman22july@gmail.com> Aman Thakur <54764701+jhonsnow456@users
 Abbas <iamabbas7@gmail.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
 Risiraj Dey <risirajdey@gmail.com> RDxR10 <risirajdey@gmail.com>
 Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
-/home/oscar/current/sympy/sympy.git
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
 *Ulrich Hecht <ulrich.hecht@gmail.com>
 David Lawrence <dmlawrence@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -601,3 +601,701 @@ Aman Thakur <thakuraman22july@gmail.com> Aman Thakur <54764701+jhonsnow456@users
 Abbas <iamabbas7@gmail.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
 Risiraj Dey <risirajdey@gmail.com> RDxR10 <risirajdey@gmail.com>
 Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
+/home/oscar/current/sympy/sympy.git
+*Marc-Etienne M.Leveille <protonyc@gmail.com>
+*Ulrich Hecht <ulrich.hecht@gmail.com>
+David Lawrence <dmlawrence@gmail.com>
+Jaroslaw Tworek <dev.jrx@gmail.com>
+Bernhard R. Link <brlink@debian.org>
+Or Dvory <gidesa@gmail.com>
+Pauli Virtanen <pav@iki.fi>
+Robert Kern <robert.kern@gmail.com>
+James Aspnes <aspnes@cs.yale.edu>
+Nimish Telang <ntelang@gmail.com>
+Abderrahim Kitouni <a.kitouni@gmail.com>
+Pan Peng <pengpanster@gmail.com>
+Friedrich Hagedorn <friedrich_h@gmx.de>
+Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
+Roberto Nobrega <rwnobrega@gmail.com>
+Riccardo Gori <goriccardo@gmail.com>
+Case Van Horsen <casevh@gmail.com>
+Stepan Roucka <stepan@roucka.eu>
+Ali Raza Syed <arsyed@gmail.com>
+Stefano Maggiolo <s.maggiolo@gmail.com>
+Bastian Weber <bastian.weber@gmx-topmail.de>
+Sebastian Krause <sebastian.krause@gmx.de>
+Sebastian Kreft <skreft@gmail.com>
+*Dan <coolg49964@gmail.com>
+Boris Timokhin <qoqenator@gmail.com>
+Robert <average.programmer@gmail.com>
+Hubert Tsang <intsangity@gmail.com>
+Konrad Meyer <konrad.meyer@gmail.com>
+Henrik Johansson <henjo2006@gmail.com>
+Priit Laes <plaes@plaes.org>
+Freddie Witherden <freddie@witherden.org>
+Andrew Straw <strawman@astraw.com>
+Kaifeng Zhu <cafeeee@gmail.com>
+Ted Horst <ted.horst@earthlink.net>
+Andrew Docherty <andrewd@maths.usyd.edu.au>
+Akshay Srinivasan <akshaysrinivasan@gmail.com>
+Aaron Meurer <asmeurer@gmail.com>
+Barry Wardell <barry.wardell@gmail.com>
+Tomasz Buchert <thinred@gmail.com>
+Vinay Kumar <gnulinooks@gmail.com>
+Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
+Jochen Voss <voss@seehuhn.de>
+Thomas Sidoti <TSidoti@gmail.com>
+Florian Mickler <florian@mickler.org>
+Ben Goodrich <goodrich.ben@gmail.com>
+James Abbatiello <abbeyj@gmail.com>
+Ryan Krauss <ryanlists@gmail.com>
+Bill Flynn <wflynny@gmail.com>
+Kevin Goodsell <kevin-opensource@omegacrash.net>
+Jorn Baayen <jorn.baayen@gmail.com>
+Eh Tan <tan2tan2@gmail.com>
+Julio Idichekop Filho <idichekop@yahoo.com.br>
+Łukasz Pankowski <lukpank@o2.pl>
+*Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
+Fernando Perez <Fernando.Perez@berkeley.edu>
+Raffaele De Feo <alberthilbert@gmail.com>
+Christian Muise <christian.muise@gmail.com>
+Matt Curry <mattjcurry@gmail.com>
+Kazuo Thow <kazuo.thow@gmail.com>
+Christian Schubert <chr.schubert@gmx.de>
+Matthew Brett <matthew.brett@gmail.com>
+Nicholas J.S. Kinar <n.kinar@usask.ca>
+Harold Erbin <harold.erbin@gmail.com>
+Thomas Dixon <thom@thomdixon.org>
+Andre de Fortier Smit <freevryheid@gmail.com>
+Mark Dewing <markdewing@gmail.com>
+Gary Kerr <gary.kerr@blueyonder.co.uk>
+Sherjil Ozair <sherjilozair@gmail.com>
+Sean Vig <sean.v.775@gmail.com>
+Vladimir Perić <vlada.peric@gmail.com>
+Yuri Karadzhov <yuri.karadzhov@gmail.com>
+Vladimir Lagunov <werehuman@gmail.com>
+Saptarshi Mandal <sapta.iitkgp@gmail.com>
+Anatolii Koval <weralwolf@gmail.com>
+Tomo Lazovich <lazovich@gmail.com>
+Pavel Fedotov <fedotovp@gmail.com>
+Jack McCaffery <jpmccaffery@gmail.com>
+Kibeom Kim <kk1674@nyu.edu>
+Gregory Ksionda <ksiondag846@gmail.com>
+Luca Weihs <astronomicalcuriosity@gmail.com>
+Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
+Óscar Nájera <najera.oscar@gmail.com>
+Mario Pernici <mario.pernici@gmail.com>
+Sam Magura <samtheman132@gmail.com>
+Stefan Krastanov <krastanov.stefan@gmail.com>
+Emma Hogan <ehogan@gemini.edu>
+Nikhil Sarda <diff.operator@gmail.com>
+Julien Rioux <julien.rioux@gmail.com>
+Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
+Srinivas Vasudevan <srvasude@gmail.com>
+Miha Marolt <tloramus@gmail.com>
+Tim Lahey <tim.lahey@gmail.com>
+Luis Garcia <ppn.online@me.com>
+Matt Rajca <matt.rajca@me.com>
+Alexandr Gudulin <alexandr.gudulin@gmail.com>
+Grzegorz Świrski <sognat@gmail.com>
+Matt Habel <habelinc@gmail.com>
+Nikolay Lazarov <qwerqwerqwer@abv.bg>
+Steve Anton <anxuiz.nx@gmail.com>
+Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
+Piotr Korgul <p.korgul@gmail.com>
+Sam Sleight <samuel.sleight@gmail.com>
+Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
+Stepan Simsa <simsa.st@gmail.com>
+Tobias Lenz <t_lenz94@web.de>
+Tiffany Zhu <bubble.wubble.303@gmail.com>
+Tristan Hume <tris.hume@gmail.com>
+Alexey Subach <alexey.subach@gmail.com>
+Joan Creus <joan.creus.c@gmail.com>
+Geoffry Song <goffrie@gmail.com>
+Puneeth Chaganti <punchagan@gmail.com>
+Marcin Kostrzewa <>
+Natalia Nawara <fankalemura@gmail.com>
+vishal <vishal.panjwani15@gmail.com>
+Shruti Mangipudi <shruti2395@gmail.com>
+Swapnil Agarwal <swapnilag29@gmail.com>
+jerryma1121 <jerryma1121@gmail.com>
+Martin Povišer <martin.povik@gmail.com>
+Siddhant Jain <getsiddhant@gmail.com>
+Kevin Hunter <hunteke@earlham.edu>
+Michael Mayorov <marchael@kb.csu.ru>
+Christian Bühler <christian@cbuehler.de>
+Carsten Knoll <CarstenKnoll@gmx.de>
+Bharath M R <catchmrbharath@gmail.com>
+Matthias Toews <mat.toews@googlemail.com>
+Sergiu Ivanov <unlimitedscolobb@gmail.com>
+Jorge E. Cardona <jorgeecardona@gmail.com>
+Sanket Agarwal <sanket@sanketagarwal.com>
+Sai Nikhil <tsnlegend@gmail.com>
+Aleksandar Makelov <amakelov@college.harvard.edu>
+Raphael Michel <webmaster@raphaelmichel.de>
+Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Prateek Papriwal <papriwalprateek@gmail.com>
+Angadh Nanjangud <angadh.n@gmail.com>
+Comer Duncan <comer.duncan@gmail.com>
+Joseph Dougherty <Github@JWDougherty.com>
+Guru Devanla <grdvnl@gmail.com>
+George Waksman <waksman@gwax.com>
+Alexandr Popov <alexandr.s.popov@gmail.com>
+Tarun Gaba <tarun.gaba7@gmail.com>
+Takafumi Arakaki <aka.tkf@gmail.com>
+Brian Stephanik <xoedusk@gmail.com>
+Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Tyler Pirtle <teeler@gmail.com>
+Vasily Povalyaev <vapovalyaev@gmail.com>
+Huijun Mai <m.maihuijun@gmail.com>
+Madeleine Ball <mpball@gmail.com>
+CJ Carey <perimosocordiae@gmail.com>
+Patrick Lacasse <patrick.m.lacasse@gmail.com>
+Christopher Dembia <cld72@cornell.edu>
+Sean Ge <seange727@gmail.com>
+Ankit Agrawal <aaaagrawal@iitb.ac.in>
+Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
+Demian Wassermann <demian@bwh.harvard.edu>
+Khagesh Patel <khageshpatel93@gmail.com>
+Stephen Loo <shikil@yahoo.com>
+hm <hacman0@gmail.com>
+Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
+Varun Joshi <joshi.142@osu.edu>
+Max Hutchinson <maxhutch@gmail.com>
+Matthew Tadd <matt.tadd@gmail.com>
+Alexander Hirzel <alex@hirzel.us>
+Randy Heydon <randy.heydon@clockworklab.net>
+Oliver Lee <oliverzlee@gmail.com>
+Erik Welch <erik.n.welch@gmail.com>
+Eric Nelson <eric.the.red.XLII@gmail.com>
+Roland Puntaier <roland.puntaier@chello.at>
+Chris Conley <chrisconley15@gmail.com>
+Tim Swast <tswast@gmail.com>
+Rick Muller <rpmuller@gmail.com>
+Manish Gill <gill.manish90@gmail.com>
+Jeremy <twobitlogic@gmail.com>
+QuaBoo <kisonchristian@gmail.com>
+Stefan van der Walt <stefan@sun.ac.za>
+Lars Buitinck <larsmans@gmail.com>
+Vinit Ravishankar <vinit.ravishankar@gmail.com>
+Mike Boyle <boyle@astro.cornell.edu>
+James Fiedler <jrfiedler@gmail.com>
+Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
+James Goppert <james.goppert@gmail.com>
+Avichal Dayal <avichal.dayal@gmail.com>
+Paul Scott <paul.scott@nicta.com.au>
+Pramod Ch <pramodch14@gmail.com>
+Abhinav Chanda <abhinavchanda01@gmail.com>
+Sudhanshu Mishra <mrsud94@gmail.com>
+Soumya Dipta Biswas <sdb1323@gmail.com>
+Ben Lucato <ben.lucato@gmail.com>
+Kunal Arora <kunalarora.135@gmail.com>
+Henry Gebhardt <hsggebhardt@gmail.com>
+Ralph Bean <rbean@redhat.com>
+richierichrawr <richierichrawr@users.noreply.github.com>
+John Connor <john.theman.connor@gmail.com>
+Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Stas Kelvich <stanconn@gmail.com>
+sevaader <sevaader@gmail.com>
+Lennart Fricke <lennart@die-frickes.eu>
+Vlad Seghete <vlad.seghete@gmail.com>
+carstimon <carstimon@gmail.com>
+Pierre Haessig <pierre.haessig@crans.org>
+Benjamin Gudehus <hastebrot@gmail.com>
+Faisal Anees <faisal.iiit@gmail.com>
+Mark Shoulson <mark@kli.org>
+Robert Johansson <jrjohansson@gmail.com>
+Ambar Mehrotra <mehrotraambar@gmail.com>
+David P. Sanders <dpsanders@gmail.com>
+Nathan Woods <charlesnwoods@gmail.com>
+Marcus Näslund <naslundx@gmail.com>
+Clemens Novak <clemens@familie-novak.net>
+Mridul Seth <seth.mridul@gmail.com>
+immerrr <immerrr@gmail.com>
+ck Lux <lux.r.ck@gmail.com>
+zsc347 <zsc347@gmail.com>
+Michael Gallaspy <gallaspy.michael@gmail.com>
+Roman Inflianskas <infroma@gmail.com>
+Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
+Victor Brebenar <v.brebenar@gmail.com>
+Juan Felipe Osorio <jfosorio@gmail.com>
+Eric Miller <emiller42@gmail.com>
+Yury G. Kudryashov <urkud.urkud@gmail.com>
+Mihir Wadwekar <m.mihirw@gmail.com>
+Ralf Stephan <ralf@ark.in-berlin.de>
+Luv Agarwal <agarwal.iiit@gmail.com>
+Jason Ly <jason.ly@gmail.com>
+Sartaj Singh <singhsartaj94@gmail.com>
+Chris Swierczewski <cswiercz@gmail.com>
+Param Singh <paramsingh258@gmail.com>
+Peter Schmidt <peter@peterjs.com>
+Lucas Jones <lucas@lucasjones.co.uk>
+Renato Orsino <renato.orsino@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com>
+Alistair Lynn <arplynn@gmail.com>
+Govind Sahai <gsiitbhu@gmail.com>
+Nguyen Truong Duy <truongduy134@yahoo.com>
+Mathew Chong <mathewchong.dev@gmail.com>
+Jason Siefken <siefkenj@gmail.com>
+Gao, Xiang <qasdfgtyuiop@gmail.com>
+Kevin Ventullo <kevin.ventullo@gmail.com>
+mao8 <thisisma08@gmail.com>
+Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
+Rich LaSota <rjlasota@gmail.com>
+dustyrockpyle <dustyrockpyle@gmail.com>
+Anton Akhmerov <anton.akhmerov@gmail.com>
+Michael Zingale <michael.zingale@stonybrook.edu>
+Chak-Pong Chung <chakpongchung@gmail.com>
+David T <derDavidT@users.noreply.github.com>
+Phil Ruffwind <rf@rufflewind.com>
+Sebastian Koslowski <koslowski@kit.edu>
+Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Yu Kobayashi <yukoba@accelart.jp>
+Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Timothy Cyrus <tcyrus@users.noreply.github.com>
+Keval Shah <kevalshah_96@yahoo.co.in>
+Dzhelil Rufat <drufat@caltech.edu>
+Pastafarianist <mr.pastafarianist@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com>
+Jacob Garber <jgarber1@ualberta.ca>
+GolimarOurHero <metalera94@hotmail.com>
+Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
+Alexander Bentkamp <bentkamp@gmail.com>
+Thomas Baruchel <baruchel@gmx.com>
+Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
+Laura Domine <temigo@gmx.com>
+Justin Blythe <jblythe29@gmail.com>
+Boris Atamanovskiy <shaomoron@gmail.com>
+Sam Tygier <sam.tygier@hep.manchester.ac.uk>
+Jai Luthra <me@jailuthra.in>
+Sandeep Veethu <sandeep.veethu@gmail.com>
+Archit Verma <architv07@gmail.com>
+Ashutosh Saboo <ashutosh.saboo96@gmail.com>
+Michael S. Hansen <michael.hansen@nih.gov>
+Anish Shah <shah.anish07@gmail.com>
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
+Michał Radwański <enedil.isildur@gmail.com>
+Jerry Li <jerry@jerryli.ca>
+Akash Trehan <akash.trehan123@gmail.com>
+Nishant Nikhil <nishantiam@gmail.com>
+Vladimir Poluhsin <vovapolu@gmail.com>
+Akshay Nagar <awesomeay13@yahoo.com>
+James Brandon Milam <jmilam343@gmail.com>
+Sanya Khurana <sanya@monica.in>
+Aman Deep <amandeep1024@gmail.com>
+Abhishek Verma <iamvermaabhishek@gmail.com>
+Matthew Parnell <matt@parnmatt.co.uk>
+Thomas Hickman <Thomas.Hickman42@gmail.com>
+YiDing Jiang <yidinggjiangg@gmail.com>
+Jatin Yadav <jatinyadav25@gmail.com>
+Matthew Thomas <mnmt@users.noreply.github.com>
+Rehas Sachdeva <aquannie@gmail.com>
+Michael Mueller <michaeldmueller7@gmail.com>
+Srajan Garg <srajan.garg@gmail.com>
+Prabhjot Singh <prabhjot.nith@gmail.com>
+Haruki Moriguchi <harukimoriguchi@gmail.com>
+Tom Gijselinck <tomgijselinck@gmail.com>
+Nathan Musoke <nathan.musoke@gmail.com>
+Dana Jacobsen <dana@acm.org>
+Vasiliy Dommes <vasdommes@gmail.com>
+Phillip Berndt <phillip.berndt@googlemail.com>
+Haimo Zhang <zh.hammer.dev@gmail.com>
+Anthony Scopatz <scopatz@gmail.com>
+bluebrook <perl4logic@gmail.com>
+Josh Burkart <jburkart@gmail.com>
+Dimitra Konomi <t8130064@dias.aueb.gr>
+G. D. McBain <gdmcbain@protonmail.com>
+Prempal Singh <prempal.42@gmail.com>
+Gabriel Orisaka <orisaka@gmail.com>
+Matthias Bussonnier <bussonniermatthias@gmail.com>
+rahuldan <rahul02013@gmail.com>
+Colin Marquardt <github@marquardt-home.de>
+Andrew Taber <andrew.e.taber@gmail.com>
+Yash Reddy <write2yashreddy@gmail.com>
+Peter Stangl <peter.stangl@ph.tum.de>
+elvis-sik <e.sikora@grad.ufsc.br>
+Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
+Dennis Meckel <meckel@datenschuppen.de>
+Harshil Meena <harshil.7535@gmail.com>
+Micky <mickydroch@gmail.com>
+Michele Zaffalon <michele.zaffalon@gmail.com>
+Martha Giannoudovardi <maapxa@gmail.com>
+Abdullah Javed Nesar <abduljaved1994@gmail.com>
+Lakshya Agrawal <zeeshan.lakshya@gmail.com>
+shruti <shrutishrm512@gmail.com>
+Hong Xu <hong@topbug.net>
+Ivan Petuhov <ivan@ostrovok.ru>
+Alsheh <alsheh@rpi.edu>
+Alexey Pakhocmhik <cool.Bakov@yandex.ru>
+Tommy Olofsson <tommy.olofsson.90@gmail.com>
+Danny Hermes <daniel.j.hermes@gmail.com>
+Marcin Briański <marcin.brianski@student.uj.edu.pl>
+andreo <andrey.torba@gmail.com>
+Flamy Owl <flamyowl@protonmail.ch>
+Yicong Guo <guoyicong100@gmail.com>
+Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
+Karan Sharma <karan1276@gmail.com>
+Vedant Rathore <vedantr1998@gmail.com>
+Raghav Jajodia <jajodia.raghav@gmail.com>
+Dhruv Bhanushali <dhruv_b@live.com>
+Barun Parruck <barun.parruck@gmail.com>
+Bao Chau <chauquocbao0907@gmail.com>
+Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
+Daniel Mahler <dmahler@gmail.com>
+Ka Yi <chua.kayi@yahoo.com.sg>
+Rishat Iskhakov <iskhakov@frtk.ru>
+Priyank Patel <pspbot7@gmail.com>
+Satya Prakash Dwibedi <akash581050@gmail.com>
+tools4origins <tools4origins@gmail.com>
+Nico Schlömer <nico.schloemer@gmail.com>
+Fermi Paradox <FermiParadox@users.noreply.github.com>
+Ekansh Purohit <purohit.e15@gmail.com>
+Vedarth Sharma <vedarth.sharma@gmail.com>
+Peeyush Kushwaha <peeyush.p97@gmail.com>
+Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+Christopher J. Wright <cjwright4242gh@gmail.com>
+Jakub Wilk <jwilk@jwilk.net>
+Chris Tefer <ctefer@gmail.com>
+Chiu-Hsiang Hsu <wdv4758h@gmail.com>
+Carlos Cordoba <ccordoba12@gmail.com>
+Fabian Ball <fabian.ball@kit.edu>
+Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
+Christiano Anderson <canderson@riseup.net>
+Robin Neatherway <robin.neatherway@gmail.com>
+Duc-Minh Phan <alephvn@gmail.com>
+Lejla Metohajrova <l.metohajrova@gmail.com>
+Aditya Rohan <riyuzakiiitk@gmail.com>
+Vincent Delecroix <vincent.delecroix@labri.fr>
+Michael Sparapany <msparapa@purdue.edu>
+Nathan Goldbaum <ngoldbau@illinois.edu>
+latot <felipematas@yahoo.com>
+Kenneth Lyons <ixjlyons@gmail.com>
+Stan Schymanski <stan.schymanski@env.ethz.ch>
+David Daly <david.daly12@kzoo.edu>
+Ayush Shridhar <ayush.shridhar1999@gmail.com>
+Javed Nissar <javednissar@gmail.com>
+Jiri Kuncar <jiri.kuncar@gmail.com>
+vedantc98 <vedantc98@gmail.com>
+Rupesh Harode <rupeshharode@gmail.com>
+Rob Zinkov <rob@zinkov.com>
+James Harrop <ebc121@gmail.com>
+Ishan Joshi <ishanaj98@gmail.com>
+Marco Mancini <marco.mancini@obspm.fr>
+Boris Ettinger <ettinger.boris@gmail.com>
+Daniel Wennberg <daniel.wennberg@gmail.com>
+Akash Vaish <akash.9712@gmail.com>
+Waldir Pimenta <waldyrious@gmail.com>
+Lucas Wiman <lucas.wiman@gmail.com>
+Rhea Parekh <rheaparekh12@gmail.com>
+James Cotton <peabody124@gmail.com>
+anca-mc <anca-mc@users.noreply.github.com>
+Jonathan Allan <jjallan@users.noreply.github.com>
+Nikhil Pappu <nkhlpappu@gmail.com>
+Cezary Marczak <zeddq1@gmail.com>
+dps7ud <dps7ud@virginia.edu>
+Itay4 <31018228+Itay4@users.noreply.github.com>
+Yang Yang <wdscxsj@gmail.com>
+Cavendish McKay <cmckay@tachycline.com>
+Bradley Gannon <bradley.m.gannon@gmail.com>
+B McG <bmcg0890@gmail.com>
+Seth Ebner <murgrehk@gmail.com>
+Mark Jeromin <mark.jeromin@sysfrog.net>
+Roberto Díaz Pérez <r.r.1994a@gmail.com>
+Gleb Siroki <g.shiroki@gmail.com>
+Segev Finer <segev208@gmail.com>
+Alex Lubbock <code@alexlubbock.com>
+Ayodeji Ige <ayodeji18@outlook.com>
+Matthew Wardrop <matthew.wardrop@airbnb.com>
+der-blaue-elefant <github@kklein.de>
+Filip Gokstorp <filip@gokstorp.se>
+Yuki Matsuda <yuki.matsuda.w@gmail.com>
+Aaron Miller <acmiller273@gmail.com>
+Salil Vishnu Kapur <salilvishnukapur@gmail.com>
+Atharva Khare <khareatharva@gmail.com>
+Rajeev Singh <rajs2010@gmail.com>
+Keno Goertz <keno@goertz-berlin.com>
+Lucas Gallindo <lgallindo@gmail.com>
+David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
+Amit Manchanda <amitdelhi1995@gmail.com>
+Rohit Jain <rohitjain3241@gmail.com>
+Jonathan A. Gross <jarthurgross@gmail.com>
+Rastislav Rabatin <rastislav.rabatin@gmail.com>
+symbolique <symbolique@users.noreply.github.com>
+Saloni Jain <tosalonijain@gmail.com>
+Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
+Abhigyan Khaund <mail@abhigyan.xyz>
+Saurabh Agarwal <shourabh.agarwal@gmail.com>
+Nirmal Sarswat <nirmalsarswat400@gmail.com>
+Himanshu Ladia <hladia199811@gmail.com>
+Mihail Tarigradschi <m.tarigradschi@gmail.com>
+Saketh <alurusaisaketh@gmail.com>
+rushyam <rushyamsonu@gmail.com>
+sfoo <sfoohei@gmail.com>
+Zach Raines <raineszm@gmail.com>
+Rishav Chakraborty <annonymousxyz@outlook.com>
+Malkhan Singh <malkhansinghrathaur@gmail.com>
+Joaquim Monserrat <qmonserrat@mailoo.org>
+Mayank Singh <mayank.singh081997@gmail.com>
+Rémy Léone <rleone@online.net>
+Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
+helo9 <helo9@users.noreply.github.com>
+Ken Wakita <wakita@is.titech.ac.jp>
+Carl Sandrock <carl.sandrock@up.ac.za>
+Fredrik Eriksson <freeriks@student.chalmers.se>
+Ian Swire <oversizedpenguin@gmail.com>
+Bulat <daianovich@mail.ru>
+Ehren Metcalfe <ehren.m@gmail.com>
+Dmitry Savransky <dsavransky@gmail.com>
+Kiyohito Yamazaki <kyamaz@openql.org>
+Caley Finn <caleyreuben@gmail.com>
+Alexander Pozdneev <pozdneev@users.noreply.github.com>
+Wes Turner <50891+westurner@users.noreply.github.com>
+JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
+Arshdeep Singh <singh.arshdeep1999@gmail.com>
+cym1 <16437732+cym1@users.noreply.github.com>
+Stewart Wadsworth <stewart.wadsworth@gmail.com>
+ramvenkat98 <ramvenkat98@gmail.com>
+Bilal Ahmed <b.ahmed0918@gmail.com>
+Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
+Miro Hrončok <miro@hroncok.cz>
+Sudarshan Kamath <sudarshan.kamath97@gmail.com>
+Ayushman Koul <ayushmankoul4570@gmail.com>
+Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
+Andrey Grozin <A.G.Grozin@inp.nsk.su>
+sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
+Zachariah Etienne <zachetie@gmail.com>
+Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
+2torus <boris.ettinger@gmail.com>
+Faisal Riyaz <faisalriyaz011@gmail.com>
+Martin Roelfs <u0114255@kuleuven.be>
+SirJohnFranklin <sirjfu@googlemail.com>
+Anthony Sottile <asottile@umich.edu>
+ViacheslavP <public.viacheslav@gmail.com>
+Safiya03 <safiyanesar@gmail.com>
+Alexander Dunlap <alexander.dunlap@gmail.com>
+Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
+Jonathan Warner <warnerjon12@gmail.com>
+Matthias Geier <Matthias.Geier@gmail.com>
+klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+Animesh Sinha <animeshsinha1309@gmail.com>
+Gaurang Tandon <1gaurangtandon@gmail.com>
+Matthew Craven <clyring@users.noreply.github.com>
+Daniel Ingram <ingramds@appstate.edu>
+Takumasa Nakamura <n.takumasa@gmail.com>
+Vera Lozhkina <veralozhkina@gmail.com>
+adhoc-king <46354827+adhoc-king@users.noreply.github.com>
+Mikel Rouco <mikel.mrm@gmail.com>
+Oscar Gustafsson <oscar.gustafsson@gmail.com>
+damianos <damianos@semmle.com>
+Martin Ueding <dev@martin-ueding.de>
+sharma-kunal <kunalsharma6914@gmail.com>
+Susumu Ishizuka <susumu.ishizuka@kii.com>
+Samnan Rahee <namanush.rsr.16@gmail.com>
+Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
+Bhavya Srivastava <bhavya17037@iiitd.ac.in>
+Alpesh Jamgade <alpeshjamgade21@gmail.com>
+Shubham Abhang <shubhamabhang77@gmail.com>
+Vishesh Mangla <manglavishesh64@gmail.com>
+Nicko van Someren <nicko@nicko.org>
+dandiez <47832466+dandiez@users.noreply.github.com>
+jhanwar <f2015463@pilani.bits-pilani.ac.in>
+Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Shivani Kohli <shivanikohli.09@gmail.com>
+Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Gaetano Guerriero <x.guerriero@tin.it>
+Anway De <anway1756@gmail.com>
+znxftw <vishnu2101@gmail.com>
+OrestisVaggelis <orestis22000@gmail.com>
+Abhinav Anand <abhinav.anand2807@gmail.com>
+Juan Barbosa <js.barbosa10@uniandes.edu.co>
+Prionti Nasir <pdn3628@rit.edu>
+arooshiverma <av22@iitbbs.ac.in>
+Christoph Gohle <ctg@mpq.mpg.de>
+Daniel Sears <highpost@users.noreply.github.com>
+Sean P. Cornelius <spcornelius@gmail.com>
+Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
+Henry Metlov <genrih.metlov@gmail.com>
+pekochun <hamburg_hamburger2000@yahoo.co.jp>
+Bendik Samseth <b.samseth@gmail.com>
+Vighnesh Shenoy <vighneshq@gmail.com>
+Versus Void <versusvoid@gmail.com>
+Denys Rybalka <rybalka.denis@gmail.com>
+Mark Dickinson <dickinsm@gmail.com>
+Rimi <rimibis@umich.edu>
+rimibis <33387803+rimibis@users.noreply.github.com>
+Gilles Schintgen <gschintgen@hambier.lu>
+Abhi58 <abhijithbharadwaj58@gmail.com>
+Tomasz Pytel <tompytel@gmail.com>
+Aadit Kamat <aadit.k12@gmail.com>
+Velibor Zeli <velibor@mech.kth.se>
+Gabriel Bernardino <gabriel.bernardino@upf.edu>
+Joseph Redfern <joseph@redfern.me>
+Cameron King <v-caking@microsoft.com>
+Miguel Marco <mmarco@unizar.es>
+David Hagen <david@drhagen.com>
+Harsh Agarwal <hagarwal9200@gmail.com>
+Enric Florit <efz1005@gmail.com>
+Denis Rykov <rykovd@gmail.com>
+Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
+Stephan Seitz <stephan.seitz@fau.de>
+TitanSnow <sweeto@live.cn>
+Pengning Chao <8857165+PengningChao@users.noreply.github.com>
+Morten Olsen Lysgaard <morten@lysgaard.no>
+Lauren Glattly <laurenglattly@gmail.com>
+George Korepanov <gkorepanov.gk@gmail.com>
+dranknight09 <cbhaavan@gmail.com>
+aditisingh2362 <aditisingh2362@gmail.com>
+Gina <Dr-G@users.noreply.github.com>
+gregmedlock <gmedlo@gmail.com>
+Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
+Eric Wieser <wieser.eric@gmail.com>
+Bradley Dowling <34559056+btdow@users.noreply.github.com>
+Maria Marginean <33810762+mmargin@users.noreply.github.com>
+Akash Agrawall <akash.wanted@gmail.com>
+jgulian <josephdgulian@gmail.com>
+Sourav Goyal <souravgl0@gmail.com>
+Zlatan Vasović <zlatanvasovic@gmail.com>
+Alex Meiburg <timeroot.alex@gmail.com>
+Julien Palard <julien@palard.fr>
+erdOne <36414270+erdOne@users.noreply.github.com>
+risubaba <risubhjain1010@gmail.com>
+abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
+Jaime R <38530589+Jaime02@users.noreply.github.com>
+Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Abhishek <uchiha@pop-os.localdomain>
+Johannes Hartung <joha2@gmx.net>
+faizan2700 <syedfaizan824@gmail.com>
+Mohit Gupta <mohitgupta@gmail.com>
+Chanakya-Ekbote <ca10@iitbbs.ac.in>
+Rashmi Shehana <rashmi.watagedara@syscolabs.com>
+Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
+Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
+vezeli <37907135+vezeli@users.noreply.github.com>
+Tim Gates <tim.gates@iress.com>
+Sandeep Murthy <smurthy@protonmail.ch>
+Neil <mistersheik@gmail.com>
+V1krant <46847915+V1krant@users.noreply.github.com>
+alejandro <amartinhernan@gmail.com>
+sbt4104 <sthorat661@gmail.com>
+Seth Troisi <sethtroisi@google.com>
+Bhaskar Gupta <guptabhanu1999@gmail.com>
+Smit Gajjar <smitgajjar.gs@gmail.com>
+rbl <rlee@grove.co>
+prshnt19 <prashant.rawat216@gmail.com>
+Johan Guzman <jguzm022@ucr.edu>
+BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
+Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
+Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
+tnzl <you@example.com>
+Dhruv Kothari <dhruvkothari22@gmail.com>
+seadavis <45022599+seadavis@users.noreply.github.com>
+kamimura <kamimura@live.jp>
+slacker404 <pchantza@gmail.com>
+Jaime Resano <gemailpersonal02@gmail.com>
+Ebrahim Byagowi <ebrahim@gnu.org>
+wuyudi <wuyudi119@163.com>
+Akira Kyle <ak@akirakyle.com>
+Calvin Jay Ross <calvinjayross@gmail.com>
+Martin Thoma <info@martin-thoma.de>
+Thomas A Caswell <tcaswell@gmail.com>
+Jerry James <loganjerry@gmail.com>
+Jan Kruse <janckruse@t-online.de>
+Nathan Taylor <pecan.pine@gmail.com>
+Vaishnav Damani <vaishnavdamani3496@gmail.com>
+Mohit Shah <mohitshah3111999@gmail.com>
+Dave Witte Morris <Dave.Morris@uleth.ca>
+soumi7 <soumibardhan10@gmail.com>
+Zhongshi <zj495@nyu.edu>
+Wes Galbraith <galbwe92@gmail.com>
+KaustubhDamania <kaustubh.damania@gmail.com>
+w495 <w495@yandex-team.ru>
+Markus Mohrhard <markus.mohrhard@googlemail.com>
+Benjamin Wolba <mail@benjaminwolba.com>
+彭于斌 <1931127624@qq.com>
+Rudr Tiwari <rudrtiwari@gmail.com>
+Benedikt Placke <benedikt.placke@outlook.com>
+Sneha Goddu <s.goddu@wustl.edu>
+goddus <39923708+goddus@users.noreply.github.com>
+Shivang Dubey <shivangdubey8@gmail.com>
+Peter Cock <p.j.a.cock@googlemail.com>
+Willem Melching <willem.melching@gmail.com>
+Elias Basler <e.e.basler@protonmail.com>
+Brandon David <brandon.david@zoho.com>
+Abhay_Dhiman <abhaysdhimans@gmail.com>
+Tasha Kim <jae_young_kim@brown.edu>
+foice <foice.news@gmail.com>
+Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
+noam simcha finkelstein <noam.finkelstein@protonmail.com>
+Islam Mansour <is3mansour@gmail.com>
+Shubham Agrawal <shubham.ag6845@gmail.com>
+numbermaniac <5206120+numbermaniac@users.noreply.github.com>
+Sakirul Alam <binarysakir@gmail.com>
+Mohammed Bilal <r.mohammedbilal@gmail.com>
+Ansh Mishra <anshmishra471@gmail.com>
+Alex Malins <github@alexmalins.com>
+Shital Mule <shitalmule04@gmail.com>
+Amanda Dsouza <meezamanda@yahoo.com>
+Nijso Beishuizen <nijso@koolmees.numerically-related.com>
+Harry Zheng <harry@harryzheng.com>
+Felix Yan <felixonmars@archlinux.org>
+Constantin Mateescu <costica1234@me.com>
+Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
+Neel Gorasiya <mgorasiya1974@gmail.com>
+Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
+Stefan Petrea <stefan@garage-coding.com>
+Mark Bell <mark00bell@googlemail.com>
+AlexCQY <alex_chua@u.nus.edu>
+Achal Jain <2achaljain@gmail.com>
+Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Wyatt Peak <wyattpeak@gmail.com>
+Aditya Jindal <jaditya8889@gmail.com>
+Saket Kumar Singh <saketkumar1202@gmail.com>
+Paul Mandel <paulmandel@google.com>
+Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Dominik Stańczak <stanczakdominik@gmail.com>
+Rodrigo Luger <rodluger@gmail.com>
+Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
+Brandon T. Willard <brandonwillard@users.noreply.github.com>
+Thomas Aarholt <thomasaarholt@gmail.com>
+Hiren Chalodiya <hirenchalodiya99@gmail.com>
+Roland Dixon <rols121@gmail.com>
+dimasvq <dimas.vq.2020@bristol.ac.uk>
+Sagar231 <sagarfeb298@gmail.com>
+Michael Chu <michael02chu@gmail.com>
+Abby Ng <abigailjng@gmail.com>
+Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
+Alexander Cockburn <alexander_cockburn12@hotmail.com>
+Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
+Lee Johnston <lee.johnston.100@gmail.com>
+Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
+Nikita <nikita.student.cse19@itbhu.ac.in>
+Aman <amanmourya295@gmail.com>
+Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
+Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
+Nils Schulte <47043622+Schnilz@users.noreply.github.com>
+Matt Bogosian <matt@bogosian.net>
+Jeffrey Ryan <jeffaryan7@gmail.com>
+Jonathan Daniel <36337649+jond01@users.noreply.github.com>
+Remco de Boer <redeboer@gmx.com>
+Jason Ross <jasonross1024@gmail.com>
+alijosephine <alijosephine@gmail.com>
+Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Travis Ens <ens.travis@gmail.com>
+Evgenia Karunus <lakesare@gmail.com>
+lastcodestanding <rohang71604@gmail.com>
+anutosh491 <andersonbhat491@gmail.com>
+Steve Kieffer <sk@skieffer.info>
+Pieter Gijsbers <p.gijsbers@tue.nl>
+Wang Ran (汪然) <wangr@smail.nju.edu.cn>
+naelsondouglas <naelson17@gmail.com>
+S. Hanko <suzy.hanko@gmail.com>
+Hampus Malmberg <hampus.malmberg88@gmail.com>
+scimax <max.kellermeier@hotmail.de>
+Nikhil Date <nikhil.s.date@gmail.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
+AkuBrain <76952313+Franck2111@users.noreply.github.com>
+Leo Battle <leowbattle@gmail.com>
+Advait <apote2050@gmail.com>
+faze-geek <bhat.1@iitj.ac.in> faze-geek <90216905+faze-geek@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1120 authors.
+There are a total of 1121 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1126,3 +1126,4 @@ Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
 AkuBrain <76952313+Franck2111@users.noreply.github.com>
 Leo Battle <leowbattle@gmail.com>
 Advait <apote2050@gmail.com>
+faze-geek <bhat.1@iitj.ac.in>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follws on from #21987 and #22650

#### Brief description of what is fixed or changed

Adds all people who are listed in any git commits to the .mailmap file. In a subsequent PR I will sort the .mailmap file into alphabetical ordering. This will make it possible for new contributors to add their identifying information to the .mailmap file without running into continuous merge conflicts. This PR just adds the missing people to .mailmap so that from now on we can require all commits to be accounted for by an entry in .mailmap (although this PR does not enforce that yet) and the AUTHORS file can be updated automatically at release time.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
