### PR TITLE
Core/function : Fixes differentiation and series for Multivariate cases (more than 2 variable)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2187,18 +2187,24 @@ class Subs(Expr):
 
         def denest(expr, variables, point):
             # Helper function to denest expressions involving Subs in some form.
-            # if expression isn't related to Subs, the expression passed is returned.
-            # Currently it can deal with expressions of type Mul(constant, Subs(...)).
+            # if expression isn't related to Subs, the sympified expression is returned.
+            # Currently it can deal with expressions of type Mul(expr, Subs(...)).
+            # where expr could be of type Constant, Mul, Number, Pow, Symbol.
+            # Check out functions: test_denesting_for_Subs1 and test_denesting_for_Subs2
+            # in core/tests/test_function.py for more information.
+            # Refer https://github.com/sympy/sympy/pull/22806#issue-1095031567
+            # for more information on implementation of this function.
             if isinstance(expr, Subs):
                 variables = expr.variables + variables
                 point = expr.point + point
                 expr = expr.expr
             elif isinstance(expr, Mul):
-                constant = expr.args[0]
-                _expr = expr.args[1]
-                if isinstance(_expr, Subs):
-                    expr, variables, point = denest(_expr, variables, point)
-                    expr = constant*expr
+                subs_arg = [arg for arg in expr.args if isinstance(arg, Subs)]
+                if subs_arg and len(subs_arg) == S.One:
+                    subs_arg = subs_arg[0]
+                    mul_arg = expr.extract_multiplicatively(subs_arg)
+                    expr, variables, point = denest(subs_arg, variables, point)
+                    expr = expr*mul_arg
             else:
                 expr = sympify(expr)
             return expr, variables, point

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2188,15 +2188,17 @@ class Subs(Expr):
         def denest(expr, variables, point):
             # Helper function to denest expressions involving Subs in some form.
             # if expression isn't related to Subs, the expression passed is returned.
-            # TODO: Code to deal with expressions of type Mul(constant, Subs(...))
-            # which currently return wrong results.
+            # Currently it can deal with expressions of type Mul(constant, Subs(...)).
             if isinstance(expr, Subs):
                 variables = expr.variables + variables
                 point = expr.point + point
                 expr = expr.expr
-            elif isinstance(-expr, Subs):
-                expr, variables, point = denest(-expr, variables, point)
-                expr = -expr
+            elif isinstance(expr, Mul):
+                constant = expr.args[0]
+                _expr = expr.args[1]
+                if isinstance(_expr, Subs):
+                    expr, variables, point = denest(_expr, variables, point)
+                    expr = constant*expr
             else:
                 expr = sympify(expr)
             return expr, variables, point

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2185,19 +2185,23 @@ class Subs(Expr):
         if not point:
             return sympify(expr)
 
-        # denest
-        if isinstance(expr, Subs):
-            variables = expr.variables + variables
-            point = expr.point + point
-            expr = expr.expr
-        elif isinstance(-expr, Subs):
-            expr = -expr
-            variables = expr.variables + variables
-            point = expr.point + point
-            expr = expr.expr
-            expr = -expr
-        else:
-            expr = sympify(expr)
+        def denest(expr, variables, point):
+            # Helper function to denest expressions involving Subs in some form.
+            # if expression isn't related to Subs, the expression passed is returned.
+            # TODO: Code to deal with expressions of type Mul(constant, Subs(...))
+            # which currently return wrong results.
+            if isinstance(expr, Subs):
+                variables = expr.variables + variables
+                point = expr.point + point
+                expr = expr.expr
+            elif isinstance(-expr, Subs):
+                expr, variables, point = denest(-expr, variables, point)
+                expr = -expr
+            else:
+                expr = sympify(expr)
+            return expr, variables, point
+
+        expr, variables, point = denest(expr, variables, point)
 
         # use symbols with names equal to the point value (with prepended _)
         # to give a variable-independent expression

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2190,6 +2190,12 @@ class Subs(Expr):
             variables = expr.variables + variables
             point = expr.point + point
             expr = expr.expr
+        elif isinstance(-expr, Subs):
+            expr = -expr
+            variables = expr.variables + variables
+            point = expr.point + point
+            expr = expr.expr
+            expr = -expr
         else:
             expr = sympify(expr)
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1352,6 +1352,8 @@ def test_issue_22439():
 
 
 def test_denesting_for_Subs():
