### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1190,6 +1190,7 @@ Seth Ebner <murgrehk@gmail.com>
 Seth Poulsen <poulsenseth@yahoo.com>
 Seth Troisi <sethtroisi@google.com>
 Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
+Shantanu Jain <hauntsaninja@gmail.com>
 Shashank Agarwal <shashank.agarwal94@gmail.com>
 Shashank KS <shashankks0987@gmail.com> Shashank KS <shashankks@sahaj.ai>
 Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ per-file-ignores = sympy/interactive/session.py:F821
 # Global mypy settings:
 [mypy]
 warn_unused_configs = True
+no_implicit_optional = True
 exclude = sympy/parsing/autolev/test-examples
 
 # Per module settings:

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1761,8 +1761,8 @@ def N(x, n=15, **options):
     return sympify(x, rational=True).evalf(n, **options)
 
 
-def _evalf_with_bounded_error(x: 'Expr', eps: 'Expr' = None, m: int = 0,
-                              options: OPT_DICT = None) -> TMP_RES:
+def _evalf_with_bounded_error(x: 'Expr', eps: Optional['Expr'] = None, m: int = 0,
+                              options: Optional[OPT_DICT] = None) -> TMP_RES:
     """
     Evaluate *x* to within a bounded absolute error.
 


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->