### PR TITLE
Add int return types

### DIFF
--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -422,7 +422,7 @@ class DiagramGrid:
                 if len([e for e in tri if skeleton[e]]) >= 2]
 
     @staticmethod
-    def _morphism_length(morphism):
+    def _morphism_length(morphism) -> int:
         """
         Returns the length of a morphism.  The length of a morphism is
         the number of components it consists of.  A non-composite

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1157,6 +1157,14 @@ class _SizedIntType(IntBaseType):
         if value > self.max:
             raise ValueError("Value is too big: %d > %d" % (value, self.max))
 
+    @property
+    def max(self) -> int:
+        raise NotImplementedError()
+
+    @property
+    def min(self) -> int:
+        raise NotImplementedError()
+
 
 class SignedIntType(_SizedIntType):
     """ Represents a signed integer type. """

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -107,7 +107,7 @@ class CosetTable(DefaultPrinting):
     __repr__ = __str__
 
     @property
-    def n(self):
+    def n(self) -> int:
         """The number `n` represents the length of the sublist containing the
         live cosets.
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -226,7 +226,7 @@ def _literal_float(f):
 # TODO caching with decorator, but not to degrade performance
 
 @lru_cache(1024)
-def igcd(*args):
+def igcd(*args) -> int:
     """Computes nonnegative integer greatest common divisor.
 
     Explanation
@@ -269,7 +269,7 @@ def igcd(*args):
 igcd2 = math.gcd
 
 
-def igcd_lehmer(a, b):
+def igcd_lehmer(a, b) -> int:
     r"""Computes greatest common divisor of two integers.
 
     Explanation

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -98,7 +98,7 @@ class factorial(CombinatorialFunction):
     _small_factorials = []  # type: List[int]
 
     @classmethod
-    def _swing(cls, n):
+    def _swing(cls, n) -> int:
         if n < 33:
             return cls._small_swing[n]
         else:
@@ -134,7 +134,7 @@ class factorial(CombinatorialFunction):
             return L_product*R_product
 
     @classmethod
-    def _recursive(cls, n):
+    def _recursive(cls, n) -> int:
         if n < 2:
             return 1
         else:
@@ -173,7 +173,7 @@ class factorial(CombinatorialFunction):
 
                     return Integer(result)
 
-    def _facmod(self, n, q):
+    def _facmod(self, n, q) -> int:
         res, N = 1, int(_sqrt(n))
 
         # Exponent of prime p in n! is e_p(n) = [n/p] + [n/p**2] + ...

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -6,11 +6,11 @@ sequences of rational numbers such as Bernoulli and Fibonacci numbers.
 Factorials, binomial coefficients and related functions are located in
 the separate 'factorials' module.
 """
-
+from __future__ import annotations
 from collections import defaultdict
 from typing import Callable, Dict as tDict, Tuple as tTuple
 
-from sympy.core import S, Symbol, Add, Dummy
+from sympy.core import S, Symbol, Add, Dummy, Basic
 from sympy.core.cache import cacheit
 from sympy.core.evalf import pure_complex
 from sympy.core.expr import Expr
@@ -1454,7 +1454,7 @@ def _multiset_histogram(n):
         return _multiset_histogram(d)
 
 
-def nP(n, k=None, replacement=False):
+def nP(n, k=None, replacement=False) -> Integer:
     """Return the number of permutations of ``n`` items taken ``k`` at a time.
 
     Possible values for ``n``:
@@ -1521,7 +1521,7 @@ def nP(n, k=None, replacement=False):
 
 
 @cacheit
-def _nP(n, k=None, replacement=False):
+def _nP(n, k=None, replacement=False) -> int | Basic | None:
 
     if k == 0:
         return 1
@@ -1571,6 +1571,7 @@ def _nP(n, k=None, replacement=False):
                     n[i] += 1
                 n[_N] += 1
             return tot
+    return None
 
 
 @cacheit
@@ -1719,7 +1720,7 @@ def nC(n, k=None, replacement=False):
         return nC(_multiset_histogram(n), k, replacement)
 
 
