### PR TITLE
printing: Indexed assignment support for NumPy and TensorFlow

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -138,7 +138,8 @@ from sympy.core.numbers import Float, Integer, oo
 from sympy.core.sympify import _sympify, sympify, SympifyError
 from sympy.utilities.iterables import (iterable, topological_sort,
                                        numbered_symbols, filter_symbols)
-
+from sympy.tensor.array.expressions.array_expressions import ArrayElement,\
+        ArraySymbol
 
 def _mk_Tuple(args):
     """
@@ -436,7 +437,8 @@ class AssignmentBase(CodegenAST):
         from sympy.tensor.indexed import Indexed
 
         # Tuple of things that can be on the lhs of an assignment
-        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable)
+        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element,
+                Variable, ArrayElement, ArraySymbol)
         if not isinstance(lhs, assignable):
             raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
 

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -197,11 +197,19 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
             "tensorflow.linalg.matmul", [expr.base]*expr.exp)
 
     def _print_Assignment(self, expr):
-        # TODO: is this necessary?
-        return "%s = %s" % (
-            self._print(expr.lhs),
-            self._print(expr.rhs),
-        )
+        from sympy.tensor.indexed import Indexed
+        from sympy.codegen.ast import Assignment
+        from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array
+        from sympy.tensor.array.expressions.array_expressions import ArrayElement
+        if expr.has(Indexed, ArrayElement):
+            try:
+                lhs = convert_indexed_to_array(expr.lhs)
+                rhs = convert_indexed_to_array(expr.rhs)
+            except Exception:
+                msg = "Could not convert this Indexed expression to numpy array"
+                raise NotImplementedError(msg)
+            return self._print(Assignment(lhs, rhs))
+        return super()._print_Assignment(expr)
 
     def _print_CodeBlock(self, expr):
         # TODO: is this necessary?

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -11,12 +11,14 @@ from sympy.utilities.lambdify import lambdify
 from sympy.matrices.dense import eye
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.core import Pow
+from sympy.codegen.ast import Assignment
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Sqrt
 from sympy.tensor.array import Array
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
-    PermuteDims, ArrayDiagonal
+    PermuteDims, ArrayDiagonal, ArraySymbol
+from sympy.tensor.indexed import Idx
 from sympy.printing.numpy import NumPyPrinter, SciPyPrinter, _numpy_known_constants, \
     _numpy_known_functions, _scipy_known_constants, _scipy_known_functions
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
@@ -353,3 +355,8 @@ def test_scipy_print_methods():
     assert hasattr(prntr, '_print_erf')
     assert hasattr(prntr, '_print_factorial')
     assert hasattr(prntr, '_print_chebyshevt')
+
+def test_tensorflow_Assignment():
+    i,j,k = Idx('i'), Idx('j'), Idx('k')
+    expr = ArraySymbol('X', (1,2,3))[i,j,k]
+    assert NumPyPrinter().doprint(Assignment(expr, expr)) == "X = X"

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -1,8 +1,9 @@
 import random
 from sympy.core.function import Derivative
 from sympy.core.symbol import symbols
+from sympy.codegen.ast import Assignment
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
-    PermuteDims, ArrayDiagonal
+    PermuteDims, ArrayDiagonal, ArraySymbol
 from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
 from sympy.external import import_module
 from sympy.functions import \
@@ -14,9 +15,11 @@ from sympy.matrices.expressions import \
     Determinant, HadamardProduct, Inverse, MatrixSymbol, Trace
 from sympy.printing.tensorflow import tensorflow_code
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
+from sympy.tensor.indexed import Idx, IndexedBase
 from sympy.utilities.lambdify import lambdify
 from sympy.testing.pytest import skip
 from sympy.testing.pytest import XFAIL
+
 
 
 tf = tensorflow = import_module("tensorflow")
@@ -463,3 +466,8 @@ def test_tensorflow_Derivative():
     expr = Derivative(sin(x), x)
     assert tensorflow_code(expr) == \
         "tensorflow.gradients(tensorflow.math.sin(x), x)[0]"
+
+def test_tensorflow_Assignment():
+    i,j,k = Idx('i'), Idx('j'), Idx('k')
+    expr = ArraySymbol('X', (1,2,3))[i,j,k]
+    assert tensorflow_code(Assignment(expr, expr)) == "X = X"

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -15,7 +15,7 @@ from sympy.matrices.expressions import \
     Determinant, HadamardProduct, Inverse, MatrixSymbol, Trace
 from sympy.printing.tensorflow import tensorflow_code
 from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
-from sympy.tensor.indexed import Idx, IndexedBase
+from sympy.tensor.indexed import Idx
 from sympy.utilities.lambdify import lambdify
 from sympy.testing.pytest import skip
 from sympy.testing.pytest import XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
I feel that the type checks are a bit of a mess. Perhaps it is possible to create a
two variables, one for indexed-style arrays (Indexed/ArrayElement/MatrixElement
etc) and one for numpy-like arrays (IndexedBase, Array, ArraySymbol, MatrixSymbol
etc). Not sure what would be the right place for these to exist though.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Assignments for indexed style objects is now supported in NumPy and TensorFlow printers.
<!-- END RELEASE NOTES -->
