### PR TITLE
Add public documentation for array expressions

### DIFF
--- a/doc/src/modules/tensor/array_expressions.rst
+++ b/doc/src/modules/tensor/array_expressions.rst
@@ -1,0 +1,5 @@
+=======================
+N-dim array expressions
+=======================
+
+.. automodule:: sympy.tensor.array.expressions

--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -13,6 +13,7 @@ Contents
     :maxdepth: 3
 
     array.rst
+    array_expressions.rst
     indexed.rst
     index_methods.rst
     tensor.rst

--- a/sympy/tensor/array/expressions/__init__.py
+++ b/sympy/tensor/array/expressions/__init__.py
@@ -1,0 +1,108 @@
+r"""
+Array expressions are expressions representing N-dimensional arrays, without evaluating them.
+They are *lazy* as they don't evaluate the operations on the arrays until required and
+can define operations on unknown array (in a certain way reminiscent of graphs of
+operations in TensorFlow).
+
+Every N-dimensional array operator has a corresponding lazy object.
+
+Table of correspondences:
+
+=============================== =============================
+         Array operator           Array expression operator
+=============================== =============================
+        tensorproduct                 ArrayTensorProduct
+        tensorcontraction             ArrayContraction
+        tensordiagonal                ArrayDiagonal
+        permutedims                   PermuteDims
+        derive_by_array               array_derive
+=============================== =============================
+
+Examples
+========
+
+>>> from sympy import MatrixSymbol
+>>> from sympy.tensor.array.expressions import ArrayTensorProduct, ArrayContraction
+>>> M = MatrixSymbol("M", 3, 3)
+>>> N = MatrixSymbol("N", 3, 3)
+
+Express the matrix product in the array expression form:
+
+>>> from sympy.tensor.array.expressions import convert_matrix_to_array
+>>> expr = convert_matrix_to_array(M*N)
+>>> expr
+ArrayContraction(ArrayTensorProduct(M, N), (1, 2))
+
+The expression can be converted back to matrix form:
+
+>>> from sympy.tensor.array.expressions import convert_array_to_matrix
+>>> convert_array_to_matrix(expr)
+M*N
+
+Add a second contraction on the remaining axes in order to get the trace of `M \cdot N`:
+
+>>> expr_tr = ArrayContraction(expr, (0, 1))
+>>> expr_tr
+ArrayContraction(ArrayContraction(ArrayTensorProduct(M, N), (1, 2)), (0, 1))
+
+Flatten the expression by calling ``.doit()`` and remove the nested array contraction operations:
+
+>>> expr_tr.doit()
+ArrayContraction(ArrayTensorProduct(M, N), (0, 3), (1, 2))
+
+Get the explicit form of the array expression:
+
+>>> expr.as_explicit()
+[[M[0, 0]*N[0, 0] + M[0, 1]*N[1, 0] + M[0, 2]*N[2, 0], M[0, 0]*N[0, 1] + M[0, 1]*N[1, 1] + M[0, 2]*N[2, 1], M[0, 0]*N[0, 2] + M[0, 1]*N[1, 2] + M[0, 2]*N[2, 2]], [M[1, 0]*N[0, 0] + M[1, 1]*N[1, 0] + M[1, 2]*N[2, 0], M[1, 0]*N[0, 1] + M[1, 1]*N[1, 1] + M[1, 2]*N[2, 1], M[1, 0]*N[0, 2] + M[1, 1]*N[1, 2] + M[1, 2]*N[2, 2]], [M[2, 0]*N[0, 0] + M[2, 1]*N[1, 0] + M[2, 2]*N[2, 0], M[2, 0]*N[0, 1] + M[2, 1]*N[1, 1] + M[2, 2]*N[2, 1], M[2, 0]*N[0, 2] + M[2, 1]*N[1, 2] + M[2, 2]*N[2, 2]]]
+
+Express the trace of a matrix:
+
+>>> from sympy import Trace
+>>> convert_matrix_to_array(Trace(M))
+ArrayContraction(M, (0, 1))
+>>> convert_matrix_to_array(Trace(M*N))
+ArrayContraction(ArrayTensorProduct(M, N), (0, 3), (1, 2))
+
+Express the transposition of a matrix (will be expressed as a permutation of the axes:
+
+>>> convert_matrix_to_array(M.T)
+PermuteDims(M, (0 1))
+
+Compute the derivative array expressions:
+
+>>> from sympy.tensor.array.expressions import array_derive
+>>> d = array_derive(M, M)
+>>> d
+PermuteDims(ArrayTensorProduct(I, I), (3)(1 2))
+
+Verify that the derivative corresponds to the form computed with explicit matrices:
+
+>>> d.as_explicit()
+[[[[1, 0, 0], [0, 0, 0], [0, 0, 0]], [[0, 1, 0], [0, 0, 0], [0, 0, 0]], [[0, 0, 1], [0, 0, 0], [0, 0, 0]]], [[[0, 0, 0], [1, 0, 0], [0, 0, 0]], [[0, 0, 0], [0, 1, 0], [0, 0, 0]], [[0, 0, 0], [0, 0, 1], [0, 0, 0]]], [[[0, 0, 0], [0, 0, 0], [1, 0, 0]], [[0, 0, 0], [0, 0, 0], [0, 1, 0]], [[0, 0, 0], [0, 0, 0], [0, 0, 1]]]]
+>>> Me = M.as_explicit()
+>>> Me.diff(Me)
+[[[[1, 0, 0], [0, 0, 0], [0, 0, 0]], [[0, 1, 0], [0, 0, 0], [0, 0, 0]], [[0, 0, 1], [0, 0, 0], [0, 0, 0]]], [[[0, 0, 0], [1, 0, 0], [0, 0, 0]], [[0, 0, 0], [0, 1, 0], [0, 0, 0]], [[0, 0, 0], [0, 0, 1], [0, 0, 0]]], [[[0, 0, 0], [0, 0, 0], [1, 0, 0]], [[0, 0, 0], [0, 0, 0], [0, 1, 0]], [[0, 0, 0], [0, 0, 0], [0, 0, 1]]]]
+
+"""
+
+__all__ = [
+    "ArraySymbol", "ArrayElement", "ZeroArray", "OneArray",
+    "ArrayTensorProduct",
+    "ArrayContraction",
+    "ArrayDiagonal",
+    "PermuteDims",
+    "ArrayAdd",
+    "ArrayElementwiseApplyFunc",
+    "Reshape",
+    "convert_array_to_matrix",
+    "convert_matrix_to_array",
+    "convert_indexed_to_array",
+    "array_derive",
+]
+
+from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
+    ArrayContraction, Reshape, ArraySymbol, ArrayElement, ZeroArray, OneArray, ArrayElementwiseApplyFunc
+from sympy.tensor.array.expressions.arrayexpr_derivatives import array_derive
+from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
+from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array
+from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -7,7 +7,9 @@ from typing import Optional, List, Dict as tDict, Tuple as tTuple
 
 import typing
 
