### PR TITLE
fix(integrals): handle degenerate case in Risch PRDE

### DIFF
--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -344,10 +344,9 @@ def prde_no_cancel_b_large(b, Q, n, DE):
 
     if all(qi.is_zero for qi in Q):
         dc = -1
-        M = zeros(0, 2, DE.t)
     else:
         dc = max([qi.degree(DE.t) for qi in Q])
-        M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
+    M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
     A, u = constant_system(M, zeros(dc + 1, 1, DE.t), DE)
     c = eye(m, DE.t)
     A = A.row_join(zeros(A.rows, m, DE.t)).col_join(c.row_join(-c))
@@ -385,10 +384,9 @@ def prde_no_cancel_b_small(b, Q, n, DE):
             Q[i] = Q[i] - derivation(si, DE) - b*si
         if all(qi.is_zero for qi in Q):
             dc = -1
-            M = Matrix()
         else:
             dc = max([qi.degree(DE.t) for qi in Q])
-            M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
+        M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
         A, u = constant_system(M, zeros(dc + 1, 1, DE.t), DE)
         c = eye(m, DE.t)
         A = A.row_join(zeros(A.rows, m, DE.t)).col_join(c.row_join(-c))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -374,12 +374,14 @@ def test_integrate_hyperexponential_returns_piecewise():
     # TODO: Add a test where two different parts of the extension use a
     # Piecewise, like y**x + z**x.
 
+
 def test_issue_13947():
     a, t, s = symbols('a t s')
     assert risch_integrate(2**(-pi)/(2**t + 1), t) == \
         2**(-pi)*t - 2**(-pi)*log(2**t + 1)/log(2)
     assert risch_integrate(a**(t - s)/(a**t + 1), t) == \
         exp(-s*log(a))*log(a**t + 1)/log(a)
+
 
 def test_integrate_primitive():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
@@ -738,3 +740,24 @@ def test_DifferentialExtension_printing():
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})")
+
+
+def test_issue_23948():
+    f = (
+        ( (-2*x**5 + 28*x**4 - 144*x**3 + 324*x**2 - 270*x)*log(x)**2
+         +(-4*x**6 + 56*x**5 - 288*x**4 + 648*x**3 - 540*x**2)*log(x)
+         +(2*x**5 - 28*x**4 + 144*x**3 - 324*x**2 + 270*x)*exp(x)
+         +(2*x**5 - 28*x**4 + 144*x**3 - 324*x**2 + 270*x)*log(5)
+         -2*x**7 + 26*x**6 - 116*x**5 + 180*x**4 + 54*x**3 - 270*x**2
+        )*log(-log(x)**2 - 2*x*log(x) + exp(x) + log(5) - x**2 - x)**2
+       +( (4*x**5 - 44*x**4 + 168*x**3 - 216*x**2 - 108*x + 324)*log(x)
+         +(-2*x**5 + 24*x**4 - 108*x**3 + 216*x**2 - 162*x)*exp(x)
+         +4*x**6 - 42*x**5 + 144*x**4 - 108*x**3 - 324*x**2 + 486*x
+        )*log(-log(x)**2 - 2*x*log(x) + exp(x) + log(5) - x**2 - x)
+    )/(x*exp(x)**2*log(x)**2 + 2*x**2*exp(x)**2*log(x) - x*exp(x)**3
+       +(-x*log(5) + x**3 + x**2)*exp(x)**2)
+
+    F = ((x**4 - 12*x**3 + 54*x**2 - 108*x + 81)*exp(-2*x)
+        *log(-x**2 - 2*x*log(x) - x + exp(x) - log(x)**2 + log(5))**2)
+
+    assert risch_integrate(f, x) == F


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23948

#### Brief description of what is fixed or changed

Ensure that while the matrix is still empty it has the right number of columns.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
   * A bug in the `risch` integration routine was fixed. Previously in certain conditions involving complicated integrands the routine would fail with `AssertionError`.
<!-- END RELEASE NOTES -->
