### PR TITLE
Make HNF require a `mode` argument.

### DIFF
--- a/doc/src/modules/matrices/normalforms.rst
+++ b/doc/src/modules/matrices/normalforms.rst
@@ -8,3 +8,4 @@ Matrix Normal Forms
 
 .. autofunction:: smith_normal_form
 .. autofunction:: hermite_normal_form
+.. autoclass:: HNFMode

--- a/doc/src/modules/polys/domainmatrix.rst
+++ b/doc/src/modules/polys/domainmatrix.rst
@@ -61,3 +61,4 @@ Normal Forms
 
 .. autofunction:: smith_normal_form
 .. autofunction:: hermite_normal_form
+.. autoclass:: HNFMode

--- a/doc/src/modules/polys/literature.rst
+++ b/doc/src/modules/polys/literature.rst
@@ -145,3 +145,6 @@ a theoretical foundation for implementing polynomials manipulation module.
 
 .. [Cohen93] Henri Cohen. "A Course in Computational Algebraic Number Theory",
    Springer, 1993.
+
+.. [Pohst89] M Pohst and H Zassenhaus. "Algorithmic Algebraic Number Theory",
+   Cambridge University Press, 1989.

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -7,8 +7,12 @@ from sympy.polys.matrices.normalforms import (
         smith_normal_form as _snf,
         invariant_factors as _invf,
         hermite_normal_form as _hnf,
+        HNFMode as _HNFMode,
     )
 
+# Redefine here so that users intending only to work with Matrices do not
+# have to import from under polys.
+HNFMode = _HNFMode
 
 def _to_domain(m, domain=None):
     """Convert Matrix to DomainMatrix"""
@@ -67,7 +71,7 @@ def invariant_factors(m, domain=None):
     return factors
 
 