-from sympy import Integer, KroneckerDelta, Equality
+from sympy.core.numbers import Integer
+from sympy.core.relational import Equality
+from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1,3 +1,4 @@
+import collections.abc
 import operator
 from collections import defaultdict, Counter
 from functools import reduce
@@ -83,6 +84,8 @@ class ArrayElement(_ArrayExpr):
         if isinstance(name, str):
             name = Symbol(name)
         name = _sympify(name)
+        if not isinstance(indices, collections.abc.Iterable):
+            indices = (indices,)
         indices = _sympify(tuple(indices))
         if hasattr(name, "shape"):
             if any((i >= s) == True for i, s in zip(indices, name.shape)):
@@ -1462,6 +1465,27 @@ class ArrayContraction(_CodegenArrayAbstract):
 
 
 class Reshape(_CodegenArrayAbstract):
+    """
+    Reshape the dimensions of an array expression.
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.array.expressions import ArraySymbol, Reshape
+    >>> A = ArraySymbol("A", (6,))
+    >>> A.shape
+    (6,)
+    >>> Reshape(A, (3, 2)).shape
+    (3, 2)
+
+    Check the component-explicit forms:
+
+    >>> A.as_explicit()
+    [A[0], A[1], A[2], A[3], A[4], A[5]]
+    >>> Reshape(A, (3, 2)).as_explicit()
+    [[A[0], A[1]], [A[2], A[3]], [A[4], A[5]]]
+
+    """
 
     def __new__(cls, expr, shape):
         expr = _sympify(expr)

