### PR TITLE
manualintegrate improve sqrt linear rule, simplify quadratic denom rule

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,13 +32,13 @@ from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer, Number, E
 from sympy.core.power import Pow
-from sympy.core.relational import Eq, Ne, Gt, Lt
+from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
-    cosh, coth, sech, sinh, tanh, asinh, acoth, atanh)
+    cosh, coth, sech, sinh, tanh, asinh, atanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
@@ -55,7 +55,7 @@ from sympy.functions.special.zeta_functions import polylog
 from .integrals import Integral
 from sympy.logic.boolalg import And
 from sympy.ntheory.factor_ import divisors
-from sympy.polys.polytools import degree
+from sympy.polys.polytools import degree, lcm_list
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.solvers.solvers import solve
@@ -99,7 +99,6 @@ HeavisideRule = Rule("HeavisideRule", "harg ibnd substep")
 TrigSubstitutionRule = Rule("TrigSubstitutionRule",
                             "theta func rewritten substep restriction")
 ArctanRule = Rule("ArctanRule", "a b c")
-ArccothRule = Rule("ArccothRule", "a b c")
 ArctanhRule = Rule("ArctanhRule", "a b c")
 JacobiRule = Rule("JacobiRule", "n a b")
 GegenbauerRule = Rule("GegenbauerRule", "n a")
@@ -764,6 +763,7 @@ def trig_product_rule(integral):
 
         return rule
 
+
 def quadratic_denom_rule(integral):
     integrand, symbol = integral
     a = Wild('a', exclude=[symbol])
@@ -774,13 +774,27 @@ def quadratic_denom_rule(integral):
 
     if match:
         a, b, c = match[a], match[b], match[c]
+        general_rule = ArctanRule(a, b, c, integrand, symbol)
         if b.is_extended_real and c.is_extended_real:
-            return PiecewiseRule([(ArctanRule(a, b, c, integrand, symbol), Gt(c / b, 0)),
-                                (ArccothRule(a, b, c, integrand, symbol), And(Gt(symbol ** 2, -c / b), Lt(c / b, 0))),
-                                (ArctanhRule(a, b, c, integrand, symbol), And(Lt(symbol ** 2, -c / b), Lt(c / b, 0))),
-            ], integrand, symbol)
-        else:
-            return ArctanRule(a, b, c, integrand, symbol)
+            positive_cond = c/b > 0
+            if positive_cond is S.true:
+                return general_rule
+            coeff = a/(2*sqrt(-c)*sqrt(b))
+            constant = sqrt(-c/b)
+            r1 = 1/(symbol-constant)
+            r2 = 1/(symbol+constant)
+            log_steps = [ReciprocalRule(symbol-constant, r1, symbol),
+                         ConstantTimesRule(-1, r2, ReciprocalRule(symbol+constant, r2, symbol), -r2, symbol)]
+            rewritten = sub = r1 - r2
+            negative_step = AddRule(log_steps, sub, symbol)
+            if coeff != 1:
+                rewritten = Mul(coeff, sub, evaluate=False)
+                negative_step = ConstantTimesRule(coeff, sub, negative_step, rewritten, symbol)
+            negative_step = RewriteRule(rewritten, negative_step, integrand, symbol)
+            if positive_cond is S.false:
+                return negative_step
+            return PiecewiseRule([(general_rule, positive_cond), (negative_step, S.true)], integrand, symbol)
+        return general_rule
 
     d = Wild('d', exclude=[symbol])
     match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))
@@ -829,6 +843,50 @@ def quadratic_denom_rule(integral):
     return
 
 
