### PR TITLE
add type hints to base and exp of Pow

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1,4 +1,5 @@
-from typing import Callable, Tuple as tTuple
+from __future__ import annotations
+from typing import Callable
 from math import log as _log, sqrt as _sqrt
 from itertools import product
 
@@ -275,7 +276,8 @@ class Pow(Expr):
 
     __slots__ = ('is_commutative',)
 
-    args: tTuple[Expr, Expr]
+    args: tuple[Expr, Expr]
+    _args: tuple[Expr, Expr]
 
     @cacheit
     def __new__(cls, b, e, evaluate=None):
@@ -383,11 +385,11 @@ class Pow(Expr):
         return None
 
     @property
-    def base(self):
+    def base(self) -> Expr:
         return self._args[0]
 
     @property
-    def exp(self):
+    def exp(self) -> Expr:
         return self._args[1]
 
     @property


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
test_exp.py:
```py
from sympy import Symbol, Pow
x = Symbol('x')
p = Pow(x, 2)
print(p.base + p.exp)
```
```sh
$ pyright test_exp.py 
No configuration file found.
No pyproject.toml file found.
stubPath .../typings is not a valid directory.
Assuming Python platform Linux
Searching for source files
Found 1 source file
.../test_exp.py
  .../test_exp.py:4:7 - error: Operator "+" not supported for types "Basic" and "Basic"
    Operator "+" not supported for types "Basic" and "Basic" when expected type is "object" (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
Completed in 0.991sec
```
Solely adding `-> Expr` makes pyright extension for vscode complain, as `_args` is declared `tuple[Basic, ...]`.
According to https://github.com/sympy/sympy/blob/9c7ebddbb7be78267f0162c75e2e66ff5b2ff5a3/sympy/core/basic.py#L765-L773
replacing `_args` makes sense.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
