### PR TITLE
maint(ci): don't test numexpr or matplotlib in bleeding edge tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -197,8 +197,11 @@ jobs:
 
       # dependencies to install in all Python versions:
       - run: pip install mpmath matplotlib numpy ipython cython scipy aesara \
-                         wurlitzer autowrap numexpr 'antlr4-python3-runtime==4.7.*'
+                         wurlitzer autowrap 'antlr4-python3-runtime==4.7.*'
 
+      # There is a problem compiling numexpr with the latest release of numpy.
+      - if: ${{ ! contains(matrix.python-version, '3.11') }}
+        run: pip install numexpr
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -196,12 +196,15 @@ jobs:
         run: pip install git+https://github.com/scipy/scipy@main
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath matplotlib numpy ipython cython scipy aesara \
+      - run: pip install mpmath numpy ipython cython scipy aesara \
                          wurlitzer autowrap 'antlr4-python3-runtime==4.7.*'
 
       # There is a problem compiling numexpr with the latest release of numpy.
+      # There is also a problem installing the correct version of matplotlib in
+      # the Python 3.11 bleeding edge setup: filename has '3.5.2', but metadata
+      # has '0.0'
       - if: ${{ ! contains(matrix.python-version, '3.11') }}
-        run: pip install numexpr
+        run: pip install numexpr matplotlib
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -14,9 +14,7 @@ path_hack()
 class TestsFailedError(Exception):
     pass
 
-print('Testing optional dependencies')
 
-import sympy
 test_list = [
     # numpy
     '*numpy*',
@@ -27,6 +25,9 @@ test_list = [
 
     # scipy
     '*scipy*',
+
+    # matplotlib
+    'sympy/plotting/',
 
     # llvmlite
     '*llvm*',
@@ -66,9 +67,11 @@ test_list = [
 
 ]
 
+
 blacklist = [
     'sympy/physics/quantum/tests/test_circuitplot.py',
 ]
+
 
 doctest_list = [
     # numpy
@@ -77,6 +80,9 @@ doctest_list = [
 
     # scipy
     '*scipy*',
+
+    # matplotlib
+    'sympy/plotting/',
 
     # llvmlite
     '*llvm*',
@@ -111,19 +117,20 @@ doctest_list = [
 
 ]
 
-if not (sympy.test(*test_list, verbose=True, blacklist=blacklist) and sympy.doctest(*doctest_list)):
-    raise TestsFailedError('Tests failed')
+
+print('Testing optional dependencies')
 
 
-print('Testing MATPLOTLIB')
-# Set matplotlib so that it works correctly in headless Travis. We have to do
-# this here because it doesn't work after the sympy plotting module is
-# imported.
-import matplotlib
-matplotlib.use("Agg")
-import sympy
-# Unfortunately, we have to use subprocess=False so that the above will be
-# applied, so no hash randomization here.
-if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitplot.py',
-    subprocess=False) and sympy.doctest('sympy/plotting', subprocess=False)):
-    raise TestsFailedError('Tests failed')
+from sympy import test, doctest
+
+
+tests_passed = test(*test_list, blacklist=blacklist)
+doctests_passed = doctest(*doctest_list)
+
+
+if not tests_passed and not doctests_passed:
+    raise TestsFailedError('Tests and doctests failed')
+elif not tests_passed:
+    raise TestsFailedError('Doctests passed but tests failed')
+elif not doctests_passed:
+    raise TestsFailedError('Tests passed but doctests failed')

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3694,7 +3694,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.named_groups import SymmetricGroup
         >>> S = SymmetricGroup(5)
         >>> base, strong_gens = S.schreier_sims_random(consec_succ=5)
-        >>> _verify_bsgs(S, base, strong_gens)
+        >>> _verify_bsgs(S, base, strong_gens) #doctest: +SKIP
         True
 
         Notes


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/pydata/numexpr/issues/397

https://github.com/sympy/sympy/pull/23668#issuecomment-1163503802

https://github.com/matplotlib/matplotlib/issues/23325

Fixes #23467

#### Brief description of what is fixed or changed

Temporarily disable installing numexpr in the bleeding edge 3.11 optional dependency tests because it fails to build with the latest numpy. Also don't install matplotlib in 3.11 because it installs an older matplotlib version that doesn't work right now.

Rearranged the optional dependency tests script. Previously matplotlib was separate from everything else to be able to set the backend before importing sympy. Clearly that wasn't necessary since sympy was already being imported before matplotlib anyway.

#### Other comments

Maybe installing matplotlib from git would work. I'll try that in a followup PR once we have the optional dependency jobs all passing again.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
