### PR TITLE
multiset_derangements update

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2205,7 +2205,8 @@ def multiset_derangements(s):
     n = len(s)
     # special cases
 
-    # 0) impossible case
+    # 0) one element has more than half the total cardinality of s: no
+    # derangements are possible.
     if mx*2 > n:
         return
 
@@ -2232,8 +2233,11 @@ def multiset_derangements(s):
             yield rv
         return
 
-    # 3) single repeat covers all but 1 of the non-repeats
-    if n - 2*mx == 1 and len(ms.values()) - 1 == n - mx:
+    # 3) single repeat covers all but 1 of the non-repeats:
+    # if there is one repeat then the multiset of the values
+    # of ms would be {mx: 1, 1: n - mx}, i.e. there would
+    # be n - mx + 1 values with the condition that n - 2*mx = 1
+    if n - 2*mx == 1 and len(ms.values()) == n - mx + 1:
         for i in range(len(inonM)):
             i1 = inonM[i]
             ifill = inonM[:i] + inonM[i+1:]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2224,14 +2224,15 @@ def multiset_derangements(s):
             ifill = inonM[:i] + inonM[i+1:]
             for j in ifill:
                 rv[j] = M
-            rv[i1] = s[i1]
             for p in permutations([s[j] for j in ifill]):
+                rv[i1] = s[i1]
                 for j, pi in zip(iM, p):
                     rv[j] = pi
+                k = i1
                 for j in iM:
-                    rv[j], rv[i1] = rv[i1], rv[j]
+                    rv[j], rv[k] = rv[k], rv[j]
                     yield rv
-                    i1 = j
+                    k = j
         return
 
     def finish_derangements():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1945,7 +1945,10 @@ def has_dups(seq):
     if isinstance(seq, (dict, set, Dict, Set)):
         return False
     unique = set()
-    return any(True for s in seq if s in unique or unique.add(s))
+    try:
+        return any(True for s in seq if s in unique or unique.add(s))
+    except TypeError:
+        return len(seq) != len(list(uniq(seq)))
 
 
 def has_variety(seq):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2401,7 +2401,7 @@ def random_derangement(t, choice=None, strict=True):
 
 def generate_derangements(perm):
     """
-    Routine to generate unique derangements or sets or multisets.
+    Routine to generate unique derangements of sets or multisets.
 
     Examples
     ========

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2288,8 +2288,8 @@ def multiset_derangements(s):
         return [i for i in range(n) if rv[i] is None and s[i] != v]
 
     def do(j):
-        if j == -1:
-            yield rv
+        if j == 1:
+            yield from finish_derangements()
         else:
             M, mx = take[j]
             for i in subsets(iopen(M), mx):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2188,7 +2188,19 @@ def multiset_derangements(s):
     >>> [i.copy() for i in multiset_derangements('1233')]
     [['3', '3', '1', '2'], ['3', '3', '2', '1']]
     """
-    ms = multiset(s)
+    try:
+        ms = multiset(s)
+    except TypeError:
+        key = dict(enumerate(uniq(s)))
+        h = []
+        for si in s:
+            for k in key:
+                if key[k] == si:
+                    h.append(k)
+                    break
+        for i in multiset_derangements(h):
+            yield [key[j] for j in i]
+        return
     mx = max(ms.values())
     n = len(s)
     # special cases

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2418,6 +2418,25 @@ def random_derangement(t, choice=None, strict=True):
     return rv
 
 
+def _set_derangements(s):
+    """
+    yield derangements of items in ``s`` which are assumed to contain
+    no repeated elements
+    """
+    if len(s) < 2:
+        return
+    if len(s) == 2:
+        yield [s[1], s[0]]
+        return
+    if len(s) == 3:
+        yield [s[1], s[2], s[0]]
+        yield [s[2], s[0], s[1]]
+        return
+    for p in permutations(s):
+        if not any(i == j for i, j in zip(p, s)):
+            yield list(p)
+
+
 def generate_derangements(perm):
     """
     Routine to generate unique derangements of sets or multisets.
@@ -2442,17 +2461,7 @@ def generate_derangements(perm):
 
     """
     if not has_dups(perm):
