### PR TITLE
Reordered imports 2

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -16,7 +16,6 @@ from sympy.polys.polytools import degree, lcm_list
 from sympy.sets.sets import (Interval, Intersection, FiniteSet, Union,
                              Complement)
 from sympy.sets.fancysets import ImageSet
-from sympy.simplify.simplify import simplify
 from sympy.utilities import filldedent
 from sympy.utilities.iterables import iterable
 
@@ -424,7 +423,7 @@ def periodicity(f, symbol, check=False):
     if isinstance(f, Relational):
         f = f.lhs - f.rhs
 
-    f = simplify(f)
+    f = f.simplify()
 
     if symbol not in f.free_symbols:
         return S.Zero

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -2,8 +2,6 @@
 
 from sympy.core import S, Dummy, symbols
 from sympy.polys import Poly, parallel_poly_from_expr, factor
-from sympy.solvers import solve
-from sympy.simplify import hypersimp
 from sympy.utilities.iterables import is_sequence
 
 
@@ -108,6 +106,7 @@ def gosper_term(f, n):
     (-n - 1/2)/(n + 1/4)
 
     """
+    from sympy.simplify import hypersimp
     r = hypersimp(f, n)
 
     if r is None:
@@ -144,6 +143,7 @@ def gosper_term(f, n):
     x = Poly(coeffs, n, domain=domain)
     H = A*x.shift(1) - B*x - C
 
+    from sympy.solvers.solvers import solve
     solution = solve(H.coeffs(), coeffs)
 
     if solution is None:

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -12,8 +12,6 @@ from sympy.functions.combinatorial.factorials import RisingFactorial
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.polys import quo, roots
-from sympy.simplify.powsimp import powsimp
-from sympy.simplify.simplify import product_simplify
 
 
 class Product(ExprWithIntLimits):
@@ -267,6 +265,7 @@ class Product(ExprWithIntLimits):
                 did = did.xreplace(undo)
             return did
 
+        from sympy.simplify.powsimp import powsimp
         f = self.function
         for index, limit in enumerate(self.limits):
             i, a, b = limit
@@ -392,6 +391,7 @@ class Product(ExprWithIntLimits):
             return self._eval_product_direct(term, limits)
 
     def _eval_simplify(self, **kwargs):
+        from sympy.simplify.simplify import product_simplify
         rv = product_simplify(self)
         return rv.doit() if kwargs['doit'] else rv
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -33,14 +33,6 @@ from sympy.series.limitseq import limit_seq
 from sympy.series.order import O
 from sympy.series.residues import residue
 from sympy.sets.sets import FiniteSet, Interval
-from sympy.simplify.combsimp import combsimp
-from sympy.simplify.hyperexpand import hyperexpand
-from sympy.simplify.powsimp import powsimp
-from sympy.simplify.radsimp import denom, fraction
-from sympy.simplify.simplify import (factor_sum, sum_combine, simplify,
-                                     nsimplify, hypersimp)
-from sympy.solvers.solvers import solve
-from sympy.solvers.solveset import solveset
 from sympy.utilities.iterables import sift
 import itertools
 
@@ -367,6 +359,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 o_t.append(term)
 
         # next try to combine any interior sums for further simplification
+        from sympy.simplify.simplify import factor_sum, sum_combine
         result = Add(sum_combine(s_t), *o_t)
 
         return factor_sum(result, limits=self.limits)
@@ -465,6 +458,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if upper_limit is S.Infinity:
                 return Sum(sequence_term, (sym, 0, S.Infinity)).is_convergent() and \
                         Sum(sequence_term, (sym, S.NegativeInfinity, 0)).is_convergent()
+            from sympy.simplify.simplify import simplify
             sequence_term = simplify(sequence_term.xreplace({sym: -sym}))
             lower_limit = -upper_limit
             upper_limit = S.Infinity
@@ -530,6 +524,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ----------- ratio test ---------------- ###
         next_sequence_term = sequence_term.xreplace({sym: sym + 1})
+        from sympy.simplify.combsimp import combsimp
+        from sympy.simplify.powsimp import powsimp
         ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         try:
             lim_ratio = limit_seq(ratio, sym)
@@ -575,6 +571,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ------------- integral test -------------- ###
         check_interval = None
+        from sympy.solvers.solveset import solveset
         maxima = solveset(sequence_term.diff(sym), sym, interval)
         if not maxima:
             check_interval = interval
@@ -989,6 +986,7 @@ def telescopic(L, R, limits):
     if s is None:
         m = Dummy('m')
         try:
+            from sympy.solvers.solvers import solve
             sol = solve(L.subs(i, i + m) + R, m) or []
         except NotImplementedError:
             return None
@@ -1216,6 +1214,8 @@ def eval_sum_symbolic(f, limits):
         r = gosper_sum(f, (i, a, b))
 
         if isinstance(r, (Mul,Add)):
+            from sympy.simplify.radsimp import denom
+            from sympy.solvers.solvers import solve
             non_limit = r.free_symbols - Tuple(*limits[1:]).free_symbols
             den = denom(together(r))
             den_sym = non_limit & den.free_symbols
@@ -1255,17 +1255,23 @@ def _eval_sum_hyper(f, i, a):
         return _eval_sum_hyper(f.subs(i, i + a), i, 0)
 
     if f.subs(i, 0) == 0:
+        from sympy.simplify.simplify import simplify
         if simplify(f.subs(i, Dummy('i', integer=True, positive=True))) == 0:
             return S.Zero, True
         return _eval_sum_hyper(f.subs(i, i + 1), i, 0)
 
+    from sympy.simplify.simplify import hypersimp
     hs = hypersimp(f, i)
     if hs is None:
         return None
 
     if isinstance(hs, Float):
+        from sympy.simplify.simplify import nsimplify
         hs = nsimplify(hs)
 
+    from sympy.simplify.combsimp import combsimp
+    from sympy.simplify.hyperexpand import hyperexpand
+    from sympy.simplify.radsimp import fraction
     numer, denom = fraction(factor(hs))
     top, topl = numer.as_coeff_mul(i)
     bot, botl = denom.as_coeff_mul(i)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -18,16 +18,19 @@ import warnings
 
 from itertools import cycle
 
-from sympy.ntheory.generate import nextprime
-from sympy.core import Rational, Symbol
-from sympy.core.numbers import igcdex, mod_inverse, igcd
+from sympy.core import Symbol
+from sympy.core.numbers import igcdex, mod_inverse, igcd, Rational
+from sympy.core.random import _randrange, _randint
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, primitive_root, factorint
+from sympy.ntheory import totient as _euler
+from sympy.ntheory import reduced_totient as _carmichael
+from sympy.ntheory.generate import nextprime
+from sympy.ntheory.modular import crt
 from sympy.polys.domains import FF
 from sympy.polys.polytools import gcd, Poly
 from sympy.utilities.misc import as_int, filldedent, translate
 from sympy.utilities.iterables import uniq, multiset
-from sympy.core.random import _randrange, _randint
 
 
 class NonInvertibleCipherWarning(RuntimeWarning):
@@ -1483,7 +1486,6 @@ def _decipher_rsa_crt(i, d, factors):
     >>> decrypted
     65
     """
