### PR TITLE
refactor(solve): make solve keyword arguments explicit

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1055,8 +1055,7 @@ class Beam:
                 (self.bending_moment(), self.variable<self.length),
                 (float("nan"), True))
 
-        points = solve(moment_curve.rewrite(Piecewise), self.variable,
-                        domain=S.Reals)
+        points = solve(moment_curve.rewrite(Piecewise), self.variable)
         return points
 
     def slope(self):
@@ -1269,8 +1268,7 @@ class Beam:
                 (self.slope(), self.variable<self.length),
                 (float("nan"), True))
 
-        points = solve(slope_curve.rewrite(Piecewise), self.variable,
-                        domain=S.Reals)
+        points = solve(slope_curve.rewrite(Piecewise), self.variable)
         deflection_curve = self.deflection()
         deflections = [deflection_curve.subs(self.variable, x) for x in points]
         deflections = list(map(abs, deflections))
@@ -3359,8 +3357,7 @@ class Beam3D(Beam):
                 (self._load_vector[dir_num], self.variable<self.length),
                 (float("nan"), True))
 
-        points = solve(load_curve.rewrite(Piecewise), self.variable,
-                        domain=S.Reals)
+        points = solve(load_curve.rewrite(Piecewise), self.variable)
         points.append(0)
         points.append(self.length)
         shear_curve = self.shear_force()[dir_num]
@@ -3434,8 +3431,7 @@ class Beam3D(Beam):
                 (self.shear_force()[dir_num], self.variable<self.length),
                 (float("nan"), True))
 
-        points = solve(shear_curve.rewrite(Piecewise), self.variable,
-                        domain=S.Reals)
+        points = solve(shear_curve.rewrite(Piecewise), self.variable)
         points.append(0)
         points.append(self.length)
         bending_moment_curve = self.bending_moment()[dir_num]
@@ -3511,8 +3507,7 @@ class Beam3D(Beam):
                 (self.slope()[dir_num], self.variable<self.length),
                 (float("nan"), True))
 
-        points = solve(slope_curve.rewrite(Piecewise), self.variable,
-                        domain=S.Reals)
+        points = solve(slope_curve.rewrite(Piecewise), self.variable)
         points.append(0)
         points.append(self._length)
         deflection_curve = self.deflection()[dir_num]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1866,9 +1866,9 @@ def _solve_system(exprs, symbols, **flags):
 
             # returns a dictionary ({symbols: values}) or None
             if flags.pop('particular', False):
-                result = minsolve_linear_system(matrix, *symbols, **flags)
+                result = minsolve_linear_system(matrix, *symbols, quick=flags['quick'])
             else:
-                result = solve_linear_system(matrix, *symbols, **flags)
+                result = solve_linear_system(matrix, *symbols)
             result = [result] if result else []
             if failed:
                 if result:
@@ -2226,7 +2226,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     return n, d
 
 
-def minsolve_linear_system(system, *symbols, **flags):
+def minsolve_linear_system(system, *symbols, quick=False):
     r"""
     Find a particular solution to a linear system.
 
@@ -2238,9 +2238,8 @@ def minsolve_linear_system(system, *symbols, **flags):
     If ``quick=True``, a heuristic is used.
 
     """
-    quick = flags['quick']
     # Check if there are any non-zero solutions at all
-    s0 = solve_linear_system(system, *symbols, **flags)
+    s0 = solve_linear_system(system, *symbols)
     if not s0 or all(v == 0 for v in s0.values()):
         return s0
     if quick:
@@ -2309,7 +2308,7 @@ def minsolve_linear_system(system, *symbols, **flags):
         return bestsol
 
 
-def solve_linear_system(system, *symbols, **flags):
+def solve_linear_system(system, *symbols):
     r"""
     Solve system of $N$ linear equations with $M$ variables, which means
     both under- and overdetermined systems are supported.

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1679,9 +1679,9 @@ def test_minsolve_linear_system():
         assert not all(v for v in solve(
             [x + y + z, y + z + a], quick=_q,
             particular=True).values())
-        # raise error if quick used w/o particular=True
-        raises(ValueError, lambda: solve([x + 1], quick=_q))
-        raises(ValueError, lambda: solve([x + 1], quick=_q, particular=False))
+    # raise error if quick used w/o particular=True
+    raises(ValueError, lambda: solve([x + 1], quick=True))
+    raises(ValueError, lambda: solve([x + 1], quick=True, particular=False))
     # and give a good error message if someone tries to use
     # particular with a single equation
     raises(ValueError, lambda: solve(x + 1, particular=True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows #23877

#### Brief description of what is fixed or changed

Make all of the flags used by `solve` explicit keyword arguments. Clarify in the code and docstring which flags are used where and also which flags are effectively three-valued.

The intention is that there should be no change in behaviour from this PR except that I might add a deprecation warning for passing unrecognised flags to solve.

Todo:

- [ ] Apply the same to the other functions that take the flags (`checksol`, `_solve`, `_solve_system`, `solve_undetermined_coefficients`).
- [ ] Check exactly which functions can recursively call each other to track which flags should be passed where.
- [ ] Separate flags for `checksol` from flags for the solver functions.
- [ ] Eliminate spaghetti code that manipulates the flags dicts.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   * The internal code of `solve` and related functions was refactored to simplify handling of flags. All flags that can be passed to `solve` are now explicit keyword arguments.
<!-- END RELEASE NOTES -->
