### PR TITLE
Removed even more Python 2-support

### DIFF
--- a/sympy/codegen/tests/test_pyutils.py
+++ b/sympy/codegen/tests/test_pyutils.py
@@ -5,5 +5,3 @@ def test_standard():
     ast = Print('x y'.split(), "coordinate: %12.5g %12.5g")
     assert render_as_module(ast, standard='python3') == \
         '\n\nprint("coordinate: %12.5g %12.5g" % (x, y))'
-    assert render_as_module(ast, standard='python2') == \
-        '\n\nprint "coordinate: %12.5g %12.5g" % (x, y)'

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -116,7 +116,7 @@ class BadArgumentsError(TypeError):
     pass
 
 
-# Python 2/3 version that does not raise a Deprecation warning
+# Python 3 version that does not raise a Deprecation warning
 def arity(cls):
     """Return the arity of the function if it is known, else None.
 

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -71,8 +71,7 @@ class SingletonRegistry(Registry):
     This is for convenience, since ``S`` is a single letter. It's mostly
     useful for defining rational numbers. Consider an expression like ``x +
     1/2``. If you enter this directly in Python, it will evaluate the ``1/2``
-    and give ``0.5`` (or just ``0`` in Python 2, because of integer division),
-    because both arguments are ints (see also
+    and give ``0.5``, because both arguments are ints (see also
     :ref:`tutorial-gotchas-final-notes`). However, in SymPy, you usually want
     the quotient of two integers to give an exact rational number. The way
     Python's evaluation works, at least one side of an operator needs to be a

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -8,7 +8,6 @@ from sympy.interactive.printing import init_printing
 from sympy.utilities.misc import ARCH
 
 preexec_source = """\
-from __future__ import division
 from sympy import *
 x, y, z, t = symbols('x y z t')
 k, m, n = symbols('k m n', integer=True)
@@ -95,7 +94,6 @@ def int_to_Integer(s):
     Examples
     ========
 
