### PR TITLE
manualintegrate (d+e*x)/sqrt(a+b*x+c*x**2)

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -43,7 +43,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
 
-x, y, z, a, b, c, s, t, x_1, x_2 = symbols('x y z a b c s t x_1 x_2')
+x, y, z, a, b, c, d, e, s, t, x_1, x_2 = symbols('x y z a b c d e s t x_1 x_2')
 n = Symbol('n', integer=True)
 f = Function('f')
 
@@ -1927,3 +1927,12 @@ def test_sqrt_quadratic():
     assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3
     assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3
     assert integrate(1/sqrt(a+b*x+c*x**2), x) == log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)
+
+    assert integrate((7*x+6)/sqrt(3*x**2+4*x+5)) == \
+           7*sqrt(3*x**2 + 4*x + 5)/3 + 4*sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/9
+    assert integrate((7*x+6)/sqrt(-3*x**2+4*x+5)) == \
+           -7*sqrt(-3*x**2 + 4*x + 5)/3 + 32*sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/9
+    assert integrate((7*x+6)/sqrt(3*x**2+4*x-5)) == \
+           7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/9
+    assert integrate((d+e*x)/sqrt(a+b*x+c*x**2), x) == \
+           e*sqrt(a + b*x + c*x**2)/c + (-b*e/(2*c) + d)*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -21,7 +21,7 @@ from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions
     _parts_rule, integral_steps, contains_dont_know, manual_subs)
 from sympy.testing.pytest import raises, slow
 
-x, y, z, u, n, a, b, c = symbols('x y z u n a b c')
+x, y, z, u, n, a, b, c, d, e = symbols('x y z u n a b c d e')
 f = Function('f')
 
 
@@ -589,3 +589,12 @@ def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(1/sqrt(-3*x**2+4*x+5), sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3)
     assert_is_integral_of(1/sqrt(3*x**2+4*x-5), sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3)
     assert manualintegrate(1/sqrt(a+b*x+c*x**2), x) == log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)
+
+    assert_is_integral_of((7*x+6)/sqrt(3*x**2+4*x+5),
+                          7*sqrt(3*x**2 + 4*x + 5)/3 + 4*sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/9)
+    assert_is_integral_of((7*x+6)/sqrt(-3*x**2+4*x+5),
+                          -7*sqrt(-3*x**2 + 4*x + 5)/3 + 32*sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/9)
+    assert_is_integral_of((7*x+6)/sqrt(3*x**2+4*x-5),
+                          7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/9)
+    assert manualintegrate((d+e*x)/sqrt(a+b*x+c*x**2), x) == \
+           e*sqrt(a + b*x + c*x**2)/c + (-b*e/(2*c) + d)*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

An intermediate step towards #23485.
Ultimate goal is to support all kinds of `P(x)*sqrt(a+bx+cx^2)` and `P(x)/sqrt(a+bx+cx^2)` where P is polynomial.
#### Brief description of what is fixed or changed
Previously these all can't be calculated.
```py
from sympy import *
from sympy.abc import a,b,c,d,e,x
integrate((7*x+6)/sqrt(3*x**2+4*x+5))
integrate((7*x+6)/sqrt(-3*x**2+4*x+5))
integrate((7*x+6)/sqrt(3*x**2+4*x-5))
```
#### Other comments
Steps in SymPy Beta. The rest steps are the same with #23489
![Screenshot from 2022-05-17 21-21-28](https://user-images.githubusercontent.com/26783539/168937893-16f2528d-fb26-4ae6-9722-156d93ae9b02.png)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Support integrate((d+ex)/sqrt(a+bx+cx**2))
<!-- END RELEASE NOTES -->
