### PR TITLE
sympify: unpack numpy 0-d arrays

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -416,7 +416,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         flat = getattr(a, "flat", None)
         if flat is not None:
             shape = getattr(a, "shape", None)
-            if shape is not None:
+            if shape is not None and shape != ():
                 from sympy.tensor.array import Array
                 return Array(a.flat, a.shape)  # works with e.g. NumPy arrays
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -822,8 +822,10 @@ def test_issue_14706():
     assert sympify(numpy.array([[[1]]])) == ImmutableDenseNDimArray([1], (1, 1, 1))
     assert sympify(z1) == ImmutableDenseNDimArray([0], (1, 1))
     assert sympify(z2) == ImmutableDenseNDimArray([0, 0, 0, 0], (2, 2))
-    assert sympify(z3) == ImmutableDenseNDimArray([0], ())
-    assert sympify(z3, strict=True) == 0.0
+    for strict in [False, True]:  # see gh-23421
+        z3_s = sympify(z3, strict=strict)
+        assert type(z3_s) == Float
+        assert z3_s == 0.0
 
     raises(SympifyError, lambda: sympify(numpy.array([1]), strict=True))
     raises(SympifyError, lambda: sympify(z1, strict=True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This partially addresses the issues in discuessed in gh-23421


#### Brief description of what is fixed or changed
Prior to sympy-1.6, np.array(1) used to sympify into `S.One`, since sympy-1.6, sympify needed the strict flag set to `True` for this conversion to keep happen. With default `strict=False` it was instead wrapped in a `ImmutableDenseNDimArray`.

#### Other comments
Having different output from `sympify` based on `strict` flag is undesirable, the strict flag should only cause exceptions to be thrown more readily when set.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Sympify of 0-dimensional numpy arrays are no longer wrapped in an ImmutableDenseNDimArray

<!-- END RELEASE NOTES -->
