### PR TITLE
docs: Fix a few typos

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -652,7 +652,7 @@ def is_convex(f, *syms, domain=S.Reals):
     To determine concavity of a function pass `-f` as the concerned function.
     To determine logarithmic convexity of a function pass `\log(f)` as
     concerned function.
-    To determine logartihmic concavity of a function pass `-\log(f)` as
+    To determine logarithmic concavity of a function pass `-\log(f)` as
     concerned function.
 
     Currently, convexity check of multivariate functions is not handled.

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -1721,7 +1721,7 @@ def CollectReciprocals(expr, x):
         pattern = u_ + e_/(a_ + b_*x) + f_/(c_+d_*x)
         match = expr.match(pattern)
         if match:
-            try: # .match() does not work peoperly always
+            try: # .match() does not work properly always
                 keys = [u_, a_, b_, c_, d_, e_, f_]
                 u, a, b, c, d, e, f = tuple([match[i] for i in keys])
                 if ZeroQ(b*c + a*d) & ZeroQ(d*e + b*f):

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -61,7 +61,7 @@ class Point:
         Add two points self and Q where diff = self - Q. Moreover the assumption
         is self.x_cord*Q.x_cord*(self.x_cord - Q.x_cord) != 0. This algorithm
         requires 6 multiplications. Here the difference between the points
-        is already known and using this algorihtm speeds up the addition
+        is already known and using this algorithm speeds up the addition
         by reducing the number of multiplication required. Also in the
         mont_ladder algorithm is constructed in a way so that the difference
         between intermediate points is always equal to the initial point.


### PR DESCRIPTION
There are small typos in:
- sympy/calculus/util.py
- sympy/integrals/rubi/utility_function.py
- sympy/ntheory/ecm.py

Fixes:
- Should read `properly` rather than `peoperly`.
- Should read `logarithmic` rather than `logartihmic`.
- Should read `algorithm` rather than `algorihtm`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
