### PR TITLE
fix: simplify Intersection of Range and Rationals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -966,6 +966,7 @@ Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
+NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -235,6 +235,11 @@ def _(a, b):
     return a
 
 
+@intersection_sets.register(Range, Rationals)
+def _(a, b):
+    return a
+
+
 @intersection_sets.register(ImageSet, Set)
 def _(self, other):
     from sympy.solvers.diophantine import diophantine

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -252,6 +252,9 @@ def test_Range_set():
     raises(TypeError, lambda: next(it))
 
     assert empty.intersect(S.Integers) == empty
+    assert Range(-1, 10, 1).intersect(S.Complexes) == Range(-1, 10, 1)
+    assert Range(-1, 10, 1).intersect(S.Reals) == Range(-1, 10, 1)
+    assert Range(-1, 10, 1).intersect(S.Rationals) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals) == Range(1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals0) == Range(0, 10, 1)
@@ -517,6 +520,11 @@ def test_range_interval_intersection():
     assert Range(4).intersect(Interval(0.1, 3.1)) == Range(1, 4)
     assert Range(4).intersect(Interval.open(0, 3)) == Range(1, 3)
     assert Range(4).intersect(Interval.open(0.1, 0.5)) is S.EmptySet
+    assert Interval(-1, 5).intersect(S.Complexes) == Interval(-1, 5)
+    assert Interval(-1, 5).intersect(S.Reals) == Interval(-1, 5)
+    assert Interval(-1, 5).intersect(S.Integers) == Range(-1, 6)
+    assert Interval(-1, 5).intersect(S.Naturals) == Range(1, 6)
+    assert Interval(-1, 5).intersect(S.Naturals0) == Range(0, 6)
 
     # Null Range intersections
     assert Range(0).intersect(Interval(0.2, 0.8)) is S.EmptySet


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`Intersection` simplifies many things including the sets `Naturals`/`Integers`/`Reals`/`Complexes`, but it was missing the case of `Range` with `Rationals`, so I added it, and a few tests.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* sets
  * Support simplifying `Intersection(Range(...), Rationals)`.
<!-- END RELEASE NOTES -->
