### PR TITLE
`_solve` and `_solve_system`: return list of dictionaries

### DIFF
--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -134,6 +134,11 @@ def test_solve_args():
     raises(ValueError, lambda: solve(x, x, x))
     # no error in exclude
     assert solve(x, x, exclude=[y, y]) == [0]
+    # duplicate symbols raises
+    raises(ValueError, lambda: solve((x - 3, y + 2), x, y, x))
+    raises(ValueError, lambda: solve(x, x, x))
+    # no error in exclude
+    assert solve(x, x, exclude=[y, y]) == [0]
     # unordered symbols
     # only 1
     assert solve(y - 3, {y}) == [3]
@@ -152,10 +157,11 @@ def test_solve_args():
     eq = a*x**2 + b*x + c - ((x - h)**2 + 4*p*k)/4/p
     # - check that flags are obeyed
     sol = solve(eq, [h, p, k], exclude=[a, b, c])
-    assert sol == {h: -b/(2*a), k: c - b**2/(4*a), p: 1/(4*a)}
+    assert sol == {h: -b/(2*a), k: (4*a*c - b**2)/(4*a), p: 1/(4*a)}
     assert solve(eq, [h, p, k], dict=True) == [sol]
     assert solve(eq, [h, p, k], set=True) == \
-        ([h, p, k], {(-b/(2*a), 1/(4*a), c - b**2/(4*a))})
+        ([h, p, k], {(-b/(2*a), 1/(4*a), (4*a*c - b**2)/(4*a))})
+    # issue 23889 - polysys not simplified
     assert solve(eq, [h, p, k], exclude=[a, b, c], simplify=False) == \
         {h: -b/(2*a), k: (4*a*c - b**2)/(4*a), p: 1/(4*a)}
     # but this only happens when system has a single solution
@@ -171,12 +177,12 @@ def test_solve_args():
         NotImplementedError, lambda: solve(exp(x) + sin(x) + exp(y) + sin(y)))
     # failed system
     # --  when no symbols given, 1 fails
-    assert solve([y, exp(x) + x]) == {x: -LambertW(1), y: 0}
+    assert solve([y, exp(x) + x]) == [{x: -LambertW(1), y: 0}]
     #     both fail
     assert solve(
-        (exp(x) - x, exp(y) - y)) == {x: -LambertW(-1), y: -LambertW(-1)}
+        (exp(x) - x, exp(y) - y)) == [{x: -LambertW(-1), y: -LambertW(-1)}]
     # --  when symbols given
-    assert solve([y, exp(x) + x], x, y) == {y: 0, x: -LambertW(1)}
+    assert solve([y, exp(x) + x], x, y) == [(-LambertW(1), 0)]
     # symbol is a number
     assert solve(x**2 - pi, pi) == [x**2]
     # no equations
@@ -1406,7 +1412,8 @@ def test_issue_5849():
 
     v = I1, I4, Q2, Q4, dI1, dI4, dQ2, dQ4
     assert solve(e, *v, manual=True, check=False, dict=True) == ans
-    assert solve(e, *v, manual=True, check=False) == ans[0]
+    assert solve(e, *v, manual=True, check=False) == [
+        tuple([a.get(i, i) for i in v]) for a in ans]
     assert solve(e, *v, manual=True) == []
     assert solve(e, *v) == []
 
@@ -1462,10 +1469,11 @@ def test_issue_21882():
     answer = [
         {a: 0, f: 0, b: 0, d: 0, c: 0, g: 0},
         {a: 0, f: -d, b: 0, k: S(5)/6, c: 0, g: 0},
-        {a: -2*c, f: 0, b: c, d: 0, k: S(13)/18, g: 0},
-    ]
-
-    assert solve(equations, unknowns, dict=True) == answer
+        {a: -2*c, f: 0, b: c, d: 0, k: S(13)/18, g: 0}]
+    # but not {a: 0, f: 0, b: 0, k: S(3)/2, c: 0, d: 0, g: 0}
+    # since this is already covered by the first solution
+    got = solve(equations, unknowns, dict=True)
+    assert got == answer, (got,answer)
 
 
 def test_issue_5901():
@@ -1487,7 +1495,8 @@ def test_issue_5901():
                 h(a), g(a), set=True) == \
         ([h(a), g(a)], {
         (-sqrt(f(a)**2*g(a)**2 - G)/f(a), g(a)),
-        (sqrt(f(a)**2*g(a)**2 - G)/f(a), g(a))})
+        (sqrt(f(a)**2*g(a)**2 - G)/f(a), g(a))}), solve(-f(a)**2*g(a)**2 + f(a)**2*h(a)**2 + g(a).diff(a),
+                h(a), g(a), set=True)
     args = [[f(x).diff(x, 2)*(f(x) + g(x)), 2 - g(x)**2], f(x), g(x)]
     assert solve(*args, set=True)[1] == \
         {(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))}
@@ -2129,7 +2138,7 @@ def test_issue_8828():
     v = x, y, z
 
     f1 = (x - x1)**2 + (y - y1)**2 - (r1 - z)**2
-    f2 = (x2 - x)**2 + (y2 - y)**2 - z**2
+    f2 = (x - x2)**2 + (y - y2)**2 - z**2
     f3 = (x - x3)**2 + (y - y3)**2 - (r3 - z)**2
     F = f1,f2,f3
 
