### PR TITLE
add type hints to printing/latex.py

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -116,6 +116,8 @@ class Basic(Printable, metaclass=ManagedProperties):
     is_Point = False
     is_MatAdd = False
     is_MatMul = False
+    is_negative: bool | None
+    is_commutative: bool | None
 
     kind: Kind = UndefinedKind
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1,20 +1,21 @@
 """
 A Printer which converts an expression into its LaTeX equivalent.
 """
-
-from typing import Any, Dict as tDict
+from __future__ import annotations
+from typing import Any, Callable, TYPE_CHECKING
 
 import itertools
 
-from sympy.core import Add, Float, Mod, Mul, Number, S, Symbol
+from sympy.core import Add, Float, Mod, Mul, Number, S, Symbol, Expr
 from sympy.core.alphabets import greeks
 from sympy.core.containers import Tuple
-from sympy.core.function import AppliedUndef, Derivative
+from sympy.core.function import Function, AppliedUndef, Derivative
 from sympy.core.operations import AssocOp
 from sympy.core.power import Pow
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
-from sympy.logic.boolalg import true
+from sympy.logic.boolalg import true, BooleanTrue, BooleanFalse
+from sympy.tensor.array import NDimArray
 
 # sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
@@ -27,6 +28,9 @@ from mpmath.libmp.libmpf import prec_to_dps, to_str as mlib_to_str
 from sympy.utilities.iterables import has_variety
 
 import re
+
+if TYPE_CHECKING:
+    from sympy.vector.basisdependent import BasisDependent
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax
 # Complete list at
@@ -81,7 +85,7 @@ other_symbols = {'aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
                      'hslash', 'mho', 'wp'}
 
 # Variable name modifiers
