### PR TITLE
Series/limits : Fixes limit computations where arg0 would evaluate to S.NaN for the ceiling and floor functions

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -11,7 +11,7 @@ from sympy.core.numbers import Integer
 from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
-from sympy.functions.elementary.complexes import im
+from sympy.functions.elementary.complexes import im, re
 from sympy.multipledispatch import dispatch
 
 ###############################################################################
@@ -144,10 +144,12 @@ class floor(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite or arg0 is S.NaN:
+        if arg0 is S.NaN:
+            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            ndir = arg.dir(x, cdir=cdir)
+            return limit - 1 if ndir.is_negative else limit
+        if arg0.is_finite:
             if arg0 == r:
-                leading_term = arg.as_leading_term(x, logx=logx, cdir=cdir)
-                leading_term = leading_term.subs(x, 0)
                 if cdir == 0:
                     ndirl = arg.dir(x, cdir=-1)
                     ndir = arg.dir(x, cdir=1)
@@ -156,12 +158,8 @@ class floor(RoundFunction):
                                     "does not exist" % self)
                 else:
                     ndir = arg.dir(x, cdir=cdir)
-                if arg0 is S.NaN:
-                    return leading_term - 1 if ndir.is_negative else leading_term
                 return r - 1 if ndir.is_negative else r
             else:
-                if arg0 is S.NaN:
-                    return leading_term
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
@@ -308,10 +306,12 @@ class ceiling(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite or arg0 is S.NaN:
+        if arg0 is S.NaN:
+            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            ndir = arg.dir(x, cdir=cdir)
+            return limit if ndir.is_negative else limit + 1
+        if arg0.is_finite:
             if arg0 == r:
-                leading_term = arg.as_leading_term(x, logx=logx, cdir=cdir)
-                leading_term = leading_term.subs(x, 0)
                 if cdir == 0:
                     ndirl = arg.dir(x, cdir=-1)
                     ndir = arg.dir(x, cdir=1)
@@ -320,12 +320,8 @@ class ceiling(RoundFunction):
                                     "does not exist" % self)
                 else:
                     ndir = arg.dir(x, cdir=cdir)
-                    if arg0 is S.NaN:
-                        return leading_term if ndir.is_negative else leading_term + 1
                 return r if ndir.is_negative else r + 1
             else:
-                if arg0 is S.NaN:
-                    return leading_term
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -145,11 +145,8 @@ class floor(RoundFunction):
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
         if arg0 is S.NaN:
-            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-            ndir = arg.dir(x, cdir=cdir)
-            if not limit.is_integer:
-                return floor(limit)
-            return limit - 1 if ndir.is_negative else limit
+            arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            r = floor(arg0)
         if arg0.is_finite:
             if arg0 == r:
                 if cdir == 0:
