### PR TITLE
manualintegrate sqrt(a+b*x+c*x**2)

### DIFF
--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -230,13 +230,6 @@ def test_issue_11813():
 
 
 @XFAIL
-def test_issue_11742():
-    i =  integrate(sqrt(-x**2 + 8*x + 48), (x, 4, 12))
-    assert not i.has(Integral)
-    # assert i == 16*pi
-
-
-@XFAIL
 def test_issue_11254a():
     assert not integrate(sech(x), (x, 0, 1)).has(Integral)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1442,6 +1442,10 @@ def test_issue_10567():
     assert integrate(vt, t) == Matrix([[a*t**2/2], [b*t], [c*t]])
 
 
+def test_issue_11742():
+    assert integrate(sqrt(-x**2 + 8*x + 48), (x, 4, 12)) == 16*pi
+
+
 def test_issue_11856():
     t = symbols('t')
     assert integrate(sinc(pi*t), t) == Si(pi*t)/pi
@@ -1936,3 +1940,9 @@ def test_sqrt_quadratic():
            7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/9
     assert integrate((d+e*x)/sqrt(a+b*x+c*x**2), x) == \
            e*sqrt(a + b*x + c*x**2)/c + (-b*e/(2*c) + d)*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c)
+
+    assert integrate(sqrt(53225*x**2-66732*x+23013)) == \
+           x*sqrt(53225*x**2 - 66732*x + 23013)/2 - 16683*sqrt(53225*x**2 - 66732*x + 23013)/53225 + \
+           111576969*sqrt(2129)*asinh(53225*x/10563 - S(11122)/3521)/1133160250
+    assert integrate(sqrt(a+b*x+c*x**2), x) == b*sqrt(a + b*x + c*x**2)/(4*c) + x*sqrt(a + b*x + c*x**2)/2 + \
+           (2*a - b**2/(2*c))*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/(4*sqrt(c))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -598,3 +598,11 @@ def test_manualintegrate_sqrt_quadratic():
                           7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/9)
     assert manualintegrate((d+e*x)/sqrt(a+b*x+c*x**2), x) == \
            e*sqrt(a + b*x + c*x**2)/c + (-b*e/(2*c) + d)*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c)
+
+    assert_is_integral_of(sqrt(53225*x**2-66732*x+23013),
+                          x*sqrt(53225*x**2 - 66732*x + 23013)/2 - 16683*sqrt(53225*x**2 - 66732*x + 23013)/53225 +
+                          111576969*sqrt(2129)*asinh(53225*x/10563 - S(11122)/3521)/1133160250)
+    assert manualintegrate(sqrt(a+c*x**2), x) == \
+           x*sqrt(a + c*x**2)/2 + 2*a*log(2*sqrt(c)*sqrt(a + c*x**2) + 2*c*x)/(4*sqrt(c))
+    assert manualintegrate(sqrt(a+b*x+c*x**2), x) == b*sqrt(a + b*x + c*x**2)/(4*c) + x*sqrt(a + b*x + c*x**2)/2 + \
+           (2*a - b**2/(2*c))*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/(4*sqrt(c))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23485
Fixes #11742
#### Brief description of what is fixed or changed
The rule of this kind of integrals is
$\int\sqrt{a+bx+cx^2}\mathrm{d}x$
$=x\sqrt{a+bx+cx^2}-\int x\mathrm{d}\sqrt{a+bx+cx^2}$
$=x\sqrt{a+bx+cx^2}-\int\frac{x(b+2cx)}{2\sqrt{a+bx+cx^2}}\mathrm{d}x$
$=x\sqrt{a+bx+cx^2}-\int\frac{2(a+bx+cx^2)-2a-bx}{2\sqrt{a+bx+cx^2}}\mathrm{d}x$
$=x\sqrt{a+bx+cx^2}-\int\sqrt{a+bx+cx^2}\mathrm{d}x+\frac{1}{2}\int\frac{2a+bx}{\sqrt{a+bx+cx^2}}\mathrm{d}x$
$=\frac{1}{2}x\sqrt{a+bx+cx^2}+\frac{1}{4}\int\frac{2a+bx}{\sqrt{a+bx+cx^2}}\mathrm{d}x$
This rule doesn't seem represent-able by existing rules, so I define a new rule for it.
Detailed steps should be provided in SymPy Beta after SymPy 1.11 is released. 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Support integrate(sqrt(a+bx+cx**2))

<!-- END RELEASE NOTES -->
