### PR TITLE
Revert "Remove the pre line-height from custom.css"

### DIFF
--- a/doc/src/_static/custom.css
+++ b/doc/src/_static/custom.css
@@ -1,5 +1,15 @@
-/* Disable most blockquotes. The Furo defaults make block quotes very
- * apparent. However, the parameter blocks from numpydoc render as block
+/* Reduce the vertical space between lines in code blocks. Required to */
+/* make Unicode pretty printing appear correctly. */
+pre {
+    line-height: 120% !important;
+}
+
+article pre {
+    line-height: 120% !important;
+}
+
+/* Disable most blockquotes. The Furo defaults make block quotes very*/
+/* apparent. However, the parameter blocks from numpydoc render as block
  * quotes, which looks bad. Furthermore, it is very easy for things to
  * accidentally have block quotes due to the fact that RST makes indented
  * blocks render as a block quote (unlike Markdown which makes indented blocks


### PR DESCRIPTION
This reverts commit ed4c87daaffc30f79a3e2f1f52ee8c9e32f1f385.

In principle the line-height should be set by the pygments theme, but Furo is
overriding it, so we need to set it in custom.css as well for now. See
https://github.com/pradyunsg/furo/discussions/438.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
