### PR TITLE
[GSoC Pr3] Fixing/Implementing nseries methods for inverse hyperbolic/trig and log functions  

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1809,7 +1809,7 @@ class Pow(Expr):
                 f = b.as_leading_term(x, logx=logx, cdir=cdir)
             except PoleError:
                 return self
-            if not e.is_integer and f.is_negative:
+            if not e.is_integer and f.is_negative and not f.has(x):
                 ndir = (b - f).dir(x, cdir)
                 if im(ndir).is_negative:
                     # Normally, f**e would evaluate to exp(e*log(f)) but on branch cuts

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1730,7 +1730,7 @@ class Pow(Expr):
         if c.is_Float and d == S.Zero:
             # Convert floats like 0.5 to exact SymPy numbers like S.Half, to
             # prevent rounding errors which can induce wrong values of d leading
-            # to execution of an inappropriate code block (line 1741 - 1750)
+            # to a NotImplementedError being returned from the block below.
             from sympy.simplify.simplify import nsimplify
             _, d = nsimplify(g).leadterm(x, logx=logx)
         if not d.is_positive:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1243,8 +1243,7 @@ class asinh(InverseHyperbolicFunction):
 
         # Handling branch points
         if arg0 in (S.ImaginaryUnit, -S.ImaginaryUnit):
-            res = I * asin(-I*arg)._eval_nseries(x, n, logx=logx, cdir=cdir)
-            return res.expand()
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
@@ -1442,9 +1441,7 @@ class acosh(InverseHyperbolicFunction):
 
         # Handling branch points
         if arg0 in (S.One, S.NegativeOne):
-            res = acos(arg)*sqrt(arg - 1)/sqrt(1 - arg)
-            res = res._eval_nseries(x, n, logx=logx, cdir=cdir)
-            return res
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
@@ -1600,7 +1597,7 @@ class atanh(InverseHyperbolicFunction):
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
 
-        # Handling series on branch points
+        # Handling branch points
         if arg0 in (S.One, S.NegativeOne):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
@@ -1608,7 +1605,7 @@ class atanh(InverseHyperbolicFunction):
         if arg0 is S.ComplexInfinity:
             return res
 
-        # Handling series for points lying on branch cuts (-oo, -1] U [1, oo)
+        # Handling points lying on branch cuts (-oo, -1] U [1, oo)
         if (1 - arg0**2).is_negative:
             ndir = arg.dir(x, cdir if cdir else 1)
             if im(ndir).is_negative:
@@ -1930,8 +1927,8 @@ class asech(InverseHyperbolicFunction):
         # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)
-            ser = asech(S.One + t**2).rewrite(log).nseries(t, 0, 2*n)
-            arg1 = -S.One + self.args[0]
+            ser = asech(S.One - t**2).rewrite(log).nseries(t, 0, 2*n)
+            arg1 = S.One - self.args[0]
             f = arg1.as_leading_term(x)
             g = (arg1 - f)/ f
             if not g.is_meromorphic(x, 0):   # cannot be expanded
@@ -2149,7 +2146,7 @@ class acsch(InverseHyperbolicFunction):
             res = ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
             return res
 
-        if arg0 is S.NegativeOne*S.ImaginaryUnit:
+        if arg0 == S.NegativeOne*S.ImaginaryUnit:
             t = Dummy('t', positive=True)
             ser = acsch(-S.ImaginaryUnit + t**2).rewrite(log).nseries(t, 0, 2*n)
             arg1 = S.ImaginaryUnit + self.args[0]
@@ -2173,7 +2170,7 @@ class acsch(InverseHyperbolicFunction):
                     return -res - I*pi
             elif re(ndir).is_negative:
                 if im(arg0).is_negative:
-                    return -self.res + I*pi
+                    return -res + I*pi
             else:
                 return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1596,6 +1596,31 @@ class atanh(InverseHyperbolicFunction):
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
 
+    def _eval_nseries(self, x, n, logx, cdir=0):  # atanh
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling series on branch points
+        if arg0 in (S.One, S.NegativeOne):
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling series for points lying on branch cuts (-oo, -1] U [1, oo)
+        if (1 - arg0**2).is_negative:
+            ndir = arg.dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_negative:
+                    return res - I*pi
+            elif im(ndir).is_positive:
+                if arg0.is_positive:
+                    return res + I*pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
+
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + x) - log(1 - x)) / 2
 
@@ -1709,6 +1734,31 @@ class acoth(InverseHyperbolicFunction):
             else:
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):  # acoth
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling branch points
+        if arg0 in (S.One, S.NegativeOne):
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling points lying on branch cuts [-1, 1]
+        if arg0.is_real and (1 - arg0**2).is_positive:
+            ndir = arg.dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_positive:
+                    return res + I*pi
+            elif im(ndir).is_positive:
+                if arg0.is_negative:
+                    return res - I*pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + 1/x) - log(1 - 1/x)) / 2

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -2,6 +2,7 @@ from sympy.core import S, sympify, cacheit, pi, I, Rational
 from sympy.core.add import Add
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_or, fuzzy_and, FuzzyBool
+from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.factorials import (binomial, factorial,
                                                       RisingFactorial)
 from sympy.functions.combinatorial.numbers import bernoulli, euler, nC
@@ -1236,6 +1237,32 @@ class asinh(InverseHyperbolicFunction):
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
 
+    def _eval_nseries(self, x, n, logx, cdir=0):  # asinh
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling branch points
+        if arg0 in (S.ImaginaryUnit, -S.ImaginaryUnit):
+            res = I * asin(-I*arg)._eval_nseries(x, n, logx=logx, cdir=cdir)
+            return res.expand()
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling points lying on branch cuts (-I*oo, -I) U (I, I*oo)
+        if (1 + arg0**2).is_negative:
+            ndir = arg.dir(x, cdir if cdir else 1)
+            if re(ndir).is_positive:
+                if im(arg0).is_negative:
+                    return -res - I*pi
+            elif re(ndir).is_negative:
+                if im(arg0).is_positive:
+                    return -res + I*pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
+
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x**2 + 1))
 
@@ -1408,6 +1435,31 @@ class acosh(InverseHyperbolicFunction):
             elif not im(ndir).is_positive:
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):  # acosh
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling branch points
+        if arg0 in (S.One, S.NegativeOne):
+            res = acos(arg)*sqrt(arg - 1)/sqrt(1 - arg)
+            res = res._eval_nseries(x, n, logx=logx, cdir=cdir)
+            return res
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling points lying on branch cuts (-oo, 1)
+        if (arg0 - 1).is_negative:
+            ndir = arg.dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if (arg0 + 1).is_negative:
+                    return res - 2*I*pi
+                return -res
+            elif not im(ndir).is_positive:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x + 1) * sqrt(x - 1))
@@ -1820,6 +1872,51 @@ class asech(InverseHyperbolicFunction):
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
 
