### PR TITLE
Add benchmarks for evaluation of float arguments to functions

### DIFF
--- a/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
+++ b/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
@@ -1,0 +1,9 @@
+from random import random
+from sympy.functions.elementary.trigonometric import atan, cos
+
+
+def timeit_atan_evalulate_float():
+    atan(random())
+
+def timeit_cos_evalulate_float():
+    cos(random())

--- a/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
+++ b/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
@@ -2,8 +2,8 @@ from random import random
 from sympy.functions.elementary.trigonometric import atan, cos
 
 
-def timeit_atan_evalulate_float():
+def timeit_atan_evaluate_float():
     atan(random())
 
-def timeit_cos_evalulate_float():
+def timeit_cos_evaluate_float():
     cos(random())

--- a/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
+++ b/sympy/functions/elementary/benchmarks/bench_trigoniometric.py
@@ -1,9 +1,16 @@
 from random import random
 from sympy.functions.elementary.trigonometric import atan, cos
+from sympy.functions.elementary.miscellaneous import sqrt
+
+sqrt3 = sqrt(3)
+
+def timeit_atan_evaluate_sqrt_3():
+    atan(sqrt3)
 
 
 def timeit_atan_evaluate_float():
     atan(random())
+
 
 def timeit_cos_evaluate_float():
     cos(random())

--- a/sympy/functions/special/benchmarks/bench_special.py
+++ b/sympy/functions/special/benchmarks/bench_special.py
@@ -8,6 +8,6 @@ x, y = symbols('x,y')
 def timeit_Ynm_xy():
     Ynm(1, 1, x, y)
 
-def timeit_beta_evalulate_float():
+def timeit_beta_evaluate_float():
     beta(3.1)
     beta(3.1, 2.1)

--- a/sympy/functions/special/benchmarks/bench_special.py
+++ b/sympy/functions/special/benchmarks/bench_special.py
@@ -1,8 +1,13 @@
 from sympy.core.symbol import symbols
 from sympy.functions.special.spherical_harmonics import Ynm
+from sympy.functions.special.beta_functions import beta
 
 x, y = symbols('x,y')
 
 
 def timeit_Ynm_xy():
     Ynm(1, 1, x, y)
+
+def timeit_beta_evalulate_float():
+    beta(3.1)
+    beta(3.1, 2.1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

See #23541 and #23582.

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This PR adds benchmarks for evaluation of float numbers, e.g. `cos(2.3)`.
Also add evaluation of a special case (`atan` of `sqrt(3)`) for comparison.

@oscarbenjamin 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
