### PR TITLE
physics : Added refractive index in Gaussian Beam Parameters and refactored code

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4912,7 +4912,7 @@ def test_sympy__physics__optics__waves__TWave():
 
 def test_sympy__physics__optics__gaussopt__BeamParameter():
     from sympy.physics.optics import BeamParameter
-    assert _test_args(BeamParameter(530e-9, 1, n=1, w=1e-3))
+    assert _test_args(BeamParameter(530e-9, 1, w=1e-3, n=1))
 
 
 def test_sympy__physics__optics__medium__Medium():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4912,7 +4912,7 @@ def test_sympy__physics__optics__waves__TWave():
 
 def test_sympy__physics__optics__gaussopt__BeamParameter():
     from sympy.physics.optics import BeamParameter
-    assert _test_args(BeamParameter(530e-9, 1, w=1e-3))
+    assert _test_args(BeamParameter(530e-9, 1, n=1, w=1e-3))
 
 
 def test_sympy__physics__optics__medium__Medium():

--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -507,9 +507,9 @@ class BeamParameter(Expr):
     >>> from sympy.physics.optics import FreeSpace
     >>> fs = FreeSpace(10)
     >>> p1 = fs*p
-    >>> p.w_z.n()
+    >>> p.w.n()
     0.00101413072159615
-    >>> p1.w_z.n()
+    >>> p1.w.n()
     0.00210803120913829
 
     See Also
@@ -588,7 +588,7 @@ class BeamParameter(Expr):
         return self.z*(1 + (self.z_r/self.z)**2)
 
     @property
-    def w_z(self):
+    def w(self):
         """
         The radius of the beam w(z), at any position z along the beam.
         The beam radius at `1/e^2` intensity (axial value).
@@ -604,7 +604,7 @@ class BeamParameter(Expr):
 
         >>> from sympy.physics.optics import BeamParameter
         >>> p = BeamParameter(530e-9, 1, w=1e-3)
-        >>> p.w_z
+        >>> p.w
         0.001*sqrt(0.2809/pi**2 + 1)
         """
         return self.w_0*sqrt(1 + (self.z/self.z_r)**2)
@@ -617,7 +617,7 @@ class BeamParameter(Expr):
         See Also
         ========
 
-        w_z : the beam radius at `1/e^2` intensity (axial value).
+        w : the beam radius at `1/e^2` intensity (axial value).
 
         Examples
         ========

--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -527,7 +527,7 @@ class BeamParameter(Expr):
     # subclass it. See:
     # https://groups.google.com/d/topic/sympy/7XkU07NRBEs/discussion
 
-    def __new__(cls, wavelen, z, n=1, z_r=None, w=None):
+    def __new__(cls, wavelen, z, z_r=None, w=None, n=1):
         wavelen = sympify(wavelen)
         z = sympify(z)
         n = sympify(n)
@@ -536,10 +536,10 @@ class BeamParameter(Expr):
             z_r = sympify(z_r)
         elif w is not None and z_r is None:
             z_r = waist2rayleigh(sympify(w), wavelen, n)
-        else:
-            raise ValueError('Constructor expects exactly one named argument.')
+        elif z_r is None and w is None:
+            raise ValueError('Must specify one of w and z_r.')
 
-        return Expr.__new__(cls, wavelen, z, n, z_r)
+        return Expr.__new__(cls, wavelen, z, z_r, n)
 
     @property
     def wavelen(self):
@@ -550,11 +550,11 @@ class BeamParameter(Expr):
         return self.args[1]
 
     @property
-    def n(self):
+    def z_r(self):
         return self.args[2]
 
     @property
-    def z_r(self):
+    def n(self):
         return self.args[3]
 
     @property

--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -530,6 +530,7 @@ class BeamParameter(Expr):
     def __new__(cls, wavelen, z, n=1, z_r=None, w=None):
         wavelen = sympify(wavelen)
         z = sympify(z)
+        n = sympify(n)
 
         if z_r is not None and w is None:
             z_r = sympify(z_r)

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -57,8 +57,8 @@ def test_gauss_opt():
     assert streq(N(p.z_r), Float(5.92753330865999))
     fs = FreeSpace(10)
     p1 = fs*p
-    assert streq(N(p.w), Float(0.00101413072159615))
-    assert streq(N(p1.w), Float(0.00210803120913829))
+    assert streq(N(p.w_z), Float(0.00101413072159615))
+    assert streq(N(p1.w_z), Float(0.00210803120913829))
 
     w, wavelen = symbols('w wavelen')
     assert waist2rayleigh(w, wavelen) == pi*w**2/wavelen
