### PR TITLE
Use LaTeX for labels in matplotlib backend

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -25,15 +25,18 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 
 from collections.abc import Callable
 
+
+from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
+from sympy.core.function import arity, Function
 from sympy.core.symbol import (Dummy, Symbol)
 from sympy.core.sympify import sympify
 from sympy.external import import_module
-from sympy.core.function import arity
+from sympy.printing.latex import latex
+from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)
-from sympy.utilities.exceptions import sympy_deprecation_warning
 
 # N.B.
 # When changing the minimum module version for matplotlib, please change
@@ -53,6 +56,11 @@ def unset_show():
     """
     global _show
     _show = False
+
+def _str_or_latex(label):
+    if isinstance(label, Basic):
+        return latex(label, mode='inline')
+    return str(label)
 
 ##############################################################################
 # The public interface
@@ -110,9 +118,9 @@ class Plot:
     The global options for a figure are:
 
     - title : str
-    - xlabel : str
-    - ylabel : str
-    - zlabel : str
+    - xlabel : str or Symbol
+    - ylabel : str or Symbol
+    - zlabel : str or Symbol
     - legend : bool
     - xscale : {'linear', 'log'}
     - yscale : {'linear', 'log'}
@@ -664,7 +672,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
     def __init__(self, expr, var_start_end, **kwargs):
         super().__init__()
         self.expr = sympify(expr)
-        self.label = kwargs.get('label', None) or str(self.expr)
+        self.label = kwargs.get('label', None) or self.expr
         self.var = sympify(var_start_end[0])
         self.start = float(var_start_end[1])
         self.end = float(var_start_end[2])
@@ -792,6 +800,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         list_y = f(list_x)
         return (list_x, list_y)
 
+
 class Parametric2DLineSeries(Line2DBaseSeries):
     """Representation for a line consisting of two parametric SymPy expressions
     over a range."""
@@ -803,7 +812,7 @@ class Parametric2DLineSeries(Line2DBaseSeries):
         self.expr_x = sympify(expr_x)
         self.expr_y = sympify(expr_y)
         self.label = kwargs.get('label', None) or \
-                            "(%s, %s)" % (str(self.expr_x), str(self.expr_y))
+                            Tuple(self.expr_x, self.expr_y)
         self.var = sympify(var_start_end[0])
         self.start = float(var_start_end[1])
         self.end = float(var_start_end[2])
@@ -958,7 +967,7 @@ class Parametric3DLineSeries(Line3DBaseSeries):
         self.expr_y = sympify(expr_y)
         self.expr_z = sympify(expr_z)
         self.label = kwargs.get('label', None) or \
-                        "(%s, %s)" % (str(self.expr_x), str(self.expr_y))
+                        Tuple(self.expr_x, self.expr_y)
         self.var = sympify(var_start_end[0])
         self.start = float(var_start_end[1])
         self.end = float(var_start_end[2])
@@ -1360,7 +1369,8 @@ class MatplotlibBackend(BaseBackend):
                     collection.set_array(s.get_color_array())
                     ax.add_collection(collection)
                 else:
-                    line, = ax.plot(x, y, label=s.label, color=s.line_color)
+                    lbl = _str_or_latex(s.label)
+                    line, = ax.plot(x, y, label=lbl, color=s.line_color)
             elif s.is_contour:
                 ax.contour(*s.get_meshes())
             elif s.is_3Dline:
@@ -1373,8 +1383,8 @@ class MatplotlibBackend(BaseBackend):
                     collection.set_array(s.get_color_array())
                     ax.add_collection(collection)
                 else:
-                    ax.plot(x, y, z, label=s.label,
-                        color=s.line_color)
+                    lbl = _str_or_latex(s.label)
+                    ax.plot(x, y, z, label=lbl, color=s.line_color)
 
                 xlims.append(s._xlim)
                 ylims.append(s._ylim)
@@ -1408,9 +1418,11 @@ class MatplotlibBackend(BaseBackend):
                     colormap = ListedColormap(["white", s.line_color])
                     xarray, yarray, zarray, plot_type = points
                     if plot_type == 'contour':
-                        ax.contour(xarray, yarray, zarray, cmap=colormap)
+                        ax.contour(xarray, yarray, zarray, cmap=colormap,
+                                   label=_str_or_latex(s.label))
                     else:
-                        ax.contourf(xarray, yarray, zarray, cmap=colormap)
+                        ax.contourf(xarray, yarray, zarray, cmap=colormap,
+                                    label=_str_or_latex(s.label))
             else:
                 raise NotImplementedError(
                     '{} is not supported in the SymPy plotting module '
@@ -1483,11 +1495,14 @@ class MatplotlibBackend(BaseBackend):
         if parent.title:
             ax.set_title(parent.title)
         if parent.xlabel:
-            ax.set_xlabel(parent.xlabel, position=(1, 0))
+            xlbl = _str_or_latex(parent.xlabel)
+            ax.set_xlabel(xlbl, position=(1, 0))
         if parent.ylabel:
-            ax.set_ylabel(parent.ylabel, position=(0, 1))
+            ylbl = _str_or_latex(parent.ylabel)
+            ax.set_ylabel(ylbl, position=(0, 1))
         if isinstance(ax, Axes3D) and parent.zlabel:
-            ax.set_zlabel(parent.zlabel, position=(0, 1))
+            zlbl = _str_or_latex(parent.zlabel)
+            ax.set_zlabel(zlbl, position=(0, 1))
         if parent.annotations:
             for a in parent.annotations:
                 ax.annotate(**a)
@@ -1695,10 +1710,10 @@ def plot(*args, show=True, **kwargs):
         called with ``legend``. Default is the name of the expression.
         e.g. ``sin(x)``
 
-    xlabel : str, optional
+    xlabel : str or expression, optional
         Label for the x-axis.
 
-    ylabel : str, optional
+    ylabel : str or expression, optional
         Label for the y-axis.
 
     xscale : 'linear' or 'log', optional
@@ -1843,8 +1858,8 @@ def plot(*args, show=True, **kwargs):
                     'The same variable should be used in all '
                     'univariate expressions being plotted.')
     x = free.pop() if free else Symbol('x')
-    kwargs.setdefault('xlabel', x.name)
-    kwargs.setdefault('ylabel', 'f(%s)' % x.name)
+    kwargs.setdefault('xlabel', x)
+    kwargs.setdefault('ylabel', Function('f')(x))
     series = []
     plot_expr = check_arguments(args, 1, 1)
     series = [LineOver1DRangeSeries(*arg, **kwargs) for arg in plot_expr]
@@ -1953,8 +1968,7 @@ def plot_parametric(*args, show=True, **kwargs):
        :format: doctest
        :include-source: True
 
-       >>> from sympy import symbols, cos, sin
-       >>> from sympy.plotting import plot_parametric
+       >>> from sympy import plot_parametric, symbols, cos, sin
        >>> u = symbols('u')
 
     A parametric plot with a single expression:
@@ -2300,11 +2314,9 @@ def plot3d(*args, show=True, **kwargs):
     series = []
     plot_expr = check_arguments(args, 1, 2)
     series = [SurfaceOver2DRangeSeries(*arg, **kwargs) for arg in plot_expr]
-    xlabel = series[0].var_x.name
-    ylabel = series[0].var_y.name
-    kwargs.setdefault("xlabel", xlabel)
-    kwargs.setdefault("ylabel", ylabel)
-    kwargs.setdefault("zlabel", "f(%s, %s)" % (xlabel, ylabel))
+    kwargs.setdefault("xlabel", series[0].var_x)
+    kwargs.setdefault("ylabel", series[0].var_y)
+    kwargs.setdefault("zlabel", Function('f')(series[0].var_x, series[0].var_y))
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -55,6 +55,7 @@ class ImplicitSeries(BaseSeries):
             line_color):
         super().__init__()
         self.expr = sympify(expr)
+        self.label = self.expr
         self.var_x = sympify(var_start_end_x[0])
         self.start_x = float(var_start_end_x[1])
         self.end_x = float(var_start_end_x[2])
@@ -423,8 +424,8 @@ def plot_implicit(expr, x_var=None, y_var=None, adaptive=True, depth=0,
     kwargs['xlim'] = tuple(float(x) for x in var_start_end_x[1:])
     kwargs['ylim'] = tuple(float(y) for y in var_start_end_y[1:])
     # set the x and y labels
-    kwargs.setdefault('xlabel', var_start_end_x[0].name)
-    kwargs.setdefault('ylabel', var_start_end_y[0].name)
+    kwargs.setdefault('xlabel', var_start_end_x[0])
+    kwargs.setdefault('ylabel', var_start_end_y[0])
     p = Plot(series_argument, **kwargs)
     if show:
         p.show()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Now, x-, y-, and z-labels are rendered by default using "LaTeX" (or Mathtext) when plotting using `plot` and `plot3d` with the Matplotlib backend. In this way, code like:
```
from sympy import *
x = Symbol('x_Delta')
plot(sin(x), (x, -1, 1))
```
renders as
![image](https://user-images.githubusercontent.com/8114497/154545549-5e3791c7-6653-4faa-a234-90d8539e9f6b.png)

#### Other comments
As one can set the labels separately, the logic is that if there is a `$` in the label, it is assumed to already be in LaTeX-format. There are some odd cases where that is not the case, but still quite unlikely that one creates a variable with a $ in the name and expect LaTeX-rendering.

I realize that setting the labels using `latex` actually only should be applied if a backend supporting this is used. Is there are way figure out which backend will be used at this stage?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Labels etc can be set to expressions, including the default values, and are latexified using the Matplotlib backend.  
<!-- END RELEASE NOTES -->