-    from sympy.ntheory.modular import crt
     moduluses = [pow(i, d, p) for p in factors]
 
     result = crt(factors, moduluses)
@@ -1507,8 +1509,6 @@ def _rsa_key(*args, public=True, private=True, totient='Euler', index=None, mult
     multipower : bool, optional
         Flag to bypass warning for multipower RSA.
     """
-    from sympy.ntheory import totient as _euler
-    from sympy.ntheory import reduced_totient as _carmichael
 
     if len(args) < 2:
         return False

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -13,6 +13,7 @@ from sympy.core.symbol import _symbol
 from sympy.geometry.entity import GeometryEntity, GeometrySet
 from sympy.geometry.point import Point
 from sympy.integrals import integrate
+from sympy.matrices import Matrix, rot_axis3
 from sympy.utilities.iterables import is_sequence
 
 from mpmath.libmp.libmpf import prec_to_dps
@@ -365,7 +366,6 @@ class Curve(GeometrySet):
         Curve((-x, x), (x, 0, 1))
 
         """
-        from sympy.matrices import Matrix, rot_axis3
         if pt:
             pt = -Point(pt, dim=2)
         else:

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -29,9 +29,11 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.trigonometric import cos, sin, atan
 from sympy.matrices import eye
 from sympy.multipledispatch import dispatch
+from sympy.printing import sstr
 from sympy.sets import Set, Union, FiniteSet
 from sympy.sets.handlers.intersection import intersection_sets
 from sympy.sets.handlers.union import union_sets
+from sympy.solvers.solvers import solve
 from sympy.utilities.misc import func_name
 from sympy.utilities.iterables import is_sequence
 
@@ -148,7 +150,6 @@ class GeometryEntity(Basic, EvalfMixin):
 
     def __str__(self):
         """String representation of a GeometryEntity."""
-        from sympy.printing import sstr
         return type(self).__name__ + sstr(self.args)
 
     def _eval_subs(self, old, new):
@@ -520,7 +521,6 @@ class GeometryEntity(Basic, EvalfMixin):
         Point2D(1, 1)
         """
         from sympy.geometry.point import Point
-        from sympy.solvers.solvers import solve
         if not isinstance(other, GeometryEntity):
             other = Point(other, dim=self.ambient_dimension)
         if not isinstance(other, Point):
@@ -567,7 +567,7 @@ def intersection_sets(self, o): # noqa:F811
     """ Returns a sympy.sets.Set of intersection objects,
     if possible. """
 
-    from sympy.geometry import Point
+    from sympy.geometry.point import Point
 
     try:
         # if o is a FiniteSet, find the intersection directly

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -36,6 +36,7 @@ from sympy.logic.boolalg import And
 from sympy.matrices import Matrix
 from sympy.sets.sets import Intersection
 from sympy.simplify.simplify import simplify
+from sympy.solvers.solvers import solve
 from sympy.solvers.solveset import linear_coeffs
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import Undecidable, filldedent
@@ -2556,7 +2557,6 @@ class Line3D(LinearEntity3D, Line):
                 feature="equation() no longer needs 'k'",
                 issue=13742,
                 deprecated_since_version="1.2").warn()
-        from sympy.solvers.solvers import solve
         x, y, z, k = [_symbol(i, real=True) for i in (x, y, z, 'k')]
         p1, p2 = self.points
         d1, d2, d3 = p1.direction_ratio(p2)

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -862,7 +862,6 @@ class Plane(GeometryEntity):
         >>> p.parameter_value(off_circle, u, v)
         {u: sqrt(10)/5, v: sqrt(10)/15}
         """
-        from sympy.geometry.point import Point
         if not isinstance(other, GeometryEntity):
             other = Point(other, dim=self.ambient_dimension)
         if not isinstance(other, Point):

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -11,7 +11,13 @@ are_similar
 
 """
 
-from .point import Point, Point2D
+from collections import deque
+from math import sqrt as _sqrt
+
+
+from .entity import GeometryEntity
+from .exceptions import GeometryError
+from .point import Point, Point2D, Point3D
 from sympy.core.containers import OrderedSet
 from sympy.core.function import Function
 from sympy.core.sorting import ordered
@@ -89,10 +95,8 @@ def are_coplanar(*e):
     False
 
     """
-    from sympy.geometry.line import LinearEntity3D
-    from sympy.geometry.entity import GeometryEntity
-    from sympy.geometry.point import Point3D
-    from sympy.geometry.plane import Plane
+    from .line import LinearEntity3D
+    from .plane import Plane
     # XXX update tests for coverage
 
     e = set(e)
@@ -182,8 +186,6 @@ def are_similar(e1, e2):
     False
 
     """
-    from .exceptions import GeometryError
-
     if e1 == e2:
         return True
     is_similar1 = getattr(e1, 'is_similar', None)
@@ -246,8 +248,8 @@ def centroid(*args):
     Point2D(11/10, 1/2)
 
     """
-
-    from sympy.geometry import Polygon, Segment, Point
+    from .line import Segment
+    from .polygon import Polygon
     if args:
         if all(isinstance(g, Point) for g in args):
             c = Point(0, 0)
@@ -308,9 +310,6 @@ def closest_points(*args):
         https://en.wikipedia.org/wiki/Sweep_line_algorithm
 
     """
-    from collections import deque
-    from math import sqrt as _sqrt
-
     p = [Point2D(i) for i in set(args)]
     if len(p) < 2:
         raise ValueError('At least 2 distinct points must be given.')
@@ -407,11 +406,8 @@ def convex_hull(*args, polygon=True):
       http://geomalgorithms.com/a10-_hull-1.html
 
     """
-    from .entity import GeometryEntity
-    from .point import Point
     from .line import Segment
     from .polygon import Polygon
-
     p = OrderedSet()
     for e in args:
         if not isinstance(e, GeometryEntity):
@@ -505,7 +501,6 @@ def farthest_points(*args):
         https://en.wikipedia.org/wiki/Rotating_calipers
 
     """
-    from math import sqrt as _sqrt
 
     def rotatingCalipers(Points):
         U, L = convex_hull(*Points, **dict(polygon=False))
@@ -688,10 +683,6 @@ def intersection(*entities, pairwise=False, **kwargs):
     [Segment2D(Point2D(0, 0), Point2D(1, 0))]
 
     """
-
-    from .entity import GeometryEntity
-    from .point import Point
-
     if len(entities) <= 1:
         return []
 

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -3,7 +3,6 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.functions import DiracDelta, Heaviside
 from .integrals import Integral, integrate
-from sympy.solvers import solve
 
 
 def change_mul(node, x):
@@ -168,6 +167,7 @@ def deltaintegrate(f, x):
                     fh = integrate(rest_mult, x)
                     return fh
             else:
+                from sympy.solvers import solve
                 deltaterm = deltaterm.expand(diracdelta=True, wrt=x)
                 if deltaterm.is_Mul:  # Take out any extracted factors
                     deltaterm, rest_mult_2 = change_mul(deltaterm, x)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -25,9 +25,6 @@ from sympy.polys import Poly, PolynomialError
 from sympy.series.formal import FormalPowerSeries
 from sympy.series.limits import limit
 from sympy.series.order import Order
-from sympy.simplify.fu import sincos_to_sum
-from sympy.simplify.simplify import simplify
-from sympy.solvers.solvers import solve, posify
 from sympy.tensor.functions import shape
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import is_sequence
@@ -311,6 +308,7 @@ class Integral(AddWithLimits):
             u must contain the same variable as in x
             or a variable that is not already an integration variable'''))
 
+        from sympy.solvers.solvers import solve
         if not x.is_Symbol:
             F = [x.subs(xvar, d)]
             soln = solve(u - x, xvar, check=False)
@@ -319,6 +317,7 @@ class Integral(AddWithLimits):
             f = [fi.subs(uvar, d) for fi in soln]
         else:
             f = [u.subs(uvar, d)]
+            from sympy.simplify.simplify import posify
             pdiff, reps = posify(u - x)
             puvar = uvar.subs([(v, k) for k, v in reps.items()])
             soln = [s.subs(reps) for s in solve(pdiff, puvar)]
@@ -983,6 +982,7 @@ class Integral(AddWithLimits):
         # because maybe the integral is a sum of an elementary part and a
         # nonelementary part (like erf(x) + exp(x)).  risch_integrate() is
         # quite fast, so this is acceptable.
+        from sympy.simplify.fu import sincos_to_sum
         parts = []
         args = Add.make_args(f)
         for g in args:
@@ -1188,6 +1188,7 @@ class Integral(AddWithLimits):
     def _eval_simplify(self, **kwargs):
         expr = factor_terms(self)
         if isinstance(expr, Integral):
+            from sympy.simplify.simplify import simplify
             return expr.func(*[simplify(i, **kwargs) for i in expr.args])
         return expr.simplify(**kwargs)
 

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -64,9 +64,6 @@ from sympy.functions.special.singularity_functions import SingularityFunction
 from .integrals import Integral
 from sympy.logic.boolalg import And, Or, BooleanAtom, Not, BooleanFunction
 from sympy.polys import cancel, factor
-from sympy.simplify.fu import sincos_to_sum
-from sympy.simplify import (collect, gammasimp, hyperexpand, powdenest,
-                            powsimp, simplify)
 from sympy.utilities.iterables import multiset_partitions
 from sympy.utilities.misc import debug as _debug
 
@@ -337,6 +334,7 @@ def _get_coeff_exp(expr, x):
     >>> _get_coeff_exp(x**3, x)
     (1, 3)
     """
+    from sympy.simplify import powsimp
     (c, m) = expand_power_base(powsimp(expr)).as_coeff_mul(x)
     if not m:
         return c, S.Zero
@@ -900,6 +898,7 @@ def _int0oo_1(g, x):
     >>> _int0oo_1(meijerg([a], [b], [c], [d], x*y), x)
     gamma(-a)*gamma(c + 1)/(y*gamma(-d)*gamma(b + 1))
     """
+    from sympy.simplify import gammasimp
     # See [L, section 5.6.1]. Note that s=1.
     eta, _ = _get_coeff_exp(g.argument, x)
     res = 1/eta
@@ -984,6 +983,7 @@ def _rewrite_saxena(fac, po, g1, g2, x, full_pb=False):
     g1 = meijerg(tr(g1.an), tr(g1.aother), tr(g1.bm), tr(g1.bother), a1*x)
     g2 = meijerg(g2.an, g2.aother, g2.bm, g2.bother, a2*x)
 
+    from sympy.simplify import powdenest
     return powdenest(fac, polar=True), g1, g2
 
 
@@ -1328,6 +1328,7 @@ def _rewrite_inversion(fac, po, g, x):
 
     def tr(l):
         return [t + s/b for t in l]
+    from sympy.simplify import powdenest
     return (powdenest(fac/a**(s/b), polar=True),
             meijerg(tr(g.an), tr(g.aother), tr(g.bm), tr(g.bother), g.argument))
 
@@ -1558,6 +1559,7 @@ def _rewrite_single(f, x, recursive=True):
             return inverse_mellin_transform(F, s, x, strip,
                                             as_meijerg=True, needeval=True)
         except MellinTransformStripError:
+            from sympy.simplify import simplify
             return inverse_mellin_transform(
                 simplify(cancel(expand(F))), s, x, strip,
                 as_meijerg=True, needeval=True)
@@ -1568,6 +1570,7 @@ def _rewrite_single(f, x, recursive=True):
     def my_integrator(f, x):
         r = _meijerint_definite_4(f, x, only_double=True)
         if r is not None:
+            from sympy.simplify import hyperexpand
             res, cond = r
             res = _my_unpolarify(hyperexpand(res, rewrite='nonrepsmall'))
             return Piecewise((res, cond),
@@ -1684,6 +1687,7 @@ def meijerint_indefinite(f, x):
             _rewrite_hyperbolics_as_exp(f), x)
         if rv:
             if not isinstance(rv, list):
+                from sympy.simplify.radsimp import collect
                 return collect(factor_terms(rv), rv.atoms(exp))
             results.extend(rv)
     if results:
@@ -1693,6 +1697,7 @@ def meijerint_indefinite(f, x):
 def _meijerint_indefinite_1(f, x):
     """ Helper that does not attempt any substitution. """
     _debug('Trying to compute the indefinite integral of', f, 'wrt', x)
+    from sympy.simplify import hyperexpand, powdenest
 
     gs = _rewrite1(f, x)
     if gs is None:
@@ -1910,6 +1915,7 @@ def meijerint_definite(f, x, a, b):
             _rewrite_hyperbolics_as_exp(f_), x_, a_, b_)
         if rv:
             if not isinstance(rv, list):
+                from sympy.simplify.radsimp import collect
                 rv = (collect(factor_terms(rv[0]), rv[0].atoms(exp)),) + rv[1:]
                 return rv
             results.extend(rv)
@@ -1940,6 +1946,7 @@ def _guess_expansion(f, x):
             saw.add(expanded)
 
     if orig.has(cos, sin):
+        from sympy.simplify.fu import sincos_to_sum
         reduced = sincos_to_sum(orig)
         if reduced not in saw:
             res += [(reduced, 'trig power reduction')]
@@ -2020,6 +2027,7 @@ def _meijerint_definite_4(f, x, only_double=False):
     The parameter ``only_double`` is used internally in the recursive algorithm
     to disable trying to rewrite f as a single G-function.
     """
+    from sympy.simplify import hyperexpand
     # This function does (2) and (3)
     _debug('Integrating', f)
     # Try single G function.
@@ -2178,6 +2186,7 @@ def meijerint_inversion(f, x, t):
             _debug('But cond is always False.')
         else:
             _debug('Result before branch substitution:', res)
+            from sympy.simplify import hyperexpand
             res = _my_unpolarify(hyperexpand(res))
             if not res.has(Heaviside):
                 res *= Heaviside(t)

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -10,7 +10,6 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import cancel
 from sympy.polys.rootoftools import RootSum
 from sympy.polys import Poly, resultant, ZZ
-from sympy.solvers.solvers import solve
 
 
 def ratint(f, x, **flags):
@@ -154,6 +153,8 @@ def ratint_ratpart(f, g, x):
 
     ratint, ratint_logpart
     """
+    from sympy.solvers.solvers import solve
+
     f = Poly(f, x)
     g = Poly(g, x)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -35,9 +35,6 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import factor, Poly
 from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import CRootOf, RootSum
-from sympy.simplify import simplify, hyperexpand
-from sympy.simplify.powsimp import powdenest
-from sympy.solvers.inequalities import _solve_inequality
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
@@ -226,6 +223,8 @@ class IntegralTransform(Function):
 
 def _simplify(expr, doit):
     if doit:
+        from sympy.simplify import simplify
+        from sympy.simplify.powsimp import powdenest
         return simplify(powdenest(piecewise_fold(expr), polar=True))
     return expr
 
@@ -291,6 +290,7 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
         """
         Turn ``cond`` into a strip (a, b), and auxiliary conditions.
         """
+        from sympy.solvers.inequalities import _solve_inequality
         a = S.NegativeInfinity
         b = S.Infinity
         aux = S.true
@@ -797,6 +797,7 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
             h = G
         else:
             try:
+                from sympy.simplify import hyperexpand
                 h = hyperexpand(G)
             except NotImplementedError:
                 raise IntegralTransformError(
@@ -1077,6 +1078,7 @@ def _laplace_transform(f, t, s_, simplify=True):
 
     def process_conds(conds):
         """ Turn ``conds`` into a strip and auxiliary conditions. """
+        from sympy.solvers.inequalities import _solve_inequality
         a = S.NegativeInfinity
         aux = S.true
         conds = conjuncts(to_cnf(conds))
@@ -1983,6 +1985,7 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
         a = arg.subs(exp(-t), u)
         if a.has(t):
             return Heaviside(arg, H0)
+        from sympy.solvers.inequalities import _solve_inequality
         rel = _solve_inequality(a > 0, u)
         if rel.lts == u:
             k = log(rel.gts)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -20,9 +20,8 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions import Abs
+from .utilities import _dotprodsimp, _simplify
 from sympy.polys.polytools import Poly
-from sympy.simplify import simplify as _simplify
-from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, is_sequence
 from sympy.utilities.misc import as_int, filldedent
@@ -2502,7 +2501,7 @@ class MatrixOperations(MatrixRequired):
         return MatrixOperations.simplify(self, **kwargs)
 
     def _eval_trigsimp(self, **opts):
-        from sympy.simplify import trigsimp
+        from sympy.simplify.trigsimp import trigsimp
         return self.applyfunc(lambda x: trigsimp(x, **opts))
 
     def upper_triangular(self, k=0):

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -5,7 +5,6 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.simplify.simplify import simplify as _simplify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import is_sequence
@@ -119,6 +118,7 @@ class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
 
         sympy.simplify.simplify.simplify
         """
+        from sympy.simplify.simplify import simplify as _simplify
         for (i, j), element in self.todok().items():
             self[i, j] = _simplify(element, **kwargs)
 

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -5,8 +5,6 @@ from sympy.core.singleton import S
 from sympy.core.symbol import uniquely_named_symbol
 from sympy.core.mul import Mul
 from sympy.polys import PurePoly, cancel
-from sympy.simplify.simplify import (simplify as _simplify,
-    dotprodsimp as _dotprodsimp)
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.numbers import nC
 from sympy.polys.matrices.domainmatrix import DomainMatrix
@@ -14,7 +12,7 @@ from sympy.polys.matrices.domainmatrix import DomainMatrix
 from .common import NonSquareMatrixError
 from .utilities import (
     _get_intermediate_simp, _get_intermediate_simp_bool,
-    _iszero, _is_zero_after_expand_mul)
+    _iszero, _is_zero_after_expand_mul, _dotprodsimp, _simplify)
 
 
 def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -13,13 +13,12 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.polys import roots, CRootOf, ZZ, QQ, EX
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.eigen import dom_eigenvects, dom_eigenvects_to_sympy
-from sympy.simplify import nsimplify, simplify as _simplify
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .common import MatrixError, NonSquareMatrixError
 from .determinant import _find_reasonable_pivot
 
-from .utilities import _iszero
+from .utilities import _iszero, _simplify
 
 
 def _eigenvals_eigenvects_mpmath(M):
@@ -163,6 +162,7 @@ def _eigenvals(
             return _eigenvals_mpmath(M, multiple=multiple)
 
     if rational:
+        from sympy.simplify import nsimplify
         M = M.applyfunc(
             lambda x: nsimplify(x, rational=True) if x.has(Float) else x)
 
@@ -414,6 +414,7 @@ def _eigenvects(M, error_when_incomplete=True, iszerofunc=_iszero, *, chop=False
     if has_floats:
         if all(x.is_number for x in M):
             return _eigenvects_mpmath(M)
+        from sympy.simplify import nsimplify
         M = M.applyfunc(lambda x: nsimplify(x, rational=True))
 
     ret = _eigenvects_DOM(M)
@@ -1183,6 +1184,7 @@ def _jordan_form(M, calc_transform=True, *, chop=False):
 
     # roots doesn't like Floats, so replace them with Rationals
     if has_floats:
+        from sympy.simplify import nsimplify
         mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
 
     # first calculate the jordan block structure

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from sympy.core import Mul, sympify
 from sympy.core.add import Add
 from sympy.core.expr import ExprBuilder
@@ -269,7 +271,6 @@ def canonicalize(x):
 
     # Rewriting with HadamardPower
     if isinstance(x, HadamardProduct):
-        from collections import Counter
         tally = Counter(x.args)
 
         new_arg = []

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -1,5 +1,5 @@
 """Implementation of the Kronecker product"""
-
+from functools import reduce
 
 from sympy.core import Mul, prod, sympify
 from sympy.functions import adjoint
@@ -358,7 +358,6 @@ def _kronecker_dims_key(expr):
 
 
 def kronecker_mat_add(expr):
-    from functools import reduce
     args = sift(expr.args, _kronecker_dims_key)
     nonkrons = args.pop((0,), None)
     if not args:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -14,7 +14,6 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.common import NonSquareMatrixError
 from sympy.matrices.matrices import MatrixKind, MatrixBase
 from sympy.multipledispatch import dispatch
-from sympy.simplify import simplify
 from sympy.utilities.misc import filldedent
 
 
@@ -203,6 +202,7 @@ class MatrixExpr(Expr):
         if self.is_Atom:
             return self
         else:
+            from sympy.simplify import simplify
             return self.func(*[simplify(x, **kwargs) for x in self.args])
 
     def _eval_adjoint(self):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -21,7 +21,7 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.polys import cancel
 from sympy.printing import sstr
 from sympy.printing.defaults import Printable
-from sympy.simplify import simplify as _simplify
+from sympy.printing.str import StrPrinter
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, NotIterable, is_sequence, reshape
@@ -31,7 +31,7 @@ from .common import (
     MatrixCommon, MatrixError, NonSquareMatrixError, NonInvertibleMatrixError,
     ShapeError, MatrixKind)
 
-from .utilities import _iszero, _is_zero_after_expand_mul
+from .utilities import _iszero, _is_zero_after_expand_mul, _simplify
 
 from .determinant import (
     _find_reasonable_pivot, _find_reasonable_pivot_naive,
@@ -855,7 +855,6 @@ class MatrixBase(MatrixDeprecated,
 
     def _format_str(self, printer=None):
         if not printer:
-            from sympy.printing.str import StrPrinter
             printer = StrPrinter()
         # Handle zero dimensions:
         if S.Zero in self.shape:

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -1,9 +1,6 @@
 from types import FunctionType
 
-from sympy.simplify.simplify import (
-    simplify as _simplify, dotprodsimp as _dotprodsimp)
-
-from .utilities import _get_intermediate_simp, _iszero
+from .utilities import _get_intermediate_simp, _iszero, _dotprodsimp, _simplify
 from .determinant import _find_reasonable_pivot
 
 

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from threading import local
 
 from sympy.core.function import expand_mul
-from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 
 
 class DotProdSimpState(local):
@@ -20,6 +19,13 @@ def dotprodsimp(x):
         yield
     finally:
         _dotprodsimp_state.state = old
+
+
+def _dotprodsimp(expr, withsimp=False):
+    """Wrapper for simplify.dotprodsimp to avoid circular imports."""
+    from sympy.simplify.simplify import dotprodsimp as dps
+    return dps(expr, withsimp=withsimp)
+
 
 def _get_intermediate_simp(deffunc=lambda x: x, offfunc=lambda x: x,
         onfunc=_dotprodsimp, dotprodsimp=None):
@@ -41,6 +47,7 @@ def _get_intermediate_simp(deffunc=lambda x: x, offfunc=lambda x: x,
 
     return deffunc # None, None
 
+
 def _get_intermediate_simp_bool(default=False, dotprodsimp=None):
     """Same as ``_get_intermediate_simp`` but returns bools instead of functions
     by default."""
@@ -57,3 +64,9 @@ def _is_zero_after_expand_mul(x):
     """Tests by expand_mul only, suitable for polynomials and rational
     functions."""
     return expand_mul(x) == 0
+
+
+def _simplify(expr):
+    """ Wrapper to avoid circular imports. """
+    from sympy.simplify.simplify import simplify
+    return simplify(expr)

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,5 +1,7 @@
+from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import Integer, Rational
 from sympy.core.singleton import S
+from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.utilities.misc import as_int
 
@@ -221,8 +223,6 @@ def continued_fraction_reduce(cf):
     continued_fraction_periodic
 
     """
-    from sympy.core.exprtools import factor_terms
-    from sympy.core.symbol import Dummy
     from sympy.solvers import solve
 
     period = []

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -36,8 +36,6 @@ from sympy.polys.ring_series import rs_compose_add
 from sympy.polys.rings import ring
 from sympy.polys.rootoftools import CRootOf
 from sympy.polys.specialpolys import cyclotomic_poly
-from sympy.simplify.radsimp import _split_gcd
-from sympy.simplify.simplify import _is_sum_surds
 from sympy.utilities import (
     numbered_symbols, public, sift
 )
@@ -89,6 +87,13 @@ def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
 
     raise NotImplementedError("multiple candidates for the minimal polynomial of %s" % v)
 
+
+def _is_sum_surds(p):
+    args = p.args if p.is_Add else [p]
+    for y in args:
+        if not ((y**2).is_Rational and y.is_extended_real):
+            return False
+    return True
 
 
 def _separate_sq(p):
@@ -142,6 +147,7 @@ def _separate_sq(p):
     for i in range(len(surds)):
         if surds[i] != 1:
             break
+    from sympy.simplify.radsimp import _split_gcd
     g, b1, b2 = _split_gcd(*surds[i:])
     a1 = []
     a2 = []

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -25,7 +25,6 @@ from sympy.polys.polyquinticconst import PolyQuintic
 from sympy.polys.polytools import Poly, cancel, factor, gcd_list, discriminant
 from sympy.polys.rationaltools import together
 from sympy.polys.specialpolys import cyclotomic_poly
-from sympy.simplify.simplify import simplify, powsimp
 from sympy.utilities import public
 
 
@@ -38,6 +37,7 @@ def roots_linear(f):
         if dom.is_Composite:
             r = factor(r)
         else:
+            from sympy.simplify.simplify import simplify
             r = simplify(r)
 
     return [r]
@@ -75,6 +75,7 @@ def roots_quadratic(f):
         if dom.is_Composite:
             return factor(expr)
         else:
+            from sympy.simplify.simplify import simplify
             return simplify(expr)
 
     if c is S.Zero:
@@ -653,6 +654,7 @@ def roots_quintic(f):
 
 
 def _quintic_simplify(expr):
+    from sympy.simplify.simplify import powsimp
     expr = powsimp(expr)
     expr = cancel(expr)
     return together(expr)

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -1,5 +1,6 @@
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
+from sympy.polys.polytools import lcm
 from sympy.utilities import public
 
 @public
@@ -55,6 +56,8 @@ def approximants(l, X=Symbol('x'), simplify=False):
     function mpmath.pade
 
     """
+    from sympy.simplify import simplify as simp
+    from sympy.simplify.radsimp import denom
     p1, q1 = [S.One], [S.Zero]
     p2, q2 = [S.Zero], [S.One]
     while len(l):
@@ -87,9 +90,6 @@ def approximants(l, X=Symbol('x'), simplify=False):
         q1, q2 = q2, q
 
         # yield result
-        from sympy.polys.polytools import lcm
-        from sympy.simplify import simplify as simp
-        from sympy.simplify.radsimp import denom
         c = 1
         for x in p:
             c = lcm(c, denom(x))

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -21,7 +21,6 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.series.limits import Limit
 from sympy.series.order import Order
-from sympy.simplify.powsimp import powsimp
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
 from sympy.utilities.iterables import iterable
@@ -862,9 +861,6 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
     # Otherwise symb is being set to S.One
     syms = f.free_symbols.difference({x})
     (f, symb) = expand(f).as_independent(*syms)
-    if symb.is_zero:
-        symb = S.One
-    symb = powsimp(symb)
 
     result = None
 
@@ -879,6 +875,11 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
     if result is None:
         return None
 
+    from sympy.simplify.powsimp import powsimp
+    if symb.is_zero:
+        symb = S.One
+    else:
+        symb = powsimp(symb)
     ak = sequence(result[0], (k, result[2], oo))
     xk_formula = powsimp(x**k * symb)
     xk = sequence(xk_formula, (k, 0, oo))

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -12,7 +12,6 @@ from sympy.functions.elementary.trigonometric import sin, cos, sinc
 from sympy.series.series_class import SeriesBase
 from sympy.series.sequences import SeqFormula
 from sympy.sets.sets import Interval
-from sympy.simplify.fu import TR2, TR1, TR10, sincos_to_sum
 from sympy.utilities.iterables import is_sequence
 
 
@@ -106,6 +105,7 @@ def finite_check(f, x, L):
             else:
                 return False
 
+    from sympy.simplify.fu import TR2, TR1, sincos_to_sum
     _expr = sincos_to_sum(TR2(TR1(f)))
     add_coeff = _expr.as_coeff_add()
 
@@ -516,6 +516,7 @@ class FiniteFourierSeries(FourierSeries):
         if not (isinstance(exprs, Tuple) and len(exprs) == 3):  # exprs is not of form (a0, an, bn)
             # Converts the expression to fourier form
             c, e = exprs.as_coeff_add()
+            from sympy.simplify.fu import TR10
             rexpr = c + Add(*[TR10(i) for i in e])
             a0, exp_ls = rexpr.expand(trig=False, power_base=False, power_exp=False, log=False).as_coeff_add()
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -126,9 +126,6 @@ from sympy.core.traversal import bottom_up
 
 from sympy.functions import log, exp, sign as _sign
 from sympy.series.order import Order
-from sympy.simplify import logcombine
-from sympy.simplify.powsimp import powsimp, powdenest
-
 from sympy.utilities.misc import debug_decorator as debug
 from sympy.utilities.timeutils import timethis
 
@@ -249,6 +246,7 @@ class SubsSet(dict):
 def mrv(e, x):
     """Returns a SubsSet of most rapidly varying (mrv) subexpressions of 'e',
        and e rewritten in terms of these"""
+    from sympy.simplify.powsimp import powsimp
     e = powsimp(e, deep=True, combine='exp')
     if not isinstance(e, Basic):
         raise TypeError("e should be an instance of Basic")
@@ -393,6 +391,7 @@ def sign(e, x):
         return 0
 
     elif not e.has(x):
+        from sympy.simplify import logcombine
         e = logcombine(e)
         return _sign(e)
     elif e == x:
@@ -438,6 +437,7 @@ def limitinf(e, x, leadsimp=False):
 
     if not e.has(x):
         return e  # e is a constant
+    from sympy.simplify.powsimp import powdenest
     if e.has(Order):
         e = e.expand().removeO()
     if not x.is_positive or x.is_integer:
@@ -489,6 +489,7 @@ def calculate_series(e, x, logx=None):
 
     This is a place that fails most often, so it is in its own function.
     """
+    from sympy.simplify.powsimp import powdenest
 
     for t in e.lseries(x, logx=logx):
         # bottom_up function is required for a specific case - when e is
@@ -650,6 +651,7 @@ def rewrite(e, Omega, x, wsym):
     # the following powsimp is necessary to automatically combine exponentials,
     # so that the .xreplace() below succeeds:
     # TODO this should not be necessary
+    from sympy.simplify.powsimp import powsimp
     f = powsimp(e, deep=True, combine='exp')
     for a, b in O2:
         f = f.xreplace({a: b})

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -8,9 +8,6 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys import PolynomialError, factor
 from sympy.series.order import Order
-from sympy.simplify.powsimp import powsimp
-from sympy.simplify.ratsimp import ratsimp
-from sympy.simplify.simplify import nsimplify, together
 from .gruntz import gruntz
 
 def limit(e, z, z0, dir="+"):
@@ -82,6 +79,7 @@ def heuristics(e, z, z0, dir):
             return
     elif e.is_Mul or e.is_Add or e.is_Pow or e.is_Function:
         r = []
+        from sympy.simplify.simplify import together
         for a in e.args:
             l = limit(a, z, z0, dir)
             if l.has(S.Infinity) and l.is_finite is None:
@@ -119,6 +117,7 @@ def heuristics(e, z, z0, dir):
 
             if rv is S.NaN:
                 try:
+                    from sympy.simplify.ratsimp import ratsimp
                     rat_e = ratsimp(e)
                 except PolynomialError:
                     return
@@ -267,6 +266,7 @@ class Limit(Expr):
             # prevent rounding errors which can lead to unexpected execution
             # of conditional blocks that work on comparisons
             # Also see comments in https://github.com/sympy/sympy/issues/19453
+            from sympy.simplify.simplify import nsimplify
             e = nsimplify(e)
         e = set_signs(e)
 
@@ -306,6 +306,7 @@ class Limit(Expr):
             coeff, ex = newe.leadterm(z, cdir=cdir)
         except (ValueError, NotImplementedError, PoleError):
             # The NotImplementedError catching is for custom functions
+            from sympy.simplify.powsimp import powsimp
             e = powsimp(e)
             if e.is_Pow:
                 r = self.pow_heuristics(e)

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -369,7 +369,6 @@ class Order(Expr):
         Return None if the inclusion relation cannot be determined
         (e.g. when self and expr have different symbols).
         """
-        from sympy.simplify.powsimp import powsimp
         expr = sympify(expr)
         if expr.is_zero:
             return True
@@ -410,6 +409,7 @@ class Order(Expr):
                             if rv is not None:
                                 return rv
 
+            from sympy.simplify.powsimp import powsimp
             r = None
             ratio = self.expr/expr.expr
             ratio = powsimp(ratio, deep=True, combine='exp')

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -3,7 +3,7 @@ from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.decorators import call_highest_priority
 from sympy.core.parameters import global_parameters
-from sympy.core.function import AppliedUndef
+from sympy.core.function import AppliedUndef, expand
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer
 from sympy.core.relational import Eq
@@ -11,12 +11,11 @@ from sympy.core.singleton import S, Singleton
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.sympify import sympify
+from sympy.matrices import Matrix
 from sympy.polys import lcm, factor
 from sympy.sets.sets import Interval, Intersection
-from sympy.simplify import simplify
 from sympy.tensor.indexed import Idx
 from sympy.utilities.iterables import flatten, is_sequence, iterable
-from sympy.core.function import expand
 
 
 ###############################################################################
@@ -336,7 +335,7 @@ class SeqBase(Basic):
         >>> sequence(lucas(n)).find_linear_recurrence(15,gfvar=x)
         ([1, 1], (x - 2)/(x**2 + x - 1))
         """
-        from sympy.matrices import Matrix
+        from sympy.simplify import simplify
         x = [simplify(expand(t)) for t in self[:n]]
         lx = len(x)
         if d is None:

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -1,11 +1,19 @@
 """ Tools for doing common subexpression elimination.
 """
+from collections import defaultdict
+
 from sympy.core import Basic, Mul, Add, Pow, sympify
 from sympy.core.containers import Tuple, OrderedSet
 from sympy.core.exprtools import factor_terms
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import symbols, Symbol
+from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
+                            SparseMatrix, ImmutableSparseMatrix)
+from sympy.matrices.expressions import (MatrixExpr, MatrixSymbol, MatMul,
+                                        MatAdd, MatPow)
+from sympy.matrices.expressions.matexpr import MatrixElement
+from sympy.polys.rootoftools import RootOf
 from sympy.utilities.iterables import numbered_symbols, sift, \
         topological_sort, iterable
 
@@ -265,7 +273,6 @@ class FuncArgTracker:
         ``argset``. Entries have at least 2 items in common.  All keys have
         value at least ``min_func_i``.
         """
-        from collections import defaultdict
         count_map = defaultdict(lambda: 0)
         if not argset:
             return count_map
@@ -478,7 +485,6 @@ def opt_cse(exprs, order='canonical'):
     >>> print((k, v.as_unevaluated_basic()))
     (x**(-2), 1/(x**2))
     """
-    from sympy.matrices.expressions import MatAdd, MatMul, MatPow
     opt_subs = dict()
 
     adds = OrderedSet()
@@ -566,10 +572,6 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
     ignore : iterable of Symbols
         Substitutions containing any Symbol from ``ignore`` will be ignored.
     """
-    from sympy.matrices.expressions import MatrixExpr, MatrixSymbol, MatMul, MatAdd
-    from sympy.matrices.expressions.matexpr import MatrixElement
-    from sympy.polys.rootoftools import RootOf
-
     if opt_subs is None:
         opt_subs = dict()
 
@@ -776,9 +778,6 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     >>> cse(x, list=False)
     ([], x)
     """
-    from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
-                                SparseMatrix, ImmutableSparseMatrix)
-
     if not list:
         return _cse_homogeneous(exprs,
             symbols=symbols, optimizations=optimizations,

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -74,7 +74,9 @@ from sympy.functions.special.hyper import (hyper, HyperRep_atanh,
         HyperRep_power1, HyperRep_power2, HyperRep_log1, HyperRep_asin1,
         HyperRep_asin2, HyperRep_sqrts1, HyperRep_sqrts2, HyperRep_log2,
         HyperRep_cosasin, HyperRep_sinasin, meijerg)
-from sympy.polys import poly, Poly
+from sympy.matrices import Matrix, eye, zeros
+from sympy.polys import apart, poly, Poly
+from sympy.series import residue
 from sympy.simplify.powsimp import powdenest
 from sympy.utilities.iterables import sift
 
@@ -96,8 +98,6 @@ def _mod1(x):
 # leave add formulae at the top for easy reference
 def add_formulae(formulae):
     """ Create our knowledge base. """
-    from sympy.matrices import Matrix
-
     a, b, c, z = symbols('a b c, z', cls=Dummy)
 
     def add(ap, bq, res):
@@ -385,8 +385,6 @@ def add_formulae(formulae):
 
 
 def add_meijerg_formulae(formulae):
-    from sympy.matrices import Matrix
-
     a, b, c, z = list(map(Dummy, 'abcz'))
     rho = Dummy('rho')
 
@@ -703,8 +701,6 @@ class Formula:
            closed_form = C B
            z d/dz B = M B.
         """
-        from sympy.matrices import Matrix, eye, zeros
-
         afactors = [_x + a for a in self.func.ap]
         bfactors = [_x + b - 1 for b in self.func.bq]
         expr = _x*Mul(*bfactors) - self.z*Mul(*afactors)
@@ -1750,8 +1746,6 @@ def try_lerchphi(func):
     # section 18.
     # We don't need to implement the reduction to polylog here, this
     # is handled by expand_func.
-    from sympy.matrices import Matrix, zeros
-    from sympy.polys import apart
 
     # First we need to figure out if the summation coefficient is a rational
     # function of the summation index, and construct that rational function.
@@ -1881,7 +1875,6 @@ def build_hypergeometric_formula(func):
     # would have kicked in. However, `ap` could be empty. In this case we can
     # use a different basis.
     # I'm not aware of a basis that works in all cases.
-    from sympy.matrices.dense import (Matrix, eye, zeros)
     z = Dummy('z')
     if func.ap:
         afactors = [_x + a for a in func.ap]
@@ -1996,7 +1989,6 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
     def carryout_plan(f, ops):
         C = apply_operators(f.C.subs(f.z, z0), ops,
                             make_derivative_operator(f.M.subs(f.z, z0), z0))
-        from sympy.matrices.dense import eye
         C = apply_operators(C, ops0,
                             make_derivative_operator(f.M.subs(f.z, z0)
                                          + prem*eye(f.M.shape[0]), z0))
@@ -2285,7 +2277,6 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
     def do_slater(an, bm, ap, bq, z, zfinal):
         # zfinal is the value that will eventually be substituted for z.
         # We pass it to _hyperexpand to improve performance.
-        from sympy.series import residue
         func = G_Function(an, bm, ap, bq)
         _, pbm, pap, _ = func.compute_buckets()
         if not can_do(pbm, pap):

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -8,6 +8,7 @@ from sympy.core.numbers import Integer, Rational
 from sympy.core.mul import prod, _keep_coeff
 from sympy.core.rules import Transform
 from sympy.functions import exp_polar, exp, log, root, polarify, unpolarify
+from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.polys import lcm, gcd
 from sympy.ntheory.factor_ import multiplicity
 
@@ -98,8 +99,6 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
     x*y*sqrt(x*sqrt(y))
 
     """
-    from sympy.matrices.expressions.matexpr import MatrixSymbol
-
     def recurse(arg, **kwargs):
         _deep = kwargs.get('deep', deep)
         _combine = kwargs.get('combine', combine)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from sympy.concrete.products import Product
+from sympy.concrete.summations import Sum
 from sympy.core import (Basic, S, Add, Mul, Pow, Symbol, sympify,
                         expand_func, Function, Dummy, Expr, factor_terms,
                         expand_power_exp, Eq)
@@ -19,12 +21,17 @@ from sympy.functions.elementary.complexes import unpolarify, Abs, sign
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.integers import ceiling
-from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
+from sympy.functions.elementary.piecewise import (Piecewise, piecewise_fold,
+                                                  piecewise_simplify)
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.special.bessel import (BesselBase, besselj, besseli,
                                             besselk, bessely, jn)
 from sympy.functions.special.tensor_functions import KroneckerDelta
+from sympy.integrals.integrals import Integral
+from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
+                                            MatPow, MatrixSymbol)
 from sympy.polys import together, cancel, factor
+from sympy.polys.numberfields.minpoly import _is_sum_surds, _minimal_polynomial_sq
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.simplify.hyperexpand import hyperexpand
@@ -207,14 +214,6 @@ def _separatevars_dict(expr, symbols):
         ret[k] = Mul(*v)
 
     return ret
-
-
-def _is_sum_surds(p):
-    args = p.args if p.is_Add else [p]
-    for y in args:
-        if not ((y**2).is_Rational and y.is_extended_real):
-            return False
-    return True
 
 
 def posify(eq):
@@ -675,7 +674,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
                 expr = kroneckersimp(expr)
             # Still a Piecewise?
             if expr.has(Piecewise):
-                from sympy.functions.elementary.piecewise import piecewise_simplify
                 # Do not apply doit on the segments as it has already
                 # been done above, but simplify
                 expr = piecewise_simplify(expr, deep=True, doit=False)
@@ -707,10 +705,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         # expression with gamma functions or non-integer arguments is
         # automatically passed to gammasimp
         expr = combsimp(expr)
-
-    from sympy.concrete.products import Product
-    from sympy.concrete.summations import Sum
-    from sympy.integrals.integrals import Integral
 
     if expr.has(Sum):
         expr = sum_simplify(expr, **kwargs)
@@ -768,8 +762,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
 def sum_simplify(s, **kwargs):
     """Main function for Sum simplification"""
-    from sympy.concrete.summations import Sum
-
     if not isinstance(s, Add):
         s = s.xreplace({a: sum_simplify(a, **kwargs)
             for a in s.atoms(Add) if a.has(Sum)})
@@ -801,8 +793,6 @@ def sum_combine(s_t):
        Attempts to simplify a list of sums, by combining limits / sum function's
        returns the simplified sum
     """
-    from sympy.concrete.summations import Sum
-
     used = [False] * len(s_t)
 
     for method in range(2):
@@ -843,7 +833,6 @@ def factor_sum(self, limits=None, radical=False, clear=False, fraction=False, si
     y*Sum(x, (x, 1, 3))
     """
     # XXX deprecate in favor of direct call to factor_terms
-    from sympy.concrete.summations import Sum
     kwargs = dict(radical=radical, clear=clear,
         fraction=fraction, sign=sign)
     expr = Sum(self, *limits) if limits else self
@@ -852,8 +841,6 @@ def factor_sum(self, limits=None, radical=False, clear=False, fraction=False, si
 
 def sum_add(self, other, method=0):
     """Helper function for Sum simplification"""
-    from sympy.concrete.summations import Sum
-
     #we know this is something in terms of a constant * a sum
     #so we temporarily put the constants inside for simplification
     #then simplify the result
@@ -898,8 +885,6 @@ def sum_add(self, other, method=0):
 
 def product_simplify(s):
     """Main function for Product simplification"""
-    from sympy.concrete.products import Product
-
     terms = Mul.make_args(s)
     p_t = [] # Product Terms
     o_t = [] # Other Terms
@@ -932,8 +917,6 @@ def product_simplify(s):
 
 def product_mul(self, other, method=0):
     """Helper function for Product simplification"""
-    from sympy.concrete.products import Product
-
     if type(self) is type(other):
         if method == 0:
             if self.limits == other.limits:
@@ -962,7 +945,6 @@ def _nthroot_solve(p, n, prec):
      helper function for ``nthroot``
      It denests ``p**Rational(1, n)`` using its minimal polynomial
     """
-    from sympy.polys.numberfields.minpoly import _minimal_polynomial_sq
     from sympy.solvers import solve
     while n % 2 == 0:
         p = sqrtdenest(sqrt(p))
@@ -1681,9 +1663,6 @@ def nc_simplify(expr, deep=True):
     (a*b*a*b)**2*(a*c)**2
 
     '''
-    from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
-                                                MatPow, MatrixSymbol)
-
     if isinstance(expr, MatrixExpr):
         expr = expr.doit(inv_expand=False)
         _Add, _Mul, _Pow, _Symbol = MatAdd, MatMul, MatPow, MatrixSymbol

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -41,7 +41,7 @@ from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, symbols
 from sympy.functions import exp
