### PR TITLE
Use `json.load` instead of `json.loads`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -951,6 +951,7 @@ Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>
+Omkaar <79257339+Pysics@users.noreply.github.com>
 Ondřej Čertík <ondrej@certik.cz>
 Ondřej Čertík <ondrej@certik.cz> <ondrej.certik@gmail.com>
 Ondřej Čertík <ondrej@certik.cz> <ondrej@certik.us>

--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,7 @@ else:
 
 if os.path.exists(blacklist_path):
     with open(blacklist_path, 'rt') as stream:
-        blacklist_group = _mk_group(json.loads(stream.read()))
+        blacklist_group = _mk_group(json.load(stream))
 else:
     warnings.warn("conftest.py:28: Could not find %s, no tests will be skipped due to blacklisting\n" % blacklist_path)
     blacklist_group = []


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The code is shortened by using `json.load` instead of `json.loads`.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->