### PR TITLE
Revert "Fix latex"

### DIFF
--- a/doc/src/guides/contributing/dependencies.md
+++ b/doc/src/guides/contributing/dependencies.md
@@ -109,7 +109,7 @@ images rendered with LaTeX. `preview()` can either save the image to a file or
 show it with a viewer.
 
 (dependencies-latex)=
-- **LaTeX**: A $\textrm{\LaTeX}$ distributions such as [TeXLive](https://tug.org/texlive/) or
+- **LaTeX**: A $\LaTeX$ distributions such as [TeXLive](https://tug.org/texlive/) or
 [MiKTeX](https://miktex.org/) is required for {func}`~.preview` to function.
 
 ### Parsing

--- a/doc/src/guides/getting_started/install.md
+++ b/doc/src/guides/getting_started/install.md
@@ -18,7 +18,7 @@ more useful packages for scientific computing. This is recommended because
 many nice features of SymPy are only enabled when certain libraries are
 installed.  For example, without Matplotlib, only simple text-based plotting
 is enabled.  With the IPython notebook or qtconsole, you can get nicer
-$\textrm{\LaTeX}$ printing by running `init_printing()`.
+$\mathrm{\LaTeX}$ printing by running `init_printing()`.
 
 If you already have Anaconda and want to update SymPy to the latest version,
 use:

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -57,19 +57,19 @@ don't need to be manually added by the user.
 
 .. autofunction:: sympy.parsing.sympy_parser.factorial_notation
 
-Experimental `\textrm{\LaTeX}` Parsing
+Experimental `\mathrm{\LaTeX}` Parsing
 --------------------------------------
 
-`\textrm{\LaTeX}` parsing was ported from
+`\mathrm{\LaTeX}` parsing was ported from
 `latex2sympy <https://github.com/augustt198/latex2sympy>`_. While functional
 and its API should remain stable, the parsing behavior or backend may change in
 future releases.
 
-`\textrm{\LaTeX}` Parsing Caveats
+`\mathrm{\LaTeX}` Parsing Caveats
 ---------------------------------
 
 The current implementation is experimental. The behavior, parser backend and
-API might change in the future. Unlike some of the other parsers, `\textrm{\LaTeX}` is
+API might change in the future. Unlike some of the other parsers, `\mathrm{\LaTeX}` is
 designed as a *type-setting* language, not a *computer algebra system* and so
 can contain typographical conventions that might be interpreted multiple ways.
 
@@ -82,12 +82,12 @@ Will simply find ``x``. What is covered by this behavior will almost certainly
 change between releases, and become stricter, more relaxed, or some mix.
 
 
-`\textrm{\LaTeX}` Parsing Functions Reference
+`\mathrm{\LaTeX}` Parsing Functions Reference
 ---------------------------------------------
 
 .. autofunction:: sympy.parsing.latex.parse_latex
 
-`\textrm{\LaTeX}` Parsing Exceptions Reference
+`\mathrm{\LaTeX}` Parsing Exceptions Reference
 ----------------------------------------------
 
 .. autoclass:: sympy.parsing.latex.LaTeXParsingError

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -196,7 +196,7 @@ Why not use dicts as output?
     represent partial solution of the given equation `fg = 0` using dicts.
     This problem is solved with sets using a ``ConditionSet`` object:
 
-    `sol_f \cup \{x | x \in \mathbb{R} \land g = 0\}`, where `sol_f` is the solution
+    `sol_f \cup \{x | x ∊ \mathbb{R} ∧ g = 0\}`, where `sol_f` is the solution
     of the equation `f = 0`.
 
   * Using a dict may lead to surprising results like:
@@ -459,7 +459,7 @@ How do we deal with cases where only some of the solutions are known?
 
  We can represent it as:
 
- `\{-2, 2\} \cup \{x | x \in \mathbb{R} \land x + \sin(x) = 0\}`
+ `\{-2, 2\} ∪ \{x | x \in \mathbb{R} ∧ x + \sin(x) = 0\}`
 
 
 What is the plan for solve and solveset?

--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -109,7 +109,7 @@ to do all sorts of computations symbolically.  SymPy can simplify expressions,
 compute derivatives, integrals, and limits, solve equations, work with
 matrices, and much, much more, and do it all symbolically.  It includes
 modules for plotting, printing (like 2D pretty printed output of math
-formulas, or `\textrm{\LaTeX}`), code generation, physics, statistics, combinatorics,
+formulas, or `\mathrm{\LaTeX}`), code generation, physics, statistics, combinatorics,
 number theory, geometry, logic, and more. Here is a small sampling of the sort
 of symbolic power SymPy is capable of, to whet your appetite.
 
@@ -173,7 +173,7 @@ spherical Bessel function `j_\nu(z)`.
   ────────────────────
            √π
 
-Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\textrm{\LaTeX}`.
+Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\mathrm{\LaTeX}`.
 
   >>> latex(Integral(cos(x)**2, (x, 0, pi)))
   \int\limits_{0}^{\pi} \cos^{2}{\left(x \right)}\, dx

--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -60,17 +60,17 @@ create some common Symbols, setup plotting, and run ``init_printing()``.
 
 In any case, this is what will happen:
 
-- In the IPython QTConsole, if `\textrm{\LaTeX}` is installed, it will enable a printer
-  that uses `\textrm{\LaTeX}`.
+- In the IPython QTConsole, if `\mathrm{\LaTeX}` is installed, it will enable a printer
+  that uses `\mathrm{\LaTeX}`.
 
   .. image:: ../pics/ipythonqtconsole.png
      :height: 500
 
-  If `\textrm{\LaTeX}` is not installed, but Matplotlib is installed, it will use the
+  If `\mathrm{\LaTeX}` is not installed, but Matplotlib is installed, it will use the
   Matplotlib rendering engine. If Matplotlib is not installed, it uses the
   Unicode pretty printer.
 
-- In the IPython notebook, it will use MathJax to render `\textrm{\LaTeX}`.
+- In the IPython notebook, it will use MathJax to render `\mathrm{\LaTeX}`.
 
   .. image:: ../pics/ipythonnotebook.png
      :height: 250
@@ -87,7 +87,7 @@ In any case, this is what will happen:
   .. image:: ../pics/consoleascii.png
      :width: 700
 
-To explicitly not use `\textrm{\LaTeX}`, pass ``use_latex=False`` to ``init_printing()``
+To explicitly not use `\mathrm{\LaTeX}`, pass ``use_latex=False`` to ``init_printing()``
 or ``init_session()``.  To explicitly not use Unicode, pass
 ``use_unicode=False``.
 
@@ -178,10 +178,10 @@ pass ``use_unicode=True`` to force it to use Unicode.
 
 .. _LaTeX:
 
-`\textrm{\LaTeX}`
+`\mathrm{\LaTeX}`
 -----------------
 
-To get the `\textrm{\LaTeX}` form of an expression, use ``latex()``.
+To get the `\mathrm{\LaTeX}` form of an expression, use ``latex()``.
 
     >>> print(latex(Integral(sqrt(1/x), x)))
     \int \sqrt{\frac{1}{x}}\, dx


### PR DESCRIPTION
Reverts sympy/sympy#23365

This change made broke the rendering of `\LaTeX` in the HTML documentation. 

<!-- BEGIN RELEASE NOTES --> 
NO ENTRY