### PR TITLE
22462: ignore sign while matching

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -213,6 +213,7 @@ class AssocOp(Basic):
         equivalent.
 
         """
+        from .function import _coeff_isneg
         # make sure expr is Expr if pattern is Expr
         from .expr import Expr
         if isinstance(self, Expr) and not isinstance(expr, Expr):
@@ -254,7 +255,10 @@ class AssocOp(Basic):
                 return None
             newexpr = self._combine_inverse(expr, exact)
             if not old and (expr.is_Add or expr.is_Mul):
-                if newexpr.count_ops() > expr.count_ops():
+                check = newexpr
+                if _coeff_isneg(check):
+                    check = -check
+                if check.count_ops() > expr.count_ops():
                     return None
             newpattern = self._new_rawargs(*wild_part)
             return newpattern.matches(newexpr, repl_dict)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -756,3 +756,11 @@ def test_match_bound():
     assert Sum(x, (x, 1, 2)).match(Sum(y, (y, 1, W))) == {W: 2}
     assert Sum(x, (x, 1, 2)).match(Sum(V, (V, 1, W))) == {W: 2, V:x}
     assert Sum(x, (x, 1, 2)).match(Sum(V, (V, 1, 2))) == {V:x}
+
+
+def test_issue_22462():
+    x, f = symbols('x'), Function('f')
+    n, Q = symbols('n Q', cls=Wild)
+    pattern = -Q*f(x)**n
+    eq = 5*f(x)**2
+    assert pattern.matches(eq) == {n: 2, Q: -5}

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -740,14 +740,16 @@ def test_undetermined_coefficients_match():
     assert _undetermined_coefficients_match(cos(x**2), x) == {'test': False}
     assert _undetermined_coefficients_match(2**(x**2), x) == {'test': False}
 
-def test_issue_4785():
+
+def test_issue_4785_22462():
     from sympy.abc import A
     eq = x + A*(x + diff(f(x), x) + f(x)) + diff(f(x), x) + f(x) + 2
     assert classify_ode(eq, f(x)) == ('factorable', '1st_exact', '1st_linear',
-        'almost_linear', '1st_power_series', 'lie_group',
+        'Bernoulli', 'almost_linear', '1st_power_series', 'lie_group',
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
-        '1st_exact_Integral', '1st_linear_Integral', 'almost_linear_Integral',
+        '1st_exact_Integral', '1st_linear_Integral', 'Bernoulli_Integral',
+        'almost_linear_Integral',
         'nth_linear_constant_coeff_variation_of_parameters_Integral')
     # issue 4864
     eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)
@@ -759,6 +761,7 @@ def test_issue_4785():
         'lie_group', '1st_exact_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
+
 
 def test_issue_4825():
     raises(ValueError, lambda: dsolve(f(x, y).diff(x) - y*f(x, y), f(x)))
@@ -1059,3 +1062,10 @@ def test_issue_22604():
     assert x1sol == Eq(x1(t), sqrt(3 - sqrt(5))*(sqrt(10) + 5*sqrt(2))*cos(sqrt(2)*t*sqrt(3 - sqrt(5))/2)/20 + \
                        (-5*sqrt(2) + sqrt(10))*sqrt(sqrt(5) + 3)*cos(sqrt(2)*t*sqrt(sqrt(5) + 3)/2)/20)
     assert x2sol == Eq(x2(t), (sqrt(5) + 5)*cos(sqrt(2)*t*sqrt(3 - sqrt(5))/2)/10 + (5 - sqrt(5))*cos(sqrt(2)*t*sqrt(sqrt(5) + 3)/2)/10)
+
+
+def test_issue_22462():
+    for de in [
+            Eq(f(x).diff(x), -20*f(x)**2 - 500*f(x)/7200),
+            Eq(f(x).diff(x), -2*f(x)**2 - 5*f(x)/7)]:
+        assert 'Bernoulli' in classify_ode(de, f(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #22462 
closes #22797 as alternate

#### Brief description of what is fixed or changed

There is some asymmetry in pattern matching when there is a leading sign on the expression as identified in #22462.
```python
>>> Q=Wild("Q")

These all work

>>> eq=5*x
>>> (Q*x).matches(eq)
{Q_: 5}
>>> (Q*x).matches(-eq)
{Q_: -5}
>>> (-Q*x).matches(-eq)
{Q_: 5}
>>> (-Q*x).matches(eq)
{Q_: -5}

But when matching two wilds, the sign is not handled as well:

>>> e=Wild('e')
>>> eq=5*x**2
>>> (Q*x**e).matches(eq)
{e_: 2, Q_: 5}
>>> (Q*x**e).matches(-eq)
{e_: 2, Q_: -5}
>>> (-Q*x**e).matches(-eq)
{e_: 2, Q_: 5}
>>> (-Q*x**e).matches(eq)  # now gives {e_: 2, Q_: -5} in stead of None
>>>
```

#### Other comments

This now allows Bernoulli ODEs to better be identified.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    - a matching issue related to matching of a leading sign on products was fixed
* solvers
    - Bernoulli differential equations are more often classified as such in `classify_ode` because of a fix to matching
<!-- END RELEASE NOTES -->
