### PR TITLE
[WIP] Add small integer lookup table for Function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -66,7 +66,7 @@ from collections import Counter
 _sympy_int_cache = {x: sympify(x) for x in range(10)}
 
 def _integer_sympify(x : int):
-    """ Fast sympiofy for small integers """
+    """ Fast sympify for small integers """
     value = _sympy_int_cache.get(x, None)
     if value is None:
         value = sympify(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

An expensive part of a function evaluation is the check whether the given number of arguments is valid for the function. The check is performed as:
```
...
n=len(args)
if n not in cls.nargs:
   ....
```
This check is rather slow because: i) cls.nargs is a `FiniteSet` and ii) len(args) is an `int` on which `sympify` is called during the check. This PR improves the speed of the check by creating a fast lookup for the `sympify` of integer types.

#### Other comments

The `Function.nargs` is part of the public API, so we keep that intact. An alternative would be to create a second structure (e.g. a python set `._nargs_plain` to perform the check.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
