### PR TITLE
Provide a `lazy` option in `CRootOf` constructor.

### DIFF
--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -919,7 +919,7 @@ class Domain:
 
         """
         from sympy.polys.rootoftools import CRootOf
-        root = CRootOf(poly, root_index)
+        root = CRootOf(poly, root_index, lazy=True)
         alpha = AlgebraicNumber(root, alias=alias)
         return self.algebraic_field(alpha, alias=alias)
 


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Resolves #23418 


#### Brief description of what is fixed or changed

* `CRootOf` constructor accepts a kwarg, `lazy=False`. If `True`, approximating the roots is postponed until needed.
* `Domain.alg_field_from_poly()` uses `lazy=True`, so that constructing fields is instantaneous.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Provide a `lazy` option in `CRootOf` constructor.
  * Speed up construction of number fields.
<!-- END RELEASE NOTES -->
