### PR TITLE
codegen: Make List hashable

### DIFF
--- a/sympy/codegen/abstract_nodes.py
+++ b/sympy/codegen/abstract_nodes.py
@@ -13,3 +13,6 @@ class List(Tuple):
             return self == List(*other)
         else:
             return self.args == other
+
+    def __hash__(self):
+        return super().__hash__()

--- a/sympy/codegen/tests/test_abstract_nodes.py
+++ b/sympy/codegen/tests/test_abstract_nodes.py
@@ -1,0 +1,14 @@
+from sympy.core.symbol import symbols
+from sympy.codegen.abstract_nodes import List
+
+
+def test_List():
+    l = List(2, 3, 4)
+    assert l == List(2, 3, 4)
+    assert str(l) == "[2, 3, 4]"
+    x, y, z = symbols('x y z')
+    l = List(x**2,y**3,z**4)
+    # contrary to python's built-in list, we can call e.g. "replace" on List.
+    m = l.replace(lambda arg: arg.is_Pow and arg.exp>2, lambda p: p.base-p.exp)
+    assert m == [x**2, y-3, z-4]
+    hash(m)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`List` had `__eq__` defined but not `__hash__` and was for that
reason not hashable. Tests are added.

Note that the codegen `List` is actually a `Tuple`, but allows for printing objects as `list` with the codegen AST, this is why it can be made hashable (which it should be since it is a subclass of `Basic`).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
