### PR TITLE
Deprecation removals

### DIFF
--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -8,7 +8,7 @@ Implementation in sympy.vector
 Scalar and vector fields
 ------------------------
 
-In :mod:`sympy.vector`, every ``CoordSysCartesian`` instance is assigned basis
+In :mod:`sympy.vector`, every ``CoordSys3D`` instance is assigned basis
 vectors corresponding to the :math:`X`, :math:`Y` and
 :math:`Z` axes. These can be accessed using the properties
 named ``i``, ``j`` and ``k`` respectively. Hence, to define a vector

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -225,7 +225,7 @@ from .parsing import parse_expr
 
 from .calculus import (euler_equations, singularities, is_increasing,
         is_strictly_increasing, is_decreasing, is_strictly_decreasing,
-        is_monotonic, finite_diff_weights, apply_finite_diff, as_finite_diff,
+        is_monotonic, finite_diff_weights, apply_finite_diff,
         differentiate_finite, periodicity, not_empty_in, AccumBounds,
         is_convex, stationary_points, minimum, maximum)
 
@@ -465,7 +465,7 @@ __all__ = [
     'euler_equations', 'singularities', 'is_increasing',
     'is_strictly_increasing', 'is_decreasing', 'is_strictly_decreasing',
     'is_monotonic', 'finite_diff_weights', 'apply_finite_diff',
-    'as_finite_diff', 'differentiate_finite', 'periodicity', 'not_empty_in',
+    'differentiate_finite', 'periodicity', 'not_empty_in',
     'AccumBounds', 'is_convex', 'stationary_points', 'minimum', 'maximum',
 
     # sympy.algebras

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -4,7 +4,7 @@ from .euler import euler_equations
 from .singularities import (singularities, is_increasing,
                             is_strictly_increasing, is_decreasing,
                             is_strictly_decreasing, is_monotonic)
-from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff, differentiate_finite
+from .finite_diff import finite_diff_weights, apply_finite_diff, differentiate_finite
 from .util import (periodicity, not_empty_in, is_convex,
                    stationary_points, minimum, maximum)
 from .accumulationbounds import AccumBounds
@@ -16,7 +16,7 @@ __all__ = [
 'is_strictly_increasing', 'is_decreasing',
 'is_strictly_decreasing', 'is_monotonic',
 
-'finite_diff_weights', 'apply_finite_diff', 'as_finite_diff', 'differentiate_finite',
+'finite_diff_weights', 'apply_finite_diff', 'differentiate_finite',
 
 'periodicity', 'not_empty_in', 'is_convex', 'stationary_points',
 'minimum', 'maximum',

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -313,25 +313,23 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
     Examples
     ========
 
-    >>> from sympy import symbols, Function, exp, sqrt, Symbol, as_finite_diff
-    >>> from sympy.utilities.exceptions import SymPyDeprecationWarning
-    >>> import warnings
-    >>> warnings.simplefilter("ignore", SymPyDeprecationWarning)
+    >>> from sympy import symbols, Function, exp, sqrt, Symbol
+    >>> from sympy.calculus.finite_diff import _as_finite_diff
     >>> x, h = symbols('x h')
     >>> f = Function('f')
-    >>> as_finite_diff(f(x).diff(x))
+    >>> _as_finite_diff(f(x).diff(x))
     -f(x - 1/2) + f(x + 1/2)
 
     The default step size and number of points are 1 and ``order + 1``
     respectively. We can change the step size by passing a symbol
     as a parameter:
 
-    >>> as_finite_diff(f(x).diff(x), h)
+    >>> _as_finite_diff(f(x).diff(x), h)
     -f(-h/2 + x)/h + f(h/2 + x)/h
 
     We can also specify the discretized values to be used in a sequence:
 
-    >>> as_finite_diff(f(x).diff(x), [x, x+h, x+2*h])
+    >>> _as_finite_diff(f(x).diff(x), [x, x+h, x+2*h])
     -3*f(x)/(2*h) + 2*f(h + x)/h - f(2*h + x)/(2*h)
 
     The algorithm is not restricted to use equidistant spacing, nor
@@ -340,7 +338,7 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
 
     >>> e, sq2 = exp(1), sqrt(2)
     >>> xl = [x-h, x+h, x+e*h]
-    >>> as_finite_diff(f(x).diff(x, 1), xl, x+h*sq2)
+    >>> _as_finite_diff(f(x).diff(x, 1), xl, x+h*sq2)
     2*h*((h + sqrt(2)*h)/(2*h) - (-sqrt(2)*h + h)/(2*h))*f(E*h + x)/((-h + E*h)*(h + E*h)) +
     (-(-sqrt(2)*h + h)/(2*h) - (-sqrt(2)*h + E*h)/(2*h))*f(-h + x)/(h + E*h) +
     (-(h + sqrt(2)*h)/(2*h) + (-sqrt(2)*h + E*h)/(2*h))*f(h + x)/(-h + E*h)
@@ -349,7 +347,7 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
 
     >>> y = Symbol('y')
     >>> d2fdxdy=f(x,y).diff(x,y)
-    >>> as_finite_diff(d2fdxdy, wrt=x)
+    >>> _as_finite_diff(d2fdxdy, wrt=x)
     -Derivative(f(x - 1/2, y), y) + Derivative(f(x + 1/2, y), y)
 
     See also
@@ -405,15 +403,6 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
     return apply_finite_diff(order, points, [
         Derivative(derivative.expr.subs({wrt: x}), *others) for
         x in points], x0)
-
-
-as_finite_diff = deprecated(
-    useinstead="Derivative.as_finite_difference",
-    deprecated_since_version="1.1", issue=11410)(_as_finite_diff)
-
-as_finite_diff.__doc__ = """
-    Deprecated function. Use Diff.as_finite_difference instead.
-    """
 
 
 def differentiate_finite(expr, *symbols,

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -23,7 +23,6 @@ from sympy.core.function import Subs
 from sympy.core.traversal import preorder_traversal
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iterable
-from sympy.utilities.decorator import deprecated
 
 
 

--- a/sympy/calculus/tests/test_finite_diff.py
+++ b/sympy/calculus/tests/test_finite_diff.py
@@ -7,7 +7,7 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.exponential import exp
 from sympy.calculus.finite_diff import (
     apply_finite_diff, differentiate_finite, finite_diff_weights,
-    as_finite_diff
+    _as_finite_diff
 )
 from sympy.testing.pytest import raises, warns_deprecated_sympy, ignore_warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -117,8 +117,7 @@ def test_as_finite_diff():
     f = Function('f')
     dx = Function('dx')
 
-    with warns_deprecated_sympy():
-        as_finite_diff(f(x).diff(x), [x-2, x-1, x, x+1, x+2])
+    _as_finite_diff(f(x).diff(x), [x-2, x-1, x, x+1, x+2])
 
     # Use of undefined functions in ``points``
     df_true = -f(x+dx(x)/2-dx(x+dx(x)/2)/2) / dx(x+dx(x)/2) \

--- a/sympy/calculus/tests/test_finite_diff.py
+++ b/sympy/calculus/tests/test_finite_diff.py
@@ -9,7 +9,7 @@ from sympy.calculus.finite_diff import (
     apply_finite_diff, differentiate_finite, finite_diff_weights,
     _as_finite_diff
 )
-from sympy.testing.pytest import raises, warns_deprecated_sympy, ignore_warnings
+from sympy.testing.pytest import raises, ignore_warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1035,17 +1035,7 @@ class Float(Number):
 
     is_Float = True
 
-    def __new__(cls, num, dps=None, prec=None, precision=None):
-        if prec is not None:
-            SymPyDeprecationWarning(
-                            feature="Using 'prec=XX' to denote decimal precision",
-                            useinstead="'dps=XX' for decimal precision and 'precision=XX' "\
-                                              "for binary precision",
-                            issue=12820,
-                            deprecated_since_version="1.1").warn()
-            dps = prec
-        del prec  # avoid using this deprecated kwarg
-
+    def __new__(cls, num, dps=None, precision=None):
         if dps is not None and precision is not None:
             raise ValueError('Both decimal and binary precision supplied. '
                              'Supply only one. ')

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -33,8 +33,6 @@ from mpmath.libmp.libmpf import (
 from sympy.utilities.misc import as_int, debug, filldedent
 from .parameters import global_parameters
 
-from sympy.utilities.exceptions import SymPyDeprecationWarning
-
 _LOG2 = math.log(2)
 
 

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -231,10 +231,6 @@ class DiracDelta(Function):
             elif k.is_even:
                 return cls(-arg, k) if k else cls(-arg)
 
-    @deprecated(useinstead="expand(diracdelta=True, wrt=x)", issue=12859, deprecated_since_version="1.1")
-    def simplify(self, x, **kwargs):
-        return self.expand(diracdelta=True, wrt=x)
-
     def _eval_expand_diracdelta(self, **hints):
         """
         Compute a simplified representation of the function using

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -5,7 +5,6 @@ from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.complexes import im, sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys.polyerrors import PolynomialError
-from sympy.utilities.decorator import deprecated
 from sympy.utilities.misc import filldedent
 
 

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -10,7 +10,7 @@ from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.simplify.simplify import signsimp
 
 
-from sympy.testing.pytest import raises, warns_deprecated_sympy
+from sympy.testing.pytest import raises
 
 from sympy.core.expr import unchanged
 
@@ -69,16 +69,11 @@ def test_DiracDelta():
     assert DiracDelta(x - y) != DiracDelta(y - x)
     assert signsimp(DiracDelta(x - y) - DiracDelta(y - x)) == 0
 
-    with warns_deprecated_sympy():
-        assert DiracDelta(x*y).simplify(x) == DiracDelta(x)/abs(y)
-    with warns_deprecated_sympy():
-        assert DiracDelta(x*y).simplify(y) == DiracDelta(y)/abs(x)
-    with warns_deprecated_sympy():
-        assert DiracDelta(x**2*y).simplify(x) == DiracDelta(x**2*y)
-    with warns_deprecated_sympy():
-        assert DiracDelta(y).simplify(x) == DiracDelta(y)
-    with warns_deprecated_sympy():
-        assert DiracDelta((x - 1)*(x - 2)*(x - 3)).simplify(x) == (
+    assert DiracDelta(x*y).expand(diracdelta=True, wrt=x) == DiracDelta(x)/abs(y)
+    assert DiracDelta(x*y).expand(diracdelta=True, wrt=y) == DiracDelta(y)/abs(x)
+    assert DiracDelta(x**2*y).expand(diracdelta=True, wrt=x) == DiracDelta(x**2*y)
+    assert DiracDelta(y).expand(diracdelta=True, wrt=x) == DiracDelta(y)
+    assert DiracDelta((x - 1)*(x - 2)*(x - 3)).expand(diracdelta=True) == (
             DiracDelta(x - 3)/2 + DiracDelta(x - 2) + DiracDelta(x - 1)/2)
 
     raises(ArgumentIndexError, lambda: DiracDelta(x).fdiff(2))

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -37,7 +37,6 @@ from sympy.matrices import Matrix
 from sympy.sets.sets import Intersection
 from sympy.simplify.simplify import simplify
 from sympy.solvers.solveset import linear_coeffs
-from sympy.utilities.decorator import deprecated
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import Undecidable, filldedent
 

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1281,10 +1281,6 @@ class Line(LinearEntity):
             return S.Zero
         return self.perpendicular_segment(other).length
 
-    @deprecated(useinstead="equals", issue=12860, deprecated_since_version="1.0")
-    def equal(self, other):
-        return self.equals(other)
-
     def equals(self, other):
         """Returns True if self and other are the same mathematical entities"""
         if not isinstance(other, Line):

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -261,17 +261,6 @@ class Dimension(Expr):
             Dimension(d)**e for d, e in dependencies.items()
         ), 1)
 
-    @classmethod
-    def _get_dimensional_dependencies_for_name(cls, name):
-        from sympy.physics.units.systems.si import dimsys_default
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="do not call from `Dimension` objects.",
-            useinstead="DimensionSystem"
-        ).warn()
-        return dimsys_default.get_dimensional_dependencies(name)
-
     @property
     def is_dimensionless(self):
         """
@@ -325,15 +314,8 @@ class DimensionSystem(Basic, _QuantityMapper):
     may be omitted.
     """
 
-    def __new__(cls, base_dims, derived_dims=(), dimensional_dependencies={}, name=None, descr=None):
+    def __new__(cls, base_dims, derived_dims=(), dimensional_dependencies={}):
         dimensional_dependencies = dict(dimensional_dependencies)
-
-        if (name is not None) or (descr is not None):
-            SymPyDeprecationWarning(
-                deprecated_since_version="1.2",
-                issue=13336,
-                useinstead="do not define a `name` or `descr`",
-            ).warn()
 
         def parse_dim(dim):
             if isinstance(dim, str):
@@ -482,15 +464,7 @@ class DimensionSystem(Basic, _QuantityMapper):
         deps2 = self.get_dimensional_dependencies(dim2)
         return deps1 == deps2
 
-    def extend(self, new_base_dims, new_derived_dims=(), new_dim_deps=None, name=None, description=None):
-        if (name is not None) or (description is not None):
-            SymPyDeprecationWarning(
-                deprecated_since_version="1.2",
-                issue=13336,
-                feature="name and descriptions of DimensionSystem",
-                useinstead="do not specify `name` or `description`",
-            ).warn()
-
+    def extend(self, new_base_dims, new_derived_dims=(), new_dim_deps=None):
         deps = dict(self.dimensional_dependencies)
         if new_dim_deps:
             deps.update(new_dim_deps)
@@ -503,62 +477,6 @@ class DimensionSystem(Basic, _QuantityMapper):
         new_dim_sys._quantity_dimension_map.update(self._quantity_dimension_map)
         new_dim_sys._quantity_scale_factors.update(self._quantity_scale_factors)
         return new_dim_sys
-
-    @staticmethod
-    def sort_dims(dims):
-        """
-        Useless method, kept for compatibility with previous versions.
-
-        DO NOT USE.
-
-        Sort dimensions given in argument using their str function.
-
-        This function will ensure that we get always the same tuple for a given
-        set of dimensions.
-        """
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="sort_dims",
-            useinstead="sorted(..., key=default_sort_key)",
-        ).warn()
-        return tuple(sorted(dims, key=str))
-
-    def __getitem__(self, key):
-        """
-        Useless method, kept for compatibility with previous versions.
-
-        DO NOT USE.
-
-        Shortcut to the get_dim method, using key access.
-        """
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="the get [ ] operator",
-            useinstead="the dimension definition",
-        ).warn()
-        d = self.get_dim(key)
-        #TODO: really want to raise an error?
-        if d is None:
-            raise KeyError(key)
-        return d
-
-    def __call__(self, unit):
-        """
-        Useless method, kept for compatibility with previous versions.
-
-        DO NOT USE.
-
-        Wrapper to the method print_dim_base
-        """
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="call DimensionSystem",
-            useinstead="the dimension definition",
-        ).warn()
-        return self.print_dim_base(unit)
 
     def is_dimensionless(self, dimension):
         """

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -1,17 +1,9 @@
-from sympy.testing.pytest import warns_deprecated_sympy
-
 from sympy.core.symbol import symbols
 from sympy.matrices.dense import (Matrix, eye)
 from sympy.physics.units.definitions.dimension_definitions import (
     action, current, length, mass, time,
     velocity)
 from sympy.physics.units.dimensions import DimensionSystem
-
-
-def test_call():
-    mksa = DimensionSystem((length, time, mass, current), (action,))
-    with warns_deprecated_sympy():
-        assert mksa(action) == mksa.print_dim_base(action)
 
 
 def test_extend():
@@ -22,12 +14,6 @@ def test_extend():
     res = DimensionSystem((length, time, mass), (velocity, action))
     assert mks.base_dims == res.base_dims
     assert mks.derived_dims == res.derived_dims
-
-
-def test_sort_dims():
-    with warns_deprecated_sympy():
-        assert (DimensionSystem.sort_dims((length, velocity, time))
-                                      == (length, time, velocity))
 
 
 def test_list_dims():

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -1,5 +1,4 @@
 from sympy.physics.units import DimensionSystem, joule, second, ampere
-from sympy.testing.pytest import warns_deprecated_sympy
 
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
@@ -7,6 +6,7 @@ from sympy.physics.units.definitions import c, kg, m, s
 from sympy.physics.units.definitions.dimension_definitions import length, time
 from sympy.physics.units.quantities import Quantity
 from sympy.physics.units.unitsystem import UnitSystem
+from sympy.physics.units.util import convert_to
 
 
 def test_definition():
@@ -32,7 +32,7 @@ def test_str_repr():
     assert repr(UnitSystem((m, s))) == "<UnitSystem: (%s, %s)>" % (m, s)
 
 
-def test_print_unit_base():
+def test_convert_to():
     A = Quantity("A")
     A.set_global_relative_scale_factor(S.One, ampere)
 
@@ -40,8 +40,7 @@ def test_print_unit_base():
     Js.set_global_relative_scale_factor(S.One, joule*second)
 
     mksa = UnitSystem((m, kg, s, A), (Js,))
-    with warns_deprecated_sympy():
-        assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
+    assert convert_to(Js, mksa._base_units) == m**2*kg*s**-1/1000
 
 
 def test_extend():

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -11,8 +11,6 @@ from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.physics.units.dimensions import _QuantityMapper
 
-from sympy.utilities.exceptions import SymPyDeprecationWarning
-
 from .dimensions import Dimension
 
 

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -72,25 +72,6 @@ class UnitSystem(_QuantityMapper):
 
         return UnitSystem(base, units, name, description, dimension_system)
 
-    def print_unit_base(self, unit):
-        """
-        Useless method.
-
-        DO NOT USE, use instead ``convert_to``.
-
-        Give the string expression of a unit in term of the basis.
-
-        Units are displayed by decreasing power.
-        """
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="print_unit_base",
-            useinstead="convert_to",
-        ).warn()
-        from sympy.physics.units import convert_to
-        return convert_to(unit, self._base_units)
-
     def get_dimension_system(self):
         return self._dimension_system
 

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -356,16 +356,6 @@ class Domain:
     rep = None  # type: Optional[str]
     alias = None  # type: Optional[str]
 
-    @property  # type: ignore
-    @deprecated(useinstead="is_Field", issue=12723, deprecated_since_version="1.1")
-    def has_Field(self):
-        return self.is_Field
-
-    @property  # type: ignore
-    @deprecated(useinstead="is_Ring", issue=12723, deprecated_since_version="1.1")
-    def has_Ring(self):
-        return self.is_Ring
-
     def __init__(self):
         raise NotImplementedError
 

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -11,7 +11,6 @@ from sympy.polys.orderings import lex
 from sympy.polys.polyerrors import UnificationFailed, CoercionFailed, DomainError
 from sympy.polys.polyutils import _unify_gens, _not_a_coeff
 from sympy.utilities import public
-from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import is_sequence
 
 

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -1,4 +1,4 @@
-from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.vector import (Vector, VectorAdd, VectorMul,
                                  BaseVector, VectorZero, Cross, Dot, cross, dot)
 from sympy.vector.dyadic import (Dyadic, DyadicAdd, DyadicMul,
@@ -28,7 +28,7 @@ __all__ = [
 
     'Del',
 
-    'CoordSys3D', 'CoordSysCartesian',
+    'CoordSys3D',
 
     'express', 'matrix_to_vector', 'laplacian', 'is_conservative',
     'is_solenoidal', 'scalar_potential', 'directional_derivative',

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,6 +1,5 @@
 from collections.abc import Callable
 
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core import S, Dummy, Lambda
@@ -21,16 +20,6 @@ from sympy.simplify.trigsimp import trigsimp
 import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-
-
-def CoordSysCartesian(*args, **kwargs):
-    SymPyDeprecationWarning(
-        feature="CoordSysCartesian",
-        useinstead="CoordSys3D",
-        issue=12865,
-        deprecated_since_version="1.1"
-    ).warn()
-    return CoordSys3D(*args, **kwargs)
 
 
 class CoordSys3D(Basic):
@@ -458,17 +447,6 @@ class CoordSys3D(Basic):
     @property
     def origin(self):
         return self._origin
-
-    @property
-    def delop(self):
-        SymPyDeprecationWarning(
-            feature="coord_system.delop has been replaced.",
-            useinstead="Use the Del() class",
-            deprecated_since_version="1.1",
-            issue=12866,
-        ).warn()
-        from sympy.vector.deloperator import Del
-        return Del()
 
     def base_vectors(self):
         return self._base_vectors

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -9,14 +9,7 @@ class Del(Basic):
     mathematical expressions as the 'nabla' symbol.
     """
 
-    def __new__(cls, system=None):
-        if system is not None:
-            SymPyDeprecationWarning(
-                feature="delop operator inside coordinate system",
-                useinstead="it as instance Del class",
-                deprecated_since_version="1.1",
-                issue=12866,
-            ).warn()
+    def __new__(cls):
         obj = super().__new__(cls)
         obj._name = "delop"
         return obj

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -1,4 +1,3 @@
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core import Basic
 from sympy.vector.operators import gradient, divergence, curl
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -157,8 +157,8 @@ def directional_derivative(field, direction_vector):
     5*R.x**2 + 30*R.x*R.z
 
     """
-    from sympy.vector.operators import _get_coord_sys_from_expr
-    coord_sys = _get_coord_sys_from_expr(field)
+    from sympy.vector.operators import _get_coord_systems
+    coord_sys = _get_coord_systems(field)
     if len(coord_sys) > 0:
         # TODO: This gets a random coordinate system in case of multiple ones:
         coord_sys = next(iter(coord_sys))

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -5,7 +5,7 @@ from sympy.core.sorting import default_sort_key
 from sympy.matrices import Matrix
 from sympy.vector import (CoordSys3D, Vector, ParametricRegion,
                         parametric_region_list, ImplicitRegion)
-from sympy.vector.operators import _get_coord_sys_from_expr
+from sympy.vector.operators import _get_coord_systems
 from sympy.integrals import Integral, integrate
 from sympy.utilities.iterables import topological_sort
 from sympy.geometry.entity import GeometryEntity
@@ -42,7 +42,7 @@ class ParametricIntegral(Basic):
 
     def __new__(cls, field, parametricregion):
 
-        coord_set = _get_coord_sys_from_expr(field)
+        coord_set = _get_coord_systems(field)
 
         if len(coord_set) == 0:
             coord_sys = CoordSys3D('C')

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -3,7 +3,6 @@ from sympy.core.expr import Expr
 from sympy.core import sympify, S, preorder_traversal
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.vector import Vector, VectorMul, VectorAdd, Cross, Dot
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.function import Derivative
 from sympy.core.add import Add
 from sympy.core.mul import Mul
@@ -19,20 +18,11 @@ def _get_coord_systems(expr):
     return frozenset(ret)
 
 
-def _get_coord_sys_from_expr(expr, coord_sys=None):
+def _get_coord_sys_from_expr(expr):
     """
     expr : expression
         The coordinate system is extracted from this parameter.
     """
-
-    # TODO: Remove this line when warning from issue #12884 will be removed
-    if coord_sys is not None:
-        SymPyDeprecationWarning(
-            feature="coord_sys parameter",
-            useinstead="do not use it",
-            deprecated_since_version="1.1",
-            issue=12884,
-        ).warn()
 
     return _get_coord_systems(expr)
 

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -18,15 +18,6 @@ def _get_coord_systems(expr):
     return frozenset(ret)
 
 
-def _get_coord_sys_from_expr(expr):
-    """
-    expr : expression
-        The coordinate system is extracted from this parameter.
-    """
-
-    return _get_coord_systems(expr)
-
-
 def _split_mul_args_wrt_coordsys(expr):
     d = collections.defaultdict(lambda: S.One)
     for i in expr.args:
@@ -109,7 +100,7 @@ class Curl(Expr):
         return curl(self._expr, doit=True)
 
 
-def curl(vect, coord_sys=None, doit=True):
+def curl(vect, doit=True):
     """
     Returns the curl of a vector field computed wrt the base scalars
     of the given coordinate system.
@@ -119,10 +110,6 @@ def curl(vect, coord_sys=None, doit=True):
 
     vect : Vector
         The vector operand
-
-    coord_sys : CoordSys3D
-        The coordinate system to calculate the gradient in.
-        Deprecated since version 1.1
 
     doit : bool
         If True, the result is returned after calling .doit() on
@@ -143,7 +130,7 @@ def curl(vect, coord_sys=None, doit=True):
 
     """
 
-    coord_sys = _get_coord_sys_from_expr(vect, coord_sys)
+    coord_sys = _get_coord_systems(vect)
 
     if len(coord_sys) == 0:
         return Vector.zero
@@ -188,7 +175,7 @@ def curl(vect, coord_sys=None, doit=True):
             raise Curl(vect)
 
 
-def divergence(vect, coord_sys=None, doit=True):
+def divergence(vect, doit=True):
     """
     Returns the divergence of a vector field computed wrt the base
     scalars of the given coordinate system.
@@ -198,10 +185,6 @@ def divergence(vect, coord_sys=None, doit=True):
 
     vector : Vector
         The vector operand
-
-    coord_sys : CoordSys3D
-        The coordinate system to calculate the gradient in
-        Deprecated since version 1.1
 
     doit : bool
         If True, the result is returned after calling .doit() on
@@ -222,7 +205,7 @@ def divergence(vect, coord_sys=None, doit=True):
     2*R.z
 
     """
-    coord_sys = _get_coord_sys_from_expr(vect, coord_sys)
+    coord_sys = _get_coord_systems(vect)
     if len(coord_sys) == 0:
         return S.Zero
     elif len(coord_sys) == 1:
@@ -259,7 +242,7 @@ def divergence(vect, coord_sys=None, doit=True):
             raise Divergence(vect)
 
 
-def gradient(scalar_field, coord_sys=None, doit=True):
+def gradient(scalar_field, doit=True):
     """
     Returns the vector gradient of a scalar field computed wrt the
     base scalars of the given coordinate system.
@@ -269,10 +252,6 @@ def gradient(scalar_field, coord_sys=None, doit=True):
 
     scalar_field : SymPy Expr
         The scalar field to compute the gradient of
-
-    coord_sys : CoordSys3D
-        The coordinate system to calculate the gradient in
-        Deprecated since version 1.1
 
     doit : bool
         If True, the result is returned after calling .doit() on
@@ -292,7 +271,7 @@ def gradient(scalar_field, coord_sys=None, doit=True):
     10*R.x*R.z*R.i + 5*R.x**2*R.k
 
     """
-    coord_sys = _get_coord_sys_from_expr(scalar_field, coord_sys)
+    coord_sys = _get_coord_systems(scalar_field)
 
     if len(coord_sys) == 0:
         return Vector.zero

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -1,5 +1,5 @@
-from sympy.testing.pytest import raises, warns_deprecated_sympy
-from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
+from sympy.testing.pytest import raises
+from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.scalar import BaseScalar
 from sympy.core.function import expand
 from sympy.core.numbers import pi
@@ -33,7 +33,7 @@ def test_func_args():
     assert A.origin.func(*A.origin.args) == A.origin
 
 
-def test_coordsyscartesian_equivalence():
+def test_coordsys3d_equivalence():
     A = CoordSys3D('A')
     A1 = CoordSys3D('A')
     assert A1 == A
@@ -273,7 +273,7 @@ def test_orient_new_methods():
 
 def test_locatenew_point():
     """
-    Tests Point class, and locate_new method in CoordSysCartesian.
+    Tests Point class, and locate_new method in CoordSys3D.
     """
     A = CoordSys3D('A')
     assert isinstance(A.origin, Point)
@@ -446,11 +446,6 @@ def test_check_orthogonality():
     raises(ValueError, lambda: CoordSys3D('a', transformation=((x, y, z), (x, x, z))))
     raises(ValueError, lambda: CoordSys3D('a', transformation=(
         (x, y, z), (x*sin(y/2)*cos(z), x*sin(y)*sin(z), x*cos(y)))))
-
-
-def test_coordsys3d():
-    with warns_deprecated_sympy():
-        assert CoordSysCartesian("C") == CoordSys3D("C")
 
 
 def test_rotation_trans_equations():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -267,10 +267,10 @@ class Vector(BasisDependent):
         (0, 0, 0)
         """
 
-        from sympy.vector.operators import _get_coord_sys_from_expr
+        from sympy.vector.operators import _get_coord_systems
         if isinstance(self, VectorZero):
             return (S.Zero, S.Zero, S.Zero)
-        base_vec = next(iter(_get_coord_sys_from_expr(self))).base_vectors()
+        base_vec = next(iter(_get_coord_systems(self))).base_vectors()
         return tuple([self.dot(i) for i in base_vec])
 
     def __or__(self, other):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #11410
Closes #12723
Closes #12820
Closes #12859
Closes #12860
Closes #12865
Closes #12866
Closes #12884
Parts of #13336

#### Brief description of what is fixed or changed

Removed deprecations from SymPy 1.0, 1.1, and 1.2

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * BREAKING: removed deprecated `as_finite_diff`.
* core
    * BREAKING: removed deprecated `prec` keyword argument to `Float`.
* functions
    * BREAKING: removed deprecated `simplify` method of `DiracDelta`.
* geometry
    * BREAKING: removed deprecated `equal` method of `Line`.
* physics.units
    * BREAKING: removed deprecated `print_unit_base` method of `UnitSystem`.
    * BREAKING: removed deprecated `desc` and `name` keyword arguments of `DimensionSystem`.
    * BREAKING: removed deprecated `description` and `name` keyword arguments of `DimensionSystem.extend`.
    * BREAKING: removed deprecated `sort_dims` method of `DimensionSystem`.
    * BREAKING: removed deprecated ability to call a `DimensionSystem`.
    * BREAKING: removed deprecated ability to get an item from a `DimensionSystem`.
* polys
    * BREAKING: removed deprecated `has_Field` and `has_Ring` methods of `Domain`.
* vector
    * BREAKING: removed deprecated `CoordSysCartesian` class.
    * BREAKING: removed deprecated `delop` method of `CoordSys3D`.
    * BREAKING: removed deprecated `system` keyword argument of `Del`.
    * BREAKING: removed deprecated `coord_sys` keyword argument of `curl`, `divergence`, and `gradient`.
<!-- END RELEASE NOTES -->
