### PR TITLE
Add config option diff_operator in latex printer

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -161,6 +161,7 @@ class LatexPrinter(Printer):
         "parenthesize_super": True,
         "min": None,
         "max": None,
+        "diff_operator": "d",
     }  # type: tDict[str, Any]
 
     def __init__(self, settings=None):
@@ -212,12 +213,17 @@ class LatexPrinter(Printer):
             "rj": r"\mathrm{j}",
             "tj": r"\text{j}",
         }
-        try:
-            self._settings['imaginary_unit_latex'] = \
-                imaginary_unit_table[self._settings['imaginary_unit']]
-        except KeyError:
-            self._settings['imaginary_unit_latex'] = \
-                self._settings['imaginary_unit']
+        imag_unit = self._settings['imaginary_unit']
+        self._settings['imaginary_unit_latex'] = imaginary_unit_table.get(imag_unit, imag_unit)
+
+        diff_operator_table = {
+            None: r"d",
+            "d": r"d",
+            "rd": r"\mathrm{d}",
+            "td": r"\text{d}",
+        }
+        diff_operator = self._settings['diff_operator']
+        self._settings["diff_operator_latex"] = diff_operator_table.get(diff_operator, diff_operator)
 
     def _add_parens(self, s):
         return r"\left({}\right)".format(s)
@@ -788,7 +794,7 @@ class LatexPrinter(Printer):
         if requires_partial(expr.expr):
             diff_symbol = r'\partial'
         else:
-            diff_symbol = r'd'
+            diff_symbol = self._settings["diff_operator_latex"]
 
         tex = ""
         dim = 0
@@ -829,13 +835,14 @@ class LatexPrinter(Printer):
 
     def _print_Integral(self, expr):
         tex, symbols = "", []
+        diff_symbol = self._settings["diff_operator_latex"]
 
         # Only up to \iiiint exists
         if len(expr.limits) <= 4 and all(len(lim) == 1 for lim in expr.limits):
             # Use len(expr.limits)-1 so that syntax highlighters don't think
             # \" is an escaped quote
             tex = r"\i" + "i"*(len(expr.limits) - 1) + "nt"
-            symbols = [r"\, d%s" % self._print(symbol[0])
+            symbols = [r"\, %s%s" % (diff_symbol, self._print(symbol[0]))
                        for symbol in expr.limits]
 
         else:
@@ -854,7 +861,7 @@ class LatexPrinter(Printer):
                     if len(lim) == 2:
                         tex += "^{%s}" % (self._print(lim[1]))
 
-                symbols.insert(0, r"\, d%s" % self._print(symbol))
+                symbols.insert(0, r"\, %s%s" % (diff_symbol, self._print(symbol)))
 
         return r"%s %s%s" % (tex, self.parenthesize(expr.function,
                                                     PRECEDENCE["Mul"],
@@ -2968,6 +2975,9 @@ def latex(expr, **settings):
     max: Integer or None, optional
         Sets the upper bound for the exponent to print floating point numbers in
         fixed-point format.
+    diff_operator: string, optional
+        String to use for differential operator. Default is ``'d'``, to print in italic
+        form. ``'rd'``, ``'td'`` are shortcuts for ``\mathrm{d}`` and ``\text{d}``.
 
     Notes
     =====

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -811,6 +811,9 @@ def test_latex_derivatives():
     assert latex(diff(f(x), (x, Max(n1, n2)))) == \
         r'\frac{d^{\max\left(n_{1}, n_{2}\right)}}{d x^{\max\left(n_{1}, n_{2}\right)}} f{\left(x \right)}'
 
+    # set diff operator
+    assert latex(diff(f(x), x), diff_operator="rd") == r'\frac{\mathrm{d}}{\mathrm{d} x} f{\left(x \right)}'
+
 
 def test_latex_subs():
     assert latex(Subs(x*y, (x, y), (1, 2))) == r'\left. x y \right|_{\substack{ x=1\\ y=2 }}'
@@ -850,6 +853,10 @@ def test_latex_integrals():
     assert latex(Integral(x+z/2, z)) == \
         r"\int \left(x + \frac{z}{2}\right)\, dz"
     assert latex(Integral(x**y, z)) == r"\int x^{y}\, dz"
+
+    # set diff operator
+    assert latex(Integral(x, x), diff_operator="rd") == r'\int x\, \mathrm{d}x'
+    assert latex(Integral(x, (x, 0, 1)), diff_operator="rd") == r'\int\limits_{0}^{1} x\, \mathrm{d}x'
 
 
 def test_latex_sets():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #23226 
Similar to #15936, so maybe @oscargus could review it.
#### Brief description of what is fixed or changed

Allow passing `diff_operator` to latex printer. The default behavior (italic d) is not changed. Shortcuts `'rd'` and `'td'` are added for convenience.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Allow to configure differential operator in latex printer. Default is "d".
<!-- END RELEASE NOTES -->
