### PR TITLE
Changed physics Vector.magnitude() to return the correct Euclidean 2-norm

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
@@ -32,11 +32,12 @@ mass of the pendulum, as well as gravity and time. ::
   >>> # Create generalized coordinates and speeds for this non-minimal realization
   >>> # q1, q2 = N.x and N.y coordinates of pendulum
   >>> # u1, u2 = N.x and N.y velocities of pendulum
-  >>> q1, q2 = dynamicsymbols('q1:3')
-  >>> q1d, q2d = dynamicsymbols('q1:3', level=1)
-  >>> u1, u2 = dynamicsymbols('u1:3')
-  >>> u1d, u2d = dynamicsymbols('u1:3', level=1)
-  >>> L, m, g, t = symbols('L, m, g, t')
+  >>> q1, q2 = dynamicsymbols('q1:3', real=True)
+  >>> q1d, q2d = dynamicsymbols('q1:3', level=1, real=True)
+  >>> u1, u2 = dynamicsymbols('u1:3', real=True)
+  >>> u1d, u2d = dynamicsymbols('u1:3', level=1, real=True)
+  >>> L, m, g = symbols('L, m, g', real=True)
+  >>> t = dynamicsymbols('t')
 
 Next, we create a world coordinate frame `N`, and its origin point `N^*`. The
 velocity of the origin is set to 0. A second coordinate frame `A` is oriented

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -1,6 +1,7 @@
 __all__ = ['Linearizer']
 
 from sympy.core.backend import Matrix, eye, zeros
+from sympy.core.symbol import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import msubs
@@ -82,14 +83,10 @@ class Linearizer:
         # qd and u vectors have any intersecting variables, this can cause
         # problems. We'll fix this with some hackery, and Dummy variables
         dup_vars = set(self._qd).intersection(self.u)
-        mat_list = []
-        for var in self._qd:
-            if var not in dup_vars:
-                mat_list.append(var)
-            else:
-                print('dummy')
-                mat_list.append(var.as_dummy())
-        self._qd_dup = Matrix(mat_list)
+        # TODO : Dummy() does not have the same assumptions as the variable it
+        # replaces.
+        self._qd_dup = Matrix([var if var not in dup_vars else Dummy()
+            for var in self._qd])
 
         # Derive dimesion terms
         l = len(self.f_c)

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -83,8 +83,14 @@ class Linearizer:
         # qd and u vectors have any intersecting variables, this can cause
         # problems. We'll fix this with some hackery, and Dummy variables
         dup_vars = set(self._qd).intersection(self.u)
-        self._qd_dup = Matrix([var if var not in dup_vars else Dummy()
-            for var in self._qd])
+        mat_list = []
+        for var in self._qd:
+            if var not in dup_vars:
+                mat_list.append(var)
+            else:
+                print('dummy')
+                mat_list.append(var.as_dummy())
+        self._qd_dup = Matrix(mat_list)
 
         # Derive dimesion terms
         l = len(self.f_c)

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -1,7 +1,6 @@
 __all__ = ['Linearizer']
 
 from sympy.core.backend import Matrix, eye, zeros
-from sympy.core.symbol import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import msubs

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -181,7 +181,7 @@ def test_pinjoint_arbitrary_axis():
                                [0, -sin(theta), cos(theta)]])
     assert A.ang_vel_in(N) == omega*N.x
     assert A.ang_vel_in(N).express(A) == omega * A.y
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     angle = A.ang_vel_in(N).angle_between(A.y)
     assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N) == omega*A.z

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -1,7 +1,8 @@
 from sympy.core.function import expand_mul
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions.elementary.miscellaneous import sqrt, Abs
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
 from sympy.core.backend import _simplify_matrix

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -201,7 +201,7 @@ def test_pinjoint_arbitrary_axis():
                                [sin(theta), 0, cos(theta)]])
     assert A.ang_vel_in(N) == omega*N.y
     assert A.ang_vel_in(N).express(A) == omega*A.x
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     angle = A.ang_vel_in(N).angle_between(A.x)
     assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == - omega*N.z
@@ -220,7 +220,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N) == omega*N.x
     assert (A.ang_vel_in(N).express(A).simplify() ==
             (omega*A.x + omega*A.y)/sqrt(2))
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     angle = A.ang_vel_in(N).angle_between(A.x + A.y)
     assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == (omega * A.z)/sqrt(2)
