### PR TITLE
Fix overflow

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -93,7 +93,7 @@ def _integer_nthroot_python(y, n):
     if n == 2:
         x, rem = mpmath_sqrtrem(y)
         return int(x), not rem
-    if n > y:
+    if n >= y.bit_length():
         return 1, False
     # Get initial estimate for Newton's method. Care must be taken to
     # avoid overflow

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -13,7 +13,7 @@ from sympy.functions.elementary.hyperbolic import cosh, sinh, tanh
 from sympy.polys import Poly
 from sympy.series.order import O
 from sympy.sets import FiniteSet
-from sympy.core.power import power
+from sympy.core.power import power, integer_nthroot
 from sympy.testing.pytest import warns, _both_exp_pow
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -607,6 +607,12 @@ def test_issue_21762():
               Pow(Integer(2), Rational(16666666666666667, 25000000000000000)),
               Pow(Integer(5), Rational(8333333333333333, 25000000000000000)))
     assert e.xreplace({x: S.Half}) == ans
+
+
+def test_issue_14704():
+    a = 144**144
+    x, xexact = integer_nthroot(a,a)
+    assert x == 1 and xexact is False
 
 
 def test_rational_powers_larger_than_one():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #14704 


#### Brief description of what is fixed or changed
Added a _tighter_ (probably tighest) condition in `_integer_nthroot_python(y,n)` to check whether `floor(y**(1/n))==1`.
This prevents overflow of integer `n` while being converted into `float` later in the function execution, beacuse the added condition prevents such big `n` from reaching down there.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
