### PR TITLE
Improve performance of inverse trigonometric functions

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -39,6 +39,14 @@ def _corem(eq, c):  # helper for extract_additively
     return Add(*co), Add(*non)
 
 
+def _imaginary_unit_as_coefficient(arg):
+    """ Helper to extract symbolic coefficient for imaginary unit """
+    if getattr(arg, 'is_real', True):
+        return None
+    else:
+        return arg.as_coefficient(S.ImaginaryUnit)
+
+
 @sympify_method_args
 class Expr(Basic, EvalfMixin):
     """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -41,7 +41,7 @@ def _corem(eq, c):  # helper for extract_additively
 
 def _imaginary_unit_as_coefficient(arg):
     """ Helper to extract symbolic coefficient for imaginary unit """
-    if getattr(arg, 'is_real', True):
+    if arg.is_real:
         return None
     else:
         return arg.as_coefficient(S.ImaginaryUnit)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -39,7 +39,6 @@ def _corem(eq, c):  # helper for extract_additively
     return Add(*co), Add(*non)
 
 
-
 @sympify_method_args
 class Expr(Basic, EvalfMixin):
     """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -39,13 +39,6 @@ def _corem(eq, c):  # helper for extract_additively
     return Add(*co), Add(*non)
 
 
-def _imaginary_unit_as_coefficient(arg):
-    """ Helper to extract symbolic coefficient for imaginary unit """
-    if arg.is_real:
-        return None
-    else:
-        return arg.as_coefficient(S.ImaginaryUnit)
-
 
 @sympify_method_args
 class Expr(Basic, EvalfMixin):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1240,6 +1240,32 @@ class acosh(InverseHyperbolicFunction):
         else:
             raise ArgumentIndexError(self, argindex)
 
+    @staticmethod
+    @cacheit
+    def _acosh_table():
+        return {
+            S.ImaginaryUnit: log(S.ImaginaryUnit*(1 + sqrt(2))),
+            -S.ImaginaryUnit: log(-S.ImaginaryUnit*(1 + sqrt(2))),
+            S.Half: S.Pi/3,
+            Rational(-1, 2): S.Pi*Rational(2, 3),
+            sqrt(2)/2: S.Pi/4,
+            -sqrt(2)/2: S.Pi*Rational(3, 4),
+            1/sqrt(2): S.Pi/4,
+            -1/sqrt(2): S.Pi*Rational(3, 4),
+            sqrt(3)/2: S.Pi/6,
+            -sqrt(3)/2: S.Pi*Rational(5, 6),
+            (sqrt(3) - 1)/sqrt(2**3): S.Pi*Rational(5, 12),
+            -(sqrt(3) - 1)/sqrt(2**3): S.Pi*Rational(7, 12),
+            sqrt(2 + sqrt(2))/2: S.Pi/8,
+            -sqrt(2 + sqrt(2))/2: S.Pi*Rational(7, 8),
+            sqrt(2 - sqrt(2))/2: S.Pi*Rational(3, 8),
+            -sqrt(2 - sqrt(2))/2: S.Pi*Rational(5, 8),
+            (1 + sqrt(3))/(2*sqrt(2)): S.Pi/12,
+            -(1 + sqrt(3))/(2*sqrt(2)): S.Pi*Rational(11, 12),
+            (sqrt(5) + 1)/4: S.Pi/5,
+            -(sqrt(5) + 1)/4: S.Pi*Rational(4, 5)
+            }
+
     @classmethod
     def eval(cls, arg):
         arg = sympify(arg)
@@ -1259,28 +1285,7 @@ class acosh(InverseHyperbolicFunction):
                 return S.Pi*S.ImaginaryUnit
 
         if arg.is_number:
-            cst_table = {
-                S.ImaginaryUnit: log(S.ImaginaryUnit*(1 + sqrt(2))),
-                -S.ImaginaryUnit: log(-S.ImaginaryUnit*(1 + sqrt(2))),
-                S.Half: S.Pi/3,
-                Rational(-1, 2): S.Pi*Rational(2, 3),
-                sqrt(2)/2: S.Pi/4,
-                -sqrt(2)/2: S.Pi*Rational(3, 4),
-                1/sqrt(2): S.Pi/4,
-                -1/sqrt(2): S.Pi*Rational(3, 4),
-                sqrt(3)/2: S.Pi/6,
-                -sqrt(3)/2: S.Pi*Rational(5, 6),
-                (sqrt(3) - 1)/sqrt(2**3): S.Pi*Rational(5, 12),
-                -(sqrt(3) - 1)/sqrt(2**3): S.Pi*Rational(7, 12),
-                sqrt(2 + sqrt(2))/2: S.Pi/8,
-                -sqrt(2 + sqrt(2))/2: S.Pi*Rational(7, 8),
-                sqrt(2 - sqrt(2))/2: S.Pi*Rational(3, 8),
-                -sqrt(2 - sqrt(2))/2: S.Pi*Rational(5, 8),
-                (1 + sqrt(3))/(2*sqrt(2)): S.Pi/12,
-                -(1 + sqrt(3))/(2*sqrt(2)): S.Pi*Rational(11, 12),
-                (sqrt(5) + 1)/4: S.Pi/5,
-                -(sqrt(5) + 1)/4: S.Pi*Rational(4, 5)
-            }
+            cst_table = cls._acosh_table()
 
             if arg in cst_table:
                 if arg.is_extended_real:
