### PR TITLE
maint: fix release script to handle multidigit release numbers

### DIFF
--- a/release/github_release.py
+++ b/release/github_release.py
@@ -145,13 +145,14 @@ def get_sympy_short_version(version):
     (like 0.7.3)
     """
     parts = version.split('.')
-    # Remove rc tags
-    # Handle both 1.0.rc1 and 1.1rc1
-    if not parts[-1].isdigit():
-        if parts[-1][0].isdigit():
-            parts[-1] = parts[-1][0]
+    # Remove rc tags e.g. 1.10rc1 -> [1, 10]
+    lastpart = ''
+    for dig in parts[-1]:
+        if dig.isdigit():
+            lastpart += dig
         else:
-            parts.pop(-1)
+            break
+    parts[-1] = lastpart
     return '.'.join(parts)
 
 


### PR DESCRIPTION
maint: fix release script to handle multidigit release numbers

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
