### PR TITLE
fix(core): don't bury SympifyError in subs

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -8,6 +8,7 @@ from sympy.core.numbers import (Float, I, Integer, Rational, oo, pi, zoo)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, Wild, symbols)
+from sympy.core.sympify import SympifyError
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
@@ -19,7 +20,7 @@ from sympy.polys.rootoftools import RootOf
 from sympy.simplify.cse_main import cse
 from sympy.simplify.simplify import nsimplify
 from sympy.core.basic import _aresame
-from sympy.testing.pytest import XFAIL
+from sympy.testing.pytest import XFAIL, raises
 from sympy.abc import a, x, y, z, t
 
 
@@ -781,8 +782,8 @@ def test_issue_8886():
     # doesn't play well with SymPy and disallow the
     # substitution
     v = R('A').x
-    assert x.subs(x, v) == x
-    assert v.subs(v, x) == v
+    raises(SympifyError, lambda: x.subs(x, v))
+    raises(SympifyError, lambda: v.subs(v, x))
     assert v.__eq__(x) is False
 
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -506,7 +506,8 @@ class exp(ExpBase, metaclass=ExpMeta):
             nterms = ceiling(n/cf)
         exp_series = exp(t)._taylor(t, nterms)
         r = exp(arg0)*exp_series.subs(t, arg_series - arg0)
-        if r.subs(logx, log(x)) == self:
+        rep = {logx: log(x)} if logx is not None else {}
+        if r.subs(rep) == self:
             return r
         if cf and cf > 1:
             r += Order((arg_series - arg0)**n, x)/x**((cf-1)*n)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -581,6 +581,7 @@ def test_cse_release_variables():
     (_3, x0/x2 + x1), (_4, x2**x0), (x2, None), (_0, x1),
     (x1, None), (_2, x0), (x0, None), (_1, x)], (_0, _1, _2, _3, _4))
     r.reverse()
+    r = [(s, v) for s, v in r if v is not None]
     assert eqs == [i.subs(r) for i in e]
 
 def test_cse_list():

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -131,7 +131,8 @@ class DiophantineSolutionSet(set):
     def __call__(self, *args):
         if len(args) > len(self.parameters):
             raise ValueError("Evaluation should have at most %s values, not %s" % (len(self.parameters), len(args)))
-        return self.subs(list(zip(self.parameters, args)))
+        rep = {p: v for p, v in zip(self.parameters, args) if v is not None}
+        return self.subs(rep)
 
 
 class DiophantineEquationType:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/23884#issuecomment-1207455018

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Calling subs with unsympifiable objects will now raise a `SympifyError` exception. The previous behaviour was to ignore any unsympifiable objects provided as arguments to subs.
<!-- END RELEASE NOTES -->
