### PR TITLE
Added support for parsing strings in Wolfram Mathematica code

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -633,7 +633,7 @@ class MathematicaParser:
             code = code[:pos_comment_start] + code[pos_comment_end+2:]
 
         # Find strings:
-        code_splits = []
+        code_splits: List[typing.Union[str, list]] = []
         while True:
             string_start = code.find("\"")
             if string_start == -1:

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -632,7 +632,25 @@ class MathematicaParser:
                 raise SyntaxError("mismatch in comment (*  *) code")
             code = code[:pos_comment_start] + code[pos_comment_end+2:]
 
-        tokens = tokenizer.findall(code)
+        # Find strings:
+        code_splits = []
+        while True:
+            string_start = code.find("\"")
+            if string_start == -1:
+                if len(code) > 0:
+                    code_splits.append(code)
+                break
+            match_end = re.search(r'(?<!\\)"', code[string_start+1:])
+            if match_end is None:
+                raise SyntaxError('mismatch in string "  " expression')
+            string_end = string_start + match_end.start() + 1
+            if string_start > 0:
+                code_splits.append(code[:string_start])
+            code_splits.append(["_Str", code[string_start+1:string_end].replace('\\"', '"')])
+            code = code[string_end+1:]
+
+        token_lists = [tokenizer.findall(i) if isinstance(i, str) else [i] for i in code_splits]
+        tokens = [j for i in token_lists for j in i]
 
         # Remove newlines at the beginning
         while tokens and tokens[0] == "\n":

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -231,6 +231,16 @@ def test_parser_mathematica_tokenizer():
     assert chain("#1 + #2 & [x, y]") == [["Function", ["Plus", ["Slot", "1"], ["Slot", "2"]]], "x", "y"]
     assert chain("#1^2#2^3&") == ["Function", ["Times", ["Power", ["Slot", "1"], "2"], ["Power", ["Slot", "2"], "3"]]]
 
+    # Strings inside Mathematica expressions:
+    assert chain('"abc"') == ["_Str", "abc"]
+    assert chain('"a\\"b"') == ["_Str", 'a"b']
+    # This expression does not make sense mathematically, it's just testing the parser:
+    assert chain('x + "abc" ^ 3') == ["Plus", "x", ["Power", ["_Str", "abc"], "3"]]
+    raises(SyntaxError, lambda: chain('"'))
+    raises(SyntaxError, lambda: chain('"\\"'))
+    raises(SyntaxError, lambda: chain('"abc'))
+    raises(SyntaxError, lambda: chain('"abc\\"def'))
+
     # Invalid expressions:
     raises(SyntaxError, lambda: chain("(,"))
     raises(SyntaxError, lambda: chain("()"))


### PR DESCRIPTION
Added support for parsing strings in Wolfram Mathematica code.

Strings are recognized at an early stage of the parser, before the tokenizer is called.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
