### PR TITLE
Added test for hanging solve_undetermined_coeffs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -938,6 +938,7 @@ Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
 Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
 Rick Muller <rpmuller@gmail.com>
 Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
+Riley Britten <nrb1324@hotmail.com>
 Rimi <rimibis@umich.edu>
 Rishabh Daal <rishabhdaal@gmail.com>
 Rishabh Dixit <rishabhdixit11@gmail.com>

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2500,3 +2500,20 @@ def test_issue_22768():
 def test_issue_22717():
     assert solve((-y**2 + log(y**2/x) + 2, -2*x*y + 2*x/y)) == [
         {y: -1, x: E}, {y: 1, x: E}]
+
+
+def test_issue_10169():
+    eq = S(-8*a - x**5*(a + b + c + e) - x**4*(4*a - 2**Rational(3,4)*c + 4*c +
+        d + 2**Rational(3,4)*e + 4*e + k) - x**3*(-4*2**Rational(3,4)*c + sqrt(2)*c -
+        2**Rational(3,4)*d + 4*d + sqrt(2)*e + 4*2**Rational(3,4)*e + 2**Rational(3,4)*k + 4*k) -
+        x**2*(4*sqrt(2)*c - 4*2**Rational(3,4)*d + sqrt(2)*d + 4*sqrt(2)*e +
+        sqrt(2)*k + 4*2**Rational(3,4)*k) - x*(2*a + 2*b + 4*sqrt(2)*d +
+        4*sqrt(2)*k) + 5)
+    assert solve_undetermined_coeffs(eq, [a, b, c, d, e, k], x) == {
+        a: Rational(5,8),
+        b: Rational(-5,1032),
+        c: Rational(-40,129) - 5*2**Rational(3,4)/129 + 5*2**Rational(1,4)/1032,
+        d: -20*2**Rational(3,4)/129 - 10*sqrt(2)/129 - 5*2**Rational(1,4)/258,
+        e: Rational(-40,129) - 5*2**Rational(1,4)/1032 + 5*2**Rational(3,4)/129,
+        k: -10*sqrt(2)/129 + 5*2**Rational(1,4)/258 + 20*2**Rational(3,4)/129
+    }


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #10169 

#### Brief description of what is fixed or changed
solve_undetermined_coeffs used to hang on this example:
-8*A - x**5*(A + B + C + E) - x**4*(4*A - 2**(3/4)*C + 4*C + D +
2**(3/4)*E + 4*E + F) - x**3*(-4*2**(3/4)*C + sqrt(2)*C -
2**(3/4)*D + 4*D + sqrt(2)*E + 4*2**(3/4)*E + 2**(3/4)*F +
4*F) - x**2*(4*sqrt(2)*C - 4*2**(3/4)*D + sqrt(2)*D + 4*sqrt(2)*E +
sqrt(2)*F + 4*2**(3/4)*F) - x*(2*A + 2*B + 4*sqrt(2)*D + 4*sqrt(2)*F) + 5
This issue was resolved in an earlier PR. This PR adds this
example as a test case.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
