### PR TITLE
maint(doc): unpin sphinx version for the docs build

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 matplotlib-inline
 mpmath
 myst-parser
-Sphinx==4.5.0
+Sphinx
 sphinx-autobuild
 sphinx-copybutton
 sphinx-math-dollar


### PR DESCRIPTION
The docs build was temporarily pinned due to

  https://github.com/sphinx-doc/sphinx/issues/10538

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/20623#issuecomment-1161692412

#### Brief description of what is fixed or changed

Unpin the sphinx version used to build the docs so that the latest release will always be used.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
