### PR TITLE
ENH: drop validation of transformations in parse_expr to save time when called in intensive loops

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -431,6 +431,7 @@ Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
 Christopher Dembia <cld72@cornell.edu>
 Christopher J. Wright <cjwright4242gh@gmail.com>
 Clemens Novak <clemens@familie-novak.net>
+Clément M.T. Robert <cr52@protonmail.com>
 Coder-RG <rgoel1999@gmail.com> Rishabh Goel <rgoel1999@gmail.com>
 Cody Herbst <cyherbst@gmail.com>
 Colin B. Macdonald <cbm@m.fsf.org>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -16,9 +16,8 @@ from typing import Tuple as tTuple, Dict as tDict, Any, Callable, \
 from sympy.assumptions.ask import AssumptionKeys
 from sympy.core.basic import Basic
 from sympy.core import Symbol
-from sympy.core.function import arity, Function
-from sympy.utilities.iterables import iterable
-from sympy.utilities.misc import filldedent, func_name
+from sympy.core.function import Function
+from sympy.utilities.misc import func_name
 from sympy.functions.elementary.miscellaneous import Max, Min
 
 
@@ -1069,19 +1068,6 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
             raise ValueError('unknown transformation group name')
     else:
         _transformations = transformations
-    if _transformations:
-        if not iterable(_transformations):
-            raise TypeError(
-                '`transformations` should be a list of functions.')
-        for _ in _transformations:
-            if not callable(_):
-                raise TypeError(filldedent('''
-                    expected a function in `transformations`,
-                    not %s''' % func_name(_)))
-            if arity(_) != 3:
-                raise TypeError(filldedent('''
-                    a transformation should be function that
-                    takes 3 arguments'''))
 
     code = stringify_expr(s, local_dict, global_dict, _transformations)
 


### PR DESCRIPTION
#### References to other Issues or PRs

None.

#### Brief description of what is fixed or changed

I noticed that validation of transformations takes about half of `parse_expr` runtime (specifically `sympy.core.function.arity` is very expensive)
In unyt, this function is called in an intensive loop (several thousands calls) at import time, with hard coded transformations, see

https://github.com/yt-project/unyt/blob/577fd554f3171b85589690f4e563bad30a84340c/unyt/_parsing.py#L92-L95

In the end, this builds up to a few 0.1s wasted every single time unyt is imported. For reference, it's on par with the import time of numpy.
So I propose allowing to skip validation as an opt-out.

#### Other comments

I'm hoping this small patch is an acceptable solution for this external problem.
If not, I'll be happy to discuss and work on other possible solutions with you.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
    * Removed the validation of transformers in `parse_expr`, for performance purposes.
<!-- END RELEASE NOTES -->
