### PR TITLE
fix(lambdify): don't import * from scipy

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -103,7 +103,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
-    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy import *; from scipy.special import *",)),
+    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracting the key fix from #23932.

https://github.com/scipy/scipy/pull/15607#issuecomment-1215110575
Fixes https://github.com/sympy/sympy/issues/23924

#### Brief description of what is fixed or changed

Remove the unneeded `from scipy import *` in lambdify. This doesn't really do anything because not much is importable at that level in `scipy`:
```python
In [8]: ns = {}

In [9]: exec('from scipy import *', ns)

In [10]: list(ns)
Out[10]: 
['__builtins__',
 'cluster',
 'fft',
 'fftpack',
 'integrate',
 'interpolate',
 'io',
 'linalg',
 'misc',
 'ndimage',
 'odr',
 'optimize',
 'signal',
 'sparse',
 'spatial',
 'special',
 'stats',
 'LowLevelCallable',
 'test',
 'show_config',
 '__version__',
 '__numpy_version__']

In [11]: import scipy

In [12]: scipy.__all__
Out[12]: 
['cluster',
 'fft',
 'fftpack',
 'integrate',
 'interpolate',
 'io',
 'linalg',
 'misc',
 'ndimage',
 'odr',
 'optimize',
 'signal',
 'sparse',
 'spatial',
 'special',
 'stats',
 'LowLevelCallable',
 'test',
 'show_config',
 '__version__',
 '__numpy_version__']
```
It is conceivable that some code might access functions like `special.zeta` but that isn't how the lambdify printed code works:
```python
In [16]: import inspect

In [17]: print(inspect.getsource(lambdify(x, zeta(x), 'scipy')))
def _lambdifygenerated(x):
    return zeta(x)
```
The import that does the work here is `from scipy.special import *` which does import `zeta`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