-def _eval_stirling1(n, k):
+def _eval_stirling1(n, k) -> Basic:
     if n == k == 0:
         return S.One
     if 0 in (n, k):
@@ -1739,7 +1740,7 @@ def _eval_stirling1(n, k):
 
 
 @cacheit
-def _stirling1(n, k):
+def _stirling1(n, k) -> Integer:
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
         for j in range(min(k,i), 0, -1):
@@ -1747,7 +1748,7 @@ def _stirling1(n, k):
     return Integer(row[k])
 
 
-def _eval_stirling2(n, k):
+def _eval_stirling2(n, k) -> Basic:
     if n == k == 0:
         return S.One
     if 0 in (n, k):
@@ -1767,7 +1768,7 @@ def _eval_stirling2(n, k):
 
 
 @cacheit
-def _stirling2(n, k):
+def _stirling2(n, k) -> Integer:
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
         for j in range(min(k,i), 0, -1):
@@ -1775,7 +1776,7 @@ def _stirling2(n, k):
     return Integer(row[k])
 
 
-def stirling(n, k, d=None, kind=2, signed=False):
+def stirling(n, k, d=None, kind=2, signed=False) -> Integer:
     r"""Return Stirling number $S(n, k)$ of the first or second (default) kind.
 
     The sum of all Stirling numbers of the second kind for $k = 1$
@@ -1884,7 +1885,7 @@ def stirling(n, k, d=None, kind=2, signed=False):
 
 
 @cacheit
-def _nT(n, k):
+def _nT(n, k) -> int:
     """Return the partitions of ``n`` items into ``k`` parts. This
     is used by ``nT`` for the case when ``n`` is an integer."""
     # really quick exits
@@ -1927,7 +1928,7 @@ def _nT(n, k):
     return (1 + sum(p[1 - k:]))
 
 
-def nT(n, k=None):
+def nT(n, k=None) -> int:
     """Return the number of ``k``-sized partitions of ``n`` items.
 
     Possible values for ``n``:
@@ -2094,7 +2095,7 @@ class motzkin(Function):
     """
 
     @staticmethod
-    def is_motzkin(n):
+    def is_motzkin(n) -> bool:
         try:
             n = as_int(n)
         except ValueError:
@@ -2121,7 +2122,7 @@ class motzkin(Function):
             return False
 
     @staticmethod
-    def find_motzkin_numbers_in_range(x, y):
+    def find_motzkin_numbers_in_range(x, y) -> list[int]:
         if 0 <= x <= y:
             motzkins = list()
             if x <= 1 <= y:
@@ -2143,7 +2144,7 @@ class motzkin(Function):
             raise ValueError('The provided range is not valid. This condition should satisfy x <= y')
 
     @staticmethod
-    def find_first_n_motzkins(n):
+    def find_first_n_motzkins(n) -> list[int]:
         try:
             n = as_int(n)
         except ValueError:
@@ -2181,7 +2182,7 @@ class motzkin(Function):
         return Integer(cls._motzkin(n - 1))
 
 
-def nD(i=None, brute=None, *, n=None, m=None):
+def nD(i=None, brute=None, *, n=None, m=None) -> Basic:
     """return the number of derangements for: ``n`` unique items, ``i``
     items (as a sequence or multiset), or multiplicities, ``m`` given
     as a sequence or multiset.
@@ -2228,7 +2229,7 @@ def nD(i=None, brute=None, *, n=None, m=None):
     from sympy.integrals.integrals import integrate
     from sympy.functions.special.polynomials import laguerre
     from sympy.abc import x
-    def ok(x):
+    def ok(x) -> bool:
         if not isinstance(x, SYMPY_INTS):
             raise TypeError('expecting integer values')
         if x < 0:

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -443,7 +443,7 @@ class KroneckerDelta(Function):
         else:
             return self.args[1]
 
