### PR TITLE
fix Sympy Lambdify error when expr atoms have brace

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1395,6 +1395,7 @@ arooshiverma <av22@iitbbs.ac.in>
 bluebrook <perl4logic@gmail.com>
 carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>
+cocolato <haiizhu@outlook.com>
 cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -404,6 +404,8 @@ class CodePrinter(StrPrinter):
                        'reserved keyword in this language.')
                 raise ValueError(msg.format(name))
             return name + self._settings['reserved_word_suffix']
+        elif '{' in name:   # Remove curly braces from subscripted variables
+            return name.replace('{', '').replace('}', '')
         else:
             return name
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -561,19 +561,6 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
     def _print_frac(self, expr):
         return self._print_Mod(Mod(expr.args[0], 1))
 
-    def _print_Symbol(self, expr):
-
-        name = super()._print_Symbol(expr)
-
-        if name in self.reserved_words:
-            if self._settings['error_on_reserved']:
-                msg = ('This expression includes the symbol "{}" which is a '
-                       'reserved keyword in this language.')
-                raise ValueError(msg.format(name))
-            return name + self._settings['reserved_word_suffix']
-        else:
-            return name
-
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
     _print_fresnelc = CodePrinter._print_not_supported

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -571,8 +571,6 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
                        'reserved keyword in this language.')
                 raise ValueError(msg.format(name))
             return name + self._settings['reserved_word_suffix']
-        elif '{' in name:   # Remove curly braces from subscripted variables
-            return name.replace('{', '').replace('}', '')
         else:
             return name
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -1,3 +1,4 @@
+from sympy import cos
 from sympy.codegen import Assignment
 from sympy.codegen.ast import none
 from sympy.codegen.cfunctions import expm1, log1p
@@ -422,3 +423,11 @@ def test_array_printer():
     assert prntr.doprint(ArrayDiagonal(A, [0,1], [2,3])) == 'tensorflow.linalg.einsum("aabbc->cab", A)'
     assert prntr.doprint(ArrayContraction(A, [2], [3])) == 'tensorflow.linalg.einsum("abcde->abe", A)'
     assert prntr.doprint(Assignment(I[i,j,k], I[i,j,k])) == 'I = I'
+
+
+def test_issue_23374():
+    prntr = SymPyPrinter({'fully_qualified_modules': False, 'inline': True,
+                           'allow_unknown_functions': True})
+    x1, x2 = symbols("x_{1} x_2")
+    assert prntr.doprint(x1) == "x_1"
+    assert prntr.doprint(cos(x1**2 + x2**2)) == "cos(x_2**2 + x_1**2)"

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1623,3 +1623,11 @@ def test_23536_lambdify_cse_dummy():
     expr = expr.expand()
     eval_expr = lambdify(((f, g), z), expr, cse=True)
     eval_expr((1.0, 2.0), 3.0)
+
+def test_23374_lambdify_brace_expr():
+    x1, x2 = symbols("x_{1} x_2")
+    f = lambdify([x1, x2], cos(x1**2 + x2**2), modules="sympy")
+    f_str = inspect.getsource(f)
+    assert f_str == """def _lambdifygenerated(x_1, x_2):
+    return cos(x_2**2 + x_1**2)
+"""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fix #23374


#### Brief description of what is fixed or changed
In #20806, When use `PythonCodePrinter` to print a `Symbol` object will remove curly braces.
https://github.com/sympy/sympy/blob/ab414d124bb9899eb9d677e95498c7a021c9bc29/sympy/printing/pycode.py#L564-L577

In `Sympy Lambdify` will use  `LambdaPrinter()` to print args but use `SymPyPrinter` to print the expr. The `SymPyPrinter` don't have the special `_print_Symbol` function to remove curly braces.

https://github.com/sympy/sympy/blob/ab414d124bb9899eb9d677e95498c7a021c9bc29/sympy/utilities/lambdify.py#L1114-L1115

https://github.com/sympy/sympy/blob/ab414d124bb9899eb9d677e95498c7a021c9bc29/sympy/utilities/lambdify.py#L1148-L1168



#### Other comments


#### Release Notes



<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Remove symbol's curly braces in `SymPyPrinter`.
<!-- END RELEASE NOTES -->
