### PR TITLE
mailmap documents python2

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -334,6 +334,7 @@ Arihant Parsoya <parsoyaarihant@gmail.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
 Arpit Goyal <agmps18@gmail.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>
+Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -34,6 +34,9 @@
 #
 #   ...
 #
+# If it fails, you may need to replace `python` by `python3`, here and below, if
+# you're on a system that still uses python2 by default.
+#
 # 3. Add a line to this file with that same name and email address like:
 #
 #   Joe Bloggs <joe@bloggs.com>

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -15,13 +15,13 @@ from __future__ import print_function
 
 import sys
 import os
+if sys.version_info < (3, 8):
+    sys.exit("This script requires Python 3.8 or newer")
+
 from pathlib import Path
 from subprocess import run, PIPE
 from collections import OrderedDict, defaultdict
 from argparse import ArgumentParser
-
-if sys.version_info < (3, 8):
-    sys.exit("This script requires Python 3.8 or newer")
 
 def sympy_dir():
     return Path(__file__).resolve().parent.parent
@@ -304,7 +304,7 @@ def make_authors_file_lines(git_people):
         to their names are not found in the metadata of the git history. This
         file is generated automatically by running `./bin/authors_update.py`.
         """).lstrip()
-    header_extra = f"There are a total of {len(git_people)} authors."""
+    header_extra = "There are a total of %d authors."  % len(git_people)
     lines = header.splitlines()
     lines.append('')
     lines.append(header_extra)


### PR DESCRIPTION
### Brief description of what is fixed or changed

If mailmap is run with python2, it fails gracefully. Documentation is slightly improved. 


#### Other comments

I believe this to be useful for at least two reasons.

Current documentation either state to use `python bin/mailmap_check.py` or just
`bin/mailmap_check.py` which itself calles `python`. In both case, on ubuntu
this will run python2.

Worse, instead of printing "This script requires Python 3.8 or newer" it prints
an error message that python don't know what to do with the f-string. If the
f-string is removed, that it does not know pathlib. So, I ensure that the script
still work as before on 3.8 and prints a more useful message on python2.  I
admit I'm not fan of removing a f-string, however, since there was a single
f-string, I assume it was relatively acceptable.

I suppose most sympy contributor are at ease with those subtilities of
python2/3. However, this will at least be useful for people, like me, who only
wanted to contribute to improving documentation and not have to deal with
complexity of system administration.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
