### PR TITLE
Refactored import ordering in functions

### DIFF
--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -4,12 +4,12 @@ only and should not be used anywhere else as these do not possess the
 signatures common to SymPy objects. For general use of logic constructs
 please refer to sympy.logic classes And, Or, Not, etc.
 """
-from itertools import combinations, product
-from sympy.core.singleton import S
-from sympy.logic.boolalg import (Equivalent, ITE, Implies, Nand, Nor, Xor)
+from itertools import combinations, product, zip_longest
+from sympy.assumptions.assume import AppliedPredicate, Predicate
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
+from sympy.core.singleton import S
 from sympy.logic.boolalg import Or, And, Not, Xnor
-from itertools import zip_longest
+from sympy.logic.boolalg import (Equivalent, ITE, Implies, Nand, Nor, Xor)
 
 
 class Literal:
@@ -171,7 +171,6 @@ def to_NNF(expr, composite_map=None):
     (Literal(Q.negative(x), False) | Literal(Q.zero(x), False))
     """
     from sympy.assumptions.ask import Q
-    from sympy.assumptions.assume import AppliedPredicate, Predicate
 
     if composite_map is None:
         composite_map = dict()

--- a/sympy/assumptions/facts.py
+++ b/sympy/assumptions/facts.py
@@ -6,7 +6,7 @@ and supports functions to generate the contents in
 ``sympy.assumptions.ask_generated`` file.
 """
 
-from sympy.assumptions import Q
+from sympy.assumptions.ask import Q
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.core.cache import cacheit
 from sympy.core.symbol import Symbol

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -11,6 +11,7 @@ from sympy.matrices.expressions import (BlockMatrix, BlockDiagMatrix, Determinan
     DiagMatrix, DiagonalMatrix, HadamardProduct, Identity, Inverse, MatAdd, MatMul,
     MatPow, MatrixExpr, MatrixSlice, MatrixSymbol, OneMatrix, Trace, Transpose,
     ZeroMatrix)
+from sympy.matrices.expressions.blockmatrix import reblock_2x2
 from sympy.matrices.expressions.factorizations import Factorization
 from sympy.matrices.expressions.fourier import DFT
 from sympy.core.logic import fuzzy_and
@@ -174,7 +175,6 @@ def _(expr, assumptions):
 
 @InvertiblePredicate.register(BlockMatrix)
 def _(expr, assumptions):
-    from sympy.matrices.expressions.blockmatrix import reblock_2x2
     if not expr.is_square:
         return False
     if expr.blockshape == (1, 1):

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -9,6 +9,9 @@ from sympy.combinatorics.coset_table import (CosetTable,
                                              coset_enumeration_r,
                                              coset_enumeration_c)
 from sympy.combinatorics import PermutationGroup
+from sympy.matrices.normalforms import invariant_factors
+from sympy.matrices import Matrix
+from sympy.polys.polytools import gcd
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 from sympy.utilities.magic import pollute
@@ -230,7 +233,6 @@ class FpGroup(DefaultPrinting):
         2
 
         """
-        from sympy.polys.polytools import gcd
         if self._order is not None:
             return self._order
         if self._coset_table is not None:
@@ -263,8 +265,6 @@ class FpGroup(DefaultPrinting):
             return True
         # Abelianisation test: check is the abelianisation is infinite
         abelian_rels = []
-        from sympy.matrices.normalforms import invariant_factors
-        from sympy.matrices import Matrix
         for rel in self.relators:
             abelian_rels.append([rel.exponent_sum(g) for g in self.generators])
         m = Matrix(Matrix(abelian_rels))
