### PR TITLE
Parametric printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1460,6 +1460,7 @@ symbolique <symbolique@users.noreply.github.com>
 tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bg>
 tnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
+tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
 vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -94,6 +94,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         fully_qualified_modules=True,
         contract=False,
         standard='python3',
+        parametric=False,
     )
 
     def __init__(self, settings=None):
@@ -115,6 +116,20 @@ class AbstractPythonCodePrinter(CodePrinter):
             'user_functions', {}))
         self.known_constants = dict(self._kc, **(settings or {}).get(
             'user_constants', {}))
+
+        # Handle parameteric form
+        self._param_count = 0
+        self.params = []
+        if self._settings['parametric']:
+            def _parametric_func(expr):
+                param = f"params_{self._param_count}"
+                self.params.append(float(expr))
+                self._param_count += 1
+                return param
+
+            self._print_Float = _parametric_func
+            self._print_Rational = _parametric_func
+            self._print_Integer = _parametric_func
 
     def _declare_number_const(self, name, value):
         return "%s = %s" % (name, value)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -357,13 +357,15 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         generated function:
 
         >>> f, params = lambdify(x, 2*x + 1, parametric=True)
+        >>> params
+        [2.0, 1.0]
         >>> f(1)
-        3
+        3.0
         >>> f(1, params=[1,0])
-        2
+        1.0
         >>> params[1] = 1
         >>> f(1, params=params)
-        2
+        2.0
 
     Examples
     ========


### PR DESCRIPTION
#### References to other Issues or PRs
Provides parametric priting support as originally introduced in #23627

#### Brief description of what is fixed or changed
Provides parametric support for all children of `AbstractPythonCodePrinter`.

#### Other comments
Responses to the concerns raised in #23627 will be edited in here shortly.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
- utilities
    - Added parametric option to lambdify, allowing numeric values in the lambdified expression to be changed after the function has been generated. For example, `f, params = lambdify([x,y], 1.0*cos(x) + 3.2*y, parametric=True)` would generate a function of the form:
      ```Python
      def _lambdifygenerated(x, y, params=params):
          [params_0, params_1] = params
          return params_0*cos(x) + params_1*y
      ```
- printing
    - Added parametric setting to AbstractPythonCodePrinter, allowing numeric values in child printers to be printed as placeholders, rather than their true numeric values. Example: `PythonCodePrinter(settings={"parametric": True}).doprint(1.0*cos(x) + 3.2*y)` would return `"params_0*cos(x)+params_1*y"`.
<!-- END RELEASE NOTES -->
