### PR TITLE
Put the `visit_Num` function back into `ast_parser.py`

### DIFF
--- a/sympy/parsing/ast_parser.py
+++ b/sympy/parsing/ast_parser.py
@@ -33,6 +33,17 @@ class Transform(NodeTransformer):
         self.global_dict = global_dict
 
     def visit_Constant(self, node):
+        if isinstance(node.value, int):
+            return fix_missing_locations(Call(func=Name('Integer', Load()),
+                    args=[node], keywords=[]))
+        elif isinstance(node.value, float):
+            return fix_missing_locations(Call(func=Name('Float', Load()),
+                    args=[node], keywords=[]))
+        return node
+
+    def visit_Num(self, node):
+        """This function exists for backwards compatibility with Python 3.7.
+           It should be removed when SymPy removes support for Python 3.7."""
         if isinstance(node.n, int):
             return fix_missing_locations(Call(func=Name('Integer', Load()),
                     args=[node], keywords=[]))

--- a/sympy/parsing/tests/test_ast_parser.py
+++ b/sympy/parsing/tests/test_ast_parser.py
@@ -1,3 +1,4 @@
+from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.parsing.ast_parser import parse_expr
@@ -23,4 +24,10 @@ def test_parse_expr():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         assert parse_expr('6 * 7', {}) == S(42)
-        assert parse_expr('1 / 2', {}) == S(1)/2
+        # Note: The test below can be removed when support for Python 3.7 is
+        # dropped. This test exists to ensure that the visit_Num function
+        # exists for Python 3.7, because in 3.7, Python didn't use the
+        # visit_Constant to create AST Nodes yet.
+        test_expr = parse_expr('1 / 3', {})
+        assert test_expr == S(1)/3 # sanity check
+        assert isinstance(test_expr, Rational)

--- a/sympy/parsing/tests/test_ast_parser.py
+++ b/sympy/parsing/tests/test_ast_parser.py
@@ -3,6 +3,7 @@ from sympy.core.symbol import symbols
 from sympy.parsing.ast_parser import parse_expr
 from sympy.testing.pytest import raises
 from sympy.core.sympify import SympifyError
+import warnings
 
 def test_parse_expr():
     a, b = symbols('a, b')
@@ -17,3 +18,9 @@ def test_parse_expr():
     # tests Transform.visit_Name
     assert parse_expr('Rational(1, 2)', {}) == S(1)/2
     assert parse_expr('a', {'a': a}) == a
+
+    # tests issue_23092
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert parse_expr('6 * 7', {}) == S(42)
+        assert parse_expr('1 / 2', {}) == S(1)/2


### PR DESCRIPTION
This was required to keep SymPy compatible with Python 3.7.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This is a follow-up to #23096, where it was discovered that the `visit_Num` must be kept for compatilibity with Python 3.7.
Fixes the new issues raised in #23092.

#### Brief description of what is fixed or changed
I added the `visit_Num` function back in. Now, `ast_parser.py` has both `visit_Constant` (for compatibility with Python >= 3.8), and `visit_Num` (for compatibility with Python 3.7).

I also changed the way the `value` attribute of the `Constant` node was being accessed, because `Constant.n` is deprecated in Python 3.11.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added the `visit_Num` function back into `ast_parser.py`.
<!-- END RELEASE NOTES -->
