### PR TITLE
doc(printing): remove note about ccode from active-deprecations

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -646,19 +646,6 @@ should be replaced with just `str()`, the `unicode` argument to `prettyForm`
 should be omitted, and the `prettyForm.unicode` attribute should be replaced
 with the `prettyForm.s` attribute.
 
-(deprecated-printing-code-submodules)=
-### The `sympy.printing.fcode`, `sympy.printing.ccode`, and `sympy.printing.cxxcode` modules
-
-The submodules `sympy.printing.ccode`, `sympy.printing.fcode`, and
-`sympy.printing.cxxcode` were renamed to {mod}`sympy.printing.c`,
-{mod}`sympy.printing.fortran`, and {mod}`sympy.printing.cxx`, respectively.
-These modules were renamed because they conflict with the corresponding
-function names. This causes issues because `from sympy.printing import ccode`
-can give the function or the module, depending on whether the `ccode`
-submodule has been imported yet or not. See [this comment on issue
-#20234](https://github.com/sympy/sympy/issues/20234#issuecomment-707574283)
-for a technical discussion on why this happens.
-
 (deprecated-lambdify-arguments-set)=
 ### Passing the arguments to `lambdify` as a `set`
 


### PR DESCRIPTION
#### References to other Issues or PRs

Follow up for #23660 (see the release note there)

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