+def sqrt_linear_rule(integral: IntegralInfo):
+    """
+    Substitute common (a+b*x)**(1/n)
+    """
+    integrand, x = integral
+    a = Wild('a', exclude=[x])
+    b = Wild('b', exclude=[x, 0])
+    a0 = b0 = 0
+    bases, qs, bs = [], [], []
+    for pow_ in integrand.find(Pow):  # collect all (a+b*x)**(p/q)
+        base, exp_ = pow_.base, pow_.exp
+        if exp_.is_Integer or x not in base.free_symbols:  # skip 1/x and sqrt(2)
+            continue
+        if not exp_.is_Rational:  # exclude x**pi
+            return
+        match = base.match(a+b*x)
+        if not match:  # exclude non-linear
+            return
+        a1, b1 = match[a], match[b]
+        if a0*b1 != a1*b0 or not (b0/b1).is_nonnegative:  # cannot transform sqrt(x) to sqrt(x+1) or sqrt(-x)
+            return
+        if b0 == 0 or (b0/b1 > 1) is S.true:  # choose the latter of sqrt(2*x) and sqrt(x) as representative
+            a0, b0 = a1, b1
+        bases.append(base)
+        bs.append(b1)
+        qs.append(exp_.q)
+    if b0 == 0:  # no such pattern found
+        return
+    q0: Integer = lcm_list(qs)
+    u_x = (a0 + b0*x)**(1/q0)
+    u = Dummy("u")
+    substituted = integrand.subs({base**(S.One/q): (b/b0)**(S.One/q)*u**(q0/q)
+                                  for base, b, q in zip(bases, bs, qs)}).subs(x, (u**q0-a0)/b0)
+    substep = integral_steps(substituted*u**(q0-1)*q0/b0, u)
+    if not contains_dont_know(substep):
+        step = URule(u, u_x, None, substep, integrand, x)
+        generate_cond = Ne(b0, 0)
+        if generate_cond is not S.true:  # possible degenerate case
+            simplified = integrand.subs({b: 0 for b in bs})
+            degenerate_step = integral_steps(simplified, x)
+            step = PiecewiseRule([(step, generate_cond), (degenerate_step, S.true)], integrand, x)
+        return step
+
+
 def sqrt_quadratic_denom_rule(integral: IntegralInfo):
     integrand, x = integral
     numer, denom = integrand.as_numer_denom()
@@ -864,34 +922,6 @@ def sqrt_quadratic_denom_rule(integral: IntegralInfo):
                 add = Add(A*pre_substitute, B/denom, evaluate=False)
                 return RewriteRule(add, AddRule([linear_step, constant_step], add, x), integrand, x)
             return linear_step or constant_step
-
-
-def root_mul_rule(integral):
-    integrand, symbol = integral
-    a = Wild('a', exclude=[symbol])
-    b = Wild('b', exclude=[symbol])
-    c = Wild('c')
-    match = integrand.match(sqrt(a * symbol + b) * c)
-
-    if not match:
-        return
-
-    a, b, c = match[a], match[b], match[c]
-    d = Wild('d', exclude=[symbol])
-    e = Wild('e', exclude=[symbol])
-    f = Wild('f')
-    recursion_test = c.match(sqrt(d * symbol + e) * f)
-    if recursion_test:
-        return
-
-    u = Dummy('u')
-    u_func = sqrt(a * symbol + b)
-    integrand = integrand.subs(u_func, u)
-    integrand = integrand.subs(symbol, (u**2 - b) / a)
-    integrand = integrand * 2 * u / a
-    next_step = integral_steps(integrand, u)
-    if next_step:
-        return URule(u, u_func, None, next_step, integrand, symbol)
 
 
 def hyperbolic_rule(integral: tuple[Expr, Symbol]):
@@ -1313,10 +1343,8 @@ def integral_steps(integrand, symbol, **options):
     >>> print(repr(integral_steps(exp(x) / (1 + exp(2 * x)), x))) \
     # doctest: +NORMALIZE_WHITESPACE
     URule(u_var=_u, u_func=exp(x), constant=1,
-    substep=PiecewiseRule(subfunctions=[(ArctanRule(a=1, b=1, c=1, context=1/(_u**2 + 1), symbol=_u), True),
-        (ArccothRule(a=1, b=1, c=1, context=1/(_u**2 + 1), symbol=_u), False),
-        (ArctanhRule(a=1, b=1, c=1, context=1/(_u**2 + 1), symbol=_u), False)],
-    context=1/(_u**2 + 1), symbol=_u), context=exp(x)/(exp(2*x) + 1), symbol=x)
+    substep=ArctanRule(a=1, b=1, c=1, context=1/(_u**2 + 1), symbol=_u),
+    context=exp(x)/(exp(2*x) + 1), symbol=x)
     >>> print(repr(integral_steps(sin(x), x))) \
     # doctest: +NORMALIZE_WHITESPACE
     TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