-def hermite_normal_form(A, *, D=None, check_rank=False):
+def hermite_normal_form(A, mode, *, D=None, check_rank=False, truncate=True):
     r"""
     Compute the Hermite Normal Form of a Matrix *A* of integers.
 
@@ -75,15 +79,18 @@ def hermite_normal_form(A, *, D=None, check_rank=False):
     ========
 
     >>> from sympy import Matrix
-    >>> from sympy.matrices.normalforms import hermite_normal_form
+    >>> from sympy.matrices.normalforms import hermite_normal_form, HNFMode
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
-    >>> print(hermite_normal_form(m))
+    >>> print(hermite_normal_form(m, HNFMode.RIGHT))
     Matrix([[10, 0, 2], [0, 15, 3], [0, 0, 2]])
 
     Parameters
     ==========
 
     A : $m \times n$ ``Matrix`` of integers.
+
+    mode : :py:class:`~HNFMode`
+        Say on which side of the pivots the reduced entries should go.
 
     D : int, optional
         Let $W$ be the HNF of *A*. If known in advance, a positive integer *D*
@@ -97,6 +104,10 @@ def hermite_normal_form(A, *, D=None, check_rank=False):
         checking it for you. If you do want this to be checked (and the
         ordinary, non-modulo *D* algorithm to be used if the check fails), then
         set *check_rank* to ``True``.
+
+    truncate : boolean, optional (default=True)
+        If ``True``, chop off rows or columns of zeros, according to the
+        *mode*. Setting ``False`` is not available when working mod *D*.
 
     Returns
     =======
@@ -124,4 +135,5 @@ def hermite_normal_form(A, *, D=None, check_rank=False):
     # Accept any of Python int, SymPy Integer, and ZZ itself:
     if D is not None and not ZZ.of_type(D):
         D = ZZ(int(D))
-    return _hnf(A._rep, D=D, check_rank=check_rank).to_Matrix()
+    return _hnf(A._rep, mode,
+                D=D, check_rank=check_rank, truncate=truncate).to_Matrix()

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -7,6 +7,7 @@ from sympy.matrices.normalforms import (
     invariant_factors,
     smith_normal_form,
     hermite_normal_form,
+    HNFMode,
 )
 from sympy.polys.domains import ZZ, QQ
 from sympy.core.numbers import Integer
@@ -58,24 +59,32 @@ def test_smith_normal_deprecated():
 
 
 def test_hermite_normal():
+    hnf = lambda m, D=None, check_rank=False: hermite_normal_form(
+        m, HNFMode.RIGHT, D=D)
     m = Matrix([[2, 7, 17, 29, 41], [3, 11, 19, 31, 43], [5, 13, 23, 37, 47]])
-    hnf = Matrix([[1, 0, 0], [0, 2, 1], [0, 0, 1]])
-    assert hermite_normal_form(m) == hnf
+    H = Matrix([[1, 0, 0], [0, 2, 1], [0, 0, 1]])
+    assert hnf(m) == H
 
     tr_hnf = Matrix([[37, 0, 19], [222, -6, 113], [48, 0, 25], [0, 2, 1], [0, 0, 1]])
-    assert hermite_normal_form(m.transpose()) == tr_hnf
+    assert hnf(m.transpose()) == tr_hnf
 
     m = Matrix([[8, 28, 68, 116, 164], [3, 11, 19, 31, 43], [5, 13, 23, 37, 47]])
-    hnf = Matrix([[4, 0, 0], [0, 2, 1], [0, 0, 1]])
-    assert hermite_normal_form(m) == hnf
-    assert hermite_normal_form(m, D=8) == hnf
-    assert hermite_normal_form(m, D=ZZ(8)) == hnf
-    assert hermite_normal_form(m, D=Integer(8)) == hnf
+    H = Matrix([[4, 0, 0], [0, 2, 1], [0, 0, 1]])
+    assert hnf(m) == H
+    assert hnf(m, D=8) == H
+    assert hnf(m, D=ZZ(8)) == H
+    assert hnf(m, D=Integer(8)) == H
 
     m = Matrix([[10, 8, 6, 30, 2], [45, 36, 27, 18, 9], [5, 4, 3, 2, 1]])
-    hnf = Matrix([[26, 2], [0, 9], [0, 1]])
-    assert hermite_normal_form(m) == hnf
+    H = Matrix([[26, 2], [0, 9], [0, 1]])
+    assert hnf(m) == H
 
     m = Matrix([[2, 7], [0, 0], [0, 0]])
-    hnf = Matrix(3, 0, [])
-    assert hermite_normal_form(m) == hnf
+    H = Matrix(3, 0, [])
+    assert hnf(m) == H
+
+
+def test_issue_23260():
+    A = Matrix([[12, 19, 28, 34], [19, 30, 44, 53]])
+    H = Matrix([[1, 0, -4, -13], [0, 1, 4, 10]])
+    assert hermite_normal_form(A, HNFMode.ABOVE) == H

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -679,6 +679,22 @@ class DomainMatrix:
         """Matrix transpose of ``self``"""
         return self.from_rep(self.rep.transpose())
 
+    def flip_top_to_bottom(self):
+        return DomainMatrix(list(reversed(self.to_list())), self.shape, self.domain)
+
+    def rotate_clockwise(self):
+        return self.flip_top_to_bottom().transpose()
+
+    def rotate_counterclockwise(self):
+        return self.transpose().flip_top_to_bottom()
+
+    def rotate_180(self):
+        return self.rotate_clockwise().rotate_clockwise()
+
+    def anti_transpose(self):
+        """Flip across the *other* diagonal. """
+        return self.flip_top_to_bottom().rotate_counterclockwise()
+
     def flat(self):
         rows, cols = self.shape
         return [self[i,j].element for i in range(rows) for j in range(cols)]

--- a/sympy/polys/numberfields/modules.py
+++ b/sympy/polys/numberfields/modules.py
@@ -186,11 +186,13 @@ from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.domains.integerring import ZZ
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.matrices.exceptions import DMBadInputError
-from sympy.polys.matrices.normalforms import hermite_normal_form
+from sympy.polys.matrices.normalforms import HNFMode, hermite_normal_form as hnf_
 from sympy.polys.polyerrors import CoercionFailed, UnificationFailed
 from sympy.polys.polyutils import IntegerPowerable
 from .exceptions import ClosureFailure, MissingUnityError
 from .utilities import AlgIntPowers, is_int, is_rat, get_num_denom
+
+hermite_normal_form = lambda A, D=None: hnf_(A, HNFMode.RIGHT, D=D)
 
 
 def to_col(coeffs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Resolves #23260 

#### Brief description of what is fixed or changed

The `hermite_normal_form()` functions (one under `matrices` and one under `polys`) now
require a `mode` argument.

This allows us to work within any of the (several) popular definitions of Hermite Normal Form.

#### Other comments

This changes behavior that was new in SymPy 1.10.
It will be considered a breaking change by users for whom `HNFMode.RIGHT` was the expected behavior.
It will be considered a bugfix by users who expected different behavior.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * HNF requires a mode argument
* polys
  * HNF requires a mode argument
<!-- END RELEASE NOTES -->
