### PR TITLE
Tweak solve an equation algebraically guide

### DIFF
--- a/doc/src/guides/solving/solve-equation-algebraically.md
+++ b/doc/src/guides/solving/solve-equation-algebraically.md
@@ -18,7 +18,7 @@ There are two high-level functions to solve equations, {func}`~.solve` and
 ```py
 >>> from sympy.abc import x, y
 >>> from sympy import solve
->>> solve(x ** 2 - y, x, dict=True)
+>>> solve(x**2 - y, x, dict=True)
 [{x: -sqrt(y)}, {x: sqrt(y)}]
 ```
 
@@ -64,7 +64,7 @@ and SymPy will solve for $y$:
 ```py
 >>> from sympy.abc import x, y
 >>> from sympy import solve
->>> solve(x ** 2 - y, dict=True)
+>>> solve(x**2 - y, dict=True)
 [{y: x**2}]
 ```
 
@@ -73,7 +73,7 @@ Specifying the variable to solve for ensures that SymPy solves for it:
 ```py
 >>> from sympy.abc import x, y
 >>> from sympy import solve
->>> solve(x ** 2 - y, x, dict=True)
+>>> solve(x**2 - y, x, dict=True)
 [{x: -sqrt(y)}, {x: sqrt(y)}]
 ```
 
@@ -103,7 +103,7 @@ $expression = 0$.
 ```py
 >>> from sympy import solve, solveset
 >>> from sympy.abc import x, y
->>> solve(x ** 2 - y, x, dict=True)
+>>> solve(x**2 - y, x, dict=True)
 [{x: -sqrt(y)}, {x: sqrt(y)}]
 >>> solveset(x**2 - y, x)
 {-sqrt(y), sqrt(y)}
@@ -143,9 +143,9 @@ real, and the last two are imaginary:
 ```py
 >>> from sympy import Symbol, solve, solveset
 >>> x = Symbol('x')
->>> solve(x ** 4 - 256, x, dict=True)
+>>> solve(x**4 - 256, x, dict=True)
 [{x: -4}, {x: 4}, {x: -4*I}, {x: 4*I}]
->>> solveset(x ** 4 - 256, x)
+>>> solveset(x**4 - 256, x)
 {-4, 4, -4*I, 4*I}
 ```
 
@@ -157,7 +157,7 @@ For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
 ```py
 >>> from sympy import Symbol, solve
 >>> x = Symbol('x', real=True)
->>> solve(x ** 4 - 256, x, dict=True)
+>>> solve(x**4 - 256, x, dict=True)
 [{x: -4}, {x: 4}]
 ```
 

--- a/doc/src/guides/solving/solve-equation-algebraically.md
+++ b/doc/src/guides/solving/solve-equation-algebraically.md
@@ -1,16 +1,16 @@
 # Solve an equation algebraically
 
-Use SymPy to solve an equation algebraically (symbolically). For example, solving $x^2 = y$ for $x$ yields $x \in \{-\sqrt{y},\sqrt{y}\}$.
+Use SymPy to solve an equation algebraically (symbolically). For example,
+solving $x^2 = y$ for $x$ yields $x \in \{-\sqrt{y},\sqrt{y}\}$.
 
 Alternatives to consider:
-- SymPy can also 
-[solve many other types of problems including sets of equations](index.md).
-- Some equations cannot be solved algebraically (either at all or by SymPy), 
-so you may have to 
-{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>` 
-instead.
+- SymPy can also [solve many other types of problems including sets of
+equations](index.md).
+- Some equations cannot be solved algebraically (either at all or by SymPy), so
+you may have to {func}`solve your equation numerically
+<sympy.solvers.solvers.nsolve>` instead.
 
-There are two high-level functions to solve equations, {func}`~.solve` and 
+There are two high-level functions to solve equations, {func}`~.solve` and
 {func}`~.solveset`. Here is a simple example of each:
 
 {func}`~.solve`
@@ -34,32 +34,31 @@ There are two high-level functions to solve equations, {func}`~.solve` and
 Here are recommendations on when to use:
 
 - {func}`~.solve`
