### PR TITLE
BUG: respect global_dict in parse_expr (master branch)

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1054,6 +1054,14 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     if global_dict is None:
         global_dict = {}
         exec('from sympy import *', global_dict)
+
+        builtins_dict = vars(builtins)
+        for name, obj in builtins_dict.items():
+            if isinstance(obj, types.BuiltinFunctionType):
+                global_dict[name] = obj
+        global_dict['max'] = Max
+        global_dict['min'] = Min
+
     elif not isinstance(global_dict, dict):
         raise TypeError('expecting global_dict to be a dict')
 
@@ -1078,13 +1086,6 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
                 raise TypeError(filldedent('''
                     a transformation should be function that
                     takes 3 arguments'''))
-
-    builtins_dict = vars(builtins)
-    for name, obj in builtins_dict.items():
-        if isinstance(obj, types.BuiltinFunctionType):
-            global_dict[name] = obj
-    global_dict['max'] = Max
-    global_dict['min'] = Min
 
     code = stringify_expr(s, local_dict, global_dict, transformations)
 

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -2,10 +2,12 @@
 
 
 import sys
+import builtins
+import types
 
 from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
-from sympy.functions import exp, factorial, factorial2, sin
+from sympy.functions import exp, factorial, factorial2, sin, Min, Max
 from sympy.logic import And
 from sympy.series import Limit
 from sympy.testing.pytest import raises, skip
@@ -146,6 +148,27 @@ def test_global_dict():
     }
     for text, result in inputs.items():
         assert parse_expr(text, global_dict=global_dict) == result
+
+
+def test_no_globals():
+
+    # Replicate creating the default global_dict:
+    default_globals = {}
+    exec('from sympy import *', default_globals)
+    builtins_dict = vars(builtins)
+    for name, obj in builtins_dict.items():
+        if isinstance(obj, types.BuiltinFunctionType):
+            default_globals[name] = obj
+    default_globals['max'] = Max
+    default_globals['min'] = Min
+
+    # Need to include Symbol or parse_expr will not work:
+    default_globals.pop('Symbol')
+    global_dict = {'Symbol':Symbol}
+
+    for name in default_globals:
+        obj = parse_expr(name, global_dict=global_dict)
+        assert obj == Symbol(name)
 
 
 def test_issue_2515():


### PR DESCRIPTION
If parse_expr is called with a global_dict then builtins will not be
added to the global_dict so that builtin names do not conflict with
possible symbol names for the parsed expression e.g.:
```
>>> parse_expr("sum", global_dict={"Symbol":Symbol}) == Symbol("sum")
True
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/23148 on the 1.10 branch
Same as #23149 but for the master branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