@@ -1080,8 +1080,6 @@ def _simplification_technique_1(rels):
     [x**2*y**4, x**4]
 
     """
-    from sympy.polys.polytools import gcd
-
     rels = rels[:]
     # dictionary with "gen: n" where gen^n is one of the relators
     exps = {}

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,8 +1,6 @@
-from sympy.core.random import randrange, choice
 from math import log
-from sympy.ntheory import primefactors
-from sympy.core.symbol import Symbol
-from sympy.ntheory.factor_ import (factorint, multiplicity)
+from itertools import chain, islice, product
+
 
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
@@ -12,12 +10,15 @@ from sympy.combinatorics.util import (_check_cycles_alt_sym,
     _handle_precomputed_bsgs, _base_ordering, _strong_gens_from_distr,
     _strip, _strip_af)
 from sympy.core import Basic
-from sympy.functions.combinatorial.factorials import factorial
-from sympy.ntheory import sieve
-from sympy.utilities.iterables import has_variety, is_sequence, uniq
-from sympy.core.random import _randrange
-from itertools import islice
+from sympy.core.random import _randrange, randrange, choice
+from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
+from sympy.functions.combinatorial.factorials import factorial
+from sympy.ntheory import primefactors, sieve
+from sympy.ntheory.factor_ import (factorint, multiplicity)
+from sympy.ntheory.primetest import isprime
+from sympy.utilities.iterables import has_variety, is_sequence, uniq
+
 rmul = Permutation.rmul_with_af
 _af_new = Permutation._af_new
 
@@ -890,7 +891,6 @@ class PermutationGroup(Basic):
         # from fp_groups.py but the class would need to be changed first
         # to be compatible with PermutationGroups
 
-        from itertools import chain, product
         if not H.is_subgroup(self):
             raise ValueError("The argument must be a subgroup")
         T = self.coset_transversal(H)
@@ -4400,7 +4400,6 @@ class PermutationGroup(Basic):
         '''
         from sympy.combinatorics.homomorphisms import (
                 orbit_homomorphism, block_homomorphism)
-        from sympy.ntheory.primetest import isprime
 
         if not isprime(p):
             raise ValueError("p must be a prime")
@@ -4808,7 +4807,6 @@ class PermutationGroup(Basic):
         from sympy.combinatorics.coset_table import CosetTable
         from sympy.combinatorics.free_groups import free_group
         from sympy.combinatorics.homomorphisms import homomorphism
-        from itertools import product
 
         if self._fp_presentation:
             return self._fp_presentation

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -10,6 +10,7 @@ from sympy.core.numbers import Integer
 from sympy.core.sympify import _sympify
 from sympy.matrices import zeros
 from sympy.polys.polytools import lcm
+from sympy.printing.repr import srepr
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs, is_sequence)
 from sympy.utilities.misc import as_int
@@ -1610,7 +1611,6 @@ class Permutation(Atom):
         yield from self.array_form
 
     def __repr__(self):
-        from sympy.printing.repr import srepr
         return srepr(self)
 
     def __call__(self, *i):

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -1,3 +1,4 @@
+from collections import deque
 from sympy.combinatorics.rewritingsystem_fsm import StateMachine
 
 class RewritingSystem:
@@ -15,7 +16,6 @@ class RewritingSystem:
 
     '''
     def __init__(self, group):
-        from collections import deque
         self.group = group
         self.alphabet = group.generators
         self._is_confluent = None

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -1,19 +1,19 @@
 """Various algorithms for helping identifying numbers and sequences."""
 
-from sympy.utilities import public
 
-from sympy.core import Function, Symbol, S
-from sympy.core.numbers import Zero
 from sympy.concrete.products import (Product, product)
-from sympy.core.numbers import (Integer, Rational)
-from sympy.core.symbol import symbols
+from sympy.core import Function, S
+from sympy.core.numbers import (Zero, Integer, Rational)
+from sympy.core.symbol import Symbol, symbols
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import integrate
+from sympy.polys.polyfuncs import rational_interpolate as rinterp
 from sympy.polys.polytools import lcm
 from sympy.simplify.radsimp import denom
-from sympy.polys.polyfuncs import rational_interpolate as rinterp
+from sympy.utilities import public
+
 
 @public
 def find_simple_recurrence_vector(l):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -275,7 +275,6 @@ class Pow(Expr):
     def __new__(cls, b, e, evaluate=None):
         if evaluate is None:
             evaluate = global_parameters.evaluate
-        from sympy.functions.elementary.exponential import exp_polar
 
         b = _sympify(b)
         e = _sympify(e)
@@ -339,6 +338,7 @@ class Pow(Expr):
                 return S.One
             else:
                 # recognize base as E
+                from sympy.functions.elementary.exponential import exp_polar
                 if not e.is_Atom and b is not S.Exp1 and not isinstance(b, exp_polar):
                     from .exprtools import factor_terms
                     from sympy.functions.elementary.exponential import log
@@ -1826,7 +1826,7 @@ class Pow(Expr):
 
     def _eval_rewrite_as_tanh(self, base, exp):
         if self.base is S.Exp1:
-            from sympy.functions.elementary.trigonometric import tanh
+            from sympy.functions.elementary.hyperbolic import tanh
             return (1 + tanh(self.exp/2))/(1 - tanh(self.exp/2))
 
     def _eval_rewrite_as_sqrt(self, base, exp, **kwargs):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1952,7 +1952,7 @@ def test_Mod():
     assert ((x - Mod(x, y))/y).rewrite(floor) == floor(x/y)
 
     # issue 21373
-    from sympy.functions.elementary.trigonometric import sinh
+    from sympy.functions.elementary.hyperbolic import sinh
     from sympy.functions.elementary.piecewise import Piecewise
 
     x_r, y_r = symbols('x_r y_r', real=True)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -8,7 +8,8 @@ from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.special.error_functions import erf
 from sympy.functions.elementary.trigonometric import (
-    sin, cos, tan, sec, csc, sinh, cosh, tanh, atan)
+    sin, cos, tan, sec, csc, atan)
+from sympy.functions.elementary.hyperbolic import cosh, sinh, tanh
 from sympy.polys import Poly
 from sympy.series.order import O
 from sympy.sets import FiniteSet

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -9,11 +9,8 @@ from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.core.numbers import pi, I, oo
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
-from sympy.functions.elementary.exponential import exp, exp_polar, log
-from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import atan, atan2
 
 ###############################################################################
 ######################### REAL and IMAGINARY PARTS ############################
@@ -562,6 +559,8 @@ class Abs(Function):
             return S.NaN
         if arg is S.ComplexInfinity:
             return S.Infinity
+        from sympy.functions.elementary.exponential import exp, log
+
         if arg.is_Pow:
             base, exponent = arg.as_base_exp()
             if base.is_extended_real:
@@ -660,6 +659,7 @@ class Abs(Function):
         return
 
     def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.functions.elementary.exponential import log
         direction = self.args[0].leadterm(x)[0]
         if direction.has(log(x)):
             direction = direction.subs(log(x), logx)
@@ -692,7 +692,7 @@ class Abs(Function):
         return arg/sign(arg)
 
     def _eval_rewrite_as_conjugate(self, arg, **kwargs):
-        return (arg*conjugate(arg))**S.Half
+        return sqrt(arg*conjugate(arg))
 
 
 class arg(Function):
@@ -760,6 +760,7 @@ class arg(Function):
                 break
         else:
             return S.NaN
+        from sympy.functions.elementary.exponential import exp_polar
         if isinstance(arg, exp_polar):
             return periodic_argument(arg, oo)
         if not arg.is_Atom:
@@ -772,6 +773,7 @@ class arg(Function):
             arg_ = arg
         if any(i.is_extended_positive is None for i in arg_.atoms(AppliedUndef)):
             return
+        from sympy.functions.elementary.trigonometric import atan2
         x, y = arg_.as_real_imag()
         rv = atan2(y, x)
         if rv.is_number:
@@ -785,6 +787,7 @@ class arg(Function):
                     Derivative(x, t, evaluate=True)) / (x**2 + y**2)
 
     def _eval_rewrite_as_atan2(self, arg, **kwargs):
+        from sympy.functions.elementary.trigonometric import atan2
         x, y = self.args[0].as_real_imag()
         return atan2(y, x)
 
@@ -1040,6 +1043,7 @@ class polar_lift(Function):
             # but for now we will just be more restrictive and
             # see that it has evaluated to one of the known values.
             if ar in (0, pi/2, -pi/2, pi):
+                from sympy.functions.elementary.exponential import exp_polar
                 return exp_polar(I*ar)*abs(arg)
 
         if arg.is_Mul:
@@ -1062,6 +1066,7 @@ class polar_lift(Function):
             elif included:
                 return Mul(*(included + positive))
             else:
+                from sympy.functions.elementary.exponential import exp_polar
                 return Mul(*positive)*exp_polar(0)
 
     def _eval_evalf(self, prec):
@@ -1115,6 +1120,7 @@ class periodic_argument(Function):
 
     @classmethod
     def _getunbranched(cls, ar):
+        from sympy.functions.elementary.exponential import exp_polar, log
         if ar.is_Mul:
             args = ar.args
         else:
@@ -1154,11 +1160,13 @@ class periodic_argument(Function):
         unbranched = cls._getunbranched(ar)
         if unbranched is None:
             return None
+        from sympy.functions.elementary.trigonometric import atan, atan2
         if unbranched.has(periodic_argument, atan2, atan):
             return None
         if period == oo:
             return unbranched
         if period != oo:
+            from sympy.functions.elementary.integers import ceiling
             n = ceiling(unbranched/period - S.Half)*period
             if not n.has(ceiling):
                 return unbranched - n
@@ -1171,6 +1179,7 @@ class periodic_argument(Function):
                 return self
             return unbranched._eval_evalf(prec)
         ub = periodic_argument(z, oo)._eval_evalf(prec)
+        from sympy.functions.elementary.integers import ceiling
         return (ub - ceiling(ub/period - S.Half)*period)._eval_evalf(prec)
 
 
@@ -1242,6 +1251,7 @@ class principal_branch(Function):
 
     @classmethod
     def eval(self, x, period):
+        from sympy.functions.elementary.exponential import exp_polar
         if isinstance(x, polar_lift):
             return principal_branch(x.args[0], period)
         if period == oo:
@@ -1296,6 +1306,7 @@ class principal_branch(Function):
         p = periodic_argument(z, period)._eval_evalf(prec)
         if abs(p) > pi or p == -pi:
             return self  # Cannot evalf for this argument.
+        from sympy.functions.elementary.exponential import exp
         return (abs(z)*exp(I*p))._eval_evalf(prec)
 
 
@@ -1387,6 +1398,7 @@ def _unpolarify(eq, exponents_only, pause=False):
         return eq
 
     if not pause:
+        from sympy.functions.elementary.exponential import exp, exp_polar
         if isinstance(eq, exp_polar):
             return exp(_unpolarify(eq.exp, exponents_only))
         if isinstance(eq, principal_branch) and eq.args[1] == 2*pi:
@@ -1451,4 +1463,5 @@ def unpolarify(eq, subs=None, exponents_only=False):
             return res
     # Finally, replacing Exp(0) by 1 is always correct.
     # So is polar_lift(0) -> 0.
+    from sympy.functions.elementary.exponential import exp_polar
     return res.subs({exp_polar(0): 1, polar_lift(0): 0})

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,3 +1,4 @@
+from itertools import product
 from typing import Tuple as tTuple
 
 from sympy.core.expr import Expr
@@ -8,15 +9,17 @@ from sympy.core.function import (Function, ArgumentIndexError, expand_log,
     expand_mul, FunctionClass, PoleError, expand_multinomial, expand_complex)
 from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.core.mul import Mul
-from sympy.core.numbers import Integer, Rational, pi, I
+from sympy.core.numbers import Integer, Rational, pi, I, ImaginaryUnit
 from sympy.core.parameters import global_parameters
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.elementary.complexes import arg, unpolarify, im, re, Abs
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
-from sympy.sets.setexpr import SetExpr
+from sympy.ntheory.factor_ import factorint
+from sympy.polys.polytools import cancel
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -174,12 +177,10 @@ class exp_polar(ExpBase):
     is_comparable = False  # cannot be evalf'd
 
     def _eval_Abs(self):   # Abs is never a polar number
-        from sympy.functions.elementary.complexes import re
         return exp(re(self.args[0]))
 
     def _eval_evalf(self, prec):
         """ Careful! any evalf of polar numbers is flaky """
-        from sympy.functions.elementary.complexes import (im, re)
         i = im(self.args[0])
         try:
             bad = (i <= -pi or i > pi)
@@ -274,7 +275,7 @@ class exp(ExpBase, metaclass=ExpMeta):
     def eval(cls, arg):
         from sympy.calculus import AccumBounds
         from sympy.matrices.matrices import MatrixBase
-        from sympy.functions.elementary.complexes import (im, re)
+        from sympy.sets.setexpr import SetExpr
         from sympy.simplify.simplify import logcombine
         if isinstance(arg, MatrixBase):
             return arg.exp()
@@ -479,7 +480,6 @@ class exp(ExpBase, metaclass=ExpMeta):
     def _eval_nseries(self, x, n, logx, cdir=0):
         # NOTE Please see the comment at the beginning of this file, labelled
         #      IMPORTANT.
-        from sympy.core.numbers import ImaginaryUnit
         from sympy.functions.elementary.complexes import sign
         from sympy.functions.elementary.integers import ceiling
         from sympy.series.limits import limit
@@ -643,9 +643,8 @@ class log(Function):
 
     @classmethod
     def eval(cls, arg, base=None):
-        from sympy.functions.elementary.complexes import unpolarify
         from sympy.calculus import AccumBounds
-        from sympy.functions.elementary.complexes import Abs
+        from sympy.sets.setexpr import SetExpr
 
         arg = sympify(arg)
 
@@ -813,8 +812,6 @@ class log(Function):
         return (1 - 2*(n % 2)) * x**(n + 1)/(n + 1)
 
     def _eval_expand_log(self, deep=True, **hints):
-        from sympy.functions.elementary.complexes import unpolarify
-        from sympy.ntheory.factor_ import factorint
         from sympy.concrete import Sum, Product
         force = hints.get('force', False)
         factor = hints.get('factor', False)
@@ -901,19 +898,18 @@ class log(Function):
         (log(Abs(x)), arg(I*x))
 
         """
-        from sympy.functions.elementary.complexes import (Abs, arg)
         sarg = self.args[0]
         if deep:
             sarg = self.args[0].expand(deep, **hints)
-        abs = Abs(sarg)
-        if abs == sarg:
+        sarg_abs = Abs(sarg)
+        if sarg_abs == sarg:
             return self, S.Zero
-        arg = arg(sarg)
+        sarg_arg = arg(sarg)
         if hints.get('log', False):  # Expand the log
             hints['complex'] = False
-            return (log(abs).expand(deep, **hints), arg)
+            return (log(sarg_abs).expand(deep, **hints), sarg_arg)
         else:
-            return log(abs), arg
+            return log(sarg_abs), sarg_arg
 
     def _eval_is_rational(self):
         s = self.func(*self.args)
@@ -961,11 +957,8 @@ class log(Function):
     def _eval_nseries(self, x, n, logx, cdir=0):
         # NOTE Please see the comment at the beginning of this file, labelled
         #      IMPORTANT.
-        from sympy.functions.elementary.complexes import im
-        from sympy.polys.polytools import cancel
         from sympy.series.order import Order
         from sympy.simplify.simplify import logcombine
-        from itertools import product
         if not logx:
             logx = log(x)
         if self.args[0] == x:
@@ -1048,7 +1041,6 @@ class log(Function):
         return res + Order(x**n, x)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import (im, re)
         arg0 = self.args[0].together()
 
         arg = arg0.as_leading_term(x, cdir=cdir)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -3,12 +3,18 @@ from sympy.core.logic import FuzzyBool
 from sympy.core import S, sympify, cacheit, pi, I, Rational
 from sympy.core.add import Add
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
+from sympy.core.logic import fuzzy_or, fuzzy_and
+from sympy.functions.combinatorial.factorials import (binomial, factorial,
+                                                      RisingFactorial)
+from sympy.functions.combinatorial.numbers import bernoulli, euler, nC
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.trigonometric import (acot, asin, atan, cos,
+                                                      cot, sin, tan)
+from sympy.polys.specialpolys import symmetric_poly
 
