### PR TITLE
Convert Reshape to indexed: multiindex issue

### DIFF
--- a/sympy/tensor/array/expressions/conv_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/conv_array_to_indexed.py
@@ -70,7 +70,10 @@ class _ConvertArrayToIndexed:
             c = 1
             for i, e in enumerate(reversed(shape_down)):
                 if c == 1:
-                    dest_indices[i] = one_index % e
+                    if i == len(shape_down) - 1:
+                        dest_indices[i] = one_index
+                    else:
+                        dest_indices[i] = one_index % e
                 elif i == len(shape_down) - 1:
                     dest_indices[i] = one_index // c
                 else:

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_indexed.py
@@ -55,3 +55,7 @@ def test_convert_array_to_indexed_main():
     one_index = 180*i + 20*j + 10*k + 5*l + m
     expected = X[one_index // (3*4*5*6), one_index // (4*5*6) % 3, one_index // (5*6) % 4, one_index // 6 % 5, one_index % 6]
     assert convert_array_to_indexed(expr, [i, j, k, l, m]) == expected
+
+    X = ArraySymbol("X", (2*3*5,))
+    expr = Reshape(X, (2, 3, 5))
+    assert convert_array_to_indexed(expr, [i, j, k]) == X[15*i + 5*j + k]


### PR DESCRIPTION
Better conversion from array expressions to indexed: avoid unnecessary `Mod` operator for some `Reshape` nodes.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
