### PR TITLE
expand(x**(a+b)) iff x != 0 or a &  b both nonneg or nonpos

### DIFF
--- a/doc/src/modules/polys/wester.rst
+++ b/doc/src/modules/polys/wester.rst
@@ -24,8 +24,8 @@ computations were done using the following setup::
 
     >>> init_printing(use_unicode=True, wrap_line=False)
 
-    >>> var('x,y,z,s,c,n')
-    (x, y, z, s, c, n)
+    >>> var('x,y,z,s,c')
+    (x, y, z, s, c)
 
 Simple univariate polynomial factorization
 ------------------------------------------
@@ -117,7 +117,18 @@ Polynomial manipulation functions provided by :mod:`sympy.polys` are mostly
 used with integer exponents. However, it's perfectly valid to compute with
 symbolic exponents, e.g.::
 
-    >>> gcd(2*x**(n + 4) - x**(n + 2), 4*x**(n + 1) + 3*x**n)
+    >>> n = var('n')
+    >>> gcd(x**n - x**(2*n), x**n)
+     n
+    x
+
+    Results may depend on powers being expanded (which will depend on
+    assumptions of the base):
+
+    >>> gcd(x**(n + 4), x**(n + 1) + 3*x**n)
+    1
+    >>> x = var('x', positive=True)
+    >>> gcd(x**(n + 4), x**(n + 1) + 3*x**n)
      n
     x
 
@@ -128,6 +139,7 @@ To test if two polynomials have a root in common we can use :func:`~.resultant`
 function. The theory says that the resultant of two polynomials vanishes if
 there is a common zero of those polynomials. For example::
 
+    >>> x = var('x')
     >>> resultant(3*x**4 + 3*x**3 + x**2 - x - 2, x**3 - 3*x**2 + x + 5)
     0
 

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -140,17 +140,17 @@ def test_deltaproduct_mul_x_add_y_kd():
         (x*y)**k + Piecewise(
             ((x*y)**(i - 1)*x*(x*y)**(k - i), And(1 <= i, i <= k)),
             (0, True)
-        )
+        ).expand()
     assert dp(x*(y + KD(i, j)), (j, k, 3)) == \
-        (x*y)**(-k + 4) + Piecewise(
+        ((x*y)**(-k + 4) + Piecewise(
             ((x*y)**(i - k)*x*(x*y)**(3 - i), And(k <= i, i <= 3)),
             (0, True)
-        )
+        )).expand()
     assert dp(x*(y + KD(i, j)), (j, k, l)) == \
-        (x*y)**(-k + l + 1) + Piecewise(
+        ((x*y)**(-k + l + 1) + Piecewise(
             ((x*y)**(i - k)*x*(x*y)**(l - i), And(k <= i, i <= l)),
             (0, True)
-        )
+        )).expand()
 
 
 def test_deltaproduct_mul_x_add_y_twokd():
@@ -163,17 +163,17 @@ def test_deltaproduct_mul_x_add_y_twokd():
         (x*y)**k + Piecewise(
             (2*(x*y)**(i - 1)*x*(x*y)**(k - i), And(1 <= i, i <= k)),
             (0, True)
-        )
+        ).expand()
     assert dp(x*(y + 2*KD(i, j)), (j, k, 3)) == \
-        (x*y)**(-k + 4) + Piecewise(
+        ((x*y)**(-k + 4) + Piecewise(
             (2*(x*y)**(i - k)*x*(x*y)**(3 - i), And(k <= i, i <= 3)),
             (0, True)
-        )
+        )).expand()
     assert dp(x*(y + 2*KD(i, j)), (j, k, l)) == \
-        (x*y)**(-k + l + 1) + Piecewise(
+        ((x*y)**(-k + l + 1) + Piecewise(
             (2*(x*y)**(i - k)*x*(x*y)**(l - i), And(k <= i, i <= l)),
             (0, True)
-        )
+        )).expand()
 
 
 def test_deltaproduct_mul_add_x_y_add_y_kd():
