### PR TITLE
polys - fixed bug in primitive_element which now does not raise zero divisor error when zero is present in input

### DIFF
--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -273,9 +273,6 @@ def dup_eval(f, a, K):
     11
 
     """
-    if not a:
-        return dup_TC(f, K)
-
     result = K.zero
 
     for c in f:

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -273,6 +273,9 @@ def dup_eval(f, a, K):
     11
 
     """
+    if not a:
+        return K.convert(dup_TC(f, K))
+
     result = K.zero
 
     for c in f:

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -387,7 +387,12 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
         ogen = K.unit - s*erep  # old gen as element of K
         reps = [dup_eval(_.rep, ogen, K) for _ in reps] + [erep]
 
-    H = [_.rep for _ in reps]
+    if K.ext.root.is_Rational:  # all extensions are rational
+        H = [K.convert(_).rep for _ in extension]
+        coeffs = [0]*len(extension)
+        f = cls(x, domain=QQ)
+    else:
+        H = [_.rep for _ in reps]
     if not polys:
         return f.as_expr(), coeffs, H
     else:

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -36,7 +36,7 @@ from sympy.core.add import Add
 from sympy.core.numbers import AlgebraicNumber
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
-from sympy.core.sympify import sympify
+from sympy.core.sympify import sympify, _sympify
 from sympy.ntheory import sieve
 from sympy.polys.densetools import dup_eval
 from sympy.polys.domains import QQ
@@ -340,7 +340,7 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
     """
     if not extension:
         raise ValueError("Cannot compute primitive element for empty extension")
-    extension = [sympify(ext) for ext in extension]
+    extension = [_sympify(ext) for ext in extension]
 
     if x is not None:
         x, cls = sympify(x), Poly
@@ -351,6 +351,9 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
         gen, coeffs = extension[0], [1]
         g = minimal_polynomial(gen, x, polys=True)
         for ext in extension[1:]:
+            if ext.is_Rational:
+                coeffs.append(0)
+                continue
             _, factors = factor_list(g, extension=ext)
             g = _choose_factor(factors, x, gen)
             s, _, g = g.sqf_norm()

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -366,6 +366,11 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
     K = QQ.algebraic_field((f, gen))  # incrementally constructed field
     reps = [K.unit]  # representations of extension elements in K
     for ext in extension[1:]:
+        ext = sympify(ext)
+        if ext.is_Rational:
+            coeffs.append(0)    # rational ext is not included in the expression of a primitive element
+            reps.append(K.convert(ext))    # but it is included in reps
+            continue
         p = minimal_polynomial(ext, x, polys=True)
         L = QQ.algebraic_field((p, ext))
         _, factors = factor_list(f, domain=L)

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -340,6 +340,7 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
     """
     if not extension:
         raise ValueError("Cannot compute primitive element for empty extension")
+    extension = [sympify(ext) for ext in extension]
 
     if x is not None:
         x, cls = sympify(x), Poly
@@ -366,7 +367,6 @@ def primitive_element(extension, x=None, *, ex=False, polys=False):
     K = QQ.algebraic_field((f, gen))  # incrementally constructed field
     reps = [K.unit]  # representations of extension elements in K
     for ext in extension[1:]:
-        ext = sympify(ext)
         if ext.is_Rational:
             coeffs.append(0)    # rational ext is not included in the expression of a primitive element
             reps.append(K.convert(ext))    # but it is included in reps

--- a/sympy/polys/numberfields/tests/test_subfield.py
+++ b/sympy/polys/numberfields/tests/test_subfield.py
@@ -273,7 +273,7 @@ def test_primitive_element():
     assert primitive_element([a, b, I], x) == (x**4 + 6*x**2 + 1, [1, 0, 0])
 
     assert primitive_element([sqrt(2), 0], x, ex=True) == (x**2 - 2, [1, 0], [[MPQ(1,1), MPQ(0,1)], []])
-    assert primitive_element([0], x) == (x, [1])
+
 
 def test_to_number_field():
     assert to_number_field(sqrt(2)) == AlgebraicNumber(sqrt(2))

--- a/sympy/polys/numberfields/tests/test_subfield.py
+++ b/sympy/polys/numberfields/tests/test_subfield.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import (AlgebraicNumber, I, pi, Rational)
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.external.pythonmpq import PythonMPQ as MPQ
+from sympy.external.gmpy import MPQ
 from sympy.polys.numberfields.subfield import (
     is_isomorphism_possible,
     field_isomorphism_pslq,

--- a/sympy/polys/numberfields/tests/test_subfield.py
+++ b/sympy/polys/numberfields/tests/test_subfield.py
@@ -4,6 +4,7 @@ from sympy.core.numbers import (AlgebraicNumber, I, pi, Rational)
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.external.pythonmpq import PythonMPQ as MPQ
 from sympy.polys.numberfields.subfield import (
     is_isomorphism_possible,
     field_isomorphism_pslq,
@@ -271,6 +272,8 @@ def test_primitive_element():
     a, b = I*sqrt(2*sqrt(2) + 3), I*sqrt(-2*sqrt(2) + 3)
     assert primitive_element([a, b, I], x) == (x**4 + 6*x**2 + 1, [1, 0, 0])
 
+    assert primitive_element([sqrt(2), 0], x, ex=True) == (x**2 - 2, [1, 0], [[MPQ(1,1), MPQ(0,1)], []])
+    assert primitive_element([0], x) == (x, [1])
 
 def test_to_number_field():
     assert to_number_field(sqrt(2)) == AlgebraicNumber(sqrt(2))

--- a/sympy/polys/numberfields/tests/test_subfield.py
+++ b/sympy/polys/numberfields/tests/test_subfield.py
@@ -272,7 +272,10 @@ def test_primitive_element():
     a, b = I*sqrt(2*sqrt(2) + 3), I*sqrt(-2*sqrt(2) + 3)
     assert primitive_element([a, b, I], x) == (x**4 + 6*x**2 + 1, [1, 0, 0])
 
+    assert primitive_element([sqrt(2), 0], x) == (x**2 - 2, [1, 0])
+    assert primitive_element([0, sqrt(2)], x) == (x**2 - 2, [1, 1])
     assert primitive_element([sqrt(2), 0], x, ex=True) == (x**2 - 2, [1, 0], [[MPQ(1,1), MPQ(0,1)], []])
+    assert primitive_element([0, sqrt(2)], x, ex=True) == (x**2 - 2, [1, 1], [[], [MPQ(1,1), MPQ(0,1)]])
 
 
 def test_to_number_field():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Helps in PR #23077 and issue #22943 and now `primitive_element` does not raise zero divisor error when zero is present in the input.
In current master,
```
>>> primitive_element([sqrt(2), 0], x, ex=True)
sympy.polys.polyerrors.NotInvertible: zero divisor
```
After this change,
```
>>> primitive_element([sqrt(2), 0], x, ex=True)
(x**2 - 2, [1, 0], [[MPQ(1,1), MPQ(0,1)], []])
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * fixed bug in `primitive_element` which now does not raise zero divisor error when zero is present in the input.
<!-- END RELEASE NOTES -->
