### PR TITLE
Changed Float handling in limits

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -819,6 +819,8 @@ class Beam:
         -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
             + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
         """
+        from sympy import nsimplify
+
         if self._composite_type == "hinge":
             return self._solve_hinge_beams(*reactions)
 
@@ -827,8 +829,13 @@ class Beam:
         C3 = Symbol('C3')
         C4 = Symbol('C4')
 
-        shear_curve = limit(self.shear_force(), x, l)
-        moment_curve = limit(self.bending_moment(), x, l)
+        # XXX: Better way to unify the typing of calculated and input loads?
+        # limit always outputs a float if the input has floats. (i.e. 26.0
+        # instead of 26), making the output here inconsistent between floats
+        # (from limit solution) and integers. nsimplify should perhaps be
+        # applied at a higher level, or not at all.
+        shear_curve = nsimplify(limit(self.shear_force(), x, l))
+        moment_curve = nsimplify(limit(self.bending_moment(), x, l))
 
         slope_eqs = []
         deflection_eqs = []

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,6 +1,7 @@
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
+from sympy.core.function import nfloat
 from sympy.core.numbers import Float, _illegal
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, sign)
@@ -261,13 +262,6 @@ class Limit(Expr):
                         return expr.args[0] if abs_flag else S.One
             return expr
 
-        if e.has(Float):
-            # Convert floats like 0.5 to exact SymPy numbers like S.Half, to
-            # prevent rounding errors which can lead to unexpected execution
-            # of conditional blocks that work on comparisons
-            # Also see comments in https://github.com/sympy/sympy/issues/19453
-            from sympy.simplify.simplify import nsimplify
-            e = nsimplify(e)
         e = set_signs(e)
 
 
@@ -347,6 +341,14 @@ class Limit(Expr):
 
         l = None
 
+        inexact = e.has(Float)
+        if inexact:
+            # Convert floats like 0.5 to exact SymPy numbers like S.Half, to
+            # prevent rounding errors which can lead to unexpected execution
+            # of conditional blocks that work on comparisons
+            # Also see comments in https://github.com/sympy/sympy/issues/19453
+            from sympy.simplify.simplify import nsimplify
+            e = nsimplify(e)
         try:
             if str(dir) == '+-':
                 r = gruntz(e, z, z0, '+')
@@ -366,4 +368,4 @@ class Limit(Expr):
             if r is None:
                 return self
 
-        return r
+        return nfloat(r) if inexact else r

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -2,7 +2,7 @@ from itertools import product
 
 from sympy.concrete.summations import Sum
 from sympy.core.function import (Function, diff)
-from sympy.core import EulerGamma
+from sympy.core import EulerGamma, N
 from sympy.core.numbers import (E, I, Rational, oo, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -137,7 +137,7 @@ def test_log():
     tau, x = symbols('tau x', positive=True)
     # The value of manualintegrate in the issue
     expr = tau**2*((tau - 1)*(tau + 1)*log(x + 1)/(tau**2 + 1)**2 + 1/((tau**2\
-            + 1)*(x + 1)) - (-2*tau*atan(x/tau) + (tau**2/2 - 1/2)*log(tau**2\
+            + 1)*(x + 1)) - (-2*tau*atan(x/tau) + (tau**2/2 - S.Half)*log(tau**2\
             + x**2))/(tau**2 + 1)**2)
     assert limit(expr, x, oo) == pi*tau**3/(tau**2 + 1)**2
 
@@ -192,7 +192,7 @@ def test_floor():
 
     # https://github.com/sympy/sympy/issues/14478
     assert limit(x*floor(3/x)/2, x, 0, '+') == Rational(3, 2)
-    assert limit(floor(x + 1/2) - floor(x), x, oo) == AccumBounds(-S.Half, S(3)/2)
+    assert limit(floor(x + S.Half) - floor(x), x, oo) == AccumBounds(-S.Half, S(3)/2)
 
 
 def test_floor_requires_robust_assumptions():
@@ -222,7 +222,7 @@ def test_ceiling():
 
     # https://github.com/sympy/sympy/issues/14478
     assert limit(x*ceiling(3/x)/2, x, 0, '+') == Rational(3, 2)
-    assert limit(ceiling(x + 1/2) - ceiling(x), x, oo) == AccumBounds(-S.Half, S(3)/2)
+    assert limit(ceiling(x + S.Half) - ceiling(x), x, oo) == AccumBounds(-S.Half, S(3)/2)
 
 
 def test_ceiling_requires_robust_assumptions():
@@ -380,7 +380,7 @@ def test_issue_5164():
 
 def test_issue_5383():
     func = (1.0 * 1 + 1.0 * x)**(1.0 * 1 / x)
-    assert limit(func, x, 0) == E
+    assert limit(func, x, 0) == N(E)
 
 
 def test_issue_14793():
@@ -705,7 +705,7 @@ def test_issue_11879():
 def test_limit_with_Float():
     k = symbols("k")
     assert limit(1.0 ** k, k, oo) == 1
-    assert limit(0.3*1.0**k, k, oo) == Rational(3, 10)
+    assert limit(0.3*1.0**k, k, oo) == 0.3
 
 
 def test_issue_10610():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -232,7 +232,7 @@ def test_issue_12791():
     sol = 0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta)\
         - 1.0)**2 + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)\
         + 0.25*cos(2*theta) + 1.25)/(0.5*cos(theta) - 1.0)**3\
-        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - S.Half)**2, (beta, S.Half))
+        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - 0.5)**2, (beta, 0.5))
 
     assert expr.series(beta, 0.5, 2).trigsimp() == sol
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#23499 

#### Brief description of what is fixed or changed
If a float is present in the original limit expression, the returned
result should also have floats

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * If the argument to limit contains floats, the final answer will also contain floats.
<!-- END RELEASE NOTES -->
