### PR TITLE
Fix integral_steps(tan(x), x)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1129,7 +1129,7 @@ def substitution_rule(integral):
             if simplify(c - 1) != 0:
                 _, denom = c.as_numer_denom()
                 if subrule:
-                    subrule = ConstantTimesRule(c, substituted, subrule, substituted, u_var)
+                    subrule = ConstantTimesRule(c, substituted, subrule, c * substituted, u_var)
 
                 if denom.free_symbols:
                     piecewise = []

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -555,3 +555,9 @@ def test_quadratic_denom():
 
 def test_issue_22757():
     assert manualintegrate(sin(x), y) == y * sin(x)
+
+
+def test_issue_23348():
+    steps = integral_steps(tan(x), x)
+    constant_times_step = steps.substep.substep
+    assert constant_times_step.context == constant_times_step.constant * constant_times_step.other


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23348 
#### Brief description of what is fixed or changed

ConstantTimesRule is a namedtuple. According to other usages like
https://github.com/sympy/sympy/blob/641a8b2839f0756808fb4cf941b82955f527a231/sympy/integrals/manualintegrate.py#L667-L668
`context == constant * other` should always hold
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
