### PR TITLE
fix(aesara): don't use deprecated functions

### DIFF
--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -19,7 +19,7 @@ if aesara:
     mapping = {
             sympy.Add: aet.add,
             sympy.Mul: aet.mul,
-            sympy.Abs: aet.abs_,
+            sympy.Abs: aet.abs,
             sympy.sign: aet.sgn,
             sympy.ceiling: aet.ceil,
             sympy.floor: aet.floor,
@@ -51,10 +51,10 @@ if aesara:
             sympy.StrictLessThan: aet.lt,
             sympy.LessThan: aet.le,
             sympy.GreaterThan: aet.ge,
-            sympy.And: aet.and_,  # bitwise
-            sympy.Or: aet.or_,  # bitwise
+            sympy.And: aet.bitwise_and,  # bitwise
+            sympy.Or: aet.bitwise_or,  # bitwise
             sympy.Not: aet.invert,  # bitwise
-            sympy.Xor: aet.xor,  # bitwise
+            sympy.Xor: aet.bitwise_xor,  # bitwise
             sympy.Max: aet.maximum,  # Sympy accept >2 inputs, Aesara only 2
             sympy.Min: aet.minimum,  # Sympy accept >2 inputs, Aesara only 2
             sympy.conjugate: aet.conj,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of #23957 for the 1.11 release branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * The Aesara printer no longer uses the deprecated Aesara functions `abs_`, `and_`, `or_` and `xor`.
<!-- END RELEASE NOTES -->
