### PR TITLE
solve_undetermined_coeffs enforces single solution

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -526,17 +526,10 @@ def solve(f, *symbols, **flags):
 
         * When undetermined coefficients are identified:
 
-            * That are linear:
-
                 >>> solve((a + b)*x - b + 2, a, b)
                 {a: -2, b: 2}
 
-            * That are nonlinear:
-
-                >>> solve((a + b)*x - b**2 + 2, a, b, set=True)
-                ([a, b], {(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))})
-
-        * If there is no linear solution, then the first successful
+         * If there is no linear solution, then the first successful
           attempt for a nonlinear solution will be returned:
 
             >>> solve(x**2 - y**2, x, y, dict=True)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -722,7 +722,17 @@ def test_solve_undetermined_coeffs():
     assert solve_undetermined_coeffs(((c + 1)*a*x**2 + (c + 1)*b*x**2 +
     (c + 1)*b*x + (c + 1)*2*c*x + (c + 1)**2)/(c + 1), [a, b, c], x) == \
         {a: -2, b: 2, c: -1}
-
+    # test that dict and set flags are ignored
+    assert solve_undetermined_coeffs(a*x - x, [a], x, set=True) == {a: 1}
+    assert solve_undetermined_coeffs(a*x - x, [a], x, dict=True) == {a: 1}
+    assert solve_undetermined_coeffs(a*x + b - 3*x + 4, [a, b, z], x
+        ) == {a: 3, b: -4}
+    # test compound generators and passing parameters in a set
+    assert solve_undetermined_coeffs(a*x + b/sin(x) - 3*x - 4/sin(x), {a, b}, x
+        ) == {a: 3, b: 4}
+    # test that it returns None for nonlinear systems
+    assert solve_undetermined_coeffs(a**2*x + b - 2*x -3, (a, b), x,
+        ) is None
 
 def test_solve_inequalities():
     x = Symbol('x')

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -143,9 +143,9 @@ def test_solve_args():
     assert solve(x + y - 3, [x, y], dict=True) == [{x: 3 - y}]
     # - or no symbols are given
     assert solve(x + y - 3) == [{x: 3 - y}]
-    # multiple symbols might represent an undetermined coefficients system
+    # multiple symbols and nonlinear system
     assert solve(a + b*x - 2, [a, b]) == {a: 2, b: 0}
-    args = (a + b)*x - b**2 + 2, a, b
+    args = [(a + b),- b**2 + 2], a, b
     assert solve(*args) == \
         [(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))]
     assert solve(*args, set=True) == \
@@ -852,7 +852,7 @@ def test_issue_5197():
     assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) == []
                  # not {x: -3, y: 1} b/c x is positive
     # The solution following should not contain (-sqrt(2), sqrt(2))
-    assert solve((x + y)*n - y**2 + 2, x, y) == [(sqrt(2), -sqrt(2))]
+    assert solve([(x + y), - y**2 + 2], x, y) == [(sqrt(2), -sqrt(2))]
     y = Symbol('y', positive=True)
     # The solution following should not contain {y: -x*exp(x/2)}
     assert solve(x**2 - y**2/exp(x), y, x, dict=True) == [{y: x*exp(x/2)}]
@@ -1481,7 +1481,7 @@ def test_issue_5901():
         ([g(a)], {
         (-sqrt(h(a)**2*f(a)**2 + G)/f(a),),
         (sqrt(h(a)**2*f(a)**2+ G)/f(a),)})
-    args = [f(x).diff(x, 2)*(f(x) + g(x)) - g(x)**2 + 2, f(x), g(x)]
+    args = [(f(x) + g(x),- g(x)**2 + 2), f(x), g(x)]
     assert set(solve(*args)) == \
         {(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))}
     eqs = [f(x)**2 + g(x) - 2*f(x).diff(x), g(x)**2 - 4]


### PR DESCRIPTION
Since flags are passed to solve, it is possible to get many different forms from this function. That has been changed and the assumption of a single solution is now enforced: the return value will be `[]` if there is no solution, a dictionary if there is a single solution, else None.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There was no enformcement in this function for the notion that it should be returning a single, unique solution for the specified parameters. Also, a solution was not being returned when the equation had a mixture of generators as in
```python
>>> solve_undetermined_coeffs(a*x + b/sin(x) - 3*x - 4/sin(x), {a, b}, x) is None  # but should be {a: 3, b: 4}
True
``` 

#### Other comments

One could test to see that the system of equation to determine the coefficients is linear, but since the flags get passed to `solve` then one would essentially doubling the work (since, after determining that the system is linear, the linear coefficients could be solved as a matrix system without a call to `solve`).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve_undetermined_coeffs` now gives a single solution as a dictionary, an empty list (if there is no solution) or None if the system was not identified
<!-- END RELEASE NOTES -->
