### PR TITLE
manualintegrate 1/sqrt(a+b*x+c*x**2)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -457,13 +457,11 @@ def inverse_trig_rule(integral):
     base, exp = integrand.as_base_exp()
     a = Wild('a', exclude=[symbol])
     b = Wild('b', exclude=[symbol])
-    match = base.match(a + b*symbol**2)
+    c = Wild('c', exclude=[symbol, 0])
+    match = base.match(a + b*symbol + c*symbol**2)
 
     if not match:
         return
-
-    def negative(x):
-        return x.is_negative or x.could_extract_minus_sign()
 
     def ArcsinhRule(integrand, symbol):
         return InverseHyperbolicRule(asinh, integrand, symbol)
@@ -471,44 +469,35 @@ def inverse_trig_rule(integral):
     def ArccoshRule(integrand, symbol):
         return InverseHyperbolicRule(acosh, integrand, symbol)
 
-    def make_inverse_trig(RuleClass, base_exp, a, sign_a, b, sign_b):
+    def make_inverse_trig(RuleClass, a, sign_a, c, sign_c, h):
+        # base equals sign_a*a + sign_c*c*(symbol-h)**2, a>0, c>0
         u_var = Dummy("u")
-        current_base = base
-        current_symbol = symbol
-        constant = u_func = u_constant = substep = None
-        factored = integrand
-        if a != 1:
-            constant = a**base_exp
-            current_base = sign_a + sign_b * (b/a) * current_symbol**2
-            factored = current_base ** base_exp
-        if (b/a) != 1:
-            u_func = sqrt(b/a) * symbol
-            u_constant = sqrt(a/b)
-            current_symbol = u_var
-            current_base = sign_a + sign_b * current_symbol**2
-
-        substep = RuleClass(current_base ** base_exp, current_symbol)
+        quadratic_base = sqrt(c/a)*(symbol-h)
+        constant = 1/sqrt(c)
+        u_func = None
+        if quadratic_base is not symbol:
+            u_func = quadratic_base
+            quadratic_base = u_var
+        standard_form = 1/sqrt(sign_a + sign_c*quadratic_base**2)
+        substep = RuleClass(standard_form, quadratic_base)
+        if constant != 1:
+            substep = ConstantTimesRule(constant, standard_form, substep, constant*standard_form, symbol)
         if u_func is not None:
-            if u_constant != 1 and substep is not None:
-                substep = ConstantTimesRule(
-                    u_constant, current_base ** base_exp, substep,
-                    u_constant * current_base ** base_exp, symbol)
-            substep = URule(u_var, u_func, u_constant, substep, factored, symbol)
-        if constant is not None and substep is not None:
-            substep = ConstantTimesRule(constant, factored, substep, integrand, symbol)
+            substep = URule(u_var, u_func, None, substep, integrand, symbol)
         return substep
 
-    a, b = [match.get(i, S.Zero) for i in (a, b)]
+    a, b, c = [match.get(i, S.Zero) for i in (a, b, c)]
     # list of (rule, base_exp, a, sign_a, b, sign_b, condition)
     possibilities = []
 
     if simplify(2*exp + 1) == 0:
-        possibilities.append((ArcsinRule, exp, a, 1, -b, -1, And(a > 0, b < 0)))
-        possibilities.append((ArcsinhRule, exp, a, 1, b, 1, And(a > 0, b > 0)))
-        possibilities.append((ArccoshRule, exp, -a, -1, b, 1, And(a < 0, b > 0)))
+        h, k = -b/(2*c), a - b**2/(4*c)  # rewrite base to k + c*(symbol-h)**2
+        possibilities.append((ArcsinRule, k, 1, -c, -1, h, And(k > 0, c < 0)))  # 1-x**2
+        possibilities.append((ArcsinhRule, k, 1, c, 1, h, And(k > 0, c > 0)))  # 1+x**2
+        possibilities.append((ArccoshRule, -k, -1, c, 1, h, And(k < 0, c > 0)))  # -1+x**2
 
     possibilities = [p for p in possibilities if p[-1] is not S.false]
-    if a.is_number and b.is_number:
+    if a.is_number and c.is_number:
         possibility = [p for p in possibilities if p[-1] is S.true]
         if len(possibility) == 1:
             return make_inverse_trig(*possibility[0][:-1])

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1920,3 +1920,9 @@ def test_hyperbolic():
     assert integrate(coth(x)) == x - log(tanh(x) + 1) + log(tanh(x))
     assert integrate(sech(x)) == 2*atan(tanh(x/2))
     assert integrate(csch(x)) == log(tanh(x/2))
+
+
+def test_sqrt_quadratic():
+    assert integrate(1/sqrt(3*x**2+4*x+5)) == sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3
+    assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3
+    assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -43,7 +43,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
 