+    # Refer https://github.com/sympy/sympy/pull/22806#issuecomment-1037339531 to see the results
+    # being displayed in their pretty printed format.
     x, y, h = symbols('x y h')
     u = Function('u')
     _xi_1, _xi_2 = [Dummy() for i in range(2)]

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1351,6 +1351,36 @@ def test_issue_22439():
             3*Derivative(u(x, y), (x, 2), y))/6 + O(h**4)
 
 
+def test_denesting_for_Subs():
+    x, y, h = symbols('x y h')
+    u = Function('u')
+    _xi_1, _xi_2 = [Dummy() for i in range(2)]
+
+    assert u(x - 2*h, y - 2*h).diff(h, 2).simplify() == 4*(Subs(Derivative(u(_xi_1, -2*h + y), (_xi_1, 2)), _xi_1, -2*h + x) + \
+            Subs(Derivative(u(-2*h + x, _xi_2), (_xi_2, 2)), _xi_2, -2*h + y) + \
+            2*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, _xi_2), (_xi_1, _xi_2), (-2*h + x, -2*h + y)))
+    assert u(x + 3*h, y + 3*h).diff(h, 3).simplify() == 27*(Subs(Derivative(u(_xi_1, 3*h + y), (_xi_1, 3)), _xi_1, 3*h + x) + \
+            Subs(Derivative(u(3*h + x, _xi_2), (_xi_2, 3)), _xi_2, 3*h + y) + \
+            3*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 2)), (_xi_2, _xi_1), (3*h + y, 3*h + x)) + \
+            3*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), _xi_2), (_xi_1, _xi_2), (3*h + x, 3*h + y)))
+    assert u(x + 2*h, y - 3*h).diff(h, 4).simplify() == 16*Subs(Derivative(u(_xi_1, -3*h + y), (_xi_1, 4)), _xi_1, 2*h + x) + \
+            81*Subs(Derivative(u(2*h + x, _xi_2), (_xi_2, 4)), _xi_2, -3*h + y) - \
+            216*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 3)), (_xi_2, _xi_1), (-3*h + y, 2*h + x)) + \
+            216*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), (_xi_2, 2)), (_xi_2, _xi_1), (-3*h + y, 2*h + x)) - \
+            96*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 3), _xi_2), (_xi_2, _xi_1), (-3*h + y, 2*h + x))
+    assert u(x - 2*h, y - 2*h).series(h, x0=0, n=4).simplify() == u(x, y) - 2*h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+            2*h**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + 2*Derivative(u(x, y), x, y)) - \
+            4*h**3*(Derivative(u(x, y), (x, 3)) + Derivative(u(x, y), (y, 3)) + 3*Derivative(u(x, y), x, (y, 2)) + \
+            3*Derivative(u(x, y), (x, 2), y))/3 + O(h**4)
+    assert u(x + 3*h, y - 2*h).series(h, x0=0, n=6).simplify() == u(x, y) + h*(3*Derivative(u(x, y), x) - 2*Derivative(u(x, y), y)) + \
+            h**2*(9*Derivative(u(x, y), (x, 2)) + 4*Derivative(u(x, y), (y, 2)) - 12*Derivative(u(x, y), x, y))/2 + \
+            h**3*(27*Derivative(u(x, y), (x, 3)) - 8*Derivative(u(x, y), (y, 3)) + 36*Derivative(u(x, y), x, (y, 2)) - \
+            54*Derivative(u(x, y), (x, 2), y))/6 + h**4*(81*Derivative(u(x, y), (x, 4)) + 16*Derivative(u(x, y), (y, 4)) - \
+            96*Derivative(u(x, y), x, (y, 3)) + 216*Derivative(u(x, y), (x, 2), (y, 2)) - 216*Derivative(u(x, y), (x, 3), y))/24 + \
+            h**5*(243*Derivative(u(x, y), (x, 5)) - 32*Derivative(u(x, y), (y, 5)) + 240*Derivative(u(x, y), x, (y, 4)) - \
+            720*Derivative(u(x, y), (x, 2), (y, 3)) + 1080*Derivative(u(x, y), (x, 3), (y, 2)) - 810*Derivative(u(x, y), (x, 4), y))/120 + O(h**6)
+
+
 def test_negative_counts():
     # issue 13873
     raises(ValueError, lambda: sin(x).diff(x, -1))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1325,6 +1325,8 @@ def test_issue_15084_13166():
 
 
 def test_issue_22439():
