### PR TITLE
adding option to return kinematic equations implicitly in KanesMethod #22818

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -14,7 +14,7 @@ __all__ = ['KanesMethod']
 
 
 class KanesMethod(_Methods):
-    """Kane's method object.
+    r"""Kane's method object.
 
     Explanation
     ===========
@@ -674,7 +674,7 @@ class KanesMethod(_Methods):
 
     @property
     def mass_matrix_kin(self):
-        """The kinematic "mass matrix" $\mathbf{k_{k\dot{q}}}$ of the system."""
+        r"""The kinematic "mass matrix" $\mathbf{k_{k\dot{q}}}$ of the system."""
         return self._k_kqdot.copy() if self.explicit_kinematics else self._k_kqdot_implicit.copy()
 
     @property

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -675,7 +675,7 @@ class KanesMethod(_Methods):
     @property
     def mass_matrix_kin(self):
         r"""The kinematic "mass matrix" $\mathbf{k_{k\dot{q}}}$ of the system."""
-        return self._k_kqdot.copy() if self.explicit_kinematics else self._k_kqdot_implicit.copy()
+        return self._k_kqdot if self.explicit_kinematics else self._k_kqdot_implicit
 
     @property
     def forcing_kin(self):

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -82,23 +82,12 @@ def test_two_dof():
     assert KM.explicit_kinematics
     assert KM.mass_matrix_kin == eye(2)
 
-    # Check that the implicit and explicit matrices are different when involving kinematics
-    mf_keys = ['mass_matrix', 'mass_matrix_kin', 'mass_matrix_full',
-               'forcing', 'forcing_kin', 'forcing_full']
-    KM_matrices = {}
-    for explicit_kinematics in [False, True]:
-        KM.explicit_kinematics = explicit_kinematics
-        KM_matrices['explicit' if explicit_kinematics else 'implicit'] = {k:KM.__getattribute__(k) for k in mf_keys}
+    # Check that for the implicit form the mass matrix is not identity
+    KM.explicit_kinematics = False
+    assert KM.mass_matrix_kin == Matrix([[1/2, 0], [0, 2]])
 
-    for k in mf_keys:
-        if k in ['mass_matrix', 'forcing']:
-            # dynamic matrix/vector are unchanged whether we use explicit or implicit kinematics
-            assert KM_matrices['explicit'][k] == KM_matrices['implicit'][k]
-        else:
-            # but matrix/vector involving kinematics are expected to be different
-            assert KM_matrices['explicit'][k] != KM_matrices['implicit'][k]
-
-    # Check that whether using implicit or explicit kinematics the RHS equations are consisten with the matrix form
+    # Check that whether using implicit or explicit kinematics the RHS
+    # equations are consisten with the matrix form
     for explicit_kinematics in [False, True]:
         KM.explicit_kinematics = explicit_kinematics
         assert simplify(KM.rhs() -

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -84,7 +84,7 @@ def test_two_dof():
 
     # Check that for the implicit form the mass matrix is not identity
     KM.explicit_kinematics = False
-    assert KM.mass_matrix_kin == Matrix([[1/2, 0], [0, 2]])
+    assert KM.mass_matrix_kin == Matrix([[S(1)/2, 0], [0, 2]])
 
     # Check that whether using implicit or explicit kinematics the RHS
     # equations are consisten with the matrix form


### PR DESCRIPTION
Fixes #22626 

This adds an option to KanesMethod to expose kinematic matrices in implicit form.

Default behavior should remain unchanged, so existing tests should be fine. Added one test to exercise the new code.

Closing PR https://github.com/sympy/sympy/pull/22818 to take a different approach as proposed by @moorepants in https://github.com/sympy/sympy/pull/22818#issuecomment-1086811861 . Doing this in a different PR in case we decide to pursue the other method at some point (and because I have some 3rd party code relying on that branch right now which I'll migrate to this PR once it's approved)

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Added option to return kinematics and full mass matrix in implicit form in KanesMethod

<!-- END RELEASE NOTES -->
