### PR TITLE
fix integrate sqrt(x**2)

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -305,13 +305,13 @@ class DifferentialExtension:
 
         # Things like sqrt(exp(x)) do not automatically simplify to
         # exp(x/2), so they will be viewed as algebraic.  The easiest way
-        # to handle this is to convert all instances of (a**b)**Rational
-        # to a**(Rational*b) before doing anything else.  Note that the
+        # to handle this is to convert all instances of exp(a)**Rational
+        # to exp(Rational*a) before doing anything else.  Note that the
         # _exp_part code can generate terms of this form, so we do need to
         # do this at each pass (or else modify it to not do that).
 
-        ratpows = [i for i in self.newf.atoms(Pow).union(self.newf.atoms(exp))
-            if (i.base.is_Pow or isinstance(i.base, exp) and i.exp.is_Rational)]
+        ratpows = [i for i in self.newf.atoms(Pow)
+                   if (isinstance(i.base, exp) and i.exp.is_Rational)]
 
         ratpows_repl = [
             (i, i.base.base**(i.exp*i.base.exp)) for i in ratpows]

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1971,6 +1971,10 @@ def test_hyperbolic():
     assert integrate(csch(x)) == log(tanh(x/2))
 
 
+def test_nested_pow():
+    assert integrate(sqrt(x**2)) == x*sqrt(x**2)/2
+
+
 def test_sqrt_quadratic():
     assert integrate(1/sqrt(3*x**2+4*x+5)) == sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3
     assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Risch is wrong for this case, leading `integrate` wrong.
```py
In [1]: integrate(sqrt(x**2), risch=True)
Out[1]: 
 2
x 
──
2 

In [2]: integrate(sqrt(x**2), heurisch=True)
Out[2]: 
     ____
    ╱  2 
x⋅╲╱  x  
─────────
    2    

In [3]: integrate(sqrt(x**2), manual=True)
Out[3]: 
     ____
    ╱  2 
x⋅╲╱  x  
─────────
    2    

In [4]: integrate(sqrt(x**2), meijerg=True)
Out[4]: 
⌠           
⎮    ____   
⎮   ╱  2    
⎮ ╲╱  x   dx
⌡           

In [5]: integrate(sqrt(x**2))
Out[5]: 
 2
x 
──
2 
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fix integrate sqrt(x**2) in risch
<!-- END RELEASE NOTES -->
