### PR TITLE
calculus : Fixes is_increasing() cases which undergo infinite recursive loop through periodicity()

### DIFF
--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -95,7 +95,7 @@ def test_is_monotonic():
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
 
 
-def test_issue():
+def test_issue_23401():
     x = Symbol('x')
     expr = (x + 1)/(-1.0e-3*x**2 + 0.1*x + 0.1)
     assert is_increasing(expr, Interval(1,2), x)

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -93,3 +93,9 @@ def test_is_monotonic():
     assert not is_monotonic(-x**2, S.Reals)
     assert is_monotonic(x**2 + y + 1, Interval(1, 2), x)
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
+
+
+def test_issue():
+    x = Symbol('x')
+    expr = (x + 1)/(-1.0e-3*x**2 + 0.1*x + 0.1)
+    assert is_increasing(expr, Interval(1,2), x)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -480,7 +480,7 @@ def periodicity(f, symbol, check=False):
 
     elif f.is_Mul:
         coeff, g = f.as_independent(symbol, as_Add=False)
-        if isinstance(g, TrigonometricFunction) or coeff is not S.One and not (coeff.is_Float and coeff == 1.0):
+        if isinstance(g, TrigonometricFunction) or coeff != 1:
             period = periodicity(g, symbol)
 
         else:

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -480,7 +480,7 @@ def periodicity(f, symbol, check=False):
 
     elif f.is_Mul:
         coeff, g = f.as_independent(symbol, as_Add=False)
-        if isinstance(g, TrigonometricFunction) or coeff is not S.One:
+        if isinstance(g, TrigonometricFunction) or coeff is not S.One and not (coeff.is_Float and coeff == 1.0):
             period = periodicity(g, symbol)
 
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23401

#### Brief description of what is fixed or changed
The `if` routine condition has been modified. The coefficient `coeff` seems to be a Float, hence earlier it did not work as expected.

On master - 
```
>>> expr = (p + 1)/(-1.0e-3*p**2 + 0.1*p + 0.1)
>>> is_increasing(expr,Interval(1,2),p)
# No result, internally evalution of infinite recursion.
```
On current branch - 
```
>>> expr = "(p + 1)/(-1.0e-3*p**2 + 0.1*p + 0.1)"
>>> is_increasing(expr,Interval(1,2))
True
>>> is_increasing(expr,Interval(1,2),p)
True
```

#### Other comments
The failing example from the issue has been used as the unit test and some other relevant examples have been tested !

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
