### PR TITLE
Reshape: conversion from array to indexed

### DIFF
--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_indexed.py
@@ -1,6 +1,6 @@
 from sympy import Sum, Dummy, sin
 from sympy.tensor.array.expressions import ArraySymbol, ArrayTensorProduct, ArrayContraction, PermuteDims, \
-    ArrayDiagonal, ArrayAdd, OneArray, ZeroArray, convert_indexed_to_array, ArrayElementwiseApplyFunc
+    ArrayDiagonal, ArrayAdd, OneArray, ZeroArray, convert_indexed_to_array, ArrayElementwiseApplyFunc, Reshape
 from sympy.tensor.array.expressions.conv_array_to_indexed import convert_array_to_indexed
 
 from sympy.abc import i, j, k, l, m, n, o
@@ -26,7 +26,6 @@ def test_convert_array_to_indexed_main():
     expr = ArrayDiagonal(A, (0, 2))
     assert convert_array_to_indexed(expr, [i, j]) == A[j, i, j]
 
-    A = ArraySymbol("A", (1, 2, 3))
     expr = PermuteDims(A, [1, 2, 0])
     conv = convert_array_to_indexed(expr, [i, j, k])
     assert conv == A[k, i, j]
@@ -44,3 +43,15 @@ def test_convert_array_to_indexed_main():
 
     assert convert_array_to_indexed(OneArray(3, 3), [i, j]) == 1
     assert convert_array_to_indexed(ZeroArray(3, 3), [i, j]) == 0
+
+    expr = Reshape(A, (27,))
+    assert convert_array_to_indexed(expr, [i]) == A[i // 9, i // 3 % 3, i % 3]
+
+    X = ArraySymbol("X", (2, 3, 4, 5, 6))
+    expr = Reshape(X, (2*3*4*5*6,))
+    assert convert_array_to_indexed(expr, [i]) == X[i // 360, i // 120 % 3, i // 30 % 4, i // 6 % 5, i % 6]
+
+    expr = Reshape(X, (4, 9, 2, 2, 5))
+    one_index = 180*i + 20*j + 10*k + 5*l + m
+    expected = X[one_index // (3*4*5*6), one_index // (4*5*6) % 3, one_index // (5*6) % 4, one_index // 6 % 5, one_index % 6]
+    assert convert_array_to_indexed(expr, [i, j, k, l, m]) == expected


### PR DESCRIPTION
Add conversion from array to indexed form for the object `Reshape` in the array expressions module.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
