### PR TITLE
solve raises error on duplicate symbols

### DIFF
--- a/doc/src/tutorials/intro-tutorial/solvers.rst
+++ b/doc/src/tutorials/intro-tutorial/solvers.rst
@@ -231,7 +231,7 @@ To solve the ODE, pass it and the function to solve for to ``dsolve``.
     f(x) = (C₁ + C₂⋅x)⋅ℯ  + ──────
                               2
 
-``dsolve`` returns an instance of ``Eq``.  This is because in general,
+``dsolve`` returns an instance of ``Eq``.  This is because, in general,
 solutions to differential equations cannot be solved explicitly for the
 function.
 

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -387,7 +387,6 @@ def test_Variable():
     assert Variable.deduced(z, value=3.0+1j).type == complex_
 
 
-
 def test_Pointer():
     p = Pointer(x)
     assert p.symbol == x
@@ -442,7 +441,6 @@ def test_Declaration():
     assert decl3.variable.value == 3.0
 
     raises(ValueError, lambda: Declaration(vi, 42))
-
 
 
 def test_IntBaseType():
@@ -554,7 +552,6 @@ def test_While():
     whl2 = While(x < 2, cblk)
     assert whl1 == whl2
     assert whl1 != While(x < 3, [xpp])
-
 
 
 def test_Scope():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -882,7 +882,6 @@ def test_issue_19558():
     assert (sin(x) + cos(x)).subs(x, oo) == AccumBounds(-2, 2)
 
 
-
 def test_issue_22033():
     xr = Symbol('xr', real=True)
     e = (1/xr)

--- a/sympy/discrete/tests/test_convolutions.py
+++ b/sympy/discrete/tests/test_convolutions.py
@@ -50,7 +50,6 @@ def test_convolution():
     raises(TypeError, lambda: convolution(a, c, subset=True, prime=q))
 
 
-
 def test_cyclic_convolution():
     # fft
     a = [1, Rational(5, 3), sqrt(3), Rational(7, 5)]

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -535,7 +535,6 @@ def test_binomial_Mod():
     assert Mod(binomial(253, 113, evaluate=False), r) == Mod(binomial(253, 113), r)
 
 
-
 @slow
 def test_binomial_Mod_slow():
     p, q = 10**5 + 3, 10**9 + 33 # prime modulo

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1502,7 +1502,6 @@ def test_inverses():
     assert acot(x).inverse() == cot
 
 
-
 def test_real_imag():
     a, b = symbols('a b', real=True)
     z = a + b*I

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -72,7 +72,6 @@ def test_angle_between():
                                 Line3D(Point3D(5, 0, 0), z)) == acos(-sqrt(3) / 3)
 
 
-
 def test_closing_angle():
     a = Ray((0, 0), angle=0)
     b = Ray((1, 2), angle=pi/2)

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -54,7 +54,6 @@ def test_issue_4525():
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)
 
 
-
 @XFAIL
 @slow
 def test_issue_4540():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -943,7 +943,6 @@ def test_issue_18153():
     )
 
 
-
 def test_is_number():
     from sympy.abc import x, y, z
     assert Integral(x).is_number is False

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -576,7 +576,6 @@ def test_to_CNF():
     assert CNF.CNF_to_cnf(CNF.to_CNF(A & B)) == to_cnf(A & B)
 
 
-
 def test_to_dnf():
     assert to_dnf(~(B | C)) == And(Not(B), Not(C))
     assert to_dnf(A & (B | C)) == Or(And(A, B), And(A, C))

--- a/sympy/matrices/expressions/tests/test_hadamard.py
+++ b/sympy/matrices/expressions/tests/test_hadamard.py
@@ -59,7 +59,6 @@ def test_canonicalize():
     assert HadamardProduct(X, Z, U, Y).doit() == Z
 
 
-
 def test_hadamard():
     m, n, p = symbols('m, n, p', integer=True)
     A = MatrixSymbol('A', m, n)

--- a/sympy/matrices/expressions/tests/test_special.py
+++ b/sympy/matrices/expressions/tests/test_special.py
@@ -111,7 +111,6 @@ def test_one_matrix_creation():
     raises(ValueError, lambda: OneMatrix(n, n))
 
 