-    - You want to get explicit symbolic representations of the different 
-    values a variable could take that would satisfy the equation.
-    - You want to substitute those explicit solution values into other 
-    equations or expressions involving the same variable using 
+    - You want to get explicit symbolic representations of the different values
+    a variable could take that would satisfy the equation.
+    - You want to substitute those explicit solution values into other equations
+    or expressions involving the same variable using
     {meth}`~sympy.core.basic.Basic.subs`
 
 - {func}`~.solveset`
-    - You want to represent the solutions in a mathematically precise way, 
-    using [mathematical sets](../../modules/sets.rst).
-    - You want a representation of all the solutions, including if there are 
+    - You want to represent the solutions in a mathematically precise way, using
+    [mathematical sets](../../modules/sets.rst).
+    - You want a representation of all the solutions, including if there are
     infinitely many.
     - You want a consistent input interface.
     - You want to limit the domain of the solutions to any arbitrary set.
-    - You do not need to programmatically extract solutions from the solution 
+    - You do not need to programmatically extract solutions from the solution
     set: solution sets cannot necessarily be interrogated programmatically.
 
 ## Guidance
 
 ### Include the variable to be solved for in the function call
 
-We recommend you include the variable to be solved for as the second argument 
-for either function. While this is optional for equations with a single 
-symbol, it is a good practice because it ensures 
-SymPy will solve for the desired symbol. For example, you may expect the 
-following to solve for $x$, 
-and SymPy will solve for $y$:
+We recommend you include the variable to be solved for as the second argument
+for either function. While this is optional for equations with a single symbol,
+it is a good practice because it ensures SymPy will solve for the desired
+symbol. For example, you may expect the following to solve for $x$, and SymPy
+will solve for $y$:
 
 ```py
 >>> from sympy.abc import x, y
@@ -79,26 +78,24 @@ Specifying the variable to solve for ensures that SymPy solves for it:
 
 ### Ensure consistent formatting from {func}`~.solve` by using `dict=True`
 
-{func}`~.solve` produces various output formats depending on the answer, 
-unless you use `dict=True` to ensure the result will be formatted as a 
-dictionary. We recommend using `dict=True`, especially if you want to 
-extract information from the result programmatically.
+{func}`~.solve` produces various output formats depending on the answer, unless
+you use `dict=True` to ensure the result will be formatted as a dictionary. We
+recommend using `dict=True`, especially if you want to extract information from
+the result programmatically.
 
 ## Solve an equation using {func}`~.solve` or {func}`~.solveset`
 
-You can solve an equation in several ways. 
-The examples below demonstrate using both {func}`~.solve` and 
-{func}`~.solveset` where applicable. 
-You can choose the function best suited to your equation.
+You can solve an equation in several ways. The examples below demonstrate using
+both {func}`~.solve` and {func}`~.solveset` where applicable. You can choose the
+function best suited to your equation.
 
 ### Make your equation into an expression that equals zero
 
-Use the fact that any expression not in an `Eq` (equation) is automatically 
-assumed to equal zero (0) by the solving functions. You can rearrange the 
-equation $x^2 = y$ to $x^2 - y = 0$, and solve that expression. This approach 
-is convenient if you are interactively solving an expression which already 
-equals zero, or an equation that you do not mind rearranging to 
-$expression = 0$.
+Use the fact that any expression not in an `Eq` (equation) is automatically
+assumed to equal zero (0) by the solving functions. You can rearrange the
+equation $x^2 = y$ to $x^2 - y = 0$, and solve that expression. This approach is
+convenient if you are interactively solving an expression which already equals
+zero, or an equation that you do not mind rearranging to $expression = 0$.
 
 ```py
 >>> from sympy import solve, solveset
@@ -111,10 +108,9 @@ $expression = 0$.
     
 ### Put your equation into `Eq` form
 
-Put your equation into `Eq` form, then solve the `Eq`. 
-This approach is convenient if you are interactively solving an equation 
-which you already have in the form of an equation,
-or which you think of as an equality.
+Put your equation into `Eq` form, then solve the `Eq`. This approach is
+convenient if you are interactively solving an equation which you already have
+in the form of an equation, or which you think of as an equality.
     
 ```py
 >>> from sympy import Eq, solve, solveset
@@ -136,8 +132,8 @@ sqrt(y)
 
 ### Restrict the domain of solutions
 
-By default, SymPy will return solutions in the complex domain, which also 
-includes purely real and imaginary values. Here, the first two solutions are 
+By default, SymPy will return solutions in the complex domain, which also
+includes purely real and imaginary values. Here, the first two solutions are
 real, and the last two are imaginary:
 
 ```py
