### PR TITLE
maint: check the right parent commit for mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -448,6 +448,7 @@ Gautam Menghani <gum3ng@protonmail.com> gum3ng <gum3ng@protonmail.com>
 Geoffry Song <goffrie@gmail.com>
 George Korepanov <gkorepanov.gk@gmail.com>
 George Waksman <waksman@gwax.com>
+Georges Khaznadar <georgesk@debian.org>
 Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
 Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -231,8 +231,10 @@ def get_authors_from_git(skip_last=False):
 
     if skip_last:
         # Skip the most recent commit. Used to ignore the merge commit created
-        # when this script runs in CI.
-        git_command.append("HEAD^")
+        # when this script runs in CI. We use HEAD^2 rather than HEAD^1 to
+        # select the parent commit that is part of the PR rather than the
+        # parent commit that was the previous tip of master.
+        git_command.append("HEAD^2")
 
     git_people = run(git_command, stdout=PIPE, encoding='utf-8').stdout.strip().split("\n")
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/pull/23363#issuecomment-1100040502

#### Brief description of what is fixed or changed

The --skip-last-commit option in the mailmap_check.py script looks for authors in HEAD^ when running in CI because HEAD is a merge commit that has different metadata created by github. However HEAD^ refers to the wrong parent of the merge commit. It should be HEAD^2 rather than HEAD^1 (which is the same as HEAD^)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
