### PR TITLE
Fixes print order of sympy.vector object.

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1147,7 +1147,9 @@ class PrettyPrinter(Printer):
                 if '\N{right parenthesis extension}' in tempstr:   # If scalar is a fraction
                     for paren in range(len(tempstr)):
                         flag[i] = 1
-                        if tempstr[paren] == '\N{right parenthesis extension}':
+                        if tempstr[paren] == '\N{right parenthesis extension}' and tempstr[paren + 1] == '\n':
+                            # We want to place the vector string after all the right parentheses, because
+                            # otherwise, the vector will be in the middle of the string
                             tempstr = tempstr[:paren] + '\N{right parenthesis extension}'\
                                          + ' '  + vectstrs[i] + tempstr[paren + 1:]
                             break

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1147,10 +1147,10 @@ class PrettyPrinter(Printer):
                 if '\N{RIGHT PARENTHESIS EXTENSION}' in tempstr:   # If scalar is a fraction
                     for paren in range(len(tempstr)):
                         flag[i] = 1
-                        if tempstr[paren] == '\N{right parenthesis extension}' and tempstr[paren + 1] == '\n':
+                        if tempstr[paren] == '\N{RIGHT PARENTHESIS EXTENSION}' and tempstr[paren + 1] == '\n':
                             # We want to place the vector string after all the right parentheses, because
                             # otherwise, the vector will be in the middle of the string
-                            tempstr = tempstr[:paren] + '\N{right parenthesis extension}'\
+                            tempstr = tempstr[:paren] + '\N{RIGHT PARENTHESIS EXTENSION}'\
                                          + ' '  + vectstrs[i] + tempstr[paren + 1:]
                             break
                 elif '\N{RIGHT PARENTHESIS LOWER HOOK}' in tempstr:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1144,7 +1144,7 @@ class PrettyPrinter(Printer):
             if '\n' in partstr:
                 tempstr = partstr
                 tempstr = tempstr.replace(vectstrs[i], '')
-                if '\N{right parenthesis extension}' in tempstr:   # If scalar is a fraction
+                if '\N{RIGHT PARENTHESIS EXTENSION}' in tempstr:   # If scalar is a fraction
                     for paren in range(len(tempstr)):
                         flag[i] = 1
                         if tempstr[paren] == '\N{right parenthesis extension}' and tempstr[paren + 1] == '\n':
@@ -1154,14 +1154,20 @@ class PrettyPrinter(Printer):
                                          + ' '  + vectstrs[i] + tempstr[paren + 1:]
                             break
                 elif '\N{RIGHT PARENTHESIS LOWER HOOK}' in tempstr:
-                    flag[i] = 1
-                    tempstr = tempstr.replace('\N{RIGHT PARENTHESIS LOWER HOOK}',
-                                        '\N{RIGHT PARENTHESIS LOWER HOOK}'
-                                        + ' ' + vectstrs[i])
+                    # We want to place the vector string after all the right parentheses, because
+                    # otherwise, the vector will be in the middle of the string. For this reason,
+                    # we insert the vector string at the rightmost index.
+                    index = tempstr.rfind('\N{RIGHT PARENTHESIS LOWER HOOK}')
+                    if index != -1: # then this character was found in this string
+                        flag[i] = 1
+                        tempstr = tempstr[:index] + '\N{RIGHT PARENTHESIS LOWER HOOK}'\
+                                     + ' '  + vectstrs[i] + tempstr[index + 1:]
                 else:
-                    tempstr = tempstr.replace('\N{RIGHT PARENTHESIS UPPER HOOK}',
-                                        '\N{RIGHT PARENTHESIS UPPER HOOK}'
-                                        + ' ' + vectstrs[i])
+                    index = tempstr.rfind('\N{RIGHT PARENTHESIS UPPER HOOK}')
+                    if index != -1: # then this character was found in this string
+                        flag[i] = 1
+                        tempstr = tempstr[:index] + '\N{RIGHT PARENTHESIS UPPER HOOK}'\
+                                     + ' '  + vectstrs[i] + tempstr[index + 1:]
                 o1[i] = tempstr
 
         o1 = [x.split('\n') for x in o1]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1162,12 +1162,6 @@ class PrettyPrinter(Printer):
                         flag[i] = 1
                         tempstr = tempstr[:index] + '\N{RIGHT PARENTHESIS LOWER HOOK}'\
                                      + ' '  + vectstrs[i] + tempstr[index + 1:]
-                else:
-                    index = tempstr.rfind('\N{RIGHT PARENTHESIS UPPER HOOK}')
-                    if index != -1: # then this character was found in this string
-                        flag[i] = 1
-                        tempstr = tempstr[:index] + '\N{RIGHT PARENTHESIS UPPER HOOK}'\
-                                     + ' '  + vectstrs[i] + tempstr[index + 1:]
                 o1[i] = tempstr
 
         o1 = [x.split('\n') for x in o1]

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -161,7 +161,7 @@ def test_latex_printing():
                             '\\hat{k}_{N}}\\right)')
 
 def test_issue_23058():
