### PR TITLE
Added lambdify for Array and fixed issue with ITE in Piecewise

### DIFF
--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -14,6 +14,7 @@ from sympy.core import Pow
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Sqrt
+from sympy.tensor.array import Array
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
     PermuteDims, ArrayDiagonal
 from sympy.printing.numpy import NumPyPrinter, SciPyPrinter, _numpy_known_constants, \
@@ -321,6 +322,10 @@ def test_issue_17006():
     n = symbols('n', integer=True)
     N = MatrixSymbol("M", n, n)
     raises(NotImplementedError, lambda: lambdify(N, N + Identity(n)))
+
+def test_numpy_array():
+    assert NumPyPrinter().doprint(Array(((1, 2), (3, 5)))) == 'numpy.array([[1, 2], [3, 5]])'
+    assert NumPyPrinter().doprint(Array((1, 2))) == 'numpy.array((1, 2))'
 
 def test_numpy_known_funcs_consts():
     assert _numpy_known_constants['NaN'] == 'numpy.nan'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -26,7 +26,7 @@ from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma)
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (And, false, ITE, Not, Or, true)
 from sympy.matrices.expressions.dotproduct import DotProduct
-from sympy.tensor.array import derive_by_array
+from sympy.tensor.array import derive_by_array, Array
 from sympy.tensor.indexed import IndexedBase
 from sympy.utilities.lambdify import lambdify
 from sympy.core.expr import UnevaluatedExpr
@@ -1344,6 +1344,16 @@ def test_issue_22739():
     F = lambdify((x1, x2), f, modules='numpy')
     point = {x1: 1, x2: 2}
     assert abs(f.subs(point) - F(*point.values())) <= 1e-10
+
+
+def test_issue_19764():
+    if not numpy:
+        skip("numpy not installed")
+
+    expr = Array([x, x**2])
+    f = lambdify(x, expr, 'numpy')
+
+    assert f(1).__class__ == numpy.ndarray
 
 
 def test_fresnel_integrals_scipy():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -20,11 +20,13 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, cos, sin, sinc, tan)
 from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely)
 from sympy.functions.special.beta_functions import (beta, betainc, betainc_regularized)
+from sympy.functions.special.delta_functions import (Heaviside)
 from sympy.functions.special.error_functions import (erf, erfc, fresnelc, fresnels)
 from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma)
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (And, false, ITE, Not, Or, true)
 from sympy.matrices.expressions.dotproduct import DotProduct
+from sympy.tensor.array import derive_by_array
 from sympy.tensor.indexed import IndexedBase
 from sympy.utilities.lambdify import lambdify
 from sympy.core.expr import UnevaluatedExpr
@@ -1319,6 +1321,29 @@ def test_issue_16536():
     f2 = uppergamma(a, x)
     F = lambdify((a, x), f2, modules='scipy')
     assert abs(uppergamma(1, 3) - F(1, 3)) <= 1e-10
+
+
+def test_issue_22726():
+    if not numpy:
+        skip("numpy not installed")
+
+    x1, x2 = symbols('x1 x2')
+    f = Max(S.Zero, Min(x1, x2))
+    g = derive_by_array(f, (x1, x2))
+    G = lambdify((x1, x2), g, modules='numpy')
+    point = {x1: 1, x2: 2}
+    assert (abs(g.subs(point) - G(*point.values())) <= 1e-10).all()
+
+
+def test_issue_22739():
+    if not numpy:
+        skip("numpy not installed")
+
+    x1, x2 = symbols('x1 x2')
+    f = Heaviside(Min(x1, x2))
+    F = lambdify((x1, x2), f, modules='numpy')
+    point = {x1: 1, x2: 2}
+    assert abs(f.subs(point) - F(*point.values())) <= 1e-10
 
 
 def test_fresnel_integrals_scipy():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #22726
Closes #22739 

Partly solves #22106 (deprecation warning)
Related to #19764 (not sure if it solves it)

#### Brief description of what is fixed or changed

Added rudimentary support for `NDimArray` (not sure why `_print_Array` does not work...). Some more thinking would get arbitrary dimensions to work, but better have 1-D and 2-D rather than none...

Fixed issue where an ITE condition in a Piecewise becomes a select inside a select and an error occur in numpy.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
   * Basic lambdify support for 1-D and 2-D `NDimArray` 
   * Fixed issue with lambdify of a `Piecewise` with `ITE` conditions.
<!-- END RELEASE NOTES -->
