### PR TITLE
activate dead code to factor constant term when solving binomial equation

### DIFF
--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -728,3 +728,12 @@ def test_issue_17454():
 def test_issue_20913():
     assert Poly(x + 9671406556917067856609794, x).real_roots() == [-9671406556917067856609794]
     assert Poly(x**3 + 4, x).real_roots() == [-2**(S(2)/3)]
+
+
+def test_issue_22768():
+    e = Rational(1, 3)
+    r = (-1/a)**e*(a + 1)**(5*e)
+    assert roots(Poly(a*x**3 + (a+1)**5, x)) == {
+        r: 1,
+        -r*(1 + sqrt(3)*I)/2: 1,
+        r*(-1 + sqrt(3)*I)/2: 1}

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2478,7 +2478,8 @@ def test_solver_flags():
 
 
 def test_issue_22768():
-    assert solve(2*x**3 - 16*(y - 1)**6*z**3, x, simplify=False
+    eq = 2*x**3 - 16*(y - 1)**6*z**3
+    assert solve(eq.expand(), x, simplify=False
         ) == [2*z*(y - 1)**2, z*(-1 + sqrt(3)*I)*(y - 1)**2,
         -z*(1 + sqrt(3)*I)*(y - 1)**2]
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2477,6 +2477,12 @@ def test_solver_flags():
     assert root != rad
 
 
+def test_issue_22768():
+    assert solve(2*x**3 - 16*(y - 1)**6*z**3, x, simplify=False
+        ) == [2*z*(y - 1)**2, z*(-1 + sqrt(3)*I)*(y - 1)**2,
+        -z*(1 + sqrt(3)*I)*(y - 1)**2]
+
+
 def test_issue_22717():
     assert solve((-y**2 + log(y**2/x) + 2, -2*x*y + 2*x/y)) == [
         {y: -1, x: E}, {y: 1, x: E}]


### PR DESCRIPTION
Code was dead because `f.length` is a method that can never equal 2. Code has now been corrected and updated to handle the re-factoring of the constant term that is expanded when the Poly is made.
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #22768
closes #22770 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * solve will give more factored results automatically when solving binomial expressions with similar powers in the constant term -- like when solving `x**3 - (1 - y)**6` for `x`.
<!-- END RELEASE NOTES -->
