### PR TITLE
Improve `PrimeIdeal` reduction methods.

### DIFF
--- a/sympy/polys/numberfields/modules.py
+++ b/sympy/polys/numberfields/modules.py
@@ -1166,7 +1166,9 @@ class Submodule(Module, IntegerPowerable):
         If this submodule $B$ has defining matrix $W$ in square, maximal-rank
         Hermite normal form, then, given an element $x$ of the parent module
         $A$, we produce an element $y \in A$ such that $x - y \in B$, and the
-        $i$th coordinate of $y$ satisfies $0 \leq y_i < w_{i,i}$.
+        $i$th coordinate of $y$ satisfies $0 \leq y_i < w_{i,i}$. This
+        representative $y$ is unique, in the sense that every element of
+        the coset $x + B$ reduces to it under this procedure.
 
         Explanation
         ===========

--- a/sympy/polys/numberfields/modules.py
+++ b/sympy/polys/numberfields/modules.py
@@ -1174,7 +1174,7 @@ class Submodule(Module, IntegerPowerable):
         In the special case where $A$ is a power basis for a number field $K$,
         and $B$ is a submodule representing an ideal $I$, this operation
         represents one of a few important ways of reducing an element of $K$
-        modulo $I$ to obtain a "small" representative. See [Cohen00] Section
+        modulo $I$ to obtain a "small" representative. See [Cohen00]_ Section
         1.4.3.
 
         Examples

--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -1,12 +1,11 @@
 """Prime ideals in number fields. """
 
-from sympy.core.expr import Expr
 from sympy.polys.polytools import Poly
 from sympy.polys.domains.finitefield import FF
 from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.domains.integerring import ZZ
 from sympy.polys.matrices.domainmatrix import DomainMatrix
-from sympy.polys.polyerrors import CoercionFailed, GeneratorsNeeded
+from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polyutils import IntegerPowerable
 from sympy.utilities.decorator import public
 from .basis import round_two, nilradical_mod_p
@@ -261,78 +260,90 @@ class PrimeIdeal(IntegerPowerable):
         """
         return prime_valuation(I, self)
 
-    def reduce_poly(self, f, gen=None):
-        r"""
-        Reduce a univariate :py:class:`~.Poly` *f*, or an :py:class:`~.Expr`
-        expressing the same, modulo this :py:class:`~.PrimeIdeal`.
-
-        Explanation
-        ===========
-
-        If our second generator $\alpha$ is zero, then we simply reduce the
-        coefficients of *f* mod the rational prime $p$ lying under this ideal.
-
-        Otherwise we first reduce *f* mod $\alpha$ (as a polynomial in the same
-        variable as *f*), and then mod $p$.
-
-        Examples
-        ========
-
-        >>> from sympy import QQ, cyclotomic_poly, symbols
-        >>> zeta = symbols('zeta')
-        >>> Phi = cyclotomic_poly(7, zeta)
-        >>> k = QQ.algebraic_field((Phi, zeta))
-        >>> P = k.primes_above(11)
-        >>> frp = P[0]
-        >>> B = k.integral_basis(fmt='sympy')
-        >>> print([frp.reduce_poly(b, zeta) for b in B])
-        [1, zeta, zeta**2, -5*zeta**2 - 4*zeta + 1, -zeta**2 - zeta - 5,
-         4*zeta**2 - zeta - 1]
+    def reduce_element(self, elt):
+        """
+        Reduce a :py:class:`~.PowerBasisElement` to a "small representative"
+        modulo this prime ideal.
 
         Parameters
         ==========
 
-        f : :py:class:`~.Poly`, :py:class:`~.Expr`
-            The univariate polynomial to be reduced.
-
-        gen : :py:class:`~.Symbol`, None, optional (default=None)
-            Symbol to use as the variable in the polynomials. If *f* is a
-            :py:class:`~.Poly` or a non-constant :py:class:`~.Expr`, this
-            replaces its variable. If *f* is a constant :py:class:`~.Expr`,
-            then *gen* must be supplied.
+        elt : :py:class:`~.PowerBasisElement`
+            The element to be reduced.
 
         Returns
         =======
 
-        :py:class:`~.Poly`, :py:class:`~.Expr`
-            Type is same as that of given *f*. If returning a
-            :py:class:`~.Poly`, its domain will be the finite field
-            $\mathbb{F}_p$.
+        :py:class:`~.PowerBasisElement`
+            The reduced element.
 
-        Raises
-        ======
+        See Also
+        ========
 
-        GeneratorsNeeded
-            If *f* is a constant :py:class:`~.Expr` and *gen* is ``None``.
-        NotImplementedError
-            If *f* is other than :py:class:`~.Poly` or :py:class:`~.Expr`,
-            or is not univariate.
+        reduce_ANP
+        reduce_alg_num
+        .Submodule.reduce_element
 
         """
