### PR TITLE
Improved ubuntu build documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -384,6 +384,7 @@ Bhavya Srivastava <bhavya17037@iiitd.ac.in>
 Bilal Ahmed <b.ahmed0918@gmail.com>
 Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>
 Bill Flynn <wflynny@gmail.com>
+Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
 Blair Azzopardi <bsdz@users.noreply.github.com>
 Boris Atamanovskiy <shaomoron@gmail.com>

--- a/doc/src/contributing/build-docs.rst
+++ b/doc/src/contributing/build-docs.rst
@@ -35,11 +35,18 @@ For Debian/Ubuntu::
    apt-get install python3-sphinx texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x graphviz
 
 Install pip using::
-   
-   sudo apt install python3-pip
-   
 
-After installing pip, run::
+   sudo apt install python3-pip
+
+However, you can also create a virtual environment and use pip in it using::
+
+   python3 -m venv /path/to/my/venv  # create the venv
+
+Then activate it using::
+
+   source /path/to/my/venv/bin/activate  # need to rerun this each time you open a new terminal
+
+After installing pip through either of the two methods given above, run::
 
    python -m pip install -r doc/requirements.txt
 
@@ -58,9 +65,9 @@ For Fedora (and maybe other RPM-based distributions), install the
 prerequisites::
 
    dnf install python3-sphinx librsvg2 ImageMagick docbook2X texlive-dvipng-bin
-   
+
    texlive-scheme-medium librsvg2-tools
-   
+
    python -m pip install -r doc/requirements.txt
 
 If you get mpmath error, install python3-mpmath package::
@@ -149,7 +156,7 @@ required dependencies locally, the documentation can be built by running the
 ``makefile`` in the ``doc`` subdirectory::
 
    cd doc
-   
+
    make html
 
 
@@ -161,7 +168,7 @@ SymPy has a collection of official logos, which can be generated from sympy.svg 
 .. code-block:: none
 
     $ cd doc
-    
+ 
     $ make logo # will be stored in the _build/logo subdirectory
 
 The license of all the logos is the same as SymPy: BSD. See the
@@ -224,7 +231,7 @@ Local Installation
 If you installed the build dependencies locally, then simply use::
 
    cd doc
-   
+
    make livehtml
 
 to start the server. Your web browser should then automatically open a new tab,
@@ -263,11 +270,11 @@ On Ubuntu, you can install these with::
 On Mac, you can use::
 
     brew install texlive
-    
+ 
     brew install --cask chromium
-    
+ 
     brew tap homebrew/cask-fonts
-    
+ 
     brew install font-dejavu
 
 On Windows 10, you can use::
@@ -281,7 +288,7 @@ right-click and click ``Install for all users``.
 To build the pdf docs run::
 
     cd doc
-    
+ 
     make pdf
 
 The resulting PDF will be in::

--- a/doc/src/contributing/build-docs.rst
+++ b/doc/src/contributing/build-docs.rst
@@ -21,6 +21,7 @@ following the OS-specific installation instructions below, you may choose to
 build a Docker image::
 
    cd doc
+
    docker build -f Dockerfile.htmldoc -t sympy_htmldoc .
 
 If you choose this option, you can now skip down to the "Build the Docs"
@@ -32,6 +33,21 @@ Debian/Ubuntu
 For Debian/Ubuntu::
 
    apt-get install python3-sphinx texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x graphviz
+
+First install pip using::
+   
+   sudo apt install python3-pip
+   
+However, you can also create a virtual environment and use pip in it using::
+
+   python3 -m venv /path/to/my/venv  # create the venv
+   
+Then activate it using::
+
+   source /path/to/my/venv/bin/activate  # need to rerun this each time you open a new terminal
+
+After installing pip through either of the two methods given above, run::
+
    python -m pip install -r doc/requirements.txt
 
 If you get mpmath error, install python-mpmath package::
@@ -49,7 +65,9 @@ For Fedora (and maybe other RPM-based distributions), install the
 prerequisites::
 
    dnf install python3-sphinx librsvg2 ImageMagick docbook2X texlive-dvipng-bin
+   
    texlive-scheme-medium librsvg2-tools
+   
    python -m pip install -r doc/requirements.txt
 
 If you get mpmath error, install python3-mpmath package::
@@ -138,6 +156,7 @@ required dependencies locally, the documentation can be built by running the
 ``makefile`` in the ``doc`` subdirectory::
 
    cd doc
+   
    make html
 
 
@@ -149,6 +168,7 @@ SymPy has a collection of official logos, which can be generated from sympy.svg 
 .. code-block:: none
 
     $ cd doc
+    
     $ make logo # will be stored in the _build/logo subdirectory
 
 The license of all the logos is the same as SymPy: BSD. See the
@@ -211,6 +231,7 @@ Local Installation
 If you installed the build dependencies locally, then simply use::
 
    cd doc
+   
    make livehtml
 
 to start the server. Your web browser should then automatically open a new tab,
@@ -249,8 +270,11 @@ On Ubuntu, you can install these with::
 On Mac, you can use::
 
     brew install texlive
+    
     brew install --cask chromium
+    
     brew tap homebrew/cask-fonts
+    
     brew install font-dejavu
 
 On Windows 10, you can use::
@@ -264,6 +288,7 @@ right-click and click ``Install for all users``.
 To build the pdf docs run::
 
     cd doc
+    
     make pdf
 
 The resulting PDF will be in::

--- a/doc/src/contributing/build-docs.rst
+++ b/doc/src/contributing/build-docs.rst
@@ -34,7 +34,7 @@ For Debian/Ubuntu::
 
    apt-get install python3-sphinx texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x graphviz
 
-First install pip using::
+Install pip using::
    
    sudo apt install python3-pip
    

--- a/doc/src/contributing/build-docs.rst
+++ b/doc/src/contributing/build-docs.rst
@@ -38,15 +38,8 @@ Install pip using::
    
    sudo apt install python3-pip
    
-However, you can also create a virtual environment and use pip in it using::
 
-   python3 -m venv /path/to/my/venv  # create the venv
-   
-Then activate it using::
-
-   source /path/to/my/venv/bin/activate  # need to rerun this each time you open a new terminal
-
-After installing pip through either of the two methods given above, run::
+After installing pip, run::
 
    python -m pip install -r doc/requirements.txt
 

--- a/doc/src/contributing/build-docs.rst
+++ b/doc/src/contributing/build-docs.rst
@@ -168,7 +168,7 @@ SymPy has a collection of official logos, which can be generated from sympy.svg 
 .. code-block:: none
 
     $ cd doc
- 
+
     $ make logo # will be stored in the _build/logo subdirectory
 
 The license of all the logos is the same as SymPy: BSD. See the
@@ -270,11 +270,11 @@ On Ubuntu, you can install these with::
 On Mac, you can use::
 
     brew install texlive
- 
+
     brew install --cask chromium
- 
+
     brew tap homebrew/cask-fonts
- 
+
     brew install font-dejavu
 
 On Windows 10, you can use::
@@ -288,7 +288,7 @@ right-click and click ``Install for all users``.
 To build the pdf docs run::
 
     cd doc
- 
+
     make pdf
 
 The resulting PDF will be in::


### PR DESCRIPTION
####  Fixed #23897 
<!--  -->


#### Added text about installation of pip on ubuntu before using pip. Also cleaned up docs a bit to enable users to copy code from documentation easily.


#### Release Notes



<!-- BEGIN RELEASE NOTES -->

- other
  - an addition to documentation about installation of pip on ubuntu before using pip.

<!-- END RELEASE NOTES -->
