### PR TITLE
Fix Chained type alias assignment for Matrix breaks mypy in SymPy 1.10.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -329,6 +329,7 @@ Arihant Parsoya <parsoyaarihant@gmail.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
 Arpit Goyal <agmps18@gmail.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>
+Arthur Ryman <arthur.ryman@gmail.com>
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
 Ashish Kumar Gaurav <ashishkg0022@gmail.com>

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -12,7 +12,8 @@ from .dense import (
 from .dense import MutableDenseMatrix
 from .matrices import DeferredVector, MatrixBase
 
-Matrix = MutableMatrix = MutableDenseMatrix
+MutableMatrix = MutableDenseMatrix
+Matrix = MutableMatrix
 
 from .sparse import MutableSparseMatrix
 from .sparsetools import banded


### PR DESCRIPTION
PEP 484 specifies that type alias assignments must be simple. The type alias for Matrix was defined in a chained assignment. This broke mypy. I split the chained assignment into two simple assignments.

Refer to issue #23647.

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Made type aliases for Matrix and MutableMatrix compliant with PEP 484
  * This enables mypy to recognize the type aliases 
<!-- END RELEASE NOTES -->