### PR TITLE
manualintegrate DiracDelta

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -230,6 +230,8 @@ class DiracDelta(Function):
                 return -cls(-arg, k)
             elif k.is_even:
                 return cls(-arg, k) if k else cls(-arg)
+        elif k.is_zero:
+            return cls(arg, evaluate=False)
 
     def _eval_expand_diracdelta(self, **hints):
         """

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -27,6 +27,7 @@ def test_DiracDelta():
     assert DiracDelta(5.1) == 0
     assert DiracDelta(-pi) == 0
     assert DiracDelta(5, 7) == 0
+    assert DiracDelta(x, 0) == DiracDelta(x)
     assert DiracDelta(i) == 0
     assert DiracDelta(j) == 0
     assert DiracDelta(k) == 0

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -10,7 +10,7 @@ from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, csc, sec, sin, tan)
-from sympy.functions.special.delta_functions import Heaviside
+from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, erf, erfi, fresnelc, fresnels, li)
 from sympy.functions.special.gamma_functions import uppergamma
@@ -302,6 +302,11 @@ def test_manualintegrate_derivative():
 
 
 def test_manualintegrate_Heaviside():
+    assert_is_integral_of(DiracDelta(3*x+2), Heaviside(3*x+2)/3)
+    assert_is_integral_of(DiracDelta(3*x, 0), Heaviside(3*x)/3)
+    assert manualintegrate(DiracDelta(a+b*x, 1), x) == \
+        Piecewise((DiracDelta(a + b*x)/b, Ne(b, 0)), (x*DiracDelta(a, 1), True))
+    assert_is_integral_of(DiracDelta(x/3-1, 2), 3*DiracDelta(x/3-1, 1))
     assert manualintegrate(Heaviside(x), x) == x*Heaviside(x)
     assert manualintegrate(x*Heaviside(2), x) == x**2/2
     assert manualintegrate(x*Heaviside(-2), x) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/pull/23559#issuecomment-1163794267
#### Brief description of what is fixed or changed

* Previously when arg has no minus sign, `DiracDelta(..., 0)` doesn't evaluate to `DiracDelta(...)`
* Support manual integrate `DiracDelta(a+b*x, n)`
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Auto evaluate DiracDelta(x, 0) to DiracDelta(x)
* integrals
  * Support integral steps for DiracDelta
<!-- END RELEASE NOTES -->
