### PR TITLE
core/function: .diff accepts string arguments again (regression)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -47,7 +47,7 @@ from .operations import LatticeOp
 from .parameters import global_parameters
 from .rules import Transform
 from .singleton import S
-from .sympify import sympify, _sympify
+from .sympify import sympify
 
 from .sorting import default_sort_key, ordered
 from sympy.utilities.exceptions import (sympy_deprecation_warning,
@@ -1304,7 +1304,7 @@ class Derivative(Expr):
                 variable_count.append(Tuple(v, count))
                 continue
 
-            v = _sympify(v)
+            v = sympify(v)
             if isinstance(v, Integer):
                 if i == 0:
                     raise ValueError("First variable cannot be a number: %i" % v)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -131,6 +131,8 @@ def test_diff_symbols():
     raises(TypeError, lambda: cos(x).diff((x, y)).variables)
     assert cos(x).diff((x, y))._wrt_variables == [x]
 
+    # issue 23222
+    assert sympify("a*x+b").diff("x") == sympify("a")
 
 def test_Function():
     class myfunc(Function):


### PR DESCRIPTION
`diff` now accepts string arguments again using `sympify` isntead of
`_sympify`. Test added to prevent future regression.

Fixes #23222

Same as #23233 but for the 1.10 release branch to go into 1.10.1

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * The `.diff` method accepts string arguments again (fixing a regression in 1.10).
<!-- END RELEASE NOTES -->