-        s = perm
-        if len(perm) == 2:
-            yield [s[1],s[0]]
-            return
-        if len(perm) == 3:
-            yield [s[1],s[2],s[0]]
-            yield [s[2],s[0],s[1]]
-            return
-        for p in permutations(s):
-            if not any(i == j for i, j in zip(p, s)):
-                yield list(p)
+        yield from _set_derangements(perm)
     else:
         for p in multiset_derangements(perm):
             yield list(p)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -560,6 +560,9 @@ def test_derangements():
         'cccabba', 'cccabab', 'cccaabb', 'ccacbba', 'ccacbab',
         'ccacabb', 'cbccbaa', 'cbccaba', 'cbccaab', 'bcccbaa',
         'bcccaba', 'bcccaab']
+    assert [''.join(i) for i in D('books')] == ['kbsoo', 'ksboo',
+        'sbkoo', 'skboo', 'oksbo', 'oskbo', 'okbso', 'obkso', 'oskob',
+        'oksob', 'osbok', 'obsok']
 
 
 def test_necklaces():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -563,7 +563,7 @@ def test_derangements():
     assert [''.join(i) for i in D('books')] == ['kbsoo', 'ksboo',
         'sbkoo', 'skboo', 'oksbo', 'oskbo', 'okbso', 'obkso', 'oskob',
         'oksob', 'osbok', 'obsok']
-    assert list(generate_derangements([[1], [2], [2], [3]])) == [
+    assert list(generate_derangements([[3], [2], [2], [1]])) == [
         [[2], [1], [3], [2]], [[2], [3], [1], [2]]]
 
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -563,6 +563,8 @@ def test_derangements():
     assert [''.join(i) for i in D('books')] == ['kbsoo', 'ksboo',
         'sbkoo', 'skboo', 'oksbo', 'oskbo', 'okbso', 'obkso', 'oskob',
         'oksob', 'osbok', 'obsok']
+    assert list(generate_derangements([[1], [2], [2], [3]])) == [
+        [[2], [1], [3], [2]], [[2], [3], [1], [2]]]
 
 
 def test_necklaces():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -797,6 +797,8 @@ def test_has_dups():
     assert has_dups(set()) is False
     assert has_dups(list(range(3))) is False
     assert has_dups([1, 2, 1]) is True
+    assert has_dups([[1], [1]]) is True
+    assert has_dups([[1], [2]]) is False
 
 
 def test__partition():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The case of "covers all but 1" was not tracking the placement of the last element properly so non-derangments were being returned, e.g. the 3rd and 4th elements below have 2 `k`s and no `b` and the 7th and 8th have two `b`s and no `k`:

```python
>>> [''.join(i) for i in multiset_derangements('books')]
['kbsoo', 'ksboo', 'kksoo', 'kskoo', 'oksbo', 'oskbo', 'obsbo', 'osbbo', 'oskob', 'oksob', 'obkob', 'okbob']
```
instead of
```python
>>> [''.join(i) for i in multiset_derangements('books')]
['kbsoo', 'ksboo', 'sbkoo', 'skboo', 'oksbo', 'oskbo', 'okbso', 'obkso', 'oskob', 'oksob', 'osbok', 'obsok']
```

Also, the code to compute the placement of the last two elements of the multiset was not getting called.
#### Other comments

Thanks to @rathmann for communicating these issues!

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * `multiset_derangements` has an optimized finishing routine
    * corrected a special-case derangement of a multiset where a single repeated element multiplicity is 1 less than the non-repeated elements (like 'mmabc' or 'mmmabcd')
    * `generate_derangements` formerly always emitted derangements from filtered permutations; now, when a multiset is involved, the much faster `multiset_derangements` is called and the ordering of derangments will be different than before.
<!-- END RELEASE NOTES -->
