### PR TITLE
Polys - RootOf now can handle polynomials with irrational algebraic coefficients

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -351,7 +351,7 @@ class ComplexRootOf(RootOf):
         if roots is not None:
             return roots[index]
 
-        if all((i.is_algebraic and (not i.is_symbol)) for i in poly.all_coeffs()):
+        if all((i.is_algebraic and i.is_number) for i in poly.all_coeffs()):
             poly = cls ._roots_Algebraic(poly, dom)
         else:
             raise NotImplementedError("CRootOf is not supported over %s" % poly)

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -353,6 +353,8 @@ class ComplexRootOf(RootOf):
 
         if all((i.is_algebraic and (not i.is_symbol)) for i in poly.all_coeffs()):
             poly = cls ._roots_Algebraic(poly, dom)
+        else:
+            raise NotImplementedError("CRootOf is not supported over %s" % poly)
 
         coeff, poly = preprocess_roots(poly)
         dom = poly.get_domain()

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -15,7 +15,7 @@ from sympy.core.numbers import (Float, I, Rational)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.trigonometric import tan
 from sympy.integrals.integrals import Integral
 from sympy.polys.orthopolys import legendre_poly
@@ -173,6 +173,17 @@ def test_CRootOf_is_real():
 
 def test_CRootOf_is_complex():
     assert rootof(x**3 + x + 3, 0).is_complex is True