+    def _eval_nseries(self, x, n, logx, cdir=0):  # asech
+        from sympy.series.order import O
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling branch points
+        if arg0 is S.One:
+            t = Dummy('t', positive=True)
+            ser = asech(S.One + t**2).rewrite(log).nseries(t, 0, 2*n)
+            arg1 = -S.One + self.args[0]
+            f = arg1.as_leading_term(x)
+            g = (arg1 - f)/ f
+            if not g.is_meromorphic(x, 0):   # cannot be expanded
+                return O(1) if n == 0 else O(sqrt(x))
+            res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
+            res = (res1.removeO()*sqrt(f)).expand()
+            return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
+
+        if arg0 is S.NegativeOne:
+            t = Dummy('t', positive=True)
+            ser = asech(S.NegativeOne + t**2).rewrite(log).nseries(t, 0, 2*n)
+            arg1 = S.One + self.args[0]
+            f = arg1.as_leading_term(x)
+            g = (arg1 - f)/ f
+            if not g.is_meromorphic(x, 0):   # cannot be expanded
+                return O(1) if n == 0 else I*pi + O(sqrt(x))
+            res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
+            res = (res1.removeO()*sqrt(f)).expand()
+            return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling points lying on branch cuts (-oo, 0] U (1, oo)
+        if arg0.is_negative or (1 - arg0).is_negative:
+            ndir = arg.dir(x, cdir if cdir else 1)
+            if im(ndir).is_positive:
+                if arg0.is_positive or (arg0 + 1).is_negative:
+                    return -res
+                return res - 2*I*pi
+            elif not im(ndir).is_negative:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
+
     def inverse(self, argindex=1):
         """
         Returns the inverse of this function.
@@ -1982,6 +2079,54 @@ class acsch(InverseHyperbolicFunction):
             else:
                 return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return self.func(x0)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):  # acsch
+        from sympy.series.order import O
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+
+        # Handling branch points
+        if arg0 is S.ImaginaryUnit:
+            t = Dummy('t', positive=True)
+            ser = acsch(S.ImaginaryUnit + t**2).rewrite(log).nseries(t, 0, 2*n)
+            arg1 = -S.ImaginaryUnit + self.args[0]
+            f = arg1.as_leading_term(x)
+            g = (arg1 - f)/ f
+            if not g.is_meromorphic(x, 0):   # cannot be expanded
+                return O(1) if n == 0 else -I*pi/2 + O(sqrt(x))
+            res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
+            res = (res1.removeO()*sqrt(f)).expand()
+            res = ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
+            return res
+
+        if arg0 is S.NegativeOne*S.ImaginaryUnit:
+            t = Dummy('t', positive=True)
+            ser = acsch(-S.ImaginaryUnit + t**2).rewrite(log).nseries(t, 0, 2*n)
+            arg1 = S.ImaginaryUnit + self.args[0]
+            f = arg1.as_leading_term(x)
+            g = (arg1 - f)/ f
+            if not g.is_meromorphic(x, 0):   # cannot be expanded
+                return O(1) if n == 0 else I*pi/2 + O(sqrt(x))
+            res1 = sqrt(S.One + g)._eval_nseries(x, n=n, logx=logx)
+            res = (res1.removeO()*sqrt(f)).expand()
+            return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
+
+        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        if arg0 is S.ComplexInfinity:
+            return res
+
+        # Handling points lying on branch cuts (-I, I)
+        if arg0.is_imaginary and (1 + arg0**2).is_positive:
+            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            if re(ndir).is_positive:
+                if im(arg0).is_positive:
+                    return -res - I*pi
+            elif re(ndir).is_negative:
+                if im(arg0).is_negative:
+                    return -self.res + I*pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+        return res
 
     def inverse(self, argindex=1):
         """

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -141,10 +141,11 @@ class floor(RoundFunction):
             return arg.approximation_interval(Integer)[0]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0 is S.NaN:
+        if arg0 is S.NaN or isinstance(arg0, AccumBounds):
             arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             r = floor(arg0)
         if arg0.is_finite:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -306,10 +306,11 @@ class ceiling(RoundFunction):
             return arg.approximation_interval(Integer)[1]
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.calculus.accumulationbounds import AccumBounds
         arg = self.args[0]
         arg0 = arg.subs(x, 0)
         r = self.subs(x, 0)
-        if arg0 is S.NaN:
+        if arg0 is S.NaN or isinstance(arg0, AccumBounds):
             arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
             r = ceiling(arg0)
         if arg0.is_finite:

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -516,17 +516,34 @@ def test_log_nseries():
     assert log(I*x**2 + I*x**3 - 1)._eval_nseries(x, 3, None, 1) == I*pi - I*x**2 + O(x**3)
     assert log(I*x**2 + I*x**3 - 1)._eval_nseries(x, 3, None, -1) == I*pi - I*x**2 + O(x**3)
     assert log(2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, 1) == log(2) + log(x) + \
-    x*(S(3)/2 - I/2) - x**2*(S(3)/2 - I/2)**2/2 + O(x**3)
+    x*(S(3)/2 - I/2) + x**2*(-1 + 3*I/4) + O(x**3)
     assert log(2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, -1) == -2*I*pi + log(2) + \
-    log(x) - x*(-S(3)/2 + I/2) - x**2*(-S(3)/2 + I/2)**2/2 + O(x**3)
-    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, 1) == -I*pi + log(2) + \
-    log(x) + x*(-S(3)/2 + I/2) - x**2*(-S(3)/2 + I/2)**2/2 + O(x**3)
-    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, -1) == -I*pi + log(2) + \
-    log(x) - x*(S(3)/2 - I/2) - x**2*(S(3)/2 - I/2)**2/2 + O(x**3)
+    log(x) - x*(-S(3)/2 + I/2) + x**2*(-1 + 3*I/4) + O(x**3)
+    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, 1) == -I*pi + log(2) + log(x) + \
+    x*(-S(3)/2 + I/2) + x**2*(-1 + 3*I/4) + O(x**3)
+    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, -1) == -I*pi + log(2) + log(x) - \
+    x*(S(3)/2 - I/2) + x**2*(-1 + 3*I/4) + O(x**3)
     assert log(sqrt(-I*x**2 - 3)*sqrt(-I*x**2 - 1) - 2)._eval_nseries(x, 3, None, 1) == -I*pi + \
-    log(sqrt(3) + 2) + 2*sqrt(3)*I*x**2/(3*sqrt(3) + 6) + O(x**3)
+    log(sqrt(3) + 2) + I*x**2*(-2 + 4*sqrt(3)/3) + O(x**3)
     assert log(-1/(1 - x))._eval_nseries(x, 3, None, 1) == I*pi + x + x**2/2 + O(x**3)
     assert log(-1/(1 - x))._eval_nseries(x, 3, None, -1) == I*pi + x + x**2/2 + O(x**3)