@@ -247,7 +247,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N) == omega*N.x
     assert A.ang_vel_in(N).express(A).simplify() == (omega*A.x + omega*A.y -
                                                      omega*A.z)/sqrt(3)
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     angle = A.ang_vel_in(N).angle_between(A.x + A.y-A.z)
     assert angle.xreplace({omega: 1}) == 0
     assert C.masscenter.vel(N).simplify() == (omega*A.y + omega*A.z)/sqrt(3)
@@ -279,7 +279,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N) == (omega*N.x - omega*N.y + omega*N.z)/sqrt(3)
     assert A.ang_vel_in(N).express(A).simplify() == (omega*A.x + omega*A.y -
                                                      omega*A.z)/sqrt(3)
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     angle = A.ang_vel_in(N).angle_between(A.x+A.y-A.z)
     assert angle.xreplace({omega: 1}) == 0
     assert (C.masscenter.vel(N).simplify() ==

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -1,7 +1,7 @@
 from sympy.core.function import expand_mul
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, Abs
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
 from sympy.core.backend import _simplify_matrix
@@ -163,7 +163,7 @@ def test_pinjoint_arbitrary_axis():
                             [0, -cos(theta), -sin(theta)],
                             [0, -sin(theta), cos(theta)]])
     assert A.ang_vel_in(N) == omega*N.x
-    assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
+    assert A.ang_vel_in(N).magnitude() == Abs(omega)
     assert C.masscenter.pos_from(P.masscenter) == 0
     assert C.masscenter.pos_from(P.masscenter).express(N).simplify() == 0
     assert C.masscenter.vel(N) == 0

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -172,11 +172,11 @@ def test_linearize_pendulum_kane_nonminimal():
     # Create generalized coordinates and speeds for this non-minimal realization
     # q1, q2 = N.x and N.y coordinates of pendulum
     # u1, u2 = N.x and N.y velocities of pendulum
-    q1, q2 = dynamicsymbols('q1:3')
-    q1d, q2d = dynamicsymbols('q1:3', level=1)
-    u1, u2 = dynamicsymbols('u1:3')
-    u1d, u2d = dynamicsymbols('u1:3', level=1)
-    L, m, t = symbols('L, m, t')
+    q1, q2 = dynamicsymbols('q1:3', real=True)
+    q1d, q2d = dynamicsymbols('q1:3', level=1, real=True)
+    u1, u2 = dynamicsymbols('u1:3', real=True)
+    u1d, u2d = dynamicsymbols('u1:3', level=1, real=True)
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
 
     # Compose world frame
@@ -229,7 +229,8 @@ def test_linearize_pendulum_kane_nonminimal():
     A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True,
                                  simplify=True)
 
-    assert A.expand() == Matrix([[0, 1], [-9.8/L, 0]])
+    assert A.expand() == Matrix([[0, 1],
+                                 [-9.8/L, 0]])
     assert B == Matrix([])
 
 def test_linearize_pendulum_lagrange_minimal():

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -176,7 +176,8 @@ def test_linearize_pendulum_kane_nonminimal():
     q1d, q2d = dynamicsymbols('q1:3', level=1, real=True)
     u1, u2 = dynamicsymbols('u1:3', real=True)
     u1d, u2d = dynamicsymbols('u1:3', level=1, real=True)
-    L, m, t = symbols('L, m, t', real=True)
+    L, m = symbols('L, m', real=True)
+    t = dynamicsymbols._t
     g = 9.8
 
     # Compose world frame

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -930,7 +930,7 @@ class ReferenceFrame:
 
         >>> from sympy import symbols
         >>> from sympy.physics.vector import ReferenceFrame
