### PR TITLE
tensor/tests: TensorProduct tests not longer use python lists

### DIFF
--- a/sympy/tensor/tests/test_functions.py
+++ b/sympy/tensor/tests/test_functions.py
@@ -21,7 +21,7 @@ def test_TensorProduct_construction():
     expr = TensorProduct(TensorProduct(A, B), C)
     assert expr == TensorProduct(A, B, C)
 
-    expr = TensorProduct(Matrix.eye(2), [[0, -1], [1, 0]])
+    expr = TensorProduct(Matrix.eye(2), Array([[0, -1], [1, 0]]))
     assert expr == Array([
         [
             [[0, -1], [1, 0]],
@@ -40,14 +40,14 @@ def test_TensorProduct_shape():
     assert expr.shape == ()
     assert expr.rank() == 0
 
-    expr = TensorProduct([1, 2], [x, y], evaluate=False)
+    expr = TensorProduct(Array([1, 2]), Array([x, y]), evaluate=False)
     assert expr.shape == (2, 2)
     assert expr.rank() == 2
     expr = TensorProduct(expr, expr, evaluate=False)
     assert expr.shape == (2, 2, 2, 2)
     assert expr.rank() == 4
 
-    expr = TensorProduct(Matrix.eye(2), [[0, -1], [1, 0]], evaluate=False)
+    expr = TensorProduct(Matrix.eye(2), Array([[0, -1], [1, 0]]), evaluate=False)
     assert expr.shape == (2, 2, 2, 2)
     assert expr.rank() == 4
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Helps with https://github.com/sympy/sympy/pull/22445

#### Brief description of what is fixed or changed
Python lists should not be used as examples for Basic subclasses
that do not `_sympify` their arguments.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
