### PR TITLE
stats - added Beta negative binomial distribution in drv_types.

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1662,6 +1662,10 @@ def test_sympy__stats__drv_types__ZetaDistribution():
     assert _test_args(ZetaDistribution(1.5))
 
 
+def test_sympy__stats__drv_types__BetaNegativeBinomialDistribution():
+    from sympy.stats.drv_types import BetaNegativeBinomialDistribution
+    assert _test_args(BetaNegativeBinomialDistribution(4, 4, 4))
+
 def test_sympy__stats__joint_rv__JointDistribution():
     from sympy.stats.joint_rv import JointDistribution
     assert _test_args(JointDistribution(1, 2, 3, 4))

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -122,7 +122,7 @@ __all__ = [
     'Trapezoidal', 'Triangular', 'Uniform', 'UniformSum', 'VonMises', 'Wald',
     'Weibull', 'WignerSemicircle', 'ContinuousDistributionHandmade',
 
-    'FlorySchulz', 'Geometric','Hermite', 'Logarithmic', 'NegativeBinomial', 'Poisson', 'Skellam',
+    'BetaNegativeBinomial', 'FlorySchulz', 'Geometric','Hermite', 'Logarithmic', 'NegativeBinomial', 'Poisson', 'Skellam',
     'YuleSimon', 'Zeta', 'DiscreteRV', 'DiscreteDistributionHandmade',
 
     'JointRV', 'Dirichlet', 'GeneralizedMultivariateLogGamma',
@@ -172,7 +172,7 @@ from .crv_types import (ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral,
         Uniform, UniformSum, VonMises, Wald, Weibull, WignerSemicircle,
         ContinuousDistributionHandmade)
 
-from .drv_types import (FlorySchulz, Geometric, Hermite, Logarithmic, NegativeBinomial, Poisson,
+from .drv_types import (BetaNegativeBinomial, FlorySchulz, Geometric, Hermite, Logarithmic, NegativeBinomial, Poisson,
         Skellam, YuleSimon, Zeta, DiscreteRV, DiscreteDistributionHandmade)
 
 from .joint_rv_types import (JointRV, Dirichlet,

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -20,7 +20,7 @@ from sympy.sets.fancysets import Range
 from sympy.stats import (P, E, variance, density, characteristic_function,
                          where, moment_generating_function, skewness, cdf,
                          kurtosis, coskewness)
-from sympy.stats.drv_types import (PoissonDistribution, GeometricDistribution,
+from sympy.stats.drv_types import (PoissonDistribution, GeometricDistribution, BetaNegativeBinomial,
                                    FlorySchulz, Poisson, Geometric, Hermite, Logarithmic,
                                     NegativeBinomial, Skellam, YuleSimon, Zeta,
                                     DiscreteRV)
@@ -50,6 +50,16 @@ def test_Poisson():
         assert isinstance(E(2*x, evaluate=False), Expectation)
     # issue 8248
     assert x.pspace.compute_expectation(1) == 1
+
+
+def test_BetaNegativeBinomial():
+    alpha = S(4)
+    beta = S(4)
+    r = S(4)
+    x = BetaNegativeBinomial('x', alpha, beta, r)
+    assert E(x) == (r*beta) / (alpha - 1)
+    assert variance(x) == (r*(alpha + r - 1)*beta*(alpha + beta - 1)) / ((alpha - 2)*(alpha - 1)**2)
+
 
 def test_FlorySchulz():
     a = Symbol("a")
@@ -231,6 +241,7 @@ def test_precomputed_characteristic_functions():
     test_cf(Poisson('p', 5), 0, mpmath.inf)
     test_cf(YuleSimon('y', 5), 1, mpmath.inf)
     test_cf(Zeta('z', 5), 1, mpmath.inf)
+    test_cf(BetaNegativeBinomial('b', 5, 5, 5), 0, mpmath.inf)
 
 
 def test_moment_generating_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In probability theory, a [beta negative binomial distribution](https://en.wikipedia.org/wiki/Beta_negative_binomial_distribution) is the probability distribution of a discrete random variable X equal to the number of failures needed to get r successes in a sequence of independent Bernoulli trials where the probability p of success on each trial, while constant within any given experiment, is itself a random variable following a beta distribution, varying between different experiments.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
   * added beta negative binomial distribution in drv_types.py.
<!-- END RELEASE NOTES -->
