### PR TITLE
Deprecate useless methods in physics.units

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -473,12 +473,12 @@ Harry Zheng <harry@harryzheng.com>
 Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>
+Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <97667942+harshrishimiglani@users.noreply.github.com>
+Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <miglaniharshrishi@gmail.com>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
-Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <miglaniharshrishi@gmail.com>
-Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <97667942+harshrishimiglani@users.noreply.github.com>
 Haruki Moriguchi <harukimoriguchi@gmail.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -473,6 +473,7 @@ Harry Zheng <harry@harryzheng.com>
 Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>
+harshrishimiglani <miglaniharshrishi@gmail.com>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -477,7 +477,8 @@ Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
-harshrishimiglani <miglaniharshrishi@gmail.com>
+Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <miglaniharshrishi@gmail.com>
+Harsh Rishi Miglani <miglaniharshrishi@gmail.com> harshrishimiglani <97667942+harshrishimiglani@users.noreply.github.com>
 Haruki Moriguchi <harukimoriguchi@gmail.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -473,11 +473,11 @@ Harry Zheng <harry@harryzheng.com>
 Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>
-harshrishimiglani <miglaniharshrishi@gmail.com>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
+harshrishimiglani <miglaniharshrishi@gmail.com>
 Haruki Moriguchi <harukimoriguchi@gmail.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -583,7 +583,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="list_can_dims",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
         dimset = set()
         for i in self.base_dims:
@@ -596,13 +596,13 @@ class DimensionSystem(Basic, _QuantityMapper):
         Useless method, kept for compatibility with previous versions.
 
         DO NOT USE.
-        
+
         Compute the inverse transformation matrix from the base to the
         canonical dimension basis.
 
         It corresponds to the matrix where columns are the vector of base
         dimensions in canonical basis.
-        
+
         This matrix will almost never be used because dimensions are always
         defined with respect to the canonical basis, so no work has to be done
         to get them in this basis. Nonetheless if this matrix is not square
@@ -613,9 +613,9 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="inv_can_transf_matrix",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
-        
+
         matrix = reduce(lambda x, y: x.row_join(y),
                         [self.dim_can_vector(d) for d in self.base_dims])
         return matrix
@@ -637,7 +637,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="can_transf_matrix",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
 
         #TODO: the inversion will fail if the system is inconsistent, for
@@ -681,7 +681,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="dim_vector",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
 
         return self.can_transf_matrix * Matrix(self.dim_can_vector(dim))
@@ -713,7 +713,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="dim",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
 
         return len(self.base_dims)
@@ -732,7 +732,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="is_consistent",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
 
         # not enough or too many base dimensions compared to independent

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -659,7 +659,7 @@ class DimensionSystem(Basic, _QuantityMapper):
             deprecated_since_version="1.10",
             issue=22953,
             feature="dim_can_vector",
-            useinstead="",
+            useinstead="Will be removed",
         ).warn()
 
         vec = []

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -602,7 +602,7 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         It corresponds to the matrix where columns are the vector of base
         dimensions in canonical basis.
-ca 
+        
         This matrix will almost never be used because dimensions are always
         defined with respect to the canonical basis, so no work has to be done
         to get them in this basis. Nonetheless if this matrix is not square

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -579,6 +579,12 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         List all canonical dimension names.
         """
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="list_can_dims",
+            useinstead="",
+        ).warn()
         dimset = set()
         for i in self.base_dims:
             dimset.update(set(self.get_dimensional_dependencies(i).keys()))
@@ -590,18 +596,26 @@ class DimensionSystem(Basic, _QuantityMapper):
         Useless method, kept for compatibility with previous versions.
 
         DO NOT USE.
-
+        
         Compute the inverse transformation matrix from the base to the
         canonical dimension basis.
 
         It corresponds to the matrix where columns are the vector of base
         dimensions in canonical basis.
-
+ca 
         This matrix will almost never be used because dimensions are always
         defined with respect to the canonical basis, so no work has to be done
         to get them in this basis. Nonetheless if this matrix is not square
         (or not invertible) it means that we have chosen a bad basis.
         """
+
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="inv_can_transf_matrix",
+            useinstead="",
+        ).warn()
+        
         matrix = reduce(lambda x, y: x.row_join(y),
                         [self.dim_can_vector(d) for d in self.base_dims])
         return matrix
@@ -619,6 +633,13 @@ class DimensionSystem(Basic, _QuantityMapper):
         It is the inverse of the matrix computed with inv_can_transf_matrix().
         """
 
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="can_transf_matrix",
+            useinstead="",
+        ).warn()
+
         #TODO: the inversion will fail if the system is inconsistent, for
         #      example if the matrix is not a square
         return reduce(lambda x, y: x.row_join(y),
@@ -634,6 +655,13 @@ class DimensionSystem(Basic, _QuantityMapper):
         Dimensional representation in terms of the canonical base dimensions.
         """
 
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="dim_can_vector",
+            useinstead="",
+        ).warn()
+
         vec = []
         for d in self.list_can_dims:
             vec.append(self.get_dimensional_dependencies(dim).get(d, 0))
@@ -648,6 +676,14 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         Vector representation in terms of the base dimensions.
         """
+
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="dim_vector",
+            useinstead="",
+        ).warn()
+
         return self.can_transf_matrix * Matrix(self.dim_can_vector(dim))
 
     def print_dim_base(self, dim):
@@ -672,6 +708,14 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         That is return the number of dimensions forming the basis.
         """
