### PR TITLE
Fixes results of evalf() function based on precision

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -186,7 +186,7 @@ Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>
 Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
 Anup Parikh <parikhanupk@gmail.com> Anup Parikh <84572003+parikhanupk@users.noreply.github.com>
-Anurag Bhat <90216905+faze-geek@users.noreply.github.com>
+Anurag Bhat <bhat.1@iitj.ac.in> Anurag Bhat <90216905+faze-geek@users.noreply.github.com>
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <90216905+faze-geek@users.noreply.github.com>
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <bhat.1@iitj.ac.in>
 Anurag Sharma <anurags92@gmail.com> <sharmaan@iitk.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -186,6 +186,7 @@ Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>
 Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
 Anup Parikh <parikhanupk@gmail.com> Anup Parikh <84572003+parikhanupk@users.noreply.github.com>
+Anurag Bhat <90216905+faze-geek@users.noreply.github.com>
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <90216905+faze-geek@users.noreply.github.com>
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <bhat.1@iitj.ac.in>
 Anurag Sharma <anurags92@gmail.com> <sharmaan@iitk.ac.in>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -710,9 +710,10 @@ def evalf_mul(v: 'Mul', prec: int, options: OPT_DICT) -> TMP_RES:
         man *= m
         exp += e
         bc += b
-        if bc > 3*working_prec:
+        while bc > 3*working_prec:
             man >>= working_prec
             exp += working_prec
+            bc -= working_prec
         acc = min(acc, w_acc)
     sign = (direction & 2) >> 1
     if not complex_factors:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -26,6 +26,7 @@ from sympy.integrals.integrals import (Integral, integrate)
 from sympy.polys.polytools import factor
 from sympy.polys.rootoftools import CRootOf
 from sympy.polys.specialpolys import cyclotomic_poly
+from sympy.printing import srepr
 from sympy.printing.str import sstr
 from sympy.simplify.simplify import simplify
 from sympy.core.numbers import comp
@@ -716,3 +717,16 @@ def test_evalf_real_alg_num():
     assert isinstance(z, Float)
     assert not hasattr(z, '_mpc_')
     assert hasattr(z, '_mpf_')
+
+
+def test_issue_20733():
+    expr = 1/((x - 9)*(x - 8)*(x - 7)*(x - 4)**2*(x - 3)**3*(x - 2))
+    assert str(expr.evalf(1, subs={x:1})) == '-4.e-5'
+    assert str(expr.evalf(2, subs={x:1})) == '-4.1e-5'
+    assert str(expr.evalf(11, subs={x:1})) == '-4.1335978836e-5'
+    assert str(expr.evalf(20, subs={x:1})) == '-0.000041335978835978835979'
+
+    expr = Mul(*((x - i) for i in range(2, 1000)))
+    assert srepr(expr.evalf(2, subs={x: 1})) == "Float('4.0271e+2561', precision=10)"
+    assert srepr(expr.evalf(10, subs={x: 1})) == "Float('4.02790050126e+2561', precision=37)"
+    assert srepr(expr.evalf(53, subs={x: 1})) == "Float('4.0279005012722099453824067459760158730668154575647110393e+2561', precision=179)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20733 
Closes #20733

#### Brief description of what is fixed or changed
Modified : `sympy/core/evalf.py`
Corrected the bit count `bc ` loop , preventing mantissa from reaching zero. 

#### Other comments
Appropriate tests have been added for particular values which gave wrong result (0) earlier.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improved results of evalf() based on precision
<!-- END RELEASE NOTES -->