@@ -186,22 +186,16 @@ def test_deltaproduct_mul_add_x_y_add_y_kd():
     assert dp((x + y)*(y + KD(i, j)), (j, 3, 3)) == (x + y)*(y + KD(i, 3))
     assert dp((x + y)*(y + KD(i, j)), (j, 1, k)) == \
         ((x + y)*y)**k + Piecewise(
-            (((x + y)*y)**(i - 1)*(x + y)*((x + y)*y)**(k - i),
-             And(1 <= i, i <= k)),
-            (0, True)
-        )
-    assert dp((x + y)*(y + KD(i, j)), (j, k, 3)) == \
-        ((x + y)*y)**(-k + 4) + Piecewise(
-            (((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(3 - i),
-             And(k <= i, i <= 3)),
-            (0, True)
-        )
+            (((x + y)*y)**(-1)*((x + y)*y)**i*(x + y)*((x + y)*y
+            )**k*((x + y)*y)**(-i), (i >= 1) & (i <= k)), (0, True))
+    assert dp((x + y)*(y + KD(i, j)), (j, k, 3)) == (
+        (x + y)*y)**4*((x + y)*y)**(-k) + Piecewise((((x + y)*y)**i*(
+        (x + y)*y)**(-k)*(x + y)*((x + y)*y)**3*((x + y)*y)**(-i),
+        (i >= k) & (i <= 3)), (0, True))
     assert dp((x + y)*(y + KD(i, j)), (j, k, l)) == \
-        ((x + y)*y)**(-k + l + 1) + Piecewise(
-            (((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(l - i),
-             And(k <= i, i <= l)),
-            (0, True)
-        )
+        (x + y)*y*((x + y)*y)**l*((x + y)*y)**(-k) + Piecewise(
+        (((x + y)*y)**i*((x + y)*y)**(-k)*(x + y)*((x + y)*y
+        )**l*((x + y)*y)**(-i), (i >= k) & (i <= l)), (0, True))
 
 
 def test_deltaproduct_mul_add_x_kd_add_y_kd():
@@ -217,23 +211,20 @@ def test_deltaproduct_mul_add_x_kd_add_y_kd():
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 3, 3)) == \
         (x + KD(i, k))*(y + KD(i, 3))
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 1, k)) == \
-        ((x + KD(i, k))*y)**k + Piecewise(
-            (((x + KD(i, k))*y)**(i - 1)*(x + KD(i, k))*
-             ((x + KD(i, k))*y)**(-i + k), And(1 <= i, i <= k)),
-            (0, True)
-        )
-    assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, 3)) == \
-        ((x + KD(i, k))*y)**(4 - k) + Piecewise(
-            (((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*
-             ((x + KD(i, k))*y)**(-i + 3), And(k <= i, i <= 3)),
-            (0, True)
-        )
-    assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, l)) == \
-        ((x + KD(i, k))*y)**(-k + l + 1) + Piecewise(
-            (((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*
-             ((x + KD(i, k))*y)**(-i + l), And(k <= i, i <= l)),
-            (0, True)
-        )
+        ((KD(i, k) + x)*y)**k + Piecewise(
+        (((KD(i, k) + x)*y)**(-1)*((KD(i, k) + x)*y)**i*(KD(i, k) + x
+        )*((KD(i, k) + x)*y)**k*((KD(i, k) + x)*y)**(-i), (i >= 1
+        ) & (i <= k)), (0, True))
+    assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, 3)) == (
+        (KD(i, k) + x)*y)**4*((KD(i, k) + x)*y)**(-k) + Piecewise(
+        (((KD(i, k) + x)*y)**i*((KD(i, k) + x)*y)**(-k)*(KD(i, k)
+        + x)*((KD(i, k) + x)*y)**3*((KD(i, k) + x)*y)**(-i),
+        (i >= k) & (i <= 3)), (0, True))
+    assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, l)) == (
+        KD(i, k) + x)*y*((KD(i, k) + x)*y)**l*((KD(i, k) + x)*y
+        )**(-k) + Piecewise((((KD(i, k) + x)*y)**i*((KD(i, k) + x
+        )*y)**(-k)*(KD(i, k) + x)*((KD(i, k) + x)*y)**l*((KD(i, k) + x
+        )*y)**(-i), (i >= k) & (i <= l)), (0, True))
 
 
 def test_deltasummation_trivial():

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -399,11 +399,12 @@ def test_KroneckerDelta_Product():
     y = Symbol('y')
     assert Product(x*KroneckerDelta(x, y), (x, 0, 1)).doit() == 0
 
