### PR TITLE
Don't use parse_latex in the printing tests

### DIFF
--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -19,7 +19,6 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayDiagonal, ArrayContraction, ZeroArray, OneArray
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import loggamma
-from sympy.parsing.latex import parse_latex
 
 
 x, y, z = symbols('x y z')
@@ -187,13 +186,11 @@ def test_pycode_reserved_words():
 
 
 def test_issue_20762():
-    antlr4 = import_module("antlr4")
-    if not antlr4:
-        skip('antlr not installed.')
     # Make sure pycode removes curly braces from subscripted variables
-    expr = parse_latex(r'a_b \cdot b')
+    a_b, b, a_11 = symbols('a_{b} b a_{11}')
+    expr = a_b*b
     assert pycode(expr) == 'a_b*b'
-    expr = parse_latex(r'a_{11} \cdot b')
+    expr = a_11*b
     assert pycode(expr) == 'a_11*b'
 
 

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -12,13 +12,7 @@ from sympy.series.limits import limit
 
 from sympy.printing.python import python
 
-from sympy.testing.pytest import raises, XFAIL, skip
-
-from sympy.parsing.latex import parse_latex
-from sympy.external import import_module
-
-# To test latex to Python printing
-antlr4 = import_module("antlr4")
+from sympy.testing.pytest import raises, XFAIL
 
 x, y = symbols('x,y')
 th = Symbol('theta')
@@ -198,10 +192,10 @@ def test_python_limits():
     assert python(limit(x**2, x, 0)) == 'e = 0'
 
 def test_issue_20762():
-    if not antlr4:
-        skip('antlr not installed')
     # Make sure Python removes curly braces from subscripted variables
-    expr = parse_latex(r'a_b \cdot b')
+    a_b = Symbol('a_{b}')
+    b = Symbol('b')
+    expr = a_b*b
     assert python(expr) == "a_b = Symbol('a_{b}')\nb = Symbol('b')\ne = a_b*b"
 
 


### PR DESCRIPTION
There is no reason for the tests to depend on parsing. They can just create
the expressions directly.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