+
+
+def test_log_series():
+    # Note Series at infinities other than oo/-oo were introduced as a part of
+    # pull request 23798. Refer https://github.com/sympy/sympy/pull/23798 for
+    # more information.
+    expr1 = log(1 + x)
+    expr2 = log(x + sqrt(x**2 + 1))
+
+    assert expr1.series(x, x0=I*oo, n=4) == 1/(3*x**3) - 1/(2*x**2) + 1/x + \
+    I*pi/2 - log(I/x) + O(x**(-4), (x, oo*I))
+    assert expr1.series(x, x0=-I*oo, n=4) == 1/(3*x**3) - 1/(2*x**2) + 1/x - \
+    I*pi/2 - log(-I/x) + O(x**(-4), (x, -oo*I))
+    assert expr2.series(x, x0=I*oo, n=4) == 1/(4*x**2) + I*pi/2 + log(2) - \
+    log(I/x) + O(x**(-4), (x, oo*I))
+    assert expr2.series(x, x0=-I*oo, n=4) == -1/(4*x**2) - I*pi/2 - log(2) + \
+    log(-I/x) + O(x**(-4), (x, -oo*I))
 
 
 def test_log_expand():

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -506,12 +506,27 @@ def test_log_leading_term():
 
 
 def test_log_nseries():
+    p = Symbol('p')
+    assert log(1/x)._eval_nseries(x, 4, logx=-p, cdir=1) == p
+    assert log(1/x)._eval_nseries(x, 4, logx=-p, cdir=-1) == p + 2*I*pi
     assert log(x - 1)._eval_nseries(x, 4, None, I) == I*pi - x - x**2/2 - x**3/3 + O(x**4)
     assert log(x - 1)._eval_nseries(x, 4, None, -I) == -I*pi - x - x**2/2 - x**3/3 + O(x**4)
     assert log(I*x + I*x**3 - 1)._eval_nseries(x, 3, None, 1) == I*pi - I*x + x**2/2 + O(x**3)
     assert log(I*x + I*x**3 - 1)._eval_nseries(x, 3, None, -1) == -I*pi - I*x + x**2/2 + O(x**3)
     assert log(I*x**2 + I*x**3 - 1)._eval_nseries(x, 3, None, 1) == I*pi - I*x**2 + O(x**3)
     assert log(I*x**2 + I*x**3 - 1)._eval_nseries(x, 3, None, -1) == I*pi - I*x**2 + O(x**3)
+    assert log(2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, 1) == log(2) + log(x) + \
+    x*(S(3)/2 - I/2) - x**2*(S(3)/2 - I/2)**2/2 + O(x**3)
+    assert log(2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, -1) == -2*I*pi + log(2) + \
+    log(x) - x*(-S(3)/2 + I/2) - x**2*(-S(3)/2 + I/2)**2/2 + O(x**3)
+    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, 1) == -I*pi + log(2) + \
+    log(x) + x*(-S(3)/2 + I/2) - x**2*(-S(3)/2 + I/2)**2/2 + O(x**3)
+    assert log(-2*x + (3 - I)*x**2)._eval_nseries(x, 3, None, -1) == -I*pi + log(2) + \
+    log(x) - x*(S(3)/2 - I/2) - x**2*(S(3)/2 - I/2)**2/2 + O(x**3)
+    assert log(sqrt(-I*x**2 - 3)*sqrt(-I*x**2 - 1) - 2)._eval_nseries(x, 3, None, 1) == -I*pi + \
+    log(sqrt(3) + 2) + 2*sqrt(3)*I*x**2/(3*sqrt(3) + 6) + O(x**3)
+    assert log(-1/(1 - x))._eval_nseries(x, 3, None, 1) == I*pi + x + x**2/2 + O(x**3)
+    assert log(-1/(1 - x))._eval_nseries(x, 3, None, -1) == I*pi + x + x**2/2 + O(x**3)
 
 
 def test_log_expand():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1055,6 +1055,33 @@ def test_atanh_series():
         x + x**3/3 + x**5/5 + x**7/7 + x**9/9 + O(x**10)
 
 
+def test_atanh_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert atanh(x + 1)._eval_nseries(x, 4, None, cdir=1) == -I*pi/2 + log(2)/2 - \
+    log(x)/2 + x/4 - x**2/16 + x**3/48 + O(x**4)
+    assert atanh(x + 1)._eval_nseries(x, 4, None, cdir=-1) == I*pi/2 + log(2)/2 - \
+    log(x)/2 + x/4 - x**2/16 + x**3/48 + O(x**4)
+    assert atanh(x - 1)._eval_nseries(x, 4, None, cdir=1) == -log(2)/2 + log(x)/2 + \
+    x/4 + x**2/16 + x**3/48 + O(x**4)
+    assert atanh(x - 1)._eval_nseries(x, 4, None, cdir=-1) == -log(2)/2 + log(x)/2 + \
+    x/4 + x**2/16 + x**3/48 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert atanh(I*x + 2)._eval_nseries(x, 4, None, cdir=1) == I*pi + atanh(2) - \
+    I*x/3 - 2*x**2/9 + 13*I*x**3/81 + O(x**4)
+    assert atanh(I*x + 2)._eval_nseries(x, 4, None, cdir=-1) == atanh(2) - I*x/3 - \
+    2*x**2/9 + 13*I*x**3/81 + O(x**4)
+    assert atanh(I*x - 2)._eval_nseries(x, 4, None, cdir=1) == -atanh(2) - I*x/3 + \
+    2*x**2/9 + 13*I*x**3/81 + O(x**4)
+    assert atanh(I*x - 2)._eval_nseries(x, 4, None, cdir=-1) == -atanh(2) - I*pi - \
+    I*x/3 + 2*x**2/9 + 13*I*x**3/81 + O(x**4)
+    # TODO: Tests concerning re(ndir) == 0
+    # atanh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=1) == -I*pi/2 - log(3)/2 - \
+    # x/3 + x**2*(-1/4 + I/2) + x**2*(1/36 - I/6) + x**3*(-1/6 + I/2) + x**3*(1/162 - I/18) + O(x**4)
+    # atanh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=-1) == -I*pi/2 - log(3)/2 - \
+    # x/3 + x**2*(-1/4 + I/2) + x**2*(1/36 - I/6) + x**3*(-1/6 + I/2) + x**3*(1/162 - I/18) + O(x**4)
+
+
 def test_atanh_fdiff():
     x = Symbol('x')
     raises(ArgumentIndexError, lambda: atanh(x).fdiff(2))
@@ -1131,6 +1158,31 @@ def test_acoth_series():
     x = Symbol('x')
     assert acoth(x).series(x, 0, 10) == \
         -I*pi/2 + x + x**3/3 + x**5/5 + x**7/7 + x**9/9 + O(x**10)
