### PR TITLE
Removed type annotations from lambdify()

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -840,7 +840,7 @@ or tuple for the function arguments.
                 )
 
     # Get the names of the args, for creating a docstring
-    iterable_args: Iterable = (args,) if isinstance(args, Expr) else args
+    iterable_args = (args,) if isinstance(args, Expr) else args
     names = []
 
     # Grab the callers frame, for getting the names by inspection (if needed)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -27,14 +27,14 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 
 # Default namespaces, letting us define translations that can't be defined
 # by simple variable maps, like I => 1j
-MATH_DEFAULT = {}  # type: tDict[str, Any]
-MPMATH_DEFAULT = {}  # type: tDict[str, Any]
-NUMPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
-SCIPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
-CUPY_DEFAULT = {"I": 1j}  # type: tDict[str, Any]
-TENSORFLOW_DEFAULT = {}  # type: tDict[str, Any]
-SYMPY_DEFAULT = {}  # type: tDict[str, Any]
-NUMEXPR_DEFAULT = {}  # type: tDict[str, Any]
+MATH_DEFAULT = {}
+MPMATH_DEFAULT = {}
+NUMPY_DEFAULT = {"I": 1j}
+SCIPY_DEFAULT = {"I": 1j}
+CUPY_DEFAULT = {"I": 1j}
+TENSORFLOW_DEFAULT = {}
+SYMPY_DEFAULT = {}
+NUMEXPR_DEFAULT = {}
 
 # These are the namespaces the lambda functions will use.
 # These are separate from the names above because they are modified
@@ -91,13 +91,13 @@ MPMATH_TRANSLATIONS = {
 
 NUMPY_TRANSLATIONS = {
     "Heaviside": "heaviside",
-    }  # type: tDict[str, str]
-SCIPY_TRANSLATIONS = {}  # type: tDict[str, str]
-CUPY_TRANSLATIONS = {}  # type: tDict[str, str]
+    }
+SCIPY_TRANSLATIONS = {}
+CUPY_TRANSLATIONS = {}
 
-TENSORFLOW_TRANSLATIONS = {}  # type: tDict[str, str]
+TENSORFLOW_TRANSLATIONS = {}
 
-NUMEXPR_TRANSLATIONS = {}  # type: tDict[str, str]
+NUMEXPR_TRANSLATIONS = {}
 
 # Available modules:
 MODULES = {
@@ -790,7 +790,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
             raise TypeError("numexpr must be the only item in 'modules'")
         namespaces += list(modules)
     # fill namespace with first having highest priority
-    namespace = {} # type: tDict[str, Any]
+    namespace = {}
     for m in namespaces[::-1]:
         buf = _get_namespace(m)
         namespace.update(buf)
@@ -804,21 +804,21 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
     if printer is None:
         if _module_present('mpmath', namespaces):
-            from sympy.printing.pycode import MpmathPrinter as Printer # type: ignore
+            from sympy.printing.pycode import MpmathPrinter as Printer
         elif _module_present('scipy', namespaces):
-            from sympy.printing.numpy import SciPyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import SciPyPrinter as Printer
         elif _module_present('numpy', namespaces):
-            from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import NumPyPrinter as Printer
         elif _module_present('cupy', namespaces):
-            from sympy.printing.numpy import CuPyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import CuPyPrinter as Printer
         elif _module_present('numexpr', namespaces):
-            from sympy.printing.lambdarepr import NumExprPrinter as Printer # type: ignore
+            from sympy.printing.lambdarepr import NumExprPrinter as Printer
         elif _module_present('tensorflow', namespaces):
-            from sympy.printing.tensorflow import TensorflowPrinter as Printer # type: ignore
+            from sympy.printing.tensorflow import TensorflowPrinter as Printer
         elif _module_present('sympy', namespaces):
-            from sympy.printing.pycode import SymPyPrinter as Printer # type: ignore
+            from sympy.printing.pycode import SymPyPrinter as Printer
         else:
-            from sympy.printing.pycode import PythonCodePrinter as Printer # type: ignore
+            from sympy.printing.pycode import PythonCodePrinter as Printer
         user_functions = {}
         for m in namespaces[::-1]:
             if isinstance(m, dict):
@@ -844,7 +844,7 @@ or tuple for the function arguments.
     names = []
 
     # Grab the callers frame, for getting the names by inspection (if needed)
-    callers_local_vars = inspect.currentframe().f_back.f_locals.items() # type: ignore
+    callers_local_vars = inspect.currentframe().f_back.f_locals.items()
     for n, var in enumerate(iterable_args):
         if hasattr(var, 'name'):
             names.append(var.name)
@@ -861,7 +861,7 @@ or tuple for the function arguments.
     # Create the function definition code and execute it
     funcname = '_lambdifygenerated'
     if _module_present('tensorflow', namespaces):
-        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify) # type: _EvaluatorPrinter
+        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify)
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
@@ -893,14 +893,14 @@ or tuple for the function arguments.
     # Provide lambda expression with builtins, and compatible implementation of range
     namespace.update({'builtins':builtins, 'range':range})
 
