### PR TITLE
solve changes

### DIFF
--- a/doc/src/citing.md
+++ b/doc/src/citing.md
@@ -30,7 +30,7 @@ A BibTeX entry for LaTeX users is
     }
 ```
 
-[SymPy is BSD licensed](https://github.com/sympy/sympy/blob/master/LICENSE), 
+[SymPy is BSD licensed](https://github.com/sympy/sympy/blob/master/LICENSE),
 so you are free to use it whatever you like, be it
 academic, commercial, creating forks or derivatives, as long as you copy the
 BSD statement if you redistribute it (see the LICENSE file for details).  That

--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -198,7 +198,7 @@ those libraries.
   functions using `lambdify(modules='cupy')`.
 
 - **Jax**: [JAX](https://github.com/google/jax) is a library that uses XLA
-  to compile and run NumPy programs on GPUs and TPUs. `lambdify` can produce 
+  to compile and run NumPy programs on GPUs and TPUs. `lambdify` can produce
   JAX compatibly functions using `lambdify(modules='jax')`.
 
 - **TensorFlow**: [TensorFlow](https://www.tensorflow.org/) is a popular

--- a/doc/src/explanation/index.rst
+++ b/doc/src/explanation/index.rst
@@ -15,5 +15,6 @@ technical implementation details, and opinionated recommendations.
    :maxdepth: 2
 
    gotchas.rst
+   solve_output.rst
    special_topics/index.rst
    active-deprecations.md

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -12,10 +12,9 @@ interaction rather than programmatic use. The type of output will depend on the
 type of equation(s) (and how they are entered) and the number of symbols that
 are provided (and how they are provided).
 
-Since this output is controllable by using the `dict=True` keyword to give
-a list of dictionaries mapping symbol to solution (when not dealing with
-relational expressions), the following is an explanation for those that
-might prefer the default output but wish to understand better the
+Since this output is controllable by setting `dict`, `set`, or `tuple` to True
+(when not dealing with relational expressions) the following is an explanation for
+those that might prefer the default output but wish to understand better the
 conditions under which it is given.
 
     >>> from sympy import sqrt, exp, solve, Symbol, Eq
@@ -51,7 +50,8 @@ when ``match=True``.
 4. A list of tuples, each giving a set of values for the symbols in the order
 they were given, is given when more than one symbol was given in a
 well defined order and either an expression was passed or a list of
-expressions with at least one being linear/monotonic:
+expressions with at least one being linear/monotonic. (This is also the
+format selected with ``tuple=True``.)
 
     >>> solve(x - 1, x, y)
     [(1, y)]
@@ -66,7 +66,7 @@ expressions with at least one being linear/monotonic:
 there was a nonlinear/nonmonotonic expression in a list *and* the order of
 symbols would otherwise be ambiguous because a) no symbols were passed or b) the
 symbols were passed as a set. The dictionary will only contain values that are
-distinct from the keys.
+distinct from the keys. (This is also the format selected with ``dict=True``.)
 
     >>> solve(x - y)
     [{x: y}]
@@ -76,8 +76,8 @@ distinct from the keys.
     [{x: -1, y: 3}, {x: 0, y: 2}]
 
 6. A boolean expression is returned when a relational expression other
-than an Equality is given as an expression to solve. A single equality, or more
-complicated relational expression, might be returned.
+than an Equality is given as an expression to solve. A single Equality
+or a more complicated relational expression might be returned.
 
     >>> from sympy import Ne
     >>> solve([x**2 - 4, Ne(x, -2)])
@@ -85,7 +85,7 @@ complicated relational expression, might be returned.
     >>> solve([x**2 > 4, x > 0])
     (2 < x) & (x < oo)
     >>> b = Symbol('b', positive=True)
-    >>> solve([x**2 > b, x > 0],x)
+    >>> solve([x**2 > b, x > 0], x)
     (0 < x) & (x < oo) & ((sqrt(b) < x) | (x < -sqrt(b)))
 
     The ``dict=True`` setting is ignored when working with relational
@@ -110,7 +110,7 @@ For those that used a version of SymPy older than 1.12, `solve` automatically
 tried to detect when a single equation might provide a solution for several
 variables by matching coefficients on expressions. The output would be a single
 dictionary (if the symbols appeared in a linear fashion) or else a list of
-tuples if the system could be solved, otherwise an algebraic solution was sought
+tuples if the system could be solved. Otherwise, an algebraic solution was sought
 for one or more of the symbols. Newer versions of SymPy require permission for
 this coefficient extraction via keyword ``match=True``, otherwise the algebraic
 solution is returned. Anyone using an older version of SymPy can avoid the

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -1,0 +1,104 @@
+
+.. _solve_output:
+
+==========================
+Understanding Solve Output
+==========================
+
+The output of the `solve` function can seem very unwieldy since it may appear to
+arbitrarily return one of 6 different types of output (in addition to raising
+errors). The reasons for this are historical and are biased toward human
+interaction rather than programmatic use. The type of output will depend on the
+type of equation(s) (and how they are entered) and the number of symbols that
+are provided (and how they are provided).
+
+Since this output is controllable by using the `dict=True` keyword to give either a
+boolean expression or a list of dictionaries, the following is an explanation
+for those that might prefer the default output but wish to understand better why
+it is being given.
+
+    >>> from sympy import sqrt, exp, solve, Symbol
+    >>> from sympy.abc import x, y
+
+1. An empty list indicates that no solution was found.
+
+    >>> solve(sqrt(x) + 1)
+    []
+
+2. A list of values is given when the symbol to solve for was
+unambiguous in context because a) the equation was univariate or b) a
+single symbol was specified as being of interest.
+
+    >>> solve(x**2 - 4)
+    [-2, 2]
+    >>> solve(x - y - 1, x)
+    [y + 1]
+
+3. A single dictionary with keys being symbols and values being the solutions
+for those symbols is the result when one or more equations (passed as a
+*list*) has only a single, unique solution (e.g. the system is linear or else is
+monotonic) for the symbols specified.
+
+    >>> solve([x + y - 2, x - y + 2], x, y)
+    {x: 0, y: 2}
+    >>> solve([exp(x) - y], x)
+    {x: log(y)}
+
+4. A list of tuples, each giving a set of values for the symbols in the order
+they were given - this is the result when more than one symbol was given in a
+well defined order and either an expression was passed or a list of
+expressions with at least one not being linear/monotonic.
+
+    >>> solve(x - 1, x, y)
+    [(1, y)]
+    >>> solve([x**2], x)
+    [(0,)]
+    >>> solve([x**2 - 1], x)
+    [(-1,), (1,)]
+    >>> solve([x**2 - 1], x, y)
+    [(-1, y), (1, y)]
+
+5. A list of dictionaries is returned when the expression was not univariate or
+there was a nonlinear/nonmonotonic expression in a list *and* the order of
+symbols would otherwise be ambiguous because a) no symbols were passed or b) the
+symbols were passed as a set.
+
+    >>> solve(x - y)
+    [{x: y}]
+    >>> solve([exp(x) - 1, x**2])
+    [{x: 0}]
+    >>> solve([x + y - 2, x**2 - y + 2], {x, y})
+    [{x: -1, y: 3}, {x: 0, y: 2}]
+
+6. A boolean expression is returned when a relational expression other
+than an Equality is given as an expression to solve. A single equality, or more
+complicated relational expression might be returned.
+
+    >>> solve([x**2 - 4, Ne(x, -2)])
+    Eq(x, 2)
+    >>> solve([x**2 > 4, x > 0])
+    (2 < x) & (x < oo)
+    >>> b = Symbol('b', positive=True)
+    >>> solve([x**2 > b, x > 0],x)
+    (0 < x) & (x < oo) & ((sqrt(b) < x) | (x < -sqrt(b)))
+
+Note: using relational expressions to filter the solution only works when
+solving for a single variable. Simple constraints to limit output to integers,
+real numbers, positive values, etc... can be accomplished by setting the
+assumptions on the variables for which a solution is being sought. This also
+prevents the solution from being returned as a boolean expression.
+
+    >>> p = Symbol('p', positive=True)
+    >>> solve(p**2  - 4)
+    [2]
+
+For those that used a version of SymPy older than 1.11, `solve` automatically
+tried to detect when single equation might provide a solution for several
+variables by matching coefficients on single variable that was not specified.
+That would happen when a single expression was passed with symbols being all
+but one of the free symbols in the equation. The output would be a single
+dictionary (if the symbols appeared in a linear fashion) or else a list of
+tuples if the system could be solved, otherwise an algebraic solution was sought
+for one or more of the symbols. Anyone using an older version can avoid the
+ undetermined coefficients solution by passing the equation as a list and
+using the keyword `dict=True`.

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -90,8 +90,8 @@ complicated relational expression, might be returned.
     a dictionary as follows:
 
     >>> soln = Eq(x, 2)
-    >>> dict(list(soln))
-    {x: 2}
+    >>> dict([soln.args]) == {soln.lhs: soln.rhs} == {x: 2}
+    True
 
 Note: using relational expressions to filter the solution only works when
 solving for a single variable. Simple constraints to limit output to integers,

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -74,6 +74,7 @@ symbols were passed as a set.
 than an Equality is given as an expression to solve. A single equality, or more
 complicated relational expression might be returned.
 
+    >>> from sympy import Ne
     >>> solve([x**2 - 4, Ne(x, -2)])
     Eq(x, 2)
     >>> solve([x**2 > 4, x > 0])
@@ -92,7 +93,7 @@ prevents the solution from being returned as a boolean expression.
     >>> solve(p**2  - 4)
     [2]
 
-For those that used a version of SymPy older than 1.11, `solve` automatically
+For those that used a version of SymPy older than 1.12, `solve` automatically
 tried to detect when single equation might provide a solution for several
 variables by matching coefficients on single variable that was not specified.
 That would happen when a single expression was passed with symbols being all

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -12,10 +12,11 @@ interaction rather than programmatic use. The type of output will depend on the
 type of equation(s) (and how they are entered) and the number of symbols that
 are provided (and how they are provided).
 
-Since this output is controllable by using the `dict=True` keyword to give either a
-boolean expression or a list of dictionaries, the following is an explanation
-for those that might prefer the default output but wish to understand better why
-it is being given.
+Since this output is controllable by using the `dict=True` keyword to give
+a list of dictionaries mapping symbol to solution (when not dealing with
+relational expressions), the following is an explanation for those that
+might prefer the default output but wish to understand better the
+conditions under which it is given.
 
     >>> from sympy import sqrt, exp, solve, Symbol
     >>> from sympy.abc import x, y
@@ -45,9 +46,9 @@ monotonic) for the symbols specified.
     {x: log(y)}
 
 4. A list of tuples, each giving a set of values for the symbols in the order
-they were given - this is the result when more than one symbol was given in a
+they were given, is given when more than one symbol was given in a
 well defined order and either an expression was passed or a list of
-expressions with at least one not being linear/monotonic.
+expressions with at least one being linear/monotonic:
 
     >>> solve(x - 1, x, y)
     [(1, y)]
@@ -61,7 +62,8 @@ expressions with at least one not being linear/monotonic.
 5. A list of dictionaries is returned when the expression was not univariate or
 there was a nonlinear/nonmonotonic expression in a list *and* the order of
 symbols would otherwise be ambiguous because a) no symbols were passed or b) the
-symbols were passed as a set.
+symbols were passed as a set. The dictionary will only contain values that are
+distinct from the keys.
 
     >>> solve(x - y)
     [{x: y}]
@@ -72,7 +74,7 @@ symbols were passed as a set.
 
 6. A boolean expression is returned when a relational expression other
 than an Equality is given as an expression to solve. A single equality, or more
-complicated relational expression might be returned.
+complicated relational expression, might be returned.
 
     >>> from sympy import Ne
     >>> solve([x**2 - 4, Ne(x, -2)])
@@ -82,6 +84,14 @@ complicated relational expression might be returned.
     >>> b = Symbol('b', positive=True)
     >>> solve([x**2 > b, x > 0],x)
     (0 < x) & (x < oo) & ((sqrt(b) < x) | (x < -sqrt(b)))
+
+    The ``dict=True`` setting is ignored when working with relational
+    expressions. When an equality is returned, it can be converted to
+    a dictionary as follows:
+
+    >>> soln = Eq(x, 2)
+    >>> dict(list(soln))
+    {x: 2}
 
 Note: using relational expressions to filter the solution only works when
 solving for a single variable. Simple constraints to limit output to integers,

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -19,7 +19,7 @@ might prefer the default output but wish to understand better the
 conditions under which it is given.
 
     >>> from sympy import sqrt, exp, solve, Symbol, Eq
-    >>> from sympy.abc import x, y
+    >>> from sympy.abc import x, y, a, b
 
 1. An empty list indicates that no solution was found.
 
@@ -38,12 +38,15 @@ single symbol was specified as being of interest.
 3. A single dictionary with keys being symbols and values being the solutions
 for those symbols is the result when one or more equations (passed as a
 *list*) has only a single, unique solution (e.g. the system is linear or else is
-monotonic) for the symbols specified.
+monotonic) for the symbols specified. Such a system is automatically generated
+when ``match=True``.
 
     >>> solve([x + y - 2, x - y + 2], x, y)
     {x: 0, y: 2}
     >>> solve([exp(x) - y], x)
     {x: log(y)}
+    >>> solve(a*x - 2*x + b - 5, {a, b}, match=True)
+    {a: 2, b: 5}
 
 4. A list of tuples, each giving a set of values for the symbols in the order
 they were given, is given when more than one symbol was given in a

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -18,7 +18,7 @@ relational expressions), the following is an explanation for those that
 might prefer the default output but wish to understand better the
 conditions under which it is given.
 
-    >>> from sympy import sqrt, exp, solve, Symbol
+    >>> from sympy import sqrt, exp, solve, Symbol, Eq
     >>> from sympy.abc import x, y
 
 1. An empty list indicates that no solution was found.

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -94,12 +94,11 @@ prevents the solution from being returned as a boolean expression.
     [2]
 
 For those that used a version of SymPy older than 1.12, `solve` automatically
-tried to detect when single equation might provide a solution for several
-variables by matching coefficients on single variable that was not specified.
-That would happen when a single expression was passed with symbols being all
-but one of the free symbols in the equation. The output would be a single
+tried to detect when a single equation might provide a solution for several
+variables by matching coefficients on expressions. The output would be a single
 dictionary (if the symbols appeared in a linear fashion) or else a list of
 tuples if the system could be solved, otherwise an algebraic solution was sought
-for one or more of the symbols. Anyone using an older version can avoid the
- undetermined coefficients solution by passing the equation as a list and
-using the keyword `dict=True`.
+for one or more of the symbols. Newer versions of SymPy require permission for
+this coefficient extraction via keyword ``match=True``, otherwise the algebraic
+solution is returned. Anyone using an older version of SymPy can avoid the
+undetermined coefficients solution by passing the equation as a *list*.

--- a/doc/src/guides/solving/index.md
+++ b/doc/src/guides/solving/index.md
@@ -1,7 +1,7 @@
 # Solve Equations
 
-The Python package SymPy can symbolically solve equations, differential equations, 
-linear equations, nonlinear equations, matrix problems, inequalities, 
+The Python package SymPy can symbolically solve equations, differential equations,
+linear equations, nonlinear equations, matrix problems, inequalities,
 Diophantine equations, and evaluate integrals. SymPy can also solve numerically.
 
 Learn how to use SymPy computer algebra system to:
@@ -20,11 +20,11 @@ Learn how to use SymPy computer algebra system to:
 | [ Solve (find the roots of) a polynomial algebraically ](../../modules/polys/basics.rst)                       | $ x^2 - x = 0 $ | $ x \in \{0, 1\} $                                                                                                |
 |  [ Solve a Diophantine equation (find integer solutions to a polynomial equation) algebraically ](../../modules/solvers/diophantine.rst)             | $x^2 - 4xy + 8y^2 - 3x + 7y - 5 = 0 $ | $ \{(x = 2, y = 1), (x = 5, y = 1)\}$                                                                                  |
 
-Note: SymPy has a function called {func}`~.solve` 
+Note: SymPy has a function called {func}`~.solve`
 which is designed to find the roots of an equation or system of equations.
-SymPy {func}`~.solve` may or may not be what you need for a particular problem, 
+SymPy {func}`~.solve` may or may not be what you need for a particular problem,
 so we recommend you use the links on this page to learn how to "solve" your problem.
-And while a common, colloquial expression is, for example, ["solve an integral"](../../modules/integrals/integrals.rst), 
+And while a common, colloquial expression is, for example, ["solve an integral"](../../modules/integrals/integrals.rst),
 in SymPy's terminology it would be ["evaluate an integral."](../../modules/integrals/integrals.rst)
 
 ```{toctree}