+
+
+def test_acoth_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert acoth(x + 1)._eval_nseries(x, 4, None) == log(2)/2 - log(x)/2 + x/4 - \
+    x**2/16 + x**3/48 + O(x**4)
+    assert acoth(x - 1)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 - log(2)/2 + \
+    log(x)/2 + x/4 + x**2/16 + x**3/48 + O(x**4)
+    assert acoth(x - 1)._eval_nseries(x, 4, None, cdir=-1) == -I*pi/2 - log(2)/2 + \
+    log(x)/2 + x/4 + x**2/16 + x**3/48 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert acoth(I*x + S(1)/2)._eval_nseries(x, 4, None, cdir=1) == acoth(S(1)/2) + \
+    4*I*x/3 - 8*x**2/9 - 112*I*x**3/81 + O(x**4)
+    assert acoth(I*x + S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == I*pi + \
+    acoth(S(1)/2) + 4*I*x/3 - 8*x**2/9 - 112*I*x**3/81 + O(x**4)
+    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=1) == -acoth(1/2) - \
+    I*pi + 4*I*x/3 + 8*x**2/9 - 112*I*x**3/81 + O(x**4)
+    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == -acoth(1/2) + \
+    4*I*x/3 + 8*x**2/9 - 112*I*x**3/81 + O(x**4)
+    # TODO: Tests concerning re(ndir) == 0
+    # acoth(-I*x**2 - x - S(1)/2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 - log(3)/2 - \
+    # 4*x/3 + x**2*(-8/9 + 2*I/3) - 2*I*x**2 + x**3*(104/81 - 16*I/9) - 8*x**3/3 + O(x**4)
+    # acoth(-I*x**2 - x - S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == I*pi/2 - log(3)/2 - \
+    # 4*x/3 + x**2*(-8/9 + 2*I/3) - 2*I*x**2 + x**3*(104/81 - 16*I/9) - 8*x**3/3 + O(x**4)
 
 
 def test_acoth_fdiff():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -594,12 +594,12 @@ def test_asinh_series():
 def test_asinh_nseries():
     x = Symbol('x')
     # Tests concerning branch points
-    assert asinh(x + I)._eval_nseries(x, 4, None) == I*pi/2 - \
-    sqrt(2)*I*sqrt(I*x) - sqrt(2)*I*(I*x)**(S(3)/2)/12 - 3*sqrt(2)*I*(I*x)**(S(5)/2)/160 - \
-    5*sqrt(2)*I*(I*x)**(S(7)/2)/896 + O(x**4)
+    assert asinh(x + I)._eval_nseries(x, 4, None) == I*pi/2 + \
+    sqrt(x)*(1 - I) + x**(S(3)/2)*(S(1)/12 + I/12) + x**(S(5)/2)*(-S(3)/160 + 3*I/160) + \
+    x**(S(7)/2)*(-S(5)/896 - 5*I/896) + O(x**4)
     assert asinh(x - I)._eval_nseries(x, 4, None) == -I*pi/2 + \
-    sqrt(2)*I*sqrt(-I*x) + sqrt(2)*I*(-I*x)**(S(3)/2)/12 + 3*sqrt(2)*I*(-I*x)**(S(5)/2)/160 + \
-    5*sqrt(2)*I*(-I*x)**(S(7)/2)/896 + O(x**4)
+    sqrt(x)*(1 + I) + x**(S(3)/2)*(S(1)/12 - I/12) + x**(S(5)/2)*(-S(3)/160 - 3*I/160) + \
+    x**(S(7)/2)*(-S(5)/896 + 5*I/896) + O(x**4)
     # Tests concerning points lying on branch cuts
     assert asinh(x + 2*I)._eval_nseries(x, 4, None, cdir=1) == I*asin(2) - \
     sqrt(3)*I*x/3 + sqrt(3)*x**2/9 + sqrt(3)*I*x**3/18 + O(x**4)
@@ -609,13 +609,9 @@ def test_asinh_nseries():
     sqrt(3)*I*x/3 + sqrt(3)*x**2/9 - sqrt(3)*I*x**3/18 + O(x**4)
     assert asinh(x - 2*I)._eval_nseries(x, 4, None, cdir=-1) == -I*asin(2) - \
     sqrt(3)*I*x/3 - sqrt(3)*x**2/9 + sqrt(3)*I*x**3/18 + O(x**4)
-    # TODO: Tests concerning re(ndir) == 0
-    # assert asinh(2*I + I*x - x**2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 + \
-    # log(2 - sqrt(3)) - sqrt(3)*x/3 - sqrt(3)*I*x**2/3 + sqrt(3)*x**2/9 + \
-    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
-    # assert asinh(2*I + I*x - x**2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 + \
-    # log(2 - sqrt(3)) - sqrt(3)*x/3 - sqrt(3)*I*x**2/3 + sqrt(3)*x**2/9 + \
-    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
+    # Tests concerning re(ndir) == 0
+    assert asinh(2*I + I*x - x**2)._eval_nseries(x, 4, None) == I*pi/2 + log(2 - sqrt(3)) - \
+    sqrt(3)*x/3 + x**2*(sqrt(3)/9 - sqrt(3)*I/3) + x**3*(-sqrt(3)/18 + 2*sqrt(3)*I/9) + O(x**4)
 
 
 def test_asinh_fdiff():
@@ -728,9 +724,8 @@ def test_acosh_series():
 def test_acosh_nseries():
     x = Symbol('x')
     # Tests concerning branch points
-    assert acosh(x + 1)._eval_nseries(x, 4, None) == -sqrt(2)*I*sqrt(-x) - \
-    sqrt(2)*I*(-x)**(S(3)/2)/12 - 3*sqrt(2)*I*(-x)**(S(5)/2)/160 - \
-    5*sqrt(2)*I*(-x)**(S(7)/2)/896 + O(x**4)
+    assert acosh(x + 1)._eval_nseries(x, 4, None) == sqrt(2)*sqrt(x) - \
+    sqrt(2)*x**(S(3)/2)/12 + 3*sqrt(2)*x**(S(5)/2)/160 - 5*sqrt(2)*x**(S(7)/2)/896 + O(x**4)
     # Tests concerning points lying on branch cuts
     assert acosh(x - 1)._eval_nseries(x, 4, None) == I*pi - \
     sqrt(2)*I*sqrt(x) - sqrt(2)*I*x**(S(3)/2)/12 - 3*sqrt(2)*I*x**(S(5)/2)/160 - \
@@ -743,13 +738,9 @@ def test_acosh_nseries():
     sqrt(2)*x/12 + 17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
     assert acosh(1/(I*x - 3))._eval_nseries(x, 4, None, cdir=-1) == acosh(-S(1)/3) - \
     sqrt(2)*x/12 - 17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