+
 def test_issue_20848():
     _i = Dummy('i')
     t, y, z = symbols('t y z')
     assert diff(Product(x, (y, 1, z)), x).as_dummy() == Sum(Product(x, (y, 1, _i - 1))*Product(x, (y, _i + 1, z)), (_i, 1, z)).as_dummy()
-    assert diff(Product(x, (y, 1, z)), x).doit() == x**z*z/x
+    assert diff(Product(x, (y, 1, z)), x).doit() == x**(z - 1)*z
     assert diff(Product(x, (y, x, z)), x) == Derivative(Product(x, (y, x, z)), x)
     assert diff(Product(t, (x, 1, z)), x) == S(0)
     assert Product(sin(n*x), (n, -1, 1)).diff(x).doit() == S(0)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -941,18 +941,22 @@ def test_factor_expand_subs():
     assert Sum(4 * x * y, (x, 1, y)).factor() == 4 * y * Sum(x, (x, 1, y))
 
     # test expand
+    _x = Symbol('x', zero=False)
     assert Sum(x+1,(x,1,y)).expand() == Sum(x,(x,1,y)) + Sum(1,(x,1,y))
     assert Sum(x+a*x**2,(x,1,y)).expand() == Sum(x,(x,1,y)) + Sum(a*x**2,(x,1,y))
-    assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand() \
-        == Sum(n*x*x**n + x*x**n, (n, -1, oo))
+    assert Sum(_x**(n + 1)*(n + 1), (n, -1, oo)).expand() \
+        == Sum(n*_x*_x**n + _x*_x**n, (n, -1, oo))
     assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand(power_exp=False) \
         == Sum(n*x**(n + 1) + x**(n + 1), (n, -1, oo))
     assert Sum(a*n+a*n**2,(n,0,4)).expand() \
         == Sum(a*n,(n,0,4)) + Sum(a*n**2,(n,0,4))
-    assert Sum(x**a*x**n,(x,0,3)) \
-        == Sum(x**(a+n),(x,0,3)).expand(power_exp=True)
-    assert Sum(x**(a+n),(x,0,3)) \
-        == Sum(x**(a+n),(x,0,3)).expand(power_exp=False)
+    assert Sum(_x**a*_x**n,(x,0,3)) \
+        == Sum(_x**(a+n),(x,0,3)).expand(power_exp=True)
+    _a, _n = symbols('a n', positive=True)
+    assert Sum(x**(_a+_n),(x,0,3)).expand(power_exp=True) \
+        == Sum(x**_a*x**_n, (x, 0, 3))
+    assert Sum(x**(_a-_n),(x,0,3)).expand(power_exp=True) \
+        == Sum(x**(_a-_n),(x,0,3)).expand(power_exp=False)
 
     # test subs
     assert Sum(1/(1+a*x**2),(x,0,3)).subs([(a,3)]) == Sum(1/(1+3*x**2),(x,0,3))
@@ -976,12 +980,18 @@ def test_issue_2787():
     res = s.doit().simplify()
     ans = Piecewise(
         (n*p, x),
-        ((1 - p)**n*Sum(k*p**k*binomial(n, k)/(1 - p)**k, (k, 0, n)),
-        True))
-    assert res == ans.subs(x, p/Abs(p - 1) <= 1)
+        (Sum(k*p**k*binomial(n, k)*(1 - p)**(n - k), (k, 0, n)),
+        True)).subs(x, (Eq(n, 1) | (n > 1)) & (p/Abs(p - 1) <= 1))
+    ans2 = Piecewise(
+        (n*p, x),
+        (factorial(n)*Sum(p**k*(1 - p)**(-k + n)/
+        (factorial(-k + n)*factorial(k - 1)), (k, 0, n)),
+        True)).subs(x, (Eq(n, 1) | (n > 1)) & (p/Abs(p - 1) <= 1))
+    assert res in [ans, ans2]  # XXX system dependent
     # Issue #17165: make sure that another simplify does not complicate
