### PR TITLE
integrals - fixes issue #23276 and double integrate with matrix does not raise exception

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -455,7 +455,7 @@ class Integral(AddWithLimits):
         # hacks to handle special cases
         if isinstance(function, MatrixBase):
             return function.applyfunc(
-                lambda f: self.func(f, self.limits).doit(**hints))
+                lambda f: self.func(f, *self.limits).doit(**hints))
 
         if isinstance(function, FormalPowerSeries):
             if len(self.limits) > 1:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -13,6 +13,7 @@ from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
+from sympy.integrals.integrals import integrate
 from sympy.polys.polytools import (Poly, PurePoly)
 from sympy.printing.str import sstr
 from sympy.sets.sets import FiniteSet
@@ -3004,3 +3005,10 @@ def test_deprecated_classof_a2idx():
     with warns_deprecated_sympy():
         from sympy.matrices.matrices import a2idx
         assert a2idx(-1, 3) == 2
+
+
+def test_issue_23276():
+    M = Matrix([x, y])
+    assert integrate(M, (x, 0, 1), (y, 0, 1)) == Matrix([
+        [1/2],
+        [1/2]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #23276 and now double `integrate` with matrix does not raise exception.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * fixes bug in `integrals` and now double integrate with matrix does not raise an exception.

<!-- END RELEASE NOTES -->
