### PR TITLE
fixes recursion error during extract_additively

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -20,6 +20,19 @@ from mpmath.libmp.libintmath import giant_steps
 from collections import defaultdict
 
 
+def _corem(eq, c):  # helper for extract_additively
+    # return co, diff from co*c + diff
+    co = []
+    non = []
+    for i in Add.make_args(eq):
+        ci = i.coeff(c)
+        if not ci:
+            non.append(i)
+        else:
+            co.append(ci)
+    return Add(*co), Add(*non)
+
+
 @sympify_method_args
 class Expr(Basic, EvalfMixin):
     """
@@ -2386,10 +2399,9 @@ class Expr(Basic, EvalfMixin):
             return xa + xa2
 
         # whole term as a term factor
-        co = self.coeff(c)
+        co, diff = _corem(self, c)
         xa0 = (co.extract_additively(1) or 0)*c
         if xa0:
-            diff = self - co*c
             return (xa0 + (diff.extract_additively(c) or diff)) or None
         # term-wise
         coeffs = []

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2332,15 +2332,6 @@ class Expr(Basic, EvalfMixin):
         >>> ((x + 1)*(x + 2*y + 1) + 3).extract_additively(x + 1)
         (x + 1)*(x + 2*y) + 3
 
-        Sometimes auto-expansion will return a less simplified result
-        than desired; gcd_terms might be used in such cases:
-
-        >>> from sympy import gcd_terms
-        >>> (4*x*(y + 1) + y).extract_additively(x)
-        4*x*(y + 1) + x*(4*y + 3) - x*(4*y + 4) + y
-        >>> gcd_terms(_)
-        x*(4*y + 3) + y
-
         See Also
         ========
         extract_multiplicatively

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1338,6 +1338,7 @@ def test_extractions():
         x + y + (x + 1)*(x + y) + 3
     assert ((y + 1)*(x + 2*y + 1) + 3).extract_additively(y + 1) == \
         (x + 2*y)*(y + 1) + 3
+    assert (-x - x*I).extract_additively(-x) == -I*x
 
     n = Symbol("n", integer=True)
     assert (Integer(-3)).could_extract_minus_sign() is True

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1339,6 +1339,8 @@ def test_extractions():
     assert ((y + 1)*(x + 2*y + 1) + 3).extract_additively(y + 1) == \
         (x + 2*y)*(y + 1) + 3
     assert (-x - x*I).extract_additively(-x) == -I*x
+    # extraction does not leave artificats, now
+    assert (4*x*(y + 1) + y).extract_additively(x) == x*(4*y + 3) + y
 
     n = Symbol("n", integer=True)
     assert (Integer(-3)).could_extract_minus_sign() is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

non-destructive reconstruction of an expression from which terms have been collected is now implemented by using a helper function to get the coefficient of interest and the terms which did not have the indicated factor. The old method left an unsimplified reconstruction that looked like the original (but was actually zero).


#### Other comments

I'm surprised we don't have a function to do this automatically. `match` is non-collecting:
```python
>>> a,b=symbols('a b ',cls=Wild)
>>> eq=-t-t*I
>>> eq.match(a*(-t)+b)
{b_: -I*t, a_: 1}
```



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