+    # Refer https://github.com/sympy/sympy/pull/22806#issuecomment-1007272066 to see the results
+    # being displayed in their pretty printed format.
     x, y, h = symbols('x y h')
     u = Function('u')
     _xi_1, _xi_2 = [Dummy() for i in range(2)]

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1324,6 +1324,30 @@ def test_issue_15084_13166():
     assert eq.diff(x, g(x)) == eq.diff(g(x), x)
 
 
+def test_issue_22439():
+    x, y, h = symbols('x y h')
+    u = Function('u')
+    assert u(x-h, y-h).diff(h, 2) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 2)), _xi_1, -h + x) + \
+            Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 2)), _xi_2, -h + y) + \
+            2*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, _xi_2), (_xi_1, _xi_2), (-h + x, -h + y))
+    assert u(x-h, y-h).diff(h, 3).simplify() == -Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 3)), _xi_1, -h + x) - \
+            Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 3)), _xi_2, -h + y) - \
+            3*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 2)), (_xi_2, _xi_1), (-h + y, -h + x)) - \
+            3*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), _xi_2), (_xi_2, _xi_1), (-h + y, -h + x))
+    assert u(x-h, y-h).diff(h, 4) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 4)), _xi_1, -h + x) + \
+            Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 4)), _xi_2, -h + y) + \
+            4*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 3)), (_xi_2, _xi_1), (-h + y, -h + x)) + \
+            6*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), (_xi_2, 2)), (_xi_1, _xi_2), (-h + x, -h + y)) + \
+            4*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 3), _xi_2), (_xi_1, _xi_2), (-h + x, -h + y))
+    assert u(x-h, y-h).series(h, x0=0, n=3).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+            h**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + \
+            2*Derivative(u(x, y), x, y))/2 + O(h**3)
+    assert u(x-h, y-h).series(h, x0=0, n=4).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+            h**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + 2*Derivative(u(x, y), x, y))/2 - \
+            h**3*(Derivative(u(x, y), (x, 3)) + Derivative(u(x, y), (y, 3)) + 3*Derivative(u(x, y), x, (y, 2)) + \
+            3*Derivative(u(x, y), (x, 2), y))/6 + O(h**4)
+
+
 def test_negative_counts():
     # issue 13873
     raises(ValueError, lambda: sin(x).diff(x, -1))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1354,6 +1354,8 @@ def test_issue_22439():
 def test_denesting_for_Subs():
     # Refer https://github.com/sympy/sympy/pull/22806#issuecomment-1037339531 to see the results
     # being displayed in their pretty printed format.
+    # This test addresses denesting for subs when we encounter expressions of type Mul(expr, Subs(...))
+    # where expr could be of type Symbol, Number/Constant.
     x, y, h = symbols('x y h')
     u = Function('u')
     _xi_1, _xi_2 = [Dummy() for i in range(2)]
@@ -1381,6 +1383,30 @@ def test_denesting_for_Subs():
             96*Derivative(u(x, y), x, (y, 3)) + 216*Derivative(u(x, y), (x, 2), (y, 2)) - 216*Derivative(u(x, y), (x, 3), y))/24 + \
             h**5*(243*Derivative(u(x, y), (x, 5)) - 32*Derivative(u(x, y), (y, 5)) + 240*Derivative(u(x, y), x, (y, 4)) - \
             720*Derivative(u(x, y), (x, 2), (y, 3)) + 1080*Derivative(u(x, y), (x, 3), (y, 2)) - 810*Derivative(u(x, y), (x, 4), y))/120 + O(h**6)
