### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', 'pypy-3.8']
 
     name: Python ${{ matrix.python-version }} test install
     steps:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -224,7 +224,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.10', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.10', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.10', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -20,8 +20,8 @@ from subprocess import run, PIPE
 from collections import OrderedDict, defaultdict
 from argparse import ArgumentParser
 
-if sys.version_info < (3, 7):
-    sys.exit("This script requires Python 3.7 or newer")
+if sys.version_info < (3, 8):
+    sys.exit("This script requires Python 3.8 or newer")
 
 def sympy_dir():
     return Path(__file__).resolve().parent.parent

--- a/doc/src/guides/getting_started/install.md
+++ b/doc/src/guides/getting_started/install.md
@@ -8,7 +8,7 @@ recommended method of installation is through Anaconda, which includes
 mpmath, as well as several other useful libraries.  Alternatively, some Linux
 distributions have SymPy packages available.
 
-SymPy officially supports Python 3.7, 3.8, 3.9, and PyPy.
+SymPy officially supports Python 3.8, 3.9, 3.10, and PyPy.
 
 ## Anaconda
 

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
 
 RUN conda config --add channels conda-forge
 RUN conda config --set always_yes yes
-RUN conda install python=3.7 rever requests requests-oauthlib \
+RUN conda install python=3.8 rever requests requests-oauthlib \
     && conda clean --all
 RUN conda info
 RUN /opt/conda/bin/pip install xonda

--- a/release/aptinstall.sh
+++ b/release/aptinstall.sh
@@ -30,6 +30,8 @@ sudo apt install\
 sudo apt install\
 	python3.9\
 	python3.9-venv\
+	python3.10\
+	python3.10-venv\
 	# python3.8 is installed by default in 20.04
 
 python3 -m venv release/venv_main

--- a/release/aptinstall.sh
+++ b/release/aptinstall.sh
@@ -28,8 +28,6 @@ sudo apt install\
 	#
 
 sudo apt install\
-	python3.7\
-	python3.7-venv\
 	python3.9\
 	python3.9-venv\
 	# python3.8 is installed by default in 20.04

--- a/release/test_install.py
+++ b/release/test_install.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from subprocess import check_call
 
 
-PY_VERSIONS = '3.8', '3.9'
+PY_VERSIONS = '3.8', '3.9', '3.10'
 
 
 def main(version, outdir):

--- a/release/test_install.py
+++ b/release/test_install.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from subprocess import check_call
 
 
-PY_VERSIONS = '3.7', '3.8', '3.9'
+PY_VERSIONS = '3.8', '3.9'
 
 
 def main(version, outdir):

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ except ImportError:
               % min_mpmath_version)
         sys.exit(-1)
 
-if sys.version_info < (3, 7):
-    print("SymPy requires Python 3.7 or newer. Python %d.%d detected"
+if sys.version_info < (3, 8):
+    print("SymPy requires Python 3.8 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 
@@ -459,7 +459,7 @@ if __name__ == '__main__':
                     'antlr': antlr,
                     'sdist': sdist_sympy,
                     },
-          python_requires='>=3.7',
+          python_requires='>=3.8',
           classifiers=[
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',
@@ -468,7 +468,6 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Physics',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -13,8 +13,8 @@ See the webpage for more information and documentation:
 
 
 import sys
-if sys.version_info < (3, 7):
-    raise ImportError("Python version 3.7 or above is required for SymPy.")
+if sys.version_info < (3, 8):
+    raise ImportError("Python version 3.8 or above is required for SymPy.")
 del sys
 
 

--- a/sympy/external/pythonmpq.py
+++ b/sympy/external/pythonmpq.py
@@ -133,37 +133,16 @@ class PythonMPQ:
         else:
             return NotImplemented
 
-    # The hashing algorithm for Fraction changed in Python 3.8
-
-    if sys.version_info >= (3, 8):
-        #
-        # Hash for Python 3.8 onwards
-        #
-        def __hash__(self):
-            """hash - same as mpq/Fraction"""
-            try:
-                dinv = pow(self.denominator, -1, _PyHASH_MODULUS)
-            except ValueError:
-                hash_ = _PyHASH_INF
-            else:
-                hash_ = hash(hash(abs(self.numerator)) * dinv)
-            result = hash_ if self.numerator >= 0 else -hash_
-            return -2 if result == -1 else result
-
-    else:
-        #
-        # Hash for Python < 3.7
-        #
-        def __hash__(self):
-            """hash - same as mpq/Fraction"""
-            # This is from fractions.py in the stdlib.
-            dinv = pow(self.denominator, _PyHASH_MODULUS - 2, _PyHASH_MODULUS)
-            if not dinv:
-                hash_ = _PyHASH_INF
-            else:
-                hash_ = abs(self.numerator) * dinv % _PyHASH_MODULUS
-            result = hash_ if self >= 0 else -hash_
-            return -2 if result == -1 else result
+    def __hash__(self):
+        """hash - same as mpq/Fraction"""
+        try:
+            dinv = pow(self.denominator, -1, _PyHASH_MODULUS)
+        except ValueError:
+            hash_ = _PyHASH_INF
+        else:
+            hash_ = hash(hash(abs(self.numerator)) * dinv)
+        result = hash_ if self.numerator >= 0 else -hash_
+        return -2 if result == -1 else result
 
     def __reduce__(self):
         """Deconstruct for pickling"""

--- a/sympy/parsing/ast_parser.py
+++ b/sympy/parsing/ast_parser.py
@@ -41,17 +41,6 @@ class Transform(NodeTransformer):
                     args=[node], keywords=[]))
         return node
 
