### PR TITLE
2 fixes for `Circle` from equation

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1557,7 +1557,7 @@ class Circle(Ellipse):
         if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
             x = kwargs.get('x', 'x')
             y = kwargs.get('y', 'y')
-            equation = args[0]
+            equation = args[0].expand()
             if isinstance(equation, Eq):
                 equation = equation.lhs - equation.rhs
             x = find(x, equation)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1573,7 +1573,7 @@ class Circle(Ellipse):
 
             center_x = -c/a/2
             center_y = -d/b/2
-            r2 = (center_x**2) + (center_y**2) - e
+            r2 = (center_x**2) + (center_y**2) - e/a
 
             return Circle((center_x, center_y), sqrt(r2), evaluate=evaluate)
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -1,3 +1,4 @@
+from sympy.core import expand
 from sympy.core.numbers import (Rational, oo, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -30,9 +31,8 @@ def test_ellipse_equation_using_slope():
 
 
 def test_object_from_equation():
-    from sympy.abc import x, y, a, b
-    assert Circle(x**2 + y**2 + 3*x + 4*y - 8) == Circle(Point2D(S(-3) / 2, -2),
-                                                                                      sqrt(57) / 2)
+    from sympy.abc import x, y, a, b, c, d, e
+    assert Circle(x**2 + y**2 + 3*x + 4*y - 8) == Circle(Point2D(S(-3) / 2, -2), sqrt(57) / 2)
     assert Circle(x**2 + y**2 + 6*x + 8*y + 25) == Circle(Point2D(-3, -4), 0)
     assert Circle(a**2 + b**2 + 6*a + 8*b + 25, x='a', y='b') == Circle(Point2D(-3, -4), 0)
     assert Circle(x**2 + y**2 - 25) == Circle(Point2D(0, 0), 5)
@@ -40,7 +40,7 @@ def test_object_from_equation():
     assert Circle(a**2 + b**2, x='a', y='b') == Circle(Point2D(0, 0), 0)
     assert Circle(x**2 + y**2 + 6*x + 8) == Circle(Point2D(-3, 0), 1)
     assert Circle(x**2 + y**2 + 6*y + 8) == Circle(Point2D(0, -3), 1)
-    assert Circle(6*(x**2) + 6*(y**2) + 6*x + 8*y - 25) == Circle(Point2D(Rational(-1, 2), Rational(-2, 3)), 5*sqrt(37)/6)
+    assert Circle(6*(x**2) + 6*(y**2) + 6*x + 8*y - 25) == Circle(Point2D(Rational(-1, 2), Rational(-2, 3)), 5*sqrt(7)/6)
     assert Circle(Eq(a**2 + b**2, 25), x='a', y=b) == Circle(Point2D(0, 0), 5)
     raises(GeometryError, lambda: Circle(x**2 + y**2 + 3*x + 4*y + 26))
     raises(GeometryError, lambda: Circle(x**2 + y**2 + 25))
@@ -48,6 +48,10 @@ def test_object_from_equation():
     raises(GeometryError, lambda: Circle(x**2 + 6*y + 8))
     raises(GeometryError, lambda: Circle(6*(x ** 2) + 4*(y**2) + 6*x + 8*y + 25))
     raises(ValueError, lambda: Circle(a**2 + b**2 + 3*a + 4*b - 8))
+    # .equation() adds 'real=True' assumption; '==' would fail if assumptions differed
+    x, y = symbols('x y', real=True)
+    eq = a*x**2 + a*y**2 + c*x + d*y + e
+    assert expand(Circle(eq).equation()*a) == eq
 
 
 @slow

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -40,6 +40,7 @@ def test_object_from_equation():
     assert Circle(a**2 + b**2, x='a', y='b') == Circle(Point2D(0, 0), 0)
     assert Circle(x**2 + y**2 + 6*x + 8) == Circle(Point2D(-3, 0), 1)
     assert Circle(x**2 + y**2 + 6*y + 8) == Circle(Point2D(0, -3), 1)
+    assert Circle((x - 1)**2 + y**2 - 9) == Circle(Point2D(1, 0), 3)
     assert Circle(6*(x**2) + 6*(y**2) + 6*x + 8*y - 25) == Circle(Point2D(Rational(-1, 2), Rational(-2, 3)), 5*sqrt(7)/6)
     assert Circle(Eq(a**2 + b**2, 25), x='a', y=b) == Circle(Point2D(0, 0), 5)
     raises(GeometryError, lambda: Circle(x**2 + y**2 + 3*x + 4*y + 26))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23264

#### Brief description of what is fixed or changed
With this PR both issues described in #23264 are fixed. Example session:
```
In [1]: from sympy.geometry import Circle

In [2]: eq = (x - 1)**2 + y**2 - 9

In [3]: expand(2*eq)
Out[3]:
   2            2
2⋅x  - 4⋅x + 2⋅y  - 16

In [4]: Circle(_3)
Out[4]: Circle(Point2D(1, 0), 3)

In [5]: Circle(eq)
Out[5]: Circle(Point2D(1, 0), 3)
```
Previously, the first `Circle` call would return an incorrect radius and the second one would throw an exception.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed `Circle` from equation (wrong radius in some cases; allow non-expanded equation).
<!-- END RELEASE NOTES -->
