### PR TITLE
printing: ArrayExpr support

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -1,5 +1,5 @@
 from sympy.core import S
-from .pycode import PythonCodePrinter, _known_functions_math, _print_known_const, _print_known_func, _unpack_integral_limits
+from .pycode import PythonCodePrinter, _known_functions_math, _print_known_const, _print_known_func, _unpack_integral_limits, ArrayPrinter
 from .codeprinter import CodePrinter
 
 
@@ -30,7 +30,7 @@ _known_constants_numpy = {
 _numpy_known_functions = {k: 'numpy.' + v for k, v in _known_functions_numpy.items()}
 _numpy_known_constants = {k: 'numpy.' + v for k, v in _known_constants_numpy.items()}
 
-class NumPyPrinter(PythonCodePrinter):
+class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
     """
     Numpy printer which handles vectorized piecewise functions,
     logical operators, etc.
@@ -250,64 +250,6 @@ class NumPyPrinter(PythonCodePrinter):
         return '{}({})'.format(self._module_format(self._module + '.block'),
                                  self._print(expr.args[0].tolist()))
 
-    def _print_ArrayTensorProduct(self, expr):
-        array_list = [j for i, arg in enumerate(expr.args) for j in
-                (self._print(arg), "[%i, %i]" % (2*i, 2*i+1))]
-        return "%s(%s)" % (self._module_format(self._module + '.einsum'), ", ".join(array_list))
-
-    def _print_ArrayContraction(self, expr):
-        from ..tensor.array.expressions.array_expressions import ArrayTensorProduct
-        base = expr.expr
-        contraction_indices = expr.contraction_indices
-        if not contraction_indices:
-            return self._print(base)
-        if isinstance(base, ArrayTensorProduct):
-            counter = 0
-            d = {j: min(i) for i in contraction_indices for j in i}
-            indices = []
-            for rank_arg in base.subranks:
-                lindices = []
-                for i in range(rank_arg):
-                    if counter in d:
-                        lindices.append(d[counter])
-                    else:
-                        lindices.append(counter)
-                    counter += 1
-                indices.append(lindices)
-            elems = ["%s, %s" % (self._print(arg), ind) for arg, ind in zip(base.args, indices)]
-            return "%s(%s)" % (
-                self._module_format(self._module + '.einsum'),
-                ", ".join(elems)
-            )
-        raise NotImplementedError()
-
-    def _print_ArrayDiagonal(self, expr):
-        diagonal_indices = list(expr.diagonal_indices)
-        if len(diagonal_indices) > 1:
-            # TODO: this should be handled in sympy.codegen.array_utils,
-            # possibly by creating the possibility of unfolding the
-            # ArrayDiagonal object into nested ones. Same reasoning for
-            # the array contraction.
-            raise NotImplementedError
-        if len(diagonal_indices[0]) != 2:
-            raise NotImplementedError
-        return "%s(%s, 0, axis1=%s, axis2=%s)" % (
-            self._module_format("numpy.diagonal"),
-            self._print(expr.expr),
-            diagonal_indices[0][0],
-            diagonal_indices[0][1],
-        )
-
-    def _print_PermuteDims(self, expr):
-        return "%s(%s, %s)" % (
-            self._module_format("numpy.transpose"),
-            self._print(expr.expr),
-            self._print(expr.permutation.array_form),
-        )
-
-    def _print_ArrayAdd(self, expr):
-        return self._expand_fold_binary_op(self._module + '.add', expr.args)
-
     def _print_NDimArray(self, expr):
         if len(expr.shape) == 1:
             return self._module + '.array(' + self._print(expr.args[0]) + ')'
@@ -315,6 +257,12 @@ class NumPyPrinter(PythonCodePrinter):
             return self._print(expr.tomatrix())
         # Should be possible to extend to more dimensions
         return CodePrinter._print_not_supported(self, expr)
+
+    _add = "add"
+    _einsum = "einsum"
+    _transpose = "transpose"
+    _ones = "ones"
+    _zeros = "zeros"
 
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -183,41 +183,6 @@ class AbstractPythonCodePrinter(CodePrinter):
                 self._expand_reduce_binary_op(args[Nhalf:]),
             )
 
-    def _get_einsum_string(self, subranks, contraction_indices):
-        letters = self._get_letter_generator_for_einsum()
-        contraction_string = ""
-        counter = 0
-        d = {j: min(i) for i in contraction_indices for j in i}
-        indices = []
-        for rank_arg in subranks:
-            lindices = []
-            for i in range(rank_arg):
-                if counter in d:
-                    lindices.append(d[counter])
-                else:
-                    lindices.append(counter)
-                counter += 1
-            indices.append(lindices)
-        mapping = {}
-        letters_free = []
-        letters_dum = []
-        for i in indices:
-            for j in i:
-                if j not in mapping:
-                    l = next(letters)
-                    mapping[j] = l
-                else:
-                    l = mapping[j]
-                contraction_string += l
-                if j in d:
-                    if l not in letters_dum:
-                        letters_dum.append(l)
-                else:
-                    letters_free.append(l)
-            contraction_string += ","
-        contraction_string = contraction_string[:-1]
-        return contraction_string, letters_free, letters_dum
-
     def _print_NaN(self, expr):
         return "float('nan')"
 
@@ -420,6 +385,142 @@ class AbstractPythonCodePrinter(CodePrinter):
         base_str = self.parenthesize(expr.base, PREC, strict=False)
         exp_str = self.parenthesize(expr.exp, PREC, strict=False)
         return "{}**{}".format(base_str, exp_str)
+
+
+class ArrayPrinter:
+
+    def _arrayify(self, indexed):
+        from sympy.tensor.array.expressions.conv_indexed_to_array import convert_indexed_to_array
+        try:
+            return convert_indexed_to_array(indexed)
+        except Exception:
+            return indexed
+
+    def _get_einsum_string(self, subranks, contraction_indices):
+        letters = self._get_letter_generator_for_einsum()
+        contraction_string = ""
+        counter = 0
+        d = {j: min(i) for i in contraction_indices for j in i}
+        indices = []
+        for rank_arg in subranks:
+            lindices = []
+            for i in range(rank_arg):
+                if counter in d:
+                    lindices.append(d[counter])
+                else:
+                    lindices.append(counter)
+                counter += 1
+            indices.append(lindices)
+        mapping = {}
+        letters_free = []
+        letters_dum = []
+        for i in indices:
+            for j in i:
+                if j not in mapping:
+                    l = next(letters)
+                    mapping[j] = l
+                else:
+                    l = mapping[j]
+                contraction_string += l
+                if j in d:
+                    if l not in letters_dum:
+                        letters_dum.append(l)
+                else:
+                    letters_free.append(l)
+            contraction_string += ","
+        contraction_string = contraction_string[:-1]
+        return contraction_string, letters_free, letters_dum
+
+    def _get_letter_generator_for_einsum(self):
+        for i in range(97, 123):
+            yield chr(i)
+        for i in range(65, 91):
+            yield chr(i)
+        raise ValueError("out of letters")
+
+    def _print_ArrayTensorProduct(self, expr):
+        letters = self._get_letter_generator_for_einsum()
+        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
+        return '%s("%s", %s)' % (
+                self._module_format(self._module + "." + self._einsum),
+                contraction_string,
+                ", ".join([self._print(arg) for arg in expr.args])
+        )
+
+    def _print_ArrayContraction(self, expr):
+        from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
+        base = expr.expr
+        contraction_indices = expr.contraction_indices
+
+        if isinstance(base, ArrayTensorProduct):
+            elems = ",".join(["%s" % (self._print(arg)) for arg in base.args])
+            ranks = base.subranks
+        else:
+            elems = self._print(base)
+            ranks = [len(base.shape)]
+
+        contraction_string, letters_free, letters_dum = self._get_einsum_string(ranks, contraction_indices)
+
+        if not contraction_indices:
+            return self._print(base)
+        if isinstance(base, ArrayTensorProduct):
+            elems = ",".join(["%s" % (self._print(arg)) for arg in base.args])
+        else:
+            elems = self._print(base)
+        return "%s(\"%s\", %s)" % (
+            self._module_format(self._module + "." + self._einsum),
+            "{}->{}".format(contraction_string, "".join(sorted(letters_free))),
+            elems,
+        )
+
+    def _print_ArrayDiagonal(self, expr):
+        from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
+        diagonal_indices = list(expr.diagonal_indices)
+        if isinstance(expr.expr, ArrayTensorProduct):
+            subranks = expr.expr.subranks
+            elems = expr.expr.args
+        else:
+            subranks = expr.subranks
+            elems = [expr.expr]
+        diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
+        elems = [self._print(i) for i in elems]
+        return '%s("%s", %s)' % (
+            self._module_format(self._module + "." + self._einsum),
+            "{}->{}".format(diagonal_string, "".join(letters_free+letters_dum)),
+            ", ".join(elems)
+        )
+
+    def _print_PermuteDims(self, expr):
+        return "%s(%s, %s)" % (
+            self._module_format(self._module + "." + self._transpose),
+            self._print(expr.expr),
+            self._print(expr.permutation.array_form),
+        )
+
+    def _print_ArrayAdd(self, expr):
+        return self._expand_fold_binary_op(self._module + "." + self._add, expr.args)
+
+    def _print_OneArray(self, expr):
+        return "%s((%s,))" % (
+            self._module_format(self._module+ "." + self._ones),
+            ','.join(map(self._print,expr.args))
+        )
+
+    def _print_ZeroArray(self, expr):
+        return "%s((%s,))" % (
+            self._module_format(self._module+ "." + self._zeros),
+            ','.join(map(self._print,expr.args))
+        )
+
+    def _print_Assignment(self, expr):
+        #XXX: maybe this needs to happen at a higher level e.g. at _print or
+        #doprint?
+        lhs = self._print(self._arrayify(expr.lhs))
+        rhs = self._print(self._arrayify(expr.rhs))
+        return "%s = %s" % ( lhs, rhs )
+
+    def _print_IndexedBase(self, expr):
+        return self._print_ArraySymbol(expr)
 
 
 class PythonCodePrinter(AbstractPythonCodePrinter):

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -6,12 +6,12 @@ from sympy.core.singleton import S
 from sympy.codegen.cfunctions import Sqrt
 from sympy.external import import_module
 from sympy.printing.precedence import PRECEDENCE
-from sympy.printing.pycode import AbstractPythonCodePrinter
+from sympy.printing.pycode import AbstractPythonCodePrinter, ArrayPrinter
 import sympy
 
 tensorflow = import_module('tensorflow')
 
-class TensorflowPrinter(AbstractPythonCodePrinter):
+class TensorflowPrinter(ArrayPrinter, AbstractPythonCodePrinter):
     """
     Tensorflow printer which handles vectorized piecewise functions,
     logical operators, max/min, and relational operators.
@@ -196,13 +196,6 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         return self._expand_fold_binary_op(
             "tensorflow.linalg.matmul", [expr.base]*expr.exp)
 
-    def _print_Assignment(self, expr):
-        # TODO: is this necessary?
-        return "%s = %s" % (
-            self._print(expr.lhs),
-            self._print(expr.rhs),
-        )
-
     def _print_CodeBlock(self, expr):
         # TODO: is this necessary?
         ret = []
@@ -210,73 +203,12 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
             ret.append(self._print(subexpr))
         return "\n".join(ret)
 
-    def _get_letter_generator_for_einsum(self):
-        for i in range(97, 123):
-            yield chr(i)
-        for i in range(65, 91):
-            yield chr(i)
-        raise ValueError("out of letters")
-
-    def _print_ArrayTensorProduct(self, expr):
-        letters = self._get_letter_generator_for_einsum()
-        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
-        return '%s("%s", %s)' % (
-                self._module_format('tensorflow.linalg.einsum'),
-                contraction_string,
-                ", ".join([self._print(arg) for arg in expr.args])
-        )
-
-    def _print_ArrayContraction(self, expr):
-        from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
-        base = expr.expr
-        contraction_indices = expr.contraction_indices
-        contraction_string, letters_free, letters_dum = self._get_einsum_string(base.subranks, contraction_indices)
-
-        if not contraction_indices:
-            return self._print(base)
-        if isinstance(base, ArrayTensorProduct):
-            elems = ["%s" % (self._print(arg)) for arg in base.args]
-            return "%s(\"%s\", %s)" % (
-                self._module_format("tensorflow.linalg.einsum"),
-                contraction_string,
-                ", ".join(elems)
-            )
-        raise NotImplementedError()
-
-    def _print_ArrayDiagonal(self, expr):
-        from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
-        diagonal_indices = list(expr.diagonal_indices)
-        if len(diagonal_indices) > 1:
-            # TODO: this should be handled in sympy.codegen.array_utils,
-            # possibly by creating the possibility of unfolding the
-            # ArrayDiagonal object into nested ones. Same reasoning for
-            # the array contraction.
-            raise NotImplementedError
-        if len(diagonal_indices[0]) != 2:
-            raise NotImplementedError
-        if isinstance(expr.expr, ArrayTensorProduct):
-            subranks = expr.expr.subranks
-            elems = expr.expr.args
-        else:
-            subranks = expr.subranks
-            elems = [expr.expr]
-        diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
-        elems = [self._print(i) for i in elems]
-        return '%s("%s", %s)' % (
-            self._module_format("tensorflow.linalg.einsum"),
-            "{}->{}{}".format(diagonal_string, "".join(letters_free), "".join(letters_dum)),
-            ", ".join(elems)
-        )
-
-    def _print_PermuteDims(self, expr):
-        return "%s(%s, %s)" % (
-            self._module_format("tensorflow.transpose"),
-            self._print(expr.expr),
-            self._print(expr.permutation.array_form),
-        )
-
-    def _print_ArrayAdd(self, expr):
-        return self._expand_fold_binary_op('tensorflow.math.add', expr.args)
+    _module = "tensorflow"
+    _einsum = "linalg.einsum"
+    _add = "math.add"
+    _transpose = "transpose"
+    _ones = "ones"
+    _zeros = "zeros"
 
 
 def tensorflow_code(expr, **settings):

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -15,7 +15,7 @@ from sympy.printing.pycode import (
 from sympy.printing.tensorflow import TensorflowPrinter
 from sympy.printing.numpy import NumPyPrinter, SciPyPrinter
 from sympy.testing.pytest import raises, skip
-from sympy.tensor import IndexedBase
+from sympy.tensor import IndexedBase, Idx
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayDiagonal, ArrayContraction, ZeroArray, OneArray
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import loggamma
@@ -397,6 +397,7 @@ def test_numerical_accuracy_functions():
 def test_array_printer():
     A = ArraySymbol('A', (4,4,6,6,6))
     I = IndexedBase('I')
+    i,j,k = Idx('i', (0,1)), Idx('j', (2,3)), Idx('k', (4,5))
 
     prntr = NumPyPrinter()
     assert prntr.doprint(ZeroArray(5)) == 'numpy.zeros((5,))'
@@ -406,6 +407,7 @@ def test_array_printer():
     assert prntr.doprint(ArrayDiagonal(A, [2,3,4])) == 'numpy.einsum("abccc->abc", A)'
     assert prntr.doprint(ArrayDiagonal(A, [0,1], [2,3])) == 'numpy.einsum("aabbc->cab", A)'
     assert prntr.doprint(ArrayContraction(A, [2], [3])) == 'numpy.einsum("abcde->abe", A)'
+    assert prntr.doprint(Assignment(I[i,j,k], I[i,j,k])) == 'I = I'
 
     prntr = TensorflowPrinter()
     assert prntr.doprint(ZeroArray(5)) == 'tensorflow.zeros((5,))'
@@ -415,3 +417,4 @@ def test_array_printer():
     assert prntr.doprint(ArrayDiagonal(A, [2,3,4])) == 'tensorflow.linalg.einsum("abccc->abc", A)'
     assert prntr.doprint(ArrayDiagonal(A, [0,1], [2,3])) == 'tensorflow.linalg.einsum("aabbc->cab", A)'
     assert prntr.doprint(ArrayContraction(A, [2], [3])) == 'tensorflow.linalg.einsum("abcde->abe", A)'
+    assert prntr.doprint(Assignment(I[i,j,k], I[i,j,k])) == 'I = I'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22968

#### Brief description of what is fixed or changed
Better support for numpy-style arrays in `TensorflowPrinter` and
`NumPyPrinter`. Printing methods are now collected in the
`ArrayPrinter` class to avoid code duplications/maintainance errors.
Printing for `ZeroArray` and `OneArray` has been added.
`ArrayDiagonal` printing now also works for multiple diagonals and
diagonals spanning more than two indices.
`ArrayContractiong` printing now also works when its base is not a
`ArrayTensorProduct`.

#### Other comments
I decided to create the new class because in the current master, tensor products are hardcoded as being along two axes for the `NumPyPrinter` (but not the `TensorFlowPrinter`). I suspect this functionality was added to `TensorFlowPrinter` at some point, but not added to the numpy printer. It would fail at e.g. `ArrayTensorProduct(-1,A)` since `-1` is a scalar and does not have any indices. It would also fail for any `A.rank != 2`. This is now fixed.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `NumPyPrinter` and `TensorflowPrinter` have improved support for array expressions.
<!-- END RELEASE NOTES -->
