### PR TITLE
Fix the URL printed by mailmap_check in the CI

### DIFF
--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -136,7 +136,8 @@ def main(*args):
     if problems:
         print(red(filldedent("""
         For instructions on updating the .mailmap file see:
-        https://github.com/sympy/sympy/wiki/Development-workflow#update-mailmap""")))
+        https://github.com/sympy/sympy/wiki/Development-workflow#update-mailmap""",
+                             break_on_hyphens=False, break_long_words=False)))
     else:
         print(green("No changes needed in .mailmap"))
 

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -136,7 +136,7 @@ def main(*args):
     if problems:
         print(red(filldedent("""
         For instructions on updating the .mailmap file see:
-        https://github.com/sympy/sympy/wiki/Development-workflow#update-mailmap""",
+        https://github.com/sympy/sympy/wiki/Development-workflow#add-your-name-and-email-address-to-the-mailmap-file""",
                              break_on_hyphens=False, break_long_words=False)))
     else:
         print(green("No changes needed in .mailmap"))

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -16,20 +16,23 @@ class Undecidable(ValueError):
     pass
 
 
-def filldedent(s, w=70):
+def filldedent(s, w=70, **kwargs):
     """
-    Strips leading and trailing empty lines from a copy of `s`, then dedents,
+    Strips leading and trailing empty lines from a copy of ``s``, then dedents,
     fills and returns it.
 
     Empty line stripping serves to deal with docstrings like this one that
     start with a newline after the initial triple quote, inserting an empty
     line at the beginning of the string.
 
+    Additional keyword arguments will be passed to ``textwrap.fill()``.
+
     See Also
     ========
     strlines, rawlines
+
     """
-    return '\n' + fill(dedent(str(s)).strip('\n'), width=w)
+    return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
 def strlines(s, c=64, short=False):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - Pass keyword arguments of `filldedent()` through to `textwrap.fill()`.
<!-- END RELEASE NOTES -->