+
+
+def test_denesting_for_Subs2():
+    # Refer https://github.com/sympy/sympy/pull/22806/files#r805224808 to see the results
+    # being displayed in their pretty printed format.
+    # This test addresses denesting for subs when we encounter expressions of type Mul(expr, Subs(...))
+    # where expr could be of type Mul, Pow.
+    x, y, z, a, h = symbols('x y z a h')
+    u = Function('u')
+    _xi_1, _xi_2 = [Dummy() for i in range(2)]
+
+    assert u(x - 2*z*h, y - 2*z*h).diff(h, 3) == -8*z**3*(Subs(Derivative(u(_xi_1, -2*h*z + y), (_xi_1, 3)), _xi_1, -2*h*z + x) + \
+            Subs(Derivative(u(-2*h*z + x, _xi_2), (_xi_2, 3)), _xi_2, -2*h*z + y) + \
+            3*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 2)), (_xi_1, _xi_2), (-2*h*z + x, -2*h*z + y)) + \
+            3*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), _xi_2), (_xi_2, _xi_1), (-2*h*z + y, -2*h*z + x)))
+    assert u(x - a*z**2*h, y - a*z**2*h).diff(h, 2) == a**2*z**4*(Subs(Derivative(u(_xi_1, -a*h*z**2 + y), (_xi_1, 2)), _xi_1, -a*h*z**2 + x) + \
+            Subs(Derivative(u(-a*h*z**2 + x, _xi_2), (_xi_2, 2)), _xi_2, -a*h*z**2 + y) + \
+            2*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, _xi_2), (_xi_2, _xi_1), (-a*h*z**2 + y, -a*h*z**2 + x)))
+    assert u(x - 3*z*h, y + 3*z*h).series(h, 0, 4).simplify() == u(x, y) - 3*h*z*(Derivative(u(x, y), x) - Derivative(u(x, y), y)) + \
+            9*h**2*z**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) - \
+            2*Derivative(u(x, y), x, y))/2 + 9*h**3*z**3*(-Derivative(u(x, y), (x, 3)) + Derivative(u(x, y), (y, 3)) - \
+            3*Derivative(u(x, y), x, (y, 2)) + 3*Derivative(u(x, y), (x, 2), y))/2 + O(h**4)
+    assert u(x + a*z**2*h, y + a*z**2*h).series(h, 0, 3).simplify() == u(x, y) + a*h*z**2*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+            a**2*h**2*z**4*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + 2*Derivative(u(x, y), x, y))/2 + O(h**3)
 
 
 def test_negative_counts():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1327,22 +1327,23 @@ def test_issue_15084_13166():
 def test_issue_22439():
     x, y, h = symbols('x y h')
     u = Function('u')
-    assert u(x-h, y-h).diff(h, 2) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 2)), _xi_1, -h + x) + \
+    _xi_1, _xi_2 = [Dummy() for i in range(2)]
+    assert u(x - h, y - h).diff(h, 2) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 2)), _xi_1, -h + x) + \
             Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 2)), _xi_2, -h + y) + \
             2*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, _xi_2), (_xi_1, _xi_2), (-h + x, -h + y))
-    assert u(x-h, y-h).diff(h, 3).simplify() == -Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 3)), _xi_1, -h + x) - \
-            Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 3)), _xi_2, -h + y) - \
-            3*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 2)), (_xi_2, _xi_1), (-h + y, -h + x)) - \
-            3*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), _xi_2), (_xi_2, _xi_1), (-h + y, -h + x))
+    assert u(x + h, y - h).diff(h, 3) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 3)), _xi_1, h + x) - \
+            Subs(Derivative(u(h + x, _xi_2), (_xi_2, 3)), _xi_2, -h + y) + \
+            3*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 2)), (_xi_1, _xi_2), (h + x, -h + y)) - \
+            3*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), _xi_2), (_xi_1, _xi_2), (h + x, -h + y))
     assert u(x-h, y-h).diff(h, 4) == Subs(Derivative(u(_xi_1, -h + y), (_xi_1, 4)), _xi_1, -h + x) + \
             Subs(Derivative(u(-h + x, _xi_2), (_xi_2, 4)), _xi_2, -h + y) + \
             4*Subs(Derivative(u(_xi_1, _xi_2), _xi_1, (_xi_2, 3)), (_xi_2, _xi_1), (-h + y, -h + x)) + \
             6*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 2), (_xi_2, 2)), (_xi_1, _xi_2), (-h + x, -h + y)) + \
             4*Subs(Derivative(u(_xi_1, _xi_2), (_xi_1, 3), _xi_2), (_xi_1, _xi_2), (-h + x, -h + y))
