### PR TITLE
Add refine for Abs

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -694,6 +694,19 @@ class Abs(Function):
     def _eval_rewrite_as_conjugate(self, arg, **kwargs):
         return sqrt(arg*conjugate(arg))
 
+    def _eval_refine(self, assumptions, **kwargs):
+        from sympy.assumptions.ask import ask
+        q = ask(self.args[0] >= 0, assumptions)
+        if q is True:
+            return self.args[0]
+        if q is False:
+            return -self.args[0]
+        q = ask(self.args[0] <= 0, assumptions)
+        if q is True:
+            return -self.args[0]
+        if q is False:
+            return self.args[0]
+
 
 class arg(Function):
     r"""

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -975,6 +975,14 @@ def test_issue_6167_6151():
         assert sign(e.subs(x, xi)) == 1
 
 
+def test_refine_abs():
+    x = Symbol('x', real=True)
+    assert Abs(x).refine(x > 0) == x
+    assert Abs(x).refine(x >= 0) == x
+    assert Abs(x).refine(x < 0) == -x
+    assert Abs(x).refine(x <= 0) == -x
+
+
 def test_issue_14216():
     from sympy.functions.elementary.complexes import unpolarify
     A = MatrixSymbol("A", 2, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #23164

#### Brief description of what is fixed or changed

Add basic refine functionality for Abs.

#### Other comments

Things like `ask(x >= 0, x >= 1)` do not work, but once that is operational, this will probably sort out #23164. Also `Abs(x).refine(Q.ge(x, 1))` does not simplify.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
   * Basic refine functionality for `Abs`.
<!-- END RELEASE NOTES -->
