### PR TITLE
Fix `__slots__` issues (overlaps, broken inheritance)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -198,6 +198,7 @@ Arafat Dad Khan <arafat.da.khan@gmail.com>
 Arafat Dad Khan <arafat.da.khan@gmail.com> <arafat@iitkpg.ac.in>
 Aravind Reddy <aravindreddy255@gmail.com>
 Archit Verma <architv07@gmail.com>
+Arie Bovenberg <a.c.bovenberg@gmail.com>
 Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
 Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
 Arihant Parsoya <parsoyaarihant@gmail.com>

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -126,7 +126,7 @@ There is a function constructing a loop (or a complete function) like this in
 
 """
 
-from typing import Any, Dict as tDict, List
+from typing import Any, Dict as tDict, List, Tuple as tTuple
 
 from collections import defaultdict
 
@@ -161,7 +161,7 @@ def _mk_Tuple(args):
 
 
 class CodegenAST(Basic):
-    pass
+    __slots__ = ()
 
 
 class Token(CodegenAST):
@@ -170,10 +170,10 @@ class Token(CodegenAST):
     Explanation
     ===========
 
-    Defining fields are set in ``__slots__``. Attributes (defined in __slots__)
+    Defining fields are set in ``_fields``. Attributes (defined in _fields)
     are only allowed to contain instances of Basic (unless atomic, see
     ``String``). The arguments to ``__new__()`` correspond to the attributes in
-    the order defined in ``__slots__`. The ``defaults`` class attribute is a
+    the order defined in ``_fields`. The ``defaults`` class attribute is a
     dictionary mapping attribute names to their default values.
 
     Subclasses should not need to override the ``__new__()`` method. They may
@@ -182,14 +182,14 @@ class Token(CodegenAST):
     in the class attribute ``not_in_args`` are not passed to :class:`~.Basic`.
     """
 
-    __slots__ = ()
+    __slots__ = _fields = ()  # type: tTuple[str, ...]
     defaults = {}  # type: tDict[str, Any]
     not_in_args = []  # type: List[str]
     indented_args = ['body']
 
     @property
     def is_Atom(self):
-        return len(self.__slots__) == 0
+        return len(self._fields) == 0
 
     @classmethod
     def _get_constructor(cls, attr):
@@ -213,20 +213,20 @@ class Token(CodegenAST):
         if len(args) == 1 and not kwargs and isinstance(args[0], cls):
             return args[0]
 
-        if len(args) > len(cls.__slots__):
-            raise ValueError("Too many arguments (%d), expected at most %d" % (len(args), len(cls.__slots__)))
+        if len(args) > len(cls._fields):
+            raise ValueError("Too many arguments (%d), expected at most %d" % (len(args), len(cls._fields)))
 
         attrvals = []
 
         # Process positional arguments
-        for attrname, argval in zip(cls.__slots__, args):
+        for attrname, argval in zip(cls._fields, args):
             if attrname in kwargs:
                 raise TypeError('Got multiple values for attribute %r' % attrname)
 
             attrvals.append(cls._construct(attrname, argval))
 
         # Process keyword arguments
-        for attrname in cls.__slots__[len(args):]:
+        for attrname in cls._fields[len(args):]:
             if attrname in kwargs:
                 argval = kwargs.pop(attrname)
 
@@ -243,13 +243,13 @@ class Token(CodegenAST):
 
         # Parent constructor
         basic_args = [
-            val for attr, val in zip(cls.__slots__, attrvals)
+            val for attr, val in zip(cls._fields, attrvals)
             if attr not in cls.not_in_args
         ]
         obj = CodegenAST.__new__(cls, *basic_args)
 
         # Set attributes
-        for attr, arg in zip(cls.__slots__, attrvals):
+        for attr, arg in zip(cls._fields, attrvals):
             setattr(obj, attr, arg)
 
         return obj
@@ -257,13 +257,13 @@ class Token(CodegenAST):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        for attr in self.__slots__:
+        for attr in self._fields:
             if getattr(self, attr) != getattr(other, attr):
                 return False
         return True
 
     def _hashable_content(self):