-modifier_dict = {
+modifier_dict: dict[str, Callable[[str], str]] = {
     # Accents
     'mathring': lambda s: r'\mathring{'+s+r'}',
     'ddddot': lambda s: r'\ddddot{'+s+r'}',
@@ -119,7 +123,7 @@ _between_two_numbers_p = (
 )
 
 
-def latex_escape(s):
+def latex_escape(s: str) -> str:
     """
     Escape a string such that latex interprets it as plaintext.
 
@@ -137,7 +141,7 @@ def latex_escape(s):
 class LatexPrinter(Printer):
     printmethod = "_latex"
 
-    _default_settings = {
+    _default_settings: dict[str, Any] = {
         "full_prec": False,
         "fold_frac_powers": False,
         "fold_func_brackets": False,
@@ -162,7 +166,7 @@ class LatexPrinter(Printer):
         "min": None,
         "max": None,
         "diff_operator": "d",
-    }  # type: tDict[str, Any]
+    }
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)
@@ -225,14 +229,14 @@ class LatexPrinter(Printer):
         diff_operator = self._settings['diff_operator']
         self._settings["diff_operator_latex"] = diff_operator_table.get(diff_operator, diff_operator)
 
-    def _add_parens(self, s):
+    def _add_parens(self, s) -> str:
         return r"\left({}\right)".format(s)
 
     # TODO: merge this with the above, which requires a lot of test changes
-    def _add_parens_lspace(self, s):
+    def _add_parens_lspace(self, s) -> str:
         return r"\left( {}\right)".format(s)
 
-    def parenthesize(self, item, level, is_neg=False, strict=False):
+    def parenthesize(self, item, level, is_neg=False, strict=False) -> str:
         prec_val = precedence_traditional(item)
         if is_neg and strict:
             return self._add_parens(self._print(item))
@@ -256,7 +260,7 @@ class LatexPrinter(Printer):
                 return "{{{}}}".format(s)
         return s
 
-    def doprint(self, expr):
+    def doprint(self, expr) -> str:
         tex = Printer.doprint(self, expr)
 
         if self._settings['mode'] == 'plain':
@@ -269,7 +273,7 @@ class LatexPrinter(Printer):
             env_str = self._settings['mode']
             return r"\begin{%s}%s\end{%s}" % (env_str, tex, env_str)
 
-    def _needs_brackets(self, expr):
+    def _needs_brackets(self, expr) -> bool:
         """
         Returns True if the expression needs to be wrapped in brackets when
         printed, False otherwise. For example: a + b => True; a => False;
@@ -279,7 +283,7 @@ class LatexPrinter(Printer):
                     or (expr.is_Atom and (expr is not S.NegativeOne
                                           and expr.is_Rational is False)))
 
-    def _needs_function_brackets(self, expr):
+    def _needs_function_brackets(self, expr) -> bool:
         """
         Returns True if the expression needs to be wrapped in brackets when
         passed as an argument to a function, False otherwise. This is a more
@@ -302,7 +306,7 @@ class LatexPrinter(Printer):
             else:
                 return False
 
-    def _needs_mul_brackets(self, expr, first=False, last=False):
+    def _needs_mul_brackets(self, expr, first=False, last=False) -> bool:
         """
         Returns True if the expression needs to be wrapped in brackets when
         printed as part of a Mul, False otherwise. This is True for Add,
@@ -333,7 +337,7 @@ class LatexPrinter(Printer):
 
         return False
 
-    def _needs_add_brackets(self, expr):
+    def _needs_add_brackets(self, expr) -> bool:
         """
         Returns True if the expression needs to be wrapped in brackets when
         printed as part of an Add, False otherwise.  This is False for most
@@ -347,16 +351,16 @@ class LatexPrinter(Printer):
             return True
         return False
 
-    def _mul_is_clean(self, expr):
+    def _mul_is_clean(self, expr) -> bool:
         for arg in expr.args:
             if arg.is_Function:
                 return False
         return True
 
-    def _pow_is_clean(self, expr):
+    def _pow_is_clean(self, expr) -> bool:
         return not self._needs_brackets(expr.base)
 
-    def _do_exponent(self, expr, exp):
+    def _do_exponent(self, expr: str, exp):
         if exp is not None:
             return r"\left(%s\right)^{%s}" % (expr, exp)
         else:
@@ -371,7 +375,7 @@ class LatexPrinter(Printer):
         else:
             return r"\text{{{}}}".format(name)
 
-    def _print_bool(self, e):
+    def _print_bool(self, e: bool | BooleanTrue | BooleanFalse):
         return r"\text{%s}" % e
 
     _print_BooleanTrue = _print_bool
@@ -510,13 +514,13 @@ class LatexPrinter(Printer):
         func = expr._expr
         return r"\Delta %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
-    def _print_Mul(self, expr):
+    def _print_Mul(self, expr: Expr):
         from sympy.physics.units import Quantity
         from sympy.simplify import fraction
-        separator = self._settings['mul_symbol_latex']
-        numbersep = self._settings['mul_symbol_latex_numbers']
+        separator: str = self._settings['mul_symbol_latex']
+        numbersep: str = self._settings['mul_symbol_latex_numbers']
 
-        def convert(expr):
+        def convert(expr) -> str:
             if not expr.is_Mul:
                 return str(self._print(expr))
             else:
@@ -532,26 +536,26 @@ class LatexPrinter(Printer):
 
                 return convert_args(args)
 
-        def convert_args(args):
-                _tex = last_term_tex = ""
+        def convert_args(args) -> str:
+            _tex = last_term_tex = ""
 
-                for i, term in enumerate(args):
-                    term_tex = self._print(term)
+            for i, term in enumerate(args):
+                term_tex = self._print(term)
 
-                    if self._needs_mul_brackets(term, first=(i == 0),
-                                                last=(i == len(args) - 1)):
-                        term_tex = r"\left(%s\right)" % term_tex
+                if self._needs_mul_brackets(term, first=(i == 0),
+                                            last=(i == len(args) - 1)):
+                    term_tex = r"\left(%s\right)" % term_tex
 
-                    if _between_two_numbers_p[0].search(last_term_tex) and \
-                            _between_two_numbers_p[1].match(str(term)):
-                        # between two numbers
-                        _tex += numbersep
-                    elif _tex:
-                        _tex += separator
+                if _between_two_numbers_p[0].search(last_term_tex) and \
+                        _between_two_numbers_p[1].match(str(term)):
+                    # between two numbers
+                    _tex += numbersep
+                elif _tex:
+                    _tex += separator
 
-                    _tex += term_tex
-                    last_term_tex = term_tex
-                return _tex
+                _tex += term_tex
+                last_term_tex = term_tex
+            return _tex
 
         # Check for unevaluated Mul. In this case we need to make sure the
         # identities are visible, multiple Rational factors are not combined
@@ -637,57 +641,52 @@ class LatexPrinter(Printer):
         alpha = self._print(expr.alpha.as_expr())
         return rf'\left({p}, {alpha}\right)'
 
-    def _print_Pow(self, expr):
+    def _print_Pow(self, expr: Pow):
         # Treat x**Rational(1,n) as special case
-        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 \
-                and self._settings['root_notation']:
-            base = self._print(expr.base)
-            expq = expr.exp.q
-
-            if expq == 2:
-                tex = r"\sqrt{%s}" % base
-            elif self._settings['itex']:
-                tex = r"\root{%d}{%s}" % (expq, base)
-            else:
-                tex = r"\sqrt[%d]{%s}" % (expq, base)
-
-            if expr.exp.is_negative:
-                return r"\frac{1}{%s}" % tex
-            else:
-                return tex
-        elif self._settings['fold_frac_powers'] \
-            and expr.exp.is_Rational \
-                and expr.exp.q != 1:
-            base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
-            p, q = expr.exp.p, expr.exp.q
-            # issue #12886: add parentheses for superscripts raised to powers
-            if expr.base.is_Symbol:
-                base = self.parenthesize_super(base)
-            if expr.base.is_Function:
-                return self._print(expr.base, exp="%s/%s" % (p, q))
-            return r"%s^{%s/%s}" % (base, p, q)
-        elif expr.exp.is_Rational and expr.exp.is_negative and \
-                expr.base.is_commutative:
-            # special case for 1^(-x), issue 9216
-            if expr.base == 1:
-                return r"%s^{%s}" % (expr.base, expr.exp)
-            # special case for (1/x)^(-y) and (-1/-x)^(-y), issue 20252
-            if expr.base.is_Rational and \
-                    expr.base.p*expr.base.q == abs(expr.base.q):
-                if expr.exp == -1:
-                    return r"\frac{1}{\frac{%s}{%s}}" % (expr.base.p, expr.base.q)
+        if expr.exp.is_Rational:
+            p: int = expr.exp.p  # type: ignore
+            q: int = expr.exp.q  # type: ignore
+            if abs(p) == 1 and q != 1 and self._settings['root_notation']:
+                base = self._print(expr.base)
+                if q == 2:
+                    tex = r"\sqrt{%s}" % base
+                elif self._settings['itex']:
+                    tex = r"\root{%d}{%s}" % (q, base)
                 else:
-                    return r"\frac{1}{(\frac{%s}{%s})^{%s}}" % (expr.base.p, expr.base.q, abs(expr.exp))
-            # things like 1/x
-            return self._print_Mul(expr)
-        else:
-            if expr.base.is_Function:
-                return self._print(expr.base, exp=self._print(expr.exp))
-            else:
-                tex = r"%s^{%s}"
-                return self._helper_print_standard_power(expr, tex)
+                    tex = r"\sqrt[%d]{%s}" % (q, base)
+                if expr.exp.is_negative:
+                    return r"\frac{1}{%s}" % tex
+                else:
+                    return tex
+            elif self._settings['fold_frac_powers'] and q != 1:
+                base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+                # issue #12886: add parentheses for superscripts raised to powers
+                if expr.base.is_Symbol:
+                    base = self.parenthesize_super(base)
+                if expr.base.is_Function:
+                    return self._print(expr.base, exp="%s/%s" % (p, q))
+                return r"%s^{%s/%s}" % (base, p, q)
+            elif expr.exp.is_negative and expr.base.is_commutative:
+                # special case for 1^(-x), issue 9216
+                if expr.base == 1:
+                    return r"%s^{%s}" % (expr.base, expr.exp)
+                # special case for (1/x)^(-y) and (-1/-x)^(-y), issue 20252
+                if expr.base.is_Rational:
+                    base_p: int = expr.base.p  # type: ignore
+                    base_q: int = expr.base.q  # type: ignore
+                    if base_p * base_q == abs(base_q):
+                        if expr.exp == -1:
+                            return r"\frac{1}{\frac{%s}{%s}}" % (base_p, base_q)
+                        else:
+                            return r"\frac{1}{(\frac{%s}{%s})^{%s}}" % (base_p, base_q, abs(expr.exp))
+                # things like 1/x
+                return self._print_Mul(expr)
+        if expr.base.is_Function:
+            return self._print(expr.base, exp=self._print(expr.exp))
+        tex = r"%s^{%s}"
+        return self._helper_print_standard_power(expr, tex)
 
-    def _helper_print_standard_power(self, expr, template):
+    def _helper_print_standard_power(self, expr, template: str) -> str:
         exp = self._print(expr.exp)
         # issue #12886: add parentheses around superscripts raised
         # to powers
@@ -743,10 +742,10 @@ class LatexPrinter(Printer):
 
         return tex
 
-    def _print_BasisDependent(self, expr):
+    def _print_BasisDependent(self, expr: 'BasisDependent'):
         from sympy.vector import Vector
 
-        o1 = []
+        o1: list[str] = []
         if expr == expr.zero:
             return expr.zero._latex_form
         if isinstance(expr, Vector):
@@ -890,7 +889,7 @@ class LatexPrinter(Printer):
         else:
             return r"%s %s" % (tex, self._print(e))
 
-    def _hprint_Function(self, func):
+    def _hprint_Function(self, func: str) -> str:
         r'''
         Logic to decide how to render a function to latex
           - if it is a recognized latex name, use the appropriate latex command
@@ -922,7 +921,7 @@ class LatexPrinter(Printer):
                 name = r"\operatorname{%s}" % func
         return name
 
-    def _print_Function(self, expr, exp=None):
+    def _print_Function(self, expr: Function, exp=None) -> str:
         r'''
         Render functions to LaTeX, handling functions that LaTeX knows about
         e.g., sin, cos, ... by using the proper LaTeX command (\sin, \cos, ...).
@@ -1042,7 +1041,7 @@ class LatexPrinter(Printer):
     def _print_IdentityFunction(self, expr):
         return r"\left( x \mapsto x \right)"
 
-    def _hprint_variadic_function(self, expr, exp=None):
+    def _hprint_variadic_function(self, expr, exp=None) -> str:
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]
         tex = r"\%s\left(%s\right)" % (str(expr.func).lower(),
@@ -1254,7 +1253,7 @@ class LatexPrinter(Printer):
         else:
             return r"\gamma%s" % tex
 
-    def _hprint_one_arg_func(self, expr, exp=None):
+    def _hprint_one_arg_func(self, expr, exp=None) -> str:
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
@@ -1346,7 +1345,7 @@ class LatexPrinter(Printer):
 
         return self._do_exponent(tex, exp)
 
-    def _hprint_BesselBase(self, expr, exp, sym):
+    def _hprint_BesselBase(self, expr, exp, sym: str) -> str:
         tex = r"%s" % (sym)
 
         need_exp = False
@@ -1363,7 +1362,7 @@ class LatexPrinter(Printer):
             tex = self._do_exponent(tex, exp)
         return tex
 
-    def _hprint_vec(self, vec):
+    def _hprint_vec(self, vec) -> str:
         if not vec:
             return ""
         s = ""
@@ -1402,7 +1401,7 @@ class LatexPrinter(Printer):
     def _print_hn2(self, expr, exp=None):
         return self._hprint_BesselBase(expr, exp, 'h^{(2)}')
 
-    def _hprint_airy(self, expr, exp=None, notation=""):
+    def _hprint_airy(self, expr, exp=None, notation="") -> str:
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
@@ -1410,7 +1409,7 @@ class LatexPrinter(Printer):
         else:
             return r"%s%s" % (notation, tex)
 
-    def _hprint_airy_prime(self, expr, exp=None, notation=""):
+    def _hprint_airy_prime(self, expr, exp=None, notation="") -> str:
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
@@ -1615,15 +1614,16 @@ class LatexPrinter(Printer):
                 s += self._print(expr.point[0])
         return r"O\left(%s\right)" % s
 
-    def _print_Symbol(self, expr, style='plain'):
-        if expr in self._settings['symbol_names']:
-            return self._settings['symbol_names'][expr]
+    def _print_Symbol(self, expr: Symbol, style='plain'):
+        name: str = self._settings['symbol_names'].get(expr)
+        if name is not None:
+            return name
 
         return self._deal_with_super_sub(expr.name, style=style)
 
     _print_RandomSymbol = _print_Symbol
 
-    def _deal_with_super_sub(self, string, style='plain'):
+    def _deal_with_super_sub(self, string: str, style='plain') -> str:
         if '{' in string:
             name, supers, subs = string, [], []
         else:
@@ -1703,7 +1703,7 @@ class LatexPrinter(Printer):
     def _print_MatrixBase(self, expr):
         out_str = self._print_matrix_contents(expr)
         if self._settings['mat_delim']:
-            left_delim = self._settings['mat_delim']
+            left_delim: str = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
             out_str = r'\left' + left_delim + out_str + \
                       r'\right' + right_delim
@@ -1858,7 +1858,7 @@ class LatexPrinter(Printer):
         perm_str = self._print(P.args[0])
         return "P_{%s}" % perm_str
 
-    def _print_NDimArray(self, expr):
+    def _print_NDimArray(self, expr: NDimArray):
 
         if expr.rank() == 0:
             return self._print(expr[()])
@@ -1875,7 +1875,7 @@ class LatexPrinter(Printer):
         block_str = r'\begin{%MATSTR%}%s\end{%MATSTR%}'
         block_str = block_str.replace('%MATSTR%', mat_str)
         if self._settings['mat_delim']:
-            left_delim = self._settings['mat_delim']
+            left_delim: str = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
             block_str = r'\left' + left_delim + block_str + \
                         r'\right' + right_delim
@@ -1883,7 +1883,7 @@ class LatexPrinter(Printer):
         if expr.rank() == 0:
             return block_str % ""
 
-        level_str = [[]] + [[] for i in range(expr.rank())]
+        level_str: list[list[str]] = [[] for i in range(expr.rank() + 1)]
         shape_ranges = [list(range(i)) for i in expr.shape]
         for outer_i in itertools.product(*shape_ranges):
             level_str[-1].append(self._print(expr[outer_i]))
@@ -1910,7 +1910,7 @@ class LatexPrinter(Printer):
 
         return out_str
 
-    def _printer_tensor_indices(self, name, indices, index_map={}):
+    def _printer_tensor_indices(self, name, indices, index_map: dict):
         out_str = self._print(name)
         last_valence = None
         prev_map = None
@@ -1941,7 +1941,7 @@ class LatexPrinter(Printer):
     def _print_Tensor(self, expr):
         name = expr.args[0].args[0]
         indices = expr.get_indices()
-        return self._printer_tensor_indices(name, indices)
+        return self._printer_tensor_indices(name, indices, {})
 
     def _print_TensorElement(self, expr):
         name = expr.expr.args[0].args[0]
@@ -2888,7 +2888,7 @@ class LatexPrinter(Printer):
         return r"\mathtt{\text{%s}}" % latex_escape(s)
 
 
-def translate(s):
+def translate(s: str) -> str:
     r'''
     Check for a modifier ending the string.  If present, convert the
     modifier to latex and translate the rest recursively.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -291,7 +291,7 @@ class Printer:
         """Returns printer's representation for expr (as a string)"""
         return self._str(self._print(expr))
 
-    def _print(self, expr, **kwargs):
+    def _print(self, expr, **kwargs) -> str:
         """Internal dispatcher
 
         Tries the following concepts to print an expression:

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -143,6 +143,9 @@ class NDimArray(Printable):
         from sympy.tensor.array import ImmutableDenseNDimArray
         return ImmutableDenseNDimArray(iterable, shape, **kwargs)
 
+    def __getitem__(self, index):
+        raise NotImplementedError("A subclass of NDimArray should implement __getitem__")
+
     def _parse_index(self, index):
         if isinstance(index, (SYMPY_INTS, Integer)):
             if index >= self._loop_size:

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict as tDict
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
-from sympy.simplify import simplify as simp, trigsimp as tsimp
+from sympy.simplify import simplify as simp, trigsimp as tsimp  # type: ignore
 from sympy.core.decorators import call_highest_priority, _sympifyit
 from sympy.core.assumptions import StdFactKB
 from sympy.core.function import diff as df
@@ -8,6 +9,9 @@ from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import factor as fctr
 from sympy.core import S, Add, Mul
 from sympy.core.expr import Expr
+
+if TYPE_CHECKING:
+    from sympy.vector.vector import BaseVector
 
 
 class BasisDependent(Expr):
@@ -17,6 +21,8 @@ class BasisDependent(Expr):
     Named so because the representation of these quantities in
     sympy.vector is dependent on the basis they are expressed in.
     """
+
+    zero: BasisDependentZero
 
     @call_highest_priority('__radd__')
     def __add__(self, other):
@@ -299,9 +305,8 @@ class BasisDependentZero(BasisDependent):
     """
     Class to denote a zero basis dependent instance.
     """
-    # XXX: Can't type the keys as BaseVector because of cyclic import
-    # problems.
-    components = {}  # type: tDict[Any, Expr]
+    components: dict['BaseVector', Expr] = {}
+    _latex_form: str
 
     def __new__(cls):
         obj = super().__new__(cls)

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Type
 
 from sympy.core.add import Add
@@ -31,7 +32,7 @@ class Vector(BasisDependent):
     _add_func = None  # type: Type[Vector]
     _zero_func = None  # type: Type[Vector]
     _base_func = None  # type: Type[Vector]
-    zero = None  # type: VectorZero
+    zero: VectorZero
 
     @property
     def components(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
There are many `_print_*` methods just return `str`. I only pick some of them whose return type can't be deduced automatically by pyright.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
