### PR TITLE
Make `CRootOf` lazy on irreducibles.

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -356,7 +356,7 @@ class ComplexRootOf(RootOf):
         if not dom.is_ZZ:
             raise NotImplementedError("CRootOf is not supported over %s" % dom)
 
-        root = cls._indexed_root(poly, index)
+        root = cls._indexed_root(poly, index, lazy=True)
         return coeff * cls._postprocess_root(root, radicals)
 
     @classmethod
@@ -395,10 +395,12 @@ class ComplexRootOf(RootOf):
 
     def _eval_is_real(self):
         """Return ``True`` if the root is real. """
+        self._ensure_reals_init()
         return self.index < len(_reals_cache[self.poly])
 
     def _eval_is_imaginary(self):
         """Return ``True`` if the root is imaginary. """
+        self._ensure_reals_init()
         if self.index >= len(_reals_cache[self.poly]):
             ivl = self._get_interval()
             return ivl.ax*ivl.bx <= 0  # all others are on one side or the other
@@ -636,9 +638,15 @@ class ComplexRootOf(RootOf):
         return sum([k for _, _, k in roots])
 
     @classmethod
-    def _indexed_root(cls, poly, index):
+    def _indexed_root(cls, poly, index, lazy=False):
         """Get a root of a composite polynomial by index. """
         factors = _pure_factors(poly)
+
+        # If the given poly is already irreducible, then the index does not
+        # need to be adjusted, and we can postpone the heavy lifting of
+        # computing and refining isolating intervals until that is needed.
+        if lazy and len(factors) == 1 and factors[0][1] == 1:
+            return poly, index
 
         reals = cls._get_reals(factors)
         reals_count = cls._count_roots(reals)
@@ -648,6 +656,16 @@ class ComplexRootOf(RootOf):
         else:
             complexes = cls._get_complexes(factors)
             return cls._complexes_index(complexes, index - reals_count)
+
+    def _ensure_reals_init(self):
+        """Ensure that our poly has entries in the reals cache. """
+        if self.poly not in _reals_cache:
+            self._indexed_root(self.poly, self.index)
+
+    def _ensure_complexes_init(self):
+        """Ensure that our poly has entries in the complexes cache. """
+        if self.poly not in _complexes_cache:
+            self._indexed_root(self.poly, self.index)
 
     @classmethod
     def _real_roots(cls, poly):
@@ -779,18 +797,22 @@ class ComplexRootOf(RootOf):
 
     def _get_interval(self):
         """Internal function for retrieving isolation interval from cache. """
+        self._ensure_reals_init()
         if self.is_real:
             return _reals_cache[self.poly][self.index]
         else:
             reals_count = len(_reals_cache[self.poly])
+            self._ensure_complexes_init()
             return _complexes_cache[self.poly][self.index - reals_count]
 
     def _set_interval(self, interval):
         """Internal function for updating isolation interval in cache. """
+        self._ensure_reals_init()
         if self.is_real:
             _reals_cache[self.poly][self.index] = interval
         else:
             reals_count = len(_reals_cache[self.poly])
+            self._ensure_complexes_init()
             _complexes_cache[self.poly][self.index - reals_count] = interval
 
     def _eval_subs(self, old, new):

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -1,6 +1,7 @@
 """Tests for the implementation of RootOf class and related tools. """
 
 from sympy.polys.polytools import Poly
+import sympy.polys.rootoftools as rootoftools
 from sympy.polys.rootoftools import (rootof, RootOf, CRootOf, RootSum,
     _pure_key_dict as D)
 
@@ -326,6 +327,50 @@ def test_CRootOf_eval_rational():
              "0.33998104358485626",
              "0.86113631159405258",
              ]
+
+
+def test_CRootOf_lazy():
+    # irreducible poly with both real and complex roots:
+    f = Poly(x**3 + 2*x + 2)
+
+    # real root:
+    CRootOf.clear_cache()
+    r = CRootOf(f, 0)
+    # Not yet in cache, after construction:
+    assert r.poly not in rootoftools._reals_cache
+    assert r.poly not in rootoftools._complexes_cache
+    r.evalf()
+    # In cache after evaluation:
+    assert r.poly in rootoftools._reals_cache
+    assert r.poly not in rootoftools._complexes_cache
+
+    # complex root:
+    CRootOf.clear_cache()
+    r = CRootOf(f, 1)
+    # Not yet in cache, after construction:
+    assert r.poly not in rootoftools._reals_cache
+    assert r.poly not in rootoftools._complexes_cache
+    r.evalf()
+    # In cache after evaluation:
+    assert r.poly in rootoftools._reals_cache
+    assert r.poly in rootoftools._complexes_cache
+
+    # composite poly with both real and complex roots:
+    f = Poly((x**2 - 2)*(x**2 + 1))
+
+    # real root:
+    CRootOf.clear_cache()
+    r = CRootOf(f, 0)
+    # In cache immediately after construction:
+    assert r.poly in rootoftools._reals_cache
+    assert r.poly not in rootoftools._complexes_cache
+
+    # complex root:
+    CRootOf.clear_cache()
+    r = CRootOf(f, 2)
+    # In cache immediately after construction:
+    assert r.poly in rootoftools._reals_cache
+    assert r.poly in rootoftools._complexes_cache
 
 
 def test_RootSum___new__():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Resolves #23418
Replaces #23419 

#### Brief description of what is fixed or changed

If `f` is irreducible, and you construct `CRootOf(f, n)`, then the index `n` need not be adjusted.
This means we are free to postpone calculation of the isolating intervals until they are needed,
and this PR makes this so.

If `f` is composite, then the index `n` may need to be adjusted, which requires calculation of the
isolating intervals at construction time, so we cannot postpone it.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Lazy interval calculation for `CRootOf` on irreducible polys
<!-- END RELEASE NOTES -->
