### PR TITLE
Fix integrate 1/sqrt(x**2-1) for heurisch

### DIFF
--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -201,6 +201,9 @@ def test_heurisch_hacking():
     assert heurisch(1/sqrt(9 + 4*x**2), x, hints=[]) == \
         asinh(x*Rational(2, 3))/2
 
+    assert heurisch(1/sqrt(3*x**2-4), x, hints=[]) == \
+           sqrt(3)*log(3*x + sqrt(3)*sqrt(3*x**2 - 4))/3
+
 
 def test_heurisch_function():
     assert heurisch(f(x), x) is None

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,3 +1,4 @@
+import math
 from sympy.concrete.summations import (Sum, summation)
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
@@ -1040,7 +1041,7 @@ def test_issue_4403():
     assert integrate(sqrt(x**2 + z**2), x) == \
         z**2*asinh(x/z)/2 + x*sqrt(x**2 + z**2)/2
     assert integrate(sqrt(x**2 - z**2), x) == \
-        -z**2*acosh(x/z)/2 + x*sqrt(x**2 - z**2)/2
+        x*sqrt(x**2 - z**2)/2 - z**2*log(x + sqrt(x**2 - z**2))/2
 
     x = Symbol('x', real=True)
     y = Symbol('y', positive=True)
@@ -1918,6 +1919,12 @@ def test_issue_18527():
     expr = (cos(x)/(4+(sin(x))**2))
     res_real = integrate(expr.subs(x, xr), xr, manual=True).subs(xr, x)
     assert integrate(expr, x, manual=True) == res_real == Integral(expr, x)
+
+
+def test_issue_23566():
+    i = integrate(1/sqrt(x**2-1), (x, -2, -1))
+    assert i == -log(2 - sqrt(3))
+    assert math.isclose(i.n(), 1.31695789692482)
 
 
 def test_pr_23583():

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -40,7 +40,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions.elementary.complexes import (im, re)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
-from sympy.functions.elementary.hyperbolic import (acosh, asinh, cosh, sinh, tanh)
+from sympy.functions.elementary.hyperbolic import (asinh, cosh, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import (cbrt, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sec, sin, tan)
@@ -2859,7 +2859,8 @@ def _get_examples_ode_sol_1st_homogeneous_coeff_best():
 
     '1st_homogeneous_coeff_best_08': {
         'eq': f(x)**2 + (x*sqrt(f(x)**2 - x**2) - x*f(x))*f(x).diff(x),
-        'sol': [Eq(log(x), C1 - log(f(x)/x) + acosh(f(x)/x))],
+        'sol': [Eq(f(x), -sqrt(-x*exp(2*C1)/(x - 2*exp(C1)))), Eq(f(x), sqrt(-x*exp(2*C1)/(x - 2*exp(C1))))],
+        'checkodesol_XFAIL': True  # solutions are valid in a range
     },
     }
     }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#23566 heurisch part. It shouldn't be closed.
#### Brief description of what is fixed or changed

Use `log` instead of `acosh`. ~~Implement a special case for evaluating derivative of log.~~ Patch heurisch to simplify a special case of derivative. 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fix integrate(1/sqrt(x**2-1))
<!-- END RELEASE NOTES -->
