### PR TITLE
Use Dimension objects instead of symbols/expressions in the dimensional dependecy dictionaries

### DIFF
--- a/doc/src/modules/physics/units/examples.rst
+++ b/doc/src/modules/physics/units/examples.rst
@@ -38,9 +38,9 @@ should be :math:`L^3 M^{-1} T^{-2}`.
     >>> F
     Dimension(acceleration*mass)
     >>> dimsys_SI.get_dimensional_dependencies(F)
-    {'length': 1, 'mass': 1, 'time': -2}
+    {Dimension(length): 1, Dimension(mass, M): 1, Dimension(time): -2}
     >>> dimsys_SI.get_dimensional_dependencies(force)
-    {'length': 1, 'mass': 1, 'time': -2}
+    {Dimension(length): 1, Dimension(mass): 1, Dimension(time): -2}
 
     Dimensions cannot compared directly, even if in the SI convention they are
     the same:

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -125,14 +125,14 @@ class Dimension(Expr):
 
         >>> from sympy.physics.units.systems.si import dimsys_SI
         >>> dimsys_SI.get_dimensional_dependencies(velocity)
-        {'length': 1, 'time': -1}
+        {Dimension(length, L): 1, Dimension(time, T): -1}
         >>> length + length
         Dimension(length)
         >>> l2 = length**2
         >>> l2
         Dimension(length**2)
         >>> dimsys_SI.get_dimensional_dependencies(l2)
-        {'length': 2}
+        {Dimension(length, L): 2}
 
     """
 

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -162,10 +162,7 @@ class Dimension(Expr):
         elif symbol is not None:
             assert isinstance(symbol, Symbol)
 
-        if symbol is not None:
-            obj = Expr.__new__(cls, name, symbol)
-        else:
-            obj = Expr.__new__(cls, name)
+        obj = Expr.__new__(cls, name)
 
         obj._name = name
         obj._symbol = symbol
@@ -178,14 +175,6 @@ class Dimension(Expr):
     @property
     def symbol(self):
         return self._symbol
-
-    def __hash__(self):
-        return Expr.__hash__(self)
-
-    def __eq__(self, other):
-        if isinstance(other, Dimension):
-            return self.name == other.name
-        return False
 
     def __str__(self):
         """
@@ -257,7 +246,7 @@ class Dimension(Expr):
     @classmethod
     def _from_dimensional_dependencies(cls, dependencies):
         return reduce(lambda x, y: x * y, (
-            Dimension(d)**e for d, e in dependencies.items()
+            d**e for d, e in dependencies.items()
         ), 1)
 
     def has_integer_powers(self, dim_sys):
@@ -311,7 +300,6 @@ class DimensionSystem(Basic, _QuantityMapper):
         derived_dims = [parse_dim(i) for i in derived_dims]
 
         for dim in base_dims:
-            dim = dim.name
             if (dim in dimensional_dependencies
                 and (len(dimensional_dependencies[dim]) != 1 or
                 dimensional_dependencies[dim].get(dim, None) != 1)):
@@ -320,11 +308,11 @@ class DimensionSystem(Basic, _QuantityMapper):
 
         def parse_dim_name(dim):
             if isinstance(dim, Dimension):
-                return dim.name
-            elif isinstance(dim, str):
-                return Symbol(dim)
-            elif isinstance(dim, Symbol):
                 return dim
+            elif isinstance(dim, str):
+                return Dimension(Symbol(dim))
+            elif isinstance(dim, Symbol):
+                return Dimension(dim)
             else:
                 raise TypeError("unrecognized type %s for %s" % (type(dim), dim))
 
@@ -343,9 +331,9 @@ class DimensionSystem(Basic, _QuantityMapper):
         for dim in derived_dims:
             if dim in base_dims:
                 raise ValueError("Dimension %s both in base and derived" % dim)
-            if dim.name not in dimensional_dependencies:
+            if dim not in dimensional_dependencies:
                 # TODO: should this raise a warning?
