### PR TITLE
maint(ci): avoid cython 0.29.31 under PyPy

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -197,10 +197,18 @@ jobs:
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/matplotlib/matplotlib@main
 
+      # SciPy 1.8.1 does not build with Cython 0.29.31 under PyPy. This can be
+      # removed when SciPy builds successfully with any newer release of
+      # Cython.
+      - run: echo 'cython!=0.29.31' > constraints.txt
+
       # dependencies to install in all Python versions:
       - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
                          aesara wurlitzer autowrap                            \
                          'antlr4-python3-runtime==4.10.*'
+        env:
+          # Remove when SciPy builds without this.
+          PIP_CONSTRAINT: /home/runner/work/sympy/sympy/constraints.txt
 
       # gmpy2 is not available for pypy
       - if: ${{ matrix.python-version != 'pypy-3.8' }}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/23061#issuecomment-1197517304

#### Brief description of what is fixed or changed

The PyPy optional dependency job avoids Cython 0.29.31 which fails to build SciPy 1.8.1. This is probably an upstream bug in either Cython or SciPy.

#### Other comments

For a brief moment the CPython 3.11.0b5 release hit CI and we actually had everything pass on master (25cbe76557c2685afc209dcca13c9e0ec3f9a68e). Within hours though two different problems emerged and the next merge to master (dc86589ada8739dfdbf3bf014e6361bc4a42ff70) has two jobs failing both in the build of SciPy.

It's not clear yet what the problems are that cause this or if they are related. They seem to be because they both show the same error pointing at
```
      FAILED: scipy/stats/_stats.cpython-311-x86_64-linux-gnu.so.p/_stats.c
      /opt/hostedtoolcache/Python/3.11.0-beta.5/x64/bin/python /tmp/pip-req-build-ftutz8xt/scipy/_build_utils/cythoner.py ../../scipy/stats/_stats.pyx scipy/stats/_stats.cpython-311-x86_64-linux-gnu.so.p/_stats.c
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          return np.array(result, dtype=np.int64)
      
      
      @cython.wraparound(False)
      @cython.boundscheck(False)
      def _weightedrankedtau(ordered[:] x, ordered[:] y, intp_t[:] rank, weigher, bool additive):
      ^
```
However the two jobs use different versions of everything. The PyPy job installs cython, numpy and scipy all from pip to retrieve the latest versions. The only thing that seems to have changed there is the release of Cython 0.29.31.

The 3.11 job now uses CPython 3.11.0b5 and installs cython, numpy and scipy from git master/main. The Cython master branch currently reports as Cython-3.0.0a10. It's not clear if there has been a change in Cython master or a change in SciPy main that has caused this to fail but since the error message is similar to the one seen with Cython 0.29.31 maybe they are releated.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