--- a/sympy/tensor/array/expressions/conv_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/conv_indexed_to_array.py
@@ -199,6 +199,13 @@ def _convert_indexed_to_array(expr):
             return _array_diagonal(expr.args[0], *diagonal_indices), ret_indices
         else:
             return expr.args[0], ret_indices
+    if isinstance(expr, ArrayElement):
+        indices = expr.indices
+        diagonal_indices, ret_indices = _get_diagonal_indices(indices)
+        if diagonal_indices:
+            return _array_diagonal(expr.name, *diagonal_indices), ret_indices
+        else:
+            return expr.name, ret_indices
     if isinstance(expr, Indexed):
         indices = expr.indices
         diagonal_indices, ret_indices = _get_diagonal_indices(indices)

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -41,6 +41,8 @@ def test_array_symbol_and_element():
     A = ArraySymbol("A", (2,))
     A0 = ArrayElement(A, (0,))
     A1 = ArrayElement(A, (1,))
+    assert A[0] == A0
+    assert A[1] != A0
     assert A.as_explicit() == ImmutableDenseNDimArray([A0, A1])
 
     A2 = tensorproduct(A, A)

--- a/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_index_to_array.py
@@ -7,7 +7,7 @@ from sympy.tensor.indexed import IndexedBase
 from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ArrayContraction, ArrayTensorProduct, \
     ArrayDiagonal, ArrayAdd, PermuteDims, ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, \
-    _array_add, _permute_dims
+    _array_add, _permute_dims, ArraySymbol
 from sympy.tensor.array.expressions.conv_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array, _convert_indexed_to_array
 from sympy.testing.pytest import raises
@@ -97,6 +97,25 @@ def test_arrayexpr_convert_indexed_to_array_expression():
     elem = expr[i, j]
     cg = convert_indexed_to_array(elem)
     assert cg == ArrayContraction(ArrayTensorProduct(-2, M, N), (1, 2))
+
+
+def test_arrayexpr_convert_array_element_to_array_expression():
+    A = ArraySymbol("A", (k,))
+    B = ArraySymbol("B", (k,))
+
+    s = Sum(A[i]*B[i], (i, 0, k-1))
+    cg = convert_indexed_to_array(s)
+    assert cg == ArrayContraction(ArrayTensorProduct(A, B), (0, 1))
+
+    s = A[i]*B[i]
+    cg = convert_indexed_to_array(s)
+    assert cg == ArrayDiagonal(ArrayTensorProduct(A, B), (0, 1))
+
+    s = A[i]*B[j]
+    cg = convert_indexed_to_array(s, [i, j])
+    assert cg == ArrayTensorProduct(A, B)
+    cg = convert_indexed_to_array(s, [j, i])
+    assert cg == ArrayTensorProduct(B, A)
 
 
 def test_arrayexpr_convert_indexed_to_array_and_back_to_matrix():


### PR DESCRIPTION
It's time to publicly announce the array expressions module. Added link to the documentation, will become available to everyone after the next version release.

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Array expression submodule has now reached a stable state and has been added to the documentation.
<!-- END RELEASE NOTES -->