-                dimensional_dependencies[dim.name] = Dict({dim.name: 1})
+                dimensional_dependencies[dim] = Dict({dim: 1})
 
         base_dims.sort(key=default_sort_key)
         derived_dims.sort(key=default_sort_key)
@@ -368,75 +356,74 @@ class DimensionSystem(Basic, _QuantityMapper):
     def dimensional_dependencies(self):
         return self.args[2]
 
-    def _get_dimensional_dependencies_for_name(self, name):
-        if isinstance(name, Dimension):
-            name = name.name
+    def _get_dimensional_dependencies_for_name(self, dimension):
+        if isinstance(dimension, str):
+            dimension = Dimension(Symbol(dimension))
+        elif not isinstance(dimension, Dimension):
+            dimension = Dimension(dimension)
 
-        if isinstance(name, str):
-            name = Symbol(name)
-
-        if name.is_Symbol:
+        if dimension.name.is_Symbol:
             # Dimensions not included in the dependencies are considered
             # as base dimensions:
-            return dict(self.dimensional_dependencies.get(name, {name: 1}))
+            return dict(self.dimensional_dependencies.get(dimension, {dimension: 1}))
 
-        if name.is_number or name.is_NumberSymbol:
+        if dimension.name.is_number or dimension.name.is_NumberSymbol:
             return {}
 
         get_for_name = self._get_dimensional_dependencies_for_name
 
-        if name.is_Mul:
+        if dimension.name.is_Mul:
             ret = collections.defaultdict(int)
-            dicts = [get_for_name(i) for i in name.args]
+            dicts = [get_for_name(i) for i in dimension.name.args]
             for d in dicts:
                 for k, v in d.items():
                     ret[k] += v
             return {k: v for (k, v) in ret.items() if v != 0}
 
-        if name.is_Add:
-            dicts = [get_for_name(i) for i in name.args]
+        if dimension.name.is_Add:
+            dicts = [get_for_name(i) for i in dimension.name.args]
             if all(d == dicts[0] for d in dicts[1:]):
                 return dicts[0]
             raise TypeError("Only equivalent dimensions can be added or subtracted.")
 
-        if name.is_Pow:
-            dim_base = get_for_name(name.base)
-            dim_exp = get_for_name(name.exp)
-            if dim_exp == {} or name.exp.is_Symbol:
-                return {k: v*name.exp for (k, v) in dim_base.items()}
+        if dimension.name.is_Pow:
+            dim_base = get_for_name(dimension.name.base)
+            dim_exp = get_for_name(dimension.name.exp)
+            if dim_exp == {} or dimension.name.exp.is_Symbol:
+                return {k: v * dimension.name.exp for (k, v) in dim_base.items()}
             else:
                 raise TypeError("The exponent for the power operator must be a Symbol or dimensionless.")
 
-        if name.is_Function:
+        if dimension.name.is_Function:
             args = (Dimension._from_dimensional_dependencies(
-                get_for_name(arg)) for arg in name.args)
-            result = name.func(*args)
+                get_for_name(arg)) for arg in dimension.name.args)
+            result = dimension.name.func(*args)
 
-            dicts = [get_for_name(i) for i in name.args]
+            dicts = [get_for_name(i) for i in dimension.name.args]
 
             if isinstance(result, Dimension):
                 return self.get_dimensional_dependencies(result)
-            elif result.func == name.func:
-                if isinstance(name, TrigonometricFunction):
-                    if dicts[0] in ({}, {Symbol('angle'): 1}):
+            elif result.func == dimension.name.func:
+                if isinstance(dimension.name, TrigonometricFunction):
+                    if dicts[0] in ({}, {Dimension('angle'): 1}):
                         return {}
                     else:
-                        raise TypeError("The input argument for the function {} must be dimensionless or have dimensions of angle.".format(name.func))
+                        raise TypeError("The input argument for the function {} must be dimensionless or have dimensions of angle.".format(dimension.func))
                 else:
