### PR TITLE
Reduce Point.acc dependency on computed velocities

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -244,10 +244,10 @@ class Point:
 
         _check_frame(frame)
         if not (frame in self._acc_dict):
-            if self._vel_dict[frame] != 0:
-                return (self._vel_dict[frame]).dt(frame)
+            if self.vel(frame) != 0:
+                self.set_acc(frame, (self._vel_dict[frame]).dt(frame))
             else:
-                return Vector(0)
+                self.set_acc(frame, 0)
         return self._acc_dict[frame]
 
     def locatenew(self, name, value):

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -245,9 +245,9 @@ class Point:
         _check_frame(frame)
         if not (frame in self._acc_dict):
             if self.vel(frame) != 0:
-                self.set_acc(frame, (self._vel_dict[frame]).dt(frame))
+                return (self._vel_dict[frame]).dt(frame)
             else:
-                self.set_acc(frame, 0)
+                return Vector(0)
         return self._acc_dict[frame]
 
     def locatenew(self, name, value):

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -347,6 +347,8 @@ def test_auto_point_acc_compute_vel():
     assert P.acc(N) == -q1.diff(t) ** 2 * A.x + q1.diff(t, 2) * A.y
 
 def test_auto_acc_derivative():
+    # Tests whether the Point.acc method gives the correct acceleration of the
+    # end point of two linkages in serie, while getting minimal information.
     q1, q2 = dynamicsymbols('q1:3')
     u1, u2 = dynamicsymbols('q1:3', 1)
     v1, v2 = dynamicsymbols('q1:3', 2)
@@ -366,6 +368,7 @@ def test_auto_acc_derivative():
     Cm.set_pos(Bm, C.x)
     Cm.set_vel(C, 0)
 
+    # Copy dictionaries to later check the calculation using the 2pt_theories
     Bm_vel_dict, Cm_vel_dict = Bm._vel_dict.copy(), Cm._vel_dict.copy()
     Bm_acc_dict, Cm_acc_dict = Bm._acc_dict.copy(), Cm._acc_dict.copy()
     check = -u1 ** 2 * B.x + v1 * B.y - (u1 + u2) ** 2 * C.x + (v1 + v2) * C.y

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -33,8 +33,10 @@ def test_point_a1pt_theorys():
     O.set_vel(N, 0)
     assert P.a1pt_theory(O, N, B) == -(qd**2) * B.x + qdd * B.y
     P.set_vel(B, q2d * B.z)
+    O._acc_dict, P._acc_dict = {}, {}
     assert P.a1pt_theory(O, N, B) == -(qd**2) * B.x + qdd * B.y + q2dd * B.z
     O.set_vel(N, q2d * B.x)
+    O._acc_dict, P._acc_dict = {}, {}
     assert P.a1pt_theory(O, N, B) == ((q2dd - qd**2) * B.x + (q2d * qd + qdd) * B.y +
                                q2dd * B.z)
 
@@ -324,3 +326,53 @@ def test_auto_vel_derivative():
     Cm._vel_dict = temp
     Cm.v2pt_theory(Bm, B, C)
     assert Cm.vel(A) == (u1 * B.y + (u1 + u2) * C.y)
+
+def test_auto_point_acc_zero_vel():
+    N = ReferenceFrame('N')
+    O = Point('O')
+    O.set_vel(N, 0)
+    assert O.acc(N) == 0 * N.x
+
+def test_auto_point_acc_compute_vel():
+    t = dynamicsymbols._t
+    q1 = dynamicsymbols('q1')
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+    A.orient_axis(N, N.z, q1)
+
+    O = Point('O')
+    O.set_vel(N, 0)
+    P = Point('P')
+    P.set_pos(O, A.x)
+    assert P.acc(N) == -q1.diff(t) ** 2 * A.x + q1.diff(t, 2) * A.y
+
+def test_auto_acc_derivative():
+    q1, q2 = dynamicsymbols('q1:3')
+    u1, u2 = dynamicsymbols('q1:3', 1)
+    v1, v2 = dynamicsymbols('q1:3', 2)
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
+    B.orient_axis(A, A.z, q1)
+    C.orient_axis(B, B.z, q2)
+
+    Am = Point('Am')
+    Am.set_vel(A, 0)
+    Bm = Point('Bm')
+    Bm.set_pos(Am, B.x)
+    Bm.set_vel(B, 0)
+    Bm.set_vel(C, 0)
+    Cm = Point('Cm')
+    Cm.set_pos(Bm, C.x)
+    Cm.set_vel(C, 0)
+
+    Bm_vel_dict, Cm_vel_dict = Bm._vel_dict.copy(), Cm._vel_dict.copy()
+    Bm_acc_dict, Cm_acc_dict = Bm._acc_dict.copy(), Cm._acc_dict.copy()
+    check = -u1 ** 2 * B.x + v1 * B.y - (u1 + u2) ** 2 * C.x + (v1 + v2) * C.y
+    assert Cm.acc(A) == check
+    Bm._vel_dict, Cm._vel_dict = Bm_vel_dict, Cm_vel_dict
+    Bm._acc_dict, Cm._acc_dict = Bm_acc_dict, Cm_acc_dict
+    Bm.v2pt_theory(Am, A, B)
+    Cm.v2pt_theory(Bm, A, C)
+    Bm.a2pt_theory(Am, A, B)
+    assert Cm.a2pt_theory(Bm, A, C) == check

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -33,10 +33,8 @@ def test_point_a1pt_theorys():
     O.set_vel(N, 0)
     assert P.a1pt_theory(O, N, B) == -(qd**2) * B.x + qdd * B.y
     P.set_vel(B, q2d * B.z)
-    O._acc_dict, P._acc_dict = {}, {}
     assert P.a1pt_theory(O, N, B) == -(qd**2) * B.x + qdd * B.y + q2dd * B.z
     O.set_vel(N, q2d * B.x)
-    O._acc_dict, P._acc_dict = {}, {}
     assert P.a1pt_theory(O, N, B) == ((q2dd - qd**2) * B.x + (q2d * qd + qdd) * B.y +
                                q2dd * B.z)
 

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -346,7 +346,7 @@ def test_auto_point_acc_compute_vel():
 
 def test_auto_acc_derivative():
     # Tests whether the Point.acc method gives the correct acceleration of the
-    # end point of two linkages in serie, while getting minimal information.
+    # end point of two linkages in series, while getting minimal information.
     q1, q2 = dynamicsymbols('q1:3')
     u1, u2 = dynamicsymbols('q1:3', 1)
     v1, v2 = dynamicsymbols('q1:3', 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None

#### Brief description of what is fixed or changed
This PR reduces the dependency of the `Point.acc` method on the computed velocities.

#### Other comments
If the velocity in the frame is not yet know. This velocity is computed with the `.vel` method. This also means that this velocity if computed is saved to the `_vel_dict`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Point.acc() will compute acceleration from the point's position vector when the point's velocity is not yet defined. 
<!-- END RELEASE NOTES -->
