### PR TITLE
Derivative, ArrayDerivative, MatrixExpr: Accept numbers.Integral as order of differentiation, index

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -32,6 +32,7 @@ There are three types of functions implemented in SymPy:
 
 from typing import Any, Dict as tDict, Optional, Set as tSet, Tuple as tTuple, Union as tUnion
 from collections.abc import Iterable
+import numbers
 
 from .add import Add
 from .assumptions import ManagedProperties
@@ -1276,12 +1277,11 @@ class Derivative(Expr):
         # derivative.
         variable_count = []
         array_likes = (tuple, list, Tuple)
-        integer_likes = (int, Integer)
 
         from sympy.tensor.array import Array, NDimArray
 
         for i, v in enumerate(variables):
-            if isinstance(v, integer_likes):
+            if isinstance(v, (int, Integer, numbers.Integral)):
                 if i == 0:
                     raise ValueError("First variable cannot be a number: %i" % v)
                 count = v

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,5 +1,6 @@
 from typing import Tuple as tTuple
 from functools import wraps
+import numbers
 
 from sympy.core import S, Integer, Basic, Mul, Add
 from sympy.core.assumptions import check_assumptions
@@ -271,7 +272,7 @@ class MatrixExpr(Expr):
 
     def valid_index(self, i, j):
         def is_valid(idx):
-            return isinstance(idx, (int, Integer, Symbol, Expr))
+            return isinstance(idx, (int, Integer, numbers.Integral, Symbol, Expr))
         return (is_valid(i) and is_valid(j) and
                 (self.rows is None or
                 (0 <= i) != False and (i < self.rows) != False) and
@@ -291,7 +292,7 @@ class MatrixExpr(Expr):
                 return self._entry(i, j)
             else:
                 raise IndexError("Invalid indices (%s, %s)" % (i, j))
-        elif isinstance(key, (SYMPY_INTS, Integer)):
+        elif isinstance(key, (SYMPY_INTS, Integer, numbers.Integral)):
             # row-wise decomposition of matrix
             rows, cols = self.shape
             # allow single indexing if number of columns is known
@@ -313,8 +314,8 @@ class MatrixExpr(Expr):
         raise IndexError("Invalid index, wanted %s[i,j]" % self)
 
     def _is_shape_symbolic(self) -> bool:
-        return (not isinstance(self.rows, (SYMPY_INTS, Integer))
-            or not isinstance(self.cols, (SYMPY_INTS, Integer)))
+        return (not isinstance(self.rows, (SYMPY_INTS, Integer, numbers.Integral))
+            or not isinstance(self.cols, (SYMPY_INTS, Integer, numbers.Integral)))
 
     def as_explicit(self):
         """

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import numbers
 
 from sympy.core.expr import Expr
 from sympy.core.function import Derivative
@@ -85,7 +86,7 @@ class ArrayDerivative(Derivative):
         # object, the default in `Basic` will call a loop over
         # `_eval_derivative`:
 
-        if not isinstance(count, (int, Integer)) or ((count <= 0) == True):
+        if not isinstance(count, (int, Integer, numbers.Integral)) or ((count <= 0) == True):
             return None
 
         # TODO: this could be done with multiple-dispatching:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
First reported in #23144.

#### Brief description of what is fixed or changed
`Derivative` accepts integers to indicate order of differentiation with respect to a variable. 
We generalize the test for integers from a hardcoded list of types to the numbers ABC `numbers.Integral`. (Such objects can be sympified to `Integer` because the existence of an `__int__` method is [guaranteed by the ABC](https://docs.python.org/3/library/numbers.html#numbers.Integral).) This fixes the following regression when passing Sage integers:

```
sage: var('y')
y
sage: f_sage = function('f_sage')(x, y)
sage: f_sage
f_sage(x, y)
sage: f_sympy = f_sage._sympy_()
sage: f_sympy
f_sage(x, y)
sage: f_sympy.diff(x, 2)
ValueError: 
Can't calculate derivative wrt 2.
```

We make similar changes to `ArrayDerivative` to fix the following problem:
```
sage:     from sympy.matrices.expressions.matexpr import MatrixSymbol
sage:     from sympy.tensor.array.array_derivatives import ArrayDerivative
....:     A = MatrixSymbol("A", 2, 2)
sage: arrder = ArrayDerivative(A, A, 2, evaluate=False)
ValueError: 
Can't calculate derivative wrt 2.
```

We make similar changes to `MatrixSymbol`, in particular the `__getitem__` method.
```
sage: from sympy import MatrixSymbol
....: A = MatrixSymbol('A', 3, 3)
sage: A[1]
IndexError: Invalid index, wanted A[i,j]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
