### PR TITLE
Fix arsinh, arcosh, etc. full names

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -915,7 +915,7 @@ class LatexPrinter(Printer):
                 if inv_trig_style == "abbreviated":
                     pass
                 elif inv_trig_style == "full":
-                    func = "arc" + func[1:]
+                    func = ("ar" if func[-1] == "h" else "arc") + func[1:]
                 elif inv_trig_style == "power":
                     func = func[1:]
                     inv_trig_power_case = True

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -469,7 +469,7 @@ def test_latex_functions():
     assert latex(acsc(x), inv_trig_style="full") == \
         r"\operatorname{arccsc}{\left(x \right)}"
     assert latex(asinh(x), inv_trig_style="full") == \
-        r"\operatorname{arcsinh}{\left(x \right)}"
+        r"\operatorname{arsinh}{\left(x \right)}"
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"


### PR DESCRIPTION
The full names of the inverse hyperbolic trigonometric functions (arsinh, arcosh, artanh, arsech, arcsch, arcoth) don't have a ‘c’, so this fixes them in the LaTeX output when `inv_trig_style="full"`.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
