### PR TITLE
Print reciprocals as division for Python printer

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -337,7 +337,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         Notes
         =====
 
-        This only preprocesses the ``sqrt`` as math formatter
+        This preprocesses the ``sqrt`` as math formatter and prints division
 
         Examples
         ========
@@ -357,6 +357,10 @@ class AbstractPythonCodePrinter(CodePrinter):
         'x**(-1/2)'
         >>> printer._hprint_Pow(1/sqrt(x), rational=False)
         '1/math.sqrt(x)'
+        >>> printer._hprint_Pow(1/x, rational=False)
+        '1/x'
+        >>> printer._hprint_Pow(1/x, rational=True)
+        'x**(-1)'
 
         Using sqrt from numpy or mpmath
 
@@ -377,13 +381,17 @@ class AbstractPythonCodePrinter(CodePrinter):
             arg = self._print(expr.base)
             return '{func}({arg})'.format(func=func, arg=arg)
 
-        if expr.is_commutative:
-            if -expr.exp is S.Half and not rational:
+        if expr.is_commutative and not rational:
+            if -expr.exp is S.Half:
                 func = self._module_format(sqrt)
                 num = self._print(S.One)
                 arg = self._print(expr.base)
-                return "{num}/{func}({arg})".format(
-                    num=num, func=func, arg=arg)
+                return f"{num}/{func}({arg})"
+            if expr.exp is S.NegativeOne:
+                num = self._print(S.One)
+                arg = self.parenthesize(expr.base, PREC, strict=False)
+                return f"{num}/{arg}"
+
 
         base_str = self.parenthesize(expr.base, PREC, strict=False)
         exp_str = self.parenthesize(expr.exp, PREC, strict=False)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -37,6 +37,7 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Mod(-x, y)) == '(-x) % y'
     assert prntr.doprint(And(x, y)) == 'x and y'
     assert prntr.doprint(Or(x, y)) == 'x or y'
+    assert prntr.doprint(1/(x+y)) == '1/(x + y)'
     assert not prntr.module_imports
 
     assert prntr.doprint(pi) == 'math.pi'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Reciprocals (`1/x`) are now printed as such. This is faster than `x**(-1)` and consistent with e.g. how `x/y` is printed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Reciprocals are printed as divisions in Python printers. 
<!-- END RELEASE NOTES -->
