### PR TITLE
typo, pep8 and note about point order in Line wrt calculated angles

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1110,6 +1110,9 @@ class Line(LinearEntity):
     for `Line2D` and the `direction_ratio` argument is only relevant
     for `Line3D`.
 
+    The order of the points will define the direction of the line
+    which is used when calculating the angle between lines.
+
     See Also
     ========
 

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -64,8 +64,13 @@ def test_angle_between():
     assert feq(Line.angle_between(Line(Point(0, 0), Point(1, 1)),
                                   Line(Point(0, 0), Point(5, 0))).evalf(), pi.evalf() / 4)
     assert Line(a, o).angle_between(Line(b, o)) == pi / 2
-    assert Line3D.angle_between(Line3D(Point3D(0, 0, 0), Point3D(1, 1, 1)),
-                                Line3D(Point3D(0, 0, 0), Point3D(5, 0, 0))) == acos(sqrt(3) / 3)
+    z = Point3D(0, 0, 0)
+    assert Line3D.angle_between(Line3D(z, Point3D(1, 1, 1)),
+                                Line3D(z, Point3D(5, 0, 0))) == acos(sqrt(3) / 3)
+    # direction of points is used to determine angle
+    assert Line3D.angle_between(Line3D(z, Point3D(1, 1, 1)),
+                                Line3D(Point3D(5, 0, 0), z)) == acos(-sqrt(3) / 3)
+
 
 
 def test_closing_angle():

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -114,13 +114,14 @@ def is_square(n, prep=True):
     #   b) even with
     #     odd multiplicity of 2 --> not square, e.g. 39040
     #     even multiplicity of 2, e.g. 4, 16, 36, ..., 16324
-    #         removal of factors of 2 to give and odd, and rejection if
+    #         removal of factors of 2 to give an odd, and rejection if
     #         any(i%2 for i in divmod(odd - 1, 4))
     #         will give an odd number in form 4*even + 1.
     # Use of `trailing` to check the power of 2 is not done since it
     # does not apply to a large percentage of arbitrary numbers
     # and the integer_nthroot is able to quickly resolve these cases.
     return integer_nthroot(n, 2)[1]
+
 
 def _test(n, base, s, t):
     """Miller-Rabin strong pseudoprime test for one base.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