-        >>> q1, q2, q3 = symbols('q1, q2, q3')
+        >>> q1, q2, q3 = symbols('q1, q2, q3', real=True)
         >>> N = ReferenceFrame('N')
         >>> B = ReferenceFrame('B')
         >>> B1 = ReferenceFrame('B1')

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,6 @@
-from sympy.core.backend import (S, sympify, expand, Add, zeros, acos,
+from sympy.core.backend import (S, sympify, expand, Add, zeros, acos, sqrt,
                                 ImmutableMatrix as Matrix, _simplify_matrix)
+from sympy.functions.elementary.complexes import Abs
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -696,7 +697,11 @@ class Vector(Printable, EvalfMixin):
 
         """
         if self.args:
-            return self.to_matrix(self.args[0][1]).norm()
+            col_vec = self.to_matrix(self.args[0][1])
+            summ = S(0)
+            for component in col_vec[:]:
+                summ += Abs(component)**2
+            return sqrt(summ)
         else:  # self is a vector of zero length
             return S(0)
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -689,7 +689,7 @@ class Vector(Printable, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy import symbols
+        >>> from sympy import symbols, sqrt
         >>> from sympy.physics.vector import ReferenceFrame
         >>> A = ReferenceFrame('A')
         >>> (1*A.x + 2*A.y + 3*A.z).magnitude()

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros, acos,
+from sympy.core.backend import (S, sympify, expand, Add, zeros, acos,
                                 ImmutableMatrix as Matrix, _simplify_matrix)
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -695,7 +695,10 @@ class Vector(Printable, EvalfMixin):
         instead of ``(-A.x).magnitude()``.
 
         """
-        return sqrt(self & self)
+        if self.args:
+            return self.to_matrix(self.args[0][1]).norm()
+        else:  # self is a vector of zero length
+            return S(0)
 
     def normalize(self):
         """Returns a Vector of magnitude 1, codirectional with self."""

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,5 @@
 from sympy.core.backend import (S, sympify, expand, Add, zeros, acos, sqrt,
                                 ImmutableMatrix as Matrix, _simplify_matrix)
-from sympy.functions.elementary.complexes import Abs
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -685,22 +684,49 @@ class Vector(Printable, EvalfMixin):
         return Vector(d)
 
     def magnitude(self):
-        """Returns the magnitude (Euclidean norm) of self.
+        """Returns the magnitude (Euclidean 2-norm) of the vector.
+
+        Examples
+        ========
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> A = ReferenceFrame('A')
+        >>> (1*A.x + 2*A.y + 3*A.z).magnitude()
+        sqrt(14)
+        >>> a, b, c = symbols('a, b, c')
+        >>> (a*A.x + b*A.y + c*A.z).magnitude()
+        sqrt(Abs(a)**2 + Abs(b)**2 + Abs(c)**2)
+
+        SymPy assumes all symbols are complex valued, so you'll need to apply
+        the ``real`` assumption to get the expected result when using
+        magnitude:
+
+        >>> a, b, c = symbols('a, b, c', real=True)
+        >>> (a*A.x + b*A.y + c*A.z).magnitude()
+        sqrt(a**2 + b**2 + c**2)
+
+        This is a vector of length ``a`` but ``a`` can be any real number,
+        positive, negative, or zero. So the magnitude retains the absolute
+        value:
+
+        >>> v = a*sqrt(2)/2*A.x + a*sqrt(2)/2*A.y
+        >>> v.magnitude()
+        Abs(a)
 
         Warnings
         ========
 
-        Python ignores the leading negative sign so that might
-        give wrong results.
-        ``-A.x.magnitude()`` would be treated as ``-(A.x.magnitude())``,
-        instead of ``(-A.x).magnitude()``.
+        Python ignores the leading negative sign so that might give wrong
+        results. ``-A.x.magnitude()`` would be treated as
+        ``-(A.x.magnitude())``, instead of ``(-A.x).magnitude()``.
 
         """
         if self.args:
             col_vec = self.to_matrix(self.args[0][1])
             summ = S(0)
             for component in col_vec[:]:
-                summ += Abs(component)**2
+                summ += abs(component)**2
             return sqrt(summ)
         else:  # self is a vector of zero length
             return S(0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23173

#### Brief description of what is fixed or changed

`Vector.magnitude()` now returns the correct result for a three dimensional 2-norm. The prior implementation was a naive one that doesn't calculate the proper mathematic norm.

#### Other comments

This is breaking a test in the linearizer and I'm not yet sure why. It will take some more digging.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Vector.magnitude() now returns the correct results. Previously a naive 2-norm calculation was used that fails to give the mathematically correct magnitude.
<!-- END RELEASE NOTES -->
