### PR TITLE
MatchPy connector: add support for pickle

### DIFF
--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -117,8 +117,8 @@ else:
 
 @doctest_depends_on(modules=('matchpy',))
 class _WildAbstract(Wildcard, Symbol):
-    min_length: int # abstract field required in subclasses
-    fixed_size: bool # abstract field required in subclasses
+    min_length: int  # abstract field required in subclasses
+    fixed_size: bool  # abstract field required in subclasses
 
     def __init__(self, variable_name=None, optional=None, **assumptions):
         min_length = self.min_length
@@ -127,12 +127,21 @@ class _WildAbstract(Wildcard, Symbol):
             optional = _sympify(optional)
         Wildcard.__init__(self, min_length, fixed_size, str(variable_name), optional)
 
+    def __getstate__(self):
+        return {
+            "min_length": self.min_length,
+            "fixed_size": self.fixed_size,
+            "min_count": self.min_count,
+            "variable_name": self.variable_name,
+            "optional": self.optional,
+        }
+
     def __new__(cls, variable_name=None, optional=None, **assumptions):
         cls._sanitize(assumptions, cls)
         return _WildAbstract.__xnew__(cls, variable_name, optional, **assumptions)
 
     def __getnewargs__(self):
-        return self.min_count, self.fixed_size, self.variable_name, self.optional
+        return self.variable_name, self.optional
 
     @staticmethod
     def __xnew__(cls, variable_name=None, optional=None, **assumptions):

--- a/sympy/utilities/tests/test_matchpy_connector.py
+++ b/sympy/utilities/tests/test_matchpy_connector.py
@@ -1,3 +1,5 @@
+import pickle
+
 from sympy.core.relational import (Eq, Ne)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
@@ -128,3 +130,24 @@ def test_replacer():
     assert replacer.replace(Eq(x**2 + 1, 0)) == Eq(x**2 + 1, 0)
     assert replacer.replace(Eq(x**2, 4)) == (Eq(x, 2) | Eq(x, -2))
     assert replacer.replace(Eq(x**2 + 4*y*x + 4*y**2, 0)) == Eq(x, -2*y)
+
+
+def test_matchpy_object_pickle():
+    if matchpy is None:
+        return
+
+    a1 = WildDot("a")
+    a2 = pickle.loads(pickle.dumps(a1))
+    assert a1 == a2
+
+    a1 = WildDot("a", S(1))
+    a2 = pickle.loads(pickle.dumps(a1))
+    assert a1 == a2
+
+    a1 = WildPlus("a", S(1))
+    a2 = pickle.loads(pickle.dumps(a1))
+    assert a1 == a2
+
+    a1 = WildStar("a", S(1))
+    a2 = pickle.loads(pickle.dumps(a1))
+    assert a1 == a2


### PR DESCRIPTION
Just realized that the objects in `sympy.utilities.matchpy_connector` cannot be pickled. This is a problem when using RUBI.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
