### PR TITLE
Basic: __eq__ now only uses sympify for user defined objects

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,14 +7,14 @@ from typing import Set, Tuple, Any
 from .assumptions import ManagedProperties
 from .cache import cacheit
 from .core import BasicMeta
-from .sympify import _sympify, sympify, SympifyError
+from .sympify import _sympify, sympify, SympifyError, _external_converter
 from .sorting import ordered
 from .kind import Kind, UndefinedKind
 from ._print_helpers import Printable
 
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import iterable, numbered_symbols, NotIterable
+from sympy.utilities.iterables import iterable, numbered_symbols
 from sympy.utilities.misc import filldedent, func_name
 
 from inspect import getmro
@@ -319,6 +319,25 @@ class Basic(Printable, metaclass=ManagedProperties):
         args = len(args), tuple([inner_key(arg) for arg in args])
         return self.class_key(), args, S.One.sort_key(), S.One
 
+    def _do_eq_sympify(self, other):
+        """Returns a boolean indicating whether a == b when either a
+        or b is not a Basic. This is only done for types that were either
+        added to `converter` by a 3rd party or when the object has `_sympy_`
+        defined. This essentially reuses the code in `_sympify` that is
+        specific for this use case. Non-user defined types that are meant
+        to work with SymPy should be handled directly in the __eq__ methods
+        of the `Basic` classes it could equate to and not be converted. Note
+        that after conversion, `==`  is used again since it is not
+        neccesarily clear whether `self` or `other`'s __eq__ method needs
+        to be used."""
+        for superclass in type(other).__mro__:
+            conv = _external_converter.get(superclass)
+            if conv is not None:
+                return self == conv(other)
+        if hasattr(other, '_sympy_'):
+            return self == other._sympy_()
+        return NotImplemented
+
     def __eq__(self, other):
         """Return a boolean indicating whether a == b on the basis of
         their symbolic trees.
@@ -344,16 +363,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             return True
 
         if not isinstance(other, Basic):
-            if iterable(other, exclude=(str, NotIterable)
-                    ) and not hasattr(other, '_sympy_'):
-                # XXX iterable self should have it's own __eq__
-                # method if the path gives a false negative
-                # comparison
-                return False
-            try:
-                other = _sympify(other)
-            except (SympifyError, SyntaxError):
-                return NotImplemented
+            return self._do_eq_sympify(other)
 
         # check for pure number expr
         if  not (self.is_Number and other.is_Number) and (

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from .basic import Basic
 from .sorting import default_sort_key, ordered
-from .sympify import _sympify, sympify, converter, SympifyError
+from .sympify import _sympify, sympify, _sympy_converter, SympifyError
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import as_int
 
@@ -145,7 +145,7 @@ class Tuple(Basic):
             return self.args.index(value, start, stop)
 
 
-converter[tuple] = lambda tup: Tuple(*tup)
+_sympy_converter[tuple] = lambda tup: Tuple(*tup)
 
 
 
@@ -302,7 +302,7 @@ class Dict(Basic):
     __hash__ : Callable[[Basic], Any] = Basic.__hash__
 
 # this handles dict, defaultdict, OrderedDict
-converter[dict] = lambda d: Dict(*d.items())
+_sympy_converter[dict] = lambda d: Dict(*d.items())
 
 class OrderedSet(MutableSet):
     def __init__(self, iterable=None):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -8,8 +8,8 @@ from functools import lru_cache
 from typing import Set as tSet, Tuple as tTuple
 
 from .containers import Tuple
-from .sympify import (SympifyError, converter, sympify, _convert_numpy_types, _sympify,
-                      _is_numpy_instance)
+from .sympify import (SympifyError, _sympy_converter, sympify, _convert_numpy_types,
+              _sympify, _is_numpy_instance)
 from .singleton import S, Singleton
 from .basic import Basic
 from .expr import Expr, AtomicExpr
@@ -1485,7 +1485,7 @@ class Float(Number):
 
 
 # Add sympify converters
-converter[float] = converter[decimal.Decimal] = Float
+_sympy_converter[float] = _sympy_converter[decimal.Decimal] = Float
 
 # this is here to work nicely in Sage
 RealNumber = Float
@@ -2510,7 +2510,7 @@ class Integer(Rational):
         return Integer(~self.p)
 
 # Add sympify converters
-converter[int] = Integer
+_sympy_converter[int] = Integer
 
 
 class AlgebraicNumber(Expr):
@@ -4481,7 +4481,7 @@ def _eval_is_eq(self, other): # noqa: F811
 def sympify_fractions(f):
     return Rational(f.numerator, f.denominator, 1)
 
-converter[fractions.Fraction] = sympify_fractions
+_sympy_converter[fractions.Fraction] = sympify_fractions
 
 if HAS_GMPY:
     def sympify_mpz(x):
@@ -4493,28 +4493,28 @@ if HAS_GMPY:
     def sympify_mpq(x):
         return Rational(int(x.numerator), int(x.denominator))
 
-    converter[type(gmpy.mpz(1))] = sympify_mpz
-    converter[type(gmpy.mpq(1, 2))] = sympify_mpq
+    _sympy_converter[type(gmpy.mpz(1))] = sympify_mpz
+    _sympy_converter[type(gmpy.mpq(1, 2))] = sympify_mpq
 
 
 def sympify_mpmath_mpq(x):
     p, q = x._mpq_
     return Rational(p, q, 1)
 
-converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
+_sympy_converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
 
 
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 
-converter[mpnumeric] = sympify_mpmath
+_sympy_converter[mpnumeric] = sympify_mpmath
 
 
 def sympify_complex(a):
     real, imag = list(map(sympify, (a.real, a.imag)))
     return real + S.ImaginaryUnit*imag
 
-converter[complex] = sympify_complex
+_sympy_converter[complex] = sympify_complex
 
 from .power import Pow, integer_nthroot
 from .mul import Mul

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -15,7 +15,7 @@ from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
-from sympy.core.sympify import converter, _sympify, sympify
+from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
@@ -348,6 +348,13 @@ class BooleanTrue(BooleanAtom, metaclass=Singleton):
     def __hash__(self):
         return hash(True)
 
+    def __eq__(self, other):
+        if other is True:
+            return True
+        if other is False:
+            return False
+        return super().__eq__(other)
+
     @property
     def negated(self):
         return S.false
@@ -416,6 +423,13 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
     def __hash__(self):
         return hash(False)
 
+    def __eq__(self, other):
+        if other is True:
+            return False
+        if other is False:
+            return True
+        return super().__eq__(other)
+
     @property
     def negated(self):
         return S.true
@@ -443,7 +457,7 @@ false = BooleanFalse()
 S.true = true
 S.false = false
 
-converter[bool] = lambda x: S.true if x else S.false
+_sympy_converter[bool] = lambda x: S.true if x else S.false
 
 
 class BooleanFunction(Application, Boolean):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -3,7 +3,7 @@ from mpmath.matrices.matrices import _matrix
 from sympy.core import Basic, Dict, Tuple
 from sympy.core.numbers import Integer
 from sympy.core.cache import cacheit
-from sympy.core.sympify import converter as sympify_converter, _sympify
+from sympy.core.sympify import _sympy_converter as sympify_converter, _sympify
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrices import MatrixBase

--- a/sympy/polys/domains/pythonrational.py
+++ b/sympy/polys/domains/pythonrational.py
@@ -9,7 +9,7 @@ This module is just left here for backwards compatibility.
 
 
 from sympy.core.numbers import Rational
-from sympy.core.sympify import converter
+from sympy.core.sympify import _sympy_converter
 from sympy.utilities import public
 from sympy.external.pythonmpq import PythonMPQ
 
@@ -19,4 +19,4 @@ PythonRational = public(PythonMPQ)
 
 def sympify_pythonrational(arg):
     return Rational(arg.numerator, arg.denominator)
-converter[PythonRational] = sympify_pythonrational
+_sympy_converter[PythonRational] = sympify_pythonrational

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -11,7 +11,7 @@ from sympy.core.numbers import oo, igcd, Rational
 from sympy.core.relational import Eq, is_eq
 from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Dummy, symbols, Symbol
-from sympy.core.sympify import _sympify, sympify, converter
+from sympy.core.sympify import _sympify, sympify, _sympy_converter
 from sympy.logic.boolalg import And, Or
 from .sets import Set, Interval, Union, FiniteSet, ProductSet
 from sympy.utilities.misc import filldedent
@@ -1007,7 +1007,7 @@ class Range(Set):
         return And(in_seq, ints, range_cond)
 
 
-converter[range] = lambda r: Range(r.start, r.stop, r.step)
+_sympy_converter[range] = lambda r: Range(r.start, r.stop, r.step)
 
 def normalize_theta_set(theta):
     r"""

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -18,7 +18,7 @@ from sympy.core.relational import Eq, Ne, is_lt
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import symbols, Symbol, Dummy, uniquely_named_symbol
-from sympy.core.sympify import _sympify, sympify, converter
+from sympy.core.sympify import _sympify, sympify, _sympy_converter
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import And, Or, Not, Xor, true, false
 from sympy.utilities.decorator import deprecated
@@ -1975,8 +1975,8 @@ class FiniteSet(Set):
 
     __hash__ : Callable[[Basic], Any] = Basic.__hash__
 
-converter[set] = lambda x: FiniteSet(*x)
-converter[frozenset] = lambda x: FiniteSet(*x)
+_sympy_converter[set] = lambda x: FiniteSet(*x)
+_sympy_converter[frozenset] = lambda x: FiniteSet(*x)
 
 
 class SymmetricDifference(Set):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Helps with #22607

#### Brief description of what is fixed or changed
`Basic.__eq__` now no longer always tries to convert non-Basic objects using `sympify`, instead, it only does so if the object has `_sympy_` defined, or if its type has been added `converter` by the user. Any classes in SymPy will have to explicitly add logic to compare to non-Basic objects, this is to encourage using properties directly, which should be more efficient than creating a SymPy object. 

In order for this to work, `BooleanFalse` and `BooleanTrue` now explicitly check if `other` is `True`/`False`, rather than attempt to convert `other` to `BooleanFalse`/`BooleanTrue`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
