### PR TITLE
Moved definition of `illegal`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -900,7 +900,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         """
         from .containers import Dict
         from .symbol import Dummy, Symbol
-        from sympy.polys.polyutils import illegal
+        from .numbers import _illegal
 
         unordered = False
         if len(args) == 1:
@@ -956,7 +956,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             if not simultaneous:
                 redo = []
                 for i in range(len(sequence)):
-                    if sequence[i][1] in illegal:  # nan, zoo and +/-oo
+                    if sequence[i][1] in _illegal:  # nan, zoo and +/-oo
                         redo.append(i)
                 for i in reversed(redo):
                     sequence.insert(0, sequence.pop(i))

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2681,7 +2681,7 @@ class Expr(Basic, EvalfMixin):
         See also is_algebraic_expr().
 
         """
-        if self in [S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
+        if self in _illegal:
             return False
 
         if syms:
@@ -3781,8 +3781,6 @@ class Expr(Basic, EvalfMixin):
         >>> isinstance(round(S(123), -2), Number)
         True
         """
-        from sympy.core.numbers import Float
-
         x = self
 
         if not x.is_number:
@@ -3791,7 +3789,7 @@ class Expr(Basic, EvalfMixin):
             if not pure_complex(x.n(2), or_real=True):
                 raise TypeError(
                     'Expected a number but got %s:' % func_name(x))
-        elif x in (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
+        elif x in _illegal:
             return x
         if x.is_extended_real is False:
             r, i = x.as_real_imag()
@@ -4104,4 +4102,4 @@ from .power import Pow
 from .function import Function, _derivative_dispatch
 from .mod import Mod
 from .exprtools import factor_terms
-from .numbers import Integer, Rational
+from .numbers import Float, Integer, Rational, _illegal

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4488,3 +4488,5 @@ def _register_classes():
     numbers.Integral.register(Integer)
 
 _register_classes()
+
+_illegal = (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1641,7 +1641,8 @@ class Pow(Expr):
         from sympy.simplify.powsimp import powdenest
         self = powdenest(self, force=True).trigsimp()
         b, e = self.as_base_exp()
-        if e.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
+        from .numbers import _illegal
+        if e.has(*_illegal):
             raise PoleError()
 
         if e.has(x):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,6 +1,6 @@
 from sympy.core import S, Function, diff, Tuple, Dummy
 from sympy.core.basic import Basic, as_Basic
-from sympy.core.numbers import Rational, NumberSymbol
+from sympy.core.numbers import Rational, NumberSymbol, _illegal
 from sympy.core.parameters import global_parameters
 from sympy.core.relational import (Lt, Gt, Eq, Ne, Relational,
     _canonical, _canonical_coeff)
@@ -8,7 +8,6 @@ from sympy.core.sorting import ordered
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or, Not,
     true, false, Or, ITE, simplify_logic, to_cnf, distribute_or_over_and)
-from sympy.polys.polyutils import illegal
 from sympy.sets.sets import Interval
 from sympy.utilities.iterables import uniq, sift, common_prefix
 from sympy.utilities.misc import filldedent, func_name
@@ -505,7 +504,7 @@ class Piecewise(Function):
             else:
                 sum = sum.subs(x, a)
                 e = anti._eval_interval(x, a, x)
-                if sum.has(*illegal) or e.has(*illegal):
+                if sum.has(*_illegal) or e.has(*_illegal):
                     sum = anti
                 else:
                     sum += e

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1,6 +1,6 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
-from sympy.core.numbers import (E, Float, I, Integer, Rational, oo, pi)
+from sympy.core.numbers import (E, Float, I, Integer, Rational, oo, pi, _illegal)
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -30,7 +30,6 @@ from sympy.polys.polyerrors import (
     CoercionFailed,
     NotInvertible,
     DomainError)
-from sympy.polys.polyutils import illegal
 
 from sympy.testing.pytest import raises
 
@@ -812,8 +811,8 @@ def test_RealField_from_sympy():
 
 
 def test_not_in_any_domain():
-    check = illegal + [x] + [
-        float(i) for i in illegal if i != S.ComplexInfinity]
+    check = list(_illegal) + [x] + [
+        float(i) for i in _illegal if i != S.ComplexInfinity]
     for dom in (ZZ, QQ, RR, CC, EX):
         for i in check:
             if i == x and dom == EX:

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -15,6 +15,7 @@ from sympy.functions import sqrt, cbrt
 
 from sympy.core.exprtools import Factors
 from sympy.core.function import _mexpand
+from sympy.core.numbers import _illegal
 from sympy.core.traversal import preorder_traversal
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.trigonometric import cos, sin, tan
@@ -31,7 +32,7 @@ from sympy.polys.polytools import (
     Poly, PurePoly, invert, factor_list, groebner, resultant,
     degree, poly_from_expr, parallel_poly_from_expr, lcm
 )
-from sympy.polys.polyutils import dict_from_expr, expr_from_dict, illegal
+from sympy.polys.polyutils import dict_from_expr, expr_from_dict
 from sympy.polys.ring_series import rs_compose_add
 from sympy.polys.rings import ring
 from sympy.polys.rootoftools import CRootOf
@@ -74,7 +75,7 @@ def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
 
             # if we get invalid numbers (e.g. from division by zero)
             # we try again
-            if any(i in illegal for i, _ in candidates):
+            if any(i in _illegal for i, _ in candidates):
                 continue
 
             # find the smallest two -- if they differ significantly

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -4,6 +4,7 @@
 from sympy.core import (S, Add, Mul, Pow, Eq, Expr,
     expand_mul, expand_multinomial)
 from sympy.core.exprtools import decompose_power, decompose_power_rat
+from sympy.core.numbers import _illegal
 from sympy.polys.polyerrors import PolynomialError, GeneratorsError
 from sympy.polys.polyoptions import build_options
 
@@ -165,9 +166,8 @@ def _sort_factors(factors, **args):
     else:
         return sorted(factors, key=order_no_multiple_key)
 
-illegal = [S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity]
-illegal_types = [type(obj) for obj in illegal]
-finf = [float(i) for i in illegal[1:3]]
+illegal_types = [type(obj) for obj in _illegal]
+finf = [float(i) for i in _illegal[1:3]]
 def _not_a_coeff(expr):
     """Do not treat NaN and infinities as valid polynomial coefficients. """
     if type(expr) in illegal_types or expr in finf:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,7 +1,7 @@
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
-from sympy.core.numbers import Float
+from sympy.core.numbers import Float, _illegal
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, sign)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -231,7 +231,7 @@ class Limit(Expr):
         if z0 is S.NaN:
             return S.NaN
 
-        if e.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
+        if e.has(*_illegal):
             return self
 
         if e.is_Order:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -20,7 +20,7 @@ from sympy.core.function import (expand_mul, expand_log, Derivative,
                                  Function, expand_power_exp, _mexpand, expand,
                                  expand_func)
 from sympy.core.logic import fuzzy_not
-from sympy.core.numbers import ilcm, Float, Rational
+from sympy.core.numbers import ilcm, Float, Rational, _illegal
 from sympy.core.power import integer_log, Pow
 from sympy.core.relational import Relational, Eq, Ne
 from sympy.core.sorting import ordered, default_sort_key
@@ -278,10 +278,7 @@ def checksol(f, symbol, sol=None, **flags):
         # if f(y) == 0, x=3 does not set f(y) to zero...nor does it not
         return None
 
-    illegal = {S.NaN,
-               S.ComplexInfinity,
-               S.Infinity,
-               S.NegativeInfinity}
+    illegal = set(_illegal)
     if any(sympify(v).atoms() & illegal for k, v in sol.items()):
         return False
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`illegal = (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity)` was defined in `polys.polytools`, but used in `core`. It makes more sense to define this in `core.numbers`.

#### Other comments

It is still possible to import from `polys.polytools`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
