### PR TITLE
Allow complex transfer functions in pole-zero plot

### DIFF
--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -42,6 +42,8 @@ def _check_system(system):
             " that there are no free symbols in the dynamical system other"
             " than the variable of Laplace transform.")
     if sys.has(exp):
+        # Should test that exp is not part of a constant, in which case
+        # no exception is required, compare exp(s) with s*exp(1)
         raise NotImplementedError("Time delay terms are not supported.")
 
 
@@ -101,8 +103,8 @@ def pole_zero_numerical_data(system):
     num_poly = Poly(system.num, system.var).all_coeffs()
     den_poly = Poly(system.den, system.var).all_coeffs()
 
-    num_poly = np.array(num_poly, dtype=np.float64)
-    den_poly = np.array(den_poly, dtype=np.float64)
+    num_poly = np.array(num_poly, dtype=np.complex128)
+    den_poly = np.array(den_poly, dtype=np.complex128)
 
     zeros = np.roots(num_poly)
     poles = np.roots(den_poly)

--- a/sympy/physics/control/tests/test_control_plots.py
+++ b/sympy/physics/control/tests/test_control_plots.py
@@ -27,6 +27,7 @@ tf4 = TransferFunction(10, p**3, p)
 tf5 = TransferFunction(5, s**2 + 2*s + 10, s)
 tf6 = TransferFunction(1, 1, s)
 tf7 = TransferFunction(4*s*3 + 9*s**2 + 0.1*s + 11, 8*s**6 + 9*s**4 + 11, s)
+tf8 = TransferFunction(5, s**2 + (2+I)*s + 10, s)
 
 ser1 = Series(tf4, TransferFunction(1, p - 5, p))
 ser2 = Series(tf3, TransferFunction(p, p + 2, p))
@@ -114,6 +115,10 @@ def test_pole_zero():
         ((-0.24999999999999986+1.3919410907075052j),
         (-0.24999999999999986-1.3919410907075052j), (-0.2499999999999998+0.32274861218395134j),
         (-0.2499999999999998-0.32274861218395134j)))
+    assert _to_tuple(*pole_zero_numerical_data(tf8)) == \
+        ((),
+         ((-1.1641600331447917-3.545808351896439j),
+          (-0.8358399668552097+2.5458083518964383j)))
 
 
 def test_bode():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The pole zero plot could only work with real-valued transfer functions (complex conjugate pole-zero pairs). No harm in allowing support for complex-valued expressions. (Realized this while I was playing around with a non-working filter design...)

#### Other comments

Also added a comment regarding a sub-optimal check. Expressions of the type `exp(s)` should not be allowed, but `s*exp(1)` can be handled. Now both are disallowed. Better to check if the numerator and denominator are polynomials in `s`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
   * `pole_zero_plot` now supports complex-valued transfer functions. 
<!-- END RELEASE NOTES -->