@@ -90,8 +90,13 @@ def test_gauss_opt():
     z, l, w = symbols('z l r', positive=True)
     p = BeamParameter(l, z, w=w)
     assert p.radius == z*(pi**2*w**4/(l**2*z**2) + 1)
-    assert p.w == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
+    assert p.w_z == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
     assert p.w_0 == w
     assert p.divergence == l/(pi*w)
     assert p.gouy == atan2(z, pi*w**2/l)
     assert p.waist_approximation_limit == 2*l/pi
+
+    p = BeamParameter(530e-9, 1, n=2, w=1e-3)
+    assert streq(p.q, 1 + 3.77358490566038*I*pi)
+    assert streq(N(p.z_r), Float(11.8550666173200))
+    assert streq(N(p.w_0), Float(0.00100000000000000))

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -96,7 +96,7 @@ def test_gauss_opt():
     assert p.gouy == atan2(z, pi*w**2/l)
     assert p.waist_approximation_limit == 2*l/pi
 
-    p = BeamParameter(530e-9, 1, n=2, w=1e-3)
+    p = BeamParameter(530e-9, 1, w=1e-3, n=2)
     assert streq(p.q, 1 + 3.77358490566038*I*pi)
     assert streq(N(p.z_r), Float(11.8550666173200))
     assert streq(N(p.w_0), Float(0.00100000000000000))

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -57,8 +57,8 @@ def test_gauss_opt():
     assert streq(N(p.z_r), Float(5.92753330865999))
     fs = FreeSpace(10)
     p1 = fs*p
-    assert streq(N(p.w_z), Float(0.00101413072159615))
-    assert streq(N(p1.w_z), Float(0.00210803120913829))
+    assert streq(N(p.w), Float(0.00101413072159615))
+    assert streq(N(p1.w), Float(0.00210803120913829))
 
     w, wavelen = symbols('w wavelen')
     assert waist2rayleigh(w, wavelen) == pi*w**2/wavelen
@@ -90,7 +90,8 @@ def test_gauss_opt():
     z, l, w = symbols('z l r', positive=True)
     p = BeamParameter(l, z, w=w)
     assert p.radius == z*(pi**2*w**4/(l**2*z**2) + 1)
-    assert p.w_z == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
+    k = p.w
+    assert k == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
     assert p.w_0 == w
     assert p.divergence == l/(pi*w)
     assert p.gouy == atan2(z, pi*w**2/l)

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -87,14 +87,13 @@ def test_gauss_opt():
         w_i**2/w_o**2 - sqrt(w_i**2/w_o**2 - pi**2*w_i**4/(f**2*l**2)))/w_i**2
     assert conjugate_gauss_beams(l, w_i, w_o, f=f)[2] == f
 
-    z, l, w = symbols('z l r', positive=True)
-    p = BeamParameter(l, z, w=w)
-    assert p.radius == z*(pi**2*w**4/(l**2*z**2) + 1)
-    k = p.w
-    assert k == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
-    assert p.w_0 == w
-    assert p.divergence == l/(pi*w)
-    assert p.gouy == atan2(z, pi*w**2/l)
+    z, l, w_0 = symbols('z l w_0', positive=True)
+    p = BeamParameter(l, z, w=w_0)
+    assert p.radius == z*(pi**2*w_0**4/(l**2*z**2) + 1)
+    assert p.w == w_0*sqrt(l**2*z**2/(pi**2*w_0**4) + 1)
+    assert p.w_0 == w_0
+    assert p.divergence == l/(pi*w_0)
+    assert p.gouy == atan2(z, pi*w_0**2/l)
     assert p.waist_approximation_limit == 2*l/pi
 
     p = BeamParameter(530e-9, 1, w=1e-3, n=2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19169 
Closes #19169 

#### Brief description of what is fixed or changed
According to earlier implementation ,when transmission to different medium would take place Rayleigh length `z_r` would change, while wavelength stays the same. Hence beam waist, `w_0` changed which is not physical.
Now as can be verified from the test cases when refractive index is doubled Rayleigh length proportionately gets doubled but beam waist remains the same.
Also code /docstring has been refactored and made more understandable for users/contributors.

1. waist is replaced by beam waist which is the fundamental parameter used .

All the information I have added/changed is validated by these online resources -
https://en.wikipedia.org/wiki/Gaussian_beam
https://phyweb.physics.nus.edu.sg/~l2000/pc2193/Experiments/lab.pdf

#### Other comments
Note : User must be aware of when the medium is changed . Users reading code must recognize what `w` is referring to at different parts of the code .
A test has been modified for better understanding of users.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.optics
  * Added refractive index to beam parameters.
<!-- END RELEASE NOTES -->