@@ -1604,26 +1609,10 @@ class asech(InverseHyperbolicFunction):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    @classmethod
-    def eval(cls, arg):
-        arg = sympify(arg)
-
-        if arg.is_Number:
-            if arg is S.NaN:
-                return S.NaN
-            elif arg is S.Infinity:
-                return S.Pi*S.ImaginaryUnit / 2
-            elif arg is S.NegativeInfinity:
-                return S.Pi*S.ImaginaryUnit / 2
-            elif arg.is_zero:
-                return S.Infinity
-            elif arg is S.One:
-                return S.Zero
-            elif arg is S.NegativeOne:
-                return S.Pi*S.ImaginaryUnit
-
-        if arg.is_number:
-            cst_table = {
+    @staticmethod
+    @cacheit
+    def _asech_table():
+            return {
                 S.ImaginaryUnit: - (S.Pi*S.ImaginaryUnit / 2) + log(1 + sqrt(2)),
                 -S.ImaginaryUnit: (S.Pi*S.ImaginaryUnit / 2) + log(1 + sqrt(2)),
                 (sqrt(6) - sqrt(2)): S.Pi / 12,
@@ -1649,6 +1638,27 @@ class asech(InverseHyperbolicFunction):
                 (sqrt(6) + sqrt(2)): 5*S.Pi / 12,
                 (-sqrt(6) - sqrt(2)): 7*S.Pi / 12,
             }
+
+    @classmethod
+    def eval(cls, arg):
+        arg = sympify(arg)
+
+        if arg.is_Number:
+            if arg is S.NaN:
+                return S.NaN
+            elif arg is S.Infinity:
+                return S.Pi*S.ImaginaryUnit / 2
+            elif arg is S.NegativeInfinity:
+                return S.Pi*S.ImaginaryUnit / 2
+            elif arg.is_zero:
+                return S.Infinity
+            elif arg is S.One:
+                return S.Zero
+            elif arg is S.NegativeOne:
+                return S.Pi*S.ImaginaryUnit
+
+        if arg.is_number:
+            cst_table = cls._asech_table()
 
             if arg in cst_table:
                 if arg.is_extended_real:
@@ -1735,6 +1745,25 @@ class acsch(InverseHyperbolicFunction):
         else:
             raise ArgumentIndexError(self, argindex)
 
+    @staticmethod
+    @cacheit
+    def _acsch_table():
+        return {
+                S.ImaginaryUnit: -S.Pi / 2,
+                S.ImaginaryUnit*(sqrt(2) + sqrt(6)): -S.Pi / 12,
+                S.ImaginaryUnit*(1 + sqrt(5)): -S.Pi / 10,
+                S.ImaginaryUnit*2 / sqrt(2 - sqrt(2)): -S.Pi / 8,
+                S.ImaginaryUnit*2: -S.Pi / 6,
+                S.ImaginaryUnit*sqrt(2 + 2/sqrt(5)): -S.Pi / 5,
+                S.ImaginaryUnit*sqrt(2): -S.Pi / 4,
+                S.ImaginaryUnit*(sqrt(5)-1): -3*S.Pi / 10,
+                S.ImaginaryUnit*2 / sqrt(3): -S.Pi / 3,
+                S.ImaginaryUnit*2 / sqrt(2 + sqrt(2)): -3*S.Pi / 8,
+                S.ImaginaryUnit*sqrt(2 - 2/sqrt(5)): -2*S.Pi / 5,
+                S.ImaginaryUnit*(sqrt(6) - sqrt(2)): -5*S.Pi / 12,
+                S(2): -S.ImaginaryUnit*log((1+sqrt(5))/2),
+            }
+
     @classmethod
     def eval(cls, arg):
         arg = sympify(arg)
@@ -1754,21 +1783,7 @@ class acsch(InverseHyperbolicFunction):
                 return - log(1 + sqrt(2))
 
         if arg.is_number:
-            cst_table = {
-                S.ImaginaryUnit: -S.Pi / 2,
-                S.ImaginaryUnit*(sqrt(2) + sqrt(6)): -S.Pi / 12,
-                S.ImaginaryUnit*(1 + sqrt(5)): -S.Pi / 10,
-                S.ImaginaryUnit*2 / sqrt(2 - sqrt(2)): -S.Pi / 8,
-                S.ImaginaryUnit*2: -S.Pi / 6,
-                S.ImaginaryUnit*sqrt(2 + 2/sqrt(5)): -S.Pi / 5,
-                S.ImaginaryUnit*sqrt(2): -S.Pi / 4,
-                S.ImaginaryUnit*(sqrt(5)-1): -3*S.Pi / 10,
-                S.ImaginaryUnit*2 / sqrt(3): -S.Pi / 3,
-                S.ImaginaryUnit*2 / sqrt(2 + sqrt(2)): -3*S.Pi / 8,
-                S.ImaginaryUnit*sqrt(2 - 2/sqrt(5)): -2*S.Pi / 5,
-                S.ImaginaryUnit*(sqrt(6) - sqrt(2)): -5*S.Pi / 12,
-                S(2): -S.ImaginaryUnit*log((1+sqrt(5))/2),
-            }
+            cst_table = cls._acsch_table()
 
             if arg in cst_table:
                 return cst_table[arg]*S.ImaginaryUnit

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -2,7 +2,6 @@ from sympy.core.logic import FuzzyBool
 
 from sympy.core import S, sympify, cacheit, pi, I, Rational
 from sympy.core.add import Add
-from sympy.core.expr import _imaginary_unit_as_coefficient
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_or, fuzzy_and
 from sympy.functions.combinatorial.factorials import (binomial, factorial,
@@ -13,7 +12,8 @@ from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.trigonometric import (acot, asin, atan, cos,
-                                                      cot, sin, tan)
+                                              cot, sin, tan,
+                                              _imaginary_unit_as_coefficient)
 from sympy.polys.specialpolys import symmetric_poly
 
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -2,6 +2,7 @@ from sympy.core.logic import FuzzyBool
 
 from sympy.core import S, sympify, cacheit, pi, I, Rational
 from sympy.core.add import Add
+from sympy.core.expr import _imaginary_unit_as_coefficient
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_or, fuzzy_and
 from sympy.functions.combinatorial.factorials import (binomial, factorial,
@@ -128,7 +129,7 @@ class sinh(HyperbolicFunction):
             if arg is S.ComplexInfinity:
                 return S.NaN
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 return S.ImaginaryUnit * sin(i_coeff)
@@ -325,7 +326,7 @@ class cosh(HyperbolicFunction):
             if arg is S.ComplexInfinity:
                 return S.NaN
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 return cos(i_coeff)
@@ -569,7 +570,7 @@ class tanh(HyperbolicFunction):
             if arg is S.ComplexInfinity:
                 return S.NaN
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 if i_coeff.could_extract_minus_sign():
@@ -782,7 +783,7 @@ class coth(HyperbolicFunction):
             if arg is S.ComplexInfinity:
                 return S.NaN
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 if i_coeff.could_extract_minus_sign():
@@ -1151,7 +1152,7 @@ class asinh(InverseHyperbolicFunction):
             if arg.is_zero:
                 return S.Zero
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 return S.ImaginaryUnit * asin(i_coeff)
@@ -1408,7 +1409,7 @@ class atanh(InverseHyperbolicFunction):
                 from sympy.calculus.accumulationbounds import AccumBounds
                 return S.ImaginaryUnit*AccumBounds(-S.Pi/2, S.Pi/2)
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 return S.ImaginaryUnit * atan(i_coeff)
@@ -1517,7 +1518,7 @@ class acoth(InverseHyperbolicFunction):
             if arg is S.ComplexInfinity:
                 return S.Zero
 
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            i_coeff = _imaginary_unit_as_coefficient(arg)
 
             if i_coeff is not None:
                 return -S.ImaginaryUnit * acot(i_coeff)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2,7 +2,7 @@ from typing import Tuple as tTuple
 
 from sympy.core.add import Add
 from sympy.core.basic import sympify, cacheit
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, _imaginary_unit_as_coefficient
 from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
 from sympy.core.numbers import igcdex, Rational, pi, Integer
@@ -20,12 +20,6 @@ from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
 
-def _imaginary_unit_as_coefficient(arg):
-    """ Extracts symbolic coefficient for imaginary unit """
-    if getattr(arg, 'is_real', True):
-        return None
-    else:
-        return arg.as_coefficient(S.ImaginaryUnit)
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -19,7 +19,6 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
-from sympy.core.cache import cacheit
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -20,6 +20,13 @@ from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
 
+def _imaginary_unit_as_coefficient(arg):
+    """ Extracts symbolic coefficient for imaginary unit """
+    if getattr(arg, 'is_real', True):
+        return None
+    else:
+        return arg.as_coefficient(S.ImaginaryUnit)
+
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
 ###############################################################################
@@ -305,7 +312,7 @@ class sin(TrigonometricFunction):
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import sinh
             return S.ImaginaryUnit*sinh(i_coeff)
@@ -598,7 +605,7 @@ class cos(TrigonometricFunction):
         if arg.could_extract_minus_sign():
             return cls(-arg)
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import cosh
             return cosh(i_coeff)
@@ -1059,7 +1066,7 @@ class tan(TrigonometricFunction):
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import tanh
             return S.ImaginaryUnit*tanh(i_coeff)
@@ -1392,7 +1399,7 @@ class cot(TrigonometricFunction):
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import coth
             return -S.ImaginaryUnit*coth(i_coeff)
@@ -2257,7 +2264,7 @@ class asin(InverseTrigonometricFunction):
             if arg in asin_table:
                 return asin_table[arg]
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import asinh
             return S.ImaginaryUnit*asinh(i_coeff)
@@ -2467,7 +2474,7 @@ class acos(InverseTrigonometricFunction):
             elif -arg in asin_table:
                 return pi/2 + asin_table[-arg]
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             return pi/2 - asin(arg)
 
@@ -2694,7 +2701,7 @@ class atan(InverseTrigonometricFunction):
             if arg in atan_table:
                 return atan_table[arg]
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import atanh
             return S.ImaginaryUnit*atanh(i_coeff)
@@ -2890,7 +2897,7 @@ class acot(InverseTrigonometricFunction):
                     ang -= pi
                 return ang
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+        i_coeff = _imaginary_unit_as_coefficient(arg)
         if i_coeff is not None:
             from sympy.functions.elementary.hyperbolic import acoth
             return -S.ImaginaryUnit*acoth(i_coeff)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -19,6 +19,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
+from sympy.core.cache import cacheit
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
@@ -114,7 +115,7 @@ def _peeloff_pi(arg):
     pi_coeff = S.Zero
     rest_terms = []
     for a in Add.make_args(arg):
-        K = a.coeff(S.Pi)
+        K = a.coeff(pi)
         if K and K.is_rational:
             pi_coeff += K
         else:
@@ -168,12 +169,12 @@ def _pi_coeff(arg, cycles=1):
 
     """
     arg = sympify(arg)
-    if arg is S.Pi:
+    if arg is pi:
         return S.One
     elif not arg:
         return S.Zero
     elif arg.is_Mul:
-        cx = arg.coeff(S.Pi)
+        cx = arg.coeff(pi)
         if cx:
             c, x = cx.as_coeff_Mul()  # pi is not included as coeff
             if c.is_Float:
@@ -280,20 +281,20 @@ class sin(TrigonometricFunction):
         if isinstance(arg, AccumBounds):
             from sympy.sets.sets import FiniteSet
             min, max = arg.min, arg.max
-            d = floor(min/(2*S.Pi))
+            d = floor(min/(2*pi))
             if min is not S.NegativeInfinity:
-                min = min - d*2*S.Pi
+                min = min - d*2*pi
             if max is not S.Infinity:
-                max = max - d*2*S.Pi
-            if AccumBounds(min, max).intersection(FiniteSet(S.Pi/2, S.Pi*Rational(5, 2))) \
+                max = max - d*2*pi
+            if AccumBounds(min, max).intersection(FiniteSet(pi/2, pi*Rational(5, 2))) \
                     is not S.EmptySet and \
-                    AccumBounds(min, max).intersection(FiniteSet(S.Pi*Rational(3, 2),
-                        S.Pi*Rational(7, 2))) is not S.EmptySet:
+                    AccumBounds(min, max).intersection(FiniteSet(pi*Rational(3, 2),
+                        pi*Rational(7, 2))) is not S.EmptySet:
                 return AccumBounds(-1, 1)
-            elif AccumBounds(min, max).intersection(FiniteSet(S.Pi/2, S.Pi*Rational(5, 2))) \
+            elif AccumBounds(min, max).intersection(FiniteSet(pi/2, pi*Rational(5, 2))) \
                     is not S.EmptySet:
                 return AccumBounds(Min(sin(min), sin(max)), 1)
-            elif AccumBounds(min, max).intersection(FiniteSet(S.Pi*Rational(3, 2), S.Pi*Rational(8, 2))) \
+            elif AccumBounds(min, max).intersection(FiniteSet(pi*Rational(3, 2), pi*Rational(8, 2))) \
                         is not S.EmptySet:
                 return AccumBounds(-1, Max(sin(min), sin(max)))
             else:
@@ -322,7 +323,7 @@ class sin(TrigonometricFunction):
                     return S.NegativeOne**(pi_coeff - S.Half)
 
             if not pi_coeff.is_Rational:
-                narg = pi_coeff*S.Pi
+                narg = pi_coeff*pi
                 if narg != arg:
                     return cls(narg)
                 return None
@@ -332,21 +333,21 @@ class sin(TrigonometricFunction):
             if pi_coeff.is_Rational:
                 x = pi_coeff % 2
                 if x > 1:
-                    return -cls((x % 1)*S.Pi)
+                    return -cls((x % 1)*pi)
                 if 2*x > 1:
-                    return cls((1 - x)*S.Pi)
-                narg = ((pi_coeff + Rational(3, 2)) % 2)*S.Pi
+                    return cls((1 - x)*pi)
+                narg = ((pi_coeff + Rational(3, 2)) % 2)*pi
                 result = cos(narg)
                 if not isinstance(result, cos):
                     return result
-                if pi_coeff*S.Pi != arg:
-                    return cls(pi_coeff*S.Pi)
+                if pi_coeff*pi != arg:
+                    return cls(pi_coeff*pi)
                 return None
 
         if arg.is_Add:
             x, m = _peeloff_pi(arg)
             if m:
-                m = m*S.Pi
+                m = m*pi
                 return sin(m)*cos(x) + cos(m)*sin(x)
 
         if arg.is_zero:
@@ -415,7 +416,7 @@ class sin(TrigonometricFunction):
             return I*x**-I/2 - I*x**I /2
 
     def _eval_rewrite_as_cos(self, arg, **kwargs):
-        return cos(arg - S.Pi/2, evaluate=False)
+        return cos(arg - pi/2, evaluate=False)
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
         tan_half = tan(S.Half*arg)
@@ -438,7 +439,7 @@ class sin(TrigonometricFunction):
         return 1/csc(arg)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
-        return 1/sec(arg - S.Pi/2, evaluate=False)
+        return 1/sec(arg - pi/2, evaluate=False)
 
     def _eval_rewrite_as_sinc(self, arg, **kwargs):
         return arg*sinc(arg)
@@ -484,9 +485,9 @@ class sin(TrigonometricFunction):
         from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = x0/S.Pi
+        n = x0/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi).as_leading_term(x)
+            lt = (arg - n*pi).as_leading_term(x)
             return (S.NegativeOne**n)*lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -588,7 +589,7 @@ class cos(TrigonometricFunction):
             return S.NaN
 
         if isinstance(arg, AccumBounds):
-            return sin(arg + S.Pi/2)
+            return sin(arg + pi/2)
         elif isinstance(arg, SetExpr):
             return arg._eval_func(cls)
 
@@ -615,7 +616,7 @@ class cos(TrigonometricFunction):
                     return S.Zero
 
             if not pi_coeff.is_Rational:
-                narg = pi_coeff*S.Pi
+                narg = pi_coeff*pi
                 if narg != arg:
                     return cls(narg)
                 return None
@@ -635,10 +636,10 @@ class cos(TrigonometricFunction):
                 q = pi_coeff.q
                 p = pi_coeff.p % (2*q)
                 if p > q:
-                    narg = (pi_coeff - 1)*S.Pi
+                    narg = (pi_coeff - 1)*pi
                     return -cls(narg)
                 if 2*p > q:
-                    narg = (1 - pi_coeff)*S.Pi
+                    narg = (1 - pi_coeff)*pi
                     return -cls(narg)
 
                 # If nested sqrt's are worse than un-evaluation
@@ -656,11 +657,11 @@ class cos(TrigonometricFunction):
                     120: (40, 60)
                     }
                 if q in table2:
-                    a, b = p*S.Pi/table2[q][0], p*S.Pi/table2[q][1]
+                    a, b = p*pi/table2[q][0], p*pi/table2[q][1]
                     nvala, nvalb = cls(a), cls(b)
                     if None in (nvala, nvalb):
                         return None
-                    return nvala*nvalb + cls(S.Pi/2 - a)*cls(S.Pi/2 - b)
+                    return nvala*nvalb + cls(pi/2 - a)*cls(pi/2 - b)
 
                 if q > 12:
                     return None
@@ -670,7 +671,7 @@ class cos(TrigonometricFunction):
                     return chebyshevt(pi_coeff.p, cts).expand()
 
                 if 0 == q % 2:
-                    narg = (pi_coeff*2)*S.Pi
+                    narg = (pi_coeff*2)*pi
                     nval = cls(narg)
                     if None == nval:
                         return None
@@ -682,7 +683,7 @@ class cos(TrigonometricFunction):
         if arg.is_Add:
             x, m = _peeloff_pi(arg)
             if m:
-                m = m*S.Pi
+                m = m*pi
                 return cos(m)*cos(x) - sin(m)*sin(x)
 
         if arg.is_zero:
@@ -751,7 +752,7 @@ class cos(TrigonometricFunction):
             return x**I/2 + x**-I/2
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
-        return sin(arg + S.Pi/2, evaluate=False)
+        return sin(arg + pi/2, evaluate=False)
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
         tan_half = tan(S.Half*arg)**2
@@ -810,7 +811,7 @@ class cos(TrigonometricFunction):
 
         if pi_coeff.is_integer:
             # it was unevaluated
-            return self.func(pi_coeff*S.Pi)
+            return self.func(pi_coeff*pi)
 
         if not pi_coeff.is_Rational:
             return None
@@ -887,7 +888,7 @@ class cos(TrigonometricFunction):
 
         if not pi_coeff.q % 2:  # recursively remove factors of 2
             pico2 = pi_coeff*2
-            nval = cos(pico2*S.Pi).rewrite(sqrt)
+            nval = cos(pico2*pi).rewrite(sqrt)
             x = (pico2 + 1)/2
             sign_cos = -1 if int(x) % 2 else 1
             return sign_cos*sqrt( (1 + nval)/2 )
@@ -895,12 +896,12 @@ class cos(TrigonometricFunction):
         FC = _fermatCoords(pi_coeff.q)
         if FC:
             decomp = ipartfrac(pi_coeff, FC)
-            X = [(x[1], x[0]*S.Pi) for x in zip(decomp, numbered_symbols('z'))]
+            X = [(x[1], x[0]*pi) for x in zip(decomp, numbered_symbols('z'))]
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls.rewrite(sqrt)
         else:
             decomp = ipartfrac(pi_coeff)
-            X = [(x[1], x[0]*S.Pi) for x in zip(decomp, numbered_symbols('z'))]
+            X = [(x[1], x[0]*pi) for x in zip(decomp, numbered_symbols('z'))]
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls
 
@@ -943,9 +944,9 @@ class cos(TrigonometricFunction):
         from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = (x0 + S.Pi/2)/S.Pi
+        n = (x0 + pi/2)/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi + S.Pi/2).as_leading_term(x)
+            lt = (arg - n*pi + pi/2).as_leading_term(x)
             return (S.NegativeOne**n)*lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -1045,13 +1046,13 @@ class tan(TrigonometricFunction):
 
         if isinstance(arg, AccumBounds):
             min, max = arg.min, arg.max
-            d = floor(min/S.Pi)
+            d = floor(min/pi)
             if min is not S.NegativeInfinity:
-                min = min - d*S.Pi
+                min = min - d*pi
             if max is not S.Infinity:
-                max = max - d*S.Pi
+                max = max - d*pi
             from sympy.sets.sets import FiniteSet
-            if AccumBounds(min, max).intersection(FiniteSet(S.Pi/2, S.Pi*Rational(3, 2))):
+            if AccumBounds(min, max).intersection(FiniteSet(pi/2, pi*Rational(3, 2))):
                 return AccumBounds(S.NegativeInfinity, S.Infinity)
             else:
                 return AccumBounds(tan(min), tan(max))
@@ -1070,7 +1071,7 @@ class tan(TrigonometricFunction):
                 return S.Zero
 
             if not pi_coeff.is_Rational:
-                narg = pi_coeff*S.Pi
+                narg = pi_coeff*pi
                 if narg != arg:
                     return cls(narg)
                 return None
@@ -1093,8 +1094,8 @@ class tan(TrigonometricFunction):
                     else:
                         return table10[n]
                 if not pi_coeff.q % 2:
-                    narg = pi_coeff*S.Pi*2
-                    cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                    narg = pi_coeff*pi*2
+                    cresult, sresult = cos(narg), cos(narg - pi/2)
                     if not isinstance(cresult, cos) \
                             and not isinstance(sresult, cos):
                         if sresult == 0:
@@ -1111,14 +1112,14 @@ class tan(TrigonometricFunction):
                     120: (40, 60)
                     }
                 if q in table2:
-                    nvala, nvalb = cls(p*S.Pi/table2[q][0]), cls(p*S.Pi/table2[q][1])
+                    nvala, nvalb = cls(p*pi/table2[q][0]), cls(p*pi/table2[q][1])
                     if None in (nvala, nvalb):
                         return None
                     return (nvala - nvalb)/(1 + nvala*nvalb)
-                narg = ((pi_coeff + S.Half) % 1 - S.Half)*S.Pi
+                narg = ((pi_coeff + S.Half) % 1 - S.Half)*pi
                 # see cos() to specify which expressions should  be
                 # expanded automatically in terms of radicals
-                cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                cresult, sresult = cos(narg), cos(narg - pi/2)
                 if not isinstance(cresult, cos) \
                         and not isinstance(sresult, cos):
                     if cresult == 0:
@@ -1130,7 +1131,7 @@ class tan(TrigonometricFunction):
         if arg.is_Add:
             x, m = _peeloff_pi(arg)
             if m:
-                tanm = tan(m*S.Pi)
+                tanm = tan(m*pi)
                 if tanm is S.ComplexInfinity:
                     return -cot(x)
                 else: # tanm == 0
@@ -1182,7 +1183,7 @@ class tan(TrigonometricFunction):
             return S.NegativeOne**a*b*(b - 1)*B/F*x**n
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        i = self.args[0].limit(x, 0)*2/S.Pi
+        i = self.args[0].limit(x, 0)*2/pi
         if i and i.is_Integer:
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
         return Function._eval_nseries(self, x, n=n, logx=logx)
@@ -1244,7 +1245,7 @@ class tan(TrigonometricFunction):
         return 2*sin(x)**2/sin(2*x)
 
     def _eval_rewrite_as_cos(self, x, **kwargs):
-        return cos(x - S.Pi/2, evaluate=False)/cos(x)
+        return cos(x - pi/2, evaluate=False)/cos(x)
 
     def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return sin(arg)/cos(arg)
@@ -1279,9 +1280,9 @@ class tan(TrigonometricFunction):
         from sympy.functions.elementary.complexes import re
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = 2*x0/S.Pi
+        n = 2*x0/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi/2).as_leading_term(x)
+            lt = (arg - n*pi/2).as_leading_term(x)
             return lt if n.is_even else -1/lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -1387,7 +1388,7 @@ class cot(TrigonometricFunction):
             return S.NaN
 
         if isinstance(arg, AccumBounds):
-            return -tan(arg + S.Pi/2)
+            return -tan(arg + pi/2)
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)
@@ -1403,17 +1404,17 @@ class cot(TrigonometricFunction):
                 return S.ComplexInfinity
 
             if not pi_coeff.is_Rational:
-                narg = pi_coeff*S.Pi
+                narg = pi_coeff*pi
                 if narg != arg:
                     return cls(narg)
                 return None
 
             if pi_coeff.is_Rational:
                 if pi_coeff.q in (5, 10):
-                    return tan(S.Pi/2 - arg)
+                    return tan(pi/2 - arg)
                 if pi_coeff.q > 2 and not pi_coeff.q % 2:
-                    narg = pi_coeff*S.Pi*2
-                    cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                    narg = pi_coeff*pi*2
+                    cresult, sresult = cos(narg), cos(narg - pi/2)
                     if not isinstance(cresult, cos) \
                             and not isinstance(sresult, cos):
                         return 1/sresult + cresult/sresult
@@ -1430,14 +1431,14 @@ class cot(TrigonometricFunction):
                 q = pi_coeff.q
                 p = pi_coeff.p % q
                 if q in table2:
-                    nvala, nvalb = cls(p*S.Pi/table2[q][0]), cls(p*S.Pi/table2[q][1])
+                    nvala, nvalb = cls(p*pi/table2[q][0]), cls(p*pi/table2[q][1])
                     if None in (nvala, nvalb):
                         return None
                     return (1 + nvala*nvalb)/(nvalb - nvala)
-                narg = (((pi_coeff + S.Half) % 1) - S.Half)*S.Pi
+                narg = (((pi_coeff + S.Half) % 1) - S.Half)*pi
                 # see cos() to specify which expressions should be
                 # expanded automatically in terms of radicals
-                cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                cresult, sresult = cos(narg), cos(narg - pi/2)
                 if not isinstance(cresult, cos) \
                         and not isinstance(sresult, cos):
                     if sresult == 0:
@@ -1449,7 +1450,7 @@ class cot(TrigonometricFunction):
         if arg.is_Add:
             x, m = _peeloff_pi(arg)
             if m:
-                cotm = cot(m*S.Pi)
+                cotm = cot(m*pi)
                 if cotm is S.ComplexInfinity:
                     return cot(x)
                 else: # cotm == 0
@@ -1501,7 +1502,7 @@ class cot(TrigonometricFunction):
             return S.NegativeOne**((n + 1)//2)*2**(n + 1)*B/F*x**n
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        i = self.args[0].limit(x, 0)/S.Pi
+        i = self.args[0].limit(x, 0)/pi
         if i and i.is_Integer:
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
         return self.rewrite(tan)._eval_nseries(x, n=n, logx=logx)
@@ -1536,7 +1537,7 @@ class cot(TrigonometricFunction):
         return sin(2*x)/(2*(sin(x)**2))
 
     def _eval_rewrite_as_cos(self, x, **kwargs):
-        return cos(x)/cos(x - S.Pi/2, evaluate=False)
+        return cos(x)/cos(x - pi/2, evaluate=False)
 
     def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return cos(arg)/sin(arg)
@@ -1571,9 +1572,9 @@ class cot(TrigonometricFunction):
         from sympy.functions.elementary.complexes import re
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = 2*x0/S.Pi
+        n = 2*x0/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi/2).as_leading_term(x)
+            lt = (arg - n*pi/2).as_leading_term(x)
             return 1/lt if n.is_even else -lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -1635,7 +1636,7 @@ class cot(TrigonometricFunction):
     def _eval_subs(self, old, new):
         arg = self.args[0]
         argnew = arg.subs(old, new)
-        if arg != argnew and (argnew/S.Pi).is_integer:
+        if arg != argnew and (argnew/pi).is_integer:
             return S.ComplexInfinity
         return cot(argnew)
 
@@ -1669,10 +1670,10 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
                 q = pi_coeff.q
                 p = pi_coeff.p % (2*q)
                 if p > q:
-                    narg = (pi_coeff - 1)*S.Pi
+                    narg = (pi_coeff - 1)*pi
                     return -cls(narg)
                 if 2*p > q:
-                    narg = (1 - pi_coeff)*S.Pi
+                    narg = (1 - pi_coeff)*pi
                     if cls._is_odd:
                         return cls(narg)
                     elif cls._is_even:
@@ -1850,9 +1851,9 @@ class sec(ReciprocalTrigonometricFunction):
         from sympy.functions.elementary.complexes import re
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = (x0 + S.Pi/2)/S.Pi
+        n = (x0 + pi/2)/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi + S.Pi/2).as_leading_term(x)
+            lt = (arg - n*pi + pi/2).as_leading_term(x)
             return (S.NegativeOne**n)/lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -1951,9 +1952,9 @@ class csc(ReciprocalTrigonometricFunction):
         from sympy.functions.elementary.complexes import re
         arg = self.args[0]
         x0 = arg.subs(x, 0).cancel()
-        n = x0/S.Pi
+        n = x0/pi
         if n.is_integer:
-            lt = (arg - n*S.Pi).as_leading_term(x)
+            lt = (arg - n*pi).as_leading_term(x)
             return (S.NegativeOne**n)/lt
         if x0 is S.ComplexInfinity:
             x0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
@@ -2091,75 +2092,79 @@ class InverseTrigonometricFunction(Function):
     _singularities = (S.One, S.NegativeOne, S.Zero, S.ComplexInfinity)  # type: tTuple[Expr, ...]
 
     @staticmethod
+    @cacheit
     def _asin_table():
         # Only keys with could_extract_minus_sign() == False
         # are actually needed.
         return {
-            sqrt(3)/2: S.Pi/3,
-            sqrt(2)/2: S.Pi/4,
-            1/sqrt(2): S.Pi/4,
-            sqrt((5 - sqrt(5))/8): S.Pi/5,
-            sqrt(2)*sqrt(5 - sqrt(5))/4: S.Pi/5,
-            sqrt((5 + sqrt(5))/8): S.Pi*Rational(2, 5),
-            sqrt(2)*sqrt(5 + sqrt(5))/4: S.Pi*Rational(2, 5),
-            S.Half: S.Pi/6,
-            sqrt(2 - sqrt(2))/2: S.Pi/8,
-            sqrt(S.Half - sqrt(2)/4): S.Pi/8,
-            sqrt(2 + sqrt(2))/2: S.Pi*Rational(3, 8),
-            sqrt(S.Half + sqrt(2)/4): S.Pi*Rational(3, 8),
-            (sqrt(5) - 1)/4: S.Pi/10,
-            (1 - sqrt(5))/4: -S.Pi/10,
-            (sqrt(5) + 1)/4: S.Pi*Rational(3, 10),
-            sqrt(6)/4 - sqrt(2)/4: S.Pi/12,
-            -sqrt(6)/4 + sqrt(2)/4: -S.Pi/12,
-            (sqrt(3) - 1)/sqrt(8): S.Pi/12,
-            (1 - sqrt(3))/sqrt(8): -S.Pi/12,
-            sqrt(6)/4 + sqrt(2)/4: S.Pi*Rational(5, 12),
-            (1 + sqrt(3))/sqrt(8): S.Pi*Rational(5, 12)
+            sqrt(3)/2: pi/3,
+            sqrt(2)/2: pi/4,
+            1/sqrt(2): pi/4,
+            sqrt((5 - sqrt(5))/8): pi/5,
+            sqrt(2)*sqrt(5 - sqrt(5))/4: pi/5,
+            sqrt((5 + sqrt(5))/8): pi*Rational(2, 5),
+            sqrt(2)*sqrt(5 + sqrt(5))/4: pi*Rational(2, 5),
+            S.Half: pi/6,
+            sqrt(2 - sqrt(2))/2: pi/8,
+            sqrt(S.Half - sqrt(2)/4): pi/8,
+            sqrt(2 + sqrt(2))/2: pi*Rational(3, 8),
+            sqrt(S.Half + sqrt(2)/4): pi*Rational(3, 8),
+            (sqrt(5) - 1)/4: pi/10,
+            (1 - sqrt(5))/4: -pi/10,
+            (sqrt(5) + 1)/4: pi*Rational(3, 10),
+            sqrt(6)/4 - sqrt(2)/4: pi/12,
+            -sqrt(6)/4 + sqrt(2)/4: -pi/12,
+            (sqrt(3) - 1)/sqrt(8): pi/12,
+            (1 - sqrt(3))/sqrt(8): -pi/12,
+            sqrt(6)/4 + sqrt(2)/4: pi*Rational(5, 12),
+            (1 + sqrt(3))/sqrt(8): pi*Rational(5, 12)
         }
 
+
     @staticmethod
+    @cacheit
     def _atan_table():
         # Only keys with could_extract_minus_sign() == False
         # are actually needed.
         return {
-            sqrt(3)/3: S.Pi/6,
-            1/sqrt(3): S.Pi/6,
-            sqrt(3): S.Pi/3,
-            sqrt(2) - 1: S.Pi/8,
-            1 - sqrt(2): -S.Pi/8,
-            1 + sqrt(2): S.Pi*Rational(3, 8),
-            sqrt(5 - 2*sqrt(5)): S.Pi/5,
-            sqrt(5 + 2*sqrt(5)): S.Pi*Rational(2, 5),
-            sqrt(1 - 2*sqrt(5)/5): S.Pi/10,
-            sqrt(1 + 2*sqrt(5)/5): S.Pi*Rational(3, 10),
-            2 - sqrt(3): S.Pi/12,
-            -2 + sqrt(3): -S.Pi/12,
-            2 + sqrt(3): S.Pi*Rational(5, 12)
+            sqrt(3)/3: pi/6,
+            1/sqrt(3): pi/6,
+            sqrt(3): pi/3,
+            sqrt(2) - 1: pi/8,
+            1 - sqrt(2): -pi/8,
+            1 + sqrt(2): pi*Rational(3, 8),
+            sqrt(5 - 2*sqrt(5)): pi/5,
+            sqrt(5 + 2*sqrt(5)): pi*Rational(2, 5),
+            sqrt(1 - 2*sqrt(5)/5): pi/10,
+            sqrt(1 + 2*sqrt(5)/5): pi*Rational(3, 10),
+            2 - sqrt(3): pi/12,
+            -2 + sqrt(3): -pi/12,
+            2 + sqrt(3): pi*Rational(5, 12)
         }
 
     @staticmethod
+    @cacheit
     def _acsc_table():
         # Keys for which could_extract_minus_sign()
         # will obviously return True are omitted.
         return {
-            2*sqrt(3)/3: S.Pi/3,
-            sqrt(2): S.Pi/4,
-            sqrt(2 + 2*sqrt(5)/5): S.Pi/5,
-            1/sqrt(Rational(5, 8) - sqrt(5)/8): S.Pi/5,
-            sqrt(2 - 2*sqrt(5)/5): S.Pi*Rational(2, 5),
-            1/sqrt(Rational(5, 8) + sqrt(5)/8): S.Pi*Rational(2, 5),
-            2: S.Pi/6,
-            sqrt(4 + 2*sqrt(2)): S.Pi/8,
-            2/sqrt(2 - sqrt(2)): S.Pi/8,
-            sqrt(4 - 2*sqrt(2)): S.Pi*Rational(3, 8),
-            2/sqrt(2 + sqrt(2)): S.Pi*Rational(3, 8),
-            1 + sqrt(5): S.Pi/10,
-            sqrt(5) - 1: S.Pi*Rational(3, 10),
-            -(sqrt(5) - 1): S.Pi*Rational(-3, 10),
-            sqrt(6) + sqrt(2): S.Pi/12,
-            sqrt(6) - sqrt(2): S.Pi*Rational(5, 12),
-            -(sqrt(6) - sqrt(2)): S.Pi*Rational(-5, 12)
+            2*sqrt(3)/3: pi/3,
+            sqrt(2): pi/4,
+            sqrt(2 + 2*sqrt(5)/5): pi/5,
+            1/sqrt(Rational(5, 8) - sqrt(5)/8): pi/5,
+            sqrt(2 - 2*sqrt(5)/5): pi*Rational(2, 5),
+            1/sqrt(Rational(5, 8) + sqrt(5)/8): pi*Rational(2, 5),
+            2: pi/6,
+            sqrt(4 + 2*sqrt(2)): pi/8,
+            2/sqrt(2 - sqrt(2)): pi/8,
+            sqrt(4 - 2*sqrt(2)): pi*Rational(3, 8),
+            2/sqrt(2 + sqrt(2)): pi*Rational(3, 8),
+            1 + sqrt(5): pi/10,
+            sqrt(5) - 1: pi*Rational(3, 10),
+            -(sqrt(5) - 1): pi*Rational(-3, 10),
+            sqrt(6) + sqrt(2): pi/12,
+            sqrt(6) - sqrt(2): pi*Rational(5, 12),
+            -(sqrt(6) - sqrt(2)): pi*Rational(-5, 12)
         }
 
 
@@ -2238,9 +2243,9 @@ class asin(InverseTrigonometricFunction):
             elif arg.is_zero:
                 return S.Zero
             elif arg is S.One:
-                return S.Pi/2
+                return pi/2
             elif arg is S.NegativeOne:
-                return -S.Pi/2
+                return -pi/2
 
         if arg is S.ComplexInfinity:
             return S.ComplexInfinity
@@ -2307,9 +2312,9 @@ class asin(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = arg.dir(x, cdir)
         if im(cdir) < 0 and x0.is_real and x0 < S.NegativeOne:
-            return -S.Pi - self.func(x0)
+            return -pi - self.func(x0)
         elif im(cdir) > 0 and x0.is_real and x0 > S.One:
-            return S.Pi - self.func(x0)
+            return pi - self.func(x0)
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # asin
@@ -2322,7 +2327,7 @@ class asin(InverseTrigonometricFunction):
             f = arg1.as_leading_term(x)
             g = (arg1 - f)/ f
             if not g.is_meromorphic(x, 0):   # cannot be expanded
-                return O(1) if n == 0 else S.Pi/2 + O(sqrt(x))
+                return O(1) if n == 0 else pi/2 + O(sqrt(x))
             res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
@@ -2334,7 +2339,7 @@ class asin(InverseTrigonometricFunction):
             f = arg1.as_leading_term(x)
             g = (arg1 - f)/ f
             if not g.is_meromorphic(x, 0):   # cannot be expanded
-                return O(1) if n == 0 else -S.Pi/2 + O(sqrt(x))
+                return O(1) if n == 0 else -pi/2 + O(sqrt(x))
             res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
@@ -2345,13 +2350,13 @@ class asin(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = self.args[0].dir(x, cdir)
         if im(cdir) < 0 and arg0.is_real and arg0 < S.NegativeOne:
-            return -S.Pi - res
+            return -pi - res
         elif im(cdir) > 0 and arg0.is_real and arg0 > S.One:
-            return S.Pi - res
+            return pi - res
         return res
 
     def _eval_rewrite_as_acos(self, x, **kwargs):
-        return S.Pi/2 - acos(x)
+        return pi/2 - acos(x)
 
     def _eval_rewrite_as_atan(self, x, **kwargs):
         return 2*atan(x/(1 + sqrt(1 - x**2)))
@@ -2363,7 +2368,7 @@ class asin(InverseTrigonometricFunction):
         return 2*acot((1 + sqrt(1 - arg**2))/arg)
 
     def _eval_rewrite_as_asec(self, arg, **kwargs):
-        return S.Pi/2 - asec(1/arg)
+        return pi/2 - asec(1/arg)
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return acsc(1/arg)
@@ -2447,11 +2452,11 @@ class acos(InverseTrigonometricFunction):
             elif arg is S.NegativeInfinity:
                 return S.NegativeInfinity*S.ImaginaryUnit
             elif arg.is_zero:
-                return S.Pi/2
+                return pi/2
             elif arg is S.One:
                 return S.Zero
             elif arg is S.NegativeOne:
-                return S.Pi
+                return pi
 
         if arg is S.ComplexInfinity:
             return S.ComplexInfinity
@@ -2485,7 +2490,7 @@ class acos(InverseTrigonometricFunction):
     @cacheit
     def taylor_term(n, x, *previous_terms):
         if n == 0:
-            return S.Pi/2
+            return pi/2
         elif n < 0 or n % 2 == 0:
             return S.Zero
         else:
@@ -2509,7 +2514,7 @@ class acos(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = arg.dir(x, cdir)
         if im(cdir) < 0 and x0.is_real and x0 < S.NegativeOne:
-            return 2*S.Pi - self.func(x0)
+            return 2*pi - self.func(x0)
         elif im(cdir) > 0 and x0.is_real and x0 > S.One:
             return -self.func(x0)
         return self.func(x0)
@@ -2543,7 +2548,7 @@ class acos(InverseTrigonometricFunction):
             f = arg1.as_leading_term(x)
             g = (arg1 - f)/ f
             if not g.is_meromorphic(x, 0):   # cannot be expanded
-                return O(1) if n == 0 else S.Pi + O(sqrt(x))
+                return O(1) if n == 0 else pi + O(sqrt(x))
             res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
@@ -2554,20 +2559,20 @@ class acos(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = self.args[0].dir(x, cdir)
         if im(cdir) < 0 and arg0.is_real and arg0 < S.NegativeOne:
-            return 2*S.Pi - res
+            return 2*pi - res
         elif im(cdir) > 0 and arg0.is_real and arg0 > S.One:
             return -res
         return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
-        return S.Pi/2 + S.ImaginaryUnit*\
+        return pi/2 + S.ImaginaryUnit*\
             log(S.ImaginaryUnit*x + sqrt(1 - x**2))
 
     def _eval_rewrite_as_asin(self, x, **kwargs):
-        return S.Pi/2 - asin(x)
+        return pi/2 - asin(x)
 
     def _eval_rewrite_as_atan(self, x, **kwargs):
-        return atan(sqrt(1 - x**2)/x) + (S.Pi/2)*(1 - x*sqrt(1/x**2))
+        return atan(sqrt(1 - x**2)/x) + (pi/2)*(1 - x*sqrt(1/x**2))
 
     def inverse(self, argindex=1):
         """
@@ -2576,13 +2581,13 @@ class acos(InverseTrigonometricFunction):
         return cos
 
     def _eval_rewrite_as_acot(self, arg, **kwargs):
-        return S.Pi/2 - 2*acot((1 + sqrt(1 - arg**2))/arg)
+        return pi/2 - 2*acot((1 + sqrt(1 - arg**2))/arg)
 
     def _eval_rewrite_as_asec(self, arg, **kwargs):
         return asec(1/arg)
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
-        return S.Pi/2 - acsc(1/arg)
+        return pi/2 - acsc(1/arg)
 
     def _eval_conjugate(self):
         z = self.args[0]
@@ -2668,19 +2673,19 @@ class atan(InverseTrigonometricFunction):
             if arg is S.NaN:
                 return S.NaN
             elif arg is S.Infinity:
-                return S.Pi/2
+                return pi/2
             elif arg is S.NegativeInfinity:
-                return -S.Pi/2
+                return -pi/2
             elif arg.is_zero:
                 return S.Zero
             elif arg is S.One:
-                return S.Pi/4
+                return pi/4
             elif arg is S.NegativeOne:
-                return -S.Pi/4
+                return -pi/4
 
         if arg is S.ComplexInfinity:
             from sympy.calculus.accumulationbounds import AccumBounds
-            return AccumBounds(-S.Pi/2, S.Pi/2)
+            return AccumBounds(-pi/2, pi/2)
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)
@@ -2734,9 +2739,9 @@ class atan(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = arg.dir(x, cdir)
         if re(cdir) < 0 and re(x0).is_zero and im(x0) > S.One:
-            return self.func(x0) - S.Pi
+            return self.func(x0) - pi
         elif re(cdir) > 0 and re(x0).is_zero and im(x0) < S.NegativeOne:
-            return self.func(x0) + S.Pi
+            return self.func(x0) + pi
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # atan
@@ -2746,12 +2751,12 @@ class atan(InverseTrigonometricFunction):
             cdir = self.args[0].dir(x, cdir)
         if arg0 is S.ComplexInfinity:
             if re(cdir) > 0:
-                return res - S.Pi
+                return res - pi
             return res
         if re(cdir) < 0 and re(arg0).is_zero and im(arg0) > S.One:
-            return res - S.Pi
+            return res - pi
         elif re(cdir) > 0 and re(arg0).is_zero and im(arg0) < S.NegativeOne:
-            return res + S.Pi
+            return res + pi
         return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
@@ -2760,9 +2765,9 @@ class atan(InverseTrigonometricFunction):
 
     def _eval_aseries(self, n, args0, x, logx):
         if args0[0] is S.Infinity:
-            return (S.Pi/2 - atan(1/self.args[0]))._eval_nseries(x, n, logx)
+            return (pi/2 - atan(1/self.args[0]))._eval_nseries(x, n, logx)
         elif args0[0] is S.NegativeInfinity:
-            return (-S.Pi/2 - atan(1/self.args[0]))._eval_nseries(x, n, logx)
+            return (-pi/2 - atan(1/self.args[0]))._eval_nseries(x, n, logx)
         else:
             return super()._eval_aseries(n, args0, x, logx)
 
@@ -2773,7 +2778,7 @@ class atan(InverseTrigonometricFunction):
         return tan
 
     def _eval_rewrite_as_asin(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(S.Pi/2 - asin(1/sqrt(1 + arg**2)))
+        return sqrt(arg**2)/arg*(pi/2 - asin(1/sqrt(1 + arg**2)))
 
     def _eval_rewrite_as_acos(self, arg, **kwargs):
         return sqrt(arg**2)/arg*acos(1/sqrt(1 + arg**2))
@@ -2785,7 +2790,7 @@ class atan(InverseTrigonometricFunction):
         return sqrt(arg**2)/arg*asec(sqrt(1 + arg**2))
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(S.Pi/2 - acsc(sqrt(1 + arg**2)))
+        return sqrt(arg**2)/arg*(pi/2 - acsc(sqrt(1 + arg**2)))
 
 
 class acot(InverseTrigonometricFunction):
@@ -2866,11 +2871,11 @@ class acot(InverseTrigonometricFunction):
             elif arg is S.NegativeInfinity:
                 return S.Zero
             elif arg.is_zero:
-                return S.Pi/ 2
+                return pi/ 2
             elif arg is S.One:
-                return S.Pi/4
+                return pi/4
             elif arg is S.NegativeOne:
-                return -S.Pi/4
+                return -pi/4
 
         if arg is S.ComplexInfinity:
             return S.Zero
@@ -2892,7 +2897,7 @@ class acot(InverseTrigonometricFunction):
             return -S.ImaginaryUnit*acoth(i_coeff)
 
         if arg.is_zero:
-            return S.Pi*S.Half
+            return pi*S.Half
 
         if isinstance(arg, cot):
             ang = arg.args[0]
@@ -2914,7 +2919,7 @@ class acot(InverseTrigonometricFunction):
     @cacheit
     def taylor_term(n, x, *previous_terms):
         if n == 0:
-            return S.Pi/2  # FIX THIS
+            return pi/2  # FIX THIS
         elif n < 0 or n % 2 == 0:
             return S.Zero
         else:
@@ -2930,12 +2935,12 @@ class acot(InverseTrigonometricFunction):
             cdir = arg.dir(x, cdir)
         if x0.is_zero:
             if re(cdir) < 0:
-                return self.func(x0) - S.Pi
+                return self.func(x0) - pi
             return self.func(x0)
         if re(cdir) > 0 and re(x0).is_zero and im(x0) > S.Zero and im(x0) < S.One:
-            return self.func(x0) + S.Pi
+            return self.func(x0) + pi
         if re(cdir) < 0 and re(x0).is_zero and im(x0) < S.Zero and im(x0) > S.NegativeOne:
-            return self.func(x0) - S.Pi
+            return self.func(x0) - pi
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acot
@@ -2947,19 +2952,19 @@ class acot(InverseTrigonometricFunction):
             cdir = self.args[0].dir(x, cdir)
         if arg0.is_zero:
             if re(cdir) < 0:
-                return res - S.Pi
+                return res - pi
             return res
         if re(cdir) > 0 and re(arg0).is_zero and im(arg0) > S.Zero and im(arg0) < S.One:
-            return res + S.Pi
+            return res + pi
         if re(cdir) < 0 and re(arg0).is_zero and im(arg0) < S.Zero and im(arg0) > S.NegativeOne:
-            return res - S.Pi
+            return res - pi
         return res
 
     def _eval_aseries(self, n, args0, x, logx):
         if args0[0] is S.Infinity:
-            return (S.Pi/2 - acot(1/self.args[0]))._eval_nseries(x, n, logx)
+            return (pi/2 - acot(1/self.args[0]))._eval_nseries(x, n, logx)
         elif args0[0] is S.NegativeInfinity:
-            return (S.Pi*Rational(3, 2) - acot(1/self.args[0]))._eval_nseries(x, n, logx)
+            return (pi*Rational(3, 2) - acot(1/self.args[0]))._eval_nseries(x, n, logx)
         else:
             return super(atan, self)._eval_aseries(n, args0, x, logx)
 
@@ -2975,7 +2980,7 @@ class acot(InverseTrigonometricFunction):
 
     def _eval_rewrite_as_asin(self, arg, **kwargs):
         return (arg*sqrt(1/arg**2)*
-                (S.Pi/2 - asin(sqrt(-arg**2)/sqrt(-arg**2 - 1))))
+                (pi/2 - asin(sqrt(-arg**2)/sqrt(-arg**2 - 1))))
 
     def _eval_rewrite_as_acos(self, arg, **kwargs):
         return arg*sqrt(1/arg**2)*acos(sqrt(-arg**2)/sqrt(-arg**2 - 1))
@@ -2987,7 +2992,7 @@ class acot(InverseTrigonometricFunction):
         return arg*sqrt(1/arg**2)*asec(sqrt((1 + arg**2)/arg**2))
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
-        return arg*sqrt(1/arg**2)*(S.Pi/2 - acsc(sqrt((1 + arg**2)/arg**2)))
+        return arg*sqrt(1/arg**2)*(pi/2 - acsc(sqrt((1 + arg**2)/arg**2)))
 
 
 class asec(InverseTrigonometricFunction):
@@ -3060,9 +3065,9 @@ class asec(InverseTrigonometricFunction):
             elif arg is S.One:
                 return S.Zero
             elif arg is S.NegativeOne:
-                return S.Pi
+                return pi
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
-            return S.Pi/2
+            return pi/2
 
         if arg.is_number:
             acsc_table = cls._acsc_table()
@@ -3109,7 +3114,7 @@ class asec(InverseTrigonometricFunction):
         if im(cdir) < 0 and x0.is_real and x0 > S.Zero and x0 < S.One:
             return -self.func(x0)
         elif im(cdir) > 0 and x0.is_real and x0 < S.Zero and x0 > S.NegativeOne:
-            return 2*S.Pi - self.func(x0)
+            return 2*pi - self.func(x0)
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # asec
@@ -3143,7 +3148,7 @@ class asec(InverseTrigonometricFunction):
         if im(cdir) < 0 and arg0.is_real and arg0 > S.Zero and arg0 < S.One:
             return -res
         elif im(cdir) > 0 and arg0.is_real and arg0 < S.Zero and arg0 > S.NegativeOne:
-            return 2*S.Pi - res
+            return 2*pi - res
         return res
 
     def _eval_is_extended_real(self):
@@ -3153,22 +3158,22 @@ class asec(InverseTrigonometricFunction):
         return fuzzy_or(((x - 1).is_nonnegative, (-x - 1).is_nonnegative))
 
     def _eval_rewrite_as_log(self, arg, **kwargs):
-        return S.Pi/2 + S.ImaginaryUnit*log(S.ImaginaryUnit/arg + sqrt(1 - 1/arg**2))
+        return pi/2 + S.ImaginaryUnit*log(S.ImaginaryUnit/arg + sqrt(1 - 1/arg**2))
 
     def _eval_rewrite_as_asin(self, arg, **kwargs):
-        return S.Pi/2 - asin(1/arg)
+        return pi/2 - asin(1/arg)
 
     def _eval_rewrite_as_acos(self, arg, **kwargs):
         return acos(1/arg)
 
     def _eval_rewrite_as_atan(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(-S.Pi/2 + 2*atan(arg + sqrt(arg**2 - 1)))
+        return sqrt(arg**2)/arg*(-pi/2 + 2*atan(arg + sqrt(arg**2 - 1)))
 
     def _eval_rewrite_as_acot(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(-S.Pi/2 + 2*acot(arg - sqrt(arg**2 - 1)))
+        return sqrt(arg**2)/arg*(-pi/2 + 2*acot(arg - sqrt(arg**2 - 1)))
 
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
-        return S.Pi/2 - acsc(arg)
+        return pi/2 - acsc(arg)
 
 
 class acsc(InverseTrigonometricFunction):
@@ -3222,9 +3227,9 @@ class acsc(InverseTrigonometricFunction):
             if arg is S.NaN:
                 return S.NaN
             elif arg is S.One:
-                return S.Pi/2
+                return pi/2
             elif arg is S.NegativeOne:
-                return -S.Pi/2
+                return -pi/2
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
             return S.Zero
 
@@ -3278,9 +3283,9 @@ class acsc(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = arg.dir(x, cdir)
         if im(cdir) < 0 and x0.is_real and x0 > S.Zero and x0 < S.One:
-            return S.Pi - self.func(x0)
+            return pi - self.func(x0)
         elif im(cdir) > 0 and x0.is_real and x0 < S.Zero and x0 > S.NegativeOne:
-            return -S.Pi - self.func(x0)
+            return -pi - self.func(x0)
         return self.func(x0)
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acsc
@@ -3312,9 +3317,9 @@ class acsc(InverseTrigonometricFunction):
         if cdir != 0:
             cdir = self.args[0].dir(x, cdir)
         if im(cdir) < 0 and arg0.is_real and arg0 > S.Zero and arg0 < S.One:
-            return S.Pi - res
+            return pi - res
         elif im(cdir) > 0 and arg0.is_real and arg0 < S.Zero and arg0 > S.NegativeOne:
-            return -S.Pi - res
+            return -pi - res
         return res
 
     def _eval_rewrite_as_log(self, arg, **kwargs):
@@ -3324,16 +3329,16 @@ class acsc(InverseTrigonometricFunction):
         return asin(1/arg)
 
     def _eval_rewrite_as_acos(self, arg, **kwargs):
-        return S.Pi/2 - acos(1/arg)
+        return pi/2 - acos(1/arg)
 
     def _eval_rewrite_as_atan(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(S.Pi/2 - atan(sqrt(arg**2 - 1)))
+        return sqrt(arg**2)/arg*(pi/2 - atan(sqrt(arg**2 - 1)))
 
     def _eval_rewrite_as_acot(self, arg, **kwargs):
-        return sqrt(arg**2)/arg*(S.Pi/2 - acot(1/sqrt(arg**2 - 1)))
+        return sqrt(arg**2)/arg*(pi/2 - acot(1/sqrt(arg**2 - 1)))
 
     def _eval_rewrite_as_asec(self, arg, **kwargs):
-        return S.Pi/2 - asec(arg)
+        return pi/2 - asec(arg)
 
 
 class atan2(InverseTrigonometricFunction):
@@ -3445,8 +3450,8 @@ class atan2(InverseTrigonometricFunction):
         if x is S.NegativeInfinity:
             if y.is_zero:
                 # Special case y = 0 because we define Heaviside(0) = 1/2
-                return S.Pi
-            return 2*S.Pi*(Heaviside(re(y))) - S.Pi
+                return pi
+            return 2*pi*(Heaviside(re(y))) - pi
         elif x is S.Infinity:
             return S.Zero
         elif x.is_imaginary and y.is_imaginary and x.is_number and y.is_number:
@@ -3458,21 +3463,21 @@ class atan2(InverseTrigonometricFunction):
                 return atan(y/x)
             elif x.is_negative:
                 if y.is_negative:
-                    return atan(y/x) - S.Pi
+                    return atan(y/x) - pi
                 elif y.is_nonnegative:
-                    return atan(y/x) + S.Pi
+                    return atan(y/x) + pi
             elif x.is_zero:
                 if y.is_positive:
-                    return S.Pi/2
+                    return pi/2
                 elif y.is_negative:
-                    return -S.Pi/2
+                    return -pi/2
                 elif y.is_zero:
                     return S.NaN
         if y.is_zero:
             if x.is_extended_nonzero:
-                return S.Pi*(S.One - Heaviside(x))
+                return pi*(S.One - Heaviside(x))
             if x.is_number:
-                return Piecewise((S.Pi, re(x) < 0),
+                return Piecewise((pi, re(x) < 0),
                                  (0, Ne(x, 0)),
                                  (S.NaN, True))
         if x.is_number and y.is_number:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2,10 +2,10 @@ from typing import Tuple as tTuple
 
 from sympy.core.add import Add
 from sympy.core.basic import sympify, cacheit
-from sympy.core.expr import Expr, _imaginary_unit_as_coefficient
+from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
-from sympy.core.numbers import igcdex, Rational, pi, Integer
+from sympy.core.numbers import igcdex, Rational, pi, Integer, Float
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
@@ -20,6 +20,18 @@ from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
 
+
+###############################################################################
+########################## UTILITIES ##########################################
+###############################################################################
+
+
+def _imaginary_unit_as_coefficient(arg):
+    """ Helper to extract symbolic coefficient for imaginary unit """
+    if isinstance(arg, Float):
+        return None
+    else:
+        return arg.as_coefficient(S.ImaginaryUnit)
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This PR improves performance of the inverse trigonometric functions by:

* Caching the lookup tables in `InverseTrigonometricFunction` (so the tables are not constructed for each invocation of the function)
* Consistently using the variable `pi` instead of `S.Pi` (which saves an attribute lookup)

The main speed improvement is for numbers. Two benchmarks:

```
%timeit atan(np.random.rand()) 
#main: 670 µs ± 19.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
#PR: 488 µs ± 1.47 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

```
%timeit asin(np.random.rand()) # 670 us on main, 512 us with class init of _atsin_table
#main: 865 µs ± 10.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
#PR: 513 µs ± 705 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
#### Other comments

The same improvements can be applied to other functions in the sympy codebase. The changes in this PR are limited to a single file to keep the PR small and first discuss whether the approach is good.

For catching the sympy `cacheit` method is used. Since the lookup table methods have no arguments, this is a bit overkill. We could replace it by `functools.lru_cache(size=1)`

Another approach would be to replace the `_atan_table` with a class attribute. This failed because of circular references.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improve performance of trigonometric functions
<!-- END RELEASE NOTES -->
