### PR TITLE
Generalize `ModuleElement.__mod__()`

### DIFF
--- a/sympy/polys/numberfields/modules.py
+++ b/sympy/polys/numberfields/modules.py
@@ -193,7 +193,7 @@ from sympy.polys.matrices.normalforms import hermite_normal_form
 from sympy.polys.polyerrors import CoercionFailed, UnificationFailed
 from sympy.polys.polyutils import IntegerPowerable
 from .exceptions import ClosureFailure, MissingUnityError, StructureError
-from .utilities import AlgIntPowers, is_int, is_rat, get_num_denom
+from .utilities import AlgIntPowers, is_rat, get_num_denom
 
 
 def to_col(coeffs):
@@ -1618,50 +1618,26 @@ class ModuleElement(IntegerPowerable):
 
     def __mod__(self, m):
         r"""
-        Reducing a :py:class:`~.ModuleElement` mod an integer *m* reduces all
-        numerator coeffs mod $d m$, where $d$ is the denominator of the
-        :py:class:`~.ModuleElement`.
+        Reduce this :py:class:`~.ModuleElement` mod a :py:class:`~.Submodule`.
 
-        Explanation
-        ===========
+        Parameters
+        ==========
 
-        Recall that a :py:class:`~.ModuleElement` $b$ represents a
-        $\mathbb{Q}$-linear combination over the basis elements
-        $\{\beta_0, \beta_1, \ldots, \beta_{n-1}\}$ of a module $B$. It uses a
-        common denominator $d$, so that the representation is in the form
-        $b=\frac{c_0 \beta_0 + c_1 \beta_1 + \cdots + c_{n-1} \beta_{n-1}}{d}$,
-        with $d$ and all $c_i$ in $\mathbb{Z}$, and $d > 0$.
+        m : int, :ref:`ZZ`, :ref:`QQ`, :py:class:`~.Submodule`
+            If a :py:class:`~.Submodule`, reduce ``self`` relative to this.
+            If an integer or rational, reduce relative to the
+            :py:class:`~.Submodule` that is our own module times this constant.
 
-        If we want to work modulo $m B$, this means we want to reduce the
-        coefficients of $b$ mod $m$. We can think of reducing an arbitrary
-        rational number $r/s$ mod $m$ as adding or subtracting an integer
-        multiple of $m$ so that the result is positive and less than $m$.
-        But this is equivalent to reducing $r$ mod $m \cdot s$.
-
-        Examples
+        See Also
         ========
 
-        >>> from sympy import Poly, cyclotomic_poly
-        >>> from sympy.polys.numberfields.modules import PowerBasis
-        >>> T = Poly(cyclotomic_poly(5))
-        >>> A = PowerBasis(T)
-        >>> a = (A(0) + 15*A(1))//2
-        >>> print(a)
-        [1, 15, 0, 0]/2
+        .Submodule.reduce_element
 
-        Here, ``a`` represents the number $\frac{1 + 15\zeta}{2}$. If we reduce
-        mod 7,
-
-        >>> print(a % 7)
-        [1, 1, 0, 0]/2
-
-        we get $\frac{1 + \zeta}{2}$. Effectively, we subtracted $7 \zeta$.
-        But it was achieved by reducing the numerator coefficients mod $14$.
         """
-        if is_int(m):
-            M = m * self.denom
-            col = to_col([c % M for c in self.coeffs])
-            return type(self)(self.module, col, denom=self.denom)
+        if is_rat(m):
+            m = m * self.module.whole_submodule()
+        if isinstance(m, Submodule) and m.parent == self.module:
+            return m.reduce_element(self)
         return NotImplemented
 
 

--- a/sympy/polys/numberfields/tests/test_modules.py
+++ b/sympy/polys/numberfields/tests/test_modules.py
@@ -663,7 +663,14 @@ def test_ModuleElement_mod():
     A = PowerBasis(T)
     e = A(to_col([1, 15, 8, 0]), denom=2)
     assert e % 7 == A(to_col([1, 1, 8, 0]), denom=2)
-    raises(TypeError, lambda: e % QQ(1, 2))
+    assert e % QQ(1, 2) == A.zero()
+    assert e % QQ(1, 3) == A(to_col([1, 1, 0, 0]), denom=6)
+
+    B = A.submodule_from_gens([A(0), 5*A(1), 3*A(2), A(3)])
+    assert e % B == A(to_col([1, 5, 2, 0]), denom=2)
+
+    C = B.whole_submodule()
+    raises(TypeError, lambda: e % C)
 
 
 def test_PowerBasisElement_polys():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Now that we have `Submodule.reduce_element()`, the `ModuleElement.__mod__()` method generalizes in a natural way.
Its docstring also becomes much shorter, because the operation is now much easier to explain.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
