### PR TITLE
return precision of Floats passed to Poly in RR

### DIFF
--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -2,10 +2,11 @@
 
 
 from sympy.core.numbers import Float
+from mpmath.libmp.libmpf import prec_to_dps
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
-from sympy.polys.domains.mpelements import MPContext
+from sympy.polys.domains.mpelements import MPContext, RealElement
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
@@ -61,12 +62,19 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     def to_sympy(self, element):
         """Convert ``element`` to SymPy number. """
-        return Float(element, self.dps)
+        _mpf = element._mpf_
+        dps = prec_to_dps(_mpf[-1])
+        return Float(_mpf, dps)
 
     def from_sympy(self, expr):
         """Convert SymPy's number to ``dtype``. """
+        if isinstance(expr, Float):
+            # I don't know how else to get the converted
+            # expr to look like the original. I tried
+            # passing (expr._mpf_, prec=expr._prec) but
+            # that did not pass the added tests
+            return RealElement(str(expr))
         number = expr.evalf(n=self.dps)
-
         if number.is_Number:
             return self.dtype(number)
         else:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -53,6 +53,7 @@ from sympy.polys.domains import FF, ZZ, QQ, ZZ_I, QQ_I, RR, EX
 from sympy.polys.domains.realfield import RealField
 from sympy.polys.domains.complexfield import ComplexField
 from sympy.polys.orderings import lex, grlex, grevlex
+from sympy.polys.rootoftools import rootof
 
 from sympy.core.add import Add
 from sympy.core.basic import _aresame
@@ -73,9 +74,10 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import sin
 from sympy.matrices.dense import Matrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
-from sympy.polys.rootoftools import rootof
+from sympy.printing.repr import srepr
 from sympy.simplify.simplify import signsimp
 from sympy.utilities.iterables import iterable
+from sympy.utilities.misc import filldedent
 
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
@@ -3567,3 +3569,15 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_issue_22988():
+    e = S('(3/100 + 1234/10*x)')
+    p = Poly(e.subs({k: k.round(15) for k in e.atoms(Rational)}))
+    assert str(p) == "Poly(123.4*x + 0.03, x, domain='RR')"
+    assert str(p.terms()) == (
+        '[((1,), 123.400000000000000), ((0,), 0.030000000000000000)]')
+    assert filldedent(srepr(p)) == filldedent("""
+        Poly(Add(Mul(Float('123.399999999999999994', precision=63),
+        Symbol('x')), Float('0.030000000000000000001', precision=60)),
+        Symbol('x'))""")

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -74,6 +74,9 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     Examples
     ========
 
+    >>> from sympy import simplify, sin rad
+    >>> abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf()
+    >>> assert _-673.447451402970 < 1e-12
     >>> from sympy.abc import x, y, z, alpha
     >>> from sympy import separatevars, sin
     >>> separatevars((x*y)**y)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -74,7 +74,7 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     Examples
     ========
 
-    >>> from sympy import simplify, sin rad
+    >>> from sympy import simplify, sin, rad
     >>> abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf())
     >>> assert _-673.447451402970 < 1e-12
     >>> from sympy.abc import x, y, z, alpha

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -75,7 +75,7 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     ========
 
     >>> from sympy import simplify, sin rad
-    >>> abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf()
+    >>> abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf())
     >>> assert _-673.447451402970 < 1e-12
     >>> from sympy.abc import x, y, z, alpha
     >>> from sympy import separatevars, sin


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Another attempt at closing #22988

#### Brief description of what is fixed or changed

That the tests pass suggests that this is a less rarely needed option, triggered by a case like that given in the issue where numbers *rounded* to the same decimal place end up with different precisions. In this case, it seems reasonable to use the minimum precision else extra garbage digits end up showing through in the representation of the object.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
