### PR TITLE
Improved functionality of invert_real() in case of Pow expressions equal to something

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -251,12 +251,22 @@ def _invert_real(f, g_ys, symbol):
                 num, den = expo.as_numer_denom()
 
                 if den % 2 == 0 and num % 2 == 1 and den.is_zero is False:
+                    # Here we have f(x)**(num/den) = y
+                    # where den is nonzero and even and y is an element
+                    # of the set g_ys.
+                    # den is even, so we are only interested in the cases
+                    # where both f(x) and y are positive.
+                    # Restricting y to be positive (using the set g_ys_pos)
+                    # means that y**(den/num) is always positive.
+                    # Therefore it isn't necessary to also constrain f(x)
+                    # to be positive because we are only going to
+                    # find solutions of f(x) = y**(d/n)
+                    # where the rhs is already required to be positive.
                     root = Lambda(n, real_root(n, expo))
                     g_ys_pos = g_ys & Interval(0, oo)
                     res = imageset(root, g_ys_pos)
-                    base_positive = solveset(base >= 0, symbol, S.Reals)
                     _inv, _set = _invert_real(base, res, symbol)
-                    return (_inv, _set.intersect(base_positive))
+                    return (_inv, _set)
 
                 if den % 2 == 1:
                     root = Lambda(n, real_root(n, expo))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -403,7 +403,9 @@ def test_solveset_sqrt_1():
     assert solveset_real(sqrt(x) - 2 - 5, x) == FiniteSet(49)
     assert solveset_real(sqrt(x**3), x) == FiniteSet(0)
     assert solveset_real(sqrt(x - 1), x) == FiniteSet(1)
-
+    assert solveset_real(sqrt((x-3)/x), x) == FiniteSet(3)
+    assert solveset_real(sqrt((x-3)/x)-Rational(1, 2), x) == \
+        FiniteSet(4)
 
 def test_solveset_sqrt_2():
     x = Symbol('x', real=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23340 


#### Brief description of what is fixed or changed

`solveset(sqrt((x-3)/x), x, domain=Interval(3, +oo))` returns `EmptySet` in place of `FiniteSet(3)`, since `invert_real((x-3)/x, 0, x)` gives `((x - 3)/x, {0})`.

The change in the commit is in the behavior of `invert_real()` in case of `Pow`.

#### Other comments

Some tests added.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solvers
  * A bug leading to incorrect solutions of some radical equations from `solveset` was fixed.


<!-- END RELEASE NOTES -->
