### PR TITLE
Remove Cython future warning

### DIFF
--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -287,7 +287,7 @@ def simple_cythonize(src, destdir=None, cwd=None, **cy_kwargs):
         # Set language_level if not set by cy_kwargs
         # as not setting it is deprecated
         if 'language_level' not in cy_kwargs:
-            cy_options['language_level'] = 3
+            cy_options.__dict__['language_level'] = 3
         cy_result = cy_compile([src], cy_options)
         if cy_result.num_errors > 0:
             raise ValueError("Cython compilation failed.")

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -284,6 +284,10 @@ def simple_cythonize(src, destdir=None, cwd=None, **cy_kwargs):
     try:
         cy_options = CompilationOptions(default_options)
         cy_options.__dict__.update(cy_kwargs)
+        # Set language_level if not set by cy_kwargs
+        # as not setting it is deprecated
+        if 'language_level' not in cy_kwargs:
+            cy_options['language_level'] = 3
         cy_result = cy_compile([src], cy_options)
         if cy_result.num_errors > 0:
             raise ValueError("Cython compilation failed.")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes the following warning in optional dependency-tests by setting language_level to 3 if it is not explicitly set elsewhere:
```
/opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /tmp/tmp4y6wzijg/_sigmoid.pyx
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * `language_level` is automatically set to 3 when compiling with cython using `utilities._compilation`, but can be overridden by providing another language_level.
<!-- END RELEASE NOTES -->