-    # the result (but why didn't first simplify handle this?)
-    assert res.simplify() == ans.subs(x, p <= S.Half)
+    # the result by much. Why didn't first simplify replace
+    # Eq(n, 1) | (n > 1) with True?
+    assert res.simplify().count_ops() <= res.count_ops() + 2
 
 
 def test_issue_4668():
@@ -1145,6 +1155,7 @@ def test_issue_10973():
 
 
 def test_issue_14129():
+    x = Symbol('x', zero=False)
     assert Sum( k*x**k, (k, 0, n-1)).doit() == \
         Piecewise((n**2/2 - n/2, Eq(x, 1)), ((n*x*x**n -
             n*x**n - x*x**n + x)/(x - 1)**2, True))
@@ -1152,11 +1163,10 @@ def test_issue_14129():
         Piecewise((n, Eq(x, 1)), ((-x**n + 1)/(-x + 1), True))
     assert Sum( k*(x/y+x)**k, (k, 0, n-1)).doit() == \
         Piecewise((n*(n - 1)/2, Eq(x, y/(y + 1))),
-        (x*(y + 1)*(n*x*y*(x + x/y)**n/(x + x/y)
-        + n*x*(x + x/y)**n/(x + x/y) - n*y*(x
-        + x/y)**n/(x + x/y) - x*y*(x + x/y)**n/(x
-        + x/y) - x*(x + x/y)**n/(x + x/y) + y)/(x*y
-        + x - y)**2, True))
+        (x*(y + 1)*(n*x*y*(x + x/y)**(n - 1) +
+        n*x*(x + x/y)**(n - 1) - n*y*(x + x/y)**(n - 1) -
+        x*y*(x + x/y)**(n - 1) - x*(x + x/y)**(n - 1) + y)/
+        (x*y + x - y)**2, True))
 
 
 def test_issue_14112():
@@ -1186,7 +1196,7 @@ def test_issue_14484():
 
 def test_issue_14640():
     i, n = symbols("i n", integer=True)