@@ -1388,8 +1416,8 @@ def integral_steps(integrand, symbol, **options):
             Add: add_rule,
             Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
-                        null_safe(sqrt_quadratic_denom_rule),
-                        null_safe(root_mul_rule)),
+                        null_safe(sqrt_linear_rule),
+                        null_safe(sqrt_quadratic_denom_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
@@ -1501,9 +1529,6 @@ def eval_hyperbolic(func: str, arg: Expr, integrand, symbol):
 def eval_arctan(a, b, c, integrand, symbol):
     return a / b * 1 / sqrt(c / b) * atan(symbol / sqrt(c / b))
 
-@evaluates(ArccothRule)
-def eval_arccoth(a, b, c, integrand, symbol):
-    return - a / b * 1 / sqrt(-c / b) * acoth(symbol / sqrt(-c / b))
 
 @evaluates(ArctanhRule)
 def eval_arctanh(a, b, c, integrand, symbol):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1535,8 +1535,7 @@ def test_issue_14437():
 
 
 def test_issue_14470():
-    assert integrate(1/sqrt(exp(x) + 1), x) == \
-        log(-1 + 1/sqrt(exp(x) + 1)) - log(1 + 1/sqrt(exp(x) + 1))
+    assert integrate(1/sqrt(exp(x) + 1), x) == log(sqrt(exp(x) + 1) - 1) - log(sqrt(exp(x) + 1) + 1)
 
 
 def test_issue_14877():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,11 +1,12 @@
 from sympy.core.expr import Expr
+from sympy.core.mul import Mul
 from sympy.core.function import (Derivative, Function, diff, expand)
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.hyperbolic import (acoth, asinh, atanh, csch, cosh, coth, sech, sinh, tanh)
+from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, csc, sec, sin, tan)
@@ -144,16 +145,13 @@ def test_manualintegrate_inversetrig():
     rb = Symbol('b', real=True)
     assert manualintegrate(1/(ra + rb*x**2), x) == \
         Piecewise((atan(x/sqrt(ra/rb))/(rb*sqrt(ra/rb)), ra/rb > 0),
-                  (-acoth(x/sqrt(-ra/rb))/(rb*sqrt(-ra/rb)), And(ra/rb < 0, x**2 > -ra/rb)),
-                  (-atanh(x/sqrt(-ra/rb))/(rb*sqrt(-ra/rb)), And(ra/rb < 0, x**2 < -ra/rb)))
+                  ((log(x - sqrt(-ra/rb)) - log(x + sqrt(-ra/rb)))/(2*sqrt(rb)*sqrt(-ra)), True))
     assert manualintegrate(1/(4 + rb*x**2), x) == \
-        Piecewise((atan(x/(2*sqrt(1/rb)))/(2*rb*sqrt(1/rb)), 4/rb > 0),
-                  (-acoth(x/(2*sqrt(-1/rb)))/(2*rb*sqrt(-1/rb)), And(4/rb < 0, x**2 > -4/rb)),
-                  (-atanh(x/(2*sqrt(-1/rb)))/(2*rb*sqrt(-1/rb)), And(4/rb < 0, x**2 < -4/rb)))
+        Piecewise((atan(x/(2*sqrt(1/rb)))/(2*rb*sqrt(1/rb)), 1/rb > 0),
+                  (-I*(log(x - 2*sqrt(-1/rb)) - log(x + 2*sqrt(-1/rb)))/(4*sqrt(rb)), True))
     assert manualintegrate(1/(ra + 4*x**2), x) == \