@@ -2187,27 +2196,23 @@ def test_issue_12114():
     a, b, c, d, e, f, g = symbols('a,b,c,d,e,f,g')
     terms = [1 + a*b + d*e, 1 + a*c + d*f, 1 + b*c + e*f,
              g - a**2 - d**2, g - b**2 - e**2, g - c**2 - f**2]
-    s = solve(terms, [a, b, c, d, e, f, g], dict=True)
-    assert s == [{a: -sqrt(-f**2 - 1), b: -sqrt(-f**2 - 1),
-                  c: -sqrt(-f**2 - 1), d: f, e: f, g: -1},
-                 {a: sqrt(-f**2 - 1), b: sqrt(-f**2 - 1),
-                  c: sqrt(-f**2 - 1), d: f, e: f, g: -1},
-                 {a: -sqrt(3)*f/2 - sqrt(-f**2 + 2)/2,
-                  b: sqrt(3)*f/2 - sqrt(-f**2 + 2)/2, c: sqrt(-f**2 + 2),
-                  d: -f/2 + sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 - sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: -sqrt(3)*f/2 + sqrt(-f**2 + 2)/2,
-                  b: sqrt(3)*f/2 + sqrt(-f**2 + 2)/2, c: -sqrt(-f**2 + 2),
-                  d: -f/2 - sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 + sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: sqrt(3)*f/2 - sqrt(-f**2 + 2)/2,
-                  b: -sqrt(3)*f/2 - sqrt(-f**2 + 2)/2, c: sqrt(-f**2 + 2),
-                  d: -f/2 - sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 + sqrt(3)*sqrt(-f**2 + 2)/2, g: 2},
-                 {a: sqrt(3)*f/2 + sqrt(-f**2 + 2)/2,
-                  b: -sqrt(3)*f/2 + sqrt(-f**2 + 2)/2, c: -sqrt(-f**2 + 2),
-                  d: -f/2 + sqrt(-3*f**2 + 6)/2,
-                  e: -f/2 - sqrt(3)*sqrt(-f**2 + 2)/2, g: 2}]
+    sol = solve(terms, [a, b, c, d, e, f, g], dict=True)
+    s = sqrt(-f**2 - 1)
+    s2 = sqrt(2 - f**2)
+    s3 = sqrt(6 - 3*f**2)
+    s4 = sqrt(3)*f
+    s5 = sqrt(3)*s2
+    assert sol == [
+        {a: -s, b: -s, c: -s, d: f, e: f, g: -1},
+        {a: s, b: s, c: s, d: f, e: f, g: -1},
+        {a: -s4/2 - s2/2, b: s4/2 - s2/2, c: s2,
+            d: -f/2 + s3/2, e: -f/2 - s5/2, g: 2},
+        {a: -s4/2 + s2/2, b: s4/2 + s2/2, c: -s2,
+            d: -f/2 - s3/2, e: -f/2 + s5/2, g: 2},
+        {a: s4/2 - s2/2, b: -s4/2 - s2/2, c: s2,
+            d: -f/2 - s3/2, e: -f/2 + s5/2, g: 2},
+        {a: s4/2 + s2/2, b: -s4/2 + s2/2, c: -s2,
+            d: -f/2 + s3/2, e: -f/2 - s5/2, g: 2}]
 
 
 def test_inf():
@@ -2469,13 +2474,12 @@ def test_issue_20902():
 def test_issue_21034():
     a = symbols('a', real=True)
     system = [x - cosh(cos(4)), y - sinh(cos(a)), z - tanh(x)]
-    assert solve(system, x, y, z) == {x: cosh(cos(4)), z: tanh(cosh(cos(4))),
-        y: sinh(cos(a))}
-    #Constants inside hyperbolic functions should not be rewritten in terms of exp
+    assert solve(system, x, y, z) == [(cosh(cos(4)), sinh(cos(a)), tanh(cosh(cos(4))))]
+    # constants inside hyperbolic functions should not be rewritten
+    # in terms of exp; rewriting should only happen with hyperbolics
+    # containing a symbol if interest
     newsystem = [(exp(x) - exp(-x)) - tanh(x)*(exp(x) + exp(-x)) + x - 5]
     assert solve(newsystem, x) == {x: 5}
-    #If the variable of interest is present in hyperbolic function, only then
-    # it shouuld be rewritten in terms of exp and solved further
 
 
 def test_issue_4886():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is mostly an internal clean-up of `solve` to work with lists of dictionaries from `_solve` and `_solve_system` while maintaining legacy output.

#### Other comments

A solution is only made canonical by solve; `_solve`, `_solve_system` and `_tsolve` no longer are guaranteed to return a canonical list. This seems appropriate for helper functions.

The bare dictionary return value will only occur when a single equation is being solved for undetermined coefficients
```python
>>> solve(a*x+b-3+2*x, a, b)
{a: -2, b: 3}
```
or when n-linear-equations in n-unknowns are being solved and manual is not True
```python
>>> solve([x+y-1,x-y-2],x,y,z)  # n +1 unknowns
{x: 3/2, y: -1/2}
>>> solve([x+y-1,x-y-2],x,y)
{x: 3/2, y: -1/2}
>>> solve([x+y-1,x-y-2],x,y,manual=1)
[(3/2, -1/2)]
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve` now only returns a bare dictionary when 1) solving a single expression (not in a list) for undetermined coefficients or 2) for a list of n linear equations in n unknowns when manual!=True
  * when using `solve` to solve for undetermined coefficients, the solution is no longer simplified (because it is detected as having been solved as a polynomial system; and such systems are not simplified)
<!-- END RELEASE NOTES -->
