### PR TITLE
maint(ci): don't install scipy for 3.11 dep tests.

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -166,8 +166,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath matplotlib numpy scipy aesara ipython cython \
+      - run: pip install mpmath matplotlib numpy ipython cython \
                          wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
+      # SciPy cannot yet be installed in Python 3.11 in CI. Also Aesara pulls
+      # in SciPy. Once it is possible to install then this should be done
+      # unconditionally.
+      - if: ${{ ! contains(matrix.python-version, '3.11') }}
+        run: pip install scipy aesara
       # These dependencies are not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}
         run: pip install gmpy2 symengine

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
-      - run: python -m pip install --upgrade pip
+      - run: python -m pip install --upgrade pip wheel
       - run: pip install mpmath matplotlib numpy ipython cython \
                          wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
       # SciPy cannot yet be installed in Python 3.11 in CI. Also Aesara pulls
@@ -173,13 +173,17 @@ jobs:
       # unconditionally.
       - if: ${{ ! contains(matrix.python-version, '3.11') }}
         run: pip install scipy aesara
-      # These dependencies are not available for pypy
+      # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}
-        run: pip install gmpy2 symengine
+        run: pip install gmpy2
+      # symengine is not available for pypy and cannot be installed in 3.11 (yet)
+      - if: ${{ matrix.python-version != 'pypy-3.8' && ! contains(matrix.python-version, '3.11') }}
+        run: pip install symengine
       # The llvmjit tests segfault on Python 3.10. For now we skip this under
       # 3.10 because the segfault prevents the other tests from running. Also
       # llvmlite cannot be installed under PyPy. Installing numba pulls in
-      # llvmlite indirectly.
+      # llvmlite indirectly. Maybe it would be better to disable the llvmlit
+      # tests but still install both of these so at least numbe can be tested.
       - if: ${{ matrix.python-version == '3.9' }}
         run: pip install llvmlite numba
       # Test external imports


### PR DESCRIPTION
This is a temporary change that should be reverted once it is possible
to install scipy under Python 3.11 in CI.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See also #23508 and #23501

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
