### PR TITLE
solvers - fixes PolynomialError raised for classify_ode

### DIFF
--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -50,6 +50,8 @@ def match_2nd_hypergeometric(eq, func):
             n, d = eq.as_numer_denom()
             eq = expand(n)
             r = collect(eq, [func.diff(x, 2), func.diff(x), func]).match(deq)
+            if not all(val.is_polynomial() for val in r.values()):
+                return []
 
     if r and r[a3]!=0:
         A = cancel(r[b3]/r[a3])

--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -50,8 +50,6 @@ def match_2nd_hypergeometric(eq, func):
             n, d = eq.as_numer_denom()
             eq = expand(n)
             r = collect(eq, [func.diff(x, 2), func.diff(x), func]).match(deq)
-            if not all(val.is_polynomial() for val in r.values()):
-                return []
 
     if r and r[a3]!=0:
         A = cancel(r[b3]/r[a3])
@@ -99,6 +97,14 @@ def equivalence_hypergeometric(A, B, func):
     # computing I0 of the given equation
     I0 = powdenest(simplify(factor(((J1/k**2) - S(1)/4)/((x**k)**2))), force=True)
     I0 = factor(cancel(powdenest(I0.subs(x, x**(S(1)/k)), force=True)))
+
+    # Before this point I0, J1 might be functions of e.g. sqrt(x) but replacing
+    # x with x**(1/k) should result in I0 being a rational function of x or
+    # otherwise the hypergeometric solver cannot be used. Note that k can be a
+    # non-integer rational such as 2/7.
+    if not I0.is_rational_function(x):
+        return None
+
     num, dem = I0.as_numer_denom()
 
     max_num_pow = max(_power_counting((num, )))

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1,5 +1,5 @@
 from sympy.core.function import (Derivative, Function, Subs, diff)
-from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -1069,3 +1069,12 @@ def test_issue_22462():
             Eq(f(x).diff(x), -20*f(x)**2 - 500*f(x)/7200),
             Eq(f(x).diff(x), -2*f(x)**2 - 5*f(x)/7)]:
         assert 'Bernoulli' in classify_ode(de, f(x))
+
+
+def test_issue_23425():
+    x = symbols('x')
+    y = Function('y')
+    eq = Eq(-E**x*y(x).diff().diff() + y(x).diff(), 0)
+    assert classify_ode(eq) == \
+        ('Liouville', 'nth_order_reducible', \
+        '2nd_power_series_ordinary', 'Liouville_Integral')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #23425 and now `classify_ode(Eq(-E**x*y(x).diff().diff() + y(x).diff(), 0))` gives `('Liouville', 'nth_order_reducible', '2nd_power_series_ordinary', 'Liouville_Integral')` instead of `PolynomialError`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * A bug was fixed in the hypergeometric solver so that `classify_ode()` does not raise `PolynomialError` for certain ODEs.
<!-- END RELEASE NOTES -->
