### PR TITLE
SymPyPrinter: And prints as & instead of and

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -733,6 +733,8 @@ class SymPyPrinter(AbstractPythonCodePrinter):
 
     language = "Python with SymPy"
 
+    _operators = {**AbstractPythonCodePrinter._operators, 'and' : '&'}
+
     def _print_Function(self, expr):
         mod = expr.func.__module__ or ''
         return '%s(%s)' % (self._module_format(mod + ('.' if mod else '') + expr.func.__name__),

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -421,3 +421,9 @@ def test_array_printer():
     assert prntr.doprint(ArrayDiagonal(A, [0,1], [2,3])) == 'tensorflow.linalg.einsum("aabbc->cab", A)'
     assert prntr.doprint(ArrayContraction(A, [2], [3])) == 'tensorflow.linalg.einsum("abcde->abe", A)'
     assert prntr.doprint(Assignment(I[i,j,k], I[i,j,k])) == 'I = I'
+
+def test_issue_23010():
+    from sympy.abc import x,y
+    from sympy.printing.pycode import SymPyPrinter
+
+    assert SymPyPrinter().doprint( x & y ) == 'x & y'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1561,6 +1561,8 @@ def test_lambdify_cse():
 
 
 def test_issue_23010():
+    if not numpy:
+        skip("numpy not installed.")
     from sympy import Eq, sin, lambdify
     from sympy.abc import x,y
     from sympy.plotting.intervalmath import interval


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23010

#### Brief description of what is fixed or changed
The SymPy printer now uses the `&` operator to represent a "logica
and" rather than `and` since `&` creates an `And` object and `and`
does not.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
