### PR TITLE
fix set=True & duplicate solution handling

### DIFF
--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -116,10 +116,10 @@ def test_parabola_intersection():
     assert parabola1.intersection(Ray2D((0, 7), (0, 14))) == []
     # parabola with ellipse/circle
     assert parabola1.intersection(Circle(p1, 2)) == [Point2D(-2, 0), Point2D(2, 0)]
-    assert parabola1.intersection(Circle(p2, 1)) == [Point2D(0, -1), Point2D(0, -1)]
-    assert parabola1.intersection(Ellipse(p2, 2, 1)) == [Point2D(0, -1), Point2D(0, -1)]
+    assert parabola1.intersection(Circle(p2, 1)) == [Point2D(0, -1)]
+    assert parabola1.intersection(Ellipse(p2, 2, 1)) == [Point2D(0, -1)]
     assert parabola1.intersection(Ellipse(Point(0, 19), 5, 7)) == []
     assert parabola1.intersection(Ellipse((0, 3), 12, 4)) == \
-           [Point2D(0, -1), Point2D(0, -1), Point2D(-4*sqrt(17)/3, Rational(59, 9)), Point2D(4*sqrt(17)/3, Rational(59, 9))]
+           [Point2D(0, -1), Point2D(-4*sqrt(17)/3, Rational(59, 9)), Point2D(4*sqrt(17)/3, Rational(59, 9))]
     # parabola with unsupported type
     raises(TypeError, lambda: parabola1.intersection(2))

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -54,7 +54,6 @@ def solve_poly_system(seq, *gens, **args):
 
     if len(polys) == len(opt.gens) == 2:
         f, g = polys
-
         if all(i <= 2 for i in f.degree_list() + g.degree_list()):
             try:
                 return solve_biquadratic(f, g, opt)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2480,10 +2480,16 @@ def test_issue_22717():
         {y: -1, x: E}, {y: 1, x: E}]
 
 
-def test_issue_23110_manual():
+def test_issue_23110():
     assert solve((a*b, a*c, c*d**2), manual=True) == [
         {a: 0, c: 0}, {a: 0, d: 0}, {b: 0 , c: 0}]
     assert solve((a*b, a*c, c*d**2), manual=True, set=True) == (
         [a, b, c, d], {(a, 0, 0, d), (0, b, 0, d), (0, b, c, 0)})
     assert solve((b*d, b*a, a*c**2), manual=True, set=True) == (
         [a, b, c, d], {(0, 0, c, d), (a, 0, 0, d), (0, b, c, 0)})
+    x0, x1, x2, x3 = symbols('x:4')
+    assert solve((-x0*x1, -x0*x2, -x3*x2**2))  == [
+        {x0: 0, x2: 0}, {x0: 0, x3: 0}, {x1: 0, x2: 0}]
+    x11_12, x8_8, x3_4, x9_12 = symbols('x11_12, x8_8, x3_4, x9_12')
+    assert solve((-x3_4*x9_12, -x11_12*x3_4, -x11_12**2*x8_8)) == [
+        {x11_12: 0, x3_4: 0}, {x11_12: 0, x9_12: 0}, {x3_4: 0, x8_8: 0}]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2487,9 +2487,13 @@ def test_issue_23110():
         [a, b, c, d], {(a, 0, 0, d), (0, b, 0, d), (0, b, c, 0)})
     assert solve((b*d, b*a, a*c**2), manual=True, set=True) == (
         [a, b, c, d], {(0, 0, c, d), (a, 0, 0, d), (0, b, c, 0)})
-    x0, x1, x2, x3 = symbols('x:4')
+
+    x0, x1, x2, x3, v = symbols('x:4 v')
     assert solve((-x0*x1, -x0*x2, -x3*x2**2))  == [
         {x0: 0, x2: 0}, {x0: 0, x3: 0}, {x1: 0, x2: 0}]
     x11_12, x8_8, x3_4, x9_12 = symbols('x11_12, x8_8, x3_4, x9_12')
     assert solve((-x3_4*x9_12, -x11_12*x3_4, -x11_12**2*x8_8)) == [
         {x11_12: 0, x3_4: 0}, {x11_12: 0, x9_12: 0}, {x3_4: 0, x8_8: 0}]
+
+    assert solve((x*y, x*z, x*v, y - 2*z)) == [
+        {x: 0, y: 2*z}, {v: 0, y: 0, z: 0}]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2478,3 +2478,12 @@ def test_solver_flags():
 def test_issue_22717():
     assert solve((-y**2 + log(y**2/x) + 2, -2*x*y + 2*x/y)) == [
         {y: -1, x: E}, {y: 1, x: E}]
+
+
+def test_issue_23110_manual():
+    assert solve((a*b, a*c, c*d**2), manual=True) == [
+        {a: 0, c: 0}, {a: 0, d: 0}, {b: 0 , c: 0}]
+    assert solve((a*b, a*c, c*d**2), manual=True, set=True) == (
+        [a, b, c, d], {(a, 0, 0, d), (0, b, 0, d), (0, b, c, 0)})
+    assert solve((b*d, b*a, a*c**2), manual=True, set=True) == (
+        [a, b, c, d], {(0, 0, c, d), (a, 0, 0, d), (0, b, c, 0)})


### PR DESCRIPTION
Although it is tempting to move the duplicate solution
removal to before the simplification and checking, it
seems better to put it afterwards in case solutions
become clear duplicates after simplication.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes returning of duplicate solutions when manual is True (#23110 )

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * set=True will now work in cases where dictionaries with different keys are returned
    * fewer redundant solutions for systems of equations will be returned
<!-- END RELEASE NOTES -->
