### PR TITLE
hep: Fixes bug in gamma_trace of sum of products containing GammaMatrix mixed with other symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -588,6 +588,8 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
 GolimarOurHero <metalera94@hotmail.com>
 Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
 Govind Sahai <gsiitbhu@gmail.com>

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -190,7 +190,7 @@ def gamma_trace(t):
 
     """
     if isinstance(t, TensAdd):
-        res = TensAdd(*[_trace_single_line(x) for x in t.args])
+        res = TensAdd(*[gamma_trace(x) for x in t.args])
         return res
     t = _simplify_single_line(t)
     res = _trace_single_line(t)

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -401,6 +401,7 @@ def test_gamma_matrix_trace():
     r = gamma_trace(t)
     assert r.equals(4*p2*p2*p2*p2)
 
+
 def test_bug_13636():
     """Test issue 13636 regarding handling traces of sums of products
     of GammaMatrix mixed with other factors."""
@@ -416,9 +417,9 @@ def test_bug_13636():
     ta = gamma_trace(a)
     tb = gamma_trace(b)
     t_a_plus_b = gamma_trace(a + b)
-    assert ta.equals(
-        -16 * ki(i0) * ki(-i0) * pf(i1) * pi(-i1)
-        + 32 * ki(i0) * ki(i1) * pf(-i0) * pi(-i1)
+    assert ta == 4 * (
+        -4 * ki(i0) * ki(-i0) * pf(i1) * pi(-i1)
+        + 8 * ki(i0) * ki(i1) * pf(-i0) * pi(-i1)
     )
-    assert tb.equals(-8 * x * ki(i0) * pf(-i0) * pi(i1) * pi(-i1))
-    assert t_a_plus_b.equals(ta + tb)
+    assert tb == -8 * x * ki(i0) * pf(-i0) * pi(i1) * pi(-i1)
+    assert t_a_plus_b == ta + tb

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -402,7 +402,7 @@ def test_gamma_matrix_trace():
     assert r.equals(4*p2*p2*p2*p2)
 
 def test_bug_13636():
-    """Test issue 13636 regarding handling traces of sums of products 
+    """Test issue 13636 regarding handling traces of sums of products
     of GammaMatrix mixed with other factors."""
     pi, ki, pf = tensor_heads("pi, ki, pf", [LorentzIndex])
     i0, i1, i2, i3, i4 = tensor_indices("i0:5", LorentzIndex)

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -3,6 +3,7 @@ from sympy.tensor.tensor import tensor_indices, TensorHead, tensor_heads, \
     TensExpr, canon_bp
 from sympy.physics.hep.gamma_matrices import GammaMatrix as G, LorentzIndex, \
     kahane_simplify, gamma_trace, _simplify_single_line, simplify_gamma_expression
+from sympy import Symbol
 
 
 def _is_tensor_eq(arg1, arg2):
@@ -399,3 +400,25 @@ def test_gamma_matrix_trace():
     t = ps*ps*ps*ps*ps*ps*ps*ps
     r = gamma_trace(t)
     assert r.equals(4*p2*p2*p2*p2)
+
+def test_bug_13636():
+    """Test issue 13636 regarding handling traces of sums of products 
+    of GammaMatrix mixed with other factors."""
+    pi, ki, pf = tensor_heads("pi, ki, pf", [LorentzIndex])
+    i0, i1, i2, i3, i4 = tensor_indices("i0:5", LorentzIndex)
+    x = Symbol("x")
+    pis = pi(i2) * G(-i2)
+    kis = ki(i3) * G(-i3)
+    pfs = pf(i4) * G(-i4)
+
+    a = pfs * G(i0) * kis * G(i1) * pis * G(-i1) * kis * G(-i0)
+    b = pfs * G(i0) * kis * G(i1) * pis * x * G(-i0) * pi(-i1)
+    ta = gamma_trace(a)
+    tb = gamma_trace(b)
+    t_a_plus_b = gamma_trace(a + b)
+    assert ta.equals(
+        -16 * ki(i0) * ki(-i0) * pf(i1) * pi(-i1)
+        + 32 * ki(i0) * ki(i1) * pf(-i0) * pi(-i1)
+    )
+    assert tb.equals(-8 * x * ki(i0) * pf(-i0) * pi(i1) * pi(-i1))
+    assert t_a_plus_b.equals(ta + tb)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13636 

#### Brief description of what is fixed or changed

<!-- BEGIN RELEASE NOTES -->
* physics.hep
  * Fixed a bug in finding traces of sums of products of GammaMatrix mixed with other factors. (#13636)
<!-- END RELEASE NOTES -->