-        Piecewise((atan(2*x/sqrt(ra))/(2*sqrt(ra)), ra/4 > 0),
-                  (-acoth(2*x/sqrt(-ra))/(2*sqrt(-ra)), And(ra/4 < 0, x**2 > -ra/4)),
-                  (-atanh(2*x/sqrt(-ra))/(2*sqrt(-ra)), And(ra/4 < 0, x**2 < -ra/4)))
+        Piecewise((atan(2*x/sqrt(ra))/(2*sqrt(ra)), ra > 0),
+                  ((log(x - sqrt(-ra)/2) - log(x + sqrt(-ra)/2))/(4*sqrt(-ra)), True))
     assert manualintegrate(1/(4 + 4*x**2), x) == atan(x) / 4
 
     assert manualintegrate(1/(a + b*x**2), x) == atan(x/sqrt(a/b))/(b*sqrt(a/b))
@@ -242,9 +240,11 @@ def test_manualintegrate_trivial_substitution():
     assert manualintegrate((f(x) - f(-x))/x, x) == \
         -Integral(f(-x)/x, x) + Integral(f(x)/x, x)
 
+
 def test_manualintegrate_rational():
-    assert manualintegrate(1/(4 - x**2), x) == Piecewise((acoth(x/2)/2, x**2 > 4), (atanh(x/2)/2, x**2 < 4))
-    assert manualintegrate(1/(-1 + x**2), x) == Piecewise((-acoth(x), x**2 > 1), (-atanh(x), x**2 < 1))
+    assert manualintegrate(1/(4 - x**2), x) == -log(x - 2)/4 + log(x + 2)/4
+    assert manualintegrate(1/(-1 + x**2), x) == log(x - 1)/2 - log(x + 1)/2
+
 
 def test_manualintegrate_special():
     f, F = 4*exp(-x**2/3), 2*sqrt(3)*sqrt(pi)*erf(sqrt(3)*x/3)
@@ -453,9 +453,8 @@ def test_issue_10847():
 
     rc = Symbol('c', real=True)
     assert manualintegrate(x**2 / (x**2 - rc), x) == \
-        rc*Piecewise((atan(x/sqrt(-rc))/sqrt(-rc), -rc > 0),
-                     (-acoth(x/sqrt(rc))/sqrt(rc), And(-rc < 0, x**2 > rc)),
-                     (-atanh(x/sqrt(rc))/sqrt(rc), And(-rc < 0, x**2 < rc))) + x
+        rc*Piecewise((atan(x/sqrt(-rc))/sqrt(-rc), rc < 0),
+                     ((log(-sqrt(rc) + x) - log(sqrt(rc) + x))/(2*sqrt(rc)), True)) + x
 
     assert manualintegrate(sqrt(x - y) * log(z / x), x) == \
         4*y**Rational(3, 2)*atan(sqrt(x - y)/sqrt(y))/3 - 4*y*sqrt(x - y)/3 +\
@@ -464,28 +463,31 @@ def test_issue_10847():
     rz = Symbol('z', real=True)
     assert manualintegrate(sqrt(x - ry) * log(rz / x), x) == \
         4*ry**2*Piecewise((atan(sqrt(x - ry)/sqrt(ry))/sqrt(ry), ry > 0),
-                         (-acoth(sqrt(x - ry)/sqrt(-ry))/sqrt(-ry), And(x - ry > -ry, ry < 0)),
-                         (-atanh(sqrt(x - ry)/sqrt(-ry))/sqrt(-ry), And(x - ry < -ry, ry < 0)))/3 \
+                         ((log(-sqrt(-ry) + sqrt(x - ry)) - log(sqrt(-ry) + sqrt(x - ry)))/(2*sqrt(-ry)), True))/3 \
                          - 4*ry*sqrt(x - ry)/3 + 2*(x - ry)**Rational(3, 2)*log(rz/x)/3 \
                          + 4*(x - ry)**Rational(3, 2)/9
 
     assert manualintegrate(sqrt(x) * log(x), x) == 2*x**Rational(3, 2)*log(x)/3 - 4*x**Rational(3, 2)/9
     assert manualintegrate(sqrt(a*x + b) / x, x) == \
