### PR TITLE
tensor/indexed: Indexed now sympifies base argument

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -165,6 +165,8 @@ class Indexed(Expr):
             else:
                 return base[args]
 
+        base = _sympify(base)
+
         obj = Expr.__new__(cls, base, *args, **kw_args)
 
         try:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Helps with https://github.com/sympy/sympy/pull/22445

#### Brief description of what is fixed or changed
`Indexed` can currently be used to symbolically indicate elements
of a `MutableArray`. However, when doing so that MutableArray is
stored in `Indexed`'s `args`, which should not be allowed since
a `MutableArray` is not a subclass of `Basic`. `Indexed` now uses
`_sympify` on its `base` argument to convert any `MutableArray`
to an `ImmutableArray`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
