### PR TITLE
Enable automatic rewrite for cot, sec, csc, and related inverse and hyperbolic functions

### DIFF
--- a/doc/src/tutorial/simplification.rst
+++ b/doc/src/tutorial/simplification.rst
@@ -623,11 +623,12 @@ another.  This works for any function in SymPy, not just special functions.
 To rewrite an expression in terms of a function, use
 ``expr.rewrite(function)``.  For example,
 
-    >>> tan(x).rewrite(sin)
-         2
-    2⋅sin (x)
-    ─────────
-     sin(2⋅x)
+    >>> tan(x).rewrite(cos)
+       ⎛    π⎞
+    cos⎜x - ─⎟
+       ⎝    2⎠
+    ──────────
+      cos(x)
     >>> factorial(x).rewrite(gamma)
     Γ(x + 1)
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1,19 +1,17 @@
-from sympy.core.logic import FuzzyBool
-
 from sympy.core import S, sympify, cacheit, pi, I, Rational
 from sympy.core.add import Add
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.logic import fuzzy_or, fuzzy_and
+from sympy.core.logic import fuzzy_or, fuzzy_and, FuzzyBool
 from sympy.functions.combinatorial.factorials import (binomial, factorial,
                                                       RisingFactorial)
 from sympy.functions.combinatorial.numbers import bernoulli, euler, nC
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log, match_real_imag
-from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.trigonometric import (acot, asin, atan, cos,
-                                              cot, sin, tan,
-                                              _imaginary_unit_as_coefficient)
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.trigonometric import (
+    acos, acot, asin, atan, cos, cot, csc, sec, sin, tan,
+    _imaginary_unit_as_coefficient)
 from sympy.polys.specialpolys import symmetric_poly
 
 
@@ -221,6 +219,12 @@ class sinh(HyperbolicFunction):
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         return (exp(arg) - exp(-arg)) / 2
 
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
+        return -I * sin(I * arg)
+
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
+        return -I / csc(I * arg)
+
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return -S.ImaginaryUnit*cosh(arg + S.Pi*S.ImaginaryUnit/2)
 
@@ -231,6 +235,9 @@ class sinh(HyperbolicFunction):
     def _eval_rewrite_as_coth(self, arg, **kwargs):
         coth_half = coth(S.Half*arg)
         return 2*coth_half/(coth_half**2 - 1)
+
+    def _eval_rewrite_as_csch(self, arg, **kwargs):
+        return 1 / csch(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
@@ -409,6 +416,12 @@ class cosh(HyperbolicFunction):
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         return (exp(arg) + exp(-arg)) / 2
 
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
+        return cos(I * arg)
+
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
+        return 1 / sec(I * arg)
+
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return -S.ImaginaryUnit*sinh(arg + S.Pi*S.ImaginaryUnit/2)
 
@@ -419,6 +432,9 @@ class cosh(HyperbolicFunction):
     def _eval_rewrite_as_coth(self, arg, **kwargs):
         coth_half = coth(S.Half*arg)**2
         return (coth_half + 1)/(coth_half - 1)
+
+    def _eval_rewrite_as_sech(self, arg, **kwargs):
+        return 1 / sech(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)
@@ -657,6 +673,12 @@ class tanh(HyperbolicFunction):
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)
         return (pos_exp - neg_exp)/(pos_exp + neg_exp)
+
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
+        return -I * tan(I * arg)
+
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
+        return -I / cot(I * arg)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return S.ImaginaryUnit*sinh(arg)/sinh(S.Pi*S.ImaginaryUnit/2 - arg)
@@ -1017,8 +1039,17 @@ class csch(ReciprocalHyperbolicFunction):
 
             return 2 * (1 - 2**n) * B/F * x**n
 
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
+        return I / sin(I * arg)
+
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
+        return I * csc(I * arg)
+
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return S.ImaginaryUnit / cosh(arg + S.ImaginaryUnit * S.Pi / 2)
+
+    def _eval_rewrite_as_sinh(self, arg, **kwargs):
+        return 1 / sinh(arg)
 
     def _eval_is_positive(self):
         if self.args[0].is_extended_real:
