### PR TITLE
include the coefficient in L(A*x')

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -510,6 +510,7 @@ JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk> <kempj@tplxdt003.nat.physics.ox.ac.uk>
 Jack McCaffery <jpmccaffery@gmail.com>
+Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
 Jacob Garber <jgarber1@ualberta.ca>
 Jai Luthra <me@jailuthra.in>
 Jaime R <38530589+Jaime02@users.noreply.github.com>

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -699,6 +699,9 @@ def test_laplace_transform():
     assert LT(diff(f(t), (t, 3)), t, s) == s**3*LaplaceTransform(f(t), t, s)\
         - s**2*f(0) - s*Subs(Derivative(f(t), t), t, 0)\
             - Subs(Derivative(f(t), (t, 2)), t, 0)
+    # Issue #23307
+    assert LT(10*diff(f(t), (t, 1)), t, s) == 10*s*LaplaceTransform(f(t), t, s)\
+        - 10*f(0)
     assert LT(a*f(b*t)+g(c*t), t, s) == a*LaplaceTransform(f(t), t, s/b)/b +\
         LaplaceTransform(g(t), t, s/c)/c
     assert inverse_laplace_transform(

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1738,7 +1738,7 @@ def _laplace_rule_diff(f, t, s, doit=True, **hints):
             d.append(s**(ma1[n]-k-1)*y)
         r = s**ma1[n]*_laplace_apply_rules(ma1[g].func(t), t, s, doit=doit,
                                            **hints)
-        return r - Add(*d)
+        return ma1[a]*(r - Add(*d))
     return None
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23307

#### Brief description of what is fixed or changed

Include the matched coefficient in the derivative rule, L(a*g'(t)), return a times the rule for the derivative,
not just the rule for the derivative.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->


<!-- BEGIN RELEASE NOTES -->

* integrals
  * fix bug in Laplace transform of a derivative 

<!-- END RELEASE NOTES -->
