### PR TITLE
solve raises error on duplicate symbols

### DIFF
--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -419,10 +419,13 @@ def test_issue_18248():
 def test_issue_13230():
     c1 = Circle(Point2D(3, sqrt(5)), 5)
     c2 = Circle(Point2D(4, sqrt(7)), 6)
-    assert intersection(c1, c2) == [Point2D(-1 + (-sqrt(7) + sqrt(5))*(-2*sqrt(7)/29
-    + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29
-    + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)
-    + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
+    s = sqrt(196*sqrt(35) + 1941)
+    d = (-sqrt(7) + sqrt(5))
+    d2 = -2*sqrt(7)/29 + 9*sqrt(5)/29
+    d3 = -9*sqrt(5) + 2*sqrt(7)
+    assert intersection(c1, c2) == [Point2D(-1 - d*(s + d3)/29, d2 - s/29),
+        Point2D(-1 + d*(s - d3)/29, d2 + s/29)]
+
 
 def test_issue_19760():
     e = 1/(sqrt(1 + sqrt(2)) - sqrt(2)*sqrt(1 + sqrt(2))) + 1

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -85,11 +85,12 @@ def test__classify_linear_system():
 
     eqs_2 = (5 * (x1**2) + 12 * x(t) - 6 * (y(t)), (2 * y1 - 11 * t * x(t) + 3 * y(t) + t))
     sol2 = {'is_implicit': True,
-            'canon_eqs': [[Eq(Derivative(x(t), t), -sqrt(-12*x(t)/5 + 6*y(t)/5)),
-            Eq(Derivative(y(t), t), 11*t*x(t)/2 - t/2 - 3*y(t)/2)],
-            [Eq(Derivative(x(t), t), sqrt(-12*x(t)/5 + 6*y(t)/5)),
-            Eq(Derivative(y(t), t), 11*t*x(t)/2 - t/2 - 3*y(t)/2)]]}
-    assert _classify_linear_system(eqs_2, funcs, t) == sol2
+           'canon_eqs': [[Eq(Derivative(x(t), t), -sqrt(-60*x(t) + 30*y(t))/5),
+           Eq(Derivative(y(t), t), 11*t*x(t)/2 - t/2 - 3*y(t)/2)],
+           [Eq(Derivative(x(t), t), sqrt(-60*x(t) + 30*y(t))/5),
+           Eq(Derivative(y(t), t), 11*t*x(t)/2 - t/2 - 3*y(t)/2)]]}
+    got = _classify_linear_system(eqs_2, funcs, t)
+    assert got == sol2
 
     eqs_2_1 = [Eq(Derivative(x(t), t), -sqrt(-12*x(t)/5 + 6*y(t)/5)),
             Eq(Derivative(y(t), t), 11*t*x(t)/2 - t/2 - 3*y(t)/2)]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1033,8 +1033,10 @@ def solve(f, *symbols, **flags):
     # we can solve for non-symbol entities by replacing them with Dummy symbols
     f, symbols, swap_sym = recast_to_symbols(f, symbols)
 
-    # this is needed in the next two events
+    # this is needed in the next two events and at the end
     symset = set(symbols)
+    if len(symbols) != len(symset):
+        raise ValueError('duplicate symbols given')
 
     # get rid of equations that have no symbols of interest; we don't
     # try to solve them because the user didn't ask and they might be

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2074,7 +2074,8 @@ def _solve_system(exprs, symbols, **flags):
     if not result:
         return []
 
-    default_simplify = bool(failed)  # rely on system-solvers to simplify
+    # rely on linear system solvers to simplify
+    default_simplify = bool(failed) or not linear
     if flags.get('simplify', default_simplify):
         for r in result:
             for k in r:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1073,6 +1073,8 @@ def solve(f, *symbols, **flags):
         if ok:
             newf.append(fi)
     if not newf:
+        if as_set:
+            return symbols, set()
         return []
     f = newf
     del newf

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -569,8 +569,8 @@ def test_solve_args():
     assert solve(42) == solve(42, x) == []
     assert solve([1, 2]) == []
     assert solve([sqrt(2)],[x]) == []
-    # duplicate symbols removed
-    assert solve((x - 3, y + 2), x, y, x) == {x: 3, y: -2}
+    # duplicate symbols raises
+    raises(ValueError, lambda: solve((x - 3, y + 2), x, y, x))
     # unordered symbols
     # only 1
     assert solve(y - 3, {y}) == [3]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -115,443 +115,259 @@ def test_guess_transcendental():
 
 
 def test_solve_io():
-    lx = x
-    nx = x**2 - 4
-    lxly = x - y + 1
-    lxny = x + y**2 - 1
-    nxly = y + x**2 - 1
-    nxny = y**2 + x**2 - 1
-    flags = {}, dict(dict=True), dict(set=True)
-    e = lx
-    assert [solve(e, **f) for f in flags] == \
-        [[0],
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve([e], **f) for f in flags] == [
-        {x: 0},
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve(e, x, **f) for f in flags] == \
-        [[0],
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        {x: 0},
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[0],
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        {x: 0},
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(y, 0)],
-        [{x: 0}],
-        ([y, x], {(y, 0)})]
-        #([x, y], {(0, y)})]master
-    assert [solve([e], y, x, **f) for f in flags] == [
-        {x: 0},
-        [{x: 0}],
-        ([y, x], {(y, 0)})]
-        #([x], {(0,)})]#master
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{x: 0}],
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve([e], {y, x}, **f) for f in flags] == [
-        #[{x: 0}],
-        {x: 0},#master
-        [{x: 0}],
-        ([x], {(0,)})]
-    assert [solve(e, y, **f) for f in flags] == \
-        [[],
-        [],
-        ([y], set())]
-    assert [solve([e], y, **f) for f in flags] == [
-        [],
-        [],
-        ([y], set())]
-    e = nx
-    def lot(lod):
-        from sympy.core.sorting import ordered
-        s = list(ordered(lod[0].keys()))
-        return [tuple([d[i] for i in s]) for d in lod]
-    assert [solve(e, **f) for f in flags] == \
-        [[-2, 2],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve([e], **f) for f in flags] == [
-        [{x: -2}, {x: 2}],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve(e, x, **f) for f in flags] == \
-        [[-2, 2],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        lot([{x: -2}, {x: 2}]),
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[-2, 2],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        [{x: -2}, {x: 2}],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve(e, x, y, **f) for f in flags] == \
-        [[(-2, y), (2, y)],
-        [{x: -2}, {x: 2}],
-        ([x, y], {(2, y), (-2, y)})]
-    assert [solve([e], x, y, **f) for f in flags] == [
-        [(-2, y), (2, y)],
-        [{x: -2}, {x: 2}],
-        ([x, y], {(2, y), (-2, y)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(y, -2), (y, 2)],
-        [{x: -2}, {x: 2}],
-        ([y, x], {(y, -2), (y, 2)})]
-    assert [solve([e], y, x, **f) for f in flags] == [
-        [(y, -2), (y, 2)],
-        [{x: -2}, {x: 2}],
-        ([y, x], {(y, -2), (y, 2)})]
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{x: -2}, {x: 2}],
-        [{x: -2}, {x: 2}],
-        ([x], {(2,), (-2,)})]
-    assert [solve(e, y, **f) for f in flags] == \
-        [[],
-        [],
-        ([y], set())]
-    e = lxly
-    assert [solve(e, **f) for f in flags] == \
-        [[{x: y - 1}],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})],[solve(e, **f) for f in flags]
-    assert [solve([e], **f) for f in flags] == [
-        {x: y - 1}, #[{x: y - 1}],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve(e, x, **f) for f in flags] == \
-        [[y - 1],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        {x: y - 1},
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[y - 1],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        {x: y - 1},
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve(e, x, y, **f) for f in flags] == \
-        [[(y - 1, y)],
-        [{x: y - 1}],
-        ([x, y], {(y - 1, y)})]
-    assert [solve([e], x, y, **f) for f in flags] == [
-        {x: y - 1},
-        [{x: y - 1}],
-        ([x, y], {(y - 1, y)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(x + 1, x)],
-        [{y: x + 1}],
-        ([y, x], {(x + 1, x)})]
-    assert [solve([e], y, x, **f) for f in flags] == [
-        {y: x + 1}, #[(x + 1, x)],
-        [{y: x + 1}],
-        ([y, x], {(x + 1, x)})]
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{x: y - 1}],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve([e], {y, x}, **f) for f in flags] == [
-        {x: y - 1}, #[{x: y - 1}],
-        [{x: y - 1}],
-        ([x], {(y - 1,)})]
-    assert [solve(e, x, z, y, **f) for f in flags] == \
-        [[(y - 1, z, y)],
-        [{x: y - 1}],
-        ([x, z, y], {(y - 1, z, y)})]
-    assert [solve([e], x, z, y, **f) for f in flags] == [
-        {x: y - 1}, #[(y - 1, z, y)],
-        [{x: y - 1}],
-        ([x, z, y], {(y - 1, z, y)})]
-    e = lxny
-    assert [solve(e, **f) for f in flags] == \
-        [[{x: 1 - y**2}],
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})]
-    Y = (y - 1)*(y + 1)*-1  # XXX solution is not being simplified
-    assert [solve([e], **f) for f in flags] == [
-        [{x: Y}],
-        [{x: Y}],
-        ([x], {(Y,)})]
-    assert [solve(e, x, **f) for f in flags] == \
-        [[1 - y**2],
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        {x: 1 - y**2},
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})],[solve(e, x, **f) for f in flags]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[1 - y**2],
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        {x: 1 - y**2},
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})],[solve(e, x, **f) for f in flags]
-    assert [solve(e, x, y, **f) for f in flags] == \
-        [[(1 - y**2, y)],
-        [{x: 1 - y**2}],
-        ([x, y], {(1 - y**2, y)})]
-    assert [solve([e], x, y, **f) for f in flags] == [
-        [(Y, y)],
-        [{x: Y}],
-        ([x, y], {(Y, y)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(y, 1 - y**2)],
-        [{x: 1 - y**2}],
-        ([y, x], {(y, 1 - y**2)})]
-    assert [solve([e], y, x, **f) for f in flags] == [
-        [(y, Y)],
-        [{x: Y}],
-        ([y, x], {(y, Y)})]
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{x: 1 - y**2}],
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})]
-    assert [solve([e], {y, x}, **f) for f in flags] == [
-        [{x: Y}],
-        [{x: Y}],
-        ([x], {(Y,)})]
-    assert [solve(e, x, z, y, **f) for f in flags] == \
-        [[(1 - y**2, z, y)],
-        [{x: 1 - y**2}],
-        ([x, z, y], {(1 - y**2, z, y)})]
-    assert [solve([e], x, z, y, **f) for f in flags] == [
-        [(Y, z, y)],
-        [{x: Y}],
-        ([x, z, y], {(Y, z, y)})]
-    assert [solve(e, {x, z, y}, **f) for f in flags] == \
-        [[{x: 1 - y**2}],
-        [{x: 1 - y**2}],
-        ([x], {(1 - y**2,)})]
-    assert [solve([e], {x, z, y}, **f) for f in flags] == [
-        [{x: Y}],
-        [{x: Y}],
-        ([x], {(Y,)})]
-    e = nxly
-    assert [solve(e, **f) for f in flags] == \
-        [[{y: 1 - x**2}],
-        [{y: 1 - x**2}],
-        ([y], {(1 - x**2,)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        lot([{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}]),
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[-sqrt(1 - y), sqrt(1 - y)],
-        [{x: -sqrt(1 - y)},
-        {x: sqrt(1 - y)}],
-        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
-    assert [solve(e, x, y, **f) for f in flags] == \
-        [[(x, 1 - x**2)],
-        [{y: 1 - x**2}],
-        ([x, y], {(x, 1 - x**2)})]
-    assert [solve([e], x, y, **f) for f in flags] == [
-        [(-sqrt(1 - y), y), (sqrt(1 - y), y)],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x, y], {(-sqrt(1 - y), y), (sqrt(1 - y), y)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(1 - x**2, x)],
-        [{y: 1 - x**2}],
-        ([y, x], {(1 - x**2, x)})]
-    assert [solve([e], y, x, **f) for f in flags] == [
-        [(y, -sqrt(1 - y)), (y, sqrt(1 - y))],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([y, x], {(y, -sqrt(1 - y)), (y, sqrt(1 - y))})]
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{y: 1 - x**2}],
-        [{y: 1 - x**2}],
-        ([y], {(1 - x**2,)})]
-    assert [solve([e], {y, x}, **f) for f in flags] == [
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x], {(sqrt(1 - y),), (-sqrt(1 - y),)})]
-    assert [solve(e, x, z, y, **f) for f in flags] == \
-        [[(x, z, 1 - x**2)],
-        [{y: 1 - x**2}],
-        ([x, z, y], {(x, z, 1 - x**2)})]
-    assert [solve([e], x, z, y, **f) for f in flags] == [
-        [(-sqrt(1 - y), z, y), (sqrt(1 - y), z, y)],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x, z, y], {(-sqrt(1 - y), z, y), (sqrt(1 - y), z, y)})]
-    assert [solve(e, {x, z, y}, **f) for f in flags] == \
-        [[{y: 1 - x**2}],
-        [{y: 1 - x**2}],
-        ([y], {(1 - x**2,)})]
-    assert [solve([e], {x, z, y}, **f) for f in flags] == [
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
-        ([x], {(sqrt(1 - y),), (-sqrt(1 - y),)})]
-    e = nxny
-    assert [solve(e, **f) for f in flags] == \
-        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
-    assert [solve([e], **f) for f in flags] == [
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
-    assert [solve(e, x, **f) for f in flags] == \
-        [[-sqrt(1 - y**2), sqrt(1 - y**2)],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
-    assert [solve([e], x, **f) for f in flags] == [
-        lot([{x: -sqrt(Y)}, {x: sqrt(Y)}]),
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
-    assert [solve(e, {x}, **f) for f in flags] == \
-        [[-sqrt(1 - y**2), sqrt(1 - y**2)],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
-    assert [solve([e], {x}, **f) for f in flags] == [
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
-    assert [solve(e, x, y, **f) for f in flags] == \
-        [[(-sqrt(1 - y**2), y), (sqrt(1 - y**2), y)],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x, y], {(-sqrt(1 - y**2), y), (sqrt(1 - y**2), y)})]
-    assert [solve([e], x, y, **f) for f in flags] == [
-        [(-sqrt(Y), y), (sqrt(Y), y)],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x, y], {(-sqrt(Y), y), (sqrt(Y), y)})]
-    assert [solve(e, y, x, **f) for f in flags] == \
-        [[(-sqrt(1 - x**2), x), (sqrt(1 - x**2), x)],
-        [{y: -sqrt(1 - x**2)}, {y: sqrt(1 - x**2)}],
-        ([y, x], {(sqrt(1 - x**2), x), (-sqrt(1 - x**2), x)})]
-    assert [solve([e], y, x, **f) for f in flags] == [
-        [(y, -sqrt(Y)), (y, sqrt(Y))],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([y, x], {(y, sqrt(Y)), (y, -sqrt(Y))})]
-    assert [solve(e, {y, x}, **f) for f in flags] == \
-        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
-    assert [solve([e], {y, x}, **f) for f in flags] == [
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
-    assert [solve(e, x, z, y, **f) for f in flags] == \
-        [[(-sqrt(1 - y**2), z, y), (sqrt(1 - y**2), z, y)],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x, z, y], {(sqrt(1 - y**2), z, y), (-sqrt(1 - y**2), z, y)})]
-    assert [solve([e], x, z, y, **f) for f in flags] == [
-        [(-sqrt(Y), z, y), (sqrt(Y), z, y)],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x, z, y], {(-sqrt(Y), z, y), (sqrt(Y), z, y)})]
-    assert [solve(e, {x, z, y}, **f) for f in flags] == \
-        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
-        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
-    assert [solve([e], {x, z, y}, **f) for f in flags] == [
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
-        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+    Y = 1 - y**2
+    X = 1 - x**2
+    flags = {}, dict(dict = True), dict(set = True)
 
-    e = lx, lxny
-    assert [solve([*e], **f) for f in flags] == \
-        [[{x: 0, y: -1}, {x: 0, y: 1}],
-        [{x: 0, y: -1}, {x: 0, y: 1}],
-        ([x, y], {(0, -1), (0, 1)})]
-    assert [solve([*e], x, **f) for f in flags] == \
-        [[],
-        [],
-        ([x], set())]
-    assert [solve([*e], {x}, **f) for f in flags] == \
-        [[],
-        [],
-        ([x], set())]
-    assert [solve([*e], x, y, **f) for f in flags] == \
-        [[(0, -1), (0, 1)],
-        [{x: 0, y: -1}, {x: 0, y: 1}],
-        ([x, y], {(0, -1), (0, 1)})]
-    assert [solve([*e], y, x, **f) for f in flags] == \
-        [[(-1, 0), (1, 0)],
-        [{y: -1, x: 0}, {y: 1, x: 0}],
-        ([y, x], {(-1, 0), (1, 0)})]
-    assert [solve([*e], {y, x}, **f) for f in flags] == \
-        [[{x: 0, y: -1}, {x: 0, y: 1}],
-        [{x: 0, y: -1}, {x: 0, y: 1}],
-        ([x, y], {(0, -1), (0, 1)})]
-    assert [solve([*e], x, z, y, **f) for f in flags] == \
-        [[(0, z, -1), (0, z, 1)],
-        [{x: 0, y: -1}, {x: 0, y: 1}],
-        ([x, z, y], {(0, z, 1), (0, z, -1)})]
-    assert [solve([*e], {x, z, y}, **f) for f in flags] == \
-        [[{x: 0, y: -1}, {x: 0, y: 1}],
-        [{x: 0, y: -1}, {x: 0, y: 1}],
-        ([x, y], {(0, -1), (0, 1)})]
-    # monotonic solution is treated like linear so some of
-    # the lines below should be a simple dict
+    ##### single one equation
+
+    d = {x: 0}
+    s = ([x], {(0,)})
+    syx = ([y, x], {(y, 0)})
+    sy = ([y], set())
+    vx = [0]
+    vyx = [(y, 0)]
+    e =                                                                         x
+    assert [solve(e, **f) for f in flags] ==            [vx,    [d],    s]      # no syms
+    assert [solve([e], **f) for f in flags] ==          [d,     [d],    s]
+
+    assert [solve(e, x, **f) for f in flags] ==         [vx,    [d],    s]      # x
+    assert [solve([e], x, **f) for f in flags] ==       [d,     [d],    s]
+
+    assert [solve(e, {x}, **f) for f in flags] ==       [vx,    [d],    s]      # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==     [d,     [d],    s]
+
+    assert [solve(e, y, x, **f) for f in flags] ==      [vyx,   [d],    syx]    # y, x
+    assert [solve([e], y, x, **f) for f in flags] ==    [d,     [d],    syx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==    [[d],   [d],    s]      # {y, x}
+    assert [solve([e], {y, x}, **f) for f in flags] ==  [d,     [d],    s]
+
+    assert [solve(e, y, **f) for f in flags] ==         [[],    [],     sy]     # y (not in equation)
+    assert [solve([e], y, **f) for f in flags] ==       [[],    [],     sy]
+
+    lod = [{x: -2}, {x: 2}]
+    s = ([x], {(2,), (-2,)})
+    sxy = ([x, y], {(2, y), (-2, y)})
+    syx = ([y, x], {(y, -2), (y, 2)})
+    vx = [-2, 2]
+    tx = [(-2,),(2,)]
+    txy = [(-2, y), (2, y)]
+    tyx = [(y, -2), (y, 2)]
+    sy = ([y], set())
+    e =                                                                         x**2 - 4
+    assert [solve(e, **f) for f in flags] ==            [vx,    lod,    s]      # no syms
+    assert [solve([e], **f) for f in flags] ==          [lod,   lod,    s]
+
+    assert [solve(e, x, **f) for f in flags] ==         [vx,    lod,    s]      # x
+    assert [solve([e], x, **f) for f in flags] ==       [tx,    lod,    s]
+
+    assert [solve(e, {x}, **f) for f in flags] ==       [vx,    lod,    s]      # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==     [lod,   lod,    s]
+
+    assert [solve(e, x, y, **f) for f in flags] ==      [txy,   lod,    sxy]    # x, y (not in equation)
+    assert [solve([e], x, y, **f) for f in flags] ==    [txy,   lod,    sxy]
+
+    assert [solve(e, y, x, **f) for f in flags] ==      [tyx,   lod,    syx]    # y (not in equation), x
+    assert [solve([e], y, x, **f) for f in flags] ==    [tyx,   lod,    syx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==    [lod,   lod,    s]      # {y (not in equation), x}
+    assert [solve(e, y, **f) for f in flags] ==         [[],    [],     sy]
+
+    vx = y - 1
+    vy = x + 1
+    dx = {x: vx}
+    dy = {y: vy}
+    txy = (vx, y)
+    tyx = (vy, x)
+    txzy = (vx, z, y)
+    s = ([x], {(vx,)})
+    sxy = ([x, y], {txy})
+    syx = ([y, x], {tyx})
+    sxzy = ([x, z, y], {txzy})
+    e =                                                                             x - y + 1
+    assert [solve(e, **f) for f in flags] ==            [[dx],      [dx],   s]      # no syms
+    assert [solve([e], **f) for f in flags] ==          [dx,        [dx],   s]
+
+    assert [solve(e, x, **f) for f in flags] ==         [[vx],      [dx],   s]      # x
+    assert [solve([e], x, **f) for f in flags] ==       [dx,        [dx],   s]
+
+    assert [solve(e, {x}, **f) for f in flags] ==       [[vx],      [dx],   s]      # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==     [dx,        [dx],   s]
+
+    assert [solve(e, x, y, **f) for f in flags] ==      [[txy],     [dx],   sxy]    # x, y
+    assert [solve([e], x, y, **f) for f in flags] ==    [dx,        [dx],   sxy]
+
+    assert [solve(e, y, x, **f) for f in flags] ==      [[tyx],     [dy],   syx]    # y, x
+    assert [solve([e], y, x, **f) for f in flags] ==    [dy,        [dy],   syx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==    [[dx],      [dx],   s]      # {x, y}
+    assert [solve([e], {y, x}, **f) for f in flags] ==  [dx,        [dx],   s]
+
+    assert [solve(e, x, z, y, **f) for f in flags] ==   [[txzy],    [dx],   sxzy]   # x, z (not in equation), y
+    assert [solve([e], x, z, y, **f) for f in flags] == [dx,        [dx],   sxzy]
+
+    d = {x: Y}
+    sx = ([x], {(Y,)})
+    txy = (Y, y)
+    tyx = (y, Y)
+    txzy = (Y, z, y)
+    sxy = ([x, y], {txy})
+    syx = ([y, x], {tyx})
+    sxzy = ([x, z, y], {txzy})
+    e =                                                                                 x + y**2 - 1
+    assert [solve(e, **f) for f in flags] ==                [[d],       [d],    sx]     # no syms
+    assert [solve([e], **f) for f in flags] ==              [[d],       [d],    sx]
+
+    assert [solve(e, x, **f) for f in flags] ==             [[Y],       [d],    sx]     # x
+    assert [solve([e], x, **f) for f in flags] ==           [d,         [d],    sx]
+
+    assert [solve(e, {x}, **f) for f in flags] ==           [[Y],       [d],    sx]     # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==         [d,         [d],    sx]
+
+    assert [solve(e, x, y, **f) for f in flags] ==          [[txy],     [d],    sxy]    # x, y }
+    assert [solve([e], x, y, **f) for f in flags] ==        [[txy],     [d],    sxy]    #      } symbol selected to solve
+                                                                                        #      } for is not the same
+    assert [solve(e, y, x, **f) for f in flags] ==          [[tyx],     [d],    syx]    # y, x }
+    assert [solve([e], y, x, **f) for f in flags] ==        [[tyx],     [d],    syx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==        [[d],       [d],    sx]     # {y,x}
+    assert [solve([e], {y, x}, **f) for f in flags] ==      [[d],       [d],    sx]
+
+    assert [solve(e, x, z, y, **f) for f in flags] ==       [[txzy],    [d],    sxzy]   # x, z (not in equation), y
+    assert [solve([e], x, z, y, **f) for f in flags] ==     [[txzy],    [d],    sxzy]
+
+    assert [solve(e, {x, z, y}, **f) for f in flags] ==     [[d],       [d],    sx]     # {x, y, z (not in equation)}
+    assert [solve([e], {x, z, y}, **f) for f in flags] ==   [[d],       [d],    sx]
+
+    vy = X
+    vx = sqrt(1 - y)
+    txy = (x, vy)
+    tyx = (vy, x)
+    sx = ([x], {(-vx,), (vx,)})
+    sy = ([y], {(vy,)})
+    sxy = ([x, y], {(-vx, y), (vx, y)})
+    sxyy = ([x, y], {txy})
+    syx = ([y, x], {(y, -vx), (y, vx)})
+    syxx = ([y, x], {(vy, x)})
+    sxzyx = ([x, z, y], {(-vx, z, y), (vx, z, y)})
+    sxzyy = ([x, z, y], {(x, z, vy)})
+    ltx = [(-vx,), (vx,)]
+    lty = [(x, z, vy)]
+    ltxy = [(-vx, y), (vx, y)]
+    ltyx = [(y, -vx), (y, vx)]
+    ltxzy = [(-vx, z, y), (vx, z, y)]
+    lvx = [-vx, vx]
+    lodx = [{x: -vx}, {x: vx}]
+    dy = {y: vy}
+    e =                                                                             y + x**2 - 1
+    assert [solve(e, **f) for f in flags] ==                [[dy],  [dy],   sy]     # no syms
+    assert [solve([e], x, **f) for f in flags] ==           [ltx,   lodx,   sx]
+
+    assert [solve(e, {x}, **f) for f in flags] ==           [lvx,   lodx,   sx]     # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==         [lodx,  lodx,   sx]
+
+    assert [solve(e, x, y, **f) for f in flags] ==          [[txy], [dy],   sxyy]   # x, y
+    assert [solve([e], x, y, **f) for f in flags] ==        [ltxy,  lodx,   sxy]
+
+    assert [solve(e, y, x, **f) for f in flags] ==          [[tyx], [dy],   syxx]   # y, x
+    assert [solve([e], y, x, **f) for f in flags] ==        [ltyx,  lodx,   syx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==        [[dy],  [dy],   sy]     # {y,x}
+    assert [solve([e], {y, x}, **f) for f in flags] ==      [lodx,  lodx,   sx]
+
+    assert [solve(e, x, z, y, **f) for f in flags] ==       [lty,   [dy],   sxzyy]  # x, z (not in equation), y
+    assert [solve([e], x, z, y, **f) for f in flags] ==     [ltxzy, lodx,   sxzyx]
+
+    assert [solve(e, {x, z, y}, **f) for f in flags] ==     [[dy],  [dy],   sy]     # {x, y, z (not in equation)}
+    assert [solve([e], {x, z, y}, **f) for f in flags] ==   [lodx,  lodx,   sx]
+
+    ry = sqrt(Y)
+    rx = sqrt(X)
+    lod = [{x: -ry}, {x: ry}]
+    lody = [{y: -rx}, {y: rx}]
+    sx = ([x], {(-ry,), (ry,)})
+    sx1 = ([x], {(ry,), (-ry,)})
+    sxy = ([x, y], {(-ry, y), (ry, y)})
+    syxy = ([y, x], {(rx, x), (-rx, x)})
+    syxx = ([y, x], {(y, -ry), (y, ry)})
+    tm = (-ry, z, y)
+    tp = (ry, z, y)
+    vx = [-ry, ry]
+    tx = [(-ry,), (ry,)]
+    txy = [(-ry, y), (ry, y)]
+    tyxx = [(-rx, x), (rx, x)]
+    tyxy = [(y, -ry), (y, ry)]
+    sxzy = ([x, z, y], {tm, tp})
+    e =                                                                                 y**2 + x**2 - 1
+    assert [solve(e, **f) for f in flags] ==                [lod,       lod,    sx]     # no syms
+    assert [solve([e], **f) for f in flags] ==              [lod,       lod,    sx1]
+
+    assert [solve(e, x, **f) for f in flags] ==             [vx,        lod,    sx]     # x
+    assert [solve([e], x, **f) for f in flags] ==           [tx,        lod,    sx1]
+
+    assert [solve(e, {x}, **f) for f in flags] ==           [vx,        lod,    sx]     # {x}
+    assert [solve([e], {x}, **f) for f in flags] ==         [lod,       lod,    sx1]
+
+    assert [solve(e, x, y, **f) for f in flags] ==          [txy,       lod,    sxy]    # x, y
+    assert [solve([e], x, y, **f) for f in flags] ==        [txy,       lod,    sxy]
+
+    assert [solve(e, y, x, **f) for f in flags] ==          [tyxx,      lody,   syxy]   # y, x
+    assert [solve([e], y, x, **f) for f in flags] ==        [tyxy,      lod,    syxx]
+
+    assert [solve(e, {y, x}, **f) for f in flags] ==        [lod,       lod,    sx]     # {x, y}
+    assert [solve([e], {y, x}, **f) for f in flags] ==      [lod,       lod,    sx1]
+
+    assert [solve(e, x, z, y, **f) for f in flags] ==       [[tm, tp],  lod,    sxzy]   # x, z (not in equation), y
+    assert [solve([e], x, z, y, **f) for f in flags] ==     [[tm, tp],  lod,    sxzy]
+
+    assert [solve(e, {x, z, y}, **f) for f in flags] ==     [lod,       lod,    sx]     # {x, y, z (not in equation)}
+    assert [solve([e], {x, z, y}, **f) for f in flags] ==   [lod,       lod,    sx1]
+
+    ##### more than one equation
+
+    sx = ([x], set())
+    sxy = ([x, y], {(0, -1), (0, 1)})
+    syx = ([y, x], {(-1, 0), (1, 0)})
+    lod = [{x: 0, y: -1}, {x: 0, y: 1}]
+    txzy = [(0, z, -1), (0, z, 1)]
+    txy = [(0, -1), (0, 1)]
+    tyx = [(-1, 0), (1, 0)]
+    sxzy = ([x, z, y], {(0, z, 1), (0, z, -1)})
+    e =                                                                            (x, x + y**2 - 1)
+    assert [solve([*e], **f) for f in flags] ==             [lod,   lod,    sxy]    # no symbol
+    assert [solve([*e], x, **f) for f in flags] ==          [[],    [],     sx]     # x
+    assert [solve([*e], {x}, **f) for f in flags] ==        [[],    [],     sx]     # {x}
+    assert [solve([*e], x, y, **f) for f in flags] ==       [txy,   lod,    sxy]    # x, y
+    assert [solve([*e], y, x, **f) for f in flags] ==       [tyx,   lod,    syx]    # y, x
+    assert [solve([*e], {y, x}, **f) for f in flags] ==     [lod,   lod,    sxy]    # {x, y}
+    assert [solve([*e], x, z, y, **f) for f in flags] ==    [txzy,  lod,    sxzy]   # x, z (missing), y
+    assert [solve([*e], {x, z, y}, **f) for f in flags] ==  [lod,   lod,    sxy]    # {x, y, z (missing)}
     assert solve((exp(x) - 1, y - 2)) == {x: 0, y: 2}
-    e = lx, nxly
-    assert [solve([*e], **f) for f in flags] == \
-        [[{x: 0, y: 1}], # {x: 0, y: 1},
-        [{x: 0, y: 1}],
-        ([x, y], {(0, 1)})]
-    assert [solve([*e], x, **f) for f in flags] == \
-        [[],
-        [],
-        ([x], set())]
-    assert [solve([*e], {x}, **f) for f in flags] == \
-        [[],
-        [],
-        ([x], set())]
-    assert [solve([*e], x, y, **f) for f in flags] == \
-        [[(0, 1)], #{x: 0, y: 1},
-        [{x: 0, y: 1}],
-        ([x, y], {(0, 1)})]
-    assert [solve([*e], y, x, **f) for f in flags] == \
-        [[(1, 0)], # {x: 0, y: 1},
-        [{y: 1, x: 0}],
-        ([y, x], {(1, 0)})]
-    assert [solve([*e], {y, x}, **f) for f in flags] == \
-        [[{x: 0, y: 1}], #{x: 0, y: 1},
-        [{x: 0, y: 1}],
-        ([x, y], {(0, 1)})]
-    assert [solve([*e], x, z, y, **f) for f in flags] == \
-        [[(0, z, 1)],
-        [{x: 0, y: 1}],
-        ([x, z, y], {(0, z, 1)})]
-    assert [solve([*e], {x, z, y}, **f) for f in flags] == \
-        [[{x: 0, y: 1}],
-        [{x: 0, y: 1}],
-        ([x, y], {(0, 1)})]
+
+    d = {x: 0, y: 1}
+    lxy = [(0, 1)]
+    lyx = [(1, 0)]
+    txzy = [(0, z, 1)]
+    sx = ([x], set())
+    sxy = ([x, y], {(0, 1)})
+    syx = ([y, x], {(1, 0)})
+    sxzy = ([x, z, y], {(0, z, 1)})
+    e =                                                                            (x, y + x**2 - 1)
+    assert [solve([*e], **f) for f in flags] ==             [[d],   [d],    sxy]    # no symbol
+    assert [solve([*e], x, **f) for f in flags] ==          [[],    [],     sx]     # x
+    assert [solve([*e], {x}, **f) for f in flags] ==        [[],    [],     sx]     # {x}
+    assert [solve([*e], x, y, **f) for f in flags] ==       [lxy,   [d],    sxy]    # x, y
+    assert [solve([*e], y, x, **f) for f in flags] ==       [lyx,   [d],    syx]    # y, x
+    assert [solve([*e], {y, x}, **f) for f in flags] ==     [[d],   [d],    sxy]    # {x, y}
+    assert [solve([*e], x, z, y, **f) for f in flags] ==    [txzy,  [d],    sxzy]   # x, z (missing), y
+    assert [solve([*e], {x, z, y}, **f) for f in flags] ==  [[d],   [d],    sxy]    # {x, y, z (missing)}
     e = a*x + b - 2*x - y
-    assert [solve(e, a, b, **f) for f in flags] == \
-        [{a: 2, b: y},
-        [{a: 2, b: y}],
-        ([a, b], {(2, y)})]
+    assert [solve(e, a, b, **f) for f in flags] == [
+        {a: 2, b: y},[{a: 2, b: y}],([a, b], {(2, y)})]
     assert [solve(e - b + b**2, a, b, **f) for f in flags] == [
-        [((-b**2 + 2*x + y)/x, b)], # master solved as nonlinear coeff sys
-        [{a: (-b**2 + 2*x + y)/x}],
-        ([a, b], {((-b**2 + 2*x + y)/x, b)})]
+        [((-b**2 + 2*x + y)/x, b)],[{a: (-b**2 + 2*x + y)/x}],(
+        [a, b], {((-b**2 + 2*x + y)/x, b)})]
 
 
 def test_solve_args():
@@ -2624,27 +2440,21 @@ def test_issue_12114():
     a, b, c, d, e, f, g = symbols('a,b,c,d,e,f,g')
     terms = [1 + a*b + d*e, 1 + a*c + d*f, 1 + b*c + e*f,
              g - a**2 - d**2, g - b**2 - e**2, g - c**2 - f**2]
-    s = solve(terms, [a, b, c, d, e, f, g], dict=True)
-    assert s == [{a: -sqrt(-f**2 - 1), b: -sqrt(-f**2 - 1),
-                  c: -sqrt(-f**2 - 1), d: f, e: f, g: -1},
-                 {a: sqrt(-f**2 - 1), b: sqrt(-f**2 - 1),
-                  c: sqrt(-f**2 - 1), d: f, e: f, g: -1},
-                 {a: -sqrt(3)*f/2 - sqrt(-f**2 + 2)/2,
-                  b: sqrt(3)*f/2 - sqrt(-f**2 + 2)/2, c: sqrt(-f**2 + 2),
-                  d: -f/2 + sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 - sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: -sqrt(3)*f/2 + sqrt(-f**2 + 2)/2,
-                  b: sqrt(3)*f/2 + sqrt(-f**2 + 2)/2, c: -sqrt(-f**2 + 2),
-                  d: -f/2 - sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 + sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: sqrt(3)*f/2 - sqrt(-f**2 + 2)/2,
-                  b: -sqrt(3)*f/2 - sqrt(-f**2 + 2)/2, c: sqrt(-f**2 + 2),
-                  d: -f/2 - sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 + sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: sqrt(3)*f/2 + sqrt(-f**2 + 2)/2,
-                  b: -sqrt(3)*f/2 + sqrt(-f**2 + 2)/2, c: -sqrt(-f**2 + 2),
-                  d: -f/2 + sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 - sqrt(3)*sqrt(-f**2 + 2)/2, g: 2}]
+    sol = solve(terms, [a, b, c, d, e, f, g], dict=True)
+    s = sqrt(-f**2 - 1)
+    s2 = sqrt(2 - f**2)
+    s3 = sqrt(6 - 3*f**2)
+    s4 = sqrt(3)*f
+    assert sol == [{a: -s, b: -s, c: -s, d: f, e: f, g: -1},
+     {a: s, b: s, c: s, d: f, e: f, g: -1},
+     {a: -s4/2 - s2/2, b: s4/2 - s2/2, c: s2, d: -f/2 + s3/2,
+        e: -f/2 - s3/2, g:2},
+     {a: -s4/2 + s2/2, b: s4/2 + s2/2, c: -s2, d: -f/2 - s3/2,
+        e: -f/2 + s3/2, g: 2},
+     {a: s4/2 - s2/2, b: -s4/2 - s2/2, c: s2, d: -f/2 - s3/2,
+        e: -f/2 + s3/2, g: 2},
+     {a: s4/2 + s2/2, b: -s4/2 + s2/2, c: -s2, d: -f/2 + s3/2,
+        e: -f/2 - s3/2, g: 2}]
 
 
 def test_inf():
@@ -2916,9 +2726,10 @@ def test_issue_21034():
 
 
 def test_issue_4886():
-    z = a*sqrt(R**2*a**2 + R**2*b**2 - c**2)/(a**2 + b**2)
-    t = b*c/(a**2 + b**2)
-    sol = [((b*(t - z) - c)/(-a), t - z), ((b*(t + z) - c)/(-a), t + z)]
+    s = sqrt(R**2*a**2 + R**2*b**2 - c**2)
+    r2 = (a**2 + b**2)
+    sol = [((a*c - b*s)/r2, (b*c + a*s)/r2),
+           ((a*c + b*s)/r2, (b*c - a*s)/r2)]
     assert solve([x**2 + y**2 - R**2, a*x + b*y - c], x, y) == sol
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -114,6 +114,446 @@ def test_guess_transcendental():
     assert guess_solve_strategy(a*x**b - y, x)  # == GS_TRANSCENDENTAL
 
 
+def test_solve_io():
+    lx = x
+    nx = x**2 - 4
+    lxly = x - y + 1
+    lxny = x + y**2 - 1
+    nxly = y + x**2 - 1
+    nxny = y**2 + x**2 - 1
+    flags = {}, dict(dict=True), dict(set=True)
+    e = lx
+    assert [solve(e, **f) for f in flags] == \
+        [[0],
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve([e], **f) for f in flags] == [
+        {x: 0},
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve(e, x, **f) for f in flags] == \
+        [[0],
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        {x: 0},
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[0],
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        {x: 0},
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(y, 0)],
+        [{x: 0}],
+        ([y, x], {(y, 0)})]
+        #([x, y], {(0, y)})]master
+    assert [solve([e], y, x, **f) for f in flags] == [
+        {x: 0},
+        [{x: 0}],
+        ([y, x], {(y, 0)})]
+        #([x], {(0,)})]#master
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{x: 0}],
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve([e], {y, x}, **f) for f in flags] == [
+        #[{x: 0}],
+        {x: 0},#master
+        [{x: 0}],
+        ([x], {(0,)})]
+    assert [solve(e, y, **f) for f in flags] == \
+        [[],
+        [],
+        []] #([y], set())]
+    assert [solve([e], y, **f) for f in flags] == [
+        [],
+        [],
+        []] #([y], set())]
+    e = nx
+    def lot(lod):
+        from sympy.core.sorting import ordered
+        s = list(ordered(lod[0].keys()))
+        return [tuple([d[i] for i in s]) for d in lod]
+    assert [solve(e, **f) for f in flags] == \
+        [[-2, 2],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve([e], **f) for f in flags] == [
+        [{x: -2}, {x: 2}],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve(e, x, **f) for f in flags] == \
+        [[-2, 2],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        lot([{x: -2}, {x: 2}]),
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[-2, 2],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        [{x: -2}, {x: 2}],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve(e, x, y, **f) for f in flags] == \
+        [[(-2, y), (2, y)],
+        [{x: -2}, {x: 2}],
+        ([x, y], {(2, y), (-2, y)})]
+    assert [solve([e], x, y, **f) for f in flags] == [
+        [(-2, y), (2, y)],
+        [{x: -2}, {x: 2}],
+        ([x, y], {(2, y), (-2, y)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(y, -2), (y, 2)],
+        [{x: -2}, {x: 2}],
+        ([y, x], {(y, -2), (y, 2)})]
+    assert [solve([e], y, x, **f) for f in flags] == [
+        [(y, -2), (y, 2)],
+        [{x: -2}, {x: 2}],
+        ([y, x], {(y, -2), (y, 2)})]
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{x: -2}, {x: 2}],
+        [{x: -2}, {x: 2}],
+        ([x], {(2,), (-2,)})]
+    assert [solve(e, y, **f) for f in flags] == \
+        [[],
+        [],
+        []] # ([y], set())]
+    e = lxly
+    assert [solve(e, **f) for f in flags] == \
+        [[{x: y - 1}],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})],[solve(e, **f) for f in flags]
+    assert [solve([e], **f) for f in flags] == [
+        {x: y - 1}, #[{x: y - 1}],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve(e, x, **f) for f in flags] == \
+        [[y - 1],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        {x: y - 1},
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[y - 1],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        {x: y - 1},
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve(e, x, y, **f) for f in flags] == \
+        [[(y - 1, y)],
+        [{x: y - 1}],
+        ([x, y], {(y - 1, y)})]
+    assert [solve([e], x, y, **f) for f in flags] == [
+        {x: y - 1},
+        [{x: y - 1}],
+        ([x, y], {(y - 1, y)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(x + 1, x)],
+        [{y: x + 1}],
+        ([y, x], {(x + 1, x)})]
+    assert [solve([e], y, x, **f) for f in flags] == [
+        {y: x + 1}, #[(x + 1, x)],
+        [{y: x + 1}],
+        ([y, x], {(x + 1, x)})]
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{x: y - 1}],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve([e], {y, x}, **f) for f in flags] == [
+        {x: y - 1}, #[{x: y - 1}],
+        [{x: y - 1}],
+        ([x], {(y - 1,)})]
+    assert [solve(e, x, z, y, **f) for f in flags] == \
+        [[(y - 1, z, y)],
+        [{x: y - 1}],
+        ([x, z, y], {(y - 1, z, y)})]
+    assert [solve([e], x, z, y, **f) for f in flags] == [
+        {x: y - 1}, #[(y - 1, z, y)],
+        [{x: y - 1}],
+        ([x, z, y], {(y - 1, z, y)})]
+    e = lxny
+    assert [solve(e, **f) for f in flags] == \
+        [[{x: 1 - y**2}],
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})]
+    Y = (y - 1)*(y + 1)*-1  # XXX solution is not being simplified
+    assert [solve([e], **f) for f in flags] == [
+        [{x: Y}],
+        [{x: Y}],
+        ([x], {(Y,)})]
+    assert [solve(e, x, **f) for f in flags] == \
+        [[1 - y**2],
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        {x: 1 - y**2},
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})],[solve(e, x, **f) for f in flags]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[1 - y**2],
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        {x: 1 - y**2},
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})],[solve(e, x, **f) for f in flags]
+    assert [solve(e, x, y, **f) for f in flags] == \
+        [[(1 - y**2, y)],
+        [{x: 1 - y**2}],
+        ([x, y], {(1 - y**2, y)})]
+    assert [solve([e], x, y, **f) for f in flags] == [
+        [(Y, y)],
+        [{x: Y}],
+        ([x, y], {(Y, y)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(y, 1 - y**2)],
+        [{x: 1 - y**2}],
+        ([y, x], {(y, 1 - y**2)})]
+    assert [solve([e], y, x, **f) for f in flags] == [
+        [(y, Y)],
+        [{x: Y}],
+        ([y, x], {(y, Y)})]
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{x: 1 - y**2}],
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})]
+    assert [solve([e], {y, x}, **f) for f in flags] == [
+        [{x: Y}],
+        [{x: Y}],
+        ([x], {(Y,)})]
+    assert [solve(e, x, z, y, **f) for f in flags] == \
+        [[(1 - y**2, z, y)],
+        [{x: 1 - y**2}],
+        ([x, z, y], {(1 - y**2, z, y)})]
+    assert [solve([e], x, z, y, **f) for f in flags] == [
+        [(Y, z, y)],
+        [{x: Y}],
+        ([x, z, y], {(Y, z, y)})]
+    assert [solve(e, {x, z, y}, **f) for f in flags] == \
+        [[{x: 1 - y**2}],
+        [{x: 1 - y**2}],
+        ([x], {(1 - y**2,)})]
+    assert [solve([e], {x, z, y}, **f) for f in flags] == [
+        [{x: Y}],
+        [{x: Y}],
+        ([x], {(Y,)})]
+    e = nxly
+    assert [solve(e, **f) for f in flags] == \
+        [[{y: 1 - x**2}],
+        [{y: 1 - x**2}],
+        ([y], {(1 - x**2,)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        lot([{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}]),
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[-sqrt(1 - y), sqrt(1 - y)],
+        [{x: -sqrt(1 - y)},
+        {x: sqrt(1 - y)}],
+        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x], {(-sqrt(1 - y),), (sqrt(1 - y),)})]
+    assert [solve(e, x, y, **f) for f in flags] == \
+        [[(x, 1 - x**2)],
+        [{y: 1 - x**2}],
+        ([x, y], {(x, 1 - x**2)})]
+    assert [solve([e], x, y, **f) for f in flags] == [
+        [(-sqrt(1 - y), y), (sqrt(1 - y), y)],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x, y], {(-sqrt(1 - y), y), (sqrt(1 - y), y)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(1 - x**2, x)],
+        [{y: 1 - x**2}],
+        ([y, x], {(1 - x**2, x)})]
+    assert [solve([e], y, x, **f) for f in flags] == [
+        [(y, -sqrt(1 - y)), (y, sqrt(1 - y))],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([y, x], {(y, -sqrt(1 - y)), (y, sqrt(1 - y))})]
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{y: 1 - x**2}],
+        [{y: 1 - x**2}],
+        ([y], {(1 - x**2,)})]
+    assert [solve([e], {y, x}, **f) for f in flags] == [
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x], {(sqrt(1 - y),), (-sqrt(1 - y),)})]
+    assert [solve(e, x, z, y, **f) for f in flags] == \
+        [[(x, z, 1 - x**2)],
+        [{y: 1 - x**2}],
+        ([x, z, y], {(x, z, 1 - x**2)})]
+    assert [solve([e], x, z, y, **f) for f in flags] == [
+        [(-sqrt(1 - y), z, y), (sqrt(1 - y), z, y)],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x, z, y], {(-sqrt(1 - y), z, y), (sqrt(1 - y), z, y)})]
+    assert [solve(e, {x, z, y}, **f) for f in flags] == \
+        [[{y: 1 - x**2}],
+        [{y: 1 - x**2}],
+        ([y], {(1 - x**2,)})]
+    assert [solve([e], {x, z, y}, **f) for f in flags] == [
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        [{x: -sqrt(1 - y)}, {x: sqrt(1 - y)}],
+        ([x], {(sqrt(1 - y),), (-sqrt(1 - y),)})]
+    e = nxny
+    assert [solve(e, **f) for f in flags] == \
+        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
+    assert [solve([e], **f) for f in flags] == [
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+    assert [solve(e, x, **f) for f in flags] == \
+        [[-sqrt(1 - y**2), sqrt(1 - y**2)],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
+    assert [solve([e], x, **f) for f in flags] == [
+        lot([{x: -sqrt(Y)}, {x: sqrt(Y)}]),
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+    assert [solve(e, {x}, **f) for f in flags] == \
+        [[-sqrt(1 - y**2), sqrt(1 - y**2)],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
+    assert [solve([e], {x}, **f) for f in flags] == [
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+    assert [solve(e, x, y, **f) for f in flags] == \
+        [[(-sqrt(1 - y**2), y), (sqrt(1 - y**2), y)],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x, y], {(-sqrt(1 - y**2), y), (sqrt(1 - y**2), y)})]
+    assert [solve([e], x, y, **f) for f in flags] == [
+        [(-sqrt(Y), y), (sqrt(Y), y)],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x, y], {(-sqrt(Y), y), (sqrt(Y), y)})]
+    assert [solve(e, y, x, **f) for f in flags] == \
+        [[(-sqrt(1 - x**2), x), (sqrt(1 - x**2), x)],
+        [{y: -sqrt(1 - x**2)}, {y: sqrt(1 - x**2)}],
+        ([y, x], {(sqrt(1 - x**2), x), (-sqrt(1 - x**2), x)})]
+    assert [solve([e], y, x, **f) for f in flags] == [
+        [(y, -sqrt(Y)), (y, sqrt(Y))],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([y, x], {(y, sqrt(Y)), (y, -sqrt(Y))})]
+    assert [solve(e, {y, x}, **f) for f in flags] == \
+        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
+    assert [solve([e], {y, x}, **f) for f in flags] == [
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+    assert [solve(e, x, z, y, **f) for f in flags] == \
+        [[(-sqrt(1 - y**2), z, y), (sqrt(1 - y**2), z, y)],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x, z, y], {(sqrt(1 - y**2), z, y), (-sqrt(1 - y**2), z, y)})]
+    assert [solve([e], x, z, y, **f) for f in flags] == [
+        [(-sqrt(Y), z, y), (sqrt(Y), z, y)],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x, z, y], {(-sqrt(Y), z, y), (sqrt(Y), z, y)})]
+    assert [solve(e, {x, z, y}, **f) for f in flags] == \
+        [[{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        [{x: -sqrt(1 - y**2)}, {x: sqrt(1 - y**2)}],
+        ([x], {(-sqrt(1 - y**2),), (sqrt(1 - y**2),)})]
+    assert [solve([e], {x, z, y}, **f) for f in flags] == [
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        [{x: -sqrt(Y)}, {x: sqrt(Y)}],
+        ([x], {(sqrt(Y),), (-sqrt(Y),)})]
+
+    e = lx, lxny
+    assert [solve([*e], **f) for f in flags] == \
+        [[{x: 0, y: -1}, {x: 0, y: 1}],
+        [{x: 0, y: -1}, {x: 0, y: 1}],
+        ([x, y], {(0, -1), (0, 1)})]
+    assert [solve([*e], x, **f) for f in flags] == \
+        [[],
+        [],
+        ([x], set())]
+    assert [solve([*e], {x}, **f) for f in flags] == \
+        [[],
+        [],
+        ([x], set())]
+    assert [solve([*e], x, y, **f) for f in flags] == \
+        [[(0, -1), (0, 1)],
+        [{x: 0, y: -1}, {x: 0, y: 1}],
+        ([x, y], {(0, -1), (0, 1)})]
+    assert [solve([*e], y, x, **f) for f in flags] == \
+        [[(-1, 0), (1, 0)],
+        [{y: -1, x: 0}, {y: 1, x: 0}],
+        ([y, x], {(-1, 0), (1, 0)})]
+    assert [solve([*e], {y, x}, **f) for f in flags] == \
+        [[{x: 0, y: -1}, {x: 0, y: 1}],
+        [{x: 0, y: -1}, {x: 0, y: 1}],
+        ([x, y], {(0, -1), (0, 1)})]
+    assert [solve([*e], x, z, y, **f) for f in flags] == \
+        [[(0, z, -1), (0, z, 1)],
+        [{x: 0, y: -1}, {x: 0, y: 1}],
+        ([x, z, y], {(0, z, 1), (0, z, -1)})]
+    assert [solve([*e], {x, z, y}, **f) for f in flags] == \
+        [[{x: 0, y: -1}, {x: 0, y: 1}],
+        [{x: 0, y: -1}, {x: 0, y: 1}],
+        ([x, y], {(0, -1), (0, 1)})]
+    # monotonic solution is treated like linear so some of
+    # the lines below should be a simple dict
+    assert solve((exp(x) - 1, y - 2)) == {x: 0, y: 2}
+    e = lx, nxly
+    assert [solve([*e], **f) for f in flags] == \
+        [[{x: 0, y: 1}], # {x: 0, y: 1},
+        [{x: 0, y: 1}],
+        ([x, y], {(0, 1)})]
+    assert [solve([*e], x, **f) for f in flags] == \
+        [[],
+        [],
+        ([x], set())]
+    assert [solve([*e], {x}, **f) for f in flags] == \
+        [[],
+        [],
+        ([x], set())]
+    assert [solve([*e], x, y, **f) for f in flags] == \
+        [[(0, 1)], #{x: 0, y: 1},
+        [{x: 0, y: 1}],
+        ([x, y], {(0, 1)})]
+    assert [solve([*e], y, x, **f) for f in flags] == \
+        [[(1, 0)], # {x: 0, y: 1},
+        [{y: 1, x: 0}],
+        ([y, x], {(1, 0)})]
+    assert [solve([*e], {y, x}, **f) for f in flags] == \
+        [[{x: 0, y: 1}], #{x: 0, y: 1},
+        [{x: 0, y: 1}],
+        ([x, y], {(0, 1)})]
+    assert [solve([*e], x, z, y, **f) for f in flags] == \
+        [[(0, z, 1)],
+        [{x: 0, y: 1}],
+        ([x, z, y], {(0, z, 1)})]
+    assert [solve([*e], {x, z, y}, **f) for f in flags] == \
+        [[{x: 0, y: 1}],
+        [{x: 0, y: 1}],
+        ([x, y], {(0, 1)})]
+    e = a*x + b - 2*x - y
+    assert [solve(e, a, b, **f) for f in flags] == \
+        [{a: 2, b: y},
+        [{a: 2, b: y}],
+        ([a, b], {(2, y)})]
+    assert [solve(e - b + b**2, a, b, **f) for f in flags] == [
+        [((-b**2 + 2*x + y)/x, b)], # master solved as nonlinear coeff sys
+        [{a: (-b**2 + 2*x + y)/x}],
+        ([a, b], {((-b**2 + 2*x + y)/x, b)})]
+
+
 def test_solve_args():
     # equation container, issue 5113
     ans = {x: -3, y: 1}

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -169,11 +169,11 @@ def test_solve_io():
     assert [solve(e, y, **f) for f in flags] == \
         [[],
         [],
-        []] #([y], set())]
+        ([y], set())]
     assert [solve([e], y, **f) for f in flags] == [
         [],
         [],
-        []] #([y], set())]
+        ([y], set())]
     e = nx
     def lot(lod):
         from sympy.core.sorting import ordered
