### PR TITLE
22531: as_coefficients_dict accepts symbols

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -415,56 +415,6 @@ class Add(Expr, AssocOp):
     def could_extract_minus_sign(self):
         return _could_extract_minus_sign(self)
 
-    def as_coefficients_dict(self, *syms):
-        """Return a dictionary mapping terms to their Rational coefficient.
-        Since the dictionary is a defaultdict, inquiries about terms which
-        were not present will return a coefficient of 0. If an expression is
-        not an Add it is considered to have a single term.
-
-        If symbols `syms` are provided, any multiplicative terms
-        independent of them will be considered a coefficient and a
-        regular dictionary of syms-dependent generators as keys and
-        their corresponding coefficients as values will be returned.
-
-        Examples
-        ========
-
-        >>> from sympy import exp
-        >>> from sympy.abc import a, x
-        >>> (3*x + a*x + 4).as_coefficients_dict()
-        {1: 4, x: 3, a*x: 1}
-        >>> _[a]
-        0
-        >>> (3*a*x).as_coefficients_dict()
-        {a*x: 3}
-
-        >>> (3*exp(x)*x + a/x + 2).as_coefficients_dict(x)
-        {1: 2, 1/x: a, x*exp(x): 3}
-        """
-        if not syms:
-            d = defaultdict(list)
-            for ai in self.args:
-                c, m = ai.as_coeff_Mul()
-                d[m].append(c)
-            for k, v in d.items():
-                if len(v) == 1:
-                    d[k] = v[0]
-                else:
-                    d[k] = Add(*v)
-            di = defaultdict(int)
-            di.update(d)
-            return di
-        else:
-            d = defaultdict(list)
-            ind, dep = self.as_independent(*syms, as_Add=True)
-            for i in Add.make_args(dep):
-                c, x = i.as_independent(*syms, as_Add=False)
-                d[x].append(c)
-            d = {k: Add(*d[k]) for k in d}
-            d.update({S.One: ind})
-            return d
-
-
     @cacheit
     def as_coeff_add(self, *deps):
         """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1960,8 +1960,7 @@ class Expr(Basic, EvalfMixin):
     def as_coefficients_dict(self, *syms):
         """Return a dictionary mapping terms to their Rational coefficient.
         Since the dictionary is a defaultdict, inquiries about terms which
-        were not present will return a coefficient of 0. If an expression is
-        not an Add it is considered to have a single term.
+        were not present will return a coefficient of 0.
 
         If symbols ``syms`` are provided, any multiplicative terms
         independent of them will be considered a coefficient and a
