### PR TITLE
[WIP] Make SymPy depend on 3rd party multipledispatch module

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -160,7 +160,7 @@ jobs:
           node-version: 16.x
       - run: wget -qO- https://github.com/pyodide/pyodide/releases/download/0.20.1a1/pyodide-build-0.20.1a1.tar.bz2 | tar xjf -
       - run: python3 setup.py bdist_wheel
-      - run: node bin/test_pyodide.mjs --split=${{ matrix.split }}
+      - run: node bin/test_pyodide.mjs --split=${{ matrix.split }} 2>/dev/null  # ignore node exception
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -147,7 +147,7 @@ jobs:
   # -------------------- Test Pyodide on node ---------------------- #
 
   test-pyodide:
-    #needs: code-quality
+    needs: code-quality
 
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -160,7 +160,7 @@ jobs:
           node-version: 16.x
       - run: wget -qO- https://github.com/pyodide/pyodide/releases/download/0.20.1a1/pyodide-build-0.20.1a1.tar.bz2 | tar xjf -
       - run: python3 setup.py bdist_wheel
-      - run: node bin/test_pyodide.mjs --split=${{ matrix.split }} 2>/dev/null  # ignore node exception
+      - run: node bin/test_pyodide.mjs --split=${{ matrix.split }}
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -158,6 +158,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
+      - run: npm install node-fetch
       - run: wget -qO- https://github.com/pyodide/pyodide/releases/download/0.20.1a1/pyodide-build-0.20.1a1.tar.bz2 | tar xjf -
       - run: python3 setup.py bdist_wheel
       - run: node bin/test_pyodide.mjs --split=${{ matrix.split }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath flake8
+      - run: pip install mpmath multipledispatch flake8
 
       - name: Basic code quality tests
         run: bin/test quality
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath mypy
+      - run: pip install mpmath multipledispatch mypy
 
       - name: Run mypy on the sympy package
         run: mypy sympy
@@ -95,7 +95,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/mailmap_check.py --skip-last-commit
 
   # -------------------- Doctests latest Python -------------------- #
@@ -110,7 +110,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/doctest --force-colors
       - run: examples/all.py -q
 
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/test --force-colors --split=1/2
 
   # -------------------- Test split 2/2 latest Python -------------- #
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/test --force-colors --split=2/2
 
   # -------------------- Test Pyodide on node ---------------------- #
@@ -198,7 +198,7 @@ jobs:
         run: pip install git+https://github.com/matplotlib/matplotlib@main
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
+      - run: pip install mpmath multipledispatch numpy numexpr matplotlib ipython cython scipy \
                          aesara wurlitzer autowrap                            \
                          'antlr4-python3-runtime==4.10.*'
 
@@ -231,7 +231,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy scipy tensorflow
+      - run: pip install mpmath multipledispatch numpy scipy tensorflow
       # Test modules that can use tensorflow
       - run: bin/test_tensorflow.py
 
@@ -247,7 +247,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy symengine
+      - run: pip install mpmath multipledispatch numpy symengine
       # Test modules that can use tensorflow
       - run: bin/test_symengine.py
         env:
@@ -265,7 +265,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: TRAVIS_BUILD_NUMBER=true bin/test --force-colors --slow --timeout=595 --split=1/2
 
   # -------------------- Slow test split 2/2 ----------------------- #
@@ -280,7 +280,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: TRAVIS_BUILD_NUMBER=true bin/test --force-colors --slow --timeout=595 --split=2/2
 
   # -------------------- Test split 1/2 older Python --------------- #
@@ -305,7 +305,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/test --force-colors --split=1/2
 
   # -------------------- Test split 2/2 older Python --------------- #
@@ -330,7 +330,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/test --force-colors --split=2/2
 
   # -------------------- Doctests older Python --------------------- #
@@ -355,7 +355,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install mpmath multipledispatch
       - run: bin/doctest --force-colors
       - run: examples/all.py -q
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -147,7 +147,7 @@ jobs:
   # -------------------- Test Pyodide on node ---------------------- #
 
   test-pyodide:
-    needs: code-quality
+    #needs: code-quality
 
     runs-on: ubuntu-20.04
     strategy:

--- a/bin/test_external_imports.py
+++ b/bin/test_external_imports.py
@@ -20,7 +20,7 @@ https://stackoverflow.com/questions/22195382/how-to-check-if-a-module-library-pa
 """
 
 # These libraries will always be imported with SymPy
-hard_dependencies = ['mpmath']
+hard_dependencies = ['mpmath', 'six', 'multipledispatch']
 
 # These libraries are optional, but are always imported at SymPy import time
 # when they are installed. External libraries should only be added to this

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -1,7 +1,6 @@
 import { argv } from 'process'
 import { readdirSync } from 'fs'
 import pyodide_pkg from '../pyodide/pyodide.js'
-import micropip from '../pyodide/pyodide.js'
 
 let sympy
 const fileNames = readdirSync('dist')
@@ -11,9 +10,15 @@ for (const fileName of fileNames) {
     }
 }
 
-await micropip.install('multipledispatch') // Not provided by pyodide
-
 const pyodide = await pyodide_pkg.loadPyodide()
+
+await pyodide.loadPackage('micropip')
+
+await pyodide.runPythonAsync(`
+  import micropip
+  await micropip.install('multipledispatch')
+`)
+
 await pyodide.loadPackage([
     'mpmath',  // provided by pyodide
     'numpy',  // built by pyodide

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -2,6 +2,16 @@ import { argv } from 'process'
 import { readdirSync } from 'fs'
 import pyodide_pkg from '../pyodide/pyodide.js'
 
+// Messing with fetch is needed to be able to use micropip in node.js. They
+// prevent the error:
+//
+// File "/lib/python3.10/site-packages/pyodide/http.py", line 228, in pyfetch
+//   from js import fetch as _jsfetch
+// ImportError: cannot import name 'fetch' from 'js' (unknown location)
+//
+import fetch from 'node-fetch'
+globalThis.fetch = fetch
+
 let sympy
 const fileNames = readdirSync('dist')
 for (const fileName of fileNames) {

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -1,7 +1,7 @@
 import { argv } from 'process'
 import { readdirSync } from 'fs'
 import pyodide_pkg from '../pyodide/pyodide.js'
-import micropip
+import micropip from '../pyodide/pyodide.js'
 
 let sympy
 const fileNames = readdirSync('dist')

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -13,6 +13,7 @@ for (const fileName of fileNames) {
 const pyodide = await pyodide_pkg.loadPyodide()
 await pyodide.loadPackage([
     'mpmath',  // provided by pyodide
+    'multipledispatch',  // provided by pyodide
     'numpy',  // built by pyodide
     `../dist/${sympy}`  // git version sympy
 ])

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -11,14 +11,14 @@ for (const fileName of fileNames) {
     }
 }
 
+await micropip.install('multipledispatch') // Not provided by pyodide
+
 const pyodide = await pyodide_pkg.loadPyodide()
 await pyodide.loadPackage([
     'mpmath',  // provided by pyodide
     'numpy',  // built by pyodide
     `../dist/${sympy}`  // git version sympy
 ])
-
-micropip.install('multipledispatch') // Not provided by pyodide
 
 let split = 'None'
 if (argv[2]) {

--- a/bin/test_pyodide.mjs
+++ b/bin/test_pyodide.mjs
@@ -1,6 +1,7 @@
 import { argv } from 'process'
 import { readdirSync } from 'fs'
 import pyodide_pkg from '../pyodide/pyodide.js'
+import micropip
 
 let sympy
 const fileNames = readdirSync('dist')
@@ -13,10 +14,11 @@ for (const fileName of fileNames) {
 const pyodide = await pyodide_pkg.loadPyodide()
 await pyodide.loadPackage([
     'mpmath',  // provided by pyodide
-    'multipledispatch',  // provided by pyodide
     'numpy',  // built by pyodide
     `../dist/${sympy}`  // git version sympy
 ])
+
+micropip.install('multipledispatch') // Not provided by pyodide
 
 let split = 'None'
 if (argv[2]) {

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,7 @@ linkify-it-py
 matplotlib
 matplotlib-inline
 mpmath
+multipledispatch
 myst-parser
 Sphinx
 sphinx-autobuild

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-mpmath.*]
 ignore_missing_imports = True
+[mypy-multipledispatch.*]
+ignore_missing_imports = True
 [mypy-numpy.*]
 ignore_missing_imports = True
 [mypy-PIL.*]

--- a/setup.py
+++ b/setup.py
@@ -481,6 +481,7 @@ if __name__ == '__main__':
             ],
           install_requires=[
             'mpmath>=%s' % min_mpmath_version,
+            'multipledispatch>=0.6.0',
             ],
           **extra_kwargs
           )

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -6,7 +6,7 @@ from sympy.core.assumptions import ManagedProperties
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean, false, true
-from sympy.multipledispatch.dispatcher import Dispatcher, str_signature
+from multipledispatch.dispatcher import Dispatcher, str_signature
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.source import get_class

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -9,7 +9,7 @@ from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NaN,
 from sympy.functions import Abs, im, re
 from sympy.ntheory import isprime
 
-from sympy.multipledispatch import MDNotImplementedError
+from multipledispatch import MDNotImplementedError
 
 from ..predicates.ntheory import (PrimePredicate, CompositePredicate,
     EvenPredicate, OddPredicate)

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -10,7 +10,7 @@ from sympy.functions import Abs, acos, acot, asin, atan, exp, factorial, log
 from sympy.matrices import Determinant, Trace
 from sympy.matrices.expressions.matexpr import MatrixElement
 
-from sympy.multipledispatch import MDNotImplementedError
+from multipledispatch import MDNotImplementedError
 
 from ..predicates.order import (NegativePredicate, NonNegativePredicate,
     NonZeroPredicate, ZeroPredicate, NonPositivePredicate, PositivePredicate,

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.complexes import conjugate
 from sympy.matrices import Determinant, MatrixBase, Trace
 from sympy.matrices.expressions.matexpr import MatrixElement
 
-from sympy.multipledispatch import MDNotImplementedError
+from multipledispatch import MDNotImplementedError
 
 from .common import test_closed_group
 from ..predicates.sets import (IntegerPredicate, RationalPredicate,

--- a/sympy/assumptions/predicates/calculus.py
+++ b/sympy/assumptions/predicates/calculus.py
@@ -1,5 +1,5 @@
 from sympy.assumptions import Predicate
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 class FinitePredicate(Predicate):
     """

--- a/sympy/assumptions/predicates/common.py
+++ b/sympy/assumptions/predicates/common.py
@@ -1,6 +1,6 @@
 from sympy.assumptions import Predicate, AppliedPredicate, Q
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 class CommutativePredicate(Predicate):

--- a/sympy/assumptions/predicates/matrices.py
+++ b/sympy/assumptions/predicates/matrices.py
@@ -1,5 +1,5 @@
 from sympy.assumptions import Predicate
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 class SquarePredicate(Predicate):
     """

--- a/sympy/assumptions/predicates/ntheory.py
+++ b/sympy/assumptions/predicates/ntheory.py
@@ -1,5 +1,5 @@
 from sympy.assumptions import Predicate
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 class PrimePredicate(Predicate):

--- a/sympy/assumptions/predicates/order.py
+++ b/sympy/assumptions/predicates/order.py
@@ -1,5 +1,5 @@
 from sympy.assumptions import Predicate
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 class NegativePredicate(Predicate):

--- a/sympy/assumptions/predicates/sets.py
+++ b/sympy/assumptions/predicates/sets.py
@@ -1,5 +1,5 @@
 from sympy.assumptions import Predicate
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 class IntegerPredicate(Predicate):

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -6,7 +6,7 @@ from sympy.core.relational import is_le, is_lt, is_ge, is_gt
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.logic.boolalg import And
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.series.order import Order
 from sympy.sets.sets import FiniteSet
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -15,7 +15,7 @@ from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs, is_sequence)
 from sympy.utilities.misc import as_int
 from mpmath.libmp.libintmath import ifac
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 
 def _af_rmul(a, b):
     """

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -28,9 +28,10 @@ This module defines basic kinds for core objects. Other kinds such as
 from collections import defaultdict
 
 from .cache import cacheit
-from sympy.multipledispatch.dispatcher import (Dispatcher,
-    ambiguity_warn, ambiguity_register_error_ignore_dup,
-    str_signature, RaiseNotImplementedError)
+from multipledispatch.dispatcher import (Dispatcher,
+    ambiguity_warn, str_signature)
+from sympy.multipledispatch.dispatcher import (ambiguity_register_error_ignore_dup,
+    RaiseNotImplementedError)
 
 
 class KindMeta(type):
@@ -187,6 +188,12 @@ class _BooleanKind(Kind):
 BooleanKind = _BooleanKind()
 
 
+class _Dispatcher(Dispatcher):
+    def add(self, signature, func, on_ambiguity=ambiguity_warn):
+        super().add(signature, func)
+        super().reorder(on_ambiguity=on_ambiguity)
+
+
 class KindDispatcher:
     """
     Dispatcher to select a kind from multiple kinds by binary dispatching.
@@ -258,7 +265,7 @@ class KindDispatcher:
         self.name = name
         self.doc = doc
         self.commutative = commutative
-        self._dispatcher = Dispatcher(name)
+        self._dispatcher = _Dispatcher(name)
 
     def __repr__(self):
         return "<dispatched %s>" % self.name

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -20,7 +20,7 @@ from .decorators import _sympifyit
 from .logic import fuzzy_not
 from .kind import NumberKind
 from sympy.external.gmpy import SYMPY_INTS, HAS_GMPY, gmpy
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 import mpmath
 import mpmath.libmp as mlib
 from mpmath.libmp import bitcount, round_nearest as rnd

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -11,9 +11,10 @@ from .sorting import ordered
 from .logic import fuzzy_and
 from .parameters import global_parameters
 from sympy.utilities.iterables import sift
-from sympy.multipledispatch.dispatcher import (Dispatcher,
-    ambiguity_register_error_ignore_dup,
-    str_signature, RaiseNotImplementedError)
+from multipledispatch.dispatcher import Dispatcher, str_signature
+from .kind import _Dispatcher
+from sympy.multipledispatch.dispatcher import (ambiguity_register_error_ignore_dup,
+    RaiseNotImplementedError)
 
 
 class AssocOp(Basic):
@@ -595,7 +596,7 @@ class AssocOpDispatcher:
         self.doc = doc
         self.handlerattr = "_%s_handler" % name
         self._handlergetter = attrgetter(self.handlerattr)
-        self._dispatcher = Dispatcher(name)
+        self._dispatcher = _Dispatcher(name)
 
     def __repr__(self):
         return "<dispatched %s>" % self.name

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -11,7 +11,7 @@ from .sorting import ordered
 from .logic import fuzzy_and
 from .parameters import global_parameters
 from sympy.utilities.iterables import sift
-from multipledispatch.dispatcher import Dispatcher, str_signature
+from multipledispatch.dispatcher import str_signature
 from .kind import _Dispatcher
 from sympy.multipledispatch.dispatcher import (ambiguity_register_error_ignore_dup,
     RaiseNotImplementedError)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -18,7 +18,7 @@ from sympy.external.gmpy import HAS_GMPY, gmpy
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import as_int
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 from mpmath.libmp import sqrtrem as mpmath_sqrtrem
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -20,7 +20,7 @@ __all__ = (
 )
 
 from .expr import Expr
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from .containers import Tuple
 from .symbol import Symbol
 
@@ -1350,7 +1350,7 @@ def is_ge(lhs, rhs, assumptions=None):
     New types can be supported by dispatching to ``_eval_is_ge``.
 
     >>> from sympy import Expr, sympify
-    >>> from sympy.multipledispatch import dispatch
+    >>> from multipledispatch import dispatch
     >>> class MyExpr(Expr):
     ...     def __new__(cls, arg):
     ...         return super().__new__(cls, sympify(arg))
@@ -1464,7 +1464,7 @@ def is_eq(lhs, rhs, assumptions=None):
     New types can be supported by dispatching to ``_eval_is_eq``.
 
     >>> from sympy import Basic, sympify
-    >>> from sympy.multipledispatch import dispatch
+    >>> from multipledispatch import dispatch
     >>> class MyBasic(Basic):
     ...     def __new__(cls, arg):
     ...         return Basic.__new__(cls, sympify(arg))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,6 +1,6 @@
 from sympy.core.logic import fuzzy_and
 from sympy.core.sympify import _sympify
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -12,7 +12,7 @@ from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.complexes import im, re
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 
 ###############################################################################
 ######################### FLOOR and CEILING FUNCTIONS #########################

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -29,7 +29,7 @@ from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.trigonometric import cos, sin, atan
 from sympy.matrices import eye
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.printing import sstr
 from sympy.sets import Set, Union, FiniteSet
 from sympy.sets.handlers.intersection import intersection_sets

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -13,7 +13,7 @@ from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.common import NonSquareMatrixError
 from sympy.matrices.matrices import MatrixKind, MatrixBase
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.utilities.misc import filldedent
 
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -9,7 +9,7 @@ from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.repmatrix import RepMatrix
 from sympy.matrices.sparse import SparseRepMatrix
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 
 
 def sympify_matrix(arg):

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -26,7 +26,7 @@ from sympy.utilities import lambdify, public, sift, numbered_symbols
 
 from mpmath import mpf, mpc, findroot, workprec
 from mpmath.libmp.libmpf import dps_to_prec, prec_to_dps
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from itertools import chain
 
 

--- a/sympy/sets/handlers/add.py
+++ b/sympy/sets/handlers/add.py
@@ -1,7 +1,7 @@
 from sympy.core.numbers import oo, Infinity, NegativeInfinity
 from sympy.core.singleton import S
 from sympy.core import Basic, Expr
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 from sympy.sets import Interval, FiniteSet
 
 

--- a/sympy/sets/handlers/comparison.py
+++ b/sympy/sets/handlers/comparison.py
@@ -2,7 +2,7 @@ from sympy.core.relational import Eq, is_eq
 from sympy.core.basic import Basic
 from sympy.core.logic import fuzzy_and, fuzzy_bool
 from sympy.logic.boolalg import And
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.sets.sets import tfn, ProductSet, Interval, FiniteSet, Set
 
 

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -8,7 +8,7 @@ from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.logic.boolalg import true
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
     Intersection, Range, Complement)
 from sympy.sets.sets import EmptySet, is_function_invertible_in_set

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.sets.fancysets import ComplexRegion
 from sympy.sets.sets import (FiniteSet, Intersection, Interval, Set, Union)
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 from sympy.sets.conditionset import ConditionSet
 from sympy.sets.fancysets import (Integers, Naturals, Reals, Range,
     ImageSet, Rationals)

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -4,7 +4,7 @@ from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
 from sympy.sets.sets import FiniteSet, Interval, Set, Union, ProductSet
 from sympy.sets.fancysets import Complexes, Reals, Range, Rationals
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 _inf_sets = [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals, S.Complexes]

--- a/sympy/sets/handlers/mul.py
+++ b/sympy/sets/handlers/mul.py
@@ -1,7 +1,7 @@
 from sympy.core import Basic, Expr
 from sympy.core.numbers import oo
 from sympy.core.symbol import symbols
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 from sympy.sets.setexpr import set_mul
 from sympy.sets.sets import Interval, Set
 

--- a/sympy/sets/handlers/power.py
+++ b/sympy/sets/handlers/power.py
@@ -7,7 +7,7 @@ from sympy.functions.elementary.miscellaneous import (Max, Min)
 from sympy.sets.fancysets import ImageSet
 from sympy.sets.setexpr import set_div
 from sympy.sets.sets import Set, Interval, FiniteSet, Union
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 _x, _y = symbols("x y")

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -5,7 +5,7 @@ from sympy.sets.sets import (EmptySet, FiniteSet, Intersection,
     Interval, ProductSet, Set, Union, UniversalSet)
 from sympy.sets.fancysets import (ComplexRegion, Naturals, Naturals0,
     Integers, Rationals, Reals)
-from sympy.multipledispatch import Dispatcher
+from multipledispatch import Dispatcher
 
 
 union_sets = Dispatcher('union_sets')

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -112,7 +112,7 @@ from sympy.core.symbol import _filter_assumptions, Symbol
 from sympy.core.logic import fuzzy_bool, fuzzy_not
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
-from sympy.multipledispatch import dispatch
+from multipledispatch import dispatch
 from sympy.utilities.iterables import is_sequence, NotIterable
 from sympy.utilities.misc import filldedent
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

An alternative to #23621. This does not yet fix the import time problem though.

#### Brief description of what is fixed or changed

Change all usage of `sympy.multipledispatch` to import from and use `multipledispatch`. Add a dependency on the 3rd party Python `multipledispatch` module.

There are some incompatibilities between SymPy's multipledispatch and the PyPI package that need to be resolved before fully deleting the module:

- [X] Change all imports
- [X] Add dependency in setup.py
- [X] Install in CI
- [ ] Make sure all tests pass
- [ ] Resolve any incompatibilities
- [ ] Move any code in the `sympy.multipledispatch` module somewhere else (maybe there could be `sympy/external/multipledispatch`).
- [ ] Delete the `sympy.multipledispatch` module and associated tests
- [ ] Remove all references e.g. in setup.py, LICENSE, etc
- [ ] Improve import time
- [ ] Update docs

#### Other comments

The 3rd party multipledispatch module does not seem to be actively maintained e.g. it hasn't had a release since 4 years ago in 2018. It's not clear that it really needs much in terms of fixes though because it is relatively simple.

We might not want to depend on it as a 3rd party package but if not then at least we should update the vendored version to match the latest PyPI release because it has a number of improvements. At least there has been one fix in SymPy (#22029) that has not been applied to the 3rd party package https://github.com/mrocklin/multipledispatch/issues/118.

Alternatively if it does need more maintenance maybe it would be possible to take over maintenance.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * SymPy now depends on the third party multipledispatch module (as installed by `pip install multipledispatch`) rather the vendoring its own older version of the same module.
<!-- END RELEASE NOTES -->