-x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')
+x, y, z, a, b, c, s, t, x_1, x_2 = symbols('x y z a b c s t x_1 x_2')
 n = Symbol('n', integer=True)
 f = Function('f')
 
@@ -1926,3 +1926,4 @@ def test_sqrt_quadratic():
     assert integrate(1/sqrt(3*x**2+4*x+5)) == sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3
     assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3
     assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3
+    assert integrate(1/sqrt(a+b*x+c*x**2), x) == log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -173,10 +173,10 @@ def test_manualintegrate_inversetrig():
         asinh(x)/2
     assert manualintegrate(1/sqrt(4*x**2 + 1), x) == \
         asinh(2*x)/2
-    assert manualintegrate(1/sqrt(a*x**2 + 1), x) == \
-        Piecewise((asin(x*sqrt(-a))/sqrt(-a), a < 0), (asinh(sqrt(a)*x)/sqrt(a), a > 0))
-    assert manualintegrate(1/sqrt(a + x**2), x) == \
-        Piecewise((asinh(x*sqrt(1/a)), a > 0), (acosh(x*sqrt(-1/a)), a < 0))
+    assert manualintegrate(1/sqrt(ra*x**2 + 1), x) == \
+        Piecewise((asin(x*sqrt(-ra))/sqrt(-ra), ra < 0), (asinh(sqrt(ra)*x)/sqrt(ra), ra > 0))
+    assert manualintegrate(1/sqrt(ra + x**2), x) == \
+        Piecewise((asinh(x*sqrt(1/ra)), ra > 0), (acosh(x*sqrt(-1/ra)), ra < 0))
 
     # acosh
     assert manualintegrate(1/sqrt(x**2 - 1), x) == \
@@ -187,10 +187,10 @@ def test_manualintegrate_inversetrig():
         acosh(x)/2
     assert manualintegrate(1/sqrt(9*x**2 - 1), x) == \
         acosh(3*x)/3
-    assert manualintegrate(1/sqrt(a*x**2 - 4), x) == \
-        Piecewise((acosh(sqrt(a)*x/2)/sqrt(a), a > 0))
-    assert manualintegrate(1/sqrt(-a + 4*x**2), x) == \
-        Piecewise((asinh(2*x*sqrt(-1/a))/2, -a > 0), (acosh(2*x*sqrt(1/a))/2, -a < 0))
+    assert manualintegrate(1/sqrt(ra*x**2 - 4), x) == \
+        Piecewise((acosh(sqrt(ra)*x/2)/sqrt(ra), ra > 0))
+    assert manualintegrate(1/sqrt(-ra + 4*x**2), x) == \
+        Piecewise((asinh(2*x*sqrt(-1/ra))/2, -ra > 0), (acosh(2*x*sqrt(1/ra))/2, -ra < 0))
 
     # From https://www.wikiwand.com/en/List_of_integrals_of_inverse_trigonometric_functions
     # asin
@@ -219,14 +219,14 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(x*acot(a*x), x) == a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*acot(a*x)/2
 
     # piecewise
-    assert manualintegrate(1/sqrt(a-b*x**2), x) == \
-        Piecewise((asin(x*sqrt(b/a))/sqrt(b), And(-b < 0, a > 0)),
-                  (asinh(x*sqrt(-b/a))/sqrt(-b), And(-b > 0, a > 0)),
-                  (acosh(x*sqrt(b/a))/sqrt(-b), And(-b > 0, a < 0)))
-    assert manualintegrate(1/sqrt(a + b*x**2), x) == \
-        Piecewise((asin(x*sqrt(-b/a))/sqrt(-b), And(a > 0, b < 0)),
-                  (asinh(x*sqrt(b/a))/sqrt(b), And(a > 0, b > 0)),
-                  (acosh(x*sqrt(-b/a))/sqrt(b), And(a < 0, b > 0)))
+    assert manualintegrate(1/sqrt(ra-rb*x**2), x) == \
+        Piecewise((asin(x*sqrt(rb/ra))/sqrt(rb), And(-rb < 0, ra > 0)),
+                  (asinh(x*sqrt(-rb/ra))/sqrt(-rb), And(-rb > 0, ra > 0)),
+                  (acosh(x*sqrt(rb/ra))/sqrt(-rb), And(-rb > 0, ra < 0)))
+    assert manualintegrate(1/sqrt(ra + rb*x**2), x) == \
+        Piecewise((asin(x*sqrt(-rb/ra))/sqrt(-rb), And(ra > 0, rb < 0)),
+                  (asinh(x*sqrt(rb/ra))/sqrt(rb), And(ra > 0, rb > 0)),
+                  (acosh(x*sqrt(-rb/ra))/sqrt(rb), And(ra < 0, rb > 0)))
 
 
 def test_manualintegrate_trig_substitution():
