### PR TITLE
Series: Fixes series for expressions of type Pow having unspecified exponents  

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3032,8 +3032,11 @@ class Expr(Basic, EvalfMixin):
             else:
                 o = Order(x**n, x)
                 s1done = s1.doit()
-                if (s1done + o).removeO() == s1done:
-                    o = S.Zero
+                try:
+                    if (s1done + o).removeO() == s1done:
+                        o = S.Zero
+                except NotImplementedError:
+                    return s1
 
             try:
                 from sympy.simplify.radsimp import collect

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3345,12 +3345,12 @@ class Expr(Basic, EvalfMixin):
         >>> e.nseries(x, 0, 6, logx=logx)
         sin(logx)
 
-        In the following example, the expansion works but gives only an Order term
+        In the following example, the expansion works but only returns self
         unless the ``logx`` parameter is used:
 
         >>> e = x**y
         >>> e.nseries(x, 0, 2)
-        O(log(x)**2)
+        x**y
         >>> e.nseries(x, 0, 2, logx=logx)
         exp(logx*y)
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1670,7 +1670,10 @@ class Pow(Expr):
             e = logcombine(e).cancel()
 
         if not (m.is_zero or e.is_number and e.is_real):
-            return exp(e*log(b))._eval_nseries(x, n=n, logx=logx, cdir=cdir)
+            res = exp(e*log(b))._eval_nseries(x, n=n, logx=logx, cdir=cdir)
+            if res is exp(e*log(b)):
+                return self
+            return res
 
         f = b.as_leading_term(x, logx=logx)
         g = (b/f - S.One).cancel(expand=False)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -479,6 +479,8 @@ class exp(ExpBase, metaclass=ExpMeta):
     def _eval_nseries(self, x, n, logx, cdir=0):
         # NOTE Please see the comment at the beginning of this file, labelled
         #      IMPORTANT.
+        from sympy.core.numbers import ImaginaryUnit
+        from sympy.functions.elementary.complexes import sign
         from sympy.functions.elementary.integers import ceiling
         from sympy.series.limits import limit
         from sympy.series.order import Order
@@ -491,6 +493,9 @@ class exp(ExpBase, metaclass=ExpMeta):
         if arg0 is S.NegativeInfinity:
             return Order(x**n, x)
         if arg0 is S.Infinity:
+            return self
+        # checking for indecisiveness/ sign terms in arg0
+        if any(isinstance(arg, (sign, ImaginaryUnit)) for arg in arg0.args):
             return self
         t = Dummy("t")
         nterms = n

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,6 +1,6 @@
 from sympy.core.evalf import N
 from sympy.core.function import (Derivative, Function, PoleError, Subs)
-from sympy.core.numbers import (E, Rational, oo, pi)
+from sympy.core.numbers import (E, Rational, oo, pi, I)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
@@ -235,6 +235,16 @@ def test_issue_12791():
         + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - S.Half)**2, (beta, S.Half))
 
     assert expr.series(beta, 0.5, 2).trigsimp() == sol
+
+
+def test_issue_14384():
+    x, a = symbols('x a')
+    assert series(x**a, x) == x**a
+    assert series(x**(-2*a), x) == x**(-2*a)
+    assert series(exp(a*log(x)), x) == exp(a*log(x))
+    assert series(x**I, x) == x**I
+    assert series(x**(I + 1), x) == x**(1 + I)
+    assert series(exp(I*log(x)), x) == exp(I*log(x))
 
 
 def test_issue_14885():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #14384 
#### Brief description of what is fixed or changed

Changes made are as follows
On **Master**
```
>>> x, a = symbols('x a')
>>> series(x**a, x)
O(log(x)**6)
>>> series(x**(-2*a), x)
O(log(x)**6)
>>> series(exp(a*log(x)), x)
O(log(x)**6)
>>> series(x**I, x)
nan
>>> series(x**(I + 1), x)
O(log(x)**6)
>>> series(exp(I*log(x)), x)
nan
```

On **Committed Branch**
```
>>> x,a = symbols('x a')
>>> series(x**a, x)
x**a
>>> series(x**(-2*a), x)
x**(-2*a)
>>> series(exp(a*log(x)), x)
exp(a*log(x))
>>> series(x**I, x)
x**I
>>> series(x**(I + 1), x)
x**(1 + I)
>>> series(exp(I*log(x)), x)
exp(I*log(x))
```

All these end up in the `_eval_nseries()` method of `exponential.py` where we can check if the series is decisive enough which is not as these depend on sign of `sign(a)` or `sign(I + 1)`. and Hence if it isn't decisive enough we return self rather than `O(log(x)**6`) which was being returned as default for all cases !
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixes series for expressions of type Pow having unspecified exponents 
<!-- END RELEASE NOTES -->
