### PR TITLE
Fix PinJoint velocity calculation

### DIFF
--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -526,9 +526,9 @@ class PinJoint(Joint):
 
     def _set_linear_velocity(self):
         self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.parent.frame, 0)
+        self.child_point.set_vel(self.child.frame, 0)
         self.child_point.set_pos(self.parent_point, 0)
-        self.child.masscenter.v2pt_theory(self.parent.masscenter,
+        self.child.masscenter.v2pt_theory(self.parent_point,
                                           self.parent.frame, self.child.frame)
 
 

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -181,8 +181,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N) == omega*N.x
     assert A.ang_vel_in(N).express(A) == omega * A.y
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
-    angle = A.ang_vel_in(N).angle_between(A.y)
-    assert angle.xreplace({omega: 1}) == 0
+    assert A.ang_vel_in(N).cross(A.y) == 0
     assert C.masscenter.vel(N) == omega*A.z
     assert C.masscenter.pos_from(P.masscenter) == -A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -203,7 +203,7 @@ def test_pinjoint_arbitrary_axis():
     assert A.ang_vel_in(N).magnitude() == sqrt(omega**2)
     angle = A.ang_vel_in(N).angle_between(A.x)
     assert angle.xreplace({omega: 1}) == 0
-    assert C.masscenter.vel(N).simplify() == - omega*N.z
+    assert C.masscenter.vel(N) == 0
     assert C.masscenter.pos_from(P.masscenter) == N.x
 
     # Both joint pos id defined but different axes
@@ -282,16 +282,15 @@ def test_pinjoint_arbitrary_axis():
     angle = A.ang_vel_in(N).angle_between(A.x+A.y-A.z)
     assert angle.xreplace({omega: 1}) == 0
     assert (C.masscenter.vel(N).simplify() ==
-            (m*omega*N.y + m*omega*N.z + n*omega*A.y + n*omega*A.z)/sqrt(3))
+            sqrt(3)*n*omega/3*A.y + sqrt(3)*n*omega/3*A.z)
     assert C.masscenter.pos_from(P.masscenter) == m*N.x - n*A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==
             (m + n*(2*cos(theta) - 1)/3)*N.x + n*(2*sin(theta + pi/6) +
             1)/3*N.y - n*(2*cos(theta + pi/3) + 1)/3*N.z)
     assert (C.masscenter.vel(N).express(N).simplify() ==
-            -2*n*omega*sin(theta)/3*N.x + (sqrt(3)*m +
-                                           2*n*cos(theta + pi/6))*omega/3*N.y
-            + (sqrt(3)*m + 2*n*sin(theta + pi/3))*omega/3*N.z)
-    assert expand_mul(C.masscenter.vel(N).angle_between(m*N.x - n*A.x)) == pi/2
+            - 2*n*omega*sin(theta)/3*N.x + 2*n*omega*cos(theta + pi/6)/3*N.y +
+            2*n*omega*sin(theta + pi/3)/3*N.z)
+    assert C.masscenter.vel(N).dot(N.x - N.y + N.z).simplify() == 0
 
 
 def test_pinjoint_pi():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22956 

#### Brief description of what is fixed or changed
Fix incorrect velocity definition of the center of mass of the child body, when the center of mass is not at the joint position.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
   * Fixed incorrect center of mass velocity bug.
<!-- END RELEASE NOTES -->
