### PR TITLE
printing/pycode: Min and Max added to _known_functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -98,6 +98,7 @@ Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>
 Advait <apote2050@gmail.com>
+Advait Pote <92469698+AdvaitPote@users.noreply.github.com>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -97,8 +97,7 @@ Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>
-Advait <apote2050@gmail.com>
-Advait Pote <92469698+AdvaitPote@users.noreply.github.com>
+Advait <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply.github.com>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -18,6 +18,8 @@ _kw = {
 
 _known_functions = {
     'Abs': 'abs',
+    'Min': 'min',
+    'Max': 'max',
 }
 _known_functions_math = {
     'acos': 'acos',

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -6,7 +6,7 @@ from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt
+from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
 from sympy.printing.pycode import (
@@ -57,6 +57,9 @@ def test_PythonCodePrinter():
 
     assert prntr.doprint((2,3)) == "(2, 3)"
     assert prntr.doprint([2,3]) == "[2, 3]"
+
+    assert prntr.doprint(Min(x, y)) == "min(x, y)"
+    assert prntr.doprint(Max(x, y)) == "max(x, y)"
 
 
 def test_PythonCodePrinter_standard():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22908 

#### Brief description of what is fixed or changed
Code originally property of @ThePauliPrinciple. 
Because of PythonCodePrinter not supporting Min and Max, these functions were added to `_known_functions`.


#### Other comments

Appropriate tests to be added.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