@@ -1971,7 +1970,7 @@ class Expr(Basic, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy.abc import a, x
+        >>> from sympy.abc import a, x, y
         >>> (3*x + a*x + 4).as_coefficients_dict()
         {1: 4, x: 3, a*x: 1}
         >>> _[a]
@@ -1980,10 +1979,12 @@ class Expr(Basic, EvalfMixin):
         {a*x: 3}
         >>> (3*a*x).as_coefficients_dict(x)
         {x: 3*a}
+        >>> (3*a*x).as_coefficients_dict(y)
+        {1: 3*a*x}
 
         """
+        d = defaultdict(list)
         if not syms:
-            d = defaultdict(list)
             for ai in Add.make_args(self):
                 c, m = ai.as_coeff_Mul()
                 d[m].append(c)
@@ -1992,11 +1993,7 @@ class Expr(Basic, EvalfMixin):
                     d[k] = v[0]
                 else:
                     d[k] = Add(*v)
-            di = defaultdict(int)
-            di.update(d)
-            return di
         else:
-            d = defaultdict(list)
             ind, dep = self.as_independent(*syms, as_Add=True)
             for i in Add.make_args(dep):
                 if i.is_Mul:
@@ -2005,12 +2002,14 @@ class Expr(Basic, EvalfMixin):
                         d[i].append(c)
                     else:
                         d[i._new_rawargs(*x)].append(c)
-                else:
+                elif i:
                     d[i].append(S.One)
             d = {k: Add(*d[k]) for k in d}
             if ind is not S.Zero:
                 d.update({S.One: ind})
-            return d
+        di = defaultdict(int)
+        di.update(d)
+        return di
 
     def as_base_exp(self) -> tuple[Expr, Expr]:
         # a -> b ** e

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1957,11 +1957,16 @@ class Expr(Basic, EvalfMixin):
         d.update(dict([self.as_base_exp()]))
         return d
 
-    def as_coefficients_dict(self):
+    def as_coefficients_dict(self, *syms):
         """Return a dictionary mapping terms to their Rational coefficient.
         Since the dictionary is a defaultdict, inquiries about terms which
         were not present will return a coefficient of 0. If an expression is
         not an Add it is considered to have a single term.
+
+        If symbols ``syms`` are provided, any multiplicative terms
+        independent of them will be considered a coefficient and a
+        regular dictionary of syms-dependent generators as keys and
+        their corresponding coefficients as values will be returned.
 
         Examples
         ========
@@ -1973,15 +1978,19 @@ class Expr(Basic, EvalfMixin):
         0
         >>> (3*a*x).as_coefficients_dict()
         {a*x: 3}
+        >>> (3*a*x).as_coefficients_dict(x)
+        {x: 3*a}
 
         """
-        c, m = self.as_coeff_Mul()
+        d = defaultdict(int)
+        c, m = self.as_coeff_mul(*syms)
         if not c.is_Rational:
             c = S.One
             m = self
-        d = defaultdict(int)
+        else:
+            m = Mul(*m, evaluate=False)
         d.update({m: c})
-        return d
+        return dict(d) if syms else d
 
     def as_base_exp(self) -> tuple[Expr, Expr]:
         # a -> b ** e

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -812,41 +812,6 @@ class Mul(Expr, AssocOp):
             return args[0], self._new_rawargs(*args[1:])
 
     @cacheit
-    def as_coefficients_dict(self, *syms):
-        """Return a dictionary mapping terms to their coefficient.
-        Since the dictionary is a defaultdict, inquiries about terms which
-        were not present will return a coefficient of 0. The dictionary
-        is considered to have a single term.
-
-        If symbols `syms` are provided, any multiplicative terms
-        independent of them will be considered a coefficient and a
-        regular dictionary of syms-dependent generators as keys and
-        their corresponding coefficients as values will be returned.
-
-        Examples
-        ========
-
-        >>> from sympy.abc import a, x
-        >>> (3*a*x).as_coefficients_dict()
-        {a*x: 3}
-        >>> _[a]
-        0
-        >>> (3*a*x*(a + 1)).as_coefficients_dict(a)
-        {a*(a + 1): 3*x}
-        """
-        if not syms:
-            d = defaultdict(int)
-            args = self.args
-            if len(args) == 1 or not args[0].is_Number:
-                d[self] = S.One
-            else:
-                d[self._new_rawargs(*args[1:])] = args[0]
-            return d
-        else:
-            i, d = self.as_independent(*syms)
-            return {d: i}
-
-    @cacheit
     def as_coeff_mul(self, *deps, rational=True, **kwargs):
         if deps:
             l1, l2 = sift(self.args, lambda x: x.has(*deps), binary=True)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1554,6 +1554,8 @@ def test_as_coefficients_dict():
     assert eq.as_coefficients_dict(x) == {x: b, 1/x: c,
         x*(x + 1): a}
     assert eq.expand().as_coefficients_dict(x) == {x**2: a, x: a + b, 1/x: c}
+    assert x.as_coefficients_dict() == {S.One: x}
+
 
 def test_args_cnc():
     A = symbols('A', commutative=False)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1552,9 +1552,8 @@ def test_as_coefficients_dict():
     assert (3.0*x*y).as_coefficients_dict()[3.0*x*y] == 0
     eq = x*(x + 1)*a + x*b + c/x
     assert eq.as_coefficients_dict(x) == {x: b, 1/x: c,
-        x*(x + 1): a, 1: 0}
-    assert eq.expand().as_coefficients_dict(x) == {x: a + b, x**2: a,
-        1/x: c, 1: 0}
+        x*(x + 1): a}
+    assert eq.expand().as_coefficients_dict(x) == {x**2: a, x: a + b, 1/x: c}
 
 def test_args_cnc():
     A = symbols('A', commutative=False)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1554,7 +1554,7 @@ def test_as_coefficients_dict():
     assert eq.as_coefficients_dict(x) == {x: b, 1/x: c,
         x*(x + 1): a}
     assert eq.expand().as_coefficients_dict(x) == {x**2: a, x: a + b, 1/x: c}
-    assert x.as_coefficients_dict() == {S.One: x}
+    assert x.as_coefficients_dict() == {x: S.One}
 
 
 def test_args_cnc():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1550,7 +1550,11 @@ def test_as_coefficients_dict():
     assert [(3.0*x*y).as_coefficients_dict()[i] for i in check] == \
         [0, 0, 0, 3.0, 0]
     assert (3.0*x*y).as_coefficients_dict()[3.0*x*y] == 0
-
+    eq = x*(x + 1)*a + x*b + c/x
+    assert eq.as_coefficients_dict(x) == {x: b, 1/x: c,
+        x*(x + 1): a, 1: 0}
+    assert eq.expand().as_coefficients_dict(x) == {x: a + b, x**2: a,
+        1/x: c, 1: 0}
 
 def test_args_cnc():
     A = symbols('A', commutative=False)

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -121,6 +121,12 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         >>> collect(a*x**7 + b*x**7, x**7, exact=True)
         x**7*(a + b)
 
+    If you want to collect on any object containing symbols, set
+    ``exact`` to None:
+
+        >>> collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None)
+        x*exp(x) + (y + 2)*sin(x) + 3*x
+
     You can also apply this function to differential equations, where
     derivatives of arbitrary order can be collected. Note that if you
     collect with respect to a function or a derivative of a function, all
@@ -165,6 +171,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     """
     expr = sympify(expr)
     syms = [sympify(i) for i in (syms if iterable(syms) else [syms])]
+
     # replace syms[i] if it is not x, -x or has Wild symbols
     cond = lambda x: x.is_Symbol or (-x).is_Symbol or bool(
         x.atoms(Wild))
@@ -181,6 +188,25 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         else:
             return {urep.get(k, k).xreplace(urep): v.xreplace(urep)
                     for k, v in rv.items()}
+
+    # see if other expressions should be considered
+    if exact is None:
+        _syms = set()
+        for i in Add.make_args(expr):
+            if not i.has_free(*syms):
+                continue
+            if not i.is_Mul and i not in syms:
+                _syms.add(i)
+            else:
+                g = i._new_rawargs(*i.as_coeff_mul(*syms)[1])
+                if g not in syms:
+                    _syms.add(g)
+        simple = all(i.is_Pow and i.base in syms for i in _syms)
+        syms = syms + list(ordered(_syms))
+        if not simple:
+            return collect(expr, syms,
+            func=func, evaluate=evaluate, exact=False,
+            distribute_order_term=distribute_order_term)
 
     if evaluate is None:
         evaluate = global_parameters.evaluate

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -125,7 +125,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     ``exact`` to None:
 
         >>> collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None)
