### PR TITLE
integrals - fixed issue#19575 and now Meijerint does not fail with float input

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1905,3 +1905,10 @@ def test_issue_18527():
     expr = (cos(x)/(4+(sin(x))**2))
     res_real = integrate(expr.subs(x, xr), xr, manual=True).subs(xr, x)
     assert integrate(expr, x, manual=True) == res_real == Integral(expr, x)
+
+
+def test_issue_19575():
+    Rn = symbols('Rn')
+    integral = Integral(0.0625*x**3.0*exp(-x/2), (x, 0, Rn))
+    r = -0.125*Rn**3*exp(-Rn/2) - 0.75*Rn**2*exp(-Rn/2) - 3.0*Rn*exp(-Rn/2) + 6.0 - 6.0*exp(-Rn/2)
+    assert integral.doit() == r

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -79,6 +79,8 @@ from sympy.polys import apart, poly, Poly
 from sympy.series import residue
 from sympy.simplify.powsimp import powdenest
 from sympy.utilities.iterables import sift
+from sympy.utilities.misc import as_int
+
 
 # function to define "buckets"
 def _mod1(x):
@@ -1661,12 +1663,12 @@ def try_shifted_sum(func, z):
     abuckets, bbuckets = sift(func.ap, _mod1), sift(func.bq, _mod1)
     if len(abuckets[S.Zero]) != 1:
         return None
-    r = int(round(abuckets[S.Zero][0]))
+    r = as_int(abuckets[S.Zero][0])  # XXX if this fails, is round necessary?
     if r <= 0:
         return None
     if S.Zero not in bbuckets:
         return None
-    k = int(round(min(bbuckets[S.Zero])))
+    k = as_int(min(bbuckets[S.Zero]))  # XXX if this fails, is round necessary?
     if k <= 0:
         return None
 
@@ -2330,8 +2332,10 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
                 s = Dummy('s')
                 integrand = z**s
                 for b in bm:
-                    if not Mod(b, 1) and b.is_Number:
-                        b = int(round(b))
+                    if b.is_Number:
+                        ib = int(b)
+                        if ib == b:
+                            b = ib
                     integrand *= gamma(b - s)
                 for a in an:
                     integrand *= gamma(1 - a + s)

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1661,14 +1661,14 @@ def try_shifted_sum(func, z):
     abuckets, bbuckets = sift(func.ap, _mod1), sift(func.bq, _mod1)
     if len(abuckets[S.Zero]) != 1:
         return None
-    r = abuckets[S.Zero][0]
+    r = int(round(abuckets[S.Zero][0]))
     if r <= 0:
         return None
     if S.Zero not in bbuckets:
         return None
     l = list(bbuckets[S.Zero])
     l.sort()
-    k = l[0]
+    k = int(round(l[0]))
     if k <= 0:
         return None
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1666,9 +1666,7 @@ def try_shifted_sum(func, z):
         return None
     if S.Zero not in bbuckets:
         return None
-    l = list(bbuckets[S.Zero])
-    l.sort()
-    k = int(round(l[0]))
+    k = int(round(min(bbuckets[S.Zero])))
     if k <= 0:
         return None
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1757,10 +1757,10 @@ def try_polynomial(func, z):
     if not al0:
         return None
 
-    a = int(al0[-1]) # make int in case `a` is Float equal to int
+    a = al0[-1] # make int in case `a` is Float equal to int
     fac = 1
     res = S.One
-    for n in Tuple(*list(range(-a))):
+    for n in Tuple(*list(range(-int(a)))):
         fac *= z
         fac /= n + 1
         for a in func.ap:

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -79,7 +79,6 @@ from sympy.polys import apart, poly, Poly
 from sympy.series import residue
 from sympy.simplify.powsimp import powdenest
 from sympy.utilities.iterables import sift
-from sympy.utilities.misc import as_int
 
 
 # function to define "buckets"
@@ -1663,12 +1662,12 @@ def try_shifted_sum(func, z):
     abuckets, bbuckets = sift(func.ap, _mod1), sift(func.bq, _mod1)
     if len(abuckets[S.Zero]) != 1:
         return None
-    r = as_int(abuckets[S.Zero][0], strict=False)  # XXX if this fails, is round necessary?
+    r = int(abuckets[S.Zero][0])
     if r <= 0:
         return None
     if S.Zero not in bbuckets:
         return None