-        return tuple([getattr(self, attr) for attr in self.__slots__])
+        return tuple([getattr(self, attr) for attr in self._fields])
 
     def __hash__(self):
         return super().__hash__()
@@ -291,12 +291,12 @@ class Token(CodegenAST):
     def _sympyrepr(self, printer, *args, joiner=', ', **kwargs):
         from sympy.printing.printer import printer_context
         exclude = kwargs.get('exclude', ())
-        values = [getattr(self, k) for k in self.__slots__]
+        values = [getattr(self, k) for k in self._fields]
         indent_level = printer._context.get('indent_level', 0)
 
         arg_reprs = []
 
-        for i, (attr, value) in enumerate(zip(self.__slots__, values)):
+        for i, (attr, value) in enumerate(zip(self._fields, values)):
             if attr in exclude:
                 continue
 
@@ -329,7 +329,7 @@ class Token(CodegenAST):
         apply : callable, optional
             Function to apply to all values.
         """
-        kwargs = {k: getattr(self, k) for k in self.__slots__ if k not in exclude}
+        kwargs = {k: getattr(self, k) for k in self._fields if k not in exclude}
         if apply is not None:
             return {k: apply(v) for k, v in kwargs.items()}
         else:
@@ -849,7 +849,7 @@ class For(Token):
         ))
     ))
     """
-    __slots__ = ('target', 'iterable', 'body')
+    __slots__ = _fields = ('target', 'iterable', 'body')
     _construct_target = staticmethod(_sympify)
 
     @classmethod
@@ -893,7 +893,7 @@ class String(Atom, Token):
     String('foo')
 
     """
-    __slots__ = ('text',)
+    __slots__ = _fields = ('text',)
     not_in_args = ['text']
     is_Atom = True
 
@@ -945,7 +945,7 @@ class Node(Token):
 
     """
 
-    __slots__ = ('attrs',)
+    __slots__ = _fields = ('attrs',)  # type: tTuple[str, ...]
 
     defaults = {'attrs': Tuple()}  # type: tDict[str, Any]
 
@@ -1013,7 +1013,7 @@ class Type(Token):
     .. [1] https://docs.scipy.org/doc/numpy/user/basics.types.html
 
     """
-    __slots__ = ('name',)
+    __slots__ = _fields = ('name',)  # type: tTuple[str, ...]
 
     _construct_name = String
 
@@ -1142,12 +1142,13 @@ class Type(Token):
 
 class IntBaseType(Type):
     """ Integer base type, contains no size information. """
-    __slots__ = ('name',)
+    __slots__ = ()
     cast_nocheck = lambda self, i: Integer(int(i))
 
 
 class _SizedIntType(IntBaseType):
-    __slots__ = ('name', 'nbits',)
+    __slots__ = ('nbits',)
+    _fields = Type._fields + __slots__
 
     _construct_nbits = Integer
 
@@ -1160,6 +1161,7 @@ class _SizedIntType(IntBaseType):
 
 class SignedIntType(_SizedIntType):
     """ Represents a signed integer type. """
+    __slots__ = ()
     @property
     def min(self):
         return -2**(self.nbits-1)
@@ -1171,6 +1173,7 @@ class SignedIntType(_SizedIntType):
 
 class UnsignedIntType(_SizedIntType):
     """ Represents an unsigned integer type. """
+    __slots__ = ()
     @property
     def min(self):
         return 0
@@ -1183,6 +1186,7 @@ two = Integer(2)
 
 class FloatBaseType(Type):
     """ Represents a floating point number type. """
+    __slots__ = ()
     cast_nocheck = Float
 
 class FloatType(FloatBaseType):
@@ -1226,7 +1230,8 @@ class FloatType(FloatBaseType):
     ValueError: Maximum value for data type smaller than new value.
     """
 
-    __slots__ = ('name', 'nbits', 'nmant', 'nexp',)
+    __slots__ = ('nbits', 'nmant', 'nexp',)
+    _fields = Type._fields + __slots__
 
     _construct_nbits = _construct_nmant = _construct_nexp = Integer
 
