### PR TITLE
XFAIL the sympy.utilities._compilation tests on Mac

### DIFF
--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -291,7 +291,7 @@ def simple_cythonize(src, destdir=None, cwd=None, **cy_kwargs):
         cy_result = cy_compile([src], cy_options)
         if cy_result.num_errors > 0:
             raise ValueError("Cython compilation failed.")
-        if os.path.abspath(os.path.dirname(src)) != os.path.abspath(destdir):
+        if os.path.realpath(os.path.dirname(src)) != os.path.realpath(destdir):
             if os.path.exists(dstfile):
                 os.unlink(dstfile)
             shutil.move(os.path.join(os.path.dirname(src), c_name), destdir)

--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -3,6 +3,7 @@ from sympy.external import import_module
 from sympy.testing.pytest import skip
 
 from sympy.utilities._compilation.compilation import compile_link_import_strings
+from sympy.utilities._compilation.util import may_xfail
 
 numpy = import_module('numpy')
 cython = import_module('cython')
@@ -38,7 +39,7 @@ def sigmoid(double [:] inp, double lim=350.0):
 def npy(data, lim=350.0):
     return data/((data/lim)**8+1)**(1/8.)
 
-
+@may_xfail
 def test_compile_link_import_strings():
     if not numpy:
         skip("numpy not installed.")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/23061

#### Brief description of what is fixed or changed

This also includes a small fix for Mac, but the test still fails. All the other places that use this submodule (in sympy.codegen) XFAIL on Mac. I don't think the module works at all on Mac right now. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
