### PR TITLE
isprime deterministic to 3317044064679887385961981

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -607,6 +607,9 @@ def isprime(n):
     #    https://miller-rabin.appspot.com/
     # for lists.  We have made sure the M-R routine will successfully handle
     # bases larger than n, so we can use the minimal set.
+    # In September 2015 deterministic numbers were extended to over 2^81.
+    #    https://arxiv.org/pdf/1509.00864.pdf
+    #    https://oeis.org/A014233
     if n < 341531:
         return mr(n, [9345883071009581737])
     if n < 885594169:
@@ -621,6 +624,10 @@ def isprime(n):
         return mr(n, [2, 123635709730000, 9233062284813009, 43835965440333360, 761179012939631437, 1263739024124850375])
     if n < 18446744073709551616:
         return mr(n, [2, 325, 9375, 28178, 450775, 9780504, 1795265022])
+    if n < 318665857834031151167461:
+        return mr(n, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37])
+    if n < 3317044064679887385961981:
+        return mr(n, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41])
 
     # We could do this instead at any point:
     #if n < 18446744073709551616:


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This extends deterministic MR solutions to 3317044064679887385961981 (over 2^81)

#### Other comments
https://arxiv.org/pdf/1509.00864.pdf
https://oeis.org/A014233

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `isprime` extend deterministic solutions to over 2^81
<!-- END RELEASE NOTES -->
