### PR TITLE
New section on function signatures to the docstring style guide.

### DIFF
--- a/doc/src/guides/contributing/docstring.rst
+++ b/doc/src/guides/contributing/docstring.rst
@@ -133,12 +133,13 @@ Sections
 In SymPy’s docstrings, it is preferred that function, class, and method
 docstrings consist of the following sections in this order:
 
-1. Single-Sentence Summary
-2. Explanation
-3. Examples
-4. Parameters
-5. See Also
-6. References
+1. Function Signature
+2. Single-Sentence Summary
+3. Explanation
+4. Examples
+5. Parameters
+6. See Also
+7. References
 
 The Single-Sentence Summary and Examples sections are **required** for every
 docstring. Docstrings will not pass review if these sections are not included.
@@ -156,7 +157,27 @@ is unnecessary, do not use it. Unnecessary sections and cluttered docstrings
 can make a function harder to understand. Aim for the minimal amount of
 information required to understand the function.
 
-1. Single-Sentence Summary
+1. Function Signature
+^^^^^^^^^^^^^^^^^^^^^
+
+The function signature is part of the Python source code but is almost always
+displayed along with the doc string. Function signatures should have
+informative argument names that follow Python variable name best practices,
+e.g. use ``coef_matrix`` instead of ``m``. It is also best to avoid the use of
+the generic ``*args`` and ``**kwargs`` in function signatures. Instead, make
+explcitly named arguments and keyword arguments as this is more informative for
+the user.
+
+Python supports `type hints`_ but these may decrease the human readability of
+the function signatures. Type hints should not be added to the function
+signatures in Python modules (``.py`` files). Instead, they should only be
+added in `stub files`_. These stub files have the extension ``.pyi`` and mirror
+the modules which are being typed.
+
+.. _type hints: https://docs.python.org/3/library/typing.html
+.. _stub files: https://mypy.readthedocs.io/en/stable/stubs.html
+
+2. Single-Sentence Summary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This section is **required** for every docstring. A docstring will not pass
@@ -176,7 +197,7 @@ in the Sphinx directive::
 
 See :ref:`deprecation-documentation` for more details.
 
-2. Explanation Section
+3. Explanation Section
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 This section is encouraged. If you choose to include an Explanation section in
@@ -193,7 +214,7 @@ class, or method does when the concise Single-Sentence Summary will not
 suffice. This section should be used to clarify functionality in several
 sentences or paragraphs.
 
-3. Examples Section
+4. Examples Section
 ^^^^^^^^^^^^^^^^^^^^
 
 This section is **required** for every docstring. A docstring will not pass
@@ -275,7 +296,7 @@ assumptions), in which case use ``symbols`` like ``x, y = symbols('x y')``.
 In general, you should run ``./bin/doctest`` to make sure your examples run
 correctly, and fix them if they do not.
 
-4. Parameters Section
+5. Parameters Section
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This section is encouraged. If you choose to include a Parameters section in
@@ -333,7 +354,7 @@ Here is an example of a correctly formatted Parameters section::
 
 .. _style_guide_see_also:
 
-5. See Also Section
+6. See Also Section
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This section is encouraged. If you choose to include a See Also section in your
@@ -390,7 +411,7 @@ Here is a correctly formatted See Also section with just a list of names::
 
         """
 
-6. References Section
+7. References Section
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This section is encouraged. If you choose to include a References section in

--- a/doc/src/guides/contributing/docstring.rst
+++ b/doc/src/guides/contributing/docstring.rst
@@ -165,7 +165,7 @@ displayed along with the doc string. Function signatures should have
 informative argument names that follow Python variable name best practices,
 e.g. use ``coef_matrix`` instead of ``m``. It is also best to avoid the use of
 the generic ``*args`` and ``**kwargs`` in function signatures. Instead, make
-explcitly named arguments and keyword arguments as this is more informative for
+explicitly named arguments and keyword arguments as this is more informative for
 the user.
 
 Python supports `type hints`_ but these may decrease the human readability of


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I opened this primarily as a way to have some rules about adding type hints to SymPy based on my concerns and the conversations here https://github.com/sympy/sympy/issues/17945. This seemed like the appropriate place for the guidelines and necessitated a section on function signatures in the style guide. I took the liberty of adding two other recommendations to the new section, as those seem to reflect the current expectations in SymPy.

Function signatures are effectively part of the docstring, so we should
have some guidelines for them. This introduces a section in the guide
with three recommendations:

- use meaningful argument names
- avoid using *args and **kwargs
- add type hints only to stub (.pyi) files

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
