### PR TITLE
Change `__init__` signature of `DomainScalar`

### DIFF
--- a/sympy/polys/matrices/domainscalar.py
+++ b/sympy/polys/matrices/domainscalar.py
@@ -19,19 +19,18 @@ class DomainScalar:
     docstring
     """
 
-    def __new__(cls, element, domain):
+    def __init__(self, element, domain):
         if not isinstance(domain, Domain):
             raise TypeError("domain should be of type Domain")
         if not domain.of_type(element):
             raise TypeError("element %s should be in domain %s" % (element, domain))
-        return cls.new(element, domain)
+
+        self.element = element
+        self.domain = domain
 
     @classmethod
     def new(cls, element, domain):
-        obj = super().__new__(cls)
-        obj.element = element
-        obj.domain = domain
-        return obj
+        return DomainScalar(element, domain)
 
     def __repr__(self):
         return repr(self.element)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There is no change in the behavior.
I found out that `mypy` is unable to infer DomainScalar has `element, domain` attributes in the class if `__init__` is customized, so it could be better to put most of the construction signatures to something that easy to infer if possible.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
