### PR TITLE
More informative error message if args are swapped in Vector.diff()

### DIFF
--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -4,6 +4,7 @@ from sympy.core.sorting import ordered
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.immutable import ImmutableDenseMatrix as Matrix
 from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols, dot
+from sympy.physics.vector.vector import VectorTypeError
 from sympy.abc import x, y, z
 from sympy.testing.pytest import raises
 
@@ -238,3 +239,9 @@ def test_vector_xreplace():
     assert v.xreplace({x:1, z:0}) == A.x + y * A.y
     raises(TypeError, lambda: v.xreplace())
     raises(TypeError, lambda: v.xreplace([x, y]))
+
+def test_issue_23366():
+    u1 = dynamicsymbols('u1')
+    N = ReferenceFrame('N')
+    N_v_A = u1*N.x
+    raises(VectorTypeError, lambda: N_v_A.diff(N, u1))

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -537,8 +537,8 @@ class Vector(Printable, EvalfMixin):
 
         from sympy.physics.vector.frame import _check_frame
 
-        var = sympify(var)
         _check_frame(frame)
+        var = sympify(var)
 
         inlist = []
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23366



#### Brief description of what is fixed or changed

New output which tells more clearly that the frame is of the wrong type.

```python
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:04:10) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %paste
import sympy as sm
import sympy.physics.mechanics as me
me.init_vprinting(use_latex='mathjax')
q1, q2, u1, u2 = me.dynamicsymbols('q1, q2, u1, u2')
N = me.ReferenceFrame('N')
N_v_A = u1*N.x
N_v_A.diff(N, u1), N_v_A.diff(N, u2)

## -- End pasted text --
---------------------------------------------------------------------------
VectorTypeError                           Traceback (most recent call last)
Input In [1], in <cell line: 7>()
      5 N = me.ReferenceFrame('N')
      6 N_v_A = u1*N.x
----> 7 N_v_A.diff(N, u1), N_v_A.diff(N, u2)

File ~/src/sympy/sympy/physics/vector/vector.py:540, in Vector.diff(self, var, frame, var_in_dcm)
    496 """Returns the partial derivative of the vector with respect to a
    497 variable in the provided reference frame.
    498 
   (...)
    535 
    536 """
    538 from sympy.physics.vector.frame import _check_frame
--> 540 _check_frame(frame)
    541 var = sympify(var)
    543 inlist = []

File ~/src/sympy/sympy/physics/vector/frame.py:1453, in _check_frame(other)
   1451 from .vector import VectorTypeError
   1452 if not isinstance(other, ReferenceFrame):
-> 1453     raise VectorTypeError(other, ReferenceFrame('A'))

VectorTypeError: 
Expected an instance of <class
'sympy.physics.vector.frame.ReferenceFrame'>, but received object
'u1(t)' of u1.
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * More informative error message if args are swapped in Vector.diff()
<!-- END RELEASE NOTES -->
