### PR TITLE
Updated default LaTeX printing of Basic

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -915,7 +915,8 @@ class String(Atom, Token):
         return lambda: self
 
     def _latex(self, printer):
-        return r'\texttt{{"{}"}}'.format(self.text)
+        from sympy.printing.latex import latex_escape
+        return r'\texttt{{"{}"}}'.format(latex_escape(self.text))
 
 class QuotedString(String):
     """ Represents a string which should be printed with quotes. """
@@ -1133,8 +1134,10 @@ class Type(Token):
         return new_val
 
     def _latex(self, printer):
-        return r"\text{{{}}}\left(\texttt{{{}}}\right)".format(self.__class__.__name__,
-                                                               self.name.text)
+        from sympy.printing.latex import latex_escape
+        type_name = latex_escape(self.__class__.__name__)
+        name = latex_escape(self.name.text)
+        return r"\text{{{}}}\left(\texttt{{{}}}\right)".format(type_name, name)
 
 
 class IntBaseType(Type):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -357,9 +357,13 @@ class LatexPrinter(Printer):
             return expr
 
     def _print_Basic(self, expr):
-        ls = [self._print(o) for o in expr.args]
-        return self._deal_with_super_sub(expr.__class__.__name__) + \
-            r"\left(%s\right)" % ", ".join(ls)
+        name = self._deal_with_super_sub(expr.__class__.__name__)
+        if expr.args:
+            ls = [self._print(o) for o in expr.args]
+            s = r"\operatorname{{{}}}\left({}\right)"
+            return s.format(name, ", ".join(ls))
+        else:
+            return r"\text{{{}}}".format(name)
 
     def _print_bool(self, e):
         return r"\text{%s}" % e
@@ -2796,7 +2800,7 @@ class LatexPrinter(Printer):
         return str(expr)
 
     def _print_Predicate(self, expr):
-        return str(expr)
+        return r"\operatorname{{Q}}_{{\text{{{}}}}}".format(latex_escape(str(expr.name)))
 
     def _print_AppliedPredicate(self, expr):
         pred = expr.function

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2688,11 +2688,11 @@ def test_print_basic():
         result.__class__.__name__ = 'UnimplementedExpr_x^1'
         return result
 
-    assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
+    assert latex(unimplemented_expr(x)) == r'\operatorname{UnimplementedExpr}\left(x\right)'
     assert latex(unimplemented_expr(x**2)) == \
-        r'UnimplementedExpr\left(x^{2}\right)'
+        r'\operatorname{UnimplementedExpr}\left(x^{2}\right)'
     assert latex(unimplemented_expr_sup_sub(x)) == \
-        r'UnimplementedExpr^{1}_{x}\left(x\right)'
+        r'\operatorname{UnimplementedExpr^{1}_{x}}\left(x\right)'
 
 
 def test_MatrixSymbol_bold():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Earlier on the LaTeX printing of Basic (and therefore all classes not having dedicated printing) resulted in a quite ugly result (as no formatting was applied). Now, these are printed as `\operatorname` if they have arguments and `\text` if not. This is a better guess in most cases.
Earlier:

![image](https://user-images.githubusercontent.com/8114497/146938394-2c650a56-8a59-4870-a467-f72fbd7929ac.png)

![image](https://user-images.githubusercontent.com/8114497/146938349-f306cd23-7cdd-4287-aca8-82c6859e56e1.png)

Now:
![image](https://user-images.githubusercontent.com/8114497/146937834-61ac5b6f-c529-44e0-ad1d-690c11a4d75e.png)
![image](https://user-images.githubusercontent.com/8114497/146938293-dc2f465b-3224-4da4-9af6-96c0bac585af.png)

Edit: oh, and predicates are printed like:
![image](https://user-images.githubusercontent.com/8114497/146939123-a8aba1e9-e5c6-4d7e-9675-b4839bd7208d.png)

#### Other comments

One thing to consider is how to deal with classes with _ in their names. Right now, the _ is used to indicate subscripts as in the rest of SymPy. This is of course a bit bad for a few classes that happens to include _, but I still think it is better than the opposite.

Also improved the recently introduced ast-printing slightly.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
