### PR TITLE
Avoid exponential time complexity in codeprinter

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -427,18 +427,17 @@ class CodePrinter(StrPrinter):
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_func = self.known_functions[expr.func.__name__]
-            func = None
             if isinstance(cond_func, str):
-                func = cond_func
+                return "%s(%s)" % (cond_func, self.stringify(expr.args, ", "))
             else:
                 for cond, func in cond_func:
                     if cond(*expr.args):
                         break
-            if func is not None:
-                try:
-                    return func(*[self.parenthesize(item, 0) for item in expr.args])
-                except TypeError:
-                    return "%s(%s)" % (func, self.stringify(expr.args, ", "))
+                if func is not None:
+                    try:
+                        return func(*[self.parenthesize(item, 0) for item in expr.args])
+                    except TypeError:
+                        return "%s(%s)" % (func, self.stringify(expr.args, ", "))
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -1,5 +1,5 @@
 from sympy.core import (
-    S, pi, oo, symbols, Rational, Integer, Float, Mod, GoldenRatio, EulerGamma, Catalan,
+    S, pi, oo, Symbol, symbols, Rational, Integer, Float, Function, Mod, GoldenRatio, EulerGamma, Catalan,
     Lambda, Dummy, nan, Mul, Pow, UnevaluatedExpr
 )
 from sympy.core.relational import (Eq, Ge, Gt, Le, Lt, Ne)
@@ -179,6 +179,15 @@ def test_ccode_user_functions():
     assert ccode(ceiling(x), user_functions=custom_functions) == "ceil(x)"
     assert ccode(Abs(x), user_functions=custom_functions) == "fabs(x)"
     assert ccode(Abs(n), user_functions=custom_functions) == "abs(n)"
+
+    expr = Symbol('a')
+    muladd = Function('muladd')
+    for i in range(0, 100):
+        # the large number of terms acts as a regression test for gh-23839
+        expr = muladd(Rational(1, 2), Symbol(f'a{i}'), expr)
+    out = ccode(expr, user_functions={'muladd':'muladd'})
+    assert 'a99' in out
+    assert out.count('muladd') == 100
 
 
 def test_ccode_boolean():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #23839


#### Brief description of what is fixed or changed
There is no need to try to call a python string. Previously work was done to parenthesize the arguments even though it could be determined that this work was in vain.

#### Other comments
I wouldn't be surprised if it's possible to construct other pathogenic expressions exhibiting exponential runtime. But this fix should nevertheless be harmless.

cc @eschnett, does this help for your real world use case as well?

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Better performance when passing `user_functions` to the printers.
<!-- END RELEASE NOTES -->
