### PR TITLE
Improve bernoulli DE matching by changing general equation and solution

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -830,7 +830,7 @@ class Bernoulli(SinglePatternODESolver):
 
     def _equation(self, fx, x, order):
         P, Q, n = self.wilds()
-        return fx.diff(x) + P*fx - Q*fx**n
+        return fx.diff(x) + P*fx + Q*fx**n
 
     def _get_general_solution(self, *, simplify_flag: bool = True):
         P, Q, n = self.wilds_match()
@@ -839,11 +839,11 @@ class Bernoulli(SinglePatternODESolver):
         (C1,) = self.ode_problem.get_numbered_constants(num=1)
         if n==1:
             gensol = Eq(log(fx), (
-            C1 + Integral((-P + Q), x)
+            C1 + Integral((-P - Q), x)
         ))
         else:
             gensol = Eq(fx**(1-n), (
-                (C1 - (n - 1) * Integral(Q*exp(-n*Integral(P, x))
+                (C1 - (n - 1) * Integral(-Q*exp(-n*Integral(P, x))
                             * exp(Integral(P, x)), x)
                 ) * exp(-(1 - n)*Integral(P, x)))
             )

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1059,3 +1059,15 @@ def test_issue_22604():
     assert x1sol == Eq(x1(t), sqrt(3 - sqrt(5))*(sqrt(10) + 5*sqrt(2))*cos(sqrt(2)*t*sqrt(3 - sqrt(5))/2)/20 + \
                        (-5*sqrt(2) + sqrt(10))*sqrt(sqrt(5) + 3)*cos(sqrt(2)*t*sqrt(sqrt(5) + 3)/2)/20)
     assert x2sol == Eq(x2(t), (sqrt(5) + 5)*cos(sqrt(2)*t*sqrt(3 - sqrt(5))/2)/10 + (5 - sqrt(5))*cos(sqrt(2)*t*sqrt(sqrt(5) + 3)/2)/10)
+
+def test_issue_22462():
+    de = Eq(f(x).diff(x), -20*f(x)**2 - 500*f(x)/7200)
+    assert classify_ode(de, f(x)) == ('factorable', 'separable', '1st_exact',
+        'Bernoulli', '1st_rational_riccati', '1st_power_series', 'lie_group',
+        'separable_Integral', '1st_exact_Integral', 'Bernoulli_Integral')
+    assert dsolve(de, hint = "Bernoulli") == Eq(f(x), 1/(symbols('C1')*exp(5*x/72) - 288))
+
+    de2 = Eq(f(x).diff(x), -2*f(x)**2 - 5*f(x)/7)
+    assert classify_ode(de2, f(x)) == ('factorable', 'separable', '1st_exact',
+        'Bernoulli', '1st_rational_riccati', '1st_power_series',
+        'lie_group', 'separable_Integral', '1st_exact_Integral', 'Bernoulli_Integral')

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -744,10 +744,10 @@ def test_issue_4785():
     from sympy.abc import A
     eq = x + A*(x + diff(f(x), x) + f(x)) + diff(f(x), x) + f(x) + 2
     assert classify_ode(eq, f(x)) == ('factorable', '1st_exact', '1st_linear',
-        'almost_linear', '1st_power_series', 'lie_group',
+        'Bernoulli', 'almost_linear', '1st_power_series', 'lie_group',
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
-        '1st_exact_Integral', '1st_linear_Integral', 'almost_linear_Integral',
+        '1st_exact_Integral', '1st_linear_Integral', 'Bernoulli_Integral', 'almost_linear_Integral',
         'nth_linear_constant_coeff_variation_of_parameters_Integral')
     # issue 4864
     eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #22462 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The general equation of a Bernoulli DE is stored as `f(x).diff(x) + P*f(x) - Q*f(x)**n`. This format fails to match some equations which can be solved as a Bernoulli DE. Some of these cases are described in this comment. https://github.com/sympy/sympy/issues/22462#issuecomment-966572294

More specifically, all equations where `Q >= 2` fail to match with the general Bernoulli DE as explained in this comment.
https://github.com/sympy/sympy/issues/22462#issuecomment-986268603

The actual problem occurs in this bit of code.
https://github.com/sympy/sympy/blob/1409fcf748d8d73014cca509f2816acb82af7fc0/sympy/core/operations.py#L255-L258

Here, 'expr ' is our part of our original equation in the form `- Q*f(x)**n`. To match the wild Q, there is a negation added to matched part of Q to counteract the negative sign in front of Q in the general equation. This increases the no of operations and the code returns None and fails to match the code.

A more detailed explanation is in this comment. https://github.com/sympy/sympy/issues/22462#issuecomment-987622991

The solution proposed is to change the general Bernoulli DE from `f(x).diff(x) + P*f(x) - Q*f(x)**n` to `f(x).diff(x) + P*f(x) + Q*f(x)**n`. This eliminates the need to negate the matched part of Q and hence it is now able to match all the equations which were earlier posing a problem.

Since the inbuilt `_equation` method of Bernoulli class is for internal use, I doubt it would break compatibility for users.

#### Other comments
A previous unit test has been modified as it was earlier not being recognised as a Bernoulli DE and now is.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