-    def _get_preferred_index(self):
+    def _get_preferred_index(self) -> int:
         """
         Returns the index which is preferred to keep in the final expression.
 

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -247,7 +247,7 @@ class GeometryEntity(Basic, EvalfMixin):
         return self
 
     @property
-    def ambient_dimension(self):
+    def ambient_dimension(self) -> int:
         """What is the dimension of the space that the object is contained in?"""
         raise NotImplementedError()
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3446,7 +3446,7 @@ def simplify_univariate(expr):
 # Used in gateinputcount method
 BooleanGates = (And, Or, Xor, Nand, Nor, Not, Xnor, ITE)
 
-def gateinputcount(expr):
+def gateinputcount(expr) -> int:
     """
     Return the total number of inputs for the logic gates realizing the
     Boolean expression.

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -172,7 +172,7 @@ def _echelon_form(M, iszerofunc=_iszero, simplify=False, with_pivots=False):
 
 
 # This functions is a candidate for caching if it gets implemented for matrices.
-def _rank(M, iszerofunc=_iszero, simplify=False):
+def _rank(M, iszerofunc=_iszero, simplify=False) -> int:
     """Returns the rank of a matrix.
 
     Examples

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -196,7 +196,7 @@ def smoothness_p(n, m=-1, power=0, visual=None):
     return '\n'.join(lines)
 
 
-def trailing(n):
+def trailing(n) -> int:
     """Count the number of trailing zero digits in the binary
     representation of n, i.e. determine the largest power of 2
     that divides n.
@@ -245,7 +245,7 @@ def trailing(n):
     return t
 
 
-def multiplicity(p, n):
+def multiplicity(p, n) -> int:
     """
     Find the greatest integer m such that p**m divides n.
 
@@ -1633,7 +1633,7 @@ def divisors(n, generator=False, proper=False):
     return rv
 
 
-def divisor_count(n, modulus=1, proper=False):
+def divisor_count(n, modulus=1, proper=False) -> int:
     """
     Return the number of divisors of ``n``. If ``modulus`` is not 1 then only
     those that are divisible by ``modulus`` are counted. If ``proper`` is True

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -541,7 +541,7 @@ class primepi(Function):
         return S(arr2[1])
 
 
-def nextprime(n, ith=1):
+def nextprime(n, ith=1) -> int:
     """ Return the ith prime greater than n.
 
         i must be an integer.

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -967,7 +967,7 @@ if cin:
 
             return combined_variables_stack[-1][0]
 
-        def priority_of(self, op):
+        def priority_of(self, op) -> int:
             """To get the priority of given operator"""
             if op in ['=', '+=', '-=', '*=', '/=', '%=']:
                 return 1

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -504,7 +504,7 @@ Bd = CreateBoson
 class FermionicOperator(SqOperator):
 
     @property
-    def is_restricted(self):
+    def is_restricted(self) -> int:
         """
         Is this FermionicOperator restricted with respect to fermi level?
 
@@ -705,7 +705,7 @@ class AnnihilateFermion(FermionicOperator, Annihilator):
             return Mul(self, state)
 
     @property
-    def is_q_creator(self):
+    def is_q_creator(self) -> int:
         """
         Can we create a quasi-particle?  (create hole or create particle)
         If so, would that be above or below the fermi surface?

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -301,7 +301,7 @@ def lbp(signature, polynomial, number):
 # signature functions
 
 
-def sig_cmp(u, v, order):
+def sig_cmp(u, v, order) -> int:
     """
     Compare two signatures by extending the term order to K[X]^n.
 
@@ -373,7 +373,7 @@ def lbp_mul_term(f, cx):
     return lbp(sig_mult(Sign(f), cx[0]), Polyn(f).mul_term(cx), Num(f))
 
 
-def lbp_cmp(f, g):
+def lbp_cmp(f, g) -> int:
     """
     Compare two labeled polynomials.
 
@@ -438,7 +438,7 @@ def critical_pair(f, g, ring):
         return (Sign(fr), um, f, Sign(gr), vm, g)
 
 
-def cp_cmp(c, d):
+def cp_cmp(c, d) -> int:
     """
     Compare two critical pairs c and d.
 

--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -377,7 +377,7 @@ def _compute_test_factor(p, gens, ZK):
 
 
 @public