-    #     # TODO: Tests concerning re(ndir) == 0
-    # assert acosh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=1) == -I*pi + \
-    # log(sqrt(3) + 2) - sqrt(3)*x/3 + sqrt(3)*I*x**2/3 - sqrt(3)*x**2/9 + \
-    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
-    # assert acosh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=-1) == -I*pi + \
-    # log(sqrt(3) + 2) - sqrt(3)*x/3 + sqrt(3)*I*x**2/3 - sqrt(3)*x**2/9 + \
-    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
+    # Tests concerning im(ndir) == 0
+    assert acosh(-I*x**2 + x - 2)._eval_nseries(x, 4, None) == -I*pi + log(sqrt(3) + 2) - \
+    sqrt(3)*x/3 + x**2*(-sqrt(3)/9 + sqrt(3)*I/3) + x**3*(-sqrt(3)/18 + 2*sqrt(3)*I/9) + O(x**4)
 
 
 def test_acosh_fdiff():
@@ -837,11 +828,34 @@ def test_asech_leading_term():
 
 def test_asech_series():
     x = Symbol('x')
-    assert asech(x).series(x, 0, 9) == log(2) - log(x) - x**2/4 - 3*x**4/32 \
+    assert asech(x).series(x, 0, 9, cdir=1) == log(2) - log(x) - x**2/4 - 3*x**4/32 \
     - 5*x**6/96 - 35*x**8/1024 + O(x**9)
+    assert asech(x).series(x, 0, 9, cdir=-1) == I*pi + log(2) - log(-x) - x**2/4 - \
+    3*x**4/32 - 5*x**6/96 - 35*x**8/1024 + O(x**9)
     t6 = asech(x).taylor_term(6, x)
     assert t6 == -5*x**6/96
     assert asech(x).taylor_term(8, x, t6, 0) == -35*x**8/1024
+
+
+def test_asech_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert asech(x + 1)._eval_nseries(x, 4, None) == sqrt(2)*sqrt(-x) + 5*sqrt(2)*(-x)**(S(3)/2)/12 + \
+    43*sqrt(2)*(-x)**(S(5)/2)/160 + 177*sqrt(2)*(-x)**(S(7)/2)/896 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert asech(x - 1)._eval_nseries(x, 4, None) == I*pi + sqrt(2)*sqrt(x) + \
+    5*sqrt(2)*x**(S(3)/2)/12 + 43*sqrt(2)*x**(S(5)/2)/160 + 177*sqrt(2)*x**(S(7)/2)/896 + O(x**4)
+    assert asech(I*x + 3)._eval_nseries(x, 4, None) == -asech(3) + sqrt(2)*x/12 - \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(-I*x + 3)._eval_nseries(x, 4, None) == asech(3) + sqrt(2)*x/12 + \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(I*x - 3)._eval_nseries(x, 4, None) == -asech(-3) - sqrt(2)*x/12 - \
+    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(-I*x - 3)._eval_nseries(x, 4, None) == asech(-3) - sqrt(2)*x/12 + \
+    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
+    # Tests concerning im(ndir) == 0
+    assert asech(-I*x**2 + x - 2)._eval_nseries(x, 3, None) == 2*I*pi/3 + sqrt(3)*I*x/6 + \
+    x**2*(sqrt(3)/6 + 7*sqrt(3)*I/72) + O(x**3)
 
 
 def test_asech_rewrite():
@@ -948,6 +962,30 @@ def test_acsch_series():
     t4 = acsch(x).taylor_term(4, x)
     assert t4 == -3*x**4/32
     assert acsch(x).taylor_term(6, x, t4, 0) == 5*x**6/96
+
+
+def test_acsch_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert acsch(x + I)._eval_nseries(x, 4, None) == -I*pi/2 + I*sqrt(x) + \
+    sqrt(x) + 5*I*x**(S(3)/2)/12 - 5*x**(S(3)/2)/12 - 43*I*x**(S(5)/2)/160 - \
+    43*x**(S(5)/2)/160 - 177*I*x**(S(7)/2)/896 + 177*x**(S(7)/2)/896 + O(x**4)
+    assert acsch(x - I)._eval_nseries(x, 4, None) == I*pi/2 - I*sqrt(x) + \
+    sqrt(x) - 5*I*x**(S(3)/2)/12 - 5*x**(S(3)/2)/12 + 43*I*x**(S(5)/2)/160 - \
+    43*x**(S(5)/2)/160 + 177*I*x**(S(7)/2)/896 + 177*x**(S(7)/2)/896 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert acsch(x + I/2)._eval_nseries(x, 4, None, cdir=1) == -acsch(I/2) - \
+    I*pi + 4*sqrt(3)*I*x/3 - 8*sqrt(3)*x**2/9 - 16*sqrt(3)*I*x**3/9 + O(x**4)
+    assert acsch(x + I/2)._eval_nseries(x, 4, None, cdir=-1) == acsch(I/2) - \
+    4*sqrt(3)*I*x/3 + 8*sqrt(3)*x**2/9 + 16*sqrt(3)*I*x**3/9 + O(x**4)
+    assert acsch(x - I/2)._eval_nseries(x, 4, None, cdir=1) == -acsch(I/2) - \
+    4*sqrt(3)*I*x/3 - 8*sqrt(3)*x**2/9 + 16*sqrt(3)*I*x**3/9 + O(x**4)
+    assert acsch(x - I/2)._eval_nseries(x, 4, None, cdir=-1) == I*pi + \
+    acsch(I/2) + 4*sqrt(3)*I*x/3 + 8*sqrt(3)*x**2/9 - 16*sqrt(3)*I*x**3/9 + O(x**4)
+    # TODO: Tests concerning re(ndir) == 0
+    assert acsch(I/2 + I*x - x**2)._eval_nseries(x, 4, None) == -I*pi/2 + \
+    log(2 - sqrt(3)) + 4*sqrt(3)*x/3 + x**2*(-8*sqrt(3)/9 + 4*sqrt(3)*I/3) + \
+    x**3*(16*sqrt(3)/9 - 16*sqrt(3)*I/9) + O(x**4)
 
 
 def test_acsch_rewrite():
@@ -1075,11 +1113,9 @@ def test_atanh_nseries():
     2*x**2/9 + 13*I*x**3/81 + O(x**4)
     assert atanh(I*x - 2)._eval_nseries(x, 4, None, cdir=-1) == -atanh(2) - I*pi - \
     I*x/3 + 2*x**2/9 + 13*I*x**3/81 + O(x**4)
-    # TODO: Tests concerning re(ndir) == 0
-    # atanh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=1) == -I*pi/2 - log(3)/2 - \
-    # x/3 + x**2*(-1/4 + I/2) + x**2*(1/36 - I/6) + x**3*(-1/6 + I/2) + x**3*(1/162 - I/18) + O(x**4)
-    # atanh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=-1) == -I*pi/2 - log(3)/2 - \
-    # x/3 + x**2*(-1/4 + I/2) + x**2*(1/36 - I/6) + x**3*(-1/6 + I/2) + x**3*(1/162 - I/18) + O(x**4)
+    # Tests concerning im(ndir) == 0
+    assert atanh(-I*x**2 + x - 2)._eval_nseries(x, 4, None) == -I*pi/2 - log(3)/2 - x/3 + \
+    x**2*(-S(1)/4 + I/2) + x**2*(S(1)/36 - I/6) + x**3*(-S(1)/6 + I/2) + x**3*(S(1)/162 - I/18) + O(x**4)
 
 
 def test_atanh_fdiff():
