### PR TITLE
Series/Limits : Fixes leading term for exponential functions involving AccumBounds based arguments

### DIFF
--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -11,7 +11,7 @@ from sympy.functions.elementary.complexes import (adjoint, conjugate, re, sign, 
 from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.trigonometric import (cos, sin, tan)
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.polys.polytools import gcd
 from sympy.series.order import O
@@ -536,6 +536,11 @@ def test_log_simplify():
 
 def test_log_AccumBounds():
     assert log(AccumBounds(1, E)) == AccumBounds(0, 1)
+    assert log(AccumBounds(0, E)) == AccumBounds(-oo, 1)
+    assert log(AccumBounds(-1, E)) == S.NaN
+    assert log(AccumBounds(0, oo)) == AccumBounds(-oo, oo)
+    assert log(AccumBounds(-oo, 0)) == S.NaN
+    assert log(AccumBounds(-oo, oo)) == S.NaN
 
 
 @_both_exp_pow
@@ -729,3 +734,20 @@ def test_log_expand_factor():
 def test_issue_9116():
     n = Symbol('n', positive=True, integer=True)
     assert log(n).is_nonnegative is True
+
+
+def test_issue_18473():
+    assert exp(x*log(cos(1/x))).as_leading_term(x) == S.NaN
+    assert exp(x*log(tan(1/x))).as_leading_term(x) == S.NaN
+    assert log(cos(1/x)).as_leading_term(x) == S.NaN
+    assert log(tan(1/x)).as_leading_term(x) == S.NaN
+    assert log(cos(1/x) + 2).as_leading_term(x) == AccumBounds(0, log(3))
+    assert exp(x*log(cos(1/x) + 2)).as_leading_term(x) == 1
+    assert log(cos(1/x) - 2).as_leading_term(x) == S.NaN
+    assert exp(x*log(cos(1/x) - 2)).as_leading_term(x) == S.NaN
+    assert log(cos(1/x) + 1).as_leading_term(x) == AccumBounds(-oo, log(2))
+    assert exp(x*log(cos(1/x) + 1)).as_leading_term(x) == AccumBounds(0, 1)
+    assert log(sin(1/x)**2).as_leading_term(x) == AccumBounds(-oo, 0)
+    assert exp(x*log(sin(1/x)**2)).as_leading_term(x) == AccumBounds(0, 1)
+    assert log(tan(1/x)**2).as_leading_term(x) == AccumBounds(-oo, oo)
+    assert exp(2*x*(log(tan(1/x)**2))).as_leading_term(x) == AccumBounds(0, oo)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -315,7 +315,7 @@ class Limit(Expr):
         else:
             if isinstance(coeff, AccumBounds) and ex == S.Zero:
                 return coeff
-            if coeff.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
+            if coeff.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
                 return self
             if not coeff.has(z):
                 if ex.is_positive:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -929,6 +929,18 @@ def test_issue_18452():
     assert limit(abs(log(x))**x, x, 0, "-") == 1
 
 
+def test_issue_18473():
+    assert limit(sin(x)**(1/x), x, oo) == Limit(sin(x)**(1/x), x, oo, dir='-')
+    assert limit(cos(x)**(1/x), x, oo) == Limit(cos(x)**(1/x), x, oo, dir='-')
+    assert limit(tan(x)**(1/x), x, oo) == Limit(tan(x)**(1/x), x, oo, dir='-')
+    assert limit((cos(x) + 2)**(1/x), x, oo) == 1
+    assert limit((sin(x) + 10)**(1/x), x, oo) == 1
+    assert limit((cos(x) - 2)**(1/x), x, oo) == Limit((cos(x) - 2)**(1/x), x, oo, dir='-')
+    assert limit((cos(x) + 1)**(1/x), x, oo) == AccumBounds(0, 1)
+    assert limit((tan(x)**2)**(2/x) , x, oo) == AccumBounds(0, oo)
+    assert limit((sin(x)**2)**(1/x), x, oo) == AccumBounds(0, 1)
+
+
 def test_issue_18482():
     assert limit((2*exp(3*x)/(exp(2*x) + 1))**(1/x), x, oo) == exp(1)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18473

#### Brief description of what is fixed or changed
On Master
```
>>> limit(sin(x)**(1/x), x, oo)
1
>>> limit(cos(x)**(1/x), x, oo)
1
>>> limit(tan(x)**(1/x), x, oo)
1
>>> exp(x*log(cos(1/x))).as_leading_term(x)
1
>>> exp(x*log(sin(1/x))).as_leading_term(x)
1
>>> exp(x*log(tan(1/x))).as_leading_term(x)
1
>>> log(cos(1/x)).as_leading_term(x)
log(AccumBounds(-1, 1))
>>> log(sin(1/x)).as_leading_term(x)
log(AccumBounds(-1, 1))
>>> log(tan(1/x)).as_leading_term(x)
log(AccumBounds(-oo, oo))
```
The limits shown above cannot be correctly claimed to be `1` . For eg the following
![image](https://user-images.githubusercontent.com/87052487/154327518-f5006089-1324-40db-98b2-0b31ec6256ce.png)

Firstly the function isn't continuous in the real domain as `x` tends to `oo` and even if it does the answer is not going to be `1` .
This is because something like `log(cos(1/x)).as_leading_term(x)` returns `log(AccumBounds(-1, 1))` which wouldn't be supportive in the `real` domain . Unfortunately a `subs` operation for `x` by `0` is taking place changing the `x*log(AccumBounds(-1, 1))` to `0` and returning `exp(0)` which is `1` . Hence the Pr fixes the above not really correct result.

On Committed branch . `S.NaN` seems to be the best option we have to tackle non real values of `log` inside `AccumBounds` !
```
>>> x = Symbol('x')
>>> limit(sin(x)**(1/x), x, oo)
Limit(sin(x)**(1/x), x, oo, dir='-')
>>> limit(cos(x)**(1/x), x, oo)
Limit(cos(x)**(1/x), x, oo, dir='-')
>>> limit(tan(x)**(1/x), x, oo)
Limit(tan(x)**(1/x), x, oo, dir='-')
>>> exp(x*log(cos(1/x))).as_leading_term(x)
nan
>>> exp(x*log(sin(1/x))).as_leading_term(x)
nan
>>> exp(x*log(tan(1/x))).as_leading_term(x)
nan
>>> log(cos(1/x)).as_leading_term(x)
nan
>>> log(tan(1/x)).as_leading_term(x)
nan
```

#### Other comments
All Discussion for this Pr had taken place in #23087 but due to couple wrong commands in the past my PR  was based on a master branch which wasn't a straight-copy of the main sympy master branch. Hence since past few Prs after switching to a new branch from master , I would get unwanted code pushed everytime  . Hence I was having problems in squashing, rebasing,reverting commits which was showing fatal error message. I followed @oscarbenjamin 's comment on another Pr helping another fellow contributor to fix a similar issue. This involved setting the main sympy repo as upstream again . This will help me in the future too as now I am sure this problem isn't going to occur again!
This is what I followed to sort the error (https://github.com/sympy/sympy/pull/22872#issuecomment-1031365942)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixes leading term for exponential functions involving AccumBounds based arguments.
<!-- END RELEASE NOTES -->
