### PR TITLE
documentation: Explainer for rop and rel_op in core.relational docstring

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -82,6 +82,62 @@ class Relational(Boolean, EvalfMixin):
     >>> Rel(y, x + x**2, '==')
     Eq(y, x**2 + x)
 
+    A relation's type can be defined upon creation using ``rop``.
+    The relation type of an exising expression can be obtained
+    using its ``rel_op`` property.
+    Here is a table of all the relation types, along with their
+    ``rop`` and ``rel_op`` values:
+
+    +---------------------+----------------------------+------------+
+    |Relation             |``rop``                     |``rel_op``  |
+    +=====================+============================+============+
+    |``Equality``         |``==`` or ``eq`` or ``None``|``==``      |
+    +---------------------+----------------------------+------------+
+    |``Unequality``       |``!=`` or ``ne``            |``!=``      |
+    +---------------------+----------------------------+------------+
+    |``GreaterThan``      |``>=`` or ``ge``            |``>=``      |
+    +---------------------+----------------------------+------------+
+    |``LessThan``         |``<=`` or ``le``            |``<=``      |
+    +---------------------+----------------------------+------------+
+    |``StrictGreaterThan``|``>`` or ``gt``             |``>``       |
+    +---------------------+----------------------------+------------+
+    |``StrictLessThan``   |``<`` or ``lt``             |``<``       |
+    +---------------------+----------------------------+------------+
+
+    For example, setting ``rop`` to ``==`` produces an
+    ``Equality`` relation, ``Eq()``.
+    So does setting ``rop`` to ``eq``, or leaving ``rop`` unspecified.
+    That is, the first three ``Rel()`` below all produce the same result.
+    Using a ``rop`` from a different row in the table produces a
+    different relation type.
+    For example, the fourth ``Rel()`` below using ``lt`` for ``rop``
+    produces a ``StrictLessThan`` inequality:
+
+    >>> from sympy import Rel
+    >>> from sympy.abc import x, y
+    >>> Rel(y, x + x**2, '==')
+        Eq(y, x**2 + x)
+    >>> Rel(y, x + x**2, 'eq')
+        Eq(y, x**2 + x)
+    >>> Rel(y, x + x**2)
+        Eq(y, x**2 + x)
+    >>> Rel(y, x + x**2, 'lt')
+        y < x**2 + x
+
+    To obtain the relation type of an exising expression,
+    get its ``rel_op`` property.
+    For example, ``rel_op`` is ``==`` for the ``Equality`` relation above,
+    and ``<`` for the strict less than inequality above:
+
+    >>> from sympy import Rel
+    >>> from sympy.abc import x, y
+    >>> my_equality = Rel(y, x + x**2, '==')
+    >>> my_equality.rel_op
+        '=='
+    >>> my_inequality = Rel(y, x + x**2, 'lt')
+    >>> my_inequality.rel_op
+        '<'
+
     """
     __slots__ = ()
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -83,7 +83,7 @@ class Relational(Boolean, EvalfMixin):
     Eq(y, x**2 + x)
 
     A relation's type can be defined upon creation using ``rop``.
-    The relation type of an exising expression can be obtained
+    The relation type of an existing expression can be obtained
     using its ``rel_op`` property.
     Here is a table of all the relation types, along with their
     ``rop`` and ``rel_op`` values:
@@ -124,7 +124,7 @@ class Relational(Boolean, EvalfMixin):
     >>> Rel(y, x + x**2, 'lt')
         y < x**2 + x
 
-    To obtain the relation type of an exising expression,
+    To obtain the relation type of an existing expression,
     get its ``rel_op`` property.
     For example, ``rel_op`` is ``==`` for the ``Equality`` relation above,
     and ``<`` for the strict less than inequality above:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22674

#### Brief description of what is fixed or changed
In core.relational docstring, added table and examples of how to use `rop` (to set the relation type upon instantiation of a relational) and `rel_op` (to extract the relation type from an existing relational).

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

Here's a screenshot. Should code entries in tables be formatted as `code`?

![Preview](https://drive.google.com/uc?export=view&id=1BeLAVcoLN5p4lX0PFEBWh35jEtPSTkjp)