### PR TITLE
edit solving via matching (with solve_undetermined_coeffs)

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1366,6 +1366,8 @@ def _solve(f, *symbols, **flags):
         if len(ex) != 1:
             ind, dep = f.as_independent(*symbols)    # (2*x - c, a*x + b)
             ex = ind.free_symbols & dep.free_symbols # {x, c} & {a, x, b} -> {x}
+        if len(ex) != 1:                           # e.g. (a+b)*x + b - c -> {c}, {a, b, x}
+            ex = dep.free_symbols - set(symbols)  # {x} = {a,b,x}-{a.b}
         if len(ex) == 1:
             ex = ex.pop()
             try:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -524,18 +524,6 @@ def solve(f, *symbols, **flags):
             >>> solve(x**2 - y, x, y, dict=True)
             [{y: x**2}]
 
-        * When undetermined coefficients are identified:
-
-            * That are linear:
-
-                >>> solve((a + b)*x - b + 2, a, b)
-                {a: -2, b: 2}
-
-            * That are nonlinear:
-
-                >>> solve((a + b)*x - b**2 + 2, a, b, set=True)
-                ([a, b], {(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))})
-
         * If there is no linear solution, then the first successful
           attempt for a nonlinear solution will be returned:
 
@@ -545,6 +533,28 @@ def solve(f, *symbols, **flags):
             [{x: 2*LambertW(-y/2)}, {x: 2*LambertW(y/2)}]
             >>> solve(x**2 - y**2/exp(x), y, x)
             [(-x*sqrt(exp(x)), x), (x*sqrt(exp(x)), x)]
+
+        * When undetermined coefficients are identified:
+
+            This happens when it is possible to form a linear set of
+            equations in the variables provided from the coefficients
+            of the expressions in symbols not provided. A single
+            dictionary with specified values will be returned:
+
+            >>> eq = (a + b)*x - b + 2
+            >>> solve(eq, a, b)
+            {a: -2, b: 2}
+
+            The coefficient system solved was:
+
+            >>> list(eq.expand().as_coefficients_dict(x).values())
+            [a + b, 2 - b]
+
+            To obtain an algebraic solution in terms of ``a`` or ``b``
+            pass the equation in a list:
+
+            >>> solve([eq], a, b)
+            {a: b*(1 - x)/x - 2/x}
 
     Iterable of one or more of the above:
 
@@ -1111,13 +1121,13 @@ def solve(f, *symbols, **flags):
     if bare_f:
         solution = _solve(f[0], *symbols, **flags)
         # solution is:
-        # dict or list of tuples for coeficient system with one/many solutions
+        # dict for coeficient system with one solution
         # list of values
         # list of dicts
     else:
         solution = _solve_system(f, symbols, **flags)
         # solution is:
-        # dict
+        # dict for linear/monotonic solution
         # list of dicts
         # list of tuples
     #
@@ -1349,41 +1359,40 @@ def _solve(f, *symbols, **flags):
 
     not_impl_msg = "No algorithms are implemented to solve equation %s"
 
-    if len(symbols) != 1:
+    if len(symbols) != 1:                            # solve(a*x + 2*x + b - c, a, b)
         soln = None
-        free = f.free_symbols
-        ex = free - set(symbols)
+        free = f.free_symbols                        # {a, b, c, x}
+        ex = free - set(symbols)                     # {c, x}
         if len(ex) != 1:
-            ind, dep = f.as_independent(*symbols)
-            ex = ind.free_symbols & dep.free_symbols
+            ind, dep = f.as_independent(*symbols)    # (2*x - c, a*x + b)
+            ex = ind.free_symbols & dep.free_symbols # {x, c} & {a, x, b} -> {x}
         if len(ex) == 1:
             ex = ex.pop()
             try:
-                # soln may come back as dict, list of dicts or tuples, or
-                # tuple of symbol list and set of solution tuples
+                # force dict return for solution
+                missing = Dummy()
+                was = {k: flags.pop(k, missing) for k in ('dict', 'set')}
+                flags['dict'] = True
+                # get solution which (because it will call solve with
+                # flags) will be simplified and checked
                 soln = solve_undetermined_coeffs(f, symbols, ex, **flags)
