### PR TITLE
Adding parse_expr in the sympify.py docstring 

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -138,6 +138,21 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: "could not parse 'x***2'"
+    
+    >>> sympify("2x")
+    Traceback (most recent call last):
+    ...
+    SympifyError: SympifyError: "could not parse '2x' "
+
+    "sympify" function only parse the input, if it follows the python-syntax.
+    In order to parse a non python syntax use "parse_exp": 
+
+    >>> from sympy.parsing.sympy_parser import (standard_transformations,
+    ...     implicit_multiplication_application, parse_expr)
+    >>> transformations = (standard_transformations +
+    ...     (implicit_multiplication_application,))
+    >>> parse_expr("2x", transformations=transformations)
+    2*x
 
     Locals
     ------
@@ -338,6 +353,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         their SymPy equivalents. If True the expression will be evaluated
         and the result will be returned.
 
+    See Also
+    ========
+
+    parse_expr
+    
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than
     # sin(x)) then a.__sympy__ will be the property. Only on the instance will

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -142,13 +142,13 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: "could not parse '2x' "
-    
+
     Sympification happens, if the expression follows the python syntax.
     If the expression is not following python syntax, use "parse_exp" to
     parse the expression:
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
-    2*x    
+    2*x
 
     Locals
     ------

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -349,7 +349,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     See Also
     ========
-    :func: `parse_expr`.
+    parse_expr from sympy.parsing.sympy_parser.py
 
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -145,6 +145,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     sympify function parse the input if it follows the python-syntax.
     To parse a non-python syntax use "parse_exp":
+    >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x
 
@@ -346,6 +347,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         If False, then arithmetic and operators will be converted into
         their SymPy equivalents. If True the expression will be evaluated
         and the result will be returned.
+
+    See Also
+    ========
+    parse_expr
+
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than
     # sin(x)) then a.__sympy__ will be the property. Only on the instance will

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -146,6 +146,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     sympify function parse the input if it follows the python-syntax.
     To parse a non-python syntax use "parse_exp": 
+    
     >>> parse_expr("2x", transformations="all")
     2*x
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -349,7 +349,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     See Also
     ========
-    parse_expr
+    :func: `parse_expr`.
 
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -142,9 +142,10 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: "could not parse '2x' "
-
-    sympify function parse the input if it follows the python-syntax.
-    To parse a non-python syntax use "parse_exp":
+    
+    Sympification happens, if the expression follows the python syntax.
+    If the expression is not following python syntax, use "parse_exp" to parse 
+    the expression:
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -137,8 +137,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     >>> sympify("x***2")
     Traceback (most recent call last):
     ...
-    SympifyError: SympifyError: "could not parse 'x***2'"
-    
+    SympifyError: SympifyError: "could not parse 'x***2'"    
     >>> sympify("2x")
     Traceback (most recent call last):
     ...
@@ -146,7 +145,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     sympify function parse the input if it follows the python-syntax.
     To parse a non-python syntax use "parse_exp": 
-    
+
     >>> parse_expr("2x", transformations="all")
     2*x
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -145,7 +145,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     sympify function parse the input if it follows the python-syntax.
     To parse a non-python syntax use "parse_exp":
-    
     >>> parse_expr("2x", transformations="all")
     2*x
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,8 +144,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     SympifyError: SympifyError: "could not parse '2x' "
 
     Sympification happens, if the expression follows the python syntax.
-    If the expression is not following python syntax, use "parse_exp" to
-    parse the expression:
+    If the expression is not following python syntax, use "parse_exp"
+    to parse the expression:
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -138,7 +138,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: "could not parse 'x***2'"
-    
     >>> sympify("2x")
     Traceback (most recent call last):
     ...

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -346,11 +346,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         If False, then arithmetic and operators will be converted into
         their SymPy equivalents. If True the expression will be evaluated
         and the result will be returned.