-    k = as_int(min(bbuckets[S.Zero]), strict=False)  # XXX if this fails, is round necessary?
+    k = int(min(bbuckets[S.Zero]))
     if k <= 0:
         return None
 
@@ -2332,7 +2331,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
                 s = Dummy('s')
                 integrand = z**s
                 for b in bm:
-                    if b.is_Number:
+                    if b.is_Number:  # XXX is it necessary to convert to int?
                         ib = int(b)
                         if ib == b:
                             b = ib

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -62,7 +62,7 @@ from functools import reduce
 
 from sympy import SYMPY_DEBUG
 from sympy.core import (S, Dummy, symbols, sympify, Tuple, expand, I, pi, Mul,
-    EulerGamma, oo, zoo, expand_func, Add, nan, Expr, Rational)
+    EulerGamma, oo, zoo, expand_func, Add, nan, Expr, Rational, Integer)
 from sympy.core.mod import Mod
 from sympy.core.sorting import default_sort_key
 from sympy.functions import (exp, sqrt, root, log, lowergamma, cos,
@@ -1707,17 +1707,12 @@ def try_shifted_sum(func, z):
     nbq = list(func.bq)
     nbq.remove(k)
 
-    # r and k might be floats equal to integers
-    # so convert them explicitly to ints now
-    r = int(r)
-    k = int(k)
-
     k -= 1
     nap = [x - k for x in nap]
     nbq = [x - k for x in nbq]
 
     ops = []
-    for n in range(r - 1):
+    for n in range(int(r) - 1):
         ops.append(ShiftA(n + 1))
     ops.reverse()
 
@@ -1730,7 +1725,7 @@ def try_shifted_sum(func, z):
     ops += [MultOperator(fac)]
 
     p = 0
-    for n in range(k):
+    for n in range(int(k)):
         m = z**n/factorial(n)
         for a in nap:
             m *= rf(a, n)
@@ -1757,11 +1752,11 @@ def try_polynomial(func, z):
     if not al0:
         return None
 
-    assert None, (func, z)  # debug to find case that comes through here
-    a = int(al0[-1]) # make int in case `a` is Float equal to int
+    a = al0[-1]
     fac = 1
     res = S.One
-    for n in Tuple(*list(range(-a))):
+    for n in range(-int(a)):
+        n = Integer(n)
         fac *= z
         fac /= n + 1
         for a in func.ap:

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1757,6 +1757,7 @@ def try_polynomial(func, z):
     if not al0:
         return None
 
+    assert None, (func, z)  # debug to find case that comes through here
     a = int(al0[-1]) # make int in case `a` is Float equal to int
     fac = 1
     res = S.One

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1663,12 +1663,12 @@ def try_shifted_sum(func, z):
     abuckets, bbuckets = sift(func.ap, _mod1), sift(func.bq, _mod1)
     if len(abuckets[S.Zero]) != 1:
         return None
-    r = as_int(abuckets[S.Zero][0])  # XXX if this fails, is round necessary?
+    r = as_int(abuckets[S.Zero][0], strict=False)  # XXX if this fails, is round necessary?
     if r <= 0:
         return None
     if S.Zero not in bbuckets:
         return None
-    k = as_int(min(bbuckets[S.Zero]))  # XXX if this fails, is round necessary?
+    k = as_int(min(bbuckets[S.Zero]), strict=False)  # XXX if this fails, is round necessary?
     if k <= 0:
         return None
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -91,7 +91,7 @@ def _mod1(x):
     # Although the sorting can be done with Basic.compare, this may
     # still require different handling of the sorted buckets.
     if x.is_Number:
-        return Mod(x, 1)
+        return Mod(x, 1) or S.Zero  # make 0. canonical S.Zero
     c, x = x.as_coeff_Add()
     return Mod(c, 1) + x
 

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1061,5 +1061,5 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(hyper((-2.,), (), z), z)
-        ) == 1.0*z**2 - 2.0*z + 1
+    assert try_polynomial(hyper((-2.,), (), z), z
+    ) == 1.0*z**2 - 2.0*z + 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1061,4 +1061,4 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(hyper((-2.,), (), z), z)) == 1.0*z**2 - 2.0*z + 1
+    assert try_polynomial(hyper((-2.,), (), z), z))) == 1.0*z**2 - 2.0*z + 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1061,5 +1061,4 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(Hyper_Function((-2.,), ()), z)
-        ) == 1.0*z**2 - 2.0*z + 1
+    assert try_polynomial(hyper((-2.,), (), z), z)) == 1.0*z**2 - 2.0*z + 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1060,7 +1060,7 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(hyper((-2.,), (), z), z)
+    assert try_polynomial(hyper((-2.,), (), z), z
         ) == 1.0*z**2 - 2.0*z + 1
     assert try_shifted_sum(Hyper_Function((2,), (2.,)), z)  # doesn't fail r
     assert try_shifted_sum(Hyper_Function((2.,), (2,)), z)  # doesn't fail k

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1061,4 +1061,5 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(hyper((-2.,), (), z), z))) == 1.0*z**2 - 2.0*z + 1
+    assert try_polynomial(hyper((-2.,), (), z), z)
+        ) == 1.0*z**2 - 2.0*z + 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -7,7 +7,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        ReduceOrder, reduce_order, apply_operators,
                        devise_plan, make_derivative_operator, Formula,
                        hyperexpand, Hyper_Function, G_Function,
