### PR TITLE
quantum: don't use deprecated scipy.sparse.base (1.10 branch)

### DIFF
--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -40,13 +40,7 @@ if not scipy:
     sparse = None
 else:
     sparse = scipy.sparse
-    # Try to find spmatrix.
-    if hasattr(sparse, 'base'):
-        # Newer versions have it under scipy.sparse.base.
-        scipy_sparse_matrix = sparse.base.spmatrix  # type: ignore
-    elif hasattr(sparse, 'sparse'):
-        # Older versions have it under scipy.sparse.sparse.
-        scipy_sparse_matrix = sparse.sparse.spmatrix  # type: ignore
+    scipy_sparse_matrix = sparse.spmatrix
 
 
 def sympy_to_numpy(m, **options):

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -40,7 +40,7 @@ if not scipy:
     sparse = None
 else:
     sparse = scipy.sparse
-    scipy_sparse_matrix = sparse.spmatrix
+    scipy_sparse_matrix = sparse.spmatrix # type: ignore
 
 
 def sympy_to_numpy(m, **options):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Same as #23026 but for the 1.10 release branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