@@ -226,7 +226,7 @@ def test_solve_io():
     assert [solve(e, y, **f) for f in flags] == \
         [[],
         [],
-        []] # ([y], set())]
+        ([y], set())]
     e = lxly
     assert [solve(e, **f) for f in flags] == \
         [[{x: y - 1}],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Rather than deal in some unique way with a solve request that contains duplicate symbols, the presence of duplicates now raises an error. This seems like a good idea because there is no reason to include duplicates and it *might* indicate a typo of the person entering the request. `nonlinsolve` raises an error, `linsolve` does not (and produces a strange output):
```python
>>> linsolve([x-1],x)
{(1,)}
>>> linsolve([x-1],x,y)
{(1, y)}
>>> linsolve([x-1],x,x)
{(x + 1, x + 1)}
```

#### Other comments

An audit-via-test of solve output has been included and highlights some gray areas that are not resolved here (but should be). Namely
1. should providing equations as a list (even of one equation) change the output?
```python
>>> solve(x)
[0]
>>> solve(x,x)
[0]
>>> solve([x],x)
{x: 0}
>>> solve([x])
{x: 0}
```
2. which multi-equation output should come back as a single dictionary. Here are 3 possiblities

a. the purely linear system `solve((x + y, x - y - 2)) -> {x:1, y: -1}`

```python
>>> solve((x + y, x - y - 2))
{x: 1, y: -1}
>>> solve((x + y, x - y - 2),x,y)
{x: 1, y: -1}
```

b. the system that has a single solution solution but contains nonlinear terms

```python
>>> solve((x**2 - y, x - 2))  # must return symbols in some way
[{x: 2, y: 4}]
>>> solve((x**2 - y, x - 2),x,y)
[(2, 4)]
```

c. a system that is linear in monotonic generators but nonlinear in symbols `solve((exp(x)-2,y-x)) -> {x: log(2), y: log(2)}`
```python
>>> solve((exp(x)-2,y-x))
{x: log(2), y: log(2)}
>>> solve((exp(x)-2,y-x),x,y)
{x: log(2), y: log(2)}
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve` raises an error if duplicate symbols are provided
  * corrected a case where set=True would send back an empty list of symbols; code which uses `set=True` and only tests whether the result is empty will now fail: `s, sol = solve(..., set=True)` will have empty `sol` if there is no solution.
<!-- END RELEASE NOTES -->