@@ -1305,6 +1310,8 @@ class FloatType(FloatBaseType):
 
 class ComplexBaseType(FloatBaseType):
 
+    __slots__ = ()
+
     def cast_nocheck(self, value):
         """ Casts without checking if out of bounds or subnormal. """
         from sympy.functions import re, im
@@ -1321,6 +1328,7 @@ class ComplexBaseType(FloatBaseType):
 
 class ComplexType(ComplexBaseType, FloatType):
     """ Represents a complex floating point number. """
+    __slots__ = ()
 
 
 # NumPy types:
@@ -1379,7 +1387,7 @@ class Attribute(Token):
     >>> a.parameters == (1, 2, 3)
     True
     """
-    __slots__ = ('name', 'parameters')
+    __slots__ = _fields = ('name', 'parameters')
     defaults = {'parameters': Tuple()}
 
     _construct_name = String
@@ -1446,7 +1454,8 @@ class Variable(Node):
 
     """
 
-    __slots__ = ('symbol', 'type', 'value') + Node.__slots__
+    __slots__ = ('symbol', 'type', 'value')
+    _fields = __slots__ + Node._fields
 
     defaults = Node.defaults.copy()
     defaults.update({'type': untyped, 'value': none})
@@ -1559,6 +1568,7 @@ class Pointer(Variable):
     Element(x, indices=(i + 1,))
 
     """
+    __slots__ = ()
 
     def __getitem__(self, key):
         try:
@@ -1586,7 +1596,7 @@ class Element(Token):
     'x[i*l + j*m + k*n + o]'
 
     """
-    __slots__ = ('symbol', 'indices', 'strides', 'offset')
+    __slots__ = _fields = ('symbol', 'indices', 'strides', 'offset')
     defaults = {'strides': none, 'offset': none}
     _construct_symbol = staticmethod(sympify)
     _construct_indices = staticmethod(lambda arg: Tuple(*arg))
@@ -1617,7 +1627,7 @@ class Declaration(Token):
     >>> z.variable.value == NoneToken()  # OK
     True
     """
-    __slots__ = ('variable',)
+    __slots__ = _fields = ('variable',)
     _construct_variable = Variable
 
 
@@ -1648,7 +1658,7 @@ class While(Token):
     ... ])
 
     """
-    __slots__ = ('condition', 'body')
+    __slots__ = _fields = ('condition', 'body')
     _construct_condition = staticmethod(lambda cond: _sympify(cond))
 
     @classmethod
@@ -1669,7 +1679,7 @@ class Scope(Token):
         When passed an iterable it is used to instantiate a CodeBlock.
 
     """
-    __slots__ = ('body',)
+    __slots__ = _fields = ('body',)
 
     @classmethod
     def _construct_body(cls, itr):
@@ -1701,7 +1711,7 @@ class Stream(Token):
     print("x", file=sys.stderr)
 
     """
-    __slots__ = ('name',)
+    __slots__ = _fields = ('name',)
     _construct_name = String
 
 stdout = Stream('stdout')
@@ -1727,7 +1737,7 @@ class Print(Token):
 
     """
 
-    __slots__ = ('print_args', 'format_string', 'file')
+    __slots__ = _fields = ('print_args', 'format_string', 'file')
     defaults = {'format_string': none, 'file': none}
 
     _construct_print_args = staticmethod(_mk_Tuple)
@@ -1760,7 +1770,8 @@ class FunctionPrototype(Node):
 
     """
 
-    __slots__ = ('return_type', 'name', 'parameters', 'attrs')
+    __slots__ = ('return_type', 'name', 'parameters')
+    _fields = __slots__ + Node._fields  # type: tTuple[str, ...]
 
     _construct_return_type = Type
     _construct_name = String
@@ -1813,7 +1824,8 @@ class FunctionDefinition(FunctionPrototype):
     }
     """
 
-    __slots__ = FunctionPrototype.__slots__[:-1] + ('body', 'attrs')
+    __slots__ = ('body', )
+    _fields = FunctionPrototype._fields[:-1] + __slots__ + Node._fields
 
     @classmethod
     def _construct_body(cls, itr):
@@ -1848,7 +1860,7 @@ class Return(Token):
     return x
 
     """
