### PR TITLE
Add Jacobi theta and elliptic functions

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -130,7 +130,9 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         chebyshevu, chebyshevu_root, chebyshevt_root, laguerre,
         assoc_laguerre, gegenbauer, jacobi, jacobi_normalized, Ynm, Ynm_c,
         Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, theta1, theta2,
-        theta3, theta4, elliptic_nome_q, jacobi_cd, beta, mathieus, mathieuc,
+        theta3, theta4, elliptic_nome_q, jacobi_cd, jacobi_cn, jacobi_cs,
+        jacobi_dc, jacobi_dn, jacobi_ds, jacobi_nc, jacobi_nd, jacobi_ns,
+        jacobi_sc, jacobi_sd, jacobi_sn, beta, mathieus, mathieuc,
         mathieusprime, mathieucprime, riemann_xi, betainc, betainc_regularized)
 
 from .ntheory import (nextprime, prevprime, prime, primepi, primerange,
@@ -355,7 +357,9 @@ __all__ = [
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi','betainc',
     'betainc_regularized', 'theta1', 'theta2', 'theta3', 'theta4',
-    'elliptic_nome_q', 'jacobi_cd',
+    'jacobi_cd', 'jacobi_cn', 'jacobi_cs', 'jacobi_dc', 'jacobi_dn',
+    'jacobi_ds', 'jacobi_nc', 'jacobi_nd', 'jacobi_ns', 'jacobi_sc',
+    'jacobi_sd', 'jacobi_sn', 'elliptic_nome_q',
 
     # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -129,8 +129,9 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         meijerg, appellf1, legendre, assoc_legendre, hermite, chebyshevt,
         chebyshevu, chebyshevu_root, chebyshevt_root, laguerre,
         assoc_laguerre, gegenbauer, jacobi, jacobi_normalized, Ynm, Ynm_c,
-        Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, beta, mathieus,
-        mathieuc, mathieusprime, mathieucprime, riemann_xi, betainc, betainc_regularized)
+        Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, JacobiTheta,
+        JacobiEllipticFunction, beta, mathieus, mathieuc, mathieusprime,
+        mathieucprime, riemann_xi, betainc, betainc_regularized)
 
 from .ntheory import (nextprime, prevprime, prime, primepi, primerange,
         randprime, Sieve, sieve, primorial, cycle_length, composite,
@@ -353,7 +354,7 @@ __all__ = [
     'gegenbauer', 'jacobi', 'jacobi_normalized', 'Ynm', 'Ynm_c', 'Znm',
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi','betainc',
-    'betainc_regularized',
+    'betainc_regularized', 'JacobiTheta', 'JacobiEllipticFunction',
 
     # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -129,9 +129,9 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         meijerg, appellf1, legendre, assoc_legendre, hermite, chebyshevt,
         chebyshevu, chebyshevu_root, chebyshevt_root, laguerre,
         assoc_laguerre, gegenbauer, jacobi, jacobi_normalized, Ynm, Ynm_c,
-        Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, JacobiTheta,
-        JacobiEllipticFunction, beta, mathieus, mathieuc, mathieusprime,
-        mathieucprime, riemann_xi, betainc, betainc_regularized)
+        Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, theta1, theta2,
+        theta3, theta4, elliptic_nome_q, jacobi_cd, beta, mathieus, mathieuc,
+        mathieusprime, mathieucprime, riemann_xi, betainc, betainc_regularized)
 
 from .ntheory import (nextprime, prevprime, prime, primepi, primerange,
         randprime, Sieve, sieve, primorial, cycle_length, composite,
@@ -354,7 +354,8 @@ __all__ = [
     'gegenbauer', 'jacobi', 'jacobi_normalized', 'Ynm', 'Ynm_c', 'Znm',
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi','betainc',
-    'betainc_regularized', 'JacobiTheta', 'JacobiEllipticFunction',
+    'betainc_regularized', 'theta1', 'theta2', 'theta3', 'theta4',
+    'elliptic_nome_q', 'jacobi_cd',
 
     # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -37,10 +37,10 @@ class Str(Atom):
     __slots__ = ('name',)
 
     def __new__(cls, name, **kwargs):
-        if not isinstance(name, str):
+        if not isinstance(name, (str, Str)):
             raise TypeError("name should be a string, not %s" % repr(type(name)))
         obj = Expr.__new__(cls, **kwargs)
-        obj.name = name
+        obj.name = str(name) # In case a Str was passed
         return obj
 
     def __getnewargs__(self):
@@ -48,6 +48,9 @@ class Str(Atom):
 
     def _hashable_content(self):
         return (self.name,)
+
+    def __len__(self):
+        return len(str(self.name))
 
 
 def _filter_assumptions(kwargs):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2424,15 +2424,47 @@ def test_sympy__functions__special__elliptic_integrals__elliptic_pi():
     assert _test_args(P(x, y, z))
 
 
-def test_sympy__functions__special__elliptic_integrals__JacobiTheta():
-    from sympy.functions.special.elliptic_integrals import JacobiTheta
-    assert _test_args(JacobiTheta(1, y))
-    assert _test_args(JacobiTheta(2, y, z))
+@SKIP("abstract class")
+def test_sympy__functions__special__elliptic_integrals__ThetaBase():
+    pass
 
 
-def test_sympy__functions__special__elliptic_integrals__JacobiEllipticFunction():
-    from sympy.functions.special.elliptic_integrals import JacobiEllipticFunction
-    assert _test_args(JacobiEllipticFunction("sn", x, y))
+def test_sympy__functions__special__elliptic_integrals__theta1():
+    from sympy.functions.special.elliptic_integrals import theta1
+    assert _test_args(theta1(y))
+    assert _test_args(theta1(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__theta2():
+    from sympy.functions.special.elliptic_integrals import theta2
+    assert _test_args(theta2(y))
+    assert _test_args(theta2(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__theta3():
+    from sympy.functions.special.elliptic_integrals import theta3
+    assert _test_args(theta3(y))
+    assert _test_args(theta3(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__theta4():
+    from sympy.functions.special.elliptic_integrals import theta4
+    assert _test_args(theta4(y))
+    assert _test_args(theta4(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__elliptic_nome_q():
+    from sympy.functions.special.elliptic_integrals import elliptic_nome_q
+    assert _test_args(elliptic_nome_q(y))
+
+
+@SKIP("abstract class")
+def test_sympy__functions__special__elliptic_integrals__JacobiEllipticFunctionBase():
+    pass
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_cd():
+    from sympy.functions.special.elliptic_integrals import jacobi_cd
+    assert _test_args(jacobi_cd(y, z))
 
 
 def test_sympy__functions__special__delta_functions__DiracDelta():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2478,7 +2478,7 @@ def test_sympy__functions__special__elliptic_integrals__jacobi_cs():
     assert _test_args(jacobi_cs(y, z))
 
 
-def test_sympy__functions__special__elliptic_integrals__jacobi_cd():
+def test_sympy__functions__special__elliptic_integrals__jacobi_dc():
     from sympy.functions.special.elliptic_integrals import jacobi_dc
     assert _test_args(jacobi_dc(y, z))
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2424,6 +2424,17 @@ def test_sympy__functions__special__elliptic_integrals__elliptic_pi():
     assert _test_args(P(x, y, z))
 
 
+def test_sympy__functions__special__elliptic_integrals__JacobiTheta():
+    from sympy.functions.special.elliptic_integrals import JacobiTheta
+    assert _test_args(JacobiTheta(1, y))
+    assert _test_args(JacobiTheta(2, y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__JacobiEllipticFunction():
+    from sympy.functions.special.elliptic_integrals import JacobiEllipticFunction
+    assert _test_args(JacobiEllipticFunction("sn", x, y))
+
+
 def test_sympy__functions__special__delta_functions__DiracDelta():
     from sympy.functions.special.delta_functions import DiracDelta
     assert _test_args(DiracDelta(x, 1))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2462,9 +2462,65 @@ def test_sympy__functions__special__elliptic_integrals__elliptic_nome_q():
 def test_sympy__functions__special__elliptic_integrals__JacobiEllipticFunctionBase():
     pass
 
+
 def test_sympy__functions__special__elliptic_integrals__jacobi_cd():
     from sympy.functions.special.elliptic_integrals import jacobi_cd
     assert _test_args(jacobi_cd(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_cn():
+    from sympy.functions.special.elliptic_integrals import jacobi_cn
+    assert _test_args(jacobi_cn(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_cs():
+    from sympy.functions.special.elliptic_integrals import jacobi_cs
+    assert _test_args(jacobi_cs(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_cd():
+    from sympy.functions.special.elliptic_integrals import jacobi_dc
+    assert _test_args(jacobi_dc(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_dn():
+    from sympy.functions.special.elliptic_integrals import jacobi_dn
+    assert _test_args(jacobi_dn(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_ds():
+    from sympy.functions.special.elliptic_integrals import jacobi_ds
+    assert _test_args(jacobi_ds(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_nc():
+    from sympy.functions.special.elliptic_integrals import jacobi_nc
+    assert _test_args(jacobi_nc(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_nd():
+    from sympy.functions.special.elliptic_integrals import jacobi_nd
+    assert _test_args(jacobi_nd(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_ns():
+    from sympy.functions.special.elliptic_integrals import jacobi_ns
+    assert _test_args(jacobi_ns(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_sc():
+    from sympy.functions.special.elliptic_integrals import jacobi_sc
+    assert _test_args(jacobi_sc(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_sd():
+    from sympy.functions.special.elliptic_integrals import jacobi_sd
+    assert _test_args(jacobi_sd(y, z))
+
+
+def test_sympy__functions__special__elliptic_integrals__jacobi_sn():
+    from sympy.functions.special.elliptic_integrals import jacobi_sn
+    assert _test_args(jacobi_sn(y, z))
 
 
 def test_sympy__functions__special__delta_functions__DiracDelta():

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -43,7 +43,7 @@ from sympy.functions.special.polynomials import (legendre, assoc_legendre,
         laguerre, assoc_laguerre, gegenbauer, jacobi, jacobi_normalized)
 from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c, Znm
 from sympy.functions.special.elliptic_integrals import (elliptic_k,
-        elliptic_f, elliptic_e, elliptic_pi)
+        elliptic_f, elliptic_e, elliptic_pi, JacobiTheta, JacobiEllipticFunction)
 from sympy.functions.special.beta_functions import beta, betainc, betainc_regularized
 from sympy.functions.special.mathieu_functions import (mathieus, mathieuc,
         mathieusprime, mathieucprime)
@@ -103,7 +103,8 @@ __all__ = [
 
     'Ynm', 'Ynm_c', 'Znm',
 
-    'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi',
+    'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'JacobiTheta',
+    'JacobiEllipticFunction',
 
     'beta', 'betainc', 'betainc_regularized',
 

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -42,9 +42,11 @@ from sympy.functions.special.polynomials import (legendre, assoc_legendre,
         hermite, chebyshevt, chebyshevu, chebyshevu_root, chebyshevt_root,
         laguerre, assoc_laguerre, gegenbauer, jacobi, jacobi_normalized)
 from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c, Znm
-from sympy.functions.special.elliptic_integrals import (elliptic_k,
-        elliptic_f, elliptic_e, elliptic_pi, theta1, theta2, theta3, theta4,
-        elliptic_nome_q, jacobi_cd)
+from sympy.functions.special.elliptic_integrals import (
+    elliptic_k, elliptic_f, elliptic_e, elliptic_pi, theta1, theta2, theta3,
+    theta4, elliptic_nome_q, jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc,
+    jacobi_dn, jacobi_ds, jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc,
+    jacobi_sd, jacobi_sn)
 from sympy.functions.special.beta_functions import beta, betainc, betainc_regularized
 from sympy.functions.special.mathieu_functions import (mathieus, mathieuc,
         mathieusprime, mathieucprime)
@@ -105,7 +107,9 @@ __all__ = [
     'Ynm', 'Ynm_c', 'Znm',
 
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'theta1',
-    'theta2', 'theta3', 'theta4', 'jacobi_cd', 'elliptic_nome_q',
+    'theta2', 'theta3', 'theta4', 'jacobi_cd', 'jacobi_cn', 'jacobi_cs',
+    'jacobi_dc', 'jacobi_dn', 'jacobi_ds', 'jacobi_nc', 'jacobi_nd',
+    'jacobi_ns', 'jacobi_sc', 'jacobi_sd', 'jacobi_sn', 'elliptic_nome_q',
 
     'beta', 'betainc', 'betainc_regularized',
 

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -43,7 +43,8 @@ from sympy.functions.special.polynomials import (legendre, assoc_legendre,
         laguerre, assoc_laguerre, gegenbauer, jacobi, jacobi_normalized)
 from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c, Znm
 from sympy.functions.special.elliptic_integrals import (elliptic_k,
-        elliptic_f, elliptic_e, elliptic_pi, JacobiTheta, JacobiEllipticFunction)
+        elliptic_f, elliptic_e, elliptic_pi, theta1, theta2, theta3, theta4,
+        elliptic_nome_q, jacobi_cd)
 from sympy.functions.special.beta_functions import beta, betainc, betainc_regularized
 from sympy.functions.special.mathieu_functions import (mathieus, mathieuc,
         mathieusprime, mathieucprime)
@@ -103,8 +104,8 @@ __all__ = [
 
     'Ynm', 'Ynm_c', 'Znm',
 
-    'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'JacobiTheta',
-    'JacobiEllipticFunction',
+    'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'theta1',
+    'theta2', 'theta3', 'theta4', 'jacobi_cd', 'elliptic_nome_q',
 
     'beta', 'betainc', 'betainc_regularized',
 

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -512,7 +512,7 @@ class JacobiEllipticFunction(Function):
 
     @property
     def type_str(self):
-        return self.args[0]
+        return str(self.args[0])
 
     @property
     def vals(self):

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -667,12 +667,18 @@ class JacobiEllipticFunctionBase(Function):
     def _eval_expand_func(self, **kwargs):
         num, den = self._type_str
         u, m = self.args
-        if den == 's':
+        if den == 'n':
             return self
-        funcs = {'c': jacobi_cs, 'd': jacobi_ds, 'n': jacobi_ns}
-        if num == 's':
+        funcs = {'c': jacobi_cn, 'd': jacobi_dn, 'n': jacobi_sn}
+        if num == 'n':
             return 1/funcs[den](u, m)
         return funcs[num](u, m)/funcs[den](u, m)
+
+    def _eval_rewrite_as_theta2(self, *args):
+        expanded = self._eval_expand_func()
+        if expanded.has(jacobi_cn, jacobi_sn, jacobi_dn):
+            return expanded.rewrite(theta2)
+        return self
 
 
 class jacobi_cd(JacobiEllipticFunctionBase):
@@ -725,7 +731,7 @@ class jacobi_cn(JacobiEllipticFunctionBase):
     jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
-    _type_str = "cm"
+    _type_str = "cn"
 
     @classmethod
     def eval(cls, u, m):
@@ -739,6 +745,12 @@ class jacobi_cn(JacobiEllipticFunctionBase):
         if argindex == 2:
             raise NotImplementedError
         raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_theta2(self, *args):
+        u, m = self.args
+        q = elliptic_nome_q(m)
+        t = u/theta3(0, q)**2
+        return theta4(0, q)/theta2(0, q)*theta2(t, q)/theta4(t, q)
 
 
 class jacobi_cs(JacobiEllipticFunctionBase):
@@ -765,6 +777,14 @@ class jacobi_cs(JacobiEllipticFunctionBase):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("cs", u, m)
 
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobi_ds(u, m)*jacobi_ns(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
 
 class jacobi_dc(JacobiEllipticFunctionBase):
     r"""
@@ -783,12 +803,20 @@ class jacobi_dc(JacobiEllipticFunctionBase):
     jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
-    _type_str = "cd"
+    _type_str = "dc"
 
     @classmethod
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("dc", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return (1 - m)*jacobi_nc(u, m)*jacobi_sd(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
 
 
 class jacobi_dn(JacobiEllipticFunctionBase):
@@ -808,12 +836,26 @@ class jacobi_dn(JacobiEllipticFunctionBase):
     jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
-    _type_str = "dm"
+    _type_str = "dn"
 
     @classmethod
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("dm", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -m*jacobi_sn(u, m)*jacobi_cn(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_theta2(self, *args):
+        u, m = self.args
+        q = elliptic_nome_q(m)
+        t = u/theta3(0, q)**2
+        return theta4(0, q)/theta3(0, q)*theta3(t, q)/theta4(t, q)
 
 
 class jacobi_ds(JacobiEllipticFunctionBase):
@@ -840,6 +882,14 @@ class jacobi_ds(JacobiEllipticFunctionBase):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("ds", u, m)
 
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobi_cs(u, m)*jacobi_ns(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
 
 class jacobi_nc(JacobiEllipticFunctionBase):
     r"""
@@ -864,6 +914,14 @@ class jacobi_nc(JacobiEllipticFunctionBase):
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("nc", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return jacobi_dc(u, m)*jacobi_sc(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
 
 
 class jacobi_nd(JacobiEllipticFunctionBase):
@@ -890,6 +948,14 @@ class jacobi_nd(JacobiEllipticFunctionBase):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("nd", u, m)
 
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return m*jacobi_cd(u, m)*jacobi_sd(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
 
 class jacobi_ns(JacobiEllipticFunctionBase):
     r"""
@@ -914,6 +980,14 @@ class jacobi_ns(JacobiEllipticFunctionBase):
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("ns", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobi_cs(u, m)*jacobi_ds(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
 
 
 class jacobi_sc(JacobiEllipticFunctionBase):
@@ -940,6 +1014,14 @@ class jacobi_sc(JacobiEllipticFunctionBase):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("sc", u, m)
 
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return jacobi_dc(u, m)*jacobi_nc(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
 
 class jacobi_sd(JacobiEllipticFunctionBase):
     r"""
@@ -965,6 +1047,14 @@ class jacobi_sd(JacobiEllipticFunctionBase):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("sd", u, m)
 
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return jacobi_cd(u, m)*jacobi_nd(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
 
 class jacobi_sn(JacobiEllipticFunctionBase):
     r"""
@@ -989,6 +1079,20 @@ class jacobi_sn(JacobiEllipticFunctionBase):
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("sn", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobi_cn(u, m)*jacobi_dn(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_theta2(self, *args):
+        u, m = self.args
+        q = elliptic_nome_q(m)
+        t = u/theta3(0, q)**2
+        return theta3(0, q)/theta2(0, q)*theta3(1, q)/theta4(t, q)
 
 
 class elliptic_nome_q(Function):
@@ -1034,8 +1138,17 @@ class elliptic_nome_q(Function):
         m = self.args[0]
         return exp(-pi*elliptic_k(1 - m)/elliptic_k(m))
 
+    _eval_rewrite_as_exp = _eval_rewrite_as_elliptic_k
+
     def fdiff(self, argindex=1):
         if argindex == 1:
             m = self.args[0]
             return pi**2*elliptic_nome_q(m)/(4*(m-1)*m*elliptic_k(m)**2)
         raise ArgumentIndexError(self, argindex)
+
+
+def elliptic_nome_q_from_k(k):
+    return elliptic_nome_q(k**2)
+
+def elliptic_modulus_from_nome_q(q):
+    return theta2(q)**2/theta3(q)**2

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -489,7 +489,8 @@ class JacobiEllipticFunction(Function):
     Base class for Jacobi elliptic functions.
     """
     def __new__(cls, type_str, u, m):
-        if not isinstance(type_str, (str, Str)) or len(type_str) != 2 or any(x not in 'cdns' for x in type_str):
+        if (not isinstance(type_str, (str, Str)) or len(type_str) != 2
+            or any(x not in 'cdns' for x in str(type_str))):
             raise ValueError("First argument must be a string with exactly two"\
                              " characters from c, d, n, s.")
 

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -618,8 +618,8 @@ class JacobiEllipticFunctionBase(Function):
     See also
     ========
 
-    jacobi_cd, jacobi_cm, jacobi_cs, jacobi_dc, jacobi_dm, jacobi_ds,
-    jacobi_mc, jacobi_md, jacobi_ms, jacobi_sc, jacobi_sd, jacobi_sm
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
     def _eval_mpmath(self):
@@ -664,6 +664,16 @@ class JacobiEllipticFunctionBase(Function):
         if m.equals(S.One):
             return (m1vals[c1]/m1vals[c2]).subs(utmp, u)
 
+    def _eval_expand_func(self, **kwargs):
+        num, den = self._type_str
+        u, m = self.args
+        if den == 's':
+            return self
+        funcs = {'c': jacobi_cs, 'd': jacobi_ds, 'n': jacobi_ns}
+        if num == 's':
+            return 1/funcs[den](u, m)
+        return funcs[num](u, m)/funcs[den](u, m)
+
 
 class jacobi_cd(JacobiEllipticFunctionBase):
     r"""
@@ -678,8 +688,8 @@ class jacobi_cd(JacobiEllipticFunctionBase):
     See also
     ========
 
-    jacobi_cd, jacobi_cm, jacobi_cs, jacobi_dc, jacobi_dm, jacobi_ds,
-    jacobi_mc, jacobi_md, jacobi_ms, jacobi_sc, jacobi_sd, jacobi_sm
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
     _type_str = "cd"
@@ -698,6 +708,164 @@ class jacobi_cd(JacobiEllipticFunctionBase):
         raise ArgumentIndexError(self, argindex)
 
 
+class jacobi_cn(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "cm"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("cm", u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobi_sn(u, m)*jacobi_dn(u, m)
+        if argindex == 2:
+            raise NotImplementedError
+        raise ArgumentIndexError(self, argindex)
+
+
+class jacobi_cs(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "cs"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("cs", u, m)
+
+
+class jacobi_dc(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function:
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "cd"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("dc", u, m)
+
+
+class jacobi_dn(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "dm"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("dm", u, m)
+
+
+class jacobi_ds(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "ds"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("ds", u, m)
+
+
+class jacobi_nc(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "nc"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("nc", u, m)
+
+
 class jacobi_nd(JacobiEllipticFunctionBase):
     r"""
     Jacobi elliptic function: (wrong)
@@ -711,8 +879,8 @@ class jacobi_nd(JacobiEllipticFunctionBase):
     See also
     ========
 
-    jacobi_cd, jacobi_cm, jacobi_cs, jacobi_dc, jacobi_dm, jacobi_ds,
-    jacobi_mc, jacobi_md, jacobi_ms, jacobi_sc, jacobi_sd, jacobi_sm
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
     _type_str = "nd"
@@ -721,6 +889,56 @@ class jacobi_nd(JacobiEllipticFunctionBase):
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("nd", u, m)
+
+
+class jacobi_ns(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "ns"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("ns", u, m)
+
+
+class jacobi_sc(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "sc"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("sc", u, m)
 
 
 class jacobi_sd(JacobiEllipticFunctionBase):
@@ -736,8 +954,8 @@ class jacobi_sd(JacobiEllipticFunctionBase):
     See also
     ========
 
-    jacobi_cd, jacobi_cm, jacobi_cs, jacobi_dc, jacobi_dm, jacobi_ds,
-    jacobi_mc, jacobi_md, jacobi_ms, jacobi_sc, jacobi_sd, jacobi_sm
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
 
     """
     _type_str = "sd"
@@ -746,6 +964,31 @@ class jacobi_sd(JacobiEllipticFunctionBase):
     def eval(cls, u, m):
         if u.is_Number and m.is_Number:
             return JacobiEllipticFunctionBase._eval("sd", u, m)
+
+
+class jacobi_sn(JacobiEllipticFunctionBase):
+    r"""
+    Jacobi elliptic function: (wrong)
+
+    .. math::
+
+        \operatorname{cd}(u \mid m) = \frac{\cos(\phi)}{\sqrt{1 - m \sin^2(\phi)}
+
+    where $\phi = \operatorname{am}(u \mid m)$.
+
+    See also
+    ========
+
+    jacobi_cd, jacobi_cn, jacobi_cs, jacobi_dc, jacobi_dn, jacobi_ds,
+    jacobi_nc, jacobi_nd, jacobi_ns, jacobi_sc, jacobi_sd, jacobi_sn
+
+    """
+    _type_str = "sn"
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_Number and m.is_Number:
+            return JacobiEllipticFunctionBase._eval("sn", u, m)
 
 
 class elliptic_nome_q(Function):

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -57,6 +57,11 @@ known_functions = {
     'fresnelc': 'FresnelC',
     'fresnels': 'FresnelS',
     'lerchphi' : 'LerchPhi',
+    'elliptic_e' : 'EllipticE',
+    'elliptic_f' : 'EllipticF',
+    'elliptic_k' : 'EllipticK',
+    'elliptic_pi' : 'EllipticPi',
+    'elliptic_nome_q' : 'EllipticNome',
 }
 
 for _func in _known_func_same_name:
@@ -217,11 +222,11 @@ class MapleCodePrinter(CodePrinter):
     def _print_SparseRepMatrix(self, expr):
         return self._get_matrix(expr, sparse=True)
 
-    def _print_JacobiTheta(self, expr):
-        return "JacobiTheta{}({})".format(expr.type_val, ', '.join(self.doprint(a) for a in expr.vals))
+    def _print_ThetaBase(self, expr):
+        return "JacobiTheta{}({})".format(expr._type_val, ', '.join(self.doprint(a) for a in expr.args))
 
-    def _print_JacobiEllipticFunction(self, expr):
-        return "Jacobi{}({})".format(str(expr.type_str).upper(), ', '.join(self.doprint(a) for a in expr.vals))
+    def _print_JacobiEllipticFunctionBase(self, expr):
+        return "Jacobi{}({})".format(str(expr._type_str).upper(), ', '.join(self.doprint(a) for a in expr.args))
 
     def _print_Identity(self, expr):
         if isinstance(expr.rows, (Integer, IntegerConstant)):

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -217,6 +217,12 @@ class MapleCodePrinter(CodePrinter):
     def _print_SparseRepMatrix(self, expr):
         return self._get_matrix(expr, sparse=True)
 
+    def _print_JacobiTheta(self, expr):
+        return "JacobiTheta{}({})".format(expr.type_val, ', '.join(self.doprint(a) for a in expr.vals))
+
+    def _print_JacobiEllipticFunction(self, expr):
+        return "Jacobi{}({})".format(str(expr.type_str).upper(), ', '.join(self.doprint(a) for a in expr.vals))
+
     def _print_Identity(self, expr):
         if isinstance(expr.rows, (Integer, IntegerConstant)):
             return self._print(sympy.SparseMatrix(expr))

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -90,7 +90,7 @@ known_functions = {
     "elliptic_f": [(lambda *x: True, "EllipticE")],
     "elliptic_k": [(lambda x: True, "EllipticK")],
     "elliptic_pi": [(lambda *x: True, "EllipticPi")],
-    "JacobiTheta": [(lambda *x: True, "EllipticTheta")],
+    "elliptic_nome_q": [(lambda x: True, "EllipticNomeQ")],
     "zeta": [(lambda *x: True, "Zeta")],
     "dirichlet_eta": [(lambda x: True, "DirichletEta")],
     "riemann_xi": [(lambda x: True, "RiemannXi")],
@@ -320,8 +320,11 @@ class MCodePrinter(CodePrinter):
         return "ProductLog[{}, {}]".format(
             self._print(expr.args[1]), self._print(expr.args[0]))
 
-    def _print_JacobiEllipticFunction(self, expr):
-        return "Jacobi{}[{}]".format(str(expr.type_str).upper(), ', '.join(self.doprint(a) for a in expr.vals))
+    def _print_ThetaBase(self, expr):
+        return "EllipticTheta[{}, {}]".format(expr._type_val, ', '.join(self.doprint(a) for a in expr.args))
+
+    def _print_JacobiEllipticFunctionBase(self, expr):
+        return "Jacobi{}[{}]".format(str(expr._type_str).upper(), ', '.join(self.doprint(a) for a in expr.args))
 
     def _print_Integral(self, expr):
         if len(expr.variables) == 1 and not expr.limits[0][1:]:

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -90,6 +90,7 @@ known_functions = {
     "elliptic_f": [(lambda *x: True, "EllipticE")],
     "elliptic_k": [(lambda x: True, "EllipticK")],
     "elliptic_pi": [(lambda *x: True, "EllipticPi")],
+    "JacobiTheta": [(lambda *x: True, "EllipticTheta")],
     "zeta": [(lambda *x: True, "Zeta")],
     "dirichlet_eta": [(lambda x: True, "DirichletEta")],
     "riemann_xi": [(lambda x: True, "RiemannXi")],
@@ -318,6 +319,9 @@ class MCodePrinter(CodePrinter):
             return "ProductLog[{}]".format(self._print(expr.args[0]))
         return "ProductLog[{}, {}]".format(
             self._print(expr.args[1]), self._print(expr.args[0]))
+
+    def _print_JacobiEllipticFunction(self, expr):
+        return "Jacobi{}[{}]".format(str(expr.type_str).upper(), ', '.join(self.doprint(a) for a in expr.vals))
 
     def _print_Integral(self, expr):
         if len(expr.variables) == 1 and not expr.limits[0][1:]:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2643,12 +2643,16 @@ class PrettyPrinter(Printer):
 
     def _print_JacobiTheta(self, e):
         if self._use_unicode:
-            return self._print_number_function(e, '\N{GREEK THETA SYMBOL}')
+            func_name = f'\N{GREEK THETA SYMBOL}{e._type_val}'
         else:
-            return self._print_number_function(e, "theta")
+            func_name = f'theta{e._type_val}'
+        return self._helper_print_function(e.func, e.args, func_name=func_name)
 
-    def _print_JacobiEllipticFunction(self, e):
-        return self._helper_print_function(e.func, e.vals, func_name=str(e.type_str))
+    def _print_JacobiEllipticFunctionBase(self, e):
+        return self._helper_print_function(e.func, e.args, func_name=e._type_str)
+
+    def _print_elliptic_nome_q(self, e):
+        return self._helper_print_function(e.func, e.args, func_name="q")
 
     def _print_KroneckerDelta(self, e):
         pform = self._print(e.args[0])

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2596,7 +2596,7 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_number_function(self, e, name):
-        # Print name_arg[0] for one argument or name_arg[0](arg[1])
+        # Print name_arg[0] for one argument or name_arg[0](arg[1], arg[2], ...)
         # for more than one argument
         pform = prettyForm(name)
         arg = self._print(e.args[0])
@@ -2605,10 +2605,10 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.right(pform_arg))
         if len(e.args) == 1:
             return pform
-        m, x = e.args
+        args = e.args[1:]
         # TODO: copy-pasted from _print_Function: can we do better?
         prettyFunc = pform
-        prettyArgs = prettyForm(*self._print_seq([x]).parens())
+        prettyArgs = prettyForm(*self._print_seq(args).parens())
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
         pform.prettyFunc = prettyFunc
@@ -2640,6 +2640,15 @@ class PrettyPrinter(Printer):
             return self._print_number_function(e, '\N{GREEK SMALL LETTER GAMMA}')
         else:
             return self._print_number_function(e, "stieltjes")
+
+    def _print_JacobiTheta(self, e):
+        if self._use_unicode:
+            return self._print_number_function(e, '\N{GREEK THETA SYMBOL}')
+        else:
+            return self._print_number_function(e, "theta")
+
+    def _print_JacobiEllipticFunction(self, e):
+        return self._helper_print_function(e.func, e.vals, func_name=str(e.type_str))
 
     def _print_KroneckerDelta(self, e):
         pform = self._print(e.args[0])

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -17,6 +17,8 @@ from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.special.bessel import (airyai, airyaiprime, airybi, airybiprime)
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.special.error_functions import (fresnelc, fresnels)
+from sympy.functions.special.elliptic_integrals import (JacobiEllipticFunction,
+                                                        JacobiTheta)
 from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import dirichlet_eta
 from sympy.geometry.line import (Ray, Segment)
@@ -7609,6 +7611,12 @@ def test_pretty_misc_functions():
     assert upretty(Heaviside(x, y)) == 'θ(x, y)'
     assert pretty(dirichlet_eta(x)) == 'dirichlet_eta(x)'
     assert upretty(dirichlet_eta(x)) == 'η(x)'
+    assert pretty(JacobiEllipticFunction("dn", x, y)) == 'dn(x, y)'
+    assert upretty(JacobiEllipticFunction("dn", x, y)) == 'dn(x, y)'
+    assert pretty(JacobiTheta(1, x, y)) == 'theta (x, y)\n'\
+                                           '     1      '
+    assert upretty(JacobiTheta(1, x, y)) == 'ϑ (x, y)\n'\
+                                            ' 1      '
 
 
 def test_hadamard_power():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -17,8 +17,8 @@ from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.special.bessel import (airyai, airyaiprime, airybi, airybiprime)
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.special.error_functions import (fresnelc, fresnels)
-from sympy.functions.special.elliptic_integrals import (JacobiEllipticFunction,
-                                                        JacobiTheta)
+from sympy.functions.special.elliptic_integrals import (
+    jacobi_cd, elliptic_nome_q, theta1)
 from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import dirichlet_eta
 from sympy.geometry.line import (Ray, Segment)
@@ -7611,12 +7611,12 @@ def test_pretty_misc_functions():
     assert upretty(Heaviside(x, y)) == 'θ(x, y)'
     assert pretty(dirichlet_eta(x)) == 'dirichlet_eta(x)'
     assert upretty(dirichlet_eta(x)) == 'η(x)'
-    assert pretty(JacobiEllipticFunction("dn", x, y)) == 'dn(x, y)'
-    assert upretty(JacobiEllipticFunction("dn", x, y)) == 'dn(x, y)'
-    assert pretty(JacobiTheta(1, x, y)) == 'theta (x, y)\n'\
-                                           '     1      '
-    assert upretty(JacobiTheta(1, x, y)) == 'ϑ (x, y)\n'\
-                                            ' 1      '
+    assert pretty(jacobi_cd(x, y)) == 'cd(x, y)'
+    assert upretty(jacobi_cd(x, y)) == 'cd(x, y)'
+    assert pretty(theta1(x, y)) == 'theta1(x, y)'
+    assert upretty(theta1(x, y)) == 'θ₁(x, y)'
+    assert pretty(elliptic_nome_q(x)) == 'q(x)'
+    assert upretty(elliptic_nome_q(x)) == 'q(x)'
 
 
 def test_hadamard_power():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -25,7 +25,8 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acsc, asin, cos, cot, sin, tan)
 from sympy.functions.special.beta_functions import beta
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
-from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f, elliptic_k, elliptic_pi)
+from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f,
+                elliptic_k, elliptic_pi, JacobiEllipticFunction, JacobiTheta)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, expint)
 from sympy.functions.special.gamma_functions import (gamma, uppergamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -688,6 +689,8 @@ def test_latex_functions():
         r"\Pi^{2}\left(x; y\middle| z\right)"
     assert latex(elliptic_pi(x, y)) == r"\Pi\left(x\middle| y\right)"
     assert latex(elliptic_pi(x, y)**2) == r"\Pi^{2}\left(x\middle| y\right)"
+    assert latex(JacobiEllipticFunction("cs", x, y)) == r"\operatorname{cs}\left(x, y\right)"
+    assert latex(JacobiTheta(3, x, y)) == r"\vartheta_3\left(x, y\right)"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
     assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -26,7 +26,7 @@ from sympy.functions.elementary.trigonometric import (acsc, asin, cos, cot, sin,
 from sympy.functions.special.beta_functions import beta
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f,
-                elliptic_k, elliptic_pi, JacobiEllipticFunction, JacobiTheta)
+                elliptic_k, elliptic_pi, theta1, jacobi_cd, elliptic_nome_q)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, expint)
 from sympy.functions.special.gamma_functions import (gamma, uppergamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -689,8 +689,9 @@ def test_latex_functions():
         r"\Pi^{2}\left(x; y\middle| z\right)"
     assert latex(elliptic_pi(x, y)) == r"\Pi\left(x\middle| y\right)"
     assert latex(elliptic_pi(x, y)**2) == r"\Pi^{2}\left(x\middle| y\right)"
-    assert latex(JacobiEllipticFunction("cs", x, y)) == r"\operatorname{cs}\left(x, y\right)"
-    assert latex(JacobiTheta(3, x, y)) == r"\vartheta_3\left(x, y\right)"
+    assert latex(jacobi_cd(x, y)) == r"\operatorname{cd}\left(x, y\right)"
+    assert latex(theta1(x, y)) == r"\vartheta_1\left(x, y\right)"
+    assert latex(elliptic_nome_q(x)) == r"q\left(x\right)"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
     assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -7,6 +7,8 @@ from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
                             HadamardProduct, SparseMatrix)
 from sympy.functions.special.bessel import besseli
+from sympy.functions.special.elliptic_integrals import (JacobiEllipticFunction,
+                                                        JacobiTheta)
 
 from sympy.printing.maple import maple_code
 
@@ -382,3 +384,5 @@ def test_automatic_rewrites():
 def test_specfun():
     assert maple_code('asin(x)') == 'arcsin(x)'
     assert maple_code(besseli(x, y)) == 'BesselI(x, y)'
+    assert maple_code(JacobiTheta(1, 1, 2)) == 'JacobiTheta1(1, 2)'
+    assert maple_code(JacobiEllipticFunction("sn", 1, 2)) == 'JacobiSN(1, 2)'

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -7,9 +7,8 @@ from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
                             HadamardProduct, SparseMatrix)
 from sympy.functions.special.bessel import besseli
-from sympy.functions.special.elliptic_integrals import (JacobiEllipticFunction,
-                                                        JacobiTheta)
-
+from sympy.functions.special.elliptic_integrals import (
+    jacobi_cd, theta1, elliptic_nome_q)
 from sympy.printing.maple import maple_code
 
 x, y, z = symbols('x,y,z')
@@ -384,5 +383,6 @@ def test_automatic_rewrites():
 def test_specfun():
     assert maple_code('asin(x)') == 'arcsin(x)'
     assert maple_code(besseli(x, y)) == 'BesselI(x, y)'
-    assert maple_code(JacobiTheta(1, 1, 2)) == 'JacobiTheta1(1, 2)'
-    assert maple_code(JacobiEllipticFunction("sn", 1, 2)) == 'JacobiSN(1, 2)'
+    assert maple_code(theta1(1, 2)) == 'JacobiTheta1(1, 2)'
+    assert maple_code(jacobi_cd(1, 2)) == 'JacobiCD(1, 2)'
+    assert maple_code(elliptic_nome_q(x)) == 'EllipticNome(x)'

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -11,7 +11,7 @@ from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
                              hermite, laguerre, assoc_laguerre, jacobi,
                              gegenbauer, chebyshevt, chebyshevu, legendre,
                              assoc_legendre, Li, LambertW,
-                             JacobiEllipticFunction, JacobiTheta)
+                             jacobi_cd, theta1, elliptic_nome_q)
 
 from sympy.printing.mathematica import mathematica_code as mcode
 
@@ -82,8 +82,9 @@ def test_Function():
     assert mcode(LambertW(x)) == "ProductLog[x]"
     assert mcode(LambertW(x, -1)) == "ProductLog[-1, x]"
     assert mcode(LambertW(x, y)) == "ProductLog[y, x]"
-    assert mcode(JacobiEllipticFunction("sn", 1, 2)) == 'JacobiSN[1, 2]'
-    assert mcode(JacobiTheta(1, 1, 2)) == 'EllipticTheta[1, 1, 2]'
+    assert mcode(jacobi_cd(1, 2)) == 'JacobiCD[1, 2]'
+    assert mcode(theta1(1, 2)) == 'EllipticTheta[1, 1, 2]'
+    assert mcode(elliptic_nome_q(x)) == 'EllipticNomeQ[x]'
 
 
 def test_special_polynomials():

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -10,7 +10,8 @@ from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
                              FallingFactorial, harmonic, atan2, sec, acsc,
                              hermite, laguerre, assoc_laguerre, jacobi,
                              gegenbauer, chebyshevt, chebyshevu, legendre,
-                             assoc_legendre, Li, LambertW)
+                             assoc_legendre, Li, LambertW,
+                             JacobiEllipticFunction, JacobiTheta)
 
 from sympy.printing.mathematica import mathematica_code as mcode
 
@@ -81,6 +82,8 @@ def test_Function():
     assert mcode(LambertW(x)) == "ProductLog[x]"
     assert mcode(LambertW(x, -1)) == "ProductLog[-1, x]"
     assert mcode(LambertW(x, y)) == "ProductLog[y, x]"
+    assert mcode(JacobiEllipticFunction("sn", 1, 2)) == 'JacobiSN[1, 2]'
+    assert mcode(JacobiTheta(1, 1, 2)) == 'EllipticTheta[1, 1, 2]'
 
 
 def test_special_polynomials():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -85,7 +85,6 @@ MPMATH_TRANSLATIONS = {
     "RisingFactorial": "rf",
     "FallingFactorial": "ff",
     "betainc_regularized": "betainc",
-    "JacobiTheta": "jtheta"
 }
 
 NUMPY_TRANSLATIONS = {

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -85,6 +85,7 @@ MPMATH_TRANSLATIONS = {
     "RisingFactorial": "rf",
     "FallingFactorial": "ff",
     "betainc_regularized": "betainc",
+    "JacobiTheta": "jtheta"
 }
 
 NUMPY_TRANSLATIONS = {

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -218,8 +218,8 @@ def test_math_transl():
 def test_mpmath_transl():
     from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
     for sym, mat in MPMATH_TRANSLATIONS.items():
-        assert sym in sympy.__dict__ or sym == 'Matrix'
-        assert mat in mpmath.__dict__
+        assert sym in sympy.__dict__ or sym == 'Matrix', "{} not a SymPy class/function".format(sym)
+        assert mat in mpmath.__dict__, "{} not a mpmath class/function".format(sym)
 
 
 def test_numpy_transl():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I needed the Jacobi elliptic integrals for another thing I am working on, so I added those and the Jacobi theta function. Still there are things to do, but I wanted to get some feedback on the design so far.

My main doubt about these is that they have a first argument that completely determines the function. In e.g. Mathematica they have specific functions for each variant (in addition to the general that takes a type argument). This can be useful when writing things, but also when rewriting as it is possible to explicitly say which form is required. 

An option will be to be able to do something like:
```
sn = JacobiEllipticIntegral('sn')
v = sn(x, y)
```
But I have not managed to get this to work (in combination with `JacobiEllipticIntegral('sn', x, y)` still working).

Things to do:
- [x] Decide on the single/multiple class issue above
- [x] Decide on naming
- [ ] Add tests
- [ ] Add documentation
- [ ] Add printer support
   - [x] LaTeX
   - [x] Pretty
   - [x] Mathematica
   - [x] Maple
   - [ ] NumPy/SciPy
   - [ ] Matlab/Octave
   - [ ] MathML

#### Other comments

The naming is not obvious.
* `JacobiTheta`: `jacobi_theta`? `elliptic_theta`?
* `JacobiEllipticFunction`: `jacobi_elliptic`? `elliptic_jacobi`? `elliptic_j`?

One may consider passing a nome instead of q and m. See https://mpmath.org/doc/current/functions/elliptic.html However, the other elliptic integrals do not use that.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Jacobi theta and elliptic functions added: `theta1`, etc and `jacobi_cd` etc.
<!-- END RELEASE NOTES -->
