### PR TITLE
fix(core): don't use evaluation in assumptions

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -678,6 +678,12 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im_I.append(a*S.ImaginaryUnit)
+            elif a.is_Mul and S.ImaginaryUnit in a.args:
+                coeff, ai = a.as_coeff_mul(S.ImaginaryUnit)
+                if ai == (S.ImaginaryUnit,) and coeff.is_extended_real:
+                    im_I.append(a*S.ImaginaryUnit)
+                else:
+                    return
             else:
                 return
         b = self.func(*nz)
@@ -706,6 +712,12 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im += 1
+            elif a.is_Mul and S.ImaginaryUnit in a.args:
+                coeff, ai = a.as_coeff_mul(S.ImaginaryUnit)
+                if ai == (S.ImaginaryUnit,) and coeff.is_extended_real:
+                    im_or_z = True
+                else:
+                    return
             else:
                 return
         if z == len(self.args):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -678,8 +678,6 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im_I.append(a*S.ImaginaryUnit)
-            elif (S.ImaginaryUnit*a).is_extended_real:
-                im_I.append(a*S.ImaginaryUnit)
             else:
                 return
         b = self.func(*nz)
@@ -708,8 +706,6 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im += 1
-            elif (S.ImaginaryUnit*a).is_extended_real:
-                im_or_z = True
             else:
                 return
         if z == len(self.args):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -681,7 +681,7 @@ class Add(Expr, AssocOp):
             elif a.is_Mul and S.ImaginaryUnit in a.args:
                 coeff, ai = a.as_coeff_mul(S.ImaginaryUnit)
                 if ai == (S.ImaginaryUnit,) and coeff.is_extended_real:
-                    im_I.append(a*S.ImaginaryUnit)
+                    im_I.append(-coeff)
                 else:
                     return
             else:

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -703,6 +703,18 @@ def test_other_symbol():
     assert x.is_integer is False
 
 
+def test_evaluate_false():
+    # Previously this failed because the assumptions query would make new
+    # expressions and some of the evaluation logic would fail under
+    # evaluate(False).
+    from sympy.core.parameters import evaluate
+    from sympy.abc import x, h
+    f = 2**x**7
+    with evaluate(False):
+        fh = f.xreplace({x: x+h})
+        assert fh.exp.is_rational is None
+
+
 def test_issue_3825():
     """catch: hash instability"""
     x = Symbol("x")
@@ -789,6 +801,7 @@ def test_Add_is_pos_neg():
     assert (p + r).is_extended_positive is None
 
 
+@XFAIL
 def test_Add_is_imaginary():
     nn = Dummy(nonnegative=True)
     assert (I*nn + I).is_imaginary  # issue 8046, 17
@@ -1158,9 +1171,14 @@ def test_issue_10302():
     r = Symbol('r', real=True)
     u = -(3*2**pi)**(1/pi) + 2*3**(1/pi)
     i = u + u*I
+
     assert i.is_real is None  # w/o simplification this should fail
     assert (u + i).is_zero is None
-    assert (1 + i).is_zero is False
+
+    # XXX: Ideally (1 + i).is_zero would give False.
+    # It fails due to a bug in numerical evaluation.
+    assert (1 + i).is_zero is None
+
     a = Dummy('a', zero=True)
     assert (a + I).is_zero is False
     assert (a + r*I).is_zero is None

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -801,7 +801,6 @@ def test_Add_is_pos_neg():
     assert (p + r).is_extended_positive is None
 
 
-@XFAIL
 def test_Add_is_imaginary():
     nn = Dummy(nonnegative=True)
     assert (I*nn + I).is_imaginary  # issue 8046, 17
@@ -1174,10 +1173,7 @@ def test_issue_10302():
 
     assert i.is_real is None  # w/o simplification this should fail
     assert (u + i).is_zero is None
-
-    # XXX: Ideally (1 + i).is_zero would give False.
-    # It fails due to a bug in numerical evaluation.
-    assert (1 + i).is_zero is None
+    assert (1 + i).is_zero is False
 
     a = Dummy('a', zero=True)
     assert (a + I).is_zero is False

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -870,7 +870,7 @@ def test_derivatives_issue_4757():
     assert im(f(x)).diff(x) == im(f(x).diff(x))
     assert re(f(y)).diff(y) == -I*im(f(y).diff(y))
     assert im(f(y)).diff(y) == -I*re(f(y).diff(y))
-    assert Abs(f(x)).diff(x).subs(f(x), 1 + I*x).doit().simplify() == x/sqrt(1 + x**2)
+    assert Abs(f(x)).diff(x).subs(f(x), 1 + I*x).doit() == x/sqrt(1 + x**2)
     assert arg(f(x)).diff(x).subs(f(x), 1 + I*x**2).doit() == 2*x/(1 + x**4)
     assert Abs(f(y)).diff(y).subs(f(y), 1 + y).doit() == -y/sqrt(1 - y**2)
     assert arg(f(y)).diff(y).subs(f(y), I + y**2).doit() == 2*y/(1 + y**4)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -870,7 +870,7 @@ def test_derivatives_issue_4757():
     assert im(f(x)).diff(x) == im(f(x).diff(x))
     assert re(f(y)).diff(y) == -I*im(f(y).diff(y))
     assert im(f(y)).diff(y) == -I*re(f(y).diff(y))
