### PR TITLE
Allow numpy to be import under pypy

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -133,17 +133,20 @@ jobs:
     needs: code-quality
 
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.9', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath gmpy2 matplotlib numpy scipy aesara ipython \
-                         symengine cython llvmlite wurlitzer \
-                         autowrap numexpr 'antlr4-python3-runtime==4.7.*' \ 
-                         numba
+      - run: pip install mpmath matplotlib numpy scipy aesara ipython cython \
+                         wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
+      - if: ${{ matrix.python-version == '3.9' }}
+        run: pip install gmpy2 symengine llvmlite numba  # not available for pypy
       # Test external imports
       - run: bin/test_external_imports.py
       - run: bin/test_submodule_imports.py

--- a/.mailmap
+++ b/.mailmap
@@ -1396,6 +1396,7 @@ dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
+extraymond <extraymond@gmail.com>
 faizan2700 <syedfaizan824@gmail.com>
 foice <foice.news@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>

--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -141,10 +141,6 @@ def import_module(module, min_module_version=None, min_python_version=None,
                     UserWarning, stacklevel=2)
             return
 
-    # PyPy 1.6 has rudimentary NumPy support and importing it produces errors, so skip it
-    if module == 'numpy' and '__pypy__' in sys.builtin_module_names:
-        return
-
     try:
         mod = __import__(module, **import_kwargs)
 

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -286,7 +286,8 @@ def test_autowrap_custom_printer():
 
     tmpdir = tempfile.mkdtemp()
     # write a trivial header file to use in the generated code
-    open(os.path.join(tmpdir, 'shortpi.h'), 'w').write('#define S_PI 3.14')
+    with open(os.path.join(tmpdir, 'shortpi.h'), 'w') as f:
+        f.write('#define S_PI 3.14')
 
     func = autowrap(expr, backend='cython', tempdir=tmpdir, code_gen=gen)
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -100,7 +100,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
-    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
+    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy import *; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -335,6 +335,8 @@ def test_trig():
 
 
 def test_integral():
+    if numpy and not scipy:
+        skip("scipy not installed.")
     f = Lambda(x, exp(-x**2))
     l = lambdify(y, Integral(f(x), (x, y, oo)))
     d = l(-oo)
@@ -342,6 +344,8 @@ def test_integral():
 
 
 def test_double_integral():
+    if numpy and not scipy:
+        skip("scipy not installed.")
     # example from http://mpmath.org/doc/current/calculus/integration.html
     i = Integral(1/(1 - x**2*y**2), (x, 0, 1), (y, 0, z))
     l = lambdify([z], i)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #14658
Revive #14664

Please review commit by commit (e.g. checkout the first commit, reproduce the result I get, then checkout the next commit). I'll amend and force-push when needed.
## The 1st commit removes the import restriction
My local environment is Ubuntu 22.04 x64, pypy3 from apt.
I can't install scipy (build fail), so I test with numpy only.
```sh
$ pypy3 -m pytest sympy/utilities/tests/test_lambdify.py
...
FAILED sympy/utilities/tests/test_lambdify.py::test_integral - NameError: name 'scipy' is not defined
FAILED sympy/utilities/tests/test_lambdify.py::test_double_integral - NameError: name 'scipy' is not defined
```
It is strange since I have no scipy locally, why it tries to import scipy? If I run the `test_integral` only, it gives another error:
```sh
$ pypy3 -m pytest sympy/utilities/tests/test_lambdify.py::test_integral
...
FAILED sympy/utilities/tests/test_lambdify.py::test_integral - NameError: name 'Integral' is not defined
```
So the previous error is dependent with tests ran before.
## The 2nd commit fixes the scipy problem
A test runs before `test_integral` tries to import scipy. At line 149 it executes `import numpy` first, which succeed and updates `namespace`, which is the global dict `SCIPY`.
After that, `test_integral` tries to import scipy. As the `namespace` is modified, at line 132 the condition becomes `True` and the function successfully returns, giving a false conclusion that scipy is available.
So this commit re-arranges the order of imports. If scipy is not available, `SCIPY` isn't modified anymore, and tests run consistently.
https://github.com/sympy/sympy/blob/ed4e06eff860e001fd7c4da7cf17fd8c1cac8c6a/sympy/utilities/lambdify.py#L132-L150
Now testing `test_lambdify.py` will also lead to the undefined `Integral` exception.
## The 3rd commit skips the 2 failing tests when numpy is installed but scipy isn't
## The 4th commit test optional dependencies for pypy
gmpy2, symengine, llvmlite and numba cannot be built. Skip them.
## The 5th commit fix the test error in the previous [PR](https://github.com/sympy/sympy/pull/14664#issuecomment-591618494)
Explanation can be found at https://stackoverflow.com/a/7396043.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * It is now possible to use `lambdify` with NumPy while running under PyPy.
<!-- END RELEASE NOTES -->
