### PR TITLE
23287: Mul.is_integer correction

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1386,6 +1386,9 @@ class Mul(Expr, AssocOp):
                     # for rational self and e equal to zero: a = b**e is 1
                     assert not e.is_zero
                     return # sign of e unknown -> self.is_integer unknown
+                else:
+                    # x**2, 2**x, or x**y with x and y int-unknown -> unknonwn
+                    return
             else:
                 return
 
@@ -1397,7 +1400,7 @@ class Mul(Expr, AssocOp):
         anyeven = lambda x: any(i.is_even for i in x)
 
         from .relational import is_gt
-        if not unknown and not numerators and denominators and all(
+        if not numerators and denominators and all(
                 is_gt(_, S.One) for _ in denominators):
             return False
         elif unknown:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1397,8 +1397,8 @@ class Mul(Expr, AssocOp):
         anyeven = lambda x: any(i.is_even for i in x)
 
         from .relational import is_gt
-        if not numerators and denominators and all(is_gt(_, S.One)
-                for _ in denominators):
+        if not unknown and not numerators and denominators and all(
+                is_gt(_, S.One) for _ in denominators):
             return False
         elif unknown:
             return

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1076,6 +1076,8 @@ def test_Pow_is_integer():
     assert (1/(x + 1)).is_integer is False
     assert (1/(-x - 1)).is_integer is False
     assert (-1/(x + 1)).is_integer is False
+    # issue 23287
+    assert (x**2/2).is_integer is None
 
     # issue 8648-like
     k = Symbol('k', even=True)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1292,3 +1292,8 @@ def test_common_assumptions():
     assert common_assumptions([0, 1, 2], []) == {}
     assert common_assumptions([], ['integer']) == {}
     assert common_assumptions([0], ['integer']) == {'integer': True}
+
+
+def test_issue_23287():
+    x = Symbol('x')
+    assert (x**2/2).is_integer is None

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1292,8 +1292,3 @@ def test_common_assumptions():
     assert common_assumptions([0, 1, 2], []) == {}
     assert common_assumptions([], ['integer']) == {}
     assert common_assumptions([0], ['integer']) == {'integer': True}
-
-
-def test_issue_23287():
-    x = Symbol('x')
-    assert (x**2/2).is_integer is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #23287

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    - rational expressions formerly reported as not-integer (False) may now be correctly reported as possibly so (None)
<!-- END RELEASE NOTES -->