-        if isinstance(f, Expr):
-            try:
-                g = Poly(f)
-            except GeneratorsNeeded as e:
-                if gen is None:
-                    raise e from None
-                g = Poly(f, gen)
-            return self.reduce_poly(g).as_expr()
-        if isinstance(f, Poly) and f.is_univariate:
-            a = self.alpha.poly(f.gen)
-            if a != 0:
-                f = f.rem(a)
-            return f.set_modulus(self.p)
-        raise NotImplementedError
+        return self.as_submodule().reduce_element(elt)
+
+    def reduce_ANP(self, a):
+        """
+        Reduce an :py:class:`~.ANP` to a "small representative" modulo this
+        prime ideal.
+
+        Parameters
+        ==========
+
+        elt : :py:class:`~.ANP`
+            The element to be reduced.
+
+        Returns
+        =======
+
+        :py:class:`~.ANP`
+            The reduced element.
+
+        See Also
+        ========
+
+        reduce_element
+        reduce_alg_num
+        .Submodule.reduce_element
+
+        """
+        elt = self.ZK.parent.element_from_ANP(a)
+        red = self.reduce_element(elt)
+        return red.to_ANP()
+
+    def reduce_alg_num(self, a):
+        """
+        Reduce an :py:class:`~.AlgebraicNumber` to a "small representative"
+        modulo this prime ideal.
+
+        Parameters
+        ==========
+
+        elt : :py:class:`~.AlgebraicNumber`
+            The element to be reduced.
+
+        Returns
+        =======
+
+        :py:class:`~.AlgebraicNumber`
+            The reduced element.
+
+        See Also
+        ========
+
+        reduce_element
+        reduce_ANP
+        .Submodule.reduce_element
+
+        """
+        elt = self.ZK.parent.element_from_alg_num(a)
+        red = self.reduce_element(elt)
+        return a.field_element(list(reversed(red.QQ_col.flat())))
 
 
 def _compute_test_factor(p, gens, ZK):

