### PR TITLE
PermuteDims: added easier API

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -363,11 +363,13 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     >>> permutedims(b, (1, 2, 0))
     [[[1, 5], [2, 6]], [[3, 7], [4, 8]]]
 
-    An alternative way to specify the same permutations as in the previous lines:
+    An alternative way to specify the same permutations as in the previous
+    lines involves passing the *old* and *new* indices, either as a list or as
+    a string:
 
-    >>> permutedims(b, index_order_old=["c", "b", "a"], index_order_new=["a", "b", "c"])
+    >>> permutedims(b, index_order_old="cba", index_order_new="abc")
     [[[1, 5], [3, 7]], [[2, 6], [4, 8]]]
-    >>> permutedims(b, index_order_old=["c", "a", "b"], index_order_new=["a", "b", "c"])
+    >>> permutedims(b, index_order_old="cab", index_order_new="abc")
     [[[1, 5], [2, 6]], [[3, 7], [4, 8]]]
 
     ``Permutation`` objects are also allowed:

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -331,7 +331,7 @@ def derive_by_array(expr, dx):
             return diff(expr, dx)
 
 
-def permutedims(expr, perm):
+def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     """
     Permutes the indices of an array.
 
@@ -363,6 +363,13 @@ def permutedims(expr, perm):
     >>> permutedims(b, (1, 2, 0))
     [[[1, 5], [2, 6]], [[3, 7], [4, 8]]]
 
+    An alternative way to specify the same permutations as in the previous lines:
+
+    >>> permutedims(b, index_order_old=["c", "b", "a"], index_order_new=["a", "b", "c"])
+    [[[1, 5], [3, 7]], [[2, 6], [4, 8]]]
+    >>> permutedims(b, index_order_old=["c", "a", "b"], index_order_new=["a", "b", "c"])
+    [[[1, 5], [2, 6]], [[3, 7], [4, 8]]]
+
     ``Permutation`` objects are also allowed:
 
     >>> from sympy.combinatorics import Permutation
@@ -376,6 +383,9 @@ def permutedims(expr, perm):
     from sympy.tensor.array.expressions.array_expressions import _CodegenArrayAbstract
     from sympy.tensor.array.expressions.array_expressions import _permute_dims
     from sympy.matrices.expressions.matexpr import MatrixSymbol
+    from sympy.tensor.array.expressions import PermuteDims
+    from sympy.tensor.array.expressions.array_expressions import get_rank
+    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_rank(expr))
     if isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
         return _permute_dims(expr, perm)
 

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -714,6 +714,10 @@ class PermuteDims(_CodegenArrayAbstract):
                 raise ValueError("Permutation not defined")
             return PermuteDims._get_permutation_from_index_orders(index_order_old, index_order_new, dim)
         else:
+            if index_order_new is not None:
+                raise ValueError("index_order_new cannot be defined with permutation")
+            if index_order_old is not None:
+                raise ValueError("index_order_old cannot be defined with permutation")
             return permutation
 
     @classmethod

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -414,7 +414,7 @@ class PermuteDims(_CodegenArrayAbstract):
 
     >>> from sympy.tensor.array.expressions import ArraySymbol, PermuteDims
     >>> M = ArraySymbol("M", (1, 2, 3, 4, 5))
-    >>> expr = PermuteDims(M, index_order_old=["i", "j", "k", "l", "m"], index_order_new=["k", "i", "j", "m", "l"])
+    >>> expr = PermuteDims(M, index_order_old="ijklm", index_order_new="kijml")
     >>> expr
     PermuteDims(M, (0 2 1)(3 4))
     >>> expr.shape

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -379,7 +379,9 @@ class ArrayAdd(_CodegenArrayAbstract):
         return new_args
 
     def as_explicit(self):
-        return reduce(operator.add, [arg.as_explicit() for arg in self.args])
+        return reduce(
+            operator.add,
+            [arg.as_explicit() if hasattr(arg, "as_explicit") else arg for arg in self.args])
 
 
 class PermuteDims(_CodegenArrayAbstract):
@@ -941,7 +943,10 @@ class ArrayDiagonal(_CodegenArrayAbstract):
         return positions, shape
 
     def as_explicit(self):
-        return tensordiagonal(self.expr.as_explicit(), *self.diagonal_indices)
+        expr = self.expr
+        if hasattr(expr, "as_explicit"):
+            expr = expr.as_explicit()
+        return tensordiagonal(expr, *self.diagonal_indices)
 
 
 class ArrayElementwiseApplyFunc(_CodegenArrayAbstract):
@@ -977,6 +982,12 @@ class ArrayElementwiseApplyFunc(_CodegenArrayAbstract):
         else:
             fdiff = Lambda(d, fdiff)
         return fdiff
+
+    def as_explicit(self):
+        expr = self.expr
+        if hasattr(expr, "as_explicit"):
+            expr = expr.as_explicit()
+        return expr.applyfunc(self.function)
 
 
 class ArrayContraction(_CodegenArrayAbstract):
@@ -1519,7 +1530,10 @@ class ArrayContraction(_CodegenArrayAbstract):
         return dlinks
 
     def as_explicit(self):
-        return tensorcontraction(self.expr.as_explicit(), *self.contraction_indices)
+        expr = self.expr
+        if hasattr(expr, "as_explicit"):
+            expr = expr.as_explicit()
+        return tensorcontraction(expr, *self.contraction_indices)
 
 
 class Reshape(_CodegenArrayAbstract):
@@ -1574,7 +1588,9 @@ class Reshape(_CodegenArrayAbstract):
         return Reshape(expr, self.shape)
 
     def as_explicit(self):
-        ee = self.expr.as_explicit()
+        ee = self.expr
+        if hasattr(ee, "as_explicit"):
+            ee = ee.as_explicit()
         if isinstance(ee, MatrixCommon):
             from sympy import Array
             ee = Array(ee)

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -736,6 +736,14 @@ def test_array_expr_construction_with_functions():
     expr = permutedims(PermuteDims(tp, [1, 0, 2, 3]), [0, 1, 3, 2])
     assert expr == PermuteDims(tp, [1, 0, 3, 2])
 
+    expr = PermuteDims(tp, index_order_new=["a", "b", "c", "d"], index_order_old=["d", "c", "b", "a"])
+    assert expr == PermuteDims(tp, [3, 2, 1, 0])
+
+    arr = Array(range(32)).reshape(2, 2, 2, 2, 2)
+    expr = PermuteDims(arr, index_order_new=["a", "b", "c", "d", "e"], index_order_old=['b', 'e', 'a', 'd', 'c'])
+    assert expr == PermuteDims(arr, [2, 0, 4, 3, 1])
+    assert expr.as_explicit() == permutedims(arr, index_order_new=["a", "b", "c", "d", "e"], index_order_old=['b', 'e', 'a', 'd', 'c'])
+
 
 def test_array_element_expressions():
     # Check commutative property:

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -792,3 +792,17 @@ def test_array_expr_reshape():
     assert expr.expr == C
     assert expr.shape == (2, 2)
     assert expr.doit() == Array([[1, 2], [3, 4]])
+
+
+def test_array_expr_as_explicit_with_explicit_component_arrays():
+    # Test if .as_explicit() works with explicit-component arrays
+    # nested in array expressions:
+    from sympy.abc import x, y, z, t
+    A = Array([[x, y], [z, t]])
+    assert ArrayTensorProduct(A, A).as_explicit() == tensorproduct(A, A)
+    assert ArrayDiagonal(A, (0, 1)).as_explicit() == tensordiagonal(A, (0, 1))
+    assert ArrayContraction(A, (0, 1)).as_explicit() == tensorcontraction(A, (0, 1))
+    assert ArrayAdd(A, A).as_explicit() == A + A
+    assert ArrayElementwiseApplyFunc(sin, A).as_explicit() == A.applyfunc(sin)
+    assert PermuteDims(A, [1, 0]).as_explicit() == permutedims(A, [1, 0])
+    assert Reshape(A, [4]).as_explicit() == A.reshape(4)

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -317,6 +317,8 @@ def test_permutedims_with_indices():
     raises(ValueError, lambda: permutedims(A, index_order_old=list("abcde"), index_order_new=list("abcce")))
     raises(ValueError, lambda: permutedims(A, index_order_old=list("abcde"), index_order_new=list("abce")))
     raises(ValueError, lambda: permutedims(A, index_order_old=list("abce"), index_order_new=list("abce")))
+    raises(ValueError, lambda: permutedims(A, [2, 1, 0, 3, 4], index_order_old=list("abcde")))
+    raises(ValueError, lambda: permutedims(A, [2, 1, 0, 3, 4], index_order_new=list("abcde")))
 
 
 def test_flatten():

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 
 from sympy.combinatorics import Permutation
@@ -299,6 +300,23 @@ def test_array_permutedims():
         assert permutedims(A, (1, 0, 2)) == SparseArrayType({1: 1, 100000000: 2}, (20000, 10000, 10000))
         B = SparseArrayType({1:1, 20000:2}, (10000, 20000))
         assert B.transpose() == SparseArrayType({10000: 1, 1: 2}, (20000, 10000))
+
+
+def test_permutedims_with_indices():
+    A = Array(range(32)).reshape(2, 2, 2, 2, 2)
+    indices_new = list("abcde")
+    indices_old = list("ebdac")
+    new_A = permutedims(A, index_order_new=indices_new, index_order_old=indices_old)
+    for a, b, c, d, e in itertools.product(range(2), range(2), range(2), range(2), range(2)):
+        assert new_A[a, b, c, d, e] == A[e, b, d, a, c]
+    indices_old = list("cabed")
+    new_A = permutedims(A, index_order_new=indices_new, index_order_old=indices_old)
+    for a, b, c, d, e in itertools.product(range(2), range(2), range(2), range(2), range(2)):
+        assert new_A[a, b, c, d, e] == A[c, a, b, e, d]
+    raises(ValueError, lambda: permutedims(A, index_order_old=list("aacde"), index_order_new=list("abcde")))
+    raises(ValueError, lambda: permutedims(A, index_order_old=list("abcde"), index_order_new=list("abcce")))
+    raises(ValueError, lambda: permutedims(A, index_order_old=list("abcde"), index_order_new=list("abce")))
+    raises(ValueError, lambda: permutedims(A, index_order_old=list("abce"), index_order_new=list("abce")))
 
 
 def test_flatten():


### PR DESCRIPTION
PermuteDims and permutedims now have an easier API based on index orders. The corresponding permutation is then derived internally.

Now you don't need to know the permutation anymore, just the old index order and the new index order.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
