### PR TITLE
compat: add back deprecated stub files in iterables

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2993,15 +2993,29 @@ def is_sequence(i, include=None):
             isinstance(i, include))
 
 
-@deprecated(useinstead="sympy.core.traversal.postorder_traversal",
+@deprecated(useinstead="from sympy import postorder_traversal",
     deprecated_since_version="1.10", issue=22288)
 def postorder_traversal(node, keys=None):
     from sympy.core.traversal import postorder_traversal as _postorder_traversal
     return _postorder_traversal(node, keys=keys)
 
 
-@deprecated(useinstead="sympy.interactive.traversal.interactive_traversal",
+@deprecated(useinstead="from sympy import interactive_traversal",
             issue=22288, deprecated_since_version="1.10")
 def interactive_traversal(expr):
     from sympy.interactive.traversal import interactive_traversal as _interactive_traversal
     return _interactive_traversal(expr)
+
+
+@deprecated(useinstead="from sympy import default_sort_key",
+            deprecated_since_version="1.10", issue=22352)
+def default_sort_key(*args, **kwargs):
+    from sympy import default_sort_key as _default_sort_key
+    return _default_sort_key(*args, **kwargs)
+
+
+@deprecated(useinstead="from sympy import ordered",
+            deprecated_since_version="1.10", issue=22352)
+def ordered(*args, **kwargs):
+    from sympy import ordered as _ordered
+    return _ordered(*args, **kwargs)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -24,9 +24,17 @@ from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
 from sympy.core.singleton import S
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 w, x, y, z = symbols('w,x,y,z')
+
+
+def test_deprecated_iterables():
+    from sympy.utilities.iterables import default_sort_key, ordered
+    with warns_deprecated_sympy():
+        assert list(ordered([y, x])) == [x, y]
+    with warns_deprecated_sympy():
+        assert sorted([y, x], key=default_sort_key) == [x, y]
 
 
 def test_is_palindromic():


### PR DESCRIPTION
The ordered and default_sort_key functions where removed from
sympy.utilities.iterables in GH-22357 but no deprecated stub functions
were left behind. This commit adds and tests the stubs to ensure that
anyone depending on importing these functions like
```
  from sympy.utilities.iterables import default_sort_key
  from sympy.utilities.iterables import ordered
```
will see a deprecation warning rather than an error.

The proper way to import these functions both before and after these
changes is:
```
  from sympy import default_sort_key
  from sympy import ordered
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Same as #23003

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
