### PR TITLE
maint(ci): skip llvmlite tests under Python 3.10

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -154,11 +154,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', 'pypy-3.8']
+        python-version: ['3.9', '3.10', 'pypy-3.8']
         experimental: [false]
         include:
-          - python-version: '3.10'
-            experimental: true
           - python-version: '3.11.0-alpha - 3.11'
             experimental: true
     steps:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -172,7 +172,13 @@ jobs:
                          wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
       # These dependencies are not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}
-        run: pip install gmpy2 symengine llvmlite numba
+        run: pip install gmpy2 symengine
+      # The llvmjit tests segfault on Python 3.10. For now we skip this under
+      # 3.10 because the segfault prevents the other tests from running. Also
+      # llvmlite cannot be installed under PyPy. Installing numba pulls in
+      # llvmlite indirectly.
+      - if: ${{ matrix.python-version == '3.9' }}
+        run: pip install llvmlite numba
       # Test external imports
       - run: bin/test_external_imports.py
       - run: bin/test_submodule_imports.py


### PR DESCRIPTION
These tests currently segfault the test runner. This commit temporarily
disables running checks with llvmlite under Python 3.10 to allow the
test runner to complete.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows #23501

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
