### PR TITLE
strict flag for coefficient extraction

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -31,6 +31,7 @@ from sympy.polys.partfrac import apart
 from sympy.polys.polytools import factor, cancel, Poly
 from sympy.polys.rationaltools import together
 from sympy.series.order import O
+from sympy.sets.sets import FiniteSet
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.gammasimp import gammasimp
 from sympy.simplify.powsimp import powsimp
@@ -1624,6 +1625,21 @@ def test_has_free():
     assert Integral(f(x), (f(x), 1, y)).has_free(y)
     assert not Integral(f(x), (f(x), 1, y)).has_free(x)
     assert not Integral(f(x), (f(x), 1, y)).has_free(f(x))
+    # simple extraction
+    assert (x + 1 + y).has_free(x + 1)
+    assert not (x + 2 + y).has_free(x + 1)
+    assert (2 + 3*x*y).has_free(3*x)
+    raises(ValueError, lambda: x.has_free({x, y}))
+    s = FiniteSet(1, 2)
+    assert Piecewise((s, x > 3), (4, True)).has_free(s)
+    assert not Piecewise((1, x > 3), (4, True)).has_free(s)
+
+
+def test_has_xfree():
+    assert (x + 1).has_xfree({x})
+    assert ((x + 1)**2).has_xfree({x + 1})
+    assert not (x + y + 1).has_xfree({x + 1})
+    raises(ValueError, lambda: x.has_xfree(x))
 
 
 def test_issue_5300():

--- a/sympy/polys/matrices/tests/test_linsolve.py
+++ b/sympy/polys/matrices/tests/test_linsolve.py
@@ -16,13 +16,16 @@ from sympy.polys.solvers import PolyNonlinearError
 
 
 def test__linsolve():
-    assert _linsolve([], [x]) == {x:x}
-    assert _linsolve([S.Zero], [x]) == {x:x}
-    assert _linsolve([x-1,x-2], [x]) is None
-    assert _linsolve([x-1], [x]) == {x:1}
-    assert _linsolve([x-1, y], [x, y]) == {x:1, y:S.Zero}
+    assert _linsolve([], [x]) == {x: x}
+    assert _linsolve([S.Zero], [x]) == {x: x}
+    assert _linsolve([x - 1, x - 2], [x]) is None
+    assert _linsolve([x - 1], [x]) == {x: 1}
+    assert _linsolve([x - 1, y], [x, y]) == {x:1, y:S.Zero}
     assert _linsolve([2*I], [x]) is None
     raises(PolyNonlinearError, lambda: _linsolve([x*(1 + x)], [x]))
+    raises(PolyNonlinearError, lambda: _linsolve([Eq(x**2, x**2 + y)], [x, y]))
+    raises(PolyNonlinearError, lambda: _linsolve([(x + y)**2 - x**2], [x]))
+    raises(PolyNonlinearError, lambda: _linsolve([Eq((x + y)**2, x**2)], [x]))
 
 
 def test__linsolve_float():
@@ -100,9 +103,3 @@ def test__linsolve_float():
     # from top and bottom. It should be possible to avoid this somehow because
     # the inverse of the matrix only has a quadratic factor (the determinant)
     # in the denominator.
-
-
-def test__linsolve_deprecated():
-    assert _linsolve([Eq(x**2, x**2+y)], [x, y]) == {x:x, y:S.Zero}
-    assert _linsolve([(x+y)**2-x**2], [x]) == {x:-y/2}
-    assert _linsolve([Eq((x+y)**2, x**2)], [x]) == {x:-y/2}

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1647,11 +1647,11 @@ def test_higher_order_to_first_order_9():
 
     eqs9 = [f(x) + g(x) - 2*exp(I*x) + 2*Derivative(f(x), x) + Derivative(f(x), (x, 2)),
             f(x) + g(x) - 2*exp(I*x) + 2*Derivative(g(x), x) + Derivative(g(x), (x, 2))]
