### PR TITLE
Fix bug in error message (cast tuple to str)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1376,7 +1376,7 @@ Yuki Matsuda <yuki.matsuda.w@gmail.com>
 Yuri Karadzhov <yuri.karadzhov@gmail.com>
 Yuriy Demidov <iurii.demidov@gmail.com>
 Yury G. Kudryashov <urkud.urkud@gmail.com>
-Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
 Zach Raines <raineszm@gmail.com>
 Zachariah Etienne <zachetie@gmail.com>
 Zamrath Nizam <zamiguy_ni@yahoo.com> <zamiguy.ni@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1376,7 +1376,8 @@ Yuki Matsuda <yuki.matsuda.w@gmail.com>
 Yuri Karadzhov <yuri.karadzhov@gmail.com>
 Yuriy Demidov <iurii.demidov@gmail.com>
 Yury G. Kudryashov <urkud.urkud@gmail.com>
-Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
 Zach Raines <raineszm@gmail.com>
 Zachariah Etienne <zachetie@gmail.com>
 Zamrath Nizam <zamiguy_ni@yahoo.com> <zamiguy.ni@gmail.com>

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -122,7 +122,8 @@ class DenseNDimArray(NDimArray):
         """
         new_total_size = functools.reduce(lambda x,y: x*y, newshape)
         if new_total_size != self._loop_size:
-            raise ValueError("Invalid reshape parameters " + str(newshape))
+            raise ValueError('Expecting reshape size to %d but got prod(%s) = %d' % (
+                self._loop_size, str(newshape), new_total_size))
 
         # there is no `.func` as this class does not subtype `Basic`:
         return type(self)(self._array, newshape)

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -122,7 +122,7 @@ class DenseNDimArray(NDimArray):
         """
         new_total_size = functools.reduce(lambda x,y: x*y, newshape)
         if new_total_size != self._loop_size:
-            raise ValueError("Invalid reshape parameters " + newshape)
+            raise ValueError("Invalid reshape parameters " + str(newshape))
 
         # there is no `.func` as this class does not subtype `Basic`:
         return type(self)(self._array, newshape)


### PR DESCRIPTION
```python
from sympy.abc import x, y, z 
from sympy import Array 
 
a2 = Array([[[x, y], [z, x*z]], [[1, x*y], [1/x, x/y]]])
a2.reshape(1)                                           
```
Out:
```text
TypeError: can only concatenate str (not "tuple") to str
```

This casts `newshape` to a string to the error message makes sense.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
