### PR TITLE
Fix issue #23823 in physics.hep.gamma_matrices.kahane_simplify()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -589,6 +589,8 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
 GolimarOurHero <metalera94@hotmail.com>
 Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
 Govind Sahai <gsiitbhu@gmail.com>

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -694,8 +694,7 @@ def kahane_simplify(expression):
 
     # If `first_dum_pos` is not zero, it means that there are trailing free gamma
     # matrices in front of `expression`, so multiply by them:
-    for i in range(0, first_dum_pos):
-        [ri.insert(0, free_pos[i]) for ri in resulting_indices]
+    resulting_indices = list( free_pos[0:first_dum_pos] + ri for ri in resulting_indices )
 
     resulting_expr = S.Zero
     for i in resulting_indices:

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -257,10 +257,12 @@ def test_kahane_simplify1():
     t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
     r = kahane_simplify(t)
     assert r.equals(-2*G(sigma)*G(rho)*G(nu))
-    t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
+    t = (G(mu)*G(-mu)*G(rho)*G(sigma))
     r = kahane_simplify(t)
-    assert r.equals(-2*G(sigma)*G(rho)*G(nu))
-
+    assert r.equals(4*G(rho)*G(sigma))
+    t = (G(rho)*G(sigma)*G(mu)*G(-mu))
+    r = kahane_simplify(t)
+    assert r.equals(4*G(rho)*G(sigma))
 
 def test_gamma_matrix_class():
     i, j, k = tensor_indices('i,j,k', LorentzIndex)


### PR DESCRIPTION
Simple fix to the order of insertion of leading uncontracted matrices.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #23823

#### Brief description of what is fixed or changed

Gamma matrices preceding the first contracted gamma matrix are now added in the correct order.
There was no test case for correct ordering in the case of more than one initial uncontracted gamma matrix, so this commit also adds a test case for two leading uncontracted gamma matrices and another for the case of two trailing gamma matrices for good measure.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.hep
  * Fixed a bug in gamma_matrices.kahane_simplify() when there is more than one uncontracted gamma matrix before the first contracted gamma matrix.
<!-- END RELEASE NOTES -->
