### PR TITLE
Fix Accumbounds output for functions at negative infinity

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -541,7 +541,7 @@ class exp(ExpBase, metaclass=ExpMeta):
             # Check out function: test_issue_18473() in test_exponential.py and
             # test_limits.py for more information.
             if re(cdir) < S.Zero:
-                return 1/exp(arg0)
+                return exp(-arg0)
             return exp(arg0)
         if arg0 is S.NaN:
             arg0 = arg.limit(x, 0)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -540,6 +540,8 @@ class exp(ExpBase, metaclass=ExpMeta):
             # AccumBounds(-oo, 0) or AccumBounds(-oo, oo).
             # Check out function: test_issue_18473() in test_exponential.py and
             # test_limits.py for more information.
+            if re(cdir) < S.Zero:
+                return 1/exp(arg0)
             return exp(arg0)
         if arg0 is S.NaN:
             arg0 = arg.limit(x, 0)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -942,6 +942,7 @@ def test_issue_18473():
     # Tests for issue #23751
     assert limit((cos(x) + 1)**(1/x), x, -oo) == AccumBounds(1, oo)
     assert limit((sin(x)**2)**(1/x), x, -oo) == AccumBounds(1, oo)
+    assert limit((tan(x)**2)**(2/x) , x, -oo) == AccumBounds(0, oo)
 
 
 def test_issue_18482():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -939,6 +939,9 @@ def test_issue_18473():
     assert limit((cos(x) + 1)**(1/x), x, oo) == AccumBounds(0, 1)
     assert limit((tan(x)**2)**(2/x) , x, oo) == AccumBounds(0, oo)
     assert limit((sin(x)**2)**(1/x), x, oo) == AccumBounds(0, 1)
+    # Tests for issue #23751
+    assert limit((cos(x) + 1)**(1/x), x, -oo) == AccumBounds(1, oo)
+    assert limit((sin(x)**2)**(1/x), x, -oo) == AccumBounds(1, oo)
 
 
 def test_issue_18482():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23751

#### Brief description of what is fixed or changed
At `S.NegativeInfinity`, limits do not give expected accumbounds output. That has been fixed here basically by returning inverse of the ouput at `S.Infinity`.

Examples on this branch - 
```
>>> limit((cos(x) + 1)**(1/x), x, -oo)
AccumBounds(1, oo)
>>> limit((sin(x)**2)**(1/x), x, -oo)
AccumBounds(1, oo)
```

#### Other comments
Relevant tests have been added, along with the tests for #18473 because of the similarity.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixes leading term for exponential functions involving AccumBounds based arguments for limits being calculated at NegativeInfinity.
<!-- END RELEASE NOTES -->
