### PR TITLE
printing/lambdarepr: NumExprPrinter can make use of codegen AST

### DIFF
--- a/sympy/codegen/pynodes.py
+++ b/sympy/codegen/pynodes.py
@@ -1,4 +1,11 @@
 from .abstract_nodes import List as AbstractList
+from .ast import Token
+
 
 class List(AbstractList):
     pass
+
+
+class NumExprEvaluate(Token):
+    """represents a call to `numexpr`s `evaluate`"""
+    __slots__ = ('expr',)

--- a/sympy/codegen/pynodes.py
+++ b/sympy/codegen/pynodes.py
@@ -7,5 +7,5 @@ class List(AbstractList):
 
 
 class NumExprEvaluate(Token):
-    """represents a call to `numexpr`s `evaluate`"""
+    """represents a call to :class:`numexpr`s :func:`evaluate`"""
     __slots__ = ('expr',)

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -487,6 +487,11 @@ def test_sympy__codegen__pynodes__List():
     assert _test_args(List(1, 2, 3))
 
 
+def test_sympy__codegen__pynodes__NumExprEvaluate():
+    from sympy.codegen.pynodes import NumExprEvaluate
+    assert _test_args(NumExprEvaluate(x))
+
+
 def test_sympy__codegen__scipy_nodes__cosm1():
     from sympy.codegen.scipy_nodes import cosm1
     assert _test_args(cosm1(x))

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -206,8 +206,17 @@ def test_numexpr():
     from sympy.logic.boolalg import ITE
     expr = ITE(x > 0, True, False, evaluate=False)
     assert NumExprPrinter().doprint(expr) == \
-           "evaluate('where((x > 0), True, False)', truediv=True)"
+           "numexpr.evaluate('where((x > 0), True, False)', truediv=True)"
 
+    from sympy.codegen.ast import Return, FunctionDefinition, Variable, Assignment
+    func_def = FunctionDefinition(None, 'foo', [Variable(x)], [Assignment(y,x), Return(y**2)])
+    print("")
+    print(NumExprPrinter().doprint(func_def))
+    expected = "def foo(x):\n"\
+               "    y = numexpr.evaluate('x', truediv=True)\n"\
+               "    return numexpr.evaluate('y**2', truediv=True)"
+    print(expected)
+    assert NumExprPrinter().doprint(func_def) == expected
 
 class CustomPrintedObject(Expr):
     def _lambdacode(self, printer):
@@ -233,7 +242,7 @@ def test_printmethod():
     obj = CustomPrintedObject()
     assert LambdaPrinter().doprint(obj) == 'lambda'
     assert TensorflowPrinter().doprint(obj) == 'tensorflow'
-    assert NumExprPrinter().doprint(obj) == "evaluate('numexpr', truediv=True)"
+    assert NumExprPrinter().doprint(obj) == "numexpr.evaluate('numexpr', truediv=True)"
 
     assert NumExprPrinter().doprint(Piecewise((y, x >= 0), (z, x < 0))) == \
-            "evaluate('where((x >= 0), y, z)', truediv=True)"
+            "numexpr.evaluate('where((x >= 0), y, z)', truediv=True)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The `NumExprPrinter` can now make use of codegen AST object as it
will no longer embed those inside `evaluate`, instead, it will embed
expressions inside codegen AST objects within `evaluate`. Additionally,
`evaluate` is now correctly added to `module_imports` and respects
the `fully_qualified_modules` keyword in the printer options.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `NumExprPrinter` now handles codegen AST objects.
<!-- END RELEASE NOTES -->
