### PR TITLE
maint(ci) add scipy back in 3.11 dep tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -169,9 +169,7 @@ jobs:
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip wheel
 
-      # Currently needed to build scipy on 3.11. This can be removed at some
-      # point probably before Python 3.11 is released either because a newer
-      # version of cython is released or scipy starts shipping wheels for 3.11.
+      # Use numpy and scipy from git for Python 3.11
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/cython/cython@master
       - if: ${{ contains(matrix.python-version, '3.11') }}
@@ -187,17 +185,9 @@ jobs:
       - if: ${{ matrix.python-version != 'pypy-3.8' }}
         run: pip install gmpy2
 
-      # symengine is not available for pypy and cannot be installed in 3.11 (yet)
+      # These are not available for pypy and cannot be installed in 3.11 (yet)
       - if: ${{ matrix.python-version != 'pypy-3.8' && ! contains(matrix.python-version, '3.11') }}
-        run: pip install symengine
-
-      # The llvmjit tests segfault on Python 3.10. For now we skip this under
-      # 3.10 because the segfault prevents the other tests from running. Also
-      # llvmlite cannot be installed under PyPy. Installing numba pulls in
-      # llvmlite indirectly. Maybe it would be better to disable the llvmlit
-      # tests but still install both of these so at least numbe can be tested.
-      - if: ${{ matrix.python-version != 'pypy-3.8' }}
-        run: pip install llvmlite numba
+        run: pip install symengine llvmlite numba
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -196,7 +196,7 @@ jobs:
       # llvmlite cannot be installed under PyPy. Installing numba pulls in
       # llvmlite indirectly. Maybe it would be better to disable the llvmlit
       # tests but still install both of these so at least numbe can be tested.
-      - if: ${{ matrix.python-version == '3.9' }}
+      - if: ${{ matrix.python-version != 'pypy-3.8' }}
         run: pip install llvmlite numba
 
       # Test external imports

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -164,21 +164,33 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+
+      # Install the non-Python dependencies
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
       - run: python -m pip install --upgrade pip wheel
-      - run: pip install mpmath matplotlib numpy ipython cython \
+
+      # Currently needed to build scipy on 3.11. This can be removed at some
+      # point probably before Python 3.11 is released either because a newer
+      # version of cython is released or scipy starts shipping wheels for 3.11.
+      - if: ${{ contains(matrix.python-version, '3.11') }}
+        run: pip install git+https://github.com/cython/cython@master
+      - if: ${{ contains(matrix.python-version, '3.11') }}
+        run: pip install git+https://github.com/numpy/numpy@main
+      - if: ${{ contains(matrix.python-version, '3.11') }}
+        run: pip install git+https://github.com/scipy/scipy@main
+
+      # dependencies to install in all Python versions:
+      - run: pip install mpmath matplotlib numpy ipython cython scipy aesara \
                          wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
-      # SciPy cannot yet be installed in Python 3.11 in CI. Also Aesara pulls
-      # in SciPy. Once it is possible to install then this should be done
-      # unconditionally.
-      - if: ${{ ! contains(matrix.python-version, '3.11') }}
-        run: pip install scipy aesara
+
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}
         run: pip install gmpy2
+
       # symengine is not available for pypy and cannot be installed in 3.11 (yet)
       - if: ${{ matrix.python-version != 'pypy-3.8' && ! contains(matrix.python-version, '3.11') }}
         run: pip install symengine
+
       # The llvmjit tests segfault on Python 3.10. For now we skip this under
       # 3.10 because the segfault prevents the other tests from running. Also
       # llvmlite cannot be installed under PyPy. Installing numba pulls in
@@ -186,10 +198,12 @@ jobs:
       # tests but still install both of these so at least numbe can be tested.
       - if: ${{ matrix.python-version == '3.9' }}
         run: pip install llvmlite numba
+
       # Test external imports
       - run: bin/test_external_imports.py
       - run: bin/test_submodule_imports.py
       - run: bin/test_executable.py
+
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -166,7 +166,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Install the non-Python dependencies
-      - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev
+      - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
       - run: python -m pip install --upgrade pip wheel
 
       # Use numpy and scipy from git for Python 3.11


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows #23512
Fixes #23509

Install scipy and numpy from git in the 3.11 tests. Also fixes a bug causing segfault with llvmlite so that llvmlite and numba can be tested with Python 3.10.

Now all dependencies are tested with Python 3.10. For Python 3.11 we are still not yet testing symengine, llvmlite or numba.

<!-- BEGIN RELEASE NOTES -->
* printing
    * The llvmjit printer now works with Python 3.10. Previously a bug caused it to segfault.
<!-- END RELEASE NOTES -->
