### PR TITLE
Use inspect.signature instead of deprecated formatargspec

### DIFF
--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -462,8 +462,7 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
-                argspec = inspect.getfullargspec(func)
-                argspec = inspect.formatargspec(*argspec)
+                argspec = str(inspect.signature(func))
                 argspec = argspec.replace('*', r'\*')
                 signature = '{}{}'.format(func_name, argspec)
             except TypeError as e:


### PR DESCRIPTION
I've opened this here because I needed it in Fedora, but I am currently herding dozens of similar issues as the Fedora's Python 3.11 mass rebuild is in progress. I won't be able to dedicate my time to fixing any style issues, changelog fragments, or similar things. Sorry about that. Feel free to adjust this in any way you see fit or even close it if it's not up to the project's standards.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->