### PR TITLE
Added test for removing the ambiguity of float('inf') expression

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -104,6 +104,7 @@ Akash Nagaraj <grassknoted@gmail.com> grassknoted <grassknoted@gmail.com>
 Akash Trehan <akash.trehan123@gmail.com>
 Akash Vaish <akash.9712@gmail.com>
 Akhil Rajput <akh1lrjput@gmail.com> Akhil Rajput <43316490+akhil-dh1@users.noreply.github.com>
+Akhila Krishna <akhilakrishnak2000@gmail.com>
 Akira Kyle <ak@akirakyle.com>
 Akshansh Bhatt <akshansh@tuta.io>
 Akshansh Bhatt <akshansh@tuta.io> <53227127+akshanshbhatt@users.noreply.github.com>

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1044,4 +1044,4 @@ def test_issue_22210():
 def test_issue_8439():
     x = Symbol('x')
     assert x + float('inf') == x + oo
-    assert S(float'inf') == oo
+    assert S(float('inf')) == oo

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1045,4 +1045,3 @@ def test_issue_8439():
     x = Symbol('x')
     assert x + float('inf') == x + oo
     assert S(float('inf')) == oo
-

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1045,3 +1045,4 @@ def test_issue_8439():
     x = Symbol('x')
     assert x + float('inf') == x + oo
     assert S(float('inf')) == oo
+

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1040,3 +1040,8 @@ def test_issue_22210():
     d = Symbol('d', integer=True)
     expr = 2*Derivative(sin(x), (x, d))
     assert expr.simplify() == expr
+
+def test_issue_8439():
+    x = Symbol('x')
+    assert x + float('inf') == x + oo
+    assert S(float'inf') == oo


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #8439 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a test in test_simplify.py which will assert `x+float('inf')` as `x+oo`  and `S(float('inf'))` as `oo`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- simplify
   - test_simplify
       - Add function to assert `x + float('inf') == x + oo` and `S(float('inf')) == oo`

<!-- END RELEASE NOTES -->