-        2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b)
+        Piecewise((2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
     ra = Symbol('a', real=True)
     rb = Symbol('b', real=True)
     assert manualintegrate(sqrt(ra*x + rb) / x, x) == \
-        -2*rb*Piecewise((-atan(sqrt(ra*x + rb)/sqrt(-rb))/sqrt(-rb), -rb > 0),
-                        (acoth(sqrt(ra*x + rb)/sqrt(rb))/sqrt(rb), And(-rb < 0, ra*x + rb > rb)),
-                        (atanh(sqrt(ra*x + rb)/sqrt(rb))/sqrt(rb), And(-rb < 0, ra*x + rb < rb))) \
-                        + 2*sqrt(ra*x + rb)
+        Piecewise(
+            (-2*rb*Piecewise(
+                (-atan(sqrt(ra*x + rb)/sqrt(-rb))/sqrt(-rb), rb < 0),
+                (-I*(log(-sqrt(rb) + sqrt(ra*x + rb)) - log(sqrt(rb) + sqrt(ra*x + rb)))/(2*sqrt(-rb)), True)) +
+             2*sqrt(ra*x + rb), Ne(ra, 0)),
+            (sqrt(rb)*log(x), True))
 
-    assert expand(manualintegrate(sqrt(ra*x + rb) / (x + rc), x)) == -2*ra*rc*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), \
-        ra*rc - rb > 0), (-acoth(sqrt(ra*x + rb)/sqrt(-ra*rc + rb))/sqrt(-ra*rc + rb), And(ra*rc - rb < 0, ra*x + rb > -ra*rc + rb)), \
-        (-atanh(sqrt(ra*x + rb)/sqrt(-ra*rc + rb))/sqrt(-ra*rc + rb), And(ra*rc - rb < 0, ra*x + rb < -ra*rc + rb))) \
-        + 2*rb*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), ra*rc - rb > 0), \
-        (-acoth(sqrt(ra*x + rb)/sqrt(-ra*rc + rb))/sqrt(-ra*rc + rb), And(ra*rc - rb < 0, ra*x + rb > -ra*rc + rb)), \
-        (-atanh(sqrt(ra*x + rb)/sqrt(-ra*rc + rb))/sqrt(-ra*rc + rb), And(ra*rc - rb < 0, ra*x + rb < -ra*rc + rb))) + 2*sqrt(ra*x + rb)
+    assert expand(manualintegrate(sqrt(ra*x + rb) / (x + rc), x)) == \
+           Piecewise((-2*ra*rc*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), ra*rc - rb > 0),
+                                       (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
+                                        log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), True)) +
+                      2*rb*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), ra*rc - rb > 0),
+                                    (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
+                                     log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), True)) +
+                      2*sqrt(ra*x + rb), Ne(ra, 0)), (sqrt(rb)*log(rc + x), True))
 
     assert manualintegrate(sqrt(2*x + 3) / (x + 1), x) == 2*sqrt(2*x + 3) - log(sqrt(2*x + 3) + 1) + log(sqrt(2*x + 3) - 1)
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**Rational(5, 2)/20 - (2*x + 3)**Rational(3, 2)/4
@@ -518,8 +520,7 @@ def test_issue_13297():
 
 
 def test_issue_14470():
-    assert manualintegrate(1/(x*sqrt(x + 1)), x) == \
-        log(-1 + 1/sqrt(x + 1)) - log(1 + 1/sqrt(x + 1))
+    assert_is_integral_of(1/(x*sqrt(x + 1)), log(sqrt(x + 1) - 1) - log(sqrt(x + 1) + 1))
 
 
 @slow
@@ -583,6 +584,19 @@ def test_issue_23566():
     i = Integral(1/sqrt(x**2 - 1), (x, -2, -1)).doit(manual=True)
     assert i == -log(4 - 2*sqrt(3)) + log(2)
     assert str(i.n()) == '1.31695789692482'
