### PR TITLE
B(1) = +½ set 1: analytically correct Hurwitz zeta

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -989,6 +989,7 @@ Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
 Pan Peng <pengpanster@gmail.com>
 Param Singh <paramsingh258@gmail.com>
+Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
 Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -18,10 +18,11 @@ from sympy.core.function import Function, expand_mul
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import E, pi, oo, Rational, Integer
-from sympy.core.relational import is_le, is_gt
+from sympy.core.relational import Eq, is_le, is_gt
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.functions.combinatorial.factorials import (binomial,
     factorial, subfactorial)
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -882,7 +882,7 @@ class harmonic(Function):
         if n == 0:
             return S.Zero
 
-        if n.is_Integer and n.is_nonnegative and m.is_Integer:
+        if n.is_Integer and n.is_nonnegative:
             if m not in cls._functions:
                 @recurrence_memo([0])
                 def f(n, prev):

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.zeta_functions import (dirichlet_eta, lerchphi, polylog, riemann_xi, stieltjes, zeta)
 from sympy.series.order import O
 from sympy.core.function import ArgumentIndexError
-from sympy.functions.combinatorial.numbers import bernoulli, factorial
+from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
 from sympy.testing.pytest import raises
 from sympy.core.random import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically)
@@ -42,12 +42,15 @@ def test_zeta_eval():
     assert zeta(6) == pi**6/945
 
     assert zeta(2, 2) == pi**2/6 - 1
+    assert zeta(3, 2) == zeta(3) - 1
     assert zeta(4, 3) == pi**4/90 - Rational(17, 16)
+    assert zeta(5, 3) == zeta(5) - Rational(33, 32)
     assert zeta(6, 4) == pi**6/945 - Rational(47449, 46656)
+    assert zeta(7, 4) == zeta(7) - Rational(282251, 279936)
 
-    assert zeta(2, -2) == pi**2/6 + Rational(5, 4)
-    assert zeta(4, -3) == pi**4/90 + Rational(1393, 1296)
-    assert zeta(6, -4) == pi**6/945 + Rational(3037465, 2985984)
+    assert zeta(2, 0) is nan
+    assert zeta(3, -1) is nan
+    assert zeta(4, -2) is nan
 
     assert zeta(oo) == 1
 
@@ -59,8 +62,8 @@ def test_zeta_eval():
 
     assert zeta(-1, 3) == Rational(-37, 12)
     assert zeta(-1, 7) == Rational(-253, 12)
-    assert zeta(-1, -4) == Rational(119, 12)
-    assert zeta(-1, -9) == Rational(539, 12)
+    assert zeta(-1, -4) == Rational(-121, 12)
+    assert zeta(-1, -9) == Rational(-541, 12)
 
     assert zeta(-4, 3) == -17
     assert zeta(-4, -8) == 8772
@@ -76,12 +79,11 @@ def test_zeta_eval():
 
 
 def test_zeta_series():
-    assert zeta(x, a).series(a, 0, 2) == \
-        zeta(x, 0) - x*a*zeta(x + 1, 0) + O(a**2)
+    assert zeta(x, a).series(a, z, 2) == \
+        zeta(x, z) - x*(a-z)*zeta(x+1, z) + O((a-z)**2, (a, z))
 
 
 def test_dirichlet_eta_eval():
-
     assert dirichlet_eta(0) == S.Half
     assert dirichlet_eta(-1) == Rational(1, 4)
     assert dirichlet_eta(1) == log(2)
@@ -239,7 +241,7 @@ def test_stieltjes():
 def test_stieltjes_evalf():
     assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
     assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
-    assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9
+    assert abs(stieltjes(1, 2).evalf() + 0.072815845) < 1E-9
 
 
 def test_issue_10475():
@@ -261,10 +263,15 @@ def test_issue_10475():
 
 
 def test_issue_14177():
-    n = Symbol('n', positive=True, integer=True)
+    n = Symbol('n', nonnegative=True, integer=True)
 
-    assert zeta(2*n) == (-1)**(n + 1)*2**(2*n - 1)*pi**(2*n)*bernoulli(2*n)/factorial(2*n)
-    assert zeta(-n) == (-1)**(-n)*bernoulli(n + 1)/(n + 1)
+    assert zeta(-n).rewrite(bernoulli) == bernoulli(n+1) / (-n-1)
+    assert zeta(-n, a).rewrite(bernoulli) == bernoulli(n+1, a) / (-n-1)
+    z2n = -(2*I*pi)**(2*n)*bernoulli(2*n) / (2*factorial(2*n))
+    assert zeta(2*n).rewrite(bernoulli) == z2n
+    assert expand_func(zeta(s, n+1)) == zeta(s) - harmonic(n, s)
+    assert expand_func(zeta(-b, -n)) is nan
+    assert expand_func(zeta(-b, n)) == zeta(-b, n)
 
     n = Symbol('n')
 

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -36,17 +36,18 @@ def test_zeta_eval():
     assert zeta(1, x) is zoo
 
     assert zeta(2, 1) == pi**2/6
