### PR TITLE
core/numbers: __eq__ no longer uses _sympify

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1382,9 +1382,10 @@ class Float(Number):
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
         if isinstance(other, float):
+            #converting here to catch inf float cases
             return self == Float(other)
         if isinstance(other, int):
-            return self == Integer(other)
+            return self.num == other
         if not isinstance(other, Basic):
             return Basic.__eq__(self, other)
         if isinstance(other, Boolean):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1387,7 +1387,7 @@ class Float(Number):
         if isinstance(other, int):
             return self.num == other
         if not isinstance(other, Basic):
-            return Basic.__eq__(self, other)
+            return self._do_eq_sympify(other)
         if isinstance(other, Boolean):
             return False
         if other.is_NumberSymbol:
@@ -1888,7 +1888,7 @@ class Rational(Number):
         if isinstance(other, float):
             return self == Float(other)
         if not isinstance(other, Basic):
-            return Basic.__eq__(self, other)
+            return self._do_eq_sympify(other)
         if not isinstance(other, Number):
             # S(0) == S.false is False
             # S(0) == False is True
@@ -2258,6 +2258,8 @@ class Integer(Rational):
     def __eq__(self, other):
         if isinstance(other, (int, float)):
             return (self.p == other)
+        if not isinstance(self, Basic):
+            return self._do_eq_sympify(other)
         elif isinstance(other, Integer):
             return (self.p == other.p)
         return Rational.__eq__(self, other)
@@ -3464,6 +3466,8 @@ class Infinity(Number, metaclass=Singleton):
         return super().__hash__()
 
     def __eq__(self, other):
+        if not isinstance(self, Basic):
+            return self._do_eq_sympify(other)
         return other is S.Infinity or other == float('inf')
 
     def __ne__(self, other):
@@ -3630,6 +3634,8 @@ class NegativeInfinity(Number, metaclass=Singleton):
         return super().__hash__()
 
     def __eq__(self, other):
+        if not isinstance(self, Basic):
+            return self._do_eq_sympify(other)
         return other is S.NegativeInfinity or other == float('-inf')
 
     def __ne__(self, other):
@@ -3761,6 +3767,8 @@ class NaN(Number, metaclass=Singleton):
         return super().__hash__()
 
     def __eq__(self, other):
+        if not isinstance(self, Basic):
+             return self._do_eq_sympify(other)
         # NaN is structurally equal to another NaN
         return other is S.NaN
 
@@ -3886,7 +3894,7 @@ class NumberSymbol(AtomicExpr):
 
     def __eq__(self, other):
         if not isinstance(other, Basic):
-            return Basic.__eq__(self, other)
+            return self._do_eq_sympify(other)
         if self is other:
             return True
         if other.is_Number and self.is_irrational:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -38,6 +38,10 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.external.pythonmpq import PythonMPQ as MPQ
 _LOG2 = math.log(2)
 
+if HAS_GMPY:
+    _mpq = gmpy.mpq
+else:
+    _mpq = MPQ
 
 def comp(z1, z2, tol=None):
     r"""Return a bool indicating whether the error between z1 and z2
@@ -1882,7 +1886,7 @@ class Rational(Number):
         return self.ceiling()
 
     def __eq__(self, other):
-        if isinstance(other, MPQ):
+        if isinstance(other, _mpq):
             return self.p == other.numerator and self.q == other.denominator
         if isinstance(other, int):
             return self.p == other*self.q

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1384,9 +1384,9 @@ class Float(Number):
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
         if isinstance(other, float):
-            other = Float(other)
+            return self == Float(other)
         if isinstance(other, int):
-            other = Integer(other)
+            return self == Integer(other)
         if not isinstance(other, Basic):
             return Basic.__eq__(self, other)
         if isinstance(other, Boolean):
@@ -1394,13 +1394,13 @@ class Float(Number):
         if other.is_NumberSymbol:
             if other.is_irrational:
                 return False
-            return other.__eq__(self)
+            return NotImplemented
         if other.is_Float:
             # comparison is exact
             # so Float(.1, 3) != Float(.1, 33)
             return self._mpf_ == other._mpf_
         if other.is_Rational:
-            return other.__eq__(self)
+            return NotImplemented
         if other.is_Number:
             # numbers should compare at the same precision;
             # all _as_mpf_val routines should be sure to abide
@@ -1885,9 +1885,9 @@ class Rational(Number):
         if isinstance(other, MPQ):
             return self.p == other.numerator and self.q == other.denominator
         if isinstance(other, int):
-            other = Integer(other)
+            return self == Integer(other)
         if isinstance(other, float):
-            other = Float(other)
+            return self == Float(other)
         if not isinstance(other, Basic):
             return Basic.__eq__(self, other)
         if not isinstance(other, Number):
@@ -1899,7 +1899,7 @@ class Rational(Number):
         if other.is_NumberSymbol:
             if other.is_irrational:
                 return False
-            return other.__eq__(self)
+            return NotImplemented
         if other.is_Rational:
             # a Rational is always in reduced form so will never be 2/4
             # so we can just check equivalence of args

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -18,7 +18,7 @@ from .cache import cacheit, clear_cache
 from .decorators import _sympifyit
 from .logic import fuzzy_not
 from .kind import NumberKind
-from sympy.external.gmpy import SYMPY_INTS, HAS_GMPY, gmpy
+from sympy.external.gmpy import SYMPY_INTS, HAS_GMPY, gmpy, MPQ
 from sympy.multipledispatch import dispatch
 import mpmath
 import mpmath.libmp as mlib
@@ -35,13 +35,7 @@ from .parameters import global_parameters
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-from sympy.external.pythonmpq import PythonMPQ as MPQ
 _LOG2 = math.log(2)
-
-if HAS_GMPY:
-    _mpq = gmpy.mpq
-else:
-    _mpq = MPQ
 
 def comp(z1, z2, tol=None):
     r"""Return a bool indicating whether the error between z1 and z2
