### PR TITLE
maint(ci): don't use scipy 1.9.0 on PyPy because it doesn't build

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -197,6 +197,10 @@ jobs:
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/matplotlib/matplotlib@main
 
+      # SciPy 1.9.0 fails to compile under PyPy
+      - if: ${{ matrix.python-version == 'pypy-3.8' }}
+        run: pip install scipy!=1.9.0
+
       # dependencies to install in all Python versions:
       - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
                          aesara wurlitzer autowrap                            \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of #23859 for the 1.11 release branch.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
