### PR TITLE
Some fixes to eval() in Function subclasses

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -47,7 +47,7 @@ from .operations import LatticeOp
 from .parameters import global_parameters
 from .rules import Transform
 from .singleton import S
-from .sympify import sympify
+from .sympify import sympify, _sympify
 
 from .sorting import default_sort_key, ordered
 from sympy.utilities.exceptions import (sympy_deprecation_warning,
@@ -480,7 +480,7 @@ class Function(Application, Expr):
                 pr = max(cls._should_evalf(a) for a in result.args)
                 result = result.evalf(prec_to_dps(pr))
 
-        return result
+        return _sympify(result)
 
     @classmethod
     def _should_evalf(cls, arg):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -185,6 +185,14 @@ class FunctionClass(ManagedProperties):
             nargs = (as_int(nargs),)
         cls._nargs = nargs
 
+        # When __init__ is called from UndefinedFunction it is called with
+        # just one arg but when it is called from subclassing Function it is
+        # called with the usual (name, bases, namespace) type() signature.
+        if len(args) == 3:
+            namespace = args[2]
+            if 'eval' in namespace and not isinstance(namespace['eval'], classmethod):
+                raise TypeError("eval on Function subclasses should be a class method (defined with @classmethod)")
+
         super().__init__(*args, **kwargs)
 
     @property

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -534,7 +534,7 @@ class Pow(Expr):
                 b, e, m = int(base), int(exp), int(q)
                 mb = m.bit_length()
                 if mb <= 80 and e >= mb and e.bit_length()**4 >= m:
-                    phi = totient(m)
+                    phi = int(totient(m))
                     return Integer(pow(b, phi + e%phi, m))
                 return Integer(pow(b, e, m))
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -24,7 +24,7 @@ from sympy.tensor.indexed import Indexed
 from sympy.core.function import (PoleError, _mexpand, arity,
         BadSignatureError, BadArgumentsError)
 from sympy.core.parameters import _exp_is_pow
-from sympy.core.sympify import sympify
+from sympy.core.sympify import sympify, SympifyError
 from sympy.matrices import MutableMatrix, ImmutableMatrix
 from sympy.sets.sets import FiniteSet
 from sympy.solvers.solveset import solveset
@@ -1428,3 +1428,27 @@ def test_issue_17382():
                "ImageSet(Lambda(_n, 6.28318530717959*_n + 5.79812359592087), Integers), " \
                "ImageSet(Lambda(_n, 6.28318530717959*_n + 0.485061711258717), Integers))"
     assert NS(expr) == expected
+
+def test_eval_sympified():
+    # Check both arguments and return types from eval are sympified
+
+    class F(Function):
+        @classmethod
+        def eval(cls, x):
+            assert x is S.One
+            return 1
+
+    assert F(1) is S.One
+
+    # String arguments are not allowed
+    class F2(Function):
+        @classmethod
+        def eval(cls, x):
+            if x == 0:
+                return '1'
+
+    raises(SympifyError, lambda: F2(0))
+    F2(1) # Doesn't raise
+
+    # TODO: Disable string inputs (https://github.com/sympy/sympy/issues/11003)
+    # raises(SympifyError, lambda: F2('2'))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1452,3 +1452,9 @@ def test_eval_sympified():
 
     # TODO: Disable string inputs (https://github.com/sympy/sympy/issues/11003)
     # raises(SympifyError, lambda: F2('2'))
+
+def test_eval_classmethod_check():
+    with raises(TypeError):
+        class F(Function):
+            def eval(self, x):
+                pass

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -654,8 +654,8 @@ def _is_nthpow_residue_bign(a, n, m):
                 return False
         return True
     f = totient(m)
-    k = f // igcd(f, n)
-    return pow(a, k, m) == 1
+    k = int(f // igcd(f, n))
+    return pow(a, k, int(m)) == 1
 
 
 def _is_nthpow_residue_bign_prime_power(a, n, p, k):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

- Made the return value of `eval()` automatically sympified (so things like `return 1` will result in `Integer(1)`).
- Includes some fixes to 3-argument `pow` in the code that were necessary after this.
- Raise an exception if `eval` is not defined as a `@classmethod` (common mistake).


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - The return values of `eval` on `Function` subclasses are now automatically sympified.
  - `Function` subclasses now raise an exception if the `eval` method is not defined as a `@classmethod`.
<!-- END RELEASE NOTES -->