+
+
+def test_manualintegrate_sqrt_linear():
+    assert_is_integral_of((5*x**3+4)/sqrt(2+3*x),
+                          10*(3*x + 2)**(S(7)/2)/567 - 4*(3*x + 2)**(S(5)/2)/27 +
+                          40*(3*x + 2)**(S(3)/2)/81 + 136*sqrt(3*x + 2)/81)
+    assert manualintegrate(x/sqrt(a+b*x)**3, x) == \
+        Piecewise((Mul(2, b**-2, a/sqrt(a + b*x) + sqrt(a + b*x)), Ne(b, 0)), (x**2/(2*a**(S(3)/2)), True))
+    assert_is_integral_of((sqrt(3*x+3)+1)/((2*x+2)**(1/S(3))+1),
+                          3*sqrt(6)*(2*x + 2)**(S(7)/6)/14 - 3*sqrt(6)*(2*x + 2)**(S(5)/6)/10 -
+                          3*sqrt(6)*(2*x + 2)**(S.One/6)/2 + 3*(2*x + 2)**(S(2)/3)/4 - 3*(2*x + 2)**(S.One/3)/2 +
+                          sqrt(6)*sqrt(2*x + 2)/2 + 3*log((2*x + 2)**(S.One/3) + 1)/2 +
+                          3*sqrt(6)*atan((2*x + 2)**(S.One/6))/2)
 
 
 def test_manualintegrate_sqrt_quadratic():

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -953,8 +953,8 @@ def _get_examples_ode_sol_factorable():
     'fact_06': {
         'eq': (f(x).diff(x, 2)-exp(f(x)))*f(x).diff(x),
         'sol': [
-            Eq(f(x), log(C1/(cos(C1*sqrt(-1/C1)*(C2 + x)) - 1))),
-            Eq(f(x), log(C1/(cos(C1*sqrt(-1/C1)*(C2 - x)) - 1))),
+            Eq(f(x), log(-C1/(cos(sqrt(-C1)*(C2 + x)) + 1))),
+            Eq(f(x), log(-C1/(cos(sqrt(-C1)*(C2 - x)) + 1))),
             Eq(f(x), C1)
         ],
         'slow': True,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

* At first I want to address https://github.com/sympy/sympy/pull/23608#discussion_r897365318 by calling `root_mul_rule`, but I find it not that powerful as
  * it doesn't address https://github.com/sympy/sympy/pull/11080#issuecomment-218954685
  * it doesn't handle degenerate case

  so I rewrite it to `sqrt_linear_rule`.
* By implementing it, some test cases have to be changed, and I find `quadratic_denom_rule` annoying to have `Piecewise` that splits `x`'s domain, which is unnecessary. So I simplify it to a log, and revert `test_manualintegrate_rational` that was changed at https://github.com/sympy/sympy/pull/11080
#### Other comments
Before:
```py
In [1]: from sympy import *

In [2]: x=Symbol('x')

In [3]: %timeit integrate((x**3+1)/sqrt(x+1), manual=True)
4.27 s ± 23.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: integrate((sqrt(3*x+3)+1)/((2*x+2)**(1/S(3))+1), manual=True)
Out[4]: 3*2**(2/3)*(x + 1)**(2/3)/4 - 3*2**(1/3)*(x + 1)**(1/3)/2 + 3*log(2**(1/3)*(x + 1)**(1/3) + 1)/2 + 2*sqrt(3)*Integral(_u**2/(2**(1/3)*(_u**2)**(1/3) + 1), (_u, sqrt(x + 1)))
```
After:
```py
In [1]: from sympy import *

In [2]: x=Symbol('x')

In [3]: %timeit integrate((x**3+1)/sqrt(x+1), manual=True)
627 ms ± 10.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: integrate((sqrt(3*x+3)+1)/((2*x+2)**(1/S(3))+1), manual=True)
Out[4]: 3*sqrt(6)*(2*x + 2)**(7/6)/14 - 3*sqrt(6)*(2*x + 2)**(5/6)/10 - 3*sqrt(6)*(2*x + 2)**(1/6)/2 + 3*(2*x + 2)**(2/3)/4 - 3*(2*x + 2)**(1/3)/2 + sqrt(6)*sqrt(2*x + 2)/2 + 3*log((2*x + 2)**(1/3) + 1)/2 + 3*sqrt(6)*atan((2*x + 2)**(1/6))/2
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * manualintegrate improves f(x, (a+b*x)**(p/q))
<!-- END RELEASE NOTES -->
