### PR TITLE
Add zero velocity constraint in v1pt and v2pt

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -68,6 +68,23 @@ class Point:
         if not isinstance(other, Point):
             raise TypeError('A Point must be supplied')
 
+    def _check_not_moving(self, frame):
+        """Checks whether the point is indeed not moving in a frame."""
+        point_valid = True
+        try:
+            if not self.vel(frame) == 0:
+                point_valid = False
+        except ValueError:
+            pass
+        try:
+            if not self.acc(frame) == 0:
+                point_valid = False
+        except (ValueError, KeyError):
+            pass
+        if not point_valid:
+            raise ValueError('Point ' + self.name + ' is not fixed in ' +
+                             'ReferenceFrame ' + frame.name)
+
     def _pdict_list(self, other, num):
         """Returns a list of points that gives the shortest path with respect
         to position, velocity, or acceleration from this point to the provided
@@ -151,7 +168,7 @@ class Point:
         >>> B = ReferenceFrame('B')
         >>> B.set_ang_vel(N, 5 * B.y)
         >>> O = Point('O')
-        >>> P = O.locatenew('P', q * B.x)
+        >>> P = O.locatenew('P', q * B.x + q2 * B.y)
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.a1pt_theory(O, N, B)
@@ -162,6 +179,7 @@ class Point:
         _check_frame(outframe)
         _check_frame(interframe)
         self._check_point(otherpoint)
+        otherpoint._check_not_moving(interframe)
         dist = self.pos_from(otherpoint)
         v = self.vel(interframe)
         a1 = otherpoint.acc(outframe)
@@ -213,6 +231,7 @@ class Point:
         _check_frame(outframe)
         _check_frame(fixedframe)
         self._check_point(otherpoint)
+        otherpoint._check_not_moving(fixedframe)
         dist = self.pos_from(otherpoint)
         a = otherpoint.acc(outframe)
         omega = fixedframe.ang_vel_in(outframe)
@@ -433,7 +452,7 @@ class Point:
         >>> B = ReferenceFrame('B')
         >>> B.set_ang_vel(N, 5 * B.y)
         >>> O = Point('O')
-        >>> P = O.locatenew('P', q * B.x)
+        >>> P = O.locatenew('P', q * B.x + q2 * B.y)
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.v1pt_theory(O, N, B)
@@ -444,6 +463,7 @@ class Point:
         _check_frame(outframe)
         _check_frame(interframe)
         self._check_point(otherpoint)
+        otherpoint._check_not_moving(interframe)
         dist = self.pos_from(otherpoint)
         v1 = self.vel(interframe)
         v2 = otherpoint.vel(outframe)
@@ -492,6 +512,7 @@ class Point:
         _check_frame(outframe)
         _check_frame(fixedframe)
         self._check_point(otherpoint)
+        otherpoint._check_not_moving(fixedframe)
         dist = self.pos_from(otherpoint)
         v = otherpoint.vel(outframe)
         omega = fixedframe.ang_vel_in(outframe)

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -2,6 +2,22 @@ from sympy.physics.vector import dynamicsymbols, Point, ReferenceFrame
 from sympy.testing.pytest import raises, ignore_warnings
 import warnings
 
+
+def test_check_fixed():
+    N = ReferenceFrame('N')
+    O = Point('O')
+    O._check_not_moving(N)
+    O.set_vel(N, N.x)
+    raises(ValueError, lambda: O._check_not_moving(N))
+    O.set_vel(N, 0)
+    O._check_not_moving(N)
+    O.set_acc(N, N.x)
+    raises(ValueError, lambda: O._check_not_moving(N))
+    O = Point('O')
+    O.set_acc(N, N.x)
+    raises(ValueError, lambda: O._check_not_moving(N))
+
+
 def test_point_v1pt_theorys():
     q, q2 = dynamicsymbols('q q2')
     qd, q2d = dynamicsymbols('q q2', 1)
@@ -18,6 +34,8 @@ def test_point_v1pt_theorys():
     assert P.v1pt_theory(O, N, B) == N.x + qd * B.y
     P.set_vel(B, B.z)
     assert P.v1pt_theory(O, N, B) == B.z + N.x + qd * B.y
+    O.set_vel(B, B.x)
+    raises(ValueError, lambda: P.v1pt_theory(O, N, B))
 
 
 def test_point_a1pt_theorys():
@@ -52,6 +70,8 @@ def test_point_v2pt_theorys():
     assert P.v2pt_theory(O, N, B) == (qd * B.z ^ B.x)
     O.set_vel(N, N.x)
     assert P.v2pt_theory(O, N, B) == N.x + qd * B.y
+    O.set_vel(B, B.x)
+    raises(ValueError, lambda: P.v1pt_theory(O, N, B))
 
 
 def test_point_a2pt_theorys():
@@ -76,8 +96,8 @@ def test_point_funcs():
     B = ReferenceFrame('B')
     B.set_ang_vel(N, 5 * B.y)
     O = Point('O')
-    P = O.locatenew('P', q * B.x)
-    assert P.pos_from(O) == q * B.x
+    P = O.locatenew('P', q * B.x + q2 * B.y)
+    assert P.pos_from(O) == q * B.x + q2 * B.y
     P.set_vel(B, qd * B.x + q2d * B.y)
     assert P.vel(B) == qd * B.x + q2d * B.y
     O.set_vel(N, 0)
@@ -94,7 +114,7 @@ def test_point_funcs():
 
     B.set_ang_vel(N, 5 * B.y)
     O = Point('O')
-    P = O.locatenew('P', q * B.x)
+    P = O.locatenew('P', q * B.x + q2 * B.y)
     P.set_vel(B, qd * B.x + q2d * B.y)
     O.set_vel(N, 0)
     assert P.v1pt_theory(O, N, B) == qd * B.x + q2d * B.y - 5 * q * B.z


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes the problem presented in pull request [12322](https://github.com/sympy/sympy/pull/12322).

#### Brief description of what is fixed or changed
Add a check if the velocity of the `otherpoint` in the velocity theorems is indeed set to `0`

#### Other comments
Possibly also add a check for the acceleration theorems (i.e. `a1pt_theory` and `a2pt_theory`).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Add a zero velocity requirement to `v1pt_theory` and `v2pt_theory`
<!-- END RELEASE NOTES -->
