### PR TITLE
limit calculates bi-directional limit by default

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -255,9 +255,9 @@ counterpart, ``Limit``.  To evaluate it, use ``doit``.
 
     >>> expr = Limit((cos(x) - 1)/x, x, 0)
     >>> expr
-         ⎛cos(x) - 1⎞
-     lim ⎜──────────⎟
-    x─→0⁺⎝    x     ⎠
+        ⎛cos(x) - 1⎞
+    lim ⎜──────────⎟
+    x─→0⎝    x     ⎠
     >>> expr.doit()
     0
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Literal, TYPE_CHECKING
 from collections.abc import Iterable
 from functools import reduce
 import re
@@ -22,6 +22,7 @@ from mpmath.libmp.libintmath import giant_steps
 
 if TYPE_CHECKING:
     from .numbers import Number
+    from .symbol import Symbol
 
 from collections import defaultdict
 
@@ -3385,7 +3386,7 @@ class Expr(Basic, EvalfMixin):
                      nseries calls it.""" % self.func)
                      )
 
-    def limit(self, x, xlim, dir='+'):
+    def limit(self, x: 'Symbol', xlim, dir: Literal['+-', '+', '-'] = '+-'):
         """ Compute limit x->xlim.
         """
         from sympy.series.limits import limit

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -692,13 +692,13 @@ class Function(Application, Expr):
         from sympy.series.order import Order
         from sympy.sets.sets import FiniteSet
         args = self.args
-        args0 = [t.limit(x, 0) for t in args]
+        args0 = [t.limit(x, 0, '+') for t in args]
         if any(t.is_finite is False for t in args0):
             from .numbers import oo, zoo, nan
             # XXX could use t.as_leading_term(x) here but it's a little
             # slower
             a = [t.compute_leading_term(x, logx=logx) for t in args]
-            a0 = [t.limit(x, 0) for t in a]
+            a0 = [t.limit(x, 0, '+') for t in a]
             if any(t.has(oo, -oo, zoo, nan) for t in a0):
                 return self._eval_aseries(n, args0, x, logx)
             # Careful: the argument goes to oo, but only logarithmically so. We

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -489,7 +489,7 @@ class exp(ExpBase, metaclass=ExpMeta):
         arg_series = arg._eval_nseries(x, n=n, logx=logx)
         if arg_series.is_Order:
             return 1 + arg_series
-        arg0 = limit(arg_series.removeO(), x, 0)
+        arg0 = limit(arg_series.removeO(), x, 0, '+')
         if arg0 is S.NegativeInfinity:
             return Order(x**n, x)
         if arg0 is S.Infinity:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1010,7 +1010,7 @@ class loggamma(Function):
         return self
 
     def _eval_nseries(self, x, n, logx=None, cdir=0):
-        x0 = self.args[0].limit(x, 0)
+        x0 = self.args[0].limit(x, 0, '+')
         if x0.is_zero:
             f = self._eval_rewrite_as_intractable(*self.args)
             return f._eval_nseries(x, n, logx)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -343,7 +343,7 @@ class Integral(AddWithLimits):
             """
             wok = F.subs(d, a)
             if wok is S.NaN or wok.is_finite is False and a.is_finite:
-                return limit(sign(b)*F, d, a)
+                return limit(sign(b)*F, d, a, '+')
             return wok
 
         def _calc_limit(a, b):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1308,7 +1308,7 @@ def test_issue_3749():
         Matrix([[oo, -oo, oo], [oo, 0, oo]])
     assert Matrix([
         [(exp(x) - 1)/x, 2*x + y*x, x**x ],
-        [1/x, abs(x), abs(sin(x + 1))]]).limit(x, 0) == \
+        [1/x, abs(x), abs(sin(x + 1))]]).limit(x, 0, '+') == \
         Matrix([[1, 0, 1], [oo, 0, sin(1)]])
     assert a.integrate(x) == Matrix([
         [Rational(1, 3)*x**3, y*x**2/2],

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -568,8 +568,10 @@ def handle_limit(func):
         var = sympy.Symbol('x')
     if sub.SUB():
         direction = "-"
-    else:
+    elif sub.ADD():
         direction = "+"
+    else:
+        direction = "+-"
     approaching = convert_expr(sub.expr())
     content = convert_mp(func.mp())
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -505,7 +505,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 
         """
         m = Mul(self.num, Pow(self.den, -1, evaluate=False), evaluate=False)
-        return limit(m, self.var, 0)
+        return limit(m, self.var, 0, '+')
 
     def poles(self):
         """

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4811,7 +4811,7 @@ x─→∞ \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(x**2, x, 0)
+    expr = Limit(x**2, x, 0, '+')
     ascii_str = \
 """\
       2\n\
@@ -4827,7 +4827,7 @@ x─→0⁺  \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(1/x, x, 0)
+    expr = Limit(1/x, x, 0, '+')
     ascii_str = \
 """\
      1\n\
@@ -4843,7 +4843,7 @@ x─→0⁺x\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(sin(x)/x, x, 0)
+    expr = Limit(sin(x)/x, x, 0, '+')
     ascii_str = \
 """\
      /sin(x)\\\n\
@@ -4875,7 +4875,7 @@ x─→0⁻⎝  x   ⎠\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(x + sin(x), x, 0)
+    expr = Limit(x + sin(x), x, 0, '+')
     ascii_str = \
 """\
  lim (x + sin(x))\n\
@@ -4889,7 +4889,7 @@ x─→0⁺            \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(x, x, 0)**2
+    expr = Limit(x, x, 0, '+')**2
     ascii_str = \
 """\
         2\n\
@@ -4905,7 +4905,7 @@ x─→0⁺            \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = Limit(x*Limit(y/2,y,0), x, 0)
+    expr = Limit(x*Limit(y/2, y, 0, '+'), x, 0, '+')
     ascii_str = \
 """\
      /       /y\\\\\n\
@@ -4921,7 +4921,7 @@ x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = 2*Limit(x*Limit(y/2,y,0), x, 0)
+    expr = 2*Limit(x*Limit(y/2, y, 0, '+'), x, 0, '+')
     ascii_str = \
 """\
        /       /y\\\\\n\

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -225,11 +225,10 @@ class StrPrinter(Printer):
 
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args
-        if str(dir) == "+":
-            return "Limit(%s, %s, %s)" % tuple(map(self._print, (e, z, z0)))
-        else:
-            return "Limit(%s, %s, %s, dir='%s')" % tuple(map(self._print,
-                                                            (e, z, z0, dir)))
+        args = list(map(self._print, (e, z, z0)))
+        if str(dir) != "+-" and z0 not in (S.Infinity, S.NegativeInfinity):
+            args.append("dir='%s'" % dir)
+        return "Limit(%s)" % ', '.join(args)
 
     def _print_list(self, expr):
         return "[%s]" % self.stringify(expr, ", ")

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1372,12 +1372,12 @@ def test_latex_limits():
 
     # issue 8175
     f = Function('f')
-    assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, "+")) == r"\lim_{x \to 0^+} f{\left(x \right)}"
     assert latex(Limit(f(x), x, 0, "-")) == \
         r"\lim_{x \to 0^-} f{\left(x \right)}"
 
     # issue #10806
-    assert latex(Limit(f(x), x, 0)**2) == \
+    assert latex(Limit(f(x), x, 0, "+")**2) == \
         r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
     # bi-directional limit
     assert latex(Limit(f(x), x, 0, dir='+-')) == \

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -156,7 +156,7 @@ def rational_algorithm(f, x, k, order=4, full=False):
             for j in range(i):
                 coeff = (coeff / (k + j + 1))
                 sep = integrate(sep, x)
-                sep += (ds.pop() - sep).limit(x, 0)  # constant of integration
+                sep += (ds.pop() - sep).limit(x, 0, '+')  # constant of integration
             return (coeff.subs(k, k - i), sep, i)
 
         else:
@@ -393,7 +393,7 @@ def _compute_formula(f, x, P, Q, k, m, k_max):
     for i in range(k_max + 1, k_max + m + 1):
         if (i < 0) == True:
             continue
-        r = f.diff(x, i).limit(x, 0) / factorial(i)
+        r = f.diff(x, i).limit(x, 0, '+') / factorial(i)
         if r.is_zero:
             continue
 
@@ -449,7 +449,7 @@ def _rsolve_hypergeometric(f, x, P, Q, k, m):
     shift = k_min + m
     f, P, Q, m = _transformation_a(f, x, P, Q, k, m, shift)
 
-    l = (x*f).limit(x, 0)
+    l = (x*f).limit(x, 0, '+')
     if not isinstance(l, Limit) and l != 0:  # Ideally should only be l != 0
         return None
 
@@ -461,7 +461,7 @@ def _rsolve_hypergeometric(f, x, P, Q, k, m):
 
     ind, mp = S.Zero, -oo
     for i in range(k_max + m + 1):
-        r = f.diff(x, i).limit(x, 0) / factorial(i)
+        r = f.diff(x, i).limit(x, 0, '+') / factorial(i)
         if r.is_finite is False:
             old_f = f
             f, P, Q, m = _transformation_a(f, x, P, Q, k, m, i)
@@ -470,7 +470,7 @@ def _rsolve_hypergeometric(f, x, P, Q, k, m):
             sol = _apply_integrate(sol, x, k)
             sol = _apply_shift(sol, i)
             ind = integrate(ind, x)
-            ind += (old_f - ind).limit(x, 0)  # constant of integration
+            ind += (old_f - ind).limit(x, 0, '+')  # constant of integration
             mp += 1
             return sol, ind, mp
         elif r:
@@ -625,7 +625,7 @@ def _solve_simple(f, x, DE, g, k):
     for i in range(len(Add.make_args(RE))):
         if i:
             f = f.diff(x)
-        init[g(k).subs(k, i)] = f.limit(x, 0) / factorial(i)
+        init[g(k).subs(k, i)] = f.limit(x, 0, '+') / factorial(i)
 
     sol = rsolve(RE, g(k), init)
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing import Literal
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
@@ -10,7 +12,8 @@ from sympy.polys import PolynomialError, factor
 from sympy.series.order import Order
 from .gruntz import gruntz
 
-def limit(e, z, z0, dir="+"):
+
+def limit(e: Expr, z: Symbol, z0, dir: Literal["+-", "+", "-"] = "+-") -> Expr:
     """Computes the limit of ``e(z)`` at the point ``z0``.
 
     Parameters
@@ -25,7 +28,7 @@ def limit(e, z, z0, dir="+"):
     z0 : the value toward which ``z`` tends. Can be any expression,
         including ``oo`` and ``-oo``.
 
-    dir : string, optional (default: "+")
+    dir : string, optional (default: "+-")
         The limit is bi-directional if ``dir="+-"``, from the right
         (z->z0+) if ``dir="+"``, and from the left (z->z0-) if
         ``dir="-"``. For infinite ``z0`` (``oo`` or ``-oo``), the ``dir``
@@ -39,12 +42,12 @@ def limit(e, z, z0, dir="+"):
     >>> from sympy.abc import x
     >>> limit(sin(x)/x, x, 0)
     1
-    >>> limit(1/x, x, 0) # default dir='+'
-    oo
+    >>> limit(1/x, x, 0) # default dir='+-'
+    zoo
     >>> limit(1/x, x, 0, dir="-")
     -oo
-    >>> limit(1/x, x, 0, dir='+-')
-    zoo
+    >>> limit(1/x, x, 0, dir="+")
+    oo
     >>> limit(1/x, x, oo)
     0
 
@@ -142,7 +145,7 @@ class Limit(Expr):
 
     """
 
-    def __new__(cls, e, z, z0, dir="+"):
+    def __new__(cls, e: Expr, z: Symbol, z0, dir: Literal["+-", "+", "-"] | Symbol = "+-"):
         e = sympify(e)
         z = sympify(z)
         z0 = sympify(z0)
@@ -179,18 +182,18 @@ class Limit(Expr):
 
 
     def pow_heuristics(self, e):
-        _, z, z0, _ = self.args
+        _, z, z0, dir = self.args
         b1, e1 = e.base, e.exp
         if not b1.has(z):
-            res = limit(e1*log(b1), z, z0)
+            res = limit(e1*log(b1), z, z0, dir)
             return exp(res)
 
-        ex_lim = limit(e1, z, z0)
-        base_lim = limit(b1, z, z0)
+        ex_lim = limit(e1, z, z0, dir)
+        base_lim = limit(b1, z, z0, dir)
 
         if base_lim is S.One:
             if ex_lim in (S.Infinity, S.NegativeInfinity):
-                res = limit(e1*(b1 - 1), z, z0)
+                res = limit(e1*(b1 - 1), z, z0, dir)
                 return exp(res)
         if base_lim is S.NegativeInfinity and ex_lim is S.Infinity:
             return S.ComplexInfinity

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -423,9 +423,9 @@ class Order(Expr):
             r = None
             ratio = self.expr/expr.expr
             ratio = powsimp(ratio, deep=True, combine='exp')
+            from sympy.series.limits import Limit
             for s in common_symbols:
-                from sympy.series.limits import Limit
-                l = Limit(ratio, s, point).doit(heuristics=False)
+                l = Limit(ratio, s, point, '+').doit(heuristics=False)
                 if not isinstance(l, Limit):
                     l = l != 0
                 else:
@@ -486,7 +486,7 @@ class Order(Expr):
                             e2 = sol.args[1]
                             sol = set(e1) - set(e2)
                         res = [dict(zip((d, ), sol))]
-                        point = d.subs(res[0]).limit(old, self.point[i])
+                        point = d.subs(res[0]).limit(old, self.point[i], '+')
                     newvars[i] = var
                     newpt[i] = point
                 elif old not in syms:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -50,8 +50,8 @@ def test_basic1():
     assert limit((1 + x)**oo, x, 0) == Limit((x + 1)**oo, x, 0)
     assert limit((1 + x)**oo, x, 0, dir='-') == Limit((x + 1)**oo, x, 0, dir='-')
     assert limit((1 + x + y)**oo, x, 0, dir='-') == Limit((1 + x + y)**oo, x, 0, dir='-')
-    assert limit(y/x/log(x), x, 0) == -oo*sign(y)
-    assert limit(cos(x + y)/x, x, 0) == sign(cos(y))*oo
+    assert limit(y/x/log(x), x, 0, '+') == -oo*sign(y)
+    assert limit(cos(x + y)/x, x, 0, '+') == sign(cos(y))*oo
     assert limit(gamma(1/x + 3), x, oo) == 2
     assert limit(S.NaN, x, -oo) is S.NaN
     assert limit(Order(2)*x, x, S.NaN) is S.NaN
@@ -81,7 +81,7 @@ def test_basic1():
     assert limit(1/x, x, 0, dir="+-") is zoo
     # approaching 0
     # from dir="+"
-    assert limit(1 + 1/x, x, 0) is oo
+    assert limit(1 + 1/x, x, 0, '+') is oo
     # from dir='-'
     # Add
     assert limit(1 + 1/x, x, 0, dir='-') is -oo
@@ -152,7 +152,7 @@ def test_piecewise2():
             >= 0), ((2 - 4*x)/Abs(sqrt(4 - 4*(2*x - 1)**2)), True))
     func2 = Piecewise((x**2/2, x <= 0.5), (x/2 - 0.125, True))
     func3 = Piecewise(((x - 9) / 5, x < -1), ((x - 9) / 5, x > 4), (sqrt(Abs(x - 3)), True))
-    assert limit(func1, x, 0) == 1
+    assert limit(func1, x, 0, '+') == 1
     assert limit(func2, x, 0) == 0
     assert limit(func3, x, -1) == 2
 
@@ -451,7 +451,7 @@ def test_issue_4546():
 
 def test_issue_3934():
     assert limit((1 + x**log(3))**(1/x), x, 0) == 1
-    assert limit((5**(1/x) + 3**(1/x))**x, x, 0) == 5
+    assert limit((5**(1/x) + 3**(1/x))**x, x, 0, '+') == 5
 
 
 def test_calculate_series():
@@ -553,50 +553,50 @@ def test_issue_7088():
 
 
 def test_branch_cuts():
-    assert limit(asin(I*x + 2), x, 0) == pi - asin(2)
+    assert limit(asin(I*x + 2), x, 0, '+') == pi - asin(2)
     assert limit(asin(I*x + 2), x, 0, '-') == asin(2)
-    assert limit(asin(I*x - 2), x, 0) == -asin(2)
+    assert limit(asin(I*x - 2), x, 0, '+') == -asin(2)
     assert limit(asin(I*x - 2), x, 0, '-') == -pi + asin(2)
-    assert limit(acos(I*x + 2), x, 0) == -acos(2)
+    assert limit(acos(I*x + 2), x, 0, '+') == -acos(2)
     assert limit(acos(I*x + 2), x, 0, '-') == acos(2)
-    assert limit(acos(I*x - 2), x, 0) == acos(-2)
+    assert limit(acos(I*x - 2), x, 0, '+') == acos(-2)
     assert limit(acos(I*x - 2), x, 0, '-') == 2*pi - acos(-2)
-    assert limit(atan(x + 2*I), x, 0) == I*atanh(2)
+    assert limit(atan(x + 2*I), x, 0, '+') == I*atanh(2)
     assert limit(atan(x + 2*I), x, 0, '-') == -pi + I*atanh(2)
-    assert limit(atan(x - 2*I), x, 0) == pi - I*atanh(2)
+    assert limit(atan(x - 2*I), x, 0, '+') == pi - I*atanh(2)
     assert limit(atan(x - 2*I), x, 0, '-') == -I*atanh(2)
-    assert limit(atan(1/x), x, 0) == pi/2
+    assert limit(atan(1/x), x, 0, '+') == pi/2
     assert limit(atan(1/x), x, 0, '-') == -pi/2
     assert limit(atan(x), x, oo) == pi/2
     assert limit(atan(x), x, -oo) == -pi/2
-    assert limit(acot(x + S(1)/2*I), x, 0) == pi - I*acoth(S(1)/2)
+    assert limit(acot(x + S(1)/2*I), x, 0, '+') == pi - I*acoth(S(1)/2)
     assert limit(acot(x + S(1)/2*I), x, 0, '-') == -I*acoth(S(1)/2)
-    assert limit(acot(x - S(1)/2*I), x, 0) == I*acoth(S(1)/2)
+    assert limit(acot(x - S(1)/2*I), x, 0, '+') == I*acoth(S(1)/2)
     assert limit(acot(x - S(1)/2*I), x, 0, '-') == -pi + I*acoth(S(1)/2)
-    assert limit(acot(x), x, 0) == pi/2
+    assert limit(acot(x), x, 0, '+') == pi/2
     assert limit(acot(x), x, 0, '-') == -pi/2
-    assert limit(asec(I*x + S(1)/2), x, 0) == asec(S(1)/2)
+    assert limit(asec(I*x + S(1)/2), x, 0, '+') == asec(S(1)/2)
     assert limit(asec(I*x + S(1)/2), x, 0, '-') == -asec(S(1)/2)
-    assert limit(asec(I*x - S(1)/2), x, 0) == 2*pi - asec(-S(1)/2)
+    assert limit(asec(I*x - S(1)/2), x, 0, '+') == 2*pi - asec(-S(1)/2)
     assert limit(asec(I*x - S(1)/2), x, 0, '-') == asec(-S(1)/2)
-    assert limit(acsc(I*x + S(1)/2), x, 0) == acsc(S(1)/2)
+    assert limit(acsc(I*x + S(1)/2), x, 0, '+') == acsc(S(1)/2)
     assert limit(acsc(I*x + S(1)/2), x, 0, '-') == pi - acsc(S(1)/2)
-    assert limit(acsc(I*x - S(1)/2), x, 0) == -pi + acsc(S(1)/2)
+    assert limit(acsc(I*x - S(1)/2), x, 0, '+') == -pi + acsc(S(1)/2)
     assert limit(acsc(I*x - S(1)/2), x, 0, '-') == -acsc(S(1)/2)
 
-    assert limit(log(I*x - 1), x, 0) == I*pi
+    assert limit(log(I*x - 1), x, 0, '+') == I*pi
     assert limit(log(I*x - 1), x, 0, '-') == -I*pi
-    assert limit(log(-I*x - 1), x, 0) == -I*pi
+    assert limit(log(-I*x - 1), x, 0, '+') == -I*pi
     assert limit(log(-I*x - 1), x, 0, '-') == I*pi
 
-    assert limit(sqrt(I*x - 1), x, 0) == I
+    assert limit(sqrt(I*x - 1), x, 0, '+') == I
     assert limit(sqrt(I*x - 1), x, 0, '-') == -I
-    assert limit(sqrt(-I*x - 1), x, 0) == -I
+    assert limit(sqrt(-I*x - 1), x, 0, '+') == -I
     assert limit(sqrt(-I*x - 1), x, 0, '-') == I
 
-    assert limit(cbrt(I*x - 1), x, 0) == (-1)**(S(1)/3)
+    assert limit(cbrt(I*x - 1), x, 0, '+') == (-1)**(S(1)/3)
     assert limit(cbrt(I*x - 1), x, 0, '-') == -(-1)**(S(2)/3)
-    assert limit(cbrt(-I*x - 1), x, 0) == -(-1)**(S(2)/3)
+    assert limit(cbrt(-I*x - 1), x, 0, '+') == -(-1)**(S(2)/3)
     assert limit(cbrt(-I*x - 1), x, 0, '-') == (-1)**(S(1)/3)
 
 
@@ -608,8 +608,8 @@ def test_issue_6364():
 
 def test_issue_4099():
     a = Symbol('a')
-    assert limit(a/x, x, 0) == oo*sign(a)
-    assert limit(-a/x, x, 0) == -oo*sign(a)
+    assert limit(a/x, x, 0, '+') == oo*sign(a)
+    assert limit(-a/x, x, 0, '+') == -oo*sign(a)
     assert limit(-a*x, x, oo) == -oo*sign(a)
     assert limit(a*x, x, oo) == oo*sign(a)
 
@@ -753,7 +753,7 @@ def test_issue_14456():
 
 
 def test_issue_14411():
-    assert limit(3*sec(4*pi*x - x/3), x, 3*pi/(24*pi - 2)) is -oo
+    assert limit(3*sec(4*pi*x - x/3), x, 3*pi/(24*pi - 2), '+') is -oo
 
 
 def test_issue_13382():
@@ -909,7 +909,7 @@ def test_issue_17431():
 
 
 def test_issue_17671():
-    assert limit(Ei(-log(x)) - log(log(x))/x, x, 1) == EulerGamma
+    assert limit(Ei(-log(x)) - log(log(x))/x, x, 1, '+') == EulerGamma
 
 
 def test_issue_17751():
@@ -965,7 +965,7 @@ def test_issue_18482():
 
 
 def test_issue_18508():
-    assert limit(sin(x)/sqrt(1-cos(x)), x, 0) == sqrt(2)
+    raises(ValueError, lambda: limit(sin(x)/sqrt(1-cos(x)), x, 0))
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='+') == sqrt(2)
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
 
@@ -1049,9 +1049,9 @@ def test_issue_19770():
 
 
 def test_issue_7535():
-    assert limit(tan(x)/sin(tan(x)), x, pi/2) == Limit(tan(x)/sin(tan(x)), x, pi/2, dir='+')
+    assert limit(tan(x)/sin(tan(x)), x, pi/2) == Limit(tan(x)/sin(tan(x)), x, pi/2, dir='+-')
     assert limit(tan(x)/sin(tan(x)), x, pi/2, dir='-') == Limit(tan(x)/sin(tan(x)), x, pi/2, dir='-')
-    assert limit(tan(x)/sin(tan(x)), x, pi/2, dir='+-') == Limit(tan(x)/sin(tan(x)), x, pi/2, dir='+-')
+    assert limit(tan(x)/sin(tan(x)), x, pi/2, dir='+') == Limit(tan(x)/sin(tan(x)), x, pi/2, dir='+')
     assert limit(sin(tan(x)),x,pi/2) == AccumBounds(-1, 1)
     assert -oo*(1/sin(-oo)) == AccumBounds(-oo, oo)
     assert oo*(1/sin(oo)) == AccumBounds(-oo, oo)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is talked about several times, e.g. https://github.com/sympy/sympy/issues/11667#issuecomment-636179241 and https://github.com/sympy/sympy/pull/13463#issuecomment-338243685. The current behavior is very [confusing](https://www.reddit.com/r/math/comments/44j0nm/sympy_gamma_good_wolfram_alpha_alternative/czqz4bc/?utm_source=reddit&utm_medium=web2x&context=3) and contradicts with https://docs.sympy.org/latest/tutorial/calculus.html#limits
#### Brief description of what is fixed or changed
Change public APIs to calculate bi-directional limit by default.
Some internal usages without an explicit direction parameter are also changed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * BREAKING: limit calculates bi-directional limit by default
<!-- END RELEASE NOTES -->
