### PR TITLE
physics/quantum: wrapper class for python functions used in OracleGate

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3523,10 +3523,20 @@ def test_sympy__physics__quantum__gate__ZGate():
     assert _test_args(ZGate(0))
 
 
-@SKIP("TODO: sympy.physics")
+def test_sympy__physics__quantum__grover__OracleGateFunction():
+    from sympy.physics.quantum.grover import OracleGateFunction
+    @OracleGateFunction
+    def f(qubit):
+        return
+    assert _test_args(f)
+
 def test_sympy__physics__quantum__grover__OracleGate():
     from sympy.physics.quantum.grover import OracleGate
-    assert _test_args(OracleGate())
+    from sympy.physics.quantum.grover import OracleGateFunction
+    @OracleGateFunction
+    def f(qubit):
+        return
+    assert _test_args(OracleGate(1,f))
 
 
 def test_sympy__physics__quantum__grover__WGate():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3532,8 +3532,6 @@ def test_sympy__physics__quantum__grover__OracleGateFunction():
 
 def test_sympy__physics__quantum__grover__OracleGate():
     from sympy.physics.quantum.grover import OracleGate
-    from sympy.physics.quantum.grover import OracleGateFunction
-    @OracleGateFunction
     def f(qubit):
         return
     assert _test_args(OracleGate(1,f))

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -10,6 +10,7 @@ Todo:
 
 from sympy.core.numbers import pi
 from sympy.core.sympify import sympify
+from sympy.core.basic import Atom
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import eye
@@ -57,6 +58,22 @@ def superposition_basis(nqubits):
 
     amp = 1/sqrt(2**nqubits)
     return sum([amp*IntQubit(n, nqubits=nqubits) for n in range(2**nqubits)])
+
+class OracleGateFunction(Atom):
+    """Wrapper for python functions used in `OracleGate`s"""
+
+    def __new__(cls, function):
+        if not callable(function):
+            raise TypeError("{func} is not a callable.".format(func = function))
+        obj = Atom.__new__(cls)
+        obj.function = function
+        return obj
+
+    def _hashable_content(self):
+        return type(self), self.function
+
+    def __call__(self, *args):
+        return self.function(*args)
 
 
 class OracleGate(Gate):

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -64,7 +64,7 @@ class OracleGateFunction(Atom):
 
     def __new__(cls, function):
         if not callable(function):
-            raise TypeError("{func} is not a callable.".format(func = function))
+            raise TypeError('Callable expected, got: %r' % function)
         obj = Atom.__new__(cls)
         obj.function = function
         return obj
@@ -117,7 +117,6 @@ class OracleGate(Gate):
 
     @classmethod
     def _eval_args(cls, args):
-        # TODO: args[1] is not a subclass of Basic
         if len(args) != 2:
             raise QuantumError(
                 'Insufficient/excessive arguments to Oracle.  Please ' +
@@ -128,9 +127,11 @@ class OracleGate(Gate):
         if not sub_args[0].is_Integer:
             raise TypeError('Integer expected, got: %r' % sub_args[0])
 
-        if not callable(args[1]):
-            raise TypeError('Callable expected, got: %r' % args[1])
-        return (sub_args[0], args[1])
+        function = args[1]
+        if not isinstance(function, OracleGateFunction):
+            function = OracleGateFunction(function)
+
+        return (sub_args[0], function)
 
     @classmethod
     def _eval_hilbert_space(cls, args):

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -10,8 +10,10 @@ from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)
 
+
 def return_one_on_one(qubits):
     return qubits == IntQubit(1, nqubits=qubits.nqubits)
+
 
 def test_superposition_basis():
     nbits = 2

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -4,16 +4,16 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
-        OracleGate, grover_iteration, WGate)
+        OracleGate, grover_iteration, WGate, OracleGateFunction)
 
 
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)
-
+return_one_on_two=OracleGateFunction(return_one_on_two)
 
 def return_one_on_one(qubits):
     return qubits == IntQubit(1, nqubits=qubits.nqubits)
-
+return_one_on_one=OracleGateFunction(return_one_on_one)
 
 def test_superposition_basis():
     nbits = 2
@@ -30,7 +30,7 @@ def test_superposition_basis():
 
 
 def test_OracleGate():
-    v = OracleGate(1, lambda qubits: qubits == IntQubit(0))
+    v = OracleGate(1, OracleGateFunction(lambda qubits: qubits == IntQubit(0)))
     assert qapply(v*IntQubit(0)) == -IntQubit(0)
     assert qapply(v*IntQubit(1)) == IntQubit(1)
 
@@ -41,7 +41,7 @@ def test_OracleGate():
     assert qapply(v*IntQubit(2, nbits)) == -IntQubit(2, nbits)
     assert qapply(v*IntQubit(3, nbits)) == IntQubit(3, nbits)
 
-    assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
+    assert represent(OracleGate(1, OracleGateFunction(lambda qubits: qubits == IntQubit(0))), nqubits=1) == \
            Matrix([[-1, 0], [0, 1]])
     assert represent(v, nqubits=2) == Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -4,16 +4,14 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
-        OracleGate, grover_iteration, WGate, OracleGateFunction)
+        OracleGate, grover_iteration, WGate)
 
 
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)
-return_one_on_two=OracleGateFunction(return_one_on_two)
 
 def return_one_on_one(qubits):
     return qubits == IntQubit(1, nqubits=qubits.nqubits)
-return_one_on_one=OracleGateFunction(return_one_on_one)
 
 def test_superposition_basis():
     nbits = 2
@@ -30,7 +28,7 @@ def test_superposition_basis():
 
 
 def test_OracleGate():
-    v = OracleGate(1, OracleGateFunction(lambda qubits: qubits == IntQubit(0)))
+    v = OracleGate(1, lambda qubits: qubits == IntQubit(0))
     assert qapply(v*IntQubit(0)) == -IntQubit(0)
     assert qapply(v*IntQubit(1)) == IntQubit(1)
 
@@ -41,7 +39,7 @@ def test_OracleGate():
     assert qapply(v*IntQubit(2, nbits)) == -IntQubit(2, nbits)
     assert qapply(v*IntQubit(3, nbits)) == IntQubit(3, nbits)
 
-    assert represent(OracleGate(1, OracleGateFunction(lambda qubits: qubits == IntQubit(0))), nqubits=1) == \
+    assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
            Matrix([[-1, 0], [0, 1]])
     assert represent(v, nqubits=2) == Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Currently python functions are stored directly in `OracleGate`'s
args. This is now updated to use a wrapper `Atom` class.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * The wrapper class `OracleGateFunction` is now provided for python functions used in `OracleGate`.
<!-- END RELEASE NOTES -->
