### PR TITLE
let decompose_power handle base reduction

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -229,10 +229,18 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
     (x, 1)
     >>> decompose_power(x**2)
     (x, 2)
+    >>> decompose_power(x**(2*y))
+    (x**y, 2)
+    >>> decompose_power(x**(2*y/3))
+    (x**(y/3), 2)
     >>> decompose_power(exp(2*y/3))
     (exp(y/3), 2)
+    >>> decompose_power(4**x)
+    (2**x, 2)
 
     """
+    from sympy.ntheory.factor_ import perfect_power
+
     base, exp = expr.as_base_exp()
 
     if exp.is_Number:
@@ -243,6 +251,21 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
         else:
             base, e = expr, 1
     else:
+        if base.is_Rational and not exp.is_Rational:
+            if base.is_Integer:
+                pp = perfect_power(base)
+                if pp:
+                    base, _exp = pp
+                    exp *= _exp
+            else:
+                npp = perfect_power(base.p)
+                if npp:
+                    n, _exp = npp
+                    dpp = perfect_power(base.q, [_exp])
+                    if dpp:
+                        d, _ = dpp
+                        base = Rational(n, d, gcd=1)
+                        exp *= _exp
         exp, tail = exp.as_coeff_Mul(rational=True)
 
         if exp is S.NegativeOne:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -258,10 +258,10 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
                     base, _exp = pp
                     exp *= _exp
             else:
-                npp = perfect_power(base.p)
+                npp = perfect_power(base.p)  # type: ignore
                 if npp:
                     n, _exp = npp
-                    dpp = perfect_power(base.q, [_exp])
+                    dpp = perfect_power(base.q, [_exp])  # type: ignore
                     if dpp:
                         d, _ = dpp
                         base = Rational(n, d, gcd=1)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -33,6 +33,7 @@ def test_decompose_power():
     assert decompose_power(x**(2*y)) == (x**y, 2)
     assert decompose_power(x**(2*y/3)) == (x**(y/3), 2)
     assert decompose_power(x**(y*Rational(2, 3))) == (x**(y/3), 2)
+    assert decompose_power(81**x) == (3**x, 4)
 
 
 def test_Factors():

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -211,7 +211,7 @@ def _parallel_dict_from_expr_if_gens(exprs, opt):
                         monom[indices[base]] = exp
                     except KeyError:
                         if not factor.has_free(*opt.gens):
-                            coeff.append(factor)
+                            coeff.append(base**exp)
                         else:
                             raise PolynomialError("%s contains an element of "
                                                   "the set of generators." % factor)

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -328,5 +328,5 @@ def test_rational_base_generator():
         assert sqf(b*a) == (B**3)**E
         assert factor(b + a) == a*(a + 1)
         assert cancel(b/a) == a
-        assert construct_domain(a + b), (ZZ[2*x], a**2 + a)
+        assert construct_domain(a + b) == (ZZ[2*x], a**2 + a)
         assert apart((b + a)/a) == a + 1

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -298,3 +298,35 @@ def test_dict_from_expr():
         ({(0,): -Integer(1), (1,): Integer(1)}, (x,))
     raises(PolynomialError, lambda: dict_from_expr(A*B - B*A))
     raises(PolynomialError, lambda: dict_from_expr(S.true))
+
+
+def test_rational_base_generator():
+    from sympy import (Poly, poly, div, rem, quo, exquo, invert, gcd,
+        primitive, content, sqf, factor, cancel, construct_domain, apart)
+    for a, b in [(2**x, 4**x), (x, x**2)]:
+        p = Poly(a + b)
+        assert poly(a + b) == p
+        assert (a + b).as_poly() == p
+        assert p.gens == (a,)
+        # give gen a
+        assert Poly(a + b, a) == p
+        assert poly(a + b, a) == p
+        assert (a + b).as_poly(a) == p
+        # give gen b
+        raises(PolynomialError, lambda: Poly(a + b, b))
+        raises(PolynomialError, lambda: poly(a + b, b))
+        assert (a + b).as_poly(b) is None
+        assert div(b, a) == (a, 0)
+        assert rem(b, a) == 0
+        assert quo(b, a) == a
+        assert exquo(b - 1, a - 1) == a + 1
+        assert invert(b - 1, 2*a - 1) == -4/S(3)
+        assert gcd(b, a) == a
+        assert primitive(b + a) == (1, a**2 + a)
+        assert content(b + a) == 1
+        B, E = a.as_base_exp()
+        assert sqf(b*a) == (B**3)**E
+        assert factor(b + a) == a*(a + 1)
+        assert cancel(b/a) == a
+        assert construct_domain(a + b), (ZZ[2*x], a**2 + a)
+        assert apart((b + a)/a) == a + 1

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -731,6 +731,7 @@ def test_frechet():
     assert density(X)(x) == a*((x - m)/s)**(-a - 1)*exp(-((x - m)/s)**(-a))/s
     assert cdf(X)(x) == Piecewise((exp(-((-m + x)/s)**(-a)), m <= x), (0, True))
 
+
 @slow
 def test_gamma():
     k = Symbol("k", positive=True)
@@ -759,8 +760,8 @@ def test_gamma():
 
     Y = Gamma('y', 2*k, 3*theta)
     assert coskewness(X, theta*X + Y, k*X + Y).simplify() == \
-        2*531441**(-k)*sqrt(k)*theta*(3*3**(12*k) - 2*531441**k) \
-        /(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
+        2*sqrt(k)*theta/(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
+
 
 def test_gamma_inverse():
     a = Symbol("a", positive=True)
@@ -771,6 +772,7 @@ def test_gamma_inverse():
     assert characteristic_function(X)(x) == 2 * (-I*b*x)**(a/2) \
             * besselk(a, 2*sqrt(b)*sqrt(-I*x))/gamma(a)
     raises(NotImplementedError, lambda: moment_generating_function(X))
+
 
 def test_gompertz():
     b = Symbol("b", positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#5149 #19776

#### Brief description of what is fixed or changed
By decomposing a Rational base into a perfect power, cases where two generators were formerly identified by Poly will now give one:

```python
>>> Poly(4**x+2**x)
Poly((2**x)**2 + (2**x), 2**x, domain='ZZ')  <-- formerly two generators 2**x and 4**x
```
#### Other comments

While `Poly` calls `decompose_power_rat`, `poly` does not, so the latter needed editing, too.

It was nice to see the continuous random variable test simplify from
```python
2*531441**(-k)*sqrt(k)*theta*(3*3**(12*k) - 2*531441**k) /(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
```
to
```python
2*sqrt(k)*theta/(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
```
When the `531441**(-k)*(3*3**(12*k) - 2*531441**k)` is recognized as 1
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `exprtools.decompose_power` identifies perfect power in Rational bases so `decompose_power(4**x)->(2**x, 2)`
* polys
  * `Poly` and `poly` should both make powers with Rational bases canonical, e.g. `2**(2*x)` instead of `4**x`
<!-- END RELEASE NOTES -->