@@ -1174,15 +1210,13 @@ def test_acoth_nseries():
     4*I*x/3 - 8*x**2/9 - 112*I*x**3/81 + O(x**4)
     assert acoth(I*x + S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == I*pi + \
     acoth(S(1)/2) + 4*I*x/3 - 8*x**2/9 - 112*I*x**3/81 + O(x**4)
-    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=1) == -acoth(1/2) - \
+    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=1) == -acoth(S(1)/2) - \
     I*pi + 4*I*x/3 + 8*x**2/9 - 112*I*x**3/81 + O(x**4)
-    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == -acoth(1/2) + \
+    assert acoth(I*x - S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == -acoth(S(1)/2) + \
     4*I*x/3 + 8*x**2/9 - 112*I*x**3/81 + O(x**4)
-    # TODO: Tests concerning re(ndir) == 0
-    # acoth(-I*x**2 - x - S(1)/2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 - log(3)/2 - \
-    # 4*x/3 + x**2*(-8/9 + 2*I/3) - 2*I*x**2 + x**3*(104/81 - 16*I/9) - 8*x**3/3 + O(x**4)
-    # acoth(-I*x**2 - x - S(1)/2)._eval_nseries(x, 4, None, cdir=-1) == I*pi/2 - log(3)/2 - \
-    # 4*x/3 + x**2*(-8/9 + 2*I/3) - 2*I*x**2 + x**3*(104/81 - 16*I/9) - 8*x**3/3 + O(x**4)
+    # Tests concerning im(ndir) == 0
+    assert acoth(-I*x**2 - x - S(1)/2)._eval_nseries(x, 4, None) == I*pi/2 - log(3)/2 - \
+    4*x/3 + x**2*(-S(8)/9 + 2*I/3) - 2*I*x**2 + x**3*(S(104)/81 - 16*I/9) - 8*x**3/3 + O(x**4)
 
 
 def test_acoth_fdiff():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -591,6 +591,33 @@ def test_asinh_series():
     assert asinh(x).taylor_term(7, x, t5, 0) == -5*x**7/112
 
 
+def test_asinh_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert asinh(x + I)._eval_nseries(x, 4, None) == I*pi/2 - \
+    sqrt(2)*I*sqrt(I*x) - sqrt(2)*I*(I*x)**(S(3)/2)/12 - 3*sqrt(2)*I*(I*x)**(S(5)/2)/160 - \
+    5*sqrt(2)*I*(I*x)**(S(7)/2)/896 + O(x**4)
+    assert asinh(x - I)._eval_nseries(x, 4, None) == -I*pi/2 + \
+    sqrt(2)*I*sqrt(-I*x) + sqrt(2)*I*(-I*x)**(S(3)/2)/12 + 3*sqrt(2)*I*(-I*x)**(S(5)/2)/160 + \
+    5*sqrt(2)*I*(-I*x)**(S(7)/2)/896 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert asinh(x + 2*I)._eval_nseries(x, 4, None, cdir=1) == I*asin(2) - \
+    sqrt(3)*I*x/3 + sqrt(3)*x**2/9 + sqrt(3)*I*x**3/18 + O(x**4)
+    assert asinh(x + 2*I)._eval_nseries(x, 4, None, cdir=-1) == I*pi - I*asin(2) + \
+    sqrt(3)*I*x/3 - sqrt(3)*x**2/9 - sqrt(3)*I*x**3/18 + O(x**4)
+    assert asinh(x - 2*I)._eval_nseries(x, 4, None, cdir=1) == I*asin(2) - I*pi + \
+    sqrt(3)*I*x/3 + sqrt(3)*x**2/9 - sqrt(3)*I*x**3/18 + O(x**4)
+    assert asinh(x - 2*I)._eval_nseries(x, 4, None, cdir=-1) == -I*asin(2) - \
+    sqrt(3)*I*x/3 - sqrt(3)*x**2/9 + sqrt(3)*I*x**3/18 + O(x**4)
+    # TODO: Tests concerning re(ndir) == 0
+    # assert asinh(2*I + I*x - x**2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 + \
+    # log(2 - sqrt(3)) - sqrt(3)*x/3 - sqrt(3)*I*x**2/3 + sqrt(3)*x**2/9 + \
+    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
+    # assert asinh(2*I + I*x - x**2)._eval_nseries(x, 4, None, cdir=1) == I*pi/2 + \
+    # log(2 - sqrt(3)) - sqrt(3)*x/3 - sqrt(3)*I*x**2/3 + sqrt(3)*x**2/9 + \
+    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
+
+
 def test_asinh_fdiff():
     x = Symbol('x')
     raises(ArgumentIndexError, lambda: asinh(x).fdiff(2))
@@ -696,6 +723,33 @@ def test_acosh_series():
     t5 = acosh(x).taylor_term(5, x)
     assert t5 == - 3*I*x**5/40
     assert acosh(x).taylor_term(7, x, t5, 0) == - 5*I*x**7/112
+
+
+def test_acosh_nseries():
+    x = Symbol('x')
+    # Tests concerning branch points
+    assert acosh(x + 1)._eval_nseries(x, 4, None) == -sqrt(2)*I*sqrt(-x) - \
+    sqrt(2)*I*(-x)**(S(3)/2)/12 - 3*sqrt(2)*I*(-x)**(S(5)/2)/160 - \
+    5*sqrt(2)*I*(-x)**(S(7)/2)/896 + O(x**4)
+    # Tests concerning points lying on branch cuts
+    assert acosh(x - 1)._eval_nseries(x, 4, None) == I*pi - \
+    sqrt(2)*I*sqrt(x) - sqrt(2)*I*x**(S(3)/2)/12 - 3*sqrt(2)*I*x**(S(5)/2)/160 - \
+    5*sqrt(2)*I*x**(S(7)/2)/896 + O(x**4)
+    assert acosh(I*x - 2)._eval_nseries(x, 4, None, cdir=1) == acosh(-2) - \
+    sqrt(3)*I*x/3 + sqrt(3)*x**2/9 + sqrt(3)*I*x**3/18 + O(x**4)
+    assert acosh(-I*x - 2)._eval_nseries(x, 4, None, cdir=1) == acosh(-2) - \
+    2*I*pi + sqrt(3)*I*x/3 + sqrt(3)*x**2/9 - sqrt(3)*I*x**3/18 + O(x**4)
+    assert acosh(1/(I*x - 3))._eval_nseries(x, 4, None, cdir=1) == -acosh(-S(1)/3) + \
+    sqrt(2)*x/12 + 17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert acosh(1/(I*x - 3))._eval_nseries(x, 4, None, cdir=-1) == acosh(-S(1)/3) - \
+    sqrt(2)*x/12 - 17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
+    #     # TODO: Tests concerning re(ndir) == 0
+    # assert acosh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=1) == -I*pi + \
+    # log(sqrt(3) + 2) - sqrt(3)*x/3 + sqrt(3)*I*x**2/3 - sqrt(3)*x**2/9 + \
+    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
+    # assert acosh(-I*x**2 + x - 2)._eval_nseries(x, 4, None, cdir=-1) == -I*pi + \
+    # log(sqrt(3) + 2) - sqrt(3)*x/3 + sqrt(3)*I*x**2/3 - sqrt(3)*x**2/9 + \
+    # 2*sqrt(3)*I*x**3/9 - sqrt(3)*x**3/18 + O(x**4)
 
 
 def test_acosh_fdiff():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1973,7 +1973,7 @@ def test_atan_nseries():
     2*I*x**2/9 + 13*x**3/81 + O(x**4)
     assert atan(1/x)._eval_nseries(x, 2, None, 1) == pi/2 - x + O(x**2)
     assert atan(1/x)._eval_nseries(x, 2, None, -1) == -pi/2 - x + O(x**2)
-    # testing nseries for asin at branch points
+    # testing nseries for atan at branch points
     assert atan(x + I)._eval_nseries(x, 4, None) == I*log(2)/2 + pi/4 - \
     I*log(x)/2 + x/4 + I*x**2/16 - x**3/48 + O(x**4)
     assert atan(x - I)._eval_nseries(x, 4, None) == -I*log(2)/2 + pi/4 + \
@@ -1991,7 +1991,7 @@ def test_acot_nseries():
     pi - 4*x/3 - 8*I*x**2/9 + 112*x**3/81 + O(x**4)
     assert acot(x)._eval_nseries(x, 2, None, 1) == pi/2 - x + O(x**2)
     assert acot(x)._eval_nseries(x, 2, None, -1) == -pi/2 - x + O(x**2)
-    # testing nseries for asin at branch points
+    # testing nseries for acot at branch points
     assert acot(x + I)._eval_nseries(x, 4, None) == -I*log(2)/2 + pi/4 + \
     I*log(x)/2 - x/4 - I*x**2/16 + x**3/48 + O(x**4)
     assert acot(x - I)._eval_nseries(x, 4, None) == I*log(2)/2 + pi/4 - \

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1973,6 +1973,11 @@ def test_atan_nseries():
     2*I*x**2/9 + 13*x**3/81 + O(x**4)
     assert atan(1/x)._eval_nseries(x, 2, None, 1) == pi/2 - x + O(x**2)
     assert atan(1/x)._eval_nseries(x, 2, None, -1) == -pi/2 - x + O(x**2)
+    # testing nseries for asin at branch points
+    assert atan(x + I)._eval_nseries(x, 4, None) == I*log(2)/2 + pi/4 - \
+    I*log(x)/2 + x/4 + I*x**2/16 - x**3/48 + O(x**4)
+    assert atan(x - I)._eval_nseries(x, 4, None) == -I*log(2)/2 + pi/4 + \
+    I*log(x)/2 + x/4 - I*x**2/16 - x**3/48 + O(x**4)
 
 
 def test_acot_nseries():
@@ -1986,6 +1991,11 @@ def test_acot_nseries():
     pi - 4*x/3 - 8*I*x**2/9 + 112*x**3/81 + O(x**4)
     assert acot(x)._eval_nseries(x, 2, None, 1) == pi/2 - x + O(x**2)
     assert acot(x)._eval_nseries(x, 2, None, -1) == -pi/2 - x + O(x**2)
+    # testing nseries for asin at branch points
+    assert acot(x + I)._eval_nseries(x, 4, None) == -I*log(2)/2 + pi/4 + \
+    I*log(x)/2 - x/4 - I*x**2/16 + x**3/48 + O(x**4)
+    assert acot(x - I)._eval_nseries(x, 4, None) == I*log(2)/2 + pi/4 - \
+    I*log(x)/2 - x/4 + I*x**2/16 + x**3/48 + O(x**4)
 
 
 def test_asec_nseries():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2341,6 +2341,7 @@ class asin(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # asin
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
+        # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)
             ser = asin(S.One - t**2).rewrite(log).nseries(t, 0, 2*n)
@@ -2368,12 +2369,17 @@ class asin(InverseTrigonometricFunction):
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
-        if im(cdir) < 0 and arg0.is_real and arg0 < S.NegativeOne:
-            return -pi - res
-        elif im(cdir) > 0 and arg0.is_real and arg0 > S.One:
-            return pi - res
+        # Handling points lying on branch cuts (-oo, -1) U (1, oo)
+        if (1 - arg0**2).is_negative:
+            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_negative:
+                    return -pi - res
+            elif im(ndir).is_positive:
+                if arg0.is_positive:
+                    return pi - res
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_rewrite_as_acos(self, x, **kwargs):
@@ -2558,6 +2564,7 @@ class acos(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # acos
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
+        # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)
             ser = acos(S.One - t**2).rewrite(log).nseries(t, 0, 2*n)
@@ -2585,12 +2592,17 @@ class acos(InverseTrigonometricFunction):
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
-        if im(cdir) < 0 and arg0.is_real and arg0 < S.NegativeOne:
-            return 2*pi - res
-        elif im(cdir) > 0 and arg0.is_real and arg0 > S.One:
-            return -res
+        # Handling points lying on branch cuts (-oo, -1) U (1, oo)
+        if (1 - arg0**2).is_negative:
+            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_negative:
+                    return 2*pi - res
+            elif im(ndir).is_positive:
+                if arg0.is_positive:
+                    return -res
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
@@ -2784,16 +2796,21 @@ class atan(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # atan
         arg0 = self.args[0].subs(x, 0)
         res = Function._eval_nseries(self, x, n=n, logx=logx)
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
+        ndir = self.args[0].dir(x, cdir if cdir else 1)
         if arg0 is S.ComplexInfinity:
-            if re(cdir) > 0:
+            if re(ndir) > 0:
                 return res - pi
             return res
-        if re(cdir) < 0 and re(arg0).is_zero and im(arg0) > S.One:
-            return res - pi
-        elif re(cdir) > 0 and re(arg0).is_zero and im(arg0) < S.NegativeOne:
-            return res + pi
+        # Handling points lying on branch cuts (-I*oo, -I) U (I, I*oo)
+        if (1 + arg0**2).is_negative:
+            if re(ndir).is_negative:
+                if im(arg0).is_positive:
+                    return res - pi
+            elif re(ndir).is_positive:
+                if im(arg0).is_negative:
+                    return res + pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_rewrite_as_log(self, x, **kwargs):
@@ -2991,16 +3008,21 @@ class acot(InverseTrigonometricFunction):
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
+        ndir = self.args[0].dir(x, cdir if cdir else 1)
         if arg0.is_zero:
-            if re(cdir) < 0:
+            if re(ndir) < 0:
                 return res - pi
             return res
-        if re(cdir) > 0 and re(arg0).is_zero and im(arg0) > S.Zero and im(arg0) < S.One:
-            return res + pi
-        if re(cdir) < 0 and re(arg0).is_zero and im(arg0) < S.Zero and im(arg0) > S.NegativeOne:
-            return res - pi
+        # Handling points lying on branch cuts [-I, I]
+        if arg0.is_imaginary and (1 + arg0**2).is_positive:
+            if re(ndir).is_positive:
+                if im(arg0).is_positive:
+                    return res + pi
+            elif re(ndir).is_negative:
+                if im(arg0).is_negative:
+                    return res - pi
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_aseries(self, n, args0, x, logx):
@@ -3192,6 +3214,7 @@ class asec(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # asec
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
+        # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)
             ser = asec(S.One + t**2).rewrite(log).nseries(t, 0, 2*n)
@@ -3215,12 +3238,17 @@ class asec(InverseTrigonometricFunction):
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
-        if im(cdir) < 0 and arg0.is_real and arg0 > S.Zero and arg0 < S.One:
-            return -res
-        elif im(cdir) > 0 and arg0.is_real and arg0 < S.Zero and arg0 > S.NegativeOne:
-            return 2*pi - res
+        # Handling points lying on branch cuts (-1, 1)
+        if arg0.is_real and (1 - arg0**2).is_positive:
+            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_positive:
+                    return -res
+            elif im(ndir).is_positive:
+                if arg0.is_negative:
+                    return 2*pi - res
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_is_extended_real(self):
@@ -3394,6 +3422,7 @@ class acsc(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # acsc
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
+        # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)
             ser = acsc(S.One + t**2).rewrite(log).nseries(t, 0, 2*n)
@@ -3417,12 +3446,17 @@ class acsc(InverseTrigonometricFunction):
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        if cdir != 0:
-            cdir = self.args[0].dir(x, cdir)
-        if im(cdir) < 0 and arg0.is_real and arg0 > S.Zero and arg0 < S.One:
-            return pi - res
-        elif im(cdir) > 0 and arg0.is_real and arg0 < S.Zero and arg0 > S.NegativeOne:
-            return -pi - res
+        # Handling points lying on branch cuts (-1, 1)
+        if arg0.is_real and (1 - arg0**2).is_positive:
+            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            if im(ndir).is_negative:
+                if arg0.is_positive:
+                    return pi - res
+            elif im(ndir).is_positive:
+                if arg0.is_negative:
+                    return -pi - res
+            else:
+                return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
         return res
 
     def _eval_rewrite_as_log(self, arg, **kwargs):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2795,6 +2795,11 @@ class atan(InverseTrigonometricFunction):
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # atan
         arg0 = self.args[0].subs(x, 0)
+
+        # Handling branch points
+        if arg0 in (S.ImaginaryUnit, S.NegativeOne*S.ImaginaryUnit):
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         ndir = self.args[0].dir(x, cdir if cdir else 1)
         if arg0 is S.ComplexInfinity:
@@ -3005,6 +3010,11 @@ class acot(InverseTrigonometricFunction):
 
     def _eval_nseries(self, x, n, logx, cdir=0):  # acot
         arg0 = self.args[0].subs(x, 0)
+
+        # Handling branch points
+        if arg0 in (S.ImaginaryUnit, S.NegativeOne*S.ImaginaryUnit):
+            return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
+
         res = Function._eval_nseries(self, x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -183,11 +183,11 @@ class Order(Expr):
             if any(p != point[0] for p in point):
                 raise NotImplementedError(
                     "Multivariable orders at different points are not supported.")
-            if point[0] is S.Infinity:
+            if point[0] in (S.Infinity, S.Infinity*S.ImaginaryUnit):
                 s = {k: 1/Dummy() for k in variables}
                 rs = {1/v: 1/k for k, v in s.items()}
                 ps = [S.Zero for p in point]
-            elif point[0] is S.NegativeInfinity:
+            elif point[0] in (S.NegativeInfinity, S.NegativeInfinity*S.ImaginaryUnit):
                 s = {k: -1/Dummy() for k in variables}
                 rs = {-1/v: -1/k for k, v in s.items()}
                 ps = [S.Zero for p in point]

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -194,6 +194,10 @@ def test_floor():
     assert limit(x*floor(3/x)/2, x, 0, '+') == Rational(3, 2)
     assert limit(floor(x + 1/2) - floor(x), x, oo) == AccumBounds(-S.Half, S(3)/2)
 
+    # test issue 9158
+    assert limit(floor(atan(x)), x, oo) == 1
+    assert limit(floor(atan(x)), x, -oo) == -2
+
 
 def test_floor_requires_robust_assumptions():
     assert limit(floor(sin(x)), x, 0, "+") == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -197,6 +197,8 @@ def test_floor():
     # test issue 9158
     assert limit(floor(atan(x)), x, oo) == 1
     assert limit(floor(atan(x)), x, -oo) == -2
+    assert limit(ceiling(atan(x)), x, oo) == 2
+    assert limit(ceiling(atan(x)), x, -oo) == -1
 
 
 def test_floor_requires_robust_assumptions():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -475,6 +475,16 @@ def test_dir():
     assert sin(x + y).series(x, 0, dir='-') == sin(x + y).series(x, 0, dir='+')
 
 
+def test_cdir():
+    assert abs(x).series(x, 0, cdir=1) == x
+    assert abs(x).series(x, 0, cdir=-1) == -x
+    assert floor(x + 2).series(x, 0, cdir=1) == 2
+    assert floor(x + 2).series(x, 0, cdir=-1) == 1
+    assert floor(x + 2.2).series(x, 0, cdir=1) == 2
+    assert ceiling(x + 2.2).series(x, 0, cdir=-1) == 3
+    assert sin(x + y).series(x, 0, cdir=-1) == sin(x + y).series(x, 0, cdir=1)
+
+
 def test_issue_3504():
     a = Symbol("a")
     e = asin(a*x)/x


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #9158

#### Brief description of what is fixed or changed
This pr is attempting to complete nseries implementation for all pending inverse functions and refactor nseries for the log function on the way.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed log._eval_nseries method to perform correctly while dealing with points on branch cuts.
  * Implemented _eval_nseries method for all inverse hyperbolic functions along with atan, acot function.
  * Refactored series method in expr.py to use the cdir parameter effectively.
  * Fixed leading term method for floor and ceiling function to handle arguments of type AccumBounds.
<!-- END RELEASE NOTES -->