-def prime_valuation(I, P):
+def prime_valuation(I, P) -> int:
     r"""
     Compute the *P*-adic valuation for an integral ideal *I*.
 

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -549,7 +549,7 @@ def res(f, g, x):
     else:
         return sylvester(f, g, x, 1).det()
 
-def res_q(f, g, x):
+def res_q(f, g, x) -> int:
     """
     The input polynomials f, g are in Z[x] or in Q[x].
 
@@ -577,7 +577,7 @@ def res_q(f, g, x):
             l = LC(g, x)
             return (-1)**(m*n) * l**(m-s)*res_q(g, r, x)
 
-def res_z(f, g, x):
+def res_z(f, g, x) -> int:
     """
     The input polynomials f, g are in Z[x] or in Q[x].
 
@@ -1755,7 +1755,7 @@ def subresultants_amv_q(p, q, x):
 
     return  subres_l
 
-def compute_sign(base, expo):
+def compute_sign(base, expo) -> int:
     '''
     base != 0 and expo >= 0 are integers;
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1720,7 +1720,7 @@ def nc_simplify(expr, deep=True):
             inv_tot -= len(inverses) - 1
         return inv_tot, tuple(args)
 
-    def get_score(s):
+    def get_score(s) -> int:
         # compute the number of arguments of s
         # (including in nested expressions) overall
         # but ignore exponents

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -12,7 +12,7 @@ def is_sqrt(expr):
     return expr.is_Pow and expr.exp.is_Rational and abs(expr.exp) is S.Half
 
 
-def sqrt_depth(p):
+def sqrt_depth(p) -> int:
     """Return the maximum depth of any square root argument of p.
 
     >>> from sympy.functions.elementary.miscellaneous import sqrt

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -90,7 +90,7 @@ def _preprocess(expr, func=None, hint='_Integral'):
     eq = expr.subs(reps)
     return eq, func
 
-def ode_order(expr, func):
+def ode_order(expr, func) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.

--- a/sympy/solvers/ode/riccati.py
+++ b/sympy/solvers/ode/riccati.py
@@ -377,7 +377,7 @@ def inverse_transform_poly(num, den, x):
     return num.cancel(den, include=True)
 
 
-def limit_at_inf(num, den, x):
+def limit_at_inf(num, den, x) -> int:
     """
     Find the limit of a rational function
     at oo

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1374,7 +1374,7 @@ class SeparableReduced(Separable):
     has_integral = True
     order = [1]
 
-    def _degree(self, expr, x):
+    def _degree(self, expr, x) -> int:
         # Made this function to calculate the degree of
         # x in an expression. If expr will be of form
         # x**p*y, (wheare p can be variables/rationals) then it

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -37,7 +37,7 @@ class FiniteDensity(dict):
     """
     A domain with Finite Density.
     """
-    def __call__(self, item):
+    def __call__(self, item) -> int:
         """
         Make instance of a class callable.
 

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1926,7 +1926,7 @@ class _EditArrayContraction:
         raise IndexError("argument not found")
 
 
-def get_rank(expr):
+def get_rank(expr) -> int:
     if isinstance(expr, (MatrixExpr, MatrixElement)):
         return 2
     if isinstance(expr, _CodegenArrayAbstract):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -28,7 +28,7 @@ symmetries of the tensors.
 If there is a (anti)symmetric metric, the indices can be raised and
 lowered when the tensor is put in canonical form.
 """
-
+from __future__ import annotations
 from typing import Any, Dict as tDict, List, Set as tSet, Tuple as tTuple
 from functools import reduce
 
@@ -348,7 +348,7 @@ class _IndexStructure(CantSympify):
 
         # Converts the symmetry of the metric into msym from .canonicalize()
         # method in the combinatorics module
-        def metric_symmetry_to_msym(metric):
+        def metric_symmetry_to_msym(metric) -> int | None:
             if metric is None:
                 return None
             sym = metric.symmetry


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Trying out what happens if `int` is added as return types to some methods that returns un-sympified `int`s. Some are most definitely wrong...

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
