### PR TITLE
allow for more telescopic handling

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -29,7 +29,6 @@ from sympy.sets.sets import Interval
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.simplify import simplify
 from sympy.tensor.indexed import (Idx, Indexed, IndexedBase)
-from sympy.abc import a, b, c, d, k, m, x, y, z
 from sympy.concrete.summations import (
     telescopic, _dummy_with_inherited_properties_concrete, eval_sum_residue)
 from sympy.concrete.expr_with_intlimits import ReorderError
@@ -38,6 +37,7 @@ from sympy.testing.pytest import XFAIL, raises, slow
 from sympy.matrices import (Matrix, SparseMatrix,
     ImmutableDenseMatrix, ImmutableSparseMatrix)
 from sympy.core.mod import Mod
+from sympy.abc import a, b, c, d, k, m, x, y, z
 
 n = Symbol('n', integer=True)
 f, g = symbols('f g', cls=Function)
@@ -542,7 +542,16 @@ def test_telescopic_sums():
     assert telescopic(1/m, -m/(1 + m), (m, n - 1, n)) == \
         telescopic(1/k, -k/(1 + k), (k, n - 1, n))
 
-    assert Sum(1/x/(x - 1), (x, a, b)).doit() == -((a - b - 1)/(b*(a - 1)))
+    assert Sum(1/x/(x - 1), (x, a, b)).doit() == 1/(a - 1) - 1/b
+    eq = 1/((5*n + 2)*(5*(n + 1) + 2))
+    assert Sum(eq, (n, 0, oo)).doit() == S(1)/10
+    nz = symbols('nz', nonzero=True)
+    v = Sum(eq.subs(5, nz), (n, 0, oo)).doit()
+    assert v.subs(nz, 5).simplify() == S(1)/10
+    # check that apart is being used in non-symbolic case
+    s = Sum(eq, (n, 0, k)).doit()
+    v = Sum(eq, (n, 0, 10**100)).doit()
+    assert v == s.subs(k, 10**100)
 
 
 def test_sum_reconstruct():
@@ -961,15 +970,14 @@ def test_issue_2787():
     binomial_dist = binomial(n, k)*p**k*(1 - p)**(n - k)
     s = Sum(binomial_dist*k, (k, 0, n))
     res = s.doit().simplify()
-    assert res == Piecewise(
-        (n*p, p/Abs(p - 1) <= 1),
-        ((-p + 1)**n*Sum(k*p**k*binomial(n, k)/(-p + 1)**(k), (k, 0, n)),
+    ans = Piecewise(
+        (n*p, x),
+        ((1 - p)**n*Sum(k*p**k*binomial(n, k)/(1 - p)**k, (k, 0, n)),
         True))
+    assert res == ans.subs(x, p/Abs(p - 1) <= 1)
     # Issue #17165: make sure that another simplify does not complicate
     # the result (but why didn't first simplify handle this?)
-    assert res.simplify() == Piecewise((n*p, p <= S.Half),
-        ((1 - p)**n*Sum(k*p**k*binomial(n, k)/(1 - p)**k,
-        (k, 0, n)), True))
+    assert res.simplify() == ans.subs(x, p <= S.Half)
 
 
 def test_issue_4668():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -658,6 +658,7 @@ def test_is_rational_function():
     assert (S.NegativeInfinity).is_rational_function() is False
     assert (S.ComplexInfinity).is_rational_function() is False
 
+
 def test_is_meromorphic():
     f = a/x**2 + b + x + c*x**2
     assert f.is_meromorphic(x, 0) is True
@@ -2211,6 +2212,7 @@ def test_21494():
 
     with warns_deprecated_sympy():
         assert Subs(x, x, 0).expr_free_symbols == set()
+
 
 def test_Expr__eq__iterable_handling():
     assert x != range(3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #23119 by allowing `apart` to be used on Add and Mul

#### Brief description of what is fixed or changed

The inline comments show how `apart` can lead to expressions recognizable as solvable by telescopic methods, whether starting as an Add or Mul.

#### Other comments

In master, one of the added tests gives this:
```python
>>> eq = 1/((5*n + 2)*(5*(n + 1) + 2))
>>> nz = symbols('nz', nonzero=True)
>>> v = Sum(eq.subs(5, nz), (n, 0, oo)).doit()
>>> v
Piecewise((lerchphi(1, 1, 2/nz)/(5*nz) - lerchphi(1, 1, 7/nz)/(5*nz), (nz + 2)/nz + (nz + 7)/nz - 9/nz > 1),
 (Sum(1/(n**2*nz**2 + 9*n*nz + 14), (n, 0, oo)), True))
>>> v.subs(nz,5)
-lerchphi(1, 1, 7/5)/25 + lerchphi(1, 1, 2/5)/25
>>> _.simplify()
-lerchphi(1, 1, 7/5)/25 + lerchphi(1, 1, 2/5)/25
>>> _.n()
oo
```
In this PR, the sum evaluation completes successfully on the lsum and rsum step. But I am still concerned that if that should fail the code that generated the `lerchphi` solution might still be activated and give an incorrect result.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
    * more summation are now recognized as telescopic sums
<!-- END RELEASE NOTES -->
