### PR TITLE
fix(solvers): make tsolve give deterministic output

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1559,7 +1559,7 @@ def _solve(f, *symbols, **flags):
                     # if no Functions left, we can proceed with usual solve
                     if not ftry.has(symbol):
                         cv_sols = _solve(ftry, t, **flags)
-                        cv_inv = _vsolve(t - f1, symbol, **flags)[0]
+                        cv_inv = list(ordered(_vsolve(t - f1, symbol, **flags)))[0]
                         result = [{symbol: cv_inv.subs(sol)} for sol in cv_sols]
 
                 if result is False:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/pull/23877#issuecomment-1211821214

#### Brief description of what is fixed or changed

For some reason `_solve` calls `_vsolve` and takes only the first argument. This leads to non-deterministic output from `solve` because the ordering of the output from `_vsolve` is non-deterministic. It's unclear why only one of the return values is taken since the other values seem to give other valid solutions. This PR just uses `ordered` to make the result deterministic because `test_lambert_bivariate` was failing intermittently in CI.

#### Other comments

smichr adds: any routine that needs canonical output from `_solve` or `_vsolve` is responsible for this extra processing, so this is the right fix for `tsolve` (making output consistent before selecting an inversion expression to use for the return value)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
