### PR TITLE
Restores pre-1.7 simplify behavior for orient_body_fixed()

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -892,6 +892,13 @@ class ReferenceFrame:
             u2 = expand(td[u2])
             u3 = expand(td[u3])
             wvec = u1 * self.x + u2 * self.y + u3 * self.z
+            # NOTE : SymPy 1.7 removed the call to simplify() that occured
+            # inside the solve() function, so this restores the pre-1.7
+            # behavior. See:
+            # https://github.com/sympy/sympy/issues/23140
+            # and
+            # https://github.com/sympy/sympy/issues/23130
+            wvec = wvec.simplify()
         except (CoercionFailed, AssertionError):
             wvec = self._w_diff_dcm(parent)
         self._ang_vel_dict.update({parent: wvec})

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -477,21 +477,22 @@ def test_orient_body():
 def test_orient_body_simple_ang_vel():
     """orient_body_fixed() uses kinematic_equations() internally and solves
     those equations for the measure numbers of the angular velocity. This test
-    ensures that the simplest form of that linear system solution is
-    returned."""
+    ensures that the simplest form of that linear system solution is returned,
+    thus the == for the expression comparison."""
 
     psi, theta, phi = dynamicsymbols('psi, theta, varphi')
+    t = dynamicsymbols._t
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
     B.orient_body_fixed(A, (psi, theta, phi), 'ZXZ')
     A_w_B = B.ang_vel_in(A)
-    mx = A_w_B.args[0][0][0]
-    my = A_w_B.args[0][0][1]
-    mz = A_w_B.args[0][0][2]
     assert A_w_B.args[0][1] == B
-    assert mx.count_ops() <= 15
-    assert my.count_ops() <= 15
-    assert mz.count_ops() <= 9
+    assert A_w_B.args[0][0][0] == (sin(theta)*sin(phi)*psi.diff(t) +
+                                   cos(phi)*theta.diff(t))
+    assert A_w_B.args[0][0][1] == (sin(theta)*cos(phi)*psi.diff(t) -
+                                   sin(phi)*theta.diff(t))
+    assert A_w_B.args[0][0][2] == cos(theta)*psi.diff(t) + phi.diff(t)
+
 
 def test_orient_space():
     A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -473,6 +473,26 @@ def test_orient_body():
     B.orient_body_fixed(A, (1,1,0), 'XYX')
     assert B.dcm(A) == Matrix([[cos(1), sin(1)**2, -sin(1)*cos(1)], [0, cos(1), sin(1)], [sin(1), -sin(1)*cos(1), cos(1)**2]])
 
+
+def test_orient_body_simple_ang_vel():
+    """orient_body_fixed() uses kinematic_equations() internally and solves
+    those equations for the measure numbers of the angular velocity. This test
+    ensures that the simplest form of that linear system solution is
+    returned."""
+
+    psi, theta, phi = dynamicsymbols('psi, theta, varphi')
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    B.orient_body_fixed(A, (psi, theta, phi), 'ZXZ')
+    A_w_B = B.ang_vel_in(A)
+    mx = A_w_B.args[0][0][0]
+    my = A_w_B.args[0][0][1]
+    mz = A_w_B.args[0][0][2]
+    assert A_w_B.args[0][1] == B
+    assert mx.count_ops() <= 15
+    assert my.count_ops() <= 15
+    assert mz.count_ops() <= 9
+
 def test_orient_space():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23130


#### Brief description of what is fixed or changed

`solve()` used `simplify()` internally when solving linear equations prior to SymPy 1.7 (see https://github.com/sympy/sympy/issues/23140). `ReferenceFrame.orient()` (and now `ReferenceFrame.orient_body_fixed()`) relied on this behavior to return the simplest statements for the angular velocities. This restores that behavior.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Restored pre-1.7 simplest form for body fixed angular velocities.
<!-- END RELEASE NOTES -->