--- a/doc/src/guides/solving/solve-equation-algebraically.md
+++ b/doc/src/guides/solving/solve-equation-algebraically.md
@@ -3,14 +3,14 @@
 Use SymPy to solve an equation algebraically (symbolically). For example, solving $x^2 = y$ for $x$ yields $x \in \{-\sqrt{y},\sqrt{y}\}$.
 
 Alternatives to consider:
-- SymPy can also 
+- SymPy can also
 [solve many other types of problems including sets of equations](index.md).
-- Some equations cannot be solved algebraically (either at all or by SymPy), 
-so you may have to 
-{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>` 
+- Some equations cannot be solved algebraically (either at all or by SymPy),
+so you may have to
+{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>`
 instead.
 
-There are two high-level functions to solve equations, {func}`~.solve` and 
+There are two high-level functions to solve equations, {func}`~.solve` and
 {func}`~.solveset`. Here is a simple example of each:
 
 {func}`~.solve`
@@ -34,31 +34,31 @@ There are two high-level functions to solve equations, {func}`~.solve` and
 Here are recommendations on when to use:
 
 - {func}`~.solve`
-    - You want to get explicit symbolic representations of the different 
+    - You want to get explicit symbolic representations of the different
     values a variable could take that would satisfy the equation.
-    - You want to substitute those explicit solution values into other 
-    equations or expressions involving the same variable using 
+    - You want to substitute those explicit solution values into other
+    equations or expressions involving the same variable using
     {meth}`~sympy.core.basic.Basic.subs`
 
 - {func}`~.solveset`
-    - You want to represent the solutions in a mathematically precise way, 
+    - You want to represent the solutions in a mathematically precise way,
     using [mathematical sets](../../modules/sets.rst).
-    - You want a representation of all the solutions, including if there are 
+    - You want a representation of all the solutions, including if there are
     infinitely many.
     - You want a consistent input interface.
     - You want to limit the domain of the solutions to any arbitrary set.
-    - You do not need to programmatically extract solutions from the solution 
+    - You do not need to programmatically extract solutions from the solution
     set: solution sets cannot necessarily be interrogated programmatically.
 
 ## Guidance
 
 ### Include the variable to be solved for in the function call
 
-We recommend you include the variable to be solved for as the second argument 
-for either function. While this is optional for equations with a single 
-symbol, it is a good practice because it ensures 
-SymPy will solve for the desired symbol. For example, you may expect the 
-following to solve for $x$, 
+We recommend you include the variable to be solved for as the second argument
+for either function. While this is optional for equations with a single
+symbol, it is a good practice because it ensures
+SymPy will solve for the desired symbol. For example, you may expect the
+following to solve for $x$,
 and SymPy will solve for $y$:
 
 ```py
@@ -79,25 +79,25 @@ Specifying the variable to solve for ensures that SymPy solves for it:
 
 ### Ensure consistent formatting from {func}`~.solve` by using `dict=True`
 
-{func}`~.solve` produces various output formats depending on the answer, 
-unless you use `dict=True` to ensure the result will be formatted as a 
-dictionary. We recommend using `dict=True`, especially if you want to 
+{func}`~.solve` produces various output formats depending on the answer,
+unless you use `dict=True` to ensure the result will be formatted as a
+dictionary. We recommend using `dict=True`, especially if you want to
 extract information from the result programmatically.
 
 ## Solve an equation using {func}`~.solve` or {func}`~.solveset`
 
-You can solve an equation in several ways. 
-The examples below demonstrate using both {func}`~.solve` and 
-{func}`~.solveset` where applicable. 
+You can solve an equation in several ways.
+The examples below demonstrate using both {func}`~.solve` and
+{func}`~.solveset` where applicable.
 You can choose the function best suited to your equation.
 
 ### Make your equation into an expression that equals zero
 
-Use the fact that any expression not in an `Eq` (equation) is automatically 
-assumed to equal zero (0) by the solving functions. You can rearrange the 
-equation $x^2 = y$ to $x^2 - y = 0$, and solve that expression. This approach 
-is convenient if you are interactively solving an expression which already 
-equals zero, or an equation that you do not mind rearranging to 
+Use the fact that any expression not in an `Eq` (equation) is automatically
+assumed to equal zero (0) by the solving functions. You can rearrange the
+equation $x^2 = y$ to $x^2 - y = 0$, and solve that expression. This approach
+is convenient if you are interactively solving an expression which already
+equals zero, or an equation that you do not mind rearranging to
 $expression = 0$.
 
 ```py
@@ -108,14 +108,14 @@ $expression = 0$.
 >>> solveset(x**2 - y, x)
 {-sqrt(y), sqrt(y)}
 ```
-    
+   
 ### Put your equation into `Eq` form
 
-Put your equation into `Eq` form, then solve the `Eq`. 
-This approach is convenient if you are interactively solving an equation 
+Put your equation into `Eq` form, then solve the `Eq`.
+This approach is convenient if you are interactively solving an equation
 which you already have in the form of an equation,
 or which you think of as an equality.
-    
+   
 ```py
 >>> from sympy import Eq, solve, solveset
 >>> from sympy.abc import x, y
@@ -136,8 +136,8 @@ sqrt(y)
 
 ### Restrict the domain of solutions
 
-By default, SymPy will return solutions in the complex domain, which also 
-includes purely real and imaginary values. Here, the first two solutions are 
+By default, SymPy will return solutions in the complex domain, which also
+includes purely real and imaginary values. Here, the first two solutions are
 real, and the last two are imaginary:
 
 ```py
@@ -149,7 +149,7 @@ real, and the last two are imaginary:
 {-4, 4, -4*I, 4*I}
 ```
 
-To restrict returned solutions to real numbers, or another domain or range, 
+To restrict returned solutions to real numbers, or another domain or range,
 the different solving functions use different methods.
 
 For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
@@ -161,8 +161,8 @@ For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
 [{x: -4}, {x: 4}]
 ```
 
-or restrict the solutions with standard Python techniques for filtering a 
-list such as a list comprehension, or 
+or restrict the solutions with standard Python techniques for filtering a
+list such as a list comprehension, or
 by adding inequalities to {func}`~.solve` (but the range must be continuous):
 
 ```py
@@ -180,7 +180,7 @@ by adding inequalities to {func}`~.solve` (but the range must be continuous):
 Eq(x, 2) | Eq(x, 3)
 ```
 
-For {func}`~.solveset`, limit the output domain in the function call by 
+For {func}`~.solveset`, limit the output domain in the function call by
 setting a domain
 
 ```py
@@ -190,7 +190,7 @@ setting a domain
 {-4, 4}
 ```
 
-or by restricting returned solutions to any arbitrary set, including an 
+or by restricting returned solutions to any arbitrary set, including an
 interval:
 
 ```py
@@ -238,9 +238,9 @@ However, {func}`~.solve` will return only a finite number of solutions:
 2*pi
 ```
 
-{func}`~.solve` tries to return just enough solutions so that all 
-(infinitely many) solutions can generated from the returned solutions 
-by adding integer multiples of the {func}`~.periodicity` of the 
+{func}`~.solve` tries to return just enough solutions so that all
+(infinitely many) solutions can generated from the returned solutions
+by adding integer multiples of the {func}`~.periodicity` of the
 equation, here $2\pi$.
 
 ## Use the solution result
@@ -249,13 +249,13 @@ equation, here $2\pi$.
 
 You can substitute solutions from {func}`~.solve` into an expression.
 
-A common use case is finding the critical points and values for a function 
-$f$. At the critical points, the {class}`~.Derivative` equals zero (or is 
+A common use case is finding the critical points and values for a function
+$f$. At the critical points, the {class}`~.Derivative` equals zero (or is
 undefined). You can then obtain the function values at those critical points
-by substituting the critical points back into the function using 
-{meth}`~sympy.core.basic.Basic.subs`. You can also tell if the critical point 
-is a maxima or minima by substituting the values into the expression for the 
-second derivative: a negative value indicates a maximum, and a positive value 
+by substituting the critical points back into the function using
+{meth}`~sympy.core.basic.Basic.subs`. You can also tell if the critical point
+is a maxima or minima by substituting the values into the expression for the
+second derivative: a negative value indicates a maximum, and a positive value
 indicates a minimum.
 
 ```py
@@ -294,7 +294,7 @@ iterate through the solutions:
 [sqrt(y), -sqrt(y)]
 ```
 
-However, for more complex results, it may not be possible to list the 
+However, for more complex results, it may not be possible to list the
 solutions:
 
 ```py
@@ -306,7 +306,7 @@ Intersection({-sqrt(y), sqrt(y)}, Reals)
 >>> list(solution_set)
 Traceback (most recent call last):
     ...
-TypeError: The computation had not completed because of the undecidable set 
+TypeError: The computation had not completed because of the undecidable set
 membership is found in every candidates.
 ```
 
@@ -348,9 +348,9 @@ Intersection({-sqrt(y), sqrt(y)}, Reals)
 
 ### Include solutions making any denominator zero by using `check=False`
 
-Normally, {func}`~.solve` checks whether any solutions make any denominator 
-zero, and automatically excludes them. If you want to include those 
-solutions, and speed up {func}`~.solve` (at the risk of obtaining invalid 
+Normally, {func}`~.solve` checks whether any solutions make any denominator
+zero, and automatically excludes them. If you want to include those
+solutions, and speed up {func}`~.solve` (at the risk of obtaining invalid
 solutions), set `check=False`:
 
 ```py
@@ -364,11 +364,11 @@ solutions), set `check=False`:
 
 ### Do not simplify solutions by using `simplify=False`
 
-Normally, {func}`~.solve` simplifies all but polynomials of order 3 or 
-greater before returning them and (if `check` is not False) uses the general 
-{func}`simplify <sympy.simplify.simplify.simplify>` function on the solutions 
-and the expression obtained when they are substituted into the function which 
-should be zero. If you do not want the solutions simplified, and want to 
+Normally, {func}`~.solve` simplifies all but polynomials of order 3 or
+greater before returning them and (if `check` is not False) uses the general
+{func}`simplify <sympy.simplify.simplify.simplify>` function on the solutions
+and the expression obtained when they are substituted into the function which
+should be zero. If you do not want the solutions simplified, and want to
 speed up {func}`~.solve`, use `simplify=False`.
 
 ```py
@@ -385,8 +385,8 @@ speed up {func}`~.solve`, use `simplify=False`.
 
 ### Equations with no solution
 
-Some equations have no solution, in which case SymPy may return an empty set. 
-For example, the equation $x - 7 = x + 2$ reduces to $-7 = 2$, which has no 
+Some equations have no solution, in which case SymPy may return an empty set.
+For example, the equation $x - 7 = x + 2$ reduces to $-7 = 2$, which has no
 solution because no value of $x$ will make it true:
 
 ```py
