### PR TITLE
functions - fixed TypeError arised by multiplying Subs expressions

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -229,6 +229,9 @@ class Basic(Printable, metaclass=ManagedProperties):
         for l, r in zip(st, ot):
             l = Basic(*l) if isinstance(l, frozenset) else l
             r = Basic(*r) if isinstance(r, frozenset) else r
+            if isinstance(l, Tuple) and isinstance(r, Tuple):
+                c = Basic(*l).compare(Basic(*r))
+                return c
             if isinstance(l, Basic):
                 c = l.compare(r)
             else:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1418,3 +1418,9 @@ def test_issue_17382():
                "ImageSet(Lambda(_n, 6.28318530717959*_n + 5.79812359592087), Integers), " \
                "ImageSet(Lambda(_n, 6.28318530717959*_n + 0.485061711258717), Integers))"
     assert NS(expr) == expected
+
+
+def test_issue_21773():
+    x = Symbol('x')
+    y = Symbol('y')
+    assert Subs(0, y, 1) * Subs(0, x, 1) == Subs(0, y, 1)*Subs(0, x, 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #21773 and now  `Subs(0, y, 1) * Subs(0, z, 1)` returns `Subs(0, y, 1)*Subs(0, z, 1)` instead of `TypeError`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * fixed bug in Subs and expression is returned instead of TypeError for multiplication of some Subs expressions.
<!-- END RELEASE NOTES -->