@@ -1886,7 +1880,7 @@ class Rational(Number):
         return self.ceiling()
 
     def __eq__(self, other):
-        if isinstance(other, _mpq):
+        if isinstance(other, MPQ):
             return self.p == other.numerator and self.q == other.denominator
         if isinstance(other, int):
             return self.p == other*self.q

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -35,6 +35,7 @@ from .parameters import global_parameters
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
+from sympy.external.pythonmpq import PythonMPQ as MPQ
 _LOG2 = math.log(2)
 
 
@@ -1382,9 +1383,9 @@ class Float(Number):
 
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
-        try:
-            other = _sympify(other)
-        except SympifyError:
+        if isinstance(other, (int, float)):
+            return self == Float(other)
+        if not isinstance(other, Basic):
             return NotImplemented
         if isinstance(other, Boolean):
             return False
@@ -1879,9 +1880,11 @@ class Rational(Number):
         return self.ceiling()
 
     def __eq__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
+        if isinstance(other, MPQ):
+            return self.p == other.numerator and self.q == other.denominator
+        if isinstance(other, (int, float)):
+            return self.p/self.q == other
+        if not isinstance(other, Basic):
             return NotImplemented
         if not isinstance(other, Number):
             # S(0) == S.false is False
@@ -2250,7 +2253,7 @@ class Integer(Rational):
         return Rational.__rmod__(self, other)
 
     def __eq__(self, other):
-        if isinstance(other, int):
+        if isinstance(other, (int, float)):
             return (self.p == other)
         elif isinstance(other, Integer):
             return (self.p == other.p)
@@ -3879,9 +3882,7 @@ class NumberSymbol(AtomicExpr):
         return Float._new(self._as_mpf_val(prec), prec)
 
     def __eq__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
+        if not isinstance(other, Basic):
             return NotImplemented
         if self is other:
             return True

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1383,10 +1383,12 @@ class Float(Number):
 
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
-        if isinstance(other, (int, float)):
-            return self == Float(other)
+        if isinstance(other, float):
+            other = Float(other)
+        if isinstance(other, int):
+            other = Integer(other)
         if not isinstance(other, Basic):
-            return NotImplemented
+            return Basic.__eq__(self, other)
         if isinstance(other, Boolean):
             return False
         if other.is_NumberSymbol:
@@ -1882,10 +1884,12 @@ class Rational(Number):
     def __eq__(self, other):
         if isinstance(other, MPQ):
             return self.p == other.numerator and self.q == other.denominator
-        if isinstance(other, (int, float)):
-            return self.p/self.q == other
+        if isinstance(other, int):
+            other = Integer(other)
+        if isinstance(other, float):
+            other = Float(other)
         if not isinstance(other, Basic):
-            return NotImplemented
+            return Basic.__eq__(self, other)
         if not isinstance(other, Number):
             # S(0) == S.false is False
             # S(0) == False is True
@@ -3883,7 +3887,7 @@ class NumberSymbol(AtomicExpr):
 
     def __eq__(self, other):
         if not isinstance(other, Basic):
-            return NotImplemented
+            return Basic.__eq__(self, other)
         if self is other:
             return True
         if other.is_Number and self.is_irrational:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1885,7 +1885,7 @@ class Rational(Number):
         if isinstance(other, MPQ):
             return self.p == other.numerator and self.q == other.denominator
         if isinstance(other, int):
-            return self == Integer(other)
+            return self.p == other*self.q
         if isinstance(other, float):
             return self == Float(other)
         if not isinstance(other, Basic):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1677,6 +1677,10 @@ def test_Rational_int():
     assert int(-Rational(7, 5)) == -1
 
 
+def test_Rational_float():
+    assert Rational(10000000000000001, 10000000000000000) != 1.0
+
+
 def test_zoo():
     b = Symbol('b', finite=True)
     nz = Symbol('nz', nonzero=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Helps with https://github.com/sympy/sympy/pull/22607

#### Brief description of what is fixed or changed
Currently `__eq__` in `numbers` always tries to convert `other` to
a SymPy type. `__eq__` now uses direct comparisons, which should be
more efficient.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