-                       reduce_order_meijer,
+                       reduce_order_meijer, try_polynomial,
                        build_hypergeometric_formula)
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple
@@ -1058,3 +1058,8 @@ def test_omgissue_203():
     assert hyperexpand(h) == Rational(1, 30)
     h = hyper((-6, -7, -5), (-6, -6), 1)
     assert hyperexpand(h) == Rational(-1, 6)
+
+
+def test_try_polynomial_floats():
+    assert try_polynomial(Hyper_Function((-2.,), ()), z)
+        ) == 1.0*z**2 - 2.0*z + 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1,14 +1,13 @@
 from sympy.core.random import randrange
 
 from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
-                       MeijerShiftA, MeijerShiftB, MeijerShiftC, MeijerShiftD,
-                       MeijerUnShiftA, MeijerUnShiftB, MeijerUnShiftC,
-                       MeijerUnShiftD,
-                       ReduceOrder, reduce_order, apply_operators,
-                       devise_plan, make_derivative_operator, Formula,
-                       hyperexpand, Hyper_Function, G_Function,
-                       reduce_order_meijer, try_polynomial,
-                       build_hypergeometric_formula)
+   MeijerShiftA, MeijerShiftB, MeijerShiftC, MeijerShiftD,
+   MeijerUnShiftA, MeijerUnShiftB, MeijerUnShiftC, MeijerUnShiftD,
+   ReduceOrder, reduce_order, apply_operators,
+   devise_plan, make_derivative_operator, Formula,
+   hyperexpand, Hyper_Function, G_Function,
+   reduce_order_meijer, try_polynomial,
+   build_hypergeometric_formula)
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
@@ -1061,5 +1060,7 @@ def test_omgissue_203():
 
 
 def test_try_polynomial_floats():
-    assert try_polynomial(hyper((-2.,), (), z), z
-    ) == 1.0*z**2 - 2.0*z + 1
+    assert try_polynomial(hyper((-2.,), (), z), z)
+        ) == 1.0*z**2 - 2.0*z + 1
+    assert try_shifted_sum(Hyper_Function((2,), (2.,)), z)  # doesn't fail r
+    assert try_shifted_sum(Hyper_Function((2.,), (2,)), z)  # doesn't fail k

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -7,7 +7,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
    devise_plan, make_derivative_operator, Formula,
    hyperexpand, Hyper_Function, G_Function,
    reduce_order_meijer, try_polynomial,
-   build_hypergeometric_formula)
+   try_shifted_sum, build_hypergeometric_formula)
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #19575 and now `Integral(0.0625*x**3.0*exp(-x/2), (x, 0, Rn)).doit()` returns 
`-0.125*Rn**3*exp(-Rn/2) - 0.75*Rn**2*exp(-Rn/2) - 3.0*Rn*exp(-Rn/2) + 6.0 - 6.0*exp(-Rn/2)` instead of 
`TypeError: 'Float' object cannot be interpreted as an integer`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * fixed a bug in `hyperexpand.py` and now float cannot be interpreted as integer is not raised for some integrals.
  
<!-- END RELEASE NOTES -->
