### PR TITLE
Fix two issues with matrices

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -123,6 +123,13 @@ functions. Instead of ``carmichael.is_perfect_square`` use
 n % p == 0
 ```
 
+(remove-check-argument-from-matrix-operations)=
+### The `check` argument to `HadamardProduct`, `MatAdd` and `MatMul`
+
+This argument can be used to pass incorrect values to `~.HadamardProduct`,
+`~.MatAdd`, and `~.MatMul` leading to later problems. The `check` argument
+will be removed and the arguments will always be checked for correctness, i.e.,
+the arguments are matrices or matrix symbols.
 
 ## Version 1.10
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -11,6 +11,7 @@ from sympy.matrices.expressions.special import ZeroMatrix, OneMatrix
 from sympy.strategies import (
     unpack, flatten, condition, exhaust, rm_id, sort
 )
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 
 def hadamard_product(*matrices):
@@ -64,10 +65,21 @@ class HadamardProduct(MatrixExpr):
     """
     is_HadamardProduct = True
 
-    def __new__(cls, *args, evaluate=False, check=True):
+    def __new__(cls, *args, evaluate=False, check=None):
         args = list(map(sympify, args))
-        if check:
+        if check is not None:
+            sympy_deprecation_warning(
+                "Passing check to HadamardProduct is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
+
+        if check in (True, None):
             validate(*args)
+        else:
+            sympy_deprecation_warning(
+                "Passing check=False to HadamardProduct is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
 
         obj = super().__new__(cls, *args)
         if evaluate:

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -12,7 +12,8 @@ from sympy.strategies import (rm_id, unpack, flatten, sort, condition,
     exhaust, do_one, glom)
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.expressions.special import ZeroMatrix, GenericZeroMatrix
-from sympy.utilities import sift
+from sympy.utilities.iterables import sift
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 # XXX: MatAdd should perhaps not subclass directly from Add
 class MatAdd(MatrixExpr, Add):
@@ -34,7 +35,7 @@ class MatAdd(MatrixExpr, Add):
 
     identity = GenericZeroMatrix()
 
-    def __new__(cls, *args, evaluate=False, check=True, _sympify=True):
+    def __new__(cls, *args, evaluate=False, check=None, _sympify=True):
         if not args:
             return cls.identity
 
@@ -46,10 +47,20 @@ class MatAdd(MatrixExpr, Add):
 
         obj = Basic.__new__(cls, *args)
 
-        if check:
+        if check is not None:
+            sympy_deprecation_warning(
+                "Passing check to MatAdd is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
+        if check in (True, None):
             if not any(isinstance(i, MatrixExpr) for i in args):
                 return Add.fromiter(args)
             validate(*args)
+        else:
+            sympy_deprecation_warning(
+                "Passing check=False to MatAdd is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
 
         if evaluate:
             obj = cls._evaluate(obj)
@@ -58,9 +69,6 @@ class MatAdd(MatrixExpr, Add):
 
     @classmethod
     def _evaluate(cls, expr):
-        args = expr.args
-        if not any(isinstance(i, MatrixExpr) for i in args):
-            return Add(*args, evaluate=True)
         return canonicalize(expr)
 
     @property

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -34,7 +34,7 @@ class MatAdd(MatrixExpr, Add):
 
     identity = GenericZeroMatrix()
 
-    def __new__(cls, *args, evaluate=False, check=False, _sympify=True):
+    def __new__(cls, *args, evaluate=False, check=True, _sympify=True):
         if not args:
             return cls.identity
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -104,22 +104,22 @@ class MatrixExpr(Expr):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__radd__')
     def __add__(self, other):
-        return MatAdd(self, other, check=True).doit()
+        return MatAdd(self, other).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__add__')
     def __radd__(self, other):
-        return MatAdd(other, self, check=True).doit()
+        return MatAdd(other, self).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
-        return MatAdd(self, -other, check=True).doit()
+        return MatAdd(self, -other).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
-        return MatAdd(other, -self, check=True).doit()
+        return MatAdd(other, -self).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rmul__')

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -398,7 +398,7 @@ class MatrixExpr(Expr):
         return self
 
     def as_coeff_mmul(self):
-        return 1, MatMul(self)
+        return S.One, MatMul(self)
 
     @staticmethod
     def from_index_summation(expr, first_index=None, last_index=None, dimensions=None):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -9,6 +9,7 @@ from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
         do_one, new)
 from sympy.matrices.common import ShapeError, NonInvertibleMatrixError
 from sympy.matrices.matrices import MatrixBase
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 from .inverse import Inverse
 from .matexpr import MatrixExpr
@@ -37,7 +38,7 @@ class MatMul(MatrixExpr, Mul):
 
     identity = GenericIdentity()
 
-    def __new__(cls, *args, evaluate=False, check=True, _sympify=True):
+    def __new__(cls, *args, evaluate=False, check=None, _sympify=True):
         if not args:
             return cls.identity
 
@@ -49,8 +50,19 @@ class MatMul(MatrixExpr, Mul):
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()
 
-        if check:
+        if check is not None:
+            sympy_deprecation_warning(
+                "Passing check to MatMul is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
+
+        if check in (True, None):
             validate(*matrices)
+        else:
+            sympy_deprecation_warning(
+                "Passing check=False to MatMul is deprecated and the check argument will be removed in a future version.",
+                deprecated_since_version="1.11",
+                active_deprecations_target='remove-check-argument-from-matrix-operations')
 
         if not matrices:
             # Should it be


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

For some reason the `check` argument to `MatAdd` is `False` which is inconsistent with `MatMul` and allows creating things like `MatAdd(matrix, scalar)` that is later on not supported.

`MatExpr.as_coeff_mmul` did not return a sympified result (compare to `MatMul.as_coeff_mmul`).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * DEPRECATION: Previously the check argument to e.g. `MatAdd` could be used to form a mathematically incorrect expression like `MatAdd(1, Matrix([[1, 2]], check=False)`. The intention of the `check=False` argument is just as an optimization to avoid checking that all arguments are matrices with matching shapes for speed. However, it allowed creating objects that were both mathematically invalid and also break the internal invariant of `MatAdd` which expects that all of its args are of type `MatrixExp` leading to obscure failures in other routines such as printing. In SymPy 1.11 passing `check` to `MatAdd`, `MatMul` and `HadamardProduct` will emit a deprecation warning. In a future version of SymPy the arguments will always be checked and passing any non-Matrix argument will give an exception.
<!-- END RELEASE NOTES -->