@@ -1067,8 +1098,17 @@ class sech(ReciprocalHyperbolicFunction):
             x = sympify(x)
             return euler(n) / factorial(n) * x**(n)
 
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
+        return 1 / cos(I * arg)
+
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
+        return sec(I * arg)
+
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return S.ImaginaryUnit / sinh(arg + S.ImaginaryUnit * S.Pi /2)
+
+    def _eval_rewrite_as_cosh(self, arg, **kwargs):
+        return 1 / cosh(arg)
 
     def _eval_is_positive(self):
         if self.args[0].is_extended_real:
@@ -1186,6 +1226,19 @@ class asinh(InverseHyperbolicFunction):
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x**2 + 1))
+
+    def _eval_rewrite_as_atanh(self, x, **kwargs):
+        return atanh(x/sqrt(1 + x**2))
+
+    def _eval_rewrite_as_acosh(self, x, **kwargs):
+        ix = I*x
+        return I*(sqrt(1 - ix)/sqrt(ix - 1) * acosh(ix) - pi/2)
+
+    def _eval_rewrite_as_asin(self, x, **kwargs):
+        return -I * asin(I * x)
+
+    def _eval_rewrite_as_acos(self, x, **kwargs):
+        return I * acos(I * x) - I*pi/2
 
     def inverse(self, argindex=1):
         """
@@ -1337,6 +1390,22 @@ class acosh(InverseHyperbolicFunction):
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x + 1) * sqrt(x - 1))
 
+    def _eval_rewrite_as_acos(self, x, **kwargs):
+        return sqrt(x - 1)/sqrt(1 - x) * acos(x)
+
+    def _eval_rewrite_as_asin(self, x, **kwargs):
+        return sqrt(x - 1)/sqrt(1 - x) * (pi/2 - asin(x))
+
+    def _eval_rewrite_as_asinh(self, x, **kwargs):
+        return sqrt(x - 1)/sqrt(1 - x) * (pi/2 + I*asinh(I*x))
+
+    def _eval_rewrite_as_atanh(self, x, **kwargs):
+        sxm1 = sqrt(x - 1)
+        s1mx = sqrt(1 - x)
+        sx2m1 = sqrt(x**2 - 1)
+        return (pi/2*sxm1/s1mx*(1 - x * sqrt(1/x**2)) +
+                sxm1*sqrt(x + 1)/sx2m1 * atanh(sx2m1/x))
+
     def inverse(self, argindex=1):
         """
         Returns the inverse of this function.
@@ -1442,6 +1511,11 @@ class atanh(InverseHyperbolicFunction):
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + x) - log(1 - x)) / 2
 
+    def _eval_rewrite_as_asinh(self, x, **kwargs):
+        f = sqrt(1/(x**2 - 1))
+        return (pi*x/(2*sqrt(-x**2)) -
+                sqrt(-x)*sqrt(1 - x**2)/sqrt(x)*f*asinh(f))
+
     def _eval_is_zero(self):
         if self.args[0].is_zero:
             return True
@@ -1537,6 +1611,13 @@ class acoth(InverseHyperbolicFunction):
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + 1/x) - log(1 - 1/x)) / 2
 
