### PR TITLE
Improve handling of inert primes

### DIFF
--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -569,6 +569,8 @@ def _prime_decomp_easy_case(p, ZK):
     T = ZK.parent.T
     T_bar = Poly(T, modulus=p)
     lc, fl = T_bar.factor_list()
+    if len(fl) == 1 and fl[0][1] == 1:
+        return [PrimeIdeal(ZK, p, ZK.parent.zero(), ZK.n, 1)]
     return [PrimeIdeal(ZK, p,
                        ZK.parent.element_from_poly(Poly(t, domain=ZZ)),
                        t.degree(), e)

--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -70,9 +70,17 @@ class PrimeIdeal(IntegerPowerable):
         self.e = e if e is not None else self.valuation(p * ZK)
 
     def __str__(self):
-        if self.alpha.is_rational:
+        if self.is_inert:
             return f'({self.p})'
         return f'({self.p}, {self.alpha.as_expr()})'
+
+    @property
+    def is_inert(self):
+        """
+        Say whether the rational prime we divide is inert, i.e. stays prime in
+        our ring of integers.
+        """
+        return self.f == self.ZK.n
 
     def repr(self, field_gen=None, just_gens=False):
         """

--- a/sympy/polys/numberfields/tests/test_primes.py
+++ b/sympy/polys/numberfields/tests/test_primes.py
@@ -287,3 +287,9 @@ def test_PrimeIdeal_reduce():
     a_bar_expected = k.to_alg_num(a_bar_expected)
     a_bar = frp.reduce_alg_num(a)
     assert a_bar == a_bar_expected
+
+
+def test_issue_23402():
+    k = QQ.alg_field_from_poly(Poly(x ** 3 + x ** 2 - 2 * x + 8))
+    P = k.primes_above(3)
+    assert P[0].alpha.equiv(0)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -632,7 +632,7 @@ class LatexPrinter(Printer):
 
     def _print_PrimeIdeal(self, expr):
         p = self._print(expr.p)
-        if expr.alpha.is_rational:
+        if expr.is_inert:
             return rf'\left({p}\right)'
         alpha = self._print(expr.alpha.as_expr())
         return rf'\left({p}, {alpha}\right)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23402


#### Brief description of what is fixed or changed

* Ensure the second generator `alpha` of a prime ideal is identically `0` whenever `p` is inert, fixing #23402.

* While we're on the subject, we also provide an `is_inert` property in the `PrimeIdeal` class, and use this to govern printing.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Repair representation of prime ideals for inert primes
<!-- END RELEASE NOTES -->
