### PR TITLE
isprime: test with `pow(2, n, n)` up to 31417

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -586,8 +586,8 @@ def isprime(n):
         return False
     if n < 2809:
         return True
-    if n <= 23001:
-        return pow(2, n, n) == 2 and n not in [7957, 8321, 13747, 18721, 19951]
+    if n < 31417:
+        return pow(2, n, n) == 2 and n not in [7957, 8321, 13747, 18721, 19951, 23377]
 
     # bisection search on the sieve if the sieve is large enough
     from sympy.ntheory.generate import sieve as s


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23451

#### Brief description of what is fixed or changed

Only one additional special case is needed to test up to 31417. And at least on my computer the difference in used time in `pow` calculation is quite small. Example with primes near the limits:
```bash
$ python3 -m timeit 'pow(2, 31397, 31397)'
500000 loops, best of 5: 675 nsec per loop
$ python3 -m timeit 'pow(2, 22993, 22993)'
500000 loops, best of 5: 645 nsec per loop
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:



or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `isprime`: test with `pow(2, n, n)` up to 31417
<!-- END RELEASE NOTES -->
