### PR TITLE
Adjust statement about namespace implementation detail.

### DIFF
--- a/doc/src/guides/contributing/docstring.rst
+++ b/doc/src/guides/contributing/docstring.rst
@@ -673,16 +673,16 @@ of objects that have conventions here:
 1. Objects that are included in ``from sympy import *``, for example,
 ``sympy.acos``.
 
-For these, use ``:obj:`~.acos()```. The ``~`` makes it so that
-the text in the rendered HTML only shows ``acos``. Without it, it would use the
-fully qualified name ``sympy.functions.elementary.trigonometric.acos``. However,
-for names that are part of the global ``sympy`` namespace, we do not want to
-encourage accessing them from their specific submodule, as this is an
-implementation detail that could change. The ``.`` makes it so that the function
-name is found automatically. Sometimes, Sphinx will give a warning that there
-are multiple names found. If that happens, replace the ``.`` with the full name.
-For example, ``:obj:`~sympy.solvers.solvers.solve()```. For functions, methods,
-and classes, it is a convention to add () after the name to indicate such.
+For these, use ``:obj:`~.acos()```. The ``~`` makes it so that the text in the
+rendered HTML only shows ``acos``. Without it, it would use the fully qualified
+name ``sympy.functions.elementary.trigonometric.acos``. For names that are part
+of the global ``sympy`` namespace, we want to encourage accessing them from
+``sympy.*``, not the specific submodule. The ``.`` makes it so that the
+function name is found automatically. Sometimes, Sphinx will give a warning
+that there are multiple names found. If that happens, replace the ``.`` with
+the full name.  For example, ``:obj:`~sympy.solvers.solvers.solve()```. For
+functions, methods, and classes, it is a convention to add () after the name to
+indicate such.
 
 You may also use a more specific type indicator instead of ``obj`` (see
 https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects).

--- a/doc/src/guides/contributing/docstring.rst
+++ b/doc/src/guides/contributing/docstring.rst
@@ -674,15 +674,14 @@ of objects that have conventions here:
 ``sympy.acos``.
 
 For these, use ``:obj:`~.acos()```. The ``~`` makes it so that the text in the
-rendered HTML only shows ``acos``. Without it, it would use the fully qualified
-name ``sympy.functions.elementary.trigonometric.acos``. For names that are part
-of the global ``sympy`` namespace, we want to encourage accessing them from
-``sympy.*``, not the specific submodule. The ``.`` makes it so that the
-function name is found automatically. Sometimes, Sphinx will give a warning
-that there are multiple names found. If that happens, replace the ``.`` with
-the full name.  For example, ``:obj:`~sympy.solvers.solvers.solve()```. For
-functions, methods, and classes, it is a convention to add () after the name to
-indicate such.
+rendered HTML only shows ``acos`` instead of the fully qualified name
+``sympy.functions.elementary.trigonometric.acos``. (This will encourage importing
+names from the global ``sympy`` namespace instead of a specific submodule.)
+The ``.`` makes it so that the function name is found automatically. (If Sphinx gives
+a warning that there are multiple names found, replace the ``.`` with
+the full name.  For example, ``:obj:`~sympy.solvers.solvers.solve()```.) Adding a trailing
+pair of parentheses is a convention for indicating the name is a function, method, or
+class.
 
 You may also use a more specific type indicator instead of ``obj`` (see
 https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects).


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I came across this statement in the docstring guide and do not consider
module layout an "implementation detail". Modules without a prepended
underscore in their filename should be considered public API because
people will import from them, regardless if a sentence in the
documentation warns them not to or if the fully qualified name is not
displayed in the cross reference. The `sympy.module.<tab>` in IPython
will show all variables, including module names, that do not start with
an underscore, so people will import from anywhere. I have yet to come
across a library that shifts module layout without deprecation and
warning to users.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
