### PR TITLE
simplify function is added in util.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -955,6 +955,7 @@ Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>
 Omkaar <79257339+Pysics@users.noreply.github.com>
+Omkar <omkarhalgi50@gmail.com>
 Ondřej Čertík <ondrej@certik.cz>
 Ondřej Čertík <ondrej@certik.cz> <ondrej.certik@gmail.com>
 Ondřej Čertík <ondrej@certik.cz> <ondrej@certik.us>

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -11,7 +11,6 @@ from sympy.core.containers import Tuple
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.sorting import ordered
-from sympy.simplify.simplify import simplify
 from sympy.core.sympify import sympify
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension, DimensionSystem

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -11,6 +11,7 @@ from sympy.core.containers import Tuple
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.sorting import ordered
+from sympy.simplify.simplify import simplify
 from sympy.core.sympify import sympify
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension, DimensionSystem
@@ -49,6 +50,7 @@ def _get_conversion_matrix_for_expr(expr, target_units, unit_system):
 
 
 def convert_to(expr, target_units, unit_system="SI"):
+    expr=expr.simplify()
     """
     Convert ``expr`` to the same expression with all of its units and quantities
     represented as factors of ``target_units``, whenever the dimension is compatible.


### PR DESCRIPTION
convert_to function in util.py is modified used simplify function from sympy to tackle the unit not showing problem

#### Fixes #23375


#### Code which does not show the unit before modifying util.py
```
import sympy
from sympy import *
from sympy.physics.units import *

expr1 = Mul(Float('2.9357798165137616e-13', precision=53), Pow(centimeter, Integer(-2)), Pow(meter, Integer(-2)), kilogram, Add(Mul(Float('415734822253.0', precision=53), Pow(centimeter, Integer(2))), Mul(Float('29293750.0', precision=53), Pow(meter, Integer(2)))))
print(expr1.simplify())
print(convert_to(expr1, kg/m**2).simplify())
```
#### Output
```
2.08050590019229e-5*kilogram/centimeter**2
0.208050590019229*kilogram
```

#### After modifying the util.py convert_to function 

![Screenshot (186)](https://user-images.githubusercontent.com/70062727/170647557-d0af6fe6-6c0d-451a-b2b1-fcea9a696b83.png)

<!-- BEGIN RELEASE NOTES -->
* core
  * simplify function is passed to convert expression to simplified expression 
* printing
  * The output is displayed with the units  
<!-- END RELEASE NOTES -->