+
+
+def test_CRootOf_Algebraic():
+    assert rootof(sqrt(2) * x ** 3 + sqrt(3) * x ** 2 + sqrt(3) * x + cbrt(3), 0) == \
+        CRootOf(64*x**36 - 576*x**34 - 1152*x**33 + 1584*x**32 + 8640*x**31 + 8640*x**30 \
+        - 17280*x**29 - 57780*x**28 - 47520*x**27 + 68364*x**26 + 217080*x**25 \
+        + 205389*x**24 - 69012*x**23 - 428166*x**22 - 535572*x**21 - 246645*x**20 \
+        + 227448*x**19 + 542232*x**18 + 548208*x**17 + 354699*x**16 + 153900*x**15 \
+        + 40014*x**14 - 10692*x**13 - 28917*x**12 - 22356*x**11 - 12150*x**10 \
+        - 9720*x**9 - 7290*x**8 - 2916*x**7 - 486*x**6 + 81, 0)
+    raises(NotImplementedError, lambda: rootof(sqrt(2) * x ** 3 + sqrt(3) * x + cbrt(3), 0))
 
 
 def test_CRootOf_subs():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -5,7 +5,6 @@ from sympy.polys.rootoftools import (rootof, RootOf, CRootOf, RootSum,
     _pure_key_dict as D)
 
 from sympy.polys.polyerrors import (
-    DomainError,
     MultivariatePolynomialError,
     GeneratorsNeeded,
     PolynomialError,
@@ -106,8 +105,8 @@ def test_CRootOf___new__():
 
     assert rootof(Poly(x**3 - y, x), 0) == y**Rational(1, 3)
 
-    assert rootof(y*x**3 + y*x + 2*y, x, 0) == -1
-    raises(DomainError, lambda: rootof(x**3 + x + 2*y, x, 0))
+    raises(NotImplementedError, lambda: rootof(y*x**3 + y*x + 2*y, x, 0))
+    raises(NotImplementedError, lambda: rootof(x**3 + x + 2*y, x, 0))
 
     assert rootof(x**3 + x + 1, 0).is_commutative is True
 
@@ -120,7 +119,7 @@ def test_CRootOf_attributes():
     # are apparently supported and the RootOf.free_symbols routine
     # should be changed to return whatever symbols would not be
     # the PurePoly dummy symbol
-    raises(DomainError, lambda: rootof(Poly(x**3 + y*x + 1, x), 0))
+    raises(NotImplementedError, lambda: rootof(Poly(x**3 + y*x + 1, x), 0))
 
 
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -5,6 +5,7 @@ from sympy.polys.rootoftools import (rootof, RootOf, CRootOf, RootSum,
     _pure_key_dict as D)
 
 from sympy.polys.polyerrors import (
+    DomainError,
     MultivariatePolynomialError,
     GeneratorsNeeded,
     PolynomialError,
@@ -80,6 +81,8 @@ def test_CRootOf___new__():
     assert rootof(x**4 + 3*x**3, 1) == 0
     assert rootof(x**4 + 3*x**3, 2) == 0
     assert rootof(x**4 + 3*x**3, 3) == 0
+    assert rootof(x**3 - x + sqrt(2), 0) == -sqrt(2)
+    assert rootof(x**3 - x + I, 0) == CRootOf(x**6 - 2*x**4 + x**2 + 1, 0)
 
     raises(GeneratorsNeeded, lambda: rootof(0, 0))
     raises(GeneratorsNeeded, lambda: rootof(1, 0))
@@ -89,9 +92,6 @@ def test_CRootOf___new__():
     raises(PolynomialError, lambda: rootof(x - y, 0))
     # issue 8617
     raises(PolynomialError, lambda: rootof(exp(x), 0))
-
-    raises(NotImplementedError, lambda: rootof(x**3 - x + sqrt(2), 0))
-    raises(NotImplementedError, lambda: rootof(x**3 - x + I, 0))
 
     raises(IndexError, lambda: rootof(x**2 - 1, -4))
     raises(IndexError, lambda: rootof(x**2 - 1, -3))
@@ -107,7 +107,7 @@ def test_CRootOf___new__():
     assert rootof(Poly(x**3 - y, x), 0) == y**Rational(1, 3)
 
     assert rootof(y*x**3 + y*x + 2*y, x, 0) == -1
-    raises(NotImplementedError, lambda: rootof(x**3 + x + 2*y, x, 0))
+    raises(DomainError, lambda: rootof(x**3 + x + 2*y, x, 0))
 
     assert rootof(x**3 + x + 1, 0).is_commutative is True
 
@@ -120,7 +120,7 @@ def test_CRootOf_attributes():
     # are apparently supported and the RootOf.free_symbols routine
     # should be changed to return whatever symbols would not be
     # the PurePoly dummy symbol
-    raises(NotImplementedError, lambda: rootof(Poly(x**3 + y*x + 1, x), 0))
+    raises(DomainError, lambda: rootof(Poly(x**3 + y*x + 1, x), 0))
 
 
 
@@ -183,7 +183,9 @@ def test_CRootOf_Algebraic():
         + 227448*x**19 + 542232*x**18 + 548208*x**17 + 354699*x**16 + 153900*x**15 \
         + 40014*x**14 - 10692*x**13 - 28917*x**12 - 22356*x**11 - 12150*x**10 \
         - 9720*x**9 - 7290*x**8 - 2916*x**7 - 486*x**6 + 81, 0)
-    raises(NotImplementedError, lambda: rootof(sqrt(2) * x ** 3 + sqrt(3) * x + cbrt(3), 0))
+    assert rootof(sqrt(2) * x ** 3 + sqrt(3) * x + cbrt(3), 0) == \
+        CRootOf(64*x**36 - 576*x**32 + 2160*x**28 - 4320*x**24 + 4860*x**20 - 144*x**18 \
+        - 2916*x**16 - 3240*x**14 + 729*x**12 - 4860*x**10 - 486*x**6 + 81, 0)
 
 
 def test_CRootOf_subs():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #22943 and now `rootof(sqrt(2) * x ** 3 + sqrt(3) * x ** 2 + sqrt(3) * x + cbrt(3), 0)` returns 
```
CRootOf(64*x**36 - 576*x**34 - 1152*x**33 + 1584*x**32 + 8640*x**31 + 8640*x**30 - 17280*x**29 - 57780*x**28 - 47520*x**27 + 68364*x**26 + 217080*x**25 + 205389*x**24 - 69012*x**23 - 428166*x**22 - 535572*x**21 - 246645*x**20 + 227448*x**19 + 542232*x**18 + 548208*x**17 + 354699*x**16 + 153900*x**15 + 40014*x**14 - 10692*x**13 - 28917*x**12 - 22356*x**11 - 12150*x**10 - 9720*x**9 - 7290*x**8 - 2916*x**7 - 486*x**6 + 81, 0)
``` 
instead of `NotImplementedError` .
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * `rootof` now can handle polynomials with irrational algebraic coefficients.
<!-- END RELEASE NOTES -->