-    def visit_Num(self, node):
-        """This function exists for backwards compatibility with Python 3.7.
-           It should be removed when SymPy removes support for Python 3.7."""
-        if isinstance(node.n, int):
-            return fix_missing_locations(Call(func=Name('Integer', Load()),
-                    args=[node], keywords=[]))
-        elif isinstance(node.n, float):
-            return fix_missing_locations(Call(func=Name('Float', Load()),
-                    args=[node], keywords=[]))
-        return node
-
     def visit_Name(self, node):
         if node.id in self.local_dict:
             return node

--- a/sympy/parsing/tests/test_ast_parser.py
+++ b/sympy/parsing/tests/test_ast_parser.py
@@ -1,4 +1,3 @@
-from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.parsing.ast_parser import parse_expr
@@ -12,7 +11,7 @@ def test_parse_expr():
     assert parse_expr('a + b', {}) == a + b
     raises(SympifyError, lambda: parse_expr('a + ', {}))
 
-    # tests Transform.visit_Num
+    # tests Transform.visit_Constant
     assert parse_expr('1 + 2', {}) == S(3)
     assert parse_expr('1 + 2.0', {}) == S(3.0)
 
@@ -24,10 +23,3 @@ def test_parse_expr():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         assert parse_expr('6 * 7', {}) == S(42)
-        # Note: The test below can be removed when support for Python 3.7 is
-        # dropped. This test exists to ensure that the visit_Num function
-        # exists for Python 3.7, because in 3.7, Python didn't use the
-        # visit_Constant to create AST Nodes yet.
-        test_expr = parse_expr('1 / 3', {})
-        assert test_expr == S(1)/3 # sanity check
-        assert isinstance(test_expr, Rational)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -300,8 +300,8 @@ def test_unicode_names():
 
 def test_python3_features():
     # Make sure the tokenizer can handle Python 3-only features
-    if sys.version_info < (3, 7):
-        skip("test_python3_features requires Python 3.7 or newer")
+    if sys.version_info < (3, 8):
+        skip("test_python3_features requires Python 3.8 or newer")
 
 
     assert parse_expr("123_456") == 123456

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -48,11 +48,8 @@ class ReprPrinter(Printer):
 
     def _print_Add(self, expr, order=None):
         args = self._as_ordered_terms(expr, order=order)
-        nargs = len(args)
         args = map(self._print, args)
         clsname = type(expr).__name__
-        if nargs > 255:  # Issue #10259, Python < 3.7
-            return clsname + "(*[%s])" % ", ".join(args)
         return clsname + "(%s)" % ", ".join(args)
 
     def _print_Cycle(self, expr):
@@ -201,11 +198,8 @@ class ReprPrinter(Printer):
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)
 
-        nargs = len(args)
         args = map(self._print, args)
         clsname = type(expr).__name__
-        if nargs > 255:  # Issue #10259, Python < 3.7
-            return clsname + "(*[%s])" % ", ".join(args)
         return clsname + "(%s)" % ", ".join(args)
 
     def _print_Rational(self, expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #21884
#### Brief description of what is fixed or changed

Follow the steps of #22383.
Remove some Python 3.7 or earlier code.
I didn't modify release/rever.xsh, because it still has test_tarball35 things and no one complains. This file should be removed I guess.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