+    def _eval_rewrite_as_atanh(self, x, **kwargs):
+        return atanh(1/x)
+
+    def _eval_rewrite_as_asinh(self, x, **kwargs):
+        return (pi*I/2*(sqrt((x - 1)/x)*sqrt(x/(x - 1)) - sqrt(1 + 1/x)*sqrt(x/(x + 1))) +
+                x*sqrt(1/x**2)*asinh(sqrt(1/(x**2 - 1))))
+
     def inverse(self, argindex=1):
         """
         Returns the inverse of this function.
@@ -1617,6 +1698,8 @@ class asech(InverseHyperbolicFunction):
                 (-1 - sqrt(5)): 3*S.Pi / 5,
                 (sqrt(6) + sqrt(2)): 5*S.Pi / 12,
                 (-sqrt(6) - sqrt(2)): 7*S.Pi / 12,
+                S.ImaginaryUnit*S.Infinity: -S.Pi*S.ImaginaryUnit / 2,
+                S.ImaginaryUnit*S.NegativeInfinity: S.Pi*S.ImaginaryUnit / 2,
             }
 
     @classmethod
@@ -1676,6 +1759,20 @@ class asech(InverseHyperbolicFunction):
 
     def _eval_rewrite_as_log(self, arg, **kwargs):
         return log(1/arg + sqrt(1/arg - 1) * sqrt(1/arg + 1))
+
+    def _eval_rewrite_as_acosh(self, arg, **kwargs):
+        return acosh(1/arg)
+
+    def _eval_rewrite_as_asinh(self, arg, **kwargs):
+        return sqrt(1/arg - 1)/sqrt(1 - 1/arg)*(S.ImaginaryUnit*asinh(S.ImaginaryUnit/arg)
+                                                + S.Pi*S.Half)
+
+    def _eval_rewrite_as_atanh(self, x, **kwargs):
+        return (I*pi*(1 - sqrt(x)*sqrt(1/x) - I/2*sqrt(-x)/sqrt(x) - I/2*sqrt(x**2)/sqrt(-x**2))
+                + sqrt(1/(x + 1))*sqrt(x + 1)*atanh(sqrt(1 - x**2)))
+
+    def _eval_rewrite_as_acsch(self, x, **kwargs):
+        return sqrt(1/x - 1)/sqrt(1 - 1/x)*(pi/2 - I*acsch(I*x))
 
 
 class acsch(InverseHyperbolicFunction):
@@ -1767,6 +1864,9 @@ class acsch(InverseHyperbolicFunction):
         if arg is S.ComplexInfinity:
             return S.Zero
 
+        if arg.is_infinite:
+            return S.Zero
+
         if arg.is_zero:
             return S.ComplexInfinity
 
@@ -1781,6 +1881,19 @@ class acsch(InverseHyperbolicFunction):
 
     def _eval_rewrite_as_log(self, arg, **kwargs):
         return log(1/arg + sqrt(1/arg**2 + 1))
+
+    def _eval_rewrite_as_asinh(self, arg, **kwargs):
+        return asinh(1/arg)
+
+    def _eval_rewrite_as_acosh(self, arg, **kwargs):
+        return S.ImaginaryUnit*(sqrt(1 - S.ImaginaryUnit/arg)/sqrt(S.ImaginaryUnit/arg - 1)*
+                                acosh(S.ImaginaryUnit/arg) - S.Pi*S.Half)
+
+    def _eval_rewrite_as_atanh(self, arg, **kwargs):
+        arg2 = arg**2
+        arg2p1 = arg2 + 1
+        return sqrt(-arg2)/arg*(S.Pi*S.Half -
+                                sqrt(-arg2p1**2)/arg2p1*atanh(sqrt(arg2p1)))
 
     def _eval_is_zero(self):
         return self.args[0].is_infinite

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -558,6 +558,10 @@ def test_asinh():
 def test_asinh_rewrite():
     x = Symbol('x')
     assert asinh(x).rewrite(log) == log(x + sqrt(x**2 + 1))
+    assert asinh(x).rewrite(atanh) == atanh(x/sqrt(1 + x**2))
+    assert asinh(x).rewrite(asin) == asinh(x)
+    assert asinh(x*(1 + I)).rewrite(asin) == -I*asin(I*x*(1+I))
+    assert asinh(x).rewrite(acos) == I*(-I*asinh(x) + pi/2) - I*pi/2
 
 
 def test_asinh_series():
@@ -637,6 +641,14 @@ def test_acosh():
 def test_acosh_rewrite():
     x = Symbol('x')
     assert acosh(x).rewrite(log) == log(x + sqrt(x - 1)*sqrt(x + 1))
+    assert acosh(x).rewrite(asin) == sqrt(x - 1)*(-asin(x) + pi/2)/sqrt(1 - x)
+    assert acosh(x).rewrite(asinh) == sqrt(x - 1)*(-asin(x) + pi/2)/sqrt(1 - x)
+    assert acosh(x).rewrite(atanh) == \
+        (sqrt(x - 1)*sqrt(x + 1)*atanh(sqrt(x**2 - 1)/x)/sqrt(x**2 - 1) +
+         pi*sqrt(x - 1)*(-x*sqrt(x**(-2)) + 1)/(2*sqrt(1 - x)))
+    x = Symbol('x', positive=True)
+    assert acosh(x).rewrite(atanh) == \
+        sqrt(x - 1)*sqrt(x + 1)*atanh(sqrt(x**2 - 1)/x)/sqrt(x**2 - 1)
 
 
 def test_acosh_series():
@@ -721,6 +733,10 @@ def test_asech_series():
 def test_asech_rewrite():
     x = Symbol('x')
     assert asech(x).rewrite(log) == log(1/x + sqrt(1/x - 1) * sqrt(1/x + 1))
+    assert asech(x).rewrite(acosh) == acosh(1/x)
+    assert asech(x).rewrite(asinh) == sqrt(-1 + 1/x)*(-asin(1/x) + pi/2)/sqrt(1 - 1/x)
+    assert asech(x).rewrite(atanh) == \
+        sqrt(x + 1)*sqrt(1/(x + 1))*atanh(sqrt(1 - x**2)) + I*pi*(-sqrt(x)*sqrt(1/x) + 1 - I*sqrt(x**2)/(2*sqrt(-x**2)) - I*sqrt(-x)/(2*sqrt(x)))
 
 
 def test_asech_fdiff():
@@ -796,6 +812,10 @@ def test_acsch_infinities():
 def test_acsch_rewrite():
     x = Symbol('x')
     assert acsch(x).rewrite(log) == log(1/x + sqrt(1/x**2 + 1))
+    assert acsch(x).rewrite(asinh) == asinh(1/x)
+    assert acsch(x).rewrite(atanh) == (sqrt(-x**2)*(-sqrt(-(x**2 + 1)**2)
+                                                    *atanh(sqrt(x**2 + 1))/(x**2 + 1)
+                                                    + pi/2)/x)
 
 
 def test_acsch_fdiff():
@@ -864,6 +884,8 @@ def test_atanh():
 def test_atanh_rewrite():
     x = Symbol('x')
     assert atanh(x).rewrite(log) == (log(1 + x) - log(1 - x)) / 2
+    assert atanh(x).rewrite(asinh) == \
+        pi*x/(2*sqrt(-x**2)) - sqrt(-x)*sqrt(1 - x**2)*sqrt(1/(x**2 - 1))*asinh(sqrt(1/(x**2 - 1)))/sqrt(x)
 
 
 def test_atanh_series():
@@ -920,6 +942,9 @@ def test_acoth():
 def test_acoth_rewrite():
     x = Symbol('x')
     assert acoth(x).rewrite(log) == (log(1 + 1/x) - log(1 - 1/x)) / 2
+    assert acoth(x).rewrite(atanh) == atanh(1/x)
+    assert acoth(x).rewrite(asinh) == \
+        x*sqrt(x**(-2))*asinh(sqrt(1/(x**2 - 1))) + I*pi*(sqrt((x - 1)/x)*sqrt(x/(x - 1)) - sqrt(x/(x + 1))*sqrt(1 + 1/x))/2
 
 
 def test_acoth_series():
@@ -956,8 +981,8 @@ def test_leading_term():
     for func in [sinh, tanh, asinh, atanh]:
         assert func(x).as_leading_term(x) == x
     for func in [sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth]:
-        for arg in (1/x, S.Half):
-            eq = func(arg)
+        for ar in (1/x, S.Half):
+            eq = func(ar)
             assert eq.as_leading_term(x) == eq
     for func in [csch, sech]:
         eq = func(S.Half)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -5,17 +5,19 @@ from sympy.core.basic import sympify, cacheit
 from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
+from sympy.core.mod import Mod
 from sympy.core.numbers import igcdex, Rational, pi, Integer, Float
-from sympy.core.relational import Ne
+from sympy.core.relational import Ne, Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.combinatorial.numbers import bernoulli, euler
-from sympy.functions.elementary.complexes import arg, im, re
+from sympy.functions.elementary.complexes import arg as arg_f, im, re
 from sympy.functions.elementary.exponential import log, exp
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy.logic.boolalg import And
 from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
@@ -438,7 +440,8 @@ class sin(TrigonometricFunction):
 
     def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half = cot(S.Half*arg)
-        return 2*cot_half/(1 + cot_half**2)
+        return Piecewise((0, And(Eq(im(arg), 0), Eq(Mod(arg, pi), 0))),
+                         (2*cot_half/(1 + cot_half**2), True))
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
         return self.rewrite(cos).rewrite(pow)
@@ -774,7 +777,8 @@ class cos(TrigonometricFunction):
 
     def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half = cot(S.Half*arg)**2
-        return (cot_half - 1)/(cot_half + 1)
+        return Piecewise((1, And(Eq(im(arg), 0), Eq(Mod(arg, 2*pi), 0))),
+                         ((cot_half - 1)/(cot_half + 1), True))
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
         return self._eval_rewrite_as_sqrt(arg)
@@ -3093,6 +3097,9 @@ class asec(InverseTrigonometricFunction):
             elif -arg in acsc_table:
                 return pi/2 + acsc_table[-arg]
 
+        if arg.is_infinite:
+            return S.Pi/2
+
         if isinstance(arg, sec):
             ang = arg.args[0]
             if ang.is_comparable:
@@ -3185,11 +3192,13 @@ class asec(InverseTrigonometricFunction):
     def _eval_rewrite_as_acos(self, arg, **kwargs):
         return acos(1/arg)
 
-    def _eval_rewrite_as_atan(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(-pi/2 + 2*atan(arg + sqrt(arg**2 - 1)))
+    def _eval_rewrite_as_atan(self, x, **kwargs):
+        sx2x = sqrt(x**2)/x
+        return pi/2*(1 - sx2x) + sx2x*atan(sqrt(x**2 - 1))
 
-    def _eval_rewrite_as_acot(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(-pi/2 + 2*acot(arg - sqrt(arg**2 - 1)))
+    def _eval_rewrite_as_acot(self, x, **kwargs):
+        sx2x = sqrt(x**2)/x
+        return pi/2*(1 - sx2x) + sx2x*acot(1/sqrt(x**2 - 1))
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return pi/2 - acsc(arg)
@@ -3254,6 +3263,9 @@ class acsc(InverseTrigonometricFunction):
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)
+
+        if arg.is_infinite:
+            return S.Zero
 
         if arg.is_number:
             acsc_table = cls._acsc_table()
@@ -3352,8 +3364,8 @@ class acsc(InverseTrigonometricFunction):
     def _eval_rewrite_as_acos(self, arg, **kwargs):
         return pi/2 - acos(1/arg)
 
-    def _eval_rewrite_as_atan(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(pi/2 - atan(sqrt(arg**2 - 1)))
+    def _eval_rewrite_as_atan(self, x, **kwargs):
+        return sqrt(x**2)/x*(pi/2 - atan(sqrt(x**2 - 1)))
 
     def _eval_rewrite_as_acot(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(pi/2 - acot(1/sqrt(arg**2 - 1)))
@@ -3516,10 +3528,10 @@ class atan2(InverseTrigonometricFunction):
 
     def _eval_rewrite_as_arg(self, y, x, **kwargs):
         if x.is_extended_real and y.is_extended_real:
-            return arg(x + y*S.ImaginaryUnit)
+            return arg_f(x + y*S.ImaginaryUnit)
         n = x + S.ImaginaryUnit*y
         d = x**2 + y**2
-        return arg(n/sqrt(d)) - S.ImaginaryUnit*log(abs(n)/sqrt(abs(d)))
+        return arg_f(n/sqrt(d)) - S.ImaginaryUnit*log(abs(n)/sqrt(abs(d)))
 
     def _eval_is_extended_real(self):
         return self.args[0].is_extended_real and self.args[1].is_extended_real

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -69,6 +69,18 @@ class CodePrinter(StrPrinter):
     # may be supported
     # function_to_rewrite : (function_to_rewrite_to, iterable_with_other_functions_required)
     _rewriteable_functions = {
+            'cot': ('tan', []),
+            'csc': ('sin', []),
+            'sec': ('cos', []),
+            'acot': ('atan', []),
+            'acsc': ('asin', []),
+            'asec': ('acos', []),
+            'coth': ('exp', []),
+            'csch': ('exp', []),
+            'sech': ('exp', []),
+            'acoth': ('log', []),
+            'acsch': ('log', []),
+            'asech': ('log', []),
             'catalan': ('gamma', []),
             'fibonacci': ('sqrt', []),
             'lucas': ('sqrt', []),

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -6,7 +6,7 @@ from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max
+from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
 from sympy.printing.pycode import (
@@ -48,6 +48,11 @@ def test_PythonCodePrinter():
     assert prntr.module_imports == {'math': {'pi', 'sqrt'}}
 
     assert prntr.doprint(acos(x)) == 'math.acos(x)'
+    assert prntr.doprint(cot(x)) == '1/math.tan(x)'
+    assert prntr.doprint(coth(x)) == '(math.exp(x) + math.exp(-x))/(math.exp(x) - math.exp(-x))'
+    assert prntr.doprint(asec(x)) == 'math.acos(1/x)'
+    assert prntr.doprint(acsch(x)) == 'math.log(math.sqrt(1 + x**(-2)) + 1/x)'
+
     assert prntr.doprint(Assignment(x, 2)) == 'x = 2'
     assert prntr.doprint(Piecewise((1, Eq(x, 0)),
                         (2, x>6))) == '((1) if (x == 0) else (2) if (x > 6) else None)'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -12,12 +12,13 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions.combinatorial.factorials import (RisingFactorial, factorial)
 from sympy.functions.elementary.complexes import Abs
-from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import acosh
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (acos, cos, sin, sinc, tan)
+from sympy.functions.elementary.trigonometric import (acos, cos, cot, sin,
+                                                      sinc, tan)
 from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely)
 from sympy.functions.special.beta_functions import (beta, betainc, betainc_regularized)
 from sympy.functions.special.delta_functions import (Heaviside)
@@ -1348,6 +1349,24 @@ def test_issue_22739():
     assert abs(f.subs(point) - F(*point.values())) <= 1e-10
 
 
+def test_issue_22992():
+    if not numpy:
+        skip("numpy not installed")
+
+    a, t = symbols('a t')
+    expr = a*(log(cot(t/2)) - cos(t))
+    F = lambdify([a, t], expr, 'numpy')
+
+    point = {a: 10, t: 2}
+
+    assert abs(expr.subs(point) - F(*point.values())) <= 1e-10
+
+    # Standard math
+    F = lambdify([a, t], expr)
+
+    assert abs(expr.subs(point) - F(*point.values())) <= 1e-10
+
+
 def test_issue_19764():
     if not numpy:
         skip("numpy not installed")
@@ -1394,6 +1413,7 @@ def test_beta_math():
 
     assert abs(beta(1.3, 2.3) - F(1.3, 2.3)) <= 1e-10
 
+
 def test_betainc_scipy():
     if not scipy:
         skip("scipy not installed")
@@ -1402,6 +1422,7 @@ def test_betainc_scipy():
     F = lambdify((w, x, y, z), f, modules='scipy')
 
     assert abs(betainc(1.4, 3.1, 0.1, 0.5) - F(1.4, 3.1, 0.1, 0.5)) <= 1e-10
+
 
 def test_betainc_regularized_scipy():
     if not scipy:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #22992 

#### Brief description of what is fixed or changed

`cot` is automatically rewritten to `tan` to support lambdifying.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * `cot`, `sec`, `csc` and related inverse and hyperbolic functions are automatically rewritten if they cannot be printed. Enables `lambdify` for these expressions. 
* functions
    * hyperbolic functions can be rewritten to more other hyperbolic functions.
<!-- END RELEASE NOTES -->