-    >>> from __future__ import division
     >>> from sympy import Integer # noqa: F401
     >>> from sympy.interactive.session import int_to_Integer
     >>> s = '1.2 + 1/2 - 0x12 + a1'

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -126,8 +126,6 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
-    # Note : Unicode of Python2 is equivalent to str in Python3. In Python 3 we have one
-    # text type: str which holds Unicode data and two byte types bytes and bytearray.
     # XXX: How can we make this ignore the terminal width? This test fails if
     # the terminal is too narrow.
     assert text in ("{pi: 3.14, n_i: 3}",

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -265,7 +265,7 @@ class Lambdifier:
             print(newexpr)
         eval_str = 'lambda %s : ( %s )' % (argstr, newexpr)
         self.eval_str = eval_str
-        exec("from __future__ import division; MYNEWLAMBDA = %s" % eval_str, namespace)
+        exec("MYNEWLAMBDA = %s" % eval_str, namespace)
         self.lambda_func = namespace['MYNEWLAMBDA']
 
     def __call__(self, *args, **kwargs):

--- a/sympy/plotting/pygletplot/plot_window.py
+++ b/sympy/plotting/pygletplot/plot_window.py
@@ -86,14 +86,7 @@ class PlotWindow(ManagedWindow):
         if len(self.plot._functions.values()) == 0:
             self.drawing_first_object = True
 
-        try:
-            dict.iteritems
-        except AttributeError:
-            # Python 3
-            iterfunctions = iter(self.plot._functions.values())
-        else:
-            # Python 2
-            iterfunctions = self.plot._functions.itervalues()
+        iterfunctions = iter(self.plot._functions.values())
 
         for r in iterfunctions:
             if self.drawing_first_object:

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -96,7 +96,7 @@ def symmetric_poly(n, *gens, **args):
     Returns a Poly object when ``polys=True``, otherwise
     (default) returns an expression.
     """
-    # TODO: use an explicit keyword argument when Python 2 support is dropped
+    # TODO: use an explicit keyword argument
     gens = _analyze_gens(gens)
 
     if n < 0 or n > len(gens) or not gens:

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -192,10 +192,8 @@ def test_multiple_sums():
 
 
 def test_sqrt():
-    prntr = LambdaPrinter({'standard' : 'python2'})
-    assert prntr._print_Pow(sqrt(x), rational=False) == 'sqrt(x)'
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
     prntr = LambdaPrinter({'standard' : 'python3'})
+    assert prntr._print_Pow(sqrt(x), rational=False) == 'sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -60,16 +60,12 @@ def test_PythonCodePrinter():
 
 
 def test_PythonCodePrinter_standard():
-    import sys
-    prntr = PythonCodePrinter({'standard':None})
+    prntr = PythonCodePrinter()
 
-    python_version = sys.version_info.major
-    if python_version == 2:
-        assert prntr.standard == 'python2'
-    if python_version == 3:
-        assert prntr.standard == 'python3'
+    assert prntr.standard == 'python3'
 
     raises(ValueError, lambda: PythonCodePrinter({'standard':'python4'}))
+
 
 def test_MpmathPrinter():
     p = MpmathPrinter()
@@ -195,10 +191,6 @@ def test_sqrt():
     assert prntr._print_Pow(sqrt(x), rational=False) == 'math.sqrt(x)'
     assert prntr._print_Pow(1/sqrt(x), rational=False) == '1/math.sqrt(x)'
 
-    prntr = PythonCodePrinter({'standard' : 'python2'})
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
-    assert prntr._print_Pow(1/sqrt(x), rational=True) == 'x**(-1./2.)'
-
     prntr = PythonCodePrinter({'standard' : 'python3'})
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
     assert prntr._print_Pow(1/sqrt(x), rational=True) == 'x**(-1/2)'
@@ -263,8 +255,9 @@ def test_codegen_ast_nodes():
 def test_issue_14283():
     prntr = PythonCodePrinter()
 
-    assert prntr.doprint(zoo) == "float('nan')"
+    assert prntr.doprint(zoo) == "math.nan"
     assert prntr.doprint(-oo) == "float('-inf')"
+
 
 def test_NumPyPrinter_print_seq():
     n = NumPyPrinter()

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 import random
 
 import itertools

--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -2,30 +2,14 @@ import re
 import fnmatch
 
 
-# XXX Python 2 unicode import test.
-# May remove after deprecating Python 2.7.
-message_unicode_A = \
-    "File contains a unicode character : %s, line %s. " \
-    "But with no encoding header. " \
-    "See https://www.python.org/dev/peps/pep-0263/ " \
-    "and add '# coding=utf-8'"
 message_unicode_B = \
     "File contains a unicode character : %s, line %s. " \
     "But not in the whitelist. " \
     "Add the file to the whitelist in " + __file__
-message_unicode_C = \
-    "File contains a unicode character : %s, line %s. " \
-    "And is in the whitelist, but without the encoding header. " \
-    "See https://www.python.org/dev/peps/pep-0263/ " \
-    "and add '# coding=utf-8'."
 message_unicode_D = \
     "File does not contain a unicode character : %s." \
     "but is in the whitelist. " \
     "Remove the file from the whitelist in " + __file__
-message_unicode_E = \
-    "File does not contain a unicode character : %s." \
-    "but contains the header '# coding=utf-8' or equivalent." \
-    "Remove the header."
 
 
 encoding_header_re = re.compile(
@@ -70,19 +54,11 @@ def _test_this_file_encoding(
     fname, test_file,
     unicode_whitelist=unicode_whitelist,
     unicode_strict_whitelist=unicode_strict_whitelist):
-    """Test helper function for Python 2 importability test
-
-    This test checks whether the file has
-    # coding=utf-8
-    or
-    # -*- coding: utf-8 -*-
-    line if there is a unicode character in the code
+    """Test helper function for unicode test
 
     The test may have to operate on filewise manner, so it had moved
     to a separate process.
-    May remove after deprecating Python 2.7.
     """
-    has_coding_utf8 = False
     has_unicode = False
 
     is_in_whitelist = False
@@ -99,38 +75,17 @@ def _test_this_file_encoding(
 
     if is_in_whitelist:
         for idx, line in enumerate(test_file):
-            if idx in (0, 1):
-                match = encoding_header_re.match(line)
-                if match and match.group(1).lower() == 'utf-8':
-                    has_coding_utf8 = True
             try:
                 line.encode(encoding='ascii')
             except (UnicodeEncodeError, UnicodeDecodeError):
                 has_unicode = True
-                if has_coding_utf8 is False:
-                    assert False, \
-                        message_unicode_C % (fname, idx + 1)
 
         if not has_unicode and not is_in_strict_whitelist:
             assert False, message_unicode_D % fname
 
     else:
         for idx, line in enumerate(test_file):
-            if idx in (0, 1):
-                match = encoding_header_re.match(line)
-                if match and match.group(1).lower() == 'utf-8':
-                    has_coding_utf8 = True
             try:
                 line.encode(encoding='ascii')
             except (UnicodeEncodeError, UnicodeDecodeError):
-                has_unicode = True
-                if has_coding_utf8:
-                    assert False, \
-                        message_unicode_B % (fname, idx + 1)
-                else:
-                    assert False, \
-                        message_unicode_A % (fname, idx + 1)
-
-        if not has_unicode and has_coding_utf8:
-            assert False, \
-                message_unicode_E % fname
+                assert False, message_unicode_B % (fname, idx + 1)

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -12,8 +12,6 @@ Goals:
 
 """
 
-from __future__ import print_function, division
-
 import os
 import sys
 import platform
@@ -94,10 +92,6 @@ class TimeOutError(Exception):
 
 class DependencyError(Exception):
     pass
-
-
-# add more flags ??
-future_flags = division.compiler_flag
 
 
 def _indent(s, indent=4):
@@ -739,7 +733,7 @@ def _get_doctest_blacklist():
 
     # blacklist these modules until issue 4840 is resolved
     blacklist.extend([
-        "sympy/conftest.py", # Python 2.7 issues
+        "sympy/conftest.py", # Depends on pytest
         "sympy/testing/benchmarking.py",
     ])
 
@@ -1083,7 +1077,7 @@ def sympytestfile(filename, module_relative=True, name=None, package=None,
 
     # Read the file, convert it to a test, and run it.
     test = parser.get_doctest(text, globs, name, filename, 0)
-    runner.run(test, compileflags=future_flags)
+    runner.run(test)
 
     if report:
         runner.summarize()
@@ -1448,13 +1442,11 @@ class SymPyDocTests:
                 # if this is uncommented then all the test would get is what
                 # comes by default with a "from sympy import *"
                 #exec('from sympy import *') in test.globs
-            test.globs['print_function'] = print_function
-
             old_displayhook = sys.displayhook
             use_unicode_prev = setup_pprint()
 
             try:
-                f, t = runner.run(test, compileflags=future_flags,
+                f, t = runner.run(test,
                                   out=new.write, clear_globs=False)
             except KeyboardInterrupt:
                 raise
@@ -1827,7 +1819,6 @@ class SymPyDocTestRunner(DocTestRunner):
         # Fail for deprecation warnings
         with raise_on_deprecated():
             try:
-                test.globs['print_function'] = print_function
                 return self.__run(test, compileflags, out)
             finally:
                 sys.stdout = save_stdout

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -497,54 +497,14 @@ def test_test_unicode_encoding():
         fname, test_file, unicode_whitelist, unicode_strict_whitelist))
 
     fname = 'abc'
-    test_file = ['# coding=utf-8', 'α']
-    raises(AssertionError, lambda: _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'abc'
-    test_file = ['# coding=utf-8', 'abc']
-    raises(AssertionError, lambda: _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'abc'
     test_file = ['abc']
     _test_this_file_encoding(
         fname, test_file, unicode_whitelist, unicode_strict_whitelist)
 
     fname = 'foo'
-    test_file = ['α']
-    raises(AssertionError, lambda: _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'foo'
-    test_file = ['# coding=utf-8', 'α']
-    _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist)
-
-    fname = 'foo'
-    test_file = ['# coding=utf-8', 'abc']
-    raises(AssertionError, lambda: _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'foo'
     test_file = ['abc']
     raises(AssertionError, lambda: _test_this_file_encoding(
         fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'bar'
-    test_file = ['α']
-    raises(AssertionError, lambda: _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist))
-
-    fname = 'bar'
-    test_file = ['# coding=utf-8', 'α']
-    _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist)
-
-    fname = 'bar'
-    test_file = ['# coding=utf-8', 'abc']
-    _test_this_file_encoding(
-        fname, test_file, unicode_whitelist, unicode_strict_whitelist)
 
     fname = 'bar'
     test_file = ['abc']

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2625,8 +2625,6 @@ def kbins(l, k, ordered=None):
     Examples
     ========
 
-    >>> from __future__ import print_function
-
     The default is to give the items in the same order, but grouped
     into k partitions without any reordering:
 

--- a/sympy/utilities/quality_unicode.py
+++ b/sympy/utilities/quality_unicode.py
@@ -1,9 +1,0 @@
-from sympy.utilities.exceptions import SymPyDeprecationWarning
-
-SymPyDeprecationWarning(
-    feature="Import sympy.utilities.quality_unicode",
-    useinstead="Import from sympy.testing.quality_unicode",
-    issue=18095,
-    deprecated_since_version="1.6").warn()
-
-from sympy.testing.quality_unicode import *  # noqa:F401

--- a/sympy/utilities/tests/test_deprecated.py
+++ b/sympy/utilities/tests/test_deprecated.py
@@ -11,8 +11,6 @@ def test_deprecated_utilities():
         import sympy.utilities.randtest  # noqa:F401
     with warns_deprecated_sympy():
         import sympy.utilities.tmpfiles  # noqa:F401
-    with warns_deprecated_sympy():
-        import sympy.utilities.quality_unicode  # noqa:F401
 
 # This fails because benchmarking isn't importable...
 @XFAIL

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -786,12 +786,6 @@ def test_namespace_order():
 
     assert if2(1) == 'function g'
 
-def test_namespace_type():
-    # lambdify had a bug where it would reject modules of type unicode
-    # on Python 2.
-    x = sympy.Symbol('x')
-    lambdify(x, x, modules='math')
-
 
 def test_imps():
     # Here we check if the default returned functions are anonymous - in

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -10,8 +10,6 @@ class BaseScalar(AtomicExpr):
 
     Ideally, users should not instantiate this class.
 
-    Unicode pretty forms in Python 2 should use the `u` prefix.
-
     """
 
     def __new__(cls, index, system, pretty_str=None, latex_str=None):

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -349,8 +349,6 @@ class BaseVector(Vector, AtomicExpr):
     """
     Class to denote a base vector.
 
-    Unicode pretty forms in Python 2 should use the prefix ``u``.
-
     """
 
     def __new__(cls, index, system, pretty_str=None, latex_str=None):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

There was still a bit of Python 2-related code left. Now, it is primarily the antlr-parsers for autolev and latex that should be updated.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