@@ -397,17 +397,17 @@ solution because no value of $x$ will make it true:
 []
 ```
 
-So if SymPy returns an empty list, you may want to check whether there is a 
+So if SymPy returns an empty list, you may want to check whether there is a
 mistake in the equation.
 
 ### Equations which have an analytical solution, and SymPy cannot solve
 
-It is also possible that there is an algebraic solution to your equation, 
-and SymPy has not implemented an appropriate algorithm. 
-If that happens, or SymPy returns an empty set or list when there is a 
-mathematical solution (indicating a bug in SymPy), please post it on the 
-[mailing list](https://groups.google.com/g/sympy), or open an issue on 
-[SymPy's GitHub page](https://github.com/sympy/sympy/issues). Until the issue 
-is resolved, you can 
-{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>` 
+It is also possible that there is an algebraic solution to your equation,
+and SymPy has not implemented an appropriate algorithm.
+If that happens, or SymPy returns an empty set or list when there is a
+mathematical solution (indicating a bug in SymPy), please post it on the
+[mailing list](https://groups.google.com/g/sympy), or open an issue on
+[SymPy's GitHub page](https://github.com/sympy/sympy/issues). Until the issue
+is resolved, you can
+{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>`
 instead.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1258,9 +1258,33 @@ class Basic(Printable, metaclass=ManagedProperties):
         """
         return self._has(iterargs, *patterns)
 
+    def has_free_arg(self, s):
+        """return True if self has any of the patterns in s as a free argument,
+        else False. This is like `Basic.has_free` but this will only report exact
+        argument matches.
+
+        Examples
+        ========
+
+        >>> from sympy import Function
+        >>> from sympy.abc import x, y
+        >>> f = Function('f')
+        >>> f(x).has_free_arg({f})
+        False
+        >>> f(x).has_free_arg({f(x)})
+        True
+        >>> f(x+1).has_free_arg({x})
+        True
+        >>> f(x+1).has_free_arg({x+1})
+        True
+        >>> f(x+1).has_free_arg({x+y+1})
+        False
+        """
+        return any(a in s for a in iterfreeargs(self))
+
     @cacheit
     def has_free(self, *patterns):
-        """return True if self has object(s) ``x`` as a free expression
+        """return True if self has any of the patterns as a free expression
         else False.
 
         Examples
@@ -1275,17 +1299,31 @@ class Basic(Printable, metaclass=ManagedProperties):
         {y}
         >>> expr.has_free(g(y))
         True
-        >>> expr.has_free(*(x, f(x)))
+        >>> expr.has_free(x, f(x))
         False
 
-        This works for subexpressions and types, too:
+        This works for literal subexpressions and types, too:
 
         >>> expr.has_free(g)
         True
         >>> (x + y + 1).has_free(y + 1)
         True
-
+        >>> (2*x*y + 3).has_free(x*y)
+        True
         """
+        if not patterns:
+            return False
+        p0 = patterns[0]
+        if len(patterns) == 1 and iterable(p0) and not isinstance(p0, Basic):
+            # Basic can contain iterables (though not non-Basic, ideally)
+            # but don't encourage mixed passing patterns
+            raise ValueError('expecting one or more Basic patterns')
+        # try quick test first
+        s = set(patterns)
+        rv = self.has_free_arg(s)
+        if rv:
+            return rv
+        # now try matching through slower _has
         return self._has(iterfreeargs, *patterns)
 
     def _has(self, iterargs, *patterns):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1277,7 +1277,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         True
         >>> f(x+1).has_free_arg({x+1})
         True
-        >>> f(x+1).has_free_arg({x+y+1})
+        >>> f(x+y+1).has_free_arg({x + 1})
         False
         """
         return any(a in s for a in iterfreeargs(self))
@@ -1285,7 +1285,7 @@ class Basic(Printable, metaclass=ManagedProperties):
     @cacheit
     def has_free(self, *patterns):
         """return True if self has any of the patterns as a free expression
-        else False.
+        (or literal subexpression) else False.
 
         Examples
         ========

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -31,6 +31,7 @@ from sympy.polys.partfrac import apart
 from sympy.polys.polytools import factor, cancel, Poly
 from sympy.polys.rationaltools import together
 from sympy.series.order import O
+from sympy.sets.sets import FiniteSet
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.gammasimp import gammasimp
 from sympy.simplify.powsimp import powsimp
@@ -1624,11 +1625,20 @@ def test_has_free():
     assert Integral(f(x), (f(x), 1, y)).has_free(y)
     assert not Integral(f(x), (f(x), 1, y)).has_free(x)
     assert not Integral(f(x), (f(x), 1, y)).has_free(f(x))
+    # simple extraction
+    assert (x + 1 + y).has_free(x + 1)
+    assert not (x + 2 + y).has_free(x + 1)
+    assert (2 + 3*x*y).has_free(3*x)
+    raises(ValueError, lambda: x.has_free({x, y}))
+    s = FiniteSet(1, 2)
+    assert Piecewise((s, x > 3), (4, True)).has_free(s)
+    assert not Piecewise((1, x > 3), (4, True)).has_free(s)
 
 
 def test_issue_5300():
     x = Symbol('x', commutative=False)
     assert x*sqrt(2)/sqrt(6) == x*sqrt(3)/3
+
 
 def test_floordiv():
     from sympy.functions.elementary.integers import floor

--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -132,10 +132,10 @@ def test_parabola_intersection():
     assert parabola1.intersection(Ray2D((0, 7), (0, 14))) == []
     # parabola with ellipse/circle
     assert parabola1.intersection(Circle(p1, 2)) == [Point2D(-2, 0), Point2D(2, 0)]
-    assert parabola1.intersection(Circle(p2, 1)) == [Point2D(0, -1), Point2D(0, -1)]
-    assert parabola1.intersection(Ellipse(p2, 2, 1)) == [Point2D(0, -1), Point2D(0, -1)]
+    assert parabola1.intersection(Circle(p2, 1)) == [Point2D(0, -1)]
+    assert parabola1.intersection(Ellipse(p2, 2, 1)) == [Point2D(0, -1)]
     assert parabola1.intersection(Ellipse(Point(0, 19), 5, 7)) == []
     assert parabola1.intersection(Ellipse((0, 3), 12, 4)) == \
-           [Point2D(0, -1), Point2D(0, -1), Point2D(-4*sqrt(17)/3, Rational(59, 9)), Point2D(4*sqrt(17)/3, Rational(59, 9))]
+           [Point2D(0, -1), Point2D(-4*sqrt(17)/3, Rational(59, 9)), Point2D(4*sqrt(17)/3, Rational(59, 9))]
     # parabola with unsupported type
     raises(TypeError, lambda: parabola1.intersection(2))

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1604,9 +1604,10 @@ class HolonomicFunction:
                     eqs.append(eq)
 
                 # solve the system of equations formed
-                soleqs = solve(eqs, *unknowns)
+                soleqs = solve(eqs, *unknowns, dict=True)
 
-                if isinstance(soleqs, dict):
+                if len(soleqs) == 1:
+                    soleqs = soleqs[0]
 
                     for i in range(len(u0), order):
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1254,8 +1254,8 @@ def recognize_log_derivative(a, d, DE, z=None):
     Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z)
 
     for s, _ in Sp:
-        # TODO also consider the complex roots
-        # incase we have complex roots it should turn the flag false
+        # TODO also consider the complex roots which should
+        # turn the flag false
         a = real_roots(s.as_poly(z))
 
         if not all(j.is_Integer for j in a):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -791,7 +791,7 @@ class MatrixSpecial(MatrixRequired):
     @classmethod
     def _eval_eye(cls, rows, cols):
         vals = [cls.zero]*(rows*cols)
-        vals[::cols+1] = [cls.one]*min(rows, cols)
+        vals[::cols + 1] = [cls.one]*min(rows, cols)
         return cls._new(rows, cols, vals, copy=False)
 
     @classmethod

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -26,14 +26,18 @@ class SparseRepMatrix(RepMatrix):
     ========
 
     >>> from sympy import SparseMatrix, ones
-    >>> SparseMatrix(2, 2, range(4))
+    >>> SparseMatrix(2, 2, range(4))  # list
     Matrix([
     [0, 1],
     [2, 3]])
-    >>> SparseMatrix(2, 2, {(1, 1): 2})
+    >>> SparseMatrix(2, 2, {(1, 1): 2})  # dictionary of locations; values
     Matrix([
     [0, 0],
     [0, 2]])
+    >>> SparseMatrix(2, 3, {0: {1: 2}, 1: {2: 3}})  # dod format
+    Matrix([
+    [0, 2, 0],
+    [0, 0, 3]])
 
     A SparseMatrix can be instantiated from a ragged list of lists:
 
@@ -158,17 +162,31 @@ class SparseRepMatrix(RepMatrix):
                         smat[i, j] = v
 
                 # manual copy, copy.deepcopy() doesn't work
-                for (r, c), v in args[2].items():
-                    if isinstance(v, MatrixBase):
-                        for (i, j), vv in v.todok().items():
-                            update(r + i, c + j, vv)
-                    elif isinstance(v, (list, tuple)):
-                        _, _, smat = cls._handle_creation_inputs(v, **kwargs)
-                        for i, j in smat:
-                            update(r + i, c + j, smat[i, j])
-                    else:
-                        v = cls._sympify(v)
-                        update(r, c, cls._sympify(v))
+                try:
+                    for (r, c), v in args[2].items():
+                        if isinstance(v, MatrixBase):
+                            for (i, j), vv in v.todok().items():
+                                update(r + i, c + j, vv)
+                        elif isinstance(v, (list, tuple)):
+                            _, _, smat = cls._handle_creation_inputs(v, **kwargs)
+                            for i, j in smat:
+                                update(r + i, c + j, smat[i, j])
+                        else:
+                            v = cls._sympify(v)
+                            update(r, c, cls._sympify(v))
+                except TypeError:  # maybe dod format
+                    for r, cv in args[2].items():
+                        for c, v in cv.items():
+                            if isinstance(v, MatrixBase):
+                                for (i, j), vv in v.todok().items():
+                                    update(r + i, c + j, vv)
+                            elif isinstance(v, (list, tuple)):
+                                _, _, smat = cls._handle_creation_inputs(v, **kwargs)
+                                for i, j in smat:
+                                    update(r + i, c + j, smat[i, j])
+                            else:
+                                v = cls._sympify(v)
+                                update(r, c, cls._sympify(v))
 
             elif is_sequence(args[2]):
                 flat = not any(is_sequence(i) for i in args[2])

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -187,7 +187,7 @@ def test_sparse_matrix():
         [0, 0, 1, 0],
         [0, 0, 0, 0]])
     assert a == b
-    assert SparseMatrix(a.todod()) == b
+    assert SparseMatrix(*a.shape, a.todod()) == b
     raises(ValueError, lambda: SparseMatrix(1, 1, {(1, 1): 1}))
     assert SparseMatrix(1, 2, [1, 2]).tolist() == [[1, 2]]
     assert SparseMatrix(2, 2, [1, [2, 3]]).tolist() == [[1, 0], [2, 3]]

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -180,11 +180,14 @@ def test_sparse_matrix():
         [1, 2, 3],
         [1, 2, 0],
         [1, 0, 0]])
-    assert SparseMatrix(4, 4, {(1, 1): sparse_eye(2)}) == Matrix([
+    a = SparseMatrix(4, 4, {(1, 1): sparse_eye(2)})
+    b = Matrix([
         [0, 0, 0, 0],
         [0, 1, 0, 0],
         [0, 0, 1, 0],
         [0, 0, 0, 0]])
+    assert a == b
+    assert SparseMatrix(a.todod()) == b
     raises(ValueError, lambda: SparseMatrix(1, 1, {(1, 1): 1}))
     assert SparseMatrix(1, 2, [1, 2]).tolist() == [[1, 2]]
     assert SparseMatrix(2, 2, [1, [2, 3]]).tolist() == [[1, 0], [2, 3]]

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -58,11 +58,10 @@ class DomainMatrix:
     ===========
 
     DomainMatrix uses :py:class:`~.Domain` for its internal representation
-    which makes it more faster for many common operations
-    than current SymPy Matrix class, but this advantage makes it not
-    entirely compatible with Matrix.
-    DomainMatrix could be found analogous to numpy arrays with "dtype".
-    In the DomainMatrix, each matrix has a domain such as :ref:`ZZ`
+    which makes it faster than the SymPy Matrix class (currently) for many
+    common operations, but this advantage makes it not entirely compatible
+    with Matrix. DomainMatrix are analogous to numpy arrays with "dtype".
+    In the DomainMatrix, each element has a domain such as :ref:`ZZ`
     or  :ref:`QQ(a)`.
 
 
@@ -80,7 +79,7 @@ class DomainMatrix:
     >>> A
     DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
 
-    Driectly forming a DomainMatrix:
+    Directly forming a DomainMatrix:
 
     >>> from sympy import ZZ
     >>> from sympy.polys.matrices import DomainMatrix

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -42,6 +42,7 @@ from .sdm import (
     sdm_particular_from_rref,
     sdm_nullspace_from_rref
 )
+from sympy.utilities.misc import filldedent
 
 
 def _linsolve(eqs, syms, strict=True, _expand=True):
@@ -137,18 +138,17 @@ def sympy_dict_to_dm(eqs_coeffs, eqs_rhs, syms):
 def _linear_eq_to_dict(eqs, syms, strict, _expand):
     """Convert a system Expr/Eq equations into dict form, returning
     the coefficient dictionaries and a list of syms-independent terms
-    from each expression in ``eqs```. Use of ``strict=False`` allows
-    symbol-dependent cross terms to be treated as independent of
-    ``syms`` but still disallows cross terms to contain more than
-    one literal element from ``syms`` (in which case a PolyNonlinear
-    error is raised).
+    from each expression in ``eqs```. When ``strict`` is False,
+    symbol-dependent cross terms are treated as independent of
+    ``syms`` but cross terms containing more than one literal element
+    from ``syms`` will still raise PolyNonlinearError.
 
     Examples
     ========
 
     >>> from sympy.polys.matrices.linsolve import _linear_eq_to_dict as F
     >>> from sympy.abc import x
-    >>> F([2*x + 3], {x})
+    >>> F([2*x + 3], {x}, True, False)
     ([{x: 2}], [3])
     """
     try:
@@ -190,7 +190,8 @@ def _lin_eq2dict(a, symset, strict=True, _expand=True):
     (3, {x: 1, y: 2})
 
     Use results with caution if the equation was not fully expanded since
-    the coefficients may contain expressions that would simplify to 0:
+    the coefficients may contain expressions that would simplify to 0.
+    For example, the following does not depend on ``x`` or ``y``:
 
     >>> _lin_eq2dict(x*(y + 1)*(y - 1) - x*y**2 + x + 2, {x})
     (2, {x: -y**2 + (y - 1)*(y + 1) + 1})
@@ -236,7 +237,7 @@ def _lin_eq2dict(a, symset, strict=True, _expand=True):
                 terms = ti
                 terms_coeff = ci
             else:
-                raise PolyNonlinearError('nonlinear cross-terms encountered: %s' % a)
+                raise PolyNonlinearError('nonlinear cross-terms encountered')
         coeff = Mul._from_args(coeff_list)
         if terms is None:
             return coeff, {}
@@ -251,4 +252,6 @@ def _lin_eq2dict(a, symset, strict=True, _expand=True):
     elif not a.has_free_arg(symset) or not strict:
         return a, {}
     else:
-        raise PolyNonlinearError('symbol-dependent term encountered: %s' % a)
+        raise PolyNonlinearError(filldedent('''
+            symbol-dependent term can be ignored using `strict=False`
+            '''))

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -43,7 +43,7 @@ from .sdm import (
 )
 
 
-def _linsolve(eqs, syms):
+def _linsolve(eqs, syms, strict=True):
     """Solve a linear system of equations.
 
     Examples
@@ -69,7 +69,7 @@ def _linsolve(eqs, syms):
     nsyms = len(syms)
 
     # Convert to sparse augmented matrix (len(eqs) x (nsyms+1))
-    eqsdict, rhs = _linear_eq_to_dict(eqs, syms)
+    eqsdict, rhs = _linear_eq_to_dict(eqs, syms, strict)
     Aaug = sympy_dict_to_dm(eqsdict, rhs, syms)
     K = Aaug.domain
 
@@ -147,17 +147,17 @@ def _expand_eqs_deprecated(eqs):
     return [expand_eq(eq) for eq in eqs]
 
 
-def _linear_eq_to_dict(eqs, syms):
+def _linear_eq_to_dict(eqs, syms, strict=True):
     """Convert a system Expr/Eq equations into dict form"""
     try:
-        return _linear_eq_to_dict_inner(eqs, syms)
+        return _linear_eq_to_dict_inner(eqs, syms, strict)
     except PolyNonlinearError:
         # XXX: This should be deprecated:
         eqs = _expand_eqs_deprecated(eqs)
-        return _linear_eq_to_dict_inner(eqs, syms)
+        return _linear_eq_to_dict_inner(eqs, syms, strict)
 
 
-def _linear_eq_to_dict_inner(eqs, syms):
+def _linear_eq_to_dict_inner(eqs, syms, strict):
     """Convert a system Expr/Eq equations into dict form, returning
     the coefficient dictionaries and a list of syms-independent terms
     from each expression in ``eqs```.
@@ -173,7 +173,7 @@ def _linear_eq_to_dict_inner(eqs, syms):
     syms = set(syms)
     eqsdict, ind = [], []
     for eq in eqs:
-        c, eqdict = _lin_eq2dict(eq, syms)
+        c, eqdict = _lin_eq2dict(eq, syms, strict)
         eqsdict.append(eqdict)
         ind.append(c)
     return eqsdict, ind

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -234,7 +234,7 @@ def _lin_eq2dict(a, symset, strict=True):
                 terms_coeff = ci
             else:
                 raise PolyNonlinearError
-        coeff = Mul(*coeff_list)
+        coeff = Mul._from_args(coeff_list)
         if terms is None:
             return coeff, {}
         else:

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -199,7 +199,7 @@ def _lin_eq2dict(a, symset, strict=True):
     Use results with caution if the equation was not fully expanded since
     the coefficients may contain expressions that would simplify to 0:
 
-    >>> _lin_eq2dict(x*(y + 1)*(y - 1) - x*y**2 + x + 2], {x})
+    >>> _lin_eq2dict(x*(y + 1)*(y - 1) - x*y**2 + x + 2, {x})
     (2, {x: -y**2 + (y - 1)*(y + 1) + 1})
     >>> c, d = _; d[x].simplify() == 0
     True

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -242,7 +242,9 @@ def _lin_eq2dict(a, symset, strict=True):
             return  coeff * terms_coeff, terms
     elif a.is_Equality:
         # don't allow nonlinear terms to cancel
-        return _lin_eq2dict(a.rewrite(Add, evaluate=False), symset, strict)
+        c, d = _lin_eq2dict(a.rewrite(Add, evaluate=False), symset, strict)
+        # but don't include any keys that ended up having cancelling terms
+        return c, {k: v for k, v in d.items() if v}
     elif not a.has_free_arg(symset) or not strict:
         return a, {}
     else:

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -29,6 +29,7 @@
 from collections import defaultdict
 
 from sympy.core.add import Add
+from sympy.core.function import _mexpand
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 
@@ -156,7 +157,6 @@ def _linear_eq_to_dict(eqs, syms, strict=True, _expand=True):
         if not _expand:
             raise err
         # XXX: This should be deprecated:
-        from sympy.core.function import _mexpand
         eqs = [_mexpand(i, recursive=True) for i in eqs]
         return _linear_eq_to_dict_inner(eqs, syms, strict)
 

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -186,6 +186,8 @@ def _lin_eq2dict(a, symset, strict=True):
     is detected. To allow cross-terms involving object containing (but not
     equal to) a symbol, use ``strict=False``
 
+    The values in the dictionary will be non-zero if the original expression was expanded
+    but may contain expressions which will simplify to zero, otherwise.
     Examples
     ========
 
@@ -193,6 +195,14 @@ def _lin_eq2dict(a, symset, strict=True):
     >>> from sympy.abc import x, y
     >>> _lin_eq2dict(x + 2*y + 3, {x, y})
     (3, {x: 1, y: 2})
+
+    Use results with caution if the equation was not fully expanded since
+    the coefficients may contain expressions that would simplify to 0:
+
+    >>> _lin_eq2dict(x*(y + 1)*(y - 1) - x*y**2 + x + 2], {x})
+    (2, {x: -y**2 + (y - 1)*(y + 1) + 1})
+    >>> c, d = _; d[x].simplify() == 0
+    True
 
     The following does not raise an error because ``x**2`` does not appear in
     ``x``:

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -241,7 +241,8 @@ def _lin_eq2dict(a, symset, strict=True):
             terms = {sym: coeff * c for sym, c in terms.items()}
             return  coeff * terms_coeff, terms
     elif a.is_Equality:
-        return _lin_eq2dict(a.lhs - a.rhs, symset, strict)
+        # don't allow nonlinear terms to cancel
+        return _lin_eq2dict(a.rewrite(Add, evaluate=False), symset, strict)
     elif not a.has_free_arg(symset) or not strict:
         return a, {}
     else:

--- a/sympy/polys/matrices/tests/test_linsolve.py
+++ b/sympy/polys/matrices/tests/test_linsolve.py
@@ -103,6 +103,8 @@ def test__linsolve_float():
 
 
 def test__linsolve_deprecated():
-    assert _linsolve([Eq(x**2, x**2+y)], [x, y]) == {x:x, y:S.Zero}
-    assert _linsolve([(x+y)**2-x**2], [x]) == {x:-y/2}
+    assert _linsolve([Eq(x**2, x**2 + y)], [x, y]) == {x:x, y:S.Zero}
+    assert _linsolve([(x+y)**2 - x**2], [x]) == {x:-y/2}
     assert _linsolve([Eq((x+y)**2, x**2)], [x]) == {x:-y/2}
+    # when these fail, special handling of Eq in solveset.linear_eq_to_matrix
+    # can be removed

--- a/sympy/polys/matrices/tests/test_linsolve.py
+++ b/sympy/polys/matrices/tests/test_linsolve.py
@@ -17,10 +17,10 @@ from sympy.polys.solvers import PolyNonlinearError
 
 def test__linsolve():
     assert _linsolve([], [x]) == {x:x}
-    assert _linsolve([S.Zero], [x]) == {x:x}
-    assert _linsolve([x-1,x-2], [x]) is None
-    assert _linsolve([x-1], [x]) == {x:1}
-    assert _linsolve([x-1, y], [x, y]) == {x:1, y:S.Zero}
+    assert _linsolve([S.Zero], [x]) == {x: x}
+    assert _linsolve([x - 1, x - 2], [x]) is None
+    assert _linsolve([x - 1], [x]) == {x: 1}
+    assert _linsolve([x - 1, y], [x, y]) == {x:1, y:S.Zero}
     assert _linsolve([2*I], [x]) is None
     raises(PolyNonlinearError, lambda: _linsolve([x*(1 + x)], [x]))
 
@@ -103,8 +103,6 @@ def test__linsolve_float():
 
 
 def test__linsolve_deprecated():
-    assert _linsolve([Eq(x**2, x**2 + y)], [x, y]) == {x:x, y:S.Zero}
-    assert _linsolve([(x+y)**2 - x**2], [x]) == {x:-y/2}
-    assert _linsolve([Eq((x+y)**2, x**2)], [x]) == {x:-y/2}
-    # when these fail, special handling of Eq in solveset.linear_eq_to_matrix
-    # can be removed
+    assert _linsolve([Eq(x**2, x**2 + y)], [x, y]) == {x: x, y:S.Zero}
+    assert _linsolve([(x + y)**2 - x**2], [x]) == {x: -y/2}
+    assert _linsolve([Eq((x + y)**2, x**2)], [x]) == {x: -y/2}

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1648,11 +1648,11 @@ def test_higher_order_to_first_order_9():
 
     eqs9 = [f(x) + g(x) - 2*exp(I*x) + 2*Derivative(f(x), x) + Derivative(f(x), (x, 2)),
             f(x) + g(x) - 2*exp(I*x) + 2*Derivative(g(x), x) + Derivative(g(x), (x, 2))]
-    sol9 =  [Eq(f(x), -C1 + C2*exp(-2*x)/2 - (C3/2 - C4/2)*exp(-x)*cos(x)
-                    + (C3/2 + C4/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
+    sol9 =  [Eq(f(x), -C1 + C4*exp(-2*x)/2 - (C2/2 - C3/2)*exp(-x)*cos(x)
+                    + (C2/2 + C3/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
                     + 2*((1 - 2*I)*exp(I*x)*cos(x)**2/5)),
-            Eq(g(x), C1 - C2*exp(-2*x)/2 - (C3/2 - C4/2)*exp(-x)*cos(x)
-                    + (C3/2 + C4/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
+            Eq(g(x), C1 - C4*exp(-2*x)/2 - (C2/2 - C3/2)*exp(-x)*cos(x)
+                    + (C2/2 + C3/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
                     + 2*((1 - 2*I)*exp(I*x)*cos(x)**2/5))]
     assert dsolve(eqs9) == sol9
     assert checksysodesol(eqs9, sol9) == (True, [0, 0])

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1071,10 +1071,11 @@ def test_sysode_linear_neq_order1_type2():
     eqs6 = [Eq(Derivative(f(x), x), -9*f(x) - 4*g(x)),
             Eq(Derivative(g(x), x), -4*g(x)),
             Eq(Derivative(h(x), x), h(x) + exp(x))]
-    sol6 = [Eq(f(x), C1*exp(-4*x)*Rational(-4, 5) + C2*exp(-9*x)),
-            Eq(g(x), C1*exp(-4*x)),
+    sol6 = [Eq(f(x), C2*exp(-4*x)*Rational(-4, 5) + C1*exp(-9*x)),
+            Eq(g(x), C2*exp(-4*x)),
             Eq(h(x), C3*exp(x) + x*exp(x))]
-    assert dsolve(eqs6) == sol6
+    got = dsolve(eqs6)
+    assert got == sol6, got
     assert checksysodesol(eqs6, sol6) == (True, [0, 0, 0])
 
     # Regression test case for issue #8859

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1435,7 +1435,8 @@ def _solve(f, *symbols, **flags):
                     v = v.cancel()
                 # check to see if this was a factor of f
                 try:
-                    w, r = div(f, xi - v)
+                    ni, di = (xi - v).as_numer_denom()
+                    w, r = div(f*di, ni)
                 except PolynomialError:
                     w, r = 1, 1
                 if not r:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1146,14 +1146,23 @@ def solve(f, *symbols, **flags):
     #
     # try to get a solution
     ###########################################################################
-    if len(f) == 1 and f[0].is_Mul:
+    if len(f) == 1 and f[0].is_Mul and len(symbols) > 1:
         solution = []
+        check = flags.get('check', True)
+        if check:
+            dens = flags.get('_denominators', _simple_dens(f, symbols))
+        else:
+            dens = None
         for fi in f[0].args:
             if not fi.has_free(*symbols):
                 continue
-            s = _solve(fi, *symbols, **flags)
-            if s:
-                solution.extend(s)
+            si = _solve(fi, *symbols, **flags)
+            if dens:
+                si = [s for s in si if
+                    not any(checksol(den, s, **flags) for den in
+                        dens)]
+            if si:
+                solution.extend(si)
         solution = list(ordered(uniq(solution)))
         flags['check'] = flags['simplify'] = False
     elif bare_f:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2443,12 +2443,24 @@ def solve_undetermined_coeffs(equ, coeffs, sym, **flags):
 
     system = list(collect(_mexpand(equ, recursive=True), sym,
         evaluate=False, exact=None).values())
+
+    # keep only symbols that appear
+    has = []
+    for i in coeffs:
+        s = {i}
+        for e in system:
+            if e.has_free_arg(s):
+                has.append(i)
+                break
+    coeffs = has
+
     try:
-        assert all(linear_coeffs(s, *coeffs) for s in system)
+        for s in system:
+            linear_coeffs(s, *coeffs)  # see if it raises error
     except NonlinearError:
         return
 
-    if not any(equ.has(sym) for equ in system):  # can this happen?
+    if not any(equ.has_free_arg({sym}) for equ in system):  # can this happen?
         miss = Dummy()
         dwas = flags.pop('dict', miss)
         swas = flags.pop('set', miss)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -45,7 +45,7 @@ from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, factor, Poly
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
-from sympy.polys.polytools import div, quo
+from sympy.polys.polytools import div
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent, debug

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -834,6 +834,11 @@ def solve(f, *symbols, **flags):
         manual=True (default is False)
             Do not use the polys/matrix method to solve a system of
             equations, solve them one at a time as you might "manually."
+        match=True (default is False)
+            For a single multivariate expression, construct a system of
+            equations in terms of other symbols that can be solved to
+            determine the given symbols (or, equivalently, the non-excluded
+            symbols) via the `solve_undetermined_coeffs` function.
         implicit=True (default is False)
             Allows ``solve`` to return a solution for a pattern in terms of
             other functions that contain that pattern; this is only

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1398,11 +1398,18 @@ def _solve(f, *symbols, **flags):
         nonlin_s = []
         result = []
         i = 0
+        saw = {}
         while i < len(symbols):
             s = symbols[i]
+            saw.setdefault((s, f), []).append(None)
+            if all(len(saw[i]) == 2 for i in saw):
+                raise AssertionError(filldedent('''
+                    Please report
+                    to https://github.com/sympy/sympy/issues that an
+                    infinite loop was encountered while trying
+                    to solve %s for %s''' % (f, symbols)))
             xi, v = solve_linear(f, symbols=[s])
             if xi == s:
-                i = 0
                 # no need to check but cancel may be needed
                 # so the div will work if we aren't already
                 # simplifying
@@ -1430,9 +1437,9 @@ def _solve(f, *symbols, **flags):
                     xi, v = ordered((xi, v))
                 result.append({xi: v})
                 got_s.add(xi)
-                if i is None:
+                if i is None or isinstance(f, Piecewise):
                     return result
-                continue
+                i = -1  # to start over
             elif xi:
                 nonlin_s.append(s)
             i += 1

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1331,7 +1331,7 @@ def solve(f, *symbols, **flags):
     as_dict = flags.get('dict', False)
     as_set = flags.get('set', False)
 
-    if type(solution) not in (list, dict, tuple):
+    if solution is not None and type(solution) not in (list, dict, tuple):
         return solution
 
     if not solution:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1176,7 +1176,10 @@ def solve(f, *symbols, **flags):
             solution = None
             free = eq.free_symbols
             syms = set(symbols) & free
-            ex = free - syms
+            # if there is no generator on which to match, the
+            # constant term can still be determined but we need
+            # a dummy generator
+            ex = {Dummy()} if len(syms) == 1 else free - syms
             if len(ex) != 1:
                 ind, dep = eq.as_independent(*symbols)
                 ex = dep.free_symbols - syms
@@ -1184,7 +1187,9 @@ def solve(f, *symbols, **flags):
                 ex = ex.pop()
                 solution = solve_undetermined_coeffs(eq, syms, ex)
             if solution is None:
-                raise ValueError('%s not recognized as a linear coefficient system in variables %s' % (eq, symbols))
+                raise ValueError(filldedent('''
+                    %s not recognized as a linear coefficient system
+                    in variables %s''' % (eq, symbols)))
         else:
             solution = _solve(eq, *symbols, **flags)
     else:
@@ -1360,7 +1365,7 @@ def solve(f, *symbols, **flags):
     if not as_dict and not as_set:
         return solution
 
-    # return a list of mappings with canonical order or []
+    # return a list of mappings with canonical order
     if isinstance(solution, dict):
         solution = [{k: v for k, v in ordered(solution.items())}]
     elif iterable(solution[0]):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -24,6 +24,7 @@ from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
+from sympy.polys.matrices.linsolve import _linear_eq_to_dict
 from sympy.polys.polyroots import UnsolvableFactorError
 from sympy.simplify.simplify import simplify, fraction, trigsimp, nsimplify
 from sympy.simplify import powdenest, logcombine
@@ -2511,6 +2512,17 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
     try:
         c, d = _lin_eq2dict(eq, symset, strict)
     except PolyNonlinearError as err:
+        # try raise a helpful error
+        if strict:
+            try:
+                noxterms = _linear_eq_to_dict(equations, symbols, strict=False, _expand=False)
+                print(filldedent('''
+                A term dependent on symbols of interest (but not appearing
+                as a symbol of interest) was detected. To ignore, use flag `strict=False`.'''))
+            except PolyNonlinearError as err:
+                print(filldedent('''
+                There are cross-terms containing symbols of interest. If expansion would
+                remove such terms, that must be done before calling this routine.'''))
         raise NonlinearError(str(err)) from err
     if dict:
         if c:
@@ -2643,7 +2655,6 @@ def linear_eq_to_matrix(equations, *symbols, strict=True):
             ...
             NonlinearError: nonlinear term: y*(x + 1)
     """
-    from sympy.polys.matrices.linsolve import _linear_eq_to_dict
     if not symbols:
         raise ValueError(filldedent('''
             Symbols must be given, for which coefficients
@@ -2684,6 +2695,17 @@ def linear_eq_to_matrix(equations, *symbols, strict=True):
     try:
         eq, c = _linear_eq_to_dict(equations, symbols, strict=strict, _expand=False)
     except PolyNonlinearError as err:
+        # try raise a helpful error
+        if strict:
+            try:
+                noxterms = _linear_eq_to_dict(equations, symbols, strict=False, _expand=False)
+                print(filldedent('''
+                A term dependent on symbols of interest (but not appearing
+                as a symbol of interest) was detected. To ignore, use flag `strict=False`.'''))
+            except PolyNonlinearError as err:
+                print(filldedent('''
+                There are cross-terms containing symbols of interest. If expansion would
+                remove such terms, that must be done before calling this routine.'''))
         raise NonlinearError(str(err)) from err
     ix = dict(zip(symbols, range(len(symbols))))
     A = zeros(len(eq), len(symbols))

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2702,7 +2702,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
             of interest (in which case expansion before calling this routine might
             help).'''))
         raise NonlinearError(str(err)) from err
-    n, m = shape = (len(eq), len(symbols)
+    n, m = shape = len(eq), len(symbols)
     ix = dict(zip(symbols, range(m)))
     rhs = [-i for i in c]
     del c

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2512,6 +2512,8 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
         raise ValueError('duplicate symbols given')
     has = set(iterfreeargs(eq)) & symset
     if not has:
+        if isinstance(eq, Equality):
+            eq = eq.rewrite(Add)
         if dict:
             return {1: eq}
         return [S.Zero]*len(syms) + [eq]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -10,6 +10,7 @@ This module contains functions to:
 
     - solve a system of Non Linear Equations with N variables and M equations
 """
+from sympy.core.basic import Basic
 from sympy.core.sympify import sympify
 from sympy.core import (S, Pow, Dummy, pi, Expr, Wild, Mul, Equality,
                         Add)
@@ -54,11 +55,10 @@ from sympy.solvers.solvers import (checksol, denoms, unrad,
 from sympy.solvers.polysys import solve_poly_system
 from sympy.utilities import filldedent
 from sympy.utilities.iterables import (numbered_symbols, has_dups,
-                                       is_sequence)
+                                       is_sequence, iterable)
 from sympy.calculus.util import periodicity, continuous_domain, function_range
 
 from types import GeneratorType
-from collections import defaultdict
 
 
 class NonlinearError(ValueError):
@@ -2411,7 +2411,7 @@ def solvify(f, symbol, domain):
 ###############################################################################
 
 
-def linear_coeffs(eq, *syms, **_kw):
+def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
     """Return a list whose elements are the coefficients of the
     corresponding symbols in the sum of terms in  ``eq``.
     The additive constant is returned as the last element of the
@@ -2422,6 +2422,19 @@ def linear_coeffs(eq, *syms, **_kw):
 
     NonlinearError
         The equation contains a nonlinear term
+    ValueError
+        duplicate or unordered symbols are passed
+
+    Parameters
+    ==========
+
+    dict - (default False) when True, return coefficients as a
+        dictionary with coefficients keyed to syms that were present;
+        key 1 gives the constant term
+    strict - (default True) when False will only raise an error
+        if any term in the expanded expression contains more than one
+        of the symbols as factors, i.e. it allows symbol-dependent
+        factors to appear in the same term
 
     Examples
     ========
@@ -2434,60 +2447,96 @@ def linear_coeffs(eq, *syms, **_kw):
 
     It is not necessary to expand the expression:
 
-    >>> linear_coeffs(x + y*(z*(x*3 + 2) + 3), x)
-    [3*y*z + 1, y*(2*z + 3)]
+        >>> linear_coeffs(x + y*(z*(3*x + 2) + 3), x)
+        [3*y*z + 1, y*(2*z + 3)]
 
     But if there are nonlinear or cross terms -- even if they would
     cancel after simplification -- an error is raised so the situation
     does not pass silently past the caller's attention:
 
-    >>> eq = 1/x*(x - 1) + 1/x
-    >>> linear_coeffs(eq.expand(), x)
-    [0, 1]
-    >>> linear_coeffs(eq, x)
-    Traceback (most recent call last):
-    ...
-    NonlinearError: nonlinear term encountered: 1/x
+        >>> eq = 1/x*(x - 1) + 1/x
+        >>> linear_coeffs(eq.expand(), x)
+        [0, 1]
+        >>> linear_coeffs(eq, x)
+        Traceback (most recent call last):
+        ...
+        NonlinearError: nonlinear term: 1/x
 
-    >>> linear_coeffs(x*(y + 1) - x*y, x, y)
-    Traceback (most recent call last):
-    ...
-    NonlinearError: nonlinear term encountered: x*(y + 1)
+        >>> linear_coeffs(x*(y + 1) + 3, x, y)
+        Traceback (most recent call last):
+        ...
+        NonlinearError: nonlinear term: x*(y + 1)
+
+    An error is not raised when dependent symbols are passed, however:
+
+        >>> linear_coeffs(x + 2*x**2, x, x**2)
+        [1, 2, 0]
+
+    To allow coefficients to contain symbol-dependent factors which are
+    not strictly one of the symbols, use keyword `strict=False`.
+    A NonlinearError will still be reported if a term contains two
+    literal symbols as factors:
+
+        >>> linear_coeffs(x*(y**2 + 1) + x*y, x, y, strict=False)
+        Traceback (most recent call last):
+        ...
+        NonlinearError: nonlinear term: x*y
+
+    But the error will no longer raise if the unexpanded expression
+    does not contain such a term:
+
+        >>> eq, v = x*(y**2 + 1) + 3, [x, y]
+        >>> linear_coeffs(eq, *v, strict=False)
+        [y**2 + 1, 0, 3]
+
+    This is likely most useful when dealing with functions and their
+    derivatives since a derivative "has" the function in its expression
+    but it might make sense to treat them as being independent.
+
+    Regardless of the setting of `strict`, it should always be
+    true that the result will reconstruct an expression that is
+    equivalent to the input expression.
+
+        >>> from math import prod
+        >>> r = _  # result from above
+        >>> eq.equals(r[-1] + sum([prod(i) for i in zip(v, r)]))
+        True
     """
-    d = defaultdict(list)
+    from builtins import dict as _dict
+    from sympy.polys.matrices.linsolve import _lin_eq2dict
     eq = _sympify(eq)
+    if isinstance(eq, Equality):
+        eq = eq.rewrite(Add, evaluate=False)
+    if len(syms) == 1 and iterable(syms[0]) and not isinstance(syms[0], Basic):
+        raise ValueError('pass unpacked symbols, *syms')
     symset = set(syms)
     if len(symset) != len(syms):
         raise ValueError('duplicate symbols given')
     has = set(iterfreeargs(eq)) & symset
     if not has:
+        if dict:
+            return {1: eq}
         return [S.Zero]*len(syms) + [eq]
-    c, terms = eq.as_coeff_add(*has)
-    d[0].extend(Add.make_args(c))
-    for t in terms:
-        m, f = t.as_coeff_mul(*has)
-        if len(f) != 1:
-            break
-        f = f[0]
-        if f in symset:
-            d[f].append(m)
-        elif f.is_Add:
-            d1 = linear_coeffs(f, *has, **{'dict': True})
-            d[0].append(m*d1.pop(0))
-            for xf, vf in d1.items():
-                d[xf].append(m*vf)
-        else:
-            break
-    else:
-        for k, v in d.items():
-            d[k] = Add(*v)
-        if not _kw:
-            return [d.get(s, S.Zero) for s in syms]+ [d[0]]
-        return d  # default is still list but this won't matter
-    raise NonlinearError('nonlinear term encountered: %s' % t)
+    try:
+        c, d = _lin_eq2dict(eq, has, strict)
+    except PolyNonlinearError as exc:
+        raise NonlinearError(str(exc))
+    if dict:
+        if c:
+            d[1] = c
+        return d
+    if len(has)*10 > 9*len(syms):
+        # dense
+        return [d.get(i, S.Zero) for i in syms] + [c]
+    # faster to set defaults and fill in non-zeros when sparse
+    rv = [S.Zero]*len(syms)
+    ix = _dict(zip(syms, range(len(syms))))
+    for k in d:
+        rv[ix[k]] = d[k]
+    return rv + [c]
 
 
-def linear_eq_to_matrix(equations, *symbols):
+def linear_eq_to_matrix(equations, *symbols, strict=True):
     r"""
     Converts a given System of Equations into Matrix form.
     Here `equations` must be a linear system of equations in
@@ -2514,6 +2563,18 @@ def linear_eq_to_matrix(equations, *symbols):
     The only simplification performed is to convert
     ``Eq(a, b)`` $\Rightarrow a - b$.
 
+    To suppress the error raised when nonlinearity is detected, pass
+    keyword `strict=False` and use the result with caution. There will
+    be a naive separation of coefficients from literal occurances of
+    the indicated symbols with limited error reporting.
+
+    Parameters
+    ==========
+
+    strict - (default True) when False, allows non-linear instances
+        of symbols and non-Symbol objects as long no more than one of
+        them appear as a literal factor in any term
+
     Raises
     ======
 
@@ -2531,39 +2592,68 @@ def linear_eq_to_matrix(equations, *symbols):
     The coefficients (numerical or symbolic) of the symbols will
     be returned as matrices:
 
-    >>> eqns = [c*x + z - 1 - c, y + z, x - y]
-    >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
-    >>> A
-    Matrix([
-    [c,  0, 1],
-    [0,  1, 1],
-    [1, -1, 0]])
-    >>> b
-    Matrix([
-    [c + 1],
-    [    0],
-    [    0]])
+        >>> eqns = [c*x + z - 1 - c, y + z, x - y]
+        >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
+        >>> A
+        Matrix([
+        [c,  0, 1],
+        [0,  1, 1],
+        [1, -1, 0]])
+        >>> b
+        Matrix([
+        [c + 1],
+        [    0],
+        [    0]])
 
     This routine does not simplify expressions and will raise an error
     if nonlinearity is encountered:
 
-    >>> eqns = [
-    ...     (x**2 - 3*x)/(x - 3) - 3,
-    ...     y**2 - 3*y - y*(y - 4) + x - 4]
-    >>> linear_eq_to_matrix(eqns, [x, y])
-    Traceback (most recent call last):
-    ...
-    NonlinearError:
-    The term (x**2 - 3*x)/(x - 3) is nonlinear in {x, y}
+            >>> eqns = [
+            ...     (x**2 - 3*x)/(x - 3) - 3,
+            ...     y**2 - 3*y - y*(y - 4) + x - 4]
+            >>> linear_eq_to_matrix(eqns, [x, y])
+            Traceback (most recent call last):
+            ...
+            NonlinearError: nonlinear term: (x**2 - 3*x)/(x - 3)
 
-    Simplifying these equations will discard the removable singularity
-    in the first, reveal the linear structure of the second:
+        Simplifying these equations will discard the removable singularity
+        in the first and reveal the linear structure of the second:
 
-    >>> [e.simplify() for e in eqns]
-    [x - 3, x + y - 4]
+            >>> [e.simplify() for e in eqns]
+            [x - 3, x + y - 4]
 
-    Any such simplification needed to eliminate nonlinear terms must
-    be done before calling this routine.
+        Any such simplification needed to eliminate nonlinear terms must
+        be done *before* calling this routine.
+
+    If one wishes to ignore nonlinear terms that are independent of
+    those that are linear (or factors that contain, but are not equal
+    to, symbols that were provided) the keyword `strict=False` can
+    be used.
+
+            >>> linear_eq_to_matrix([x**2 + x + y], [x], strict=False)
+            (Matrix([[1]]), Matrix([[-x**2 - y]]))
+
+        Symbols may then contain non-Symbol objects, too:
+
+            >>> from sympy import Function
+            >>> f = Function('f')
+            >>> linear_eq_to_matrix([f(x)*f(x).diff() + y], [f(x)], strict=False)
+            (Matrix([[Derivative(f(x), x)]]), Matrix([[-y]]))
+
+        An error will only be raised when two or more factors are
+        identical to specified symbols. For example, ``x`` and ``x**2``
+        will not usually appear as factors in the same term:
+
+            >>> linear_eq_to_matrix([x**2*y + x + x**3], [x**2, x], strict=False)
+            (Matrix([[y, 1]]), Matrix([[-x**3]]))
+
+        But the error will be raised if more than one factor has a given
+        symbol as a literal factor whether the expression is expanded or not:
+
+            >>> linear_eq_to_matrix([x + y + y*(x + 1)], [x, y], strict=False)
+            Traceback (most recent call last):
+            ...
+            NonlinearError: nonlinear term: y*(x + 1)
     """
     if not symbols:
         raise ValueError(filldedent('''
@@ -2574,11 +2664,12 @@ def linear_eq_to_matrix(equations, *symbols):
     if hasattr(symbols[0], '__iter__'):
         symbols = symbols[0]
 
-    for i in symbols:
-        if not isinstance(i, Symbol):
-            raise ValueError(filldedent('''
-            Expecting a Symbol but got %s
-            ''' % i))
+    if strict:
+        for i in symbols:
+            if not isinstance(i, Symbol):
+                raise ValueError(filldedent('''
+                Expecting a Symbol but got %s
+                ''' % i))
 
     if has_dups(symbols):
         raise ValueError('Symbols must be unique')
@@ -2596,9 +2687,7 @@ def linear_eq_to_matrix(equations, *symbols):
 
     A, b = [], []
     for i, f in enumerate(equations):
-        if isinstance(f, Equality):
-            f = f.rewrite(Add, evaluate=False)
-        coeff_list = linear_coeffs(f, *symbols)
+        coeff_list = linear_coeffs(f, *symbols, strict=strict)
         b.append(-coeff_list.pop())
         A.append(coeff_list)
     A, b = map(Matrix, (A, b))
@@ -2769,7 +2858,7 @@ def linsolve(system, *symbols):
     Traceback (most recent call last):
     ...
     NonlinearError:
-    nonlinear term encountered: x**2
+    nonlinear term: x**2
     """
     if not system:
         return S.EmptySet

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2505,8 +2505,6 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
     from builtins import dict as _dict
     from sympy.polys.matrices.linsolve import _lin_eq2dict
     eq = _sympify(eq)
-    if isinstance(eq, Equality):
-        eq = eq.rewrite(Add, evaluate=False)
     if len(syms) == 1 and iterable(syms[0]) and not isinstance(syms[0], Basic):
         raise ValueError('pass unpacked symbols, *syms')
     symset = set(syms)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2730,7 +2730,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
     return A, b
 
 
-def linsolve(system, *symbols, strict=False):
+def linsolve(system, *symbols, strict=True, _expand=True):
     r"""
     Solve system of $N$ linear equations with $M$ variables; both
     underdetermined and overdetermined systems are supported.
@@ -2935,8 +2935,10 @@ def linsolve(system, *symbols, strict=False):
             #
             eqs = system
             eqs = [sympify(eq) for eq in eqs]
+            eqs = [i.rewrite(Add, evaluate=_expand) if isinstance(i, Eq
+                ) else i for i in eqs]
             try:
-                sol = _linsolve(eqs, symbols, strict)
+                sol = _linsolve(eqs, symbols, strict, _expand)
             except PolyNonlinearError as err:
                 if strict:
                     print(filldedent('''

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2730,7 +2730,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
     return A, b
 
 
-def linsolve(system, *symbols, strict=True):
+def linsolve(system, *symbols, strict=False):
     r"""
     Solve system of $N$ linear equations with $M$ variables; both
     underdetermined and overdetermined systems are supported.
@@ -2741,7 +2741,9 @@ def linsolve(system, *symbols, strict=True):
     is returned. To treat symbol-dependent expressions that do not
     appear in ``symbols`` (but are dependent on one or more of the
     symbols) use ``strict=False``; an error will then only be raised
-    when cross-terms containing symbols are detected.
+    when cross-terms containing symbols are detected; if the flag is
+    True then cross-terms or extra symbol-dependent objects will raise
+    the NonlinearError.
 
     All standard input formats are supported:
     For the given set of equations, the respective input types

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -41,7 +41,7 @@ from sympy.logic.boolalg import And, BooleanTrue
 from sympy.sets import (FiniteSet, imageset, Interval, Intersection,
                         Union, ConditionSet, ImageSet, Complement, Contains)
 from sympy.sets.sets import Set, ProductSet
-from sympy.matrices import zeros, MatrixBase
+from sympy.matrices import SparseMatrix, MatrixBase
 from sympy.ntheory import totient
 from sympy.ntheory.factor_ import divisors
 from sympy.ntheory.residue_ntheory import discrete_log, nthroot_mod
@@ -2690,6 +2690,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
         raise NonlinearError(str(err)) from err
     n, m = shape = len(eq), len(symbols)
     ix = dict(zip(symbols, range(m)))
+    dod = {row: {ix[k]: d[k] for k in d} for row, d in enumerate(eq)}
     rhs = [-i for i in c]
     del c
     if fmt != '':
@@ -2702,17 +2703,11 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
                 dom = QQ
         if dom is None:
             dom = EXRAW
-        dod = {row: {ix[k]: d[k] for k in d} for row, d in enumerate(eq)}
         A = DomainMatrix(dod, shape, dom, fmt=fmt)
         b = DomainMatrix([[i] for i in rhs], (n, 1), dom, fmt=fmt)
     else:
-        A = zeros(*shape)
-        b = zeros(n, 1)
-        for i, d in enumerate(eq):
-            for s in d:
-                j = ix[s]
-                A[i, j] = d[s]
-            b[i, 0] = rhs[i]
+        A = SparseMatrix(*shape, dod)
+        b = SparseMatrix(n, 1, rhs)
     return A, b
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2510,29 +2510,19 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
     symset = set(syms)
     if len(symset) != len(syms):
         raise ValueError('duplicate symbols given')
-    has = set(iterfreeargs(eq)) & symset
-    if not has:
-        if isinstance(eq, Equality):
-            eq = eq.rewrite(Add)
-        if dict:
-            return {1: eq}
-        return [S.Zero]*len(syms) + [eq]
     try:
-        c, d = _lin_eq2dict(eq, has, strict)
+        c, d = _lin_eq2dict(eq, symset, strict)
     except PolyNonlinearError as exc:
         raise NonlinearError(str(exc))
     if dict:
         if c:
             d[1] = c
         return d
-    if len(has)*10 > 9*len(syms):
-        # dense
-        return [d.get(i, S.Zero) for i in syms] + [c]
-    # faster to set defaults and fill in non-zeros when sparse
     rv = [S.Zero]*len(syms)
-    ix = _dict(zip(syms, range(len(syms))))
-    for k in d:
-        rv[ix[k]] = d[k]
+    for i, k in enumerate(syms):
+        if k not in d:
+            continue
+        rv[i] = d[k]
     return rv + [c]
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -24,7 +24,6 @@ from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
-from sympy.core.traversal import iterfreeargs
 from sympy.polys.polyroots import UnsolvableFactorError
 from sympy.simplify.simplify import simplify, fraction, trigsimp, nsimplify
 from sympy.simplify import powdenest, logcombine
@@ -2502,7 +2501,6 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
         >>> eq.equals(r[-1] + sum([prod(i) for i in zip(v, r)]))
         True
     """
-    from builtins import dict as _dict
     from sympy.polys.matrices.linsolve import _lin_eq2dict
     eq = _sympify(eq)
     if len(syms) == 1 and iterable(syms[0]) and not isinstance(syms[0], Basic):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2515,11 +2515,11 @@ def linear_coeffs(eq, *syms, dict=False, strict=True, first=True):
         # try raise a helpful error
         if strict:
             try:
-                noxterms = _linear_eq_to_dict(equations, symbols, strict=False, _expand=False)
+                _linear_eq_to_dict([eq], syms, strict=False, _expand=False)
                 print(filldedent('''
                 A term dependent on symbols of interest (but not appearing
                 as a symbol of interest) was detected. To ignore, use flag `strict=False`.'''))
-            except PolyNonlinearError as err:
+            except PolyNonlinearError:
                 print(filldedent('''
                 There are cross-terms containing symbols of interest. If expansion would
                 remove such terms, that must be done before calling this routine.'''))
@@ -2698,11 +2698,11 @@ def linear_eq_to_matrix(equations, *symbols, strict=True):
         # try raise a helpful error
         if strict:
             try:
-                noxterms = _linear_eq_to_dict(equations, symbols, strict=False, _expand=False)
+                _linear_eq_to_dict(equations, symbols, strict=False, _expand=False)
                 print(filldedent('''
                 A term dependent on symbols of interest (but not appearing
                 as a symbol of interest) was detected. To ignore, use flag `strict=False`.'''))
-            except PolyNonlinearError as err:
+            except PolyNonlinearError:
                 print(filldedent('''
                 There are cross-terms containing symbols of interest. If expansion would
                 remove such terms, that must be done before calling this routine.'''))

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2707,7 +2707,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
     rhs = [-i for i in c]
     del c
     if fmt != '':
-        types = set(map(type, eq.values())) | set(map(type, c))
+        types = set(map(type, eq.values())) | set(map(type, rhs))
         dom = None
         if len(types) == 1:
             if rhs[0].is_Integer:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2682,7 +2682,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True):
 
     # construct the dictionaries
     try:
-        eq, c = _linear_eq_to_dict(equations, symbols, strict=strict)
+        eq, c = _linear_eq_to_dict(equations, symbols, strict=strict, _expand=False)
     except PolyNonlinearError as err:
         raise NonlinearError(str(err)) from err
     ix = dict(zip(symbols, range(len(symbols))))

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2730,7 +2730,7 @@ def linear_eq_to_matrix(equations, *symbols, strict=True, fmt=''):
     return A, b
 
 
-def linsolve(system, *symbols):
+def linsolve(system, *symbols, strict=True):
     r"""
     Solve system of $N$ linear equations with $M$ variables; both
     underdetermined and overdetermined systems are supported.
@@ -2738,7 +2738,10 @@ def linsolve(system, *symbols):
     Zero solutions throws a ValueError, whereas infinite
     solutions are represented parametrically in terms of the given
     symbols. For unique solution a :class:`~.FiniteSet` of ordered tuples
-    is returned.
+    is returned. To treat symbol-dependent expressions that do not
+    appear in ``symbols`` (but are dependent on one or more of the
+    symbols) use ``strict=False``; an error will then only be raised
+    when cross-terms containing symbols are detected.
 
     All standard input formats are supported:
     For the given set of equations, the respective input types
@@ -2931,9 +2934,15 @@ def linsolve(system, *symbols):
             eqs = system
             eqs = [sympify(eq) for eq in eqs]
             try:
-                sol = _linsolve(eqs, symbols)
+                sol = _linsolve(eqs, symbols, strict)
             except PolyNonlinearError as err:
-                # e.g. cos(x) contains an element of the set of generators
+                if strict:
+                    print(filldedent('''
+                    Either a term dependent on symbols of interest (but not appearing
+                    as a symbol of interest) was detected (in which case using `strict=False`
+                    might make more sense) or else there was a cross-term containing symbols
+                    of interest (in which case expansion before calling this routine might
+                    help).'''))
                 raise NonlinearError(str(err)) from err
 
             if sol is None:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -51,7 +51,7 @@ def test_swap_back():
     fx, gx = f(x), g(x)
     assert solve([fx + y - 2, fx - gx - 5], fx, y, gx) == \
         {fx: gx + 5, y: -gx - 3}
-    assert solve(fx + gx*x - 2, [fx, gx], dict=True)[0] == {fx: 2, gx: 0}
+    assert solve(fx + gx*x - 2, [fx, gx], dict=True) == [{fx: -x*gx + 2}]
     assert solve(fx + gx**2*x - y, [fx, gx], dict=True) == [{fx: y - gx**2*x}]
     assert solve([f(1) - 2, x + 2], dict=True) == [{x: -2, f(1): 2}]
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -217,7 +217,7 @@ def test_solve_match():
 
 def test_removing_linear_factors():
     eq = (a*x + b - 2*x - 5)*(c - 4)
-    sol = solve(eq, a, b, c)
+    sol = solve(eq.expand(), a, b, c)
     assert sol == [(a, b, 4), ((-b + 2*x + 5)/x, b, c)]
     # use unambiguous return value
     assert solve(eq, {a, b, c}) == [{a: (-b + 2*x + 5)/x}, {c: 4}]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -198,6 +198,7 @@ def test_solve_match():
         ) == {a: 3, b: 4}
     assert solve(a*x + b/sin(x) - 3*x - 4/sin(x), a, b, match=True
         ) == {a: 3, b: 4}
+    assert solve(a*x + b - 3*x + 4, [a, b, z], match=True) == {a: 3, b: -4}
     # - nonlinear in coefficients
     raises(ValueError, lambda: solve(a*x + b**2/x - 3*x - 4/x, a, b, match=True))
 
@@ -731,12 +732,11 @@ def test_solve_undetermined_coeffs():
     # test that dict and set flags are ignored
     assert solve_undetermined_coeffs(a*x - x, [a], x, set=True) == {a: 1}
     assert solve_undetermined_coeffs(a*x - x, [a], x, dict=True) == {a: 1}
-    # <mark> can be removed after solve_undetermined_coeffs handling is
-    # removed from solve
-    assert solve(a*x - x + b, a, b) == {a: 1, b: 0}
-    assert solve(a*x - x + b, a, b, dict=True) == [{a: 1, b: 0}]
-    assert solve(a*x - x + b, a, b, set=True) == ([a, b], {(1, 0)})
-    # </mark>
+    assert solve_undetermined_coeffs(a*x + b - 3*x + 4, [a, b, z], x
+        ) == {a: 3, b: -4}
+    # test compound generators and passing parameters in a set
+    assert solve_undetermined_coeffs(a*x + b/sin(x) - 3*x - 4/sin(x), {a, b}, x
+        ) == {a: 3, b: 4}
     # test that it returns None for nonlinear systems
     assert solve_undetermined_coeffs(a**2*x + b - 2*x -3, (a, b), x,
         ) is None

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -731,9 +731,9 @@ def test_solve_undetermined_coeffs():
     assert solve(a*x - x + b, a, b, dict=True) == [{a: 1, b: 0}]
     assert solve(a*x - x + b, a, b, set=True) == ([a, b], {(1, 0)})
     # </mark>
-    # test that it fails for nonlinear systems
-    raises(ValueError, lambda: solve_undetermined_coeffs(
-        a**2*x + b - 2*x -3, (a, b), x))
+    # test that it returns None for nonlinear systems
+    assert solve_undetermined_coeffs(a**2*x + b - 2*x -3, (a, b), x,
+        ) is None
 
 
 def test_solve_inequalities():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -182,6 +182,15 @@ def test_solve_args():
     assert solve([x - 1, False], [x], set=True) == ([], set())
     assert solve([-y*(x + y - 1)/2, (y - 1)/x/y + 1/y],
         set=True, check=False) == ([x, y], {(1 - y, y), (x, 0)})
+    # tuple=True
+    assert solve(x, x, tuple=True) == [(0,)]
+    assert solve(x, {x}, tuple=True) == [(0,)]
+    assert solve(x, x, y, tuple=True) == [(0, y)]
+    assert solve(x**2 - 4, x, y, tuple=True) == [(-2, y), (2, y)]
+    assert solve([x], x, y, tuple=True) == [(0, y)]
+    assert solve(a*x - 3*x + b - 2, a, b, c, tuple=True, match=True
+        ) == [(3, 2, c)]
+    raises(ValueError, lambda: solve(x, {x, y}, tuple=True))
 
 
 def test_solve_match():
@@ -213,6 +222,13 @@ def test_solve_match():
         ) == {a: 2, b: 5}
     # use dummy generator if necessary
     assert solve(c - 4, a, b, c, match=True) == {c: 4}
+    # independent appears to be `b` and there is no coeff
+    # to match so there is no solution
+    assert solve(c - a, a, match=True) == []
+    # not recognized since this has mv generators: b and c
+    raises(ValueError, lambda: solve(a + b + c, a, match=True))
+    # match is not for lists, only single expressions
+    raises(ValueError, lambda: solve([a*x - 2*x], a, match=True))
 
 
 def test_removing_linear_factors():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -150,25 +150,6 @@ def test_solve_args():
     flags.update(dict(simplify=False))
     assert solve(eq, [h, p, k], exclude=[a, b, c], **flags) == \
         [{p: (-h + x)**2/(4*a*x**2 + 4*b*x + 4*c - 4*k)}]
-    # multiple symbols might represent a coefficients system
-    # - that is linear
-    assert solve(a + b*x - 2, [a, b]) == {b: 0, a: 2}
-    # - this is linear and can be solved as undetermined coefficients
-    # system but it fails the expectation that we are solving for all
-    # symbols except one, so an algebraic solution is returned
-    assert solve((a*x + b*x - b + d), (a, b)) == [((-b*x + b - d)/x, b)]
-    # - this is not linear and also fails the expectations
-    assert solve(a*x + b**2/x - 3*x - 4/x, a, b, **flags) == [
-        {a: -b**2/x**2 + 3 + 4/x**2}]
-    # Examples like the last two will require the user to build the
-    # system of equations and pass them to solve if they want to solve
-    # for coefficients:
-    #>>> list((a*x + b**2/x - 3*x - 4/x).as_coefficients_dict(x).values())
-    #[b**2 - 4, a - 3]
-    #>>> solve(_)
-    #[{b: -2, a: 3}, {b: 2, a: 3}]
-    assert solve(a*x + b**2/x - 3*x - 4/x, a, b, undetermined=False) == [
-        ((-b**2 + 3*x**2 + 4)/x**2, b)]
     # failed single equation
     assert solve(1/(1/x - y + exp(y))) == []
     raises(
@@ -201,6 +182,24 @@ def test_solve_args():
     assert solve([x - 1, False], [x], set=True) == ([], set())
     assert solve([-y*(x + y - 1)/2, (y - 1)/x/y + 1/y],
         set=True, check=False) == ([x, y], {(1 - y, y), (x, 0)})
+
+
+def test_solve_match():
+    # using match=True
+    # - linear in coefficients
+    fx = Function('f')(x)
+    assert solve(a + a*x - 2, [a], match=True) == []
+    assert solve(fx + b*x - 2, [fx, b], match=True) == {b: 0, fx: 2}
+    assert solve(a + b*fx - 2, [a, b], match=True) == {b: 0, a: 2}
+    assert solve(a + b*x - 2, [a, b], match=True) == {b: 0, a: 2}
+    assert solve((a*x + b*x - b + d), (a, b), match=True
+        ) == {a: -d, b: d}
+    assert solve(a*x + b/x - 3*x - 4/x, a, b, match=True
+        ) == {a: 3, b: 4}
+    assert solve(a*x + b/sin(x) - 3*x - 4/sin(x), a, b, match=True
+        ) == {a: 3, b: 4}
+    # - nonlinear in coefficients
+    raises(ValueError, lambda: solve(a*x + b**2/x - 3*x - 4/x, a, b, match=True))
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -722,6 +722,18 @@ def test_solve_undetermined_coeffs():
     assert solve_undetermined_coeffs(((c + 1)*a*x**2 + (c + 1)*b*x**2 +
     (c + 1)*b*x + (c + 1)*2*c*x + (c + 1)**2)/(c + 1), [a, b, c], x) == \
         {a: -2, b: 2, c: -1}
+    # test that dict and set flags are ignored
+    assert solve_undetermined_coeffs(a*x - x, [a], x, set=True) == {a: 1}
+    assert solve_undetermined_coeffs(a*x - x, [a], x, dict=True) == {a: 1}
+    # <mark> can be removed after solve_undetermined_coeffs handling is
+    # removed from solve
+    assert solve(a*x - x + b, a, b) == {a: 1, b: 0}
+    assert solve(a*x - x + b, a, b, dict=True) == [{a: 1, b: 0}]
+    assert solve(a*x - x + b, a, b, set=True) == ([a, b], {(1, 0)})
+    # </mark>
+    # test that it fails for nonlinear systems
+    raises(ValueError, lambda: solve_undetermined_coeffs(
+        a**2*x + b - 2*x -3, (a, b), x))
 
 
 def test_solve_inequalities():
@@ -1659,7 +1671,6 @@ def test_minsolve_linear_system():
     # and give a good error message if someone tries to use
     # particular with a single equation
     raises(ValueError, lambda: solve(x + 1, particular=True))
-
 
 
 def test_real_roots():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -149,7 +149,7 @@ def test_solve_args():
         [{p: (h - x)**2/(a*x**2 + b*x + c - k)/4}]
     flags.update(dict(simplify=False))
     assert solve(eq, [h, p, k], exclude=[a, b, c], **flags) == \
-        [{p: (-h + x)**2/(4*a*x**2 + 4*b*x + 4*c - 4*k)}]
+        [{p: (h**2 - 2*h*x + x**2)/(4*a*x**2 + 4*b*x + 4*c - 4*k)}]
     # failed single equation
     assert solve(1/(1/x - y + exp(y))) == []
     raises(
@@ -2546,3 +2546,13 @@ def test_issue_10169():
         e: Rational(-40,129) - 5*2**Rational(1,4)/1032 + 5*2**Rational(3,4)/129,
         k: -10*sqrt(2)/129 + 5*2**Rational(1,4)/258 + 20*2**Rational(3,4)/129
     }
+
+
+def test_choose_canonical_linear_solns():
+    eq = a**3*c - a**3*x - c**2 + c*x
+    sol = [{c: a**3}, {c: x}]
+    assert solve(eq) == sol
+    # make sure cancel is at least applied
+    assert solve(eq, simplify=False) == sol
+    assert solve(eq.factor()) == sol
+    assert solve(eq, c) == [a**3, x]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -174,10 +174,10 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve(Eq(x**2, 0.0)) == [0]  # issue 19048
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
-    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
-    assert not solve([Eq(x, x+1), x < 2], x)
-    assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
-    assert solve([Eq(x, x), Eq(x, x+1)], x) == []
+    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x + 1)], [x], dict=True) == []
+    assert not solve([Eq(x, x + 1), x < 2], x)
+    assert solve([Eq(x, 0), x + 1 < 2]) == Eq(x, 0)
+    assert solve([Eq(x, x), Eq(x, x + 1)], x) == []
     assert solve(True, x) == []
     assert solve([x - 1, False], [x], set=True) == ([], set())
     assert solve([-y*(x + y - 1)/2, (y - 1)/x/y + 1/y],
@@ -200,7 +200,27 @@ def test_solve_match():
         ) == {a: 3, b: 4}
     assert solve(a*x + b - 3*x + 4, [a, b, z], match=True) == {a: 3, b: -4}
     # - nonlinear in coefficients
-    raises(ValueError, lambda: solve(a*x + b**2/x - 3*x - 4/x, a, b, match=True))
+    raises(ValueError, lambda: solve(a*x + b**2/x - 3*x - 4/x, a, b,
+        match=True))
+    # product of linear factors still fails on purpose -- user
+    # should build list of solutions made by solving each factor;
+    # to do so automatically is an abuse of "solving an equation
+    # via undetermined coefficient"
+    eq = (a*x + b - 2*x - 5)*(c - 4)
+    raises(ValueError, lambda: solve(eq, a, b, c, match=True))
+    # return value of dict is always unambiguous
+    assert solve(a*x + b - 2*x - 5, {a, b, c}, match=True
+        ) == {a: 2, b: 5}
+    # use dummy generator if necessary
+    assert solve(c - 4, a, b, c, match=True) == {c: 4}
+
+
+def test_removing_linear_factors():
+    eq = (a*x + b - 2*x - 5)*(c - 4)
+    sol = solve(eq, a, b, c)
+    assert sol == [(a, b, 4), ((-b + 2*x + 5)/x, b, c)]
+    # use unambiguous return value
+    assert solve(eq, {a, b, c}) == [{a: (-b + 2*x + 5)/x}, {c: 4}]
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2830,8 +2830,8 @@ def test_linear_coeffs():
     assert F(a*(x + y), x, y) == [a, a, 0]
     assert F(1.0, x, y) == [0, 0, 1.0]
     assert F(x*(y + 1) + x*y, y, 1 + y) == [x, x, 0]
-    z = y*(x**2 + 1)
-    assert F(y*(x + 2)*(x**2 + 1), x) == [z, 2*z]
+    _ = y*(x**2 + 1)
+    assert F(y*(x + 2)*(x**2 + 1), x) == [_, 2*_]
     raises(NonlinearError, lambda: F((x + 1)*(x + 2), x))
     assert linear_coeffs(Eq(a*(2*x + 3*y) + 4*y, 5), x, y) == [2*a, 3*a + 4, -5]
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1365,19 +1365,42 @@ def test_linear_eq_to_matrix():
     eqns1 = [2*x + y - 2*z - 3, x - y - z, x + y + 3*z - 12]
     eqns2 = [Eq(3*x + 2*y - z, 1), Eq(2*x - 2*y + 4*z, -2), -2*x + y - 2*z]
 
-    A, B = linear_eq_to_matrix(eqns1, x, y, z)
-    assert A == Matrix([[2, 1, -2], [1, -1, -1], [1, 1, 3]])
-    assert B == Matrix([[3], [0], [12]])
+    for strict in (True, False):
+        K = dict(strict=strict)
+        assert linear_eq_to_matrix([x], [y], **K) == (
+            Matrix([[0]]), Matrix([[-x]]))
+        assert linear_eq_to_matrix([x],[x], **K) == (
+            Matrix([[1]]), Matrix([[0]]))
 
-    A, B = linear_eq_to_matrix(eqns2, x, y, z)
-    assert A == Matrix([[3, 2, -1], [2, -2, 4], [-2, 1, -2]])
-    assert B == Matrix([[1], [-2], [0]])
+        A, B = linear_eq_to_matrix(eqns1, x, y, z, **K)
+        assert A == Matrix([[2, 1, -2], [1, -1, -1], [1, 1, 3]])
+        assert B == Matrix([[3], [0], [12]])
 
-    # Pure symbolic coefficients
-    eqns3 = [a*b*x + b*y + c*z - d, e*x + d*x + f*y + g*z - h, i*x + j*y + k*z - l]
-    A, B = linear_eq_to_matrix(eqns3, x, y, z)
-    assert A == Matrix([[a*b, b, c], [d + e, f, g], [i, j, k]])
-    assert B == Matrix([[d], [h], [l]])
+        A, B = linear_eq_to_matrix(eqns2, x, y, z, **K)
+        assert A == Matrix([[3, 2, -1], [2, -2, 4], [-2, 1, -2]])
+        assert B == Matrix([[1], [-2], [0]])
+
+        # Pure symbolic coefficients
+        eqns3 = [a*b*x + b*y + c*z - d, e*x + d*x + f*y + g*z - h, i*x + j*y + k*z - l]
+        A, B = linear_eq_to_matrix(eqns3, x, y, z, **K)
+        assert A == Matrix([[a*b, b, c], [d + e, f, g], [i, j, k]])
+        assert B == Matrix([[d], [h], [l]])
+
+        assert linear_eq_to_matrix(1, x, **K) == (
+            Matrix([[0]]), Matrix([[-1]]))
+
+        # issue 15195 - /!\ user of `strict`, you were warned
+        assert linear_eq_to_matrix(x + y*(z*(3*x + 2) + 3), x, **K) == (
+            Matrix([[3*y*z + 1]]), Matrix([[-y*(2*z + 3)]])
+            ) if strict else (
+            Matrix([[1]]), Matrix([[-y*(z*(3*x + 2) + 3)]]))
+        assert linear_eq_to_matrix(Matrix(
+            [[a*x + b*y - 7], [5*x + 6*y - c]]), x, y, **K) == (
+            Matrix([[a, b], [5, 6]]), Matrix([[7], [c]]))
+
+        # issue 15312
+        assert linear_eq_to_matrix(Eq(x + 2, 1), x, **K) == (
+            Matrix([[1]]), Matrix([[-1]]))
 
     # raise ValueError if
     # 1) no symbols are given
@@ -1386,20 +1409,26 @@ def test_linear_eq_to_matrix():
     raises(ValueError, lambda: linear_eq_to_matrix(eqns3, [x, x, y]))
     # 3) there are non-symbols
     raises(ValueError, lambda: linear_eq_to_matrix(eqns3, [x, 1/a, y]))
+    # -- but not when strict is False
+    assert linear_eq_to_matrix(eqns3, [x, 1/a, y], strict=False) == (
+        Matrix([
+        [  a*b, 0, b],
+        [d + e, 0, f],
+        [    i, 0, j]]), Matrix([
+        [-c*z + d],
+        [-g*z + h],
+        [-k*z + l]]))
+    assert linear_eq_to_matrix([2*y/a], [x, 1/a], strict=False) == (
+        Matrix([[0, 2*y]]), Matrix([[0]]))
     # 4) a nonlinear term is detected in the original expression
     raises(NonlinearError, lambda: linear_eq_to_matrix(Eq(1/x + x, 1/x), [x]))
-
-    assert linear_eq_to_matrix(1, x) == (Matrix([[0]]), Matrix([[-1]]))
-    # issue 15195
-    assert linear_eq_to_matrix(x + y*(z*(3*x + 2) + 3), x) == (
-        Matrix([[3*y*z + 1]]), Matrix([[-y*(2*z + 3)]]))
-    assert linear_eq_to_matrix(Matrix(
-        [[a*x + b*y - 7], [5*x + 6*y - c]]), x, y) == (
-        Matrix([[a, b], [5, 6]]), Matrix([[7], [c]]))
-
-    # issue 15312
-    assert linear_eq_to_matrix(Eq(x + 2, 1), x) == (
-        Matrix([[1]]), Matrix([[-1]]))
+    # -- but not when strict is False
+    assert linear_eq_to_matrix(Eq(1/x + x, 1/x), [x], strict=False) == (
+        Matrix([[1]]), Matrix([[0]]))
+    F = Function('F')
+    df = F(x).diff()
+    assert linear_eq_to_matrix([x*F(x) - df], [x], strict=False
+        ) == (Matrix([[F(x)]]), Matrix([[df]]))
 
 
 def test_issue_16577():
@@ -2777,14 +2806,34 @@ def test_linear_coeffs():
     assert linear_coeffs(x + 2*y + 3, x, y) == [1, 2, 3]
     assert linear_coeffs(x + 2*y + 3, y, x) == [2, 1, 3]
     assert linear_coeffs(x + 2*x**2 + 3, x, x**2) == [1, 2, 3]
-    raises(ValueError, lambda:
+    raises(NonlinearError, lambda:
         linear_coeffs(x + 2*x**2 + x**3, x, x**2))
-    raises(ValueError, lambda:
+    raises(NonlinearError, lambda:
         linear_coeffs(1/x*(x - 1) + 1/x, x))
-    raises(ValueError, lambda:
-        linear_coeffs(x, x, x))
     assert linear_coeffs(a*(x + y), x, y) == [a, a, 0]
     assert linear_coeffs(1.0, x, y) == [0, 0, 1.0]
+    # duplicate symbols
+    raises(ValueError, lambda: linear_coeffs(x, x, x))
+    # unordered symbols
+    raises(ValueError, lambda: linear_coeffs(x, {x, y}))
+    assert linear_coeffs(y, x, dict=True) == {1: y}
+    # strict=False
+    F = lambda a, *b: linear_coeffs(a, *b, strict=False)
+    assert F(0, x) == [0, 0]
+    assert all(i is S.Zero for i in F(0, x))
+    assert F(x + 2*y + 3, x, y) == [1, 2, 3]
+    assert F(x + 2*y + 3, y, x) == [2, 1, 3]
+    assert F(x + 2*x**2 + 3, x, x**2) == [1, 2, 3]
+    assert F(x + 2*x**2 + x**3, x, x**2) == [1, 2, x**3]
+    #assert F(1/x*(x - 1) + 1/x, x) == [1/x, 0]
+    assert F(a*(x + y), x, y) == [a, a, 0]
+    assert F(1.0, x, y) == [0, 0, 1.0]
+    assert F(x*(y + 1) + x*y, y, 1 + y) == [x, x, 0]
+    z = y*(x**2 + 1)
+    assert F(y*(x + 2)*(x**2 + 1), x) == [z, 2*z]
+    raises(NonlinearError, lambda: F((x + 1)*(x + 2), x))
+    assert linear_coeffs(Eq(a*(2*x + 3*y) + 4*y, 5), x, y) == [2*a, 3*a + 4, -5]
+
 
 # modular tests
 def test_is_modular():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2333,23 +2333,23 @@ def test_issue_10397():
 
 
 def test_issue_14987():
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [x**2], x))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [x*(-3/x + 1) + 2*y - a], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [(x**2 - 3*x)/(x - 3) - 3], x))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [(x + 1)**3 - x**3 - 3*x**2 + 7], x))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [x*(1/x + 1) + y], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [(x + 1)*y], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [Eq(1/x, 1/x + y)], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [Eq(y/x, y/x + y)], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix(
+    raises(NonlinearError, lambda: linear_eq_to_matrix(
         [Eq(x*(x + 1), x**2 + y)], [x, y]))
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2806,6 +2806,7 @@ def test_linear_coeffs():
     assert linear_coeffs(x + 2*y + 3, x, y) == [1, 2, 3]
     assert linear_coeffs(x + 2*y + 3, y, x) == [2, 1, 3]
     assert linear_coeffs(x + 2*x**2 + 3, x, x**2) == [1, 2, 3]
+    assert linear_coeffs(x*y + x*z + 3, x) == [y + z, 3]
     raises(NonlinearError, lambda:
         linear_coeffs(x + 2*x**2 + x**3, x, x**2))
     raises(NonlinearError, lambda:
@@ -2825,7 +2826,7 @@ def test_linear_coeffs():
     assert F(x + 2*y + 3, y, x) == [2, 1, 3]
     assert F(x + 2*x**2 + 3, x, x**2) == [1, 2, 3]
     assert F(x + 2*x**2 + x**3, x, x**2) == [1, 2, x**3]
-    #assert F(1/x*(x - 1) + 1/x, x) == [1/x, 0]
+    assert F(1/x*(x - 1) + 1/x, x) == [1/x, 0]
     assert F(a*(x + y), x, y) == [a, a, 0]
     assert F(1.0, x, y) == [0, 0, 1.0]
     assert F(x*(y + 1) + x*y, y, 1 + y) == [x, x, 0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed



#### Other comments

When a single equation has several factors, the factors are now removed as they are found. This makes the solution process more efficient, e.g.
```python
>>> t=time();ok=solve(expand(Mul(*[(x-i) for i in var('a:f')])),var('a:f'));time()-t
3.4788060188293457
```
In master that takes 14.5 seconds.

It is not that the expression is factored -- that case is already handled by `solve`. In this case the expanded expression is linear in each of the parameters when viewed individually so the linear solution can be found easily and then the expression (which contains that solution as a linear factor, though not explicitly) can have that factor removed.
```python
>>> eq= expand((x-a)*(x-b)); eq
a*b - a*x - b*x + x**2
>>> eq= expand((x-a)*(x-b)); eq
a*b - a*x - b*x + x**2
>>> solve(eq,a)
[x]
>>> div(eq,a-x)
(b - x, 0)
```

The docstring has been updated to indicate that the automatic solving for undetermined coefficients must be enabled.

The implicit assumption of `solve_undetermined_coeffs` is that the system is linear in specified parameters. This is now enforced. This means that systems formerly recognized and solved as coefficient systems may no longer be recognized as such:

***formerly***
```python
>>> solve(a**2*x+b-4*x+3, a, b)
[(-2, -3), (2, -3)]
>>> solve(a**2*x+b-4*x+3, {a,b})  # /!\ ambiguously ordered solution
[(-2, -3), (2, -3)]
```
***now***
```python
>>> solve(a**2*x+b-4*x+3,a,b)
[(a, -a**2*x + 4*x - 3)]
>>> solve(a**2*x+b-4*x+3,{a,b})
[{b: -a**2*x + 4*x - 3}]
```

For those that like explicit solutions showing every symbol requested -- even if it is an arbitrary parameter -- the flag `tuple=True` can be used:
```python
>>> solve(x, x, tuple=True)
[(0,)]
>>> solve(x, x, y, z, tuple=True)
[(0, y, z)]
>>> solve([x, y], x, y, z, tuple=True)
[(0, 0, z)]
```
(This was formerly only used for lists of equations which were nonlinear in some way.)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * solve can return full tuple(s) containing values for all symbols by using ``tuple=True``; set and dict output is ecomonical and does not report symbols that can have arbitrary values
  * solve returns dict when solving single equation for one of several provided symbols (was formerly tuple)
  * more efficient solving of an equation for several factors is implemented
  * when passing a single polynomial expression in some variable `x` and desiring to find solutions for symbols that appear linearly as symbolic coefficients, use the flag `match=True`, e.g. `solve(Eq(a*x**2 + b*x,  3*x**2), a, b, match=True) -> {a: 3, b: 0}` otherwise a more general algebraic solution like `[{a: -b/x + 3}]` will be returned.
  * `solve_undetermined_coeffs` now enforces that the coefficient system is linear in parameters; systems that are nonlinear in parameters will have to be created explicitly and passed to `solve` for a solution.
* other
  * added a "solve_output" explanation file to the documentation
<!-- END RELEASE NOTES -->
