### PR TITLE
[GSoC] physics/continuum_mechanics: solve Method along with documentation and tests added for the Truss class 

### DIFF
--- a/sympy/physics/continuum_mechanics/tests/test_truss.py
+++ b/sympy/physics/continuum_mechanics/tests/test_truss.py
@@ -1,6 +1,7 @@
 from sympy.core.symbol import Symbol, symbols
 from sympy.physics.continuum_mechanics.truss import Truss
 
+
 def test_truss():
     A = Symbol('A')
     B = Symbol('B')

--- a/sympy/physics/continuum_mechanics/tests/test_truss.py
+++ b/sympy/physics/continuum_mechanics/tests/test_truss.py
@@ -93,3 +93,15 @@ def test_truss():
     assert t.supports == {D: 'roller'}
     assert t.reaction_loads == {}
     assert t.loads == {A: [[P, 90], [2*P, 45]], D: [[P/2, 90], [Symbol('R_D_y'), 90]]}
+
+    t.apply_support(A, "pinned")
+
+    # testing the solve method
+    t.solve()
+    assert t.reaction_loads['R_A_x']/P - (-1.4142135623731) < 1e-10
+    assert t.reaction_loads['R_A_y']/P - (-2.41421356237309) < 1e-10
+    assert t.reaction_loads['R_D_y']/P - (-0.5) < 1e-10
+    assert t.internal_forces[AB]/P < 1e-10
+    assert t.internal_forces[CD] < 1e-10
+    assert t.internal_forces[AC] < 1e-10
+    # assert t.internal_forces == {AB: 3.06161699786838e-17*P, CD: 0, AC: 0}

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -624,8 +624,9 @@ class Truss:
         The given condition is derived from the fact that a system of equations is solvable
         only when the number of variables is lesser than or equal to the number of equations.
         Equilibrium Equations in x and y directions give two equations per node giving 2n number
-        equations. The number of variables is simply the sum of the number of reaction forces and
-        member forces.
+        equations. However, the truss needs to be stable as well and may be unstable if 2n > r + m.
+        The number of variables is simply the sum of the number of reaction forces and member
+        forces.
 
         Examples
         ========
@@ -652,11 +653,13 @@ class Truss:
         """
         count_reaction_loads = 0
         for node in self._nodes:
-            if node in list(self._supports):
+            if node[0] in list(self._supports):
                 if self._supports[node[0]]=='pinned':
                     count_reaction_loads += 2
                 elif self._supports[node[0]]=='roller':
                     count_reaction_loads += 1
+        if 2*len(self._nodes) != len(self._members) + count_reaction_loads:
+            raise ValueError("The given truss cannot be solved")
         coefficients_matrix = [[0 for i in range(2*len(self._nodes))] for j in range(2*len(self._nodes))]
         load_matrix = zeros(2*len(self.nodes), 1)
         load_matrix_row = 0

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -5,6 +5,10 @@ to 2D Trusses.
 
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
+from sympy import Matrix, pi
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.matrices.dense import zeros
+import math
 
 
 
@@ -59,6 +63,7 @@ class Truss:
         self._nodes_occupied = {}
         self._reaction_loads = {}
         self._internal_forces = {}
+        self._node_coordinates = {}
 
     @property
     def nodes(self):
@@ -166,6 +171,7 @@ class Truss:
             self._node_positions.append((x, y))
             self._node_position_x.append(x)
             self._node_position_y.append(y)
+            self._node_coordinates[label] = [x, y]
 
     def remove_node(self, label):
         """
@@ -213,6 +219,7 @@ class Truss:
                 self._loads.pop(label)
             if label in list(self._supports):
                 self._supports.pop(label)
