### PR TITLE
Do not re-express differentiated vectors back into the original frame

### DIFF
--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -81,7 +81,7 @@ def test_Vector_diffs():
 
     assert v1.dt(N) == q2d * A.x + q2 * q3d * A.y + q3d * N.y
     assert v1.dt(A) == q2d * A.x + q3 * q3d * N.x + q3d * N.y
-    assert v1.dt(B) == (q2d * A.x + q3 * q3d * N.x + q3d *\
+    assert v1.dt(B) == (q2d * A.x + q3 * q3d * N.x + q3d *
                         N.y - q3 * cos(q3) * q2d * N.z)
     assert v2.dt(N) == (q2d * A.x + (q2 + q3) * q3d * A.y + q3d * B.x + q3d *
                         N.y)
@@ -131,6 +131,24 @@ def test_Vector_diffs():
     assert v4.diff(q1d, B) == 0
     assert v4.diff(q2d, B) == A.x - q3 * cos(q3) * N.z
     assert v4.diff(q3d, B) == B.x + q3 * N.x + N.y
+
+    # diff() should only express vector components in the derivative frame if
+    # the orientation of the component's frame depends on the variable
+    v6 = q2**2*N.y + q2**2*A.y + q2**2*B.y
+    # already expressed in N
+    n_measy = 2*q2
+    # A_C_N does not depend on q2, so don't express in N
+    a_measy = 2*q2
+    # B_C_N depends on q2, so express in N
+    b_measx = (q2**2*B.y).dot(N.x).diff(q2)
+    b_measy = (q2**2*B.y).dot(N.y).diff(q2)
+    b_measz = (q2**2*B.y).dot(N.z).diff(q2)
+    n_comp, a_comp = v6.diff(q2, N).args
+    assert len(v6.diff(q2, N).args) == 2  # only N and A parts
+    assert n_comp[1] == N
+    assert a_comp[1] == A
+    assert n_comp[0] == Matrix([b_measx, b_measy + n_measy, b_measz])
+    assert a_comp[0] == Matrix([0, a_measy, 0])
 
 
 def test_vector_var_in_dcm():

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -522,6 +522,8 @@ class Vector(Printable, EvalfMixin):
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.diff(t, N)
+        - sin(q1)*q1'*N.x - cos(q1)*q1'*N.z
+        >>> A.x.diff(t, N).express(A)
         - q1'*A.z
         >>> B = ReferenceFrame('B')
         >>> u1, u2 = dynamicsymbols('u1, u2')

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -553,7 +553,7 @@ class Vector(Printable, EvalfMixin):
                 else:  # else express in the frame
                     reexp_vec_comp = Vector([vector_component]).express(frame)
                     deriv = reexp_vec_comp.args[0][0].diff(var)
-                    inlist += Vector([(deriv, frame)]).express(component_frame).args
+                    inlist += Vector([(deriv, frame)]).args
 
         return Vector(inlist)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23078

#### Brief description of what is fixed or changed

The prior behavior of sympy.physics.vector.vector.Vector.diff() creates
more complex equations that it should in some scenarios. Take this
example:

```python
import sympy as sm
import sympy.physics.mechanics as me

a, b, c, d, e, f = sm.symbols('a, b, c, d, e, f')
alpha, beta = sm.symbols('alpha, beta')

A = me.ReferenceFrame('A')
B = me.ReferenceFrame('B')
C = me.ReferenceFrame('C')

B.orient_axis(A, alpha, A.x)
C.orient_axis(B, beta, B.y)

v = a*A.x + b*A.y + c*B.x + d*B.y + e*C.x + f*C.y

v.diff(alpha, A)
```

Prior to this commit, the prior result would be:

```python
(d*sin(alpha)**2 + d*cos(alpha)**2)*B.z + (-(e*sin(alpha)*sin(beta) + f*cos(alpha))*sin(beta)*cos(alpha) + (e*sin(beta)*cos(alpha) - f*sin(alpha))*sin(alpha)*sin(beta))*C.x + ((e*sin(alpha)*sin(beta) + f*cos(alpha))*sin(alpha) + (e*sin(beta)*cos(alpha) - f*sin(alpha))*cos(alpha))*C.y + ((e*sin(alpha)*sin(beta) + f*cos(alpha))*cos(alpha)*cos(beta) - (e*sin(beta)*cos(alpha) - f*sin(alpha))*sin(alpha)*cos(beta))*C.z
```

and the result in this commit is:

```python
(-d*sin(alpha) + e*sin(beta)*cos(alpha) - f*sin(alpha))*A.y + (d*cos(alpha) + e*sin(alpha)*sin(beta) + f*cos(alpha))*A.z
```

These are mathematically the equivalent results.

The prior implementation re-expresses each component back in the
original reference frames the vector is expressed in. If the user wants
this they can express the vector in whatever reference frame they want
after the differentiation step to control the complexity and reference
frame expression. This change will result in simpler expressions by
default.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * Physics Vector differentiation now outputs simpler expressions.

<!-- END RELEASE NOTES -->
