### PR TITLE
Dummies now replaced in lambdify cse subexpressions.

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1119,7 +1119,21 @@ class _EvaluatorPrinter:
         if not iterable(args):
             args = [args]
 
-        argstrs, expr = self._preprocess(args, expr)
+        if cses:
+            subvars, subexprs = zip(*cses)
+            try:
+                exprs = expr + list(subexprs)
+            except TypeError:
+                try:
+                    exprs = expr + tuple(subexprs)
+                except TypeError:
+                    expr = [expr]
+                    exprs = expr + list(subexprs)
+            argstrs, exprs = self._preprocess(args, exprs)
+            expr, subexprs = exprs[:len(expr)], exprs[len(expr):]
+            cses = zip(subvars, subexprs)
+        else:
+            argstrs, expr = self._preprocess(args, expr)
 
         # Generate argument unpacking and final argument list
         funcargs = []
@@ -1146,7 +1160,6 @@ class _EvaluatorPrinter:
                 funcbody.append('{} = {}'.format(s, self._exprrepr(e)))
 
         str_expr = _recursive_to_string(self._exprrepr, expr)
-
 
         if '\n' in str_expr:
             str_expr = '({})'.format(str_expr)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1576,3 +1576,12 @@ def test_lambdify_cse():
 def test_deprecated_set():
     with warns_deprecated_sympy():
         lambdify({x, y}, x + y)
+
+def test_23536_lambdify_cse_dummy():
+
+    f = Function('x')(y)
+    g = Function('w')(y)
+    expr = z + (f**4 + g**5)*(f**3 + (g*f)**3)
+    expr = expr.expand()
+    eval_expr = lambdify(((f, g), z), expr, cse=True)
+    eval_expr((1.0, 2.0), 3.0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23536

#### Brief description of what is fixed or changed

lambdify automatically replaces some objects with dummies. If lambdify's cse is used with these objects, the subexpressions did not get replacements. This ensures the subexpressions go through the preprocessor and dummies are swapped in.

#### Other comments

This isn't an elegant fix, but seems to work.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Dummies now replaced in lambdify cse subexpressions.
<!-- END RELEASE NOTES -->