@@ -168,19 +165,16 @@ class floor(RoundFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
+        r = self.subs(x, 0)
         if arg0 is S.NaN:
-            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
-            series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
-            if not series.is_integer:
-                return floor(series)
-            return series - 1 if ndir.is_negative else series
+            arg0 = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            r = floor(arg0)
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
             from sympy.series.order import Order
             s = arg._eval_nseries(x, n, logx, cdir)
             o = Order(1, (x, 0)) if n <= 0 else AccumBounds(-1, 0)
             return s + o
-        r = self.subs(x, 0)
         if arg0 == r:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
             return r - 1 if ndir.is_negative else r
@@ -315,11 +309,8 @@ class ceiling(RoundFunction):
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
         if arg0 is S.NaN:
-            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-            ndir = arg.dir(x, cdir=cdir)
-            if not limit.is_integer:
-                return ceiling(limit)
-            return limit if ndir.is_negative else limit + 1
+            arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            r = ceiling(arg0)
         if arg0.is_finite:
             if arg0 == r:
                 if cdir == 0:
@@ -338,19 +329,16 @@ class ceiling(RoundFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
+        r = self.subs(x, 0)
         if arg0 is S.NaN:
-            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
-            series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
-            if not series.is_integer:
-                return ceiling(series)
-            return series if ndir.is_negative else series + 1
+            arg0 = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            r = ceiling(arg0)
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
             from sympy.series.order import Order
             s = arg._eval_nseries(x, n, logx, cdir)
             o = Order(1, (x, 0)) if n <= 0 else AccumBounds(0, 1)
             return s + o
-        r = self.subs(x, 0)
         if arg0 == r:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
             return r if ndir.is_negative else r + 1

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -144,23 +144,23 @@ class floor(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0 is S.NaN:
-            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-            ndir = arg.dir(x, cdir=cdir)
-            return limit - 1 if ndir.is_negative else limit
-        if arg0.is_finite:
-            if arg0 == r:
-                if cdir == 0:
-                    ndirl = arg.dir(x, cdir=-1)
-                    ndir = arg.dir(x, cdir=1)
-                    if ndir != ndirl:
-                        raise ValueError("Two sided limit of %s around 0"
-                                    "does not exist" % self)
-                else:
-                    ndir = arg.dir(x, cdir=cdir)
-                return r - 1 if ndir.is_negative else r
+        if arg0.is_finite or arg0 is S.NaN:
+            if cdir == 0:
+                ndirl = arg.dir(x, cdir=-1)
+                ndir = arg.dir(x, cdir=1)
+                if ndir != ndirl:
+                    raise ValueError("Two sided limit of %s around 0"
+                                     "does not exist" % self)
             else:
-                return r
+                ndir = arg.dir(x, cdir=cdir)
+            if arg0.is_finite:
+                if arg0 == r:
+                    return r - 1 if ndir.is_negative else r
+                else:
+                    return r
+            if arg0 is S.NaN:
+                limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+                return limit - 1 if ndir.is_negative else limit
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
@@ -306,23 +306,23 @@ class ceiling(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0 is S.NaN:
-            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-            ndir = arg.dir(x, cdir=cdir)
-            return limit if ndir.is_negative else limit + 1
-        if arg0.is_finite:
-            if arg0 == r:
-                if cdir == 0:
-                    ndirl = arg.dir(x, cdir=-1)
-                    ndir = arg.dir(x, cdir=1)
-                    if ndir != ndirl:
-                        raise ValueError("Two sided limit of %s around 0"
-                                    "does not exist" % self)
-                else:
-                    ndir = arg.dir(x, cdir=cdir)
-                return r if ndir.is_negative else r + 1
+        if arg0.is_finite or arg0 is S.NaN:
+            if cdir == 0:
+                ndirl = arg.dir(x, cdir=-1)
+                ndir = arg.dir(x, cdir=1)
+                if ndir != ndirl:
+                    raise ValueError("Two sided limit of %s around 0"
+                                     "does not exist" % self)
             else:
-                return r
+                ndir = arg.dir(x, cdir=cdir)
+            if arg0.is_finite:
+                if arg0 == r:
+                    return r if ndir.is_negative else r + 1
+                else:
+                    return r
+            if arg0 is S.NaN:
+                limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+                return limit if ndir.is_negative else limit + 1
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -144,23 +144,23 @@ class floor(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite or arg0 is S.NaN:
-            if cdir == 0:
-                ndirl = arg.dir(x, cdir=-1)
-                ndir = arg.dir(x, cdir=1)
-                if ndir != ndirl:
-                    raise ValueError("Two sided limit of %s around 0"
-                                     "does not exist" % self)
-            else:
-                ndir = arg.dir(x, cdir=cdir)
-            if arg0.is_finite:
-                if arg0 == r:
-                    return r - 1 if ndir.is_negative else r
+        if arg0 is S.NaN:
+            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            ndir = arg.dir(x, cdir=cdir)
+            return limit - 1 if ndir.is_negative else limit
+        if arg0.is_finite:
+            if arg0 == r:
+                if cdir == 0:
+                    ndirl = arg.dir(x, cdir=-1)
+                    ndir = arg.dir(x, cdir=1)
+                    if ndir != ndirl:
+                        raise ValueError("Two sided limit of %s around 0"
+                                    "does not exist" % self)
                 else:
-                    return r
-            if arg0 is S.NaN:
-                limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-                return limit - 1 if ndir.is_negative else limit
+                    ndir = arg.dir(x, cdir=cdir)
+                return r - 1 if ndir.is_negative else r
+            else:
+                return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
@@ -306,23 +306,23 @@ class ceiling(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite or arg0 is S.NaN:
-            if cdir == 0:
-                ndirl = arg.dir(x, cdir=-1)
-                ndir = arg.dir(x, cdir=1)
-                if ndir != ndirl:
-                    raise ValueError("Two sided limit of %s around 0"
-                                     "does not exist" % self)
-            else:
-                ndir = arg.dir(x, cdir=cdir)
-            if arg0.is_finite:
-                if arg0 == r:
-                    return r if ndir.is_negative else r + 1
+        if arg0 is S.NaN:
+            limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+            ndir = arg.dir(x, cdir=cdir)
+            return limit if ndir.is_negative else limit + 1
+        if arg0.is_finite:
+            if arg0 == r:
+                if cdir == 0:
+                    ndirl = arg.dir(x, cdir=-1)
+                    ndir = arg.dir(x, cdir=1)
+                    if ndir != ndirl:
+                        raise ValueError("Two sided limit of %s around 0"
+                                    "does not exist" % self)
                 else:
-                    return r
-            if arg0 is S.NaN:
-                limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
-                return limit if ndir.is_negative else limit + 1
+                    ndir = arg.dir(x, cdir=cdir)
+                return r if ndir.is_negative else r + 1
+            else:
+                return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -166,6 +166,10 @@ class floor(RoundFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
+        if arg0 is S.NaN:
+            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+            series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            return series - 1 if ndir.is_negative else series
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
             from sympy.series.order import Order
@@ -328,6 +332,10 @@ class ceiling(RoundFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
+        if arg0 is S.NaN:
+            ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+            series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            return series if ndir.is_negative else series + 1
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
             from sympy.series.order import Order

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -144,8 +144,10 @@ class floor(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite:
+        if arg0.is_finite or arg0 is S.NaN:
             if arg0 == r:
+                leading_term = arg.as_leading_term(x, logx=logx, cdir=cdir)
+                leading_term = leading_term.subs(x, 0)
                 if cdir == 0:
                     ndirl = arg.dir(x, cdir=-1)
                     ndir = arg.dir(x, cdir=1)
@@ -154,8 +156,12 @@ class floor(RoundFunction):
                                     "does not exist" % self)
                 else:
                     ndir = arg.dir(x, cdir=cdir)
+                if arg0 is S.NaN:
+                    return leading_term - 1 if ndir.is_negative else leading_term
                 return r - 1 if ndir.is_negative else r
             else:
+                if arg0 is S.NaN:
+                    return leading_term
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 
@@ -302,8 +308,10 @@ class ceiling(RoundFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0.is_finite:
+        if arg0.is_finite or arg0 is S.NaN:
             if arg0 == r:
+                leading_term = arg.as_leading_term(x, logx=logx, cdir=cdir)
+                leading_term = leading_term.subs(x, 0)
                 if cdir == 0:
                     ndirl = arg.dir(x, cdir=-1)
                     ndir = arg.dir(x, cdir=1)
@@ -312,8 +320,12 @@ class ceiling(RoundFunction):
                                     "does not exist" % self)
                 else:
                     ndir = arg.dir(x, cdir=cdir)
+                    if arg0 is S.NaN:
+                        return leading_term if ndir.is_negative else leading_term + 1
                 return r if ndir.is_negative else r + 1
             else:
+                if arg0 is S.NaN:
+                    return leading_term
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -167,7 +167,7 @@ class floor(RoundFunction):
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
         if arg0 is S.NaN:
-            arg0 = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             r = floor(arg0)
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
@@ -331,7 +331,7 @@ class ceiling(RoundFunction):
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
         if arg0 is S.NaN:
-            arg0 = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             r = ceiling(arg0)
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -147,6 +147,8 @@ class floor(RoundFunction):
         if arg0 is S.NaN:
             limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             ndir = arg.dir(x, cdir=cdir)
+            if not limit.is_integer:
+                return floor(limit)
             return limit - 1 if ndir.is_negative else limit
         if arg0.is_finite:
             if arg0 == r:
@@ -169,6 +171,8 @@ class floor(RoundFunction):
         if arg0 is S.NaN:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
             series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            if not series.is_integer:
+                return floor(series)
             return series - 1 if ndir.is_negative else series
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds
@@ -313,6 +317,8 @@ class ceiling(RoundFunction):
         if arg0 is S.NaN:
             limit = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             ndir = arg.dir(x, cdir=cdir)
+            if not limit.is_integer:
+                return ceiling(limit)
             return limit if ndir.is_negative else limit + 1
         if arg0.is_finite:
             if arg0 == r:
@@ -335,6 +341,8 @@ class ceiling(RoundFunction):
         if arg0 is S.NaN:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
             series = arg._eval_nseries(x, n, logx, cdir).subs(x, 0)
+            if not series.is_integer:
+                return ceiling(series)
             return series if ndir.is_negative else series + 1
         if arg0.is_infinite:
             from sympy.calculus.accumulationbounds import AccumBounds

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -7,7 +7,7 @@ from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.integers import (ceiling, floor, frac)
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import sin
+from sympy.functions.elementary.trigonometric import sin, cos, tan
 
 from sympy.core.expr import unchanged
 from sympy.testing.pytest import XFAIL
@@ -546,6 +546,27 @@ def test_series():
     assert ceiling(x).nseries(x, 0, 100) == 1
     assert floor(-x).nseries(x, 0, 100) == -1
     assert ceiling(-x).nseries(x, 0, 100) == 0
+
+
+def test_issue_14355():
+    # This test checks the leading term for the floor and ceil
+    # functions when arg0 evaluates to S.NaN.
+    assert floor((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = 1) == -2
+    assert floor((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = -1) == -1
+    assert floor((cos(x) - 1)/x).as_leading_term(x, cdir = 1) == -1
+    assert floor((cos(x) - 1)/x).as_leading_term(x, cdir = -1) == 0
+    assert floor(sin(x)/x).as_leading_term(x, cdir = 1) == 0
+    assert floor(sin(x)/x).as_leading_term(x, cdir = -1) == 0
+    assert floor(-tan(x)/x).as_leading_term(x, cdir = 1) == -2
+    assert floor(-tan(x)/x).as_leading_term(x, cdir = -1) == -2
+    assert ceiling((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = 1) == -1
+    assert ceiling((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = -1) == 0
+    assert ceiling((cos(x) - 1)/x).as_leading_term(x, cdir = 1) == 0
+    assert ceiling((cos(x) - 1)/x).as_leading_term(x, cdir = -1) == 1
+    assert ceiling(sin(x)/x).as_leading_term(x, cdir = 1) == 1
+    assert ceiling(sin(x)/x).as_leading_term(x, cdir = -1) == 1
+    assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
+    assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
 
 
 @XFAIL

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -549,8 +549,8 @@ def test_series():
 
 
 def test_issue_14355():
-    # This test checks the leading term for the floor and ceil
-    # functions when arg0 evaluates to S.NaN.
+    # This test checks the leading term and series for the floor and ceil
+    # function when arg0 evaluates to S.NaN.
     assert floor((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = 1) == -2
     assert floor((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = -1) == -1
     assert floor((cos(x) - 1)/x).as_leading_term(x, cdir = 1) == -1
@@ -567,6 +567,15 @@ def test_issue_14355():
     assert ceiling(sin(x)/x).as_leading_term(x, cdir = -1) == 1
     assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
     assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
+    # test for series
+    assert floor(sin(x)/x).series(x, 0, 100, cdir = 1) == 0
+    assert floor(sin(x)/x).series(x, 0, 100, cdir = 1) == 0
+    assert floor((x**3 + x)/(x**2 - x)).series(x, 0, 100, cdir = 1) == -2
+    assert floor((x**3 + x)/(x**2 - x)).series(x, 0, 100, cdir = -1) == -1
+    assert ceiling(sin(x)/x).series(x, 0, 100, cdir = 1) == 1
+    assert ceiling(sin(x)/x).series(x, 0, 100, cdir = -1) == 1
+    assert ceiling((x**3 + x)/(x**2 - x)).series(x, 0, 100, cdir = 1) == -1
+    assert ceiling((x**3 + x)/(x**2 - x)).series(x, 0, 100, cdir = -1) == 0
 
 
 @XFAIL

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -559,6 +559,8 @@ def test_issue_14355():
     assert floor(sin(x)/x).as_leading_term(x, cdir = -1) == 0
     assert floor(-tan(x)/x).as_leading_term(x, cdir = 1) == -2
     assert floor(-tan(x)/x).as_leading_term(x, cdir = -1) == -2
+    assert floor(sin(x)/x/3).as_leading_term(x, cdir = 1) == 0
+    assert floor(sin(x)/x/3).as_leading_term(x, cdir = -1) == 0
     assert ceiling((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = 1) == -1
     assert ceiling((x**3 + x)/(x**2 - x)).as_leading_term(x, cdir = -1) == 0
     assert ceiling((cos(x) - 1)/x).as_leading_term(x, cdir = 1) == 0
@@ -567,6 +569,8 @@ def test_issue_14355():
     assert ceiling(sin(x)/x).as_leading_term(x, cdir = -1) == 1
     assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
     assert ceiling(-tan(x)/x).as_leading_term(x, cdir = 1) == -1
+    assert ceiling(sin(x)/x/3).as_leading_term(x, cdir = 1) == 1
+    assert ceiling(sin(x)/x/3).as_leading_term(x, cdir = -1) == 1
     # test for series
     assert floor(sin(x)/x).series(x, 0, 100, cdir = 1) == 0
     assert floor(sin(x)/x).series(x, 0, 100, cdir = 1) == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -233,17 +233,21 @@ def test_floor_ceiling_for_arg0_evaluating_to_nan():
     # issue 14355
     assert limit(floor(sin(x)/x), x, 0, '+') == 0
     assert limit(floor(sin(x)/x), x, 0, '-') == 0
+    assert limit(floor(sin(x)/x), x, 0, '+-') == 0
     # test comment https://github.com/sympy/sympy/issues/14355#issuecomment-372121314
     assert limit(floor(-tan(x)/x), x, 0, '+') == -2
     assert limit(floor(-tan(x)/x), x, 0, '-') == -2
+    assert limit(floor(-tan(x)/x), x, 0, '+-') == -2
     assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '+') == -1
     assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '-') == 0
     assert limit(ceiling((cos(x) - 1)/x), x, 0, '+') == 0
     assert limit(ceiling((cos(x) - 1)/x), x, 0, '-') == 1
     assert limit(ceiling(sin(x)/x), x, 0, '+') == 1
     assert limit(ceiling(sin(x)/x), x, 0, '-') == 1
+    assert limit(ceiling(sin(x)/x), x, 0, '+-') == 1
     assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
     assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
+    assert limit(ceiling(-tan(x)/x), x, 0, '+-') == -1
 
 
 def test_atan():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -225,25 +225,12 @@ def test_ceiling_requires_robust_assumptions():
     assert limit(ceiling(5 + cos(x)), x, 0, "-") == 6
 
 
-def test_floor_ceiling_for_arg0_evaluating_to_nan():
-    assert limit(floor((x**3 + x)/(x**2 - x)), x, 0, '+') == -2
-    assert limit(floor((x**3 + x)/(x**2 - x)), x, 0, '-') == -1
-    assert limit(floor((cos(x) - 1)/x), x, 0, '+') == -1
-    assert limit(floor((cos(x) - 1)/x), x, 0, '-') == 0
-    # issue 14355
+def test_issue_14355():
     assert limit(floor(sin(x)/x), x, 0, '+') == 0
     assert limit(floor(sin(x)/x), x, 0, '-') == 0
     # test comment https://github.com/sympy/sympy/issues/14355#issuecomment-372121314
     assert limit(floor(-tan(x)/x), x, 0, '+') == -2
     assert limit(floor(-tan(x)/x), x, 0, '-') == -2
-    assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '+') == -1
-    assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '-') == 0
-    assert limit(ceiling((cos(x) - 1)/x), x, 0, '+') == 0
-    assert limit(ceiling((cos(x) - 1)/x), x, 0, '-') == 1
-    assert limit(ceiling(sin(x)/x), x, 0, '+') == 1
-    assert limit(ceiling(sin(x)/x), x, 0, '-') == 1
-    assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
-    assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
 
 
 def test_atan():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -225,6 +225,27 @@ def test_ceiling_requires_robust_assumptions():
     assert limit(ceiling(5 + cos(x)), x, 0, "-") == 6
 
 
+def test_floor_ceiling_for_arg0_evaluating_to_nan():
+    assert limit(floor((x**3 + x)/(x**2 - x)), x, 0, '+') == -2
+    assert limit(floor((x**3 + x)/(x**2 - x)), x, 0, '-') == -1
+    assert limit(floor((cos(x) - 1)/x), x, 0, '+') == -1
+    assert limit(floor((cos(x) - 1)/x), x, 0, '-') == 0
+    # issue 14355
+    assert limit(floor(sin(x)/x), x, 0, '+') == 0
+    assert limit(floor(sin(x)/x), x, 0, '-') == 0
+    # test comment https://github.com/sympy/sympy/issues/14355#issuecomment-372121314
+    assert limit(floor(-tan(x)/x), x, 0, '+') == -2
+    assert limit(floor(-tan(x)/x), x, 0, '-') == -2
+    assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '+') == -1
+    assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '-') == 0
+    assert limit(ceiling((cos(x) - 1)/x), x, 0, '+') == 0
+    assert limit(ceiling((cos(x) - 1)/x), x, 0, '-') == 1
+    assert limit(ceiling(sin(x)/x), x, 0, '+') == 1
+    assert limit(ceiling(sin(x)/x), x, 0, '-') == 1
+    assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
+    assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
+
+
 def test_atan():
     x = Symbol("x", real=True)
     assert limit(atan(x)*sin(1/x), x, 0) == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -233,21 +233,17 @@ def test_floor_ceiling_for_arg0_evaluating_to_nan():
     # issue 14355
     assert limit(floor(sin(x)/x), x, 0, '+') == 0
     assert limit(floor(sin(x)/x), x, 0, '-') == 0
-    assert limit(floor(sin(x)/x), x, 0, '+-') == 0
     # test comment https://github.com/sympy/sympy/issues/14355#issuecomment-372121314
     assert limit(floor(-tan(x)/x), x, 0, '+') == -2
     assert limit(floor(-tan(x)/x), x, 0, '-') == -2
-    assert limit(floor(-tan(x)/x), x, 0, '+-') == -2
     assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '+') == -1
     assert limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '-') == 0
     assert limit(ceiling((cos(x) - 1)/x), x, 0, '+') == 0
     assert limit(ceiling((cos(x) - 1)/x), x, 0, '-') == 1
     assert limit(ceiling(sin(x)/x), x, 0, '+') == 1
     assert limit(ceiling(sin(x)/x), x, 0, '-') == 1
-    assert limit(ceiling(sin(x)/x), x, 0, '+-') == 1
     assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
     assert limit(ceiling(-tan(x)/x), x, 0, '+') == -1
-    assert limit(ceiling(-tan(x)/x), x, 0, '+-') == -1
 
 
 def test_atan():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #14355 

Also addresses https://github.com/sympy/sympy/issues/14355#issuecomment-372121314

#### Brief description of what is fixed or changed
This Pr fixes cases where `arg0` would evaluate to `S.NaN` and this case currently lacks support. Few results which have been addressed have been noted below !! 

```
>>> limit(floor((x**3 + x)/(x**2 - x)), x, 0, '+')  # -1 on master
-2
>>> limit(floor((x**3 + x)/(x**2 - x)), x, 0, '-')   # -1 on master but not through intended code
-1
>>> limit(floor((cos(x) - 1)/x), x, 0, '-')   # 0 on master but not through intended code
0
>>> limit(floor((cos(x) - 1)/x), x, 0, '+')  # 0 on master
-1
>>> limit(floor(sin(x)/x), x, 0, '+')   # 1 on master
0
>>> limit(floor(sin(x)/x), x, 0, '-')   # 1 on master
0
>>> limit(floor(-tan(x)/x), x, 0, '-')   # -1 on master
-2
>>> limit(floor(-tan(x)/x), x, 0, '+')   # -1 on master
-2
>>> # ceiling cases
>>> limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '-')  # -1 on master
0
>>> limit(ceiling((x**3 + x)/(x**2 - x)), x, 0, '+')   # -1 on master but not through intended code
-1
>>> limit(ceiling((cos(x) - 1)/x), x, 0, '+')  # 0 on master but not through intended code
0
>>> limit(ceiling((cos(x) - 1)/x), x, 0, '-')  # 0 on master
1
```

The issue deserved calculation of the **leading term** and then dealing with it similarly as all other cases for **leading terms** are dealt , hence this has good resonance with already implemented code !


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixes limit computations where arg0 would evaluate to S.NaN for the ceiling and floor functions.
<!-- END RELEASE NOTES -->
