### PR TITLE
Add dontcare argument to simplify_logic

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2396,10 +2396,16 @@ def SOPform(variables, minterms, dontcares=None):
     >>> SOPform([w, x, y, z], minterms, dontcares)
     (w & y & z) | (~w & ~y) | (x & z & ~w)
 
+    See also
+    ========
+
+    POSform
+
     References
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Quine-McCluskey_algorithm
+    .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
     if not minterms:
@@ -2471,11 +2477,16 @@ def POSform(variables, minterms, dontcares=None):
     >>> POSform([w, x, y, z], minterms, dontcares)
     (w | x) & (y | ~w) & (z | ~y)
 
+    See also
+    ========
+
+    SOPform
 
     References
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Quine-McCluskey_algorithm
+    .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
     if not minterms:
@@ -2741,7 +2752,7 @@ def _find_predicates(expr):
     return set().union(*(map(_find_predicates, expr.args)))
 
 
-def simplify_logic(expr, form=None, deep=True, force=False):
+def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
     """
     This function simplifies a boolean function to its simplified version
     in SOP or POS form. The return type is an :py:class:`~.Or` or
@@ -2769,20 +2780,29 @@ def simplify_logic(expr, form=None, deep=True, force=False):
         made. By setting ``force`` to ``True``, this limit is removed. Be
         aware that this can lead to very long simplification times.
 
+    dontcare : Boolean expression
+        Optimize expression under the assumption that inputs where this
+        expression is true are don't care. This is useful in e.g. Piecewise
+        conditions, where later conditions do not need to consider inputs that
+        are convered by previous conditions. For example, if a previous
+        condition is ``And(A, B)``, the simplification of expr can be made
+        with don't cares for ``And(A, B)``.
+
     Examples
     ========
 
     >>> from sympy.logic import simplify_logic
     >>> from sympy.abc import x, y, z
-    >>> from sympy import S
     >>> b = (~x & ~y & ~z) | ( ~x & ~y & z)
     >>> simplify_logic(b)
     ~x & ~y
+    >>> simplify_logic(x | y, dontcare=y)
+    x
 
-    >>> S(b)
-    (z & ~x & ~y) | (~x & ~y & ~z)
-    >>> simplify_logic(_)
-    ~x & ~y
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
 
@@ -2815,6 +2835,9 @@ def simplify_logic(expr, form=None, deep=True, force=False):
     undo = {}
     from sympy.core.symbol import Dummy
     variables = expr.atoms(Relational)
+    if dontcare is not None:
+        dontcare = sympify(dontcare)
+        variables.update(dontcare.atoms(Relational))
     while variables:
         var = variables.pop()
         if var.is_Relational:
@@ -2828,34 +2851,54 @@ def simplify_logic(expr, form=None, deep=True, force=False):
 
     expr = expr.xreplace(repl)
 
+    if dontcare is not None:
+        dontcare = dontcare.xreplace(repl)
+
     # Get new variables after replacing
     variables = _find_predicates(expr)
     if not force and len(variables) > 8:
         return expr.xreplace(undo)
+    if dontcare is not None:
+        # Add variables from dontcare
+        dcvariables = _find_predicates(dontcare)
+        variables.update(dcvariables)
+        # if too many restore to variables only
+        if not force and len(variables) > 8:
+            variables = _find_predicates(expr)
+            dontcare = None
     # group into constants and variable values
     c, v = sift(ordered(variables), lambda x: x in (True, False), binary=True)
     variables = c + v
-    truthtable = []
     # standardize constants to be 1 or 0 in keeping with truthtable
     c = [1 if i == True else 0 for i in c]
     truthtable = _get_truthtable(v, expr, c)
+    if dontcare is not None:
+        dctruthtable = _get_truthtable(v, dontcare, c)
+        truthtable = [t for t in truthtable if t not in dctruthtable]
+    else:
+        dctruthtable = []
     big = len(truthtable) >= (2 ** (len(variables) - 1))
     if form == 'dnf' or form is None and big:
-        return _sop_form(variables, truthtable, []).xreplace(undo)
-    return POSform(variables, truthtable).xreplace(undo)
+        return _sop_form(variables, truthtable, dctruthtable).xreplace(undo)
+    return POSform(variables, truthtable, dctruthtable).xreplace(undo)
 
 
 def _get_truthtable(variables, expr, const):
     """ Return a list of all combinations leading to a True result for ``expr``.
     """
+    _variables = variables.copy()
     def _get_tt(inputs):
-        if variables:
-            v = variables.pop()
+        if _variables:
+            v = _variables.pop()
             tab = [[i[0].xreplace({v: false}), [0] + i[1]] for i in inputs if i[0] is not false]
             tab.extend([[i[0].xreplace({v: true}), [1] + i[1]] for i in inputs if i[0] is not false])
             return _get_tt(tab)
         return inputs
-    return [const + k[1] for k in _get_tt([[expr, []]]) if k[0]]
+    res = [const + k[1] for k in _get_tt([[expr, []]]) if k[0]]
+    if res == [[]]:
+        return []
+    else:
+        return res
 
 
 def _finger(eq):
@@ -3028,7 +3071,8 @@ def _apply_patternbased_simplification(rv, patterns, measure,
         Boolean expression
 
     patterns : tuple
-        Tuple of tuples, with (pattern to simplify, simplified pattern).
+        Tuple of tuples, with (pattern to simplify, simplified pattern) with
+        two terms.
 
     measure : function
         Simplification measure.
@@ -3046,6 +3090,10 @@ def _apply_patternbased_simplification(rv, patterns, measure,
         in this case the resulting value is ``S.true``. Default is ``None``.
         If ``replacementvalue`` is ``None`` and ``dominatingvalue`` is not
         ``None``, ``replacementvalue = dominatingvalue``.
+
+    threeterm_patterns : tuple, optional
+        Tuple of tuples, with (pattern to simplify, simplified pattern) with
+        three terms.
 
     """
     from sympy.core.relational import Relational, _canonical

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -324,6 +324,9 @@ def test_simplification_boolalg():
     # This expression can be simplified to get rid of the j variables
     assert simplify_logic(expr) == expr
 
+    # Test dontcare
+    assert simplify_logic((a & b) | c | d, dontcare=(a & b)) == c | d
+
     # check input
     ans = SOPform([x, y], [[1, 0]])
     assert SOPform([x, y], [[1, 0]]) == ans


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Another part of #22753

#### Brief description of what is fixed or changed
`simplify_logic` now has a `dontcare` keyword argument, so that one can simplify the expression under the assumption that the `dontcare`-expression does not matter. Useful in general, but especially for Piecewise simplification where one then can set the previous conditions to don't care.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
    * `simplify_logic` now has a `dontcare` keyword argument for simplifying under don't care-conditions.
<!-- END RELEASE NOTES -->
