### PR TITLE
extend sqrt_linear_rule to handle nested sqrt

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -879,8 +879,8 @@ def sqrt_linear_rule(integral: IntegralInfo):
         if not exp_.is_Rational:  # exclude x**pi
             return
         match = base.match(a+b*x)
-        if not match:  # exclude non-linear
-            return
+        if not match:  # skip non-linear
+            continue  # for sqrt(x+sqrt(x)), although base is non-linear, we can still substitute sqrt(x)
         a1, b1 = match[a], match[b]
         if a0*b1 != a1*b0 or not (b0/b1).is_nonnegative:  # cannot transform sqrt(x) to sqrt(x+1) or sqrt(-x)
             return
@@ -1474,8 +1474,9 @@ def integral_steps(integrand, symbol, **options):
     result = do_one(
         null_safe(special_function_rule),
         null_safe(switch(key, {
-            Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule), \
-                              null_safe(quadratic_denom_rule)),
+            Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule),
+                        null_safe(sqrt_linear_rule),
+                        null_safe(quadratic_denom_rule)),
             Symbol: power_rule,
             exp: exp_rule,
             Add: add_rule,

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -234,11 +234,6 @@ def test_issue_10584():
 
 
 @XFAIL
-def test_issue_9723():
-    assert not integrate(sqrt(x + sqrt(x))).has(Integral)
-
-
-@XFAIL
 def test_issue_9101():
     assert not integrate(log(x + sqrt(x**2 + y**2 + z**2)), z).has(Integral)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1953,6 +1953,14 @@ def test_issue_22863():
     assert math.isclose(i.n(), -2.98126694400554)
 
 
+def test_issue_9723():
+    assert integrate(sqrt(x + sqrt(x))) == \
+        2*sqrt(sqrt(x) + x)*(sqrt(x)/12 + x/3 - S(1)/8) + log(2*sqrt(x) + 2*sqrt(sqrt(x) + x) + 1)/8
+    assert integrate(sqrt(2*x+3+sqrt(4*x+5))**3) == \
+        sqrt(2*x + sqrt(4*x + 5) + 3) * \
+           (9*x/10 + 11*(4*x + 5)**(S(3)/2)/40 + sqrt(4*x + 5)/40 + (4*x + 5)**2/10 + S(11)/10)/2
+
+
 def test_hyperbolic():
     assert integrate(coth(x)) == x - log(tanh(x) + 1) + log(tanh(x))
     assert integrate(sech(x)) == 2*atan(tanh(x/2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -611,6 +611,11 @@ def test_manualintegrate_sqrt_linear():
                           3*sqrt(6)*(2*x + 2)**(S.One/6)/2 + 3*(2*x + 2)**(S(2)/3)/4 - 3*(2*x + 2)**(S.One/3)/2 +
                           sqrt(6)*sqrt(2*x + 2)/2 + 3*log((2*x + 2)**(S.One/3) + 1)/2 +
                           3*sqrt(6)*atan((2*x + 2)**(S.One/6))/2)
+    assert_is_integral_of(sqrt(x+sqrt(x)),
+                          2*sqrt(sqrt(x) + x)*(sqrt(x)/12 + x/3 - S(1)/8) + log(2*sqrt(x) + 2*sqrt(sqrt(x) + x) + 1)/8)
+    assert_is_integral_of(sqrt(2*x+3+sqrt(4*x+5))**3,
+                          sqrt(2*x + sqrt(4*x + 5) + 3) *
+                          (9*x/10 + 11*(4*x + 5)**(S(3)/2)/40 + sqrt(4*x + 5)/40 + (4*x + 5)**2/10 + S(11)/10)/2)
 
 
 def test_manualintegrate_sqrt_quadratic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #9723
#### Brief description of what is fixed or changed
On top of #23674, with a little extension to #23642, `sqrt(x+sqrt(x))` can be integrated.
#### Other comments
First several steps from SymPy Beta
![Screenshot from 2022-06-25 14-39-29](https://user-images.githubusercontent.com/26783539/175786536-6dfc54cc-a410-4fed-81ec-9a4e330f9ccc.png)
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