-    __slots__ = ('return',)
+    __slots__ = _fields = ('return',)
     _construct_return=staticmethod(_sympify)
 
 
@@ -1871,7 +1883,7 @@ class FunctionCall(Token, Expr):
     foo(bar, baz)
 
     """
-    __slots__ = ('name', 'function_args')
+    __slots__ = _fields = ('name', 'function_args')
 
     _construct_name = String
     _construct_function_args = staticmethod(lambda args: Tuple(*args))

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -58,7 +58,7 @@ class Label(Node):
     ++(a);
 
     """
-    __slots__ = ('name', 'body')
+    __slots__ = _fields = ('name', 'body')
     defaults = {'body': none}
     _construct_name = String
 
@@ -72,7 +72,7 @@ class Label(Node):
 
 class goto(Token):
     """ Represents goto in C """
-    __slots__ = ('label',)
+    __slots__ = _fields = ('label',)
     _construct_label = Label
 
 
@@ -109,7 +109,7 @@ class PostIncrement(Basic):
 
 class struct(Node):
     """ Represents a struct in C """
-    __slots__ = ('name', 'declarations')
+    __slots__ = _fields = ('name', 'declarations')
     defaults = {'name': none}
     _construct_name = String
 
@@ -120,3 +120,4 @@ class struct(Node):
 
 class union(struct):
     """ Represents a union in C """
+    __slots__ = ()

--- a/sympy/codegen/cxxnodes.py
+++ b/sympy/codegen/cxxnodes.py
@@ -6,7 +6,7 @@ from sympy.codegen.ast import Attribute, String, Token, Type, none
 
 class using(Token):
     """ Represents a 'using' statement in C++ """
-    __slots__ = ('type', 'alias')
+    __slots__ = _fields = ('type', 'alias')
     defaults = {'alias': none}
     _construct_type = Type
     _construct_alias = String

--- a/sympy/codegen/fnodes.py
+++ b/sympy/codegen/fnodes.py
@@ -45,7 +45,7 @@ class Program(Token):
     end program
 
     """
-    __slots__ = ('name', 'body')
+    __slots__ = _fields = ('name', 'body')
     _construct_name = String
     _construct_body = staticmethod(lambda body: CodeBlock(*body))
 
@@ -66,7 +66,7 @@ class use_rename(Token):
     use signallib, only: snr, thingy => convolution2d
 
     """
-    __slots__ = ('local', 'original')
+    __slots__ = _fields = ('local', 'original')
     _construct_local = String
     _construct_original = String
 
@@ -92,7 +92,7 @@ class use(Token):
     'use signallib, only: snr, convolution2d'
 
     """
-    __slots__ = ('namespace', 'rename', 'only')
+    __slots__ = _fields = ('namespace', 'rename', 'only')
     defaults = {'rename': none, 'only': none}
     _construct_namespace = staticmethod(_name)
     _construct_rename = staticmethod(lambda args: Tuple(*[arg if isinstance(arg, use_rename) else use_rename(*arg) for arg in args]))
@@ -117,7 +117,7 @@ class Module(Token):
     end module
 
     """
-    __slots__ = ('name', 'declarations', 'definitions')
+    __slots__ = _fields = ('name', 'declarations', 'definitions')
     defaults = {'declarations': Tuple()}
     _construct_name = String
     _construct_declarations = staticmethod(lambda arg: CodeBlock(*arg))
@@ -143,7 +143,8 @@ class Subroutine(Node):
     end subroutine
 
     """
-    __slots__ = ('name', 'parameters', 'body', 'attrs')
+    __slots__ = ('name', 'parameters', 'body')
+    _fields = __slots__ + Node._fields
     _construct_name = String
     _construct_parameters = staticmethod(lambda params: Tuple(*map(Variable.deduced, params)))
 
@@ -166,7 +167,7 @@ class SubroutineCall(Token):
     '       call mysub(x, y)'
 
     """
