### PR TITLE
manualintegrate x**n*(trig or Derivative)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -580,7 +580,7 @@ def _parts_rule(integrand, symbol):
     def pull_out_algebraic(integrand):
         integrand = integrand.cancel().together()
         # iterating over Piecewise args would not work here
-        algebraic = ([] if isinstance(integrand, Piecewise)
+        algebraic = ([] if isinstance(integrand, Piecewise) or not integrand.is_Mul
             else [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)])
         if algebraic:
             u = Mul(*algebraic)
@@ -633,7 +633,9 @@ def _parts_rule(integrand, symbol):
                         return
 
             # Can integrate a polynomial times OrthogonalPolynomial
-            if rule == pull_out_algebraic and isinstance(dv, OrthogonalPolynomial):
+            if rule == pull_out_algebraic:
+                if dv.is_Derivative or dv.has(TrigonometricFunction) or \
+                        isinstance(dv, OrthogonalPolynomial):
                     v_step = integral_steps(dv, symbol)
                     if contains_dont_know(v_step):
                         return
@@ -723,12 +725,7 @@ def parts_rule(integral):
             return PartsRule(u, dv, v_step,
                              make_second_step(steps[1:], v * du),
                              integrand, symbol)
-        else:
-            steps = integral_steps(integrand, symbol)
-            if steps:
-                return steps
-            else:
-                return DontKnowRule(integrand, symbol)
+        return integral_steps(integrand, symbol)
 
     if steps:
         u, dv, v, du, v_step = steps[0]

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -8,7 +8,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (sech, sinh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (acos, atan, cos, sec, sin, tan)
+from sympy.functions.elementary.trigonometric import (acos, atan, cos, sin, tan)
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy.functions.special.gamma_functions import gamma
 from sympy.integrals.integrals import (Integral, integrate)
@@ -118,13 +118,6 @@ def test_issue_16396a():
 def test_issue_16396b():
     i = integrate(x*sin(x)/(1+cos(x)**2), (x, 0, pi))
     assert not i.has(Integral)
-
-
-@XFAIL
-def test_issue_16161():
-    i = integrate(x*sec(x)**2, x)
-    assert not i.has(Integral)
-    # assert i == x*tan(x) + log(cos(x))
 
 
 @XFAIL
@@ -266,3 +259,15 @@ def test_issue_4311_slow():
 def test_issue_20370():
     a = symbols('a', positive=True)
     assert integrate((1 + a * cos(x))**-1, (x, 0, 2 * pi)) == (2 * pi / sqrt(1 - a**2))
+
+
+@XFAIL
+def test_polylog():
+    # log(1/x)*log(x+1)-polylog(2, -x)
+    assert not integrate(log(1/x)/(x + 1), x).has(Integral)
+
+
+@XFAIL
+def test_polylog_manual():
+    # Make sure _parts_rule does not go into an infinite loop here
+    assert not integrate(log(1/x)/(x + 1), x, manual=True).has(Integral)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -15,7 +15,7 @@ from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, lo
 from sympy.functions.elementary.hyperbolic import (acosh, asinh, cosh, coth, csch, sinh, tanh, sech)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin, sinc, tan)
+from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin, sinc, tan, sec)
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy.functions.special.error_functions import (Ci, Ei, Si, erf, erfc, erfi, fresnelc, li)
 from sympy.functions.special.gamma_functions import (gamma, polygamma)
@@ -2005,3 +2005,10 @@ def test_sqrt_quadratic():
 
     assert integrate(x*sqrt(x**2+2*x+4)) == \
         (x**2/3 + x/6 + S(5)/6)*sqrt(x**2 + 2*x + 4) - 3*asinh(sqrt(3)*(x + 1)/3)/2
+
+
+def test_mul_pow_derivative():
+    assert integrate(x*sec(x)*tan(x)) == x*sec(x) - log(tan(x) + sec(x))
+    assert integrate(x*sec(x)**2, x) == x*tan(x) + log(cos(x))
+    assert integrate(x**3*Derivative(f(x), (x, 4))) == \
+           x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) + 6*x*Derivative(f(x), x) - 6*f(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -74,8 +74,6 @@ def test_manualintegrate_parts():
     assert manualintegrate((3*x**2 + 5) * exp(x), x) == \
         3*x**2*exp(x) - 6*x*exp(x) + 11*exp(x)
     assert manualintegrate(atan(x), x) == x*atan(x) - log(x**2 + 1)/2
-    # Make sure _parts_rule does not go into an infinite loop here
-    assert manualintegrate(log(1/x)/(x + 1), x).has(Integral)
 
     # Make sure _parts_rule doesn't pick u = constant but can pick dv =
     # constant if necessary, e.g. for integrate(atan(x))
@@ -658,3 +656,11 @@ def test_manualintegrate_sqrt_quadratic():
 
     assert_is_integral_of(x*sqrt(x**2+2*x+4),
                           (x**2/3 + x/6 + S(5)/6)*sqrt(x**2 + 2*x + 4) - 3*asinh(sqrt(3)*(x + 1)/3)/2)
+
+
+def test_mul_pow_derivative():
+    assert_is_integral_of(x*sec(x)*tan(x), x*sec(x) - log(tan(x) + sec(x)))
+    assert_is_integral_of(x*sec(x)**2, x*tan(x) + log(cos(x)))
+    assert_is_integral_of(x**3*Derivative(f(x), (x, 4)),
+                          x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) +
+                          6*x*Derivative(f(x), x) - 6*f(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23495 
Fixes #16161
#### Brief description of what is fixed or changed
$\int x^n f^{(n+1)}(x)\mathrm{d}x=\int x^n\mathrm{d}f^{(n)}(x)$
$=x^n f^{(n)}(x)-n\int x^{n-1}f^{(n)}(x)\mathrm{d}x$
$=x^n f^{(n)}(x)-nx^{n-1}f^{(n-1)}(x)+n(n-1)x^{n-2}f^{(n-2)}(x)-\cdots+(-1)^{n}n!f(x)$
$=\Sigma_{i=0}^n (-1)^{i}\frac{n!}{(n-i)!}x^{n-i} f^{(n-i)}(x)$

Edit:
This rule is too aggressive that may slow down many cases.
Enlarge the range of `dv` when `u` is algebraic for parts rule instead.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Support integrate(x**n*(trig or Derivative))
<!-- END RELEASE NOTES -->
