### PR TITLE
WIP: feat(physics.units): `quantity_simplify()` can optionally derive the most appropriate unit prefix with `add_prefix=True`

### DIFF
--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -58,6 +58,10 @@ class Prefix(Expr):
         return self._scale_factor
 
     @property
+    def exponent(self):
+        return self._exponent
+
+    @property
     def base(self):
         return self._base
 
@@ -65,10 +69,10 @@ class Prefix(Expr):
         # TODO: add proper printers and tests:
         if self.base == 10:
             return "Prefix(%r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent)
+                str(self.name), str(self.abbrev), self.exponent)
         else:
             return "Prefix(%r, %r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent, self.base)
+                str(self.name), str(self.abbrev), self.exponent, self.base)
 
     __repr__ = __str__
 

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -145,6 +145,20 @@ def test_quantity_simplify_across_dimensions():
     assert quantity_simplify(5*kilometer/hour, across_dimensions=True, unit_system="SI") == 25*meter/(18*second)
     assert quantity_simplify(5*kilogram*meter/second**2, across_dimensions=True, unit_system="SI") == 5*newton
 
+def test_quantity_simplify_with_prefix():
+    from sympy.physics.units.util import quantity_simplify
+    from sympy.physics.units import meter, kilo, centi, kilometer, centimeter, second, microsecond
+
+    assert quantity_simplify(1000*meter, add_prefix=True, unit_system="SI") == kilometer
+    assert quantity_simplify(kilo*meter, add_prefix=True, unit_system="SI") == kilometer
+    assert quantity_simplify(centi*meter, add_prefix=True, unit_system="SI") == centimeter
+    assert quantity_simplify(100000*centi*meter, add_prefix=True, unit_system="SI") == kilometer
+    assert quantity_simplify(2000*meter, add_prefix=True, unit_system="SI") == 2*kilometer
+    assert quantity_simplify(200000*centi*meter, add_prefix=True, unit_system="SI") == 2*kilometer
+    assert quantity_simplify(1e-2*meter, add_prefix=True, unit_system="SI") == 1.0*centimeter
+    # FIXME: this test case appears to work as intended, but the assertion still fails.
+    assert quantity_simplify(6.83e-6*second, add_prefix=True, unit_system="SI") == 6.83*microsecond
+
 def test_check_dimensions():
     x = symbols('x')
     assert check_dimensions(inch + x) == inch + x

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -4,6 +4,9 @@ Several methods to simplify expressions involving unit objects.
 from functools import reduce
 from collections.abc import Iterable
 from typing import Optional
+from matplotlib.pyplot import sca
+
+from matplotlib.style import available
 
 from sympy import default_sort_key
 from sympy.core.add import Add
@@ -14,7 +17,7 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension, DimensionSystem
-from sympy.physics.units.prefixes import Prefix
+from sympy.physics.units.prefixes import Prefix, PREFIXES
 from sympy.physics.units.quantities import Quantity
 from sympy.physics.units.unitsystem import UnitSystem
 from sympy.utilities.iterables import sift
@@ -123,11 +126,14 @@ def convert_to(expr, target_units, unit_system="SI"):
     return expr_scale_factor * Mul.fromiter((1/get_total_scale_factor(u) * u) ** p for u, p in zip(target_units, depmat))
 
 
-def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None):
+def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None, add_prefix=False):
     """Return an equivalent expression in which prefixes are replaced
     with numerical values and all units of a given dimension are the
     unified in a canonical manner by default. `across_dimensions` allows
     for units of different dimensions to be simplified together.
+
+    `add_prefix` allows for determining the most appropriate prefix to
+    use for the units in the expression.
 
     `unit_system` must be specified if `across_dimensions` is True.
 
@@ -143,6 +149,8 @@ def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None):
     foot/2
     >>> quantity_simplify(5*joule/coulomb, across_dimensions=True, unit_system="SI")
     5*volt
+    >>> quantity_simplify(200000*centi*meter, add_prefix=True, unit_system="SI")
+    2*kilometer
     """
 
     if expr.is_Atom or not expr.has(Prefix, Quantity):
@@ -187,6 +195,40 @@ def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None):
         target_unit = unit_system.derived_units.get(target_dimension)
         if target_unit:
             expr = convert_to(expr, target_unit, unit_system)
+
+    if add_prefix:
+        if unit_system is None:
+            raise ValueError("unit_system must be specified if add_prefix is True")
+
+        unit_system = UnitSystem.get_unit_system(unit_system)
+
+        if isinstance(expr, Mul) and expr.args[0].is_Number:
+            scale, unit = expr.as_coeff_Mul()
+        else:
+            scale, unit = 1, expr
+
+        power = 0
+        for i in range(-24, 25): # TODO: derive possible powers from PREFIXES
+            if scale / 10**i <= 1:
+                power = i
+                break
+
+        if power == 0:
+            return expr
+
+        available_prefix_powers = list(map(lambda p: p.exponent, PREFIXES.values()))
+        closest_power = available_prefix_powers[min(range(len(available_prefix_powers)), key=lambda i: abs(available_prefix_powers[i] - power))]
+        closest_prefix = list(PREFIXES.values())[available_prefix_powers.index(closest_power)]
+
+        # find the prefixed unit that matches
+        matching_units = list(filter(lambda u: u.is_prefixed and u.scale_factor == closest_prefix.scale_factor and u.name.name.endswith(unit.name.name), unit_system._units))
+        assert len(matching_units) == 1
+        prefixed_unit: Quantity = matching_units[0]
+
+        scale /= closest_prefix.scale_factor
+        print("before:", expr)
+        expr = scale * prefixed_unit
+        print("after:", expr)
 
     return expr
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Adds a new optional flag to `quantity_simplify()`: `add_prefix` that allows it
to derive the most appropriate unit prefix.

#### Other comments
It's unclear whether or not we should grab the prefixed unit from the unit system as a single `Quantity` (eg. `microsecond` or `kilometer`),
or if it's better to have prefixes as `Prefix*Quantity` (eg. `micro*second` or `kilo*meter`).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * `quantity_simplify()` can add prefixes to the resulting units with the optional flag `add_prefix=True` to make the resulting value more human readable.
<!-- END RELEASE NOTES -->