-
 def test_ZeroMatrix():
     n, m = symbols('n m', integer=True)
     A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -131,7 +131,6 @@ def test_singular_value_decompositionD():
     assert simplify(U * S * V.T) == D
 
 
-
 def test_QR():
     A = Matrix([[1, 2], [2, 3]])
     Q, S = A.QRdecomposition()

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -71,7 +71,6 @@ def test_implicit_application():
            lambda: parse_expr('sin**2(x)', transformations=transformations2))
 
 
-
 def test_function_exponentiation():
     cases = {
         'sin**2(x)': 'sin(x)**2',

--- a/sympy/parsing/tests/test_sym_expr.py
+++ b/sympy/parsing/tests/test_sym_expr.py
@@ -125,7 +125,6 @@ if lfortran and cin:
         )
 
 
-
     def test_convert_py():
         src1 = (
             src +

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -29,6 +29,10 @@ from sympy.utilities import public
 from sympy.utilities.misc import filldedent
 
 
+
+z = Symbol('z')  # importing from abc cause O to be lost as clashing symbol
+
+
 def roots_linear(f):
     """Returns a list of roots of a linear polynomial."""
     r = -f.nth(0)/f.nth(1)
@@ -568,7 +572,6 @@ def roots_quintic(f):
 
     Res = [None, [None]*5, [None]*5, [None]*5, [None]*5]
     Res_n = [None, [None]*5, [None]*5, [None]*5, [None]*5]
-    sol = Symbol('sol')
 
     # Simplifying improves performance a lot for exact expressions
     R1 = _quintic_simplify(R1)
@@ -576,23 +579,27 @@ def roots_quintic(f):
     R3 = _quintic_simplify(R3)
     R4 = _quintic_simplify(R4)
 
-    # Solve imported here. Causing problems if imported as 'solve'
-    # and hence the changed name
-    from sympy.solvers.solvers import solve as _solve
-    a, b = symbols('a b', cls=Dummy)
-    _sol = _solve( sol**5 - a - I*b, sol)
-    for i in range(5):
-        _sol[i] = factor(_sol[i])
+    # hard-coded results for [factor(i) for i in _vsolve(x**5 - a - I*b, x)]
+    x0 = z**(S(1)/5)
+    x1 = sqrt(2)
+    x2 = sqrt(5)
+    x3 = sqrt(5 - x2)
+    x4 = I*x2
+    x5 = x4 + I
+    x6 = I*x0/4
+    x7 = x1*sqrt(x2 + 5)
+    sol = [x0, -x6*(x1*x3 - x5), x6*(x1*x3 + x5), -x6*(x4 + x7 - I), x6*(-x4 + x7 + I)]
+
     R1 = R1.as_real_imag()
     R2 = R2.as_real_imag()
     R3 = R3.as_real_imag()
     R4 = R4.as_real_imag()
 
-    for i, currentroot in enumerate(_sol):
-        Res[1][i] = _quintic_simplify(currentroot.subs({ a: R1[0], b: R1[1] }))
-        Res[2][i] = _quintic_simplify(currentroot.subs({ a: R2[0], b: R2[1] }))
-        Res[3][i] = _quintic_simplify(currentroot.subs({ a: R3[0], b: R3[1] }))
-        Res[4][i] = _quintic_simplify(currentroot.subs({ a: R4[0], b: R4[1] }))
+    for i, s in enumerate(sol):
+        Res[1][i] = _quintic_simplify(s.xreplace({z: R1[0] + I*R1[1]}))
+        Res[2][i] = _quintic_simplify(s.xreplace({z: R2[0] + I*R2[1]}))
+        Res[3][i] = _quintic_simplify(s.xreplace({z: R3[0] + I*R3[1]}))
+        Res[4][i] = _quintic_simplify(s.xreplace({z: R4[0] + I*R4[1]}))
 
     for i in range(1, 5):
         for j in range(5):

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -124,7 +124,6 @@ def test_CRootOf_attributes():
     raises(NotImplementedError, lambda: rootof(Poly(x**3 + y*x + 1, x), 0))
 
 
-
 def test_CRootOf___eq__():
     assert (rootof(x**3 + x + 3, 0) == rootof(x**3 + x + 3, 0)) is True
     assert (rootof(x**3 + x + 3, 0) == rootof(x**3 + x + 3, 1)) is False

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7771,7 +7771,6 @@ def test_Str():
     assert pretty(Str('x')) == 'x'
 
 
-
 def test_symbolic_probability():
     mu = symbols("mu")
     sigma = symbols("sigma", positive=True)

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -90,7 +90,6 @@ def test_ccode_constants_mathh():
     assert ccode(pi, type_aliases={real: float80}) == "M_PIl"
 
 
-
 def test_ccode_constants_other():
     assert ccode(2*GoldenRatio) == "const double GoldenRatio = %s;\n2*GoldenRatio" % GoldenRatio.evalf(17)
     assert ccode(

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2927,7 +2927,6 @@ def test_PermutationMatrix():
         r'P_{\left( 0\; 3\right)\left( 1\; 2\right)}'
 
 
-
 def test_issue_21758():
     from sympy.functions.elementary.piecewise import piecewise_fold
     from sympy.series.fourier import FourierSeries

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -310,7 +310,6 @@ def test_maple_not_supported():
     )  # PROBLEM
 
 
-
 def test_MatrixElement_printing():
     # test cases for issue #11821
     A = MatrixSymbol("A", 1, 3)

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -45,10 +45,10 @@ def test_rcode_Pow():
     assert rcode(x**3.2, user_functions={'Pow': _cond_cfunc}) == 'pow(x, 3.2)'
 
 
-
 def test_rcode_Max():
     # Test for gh-11926
     assert rcode(Max(x,x*x),user_functions={"Max":"my_max", "Pow":"my_pow"}) == 'my_max(x, my_pow(x, 2))'
+
 
 def test_rcode_constants_mathh():
     assert rcode(exp(1)) == "exp(1)"
@@ -434,8 +434,6 @@ def test_Matrix_printing():
         "M[6] = 2*q[4]/q[1];\n"
         "M[7] = sqrt(q[0]) + 4;\n"
         "M[8] = 0;")