-    assert Abs(f(x)).diff(x).subs(f(x), 1 + I*x).doit() == x/sqrt(1 + x**2)
+    assert Abs(f(x)).diff(x).subs(f(x), 1 + I*x).doit().simplify() == x/sqrt(1 + x**2)
     assert arg(f(x)).diff(x).subs(f(x), 1 + I*x**2).doit() == 2*x/(1 + x**4)
     assert Abs(f(y)).diff(y).subs(f(y), 1 + y).doit() == -y/sqrt(1 - y**2)
     assert arg(f(y)).diff(y).subs(f(y), I + y**2).doit() == 2*y/(1 + y**4)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -879,17 +879,35 @@ def _solve_radical(f, unradf, symbol, solveset_solver):
         result = Union(*[imageset(Lambda(y, g_y), f_y_sols)
                          for g_y in g_y_s])
 
-    if not isinstance(result, FiniteSet):
-        solution_set = result
-    else:
+    def check_finiteset(solutions):
         f_set = []  # solutions for FiniteSet
         c_set = []  # solutions for ConditionSet
-        for s in result:
+        for s in solutions:
             if checksol(f, symbol, s):
                 f_set.append(s)
             else:
                 c_set.append(s)
-        solution_set = FiniteSet(*f_set) + ConditionSet(symbol, Eq(f, 0), FiniteSet(*c_set))
+        return FiniteSet(*f_set) + ConditionSet(symbol, Eq(f, 0), FiniteSet(*c_set))
+
+    def check_set(solutions):
+        if solutions is S.EmptySet:
+            return solutions
+        elif isinstance(solutions, ConditionSet):
+            # XXX: Maybe the base set should be checked?
+            return solutions
+        elif isinstance(solutions, FiniteSet):
+            return check_finiteset(solutions)
+        elif isinstance(solutions, Complement):
+            A, B = solutions.args
+            return Complement(check_set(A), B)
+        elif isinstance(solutions, Union):
+            return Union(*[check_set(s) for s in solutions.args])
+        else:
+            # XXX: There should be more cases checked here. The cases above
+            # are all those that come up in the test suite for now.
+            return solutions
+
+    solution_set = check_set(result)
 
     return solution_set
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -533,11 +533,9 @@ def test_solve_sqrt_3():
                sqrt(10)*sin(atan(3*sqrt(111)/251)/3)/3 +
                sqrt(30)*cos(atan(3*sqrt(111)/251)/3)/3)]
 
-    assert sol._args[0] == FiniteSet(*fset)
-    assert sol._args[1] == ConditionSet(
-        R,
-        Eq(sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1), 0),
-        FiniteSet(*cset))
+    fs = FiniteSet(*fset)
+    cs = ConditionSet(R, Eq(eq, 0), FiniteSet(*cset))
+    assert sol == (fs - {-1}) | (cs - {-1})
 
     # the number of real roots will depend on the value of m: for m=1 there are 4
     # and for m=-1 there are none.
@@ -2404,14 +2402,30 @@ def test_issue_11174():
 
 
 def test_issue_11534():
-    # eq and eq2 should give the same solution as a Complement
+    # eq1 and eq2 should not have the same solutions because squaring both
+    # sides of the radical equation introduces a spurious solution branch.
+    # The equations have a symbolic parameter y and it is easy to see that for
+    # y != 0 the solution s1 will not be valid for eq1.
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
-    eq = -y + x/sqrt(-x**2 + 1)
+    eq1 = -y + x/sqrt(-x**2 + 1)
     eq2 = -y**2 + x**2/(-x**2 + 1)
-    soln = Complement(FiniteSet(-y/sqrt(y**2 + 1), y/sqrt(y**2 + 1)), FiniteSet(-1, 1))
-    assert solveset(eq, x, S.Reals) == soln
-    assert solveset(eq2, x, S.Reals) == soln
+
+    # We get a ConditionSet here because s1 works in eq1 if y is equal to zero
+    # although not for any other value of y. That case is redundant though
+    # because if y=0 then s1=s2 so the solution for eq1 could just be returned
+    # as s2 - {-1, 1}. In fact we have
+    #   |y/sqrt(y**2 + 1)| < 1
+    # So the complements are not needed either. The ideal output here would be
+    #   sol1 = s2
+    #   sol2 = s1 | s2.
+    s1, s2 = FiniteSet(-y/sqrt(y**2 + 1)), FiniteSet(y/sqrt(y**2 + 1))
+    cset = ConditionSet(x, Eq(eq1, 0), s1)
+    sol1 = (s2 - {-1, 1}) | (cset - {-1, 1})
+    sol2 = (s1 | s2) - {-1, 1}
+
+    assert solveset(eq1, x, S.Reals) == sol1
+    assert solveset(eq2, x, S.Reals) == sol2
 
 
 def test_issue_10477():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22428

See also the discussion about evaluation in the assumptions system here: https://github.com/sympy/sympy/pull/23488#discussion_r903204398

#### Brief description of what is fixed or changed

Avoid creating new expressions during assumptions queries. This makes the old assumptions slightly less powerful but at the same time faster and simpler and more robust. This also fixes a bug making it safe to query the old assumptions under `evaluate(False)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * A bug preventing the use of the old assumptions under `evaluate(False)` was fixed.
<!-- END RELEASE NOTES -->