@@ -149,8 +145,8 @@ real, and the last two are imaginary:
 {-4, 4, -4*I, 4*I}
 ```
 
-To restrict returned solutions to real numbers, or another domain or range, 
-the different solving functions use different methods.
+To restrict returned solutions to real numbers, or another domain or range, the
+different solving functions use different methods.
 
 For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
 
@@ -161,8 +157,8 @@ For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
 [{x: -4}, {x: 4}]
 ```
 
-or restrict the solutions with standard Python techniques for filtering a 
-list such as a list comprehension:
+or restrict the solutions with standard Python techniques for filtering a list
+such as a list comprehension:
 
 ```py
 >>> from sympy import Or, Symbol, solve
@@ -176,8 +172,8 @@ list such as a list comprehension:
 [1, 4]
 ```
 
-For {func}`~.solveset`, limit the output domain in the function call by 
-setting a domain
+For {func}`~.solveset`, limit the output domain in the function call by setting
+a domain
 
 ```py
 >>> from sympy import S, solveset
@@ -186,7 +182,7 @@ setting a domain
 {-4, 4}
 ```
 
-or by restricting returned solutions to any arbitrary set, including an 
+or by restricting returned solutions to any arbitrary set, including an
 interval:
 
 ```py
@@ -234,10 +230,9 @@ However, {func}`~.solve` will return only a finite number of solutions:
 2*pi
 ```
 
-{func}`~.solve` tries to return just enough solutions so that all 
-(infinitely many) solutions can generated from the returned solutions 
-by adding integer multiples of the {func}`~.periodicity` of the 
-equation, here $2\pi$.
+{func}`~.solve` tries to return just enough solutions so that all (infinitely
+many) solutions can generated from the returned solutions by adding integer
+multiples of the {func}`~.periodicity` of the equation, here $2\pi$.
 
 ## Use the solution result
 
@@ -245,14 +240,14 @@ equation, here $2\pi$.
 
 You can substitute solutions from {func}`~.solve` into an expression.
 
-A common use case is finding the critical points and values for a function 
-$f$. At the critical points, the {class}`~.Derivative` equals zero (or is 
-undefined). You can then obtain the function values at those critical points
-by substituting the critical points back into the function using 
-{meth}`~sympy.core.basic.Basic.subs`. You can also tell if the critical point 
-is a maxima or minima by substituting the values into the expression for the 
-second derivative: a negative value indicates a maximum, and a positive value 
-indicates a minimum.
+A common use case is finding the critical points and values for a function $f$.
+At the critical points, the {class}`~.Derivative` equals zero (or is undefined).
+You can then obtain the function values at those critical points by substituting
+the critical points back into the function using
+{meth}`~sympy.core.basic.Basic.subs`. You can also tell if the critical point is
+a maxima or minima by substituting the values into the expression for the second
+derivative: a negative value indicates a maximum, and a positive value indicates
+a minimum.
 
 ```py
 >>> from sympy.abc import x
@@ -290,8 +285,7 @@ iterate through the solutions:
 [sqrt(y), -sqrt(y)]
 ```
 
-However, for more complex results, it may not be possible to list the 
-solutions:
+However, for more complex results, it may not be possible to list the solutions:
 
 ```py
 >>> from sympy import S, solveset, symbols
@@ -344,10 +338,10 @@ Intersection({-sqrt(y), sqrt(y)}, Reals)
 
 ### Include solutions making any denominator zero by using `check=False`
 
-Normally, {func}`~.solve` checks whether any solutions make any denominator 
-zero, and automatically excludes them. If you want to include those 
-solutions, and speed up {func}`~.solve` (at the risk of obtaining invalid 
-solutions), set `check=False`:
+Normally, {func}`~.solve` checks whether any solutions make any denominator
+zero, and automatically excludes them. If you want to include those solutions,
+and speed up {func}`~.solve` (at the risk of obtaining invalid solutions), set
+`check=False`:
 
 ```py
 >>> from sympy import Symbol, sin, solve
