### PR TITLE
polys/ring_series: Added rs_csc and rs_sec for handling univariate expansions

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1548,6 +1548,73 @@ def rs_cos_sin(p, x, prec):
     p1 = rs_series_inversion(1 + t2, x, prec)
     return (rs_mul(p1, 1 - t2, x, prec), rs_mul(p1, 2*t, x, prec))
 
+def rs_sec(p, x, prec):
+    """
+    Secant of a series
+
+    Return the series expansion of the sec of ``p``, about 0.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_sec
+    >>> R, x = ring('x', QQ)
+    >>> rs_sec(x, x, 4)
+    1/2*x**2 + 1
+    >>> p = x**QQ(2,3) + x
+    >>> rs_sec(p, x, 3)
+    5/24*x**(8/3) + 1/2*x**2 + x**(5/3) + 1/2*x**(4/3) + 1
+
+    See Also
+    ========
+
+    csc
+    """
+    if rs_is_puiseux(p, x):
+        return rs_puiseux(rs_sec, p, x, prec)
+    i, m = _check_series_var(p, x, 'sec')
+    prec1 = prec + 2*int(m)
+    t = rs_cos(p, x, prec1)
+    t1 = rs_series_inversion(t, x, prec1)
+    t1 = rs_trunc(t1, x, prec)
+    return t1
+
+def rs_csc(p, x, prec):
+    """
+    Cosecant of a series
+
+    Return the series expansion of the cosecant of ``p``, about 0.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_csc
+    >>> R, x = ring('x', QQ)
+    >>> rs_csc(x, x, 4)
+    7/360*x**3 + 1/6*x + x**(-1)
+    >>> p = x**QQ(2,3) + x
+    >>> rs_csc(p, x, 3)
+    127/120*x**(8/3) - 113/120*x**(7/3) + 367/360*x**2 - x**(5/3) + \
+    x**(4/3) - 5/6*x + 7/6*x**(2/3) - x**(1/3) + 1 - x**(-1/3) + x**(-2/3)
+
+    See Also
+    ========
+
+    sec
+    """
+    if rs_is_puiseux(p, x):
+        return rs_puiseux(rs_csc, p, x, prec)
+    i, m = _check_series_var(p, x, 'csc')
+    prec1 = prec + 2*int(m)
+    t = rs_sin(p, x, prec1)
+    t1 = rs_series_inversion(t, x, prec1)
+    t1 = rs_trunc(t1, x, prec)
+    return t1
+
 def _atanh(p, x, prec):
     """
     Expansion using formula

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1574,6 +1574,9 @@ def rs_sec(p, x, prec):
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_sec, p, x, prec)
+    if _has_constant_term(p, x):
+        raise NotImplementedError("Polynomial must not have constant term in "
+                                  "series variables")
     i, m = _check_series_var(p, x, 'sec')
     prec1 = prec + 2*int(m)
     t = rs_cos(p, x, prec1)
@@ -1608,6 +1611,9 @@ def rs_csc(p, x, prec):
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_csc, p, x, prec)
+    if _has_constant_term(p, x):
+        raise NotImplementedError("Polynomial must not have constant term in "
+                                  "series variables")
     i, m = _check_series_var(p, x, 'csc')
     prec1 = prec + 2*int(m)
     t = rs_sin(p, x, prec1)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -4,7 +4,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
     rs_compose_add, rs_asin, rs_atan, rs_atanh, rs_tan, rs_cot, rs_sin, rs_cos,
-    rs_cos_sin, rs_sinh, rs_cosh, rs_tanh, _tan1, rs_fun, rs_nth_root,
+    rs_cos_sin, rs_sec, rs_csc, rs_sinh, rs_cosh, rs_tanh, _tan1, rs_fun, rs_nth_root,
     rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
@@ -370,6 +370,17 @@ def test_cos_sin():
     assert cos == rs_cos(x + x*y, x, 5)
     assert sin == rs_sin(x + x*y, x, 5)
 
+
+def test_sec_csc():
+    R, x = ring('x', QQ)
+    p = x**QQ(2,3) + x
+    assert rs_sec(x, x, 4) == 1/2*x**2 + 1
+    assert rs_sec(p, x, 3) == 5/24*x**QQ(8, 3) + 1/2*x**2 + x**QQ(5, 3) + 1/2*x**QQ(4, 3) + 1
+    assert rs_csc(x, x, 4) == 7/360*x**3 + 1/6*x + x**(-1)
+    assert rs_csc(p, x, 3) == 127/120*x**QQ(8, 3) - 113/120*x**QQ(7, 3) + 367/360*x**2 - \
+        x**QQ(5, 3) + x**QQ(4, 3) - 5/6*x + 7/6*x**QQ(2, 3) - x**QQ(1, 3) + 1 - x**QQ(-1, 3) + x**QQ(-2, 3)
+
+
 def test_atanh():
     R, x, y = ring('x, y', QQ)
     assert rs_atanh(x, x, 9)/x**5 == Rational(1, 7)*x**2 + Rational(1, 5) + Rational(1, 3)*x**(-2) + x**(-4)
@@ -501,6 +512,15 @@ def test_puiseux():
         x**QQ(4,3)/2 - x**QQ(16,15) - x**QQ(4,5)/2 + 1
     assert r[1] == -x**QQ(9,5)/2 - x**QQ(26,15)/2 - x**QQ(22,15)/2 - \
         x**QQ(6,5)/6 + x + x**QQ(2,3) + x**QQ(2,5)
+
+    r = rs_sec(p, x, 2)
+    assert r == 5/6*x**QQ(28, 15) + x**QQ(5, 3) + 5/24*x**QQ(8, 5) + \
+        x**QQ(7, 5) + 1/2*x**QQ(4, 3) + x**QQ(16, 15) + 1/2*x**QQ(4, 5) + 1
+
+    r = rs_csc(p, x, 1)
+    assert r == -x**QQ(14, 15) + x**QQ(4, 5) - 3*x**QQ(11, 15) + 7/6*x**QQ(2, 3) + \
+        2*x**QQ(7, 15) - 5/6*x**QQ(2, 5) - x**QQ(1, 5) + x**QQ(2, 15) - \
+        x**QQ(-2, 15) + x**QQ(-2, 5)
 
     r = rs_atanh(p, x, 2)
     assert r == x**QQ(9,5) + x**QQ(26,15) + x**QQ(22,15) + x**QQ(6,5)/3 + x + \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I have added `rs_csc` and `rs_sec` series for handling all kinds of univariate expansions including any sort of puiseux series . Some results for reference

```
>>> R, x = ring('x', QQ)
>>> rs_csc(x, x, 4)
7/360*x**3 + 1/6*x + x**(-1)
>>>
>>> rs_csc(x**QQ(2, 3), x, 3)
7/360*x**2 + 1/6*x**(2/3) + x**(-2/3)
>>>
>>> rs_sec(x, x, 4)
1/2*x**2 + 1
>>> rs_sec(x**QQ(2, 3), x, 3)
5/24*x**(8/3) + 1/2*x**(4/3) + 1
>>>
>>> # Comparing with regular expansions show exactly same results 
>>> x = Symbol('x')
>>>
>>> csc(x).series(x, 0, 4)
1/x + x/6 + 7*x**3/360 + O(x**4)
>>> csc(x**(2/3)).series(x, 0, 3)
x**2.0/36 - x**2.0/120 + x**0.666666666666667/6 + x**(-0.666666666666667) + O(x**3)
>>>
>>> sec(x).series(x, 0, 4)
1 + x**2/2 + O(x**4)
>>> sec(x**(2/3)).series(x, 0, 3)
1 + 5*x**2.66666666666667/24 + x**1.33333333333333/2 + O(x**3)
```
I am quite confident of the change here except one thing which is this line `prec1 = prec + 2*int(m)` , though I wanted to go with `prec1 = prec + 2*m` , but when I use this the puiseux cases fail.

```
>>> p = x**QQ(2, 3)
>>> rs_csc(p, x, 4)
Traceback (most recent call last):
  File "C:\Users\anuto\sympy\sympy\sympy\polys\ring_series.py", line 1459, in rs_sin
    for k in range(2, prec + 2, 2):
TypeError: 'PythonMPQ' object cannot be interpreted as an integer
```
This tells me that while executing the following(code attached below this para) , m comes out to be an object of `PythonMPQ`, while doing the `puiseux` cases and is an `int` object while doing the general cases. This being my first pr with the `ring_series` module( though I have experience with pr's dealing with `rings.py `)I would like some assistance here . Maybe @jksuom could help me out ?!
```
    i, m = _check_series_var(p, x, 'csc')
    prec1 = prec + 2*(m)
```
 Other than this I'm quite happy with all other parts 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added rs_csc and rs_sec for handling univariate expansions including puiseux series cases .
<!-- END RELEASE NOTES -->