-from sympy.integrals.integrals import Integral
+from sympy.integrals.integrals import Integral, integrate
 from sympy.utilities.iterables import has_dups, is_sequence
 from sympy.utilities.misc import filldedent
 
@@ -727,7 +727,6 @@ def pde_1st_linear_variable_coeff(eq, func, order, match, solvefun):
       Math 124A - Fall 2010, pp.7
 
     """
-    from sympy.integrals.integrals import integrate
     from sympy.solvers.ode import dsolve
 
     xi, eta = symbols("xi eta")

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -48,6 +48,7 @@ For the sake of completeness, `f(n)` can be:
 """
 from collections import defaultdict
 
+from sympy.concrete import product
 from sympy.core.singleton import S
 from sympy.core.numbers import Rational, I
 from sympy.core.symbol import Symbol, Wild, Dummy
@@ -509,8 +510,6 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
     .. [2] M. Petkovsek, H. S. Wilf, D. Zeilberger, A = B, 1996.
     """
-    from sympy.concrete import product
-
     coeffs = list(map(sympify, coeffs))
 
     f = sympify(f)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -34,6 +34,7 @@ from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
+from sympy.integrals.integrals import Integral
 from sympy.ntheory.factor_ import divisors
 from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
@@ -57,7 +58,7 @@ from sympy.solvers.polysys import solve_poly_system
 
 from types import GeneratorType
 from collections import defaultdict
-from itertools import product
+from itertools import combinations, product
 
 import warnings
 
@@ -2137,8 +2138,6 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     if not symbols:
         return S.Zero, S.One
 
-    from sympy.integrals.integrals import Integral
-
     # derivatives are easy to do but tricky to analyze to see if they
     # are going to disallow a linear solution, so for simplicity we
     # just evaluate the ones that have the symbols of interest
@@ -2236,7 +2235,6 @@ def minsolve_linear_system(system, *symbols, **flags):
         # variables, we will find an optimal solution.
         # We speed up slightly by starting at one less than the number of
         # variables the quick method manages.
-        from itertools import combinations
         N = len(symbols)
         bestsol = minsolve_linear_system(system, *symbols, quick=True)
         n0 = len([x for x in bestsol.values() if x != 0])

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -5,7 +5,6 @@ from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.singleton import S
 from sympy.core.sympify import _sympify
-from sympy.simplify.simplify import simplify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray, ArrayKind
 from sympy.utilities.iterables import flatten
@@ -158,6 +157,7 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray): # type: ignor
         return MutableDenseNDimArray(self)
 
     def _eval_simplify(self, **kwargs):
+        from sympy.simplify.simplify import simplify
         return self.applyfunc(simplify)
 
 class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #23000

#### Brief description of what is fixed or changed

Major change here:

`solvers` is moved down the import chain (so one can import almost anything on top level in solv`solvers`ers, but not import `solvers`on top level anywhere else)

`simplify` is similarly moved, but still possible to import simplify from top level in `solvers`.

This should break some of the non-obvious import cycles. For example make it easier to import from concrete at top level.

Motivation: both `simplify` and `solvers` should be restrictively used in library code. So it makes more sense to be able to import "everything else" in those two at top level.

#### Other comments

Some minor other changes, primarily moving imports to top-level.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