-    assert u(x-h, y-h).series(h, x0=0, n=3).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+    assert u(x - h, y - h).series(h, x0 = 0, n = 3).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
             h**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + \
             2*Derivative(u(x, y), x, y))/2 + O(h**3)
-    assert u(x-h, y-h).series(h, x0=0, n=4).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
+    assert u(x - h, y - h).series(h, x0 = 0, n = 4).simplify() == u(x, y) - h*(Derivative(u(x, y), x) + Derivative(u(x, y), y)) + \
             h**2*(Derivative(u(x, y), (x, 2)) + Derivative(u(x, y), (y, 2)) + 2*Derivative(u(x, y), x, y))/2 - \
             h**3*(Derivative(u(x, y), (x, 3)) + Derivative(u(x, y), (y, 3)) + 3*Derivative(u(x, y), x, (y, 2)) + \
             3*Derivative(u(x, y), (x, 2), y))/6 + O(h**4)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #22493 

#### Brief description of what is fixed or changed
While I was going through the issue , I realized that there's no error actually from sympy's side . We get the correct answer but then the function call for subs doesn't stop as intended .
For example while calculating the following we get the result as shown below 
```
>>> from sympy import *
>>> x, y, h = symbols('x y h')
>>> u = Function('u')
>>> u(x-h, y-h).series(h, x0=0, n=3).simplify()

                                             ⎛  2              2
                                           2 ⎜ ∂              ∂
                                          h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 2⋅
                                             ⎜  2              2
            ⎛∂             ∂          ⎞      ⎝∂x             ∂y
u(x, y) - h⋅⎜──(u(x, y)) + ──(u(x, y))⎟ + ────────────────────────────────────
            ⎝∂x            ∂y         ⎠                                  2

      2                   ⎞
     ∂                    ⎟
───────────(u(_x - xi, y))⎟
∂y ∂_x - xi               ⎟
                          ⎠    ⎛ 3⎞
─────────────────────────── + O⎝h ⎠

```

Now the third term here is not what we expect to have , so I printed out the `self` term during the function call for `Subs` to see how sympy works for the same and after going through the code I realized there is no mistake from sympy's side as everything works as expected . We also get the correct answer but move on from that case 
```
# we encounter the correct forms here where the calls should maybe return but it goes on to give the wrong answer
    2
   ∂
───────( u(ξ₁, ξ₂))
∂ξ₂ ∂ξ₁
    2
   ∂
───────( u(ξ₁, ξ₂))
∂ξ₂ ∂ξ₁
    2
   ∂
───────( u(ξ₁, ξ₂))
∂ξ₂ ∂ξ₁
    2
   ∂
───────( u(ξ₁, ξ₂))
∂ξ₂ ∂ξ₁
 ⎛    2              ⎞│
 ⎜   ∂               ⎟│
-⎜───────( u(ξ₁, ξ₂))⎟│           # correct answer we expect but call goes on instead of stopping
 ⎝∂ξ₂ ∂ξ₁            ⎠│ξ₁=-h + x
      2
     ∂
────────────( u(ξ₁, _-h + y)) # the wrong form involving ∂_-h is encountered after the correct forms
∂_-h + y ∂ξ₁
```

The answer we expect obviously needs denesting and thus I realized that we do denest expressions of type `Sub` but we weren't doing so to expressions of type `-1*Sub` (basically type `Mul`) , hence leading to the wrong answer . Adding denesting for the above type of expressions fixes all cases as sympy was anyways working good enough for everything else

