### PR TITLE
Issue a warning when is_assumption is defined as a @property method

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -210,6 +210,8 @@ References
 
 """
 
+import warnings
+
 from .facts import FactRules, FactKB
 from .core import BasicMeta
 from .sympify import sympify
@@ -620,6 +622,16 @@ class ManagedProperties(BasicMeta):
             eval_is_meth = getattr(cls, '_eval_is_%s' % k, None)
             if eval_is_meth is not None:
                 cls._prop_handler[k] = eval_is_meth
+
+            # When __init__ is called from UndefinedFunction it is called with
+            # just one arg. When it is called from subclassing Basic it is
+            # called with the usual (name, bases, namespace) type() signature.
+            if len(args) == 3:
+                namespace = args[2]
+                is_assump = 'is_%s' % k
+                if is_assump in namespace:
+                    if isinstance(namespace[is_assump], property):
+                        warnings.warn(f"{is_assump} is defined as a property method on {cls}. Doing so will break the automatic deduction of other assumptions. Either define {is_assump} as a simple bool or define _eval_{is_assump} instead.", stacklevel=2)
 
         # Put definite results directly into the class dict, for speed
         for k, v in cls.default_assumptions.items():

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -50,7 +50,7 @@ class ExprCondPair(Tuple):
         return self.args[1]
 
     @property
-    def is_commutative(self):
+    def _eval_is_commutative(self):
         return self.expr.is_commutative
 
     def __iter__(self):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -49,7 +49,6 @@ class ExprCondPair(Tuple):
         """
         return self.args[1]
 
-    @property
     def _eval_is_commutative(self):
         return self.expr.is_commutative
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1211,9 +1211,7 @@ class RootSum(Expr):
     def free_symbols(self):
         return self.poly.free_symbols | self.fun.free_symbols
 
-    @property
-    def is_commutative(self):
-        return True
+    is_commutative = True
 
     def doit(self, **hints):
         if not hints.get('roots', True):


### PR DESCRIPTION
For example

```py
>>> class Bad(Function):
...     @property
...     def is_zero(self):
...         return self.args[0].is_zero
./sympy/core/function.py:197: UserWarning: is_zero is defined as a property method on Bad. Doing so will break the automatic deduction of other assumptions. Either define is_zero as a simple bool or define _eval_is_zero instead.
  super().__init__(*args, **kwargs)
```

A few cases of this in library code have been fixed.

However, there are still a few instances of the warning when importing sympy

```
./sympy/polys/polytools.py:102: UserWarning: is_zero is defined as a property method on <class 'sympy.polys.polytools.Poly'>. Doing so will break the automatic deduction of other assumptions. Either define is_zero as a simple bool or define _eval_is_zero instead.
  class Poly(Basic):
./sympy/geometry/point.py:42: UserWarning: is_nonzero is defined as a property method on <class 'sympy.geometry.point.Point'>. Doing so will break the automatic deduction of other assumptions. Either define is_nonzero as a simple bool or define _eval_is_nonzero instead.
  class Point(GeometryEntity):
./sympy/geometry/point.py:42: UserWarning: is_zero is defined as a property method on <class 'sympy.geometry.point.Point'>. Doing so will break the automatic deduction of other assumptions. Either define is_zero as a simple bool or define _eval_is_zero instead.
  class Point(GeometryEntity):
```

(I haven't yet checked the parts of SymPy that aren't imported automatically).

These are all instances where is_zero is used as its own thing, and doesn't
really seem to be indented to be part of the assumptions system. I'm not sure
what should be done about them.

I haven't yet checked if this check affects the performance in any way. The
main thing to check would be the import time, since this runs when classes are
defined.

This is based on the discussion at
https://github.com/sympy/sympy/pull/23488#discussion_r900465301.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - `Basic` subclasses now warn when `is_assumption` is defined as a `@property` method. Either define it as a simple `bool` or use `_eval_is_assumption` instead.
<!-- END RELEASE NOTES -->
