### PR TITLE
Updated arguments for proper testing

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -510,7 +510,7 @@ def test_sympy__combinatorics__permutations__AppliedPermutation():
     from sympy.combinatorics.permutations import Permutation
     from sympy.combinatorics.permutations import AppliedPermutation
     p = Permutation([0, 1, 2, 3])
-    assert _test_args(AppliedPermutation(p, 1))
+    assert _test_args(AppliedPermutation(p, x))
 
 def test_sympy__combinatorics__perm_groups__PermutationGroup():
     from sympy.combinatorics.permutations import Permutation
@@ -1945,7 +1945,7 @@ def test_sympy__functions__combinatorial__factorials__binomial():
 
 def test_sympy__functions__combinatorial__factorials__subfactorial():
     from sympy.functions.combinatorial.factorials import subfactorial
-    assert _test_args(subfactorial(1))
+    assert _test_args(subfactorial(x))
 
 
 def test_sympy__functions__combinatorial__factorials__factorial():
@@ -2500,7 +2500,7 @@ def test_sympy__functions__special__error_functions__li():
 
 def test_sympy__functions__special__error_functions__Li():
     from sympy.functions.special.error_functions import Li
-    assert _test_args(Li(2))
+    assert _test_args(Li(5))
 
 
 @SKIP("abstract class")
@@ -2540,7 +2540,7 @@ def test_sympy__functions__special__gamma_functions__gamma():
 
 def test_sympy__functions__special__gamma_functions__loggamma():
     from sympy.functions.special.gamma_functions import loggamma
-    assert _test_args(loggamma(2))
+    assert _test_args(loggamma(x))
 
 
 def test_sympy__functions__special__gamma_functions__lowergamma():
@@ -4056,6 +4056,7 @@ def test_sympy__physics__secondquant__BosonicOperator():
 
 def test_sympy__physics__secondquant__Commutator():
     from sympy.physics.secondquant import Commutator
+    x, y = symbols('x y', commutative=False)
     assert _test_args(Commutator(x, y))
 
 
@@ -4076,8 +4077,7 @@ def test_sympy__physics__secondquant__Creator():
 
 def test_sympy__physics__secondquant__Dagger():
     from sympy.physics.secondquant import Dagger
-    from sympy.core.numbers import I
-    assert _test_args(Dagger(2*I))
+    assert _test_args(Dagger(x))
 
 
 def test_sympy__physics__secondquant__FermionState():
@@ -4479,7 +4479,9 @@ def test_sympy__tensor__functions__TensorProduct():
 def test_sympy__tensor__indexed__Idx():
     from sympy.tensor.indexed import Idx
     assert _test_args(Idx('test'))
-    assert _test_args(Idx(1, (0, 10)))
+    assert _test_args(Idx('test', (0, 10)))
+    assert _test_args(Idx('test', 2))
+    assert _test_args(Idx('test', x))
 
 
 def test_sympy__tensor__indexed__Indexed():
@@ -4776,7 +4778,6 @@ def test_sympy__diffgeom__diffgeom__LieDerivative():
     assert _test_args(LieDerivative(v, d))
 
 
-@XFAIL
 def test_sympy__diffgeom__diffgeom__BaseCovarDerivativeOp():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseCovarDerivativeOp
     cs = CoordSystem('name', Patch('name', Manifold('name', 3)), [a, b, c])
@@ -4800,10 +4801,9 @@ def test_sympy__categories__baseclasses__Object():
     assert _test_args(Object("A"))
 
 
-@XFAIL
+@SKIP("abstract class")
 def test_sympy__categories__baseclasses__Morphism():
-    from sympy.categories import Object, Morphism
-    assert _test_args(Morphism(Object("A"), Object("B")))
+    pass
 
 
 def test_sympy__categories__baseclasses__IdentityMorphism():
@@ -5322,7 +5322,7 @@ def test_sympy__integrals__rubi__utility_function__Util_Coefficient():
 
 def test_sympy__integrals__rubi__utility_function__Gamma():
     from sympy.integrals.rubi.utility_function import Gamma
-    assert _test_args(Gamma(5))
+    assert _test_args(Gamma(x))
 
 
 def test_sympy__integrals__rubi__utility_function__Util_Part():
@@ -5333,7 +5333,7 @@ def test_sympy__integrals__rubi__utility_function__Util_Part():
 
 def test_sympy__integrals__rubi__utility_function__PolyGamma():
     from sympy.integrals.rubi.utility_function import PolyGamma
-    assert _test_args(PolyGamma(1, 1))
+    assert _test_args(PolyGamma(1, x))
 
 
 def test_sympy__integrals__rubi__utility_function__ProductLog():
@@ -5343,7 +5343,7 @@ def test_sympy__integrals__rubi__utility_function__ProductLog():
 
 def test_sympy__combinatorics__schur_number__SchurNumber():
     from sympy.combinatorics.schur_number import SchurNumber
-    assert _test_args(SchurNumber(1))
+    assert _test_args(SchurNumber(x))
 
 
 def test_sympy__combinatorics__perm_groups__SymmetricPermutationGroup():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
While playing around with #22654 I realized that e.g. `Integer` was tested in `test_args` rather often. The reason is that many of the test cases was evaluated to an `Integer`, so the actual purpose of testing the class was not there.

I have changed some of them. Some classes should probably be functions instead, this holds for e.g. `motzkin` that cannot use symbolic arguments as well as some classes in the rubi utility functions which are always returning a standard SymPy class (it seems like when there is a one-to-one mapping a function is used, but if one selects among two classes based on the number of arguments, a class is used, probably to have a variable number of arguments). Also, some of the quantum classes do not handle symbolic arguments (and have comments saying that they should be extended to do that).

#### Other comments

In the long run, one should maybe also send the class as an argument to `test_args` to make sure that the class is actually tested and that the provide arguments do return the class, rather than just testing `Integer` multiple times...

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