**Some wrong answers obtained on master**
```
>>> (u(x -h, y -h).diff(h, 2))

⎛  2                ⎞│            ⎛  2                ⎞│              ⎛      2
⎜ ∂                 ⎟│            ⎜ ∂                 ⎟│              ⎜     ∂
⎜────(u(ξ₁, -h + y))⎟│          + ⎜────(u(-h + x, ξ₂))⎟│          + 2⋅⎜───────
⎜   2               ⎟│            ⎜   2               ⎟│              ⎝∂_-h +
⎝∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂ξ₂                ⎠│ξ₂=-h + y

                     ⎞│
                     ⎟│
─────(u(_-h + x, ξ₂))⎟│
x ∂ξ₂                ⎠│ξ₂=-h + y

>>> ((u(x -h, y -h).diff(h, 3)

 ⎛⎛  3                ⎞│            ⎛  3                ⎞│            ⎛
 ⎜⎜ ∂                 ⎟│            ⎜ ∂                 ⎟│            ⎜      ∂
-⎜⎜────(u(ξ₁, -h + y))⎟│          + ⎜────(u(-h + x, ξ₂))⎟│          + ⎜───────
 ⎜⎜   3               ⎟│            ⎜   3               ⎟│            ⎜
 ⎝⎝∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂ξ₂                ⎠│ξ₂=-h + y   ⎝∂_-h +

3                     ⎞│            ⎛       3                     ⎞│
                      ⎟│            ⎜      ∂                      ⎟│
──────(u(ξ₁, _-h + y))⎟│          + ⎜─────────────(u(_-h + x, ξ₂))⎟│
 2                    ⎟│            ⎜        2                    ⎟│
y  ∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂_-h + x  ∂ξ₂                ⎠│ξ₂=-h + y

    ⎛       3                     ⎞│         ⎞
    ⎜      ∂                      ⎟│         ⎟
+ 2⋅⎜─────────────(u(_-h + x, ξ₂))⎟│         ⎟
    ⎜            2                ⎟│         ⎟
    ⎝∂_-h + x ∂ξ₂                 ⎠│ξ₂=-h + y⎠

>>> u(x-h, y-h).series(h, x0=0, n=4).simplify()

                                             ⎛  2              2
                                           2 ⎜ ∂              ∂
                                          h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 2⋅
                                             ⎜  2              2
            ⎛∂             ∂          ⎞      ⎝∂x             ∂y
u(x, y) - h⋅⎜──(u(x, y)) + ──(u(x, y))⎟ + ────────────────────────────────────
            ⎝∂x            ∂y         ⎠                                  2

      2                   ⎞      ⎛  3              3                    3
     ∂                    ⎟    3 ⎜ ∂              ∂                    ∂
───────────(u(_x - xi, y))⎟   h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 2⋅────────────
∂y ∂_x - xi               ⎟      ⎜  3              3                2
                          ⎠      ⎝∂x             ∂y               ∂y  ∂_x - xi
─────────────────────────── - ────────────────────────────────────────────────


                        3                              3                     ⎞
                       ∂                              ∂                      ⎟
(u(_x - xi, y)) + ────────────(u(_x - xi, y)) + ─────────────(u(x, _-xi + y))⎟
                             2                              2                ⎟
                  ∂y ∂_x - xi                   ∂x ∂_-xi + y                 ⎠
──────────────────────────────────────────────────────────────────────────────
              6





    ⎛ 4⎞
 + O⎝h ⎠
```

