### PR TITLE
Use @staticmethod in Symbol

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -295,7 +295,8 @@ class Symbol(AtomicExpr, Boolean):
         cls._sanitize(assumptions, cls)
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 
-    def __new_stage2__(cls, name, **assumptions):
+    @staticmethod
+    def __xnew__(cls, name, **assumptions):  # never cached (e.g. dummy)
         if not isinstance(name, str):
             raise TypeError("name should be a string, not %s" % repr(type(name)))
 
@@ -319,10 +320,10 @@ class Symbol(AtomicExpr, Boolean):
         obj._assumptions._generator = tmp_asm_copy  # Issue #8873
         return obj
 
-    __xnew__ = staticmethod(
-        __new_stage2__)            # never cached (e.g. dummy)
-    __xnew_cached_ = staticmethod(
-        cacheit(__new_stage2__))   # symbols are always cached
+    @staticmethod
+    @cacheit
+    def __xnew_cached_(cls, name, **assumptions):  # symbols are always cached
+        return Symbol.__xnew__(cls, name, **assumptions)
 
     def __getnewargs_ex__(self):
         return ((self.name,), self.assumptions0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`staticmethod()` is [not a pythonic way](https://www.programiz.com/python-programming/methods/built-in/staticmethod) to define static method.
Previously `__new_stage2__` seems a normal method at first look, which confuses pyright.
```sh
$ pyright sympy/core/symbol.py
...
.../sympy/core/symbol.py:302:28 - error: Argument of type "Self@Symbol" cannot be assigned to parameter "cls" of type "Type[Expr]" in function "__new__"
...
```
Using staticmethod decorator is a better way.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
