### PR TITLE
maint: ignore last commit for authors check in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Clone full git history (needed for AUTHORS/mailmap)
-          fetch-depth: '0'
 
       - uses: actions/setup-python@v3
         with:
@@ -58,10 +55,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Clone full git history (needed for AUTHORS/mailmap)
-          fetch-depth: '0'
-
       - uses: actions/setup-python@v3
         with:
           python-version: '3.9'
@@ -79,13 +72,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # Clone full git history (needed for detecting authors)
           fetch-depth: 0
       - uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - run: python -m pip install --upgrade pip
       - run: pip install mpmath
-      - run: bin/mailmap_check.py
+      - run: bin/mailmap_check.py --skip-last-commit
 
   # -------------------- Doctests latest Python -------------------- #
 

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -35,12 +35,17 @@ from sympy.external.importtools import version_tuple
 
 def main(*args):
 
-    parser = ArgumentParser(description='Update the .mailmap and/or AUTHORS files')
+    parser = ArgumentParser(description='Update the .mailmap file')
+    parser.add_argument('--skip-last-commit', action='store_true',
+            help=filldedent("""
+            Do not check metadata from the most recent commit. This is used
+            when the script runs in CI to ignore the merge commit that is
+            implicitly created by github."""))
     parser.add_argument('--update-authors', action='store_true',
             help=filldedent("""
-            Also update the AUTHORS file. Note that it
-            should only necessary for the release manager to do this as part of
-            the release process for SymPy."""))
+            Also updates the AUTHORS file. DO NOT use this option as part of a
+            pull request. The AUTHORS file will be updated later at the time a
+            new version of SymPy is released."""))
     args = parser.parse_args(args)
 
     if not check_git_version():
@@ -48,7 +53,7 @@ def main(*args):
 
     # find who git knows ahout
     try:
-        git_people = get_authors_from_git()
+        git_people = get_authors_from_git(skip_last=args.skip_last_commit)
     except AssertionError as msg:
         print(red(msg))
         return 1
@@ -221,8 +226,14 @@ def author_name(line):
     return line.split("<", 1)[0].strip()
 
 
-def get_authors_from_git():
+def get_authors_from_git(skip_last=False):
     git_command = ["git", "log", "--topo-order", "--reverse", "--format=%aN <%aE>"]
+
+    if skip_last:
+        # Skip the most recent commit. Used to ignore the merge commit created
+        # when this script runs in CI.
+        git_command.append("HEAD^")
+
     git_people = run(git_command, stdout=PIPE, encoding='utf-8').stdout.strip().split("\n")
 
     # remove duplicates, keeping the original order


### PR DESCRIPTION
When the mailmap_check.py script runs in CI it runs in a checkout of
temporary merge commit. The merge commit created by GitHub usually does
not use the same metadata as commits created locally by the author. This
required redundant additions to .mailmap. This commit makes it so that
when the script runs in CI the most recent commit is ignored.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