--- a/sympy/polys/numberfields/tests/test_modules.py
+++ b/sympy/polys/numberfields/tests/test_modules.py
@@ -3,7 +3,7 @@ from sympy.polys import Poly, cyclotomic_poly
 from sympy.polys.domains import FF, QQ, ZZ
 from sympy.polys.matrices import DomainMatrix, DM
 from sympy.polys.numberfields.exceptions import (
-    ClosureFailure, MissingUnityError
+    ClosureFailure, MissingUnityError, StructureError
 )
 from sympy.polys.numberfields.modules import (
     Module, ModuleElement, ModuleEndomorphism, PowerBasis, PowerBasisElement,
@@ -214,6 +214,47 @@ def test_PowerBasis_element_from_poly():
     assert A.element_from_poly(h).coeffs == [0, 0, 0, 0]
 
 
+def test_PowerBasis_element__conversions():
+    k = QQ.cyclotomic_field(5)
+    L = QQ.cyclotomic_field(7)
+    B = PowerBasis(k)
+
+    # ANP --> PowerBasisElement
+    a = k([QQ(1, 2), QQ(1, 3), 5, 7])
+    e = B.element_from_ANP(a)
+    assert e.coeffs == [42, 30, 2, 3]
+    assert e.denom == 6
+
+    # PowerBasisElement --> ANP
+    assert e.to_ANP() == a
+
+    # Cannot convert ANP from different field
+    d = L([QQ(1, 2), QQ(1, 3), 5, 7])
+    raises(UnificationFailed, lambda: B.element_from_ANP(d))
+
+    # AlgebraicNumber --> PowerBasisElement
+    alpha = k.to_alg_num(a)
+    eps = B.element_from_alg_num(alpha)
+    assert eps.coeffs == [42, 30, 2, 3]
+    assert eps.denom == 6
+
+    # PowerBasisElement --> AlgebraicNumber
+    assert eps.to_alg_num() == alpha
+
+    # Cannot convert AlgebraicNumber from different field
+    delta = L.to_alg_num(d)
+    raises(UnificationFailed, lambda: B.element_from_alg_num(delta))
+
+    # When we don't know the field:
+    C = PowerBasis(k.ext.minpoly)
+    # Can convert from AlgebraicNumber:
+    eps = C.element_from_alg_num(alpha)
+    assert eps.coeffs == [42, 30, 2, 3]
+    assert eps.denom == 6
+    # But can't convert back:
+    raises(StructureError, lambda: eps.to_alg_num())
+
+
 def test_Submodule_repr():
     T = Poly(cyclotomic_poly(5, x))
     A = PowerBasis(T)
@@ -356,6 +397,39 @@ def test_Submodule_mul():
     assert C.mul(C, hnf=False) == C3_unred
     assert C * C == C3
     assert C ** 2 == C3
+
+
+def test_Submodule_reduce_element():
+    T = Poly(cyclotomic_poly(5, x))
+    A = PowerBasis(T)
+    B = A.whole_submodule()
+    b = B(to_col([90, 84, 80, 75]), denom=120)
+
+    C = B.submodule_from_matrix(DomainMatrix.eye(4, ZZ), denom=2)
+    b_bar_expected = B(to_col([30, 24, 20, 15]), denom=120)
+    b_bar = C.reduce_element(b)
+    assert b_bar == b_bar_expected
+
+    C = B.submodule_from_matrix(DomainMatrix.eye(4, ZZ), denom=4)
+    b_bar_expected = B(to_col([0, 24, 20, 15]), denom=120)
+    b_bar = C.reduce_element(b)
+    assert b_bar == b_bar_expected
+
+    C = B.submodule_from_matrix(DomainMatrix.eye(4, ZZ), denom=8)
+    b_bar_expected = B(to_col([0, 9, 5, 0]), denom=120)
+    b_bar = C.reduce_element(b)
+    assert b_bar == b_bar_expected
+
+    a = A(to_col([1, 2, 3, 4]))
+    raises(NotImplementedError, lambda: C.reduce_element(a))
+
+    C = B.submodule_from_matrix(DomainMatrix([
+        [5, 4, 3, 2],
+        [0, 8, 7, 6],
+        [0, 0,11,12],
+        [0, 0, 0, 1]
+    ], (4, 4), ZZ).transpose())
+    raises(StructureError, lambda: C.reduce_element(b))
 
 
 def test_is_HNF():

--- a/sympy/polys/numberfields/tests/test_primes.py
+++ b/sympy/polys/numberfields/tests/test_primes.py
@@ -1,4 +1,4 @@
-from sympy import QQ, ZZ, S
+from sympy import QQ, ZZ
 from sympy.abc import x, theta
 from sympy.core.mul import prod
 from sympy.ntheory import factorint
@@ -7,12 +7,11 @@ from sympy.polys import Poly, cyclotomic_poly
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.numberfields.basis import round_two
 from sympy.polys.numberfields.exceptions import StructureError
-from sympy.polys.numberfields.modules import PowerBasis
+from sympy.polys.numberfields.modules import PowerBasis, to_col
 from sympy.polys.numberfields.primes import (
     prime_decomp, _two_elt_rep,
     _check_formal_conditions_for_maximal_order,
 )
-from sympy.polys.polyerrors import GeneratorsNeeded
 from sympy.testing.pytest import raises
 
 
@@ -265,20 +264,26 @@ def test_repr():
     assert P[0].repr(field_gen=theta, just_gens=True) == '(2, (3*theta + 1)/2)'
 
 
-def test_PrimeIdeal_reduce_poly():
-    T = Poly(cyclotomic_poly(7, x))
-    k = QQ.algebraic_field((T, x))
-    P = k.primes_above(11)
-    frp = P[0]
-    B = k.integral_basis(fmt='sympy')
-    assert [frp.reduce_poly(b, x) for b in B] == [
-        1, x, x ** 2, -5 * x ** 2 - 4 * x + 1, -x ** 2 - x - 5,
-        4 * x ** 2 - x - 1]
+def test_PrimeIdeal_reduce():
+    k = QQ.alg_field_from_poly(Poly(x ** 3 + x ** 2 - 2 * x + 8))
+    Zk = k.maximal_order()
+    P = k.primes_above(2)
+    frp = P[2]
 
-    Q = k.primes_above(19)
-    frq = Q[0]
-    assert frq.alpha.equiv(0)
-    assert frq.reduce_poly(20*x**2 + 10) == x**2 - 9
+    # reduce_element
+    a = Zk.parent(to_col([23, 20, 11]), denom=6)
+    a_bar_expected = Zk.parent(to_col([11, 5, 2]), denom=6)
+    a_bar = frp.reduce_element(a)
+    assert a_bar == a_bar_expected
 
-    raises(GeneratorsNeeded, lambda: frp.reduce_poly(S(1)))
-    raises(NotImplementedError, lambda: frp.reduce_poly(1))
+    # reduce_ANP
+    a = k([QQ(11, 6), QQ(20, 6), QQ(23, 6)])
+    a_bar_expected = k([QQ(2, 6), QQ(5, 6), QQ(11, 6)])
+    a_bar = frp.reduce_ANP(a)
+    assert a_bar == a_bar_expected
+
+    # reduce_alg_num
+    a = k.to_alg_num(a)
+    a_bar_expected = k.to_alg_num(a_bar_expected)
+    a_bar = frp.reduce_alg_num(a)
+    assert a_bar == a_bar_expected


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Resolves #23403 

#### Brief description of what is fixed or changed

Provides reduction mod ideals, according to Alg 1.4.12 of [Cohen00].

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Provide method to reduce an algebraic number to a small representative mod an ideal.
<!-- END RELEASE NOTES -->
