### PR TITLE
fix(core): don't simplify sqrt(x**2) if x is not positive

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -470,8 +470,6 @@ class Pow(Expr):
                     s = 1  # floor = 0
                 elif re(b).is_extended_nonnegative and (abs(e) < 2) == True:
                     s = 1  # floor = 0
-                elif fuzzy_not(im(b).is_zero) and abs(e) == 2:
-                    s = 1  # floor = 0
                 elif _half(other):
                     s = exp(2*S.Pi*S.ImaginaryUnit*other*floor(
                         S.Half - e*arg(b)/(2*S.Pi)))

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -403,8 +403,12 @@ def test_issue_7638():
                                                               Rational(3, 2) + I/2]
     assert sqrt(r**Rational(4, 3)) != r**Rational(2, 3)
     assert sqrt((p + I)**Rational(4, 3)) == (p + I)**Rational(2, 3)
-    assert sqrt((p - p**2*I)**2) == p - p**2*I
-    assert sqrt((p**2*I - p)**2) == p**2*I - p  # XXX ok?
+
+    for q in 1+I, 1-I:
+        assert sqrt(q**2) == q
+    for q in -1+I, -1-I:
+        assert sqrt(q**2) == -q
+
     assert sqrt((p + r*I)**2) != p + r*I
     e = (1 + I/5)
     assert sqrt(e**5) == e**(5*S.Half)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is an old bug dating back to #7638.

This was discovered during #22993 (https://github.com/sympy/sympy/pull/22993#issuecomment-1159711004).

#### Brief description of what is fixed or changed

This PR makes `Pow._eval_power` more conservative about simplifying `(z**a)**b` to `z**(a*b)` in the case of square rooting a square.

On master we have:
```python
In [2]: p = (-1 + I)**2

In [3]: p
Out[3]: 
        2
(-1 + ⅈ) 

In [4]: sqrt(p)
Out[4]: -1 + ⅈ

In [5]: sqrt(expand(p))
Out[5]: 1 - ⅈ
```
It is `In [4]` that is incorrect as it does not give the principal root:
```python
In [6]: arg(sqrt(p))
Out[6]: 
3⋅π
───
 4 

In [7]: arg(sqrt(expand(p)))
Out[7]: 
-π 
───
 4 
```
The change here just removes a special case from `Pow._eval_power`:
https://github.com/sympy/sympy/blob/e614ccb66ad8d75e817de17f419f4b8e4469fd1f/sympy/core/power.py#L473-L474
The logic can the fall back to the more general code that can correctly handle this case:
https://github.com/sympy/sympy/blob/e614ccb66ad8d75e817de17f419f4b8e4469fd1f/sympy/core/power.py#L475-L481

See the discussion in #7638 and https://github.com/certik/theoretical-physics/issues/23 to understand the formula that is being used for simplification in this case.

#### Other comments

I expect this will break a few tests so I'm just putting it up first to see how it fares.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
