### PR TITLE
Fix type inconsistency inside symbols

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .assumptions import StdFactKB, _assume_defined
 from .basic import Basic, Atom
 from .cache import cacheit
@@ -17,6 +19,8 @@ import string
 import re as _re
 import random
 from itertools import product
+from typing import Any
+
 
 class Str(Atom):
     """
@@ -577,7 +581,8 @@ class Wild(Symbol):
 
 _range = _re.compile('([0-9]*:[0-9]+|[a-zA-Z]?:[a-zA-Z])')
 
-def symbols(names, *, cls=Symbol, **args):
+
+def symbols(names, *, cls=Symbol, **args) -> Any:
     r"""
     Transform strings into instances of :class:`Symbol` class.
 
@@ -697,16 +702,16 @@ def symbols(names, *, cls=Symbol, **args):
 
     if isinstance(names, str):
         marker = 0
-        literals = [r'\,', r'\:', r'\ ']
-        for i in range(len(literals)):
-            lit = literals.pop(0)
-            if lit in names:
+        splitters = r'\,', r'\:', r'\ '
+        literals: list[tuple[str, str]] = []
+        for splitter in splitters:
+            if splitter in names:
                 while chr(marker) in names:
                     marker += 1
                 lit_char = chr(marker)
                 marker += 1
-                names = names.replace(lit, lit_char)
-                literals.append((lit_char, lit[1:]))
+                names = names.replace(splitter, lit_char)
+                literals.append((lit_char, splitter[1:]))
         def literal(s):
             if literals:
                 for c, l in literals:
@@ -739,7 +744,8 @@ def symbols(names, *, cls=Symbol, **args):
                 result.append(symbol)
                 continue
 
-            split = _range.split(name)
+            split: list[str] = _range.split(name)
+            split_list: list[list[str]] = []
             # remove 1 layer of bounding parentheses around ranges
             for i in range(len(split) - 1):
                 if i and ':' in split[i] and split[i] != ':' and \
@@ -747,30 +753,30 @@ def symbols(names, *, cls=Symbol, **args):
                         split[i + 1].startswith(')'):
                     split[i - 1] = split[i - 1][:-1]
                     split[i + 1] = split[i + 1][1:]
-            for i, s in enumerate(split):
+            for s in split:
                 if ':' in s:
-                    if s[-1].endswith(':'):
+                    if s.endswith(':'):
                         raise ValueError('missing end range')
                     a, b = s.split(':')
                     if b[-1] in string.digits:
-                        a = 0 if not a else int(a)
-                        b = int(b)
-                        split[i] = [str(c) for c in range(a, b)]
+                        a_i = 0 if not a else int(a)
+                        b_i = int(b)
+                        split_list.append([str(c) for c in range(a_i, b_i)])
                     else:
                         a = a or 'a'
-                        split[i] = [string.ascii_letters[c] for c in range(
+                        split_list.append([string.ascii_letters[c] for c in range(
                             string.ascii_letters.index(a),
-                            string.ascii_letters.index(b) + 1)]  # inclusive
-                    if not split[i]:
+                            string.ascii_letters.index(b) + 1)])  # inclusive
+                    if not split_list[-1]:
                         break
                 else:
-                    split[i] = [s]
+                    split_list.append([s])
             else:
                 seq = True
-                if len(split) == 1:
-                    names = split[0]
+                if len(split_list) == 1:
+                    names = split_list[0]
                 else:
-                    names = [''.join(s) for s in product(*split)]
+                    names = [''.join(s) for s in product(*split_list)]
                 if literals:
                     result.extend([cls(literal(s), **args) for s in names])
                 else:

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -27,8 +27,7 @@ from sympy.tensor.array.array_derivatives import ArrayDerivative
 from sympy.matrices.expressions import hadamard_power
 from sympy.tensor.array.expressions.array_expressions import ArrayAdd, ArrayTensorProduct, PermuteDims
 
-k = symbols("k")
-i, j = symbols("i j")
+i, j, k = symbols("i j k")
 m, n = symbols("m n")
 
 X = MatrixSymbol("X", k, k)

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -550,7 +550,7 @@ class BinaryQuadratic(DiophantineEquationType):
                 sqc = isqrt(c)
                 _c = e*sqc*D - sqa*E
                 if not _c:
-                    z = symbols("z", real=True)
+                    z = Symbol("z", real=True)
                     eq = sqa*g*z**2 + D*z + sqa*F
                     roots = solveset_real(eq, z).intersect(S.Integers)
                     for root in roots:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #22180

#### Brief description of what is fixed or changed
Add type hints to `symbols`.
It's **impossible** to add type hints to it **accurately**, since return type depends on whether there are `,` and ` ` in `names`.
However, in most use cases, we call it using string literal. (Imagine calling `res = symbols(s)` when `s` is a string var, then check whether `res` is a tuple or a `Symbol`.) So we know how many `Symbol`s we want.
If we want only one symbol, we can just write `x = Symbol('x')` or `x, = symbols('x,')` or even `x, = symbols('x', seq=True)`. There is really no need for writing `x = symbols('x')` in sympy code base. For downstream users, we can give them choice: either receive type hints from `symbols`, or still using `x = symbols('x')` without being broken and without correct type hints.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
