### PR TITLE
Fix `QRdecomposition` for symbolic cases

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1363,7 +1363,7 @@ def _QRdecomposition_optional(M, normalize=True):
             Q[:, j] -= Q[:, i] * R[i, j]
 
         Q[:, j] = dps(Q[:, j])
-        if Q[:, j].is_zero_matrix is False:
+        if Q[:, j].is_zero_matrix is not True:
             ranked.append(j)
             R[j, j] = M.one
 

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -1,7 +1,9 @@
 from sympy.core.function import expand_mul
-from sympy.core.numbers import (I, Rational)
+from sympy.core.numbers import I, Rational
 from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.complexes import Abs
 from sympy.simplify.simplify import simplify
 from sympy.matrices.matrices import NonSquareMatrixError
 from sympy.matrices import Matrix, zeros, eye, SparseMatrix
@@ -152,6 +154,18 @@ def test_QR():
     assert Q.T * Q == eye(Q.cols)
     assert R.is_upper
     assert A == Q*R
+
+    x = Symbol('x')
+    A = Matrix([x])
+    Q, R = A.QRdecomposition()
+    assert Q == Matrix([x / Abs(x)])
+    assert R == Matrix([Abs(x)])
+
+    A = Matrix([[x, 0], [0, x]])
+    Q, R = A.QRdecomposition()
+    assert Q == x / Abs(x) * Matrix([[1, 0], [0, 1]])
+    assert R == Abs(x) * Matrix([[1, 0], [0, 1]])
+
 
 def test_QR_non_square():
     # Narrow (cols < rows) matrices


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/23313

#### Brief description of what is fixed or changed

I'm attempting to fix the issue by changing the fuzzy logic to infer `is_zero == None` as nonzero.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Fixed `Matrix.QRdecomposition` giving wrong results for matrices containing symbols (for most cases where zero test can automatically infer the correct results)

<!-- END RELEASE NOTES -->
