### PR TITLE
fix 'KeyError: 'ComplexInfinity'' with PythonCodePrinter 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -157,6 +157,7 @@ Amit Kumar <dtu.amit@gmail.com>
 Amit Kumar <dtu.amit@gmail.com> <aktech@users.noreply.github.com>
 Amit Kumar <dtu.amit@gmail.com> <dtu.amit+gh@gmail.com>
 Amit Manchanda <amitdelhi1995@gmail.com>
+Amit Portnoy <amit.portnoy@gmail.com> Amit Portnoy <1131991+amitport@users.noreply.github.com>
 Amit Saha <amitsaha.in@gmail.com> <asaha@redhat.com>
 Ananya H <ananyaha93@gmail.com>
 Anatolii Koval <weralwolf@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1127 authors.
+There are a total of 1129 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1133,3 +1133,5 @@ Tom Fryers <61272761+TomFryers@users.noreply.github.com>
 Zouhair <zouhair.mahboubi@gmail.com>
 zzj <29055749+zjzh@users.noreply.github.com>
 shubhayu09 <guptashubhayu601@gmail.com>
+Siddhant Jain <siddhantashoknagar@gmail.com>
+Amit Portnoy <amit.portnoy@gmail.com>

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -24,7 +24,8 @@ _known_constants_numpy = {
     'EulerGamma': 'euler_gamma',
     'NaN': 'nan',
     'Infinity': 'PINF',
-    'NegativeInfinity': 'NINF'
+    'NegativeInfinity': 'NINF',
+    'ComplexInfinity': 'nan',
 }
 
 _numpy_known_functions = {k: 'numpy.' + v for k, v in _known_functions_numpy.items()}

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -631,7 +631,8 @@ _known_constants_mpmath = {
     'Catalan': 'catalan',
     'NaN': 'nan',
     'Infinity': 'inf',
-    'NegativeInfinity': 'ninf'
+    'NegativeInfinity': 'ninf',
+    'ComplexInfinity': 'nan',
 }
 
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -84,6 +84,7 @@ def test_MpmathPrinter():
     assert p.doprint(S.NaN) == 'mpmath.nan'
     assert p.doprint(S.Infinity) == 'mpmath.inf'
     assert p.doprint(S.NegativeInfinity) == 'mpmath.ninf'
+    assert p.doprint(S.ComplexInfinity) == 'mpmath.nan'
     assert p.doprint(loggamma(x)) == 'mpmath.loggamma(x)'
 
 
@@ -135,6 +136,7 @@ def test_NumPyPrinter():
     assert p.doprint(S.NaN) == 'numpy.nan'
     assert p.doprint(S.Infinity) == 'numpy.PINF'
     assert p.doprint(S.NegativeInfinity) == 'numpy.NINF'
+    assert p.doprint(S.ComplexInfinity) == 'numpy.nan'
 
 
 def test_issue_18770():
@@ -171,6 +173,7 @@ def test_SciPyPrinter():
     assert p.doprint(S.GoldenRatio) == 'scipy.constants.golden_ratio'
     assert p.doprint(S.Pi) == 'scipy.constants.pi'
     assert p.doprint(S.Exp1) == 'numpy.e'
+    assert p.doprint(S.ComplexInfinity) == 'numpy.nan'
 
 
 def test_pycode_reserved_words():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

When using scypi or mpmath module, `_print_NaN` is being overridden by `_print_known_const`, which relies on the input `expr` to hold the correct expression.

`_print_ComplexInfinity` delegates to `_print_NaN` but sends the original `ComplexInfinity` expr which causes an exception since it is not in `known_constants`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
