### PR TITLE
series - Fixes series expansion around float failing with NotImplementedError

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1735,9 +1735,14 @@ class Pow(Expr):
                 raise NotImplementedError()
         if not d.is_positive:
             g = g.simplify()
+            if g.is_zero:
+                return f**e
             _, d = g.leadterm(x)
             if not d.is_positive:
-                raise NotImplementedError()
+                g = ((b - f)/f).expand()
+                _, d = g.leadterm(x)
+                if not d.is_positive:
+                    raise NotImplementedError()
 
         from sympy.functions.elementary.integers import ceiling
         gpoly = g._eval_nseries(x, n=ceiling(maxpow), logx=logx, cdir=cdir).removeO()

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -362,3 +362,9 @@ def test_issue_21245():
 def test_issue_21938():
     expr = sin(1/x + exp(-x)) - sin(1/x)
     assert expr.series(x, oo) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)
+
+
+def test_issue_23432():
+    expr = 1/sqrt(1 - x**2)
+    result = expr.series(x, 0.5)
+    assert result.is_Add and len(result.args) == 7


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #23432 and now `series(1/sqrt(1-x**2), x, 0.5)` returns 
```
0.769800358919501 + 1.539600717839*(x - 0.5)**2 + 2.39493444997178*(x - 0.5)**3 + 4.33369090947275*(x - 0.5)**4 + 7.75502583800386*(x - 0.5)**5 + 0.769800358919501*x + O((x - 1/2)**6, (x, 1/2))
```
instead of `NotImplementedError`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * fixes bug in `series` and now series expansion with float does not give `NotImplementedError`.
<!-- END RELEASE NOTES -->
