### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ env:
   release_version: '1.10rc1'
   previous_version: '1.9'
 
+permissions:
+  contents: read
+
 jobs:
 
   # -------------------- Build artifacts --------------------------- #
@@ -49,6 +52,8 @@ jobs:
   # -------------------- Test installation ------------------------- #
 
   test-install:
+    permissions:
+      contents: none
     needs: [build]
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -8,6 +8,9 @@
 
 name: test
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
 
   # -------------------- Code quality ------------------------------ #
@@ -447,6 +450,8 @@ jobs:
   # -------------------- Save PR number ---------------------------- #
 
   save-pr-number:
+    permissions:
+      contents: none
     needs: [doctests-latest, tests1-latest, tests2-latest]
 
     # The comment-on-pr workflow needs the issue number of the PR to be able to


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
