### PR TITLE
Cache FiniteSet for function calls

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -149,12 +149,15 @@ else:
     raise RuntimeError(
         'unrecognized value for SYMPY_USE_CACHE: %s' % USE_CACHE)
 
+_cached_property_sentinel = object()
+
+
 def cached_property(func):
     '''Decorator to cache property method'''
     attrname = '__' + func.__name__
     def propfunc(self):
-        val = getattr(self, attrname, None)
-        if val is None:
+        val = getattr(self, attrname, _cached_property_sentinel)
+        if val is _cached_property_sentinel:
             val = func(self)
             setattr(self, attrname, val)
         return val

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -151,7 +151,7 @@ else:
 
 def cached_property(func):
     '''Decorator to cache property method'''
-    attrname = '_' + func.__name__
+    attrname = '__' + func.__name__
     def propfunc(self):
         val = getattr(self, attrname, None)
         if val is None:

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -148,3 +148,14 @@ elif USE_CACHE == 'debug':
 else:
     raise RuntimeError(
         'unrecognized value for SYMPY_USE_CACHE: %s' % USE_CACHE)
+
+def cached_property(func):
+    '''Decorator to cache property method'''
+    attrname = '_' + func.__name__
+    def propfunc(self):
+        val = getattr(self, attrname, None)
+        if val is None:
+            val = func(self)
+            setattr(self, attrname, val)
+        return val
+    return property(propfunc)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -36,7 +36,7 @@ from collections.abc import Iterable
 from .add import Add
 from .assumptions import ManagedProperties
 from .basic import Basic, _atomic
-from .cache import cacheit
+from .cache import cacheit, cached_property
 from .containers import Tuple, Dict
 from .decorators import _sympifyit
 from .evalf import pure_complex
@@ -223,7 +223,7 @@ class FunctionClass(ManagedProperties):
         # to return the right value
         return lambda rule, **_: rule.get(self, self)
 
-    @property
+    @cached_property
     def nargs(self):
         """Return a set of the allowed number of arguments for the function.
 
@@ -2016,7 +2016,7 @@ class Lambda(Expr):
                 yield args
         return tuple(_variables(self.signature))
 
-    @property
+    @cached_property
     def nargs(self):
         from sympy.sets.sets import FiniteSet
         return FiniteSet(len(self.signature))

--- a/sympy/core/tests/test_cache.py
+++ b/sympy/core/tests/test_cache.py
@@ -1,4 +1,4 @@
-from sympy.core.cache import cacheit
+from sympy.core.cache import cacheit, cached_property
 from sympy.testing.pytest import raises
 
 def test_cacheit_doc():
@@ -54,3 +54,23 @@ def test_cachit_exception():
     # Unhashable type
     raises(TypeError, lambda: testf2([]))
     assert len(a) == 1
+
+def test_cached_property():
+    class A:
+        def __init__(self, value):
+            self.value = value
+            self.calls = 0
+
+        @cached_property
+        def prop(self):
+            self.calls = self.calls + 1
+            return self.value
+
+    a = A(2)
+    assert a.calls == 0
+    assert a.prop == 2
+    assert a.calls == 1
+    assert a.prop == 2
+    assert a.calls == 1
+    b = A(None)
+    assert b.prop == None

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -9,6 +9,7 @@ from typing import Dict as tDict, Type, Iterator, List, Optional
 
 from .riccati import match_riccati, solve_riccati
 from sympy.core import Add, S, Pow, Rational
+from sympy.core.cache import cached_property
 from sympy.core.exprtools import factor_terms
 from sympy.core.expr import Expr
 from sympy.core.function import AppliedUndef, Derivative, diff, Function, expand, Subs, _mexpand
@@ -38,18 +39,6 @@ from .lie_group import _ode_lie_group
 class ODEMatchError(NotImplementedError):
     """Raised if a SingleODESolver is asked to solve an ODE it does not match"""
     pass
-
-
-def cached_property(func):
-    '''Decorator to cache property method'''
-    attrname = '_' + func.__name__
-    def propfunc(self):
-        val = getattr(self, attrname, None)
-        if val is None:
-            val = func(self)
-            setattr(self, attrname, val)
-        return val
-    return property(propfunc)
 
 
 class SingleODEProblem:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed

**Update**: since #23593 is merged, the analysis below is not valid any more.

The evaluation of a `Function` can be improved by avoiding the repeated construction of a `FiniteSet` object for simple arguments. Profiling shows this is a significant part of the evaluation

![function_finiteset_overhead](https://user-images.githubusercontent.com/883786/172146195-4544db1c-e21b-45eb-adcf-83a11a1c9890.png)

(profiling results in the context of #23582)

Benchmark results: **main**
```
In [5]: %timeit re(random())
36.1 µs ± 343 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
Benchmark results: **this PR**
```
15.3 µs ± 127 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.


or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improve performance of function evaluation by caching the construction of `nargs`

<!-- END RELEASE NOTES -->
