### PR TITLE
add type hints to continued_fraction[_periodic]

### DIFF
--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import Integer, Rational
 from sympy.core.singleton import S
@@ -6,7 +7,7 @@ from sympy.core.sympify import _sympify
 from sympy.utilities.misc import as_int
 
 
-def continued_fraction(a):
+def continued_fraction(a) -> list:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -71,7 +72,7 @@ def continued_fraction(a):
         'expecting a rational or quadratic irrational, not %s' % e)
 
 
-def continued_fraction_periodic(p, q, d=0, s=1):
+def continued_fraction_periodic(p, q, d=0, s=1) -> list:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -167,7 +168,7 @@ def continued_fraction_periodic(p, q, d=0, s=1):
         p *= q
         q *= q
 
-    terms = []
+    terms: list[int] = []
     pq = {}
 
     while (p, q) not in pq:
@@ -177,7 +178,7 @@ def continued_fraction_periodic(p, q, d=0, s=1):
         q = (d - p**2)//q
 
     i = pq[(p, q)]
-    return terms[:i] + [terms[i:]]
+    return terms[:i] + [terms[i:]]  # type: ignore
 
 
 def continued_fraction_reduce(cf):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`continued_fraction` and `continued_fraction_periodic` are mutually recursive, so pyright fails to deduce the return type of both.
After adding return type, mypy complains the type of `terms`. After that, the `terms[:i] + [terms[i:]]` must be ignored due to https://github.com/python/typeshed/issues/2383

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