-    funclocals = {} # type: tDict[str, Any]
+    funclocals = {}
     global _lambdify_generated_counter
     filename = '<lambdifygenerated-%s>' % _lambdify_generated_counter
     _lambdify_generated_counter += 1
     c = compile(funcstr, filename, 'exec')
     exec(c, namespace, funclocals)
     # mtime has to be None or else linecache.checkcache will remove it
-    linecache.cache[filename] = (len(funcstr), None, funcstr.splitlines(True), filename) # type: ignore
+    linecache.cache[filename] = (len(funcstr), None, funcstr.splitlines(True), filename)
 
     func = funclocals[funcname]
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -3,7 +3,7 @@ This module provides convenient functions to transform SymPy expressions to
 lambda functions which can be used to calculate numerical values very fast.
 """
 
-from typing import Any, Dict as tDict, Iterable, Union as tUnion, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import builtins
 import inspect

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -179,7 +179,7 @@ _lambdify_generated_counter = 1
 
 
 @doctest_depends_on(modules=('numpy', 'scipy', 'tensorflow',), python_version=(3,))
-def lambdify(args: tUnion[Iterable, 'sympy.core.expr.Expr'], expr: 'sympy.core.expr.Expr', modules=None, printer=None, use_imps=True,
+def lambdify(args, expr, modules=None, printer=None, use_imps=True,
              dummify=False, cse=False):
     """Convert a SymPy expression into a function that allows for fast
     numeric evaluation.

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -3,8 +3,6 @@ This module provides convenient functions to transform SymPy expressions to
 lambda functions which can be used to calculate numerical values very fast.
 """
 
-from typing import TYPE_CHECKING
-
 import builtins
 import inspect
 import keyword
@@ -15,13 +13,9 @@ import linecache
 from sympy.external import import_module # noqa:F401
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.iterables import (is_sequence, iterable,
-    NotIterable, flatten)
+from sympy.utilities.iterables import (is_sequence, iterable, NotIterable,
+                                       flatten)
 from sympy.utilities.misc import filldedent
-
-
-if TYPE_CHECKING:
-    import sympy.core.expr
 
 __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 


### PR DESCRIPTION
The type annotations add extra noise when trying to read a doc string
and offer no useful addition over the docstring itself. The annotations
on lambdify's first two args are removed.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

No decision has been made on whether we are introducing these type hints or not, see #17945 

#### Brief description of what is fixed or changed

I noticed that the docstring had changed when writing code and thought that function signature was no longer easily readable. Here is a screenshot from my editor:
![image](https://user-images.githubusercontent.com/276007/158651861-e52b2405-0f74-4ab1-ad4b-d3b7607ee876.png)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