-            except NotImplementedError:
-                pass
-            if soln:
-                if flags.get('simplify', True):
-                    if isinstance(soln, dict):
+                flags['check'] = False  # already checked
+                # restore keys that weren't missing
+                for k in was:
+                    if was[k] != missing:
+                        flags[k] = was[k]
+                if soln and len(soln) == 1:
+                    soln = soln[0]
+                    if flags.get('simplify', True):
                         for k in soln:
                             soln[k] = simplify(soln[k])
-                    elif isinstance(soln, list):
-                        if isinstance(soln[0], dict):
-                            for d in soln:
-                                for k in d:
-                                    d[k] = simplify(d[k])
-                        elif isinstance(soln[0], tuple):
-                            soln = [tuple(simplify(i) for i in j) for j in soln]
-                        else:
-                            raise TypeError('unrecognized args in list')
-                    elif isinstance(soln, tuple):
-                        sym, sols = soln
-                        soln = sym, {tuple(simplify(i) for i in j) for j in sols}
-                    else:
-                        raise TypeError('unrecognized solution type')
-                return soln
+                    return soln
+                # solve_undetermined_coeffs assumes a linear system
+                # and we actually don't want this nonalgebraic feature
+                # enabled by default, so take this as a first step
+                # and fall back now to normal algebraic rearrangement
+            except NotImplementedError:
+                pass
 
         # look for solutions for desired symbols that are independent
         # of symbols already solved for, e.g. if we solve for x = y

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -51,8 +51,8 @@ def test_swap_back():
     fx, gx = f(x), g(x)
     assert solve([fx + y - 2, fx - gx - 5], fx, y, gx) == \
         {fx: gx + 5, y: -gx - 3}
-    assert solve(fx + gx*x - 2, [fx, gx], dict=True)[0] == {fx: 2, gx: 0}
-    assert solve(fx + gx**2*x - y, [fx, gx], dict=True) == [{fx: y - gx**2*x}]
+    assert solve(fx + gx*x - 2, [fx, gx], dict=True) == [{fx: 2, gx: 0}]
+    assert solve(fx + gx**2*x - y, [fx, gx], dict=True) == [{fx: y, gx: 0}]
     assert solve([f(1) - 2, x + 2], dict=True) == [{x: -2, f(1): 2}]
 
 
@@ -145,6 +145,7 @@ def test_solve_args():
     assert solve(x + y - 3) == [{x: 3 - y}]
     # multiple symbols might represent an undetermined coefficients system
     assert solve(a + b*x - 2, [a, b]) == {a: 2, b: 0}
+    assert solve((a + b)*x + b - c, [a, b]) == {a: -c, b: c}
     eq = a*x**2 + b*x + c - ((x - h)**2 + 4*p*k)/4/p
     # - check that flags are obeyed
     sol = solve(eq, [h, p, k], exclude=[a, b, c])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

#### Brief description of what is fixed or changed

When solving a single equation and specifying more than one variable, a check is made to see if the values for all variables can be made simultaneously by considering coefficients on a variable not given. Such is common when trying to match a generic form of an expression like `a*x + b` to a specific form like `2*x + 3` for which a solution for `a` and `b` is `{a: 2, b:3}`. But this is a surprising result if one is expecting an algebraic re-arrangement to give one of `a` or `b`, e.g. `a = (2*x + 3 - b)/x`. If a set of equations cannot be assembled or has no solution, the undetermined coefficients solution attempt is abandoned and an algebraic solution is sought.

A couple of improvements regarding this situation are made.

1. if the coefficient system does not have a single unique solution, the algebraic solution for one of the variables is sought; formerly, even nonlinear systems with multiple solutions would give an undetermined coefficients solution
2. since flags passed to `solve` are re-sent to `solve` from `solve_undetermined_coeffs` the form of the solution could be one of many; now the flag passed to `solve_undetermined_coeffs` is temporarily set to `dict=True` so the simplification of the result can be done on a well-defined return type.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * automatic detection of undetermined coefficient solutions will only succeed when there is a single solution
<!-- END RELEASE NOTES -->