+    assert zeta(3, 1) == zeta(3)
 
     assert zeta(2) == pi**2/6
     assert zeta(4) == pi**4/90
     assert zeta(6) == pi**6/945
 
-    assert zeta(2, 2) == pi**2/6 - 1
-    assert zeta(3, 2) == zeta(3) - 1
     assert zeta(4, 3) == pi**4/90 - Rational(17, 16)
-    assert zeta(5, 3) == zeta(5) - Rational(33, 32)
-    assert zeta(6, 4) == pi**6/945 - Rational(47449, 46656)
     assert zeta(7, 4) == zeta(7) - Rational(282251, 279936)
+    assert zeta(S.Half, 2).func == zeta
+    assert expand_func(zeta(S.Half, 2)) == zeta(S.Half) - 1
+    assert zeta(x, 3).func == zeta
+    assert expand_func(zeta(x, 3)) == zeta(x) - 1 - 1/2**x
 
     assert zeta(2, 0) is nan
     assert zeta(3, -1) is nan

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -517,13 +517,13 @@ class zeta(Function):
         elif a is S.One:
             if sint and s.is_even:
                 return -(2*pi*I)**s * bernoulli(s) / (2*factorial(s))
-        elif s.is_number and a.is_Integer:
+        elif sint and a.is_Integer:
             if a.is_positive:
                 return cls(s) - harmonic(a-1, s)
             return S.NaN
 
     def _eval_rewrite_as_bernoulli(self, s, a=1, **kwargs):
-        if a == 1 and s.is_integer and s.is_even:
+        if a == 1 and s.is_integer and s.is_nonnegative and s.is_even:
             return -(2*pi*I)**s * bernoulli(s) / (2*factorial(s))
         return bernoulli(1-s, a) / (s-1)
 
@@ -543,7 +543,7 @@ class zeta(Function):
 
     def _eval_expand_func(self, **hints):
         s = self.args[0]
-        a = self.args[1] if len(self.args) == 2 else S.One
+        a = self.args[1] if len(self.args) > 1 else S.One
         if a.is_integer:
             if a.is_positive:
                 return zeta(s) - harmonic(a-1, s)

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -402,12 +402,9 @@ class zeta(Function):
     .. math:: \zeta(s, a) = \sum_{n=0}^\infty \frac{1}{(n + a)^s},
 
     where the standard choice of argument for $n + a$ is used. For fixed
-    $a$ with $\operatorname{Re}(a) > 0$ the Hurwitz zeta function admits a
-    meromorphic continuation to all of $\mathbb{C}$, it is an unbranched
+    $a$ not a nonpositive integer the Hurwitz zeta function admits a
+    meromorphic continuation to all of $\mathbb{C}$; it is an unbranched
     function with a simple pole at $s = 1$.
-
-    Analytic continuation to other $a$ is possible under some circumstances,
-    but this is not typically done.
 
     The Hurwitz zeta function is a special case of the Lerch transcendent:
 
@@ -417,8 +414,8 @@ class zeta(Function):
     $s$ and $a$ (also $\operatorname{Re}(a) < 0$), see the documentation of
     :class:`lerchphi` for a description of the branching behavior.
 
-    If no value is passed for $a$, by this function assumes a default value
-    of $a = 1$, yielding the Riemann zeta function.
+    If no value is passed for $a$ a default value of $a = 1$ is assumed,
+    yielding the Riemann zeta function.
 
     Examples
     ========
@@ -442,25 +439,24 @@ class zeta(Function):
     >>> zeta(s).rewrite(dirichlet_eta)
     dirichlet_eta(s)/(1 - 2**(1 - s))
 
-    The Riemann zeta function at positive even integer and negative odd integer
-    values is related to the Bernoulli numbers:
+    The Riemann zeta function at nonnegative even and negative integer
+    values is related to the Bernoulli numbers and polynomials:
 
     >>> zeta(2)
     pi**2/6
     >>> zeta(4)
     pi**4/90
+    >>> zeta(0)
+    -1/2
     >>> zeta(-1)
     -1/12
+    >>> zeta(-4)
+    0
 
     The specific formulae are:
 