-
-
 
 
 def test_rcode_sgn():

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -139,7 +139,6 @@ def theq(a, b):
     return astr == bstr
 
 
-
 def test_example_symbols():
     """
     Check that the example symbols in this module print to their Theano

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -546,7 +546,6 @@ def test_range_is_finite_set():
     assert Range(oo, n).is_finite_set is True
 
 
-
 def test_Range_is_iterable():
     assert Range(-100, 100).is_iterable is True
     assert Range(2, oo).is_iterable is False

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -190,9 +190,6 @@ def test_Interval_arithmetic():
     assert n23cc/i12cc == SetExpr(Interval(-2, 3))
 
 
-
-
-
 def test_SetExpr_Intersection():
     x, y, z, w = symbols("x y z w")
     set1 = Interval(x, y)

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -575,7 +575,6 @@ def test_diophantine():
     assert diophantine((y**2-x), t) == {(t**2, -t)}
 
 
-
 def test_general_pythagorean():
     from sympy.abc import a, b, c, d, e
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -901,14 +901,16 @@ def solve(f, *symbols, **flags):
         else:
             symbols = _symbols
 
-
-    # remove symbols the user is not interested in
+    # check for duplicates
+    if len(symbols) != len(set(symbols)):
+        raise ValueError('duplicate symbols given')
+    # remove those not of interest
     exclude = flags.pop('exclude', set())
     if exclude:
         if isinstance(exclude, Expr):
             exclude = [exclude]
         exclude = set().union(*[e.free_symbols for e in sympify(exclude)])
-    symbols = [s for s in symbols if s not in exclude]
+        symbols = [s for s in symbols if s not in exclude]
 
 
     # preprocess equation(s)
@@ -1016,11 +1018,8 @@ def solve(f, *symbols, **flags):
 
     # we can solve for non-symbol entities by replacing them with Dummy symbols
     f, symbols, swap_sym = recast_to_symbols(f, symbols)
-
-    # this is needed in the next two events
+    # udpate symset
     symset = set(symbols)
-    if len(symbols) != len(symset):
-        raise ValueError('duplicate symbols given')
 
     # get rid of equations that have no symbols of interest; we don't
     # try to solve them because the user didn't ask and they might be

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1018,7 +1018,7 @@ def solve(f, *symbols, **flags):
 
     # we can solve for non-symbol entities by replacing them with Dummy symbols
     f, symbols, swap_sym = recast_to_symbols(f, symbols)
-    # udpate symset
+    # this set of symbols (perhaps recast) is needed below
     symset = set(symbols)
 
     # get rid of equations that have no symbols of interest; we don't

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1019,6 +1019,8 @@ def solve(f, *symbols, **flags):
 
     # this is needed in the next two events
     symset = set(symbols)
+    if len(symbols) != len(symset):
+        raise ValueError('duplicate symbols given')
 
     # get rid of equations that have no symbols of interest; we don't
     # try to solve them because the user didn't ask and they might be

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -70,7 +70,6 @@ def test_nsolve():
         mpf('0.31883011387318591')) < 1e-15
 
 
-
 def test_issue_6408():
     x = Symbol('x')
     assert nsolve(Piecewise((x, x < 1), (x**2, True)), x, 2) == 0.0

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -129,8 +129,8 @@ def test_solve_args():
     assert solve(42) == solve(42, x) == []
     assert solve([1, 2]) == []
     assert solve([sqrt(2)],[x]) == []
-    # duplicate symbols removed
-    assert solve((x - 3, y + 2), x, y, x) == {x: 3, y: -2}
+    # duplicate symbols raises
+    raises(ValueError, lambda: solve((x - 3, y + 2), x, y, x))
     # unordered symbols
     # only 1
     assert solve(y - 3, {y}) == [3]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -131,6 +131,9 @@ def test_solve_args():
     assert solve([sqrt(2)],[x]) == []
     # duplicate symbols raises
     raises(ValueError, lambda: solve((x - 3, y + 2), x, y, x))
+    raises(ValueError, lambda: solve(x, x, x))
+    # no error in exclude
+    assert solve(x, x, exclude=[y, y]) == [0]
     # unordered symbols
     # only 1
     assert solve(y - 3, {y}) == [3]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1236,7 +1236,6 @@ def test_multi_exp():
              ProductSet(S.Integers, S.Integers, S.Integers, S.Integers))))
 
 
-
 def test__solveset_multi():
     from sympy.solvers.solveset import _solveset_multi
     from sympy.sets import Reals

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -422,7 +422,6 @@ def test_eval_partial_derivative_divergence_type():
             - expr2c._perform_derivative()).contract_delta(L.delta) == 0
 
 
-
 def test_eval_partial_derivative_expr1():
 
     tau, alpha = symbols("tau alpha")

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -269,7 +269,6 @@ def test_autowrap_store_files_issue_gh12939():
         shutil.rmtree(tmp)
 
 
-
 def test_binary_function():
     x, y = symbols('x y')
     f = binary_function('f', x + y, backend='dummy')

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1181,7 +1181,6 @@ def test_scipy_polys():
                     )
 
 
-
 def test_lambdify_inspect():
     f = lambdify(x, x**2)
     # Test that inspect.getsource works but don't hard-code implementation

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2630,7 +2630,6 @@ def test_W25():
     assert (i2 - pi*a/2).simplify() == 0
 
 
-
 def test_W26():
     x, y = symbols('x y', real=True)
     assert integrate(integrate(abs(y - x**2), (y, 0, 2)),

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -115,7 +115,6 @@ def test_del_operator():
                             2*x*z*i + 2*x*z*j + 2*x*z*k
 
 
-
 def test_product_rules():
     """
     Tests the six product rules defined with respect to the Del


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Rather than deal in some unique way with a solve request that contains duplicate symbols, the presence of duplicates now raises an error. This seems like a good idea because there is no reason to include duplicates and it *might* indicate a typo of the person entering the request. Disallowing duplicates matches the behvior of `nonlinsolve` and `linsolve`

#### Other comments

There are lots of stray extra lines fixed in the first commit. Please review commits starting at 2 instead of looking at "Files changed" if that much noise is bothersome.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve` now raises an error if duplicate symbols are given in the unknowns to be solved for such as `solve(equations, [x, y, x])`.
<!-- END RELEASE NOTES -->