@@ -588,3 +588,4 @@ def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(1/sqrt(3*x**2+4*x+5), sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3)
     assert_is_integral_of(1/sqrt(-3*x**2+4*x+5), sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3)
     assert_is_integral_of(1/sqrt(3*x**2+4*x-5), sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3)
+    assert manualintegrate(1/sqrt(a+b*x+c*x**2), x) == log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -174,7 +174,7 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(1/sqrt(4*x**2 + 1), x) == \
         asinh(2*x)/2
     assert manualintegrate(1/sqrt(a*x**2 + 1), x) == \
-        Piecewise((sqrt(-1/a)*asin(x*sqrt(-a)), a < 0), (sqrt(1/a)*asinh(sqrt(a)*x), a > 0))
+        Piecewise((asin(x*sqrt(-a))/sqrt(-a), a < 0), (asinh(sqrt(a)*x)/sqrt(a), a > 0))
     assert manualintegrate(1/sqrt(a + x**2), x) == \
         Piecewise((asinh(x*sqrt(1/a)), a > 0), (acosh(x*sqrt(-1/a)), a < 0))
 
@@ -188,7 +188,7 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(1/sqrt(9*x**2 - 1), x) == \
         acosh(3*x)/3
     assert manualintegrate(1/sqrt(a*x**2 - 4), x) == \
-        Piecewise((sqrt(1/a)*acosh(sqrt(a)*x/2), a > 0))
+        Piecewise((acosh(sqrt(a)*x/2)/sqrt(a), a > 0))
     assert manualintegrate(1/sqrt(-a + 4*x**2), x) == \
         Piecewise((asinh(2*x*sqrt(-1/a))/2, -a > 0), (acosh(2*x*sqrt(1/a))/2, -a < 0))
 
@@ -220,13 +220,13 @@ def test_manualintegrate_inversetrig():
 
     # piecewise
     assert manualintegrate(1/sqrt(a-b*x**2), x) == \
-        Piecewise((sqrt(a/b)*asin(x*sqrt(b/a))/sqrt(a), And(-b < 0, a > 0)),
-                  (sqrt(-a/b)*asinh(x*sqrt(-b/a))/sqrt(a), And(-b > 0, a > 0)),
-                  (sqrt(a/b)*acosh(x*sqrt(b/a))/sqrt(-a), And(-b > 0, a < 0)))
+        Piecewise((asin(x*sqrt(b/a))/sqrt(b), And(-b < 0, a > 0)),
+                  (asinh(x*sqrt(-b/a))/sqrt(-b), And(-b > 0, a > 0)),
+                  (acosh(x*sqrt(b/a))/sqrt(-b), And(-b > 0, a < 0)))
     assert manualintegrate(1/sqrt(a + b*x**2), x) == \
-        Piecewise((sqrt(-a/b)*asin(x*sqrt(-b/a))/sqrt(a), And(a > 0, b < 0)),
-                  (sqrt(a/b)*asinh(x*sqrt(b/a))/sqrt(a), And(a > 0, b > 0)),
-                  (sqrt(-a/b)*acosh(x*sqrt(-b/a))/sqrt(-a), And(a < 0, b > 0)))
+        Piecewise((asin(x*sqrt(-b/a))/sqrt(-b), And(a > 0, b < 0)),
+                  (asinh(x*sqrt(b/a))/sqrt(b), And(a > 0, b > 0)),
+                  (acosh(x*sqrt(-b/a))/sqrt(b), And(a < 0, b > 0)))
 
 
 def test_manualintegrate_trig_substitution():
@@ -582,3 +582,9 @@ def test_issue_23348():
     steps = integral_steps(tan(x), x)
     constant_times_step = steps.substep.substep
     assert constant_times_step.context == constant_times_step.constant * constant_times_step.other
+
+
+def test_manualintegrate_sqrt_quadratic():
+    assert_is_integral_of(1/sqrt(3*x**2+4*x+5), sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3)
+    assert_is_integral_of(1/sqrt(-3*x**2+4*x+5), sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3)
+    assert_is_integral_of(1/sqrt(3*x**2+4*x-5), sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously these all can't be calculated.
```py
from sympy import *
x=Symbol('x')
integrate(1/sqrt(3*x**2+4*x+5))
integrate(1/sqrt(-3*x**2+4*x+5))
integrate(1/sqrt(3*x**2+4*x-5))
```
Moreover, `manualintegrate(1/sqrt(3*x**2+4), x)` gives unnecessary step. Left is current master, right is this branch:

![Screenshot from 2022-05-11 23-28-59](https://user-images.githubusercontent.com/26783539/167986375-5a97eeb3-dcc2-4a26-865e-40e0e3d94abd.png)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Support integrate(1/sqrt(a+bx+cx**2))
<!-- END RELEASE NOTES -->
