### PR TITLE
make `quantity_simplify()` able to simplify more complex expressions

### DIFF
--- a/sympy/physics/units/systems/si.py
+++ b/sympy/physics/units/systems/si.py
@@ -18,7 +18,7 @@ from sympy.physics.units.definitions.dimension_definitions import (
     acceleration, action, current, impedance, length, mass, time, velocity,
     amount_of_substance, temperature, information, frequency, force, pressure,
     energy, power, charge, voltage, capacitance, conductance, magnetic_flux,
-    magnetic_density, inductance, luminous_intensity
+    magnetic_density, inductance, luminous_intensity, volume, area,
 )
 from sympy.physics.units.definitions import (
     kilogram, newton, second, meter, gram, cd, K, joule, watt, pascal, hertz,
@@ -81,6 +81,8 @@ SI = MKSA.extend(base=(mol, cd, K), units=all_units, name='SI', dimension_system
     current: ampere,
     voltage: volt,
     length: meter,
+    area: meter**2,
+    volume: meter**3,
     frequency: hertz,
     inductance: henry,
     temperature: kelvin,

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -3,6 +3,8 @@ from sympy.core.numbers import pi
 from sympy.core.power import Pow
 from sympy.core.symbol import symbols
 from sympy.core.sympify import sympify
+from sympy.physics.units.dimensions import Dimension
+from sympy.physics.units.unitsystem import UnitSystem
 from sympy.printing.str import sstr
 from sympy.physics.units import (
     G, centimeter, coulomb, day, degree, gram, hbar, hour, inch, joule, kelvin,
@@ -160,3 +162,32 @@ def test_check_dimensions():
     raises(ValueError, lambda: check_dimensions(2 * meter + 3 * second))
     raises(ValueError, lambda: check_dimensions(1 / second + 1 / meter))
     raises(ValueError, lambda: check_dimensions(2 * meter*(mile + centimeter) + km))
+
+
+def test_is_dimensionally_equivalent():
+    from sympy.physics.units.util import is_dimensionally_equivalent
+    from sympy.physics.units import ampere, ohm, volt, joule, farad, second, weber, newton
+    from sympy.physics.units import length, time, mass, current
+
+    unit_system = UnitSystem.get_unit_system("SI")
+
+    assert is_dimensionally_equivalent(meter, meter, unit_system)
+    assert is_dimensionally_equivalent(meter, centimeter, unit_system)
+    assert is_dimensionally_equivalent(meter, kilometer, unit_system)
+    assert not is_dimensionally_equivalent(meter, second, unit_system)
+    assert not is_dimensionally_equivalent(meter, newton, unit_system)
+    assert not is_dimensionally_equivalent(newton, ampere, unit_system)
+    assert not is_dimensionally_equivalent(meter, meter**2, unit_system)
+    assert is_dimensionally_equivalent(volt, ohm*ampere, unit_system)
+    assert is_dimensionally_equivalent(ohm, volt/ampere, unit_system)
+    assert is_dimensionally_equivalent(joule/ampere, weber, unit_system)
+    assert is_dimensionally_equivalent(farad, coulomb/volt, unit_system)
+
+    assert is_dimensionally_equivalent(length, meter, unit_system)
+    assert is_dimensionally_equivalent(length**2, meter**2, unit_system)
+    assert is_dimensionally_equivalent(time, second, unit_system)
+    assert is_dimensionally_equivalent(mass, kilogram, unit_system)
+    assert is_dimensionally_equivalent(kilogram, mass, unit_system)
+
+    assert is_dimensionally_equivalent(current, { current: 1 }, unit_system)
+    assert is_dimensionally_equivalent({ length: 1, time: -2 }, meter/second**2, unit_system)

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -1,5 +1,6 @@
 from sympy.core.containers import Tuple
-from sympy.core.numbers import pi
+from sympy.core.mul import Mul
+from sympy.core.numbers import Float, Integer, pi
 from sympy.core.power import Pow
 from sympy.core.symbol import symbols
 from sympy.core.sympify import sympify
@@ -146,6 +147,14 @@ def test_quantity_simplify_across_dimensions():
 
     assert quantity_simplify(5*kilometer/hour, across_dimensions=True, unit_system="SI") == 25*meter/(18*second)
     assert quantity_simplify(5*kilogram*meter/second**2, across_dimensions=True, unit_system="SI") == 5*newton
+
+    assert quantity_simplify(3*volt + 2*ampere*ohm, across_dimensions=True, unit_system="SI") == 5*volt
+    assert quantity_simplify(3*meter * 2*meter, across_dimensions=True, unit_system="SI") == 6*meter**2
+    assert quantity_simplify(ampere*meter*ohm, across_dimensions=True, unit_system="SI") == volt*meter
+    assert quantity_simplify(ampere*meter**3*ohm, across_dimensions=True, unit_system="SI") == volt*meter**3
+    assert quantity_simplify((2*volt + 2*ohm*ampere) / meter, across_dimensions=True, unit_system="SI") == 4*volt/meter
+    assert quantity_simplify(13140019104.1279*(-7209794853.0*ampere*ohm + 9125000000.0*volt)/(ampere*meter**3*ohm), across_dimensions=True, unit_system="SI") == Mul(Float('2.5165832219904086e+19', precision=53), Pow(meter, Integer(-3)))
+
 
 def test_check_dimensions():
     x = symbols('x')

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -19,6 +19,7 @@ from sympy.physics.units.prefixes import Prefix
 from sympy.physics.units.quantities import Quantity
 from sympy.physics.units.unitsystem import UnitSystem
 from sympy.utilities.iterables import sift
+from sympy.physics.units.definitions import dimension_definitions
 
 
 def _get_conversion_matrix_for_expr(expr, target_units, unit_system):
@@ -181,15 +182,77 @@ def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None):
                 target_dimension = ds_dim
                 break
 
-        if target_dimension is None:
-            # if we can't find a target dimension, we can't do anything. unsure how to handle this case.
-            return expr
+        if target_dimension is not None:
+            target_unit = unit_system.derived_units.get(target_dimension)
+        elif target_dimension is None:
+            # There is no single regular dimension in the unit system that matches
+            # the dimensions of the expression, so we need to build one out of 2
+            # or more existing dimensions.
+            # We'll do this by brute force combining the units in the unit system, flipping them around,
+            # and finding the first that matches the expression's dimensionality.
 
-        target_unit = unit_system.derived_units.get(target_dimension)
+            # TODO: To be true to the spirit of "simplification", we need to find all possible combinations
+            # and then find the one that is "shortest".
+            target_dimension = __find_compound_dimension(dimension_system, dim_deps)
+            # Dimensions are special. When you do math with them, you get a Dimension object, not a normal sympy expression. The sympy expression is actually in the Dimension's symbol: `name`.
+
+            # replace each dimension in target_dimension with derived unit from the unit system
+            dim_map = { symbol: unit_system.derived_units.get(vars(dimension_definitions)[symbol.name]) for symbol in target_dimension.free_symbols }
+            print(dim_map)
+            target_unit = target_dimension.name.subs(dim_map)
+            assert not isinstance(target_unit, Dimension)
+
+            # find Adds that we can safely add together because they have the same dimensions
+            adds = expr.atoms(Add)
+            for add in adds:
+                add_dim_deps = dimension_system.get_dimensional_dependencies(unit_system.get_dimensional_expr(add))
+                if all(is_dimensionally_equivalent(add_dim_deps, arg, unit_system) for arg in add.args):
+                    units = [unit for unit in unit_system.get_units_non_prefixed() if is_dimensionally_equivalent(unit, add_dim_deps, unit_system)]
+                    if units:
+                        new_add = add.xreplace({u: 1 for u in add.atoms(Quantity)}) * units[0]
+                        expr = expr.xreplace({add: new_add})
+                        print("REPLACED", add, "with", new_add)
+
         if target_unit:
             expr = convert_to(expr, target_unit, unit_system)
 
     return expr
+
+
+def __find_compound_dimension(dimension_system: DimensionSystem, dimensional_dependencies) -> Dimension:
+    # This can and should be switched out for something more intelligent.
+
+    all_dimensions = dimension_system.base_dims + dimension_system.derived_dims
+    # test all reciprocals of all dimensions
+    for dim in all_dimensions:
+        new_dim = 1 / dim
+        new_dim_deps = dimension_system.get_dimensional_dependencies(new_dim)
+        if new_dim_deps == dimensional_dependencies:
+            print("FOUND COMPATIBLE: ", new_dim)
+            return new_dim
+
+    # test all 2 dim combinations of all dimensions
+    for dA in all_dimensions:
+        for dB in all_dimensions:
+            if dA == dB:
+                continue
+            new_dim = dA * dB
+            new_dim_deps = dimension_system.get_dimensional_dependencies(new_dim)
+            if new_dim_deps == dimensional_dependencies:
+                print("FOUND COMPATIBLE: ", new_dim)
+                return new_dim
+
+            new_dim = dA / dB
+            new_dim_deps = dimension_system.get_dimensional_dependencies(new_dim)
+            if new_dim_deps == dimensional_dependencies:
+                print("FOUND COMPATIBLE: ", new_dim)
+                return new_dim
+
+            new_dim = dB / dA
+            new_dim_deps = dimension_system.get_dimensional_dependencies(new_dim)
+            if new_dim_deps == dimensional_dependencies:
+                print("FOUND COMPATIBLE: ", new_dim)
+                return new_dim
 
 
 def check_dimensions(expr, unit_system="SI"):


### PR DESCRIPTION
- add area, volume to si derived units
- fix(physics.units): quantity_symplify is now able to symplify more complex expressions

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #23452

#### Brief description of what is fixed or changed
`quantity_simplify()` and `convert_to()` struggle when the expression is not trivial. This is because the unit's dimensionality is not fully taken into consideration when simplifing expressions.
Additionally, `quantity_simplify()` struggles when the target dimension is not in the derived units map.

For example:
Both sides of this equality are equivalent dimensionally, but sympy doesn't think so because it sees these as 2 different expressions.
```
ohm*ampere == volt
```

This PR attempts to remedy this problem at least a little bit by providing a mechanism to convert the expression into a compound unit.


#### Other comments
I am not super confident about this solution. I would feel more comfortable if we had more test cases that were as complex as the one in #23452.

This PR is a work in progress. I'm looking for feedback on what direction to go in before I work on this any more.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