-                    if all( (item == {} for item in dicts) ):
+                    if all(item == {} for item in dicts):
                         return {}
                     else:
-                        raise TypeError("The input arguments for the function {} must be dimensionless.".format(name.func))
+                        raise TypeError("The input arguments for the function {} must be dimensionless.".format(dimension.func))
             else:
                 return get_for_name(result)
 
-        raise TypeError("Type {} not implemented for get_dimensional_dependencies".format(type(name)))
+        raise TypeError("Type {} not implemented for get_dimensional_dependencies".format(type(dimension.name)))
 
     def get_dimensional_dependencies(self, name, mark_dimensionless=False):
         dimdep = self._get_dimensional_dependencies_for_name(name)
         if mark_dimensionless and dimdep == {}:
-            return {'dimensionless': 1}
-        return {str(i): j for i, j in dimdep.items()}
+            return {Dimension(1): 1}
+        return {k: v for k, v in dimdep.items()}
 
     def equivalent_dims(self, dim1, dim2):
         deps1 = self.get_dimensional_dependencies(dim1)

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -16,12 +16,12 @@ from sympy.testing.pytest import raises
 
 
 def test_Dimension_definition():
-    assert dimsys_SI.get_dimensional_dependencies(length) == {"length": 1}
+    assert dimsys_SI.get_dimensional_dependencies(length) == {length: 1}
     assert length.name == Symbol("length")
     assert length.symbol == Symbol("L")
 
     halflength = sqrt(length)
-    assert dimsys_SI.get_dimensional_dependencies(halflength) == {"length": S.Half}
+    assert dimsys_SI.get_dimensional_dependencies(halflength) == {length: S.Half}
 
 
 def test_Dimension_error_definition():
@@ -72,11 +72,11 @@ def test_Dimension_add_sub():
     e = length + 1
     assert e == 1 + length == 1 - length and e.is_Add and set(e.args) == {length, 1}
 
-    assert  dimsys_SI.get_dimensional_dependencies(mass * length / time**2 + force) == \
-            {'length': 1, 'mass': 1, 'time': -2}
-    assert  dimsys_SI.get_dimensional_dependencies(mass * length / time**2 + force -
+    assert dimsys_SI.get_dimensional_dependencies(mass * length / time**2 + force) == \
+            {length: 1, mass: 1, time: -2}
+    assert dimsys_SI.get_dimensional_dependencies(mass * length / time**2 + force -
                                                    pressure * length**2) == \
-            {'length': 1, 'mass': 1, 'time': -2}
+            {length: 1, mass: 1, time: -2}
 
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(mass * length / time**2 + pressure))
 
@@ -95,22 +95,22 @@ def test_Dimension_mul_div_exp():
 
     assert (length * length) == length ** 2
 
-    assert dimsys_SI.get_dimensional_dependencies(length * length) == {"length": 2}
-    assert dimsys_SI.get_dimensional_dependencies(length ** 2) == {"length": 2}
-    assert dimsys_SI.get_dimensional_dependencies(length * time) == { "length": 1, "time": 1}
-    assert dimsys_SI.get_dimensional_dependencies(velo) == { "length": 1, "time": -1}
-    assert dimsys_SI.get_dimensional_dependencies(velo ** 2) == {"length": 2, "time": -2}
+    assert dimsys_SI.get_dimensional_dependencies(length * length) == {length: 2}
+    assert dimsys_SI.get_dimensional_dependencies(length ** 2) == {length: 2}
+    assert dimsys_SI.get_dimensional_dependencies(length * time) == {length: 1, time: 1}
+    assert dimsys_SI.get_dimensional_dependencies(velo) == {length: 1, time: -1}
+    assert dimsys_SI.get_dimensional_dependencies(velo ** 2) == {length: 2, time: -2}
 
     assert dimsys_SI.get_dimensional_dependencies(length / length) == {}
     assert dimsys_SI.get_dimensional_dependencies(velo / length * time) == {}
