### PR TITLE
Piecewise rewrite of Heaviside ends with True conditional

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -567,23 +567,23 @@ class Heaviside(Function):
         >>> x = Symbol('x')
 
         >>> Heaviside(x).rewrite(Piecewise)
-        Piecewise((0, x < 0), (1/2, Eq(x, 0)), (1, x > 0))
+        Piecewise((0, x < 0), (1/2, Eq(x, 0)), (1, True))
 
         >>> Heaviside(x,nan).rewrite(Piecewise)
-        Piecewise((0, x < 0), (nan, Eq(x, 0)), (1, x > 0))
+        Piecewise((0, x < 0), (nan, Eq(x, 0)), (1, True))
 
         >>> Heaviside(x - 5).rewrite(Piecewise)
-        Piecewise((0, x < 5), (1/2, Eq(x, 5)), (1, x > 5))
+        Piecewise((0, x < 5), (1/2, Eq(x, 5)), (1, True))
 
         >>> Heaviside(x**2 - 1).rewrite(Piecewise)
-        Piecewise((0, x**2 < 1), (1/2, Eq(x**2, 1)), (1, x**2 > 1))
+        Piecewise((0, x**2 < 1), (1/2, Eq(x**2, 1)), (1, True))
 
         """
         if H0 == 0:
-            return Piecewise((0, arg <= 0), (1, arg > 0))
+            return Piecewise((0, arg <= 0), (1, True))
         if H0 == 1:
-            return Piecewise((0, arg < 0), (1, arg >= 0))
-        return Piecewise((0, arg < 0), (H0, Eq(arg, 0)), (1, arg > 0))
+            return Piecewise((0, arg < 0), (1, True))
+        return Piecewise((0, arg < 0), (H0, Eq(arg, 0)), (1, True))
 
     def _eval_rewrite_as_sign(self, arg, H0=S.Half, **kwargs):
         """

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -120,17 +120,17 @@ def test_heaviside():
 def test_rewrite():
     x, y = Symbol('x', real=True), Symbol('y')
     assert Heaviside(x).rewrite(Piecewise) == (
-        Piecewise((0, x < 0), (Heaviside(0), Eq(x, 0)), (1, x > 0)))
+        Piecewise((0, x < 0), (Heaviside(0), Eq(x, 0)), (1, True)))
     assert Heaviside(y).rewrite(Piecewise) == (
-        Piecewise((0, y < 0), (Heaviside(0), Eq(y, 0)), (1, y > 0)))
+        Piecewise((0, y < 0), (Heaviside(0), Eq(y, 0)), (1, True)))
     assert Heaviside(x, y).rewrite(Piecewise) == (
-        Piecewise((0, x < 0), (y, Eq(x, 0)), (1, x > 0)))
+        Piecewise((0, x < 0), (y, Eq(x, 0)), (1, True)))
     assert Heaviside(x, 0).rewrite(Piecewise) == (
-        Piecewise((0, x <= 0), (1, x > 0)))
+        Piecewise((0, x <= 0), (1, True)))
     assert Heaviside(x, 1).rewrite(Piecewise) == (
-        Piecewise((0, x < 0), (1, x >= 0)))
+        Piecewise((0, x < 0), (1, True)))
     assert Heaviside(x, nan).rewrite(Piecewise) == (
-        Piecewise((0, x < 0), (nan, Eq(x, 0)), (1, x > 0)))
+        Piecewise((0, x < 0), (nan, Eq(x, 0)), (1, True)))
 
     assert Heaviside(x).rewrite(sign) == \
         Heaviside(x, H0=Heaviside(0)).rewrite(sign) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Helps with #23417

(Remake of parts of messed up #23666)
#### Brief description of what is fixed or changed

autowrap breaks if the Piecewise doesn't end with a True conditional (which is a bit strange in itself, but there are probably reasons). All(?) other functions in SymPy except for Heaviside did this. Now, also Heaviside does this.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `Heaviside` rewrites as a `Piecewise` with a `True` final condition, in consistency with other functions and for better `autowrap` support. 
<!-- END RELEASE NOTES -->