-    sol9 =  [Eq(f(x), -C1 + C2*exp(-2*x)/2 - (C3/2 - C4/2)*exp(-x)*cos(x)
-                    + (C3/2 + C4/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
+    sol9 =  [Eq(f(x), -C1 + C4*exp(-2*x)/2 - (C2/2 - C3/2)*exp(-x)*cos(x)
+                    + (C2/2 + C3/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
                     + 2*((1 - 2*I)*exp(I*x)*cos(x)**2/5)),
-            Eq(g(x), C1 - C2*exp(-2*x)/2 - (C3/2 - C4/2)*exp(-x)*cos(x)
-                    + (C3/2 + C4/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
+            Eq(g(x), C1 - C4*exp(-2*x)/2 - (C2/2 - C3/2)*exp(-x)*cos(x)
+                    + (C2/2 + C3/2)*exp(-x)*sin(x) + 2*((1 - 2*I)*exp(I*x)*sin(x)**2/5)
                     + 2*((1 - 2*I)*exp(I*x)*cos(x)**2/5))]
     assert dsolve(eqs9) == sol9
     assert checksysodesol(eqs9, sol9) == (True, [0, 0])

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1071,8 +1071,8 @@ def test_sysode_linear_neq_order1_type2():
     eqs6 = [Eq(Derivative(f(x), x), -9*f(x) - 4*g(x)),
             Eq(Derivative(g(x), x), -4*g(x)),
             Eq(Derivative(h(x), x), h(x) + exp(x))]
-    sol6 = [Eq(f(x), C1*exp(-4*x)*Rational(-4, 5) + C2*exp(-9*x)),
-            Eq(g(x), C1*exp(-4*x)),
+    sol6 = [Eq(f(x), C2*exp(-4*x)*Rational(-4, 5) + C1*exp(-9*x)),
+            Eq(g(x), C2*exp(-4*x)),
             Eq(h(x), C3*exp(x) + x*exp(x))]
     assert dsolve(eqs6) == sol6
     assert checksysodesol(eqs6, sol6) == (True, [0, 0, 0])

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -23,7 +23,7 @@ from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
-from sympy.polys.matrices.linsolve import _linear_eq_to_dict
+from sympy.polys.matrices.linsolve import _linear_eq_to_dict, _lin_eq2dict
 from sympy.polys.polyroots import UnsolvableFactorError
 from sympy.simplify.simplify import simplify, fraction, trigsimp, nsimplify
 from sympy.simplify import powdenest, logcombine
@@ -2509,7 +2509,6 @@ def linear_coeffs(eq, *syms, dict=False, strict=True):
         >>> eq.equals(r[-1] + sum([prod(i) for i in zip(v, r)]))
         True
     """
-    from sympy.polys.matrices.linsolve import _lin_eq2dict
     eq = _sympify(eq)
     if len(syms) == 1 and iterable(syms[0]) and not isinstance(syms[0], Basic):
         raise ValueError('pass unpacked symbols, *syms')
@@ -2522,14 +2521,15 @@ def linear_coeffs(eq, *syms, dict=False, strict=True):
         raise NonlinearError(str(err)) from err
     if dict:
         if c:
-            d[1] = c
+            d[S.One] = c
         return d
-    rv = [S.Zero]*len(syms)
+    rv = [S.Zero]*(len(syms) + 1)
+    rv[-1] = c
     for i, k in enumerate(syms):
         if k not in d:
             continue
         rv[i] = d[k]
-    return rv + [c]
+    return rv
 
 
 def linear_eq_to_matrix(equations, *symbols, strict=True):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #23459 
fixes #23775 by removing auto-expansion by linsolve (while still handling Eq)

#### Brief description of what is fixed or changed

The several functions can now treat dependent objects as independent by using flag `strict=False` when necessary.

```python
>>> f, g = [i(t).diff() for i in map(Function, 'fg')]
>>> linear_eq_to_matrix([f*a + g*b, f*b**2 + g*a**2], [f,g], strict=False)
(Matrix([
[   a,    b],
[b**2, a**2]]), Matrix([
[0],
[0]]))
>>> F, G = [i(t) for i in map(Function, 'fg')]
>>> assert linear_eq_to_matrix([F*f +g + G], [f, g], strict=False) == (Matrix([[F, 1]]), Matrix([[-G]]))
```

The capability is a result of making changes to `_lin_eq2dict` which will now allow one to request coefficients and ignore cross terms that are symbol-dependent in a non-literal way, e.g. `x` does not have `x**2` as a literal factor while the reverse does, and `f(x)` is not a factor of `f(x).diff(x)`. Functions which depend on `_lin_eq2dict` have a `strict` keyword: `linsolve`, `linear_eq_to_matrix` and `linear_coeffs`.

#### Other comments

A significant gain in efficiency was made possible by adding a new method, `Basic.has_xfree` which tests to see if any literal free argument of an expression is in the supplied set of expressions. Like `xreplace`, `has_xfree` is literal and does not attempt subexpression matching: `(x + y + 1).has_free(y + 1) -> True` while the result from `has_xfree` is False.

The fallback of `linsolve` to expand expressions to remove nonlinearity was marked as a deprecation. That feature has been removed and the case place where it was most practically needed -- when working with Eq instances -- has been handled to allow cancellation of linear terms, while warning when encountering nonlinear terms.

~~Perhaps `_lin_eq2dict` could be replaced with a call as `d = _le2d(eq, syms, strict); return d.pop(1, S.Zero), d` and anything that calls it could decide whether to pass the `strict` argument as True or False.~~ this has been done.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `linear_coeffs` has been rewritten to be more efficient, especially for sparse equations
  * `linear_coeffs` can return results in a dictionary with use of keyword `dict=True`
  * `linear_coeffs` recognizes keyword `strict=False` per comments below for `linear_eq_to_matrix`
  * `linear_eq_to_matrix` recognizes `strict=True` to allow relaxed extraction of coefficients even though non-linear terms might be present, as long as they are none provided appear literally as factors in the expression e.g. `x**2 + x + y` can have coefficients of `x` and `y` extracted (reporting `x**2` as the constant terms) but `x*y + x` has a cross term of `x` and `y` and will raise an error; this allows `f(x)` to be extracted independent of `f(x).diff()`, too.
  * `linsolve` can also use the `strict` flag to allow one to ignore superficial dependency between object containing symbols in common
  * `linsolve` will no longer expand equations to allow removable singularities to be removed
* core
  * `Basic.has_xfree` has been added for fast detection of any element of passed set; matching is full while `has_free` can be slower since it looks for sub-expressions that match
<!-- END RELEASE NOTES -->