-    __slots__ = ('name', 'subroutine_args')
+    __slots__ = _fields = ('name', 'subroutine_args')
     _construct_name = staticmethod(_name)
     _construct_subroutine_args = staticmethod(_mk_Tuple)
 
@@ -198,7 +199,7 @@ class Do(Token):
 
     """
 
-    __slots__ = ('body', 'counter', 'first', 'last', 'step', 'concurrent')
+    __slots__ = _fields = ('body', 'counter', 'first', 'last', 'step', 'concurrent')
     defaults = {'step': Integer(1), 'concurrent': false}
     _construct_body = staticmethod(lambda body: CodeBlock(*body))
     _construct_counter = staticmethod(sympify)
@@ -223,7 +224,7 @@ class ArrayConstructor(Token):
     '[1, 2, 3]'
 
     """
-    __slots__ = ('elements',)
+    __slots__ = _fields = ('elements',)
     _construct_elements = staticmethod(_mk_Tuple)
 
 
@@ -242,7 +243,7 @@ class ImpliedDoLoop(Token):
     '[-28, (i**3, i = -3, 3, 2), 28]'
 
     """
-    __slots__ = ('expr', 'counter', 'first', 'last', 'step')
+    __slots__ = _fields = ('expr', 'counter', 'first', 'last', 'step')
     defaults = {'step': Integer(1)}
     _construct_expr = staticmethod(sympify)
     _construct_counter = staticmethod(sympify)
@@ -540,7 +541,7 @@ class GoTo(Token):
     'go to (10, 20, 30), i'
 
     """
-    __slots__ = ('labels', 'expr')
+    __slots__ = _fields = ('labels', 'expr')
     defaults = {'expr': none}
     _construct_labels = staticmethod(_mk_Tuple)
     _construct_expr = staticmethod(sympify)
@@ -567,7 +568,7 @@ class FortranReturn(Token):
     '       return x'
 
     """
-    __slots__ = ('return_value',)
+    __slots__ = _fields = ('return_value',)
     defaults = {'return_value': none}
     _construct_return_value = staticmethod(sympify)
 
@@ -637,14 +638,14 @@ class literal_dp(_literal):
 
 
 class sum_(Token, Expr):
-    __slots__ = ('array', 'dim', 'mask')
+    __slots__ = _fields = ('array', 'dim', 'mask')
     defaults = {'dim': none, 'mask': none}
     _construct_array = staticmethod(sympify)
     _construct_dim = staticmethod(sympify)
 
 
 class product_(Token, Expr):
-    __slots__ = ('array', 'dim', 'mask')
+    __slots__ = _fields = ('array', 'dim', 'mask')
     defaults = {'dim': none, 'mask': none}
     _construct_array = staticmethod(sympify)
     _construct_dim = staticmethod(sympify)

--- a/sympy/codegen/matrix_nodes.py
+++ b/sympy/codegen/matrix_nodes.py
@@ -57,7 +57,7 @@ class MatrixSolve(Token, MatrixExpr):
     'A \\\\ x'
 
     """
-    __slots__ = ('matrix', 'vector')
+    __slots__ = _fields = ('matrix', 'vector')
 
     _construct_matrix = staticmethod(sympify)
 

--- a/sympy/concrete/expr_with_intlimits.py
+++ b/sympy/concrete/expr_with_intlimits.py
@@ -21,6 +21,8 @@ class ExprWithIntLimits(ExprWithLimits):
     sympy.concrete.products.Product
     sympy.concrete.summations.Sum
     """
+    __slots__ = ()
+
     def change_index(self, var, trafo, newvar=None):
         r"""
         Change index of a Sum or Product.

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -532,6 +532,8 @@ class AddWithLimits(ExprWithLimits):
         Parent class for Integral and Sum.
     """
 
+    __slots__ = ()
+
     def __new__(cls, function, *symbols, **assumptions):
         from sympy.concrete.summations import Sum
         pre = _common_new(cls, function, *symbols,

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -191,7 +191,7 @@ class Product(ExprWithIntLimits):
     .. [3] https://en.wikipedia.org/wiki/Empty_product
     """
 