-    from sympy import symbols, sin, cos, pi
+    from sympy import symbols, sin, cos, pi, UnevaluatedExpr
 
     delop = Del()
     CC_   = CoordSys3D("C")
@@ -184,17 +184,31 @@ def test_issue_23058():
 ⎜     ⎝10 ⎠           ⎟    \n\
 ⎜─────────────────────⎟    \n\
 ⎜           4         ⎟    \n\
-⎝         10          ⎠    """
+⎝         10          ⎠    \
+"""
     vecE_str = """\
 ⎛   4    ⎛  5  ⎞    ⎛y_C⎞ ⎞    \n\
 ⎜-10 ⋅sin⎝10 ⋅t⎠⋅cos⎜───⎟ ⎟ k_C\n\
 ⎜                   ⎜  3⎟ ⎟    \n\
 ⎜                   ⎝10 ⎠ ⎟    \n\
 ⎜─────────────────────────⎟    \n\
-⎝           2⋅π           ⎠    """
+⎝           2⋅π           ⎠    \
+"""
 
     assert upretty(vecB) == vecB_str
     assert upretty(vecE) == vecE_str
+
+    ten = UnevaluatedExpr(10)
+    eps, mu = 4*pi*ten**(-11), ten**(-5)
+
+    Bx = 2 * ten**(-4) * cos(ten**5 * t) * sin(ten**(-3) * y)
+    vecB = Bx * xhat
+
+    vecB_str = """\
+⎛    -4    ⎛    5⎞    ⎛      -3⎞⎞     \n\
+⎝2⋅10  ⋅cos⎝t⋅10 ⎠⋅sin⎝y_C⋅10  ⎠⎠ i_C \
+"""
+    assert upretty(vecB) == vecB_str
 
 def test_custom_names():
     A = CoordSys3D('A', vector_names=['x', 'y', 'z'],

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -3,7 +3,7 @@ from sympy.core.function import Function
 from sympy.integrals.integrals import Integral
 from sympy.printing.latex import latex
 from sympy.printing.pretty import pretty as xpretty
-from sympy.vector import CoordSys3D, Vector, express
+from sympy.vector import CoordSys3D, Del, Vector, express
 from sympy.abc import a, b, c
 from sympy.testing.pytest import XFAIL
 
@@ -160,6 +160,41 @@ def test_latex_printing():
                             '\\mathbf{\\hat{k}_{N}}{\\middle|}\\mathbf{' +
                             '\\hat{k}_{N}}\\right)')
 
+def test_issue_23058():
+    from sympy import symbols, sin, cos, pi
+
+    delop = Del()
+    CC_   = CoordSys3D("C")
+    y     = CC_.y
+    xhat  = CC_.i
+
+    t = symbols("t")
+    ten = symbols("10", positive=True)
+    eps, mu = 4*pi*ten**(-11), ten**(-5)
+
+    Bx = 2 * ten**(-4) * cos(ten**5 * t) * sin(ten**(-3) * y)
+    vecB = Bx * xhat
+    vecE = (1/eps) * Integral(delop.cross(vecB/mu).doit(), t)
+    vecE = vecE.doit()
+
+    vecB_str = """\
+⎛     ⎛y_C⎞    ⎛  5  ⎞⎞    \n\
+⎜2⋅sin⎜───⎟⋅cos⎝10 ⋅t⎠⎟ i_C\n\
+⎜     ⎜  3⎟           ⎟    \n\
+⎜     ⎝10 ⎠           ⎟    \n\
+⎜─────────────────────⎟    \n\
+⎜           4         ⎟    \n\
+⎝         10          ⎠    """
+    vecE_str = """\
+⎛   4    ⎛  5  ⎞    ⎛y_C⎞ ⎞    \n\
+⎜-10 ⋅sin⎝10 ⋅t⎠⋅cos⎜───⎟ ⎟ k_C\n\
+⎜                   ⎜  3⎟ ⎟    \n\
+⎜                   ⎝10 ⎠ ⎟    \n\
+⎜─────────────────────────⎟    \n\
+⎝           2⋅π           ⎠    """
+
+    assert upretty(vecB) == vecB_str
+    assert upretty(vecE) == vecE_str
 
 def test_custom_names():
     A = CoordSys3D('A', vector_names=['x', 'y', 'z'],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23058 

#### Brief description of what is fixed or changed
The algorithm for placing the vector string assumed that there was only one pair of parentheses and didn't account for the possibility of multiple pairs. I added support for multiple pairs of parentheses.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug in pretty_print, where sympy.vector objects were being incorrectly printed in certain cases.
<!-- END RELEASE NOTES -->