-
-    See Also
-    ========
-    parse_expr from sympy.parsing.sympy_parser.py
-
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than
     # sin(x)) then a.__sympy__ will be the property. Only on the instance will

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -146,6 +146,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Sympification happens, if the expression follows the python syntax.
     If the expression is not following python syntax, use "parse_exp" to parse 
     the expression:
+    
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,8 +144,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     SympifyError: SympifyError: "could not parse '2x' "
     
     Sympification happens, if the expression follows the python syntax.
-    If the expression is not following python syntax, use "parse_exp" to parse
-    the expression:
+    If the expression is not following python syntax, use "parse_exp" to parse the expression:
+    
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -137,7 +137,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     >>> sympify("x***2")
     Traceback (most recent call last):
     ...
-    SympifyError: SympifyError: "could not parse 'x***2'"    
+    SympifyError: SympifyError: "could not parse 'x***2'"
+    
     >>> sympify("2x")
     Traceback (most recent call last):
     ...

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -357,7 +357,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     ========
 
     parse_expr
-    
+
     """
     # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than
     # sin(x)) then a.__sympy__ will be the property. Only on the instance will

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,8 +144,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     ...
     SympifyError: SympifyError: "could not parse '2x' "
 
-    "sympify" function parse the input, if it follows the python-syntax.
-    In order to parse a non python syntax use "parse_exp": 
+    sympify function parse the input if it follows the python-syntax.
+    To parse a non-python syntax use "parse_exp": 
     >>> parse_expr("2x", transformations="all")
     2*x
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,8 +144,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     SympifyError: SympifyError: "could not parse '2x' "
 
     sympify function parse the input if it follows the python-syntax.
-    To parse a non-python syntax use "parse_exp": 
-
+    To parse a non-python syntax use "parse_exp":
+    
     >>> parse_expr("2x", transformations="all")
     2*x
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,14 +144,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     ...
     SympifyError: SympifyError: "could not parse '2x' "
 
-    "sympify" function only parse the input, if it follows the python-syntax.
+    "sympify" function parse the input, if it follows the python-syntax.
     In order to parse a non python syntax use "parse_exp": 
-
-    >>> from sympy.parsing.sympy_parser import (standard_transformations,
-    ...     implicit_multiplication_application, parse_expr)
-    >>> transformations = (standard_transformations +
-    ...     (implicit_multiplication_application,))
-    >>> parse_expr("2x", transformations=transformations)
+    >>> parse_expr("2x", transformations="all")
     2*x
 
     Locals
@@ -355,7 +350,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     See Also
     ========
-
+    
     parse_expr
 
     """

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -349,7 +349,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     See Also
     ========
-    
     parse_expr
 
     """

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,11 +144,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     SympifyError: SympifyError: "could not parse '2x' "
     
     Sympification happens, if the expression follows the python syntax.
-    If the expression is not following python syntax, use "parse_exp" to parse the expression:
-    
+    If the expression is not following python syntax, use "parse_exp" to
+    parse the expression:
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
-    2*x
+    2*x    
 
     Locals
     ------

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -146,7 +146,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Sympification happens, if the expression follows the python syntax.
     If the expression is not following python syntax, use "parse_exp" to parse 
     the expression:
-    
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")
     2*x

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -144,7 +144,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     SympifyError: SympifyError: "could not parse '2x' "
     
     Sympification happens, if the expression follows the python syntax.
-    If the expression is not following python syntax, use "parse_exp" to parse 
+    If the expression is not following python syntax, use "parse_exp" to parse
     the expression:
     >>> from sympy.parsing.sympy_parser import parse_expr
     >>> parse_expr("2x", transformations="all")


### PR DESCRIPTION
#### References to other Issues or PRs

- Fixes #21207
- Reference #21230
This PR adds documentation of parse_expr in the sympify.py docstring.


#### Brief description of what is fixed or changed
"sympify" function parse the input if it follows the python-syntax. In order to parse a non-python syntax use "parse_exp".

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->