### PR TITLE
Subsets

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -398,7 +398,7 @@ def ibin(n, bits=None, str=False):
 
 
 def variations(seq, n, repetition=False):
-    r"""Returns a generator of the n-sized variations of ``seq`` (size N).
+    r"""Returns an iterator over the n-sized variations of ``seq`` (size N).
     ``repetition`` controls whether items in ``seq`` can appear more than once;
 
     Examples
@@ -433,11 +433,11 @@ def variations(seq, n, repetition=False):
     if not repetition:
         seq = tuple(seq)
         if len(seq) < n:
-            return (val for val in [])  # 0 length generator
+            return iter(())  # 0 length iterator
         return permutations(seq, n)
     else:
         if n == 0:
-            return (val for val in [()])   # yields 1 empty tuple
+            return iter(((),))  # yields 1 empty tuple
         else:
             return product(seq, repeat=n)
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, OrderedDict
 from itertools import (
-    combinations, combinations_with_replacement, permutations,
+    chain, combinations, combinations_with_replacement, permutations,
     product
 )
 
@@ -483,13 +483,17 @@ def subsets(seq, k=None, repetition=False):
 
     """
     if k is None:
-        for k in range(len(seq) + 1):
-            yield from subsets(seq, k, repetition)
+        if not repetition:
+            return chain.from_iterable((combinations(seq, k)
+                                        for k in range(len(seq) + 1)))
+        else:
+            return chain.from_iterable((combinations_with_replacement(seq, k)
+                                        for k in range(len(seq) + 1)))
     else:
         if not repetition:
-            yield from combinations(seq, k)
+            return combinations(seq, k)
         else:
-            yield from combinations_with_replacement(seq, k)
+            return combinations_with_replacement(seq, k)
 
 
 def filter_symbols(iterator, exclude):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -433,13 +433,13 @@ def variations(seq, n, repetition=False):
     if not repetition:
         seq = tuple(seq)
         if len(seq) < n:
-            return
-        yield from permutations(seq, n)
+            return (val for val in [])  # 0 length generator
+        return permutations(seq, n)
     else:
         if n == 0:
-            yield ()
+            return (val for val in [()])   # yields 1 empty tuple
         else:
-            yield from product(seq, repeat=n)
+            return product(seq, repeat=n)
 
 
 def subsets(seq, k=None, repetition=False):


### PR DESCRIPTION
<!-- Optimize Itertools.subsets() to use return rather than yield from -->

#### References to other Issues or PRs
<!-- Fixes #23056 -->
Fixes #23056

#### Brief description of what is fixed or changed
When a Python function delegates to a generator or other Iterator, common practice is for the caller to be a generator and to use yield from. However, in certain simple circumstances, it is OK for the caller not to be a generator itself, and to just return the result (some kind of Iterator) of the call. This can save some overhead.


#### Other comments
This PR applies this technique to `itertools.subsets()` and  `itertools.variations()`.  

The function `subsets()` has been part of SymPy for quite some time, and is used in various places around the code base.   In these cases I suspect that the cost of `subsets()` itself is a fairly small part of the overall execution path, so I don't want to claim that end-users of that functionality will notice any significant difference.

Question for reviewers - does this need a comment in the body of the function explaining the approach?  I didn't change the docstring, since behavior should be unchanged.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * itertools.subsets() and itertools.variations() should be a bit faster.  The return type of these functions now depends on the arguments, but is always an iterator.  In particular, isinstance(result, collections.abc.Iterator) should always be True.
<!-- END RELEASE NOTES -->
