### PR TITLE
Different symbols for Laplacian

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -502,7 +502,7 @@ class LatexPrinter(Printer):
 
     def _print_Laplacian(self, expr):
         func = expr._expr
-        return r"\triangle %s" % self.parenthesize(func, PRECEDENCE['Mul'])
+        return r"\Delta %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
     def _print_Mul(self, expr):
         from sympy.physics.units import Quantity

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -370,11 +370,11 @@ def test_latex_vector_expressions():
     assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
     assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
 
-    assert latex(Laplacian(A.x)) == r"\triangle \mathbf{{x}_{A}}"
+    assert latex(Laplacian(A.x)) == r"\Delta \mathbf{{x}_{A}}"
     assert latex(Laplacian(A.x + 3*A.y)) == \
-        r"\triangle \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Laplacian(A.x)) == r"x \left(\triangle \mathbf{{x}_{A}}\right)"
-    assert latex(Laplacian(x*A.x)) == r"\triangle \left(\mathbf{{x}_{A}} x\right)"
+        r"\Delta \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
+    assert latex(x*Laplacian(A.x)) == r"x \left(\Delta \mathbf{{x}_{A}}\right)"
+    assert latex(Laplacian(x*A.x)) == r"\Delta \left(\mathbf{{x}_{A}} x\right)"
 
 def test_latex_symbols():
     Gamma, lmbda, rho = symbols('Gamma, lambda, rho')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
SymPy uses `\triangle` to denote the Laplacian, which is nonstandard. However, using `\Delta` for that is very widespread:
* The [Comprehensive LaTeX Symbol List](https://mirror.kku.ac.th/CTAN/info/symbols/comprehensive/symbols-a4.pdf) lists \Delta as the symbol for the Laplacian on page 318. This is also mentioned in [this answer on tex.stackexchange.com](https://tex.stackexchange.com/a/76563/203821).
![image](https://user-images.githubusercontent.com/63574588/156509310-420e13f1-07ff-4304-9777-2c0034563d9c.png)
* As [this answer to a question about what to use for the Laplace Operator](https://tex.stackexchange.com/a/76564/203821) states, one of the aliases of U+2206 (increment) is indeed [Laplace Operator](https://unicode-table.com/en/2206/).
* [Wikipedia](https://en.wikipedia.org/wiki/Laplace_operator) exclusively uses \Delta, or U+0394 to denote the Laplace operator.

Because using `\Delta` is much more common than using `\triangle` for the Laplace operator, I propose changing the symbol used in the LaTeX printer.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * The LaTeX printer now uses `\Delta` instead of `\triangle` for the Laplace operator.
<!-- END RELEASE NOTES -->