-        x*exp(x) + (y + 2)*sin(x) + 3*x
+        x*exp(x) + 3*x + (y + 2)*sin(x)
 
     You can also apply this function to differential equations, where
     derivatives of arbitrary order can be collected. Note that if you

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -114,7 +114,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         (a + b)*exp(2*x)
 
     If you are interested only in collecting specific powers of some symbols
-    then set ``exact`` flag in arguments::
+    then set ``exact`` flag to True::
 
         >>> collect(a*x**7 + b*x**7, x, exact=True)
         a*x**7 + b*x**7
@@ -125,7 +125,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     ``exact`` to None:
 
         >>> collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None)
-        x*exp(x) + 3*x + (y + 2)*sin(x)
+        x*(exp(x) + 3) + (y + 2)*sin(x)
 
     You can also apply this function to differential equations, where
     derivatives of arbitrary order can be collected. Note that if you
@@ -193,12 +193,13 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     if exact is None:
         _syms = set()
         for i in Add.make_args(expr):
-            if not i.has_free(*syms):
+            if not i.has_free(*syms) or i in syms:
                 continue
             if not i.is_Mul and i not in syms:
                 _syms.add(i)
             else:
-                g = i._new_rawargs(*i.as_coeff_mul(*syms)[1])
+                g = i._new_rawargs(*[_ for _ in
+                    i.as_coeff_mul(*syms)[1] if _ not in syms])
                 if g not in syms:
                     _syms.add(g)
         simple = all(i.is_Pow and i.base in syms for i in _syms)

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -168,7 +168,7 @@ def test_radsimp_issue_3214():
 
 
 def test_collect_1():
-    """Collect with respect to a Symbol"""
+    """Collect with respect to Symbol"""
     x, y, z, n = symbols('x,y,z,n')
     assert collect(1, x) == 1
     assert collect( x + y*x, x ) == x * (1 + y)
@@ -184,6 +184,8 @@ def test_collect_1():
     # symbols can be given as any iterable
     expr = x + y
     assert collect(expr, expr.free_symbols) == expr
+    assert collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None
+        ) == x*(exp(x) + 3) + (y + 2)*sin(x)
 
 
 def test_collect_2():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
closes #22531

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `Expr.as_coefficient_dict` now accepts one or more symbols so symbolic coefficients can be extracted
<!-- END RELEASE NOTES -->
