### PR TITLE
test: fix use of Float/Rational in tests

### DIFF
--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -62,6 +62,7 @@ def test_is_strictly_increasing():
 
     assert is_strictly_increasing(4*x**3 - 6*x**2 - 72*x + 30, Interval.open(-2, 3)) is False
 
+
 def test_is_decreasing():
     """Test whether is_decreasing returns correct value."""
     b = Symbol('b', positive=True)
@@ -83,6 +84,7 @@ def test_is_strictly_decreasing():
     assert not is_strictly_decreasing(1)
     assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(Rational(3,2), 3))
     assert is_strictly_decreasing(1/(x**2 - 3*x), Interval.open(1.5, 3))
+
 
 def test_is_monotonic():
     """Test whether is_monotonic returns correct value."""

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1535,7 +1535,7 @@ class Variable(Node):
         >>> decl1.variable.value == NoneToken()  # OK
         True
         >>> decl2 = x.as_Declaration(value=42.0)
-        >>> decl2.variable.value == 42
+        >>> decl2.variable.value == 42.0
         True
 
         """

--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -181,7 +181,7 @@ class exp2(Function):
 
     >>> from sympy.abc import x
     >>> from sympy.codegen.cfunctions import exp2
-    >>> exp2(2).evalf() == 4
+    >>> exp2(2).evalf() == 4.0
     True
     >>> exp2(x).diff(x)
     log(2)*exp2(x)
@@ -237,7 +237,7 @@ class log2(Function):
 
     >>> from sympy.abc import x
     >>> from sympy.codegen.cfunctions import log2
-    >>> log2(4).evalf() == 2
+    >>> log2(4).evalf() == 2.0
     True
     >>> log2(x).diff(x)
     1/(x*log(2))
@@ -342,7 +342,7 @@ class log10(Function):
 
     >>> from sympy.abc import x
     >>> from sympy.codegen.cfunctions import log10
-    >>> log10(100).evalf() == 2
+    >>> log10(100).evalf() == 2.0
     True
     >>> log10(x).diff(x)
     1/(x*log(10))
@@ -503,7 +503,7 @@ class hypot(Function):
 
     >>> from sympy.abc import x, y
     >>> from sympy.codegen.cfunctions import hypot
-    >>> hypot(3, 4).evalf() == 5
+    >>> hypot(3, 4).evalf() == 5.0
     True
     >>> hypot(x, y)
     hypot(x, y)

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -493,7 +493,7 @@ def test_FloatType():
     assert abs(f80.tiny / Float('3.36210314311209350626e-4932', precision=80) - 1) < 0.1*10**-f80.dig
     assert abs(f128.tiny / Float('3.3621031431120935062626778173217526e-4932', precision=128) - 1) < 0.1*10**-f128.dig
 
-    assert f64.cast_check(0.5) == 0.5
+    assert f64.cast_check(0.5) == Float(0.5, 17)
     assert abs(f64.cast_check(3.7) - 3.7) < 3e-17
     assert isinstance(f64.cast_check(3), (Float, float))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -10,6 +10,7 @@ from sympy.core.facts import InconsistentAssumptions
 from sympy.core.mod import Mod
 from sympy.core.numbers import (E, I, Rational, nan, oo, pi)
 from sympy.core.relational import Eq
+from sympy.core.numbers import Float
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.core.sympify import sympify
@@ -288,7 +289,7 @@ def test_geometric_sums():
 
     #issue 11642:
     result = Sum(0.5**n, (n, 1, oo)).doit()
-    assert result == 1
+    assert result == 1.0
     assert result.is_Float
 
     result = Sum(0.25**n, (n, 1, oo)).doit()
@@ -296,7 +297,7 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()
-    assert result == 99999
+    assert result == 99999.0
     assert result.is_Float
 
     result = Sum(S.Half**n, (n, 1, oo)).doit()
@@ -802,7 +803,7 @@ def test_issue_4171():
 
 
 def test_issue_6273():
-    assert Sum(x, (x, 1, n)).n(2, subs={n: 1}) == 1
+    assert Sum(x, (x, 1, n)).n(2, subs={n: 1}) == Float(1, 2)
 
 
 def test_issue_6274():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -272,8 +272,8 @@ def test_evalf_bugs():
 def test_evalf_integer_parts():
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)
     b = floor(log(8)/log(2), evaluate=False)
-    assert a.evalf() == 3
-    assert b.evalf() == 3
+    assert a.evalf() == 3.0
+    assert b.evalf() == 3.0
     # equals, as a fallback, can still fail but it might succeed as here
     assert ceiling(10*(sin(1)**2 + cos(1)**2)) == 10
 
@@ -286,10 +286,10 @@ def test_evalf_integer_parts():
     assert int(floor(GoldenRatio**1000 / sqrt(5) + S.Half)
                .evalf(1000)) == fibonacci(1000)
 
-    assert ceiling(x).evalf(subs={x: 3}) == 3
+    assert ceiling(x).evalf(subs={x: 3}) == 3.0
     assert ceiling(x).evalf(subs={x: 3*I}) == 3.0*I
     assert ceiling(x).evalf(subs={x: 2 + 3*I}) == 2.0 + 3.0*I
-    assert ceiling(x).evalf(subs={x: 3.}) == 3
+    assert ceiling(x).evalf(subs={x: 3.}) == 3.0
     assert ceiling(x).evalf(subs={x: 3.*I}) == 3.0*I
     assert ceiling(x).evalf(subs={x: 2. + 3*I}) == 2.0 + 3.0*I
 
@@ -361,11 +361,11 @@ def test_evalf_power_subs_bugs():
     assert (x**2).evalf(subs={x: 0}) == 0
     assert sqrt(x).evalf(subs={x: 0}) == 0
     assert (x**Rational(2, 3)).evalf(subs={x: 0}) == 0
-    assert (x**x).evalf(subs={x: 0}) == 1
-    assert (3**x).evalf(subs={x: 0}) == 1
-    assert exp(x).evalf(subs={x: 0}) == 1
-    assert ((2 + I)**x).evalf(subs={x: 0}) == 1
-    assert (0**x).evalf(subs={x: 0}) == 1
+    assert (x**x).evalf(subs={x: 0}) == 1.0
+    assert (3**x).evalf(subs={x: 0}) == 1.0
+    assert exp(x).evalf(subs={x: 0}) == 1.0
+    assert ((2 + I)**x).evalf(subs={x: 0}) == 1.0
+    assert (0**x).evalf(subs={x: 0}) == 1.0
 
 
 def test_evalf_arguments():
@@ -378,7 +378,7 @@ def test_implemented_function_evalf():
     f = implemented_function(f, lambda x: x + 1)
     assert str(f(x)) == "f(x)"
     assert str(f(2)) == "f(2)"
-    assert f(2).evalf() == 3
+    assert f(2).evalf() == 3.0
     assert f(x).evalf() == f(x)
     f = implemented_function(Function('sin'), lambda x: x + 1)
     assert f(2).evalf() != sin(2)
@@ -460,7 +460,7 @@ def test_old_docstring():
 
 
 def test_issue_4806():
-    assert integrate(atan(x)**2, (x, -1, 1)).evalf().round(1) == 0.5
+    assert integrate(atan(x)**2, (x, -1, 1)).evalf().round(1) == Float(0.5, 1)
     assert atan(0, evaluate=False).n() == 0
 
 
@@ -551,7 +551,7 @@ def test_issue_9326():
     d1 = Dummy('d')
     d2 = Dummy('d')
     e = d1 + d2
-    assert e.evalf(subs = {d1: 1, d2: 2}) == 3
+    assert e.evalf(subs = {d1: 1, d2: 2}) == 3.0
 
 
 def test_issue_10323():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1323,6 +1323,7 @@ def test_extractions():
     assert (2*x + 3).extract_additively(2*x) == 3
     assert x.extract_additively(0) == x
     assert S(2).extract_additively(x) is None
+    assert S(2.).extract_additively(2.) is S.Zero
     assert S(2.).extract_additively(2) is S.Zero
     assert S(2*x + 3).extract_additively(x + 1) == x + 2
     assert S(2*x + 3).extract_additively(y + 1) is None
@@ -1966,12 +1967,12 @@ def test_round():
     assert n.round(-1) == 12340
 
     r = Float(str(n)).round(-4)
-    assert r == 10000
+    assert r == 10000.0
 
     assert n.round(-5) == 0
 
     assert str((pi + sqrt(2)).round(2)) == '4.56'
-    assert (10*(pi + sqrt(2))).round(-1) == 50
+    assert (10*(pi + sqrt(2))).round(-1) == 50.0
     raises(TypeError, lambda: round(x + 2, 2))
     assert str(S(2.3).round(1)) == '2.3'
     # rounding in SymPy (as in Decimal) should be
@@ -2004,11 +2005,21 @@ def test_round():
     assert S.Zero.round() == 0
 
     a = (Add(1, Float('1.' + '9'*27, ''), evaluate=0))
-    assert a.round(10) == Float('3.0000000000', '')
-    assert a.round(25) == Float('3.0000000000000000000000000', '')
-    assert a.round(26) == Float('3.00000000000000000000000000', '')
+    assert a.round(10) == Float('3.000000000000000000000000000', '')
+    assert a.round(25) == Float('3.000000000000000000000000000', '')
+    assert a.round(26) == Float('3.000000000000000000000000000', '')
     assert a.round(27) == Float('2.999999999999999999999999999', '')
     assert a.round(30) == Float('2.999999999999999999999999999', '')
+
+    # XXX: Should round set the precision of the result?
+    #      The previous version of the tests above is this but they only pass
+    #      because Floats with unequal precision compare equal:
+    #
+    # assert a.round(10) == Float('3.0000000000', '')
+    # assert a.round(25) == Float('3.0000000000000000000000000', '')
+    # assert a.round(26) == Float('3.00000000000000000000000000', '')
+    # assert a.round(27) == Float('2.999999999999999999999999999', '')
+    # assert a.round(30) == Float('2.999999999999999999999999999', '')
 
     raises(TypeError, lambda: x.round())
     raises(TypeError, lambda: f(1).round())

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1597,25 +1597,25 @@ def test_Rational_gcd_lcm_cofactors():
     assert Integer(4).cofactors(Integer(2)) == \
         (Integer(2), Integer(2), Integer(1))
 
-    assert Integer(4).gcd(Float(2.0)) == S.One
+    assert Integer(4).gcd(Float(2.0)) == Float(1.0)
     assert Integer(4).lcm(Float(2.0)) == Float(8.0)
-    assert Integer(4).cofactors(Float(2.0)) == (S.One, Integer(4), Float(2.0))
+    assert Integer(4).cofactors(Float(2.0)) == (Float(1.0), Float(4.0), Float(2.0))
 
-    assert S.Half.gcd(Float(2.0)) == S.One
+    assert S.Half.gcd(Float(2.0)) == Float(1.0)
     assert S.Half.lcm(Float(2.0)) == Float(1.0)
     assert S.Half.cofactors(Float(2.0)) == \
-        (S.One, S.Half, Float(2.0))
+        (Float(1.0), Float(0.5), Float(2.0))
 
 
 def test_Float_gcd_lcm_cofactors():
-    assert Float(2.0).gcd(Integer(4)) == S.One
+    assert Float(2.0).gcd(Integer(4)) == Float(1.0)
     assert Float(2.0).lcm(Integer(4)) == Float(8.0)
-    assert Float(2.0).cofactors(Integer(4)) == (S.One, Float(2.0), Integer(4))
+    assert Float(2.0).cofactors(Integer(4)) == (Float(1.0), Float(2.0), Float(4.0))
 
-    assert Float(2.0).gcd(S.Half) == S.One
+    assert Float(2.0).gcd(S.Half) == Float(1.0)
     assert Float(2.0).lcm(S.Half) == Float(1.0)
     assert Float(2.0).cofactors(S.Half) == \
-        (S.One, Float(2.0), S.Half)
+        (Float(1.0), Float(2.0), Float(0.5))
 
 
 def test_issue_4611():
@@ -2013,7 +2013,7 @@ def test_issue_10020():
 def test_invert_numbers():
     assert S(2).invert(5) == 3
     assert S(2).invert(Rational(5, 2)) == S.Half
-    assert S(2).invert(5.) == 0.5
+    assert S(2).invert(5.) == S.Half
     assert S(2).invert(S(5)) == 3
     assert S(2.).invert(5) == 0.5
     assert S(sqrt(2)).invert(5) == 1/sqrt(2)
@@ -2222,7 +2222,7 @@ def test_floordiv():
 
 def test_negation():
     assert -S.Zero is S.Zero
-    assert -Float(0) is not S.Zero and -Float(0) == 0
+    assert -Float(0) is not S.Zero and -Float(0) == 0.0
 
 
 def test_exponentiation_of_0():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -681,8 +681,8 @@ def test_issue_8245():
     assert rel_check(a, a.n(10))
     assert rel_check(a, a.n(20))
     assert rel_check(a, a.n())
-    # prec of 30 is enough to fully capture a as mpf
-    assert Float(a, 30) == Float(str(a.p), '')/Float(str(a.q), '')
+    # prec of 31 is enough to fully capture a as mpf
+    assert Float(a, 31) == Float(str(a.p), '')/Float(str(a.q), '')
     for i in range(31):
         r = Rational(Float(a, i))
         f = Float(r)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -51,10 +51,9 @@ def test_sympify1():
     assert sympify("   x") == Symbol("x")
     assert sympify("   x   ") == Symbol("x")
     # issue 4877
-    n1 = S.Half
-    assert sympify('--.5') == n1
-    assert sympify('-1/2') == -n1
-    assert sympify('-+--.5') == -n1
+    assert sympify('--.5') == 0.5
+    assert sympify('-1/2') == -S.Half
+    assert sympify('-+--.5') == -0.5
     assert sympify('-.[3]') == Rational(-1, 3)
     assert sympify('.[3]') == Rational(1, 3)
     assert sympify('+.[3]') == Rational(1, 3)
@@ -132,6 +131,7 @@ def test_sympify_mpmath():
     assert sympify(
         mpmath.pi).epsilon_eq(Float("3.14159"), Float("1e-6")) == False
 
+    mpmath.mp.dps = 15
     assert sympify(mpmath.mpc(1.0 + 2.0j)) == Float(1.0) + Float(2.0)*I
 
     assert sympify(mpq(1, 2)) == S.Half
@@ -407,7 +407,7 @@ def test_int_float():
     f1_1c = F1_1c()
     assert sympify(i5) == 5
     assert isinstance(sympify(i5), Integer)
-    assert sympify(i5b) == 5
+    assert sympify(i5b) == 5.0
     assert isinstance(sympify(i5b), Float)
     assert sympify(i5c) == 5
     assert isinstance(sympify(i5c), Integer)
@@ -417,7 +417,7 @@ def test_int_float():
 
     assert _sympify(i5) == 5
     assert isinstance(_sympify(i5), Integer)
-    assert _sympify(i5b) == 5
+    assert _sympify(i5b) == 5.0
     assert isinstance(_sympify(i5b), Float)
     assert _sympify(i5c) == 5
     assert isinstance(_sympify(i5c), Integer)
@@ -625,20 +625,31 @@ def test_sympify_numpy():
     assert equal(sympify(np.float32(1.123456)), Float(1.123456, precision=24))
     assert equal(sympify(np.float64(1.1234567891234)),
                 Float(1.1234567891234, precision=53))
+
+    # The exact precision of np.longdouble, npfloat128 and other extended
+    # precision dtypes is platform dependent.
+    ldprec = np.finfo(np.longdouble(1)).nmant + 1
     assert equal(sympify(np.longdouble(1.123456789)),
-                 Float(1.123456789, precision=80))
+                 Float(1.123456789, precision=ldprec))
+
     assert equal(sympify(np.complex64(1 + 2j)), S(1.0 + 2.0*I))
     assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
-    assert equal(sympify(np.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
+
+    lcprec = np.finfo(np.longcomplex(1)).nmant + 1
+    assert equal(sympify(np.longcomplex(1 + 2j)),
+                Float(1.0, precision=lcprec) + Float(2.0, precision=lcprec)*I)
 
     #float96 does not exist on all platforms
     if hasattr(np, 'float96'):
+        f96prec = np.finfo(np.float96(1)).nmant + 1
         assert equal(sympify(np.float96(1.123456789)),
-                    Float(1.123456789, precision=80))
+                    Float(1.123456789, precision=f96prec))
+
     #float128 does not exist on all platforms
     if hasattr(np, 'float128'):
+        f128prec = np.finfo(np.float128(1)).nmant + 1
         assert equal(sympify(np.float128(1.123456789123)),
-                    Float(1.123456789123, precision=80))
+                    Float(1.123456789123, precision=f128prec))
 
 
 @XFAIL
@@ -820,9 +831,9 @@ def test_issue_14706():
 
     assert sympify(numpy.array([1])) == ImmutableDenseNDimArray([1], 1)
     assert sympify(numpy.array([[[1]]])) == ImmutableDenseNDimArray([1], (1, 1, 1))
-    assert sympify(z1) == ImmutableDenseNDimArray([0], (1, 1))
-    assert sympify(z2) == ImmutableDenseNDimArray([0, 0, 0, 0], (2, 2))
-    assert sympify(z3) == ImmutableDenseNDimArray([0], ())
+    assert sympify(z1) == ImmutableDenseNDimArray([0.0], (1, 1))
+    assert sympify(z2) == ImmutableDenseNDimArray([0.0, 0.0, 0.0, 0.0], (2, 2))
+    assert sympify(z3) == ImmutableDenseNDimArray([0.0], ())
     assert sympify(z3, strict=True) == 0.0
 
     raises(SympifyError, lambda: sympify(numpy.array([1]), strict=True))

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -4,7 +4,7 @@ from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.function import (diff, expand_func)
 from sympy.core import (EulerGamma, TribonacciConstant)
-from sympy.core.numbers import (I, Rational, oo, pi)
+from sympy.core.numbers import (Float, I, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.combinatorial.numbers import carmichael
@@ -118,7 +118,7 @@ def test_fibonacci():
         2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5
     assert fibonacci(n).rewrite(sqrt).subs(n, 10).expand() == fibonacci(10)
     assert fibonacci(n).rewrite(GoldenRatio).subs(n,10).evalf() == \
-        fibonacci(10)
+        Float(fibonacci(10))
     assert lucas(n).rewrite(sqrt) == \
         (fibonacci(n-1).rewrite(sqrt) + fibonacci(n+1).rewrite(sqrt)).simplify()
     assert lucas(n).rewrite(sqrt).subs(n, 10).expand() == lucas(10)
@@ -149,7 +149,7 @@ def test_tribonacci():
       + c**(n + 1)/((c - a)*(c - b)))
     assert tribonacci(n).rewrite(sqrt).subs(n, 4).simplify() == tribonacci(4)
     assert tribonacci(n).rewrite(GoldenRatio).subs(n,10).evalf() == \
-        tribonacci(10)
+        Float(tribonacci(10))
     assert tribonacci(n).rewrite(TribonacciConstant) == floor(
             3*TribonacciConstant**n*(102*sqrt(33) + 586)**Rational(1, 3)/
             (-2*(102*sqrt(33) + 586)**Rational(1, 3) + 4 + (102*sqrt(33)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -324,7 +324,7 @@ def test_real_root():
     r3 = root(-1, 4)
     assert real_root(r1 + r2 + r3) == -1 + r2 + r3
     assert real_root(root(-2, 3)) == -root(2, 3)
-    assert real_root(-8., 3) == -2
+    assert real_root(-8., 3) == -2.0
     x = Symbol('x')
     n = Symbol('n')
     g = real_root(x, n)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -124,8 +124,8 @@ def test_piecewise1():
 
     # Test evalf
     assert p.evalf() == Piecewise((-1.0, x < -1), (x**2, x < 0), (log(x), True))
-    assert p.evalf(subs={x: -2}) == -1
-    assert p.evalf(subs={x: -1}) == 1
+    assert p.evalf(subs={x: -2}) == -1.0
+    assert p.evalf(subs={x: -1}) == 1.0
     assert p.evalf(subs={x: 1}) == log(1)
     assert p6.evalf(subs={x: -5}) == Undefined
 
@@ -419,11 +419,11 @@ def test_piecewise_integrate4_symbolic_conditions():
         (-a + x, x <= Max(a, b)),
         (-a + Max(a, b), True))
 
-    p1 = Piecewise((0, x < a), (0.5, x > b), (1, True))
-    p2 = Piecewise((0.5, x > b), (0, x < a), (1, True))
-    p3 = Piecewise((0, x < a), (1, x < b), (0.5, True))
-    p4 = Piecewise((0.5, x > b), (1, x > a), (0, True))
-    p5 = Piecewise((1, And(a < x, x < b)), (0.5, x > b), (0, True))
+    p1 = Piecewise((0, x < a), (S.Half, x > b), (1, True))
+    p2 = Piecewise((S.Half, x > b), (0, x < a), (1, True))
+    p3 = Piecewise((0, x < a), (1, x < b), (S.Half, True))
+    p4 = Piecewise((S.Half, x > b), (1, x > a), (0, True))
+    p5 = Piecewise((1, And(a < x, x < b)), (S.Half, x > b), (0, True))
 
     # check values of a=1, b=3 (and reversed) with values
     # of y of 0, 1, 2, 3, 4
@@ -1268,7 +1268,7 @@ def test_unevaluated_integrals():
     # test it by replacing f(x) with x%2 which will not
     # affect the answer: the integrand is essentially 2 over
     # the domain of integration
-    assert Integral(p, (x, 0, 5)).subs(f(x), x%2).n() == 10
+    assert Integral(p, (x, 0, 5)).subs(f(x), x%2).n() == 10.0
 
     # this is a test of using _solve_inequality when
     # solve_univariate_inequality fails

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -320,9 +320,9 @@ def test_Point2D():
     assert p1.x == 1
     assert p1.y == 5
     assert p2.x == 4
-    assert p2.y == 2.5
+    assert p2.y == S(5)/2
     assert p1.coordinates == (1, 5)
-    assert p2.coordinates == (4, 2.5)
+    assert p2.coordinates == (4, S(5)/2)
 
     # test bounds
     assert p1.bounds == (1, 5, 1, 5)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -966,7 +966,7 @@ def test_is_number():
     i = Integral(x, (y, z, z))
     assert i.is_number is False and i.n() == 0
     i = Integral(1, (y, z, z + 2))
-    assert i.is_number is False and i.n() == 2
+    assert i.is_number is False and i.n() == 2.0
 
     assert Integral(x*y, (x, 1, 2), (y, 1, 3)).is_number is True
     assert Integral(x*y, (x, 1, 2), (y, 1, z)).is_number is False

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -51,8 +51,10 @@ def test_best_origin():
     l6 = Segment2D(Point(2, 0), Point(1, 1))
 
     assert best_origin((2, 1), 3, l1, expr1) == (0, 3)
-    assert best_origin((2, 0), 3, l2, x ** 7) == (S(3) / 2, 0)
-    assert best_origin((0, 2), 3, l3, x ** 7) == (0, S(3) / 2)
+    # XXX: Should these return exact Rational output? Maybe best_origin should
+    #      sympify its arguments...
+    assert best_origin((2, 0), 3, l2, x ** 7) == (1.5, 0)
+    assert best_origin((0, 2), 3, l3, x ** 7) == (0, 1.5)
     assert best_origin((1, 1), 2, l4, x ** 7 * y ** 3) == (0, 2)
     assert best_origin((1, 1), 2, l4, x ** 3 * y ** 7) == (2, 0)
     assert best_origin((1, 1), 2, l5, x ** 2 * y ** 9) == (0, 2)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -247,7 +247,7 @@ def test_power():
     assert (A**S.Half)**2 == A
 
     assert Matrix([[1, 0], [1, 1]])**S.Half == Matrix([[1, 0], [S.Half, 1]])
-    assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1.0, 0], [0.5, 1.0]])
+    assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1, 0], [0.5, 1]])
     from sympy.abc import n
     assert Matrix([[1, a], [0, 1]])**n == Matrix([[1, a*n], [0, 1]])
     assert Matrix([[b, a], [0, b]])**n == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
@@ -673,14 +673,14 @@ def test_issue_18531():
         ])
     with dotprodsimp(True):
         assert M.rref() == (Matrix([
-            [1, 0, 0, 0, 0, 0, 0, 0,  1/2],
-            [0, 1, 0, 0, 0, 0, 0, 0, -1/2],
-            [0, 0, 1, 0, 0, 0, 0, 0,  1/2],
-            [0, 0, 0, 1, 0, 0, 0, 0, -1/2],
+            [1, 0, 0, 0, 0, 0, 0, 0,  S(1)/2],
+            [0, 1, 0, 0, 0, 0, 0, 0, -S(1)/2],
+            [0, 0, 1, 0, 0, 0, 0, 0,  S(1)/2],
+            [0, 0, 0, 1, 0, 0, 0, 0, -S(1)/2],
             [0, 0, 0, 0, 1, 0, 0, 0,    0],
-            [0, 0, 0, 0, 0, 1, 0, 0, -1/2],
+            [0, 0, 0, 0, 0, 1, 0, 0, -S(1)/2],
             [0, 0, 0, 0, 0, 0, 1, 0,    0],
-            [0, 0, 0, 0, 0, 0, 0, 1, -1/2]]), (0, 1, 2, 3, 4, 5, 6, 7))
+            [0, 0, 0, 0, 0, 0, 0, 1, -S(1)/2]]), (0, 1, 2, 3, 4, 5, 6, 7))
 
 
 def test_creation():
@@ -2716,8 +2716,8 @@ def test_17522_mpmath():
         skip('mpmath must be available to test indexing matrixified mpmath matrices')
 
     m = _matrixify(matrix([[1, 2], [3, 4]]))
-    assert m[3] == 4
-    assert list(m) == [1, 2, 3, 4]
+    assert m[3] == 4.0
+    assert list(m) == [1.0, 2.0, 3.0, 4.0]
 
 def test_17522_scipy():
     from sympy.matrices.common import _matrixify
@@ -3004,5 +3004,5 @@ def test_issue_19809():
 def test_issue_23276():
     M = Matrix([x, y])
     assert integrate(M, (x, 0, 1), (y, 0, 1)) == Matrix([
-        [1/2],
-        [1/2]])
+        [S.Half],
+        [S.Half]])

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -47,7 +47,7 @@ def test_sympy_parser():
         '-(2)': -Integer(2),
         '[-1, -2, 3]': [Integer(-1), Integer(-2), Integer(3)],
         'Symbol("x").free_symbols': x.free_symbols,
-        "S('S(3).n(n=3)')": 3.00,
+        "S('S(3).n(n=3)')": Float(3, 3),
         'factorint(12, visual=True)': Mul(
             Pow(2, 2, evaluate=False),
             Pow(3, 1, evaluate=False),

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1060,7 +1060,7 @@ def test_MIMOFeedback_functions():
     F_1 = MIMOFeedback(tfm_2, tfm_3)
     F_2 = MIMOFeedback(tfm_2, MIMOSeries(tfm_4, -tfm_1), 1)
 
-    assert F_1.sensitivity == Matrix([[1/2, 0], [0, 1/2]])
+    assert F_1.sensitivity == Matrix([[S.Half, 0], [0, S.Half]])
     assert F_2.sensitivity == Matrix([[(-2*s**4 + s**2)/(s**2 - s + 1),
         (2*s**3 - s**2)/(s**2 - s + 1)], [-s**2, s]])
 

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -193,7 +193,7 @@ def test_eval_trace():
     d = Density((up, 0.5), (down, 0.5))
 
     t = Tr(d)
-    assert t.doit() == 1
+    assert t.doit() == 1.0
 
     #test dummy time dependent states
     class TestTimeDepKet(TimeDepKet):
@@ -208,7 +208,7 @@ def test_eval_trace():
                         0.5 * OuterProduct(k2, k2.dual))
 
     t = Tr(d)
-    assert t.doit() == 1
+    assert t.doit() == 1.0
 
 
 def test_fidelity():

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -199,7 +199,7 @@ def test_eval_trace():
     d = Density([q1, 0.6], [q2, 0.4])
 
     t = Tr(d)
-    assert t.doit() == 1
+    assert t.doit() == 1.0
 
     # extreme bits
     t = Tr(d, 0)
@@ -214,7 +214,7 @@ def test_eval_trace():
                         0.6*Density([Qubit('1010'), 1]))
     #trace all indices
     t = Tr(d, [0, 1, 2, 3, 4])
-    assert t.doit() == 1
+    assert t.doit() == 1.0
 
     # trace some indices, initialized in
     # non-canonical order

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2900,9 +2900,9 @@ def test_nroots():
 
     assert re(roots[0]).epsilon_eq(-0.75487, eps) is S.true
     assert im(roots[0]) == 0.0
-    assert re(roots[1]) == -0.5
+    assert re(roots[1]) == Float(-0.5, 5)
     assert im(roots[1]).epsilon_eq(-0.86602, eps) is S.true
-    assert re(roots[2]) == -0.5
+    assert re(roots[2]) == Float(-0.5, 5)
     assert im(roots[2]).epsilon_eq(+0.86602, eps) is S.true
     assert re(roots[3]).epsilon_eq(+0.87743, eps) is S.true
     assert im(roots[3]).epsilon_eq(-0.74486, eps) is S.true
@@ -2913,9 +2913,9 @@ def test_nroots():
 
     assert re(roots[0]).epsilon_eq(-0.75487, eps) is S.false
     assert im(roots[0]) == 0.0
-    assert re(roots[1]) == -0.5
+    assert re(roots[1]) == Float(-0.5, 5)
     assert im(roots[1]).epsilon_eq(-0.86602, eps) is S.false
-    assert re(roots[2]) == -0.5
+    assert re(roots[2]) == Float(-0.5, 5)
     assert im(roots[2]).epsilon_eq(+0.86602, eps) is S.false
     assert re(roots[3]).epsilon_eq(+0.87743, eps) is S.false
     assert im(roots[3]).epsilon_eq(-0.74486, eps) is S.false

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -248,8 +248,8 @@ def test_CRootOf_evalf():
     # issue 9019
     r0 = rootof(x**2 + 1, 0, radicals=False)
     r1 = rootof(x**2 + 1, 1, radicals=False)
-    assert r0.n(4) == -1.0*I
-    assert r1.n(4) == 1.0*I
+    assert r0.n(4) == Float(-1.0, 4) * I
+    assert r1.n(4) == Float(1.0, 4) * I
 
     # make sure verification is used in case a max/min traps the "root"
     assert str(rootof(4*x**5 + 16*x**3 + 12*x**2 + 7, 0).n(3)) == '-0.976'

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,6 +1,6 @@
 from sympy.core.evalf import N
 from sympy.core.function import (Derivative, Function, PoleError, Subs)
-from sympy.core.numbers import (E, Rational, oo, pi, I)
+from sympy.core.numbers import (E, Float, Rational, oo, pi, I)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
@@ -326,9 +326,16 @@ def test_issue_19534():
             0.96296296296296296296*dt + 1.0) + 0.22431393315265061193*dt + 1.0) - \
             0.35816132904077632692*dt + 1.0) + 5.5065024887242400038*dt + 1.0)/20 + dt/20 + 1
 
-    assert N(expr.series(dt, 0, 8), 20) == -0.00092592592592592596126*dt**7 + 0.0027777777777777783175*dt**6 + \
-    0.016666666666666656027*dt**5 + 0.083333333333333300952*dt**4 + 0.33333333333333337034*dt**3 + \
-    1.0*dt**2 + 1.0*dt + 1.0
+    assert N(expr.series(dt, 0, 8), 20) == (
+            - Float('0.00092592592592592596126289', precision=70) * dt**7
+            + Float('0.0027777777777777783174695', precision=70) * dt**6
+            + Float('0.016666666666666656027029', precision=70) * dt**5
+            + Float('0.083333333333333300951828', precision=70) * dt**4
+            + Float('0.33333333333333337034077', precision=70) * dt**3
+            + Float('1.0', precision=70) * dt**2
+            + Float('1.0', precision=70) * dt
+            + Float('1.0', precision=70)
+        )
 
 
 def test_issue_11407():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -919,7 +919,7 @@ def test_issue_7971_21740():
     assert simplify(z) is S.Zero
     assert simplify(S.Zero) is S.Zero
     z = simplify(Float(0))
-    assert z is not S.Zero and z == 0
+    assert z is not S.Zero and z == 0.0
 
 
 @slow

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -58,7 +58,7 @@ def test_trigsimp1():
     assert trigsimp(tanh(x + y) - tanh(x)/(1 + tanh(x)*tanh(y))) == \
         sinh(y)/(sinh(y)*tanh(x) + cosh(y))
 
-    assert trigsimp(cos(0.12345)**2 + sin(0.12345)**2) == 1
+    assert trigsimp(cos(0.12345)**2 + sin(0.12345)**2) == 1.0
     e = 2*sin(x)**2 + 2*cos(x)**2
     assert trigsimp(log(e)) == log(2)
 
@@ -493,7 +493,7 @@ def test_trigsimp_old():
     assert trigsimp(cosh(x + y) + cosh(x - y), old=True) == 2*cosh(x)*cosh(y)
     assert trigsimp(cosh(x + y) - cosh(x - y), old=True) == 2*sinh(x)*sinh(y)
 
-    assert trigsimp(cos(0.12345)**2 + sin(0.12345)**2, old=True) == 1
+    assert trigsimp(cos(0.12345)**2 + sin(0.12345)**2, old=True) == 1.0
 
     assert trigsimp(sin(x)/cos(x), old=True, method='combined') == tan(x)
     assert trigsimp(sin(x)/cos(x), old=True, method='groebner') == sin(x)/cos(x)

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -1,3 +1,4 @@
+from sympy.core.function import nfloat
 from sympy.core.numbers import (Float, I, Rational, pi)
 from sympy.core.relational import Eq
 from sympy.core.symbol import (Symbol, symbols)
@@ -62,7 +63,7 @@ def test_nsolve():
         root = nsolve(f, (x, y, z), x0)
         assert mnorm(F(*root), 1) <= 1.e-8
         return root
-    assert list(map(round, getroot((1, 1, 1)))) == [2.0, 1.0, 0.0]
+    assert list(map(round, getroot((1, 1, 1)))) == [2, 1, 0]
     assert nsolve([Eq(
         f1, 0), Eq(f2, 0), Eq(f3, 0)], [x, y, z], (1, 1, 1))  # just see that it works
     a = Symbol('a')
@@ -134,5 +135,5 @@ def test_issue_14950():
     x = Matrix(symbols('t s'))
     x0 = Matrix([17, 23])
     eqn = x + x0
-    assert nsolve(eqn, x, x0) == -x0
-    assert nsolve(eqn.T, x.T, x0.T) == -x0
+    assert nsolve(eqn, x, x0) == nfloat(-x0)
+    assert nsolve(eqn.T, x.T, x0.T) == nfloat(-x0)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -200,7 +200,7 @@ def test_solve_args():
     # - linear
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
     # When one or more args are Boolean
-    assert solve(Eq(x**2, 0.0)) == [0]  # issue 19048
+    assert solve(Eq(x**2, 0.0)) == [0.0]  # issue 19048
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
     assert not solve([Eq(x, x+1), x < 2], x)
@@ -673,7 +673,7 @@ def test_solve_for_functions_derivatives():
     f = Function('f')
     soln = solve([f(x).diff(x) + f(x).diff(x, 2) - 1, f(x).diff(x) - f(x).diff(x, 2)],
             f(x).diff(x), f(x).diff(x, 2))
-    assert soln == { f(x).diff(x, 2): 1/2, f(x).diff(x): 1/2 }
+    assert soln == { f(x).diff(x, 2): S(1)/2, f(x).diff(x): S(1)/2 }
 
     soln = solve([f(x).diff(x, 2) + f(x).diff(x, 3) - 1, 1 - f(x).diff(x, 2) -
             f(x).diff(x, 3), 1 - f(x).diff(x,3)], f(x).diff(x, 2), f(x).diff(x, 3))

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -47,7 +47,7 @@ def test_Normal():
     assert density(m)(x, y) == density(p)(x, y)
     assert marginal_distribution(n, 0, 1)(1, 2) == 1/(2*pi)
     raises(ValueError, lambda: marginal_distribution(m))
-    assert integrate(density(m)(x, y), (x, -oo, oo), (y, -oo, oo)).evalf() == 1
+    assert integrate(density(m)(x, y), (x, -oo, oo), (y, -oo, oo)).evalf() == 1.0
     N = Normal('N', [1, 2], [[x, 0], [0, y]])
     assert density(N)(0, 0) == exp(-((4*x + y)/(2*x*y)))/(2*pi*sqrt(x*y))
 
@@ -101,7 +101,7 @@ def test_MultivariateTDist():
     assert(density(t1))(1, 1) == 1/(8*pi)
     assert t1.pspace.distribution.set == ProductSet(S.Reals, S.Reals)
     assert integrate(density(t1)(x, y), (x, -oo, oo), \
-        (y, -oo, oo)).evalf() == 1
+        (y, -oo, oo)).evalf() == 1.0
     raises(ValueError, lambda: MultivariateT('T', [1, 2], [[1, 1], [1, -1]], 1))
     t2 = MultivariateT('t2', [1, 2], [[x, 0], [0, y]], 1)
     assert density(t2)(1, 2) == 1/(2*pi*sqrt(x*y))

--- a/sympy/stats/tests/test_matrix_distributions.py
+++ b/sympy/stats/tests/test_matrix_distributions.py
@@ -78,7 +78,7 @@ def test_MatrixNormal():
     assert M.pspace.distribution.set == MatrixSet(1, 2, S.Reals)
     X = MatrixSymbol('X', 1, 2)
     term1 = exp(-Trace(Matrix([[ S(2)/3, -S(1)/3], [-S(1)/3, S(2)/3]])*(
-            Matrix([[-5], [-6]]) + X.T)*Matrix([[1/4]])*(Matrix([[-5, -6]]) + X))/2)
+            Matrix([[-5], [-6]]) + X.T)*Matrix([[S(1)/4]])*(Matrix([[-5, -6]]) + X))/2)
     assert density(M)(X).doit() == term1/(24*pi)
     assert density(M)([[7, 8]]).doit() == exp(-S(1)/3)/(24*pi)
     d, n = symbols('d n', positive=True, integer=True)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -218,8 +218,8 @@ def test_Sample():
 
     raises(TypeError, lambda: P(Y > z, numsamples=5))
 
-    assert P(sin(Y) <= 1, numsamples=10) == 1
-    assert P(sin(Y) <= 1, cos(Y) < 1, numsamples=10) == 1
+    assert P(sin(Y) <= 1, numsamples=10) == 1.0
+    assert P(sin(Y) <= 1, cos(Y) < 1, numsamples=10) == 1.0
 
     assert all(i in range(1, 7) for i in density(X, numsamples=10))
     assert all(i in range(4, 7) for i in density(X, X>3, numsamples=10))

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -353,10 +353,10 @@ def test_DiscreteMarkovChain():
     assert query.subs({a:15, b:0, c:10, d:1}).evalf().round(4) == P(Eq(Y[15], 0), Eq(Y[10], 1)).round(4)
     query_gt = P(Gt(Y[a], b), Eq(Y[c], d))
     query_le = P(Le(Y[a], b), Eq(Y[c], d))
-    assert query_gt.subs({a:5, b:2, c:1, d:0}).evalf() + query_le.subs({a:5, b:2, c:1, d:0}).evalf() == 1
+    assert query_gt.subs({a:5, b:2, c:1, d:0}).evalf() + query_le.subs({a:5, b:2, c:1, d:0}).evalf() == 1.0
     query_ge = P(Ge(Y[a], b), Eq(Y[c], d))
     query_lt = P(Lt(Y[a], b), Eq(Y[c], d))
-    assert query_ge.subs({a:4, b:1, c:0, d:2}).evalf() + query_lt.subs({a:4, b:1, c:0, d:2}).evalf() == 1
+    assert query_ge.subs({a:4, b:1, c:0, d:2}).evalf() + query_lt.subs({a:4, b:1, c:0, d:2}).evalf() == 1.0
 
     #test issue 20078
     assert (2*Y[1] + 3*Y[1]).simplify() == 5*Y[1]
@@ -446,10 +446,10 @@ def test_ContinuousMarkovChain():
     assert query.subs({a:3.65, b:2, c:1.78, d:1}).evalf().round(10) == P(Eq(C(3.65), 2), Eq(C(1.78), 1)).round(10)
     query_gt = P(Gt(C(a), b), Eq(C(c), d))
     query_le = P(Le(C(a), b), Eq(C(c), d))
-    assert query_gt.subs({a:13.2, b:0, c:3.29, d:2}).evalf() + query_le.subs({a:13.2, b:0, c:3.29, d:2}).evalf() == 1
+    assert query_gt.subs({a:13.2, b:0, c:3.29, d:2}).evalf() + query_le.subs({a:13.2, b:0, c:3.29, d:2}).evalf() == 1.0
     query_ge = P(Ge(C(a), b), Eq(C(c), d))
     query_lt = P(Lt(C(a), b), Eq(C(c), d))
-    assert query_ge.subs({a:7.43, b:1, c:1.45, d:0}).evalf() + query_lt.subs({a:7.43, b:1, c:1.45, d:0}).evalf() == 1
+    assert query_ge.subs({a:7.43, b:1, c:1.45, d:0}).evalf() + query_lt.subs({a:7.43, b:1, c:1.45, d:0}).evalf() == 1.0
 
     #test issue 20078
     assert (2*C(1) + 3*C(1)).simplify() == 5*C(1)
@@ -505,7 +505,7 @@ def test_BernoulliProcess():
     assert P(B[1] > 0, B[2] <= 1).round(2) == Float(0.60, 2)
     assert P(B[12] * B[5] > 0).round(2) == Float(0.36, 2)
     assert P(B[12] * B[5] > 0, B[4] < 1).round(2) == Float(0.36, 2)
-    assert P(Eq(B[2], 1), B[2] > 0) == 1
+    assert P(Eq(B[2], 1), B[2] > 0) == 1.0
     assert P(Eq(B[5], 3)) == 0
     assert P(Eq(B[1], 1), B[1] < 0) == 0
     assert P(B[2] > 0, Eq(B[2], 1)) == 1

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -700,7 +700,7 @@ def test_deprecation_warning():
     check(w)
 
 def test_issue_18438():
-    assert pickle.loads(pickle.dumps(S.Half)) == 1/2
+    assert pickle.loads(pickle.dumps(S.Half)) == S.Half
 
 
 #================= old pickles =================


### PR DESCRIPTION
This commit changes tests that assert comparisons between Floats and
Rationals as well as Floats with different precision. Where a tested
function returns a Float (or an expression involving Floats) then the
test should compare the returned value with a Float. Likewise if exact
Rationals are returned then the test should assert that.

There were also many tests that use Floats with specific precision but
compare against Floats with different precision. This commit ensures
that a correct precision Float is always used in these comparisons.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This extracts some of the harmless changes from #20033.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