-    __slots__ = ('is_commutative',)
+    __slots__ = ()
 
     limits: tTuple[tTuple[Symbol, Expr, Expr]]
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -178,7 +178,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
     .. [3] https://en.wikipedia.org/wiki/Empty_sum
     """
 
-    __slots__ = ('is_commutative',)
+    __slots__ = ()
 
     limits: tTuple[tTuple[Symbol, Expr, Expr]]
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2087,7 +2087,7 @@ class Integer(Rational):
 
     is_Integer = True
 
-    __slots__ = ('p',)
+    __slots__ = ()
 
     def _as_mpf_val(self, prec):
         return mlib.from_int(self.p, prec, rnd)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -61,7 +61,8 @@ class CantSympify:
     SympifyError: SympifyError: {}
 
     """
-    pass
+
+    __slots__ = ()
 
 
 def _is_numpy_instance(a):

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -19,6 +19,7 @@ Rn is a GeometrySet representing n-dimensional Euclidean space. R2 and
 R3 are currently the only ambient spaces implemented.
 
 """
+from typing import Tuple as tTuple
 
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -68,6 +69,8 @@ class GeometryEntity(Basic, EvalfMixin):
     provides the implementation of some methods common to all subclasses.
 
     """
+
+    __slots__ = ()  # type: tTuple[str, ...]
 
     def __cmp__(self, other):
         """Comparison of two GeometryEntities."""
@@ -536,6 +539,8 @@ class GeometrySet(GeometryEntity, Set):
     """Parent class of all GeometryEntity that are also Sets
     (compatible with sympy.sets)
     """
+    __slots__ = ()
+
     def _contains(self, other):
         """sympy.sets uses the _contains method, so include it for compatibility."""
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -115,6 +115,8 @@ class Polygon(GeometrySet):
 
     """
 
+    __slots__ = ()
+
     def __new__(cls, *args, n = 0, **kwargs):
         if n:
             args = list(args)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -37,7 +37,7 @@ from sympy.utilities.misc import filldedent
 class Integral(AddWithLimits):
     """Represents unevaluated integral."""
 
-    __slots__ = ('is_commutative',)
+    __slots__ = ()
 
     args: tTuple[Expr, Tuple]
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -53,6 +53,7 @@ class MatrixExpr(Expr):
 
     MatrixSymbol, MatAdd, MatMul, Transpose, Inverse
     """
+    __slots__ = ()  # type: tTuple[str, ...]
 
     # Should not be considered iterable by the
     # sympy.utilities.iterables.iterable function. Subclass that actually are

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -90,7 +90,7 @@ class QExpr(Expr):
     # derive from args.
 
     # The Hilbert space a quantum Object belongs to.
-    __slots__ = ('hilbert_space')
+    __slots__ = ('hilbert_space', )
 
     is_commutative = False
 

--- a/sympy/polys/domains/domainelement.py
+++ b/sympy/polys/domains/domainelement.py
@@ -12,6 +12,8 @@ class DomainElement:
     elements of a domain. Method ``parent()`` gives that domain.
     """
 
+    __slots__ = ()
+
     def parent(self):
         """Get the domain associated with ``self``
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -54,6 +54,9 @@ class Set(Basic, EvalfMixin):
     sets by the :class:`Union` class. The empty set is represented by the
     :class:`EmptySet` class and available as a singleton as ``S.EmptySet``.
     """
+
+    __slots__ = ()
+
     is_number = False
     is_iterable = False
     is_interval = False


### PR DESCRIPTION
#### References to other Issues or PRs

fixes #22922 

#### Brief description of what is fixed or changed

- `__slots__` added to some base classes
- specific slot names removed that were already declared on base classes

#### Other comments

I discovered the slots issues with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I maintain. Of course, If you like, I can add it to tox/CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615), [dry-python/returns](https://github.com/dry-python/returns/pull/1233), and [aio-libs/aiohttp](https://github.com/aio-libs/aiohttp/pull/6547).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* other
  * Fixed several issues with `__slots__` (overlaps and omission in base classes)
<!-- END RELEASE NOTES -->
