### PR TITLE
Mark two `PrimeIdeal` methods non-public.

### DIFF
--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -70,7 +70,7 @@ class PrimeIdeal(IntegerPowerable):
         self._test_factor = None
         self.e = e if e is not None else self.valuation(p * ZK)
 
-    def pretty(self, field_gen=None, just_gens=False):
+    def _pretty(self, field_gen=None, just_gens=False):
         """
         Print a representation of this prime ideal.
 
@@ -82,11 +82,11 @@ class PrimeIdeal(IntegerPowerable):
         >>> T = cyclotomic_poly(7, x)
         >>> K = QQ.algebraic_field((T, zeta))
         >>> P = K.primes_above(11)
-        >>> print(P[0].pretty())
+        >>> print(P[0]._pretty())
         [ (11, x**3 + 5*x**2 + 4*x - 1) e=1, f=3 ]
-        >>> print(P[0].pretty(field_gen=zeta))
+        >>> print(P[0]._pretty(field_gen=zeta))
         [ (11, zeta**3 + 5*zeta**2 + 4*zeta - 1) e=1, f=3 ]
-        >>> print(P[0].pretty(field_gen=zeta, just_gens=True))
+        >>> print(P[0]._pretty(field_gen=zeta, just_gens=True))
         (11, zeta**3 + 5*zeta**2 + 4*zeta - 1)
 
         Parameters
@@ -114,7 +114,7 @@ class PrimeIdeal(IntegerPowerable):
         return f'[ {gens} e={e}, f={f} ]'
 
     def __repr__(self):
-        return self.pretty()
+        return self._pretty()
 
     def as_submodule(self):
         r"""
@@ -256,7 +256,7 @@ class PrimeIdeal(IntegerPowerable):
         """
         return prime_valuation(I, self)
 
-    def reduce_poly(self, f, gen=None):
+    def _reduce_poly(self, f, gen=None):
         r"""
         Reduce a univariate :py:class:`~.Poly` *f*, or an :py:class:`~.Expr`
         expressing the same, modulo this :py:class:`~.PrimeIdeal`.
@@ -280,7 +280,7 @@ class PrimeIdeal(IntegerPowerable):
         >>> P = k.primes_above(11)
         >>> frp = P[0]
         >>> B = k.integral_basis(fmt='sympy')
-        >>> print([frp.reduce_poly(b, zeta) for b in B])
+        >>> print([frp._reduce_poly(b, zeta) for b in B])
         [1, zeta, zeta**2, -5*zeta**2 - 4*zeta + 1, -zeta**2 - zeta - 5,
          4*zeta**2 - zeta - 1]
 
@@ -321,7 +321,7 @@ class PrimeIdeal(IntegerPowerable):
                 if gen is None:
                     raise e from None
                 g = Poly(f, gen)
-            return self.reduce_poly(g).as_expr()
+            return self._reduce_poly(g).as_expr()
         if isinstance(f, Poly) and f.is_univariate:
             a = self.alpha.poly(f.gen)
             if a != 0:

--- a/sympy/polys/numberfields/tests/test_primes.py
+++ b/sympy/polys/numberfields/tests/test_primes.py
@@ -246,8 +246,8 @@ def test_pretty_printing():
     p = 2
     P = prime_decomp(p, T, dK=dK, ZK=ZK, radical=rad.get(p))
     assert repr(P[0]) == '[ (2, (3*x + 1)/2) e=1, f=1 ]'
-    assert P[0].pretty(field_gen=theta) == '[ (2, (3*theta + 1)/2) e=1, f=1 ]'
-    assert P[0].pretty(field_gen=theta, just_gens=True) == '(2, (3*theta + 1)/2)'
+    assert P[0]._pretty(field_gen=theta) == '[ (2, (3*theta + 1)/2) e=1, f=1 ]'
+    assert P[0]._pretty(field_gen=theta, just_gens=True) == '(2, (3*theta + 1)/2)'
 
 
 def test_PrimeIdeal_reduce_poly():
@@ -256,14 +256,14 @@ def test_PrimeIdeal_reduce_poly():
     P = k.primes_above(11)
     frp = P[0]
     B = k.integral_basis(fmt='sympy')
-    assert [frp.reduce_poly(b, x) for b in B] == [
+    assert [frp._reduce_poly(b, x) for b in B] == [
         1, x, x ** 2, -5 * x ** 2 - 4 * x + 1, -x ** 2 - x - 5,
         4 * x ** 2 - x - 1]
 
     Q = k.primes_above(19)
     frq = Q[0]
     assert frq.alpha.equiv(0)
-    assert frq.reduce_poly(20*x**2 + 10) == x**2 - 9
+    assert frq._reduce_poly(20 * x ** 2 + 10) == x ** 2 - 9
 
-    raises(GeneratorsNeeded, lambda: frp.reduce_poly(S(1)))
-    raises(NotImplementedError, lambda: frp.reduce_poly(1))
+    raises(GeneratorsNeeded, lambda: frp._reduce_poly(S(1)))
+    raises(NotImplementedError, lambda: frp._reduce_poly(1))


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Temporary way of addressing #22974 


#### Brief description of what is fixed or changed

Makes two `PrimeIdeal` methods non-public.


#### Other comments

A proper solution to #22974 may take a little time. It would be hard to squeeze that in before the release of v1.10. For now, I think it's best to keep these methods out of the public API, so that we don't have to commit to backwards compatibility on them.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