@@ -360,12 +354,12 @@ solutions), set `check=False`:
 
 ### Do not simplify solutions by using `simplify=False`
 
-Normally, {func}`~.solve` simplifies all but polynomials of order 3 or 
-greater before returning them and (if `check` is not False) uses the general 
-{func}`simplify <sympy.simplify.simplify.simplify>` function on the solutions 
-and the expression obtained when they are substituted into the function which 
-should be zero. If you do not want the solutions simplified, and want to 
-speed up {func}`~.solve`, use `simplify=False`.
+Normally, {func}`~.solve` simplifies all but polynomials of order 3 or greater
+before returning them and (if `check` is not False) uses the general
+{func}`simplify <sympy.simplify.simplify.simplify>` function on the solutions
+and the expression obtained when they are substituted into the function which
+should be zero. If you do not want the solutions simplified, and want to speed
+up {func}`~.solve`, use `simplify=False`.
 
 ```py
 >>> from sympy import solve
@@ -381,8 +375,8 @@ speed up {func}`~.solve`, use `simplify=False`.
 
 ### Equations with no solution
 
-Some equations have no solution, in which case SymPy may return an empty set. 
-For example, the equation $x - 7 = x + 2$ reduces to $-7 = 2$, which has no 
+Some equations have no solution, in which case SymPy may return an empty set.
+For example, the equation $x - 7 = x + 2$ reduces to $-7 = 2$, which has no
 solution because no value of $x$ will make it true:
 
 ```py
@@ -393,17 +387,16 @@ solution because no value of $x$ will make it true:
 []
 ```
 
-So if SymPy returns an empty list, you may want to check whether there is a 
+So if SymPy returns an empty list, you may want to check whether there is a
 mistake in the equation.
 
 ### Equations which have an analytical solution, and SymPy cannot solve
 
-It is also possible that there is an algebraic solution to your equation, 
-and SymPy has not implemented an appropriate algorithm. 
-If that happens, or SymPy returns an empty set or list when there is a 
-mathematical solution (indicating a bug in SymPy), please post it on the 
-[mailing list](https://groups.google.com/g/sympy), or open an issue on 
-[SymPy's GitHub page](https://github.com/sympy/sympy/issues). Until the issue 
-is resolved, you can 
-{func}`solve your equation numerically <sympy.solvers.solvers.nsolve>` 
+It is also possible that there is an algebraic solution to your equation, and
+SymPy has not implemented an appropriate algorithm. If that happens, or SymPy
+returns an empty set or list when there is a mathematical solution (indicating a
+bug in SymPy), please post it on the [mailing
+list](https://groups.google.com/g/sympy), or open an issue on [SymPy's GitHub
+page](https://github.com/sympy/sympy/issues). Until the issue is resolved, you
+can {func}`solve your equation numerically <sympy.solvers.solvers.nsolve>`
 instead.

--- a/doc/src/guides/solving/solve-equation-algebraically.md
+++ b/doc/src/guides/solving/solve-equation-algebraically.md
@@ -162,8 +162,7 @@ For {func}`~.solve`, place an assumption on the symbol to be solved for, $x$
 ```
 
 or restrict the solutions with standard Python techniques for filtering a 
-list such as a list comprehension, or 
-by adding inequalities to {func}`~.solve` (but the range must be continuous):
+list such as a list comprehension:
 
 ```py
 >>> from sympy import Or, Symbol, solve
@@ -175,9 +174,6 @@ by adding inequalities to {func}`~.solve` (but the range must be continuous):
 >>> solution_outside_2_3 = [v for v in solution if (v.is_real and Or(v<2,v>3))]
 >>> print(solution_outside_2_3)
 [1, 4]
->>> solution_2_3 = solve((expr,x>=2,x<=3), x)
->>> print(solution_2_3)
-Eq(x, 2) | Eq(x, 3)
 ```
 
 For {func}`~.solveset`, limit the output domain in the function call by 


### PR DESCRIPTION
Remove suggestion to filter using inequalities. Remove spaces around `**` to make e.g. `x**2` not `x ** 2`. Limit line width globally.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fix changes suggested after #23638 merged

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
