### PR TITLE
Added example for Matrix.rref() parameter iszerofunc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1133,3 +1133,4 @@ Tom Fryers <61272761+TomFryers@users.noreply.github.com>
 Zouhair <zouhair.mahboubi@gmail.com>
 zzj <29055749+zjzh@users.noreply.github.com>
 shubhayu09 <guptashubhayu601@gmail.com>
+Donald Wilson <donwilson1029@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1133,4 +1133,4 @@ Tom Fryers <61272761+TomFryers@users.noreply.github.com>
 Zouhair <zouhair.mahboubi@gmail.com>
 zzj <29055749+zjzh@users.noreply.github.com>
 shubhayu09 <guptashubhayu601@gmail.com>
-Donald Wilson <donwilson1029@gmail.com>
+wilds-23 <wilds-23@rhodes.edu>

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -4,6 +4,3 @@ Style Guide <https://docs.sympy.org/dev/documentation-style-guide.html>`_.
 
 The SymPy Documentation Style Guide can also be read at
 src/documentation-style-guide.rst.
-
-
-

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -4,3 +4,6 @@ Style Guide <https://docs.sympy.org/dev/documentation-style-guide.html>`_.
 
 The SymPy Documentation Style Guide can also be read at
 src/documentation-style-guide.rst.
+
+
+

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -298,7 +298,7 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     [1, 0, 0, 0],
     [0, 1, 0, 0],
     [0, 0, 1, 0]]), (0, 1, 2))
-    >>> m.rref(iszerofunc=lambda x:comp(x,0,1e-9))
+    >>> m.rref(iszerofunc=lambda x:abs(x)<1e-9))
     (Matrix([
     [1, 0, -0.301369863013699, 0],
     [0, 1, -0.712328767123288, 0],

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -290,14 +290,14 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
 
     iszerofunc can correct rounding errors in matrices with float values.
     In the following example, calling rref leads to floating point errors,
-    incorrectly row reducing the matrix. iszerofunc can set sufficiently 
+    incorrectly row reducing the matrix. iszerofunc can set sufficiently
     small numbers to zero and avoid this error.
     >>> m = Matrix([[0.9, -0.1, -0.2, 0], [-0.8, 0.9, -0.4, 0], [-0.1, -0.8, 0.6, 0]])
     >>> m.rref()
     (Matrix([
     [1, 0, 0, 0],
     [0, 1, 0, 0],
-    [0, 0, 1, 0]]), (0, 1, 2))  
+    [0, 0, 1, 0]]), (0, 1, 2))
     >>> m.rref(iszerofunc=lambda x:comp(x,0,1e-9))
     (Matrix([
     [1, 0, -0.301369863013699, 0],

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -288,6 +288,22 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     >>> rref_pivots
     (0, 1)
 
+    iszerofunc can correct rounding errors in matrices with float values.
+    In the following example, calling rref leads to floating point errors,
+    incorrectly row reducing the matrix. iszerofunc can set sufficiently 
+    small numbers to zero and avoid this error.
+    >>> m = Matrix([[0.9, -0.1, -0.2, 0], [-0.8, 0.9, -0.4, 0], [-0.1, -0.8, 0.6, 0]])
+    >>> m.rref()
+    (Matrix([
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0]]), (0, 1, 2))  
+    >>> m.rref(iszerofunc=lambda x:comp(x,0,1e-9))
+    (Matrix([
+    [1, 0, -0.301369863013699, 0],
+    [0, 1, -0.712328767123288, 0],
+    [0, 0,         0,          0]]), (0, 1))
+
     Notes
     =====
 

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -298,7 +298,7 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     [1, 0, 0, 0],
     [0, 1, 0, 0],
     [0, 0, 1, 0]]), (0, 1, 2))
-    >>> m.rref(iszerofunc=lambda x:abs(x)<1e-9))
+    >>> m.rref(iszerofunc=lambda x:abs(x)<1e-9)
     (Matrix([
     [1, 0, -0.301369863013699, 0],
     [0, 1, -0.712328767123288, 0],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #12006

#### Brief description of what is fixed or changed
Added example of how the optional parameter iszerofunc can be used to avoid floating point errors in matrix reduction.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
