### PR TITLE
Fixed UnevaluatedExpr.is_commutative is None

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -384,6 +384,7 @@ Bhavya Srivastava <bhavya17037@iiitd.ac.in>
 Bilal Ahmed <b.ahmed0918@gmail.com>
 Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>
 Bill Flynn <wflynny@gmail.com>
+Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
 Blair Azzopardi <bsdz@users.noreply.github.com>
 Boris Atamanovskiy <shaomoron@gmail.com>

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1994,7 +1994,7 @@ class PrettyPrinter(Printer):
 
         # Gather terms for numerator/denominator
         for item in args:
-            if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
+            if item.is_commutative is not False and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
@@ -2067,7 +2067,7 @@ class PrettyPrinter(Printer):
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
-        if power.is_commutative:
+        if power.is_commutative is not False:
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -16,6 +16,7 @@ from .printer import Printer, print_function
 from mpmath.libmp import prec_to_dps, to_str as mlib_to_str
 
 
+
 class StrPrinter(Printer):
     printmethod = "_sympystr"
     _default_settings = {
@@ -342,7 +343,7 @@ class StrPrinter(Printer):
                 return i.func(b, e, evaluate=False)
             return i.func(e, evaluate=False)
         for item in args:
-            if (item.is_commutative and
+            if (item.is_commutative is not False and
                     isinstance(item, Pow) and
                     bool(item.exp.as_coeff_Mul()[0] < 0)):
                 if item.exp is not S.NegativeOne:
@@ -649,7 +650,7 @@ class StrPrinter(Printer):
         if expr.exp is S.Half and not rational:
             return "sqrt(%s)" % self._print(expr.base)
 
-        if expr.is_commutative:
+        if expr.is_commutative is not False:
             if -expr.exp is S.Half and not rational:
                 # Note: Don't test "expr.exp == -S.Half" here, because that will
                 # match -0.5, which we don't want.


### PR DESCRIPTION
#### Fixed #19435
<!-- -->

#### Modified conditions to account for trueness of item.is_commutative

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

- functions
  - fixed bug with UnevaluatedExpr.is_commutative is None

<!-- END RELEASE NOTES -->