### PR TITLE
remove redundant checks in _should_evalf

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -2,7 +2,7 @@
 Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
-
+from __future__ import annotations
 from typing import Tuple as tTuple, Optional, Union as tUnion, Callable, List, Dict as tDict, Type, TYPE_CHECKING, \
     Any, overload
 
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from sympy.functions.elementary.integers import ceiling, floor
     from sympy.functions.elementary.trigonometric import atan
     from sympy.functions.combinatorial.numbers import bernoulli
-    from .numbers import Float, Rational, Integer, AlgebraicNumber
+    from .numbers import Float, Rational, Integer, AlgebraicNumber, Number
 
 LG10 = math.log(10, 2)
 rnd = round_nearest
@@ -149,7 +149,7 @@ def fastlog(x: Optional[MPF_TUP]) -> tUnion[int, Any]:
     return x[2] + x[3]
 
 
-def pure_complex(v: 'Expr', or_real=False) -> Optional[tTuple['Expr', 'Expr']]:
+def pure_complex(v: 'Expr', or_real=False) -> tuple['Number', 'Number'] | None:
     """Return a and b if v matches a + I*b where b is not zero and
     a and b are Numbers, else None. If `or_real` is True then 0 will
     be returned for `b` if `v` is a real number.
@@ -175,7 +175,7 @@ def pure_complex(v: 'Expr', or_real=False) -> Optional[tTuple['Expr', 'Expr']]:
         if i is S.ImaginaryUnit:
             return h, c
     elif or_real:
-        return h, t
+        return h, S.Zero
     return None
 
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3528,7 +3528,7 @@ class Expr(Basic, EvalfMixin):
         """Efficiently extract the coefficient of a product. """
         return S.One, self
 
-    def as_coeff_Add(self, rational=False):
+    def as_coeff_Add(self, rational=False) -> tuple['Number', Expr]:
         """Efficiently extract the coefficient of a summation. """
         return S.Zero, self
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -499,7 +499,7 @@ class Function(Application, Expr):
         ===========
 
         By default (in this implementation), this happens if (and only if) the
-        ARG is a floating point number.
+        ARG is a floating point number (including complex numbers).
         This function is used by __new__.
 
         Returns the precision to evalf to, or -1 if it should not evalf.
@@ -512,9 +512,8 @@ class Function(Application, Expr):
         m = pure_complex(arg)
         if m is None or not (m[0].is_Float or m[1].is_Float):
             return -1
-        l = [i._prec for i in m if i.is_Float]
-        l.append(-1)
-        return max(l)
+        # the elements of m are of type Number, so have a _prec
+        return max(m[0]._prec, m[1]._prec)
 
     @classmethod
     def class_key(cls):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -510,7 +510,7 @@ class Function(Application, Expr):
         if not arg.is_Add:
             return -1
         m = pure_complex(arg)
-        if m is None or not (m[0].is_Float or m[1].is_Float):
+        if m is None:
             return -1
         # the elements of m are of type Number, so have a _prec
         return max(m[0]._prec, m[1]._prec)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -39,6 +39,7 @@ from .basic import Basic, _atomic
 from .cache import cacheit
 from .containers import Tuple, Dict
 from .decorators import _sympifyit
+from .evalf import pure_complex
 from .expr import Expr, AtomicExpr
 from .logic import fuzzy_and, fuzzy_or, fuzzy_not, FuzzyBool
 from .mul import Mul
@@ -508,7 +509,6 @@ class Function(Application, Expr):
             return arg._prec
         if not arg.is_Add:
             return -1
-        from .evalf import pure_complex
         m = pure_complex(arg)
         if m is None or not (m[0].is_Float or m[1].is_Float):
             return -1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Remove redundant checks in `_should_evalf`:

* The result of `pure_complex` is a tuple with 2 elements, no needs to check  `.is_Float` twice
* The list is never empty, so no need to add default value -1


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