-    assert dimsys_SI.get_dimensional_dependencies(length ** -1) == {"length": -1}
-    assert dimsys_SI.get_dimensional_dependencies(velo ** -1.5) == {"length": -1.5, "time": 1.5}
+    assert dimsys_SI.get_dimensional_dependencies(length ** -1) == {length: -1}
+    assert dimsys_SI.get_dimensional_dependencies(velo ** -1.5) == {length: -1.5, time: 1.5}
 
     length_a = length**"a"
-    assert dimsys_SI.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
+    assert dimsys_SI.get_dimensional_dependencies(length_a) == {length: Symbol("a")}
 
-    assert dimsys_SI.get_dimensional_dependencies(length**pi) == {"length": pi}
-    assert dimsys_SI.get_dimensional_dependencies(length**(length/length)) == {"length": Dimension(1)}
+    assert dimsys_SI.get_dimensional_dependencies(length**pi) == {length: pi}
+    assert dimsys_SI.get_dimensional_dependencies(length**(length/length)) == {length: Dimension(1)}
 
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(length**length))
 
@@ -144,7 +144,7 @@ def test_Dimension_functions():
 
     assert dimsys_SI.get_dimensional_dependencies(log(length / length, length / length)) == {}
 
-    assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {"length": 1}
+    assert dimsys_SI.get_dimensional_dependencies(Abs(length)) == {length: 1}
     assert dimsys_SI.get_dimensional_dependencies(Abs(length / length)) == {}
 
     assert dimsys_SI.get_dimensional_dependencies(sqrt(-1)) == {}

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -19,7 +19,7 @@ def test_extend():
 def test_list_dims():
     dimsys = DimensionSystem((length, time, mass))
 
-    assert dimsys.list_can_dims == ("length", "mass", "time")
+    assert dimsys.list_can_dims == (length, mass, time)
 
 
 def test_dim_can_vector():

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -22,7 +22,7 @@ from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
 
 from sympy.physics.units.definitions.dimension_definitions import (
     Dimension, charge, length, time, temperature, pressure,
-    energy
+    energy, mass
 )
 from sympy.physics.units.prefixes import PREFIXES, kilo
 from sympy.physics.units.quantities import PhysicalConstant, Quantity
@@ -170,8 +170,8 @@ def test_quantity_abs():
         assert Dq == Dq1
 
     assert SI.get_dimension_system().get_dimensional_dependencies(Dq) == {
-        'length': 1,
-        'time': -1,
+        length: 1,
+        time: -1,
     }
     assert meter == sqrt(meter**2)
 
@@ -330,10 +330,10 @@ def test_quantity_postprocessing():
     q = q1 + q2
     Dq = Dimension(SI.get_dimensional_expr(q))
     assert SI.get_dimension_system().get_dimensional_dependencies(Dq) == {
-        'length': -1,
-        'mass': 2,
-        'temperature': 1,
-        'time': -5,
+        length: -1,
+        mass: 2,
+        temperature: 1,
+        time: -5,
     }
 
 
@@ -524,7 +524,7 @@ def test_issue_22819():
     from sympy.physics.units import tonne, gram, Da
     from sympy.physics.units.systems.si import dimsys_SI
     assert tonne.convert_to(gram) == 1000000*gram
-    assert dimsys_SI.get_dimensional_dependencies(area) == {'length': 2}
+    assert dimsys_SI.get_dimensional_dependencies(area) == {length: 2}
     assert Da.scale_factor == 1.66053906660000e-24
 
 


### PR DESCRIPTION
Use `Dimension` objects instead of symbols/expressions in the dimensional dependecy dictionaries.

There was once a bug which prevented `Dimension` objects from having a proper hash, thus they could not be used as keys in a dictionary. This bug has since been fixed, so no need to hide the `Dimension` objects anymore.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
