### PR TITLE
Add sphinx test coverage to coverage_doctest.py

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -31,6 +31,8 @@ except ImportError:
     from html.parser import HTMLParser
 
 from sympy.utilities.misc import filldedent
+from lxml import html
+import requests
 
 
 # Load color templates, duplicated from sympy/testing/runtests.py
@@ -260,28 +262,73 @@ def get_mod_name(path, base):
 
     return file_module[:-1]
 
-class FindInSphinx(HTMLParser):
-    is_imported = []
-    def handle_starttag(self, tag, attr):
-        a = dict(attr)
-        if tag == "div" and a.get('class', None) == "viewcode-block":
-            self.is_imported.append(a['id'])
-
-def find_sphinx(name, mod_path, found={}):
-    if mod_path in found: # Cache results
-        return name in found[mod_path]
-
-    doc_path = mod_path.split('.')
-    doc_path[-1] += '.html'
-    sphinx_path = os.path.join(sympy_top, 'doc', '_build', 'html', '_modules', *doc_path)
-    if not os.path.exists(sphinx_path):
+def find_codeblock(html_tree, name):
+    # Code block element has class 'highlight-default notranslate'
+    # so this xpath checks if html tree that follows an element
+    # with the module name contains a code block
+    xpath = "//*[@id='" + name + \
+            "']/following-sibling::*/descendant-or-self::" \
+            "div[contains(@class, 'highlight-default notranslate')]"
+    codeblock_element = html_tree.xpath(xpath)
+    if not codeblock_element:
         return False
-    with open(sphinx_path) as f:
-        html_txt = f.read()
-    p = FindInSphinx()
-    p.feed(html_txt)
-    found[mod_path] = p.is_imported
-    return name in p.is_imported
+    return True
+
+def find_sphinx(name, mod_path):
+    # Find sphinx coverage based on a few possible paths for html file,
+    # returns False if there is no code example for module
+    doc_path = mod_path.split('.')
+    fin = doc_path[1:]
+    document_path = fin[:3]
+
+    document_path_tmp = document_path.copy()
+    document_path_other_version = document_path.copy()
+
+    possible_path_list = find_module_html_paths(document_path)
+
+    for path in possible_path_list:
+        if os.path.exists(path):
+            with open(path) as f:
+                html_txt = f.read()
+            html_tree = html.fromstring(html_txt)
+            document_path_tmp.insert(0, "sympy")
+            document_path_tmp.append(name)
+            fullname = ".".join(document_path_tmp)
+
+            if document_path_other_version[-1] == document_path_other_version[-2]:
+                document_path_other_version.pop()
+            document_path_other_version.insert(0, "sympy")
+            document_path_other_version.append(name)
+            othername = ".".join(document_path_other_version)
+
+            if find_codeblock(html_tree, fullname) or find_codeblock(html_tree, othername):
+                return True
+        else:
+            continue
+        return False
+
+def find_module_html_paths(document_path):
+    # Find all paths that should be checked given the module name
+    # (i.e. look for a self titled html file or index.html as well as
+    # a html file with the module name)
+    path_list = []
+    # While not os.path.exists(sphinx_path):
+    while len(document_path) > 1:
+        document_path[-1] = document_path[-1].replace('_', '')
+        document_path[-1] += '.html'
+        path_list.append(os.path.join(sympy_top, 'doc', '_build', 'html', 'modules', *document_path))
+        document_path[-1] = "index.html"
+        path_list.append(os.path.join(sympy_top, 'doc', '_build', 'html', 'modules', *document_path))
+
+        # Look if module is in self titled html file (i.e. file for modules that dont deserve their own)
+        if len(document_path) > 1:
+            document_path[-1] = document_path[-2]
+            document_path[-1] += '.html'
+            path_list.append(os.path.join(sympy_top, 'doc', '_build', 'html', 'modules', *document_path))
+        document_path.pop()
+    document_path[-1] += '.html'
+    path_list.append(os.path.join(sympy_top, 'doc', '_build', 'html', 'modules', *document_path))
+    return path_list
 
 def process_function(name, c_name, b_obj, mod_path, f_skip, f_missing_doc, f_missing_doctest, f_indirect_doctest,
                      f_has_doctest, skip_list, sph, sphinx=True):

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -281,8 +281,8 @@ def find_sphinx(name, mod_path):
     fin = doc_path[1:]
     document_path = fin[:3]
 
-    document_path_tmp = document_path.copy()
-    document_path_other_version = document_path.copy()
+    document_path_copy_1 = document_path.copy()
+    document_path_copy_2 = document_path.copy()
 
     possible_path_list = find_module_html_paths(document_path)
 
@@ -291,15 +291,18 @@ def find_sphinx(name, mod_path):
             with open(path) as f:
                 html_txt = f.read()
             html_tree = html.fromstring(html_txt)
-            document_path_tmp.insert(0, "sympy")
-            document_path_tmp.append(name)
-            fullname = ".".join(document_path_tmp)
 
-            if document_path_other_version[-1] == document_path_other_version[-2]:
-                document_path_other_version.pop()
-            document_path_other_version.insert(0, "sympy")
-            document_path_other_version.append(name)
-            othername = ".".join(document_path_other_version)
+            # Create the formatted module name to be searched for in the html file
+            document_path_copy_1.insert(0, "sympy")
+            document_path_copy_1.append(name)
+            fullname = ".".join(document_path_copy_1)
+
+            # Find another possible module name
+            if document_path_copy_2[-1] == document_path_copy_2[-2]:
+                document_path_copy_2.pop()
+            document_path_copy_2.insert(0, "sympy")
+            document_path_copy_2.append(name)
+            othername = ".".join(document_path_copy_2)
 
             if find_codeblock(html_tree, fullname) or find_codeblock(html_tree, othername):
                 return True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #22429

#### Brief description of what is fixed or changed
Coverage_doctest.py’s sphinx coverage test is failing due to failure to find html file paths correctly and issues with reading html file contents incorrectly. This fix updates the way that coverage_doctest looks for html files, and looks in several possible locations. It also uses xpaths to find html elements that are used to show code examples. Coverage_doctest now has a 9% sphinx success rate.

#### Other comments
Output:
```
======================================================================
TOTAL DOCTEST SCORE for sympy: 82% (13741 of 16574)
TOTAL SPHINX SCORE for sympy: 9% (1592 of 16574)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
