### PR TITLE
Fuzzy bool explained for vague subets

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -399,6 +399,9 @@ class Set(Basic, EvalfMixin):
         if self.intersect(other) == self:
             return True
 
+        # Function defaults to None!
+        print("Boolean undeterminable. Set is defined vaguely")
+
     def _eval_is_subset(self, other):
         '''Returns a fuzzy bool for whether self is a subset of other.'''
         return None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #9855


#### Brief description of what is fixed or changed
Added a useful printout for the fuzzy bool returned in the "is_subset" method. This is caused by intervals defined with variables. In the case (1, x) where x is a symbol in the real number domain, if x < 1 the set is empty, leading to unclear truth tables.

#### Other comments
Please accept part of a class assignment due 12/20/21 11:59:00 PM EST

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
