### PR TITLE
Allow initial conditions of the form f(0): f(0) in dsolve

### DIFF
--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -995,22 +995,22 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
                     AppliedUndef) and deriv.args[0].func == f and
                     len(deriv.args[0].args) == 1 and old == x and not
                     new.has(x) and all(i == deriv.variables[0] for i in
-                    deriv.variables) and not ics[funcarg].has(f)):
+                    deriv.variables) and x not in ics[funcarg].free_symbols):
 
                     dorder = ode_order(deriv, x)
                     temp = 'f' + str(dorder)
                     boundary.update({temp: new, temp + 'val': ics[funcarg]})
                 else:
-                    raise ValueError("Enter valid boundary conditions for Derivatives")
+                    raise ValueError("Invalid boundary conditions for Derivatives")
 
 
             # Separating functions
             elif isinstance(funcarg, AppliedUndef):
                 if (funcarg.func == f and len(funcarg.args) == 1 and
-                    not funcarg.args[0].has(x) and not ics[funcarg].has(f)):
+                    not funcarg.args[0].has(x) and x not in ics[funcarg].free_symbols):
                     boundary.update({'f0': funcarg.args[0], 'f0val': ics[funcarg]})
                 else:
-                    raise ValueError("Enter valid boundary conditions for Function")
+                    raise ValueError("Invalid boundary conditions for Function")
 
             else:
                 raise ValueError("Enter boundary conditions of the form ics={f(point): value, f(x).diff(x, order).subs(x, point): value}")

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -351,10 +351,13 @@ def test_classify_ode_ics():
     ics = {f(0, 0): 1}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
 
-    # point contains f
-    # XXX: Should be NotImplementedError
-    ics = {f(0): f(1)}
+    # point contains x
+    ics = {f(0): f(x)}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
+
+    # Does not raise
+    ics = {f(0): f(0)}
+    classify_ode(eq, f(x), ics=ics)
 
     # Does not raise
     ics = {f(0): 1}
@@ -385,10 +388,13 @@ def test_classify_ode_ics():
     ics = {Derivative(f(x), x, y).subs(x, 0): 1}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
 
-    # point contains f
-    # XXX: Should be NotImplementedError
-    ics = {f(x).diff(x).subs(x, 0): f(0)}
+    # point contains x
+    ics = {f(x).diff(x).subs(x, 0): f(x)}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
+
+    # Does not raise
+    ics = {f(x).diff(x).subs(x, 0): f(x).diff(x).subs(x, 0)}
+    classify_ode(eq, f(x), ics=ics)
 
     # Does not raise
     ics = {f(x).diff(x).subs(x, 0): 1}
@@ -414,10 +420,13 @@ def test_classify_ode_ics():
     ics = {Derivative(f(x), x, z).subs(x, y): 1}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
 
-    # point contains f
-    # XXX: Should be NotImplementedError
-    ics = {f(x).diff(x).subs(x, y): f(0)}
+    # point contains x
+    ics = {f(x).diff(x).subs(x, y): f(x)}
     raises(ValueError, lambda: classify_ode(eq, f(x), ics=ics))
+
+    # Does not raise
+    ics = {f(x).diff(x).subs(x, 0): f(0)}
+    classify_ode(eq, f(x), ics=ics)
 
     # Does not raise
     ics = {f(x).diff(x).subs(x, y): 1}
@@ -553,6 +562,13 @@ def test_solve_ics():
         C3: L**2*q/(4*EI),
         C4: -L*q/(6*EI)}
 
+    # Allow the ics to refer to f
+    ics = {f(0): f(0)}
+    assert dsolve(f(x).diff(x) - f(x), f(x), ics=ics) == Eq(f(x), f(0)*exp(x))
+
+    ics = {f(x).diff(x).subs(x, 0): f(x).diff(x).subs(x, 0), f(0): f(0)}
+    assert dsolve(f(x).diff(x, x) + f(x), f(x), ics=ics) == \
+        Eq(f(x), f(0)*cos(x) + f(x).diff(x).subs(x, 0)*sin(x))
 
 def test_ode_order():
     f = Function('f')


### PR DESCRIPTION
There was a check that the replacement value does not contain f, but this
makes perfect sense. The check was changed to checking that the value doesn't
contain x.

Fixes #23702

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - Allow initial conditions of the form `{f(0): f(0)}` in `dsolve()`.
<!-- END RELEASE NOTES -->
