### PR TITLE
allow collect to work with compound generators

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -125,7 +125,9 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     ``exact`` to None:
 
         >>> collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None)
-        x*(exp(x) + 3) + (y + 2)*sin(x)
+        x*exp(x) + 3*x + (y + 2)*sin(x)
+        >>> collect(a*x*y + x*y + b*x + x, [x, y], exact=None)
+        x*y*(a + 1) + x*(b + 1)
 
     You can also apply this function to differential equations, where
     derivatives of arbitrary order can be collected. Note that if you
@@ -198,8 +200,8 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
             if not i.is_Mul and i not in syms:
                 _syms.add(i)
             else:
-                g = i._new_rawargs(*[_ for _ in
-                    i.as_coeff_mul(*syms)[1] if _ not in syms])
+                # identify compound generators
+                g = i._new_rawargs(*i.as_coeff_mul(*syms)[1])
                 if g not in syms:
                     _syms.add(g)
         simple = all(i.is_Pow and i.base in syms for i in _syms)

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -185,7 +185,10 @@ def test_collect_1():
     expr = x + y
     assert collect(expr, expr.free_symbols) == expr
     assert collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x, x, exact=None
-        ) == x*(exp(x) + 3) + (y + 2)*sin(x)
+        ) == x*exp(x) + 3*x + (y + 2)*sin(x)
+    assert collect(x*exp(x) + sin(x)*y + sin(x)*2 + 3*x + y*x +
+        y*x*exp(x), x, exact=None
+        ) == x*exp(x)*(y + 1) + (3 + y)*x + (y + 2)*sin(x)
 
 
 def test_collect_2():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

now:
```python
>>> collect(x+a*x+x*y+b*x*y+y+3*y,[x,y],exact=None)
x*y*(b + 1) + x*(a + 1) + 4*y
>>> ^Z
```

master:
```python
>>> collect(x+a*x+x*y+b*x*y+y+3*y,[x,y],exact=None)
x*(a + b*y + y + 1) + 4*y
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * `collect` will now allow collection of coefficients in products of generators to be collected when exact=None
<!-- END RELEASE NOTES -->
