### PR TITLE
Documenting matrix derivatives

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -22,6 +22,22 @@ The Matrix expression module allows users to write down statements like
 
 where ``X`` and ``Y`` are :class:`MatrixSymbol`'s rather than scalar symbols.
 
+Matrix expression derivatives are supported. The derivative of a matrix by another matrix
+is generally a 4-dimensional array, but if some dimensions are trivial or diagonal,
+the derivation algorithm will try to express the result as a matrix expression:
+
+    >>> a = MatrixSymbol("a", 3, 1)
+    >>> b = MatrixSymbol("b", 3, 1)
+    >>> (a.T*X**2*b).diff(X)
+    a*b.T*X.T + X.T*a*b.T
+
+    >>> X = MatrixSymbol("X", 3, 3)
+    >>> X.diff(X)
+    PermuteDims(ArrayTensorProduct(I, I), (3)(1 2))
+
+The last output is an array expression, as the returned symbol
+is 4-dimensional.
+
 Matrix Expressions Core Reference
 ---------------------------------
 .. autoclass:: MatrixExpr

--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -31,7 +31,6 @@ the derivation algorithm will try to express the result as a matrix expression:
     >>> (a.T*X**2*b).diff(X)
     a*b.T*X.T + X.T*a*b.T
 
-    >>> X = MatrixSymbol("X", 3, 3)
     >>> X.diff(X)
     PermuteDims(ArrayTensorProduct(I, I), (3)(1 2))
 


### PR DESCRIPTION
It's time to announce the matrix expression derivative algorithm in the documentation, so that word will spread about this algorithm (probably currently the only CAS apart from the website [matrixcalculus.org](http://www.matrixcalculus.org/) to support such a feature).

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Matrix expression derivative algorithm add support for matrix calculus. The derivative of a matrix expression by another matrix expression can now be computed and the result is either an array expression (4-dimensional) or, if two of the resulting dimensions can be suppressed, a matrix expression (2-dimensional).
<!-- END RELEASE NOTES -->