-from sympy.core.logic import fuzzy_or, fuzzy_and
 
 def _rewrite_hyperbolics_as_exp(expr):
     expr = sympify(expr)
@@ -105,8 +111,6 @@ class sinh(HyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import sin
-
         arg = sympify(arg)
 
         if arg.is_Number:
@@ -180,7 +184,6 @@ class sinh(HyperbolicFunction):
         """
         Returns this function as a complex coordinate.
         """
-        from sympy.functions.elementary.trigonometric import (cos, sin)
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
@@ -370,7 +373,6 @@ class cosh(HyperbolicFunction):
         return self.func(self.args[0].conjugate())
 
     def as_real_imag(self, deep=True, **hints):
-        from sympy.functions.elementary.trigonometric import (cos, sin)
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
@@ -550,7 +552,6 @@ class tanh(HyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import tan
         arg = sympify(arg)
 
         if arg.is_Number:
@@ -607,7 +608,6 @@ class tanh(HyperbolicFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n < 0 or n % 2 == 0:
             return S.Zero
         else:
@@ -624,7 +624,6 @@ class tanh(HyperbolicFunction):
         return self.func(self.args[0].conjugate())
 
     def as_real_imag(self, deep=True, **hints):
-        from sympy.functions.elementary.trigonometric import (cos, sin)
         if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
@@ -641,7 +640,6 @@ class tanh(HyperbolicFunction):
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
         if arg.is_Add:
-            from sympy.polys.specialpolys import symmetric_poly
             n = len(arg.args)
             TX = [tanh(x, evaluate=False)._eval_expand_trig()
                 for x in arg.args]
@@ -650,7 +648,6 @@ class tanh(HyperbolicFunction):
                 p[i % 2] += symmetric_poly(i, TX)
             return p[1]/p[0]
         elif arg.is_Mul:
-            from sympy.functions.combinatorial.numbers import nC
             coeff, terms = arg.as_coeff_Mul()
             if coeff.is_Integer and coeff > 1:
                 n = []
@@ -717,7 +714,6 @@ class tanh(HyperbolicFunction):
             return self.args[0].is_negative
 
     def _eval_is_finite(self):
-        from sympy.functions.elementary.trigonometric import cos
         arg = self.args[0]
 
         re, im = arg.as_real_imag()
@@ -769,7 +765,6 @@ class coth(HyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import cot
         arg = sympify(arg)
 
         if arg.is_Number:
@@ -826,7 +821,6 @@ class coth(HyperbolicFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n == 0:
             return 1 / sympify(x)
         elif n < 0 or n % 2 == 0:
@@ -894,7 +888,6 @@ class coth(HyperbolicFunction):
     def _eval_expand_trig(self, **hints):
         arg = self.args[0]
         if arg.is_Add:
-            from sympy.polys.specialpolys import symmetric_poly
             CX = [coth(x, evaluate=False)._eval_expand_trig() for x in arg.args]
             p = [[], []]
             n = len(arg.args)
@@ -902,7 +895,6 @@ class coth(HyperbolicFunction):
                 p[(n - i) % 2].append(symmetric_poly(i, CX))
             return Add(*p[0])/Add(*p[1])
         elif arg.is_Mul:
-            from sympy.functions.combinatorial.factorials import binomial
             coeff, x = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer and coeff > 1:
                 c = coth(x, evaluate=False)
@@ -1025,7 +1017,6 @@ class csch(ReciprocalHyperbolicFunction):
         """
         Returns the next term in the Taylor series expansion
         """
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n == 0:
             return 1/sympify(x)
         elif n < 0 or n % 2 == 0:
@@ -1082,7 +1073,6 @@ class sech(ReciprocalHyperbolicFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import euler
         if n < 0 or n % 2 == 1:
             return S.Zero
         else:
@@ -1137,7 +1127,6 @@ class asinh(InverseHyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import asin
         arg = sympify(arg)
 
         if arg.is_Number:
@@ -1310,7 +1299,6 @@ class acosh(InverseHyperbolicFunction):
         if isinstance(arg, cosh) and arg.args[0].is_number:
             z = arg.args[0]
             if z.is_real:
-                from sympy.functions.elementary.complexes import Abs
                 return Abs(z)
             r, i = match_real_imag(z)
             if r is not None and i is not None:
@@ -1398,7 +1386,6 @@ class atanh(InverseHyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import atan
         arg = sympify(arg)
 
         if arg.is_Number:
@@ -1509,7 +1496,6 @@ class acoth(InverseHyperbolicFunction):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.trigonometric import acot
         arg = sympify(arg)
 
         if arg.is_Number:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -11,6 +11,7 @@ from sympy.core.numbers import Integer
 from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
+from sympy.functions.elementary.complexes import im
 from sympy.multipledispatch import dispatch
 
 ###############################################################################
@@ -25,7 +26,6 @@ class RoundFunction(Function):
 
     @classmethod
     def eval(cls, arg):
-        from sympy.functions.elementary.complexes import im
         v = cls._eval_number(arg)
         if v is not None:
             return v
@@ -459,7 +459,6 @@ class frac(Function):
     @classmethod
     def eval(cls, arg):
         from sympy.calculus.accumulationbounds import AccumBounds
-        from sympy.functions.elementary.complexes import im
 
         def _eval(arg):
             if arg in (S.Infinity, S.NegativeInfinity):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -8,7 +8,6 @@ from sympy.core.sorting import ordered
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or, Not,
     true, false, Or, ITE, simplify_logic, to_cnf, distribute_or_over_and)
-from sympy.sets.sets import Interval
 from sympy.utilities.iterables import uniq, sift, common_prefix
 from sympy.utilities.misc import filldedent, func_name
 
@@ -1234,6 +1233,7 @@ def piecewise_simplify_arguments(expr, **kwargs):
         if ok:
             args = []
             covered = S.EmptySet
+            from sympy.sets.sets import Interval
             for a, b, e, i in abe_:
                 c = expr.args[i].cond
                 incl_a = include(c, x, a)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -10,14 +10,14 @@ from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
+from sympy.functions.combinatorial.numbers import bernoulli, euler
+from sympy.functions.elementary.complexes import arg, im, re
 from sympy.functions.elementary.exponential import log, exp
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.hyperbolic import (acoth, asinh, atanh, cosh,
-    coth, HyperbolicFunction, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.sets.setexpr import SetExpr
-from sympy.sets.sets import FiniteSet
+from sympy.ntheory import factorint
+from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
 
 ###############################################################################
@@ -265,6 +265,7 @@ class sin(TrigonometricFunction):
     @classmethod
     def eval(cls, arg):
         from sympy.calculus.accumulationbounds import AccumBounds
+        from sympy.sets.setexpr import SetExpr
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -277,6 +278,7 @@ class sin(TrigonometricFunction):
             return S.NaN
 
         if isinstance(arg, AccumBounds):
+            from sympy.sets.sets import FiniteSet
             min, max = arg.min, arg.max
             d = floor(min/(2*S.Pi))
             if min is not S.NegativeInfinity:
@@ -305,6 +307,7 @@ class sin(TrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import sinh
             return S.ImaginaryUnit*sinh(i_coeff)
 
         pi_coeff = _pi_coeff(arg)
@@ -399,6 +402,7 @@ class sin(TrigonometricFunction):
         return Function._eval_nseries(self, x, n=n, logx=logx, cdir=cdir)
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
+        from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         I = S.ImaginaryUnit
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
             arg = arg.func(arg.args[0]).rewrite(exp)
@@ -443,6 +447,7 @@ class sin(TrigonometricFunction):
         return self.func(self.args[0].conjugate())
 
     def as_real_imag(self, deep=True, **hints):
+        from sympy.functions.elementary.hyperbolic import cosh, sinh
         re, im = self._as_real_imag(deep=deep, **hints)
         return (sin(re)*cosh(im), cos(re)*sinh(im))
 
@@ -476,7 +481,6 @@ class sin(TrigonometricFunction):
         return sin(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import re
         from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
@@ -567,6 +571,7 @@ class cos(TrigonometricFunction):
     def eval(cls, arg):
         from sympy.functions.special.polynomials import chebyshevt
         from sympy.calculus.accumulationbounds import AccumBounds
+        from sympy.sets.setexpr import SetExpr
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -595,6 +600,7 @@ class cos(TrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import cosh
             return cosh(i_coeff)
 
         pi_coeff = _pi_coeff(arg)
@@ -733,6 +739,7 @@ class cos(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
+        from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
             arg = arg.func(arg.args[0]).rewrite(exp)
         return (exp(arg*I) + exp(-arg*I))/2
@@ -779,7 +786,6 @@ class cos(TrigonometricFunction):
             return tuple([u] + [v*i for i in g[0:-1] ] + [h])
 
         def ipartfrac(r, factors=None):
-            from sympy.ntheory import factorint
             if isinstance(r, int):
                 return r
             if not isinstance(r, Rational):
@@ -908,6 +914,7 @@ class cos(TrigonometricFunction):
         return self.func(self.args[0].conjugate())
 
     def as_real_imag(self, deep=True, **hints):
+        from sympy.functions.elementary.hyperbolic import cosh, sinh
         re, im = self._as_real_imag(deep=deep, **hints)
         return (cos(re)*cosh(im), -sin(re)*sinh(im))
 
@@ -933,7 +940,6 @@ class cos(TrigonometricFunction):
         return cos(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import re
         from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
@@ -1044,6 +1050,7 @@ class tan(TrigonometricFunction):
                 min = min - d*S.Pi
             if max is not S.Infinity:
                 max = max - d*S.Pi
+            from sympy.sets.sets import FiniteSet
             if AccumBounds(min, max).intersection(FiniteSet(S.Pi/2, S.Pi*Rational(3, 2))):
                 return AccumBounds(S.NegativeInfinity, S.Infinity)
             else:
@@ -1054,6 +1061,7 @@ class tan(TrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import tanh
             return S.ImaginaryUnit*tanh(i_coeff)
 
         pi_coeff = _pi_coeff(arg, 2)
@@ -1161,7 +1169,6 @@ class tan(TrigonometricFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n < 0 or n % 2 == 0:
             return S.Zero
         else:
@@ -1192,17 +1199,16 @@ class tan(TrigonometricFunction):
     def as_real_imag(self, deep=True, **hints):
         re, im = self._as_real_imag(deep=deep, **hints)
         if im:
+            from sympy.functions.elementary.hyperbolic import cosh, sinh
             denom = cos(2*re) + cosh(2*im)
             return (sin(2*re)/denom, sinh(2*im)/denom)
         else:
             return (self.func(re), S.Zero)
 
     def _eval_expand_trig(self, **hints):
-        from sympy.functions.elementary.complexes import (im, re)
         arg = self.args[0]
         x = None
         if arg.is_Add:
-            from sympy.polys.specialpolys import symmetric_poly
             n = len(arg.args)
             TX = []
             for x in arg.args:
@@ -1228,6 +1234,7 @@ class tan(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
+        from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
             arg = arg.func(arg.args[0]).rewrite(exp)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
@@ -1379,6 +1386,7 @@ class cot(TrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import coth
             return -S.ImaginaryUnit*coth(i_coeff)
 
         pi_coeff = _pi_coeff(arg, 2)
@@ -1472,7 +1480,6 @@ class cot(TrigonometricFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n == 0:
             return 1/sympify(x)
         elif n < 0 or n % 2 == 0:
@@ -1497,12 +1504,14 @@ class cot(TrigonometricFunction):
     def as_real_imag(self, deep=True, **hints):
         re, im = self._as_real_imag(deep=deep, **hints)
         if im:
+            from sympy.functions.elementary.hyperbolic import cosh, sinh
             denom = cos(2*re) - cosh(2*im)
             return (-sin(2*re)/denom, sinh(2*im)/denom)
         else:
             return (self.func(re), S.Zero)
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
+        from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         I = S.ImaginaryUnit
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
             arg = arg.func(arg.args[0]).rewrite(exp)
@@ -1562,11 +1571,9 @@ class cot(TrigonometricFunction):
         return self.args[0].is_extended_real
 
     def _eval_expand_trig(self, **hints):
-        from sympy.functions.elementary.complexes import (im, re)
         arg = self.args[0]
         x = None
         if arg.is_Add:
-            from sympy.polys.specialpolys import symmetric_poly
             n = len(arg.args)
             CX = []
             for x in arg.args:
@@ -1817,7 +1824,6 @@ class sec(ReciprocalTrigonometricFunction):
     def taylor_term(n, x, *previous_terms):
         # Reference Formula:
         # http://functions.wolfram.com/ElementaryFunctions/Sec/06/01/02/01/
-        from sympy.functions.combinatorial.numbers import euler
         if n < 0 or n % 2 == 1:
             return S.Zero
         else:
@@ -1910,7 +1916,6 @@ class csc(ReciprocalTrigonometricFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
-        from sympy.functions.combinatorial.numbers import bernoulli
         if n == 0:
             return 1/sympify(x)
         elif n < 0 or n % 2 == 0:
@@ -2215,6 +2220,7 @@ class asin(InverseTrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import asinh
             return S.ImaginaryUnit*asinh(i_coeff)
 
         if arg.is_zero:
@@ -2257,7 +2263,6 @@ class asin(InverseTrigonometricFunction):
                 return R/F*x**n/n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import im
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0.is_zero:
@@ -2273,7 +2278,6 @@ class asin(InverseTrigonometricFunction):
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # asin
-        from sympy.functions.elementary.complexes import im
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
         if arg0 is S.One:
@@ -2461,7 +2465,6 @@ class acos(InverseTrigonometricFunction):
                 return -R/F*x**n/n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import im
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0 == 1:
@@ -2484,7 +2487,6 @@ class acos(InverseTrigonometricFunction):
         return self._eval_is_extended_real()
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acos
-        from sympy.functions.elementary.complexes import im
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
         if arg0 is S.One:
@@ -2655,6 +2657,7 @@ class atan(InverseTrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import atanh
             return S.ImaginaryUnit*atanh(i_coeff)
 
         if arg.is_zero:
@@ -2687,7 +2690,6 @@ class atan(InverseTrigonometricFunction):
             return S.NegativeOne**((n - 1)//2)*x**n/n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import (im, re)
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0.is_zero:
@@ -2703,7 +2705,6 @@ class atan(InverseTrigonometricFunction):
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # atan
-        from sympy.functions.elementary.complexes import (im, re)
         arg0 = self.args[0].subs(x, 0)
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if cdir != 0:
@@ -2852,6 +2853,7 @@ class acot(InverseTrigonometricFunction):
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
+            from sympy.functions.elementary.hyperbolic import acoth
             return -S.ImaginaryUnit*acoth(i_coeff)
 
         if arg.is_zero:
@@ -2885,7 +2887,6 @@ class acot(InverseTrigonometricFunction):
             return S.NegativeOne**((n + 1)//2)*x**n/n
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import (im, re)
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0 is S.ComplexInfinity:
@@ -2903,7 +2904,6 @@ class acot(InverseTrigonometricFunction):
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acot
-        from sympy.functions.elementary.complexes import (im, re)
         arg0 = self.args[0].subs(x, 0)
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
@@ -3063,7 +3063,6 @@ class asec(InverseTrigonometricFunction):
         return sec
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import im
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0 == 1:
@@ -3079,7 +3078,6 @@ class asec(InverseTrigonometricFunction):
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # asec
-        from sympy.functions.elementary.complexes import im
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
         if arg0 is S.One:
@@ -3236,7 +3234,6 @@ class acsc(InverseTrigonometricFunction):
         return csc
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        from sympy.functions.elementary.complexes import im
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
         if x0.is_zero:
@@ -3252,7 +3249,6 @@ class acsc(InverseTrigonometricFunction):
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acsc
-        from sympy.functions.elementary.complexes import im
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
         if arg0 is S.One:
@@ -3410,7 +3406,6 @@ class atan2(InverseTrigonometricFunction):
 
     @classmethod
     def eval(cls, y, x):
-        from sympy.functions.elementary.complexes import (im, re)
         from sympy.functions.special.delta_functions import Heaviside
         if x is S.NegativeInfinity:
             if y.is_zero:
@@ -3453,14 +3448,12 @@ class atan2(InverseTrigonometricFunction):
         return -S.ImaginaryUnit*log((x + S.ImaginaryUnit*y)/sqrt(x**2 + y**2))
 
     def _eval_rewrite_as_atan(self, y, x, **kwargs):
-        from sympy.functions.elementary.complexes import re
         return Piecewise((2*atan(y/(x + sqrt(x**2 + y**2))), Ne(y, 0)),
                          (pi, re(x) < 0),
                          (0, Ne(x, 0)),
                          (S.NaN, True))
 
     def _eval_rewrite_as_arg(self, y, x, **kwargs):
-        from sympy.functions.elementary.complexes import arg
         if x.is_extended_real and y.is_extended_real:
             return arg(x + y*S.ImaginaryUnit)
         n = x + S.ImaginaryUnit*y

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -13,10 +13,9 @@ from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
 from sympy.functions.elementary.integers import ceiling
-from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.miscellaneous import sqrt, root
-from sympy.functions.elementary.complexes import re, im
+from sympy.functions.elementary.miscellaneous import cbrt, sqrt, root
+from sympy.functions.elementary.complexes import (Abs, re, im, polar_lift, unpolarify)
 from sympy.functions.special.gamma_functions import gamma, digamma, uppergamma
 from sympy.functions.special.hyper import hyper
 from sympy.polys.orthopolys import spherical_bessel_fn
@@ -200,7 +199,6 @@ class besselj(BesselBase):
                 return I**(nu)*besseli(nu, newz)
 
         # branch handling:
-        from sympy.functions.elementary.complexes import unpolarify
         if nu.is_integer:
             newz = unpolarify(z)
             if newz != z:
@@ -214,7 +212,6 @@ class besselj(BesselBase):
             return besselj(nnu, z)
 
     def _eval_rewrite_as_besseli(self, nu, z, **kwargs):
-        from sympy.functions.elementary.complexes import polar_lift
         return exp(I*pi*nu/2)*besseli(nu, polar_lift(-I)*z)
 
     def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
@@ -466,7 +463,6 @@ class besseli(BesselBase):
                 return I**(-nu)*besselj(nu, -newz)
 
         # branch handling:
-        from sympy.functions.elementary.complexes import unpolarify
         if nu.is_integer:
             newz = unpolarify(z)
             if newz != z:
@@ -480,7 +476,6 @@ class besseli(BesselBase):
             return besseli(nnu, z)
 
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
-        from sympy.functions.elementary.complexes import polar_lift
         return exp(-I*pi*nu/2)*besselj(nu, polar_lift(I)*z)
 
     def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
@@ -1274,11 +1269,11 @@ class airyai(AiryBase):
             x = sympify(x)
             if len(previous_terms) > 1:
                 p = previous_terms[-1]
-                return ((3**Rational(1, 3)*x)**(-n)*(3**Rational(1, 3)*x)**(n + 1)*sin(pi*(n*Rational(2, 3) + Rational(4, 3)))*factorial(n) *
+                return ((cbrt(3)*x)**(-n)*(cbrt(3)*x)**(n + 1)*sin(pi*(n*Rational(2, 3) + Rational(4, 3)))*factorial(n) *
                         gamma(n/3 + Rational(2, 3))/(sin(pi*(n*Rational(2, 3) + Rational(2, 3)))*factorial(n + 1)*gamma(n/3 + Rational(1, 3))) * p)
             else:
-                return (S.One/(3**Rational(2, 3)*pi) * gamma((n+S.One)/S(3)) * sin(2*pi*(n+S.One)/S(3)) /
-                        factorial(n) * (root(3, 3)*x)**n)
+                return (S.One/(3**Rational(2, 3)*pi) * gamma((n+S.One)/S(3)) * sin(Rational(2, 3)*pi*(n+S.One)) /
+                        factorial(n) * (cbrt(3)*x)**n)
 
     def _eval_rewrite_as_besselj(self, z, **kwargs):
         ot = Rational(1, 3)
@@ -1449,11 +1444,11 @@ class airybi(AiryBase):
             x = sympify(x)
             if len(previous_terms) > 1:
                 p = previous_terms[-1]
-                return (3**Rational(1, 3)*x * Abs(sin(2*pi*(n + S.One)/S(3))) * factorial((n - S.One)/S(3)) /
-                        ((n + S.One) * Abs(cos(2*pi*(n + S.Half)/S(3))) * factorial((n - 2)/S(3))) * p)
+                return (cbrt(3)*x * Abs(sin(Rational(2, 3)*pi*(n + S.One))) * factorial((n - S.One)/S(3)) /
+                        ((n + S.One) * Abs(cos(Rational(2, 3)*pi*(n + S.Half))) * factorial((n - 2)/S(3))) * p)
             else:
-                return (S.One/(root(3, 6)*pi) * gamma((n + S.One)/S(3)) * Abs(sin(2*pi*(n + S.One)/S(3))) /
-                        factorial(n) * (root(3, 3)*x)**n)
+                return (S.One/(root(3, 6)*pi) * gamma((n + S.One)/S(3)) * Abs(sin(Rational(2, 3)*pi*(n + S.One))) /
+                        factorial(n) * (cbrt(3)*x)**n)
 
     def _eval_rewrite_as_besselj(self, z, **kwargs):
         ot = Rational(1, 3)

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -1,6 +1,7 @@
 from sympy.core import S, sympify
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise, piecewise_fold
+from sympy.logic.boolalg import And
 from sympy.sets.sets import Interval
 
 from functools import lru_cache
@@ -13,7 +14,6 @@ def _ivl(cond, x):
     which an expression is valid like (lo <= x) & (x <= hi).
     This function returns (lo, hi).
     """
-    from sympy.logic.boolalg import And
     if isinstance(cond, And) and len(cond.args) == 2:
         a, b = cond.args
         if a.lts == x:

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -5,6 +5,7 @@ from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.complexes import im, sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polyroots import roots
 from sympy.utilities.misc import filldedent
 
 
@@ -264,8 +265,6 @@ class DiracDelta(Function):
         is_simple, Diracdelta
 
         """
-        from sympy.polys.polyroots import roots
-
         wrt = hints.get('wrt', None)
         if wrt is None:
             free = self.free_symbols
@@ -370,7 +369,7 @@ class DiracDelta(Function):
 
         """
         from sympy.solvers import solve
-        from sympy.functions import SingularityFunction
+        from sympy.functions.special.singularity_functions import SingularityFunction
         if self == DiracDelta(0):
             return SingularityFunction(0, 0, -1)
         if self == DiracDelta(0, 1):
@@ -655,7 +654,7 @@ class Heaviside(Function):
 
         """
         from sympy.solvers import solve
-        from sympy.functions import SingularityFunction
+        from sympy.functions.special.singularity_functions import SingularityFunction
         if self == Heaviside(0):
             return SingularityFunction(0, 0, 0)
         free = self.free_symbols

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -7,11 +7,10 @@ from sympy.core.relational import is_eq
 from sympy.core.power import Pow
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial, factorial2, RisingFactorial
-from sympy.functions.elementary.complexes import re
-from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.complexes import  polar_lift, re, unpolarify
+from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import sqrt, root
 from sympy.functions.elementary.exponential import exp, log, exp_polar
-from sympy.functions.elementary.complexes import polar_lift, unpolarify
 from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc
 from sympy.functions.special.hyper import hyper, meijerg
@@ -244,7 +243,6 @@ class erf(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.series.order import Order
-        from sympy.functions.elementary.integers import ceiling
         point = args0[0]
 
         if point in [S.Infinity, S.NegativeInfinity]:

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -13,7 +13,12 @@ from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy
 
 from sympy.functions import (sqrt, exp, log, sin, cos, asin, atan,
-        sinh, cosh, asinh, acosh, atanh, acoth, Abs, re, factorial, RisingFactorial)
+        sinh, cosh, asinh, acosh, atanh, acoth)
+from sympy.functions import factorial, RisingFactorial
+from sympy.functions.elementary.complexes import Abs, re, unpolarify
+from sympy.functions.elementary.exponential import exp_polar
+from sympy.functions.elementary.integers import ceiling
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import (And, Or)
 
 class TupleArg(Tuple):
@@ -45,7 +50,6 @@ def _prep_tuple(v):
     (7, 8, 9)
 
     """
-    from sympy.functions.elementary.complexes import unpolarify
     return TupleArg(*[unpolarify(x) for x in v])
 
 
@@ -191,7 +195,6 @@ class hyper(TupleParametersBase):
 
     @classmethod
     def eval(cls, ap, bq, z):
-        from sympy.functions.elementary.complexes import unpolarify
         if len(ap) <= len(bq) or (len(ap) == len(bq) + 1 and (Abs(z) <= 1) == True):
             nz = unpolarify(z)
             if z != nz:
@@ -215,7 +218,6 @@ class hyper(TupleParametersBase):
         return hyperexpand(self)
 
     def _eval_rewrite_as_Sum(self, ap, bq, z, **kwargs):
-        from sympy.functions import factorial, RisingFactorial, Piecewise
         from sympy.concrete.summations import Sum
         n = Dummy("n", integer=True)
         rfap = Tuple(*[RisingFactorial(a, n) for a in ap])
@@ -669,7 +671,6 @@ class meijerg(TupleParametersBase):
         # less than (say) n*pi, we put r=1/n, compute z' = root(z, n)
         # (carefully so as not to loose the branch information), and evaluate
         # G(z'**(1/r)) = G(z'**n) = G(z).
-        from sympy.functions import exp_polar, ceiling
         import mpmath
         znum = self.argument._eval_evalf(prec)
         if znum.has(exp_polar):
@@ -783,7 +784,6 @@ class HyperRep(Function):
 
     @classmethod
     def eval(cls, *args):
-        from sympy.functions.elementary.complexes import unpolarify
         newargs = tuple(map(unpolarify, args[:-1])) + args[-1:]
         if args != newargs:
             return cls(*newargs)
@@ -809,7 +809,6 @@ class HyperRep(Function):
         raise NotImplementedError
 
     def _eval_rewrite_as_nonrep(self, *args, **kwargs):
-        from sympy.functions.elementary.piecewise import Piecewise
         x, n = self.args[-1].extract_branch_factor(allow_half=True)
         minus = False
         newargs = self.args[:-1] + (x,)

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -18,16 +18,9 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sec
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper
-
-from sympy.polys.orthopolys import (
-    jacobi_poly,
-    gegenbauer_poly,
-    chebyshevt_poly,
-    chebyshevu_poly,
-    laguerre_poly,
-    hermite_poly,
-    legendre_poly
-)
+from sympy.polys.orthopolys import (chebyshevt_poly, chebyshevu_poly,
+                                    gegenbauer_poly, hermite_poly, jacobi_poly,
+                                    laguerre_poly, legendre_poly)
 
 _x = Dummy('x')
 

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -6,7 +6,7 @@ from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
 from sympy.functions import assoc_legendre
 from sympy.functions.combinatorial.factorials import factorial
-from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin, cos, cot
@@ -264,7 +264,6 @@ def Ynm_c(n, m, theta, phi):
     .. [3] http://functions.wolfram.com/Polynomials/SphericalHarmonicY/
 
     """
-    from sympy.functions.elementary.complexes import conjugate
     return conjugate(Ynm(n, m, theta, phi))
 
 

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -5,6 +5,8 @@ from sympy.core.mul import prod
 from sympy.core.relational import Ne
 from sympy.core.sorting import default_sort_key
 from sympy.external.gmpy import SYMPY_INTS
+from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.utilities.iterables import has_dups
 
 ###############################################################################
@@ -29,7 +31,6 @@ def Eijk(*args, **kwargs):
 
 def eval_levicivita(*args):
     """Evaluate Levi-Civita symbol."""
-    from sympy.functions.combinatorial.factorials import factorial
     n = len(args)
     return prod(
         prod(args[j] - args[i] for j in range(i + 1, n))
@@ -468,6 +469,5 @@ class KroneckerDelta(Function):
         return self.args[0:2]
 
     def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
-        from sympy.functions.elementary.piecewise import Piecewise
         i, j = args
         return Piecewise((0, Ne(i, j)), (1, True))

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -7,8 +7,9 @@ from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
 from sympy.functions.elementary.complexes import re, unpolarify, Abs, polar_lift
 from sympy.functions.elementary.exponential import log, exp_polar, exp
-from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.polys.polytools import Poly
 
 ###############################################################################
 ###################### LERCH TRANSCENDENT #####################################
@@ -122,7 +123,6 @@ class lerchphi(Function):
     """
 
     def _eval_expand_func(self, **hints):
-        from sympy.polys.polytools import Poly
         z, s, a = self.args
         if z == 1:
             return zeta(s, a)
@@ -354,7 +354,6 @@ class polylog(Function):
             return True
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        from sympy.functions.elementary.integers import ceiling
         from sympy.series.order import Order
         nu, z = self.args
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1458,7 +1458,7 @@ class ITE(BooleanFunction):
         return self.to_nnf().as_set()
 
     def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
-        from sympy.functions import Piecewise
+        from sympy.functions.elementary.piecewise import Piecewise
         return Piecewise((args[1], args[0]), (args[2], True))
 
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -19,7 +19,7 @@ from sympy.core.mod import Mod
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.functions import Abs
+from sympy.functions.elementary.complexes import Abs, re, im
 from .utilities import _dotprodsimp, _simplify
 from sympy.polys.polytools import Poly
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -1985,8 +1985,6 @@ class MatrixOperations(MatrixRequired):
         return out
 
     def _eval_as_real_imag(self):  # type: ignore
-        from sympy.functions.elementary.complexes import re, im
-
         return (self.applyfunc(re), self.applyfunc(im))
 
     def _eval_conjugate(self):

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -13,6 +13,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.polys import roots, CRootOf, ZZ, QQ, EX
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.eigen import dom_eigenvects, dom_eigenvects_to_sympy
+from sympy.polys.polytools import gcd
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .common import MatrixError, NonSquareMatrixError
@@ -425,7 +426,6 @@ def _eigenvects(M, error_when_incomplete=True, iszerofunc=_iszero, *, chop=False
         # if the primitive flag is set, get rid of any common
         # integer denominators
         def denom_clean(l):
-            from sympy.polys.polytools import gcd
             return [(v / gcd(list(v))).applyfunc(simpfunc) for v in l]
 
         ret = [(val, mult, denom_clean(es)) for val, mult, es in ret]

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -4,6 +4,7 @@ from sympy.core import Mul, sympify
 from sympy.core.add import Add
 from sympy.core.expr import ExprBuilder
 from sympy.core.sorting import default_sort_key
+from sympy.functions.elementary.exponential import log
 from sympy.matrices.common import ShapeError
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.expressions.special import ZeroMatrix, OneMatrix
@@ -420,7 +421,6 @@ class HadamardPower(MatrixExpr):
         return HadamardPower(transpose(self.base), self.exp)
 
     def _eval_derivative(self, x):
-        from sympy.functions.elementary.exponential import log
         dexp = self.exp.diff(x)
         logbase = self.base.applyfunc(log)
         dlbase = logbase.diff(x)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -11,13 +11,12 @@ from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol, uniquely_named_symbol
-from sympy.core.sympify import sympify
-from sympy.core.sympify import _sympify
-from sympy.functions import factorial
+from sympy.core.sympify import sympify, _sympify
+from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.functions.elementary.complexes import re
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import Max, Min, sqrt
-from sympy.functions.special.tensor_functions import KroneckerDelta
+from sympy.functions.special.tensor_functions import KroneckerDelta, LeviCivita
 from sympy.polys import cancel
 from sympy.printing import sstr
 from sympy.printing.defaults import Printable
@@ -816,7 +815,6 @@ class MatrixBase(MatrixDeprecated,
 
     def _matrix_pow_by_jordan_blocks(self, num):
         from sympy.matrices import diag, MutableMatrix
-        from sympy.functions.combinatorial.factorials import binomial
 
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
@@ -1457,7 +1455,6 @@ class MatrixBase(MatrixDeprecated,
         so that the dual is a covariant second rank tensor.
 
         """
-        from sympy.functions.special.tensor_functions import LeviCivita
         from sympy.matrices import zeros
 
         M, n = self[:, :], self.rows

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -290,7 +290,6 @@ def continued_fraction_iterator(x):
 
     """
     from sympy.functions import floor
-
     while True:
         i = floor(x)
         yield i

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -193,8 +193,6 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     .. [1]  Carl Pomerance and Richard Crandall "Prime Numbers:
         A Computational Perspective" (2nd Ed.), page 344
     """
-    from sympy.functions.elementary.miscellaneous import sqrt
-    from sympy.polys.polytools import gcd
     n = as_int(n)
     if B1 % 2 != 0 or B2 % 2 != 0:
         raise ValueError("The Bounds should be an even integer")
@@ -203,6 +201,8 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     if isprime(n):
         return n
 
+    from sympy.functions.elementary.miscellaneous import sqrt
+    from sympy.polys.polytools import gcd
     curve = 0
     D = int(sqrt(B2))
     beta = [0]*(D + 1)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -3,6 +3,7 @@ Integer factorization
 """
 
 from collections import defaultdict
+from functools import reduce
 import random
 import math
 
@@ -272,11 +273,10 @@ def multiplicity(p, n):
     True
 
     """
-    from sympy.functions.combinatorial.factorials import factorial
-
     try:
         p, n = as_int(p), as_int(n)
     except ValueError:
+        from sympy.functions.combinatorial.factorials import factorial
         if all(isinstance(i, (SYMPY_INTS, Rational)) for i in (p, n)):
             p = Rational(p)
             n = Rational(n)
@@ -1963,7 +1963,6 @@ class totient(Function):
         >>> totient._from_distinct_primes(5, 7)
         24
         """
-        from functools import reduce
         return reduce(lambda i, j: i * (j-1), args, 1)
 
     @classmethod

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -28,6 +28,13 @@ def _arange(a, b):
     return _array('l', range(a, b))
 
 
+def _as_int_ceiling(a):
+    """ Wrapping ceiling in as_int will raise an error if there was a problem
+        determining whether the expression was exactly an integer or not."""
+    from sympy.functions.elementary.integers import ceiling
+    return as_int(ceiling(a))
+
+
 class Sieve:
     """An infinite list of prime numbers, implemented as a dynamically
     growing sieve of Eratosthenes. When a lookup is requested involving
@@ -167,16 +174,13 @@ class Sieve:
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
         """
-        from sympy.functions.elementary.integers import ceiling
 
-        # wrapping ceiling in as_int will raise an error if there was a problem
-        # determining whether the expression was exactly an integer or not
         if b is None:
-            b = as_int(ceiling(a))
+            b = _as_int_ceiling(a)
             a = 2
         else:
-            a = max(2, as_int(ceiling(a)))
-            b = as_int(ceiling(b))
+            a = max(2, _as_int_ceiling(a))
+            b = _as_int_ceiling(b)
         if a >= b:
             return
         self.extend(b)
@@ -200,12 +204,8 @@ class Sieve:
         >>> print([i for i in sieve.totientrange(7, 18)])
         [6, 4, 6, 4, 10, 4, 12, 6, 8, 8, 16]
         """
-        from sympy.functions.elementary.integers import ceiling
-
-        # wrapping ceiling in as_int will raise an error if there was a problem
-        # determining whether the expression was exactly an integer or not
-        a = max(1, as_int(ceiling(a)))
-        b = as_int(ceiling(b))
+        a = max(1, _as_int_ceiling(a))
+        b = _as_int_ceiling(b)
         n = len(self._tlist)
         if a >= b:
             return
@@ -248,12 +248,8 @@ class Sieve:
         >>> print([i for i in sieve.mobiusrange(7, 18)])
         [-1, 0, 0, 1, -1, 0, -1, 1, 1, 0, -1]
         """
-        from sympy.functions.elementary.integers import ceiling
-
-        # wrapping ceiling in as_int will raise an error if there was a problem
-        # determining whether the expression was exactly an integer or not
-        a = max(1, as_int(ceiling(a)))
-        b = as_int(ceiling(b))
+        a = max(1, _as_int_ceiling(a))
+        b = _as_int_ceiling(b)
         n = len(self._mlist)
         if a >= b:
             return
@@ -294,11 +290,7 @@ class Sieve:
         >>> sieve.search(23)
         (9, 9)
         """
-        from sympy.functions.elementary.integers import ceiling
-
-        # wrapping ceiling in as_int will raise an error if there was a problem
-        # determining whether the expression was exactly an integer or not
-        test = as_int(ceiling(n))
+        test = _as_int_ceiling(n)
         n = as_int(n)
         if n < 2:
             raise ValueError("n should be >= 2 but got: %s" % n)
@@ -405,9 +397,8 @@ def prime(nth):
     if n <= len(sieve._list):
         return sieve[n]
 
-    from sympy.functions.special.error_functions import li
     from sympy.functions.elementary.exponential import log
-
+    from sympy.functions.special.error_functions import li
     a = 2 # Lower bound for binary search
     b = int(n*(log(n) + log(log(n)))) # Upper bound for the search.
 
@@ -637,11 +628,7 @@ def prevprime(n):
         nextprime : Return the ith prime greater than n
         primerange : Generates all primes in a given range
     """
-    from sympy.functions.elementary.integers import ceiling
-
-    # wrapping ceiling in as_int will raise an error if there was a problem
-    # determining whether the expression was exactly an integer or not
-    n = as_int(ceiling(n))
+    n = _as_int_ceiling(n)
     if n < 3:
         raise ValueError("no preceding primes")
     if n < 8:
@@ -744,8 +731,6 @@ def primerange(a, b=None):
         .. [1] https://en.wikipedia.org/wiki/Prime_number
         .. [2] http://primes.utm.edu/notes/gaps.html
     """
-    from sympy.functions.elementary.integers import ceiling
-
     if b is None:
         a, b = 2, a
     if a >= b:
@@ -756,10 +741,8 @@ def primerange(a, b=None):
         return
     # otherwise compute, without storing, the desired range.
 
-    # wrapping ceiling in as_int will raise an error if there was a problem
-    # determining whether the expression was exactly an integer or not
-    a = as_int(ceiling(a)) - 1
-    b = as_int(ceiling(b))
+    a = _as_int_ceiling(a) - 1
+    b = _as_int_ceiling(b)
     while 1:
         a = nextprime(a)
         if a < b:
@@ -1004,9 +987,8 @@ def composite(nth):
             a -= 1
         return a
 
-    from sympy.functions.special.error_functions import li
     from sympy.functions.elementary.exponential import log
-
+    from sympy.functions.special.error_functions import li
     a = 4 # Lower bound for binary search
     b = int(n*(log(n) + log(log(n)))) # Upper bound for the search.
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -2,7 +2,9 @@ from sympy.core.function import Function
 from sympy.core.numbers import igcd, igcdex, mod_inverse
 from sympy.core.power import isqrt
 from sympy.core.singleton import S
+from sympy.polys import Poly
 from sympy.polys.domains import ZZ
+from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence
 from .primetest import isprime
 from .factor_ import factorint, trailing, totient, multiplicity
 from sympy.utilities.misc import as_int
@@ -316,7 +318,6 @@ def sqrt_mod_iter(a, p, domain=int):
     >>> list(sqrt_mod_iter(11, 43))
     [21, 22]
     """
-    from sympy.polys.galoistools import gf_crt1, gf_crt2
     a, p = as_int(a), abs(as_int(p))
     if isprime(p):
         a = a % p
@@ -1372,7 +1373,6 @@ def quadratic_congruence(a, b, c, p):
     c : integer
     p : positive integer
     """
-    from sympy.polys.galoistools import linear_congruence
     a = as_int(a)
     b = as_int(b)
     c = as_int(c)
@@ -1486,7 +1486,6 @@ def _valid_expr(expr):
 
     if not expr.is_polynomial():
         raise ValueError("The expression should be a polynomial")
-    from sympy.polys import Poly
     polynomial = Poly(expr)
     if not polynomial.is_univariate:
         raise ValueError("The expression should be univariate")

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1,7 +1,6 @@
 """Euclidean algorithms, GCDs, LCMs and polynomial remainder sequences. """
 
 
-from sympy.ntheory import nextprime
 from sympy.polys.densearith import (
     dup_sub_mul,
     dup_neg, dmp_neg,
@@ -702,6 +701,8 @@ def dmp_zz_collins_resultant(f, g, u, K):
 
     B = K(2)*K.factorial(K(n + m))*A**m*B**n
     r, p, P = dmp_zero(v), K.one, K.one
+
+    from sympy.ntheory import nextprime
 
     while P <= B:
         p = K(nextprime(p))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1,5 +1,6 @@
 """Polynomial factorization routines in characteristic zero. """
 
+from sympy.core.random import _randint
 
 from sympy.polys.galoistools import (
     gf_from_int_poly, gf_to_int_poly,
@@ -70,7 +71,6 @@ from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import (
     ExtraneousFactors, DomainError, CoercionFailed, EvaluationFailed)
 
-from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import subsets
 
 from math import ceil as _ceil, log as _log
@@ -163,7 +163,6 @@ def dup_zz_mignotte_bound(f, K):
 
     """
     from sympy.functions.combinatorial.factorials import binomial
-
     d = dup_degree(f)
     delta = _ceil(d / 2)
     delta2 = _ceil(delta / 2)
@@ -319,6 +318,8 @@ def dup_zz_zassenhaus(f, K):
     if n == 1:
         return [f]
 
+    from sympy.ntheory import isprime
+
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
@@ -423,6 +424,7 @@ def dup_zz_irreducible_p(f, K):
     e_fc = dup_content(f[1:], K)
 
     if e_fc:
+        from sympy.ntheory import factorint
         e_ff = factorint(int(e_fc))
 
         for p in e_ff.keys():
@@ -508,6 +510,7 @@ def dup_cyclotomic_p(f, K, irreducible=False):
 
 def dup_zz_cyclotomic_poly(n, K):
     """Efficiently generate n-th cyclotomic polynomial. """
+    from sympy.ntheory import factorint
     h = [K.one, -K.one]
 
     for p, k in factorint(n).items():
@@ -518,6 +521,8 @@ def dup_zz_cyclotomic_poly(n, K):
 
 
 def _dup_cyclotomic_decompose(n, K):
+    from sympy.ntheory import factorint
+
     H = [[K.one, -K.one]]
 
     for p, k in factorint(n).items():
@@ -977,7 +982,7 @@ def dmp_zz_wang(f, u, K, mod=None, seed=None):
     .. [2] [Geddes92]_
 
     """
-    from sympy.core.random import _randint
+    from sympy.ntheory import nextprime
 
     randint = _randint(seed)
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -6,7 +6,6 @@ from math import ceil as _ceil, sqrt as _sqrt
 
 from sympy.core.mul import prod
 from sympy.external.gmpy import SYMPY_INTS
-from sympy.ntheory import factorint
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import _sort_factors
@@ -1465,6 +1464,8 @@ def gf_irred_p_rabin(f, p, K):
 
     x = [K.one, K.zero]
 
+    from sympy.ntheory import factorint
+
     indices = { n//d for d in factorint(n) }
 
     b = gf_frobenius_monomial_base(f, p, K)
@@ -2345,6 +2346,7 @@ def gf_csolve(f, n):
 
     """
     from sympy.polys.domains import ZZ
+    from sympy.ntheory import factorint
     P = factorint(n)
     X = [csolve_prime(f, p, e) for p, e in P.items()]
     pools = list(map(tuple, X))

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -3,21 +3,16 @@
 from functools import reduce
 
 from sympy.core.add import Add
-from sympy.core.function import expand_mul, expand_multinomial
+from sympy.core.exprtools import Factors
+from sympy.core.function import expand_mul, expand_multinomial, _mexpand
 from sympy.core.mul import Mul
-from sympy.core import (GoldenRatio, TribonacciConstant)
-from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.numbers import (I, Rational, pi, _illegal)
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
-
-from sympy.functions import sqrt, cbrt
-
-from sympy.core.exprtools import Factors
-from sympy.core.function import _mexpand
-from sympy.core.numbers import _illegal
 from sympy.core.traversal import preorder_traversal
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.trigonometric import cos, sin, tan
 from sympy.ntheory.factor_ import divisors
 from sympy.utilities.iterables import subsets
@@ -556,14 +551,14 @@ def _minpoly_compose(ex, x, dom):
         _, factors = factor_list(x**2 + 1, x, domain=dom)
         return x**2 + 1 if len(factors) == 1 else x - I
 
-    if ex is GoldenRatio:
+    if ex is S.GoldenRatio:
         _, factors = factor_list(x**2 - x - 1, x, domain=dom)
         if len(factors) == 1:
             return x**2 - x - 1
         else:
             return _choose_factor(factors, x, (1 + sqrt(5))/2, dom=dom)
 
-    if ex is TribonacciConstant:
+    if ex is S.TribonacciConstant:
         _, factors = factor_list(x**3 - x**2 - x - 1, x, domain=dom)
         if len(factors) == 1:
             return x**3 - x**2 - x - 1

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -15,8 +15,8 @@ from sympy.core.relational import Eq
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol, symbols
 from sympy.core.sympify import sympify
-from sympy.functions import exp, sqrt, im, cos, acos, Piecewise
-from sympy.functions.elementary.miscellaneous import root
+from sympy.functions import exp, im, cos, acos, Piecewise
+from sympy.functions.elementary.miscellaneous import root, sqrt
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.polys.domains import EX
 from sympy.polys.polyerrors import (PolynomialError, GeneratorsNeeded,

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3652,7 +3652,6 @@ class Poly(Basic):
         [-1.73205080756887729352744634151, 1.73205080756887729352744634151]
 
         """
-        from sympy.functions.elementary.complexes import sign
         if f.is_multivariate:
             raise MultivariatePolynomialError(
                 "Cannot compute numerical roots of %s" % f)
@@ -3681,6 +3680,7 @@ class Poly(Basic):
         dps = mpmath.mp.dps
         mpmath.mp.dps = n
 
+        from sympy.functions.elementary.complexes import sign
         try:
             # We need to add extra precision to guard against losing accuracy.
             # 10 times the degree of the polynomial seems to work well.
@@ -4405,8 +4405,6 @@ def parallel_poly_from_expr(exprs, *gens, **args):
 
 def _parallel_poly_from_expr(exprs, opt):
     """Construct polynomials from expressions. """
-    from sympy.functions.elementary.piecewise import Piecewise
-
     if len(exprs) == 2:
         f, g = exprs
 
@@ -4457,6 +4455,7 @@ def _parallel_poly_from_expr(exprs, opt):
     if not opt.gens:
         raise PolificationFailed(opt, origs, exprs, True)
 
+    from sympy.functions.elementary.piecewise import Piecewise
     for k in opt.gens:
         if isinstance(k, Piecewise):
             raise PolynomialError("Piecewise generators do not make sense")
@@ -6724,7 +6723,6 @@ def cancel(f, *gens, _signsimp=True, **args):
     (x + 2)/2
     """
     from sympy.simplify.simplify import signsimp
-    from sympy.functions.elementary.piecewise import Piecewise
     from sympy.polys.rings import sring
     options.allowed_flags(args, ['polys'])
 
@@ -6753,6 +6751,7 @@ def cancel(f, *gens, _signsimp=True, **args):
     else:
         raise ValueError('unexpected argument: %s' % f)
 
+    from sympy.functions.elementary.piecewise import Piecewise
     try:
         if f.has(Piecewise):
             raise PolynomialError()

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -4,7 +4,6 @@
 from sympy.core import Add, Mul, Symbol, sympify, Dummy, symbols
 from sympy.core.containers import Tuple
 from sympy.core.singleton import S
-from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import nextprime
 from sympy.polys.densearith import (
     dmp_add_term, dmp_neg, dmp_mul, dmp_sqr
@@ -34,7 +33,6 @@ def swinnerton_dyer_poly(n, x=None, polys=False):
         ``polys=True`` returns an expression, otherwise
         (default) returns an expression.
     """
-    from .numberfields import minimal_polynomial
     if n <= 0:
         raise ValueError(
             "Cannot generate Swinnerton-Dyer polynomial of order %s" % n)
@@ -45,6 +43,8 @@ def swinnerton_dyer_poly(n, x=None, polys=False):
         x = Dummy('x')
 
     if n > 3:
+        from sympy.functions.elementary.miscellaneous import sqrt
+        from .numberfields import minimal_polynomial
         p = 2
         a = [sqrt(2)]
         for i in range(2, n + 1):

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -1,4 +1,6 @@
 from sympy.core import S
+from sympy.core.function import Lambda
+from sympy.core.power import Pow
 from .pycode import PythonCodePrinter, _known_functions_math, _print_known_const, _print_known_func, _unpack_integral_limits, ArrayPrinter
 from .codeprinter import CodePrinter
 
@@ -104,7 +106,6 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
             self._print(expr.shape))
 
     def _print_FunctionMatrix(self, expr):
-        from sympy.core.function import Lambda
         from sympy.abc import i, j
         lamda = expr.lamda
         if not isinstance(lamda, Lambda):
@@ -206,7 +207,6 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
 
     def _print_Pow(self, expr, rational=False):
         # XXX Workaround for negative integer power error
-        from sympy.core.power import Pow
         if expr.exp.is_integer and expr.exp.is_negative:
             expr = Pow(expr.base, expr.exp.evalf(), evaluate=False)
         return self._hprint_Pow(expr, rational=rational, sqrt=self._module + '.sqrt')

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -6,6 +6,7 @@ This module contains Python code printers for plain Python as well as NumPy & Sc
 from collections import defaultdict
 from itertools import chain
 from sympy.core import S
+from sympy.core.mod import Mod
 from .precedence import precedence
 from .codeprinter import CodePrinter
 
@@ -550,7 +551,6 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         return self._print_Rational(expr)
 
     def _print_frac(self, expr):
-        from sympy.core.mod import Mod
         return self._print_Mod(Mod(expr.args[0], 1))
 
     def _print_Symbol(self, expr):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -9,7 +9,6 @@ from sympy.core.mul import _keep_coeff
 from sympy.core.relational import Relational
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
-from sympy.sets.sets import FiniteSet
 from sympy.utilities.iterables import sift
 from .precedence import precedence, PRECEDENCE
 from .printer import Printer, print_function
@@ -815,6 +814,7 @@ class StrPrinter(Printer):
         return '{%s}' % args
 
     def _print_FiniteSet(self, s):
+        from sympy.sets.sets import FiniteSet
         items = sorted(s, key=default_sort_key)
 
         args = ', '.join(self._print(item) for item in items)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -13,6 +13,8 @@ from sympy.core.kind import NumberKind
 from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Dummy, symbols, Symbol
 from sympy.core.sympify import _sympify, sympify, _sympy_converter
+from sympy.functions.elementary.integers import ceiling, floor
+from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.logic.boolalg import And, Or
 from .sets import Set, Interval, Union, FiniteSet, ProductSet, SetKind
 from sympy.utilities.misc import filldedent
@@ -127,7 +129,6 @@ class Naturals(Set, metaclass=Singleton):
         return self
 
     def as_relational(self, x):
-        from sympy.functions.elementary.integers import floor
         return And(Eq(floor(x), x), x >= self.inf, x < oo)
 
     def _kind(self):
@@ -225,7 +226,6 @@ class Integers(Set, metaclass=Singleton):
         return SetKind(NumberKind)
 
     def as_relational(self, x):
-        from sympy.functions.elementary.integers import floor
         return And(Eq(floor(x), x), -oo < x, x < oo)
 
     def _eval_is_subset(self, other):
@@ -599,7 +599,6 @@ class Range(Set):
     """
 
     def __new__(cls, *args):
-        from sympy.functions.elementary.integers import ceiling
         if len(args) == 1:
             if isinstance(args[0], range):
                 raise TypeError(
@@ -637,7 +636,6 @@ class Range(Set):
             dif = stop - start
             n = dif/step
             if n.is_Rational:
-                from sympy.functions.elementary.integers import floor
                 if dif == 0:
                     null = True
                 else:  # (x, x + 5, 2) or (x, 3*x, x)
@@ -785,7 +783,6 @@ class Range(Set):
         if n.is_infinite:
             return S.Infinity
         if  n.is_extended_nonnegative and all(i.is_integer for i in self.args):
-            from sympy.functions.elementary.integers import floor
             return abs(floor(n))
         raise ValueError('Invalid method for symbolic Range')
 
@@ -812,7 +809,6 @@ class Range(Set):
         return not bool(b)
 
     def __getitem__(self, i):
-        from sympy.functions.elementary.integers import ceiling
         ooslice = "cannot slice from the end with an infinite value"
         zerostep = "slice step cannot be zero"
         infinite = "slicing not possible on range with infinite start"
@@ -1488,7 +1484,6 @@ class PolarComplexRegion(ComplexRegion):
 
     @property
     def expr(self):
-        from sympy.functions.elementary.trigonometric import sin, cos
         r, theta = self.variables
         return r*(cos(theta) + S.ImaginaryUnit*sin(theta))
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -5,6 +5,8 @@ from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.core.sorting import ordered
+from sympy.functions.elementary.complexes import sign
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.sets.fancysets import ComplexRegion
 from sympy.sets.sets import (FiniteSet, Intersection, Interval, Set, Union)
 from sympy.multipledispatch import Dispatcher
@@ -99,7 +101,6 @@ def _(a, b):
     if a.size == 0:
         return S.EmptySet
 
-    from sympy.functions.elementary.integers import floor, ceiling
     # trim down to self's size, and represent
     # as a Range with step 1.
     start = ceiling(max(b.inf, a.inf))
@@ -146,7 +147,6 @@ def _(a, b):
         return a
 
     from sympy.solvers.diophantine.diophantine import diop_linear
-    from sympy.functions.elementary.complexes import sign
 
     # this equation represents the values of the Range;
     # it's a linear equation
@@ -493,7 +493,6 @@ def _(a, b):
 
 def _intlike_interval(a, b):
     try:
-        from sympy.functions.elementary.integers import floor, ceiling
         if b._inf is S.NegativeInfinity and b._sup is S.Infinity:
             return a
         s = Range(max(a.inf, ceiling(b.left)), floor(b.right) + 1)

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -1,5 +1,6 @@
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.sets.sets import (EmptySet, FiniteSet, Intersection,
     Interval, ProductSet, Set, Union, UniversalSet)
 from sympy.sets.fancysets import (ComplexRegion, Naturals, Naturals0,
@@ -90,7 +91,6 @@ def _(a, b):
 @union_sets.register(Interval, Interval)
 def _(a, b):
     if a._is_comparable(b):
-        from sympy.functions.elementary.miscellaneous import Min, Max
         # Non-overlapping intervals
         end = Min(a.end, b.end)
         start = Max(a.start, b.start)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -20,6 +20,7 @@ from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import symbols, Symbol, Dummy, uniquely_named_symbol
 from sympy.core.sympify import _sympify, sympify, _sympy_converter
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import And, Or, Not, Xor, true, false
 from sympy.utilities.decorator import deprecated
@@ -2466,7 +2467,6 @@ def is_function_invertible_in_set(func, setv):
     Checks whether function ``func`` is invertible when the domain is
     restricted to set ``setv``.
     """
-    from sympy.functions.elementary.exponential import exp, log
     # Functions known to always be invertible:
     if func in (exp, log):
         return True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -31,9 +31,9 @@ from sympy.logic.boolalg import And, Or, BooleanAtom
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, acos, asin, atan,
                              Abs, re, im, arg, sqrt, atan2)
 from sympy.functions.combinatorial.factorials import binomial
-from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
-                                                      HyperbolicFunction)
+from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.integrals.integrals import Integral
 from sympy.ntheory.factor_ import divisors
 from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -23,15 +23,16 @@ from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
+from sympy.core.traversal import iterfreeargs
 from sympy.simplify.simplify import simplify, fraction, trigsimp
 from sympy.simplify import powdenest, logcombine
-from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
-                             acos, asin, acsc, asec, arg,
+from sympy.functions import (log, tan, cot, sin, cos, sec, csc, exp,
+                             acos, asin, acsc, asec,
                              piecewise_fold, Piecewise)
-from sympy.functions.elementary.complexes import re, im
-from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
-                                                      HyperbolicFunction)
+from sympy.functions.elementary.complexes import Abs, arg, re, im
+from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.miscellaneous import real_root
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.logic.boolalg import And, BooleanTrue
 from sympy.sets import (FiniteSet, imageset, Interval, Intersection,
                         Union, ConditionSet, ImageSet, Complement, Contains)
@@ -534,8 +535,8 @@ def _is_function_class_equation(func_class, f, symbol):
     >>> from sympy.solvers.solveset import _is_function_class_equation
     >>> from sympy import tan, sin, tanh, sinh, exp
     >>> from sympy.abc import x
-    >>> from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
-    ... HyperbolicFunction)
+    >>> from sympy.functions.elementary.trigonometric import TrigonometricFunction
+    >>> from sympy.functions.elementary.hyperbolic import HyperbolicFunction
     >>> _is_function_class_equation(TrigonometricFunction, exp(x) + tan(x), x)
     False
     >>> _is_function_class_equation(TrigonometricFunction, tan(x) + sin(x), x)
@@ -2438,7 +2439,6 @@ def linear_coeffs(eq, *syms, **_kw):
     ...
     NonlinearError: nonlinear term encountered: x*(y + 1)
     """
-    from sympy.core.traversal import iterfreeargs
     d = defaultdict(list)
     eq = _sympify(eq)
     symset = set(syms)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -75,7 +75,7 @@ from sympy.functions.elementary.complexes import (Abs, sign)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import sinh
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import asin
 from sympy.functions.special.error_functions import (erf, erfc, erfi, erfinv, expint)
@@ -4248,7 +4248,6 @@ class UniformDistribution(SingleContinuousDistribution):
                          (S.One, True))
 
     def expectation(self, expr, var, **kwargs):
-        from sympy.functions.elementary.miscellaneous import (Max, Min)
         kwargs['evaluate'] = True
         result = SingleContinuousDistribution.expectation(self, expr, var, **kwargs)
         result = result.subs({Max(self.left, self.right): self.right,

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -654,7 +654,6 @@ class GeneralizedMultivariateLogGammaDistribution(JointDistribution):
         return S.Reals**len(self.lamda)
 
     def pdf(self, *y):
-        from sympy.functions.special.gamma_functions import gamma
         d, v, l, mu = self.delta, self.v, self.lamda, self.mu
         n = Symbol('n', negative=False, integer=True)
         k = len(l)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Change the import precedence in functions using a "natural" ordering (trig before hyperbolic, elementary before special, etc). Except that combinational comes before elementary since there are more dependencies in that direction.

In some files there are improvements, in other it gets worse. However, one can use the total number of removed line as a measure.

(#22993 can be rewritten to reduce the number of imports subject to this one)

#### Other comments

Also changed some incorrect import locations in solvers.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
