### PR TITLE
do not use solve in idiff

### DIFF
--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -18,17 +18,17 @@ def test_idiff():
     g = Function('g')
     # the use of idiff in ellipse also provides coverage
     circ = x**2 + y**2 - 4
-    ans = -3*x*(x**2 + y**2)/y**5
-    assert ans == idiff(circ, y, x, 3)
+    ans = -3*x*(x**2/y**2 + 1)/y**3
+    assert ans == idiff(circ, y, x, 3), idiff(circ, y, x, 3)
     assert ans == idiff(circ, [y], x, 3)
     assert idiff(circ, y, x, 3) == ans
     explicit  = 12*x/sqrt(-x**2 + 4)**5
     assert ans.subs(y, solve(circ, y)[0]).equals(explicit)
     assert True in [sol.diff(x, 3).equals(explicit) for sol in solve(circ, y)]
     assert idiff(x + t + y, [y, t], x) == -Derivative(t, x) - 1
-    assert idiff(f(x) * exp(f(x)) - x * exp(x), f(x), x) == (x + 1) * exp(x - f(x))/(f(x) + 1)
-    assert idiff(f(x) - y * exp(x), [f(x), y], x) == (y + Derivative(y, x)) * exp(x)
-    assert idiff(f(x) - y * exp(x), [y, f(x)], x) == -y + exp(-x) * Derivative(f(x), x)
+    assert idiff(f(x) * exp(f(x)) - x * exp(x), f(x), x) == (x + 1)*exp(x)*exp(-f(x))/(f(x) + 1)
+    assert idiff(f(x) - y * exp(x), [f(x), y], x) == (y + Derivative(y, x))*exp(x)
+    assert idiff(f(x) - y * exp(x), [y, f(x)], x) == -y + Derivative(f(x), x)*exp(-x)
     assert idiff(f(x) - g(x), [f(x), g(x)], x) == Derivative(g(x), x)
 
 

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -18,10 +18,10 @@ def test_idiff():
     g = Function('g')
     # the use of idiff in ellipse also provides coverage
     circ = x**2 + y**2 - 4
-    ans = 3*x*(-x**2 - y**2)/y**5
-    assert ans == idiff(circ, y, x, 3).simplify()
-    assert ans == idiff(circ, [y], x, 3).simplify()
-    assert idiff(circ, y, x, 3).simplify() == ans
+    ans = -3*x*(x**2 + y**2)/y**5
+    assert ans == idiff(circ, y, x, 3)
+    assert ans == idiff(circ, [y], x, 3)
+    assert idiff(circ, y, x, 3) == ans
     explicit  = 12*x/sqrt(-x**2 + 4)**5
     assert ans.subs(y, solve(circ, y)[0]).equals(explicit)
     assert True in [sol.diff(x, 3).equals(explicit) for sol in solve(circ, y)]

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,7 +1,7 @@
 from sympy.core.function import (Derivative, Function)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
-from sympy.functions.elementary.exponential import exp
+from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
     intersection, centroid, Point3D, Line3D
@@ -30,6 +30,10 @@ def test_idiff():
     assert idiff(f(x) - y * exp(x), [f(x), y], x) == (y + Derivative(y, x))*exp(x)
     assert idiff(f(x) - y * exp(x), [y, f(x)], x) == -y + Derivative(f(x), x)*exp(-x)
     assert idiff(f(x) - g(x), [f(x), g(x)], x) == Derivative(g(x), x)
+    # this should be fast
+    fxy = y - (-10*(-sin(x) + 1/x)**2 + tan(x)**2 + 2*cosh(x/10))
+    assert idiff(fxy, y, x) == -20*sin(x)*cos(x) + 2*tan(x)**3 + \
+        2*tan(x) + sinh(x/10)/5 + 20*cos(x)/x - 20*sin(x)/x**2 + 20/x**3
 
 
 def test_intersection():

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -22,8 +22,9 @@ from sympy.core.containers import OrderedSet
 from sympy.core.function import Function
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Symbol
+from sympy.core.singleton import S
+from sympy.simplify import simplify
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import is_sequence
 
 
@@ -615,7 +616,11 @@ def idiff(eq, y, x, n=1):
     eq = eq.subs(f)
     derivs = {}
     for i in range(n):
-        yp = solve(eq.diff(x), dydx)[0].subs(derivs)
+        # equation will be linear in dydx, a*dydx + b, so dydx = -b/a
+        deq = eq.diff(x)
+        b = deq.xreplace({dydx: S.Zero})
+        a = (deq - b).xreplace({dydx: S.One})
+        yp = simplify((-b/a)).subs(derivs)
         if i == n - 1:
             return yp.subs([(v, k) for k, v in f.items()])
         derivs[dydx] = yp

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -19,11 +19,12 @@ from .entity import GeometryEntity
 from .exceptions import GeometryError
 from .point import Point, Point2D, Point3D
 from sympy.core.containers import OrderedSet
-from sympy.core.function import Function
+from sympy.core.exprtools import factor_terms
+from sympy.core.function import Function, expand_mul
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Symbol
 from sympy.core.singleton import S
-from sympy.simplify import simplify
+from sympy.polys.polytools import cancel
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import is_sequence
 
@@ -620,7 +621,7 @@ def idiff(eq, y, x, n=1):
         deq = eq.diff(x)
         b = deq.xreplace({dydx: S.Zero})
         a = (deq - b).xreplace({dydx: S.One})
-        yp = simplify((-b/a)).subs(derivs)
+        yp = factor_terms(expand_mul(cancel((-b/a).subs(derivs)), deep=False))
         if i == n - 1:
             return yp.subs([(v, k) for k, v in f.items()])
         derivs[dydx] = yp


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #23554 

#### Brief description of what is fixed or changed

A more optimized internal solving process is used to calculate the derivatives. The existing tests already run faster. The expression below runs about 4X faster relative to master:

```python
eq=x**3 + y**3 - (3*x*y**2 - x - 1)*(x**2 + x*y + y**2 - 10)
t=time()
y1=idiff(eq, y,x)
time()-t
t=time()
y2=idiff(eq, y,x,2)
time()-t
```

The equation given on the issue page runs about 200X faster.

#### Other comments

It seems like this should be faster than it is.... Would using `cse` help in any way?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * idiff is more efficient at calculating derivatives
<!-- END RELEASE NOTES -->
