### PR TITLE
Moved fixed integrals from failing_integrals

### DIFF
--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -5,7 +5,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.hyperbolic import (csch, sech, sinh)
+from sympy.functions.elementary.hyperbolic import (sech, sinh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, atan, cos, sec, sin, tan)
@@ -230,13 +230,8 @@ def test_issue_11813():
 
 
 @XFAIL
-def test_issue_11254a():
-    assert not integrate(sech(x), (x, 0, 1)).has(Integral)
-
-
-@XFAIL
-def test_issue_11254b():
-    assert not integrate(csch(x), (x, 0, 1)).has(Integral)
+def test_issue_11254c():
+    assert not integrate(sech(x)**2, (x, 0, 1)).has(Integral)
 
 
 @XFAIL
@@ -252,11 +247,6 @@ def test_issue_9723():
 @XFAIL
 def test_issue_9101():
     assert not integrate(log(x + sqrt(x**2 + y**2 + z**2)), z).has(Integral)
-
-
-@XFAIL
-def test_issue_7264():
-    assert not integrate(exp(x)*sqrt(1 + exp(2*x))).has(Integral)
 
 
 @XFAIL

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1931,6 +1931,23 @@ def test_pr_23583():
     assert integrate(1/sqrt((x - I)**2-1)) == Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
 
 
+def test_issue_7264():
+    assert integrate(exp(x)*sqrt(1 + exp(2*x))) == sqrt(exp(2*x) + 1)*exp(x)/2 + asinh(exp(x))/2
+
+
+def test_issue_11254a():
+    assert integrate(sech(x), (x, 0, 1)) == 2*atan(tanh(S.Half))
+
+
+def test_issue_11254b():
+    assert integrate(csch(x), x) == log(tanh(x/2))
+    assert integrate(csch(x), (x, 0, 1)) == oo
+
+
+def test_issue_11254d():
+    assert integrate((sech(x)**2).rewrite(sinh), x) == 2*tanh(x/2)/(tanh(x/2)**2 + 1)
+
+
 def test_hyperbolic():
     assert integrate(coth(x)) == x - log(tanh(x) + 1) + log(tanh(x))
     assert integrate(sech(x)) == 2*atan(tanh(x/2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #7264

#### Brief description of what is fixed or changed

Some of the integrals in failing_integrals have been fixed over time. Not enough to sort out #11254 though. But at least #7264

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
