### PR TITLE
geometry - projection method returns EmptySet when there is no projection

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -28,7 +28,6 @@ from sympy.core.symbol import _symbol, Dummy, uniquely_named_symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (_pi_coeff as pi_coeff, acos, tan, atan2)
-from sympy.sets import EmptySet
 from .entity import GeometryEntity, GeometrySet
 from .exceptions import GeometryError
 from .point import Point, Point3D

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -28,6 +28,7 @@ from sympy.core.symbol import _symbol, Dummy, uniquely_named_symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (_pi_coeff as pi_coeff, acos, tan, atan2)
+from sympy.sets import EmptySet
 from .entity import GeometryEntity, GeometrySet
 from .exceptions import GeometryError
 from .point import Point, Point3D
@@ -966,6 +967,8 @@ class LinearEntity(GeometrySet):
                 return p1
             projected = other.__class__(p1, p2)
             projected = Intersection(self, projected)
+            if projected.is_empty:
+                return projected
             # if we happen to have intersected in only a point, return that
             if projected.is_FiniteSet and len(projected) == 1:
                 # projected is a set of size 1, so unpack it in `a`

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -4,6 +4,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, cos, sin)
+from sympy.sets import EmptySet
 from sympy.simplify.simplify import simplify
 from sympy.functions.elementary.trigonometric import tan
 from sympy.geometry import (Circle, GeometryError, Line, Point, Ray,
@@ -697,10 +698,14 @@ def test_projection():
 
     r1 = Ray(Point(1, 1), Point(2, 2))
 
+    s1 = Segment(Point2D(0, 0), Point2D(0, 1))
+    s2 = Segment(Point2D(1, 0), Point2D(2, 1/2))
+
     assert Line(Point(x1, x1), Point(y1, y1)).projection(Point(y1, y1)) == Point(y1, y1)
     assert Line(Point(x1, x1), Point(x1, 1 + x1)).projection(Point(1, 1)) == Point(x1, 1)
     assert Segment(Point(-2, 2), Point(0, 4)).projection(r1) == Segment(Point(-1, 3), Point(0, 4))
     assert Segment(Point(0, 4), Point(-2, 2)).projection(r1) == Segment(Point(0, 4), Point(-1, 3))
+    assert s2.projection(s1) == EmptySet
     assert l1.projection(p3) == p1
     assert l1.projection(Ray(p1, Point(-1, 5))) == Ray(Point(0, 0), Point(2, 2))
     assert l1.projection(Ray(p1, Point(-1, 1))) == p1
@@ -715,6 +720,7 @@ def test_projection():
     assert l3.projection(Ray3D(p2, Point3D(-1, 1, 1))) == Ray3D(Point3D(0, 0, 0), Point3D(Rational(1, 3), Rational(1, 3), Rational(1, 3)))
     assert l2.projection(Point3D(5, 5, 0)) == Point3D(5, 0)
     assert l2.projection(Line3D(Point3D(0, 1, 0), Point3D(1, 1, 0))).equals(l2)
+
 
 
 def test_perpendicular_bisector():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Partially Fixes #22807 and now `projection` method returns EmptySet when there is no projection of one entity onto another.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
   * `projection` method of `line.py` now returns EmptySet when there is no projection of one entity onto another.
<!-- END RELEASE NOTES -->
