### PR TITLE
Making Expr.pow type consistent by sympify the returned ints

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1306,6 +1306,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -18,6 +18,7 @@ from sympy.utilities.iterables import has_variety, sift
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
+
 if TYPE_CHECKING:
     from .numbers import Number
 
@@ -225,16 +226,16 @@ class Expr(Basic, EvalfMixin):
     def _pow(self, other):
         return Pow(self, other)
 
-    def __pow__(self, other, mod=None):
+    def __pow__(self, other, mod=None) -> Expr:
         if mod is None:
             return self._pow(other)
         try:
             _self, other, mod = as_int(self), as_int(other), as_int(mod)
             if other >= 0:
-                return pow(_self, other, mod)
+                return _sympify(pow(_self, other, mod))
             else:
                 from .numbers import mod_inverse
-                return mod_inverse(pow(_self, -other, mod), mod)
+                return _sympify(mod_inverse(pow(_self, -other, mod), mod))
         except ValueError:
             power = self._pow(other)
             try:


### PR DESCRIPTION
### Making Expr.__pow__ type consistent by sympify the returned ints

<!-- BEGIN RELEASE NOTES -->
* core
  * Making Expr.__pow__ type consistent by sympify the returned ints
<!-- END RELEASE NOTES -->