### PR TITLE
Fix integrate 1/sqrt(x**2-1) for manual

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1920,6 +1920,11 @@ def test_issue_18527():
     assert integrate(expr, x, manual=True) == res_real == Integral(expr, x)
 
 
+def test_pr_23583():
+    # This result from meijerg is wrong. Check whether new result is correct when this test fail.
+    assert integrate(1/sqrt((x - I)**2-1)) == Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+
+
 def test_hyperbolic():
     assert integrate(coth(x)) == x - log(tanh(x) + 1) + log(tanh(x))
     assert integrate(sech(x)) == 2*atan(tanh(x/2))
@@ -1929,7 +1934,7 @@ def test_hyperbolic():
 def test_sqrt_quadratic():
     assert integrate(1/sqrt(3*x**2+4*x+5)) == sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3
     assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3
-    assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/3
+    assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*log(6*x + 2*sqrt(3)*sqrt(3*x**2 + 4*x - 5) + 4)/3
     assert integrate(1/sqrt(a+b*x+c*x**2), x) == log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)
 
     assert integrate((7*x+6)/sqrt(3*x**2+4*x+5)) == \
@@ -1937,7 +1942,7 @@ def test_sqrt_quadratic():
     assert integrate((7*x+6)/sqrt(-3*x**2+4*x+5)) == \
            -7*sqrt(-3*x**2 + 4*x + 5)/3 + 32*sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/9
     assert integrate((7*x+6)/sqrt(3*x**2+4*x-5)) == \
-           7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*acosh(3*sqrt(19)*(x + S(2)/3)/19)/9
+           7*sqrt(3*x**2 + 4*x - 5)/3 + 4*sqrt(3)*log(6*x + 2*sqrt(3)*sqrt(3*x**2 + 4*x - 5) + 4)/9
     assert integrate((d+e*x)/sqrt(a+b*x+c*x**2), x) == \
            e*sqrt(a + b*x + c*x**2)/c + (-b*e/(2*c) + d)*log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c)
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -2,10 +2,12 @@ from sympy.core.function import expand_func
 from sympy.core.numbers import (I, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
+from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
-from sympy.functions.elementary.hyperbolic import cosh
+from sympy.functions.elementary.hyperbolic import cosh, acosh
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
+from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
+from sympy.functions.elementary.trigonometric import (cos, sin, sinc, asin)
 from sympy.functions.special.error_functions import (erf, erfc)
 from sympy.functions.special.gamma_functions import (gamma, polygamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -129,7 +131,6 @@ def test_recursive():
 def test_meijerint():
     from sympy.core.function import expand
     from sympy.core.symbol import symbols
-    from sympy.functions.elementary.complexes import arg
     s, t, mu = symbols('s t mu', real=True)
     assert integrate(meijerg([], [], [0], [], s*t)
                      *meijerg([], [], [mu/2], [-mu/2], t**2/4),
@@ -199,7 +200,6 @@ def test_meijerint():
     # (This is besselj*besselj in disguise, to stop the product from being
     #  recognised in the tables.)
     a, b, s = symbols('a b s')
-    from sympy.functions.elementary.complexes import re
     assert meijerint_definite(meijerg([], [], [a/2], [-a/2], x/4)
                   *meijerg([], [], [b/2], [-b/2], x/4)*x**(s - 1), x, 0, oo
         ) == (
@@ -283,7 +283,6 @@ def test_bessel():
 
 
 def test_inversion():
-    from sympy.functions.elementary.piecewise import piecewise_fold
     from sympy.functions.special.bessel import besselj
     from sympy.functions.special.delta_functions import Heaviside
 
@@ -391,7 +390,6 @@ def test_probability():
     # various integrals from probability theory
     from sympy.core.function import expand_mul
     from sympy.core.symbol import (Symbol, symbols)
-    from sympy.functions.elementary.complexes import Abs
     from sympy.simplify.gammasimp import gammasimp
     from sympy.simplify.powsimp import powsimp
     mu1, mu2 = symbols('mu1 mu2', nonzero=True)
@@ -590,7 +588,6 @@ def test_probability():
 def test_expint():
     """ Test various exponential integrals. """
     from sympy.core.symbol import Symbol
-    from sympy.functions.elementary.complexes import unpolarify
     from sympy.functions.elementary.hyperbolic import sinh
     from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, expint)
     assert simplify(unpolarify(integrate(exp(-z*x)/x**y, (x, 1, oo),
@@ -643,9 +640,7 @@ def test_expint():
 
 
 def test_messy():
-    from sympy.functions.elementary.complexes import re
     from sympy.functions.elementary.hyperbolic import (acosh, acoth)
-    from sympy.functions.elementary.piecewise import Piecewise
     from sympy.functions.elementary.trigonometric import (asin, atan)
     from sympy.functions.special.bessel import besselj
     from sympy.functions.special.error_functions import (Chi, E1, Shi, Si)
@@ -761,3 +756,9 @@ def test_indefinite_1_bug():
     assert integrate((b + t)**(-a), t, meijerg=True
         ) == -b/(b**a*(1 + t/b)**a*(a - 1)
         ) - t/(b**a*(1 + t/b)**a*(a - 1))
+
+
+def test_pr_23583():
+    # This result is wrong. Check whether new result is correct when this test fail.
+    assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
+           Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#23566 manual part.
#### Brief description of what is fixed or changed
The `acosh` is replaced with a ~~`Piecewise`~~ `log`
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
