### PR TITLE
no longer treating MatrixElement as an atom

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -567,7 +567,6 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
         Substitutions containing any Symbol from ``ignore`` will be ignored.
     """
     from sympy.matrices.expressions import MatrixExpr, MatrixSymbol, MatMul, MatAdd
-    from sympy.matrices.expressions.matexpr import MatrixElement
     from sympy.polys.rootoftools import RootOf
 
     if opt_subs is None:
@@ -590,7 +589,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
         if isinstance(expr, Basic) and (
                 expr.is_Atom or
                 expr.is_Order or
-                isinstance(expr, (MatrixSymbol, MatrixElement))):
+                isinstance(expr, MatrixSymbol)):
             if expr.is_Symbol:
                 excluded_symbols.add(expr)
             return


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #22901

#### Brief description of what is fixed or changed
After recent PR #22840 which improved CSE behavior to avoid unnecessary substitution of matrix symbols, @asmeurer had a suggestion that not treating matrix element as an atom would keep that behavior while still allowing cse to process potentially common index expressions

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* simplify
  * CSE no longer treats matrix element as atomic (matrix symbols are still atomic)

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* simplify
  * CSE no longer treats matrix element as atomic (matrix symbols are still atomic)

<!-- END RELEASE NOTES -->
