### PR TITLE
maint(ci): install matplotlib from git on 3.11

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -198,14 +198,8 @@ jobs:
         run: pip install git+https://github.com/matplotlib/matplotlib@main
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath numpy ipython cython scipy aesara \
+      - run: pip install mpmath numpy numexpr ipython cython scipy aesara \
                          wurlitzer autowrap 'antlr4-python3-runtime==4.7.*'
-
-      # There is a problem compiling numexpr with the latest release of numpy:
-      #
-      # https://github.com/pydata/numexpr/issues/397
-      - if: ${{ ! contains(matrix.python-version, '3.11') }}
-        run: pip install numexpr
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -198,8 +198,9 @@ jobs:
         run: pip install git+https://github.com/matplotlib/matplotlib@main
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath numpy numexpr ipython cython scipy aesara \
-                         wurlitzer autowrap 'antlr4-python3-runtime==4.7.*'
+      - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
+                         aesara wurlitzer autowrap                            \
+                         'antlr4-python3-runtime==4.7.*'
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -187,24 +187,25 @@ jobs:
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
       - run: python -m pip install --upgrade pip wheel
 
-      # Use numpy and scipy from git for Python 3.11
+      # Use various libs from git for Python 3.11
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/cython/cython@master
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/numpy/numpy@main
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/scipy/scipy@main
+      - if: ${{ contains(matrix.python-version, '3.11') }}
+        run: pip install git+https://github.com/matplotlib/matplotlib@main
 
       # dependencies to install in all Python versions:
       - run: pip install mpmath numpy ipython cython scipy aesara \
                          wurlitzer autowrap 'antlr4-python3-runtime==4.7.*'
 
-      # There is a problem compiling numexpr with the latest release of numpy.
-      # There is also a problem installing the correct version of matplotlib in
-      # the Python 3.11 bleeding edge setup: filename has '3.5.2', but metadata
-      # has '0.0'
+      # There is a problem compiling numexpr with the latest release of numpy:
+      #
+      # https://github.com/pydata/numexpr/issues/397
       - if: ${{ ! contains(matrix.python-version, '3.11') }}
-        run: pip install numexpr matplotlib
+        run: pip install numexpr
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follow on from #23684

https://github.com/matplotlib/matplotlib/issues/23325

https://github.com/pydata/numexpr/issues/397

#### Brief description of what is fixed or changed

Install matplotlib from git on Python 3.11 because there are no wheels and there is a bug installing from sdist.

Also it looks like numexpr should work again now.

#### Other comments

It's probably also good to test against matplotlib master anyway. Once 3.11 is stabilised I think we should still keep a CI job that just uses master branches of various dependencies like matplotlib.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