+            self._node_coordinates.pop(label)
 
     def add_member(self, label, start, end):
         """
@@ -327,6 +334,8 @@ class Truss:
                 if node[0] == label:
                     self._nodes[self._nodes.index((label, node[1], node[2]))] = (new_label, node[1], node[2])
                     self._node_labels[self._node_labels.index(node[0])] = new_label
+                    self._node_coordinates[new_label] = self._node_coordinates[label]
+                    self._node_coordinates.pop(label)
                     if node[0] in list(self._supports):
                         self._supports[new_label] = self._supports[node[0]]
                         self._supports.pop(node[0])
@@ -599,3 +608,105 @@ class Truss:
             elif self._supports[location] == 'roller':
                 self.remove_load(location, Symbol('R_'+str(location)+'_y'), 90)
             self._supports.pop(location)
+
+    def solve(self):
+        """
+        This method solves for all reaction forces of all supports and all internal forces
+        of all the members in the truss, provided the Truss is solvable.
+
+        A Truss is solvable if the following condition is met,
+
+        2n >= r + m
+
+        Where n is the number of nodes, r is the number of reaction forces, where each pinned
+        support has 2 reaction forces and each roller has 1, and m is the number of members.
+
+        The given condition is derived from the fact that a system of equations is solvable
+        only when the number of variables is lesser than or equal to the number of equations.
+        Equilibrium Equations in x and y directions give two equations per node giving 2n number
+        equations. The number of variables is simply the sum of the number of reaction forces and
+        member forces.
+
+        Examples
+        ========
+
+        >>> from sympy.physics.continuum_mechanics.truss import Truss
+        >>> t = Truss()
+        >>> t.add_node("node_1", 0, 0)
+        >>> t.add_node("node_2", 6, 0)
+        >>> t.add_node("node_3", 2, 2)
+        >>> t.add_node("node_4", 2, 0)
+        >>> t.add_member("member_1", "node_1", "node_4")
+        >>> t.add_member("member_2", "node_2", "node_4")
+        >>> t.add_member("member_3", "node_1", "node_3")
+        >>> t.add_member("member_4", "node_2", "node_3")
+        >>> t.add_member("member_5", "node_3", "node_4")
+        >>> t.apply_load("node_4", magnitude=10, direction=270)
+        >>> t.apply_support("node_1", type="pinned")
+        >>> t.apply_support("node_2", type="roller")
+        >>> t.solve()
+        >>> t.reaction_loads
+        {'R_node_1_x': 1.83697019872103e-15, 'R_node_1_y': 6.66666666666667, 'R_node_2_y': 3.33333333333333}
+        >>> t.internal_forces
+        {'member_1': 6.66666666666666, 'member_2': 6.66666666666667, 'member_3': -6.66666666666667*sqrt(2), 'member_4': -3.33333333333333*sqrt(5), 'member_5': 10.0}
+        """
+        count_reaction_loads = 0
+        for node in self._nodes:
+            if node in list(self._supports):
+                if self._supports[node[0]]=='pinned':
+                    count_reaction_loads += 2
+                elif self._supports[node[0]]=='roller':
+                    count_reaction_loads += 1
+        coefficients_matrix = [[0 for i in range(2*len(self._nodes))] for j in range(2*len(self._nodes))]
+        load_matrix = zeros(2*len(self.nodes), 1)
+        load_matrix_row = 0
+        for node in self._nodes:
+            if node[0] in list(self._loads):
+                for load in self._loads[node[0]]:
+                    if load[0]!=Symbol('R_'+str(node[0])+'_x') and load[0]!=Symbol('R_'+str(node[0])+'_y'):
+                        load_matrix[load_matrix_row] -= load[0]*math.cos(pi*load[1]/180)
+                        load_matrix[load_matrix_row + 1] -= load[0]*math.sin(pi*load[1]/180)
+            load_matrix_row += 2
+        cols = 0
+        row = 0
+        for node in self._nodes:
+            if node[0] in list(self._supports):
+                if self._supports[node[0]]=='pinned':
+                    coefficients_matrix[row][cols] += 1
+                    coefficients_matrix[row+1][cols+1] += 1
+                    cols += 2
+                elif self._supports[node[0]]=='roller':
+                    coefficients_matrix[row+1][cols] += 1
+                    cols += 1
+            row += 2
+        for member in list(self._members):
+            start = self._members[member][0]
+            end = self._members[member][1]
+            length = sqrt((self._node_coordinates[start][0]-self._node_coordinates[end][0])**2 + (self._node_coordinates[start][1]-self._node_coordinates[end][1])**2)
+            start_index = self._node_labels.index(start)
+            end_index = self._node_labels.index(end)
+            horizontal_component_start = (self._node_coordinates[end][0]-self._node_coordinates[start][0])/length
+            vertical_component_start = (self._node_coordinates[end][1]-self._node_coordinates[start][1])/length
+            horizontal_component_end = (self._node_coordinates[start][0]-self._node_coordinates[end][0])/length
+            vertical_component_end = (self._node_coordinates[start][1]-self._node_coordinates[end][1])/length
+            coefficients_matrix[start_index*2][cols] += horizontal_component_start
+            coefficients_matrix[start_index*2+1][cols] += vertical_component_start
+            coefficients_matrix[end_index*2][cols] += horizontal_component_end
+            coefficients_matrix[end_index*2+1][cols] += vertical_component_end
+            cols += 1
+        forces_matrix = (Matrix(coefficients_matrix)**-1)*load_matrix
+        self._reaction_loads = {}
+        i = 0
+        for node in self._nodes:
+            if node[0] in list(self._supports):
+                if self._supports[node[0]]=='pinned':
+                    self._reaction_loads['R_'+str(node[0])+'_x'] = forces_matrix[i]
+                    self._reaction_loads['R_'+str(node[0])+'_y'] = forces_matrix[i+1]
+                    i += 2
+                elif self._supports[node[0]]=='roller':
+                    self._reaction_loads['R_'+str(node[0])+'_y'] = forces_matrix[i]
+                    i += 1
+        for member in list(self._members):
+            self._internal_forces[member] = forces_matrix[i]
+            i += 1
+        return


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
After the implementation of the `truss` class with the initialising methods like `add_node` and `add_method` along with many others, the main solving method responsible for solving a given Truss added. After calling the `solve` method for a given truss, the `reaction_loads` and `internal_forces` are updated with the calculated values. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Added the `solve` method for solving a given `truss` for its reaction loads and internal forces. 
<!-- END RELEASE NOTES -->