-    .. math:: \zeta(2n) = (-1)^{n+1} \frac{B_{2n} (2\pi)^{2n}}{2(2n)!}
-    .. math:: \zeta(-n) = -\frac{B_{n+1}}{n+1}
-
-    At negative even integers the Riemann zeta function is zero:
-
-    >>> zeta(-4)
-    0
+    .. math:: \zeta(2n) = -\frac{(2\pi i)^{2n} B_{2n}}{2(2n)!}
+    .. math:: \zeta(-n,a) = -\frac{B_{n+1}(a)}{n+1}
 
     No closed-form expressions are known at positive odd integers, but
     numerical evaluation is possible:
@@ -501,44 +497,35 @@ class zeta(Function):
     """
 
     @classmethod
-    def eval(cls, z, a_=None):
-        if a_ is None:
-            z, a = list(map(sympify, (z, 1)))
-        else:
-            z, a = list(map(sympify, (z, a_)))
+    def eval(cls, s, a=None):
+        if a is S.One:
+            return cls(s)
+        elif s is S.NaN or a is S.NaN:
+            return S.NaN
+        elif s is S.One:
+            return S.ComplexInfinity
+        elif s is S.Infinity:
+            return S.One
 
-        if a.is_Number:
-            if a is S.NaN:
-                return S.NaN
-            elif a is S.One and a_ is not None:
-                return cls(z)
-            # TODO Should a == 0 return S.NaN as well?
-
-        if z.is_Number:
-            if z is S.NaN:
-                return S.NaN
-            elif z is S.Infinity:
-                return S.One
-            elif z.is_zero:
-                return S.Half - a
-            elif z is S.One:
-                return S.ComplexInfinity
-        if z.is_integer:
-            if a.is_Integer:
-                if z.is_negative:
-                    zeta = S.NegativeOne**z * bernoulli(-z + 1)/(-z + 1)
-                elif z.is_even and z.is_positive:
-                    B, F = bernoulli(z), factorial(z)
-                    zeta = (S.NegativeOne**(z/2+1) * 2**(z - 1) * B * pi**z) / F
-                else:
-                    return
-
-                if a.is_negative:
-                    return zeta + harmonic(abs(a), z)
-                else:
-                    return zeta - harmonic(a - 1, z)
-        if z.is_zero:
+        sint = s.is_Integer
+        if a is None:
+            a = S.One
+        if s.is_zero:
             return S.Half - a
+        elif sint and s.is_nonpositive:
+            return bernoulli(1-s, a) / (s-1)
+        elif a is S.One:
+            if sint and s.is_even:
+                return -(2*pi*I)**s * bernoulli(s) / (2*factorial(s))
+        elif s.is_number and a.is_Integer:
+            if a.is_positive:
+                return cls(s) - harmonic(a-1, s)
+            return S.NaN
+
+    def _eval_rewrite_as_bernoulli(self, s, a=1, **kwargs):
+        if a == 1 and s.is_integer and s.is_even:
+            return -(2*pi*I)**s * bernoulli(s) / (2*factorial(s))
+        return bernoulli(1-s, a) / (s-1)
 
     def _eval_rewrite_as_dirichlet_eta(self, s, a=1, **kwargs):
         if a != 1:
@@ -553,6 +540,17 @@ class zeta(Function):
         arg_is_one = (self.args[0] - 1).is_zero
         if arg_is_one is not None:
             return not arg_is_one
+
+    def _eval_expand_func(self, **hints):
+        s = self.args[0]
+        a = self.args[1] if len(self.args) == 2 else S.One
+        if a.is_integer:
+            if a.is_positive:
+                return zeta(s) - harmonic(a-1, s)
+            if a.is_nonpositive and (s.is_integer is False or
+                    s.is_nonpositive is False):
+                return S.NaN
+        return self
 
     def fdiff(self, argindex=1):
         if len(self.args) == 2:


### PR DESCRIPTION
#### References to other Issues or PRs

This is part 1 of the changes formerly included in #23926.

#### Brief description of what is fixed or changed

mpmath's implementation of the Hurwitz zeta function agrees with Mathematica's `HurwitzZeta[]`, but the symbolic code in SymPy currently parallels `Zeta[]` instead. This PR rectifies the discrepancy, especially since `HurwitzZeta[]` is the correct analytic continuation of the Riemann zeta function and thus has the nicer properties.

#### Other comments

`bernoulli()` is also refactored in this PR, but its user-facing behaviour is not changed; `bernoulli(1)` still returns `-1/2`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
    * BREAKING: `zeta(s, a)` now implements the analytically continued Hurwitz zeta function (Mathematica's `HurwitzZeta[]`), not Mathematica's `Zeta[]`.
    * `zeta()` now simplifies for more sets of parameters.
<!-- END RELEASE NOTES -->
