### PR TITLE
Cleanup of warnings from the test suite

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -185,7 +185,7 @@ jobs:
 
       # Install the non-Python dependencies
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
-      - run: python -m pip install --upgrade pip wheel
+      - run: python -m pip install --upgrade pip wheel setuptools
 
       # Use various libs from git for Python 3.11
       - if: ${{ contains(matrix.python-version, '3.11') }}

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -99,7 +99,7 @@ doctest_list = [
     '*aesara*',
 
     # gmpy
-    'polys',
+    'sympy/polys',
 
     # autowrap
     '*autowrap*',
@@ -132,8 +132,8 @@ print('Testing optional dependencies')
 from sympy import test, doctest
 
 
-tests_passed = test(*test_list, blacklist=blacklist)
-doctests_passed = doctest(*doctest_list)
+tests_passed = test(*test_list, blacklist=blacklist, force_colors=True)
+doctests_passed = doctest(*doctest_list, force_colors=True)
 
 
 if not tests_passed and not doctests_passed:

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -98,7 +98,7 @@ specify this conversion was:
 
 ```py
 >>> from sympy.parsing.mathematica import mathematica
->>> mathematica('F[7,5,3]', {'F[*x]': 'Max(*x)*Min(*x)'})
+>>> mathematica('F[7,5,3]', {'F[*x]': 'Max(*x)*Min(*x)'})   # doctest: +SKIP
 21
 ```
 

--- a/examples/all.py
+++ b/examples/all.py
@@ -33,7 +33,6 @@ Example Usage:
    Obviously, we want to achieve the first result.
 """
 
-import imp
 import optparse
 import os
 import sys
@@ -86,37 +85,13 @@ WINDOWED_EXAMPLES = [
 EXAMPLE_DIR = os.path.dirname(__file__)
 
 
-def __import__(name, globals=None, locals=None, fromlist=None):
-    """An alternative to the import function so that we can import
-    modules defined as strings.
-
-    This code was taken from: http://docs.python.org/lib/examples-imp.html
-    """
-    # Fast path: see if the module has already been imported.
-    try:
-        return sys.modules[name]
-    except KeyError:
-        pass
-
-    # If any of the following calls raises an exception,
-    # there's a problem we can't handle -- let the caller handle it.
-    module_name = name.split('.')[-1]
-    module_path = os.path.join(EXAMPLE_DIR, *name.split('.')[:-1])
-
-    fp, pathname, description = imp.find_module(module_name, [module_path])
-
-    try:
-        return imp.load_module(module_name, fp, pathname, description)
-    finally:
-        # Since we may exit via an exception, close fp explicitly.
-        if fp:
-            fp.close()
-
-
 def load_example_module(example):
     """Loads modules based upon the given package name"""
-    mod = __import__(example)
-    return mod
+    from importlib import import_module
+
+    exmod = os.path.split(EXAMPLE_DIR)[1]
+    modname = exmod + '.' + example
+    return import_module(modname)
 
 
 def run_examples(*, windowed=False, quiet=False, summary=True):

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -112,8 +112,10 @@ def runtest_issue_10274(language, backend):
     assert f(1, 1, 1) == 1
 
     for file in os.listdir(tmp):
-        if file.startswith("wrapped_code_") and file.endswith(".c"):
-            fil = open(tmp + '/' + file)
+        if not (file.startswith("wrapped_code_") and file.endswith(".c")):
+            continue
+
+        with open(tmp + '/' + file) as fil:
             lines = fil.readlines()
             assert lines[0] == "/******************************************************************************\n"
             assert "Code generated with SymPy " + sympy.__version__ in lines[1]

--- a/sympy/external/tests/test_codegen.py
+++ b/sympy/external/tests/test_codegen.py
@@ -120,12 +120,12 @@ def try_run(commands):
     """Run a series of commands and only return True if all ran fine."""
     if pyodide_js:
         return False
-    null = open(os.devnull, 'w')
-    for command in commands:
-        retcode = subprocess.call(command, stdout=null, shell=True,
-                stderr=subprocess.STDOUT)
-        if retcode != 0:
-            return False
+    with open(os.devnull, 'w') as null:
+        for command in commands:
+            retcode = subprocess.call(command, stdout=null, shell=True,
+                    stderr=subprocess.STDOUT)
+            if retcode != 0:
+                return False
     return True
 
 

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -25,6 +25,7 @@ import sympy
 import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.utilities.exceptions import ignore_warnings
 from sympy.testing.pytest import raises
 
 
@@ -138,9 +139,11 @@ def test_Matrix1():
 
 def test_Matrix2():
     m = Matrix([[x, x**2], [5, 2/x]])
-    assert (matrix(m.subs(x, 2)) == matrix([[2, 4], [5, 1]])).all()
+    with ignore_warnings(PendingDeprecationWarning):
+        assert (matrix(m.subs(x, 2)) == matrix([[2, 4], [5, 1]])).all()
     m = Matrix([[sin(x), x**2], [5, 2/x]])
-    assert (matrix(m.subs(x, 2)) == matrix([[sin(2), 4], [5, 1]])).all()
+    with ignore_warnings(PendingDeprecationWarning):
+        assert (matrix(m.subs(x, 2)) == matrix([[sin(2), 4], [5, 1]])).all()
 
 
 def test_Matrix3():
@@ -153,17 +156,20 @@ def test_Matrix3():
 
 
 def test_Matrix4():
-    a = matrix([[2, 4], [5, 1]])
+    with ignore_warnings(PendingDeprecationWarning):
+        a = matrix([[2, 4], [5, 1]])
     assert Matrix(a) == Matrix([[2, 4], [5, 1]])
     assert Matrix(a) != Matrix([[2, 4], [5, 2]])
-    a = matrix([[sin(2), 4], [5, 1]])
+    with ignore_warnings(PendingDeprecationWarning):
+        a = matrix([[sin(2), 4], [5, 1]])
     assert Matrix(a) == Matrix([[sin(2), 4], [5, 1]])
     assert Matrix(a) != Matrix([[sin(0), 4], [5, 1]])
 
 
 def test_Matrix_sum():
     M = Matrix([[1, 2, 3], [x, y, x], [2*y, -50, z*x]])
-    m = matrix([[2, 3, 4], [x, 5, 6], [x, y, z**2]])
+    with ignore_warnings(PendingDeprecationWarning):
+        m = matrix([[2, 3, 4], [x, 5, 6], [x, y, z**2]])
     assert M + m == Matrix([[3, 5, 7], [2*x, y + 5, x + 6], [2*y + x, y - 50, z*x + z**2]])
     assert m + M == Matrix([[3, 5, 7], [2*x, y + 5, x + 6], [2*y + x, y - 50, z*x + z**2]])
     assert M + m == M.add(m)
@@ -171,7 +177,8 @@ def test_Matrix_sum():
 
 def test_Matrix_mul():
     M = Matrix([[1, 2, 3], [x, y, x]])
-    m = matrix([[2, 4], [x, 6], [x, z**2]])
+    with ignore_warnings(PendingDeprecationWarning):
+        m = matrix([[2, 4], [x, 6], [x, z**2]])
     assert M*m == Matrix([
         [         2 + 5*x,        16 + 3*z**2],
         [2*x + x*y + x**2, 4*x + 6*y + x*z**2],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -32,7 +32,7 @@ from sympy.matrices.utilities import _dotprodsimp_state
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture, iterable
-from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.exceptions import ignore_warnings, SymPyDeprecationWarning
 from sympy.testing.pytest import (raises, XFAIL, slow, skip,
                                   warns_deprecated_sympy, warns)
 from sympy.assumptions import Q
@@ -2702,7 +2702,8 @@ def test_17522_numpy():
     assert m[3] == 4
     assert list(m) == [1, 2, 3, 4]
 
-    m = _matrixify(matrix([[1, 2], [3, 4]]))
+    with ignore_warnings(PendingDeprecationWarning):
+        m = _matrixify(matrix([[1, 2], [3, 4]]))
     assert m[3] == 4
     assert list(m) == [1, 2, 3, 4]
 

--- a/sympy/plotting/tests/test_textplot.py
+++ b/sympy/plotting/tests/test_textplot.py
@@ -5,6 +5,8 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
 from sympy.plotting.textplot import textplot_str
 
+from sympy.utilities.exceptions import ignore_warnings
+
 
 def test_axes_alignment():
     x = Symbol('x')
@@ -108,7 +110,9 @@ def test_singularity():
         '     -4 |_______________________________________________________',
         '         0                          0.5                        1'
     ]
-    assert lines == list(textplot_str(log(x), 0, 1))
+    # RuntimeWarning: divide by zero encountered in log
+    with ignore_warnings(RuntimeWarning):
+        assert lines == list(textplot_str(log(x), 0, 1))
 
 
 def test_sinc():
@@ -137,7 +141,9 @@ def test_sinc():
         '   -0.2 |_______________________________________________________',
         '         -10                        0                          10'
     ]
-    assert lines == list(textplot_str(sin(x)/x, -10, 10))
+    # RuntimeWarning: invalid value encountered in double_scalars
+    with ignore_warnings(RuntimeWarning):
+        assert lines == list(textplot_str(sin(x)/x, -10, 10))
 
 
 def test_imaginary():
@@ -166,7 +172,9 @@ def test_imaginary():
         '      0 |_______________________________________________________',
         '         -1                         0                          1'
     ]
-    assert list(textplot_str(sqrt(x), -1, 1)) == lines
+    # RuntimeWarning: invalid value encountered in sqrt
+    with ignore_warnings(RuntimeWarning):
+        assert list(textplot_str(sqrt(x), -1, 1)) == lines
 
     lines = [
         '      1 |                                                       ',

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -139,7 +139,7 @@ class AesaraPrinter(Printer):
         if key in self.cache:
             return self.cache[key]
 
-        value = aet.tensor(name=name, dtype=dtype, shape=broadcastable)
+        value = aet.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
         self.cache[key] = value
         return value
 

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -139,7 +139,7 @@ class AesaraPrinter(Printer):
         if key in self.cache:
             return self.cache[key]
 
-        value = aet.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
+        value = aet.tensor(name=name, dtype=dtype, shape=broadcastable)
         self.cache[key] = value
         return value
 

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -150,8 +150,20 @@ class NumExprPrinter(LambdaPrinter):
                 ans.append('where(%s, %s, ' % (cond, expr))
                 parenthesis_count += 1
         if not is_last_cond_True:
+            # See https://github.com/pydata/numexpr/issues/298
+            #
             # simplest way to put a nan but raises
             # 'RuntimeWarning: invalid value encountered in log'
+            #
+            # There are other ways to do this such as
+            #
+            #   >>> import numexpr as ne
+            #   >>> nan = float('nan')
+            #   >>> ne.evaluate('where(x < 0, -1, nan)', {'x': [-1, 2, 3], 'nan':nan})
+            #   array([-1., nan, nan])
+            #
+            # That needs to be handled in the lambdified function though rather
+            # than here in the printer.
             ans.append('log(-1)')
         return ''.join(ans) + ')' * parenthesis_count
 

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -12,6 +12,9 @@ import logging
 from sympy.external import import_module
 from sympy.testing.pytest import raises, SKIP
 
+from sympy.utilities.exceptions import ignore_warnings
+
+
 aesaralogger = logging.getLogger('aesara.configdefaults')
 aesaralogger.setLevel(logging.CRITICAL)
 aesara = import_module('aesara')
@@ -272,9 +275,10 @@ def test_factorial():
     assert aesara_code_(sy.factorial(n))
 
 def test_Derivative():
-    simp = lambda expr: aesara_simplify(fgraph_of(expr))
-    assert theq(simp(aesara_code_(sy.Derivative(sy.sin(x), x, evaluate=False))),
-                simp(aesara.grad(aet.sin(xt), xt)))
+    with ignore_warnings(UserWarning):
+        simp = lambda expr: aesara_simplify(fgraph_of(expr))
+        assert theq(simp(aesara_code_(sy.Derivative(sy.sin(x), x, evaluate=False))),
+                    simp(aesara.grad(aet.sin(xt), xt)))
 
 
 def test_aesara_function_simple():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -210,13 +210,11 @@ def test_numexpr():
 
     from sympy.codegen.ast import Return, FunctionDefinition, Variable, Assignment
     func_def = FunctionDefinition(None, 'foo', [Variable(x)], [Assignment(y,x), Return(y**2)])
-    print("")
-    print(NumExprPrinter().doprint(func_def))
     expected = "def foo(x):\n"\
                "    y = numexpr.evaluate('x', truediv=True)\n"\
                "    return numexpr.evaluate('y**2', truediv=True)"
-    print(expected)
     assert NumExprPrinter().doprint(func_def) == expected
+
 
 class CustomPrintedObject(Expr):
     def _lambdacode(self, printer):

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -2030,7 +2030,7 @@ class PyTestReporter(Reporter):
                 process = subprocess.Popen(['stty', '-a'],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
-                stdout = process.stdout.read()
+                stdout, stderr = process.communicate()
                 stdout = stdout.decode("utf-8")
             except OSError:
                 pass

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -535,7 +535,8 @@ def _write_sources_to_build_dir(sources, build_dir):
         sha256_in_mem = sha256_of_string(src.encode('utf-8')).hexdigest()
         if os.path.exists(dest):
             if os.path.exists(dest + '.sha256'):
-                sha256_on_disk = open(dest + '.sha256').read()
+                with open(dest + '.sha256') as fh:
+                    sha256_on_disk = fh.read()
             else:
                 sha256_on_disk = sha256_of_file(dest).hexdigest()
 
@@ -543,7 +544,8 @@ def _write_sources_to_build_dir(sources, build_dir):
         if differs:
             with open(dest, 'wt') as fh:
                 fh.write(src)
-                open(dest + '.sha256', 'wt').write(sha256_in_mem)
+            with open(dest + '.sha256', 'wt') as fh:
+                fh.write(sha256_in_mem)
         source_files.append(dest)
     return source_files, build_dir
 

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -192,15 +192,16 @@ def pyx_is_cplus(path):
 
     Returns True if such a file is present in the file, else False.
     """
-    for line in open(path):
-        if line.startswith('#') and '=' in line:
-            splitted = line.split('=')
-            if len(splitted) != 2:
-                continue
-            lhs, rhs = splitted
-            if lhs.strip().split()[-1].lower() == 'language' and \
-               rhs.strip().split()[0].lower() == 'c++':
-                    return True
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith('#') and '=' in line:
+                splitted = line.split('=')
+                if len(splitted) != 2:
+                    continue
+                lhs, rhs = splitted
+                if lhs.strip().split()[-1].lower() == 'language' and \
+                       rhs.strip().split()[0].lower() == 'c++':
+                            return True
     return False
 
 def import_module_from_file(filename, only_if_newer_than=None):

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -254,6 +254,8 @@ ext_mods = [Extension(
 setup(ext_modules=cythonize(ext_mods, **cy_opts))
 """
 
+    _cythonize_options = {'compiler_directives':{'language_level' : "3"}}
+
     pyx_imports = (
         "import numpy as np\n"
         "cimport numpy as np\n\n")
@@ -309,7 +311,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
         self._extra_compile_args = kwargs.pop('extra_compile_args', [])
         self._extra_compile_args.append(self.std_compile_flag)
         self._extra_link_args = kwargs.pop('extra_link_args', [])
-        self._cythonize_options = kwargs.pop('cythonize_options', {})
+        self._cythonize_options = kwargs.pop('cythonize_options', self._cythonize_options)
 
         self._need_numpy = False
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -470,25 +470,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
       of numexpr functions can be found at:
       https://numexpr.readthedocs.io/en/latest/user_guide.html#supported-functions
 
-    - In previous versions of SymPy, ``lambdify`` replaced ``Matrix`` with
-      ``numpy.matrix`` by default. As of SymPy 1.0 ``numpy.array`` is the
-      default. To get the old default behavior you must pass in
-      ``[{'ImmutableDenseMatrix':  numpy.matrix}, 'numpy']`` to the
-      ``modules`` kwarg.
-
-      >>> from sympy import lambdify, Matrix
-      >>> from sympy.abc import x, y
-      >>> import numpy
-      >>> array2mat = [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy']
-      >>> f = lambdify((x, y), Matrix([x, y]), modules=array2mat)
-      >>> f(1, 2)
-      [[1]
-       [2]]
-
     - In the above examples, the generated functions can accept scalar
       values or numpy arrays as arguments.  However, in some cases
       the generated function relies on the input being a numpy array:
 
+      >>> import numpy
       >>> from sympy import Piecewise
       >>> from sympy.testing.pytest import ignore_warnings
       >>> f = lambdify(x, Piecewise((x, x <= 1), (1/x, x > 1)), "numpy")

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -99,7 +99,7 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
 from Cython.Build import cythonize
-cy_opts = {}
+cy_opts = {'compiler_directives': {'language_level': '3'}}
 
 ext_mods = [Extension(
     'wrapper_module_%(num)s', ['wrapper_module_%(num)s.pyx', 'wrapped_code_%(num)s.c'],

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -43,6 +43,7 @@ from sympy.printing.numpy import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function, lambdastr
 from sympy.testing.pytest import skip
 from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma
 
@@ -283,14 +284,13 @@ def test_issue_9334():
     foo, bar = numpy.random.random((2, 4))
     func_numexpr(foo, bar)
 
+
 def test_issue_12984():
-    import warnings
     if not numexpr:
         skip("numexpr not installed.")
     func_numexpr = lambdify((x,y,z), Piecewise((y, x >= 0), (z, x > -1)), numexpr)
-    assert func_numexpr(1, 24, 42) == 24
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)
+    with ignore_warnings(RuntimeWarning):
+        assert func_numexpr(1, 24, 42) == 24
         assert str(func_numexpr(-1, 24, 42)) == 'nan'
 
 
@@ -491,8 +491,9 @@ def test_numpy_old_matrix():
     A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     f = lambdify((x, y, z), A, [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy'])
-    numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
-    assert isinstance(f(1, 2, 3), numpy.matrix)
+    with ignore_warnings(PendingDeprecationWarning):
+        numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
+        assert isinstance(f(1, 2, 3), numpy.matrix)
 
 
 def test_scipy_sparse_matrix():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

- Partial fix for #23061
- Extracts the more straight-forward parts of #23745

#### Brief description of what is fixed or changed

Various fixes related to things that give warnings in the test suite (including some warnings that are hidden by default):

- Not closing files properly (i.e. use `with open()`)
- Not closing subprocesses properly (use `communicate` etc)
- Using the deprecated `imp` module
- Using the deprecated `np.matrix` type
- Plotting code that passes out of range values to numpy functions

Also:

- Aesara has deprecated the `broadcastable` argument in favour of `shape`.
- Some warnings from Aesara are now suppressed (in the test suite).
- Autowrap now sets `language_level=3` in the generated cython code.

#### Other comments

I would like to merge this as a bunch of minor fixes and then rebase #23745 and think more generally about how to handle warnings in CI.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * The autowrap module now sets `language_level = 3` in the generated Cython code.
<!-- END RELEASE NOTES -->