+
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="dim",
+            useinstead="",
+        ).warn()
+
         return len(self.base_dims)
 
     @property
@@ -683,6 +727,13 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         Check if the system is well defined.
         """
+
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="is_consistent",
+            useinstead="",
+        ).warn()
 
         # not enough or too many base dimensions compared to independent
         # dimensions

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -688,8 +688,20 @@ class DimensionSystem(Basic, _QuantityMapper):
 
     def print_dim_base(self, dim):
         """
+        Useless method, kept for compatibility with previous versions.
+
+        DO NOT USE.
+
         Give the string expression of a dimension in term of the basis symbols.
         """
+
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.10",
+            issue=22953,
+            feature="print_dim_base",
+            useinstead="Will be removed",
+        ).warn()
+
         dims = self.dim_vector(dim)
         symbols = [i.symbol if i.symbol is not None else i.name for i in self.base_dims]
         res = S.One

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -32,8 +32,8 @@ def test_sort_dims():
 
 def test_list_dims():
     dimsys = DimensionSystem((length, time, mass))
-
-    assert dimsys.list_can_dims == ("length", "mass", "time")
+    with warns_deprecated_sympy():
+        assert dimsys.list_can_dims == ("length", "mass", "time")
 
 
 def test_dim_can_vector():
@@ -45,8 +45,10 @@ def test_dim_can_vector():
         }
     )
 
-    assert dimsys.dim_can_vector(length) == Matrix([1, 0, 0])
-    assert dimsys.dim_can_vector(velocity) == Matrix([1, 0, -1])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_can_vector(length) == Matrix([1, 0, 0])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_can_vector(velocity) == Matrix([1, 0, -1])
 
     dimsys = DimensionSystem(
         (length, velocity, action),
@@ -56,9 +58,12 @@ def test_dim_can_vector():
         }
     )
 
-    assert dimsys.dim_can_vector(length) == Matrix([0, 1, 0])
-    assert dimsys.dim_can_vector(velocity) == Matrix([0, 0, 1])
-    assert dimsys.dim_can_vector(time) == Matrix([0, 1, -1])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_can_vector(length) == Matrix([0, 1, 0])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_can_vector(velocity) == Matrix([0, 0, 1])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_can_vector(time) == Matrix([0, 1, -1])
 
     dimsys = DimensionSystem(
         (length, mass, time),
@@ -66,28 +71,35 @@ def test_dim_can_vector():
         {velocity: {length: 1, time: -1},
          action: {mass: 1, length: 2, time: -1}})
 
-    assert dimsys.dim_vector(length) == Matrix([1, 0, 0])
-    assert dimsys.dim_vector(velocity) == Matrix([1, 0, -1])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_vector(length) == Matrix([1, 0, 0])
+    with warns_deprecated_sympy():
+        assert dimsys.dim_vector(velocity) == Matrix([1, 0, -1])
 
 
 def test_inv_can_transf_matrix():
     dimsys = DimensionSystem((length, mass, time))
-    assert dimsys.inv_can_transf_matrix == eye(3)
+    with warns_deprecated_sympy():
+        assert dimsys.inv_can_transf_matrix == eye(3)
 
 
 def test_can_transf_matrix():
     dimsys = DimensionSystem((length, mass, time))
-    assert dimsys.can_transf_matrix == eye(3)
+    with warns_deprecated_sympy():
+        assert dimsys.can_transf_matrix == eye(3)
 
     dimsys = DimensionSystem((length, velocity, action))
-    assert dimsys.can_transf_matrix == eye(3)
+    with warns_deprecated_sympy():
+        assert dimsys.can_transf_matrix == eye(3)
 
     dimsys = DimensionSystem((length, time), (velocity,), {velocity: {length: 1, time: -1}})
-    assert dimsys.can_transf_matrix == eye(2)
+    with warns_deprecated_sympy():
+        assert dimsys.can_transf_matrix == eye(2)
 
 
 def test_is_consistent():
-    assert DimensionSystem((length, time)).is_consistent is True
+    with warns_deprecated_sympy():
+        assert DimensionSystem((length, time)).is_consistent is True
 
 
 def test_print_dim_base():
@@ -106,4 +118,5 @@ def test_dim():
         {velocity: {length: 1, time: -1},
          action: {mass: 1, length: 2, time: -1}}
     )
-    assert dimsys.dim == 3
+    with warns_deprecated_sympy():
+        assert dimsys.dim == 3

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -108,7 +108,8 @@ def test_print_dim_base():
         (action,),
         {action: {mass: 1, length: 2, time: -1}})
     L, M, T = symbols("L M T")
-    assert mksa.print_dim_base(action) == L**2*M/T
+    with warns_deprecated_sympy():
+        assert mksa.print_dim_base(action) == L**2*M/T
 
 
 def test_dim():

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -63,4 +63,5 @@ def test_dim():
 def test_is_consistent():
     dimension_system = DimensionSystem([length, time])
     us = UnitSystem([m, s], dimension_system=dimension_system)
-    assert us.is_consistent == True
+    with warns_deprecated_sympy():
+        assert us.is_consistent == True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #22953 

#### Brief description of what is fixed or changed

In this PR following useless functions are deprecated in `physics.units` module.

1. `list_can_dims`
2. `inv_can_transf_matrix`
3. `can_transf_matrix`
4. `dim_can_vector`
5. `dim_vector`
6. `dim`
7. `is_consistent`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
    * Deprecate useless methods in `Dimension`
<!-- END RELEASE NOTES -->
