### PR TITLE
Fixed a typo in physics/secondquant.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1491,4 +1491,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Stefan Behnle <stefan.behnle@uni-tuebingen.de>
+Stefan Behnle <84378403+behnle@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1240,6 +1240,7 @@ Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun <ysarun1999@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun-y99 <ysarun1999@gmail.com>
 Stan Schymanski <stan.schymanski@env.ethz.ch>
 Stas Kelvich <stanconn@gmail.com>
+Stefan Behnle <84378403+behnle@users.noreply.github.com>
 Stefan Krastanov <krastanov.stefan@gmail.com>
 Stefan Petrea <stefan@garage-coding.com>
 Stefan van der Walt <stefan@sun.ac.za>
@@ -1491,4 +1492,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Stefan Behnle <84378403+behnle@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1491,3 +1491,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Stefan Behnle <stefan.behnle@uni-tuebingen.de>

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1450,7 +1450,7 @@ class InnerProduct(Basic):
         if not isinstance(bra, FockStateBra):
             raise TypeError("must be a bra")
         if not isinstance(ket, FockStateKet):
-            raise TypeError("must be a key")
+            raise TypeError("must be a ket")
         return cls.eval(bra, ket)
 
     @classmethod


### PR DESCRIPTION
Just a tiny typo (`key` instead of `ket`).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
none
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes a typo in an exception

#### Other comments
none

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