-    a, b, c = symbols("a b c")
+    a, b, c = symbols("a b c", zero=False)
 
     assert Sum(a**-i/(a - b), (i, 0, n)).doit() == Sum(
         1/(a*a**i - a**i*b), (i, 0, n)).doit() == Piecewise(
@@ -1622,3 +1632,12 @@ def test_pr_22677():
     assert Sum(1/x**2,(x, 0, b)).doit() == Sum(x**(-2), (x, 0, b))
     assert Sum(1/(x - b)**2,(x, 0, b-1)).doit() == Sum(
         (-b + x)**(-2), (x, 0, b - 1))
+
+
+def test_issue_23952():
+    p, q = symbols("p q", real=True, nonnegative=True)
+    k1, k2 = symbols("k1 k2", integer=True, nonnegative=True)
+    n = Symbol("n", integer=True, positive=True)
+    expr = Sum(abs(k1 - k2)*p**k1 *(1 - q)**(n - k2),
+        (k1, 0, n), (k2, 0, n))
+    assert expr.subs(p,0).subs(q,1).subs(n, 3).doit() == 3

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -747,6 +747,22 @@ class Add(Expr, AssocOp):
                 return
         return False
 
+    def _all_nonneg_or_nonppos(self):
+        nn = np = 0
+        for a in self.args:
+            if a.is_nonnegative:
+                if np:
+                    return False
+                nn = 1
+            elif a.is_nonpositive:
+                if nn:
+                    return False
+                np = 1
+            else:
+                break
+        else:
+            return True
+
     def _eval_is_extended_positive(self):
         if self.is_number:
             return super()._eval_is_extended_positive()

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2695,22 +2695,19 @@ class Expr(Basic, EvalfMixin):
         See also is_algebraic_expr().
 
         """
-        if self in _illegal:
-            return False
-
         if syms:
             syms = set(map(sympify, syms))
         else:
             syms = self.free_symbols
             if not syms:
-                return True
+                return self not in _illegal
 
         return self._eval_is_rational_function(syms)
 
     def _eval_is_rational_function(self, syms):
         if self in syms:
             return True
-        if not self.has_free(*syms):
+        if not self.has_xfree(syms):
             return True
         # subclasses should return True or False
 
@@ -3972,7 +3969,7 @@ class AtomicExpr(Atom, Expr):
         return True
 
     def _eval_is_rational_function(self, syms):
-        return True
+        return self not in _illegal
 
     def _eval_is_meromorphic(self, x, a):
         from sympy.calculus.accumulationbounds import AccumBounds

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -5,6 +5,7 @@ from .mul import Mul, _keep_coeff
 from .power import Pow
 from .basic import Basic
 from .expr import Expr
+from .function import expand_power_exp
 from .sympify import sympify
 from .numbers import Rational, Integer, Number, I
 from .singleton import S
@@ -1411,9 +1412,11 @@ def factor_nc(expr):
         return expr
     if not expr.is_Add:
         return expr.func(*[factor_nc(a) for a in expr.args])
+    expr = expr.func(*[expand_power_exp(i) for i in expr.args])
 
     from sympy.polys.polytools import gcd, factor
     expr, rep, nc_symbols = _mask_nc(expr)
+
     if rep:
         return factor(expr).subs(rep)
     else:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2986,7 +2986,7 @@ def expand_power_base(expr, deep=True, force=False):
     only happen if the base is non-negative or the exponent is an integer.
 
     >>> from sympy.abc import x, y, z
-    >>> from sympy import expand_power_base, sin, cos, exp
+    >>> from sympy import expand_power_base, sin, cos, exp, Symbol
 
     >>> (x*y)**2
     x**2*y**2
@@ -3025,7 +3025,24 @@ def expand_power_base(expr, deep=True, force=False):
     >>> expand_power_base((2*y)**(1+z))
     2**(z + 1)*y**(z + 1)
     >>> ((2*y)**(1+z)).expand()
-    2*2**z*y*y**z
+    2*2**z*y**(z + 1)
+
+    The power that is unexpanded can be expanded safely when
+    ``y != 0``, otherwise different values might be obtained for the expression:
+
+    >>> prev = _
+
+    If we indicate that ``y`` is positive but then replace it with
+    a value of 0 after expansion, the expression becomes 0:
+
+    >>> p = Symbol('p', positive=True)
+    >>> prev.subs(y, p).expand().subs(p, 0)
+    0
+
+    But if ``z = -1`` the expression would not be zero:
+
+    >>> prev.subs(y, 0).subs(z, -1)
+    1
 
     See Also
     ========
@@ -3047,9 +3064,18 @@ def expand_power_exp(expr, deep=True):
     Examples
     ========
 
-    >>> from sympy import expand_power_exp
+    >>> from sympy import expand_power_exp, Symbol
     >>> from sympy.abc import x, y
+    >>> expand_power_exp(3**(y + 2))
+    9*3**y
     >>> expand_power_exp(x**(y + 2))
+    x**(y + 2)
+
+    If ``x = 0`` the value of the expression depends on the
+    value of ``y``; if the expression were expanded the result
+    would be 0. So expansion is only done if ``x != 0``:
+
+    >>> expand_power_exp(Symbol('x', zero=False)**(y + 2))
     x**2*x**y
     """
     return sympify(expr).expand(deep=deep, complex=False, basic=False,

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3088,9 +3088,12 @@ class Zero(IntegerConstant, metaclass=Singleton):
             return S.ComplexInfinity
         if expt.is_extended_real is False:
             return S.NaN
+        if expt.is_zero:
+            return S.One
+
         # infinities are already handled with pos and neg
         # tests above; now throw away leading numbers on Mul
-        # exponent
+        # exponent since 0**-x = zoo**x even when x == 0
         coeff, terms = expt.as_coeff_Mul()
         if coeff.is_negative:
             return S.ComplexInfinity**terms

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -120,7 +120,7 @@ def test_div():
     assert e == (1 + -b)*((-1) + b)**(-1)
 
 
-def test_pow():
+def test_pow_arit():
     n1 = Rational(1)
     n2 = Rational(2)
     n5 = Rational(5)
@@ -174,10 +174,12 @@ def test_pow():
     assert (x**5*(-3*x)**(-3)).expand() == x**2 * Rational(-1, 27)
 
     # expand_power_exp
-    assert (x**(y**(x + exp(x + y)) + z)).expand(deep=False) == \
-        x**z*x**(y**(x + exp(x + y)))
-    assert (x**(y**(x + exp(x + y)) + z)).expand() == \
-        x**z*x**(y**x*y**(exp(x)*exp(y)))
+    _x = Symbol('x', zero=False)
+    _y = Symbol('y', zero=False)
+    assert (_x**(y**(x + exp(x + y)) + z)).expand(deep=False) == \
+        _x**z*_x**(y**(x + exp(x + y)))
+    assert (_x**(_y**(x + exp(x + y)) + z)).expand() == \
+        _x**z*_x**(_y**x*_y**(exp(x)*exp(y)))
 
     n = Symbol('n', even=False)
     k = Symbol('k', even=True)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -9,7 +9,7 @@ from sympy.core.function import (Function, expand, WildFunction,
     AppliedUndef, Derivative, diff, Subs)
 from sympy.core.mul import Mul
 from sympy.core.numbers import (NumberSymbol, E, zoo, oo, Float, I,
-    Rational, nan, Integer, Number, pi)
+    Rational, nan, Integer, Number, pi, _illegal)
 from sympy.core.power import Pow
 from sympy.core.relational import Ge, Lt, Gt, Le
 from sympy.core.singleton import S
@@ -654,10 +654,10 @@ def test_is_rational_function():
     assert (sin(y)/x).is_rational_function(x) is True
     assert (sin(y)/x).is_rational_function(x, y) is False
 
-    assert (S.NaN).is_rational_function() is False
-    assert (S.Infinity).is_rational_function() is False
-    assert (S.NegativeInfinity).is_rational_function() is False
-    assert (S.ComplexInfinity).is_rational_function() is False
+    for i in _illegal:
+        assert not i.is_rational_function()
+        for d in (1, x):
+            assert not (i/d).is_rational_function()
 
 
 def test_is_meromorphic():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -388,7 +388,8 @@ def test_factor_nc():
     assert (2*n + 2*m).factor() == 2*(n + m)
 
     # issue 6701
-    assert factor_nc(n**k + n**(k + 1)) == n**k*(1 + n)
+    _n = symbols('nz', zero=False, commutative=False)
+    assert factor_nc(_n**k + _n**(k + 1)) == _n**k*(1 + _n)
     assert factor_nc((m*n)**k + (m*n)**(k + 1)) == (1 + m*n)*(m*n)**k
 
     # issue 6918

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -4,6 +4,7 @@ from sympy.concrete.summations import Sum
 from sympy.core import (EulerGamma, Catalan, TribonacciConstant,
     GoldenRatio)
 from sympy.core.containers import Tuple
+from sympy.core.expr import unchanged
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import (mpf_norm, mod_inverse, igcd, seterr,
@@ -2212,3 +2213,12 @@ def test_floordiv():
 def test_negation():
     assert -S.Zero is S.Zero
     assert -Float(0) is not S.Zero and -Float(0) == 0
+
+
+def test_exponentiation_of_0():
+    x = Symbol('x')
+    assert 0**-x == zoo**x
+    assert unchanged(Pow, 0, x)
+    x = Symbol('x', zero=True)
+    assert 0**-x == S.One
+    assert 0**x == S.One

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1718,10 +1718,14 @@ def test_li_integral():
 def test_issue_17473():
     x = Symbol('x')
     n = Symbol('n')
-    assert integrate(sin(x**n), x) == \
-        x*x**n*gamma(S(1)/2 + 1/(2*n))*hyper((S(1)/2 + 1/(2*n),),
-                     (S(3)/2, S(3)/2 + 1/(2*n)),
-                     -x**(2*n)/4)/(2*n*gamma(S(3)/2 + 1/(2*n)))
+    h = S.Half
+    ans = x**(n + 1)*gamma(h + h/n)*hyper((h + h/n,),
+        (3*h, 3*h + h/n), -x**(2*n)/4)/(2*n*gamma(3*h + h/n))
+    got = integrate(sin(x**n), x)
+    assert got == ans
+    _x = Symbol('x', zero=False)
+    reps = {x: _x}
+    assert integrate(sin(_x**n), _x) == ans.xreplace(reps).expand()
 
 
 def test_issue_17671():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -754,8 +754,7 @@ def test_issue_6462():
 
 def test_indefinite_1_bug():
     assert integrate((b + t)**(-a), t, meijerg=True
-        ) == -b/(b**a*(1 + t/b)**a*(a - 1)
-        ) - t/(b**a*(1 + t/b)**a*(a - 1))
+        ) == -b**(1 - a)*(1 + t/b)**(1 - a)/(a - 1)
 
 
 def test_pr_23583():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -383,8 +383,8 @@ def test_inverse_mellin_transform():
         (1 + sqrt(x + 1))**c
     assert simplify(IMT(2**(a + 2*s)*b**(a + 2*s - 1)*gamma(s)*gamma(1 - a - 2*s)
                         /gamma(1 - a - s), s, x, (0, (-re(a) + 1)/2))) == \
-        b**(a - 1)*(sqrt(1 + x/b**2) + 1)**(a - 1)*(b**2*sqrt(1 + x/b**2) +
-        b**2 + x)/(b**2 + x)
+        b**(a - 1)*(b**2*(sqrt(1 + x/b**2) + 1)**a + x*(sqrt(1 + x/b**2) + 1
+        )**(a - 1))/(b**2 + x)
     assert simplify(IMT(-2**(c + 2*s)*c*b**(c + 2*s)*gamma(s)*gamma(-c - 2*s)
                         / gamma(-c - s + 1), s, x, (0, -re(c)/2))) == \
         b**c*(sqrt(1 + x/b**2) + 1)**c

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1889,7 +1889,7 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
     >>> laplace_transform(t**4, t, s)
     (24/s**5, 0, True)
     >>> laplace_transform(t**a, t, s)
-    (gamma(a + 1)/(s*s**a), 0, re(a) > -1)
+    (s**(-a - 1)*gamma(a + 1), 0, re(a) > -1)
     >>> laplace_transform(DiracDelta(t)-a*exp(-a*t),t,s)
     (s/(a + s), Max(0, -a), True)
 

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -416,12 +416,12 @@ def test_fps_symbolic():
 
     f = x**(n - 2)*cos(x)
     assert fps(f, x).truncate() == \
-        (x**(n - 2) - x**n/2 + x**(n + 2)/24 - x**(n + 4)/720 + O(x**(n + 6), x))
+        (x**(n - 2) - x**n/2 + x**(n + 2)/24 + O(x**(n + 4), x))
 
     f = x**(n - 2)*sin(x) + x**n*exp(x)
     assert fps(f, x).truncate() == \
-        (x**(n - 1) + x**n + 5*x**(n + 1)/6 + x**(n + 2)/2 + 7*x**(n + 3)/40 +
-         x**(n + 4)/24 + 41*x**(n + 5)/5040 + O(x**(n + 6), x))
+        (x**(n - 1) + x**(n + 1) + x**(n + 2)/2 + x**n +
+         x**(n + 4)/24 + x**(n + 5)/60 + O(x**(n + 6), x))
 
     f = x**n*atan(x)
     assert fps(f, x, oo).truncate() == \

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -186,7 +186,7 @@ def test_rsolve():
 
     assert rsolve(y(n) - a*y(n-2),y(n), \
             {y(1): sqrt(a)*(a + b), y(2): a*(a - b)}).simplify() == \
-            a**(n/2)*(-(-1)**n*b + a)
+            a**(n/2 + 1) - b*(-sqrt(a))**n
 
     f = (-16*n**2 + 32*n - 12)*y(n - 1) + (4*n**2 - 12*n + 9)*y(n)
 
@@ -195,8 +195,7 @@ def test_rsolve():
     assert factor(expand(yn, func=True)) == sol
 
     sol = rsolve(y(n) + a*(y(n + 1) + y(n - 1))/2, y(n))
-    Y = lambda i: sol.subs(n, i)
-    assert (Y(n) + a*(Y(n + 1) + Y(n - 1))/2).expand().cancel() == 0
+    assert str(sol) == 'C0*((-sqrt(1 - a**2) - 1)/a)**n + C1*((sqrt(1 - a**2) - 1)/a)**n'
 
     assert rsolve((k + 1)*y(k), y(k)) is None
     assert (rsolve((k + 1)*y(k) + (k + 3)*y(k + 1) + (k + 5)*y(k + 2), y(k))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2535,7 +2535,8 @@ def test_issue_21852():
 def test_issue_21942():
     eq = -d + (a*c**(1 - e) + b**(1 - e)*(1 - a))**(1/(1 - e))
     sol = solve(eq, c, simplify=False, check=False)
-    assert sol == [(b/b**e - b/(a*b**e) + d**(1 - e)/a)**(1/(1 - e))]
+    assert sol == [((a*b**(1 - e) - b**(1 - e) +
+        d**(1 - e))/a)**(1/(1 - e))]
 
 
 def test_solver_flags():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -485,6 +485,7 @@ def test_H8():
 
 
 def test_H9():
+    x = Symbol('x', zero=False)
     p1 = 2*x**(n + 4) - x**(n + 2)
     p2 = 4*x**(n + 1) + 3*x**n
     assert gcd(p1, p2) == x**n


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

fixes #23952 but required treating zoo/x as non-rational.

#### Other comments

This fixes the root issue (of the expansion to 0) but better handling needs to be implemented to get the original issue to be solved:
```python
>>> import sympy as sp
>>> p, q = sp.symbols("p q", real=True, nonnegative=True)
>>> k1,k2 = sp.symbols("k1 k2", integer=True, nonnegative=True)
>>> n = sp.Symbol("n", integer=True, positive=True)
>>> expr = sp.Sum(sp.Abs(k1 - k2)*p**k1 *(1-q)**(n-k2), (k1,0,n), (k2,0,n))
>>> expr.subs(p,0).subs(q,1)
Sum(0**k1*0**(-k2 + n)*Abs(k1 - k2), (k1, 0, n), (k2, 0, n))
>>> _.doit()
...
sympy.polys.polyerrors.CoercionFailed: zoo is not in any domain
```
If the assumptions are omitted then
```python
>>> S('''Sum(p**k1*(1 - q)**(-k2 + n)*Abs(k1 - k2), (k1, 0, n), (k2, 0, n))''')
Sum(p**k1*(1 - q)**(-k2 + n)*Abs(k1 - k2), (k1, 0, n), (k2, 0, n))
>>> ok=_;var('p q');ok.subs(p,0).subs(q,1)
(p, q)
Sum(0**k1*0**(-k2 + n)*Abs(k1 - k2), (k1, 0, n), (k2, 0, n))
>>> _.doit()
Sum(0**k1*0**(-k2 + n)*Abs(k1 - k2), (k1, 0, n), (k2, 0, n))
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `x**(a + b)` will not expand unless `a` and `b` are both nonnegative or nonpositive or `x` is not zero
    * expressions containing any illegal character as defined in numbers now gives `expr.is_rational_function()->False`
<!-- END RELEASE NOTES -->
