### PR TITLE
[WIP] Remove nargs check in Function.__new__

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -465,22 +465,6 @@ class Function(Application, Expr):
         if cls is Function:
             return UndefinedFunction(*args, **options)
 
-        n = len(args)
-        if n not in cls.nargs:
-            # XXX: exception message must be in exactly this format to
-            # make it work with NumPy's functions like vectorize(). See,
-            # for example, https://github.com/numpy/numpy/issues/1697.
-            # The ideal solution would be just to attach metadata to
-            # the exception and change NumPy to take advantage of this.
-            temp = ('%(name)s takes %(qual)s %(args)s '
-                   'argument%(plural)s (%(given)s given)')
-            raise TypeError(temp % {
-                'name': cls,
-                'qual': 'exactly' if len(cls.nargs) == 1 else 'at least',
-                'args': min(cls.nargs),
-                'plural': 's'*(min(cls.nargs) != 1),
-                'given': n})
-
         evaluate = options.get('evaluate', global_parameters.evaluate)
         result = super().__new__(cls, *args, **options)
         if evaluate and isinstance(result, cls) and result.args:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -639,7 +639,6 @@ def test_fdiff_argument_index_error():
             raise ArgumentIndexError
     mf = myfunc(x)
     assert mf.diff(x) == Derivative(mf, x)
-    raises(TypeError, lambda: myfunc(x, x))
 
 
 def test_deriv_wrt_function():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Also see #23593

#### Brief description of what is fixed or changed


This PR removes the check on the number of arguments in `Function.__new__`. This was suggested in #23593


- For many functions a reasonable error message is given when the number of arguments does not match. For example
```
from sympy import cos
cos(1, 2)
Traceback (most recent call last):

  Input In [2] in <cell line: 2>
    cos(1, 2)

  File /mnt/data/sympy/sympy/core/cache.py:70 in wrapper
    retval = cfunc(*args, **kwargs)

  File /mnt/data/sympy/sympy/core/function.py:469 in __new__
    result = super().__new__(cls, *args, **options)

  File /mnt/data/sympy/sympy/core/cache.py:70 in wrapper
    retval = cfunc(*args, **kwargs)

  File /mnt/data/sympy/sympy/core/function.py:297 in __new__
    evaluated = cls.eval(*args)

TypeError: eval() takes 2 positional arguments but 3 were given
```
The original error message was more informative though:
```
Traceback (most recent call last):

  Input In [1] in <cell line: 2>
    cos(1, 2)

  File /mnt/data/sympy/sympy/core/cache.py:70 in wrapper
    retval = cfunc(*args, **kwargs)

  File /mnt/data/sympy/sympy/core/function.py:477 in __new__
    raise TypeError(temp % {

TypeError: cos takes exactly 1 argument (2 given)
```

- The removed code contains an old comment about `numpy.vectorize`. This PR works well with recent versions of numpy. For example
```
In [2]: from sympy import cos
   ...: import numpy as np
   ...: 
   ...: f = np.vectorize(cos)
   ...: print(f(1))
   ...: print(f([1, 2, 3]))
cos(1)
[cos(1) cos(2) cos(3)]
```
(but it is unknown whether this snippet of code tests for the original problem)

- All relevant tests pass. Not passing:
```
def test_fdiff_argument_index_error():
    from sympy.core.function import ArgumentIndexError

    class myfunc(Function):
        nargs = 1  # define since there is no eval routine

        def fdiff(self, idx):
            raise ArgumentIndexError
    mf = myfunc(x)
    assert mf.diff(x) == Derivative(mf, x)
    raises(TypeError, lambda: myfunc(x, x))
```
Fixed by removing the last `raises` statement. Not sure what this was really testing.

- The PR is not 100% backwards compatible. In particular for user defined `eval` methods, there could be differences.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Improve performance 
<!-- END RELEASE NOTES -->
