### PR TITLE
Preserve original return value in patched run_cell

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1306,6 +1306,7 @@ symbolique <symbolique@users.noreply.github.com>
 tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bg>
 tnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
+user202729 <25191436+user202729@users.noreply.github.com>
 vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -153,7 +153,7 @@ def enable_automatic_int_sympification(shell):
             pass
         else:
             cell = int_to_Integer(cell)
-        old_run_cell(cell, *args, **kwargs)
+        return old_run_cell(cell, *args, **kwargs)
 
     shell.run_cell = my_run_cell
 


### PR DESCRIPTION
Fixes #23183.

See the linked issue for explanation.

<!-- BEGIN RELEASE NOTES -->
* interactive
  * Allow `auto_int_to_Integer` to be used with `jupyter console`
<!-- END RELEASE NOTES -->
