### PR TITLE
Removed ^ and & from the mechanics documentation.

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
@@ -158,9 +158,9 @@ constraint forces the front wheel contact point to not move away from the
 ground frame, essentially replicating the holonomic constraint which does not
 allow the frame pitch to change in an invalid fashion. ::
 
-  >>> conlist_speed = [WF_cont.vel(N) & Y.x,
-  ...                  WF_cont.vel(N) & Y.y,
-  ...                  WF_cont.vel(N) & Y.z]
+  >>> conlist_speed = [dot(WF_cont.vel(N), Y.x),
+  ...                  dot(WF_cont.vel(N), Y.y),
+  ...                  dot(WF_cont.vel(N), Y.z)]
 
 The holonomic constraint is that the position from the rear wheel contact point
 to the front wheel contact point when dotted into the normal-to-ground plane
@@ -168,7 +168,7 @@ direction must be zero; effectively that the front and rear wheel contact
 points are always touching the ground plane. This is actually not part of the
 dynamic equations, but instead is necessary for the linearization process. ::
 
-  >>> conlist_coord = [WF_cont.pos_from(WR_cont) & Y.z]
+  >>> conlist_coord = [dot(WF_cont.pos_from(WR_cont), Y.z)]
 
 The force list; each body has the appropriate gravitational force applied at
 its center of mass. ::

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
@@ -36,7 +36,7 @@ zero. They are normal to the ground, along the path which the disc is rolling,
 and along the ground in a perpendicular direction. ::
 
   >>> C = Point('C')
-  >>> C.set_vel(N, u4 * L.x + u5 * (Y.z ^ L.x) + u6 * Y.z)
+  >>> C.set_vel(N, u4 * L.x + u5 * cross(Y.z, L.x) + u6 * Y.z)
   >>> Dmc = C.locatenew('Dmc', r * L.z)
   >>> vel = Dmc.v2pt_theory(C, N, R)
   >>> I = inertia(L, m / 4 * r**2, m / 2 * r**2, m / 4 * r**2)
@@ -46,7 +46,7 @@ Just as we previously introduced three speeds as part of this process, we also
 introduce three forces; they are in the same direction as the speeds, and
 represent the constraint forces in those directions. ::
 
-  >>> ForceList = [(Dmc, - m * g * Y.z), (C, f1 * L.x + f2 * (Y.z ^ L.x) + f3 * Y.z)]
+  >>> ForceList = [(Dmc, - m * g * Y.z), (C, f1 * L.x + f2 * cross(Y.z, L.x) + f3 * Y.z)]
   >>> BodyD = RigidBody('BodyD', Dmc, R, m, (I, Dmc))
   >>> BodyList = [BodyD]
 

--- a/doc/src/modules/physics/vector/vectors.rst
+++ b/doc/src/modules/physics/vector/vectors.rst
@@ -549,10 +549,6 @@ In :mod:`sympy.physics.vector` multiple interfaces to vector multiplication have
 implemented, at the operator level, method level, and function level. The
 vector dot product can work as follows: ::
 
-  >>> N.x & N.x
-  1
-  >>> N.x & N.y
-  0
   >>> N.x.dot(N.x)
   1
   >>> N.x.dot(N.y)
@@ -573,17 +569,13 @@ The cross product is the other vector multiplication which will be discussed
 here. It offers similar interfaces to the dot product, and comes with the same
 warnings. ::
 
-  >>> N.x ^ N.x
-  0
-  >>> N.x ^ N.y
-  N.z
   >>> N.x.cross(N.x)
   0
   >>> N.x.cross(N.z)
   - N.y
   >>> cross(N.x, N.y)
   N.z
-  >>> N.x ^ (N.y + N.z)
+  >>> cross(N.x, (N.y + N.z))
   - N.y + N.z
 
 Two additional operations can be done with vectors: normalizing the vector to

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -403,16 +403,17 @@ class Vector(Printable, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy.physics.vector import ReferenceFrame
         >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame, cross
         >>> q1 = symbols('q1')
         >>> N = ReferenceFrame('N')
-        >>> N.x ^ N.y
+        >>> cross(N.x, N.y)
         N.z
-        >>> A = N.orientnew('A', 'Axis', [q1, N.x])
-        >>> A.x ^ N.y
+        >>> A = ReferenceFrame('A')
+        >>> A.orient_axis(N, q1, N.x)
+        >>> cross(A.x, N.y)
         N.z
-        >>> N.y ^ A.x
+        >>> cross(N.y, A.x)
         - sin(q1)*A.y - cos(q1)*A.z
 
         """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The `__xor__` and `__and__` methods are overridden for physics vectors to be
the cross product and dot product, but I want to leave these as
undocumented features and even possibly remove in the distant future. I
don't think it is good practice to override builtin methods with
functionality that does not resemble the intended functionality, i.e.
don't make `__add__` do multiplication. Using the .cross/.dot and
cross()/dot() methods and functions is clearer to read and more
pythonic. We also don't need 3 ways to do one thing (unpythonic). This
PR just stops advertising the overridden methods.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

/cc @sidhu1012 
