### PR TITLE
[WIP] Optimize evaluation for float arguments

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -480,13 +480,17 @@ class Function(Application, Expr):
                 'plural': 's'*(min(cls.nargs) != 1),
                 'given': n})
 
-        evaluate = options.get('evaluate', global_parameters.evaluate)
-        result = super().__new__(cls, *args, **options)
-        if evaluate and isinstance(result, cls) and result.args:
-            pr2 = min(cls._should_evalf(a) for a in result.args)
-            if pr2 > 0:
-                pr = max(cls._should_evalf(a) for a in result.args)
-                result = result.evalf(prec_to_dps(pr))
+        evaluate = options.pop('evaluate', global_parameters.evaluate)
+ 
+        if evaluate and len(args)>0:
+             should = [cls._should_evalf(_sympify(a)) for a in args]
+             if not any(p <= 0 for p in should):
+                 pr = max(should)
+                 result = super().__new__(cls, *args, evaluate=False, **options)
+                 return result.evalf(prec_to_dps(pr))
+ 
+        result = super().__new__(cls, *args, evaluate=evaluate, **options)
+
 
         return _sympify(result)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -481,7 +481,7 @@ class Function(Application, Expr):
                 'given': n})
 
         evaluate = options.pop('evaluate', global_parameters.evaluate)
- 
+
         if evaluate and len(args)>0:
              should = [cls._should_evalf(_sympify(a)) for a in args]
              if not any(p <= 0 for p in should):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -483,7 +483,8 @@ class Function(Application, Expr):
         evaluate = options.pop('evaluate', global_parameters.evaluate)
 
         if evaluate and len(args)>0:
-             should = [cls._should_evalf(_sympify(a)) for a in args]
+             args =[sympify(a)for a in args]
+             should = [cls._should_evalf(a) for a in args]
              if not any(p <= 0 for p in should):
                  pr = max(should)
                  result = super().__new__(cls, *args, evaluate=False, **options)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -488,9 +488,8 @@ class Function(Application, Expr):
                  pr = max(should)
                  result = super().__new__(cls, *args, evaluate=False, **options)
                  return result.evalf(prec_to_dps(pr))
- 
-        result = super().__new__(cls, *args, evaluate=evaluate, **options)
 
+        result = super().__new__(cls, *args, evaluate=evaluate, **options)
 
         return _sympify(result)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

This PR explores how we can improve the evaluation of floating point types (e.g. `float`, `sympy.Float`, complex numbers). In #23541 it was found that the performance of evaluations of floats is unneccary slow because in the `eval` method of a `Function` much work is peformed for general arguments that can be avoided with a fast path for floats.

The general workflow for an evaluation of a `Function` like `atan` on a float, e.g. `atan(2.3)` is:

1) Sympify the argument 2.3. Result: `Float(2.3)` 
2) In the `__new__` of the `Function` the `eval` method of `atan` is called.
3) The `eval` handles special cases (like `sympy.core.singleton.Infinity`)
4) If evaluation is requested (default: True), then a call to `evalf` is made.

**Options**

1) In #23541 a fast path for float arguments was added to the `eval` of `atan` and several other methods. This approach is specific to these functions are could lead to many small exceptions.

2) In the approach of this PR a more general approach was tried. In the `__new__` of the method it is checked whether the arguments are of float type or not (more details below). This works for many methods (e.g. `atan`), but some of the sympy tests have errors. One of the themes is that some functions rely (partly) on `eval` for the evaluation of floats. (e.g. `DiracDelta`,  does not implement the `evalf` itself)
Fixing the tests might be possible, but does not guarantee that the behavior is unchanged. (not everything is covered by tests, users can have subclassed sympy objects)

3) A third approach is to add a new attribute to the `Function` class `skip_eval_for_float`. The default value could be set to `False`, but for functions where skipping the eval is safe (checked manually) we can set it to `True`. An advantage is that it allows users to disable to new optimization for subclasses.
A variation is to set the default `skip_eval_for_float=True`, and set it to `False` for all function that fail tests.
This option is tested in #23582.

**Float type**

Which objects do we consider for a fast path? In any case the `Float` objects. But also complex numbers could be interesting. The check should be fast, otherwise performance of the evaluation of non-float numbers will suffer. Here are some options:

i) Only check on `Float`:

```
%timeit [isinstance(q, Float) for q in args]
189 ns ± 1.27 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

ii) Check with `_should_evalf`. This was already used in the `__new__` of `Function` (on the `result.args`, we need it on the `args`)
```
%timeit [atan._should_evalf(a) for a in args]
299 ns ± 5.22 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
iii) Test for complex numbers and floats. (could probably be improved)
```
def is_float_like(q):
    if isinstance(q, Float):
        return True
    if isinstance(q, Add):
        terms = q.args
        if len(terms)==2:
            if isinstance(terms[0], Float):
                if isinstance(terms[1], Mul):
                    terms = terms[1].args
                    print(terms)
                    if isinstance(terms[0], Float) and terms[1]==sympy.core.numbers.ImaginaryUnit():
                        return True
    return False
%timeit [is_float_like(q) for q in args]
241 ns ± 0.384 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
WIP
<!-- END RELEASE NOTES -->