**Correct answers obtained on committed branch**
```
>>> (u(x -h, y -h).diff(h, 2))

⎛  2                ⎞│            ⎛  2                ⎞│              ⎛    2
⎜ ∂                 ⎟│            ⎜ ∂                 ⎟│              ⎜   ∂
⎜────(u(ξ₁, -h + y))⎟│          + ⎜────(u(-h + x, ξ₂))⎟│          + 2⋅⎜───────
⎜   2               ⎟│            ⎜   2               ⎟│              ⎝∂ξ₂ ∂ξ₁
⎝∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂ξ₂                ⎠│ξ₂=-h + y

           ⎞│
           ⎟│
(u(ξ₁, ξ₂))⎟│
           ⎠│ξ₁=-h + x, ξ₂=-h + y

>>> (u(x -h, y -h).diff(h, 3))


 ⎛⎛  3                ⎞│            ⎛  3                ⎞│              ⎛    3
 ⎜⎜ ∂                 ⎟│            ⎜ ∂                 ⎟│              ⎜   ∂
-⎜⎜────(u(ξ₁, -h + y))⎟│          + ⎜────(u(-h + x, ξ₂))⎟│          + 3⋅⎜─────
 ⎜⎜   3               ⎟│            ⎜   3               ⎟│              ⎜   2
 ⎝⎝∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂ξ₂                ⎠│ξ₂=-h + y     ⎝∂ξ₂

              ⎞│                         ⎛    3              ⎞│
              ⎟│                         ⎜   ∂               ⎟│
───(u(ξ₁, ξ₂))⎟│                     + 3⋅⎜────────(u(ξ₁, ξ₂))⎟│
              ⎟│                         ⎜       2           ⎟│
∂ξ₁           ⎠│ξ₂=-h + y, ξ₁=-h + x     ⎝∂ξ₂ ∂ξ₁            ⎠│ξ₂=-h + y, ξ₁=-

     ⎞
     ⎟
     ⎟
     ⎟
h + x⎠
>>> (u(x -h, y -h).diff(h, 4))


⎛  4                ⎞│            ⎛  4                ⎞│              ⎛    4
⎜ ∂                 ⎟│            ⎜ ∂                 ⎟│              ⎜   ∂
⎜────(u(ξ₁, -h + y))⎟│          + ⎜────(u(-h + x, ξ₂))⎟│          + 4⋅⎜───────
⎜   4               ⎟│            ⎜   4               ⎟│              ⎜   3
⎝∂ξ₁                ⎠│ξ₁=-h + x   ⎝∂ξ₂                ⎠│ξ₂=-h + y     ⎝∂ξ₂  ∂ξ

            ⎞│                         ⎛     4              ⎞│
            ⎟│                         ⎜    ∂               ⎟│
─(u(ξ₁, ξ₂))⎟│                     + 6⋅⎜─────────(u(ξ₁, ξ₂))⎟│
            ⎟│                         ⎜   2    2           ⎟│
₁           ⎠│ξ₂=-h + y, ξ₁=-h + x     ⎝∂ξ₂  ∂ξ₁            ⎠│ξ₁=-h + x, ξ₂=-h

         ⎛    4              ⎞│
         ⎜   ∂               ⎟│
     + 4⋅⎜────────(u(ξ₁, ξ₂))⎟│
         ⎜       3           ⎟│
 + y     ⎝∂ξ₂ ∂ξ₁            ⎠│ξ₁=-h + x, ξ₂=-h + y

# All were returning wrong results before . Also checking for the issue whether that works fine .... does according to me!

>>> (u(x-h, y-h).series(h, x0=0, n=3).simplify())

                                             ⎛  2              2
                                           2 ⎜ ∂              ∂
                                          h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 2⋅
                                             ⎜  2              2
            ⎛∂             ∂          ⎞      ⎝∂x             ∂y
u(x, y) - h⋅⎜──(u(x, y)) + ──(u(x, y))⎟ + ────────────────────────────────────
            ⎝∂x            ∂y         ⎠                            2

   2          ⎞
  ∂           ⎟
─────(u(x, y))⎟
∂y ∂x         ⎟
              ⎠    ⎛ 3⎞
─────────────── + O⎝h ⎠

>>> (u(x-h, y-h).series(h, x0=0, n=4).simplify())

                                             ⎛  2              2
                                           2 ⎜ ∂              ∂
                                          h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 2⋅
                                             ⎜  2              2
            ⎛∂             ∂          ⎞      ⎝∂x             ∂y
u(x, y) - h⋅⎜──(u(x, y)) + ──(u(x, y))⎟ + ────────────────────────────────────
            ⎝∂x            ∂y         ⎠                            2

   2          ⎞      ⎛  3              3                 3                   3
  ∂           ⎟    3 ⎜ ∂              ∂                 ∂                   ∂
─────(u(x, y))⎟   h ⋅⎜───(u(x, y)) + ───(u(x, y)) + 3⋅──────(u(x, y)) + 3⋅────
∂y ∂x         ⎟      ⎜  3              3                2
              ⎠      ⎝∂x             ∂y               ∂y  ∂x              ∂y ∂
─────────────── - ────────────────────────────────────────────────────────────
                                                     6

           ⎞
           ⎟
──(u(x, y))⎟
 2         ⎟
x          ⎠    ⎛ 4⎞
──────────── + O⎝h ⎠

```

#### Other comments
ping @smichr @oscargus @0sidharth for review !

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixes differentiation and series for Multivariate cases (more than 2 variable) by adding denesting for a specific case.
<!-- END RELEASE NOTES -->
