### PR TITLE
PartialDerivative.replace_with_arrays now respects the index order

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2337,6 +2337,14 @@ class TensExpr(Expr, metaclass=_TensorMetaclass):
         from .array import Array
 
         indices = indices or []
+        remap = {k.args[0] if k.is_up else -k.args[0]: k for k in self.get_free_indices()}
+        for i, index in enumerate(indices):
+            if isinstance(index, (Symbol, Mul)):
+                if index in remap:
+                    indices[i] = remap[index]
+                else:
+                    indices[i] = -remap[-index]
+
         replacement_dict = {tensor: Array(array) for tensor, array in replacement_dict.items()}
 
         # Check dimensions of replaced arrays:

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1827,6 +1827,7 @@ def test_tensor_replacement():
     assert expr.replace_with_arrays(repl) == Array([[1, -2], [3, -4]])
     assert expr.replace_with_arrays(repl, [i, j]) == Array([[1, -2], [3, -4]])
     assert expr.replace_with_arrays(repl, [i, -j]) == Array([[1, 2], [3, 4]])
+    assert expr.replace_with_arrays(repl, [Symbol("i"), -Symbol("j")]) == Array([[1, 2], [3, 4]])
     assert expr.replace_with_arrays(repl, [-i, j]) == Array([[1, -2], [-3, 4]])
     assert expr.replace_with_arrays(repl, [-i, -j]) == Array([[1, 2], [-3, -4]])
     assert expr.replace_with_arrays(repl, [j, i]) == Array([[1, 3], [-2, -4]])

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -1,3 +1,4 @@
+from sympy import sin, cos
 from sympy.testing.pytest import raises
 
 from sympy.tensor.toperators import PartialDerivative
@@ -29,6 +30,13 @@ def test_invalid_partial_derivative_valence():
 
 def test_tensor_partial_deriv():
     # Test flatten:
+    expr = PartialDerivative(PartialDerivative(A(i), A(j)), A(k))
+    assert expr == PartialDerivative(A(i), A(j), A(k))
+    assert expr.expr == A(i)
+    assert expr.variables == (A(j), A(k))
+    assert expr.get_indices() == [i, -j, -k]
+    assert expr.get_free_indices() == [i, -j, -k]
+
     expr = PartialDerivative(PartialDerivative(A(i), A(j)), A(i))
     assert expr.expr == A(L_0)
     assert expr.variables == (A(j), A(L_0))
@@ -59,6 +67,12 @@ def test_tensor_partial_deriv():
 def test_replace_arrays_partial_derivative():
 
     x, y, z, t = symbols("x y z t")
+
+    expr = PartialDerivative(A(i), B(j))
+    repl = expr.replace_with_arrays({A(i): [sin(x)*cos(y), x**3*y**2], B(i): [x, y]})
+    assert repl == Array([[cos(x)*cos(y), -sin(x)*sin(y)], [3*x**2*y**2, 2*x**3*y]])
+    repl = expr.replace_with_arrays({A(i): [sin(x)*cos(y), x**3*y**2], B(i): [x, y]}, [-j, i])
+    assert repl == Array([[cos(x)*cos(y), 3*x**2*y**2], [-sin(x)*sin(y), 2*x**3*y]])
 
     # d(A^i)/d(A_j) = d(g^ik A_k)/d(A_j) = g^ik delta_jk
     expr = PartialDerivative(A(i), A(-j))

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -15,12 +15,13 @@ class PartialDerivative(TensExpr):
     Examples
     ========
 
-    >>> from sympy.tensor.tensor import TensorIndexType, TensorHead, tensor_indices
+    >>> from sympy.tensor.tensor import TensorIndexType, TensorHead
     >>> from sympy.tensor.toperators import PartialDerivative
+    >>> from sympy import symbols
     >>> L = TensorIndexType("L")
     >>> A = TensorHead("A", [L])
     >>> B = TensorHead("B", [L])
-    >>> i, j, k = tensor_indices("i j k", L)
+    >>> i, j, k = symbols("i j k")
 
     >>> expr = PartialDerivative(A(i), A(j))
     >>> expr

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -33,8 +33,8 @@ class PartialDerivative(TensExpr):
     [i, -j]
 
     Notice that the deriving variables have opposite valence than the
-    printed one: ``A(j)`` is printed as covariant, but the index is actually
-    contravariant in the derivative, i.e. ``-j``.
+    printed one: ``A(j)`` is printed as covariant, but the index of the
+    derivative is actually contravariant, i.e. ``-j``.
 
     Indices can be contracted:
 
@@ -43,6 +43,13 @@ class PartialDerivative(TensExpr):
     PartialDerivative(A(L_0), A(L_0))
     >>> expr.get_indices()
     [L_0, -L_0]
+
+    The method ``.get_indices()`` always returns all indices (even the
+    contracted ones). If only uncontracted indices are needed, call
+    ``.get_free_indices()``:
+
+    >>> expr.get_free_indices()
+    []
 
     Nested partial derivatives are flattened:
 
@@ -62,10 +69,14 @@ class PartialDerivative(TensExpr):
     >>> expr.replace_with_arrays({A(i): compA, B(i): compB})
     [[cos(x), 0], [y**3/x, 3*y**2*log(x)]]
 
-    The returned array is indexed by `(i, j)`.
+    The returned array is indexed by `(i, -j)`.
+
     Be careful that other SymPy modules put the indices of the deriving
     variables before the indices of the derivand in the derivative result.
     For example:
+
+    >>> expr.get_free_indices()
+    [i, -j]
 
     >>> from sympy import Matrix, Array
     >>> Matrix(compA).diff(Matrix(compB)).reshape(2, 2)
@@ -74,10 +85,11 @@ class PartialDerivative(TensExpr):
     [[cos(x), y**3/x], [0, 3*y**2*log(x)]]
 
     These are the transpose of the result of ``PartialDerivative``,
-    as the matrix and the array modules put the index `j` before `i` in the
-    derivative result. An array read with indices `(j, i)` is indeed the
-    transpose of the same array read with indices `(i, j)`. By specifying the
-    index order to ``.replace_with_arrays`` one can get a compatible expression
+    as the matrix and the array modules put the index `-j` before `i` in the
+    derivative result. An array read with index order `(-j, i)` is indeed the
+    transpose of the same array read with index order `(i, -j)`. By specifying
+    the index order to ``.replace_with_arrays`` one can get a compatible
+    expression:
 
     >>> expr.replace_with_arrays({A(i): compA, B(i): compB}, [-j, i])
     [[cos(x), y**3/x], [0, 3*y**2*log(x)]]


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/23073

Alternative to https://github.com/sympy/sympy/pull/23093

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
