### PR TITLE
piecewise_fold always folds internal Piecewise functions

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1071,6 +1071,8 @@ def piecewise_fold(expr, evaluate=True):
     rv = Piecewise(*new_args, evaluate=evaluate)
     if evaluate is None and len(rv.args) == 1 and rv.args[0].cond == True:
         return rv.args[0].expr
+    if any(s.expr.has(Piecewise) for p in rv.atoms(Piecewise) for s in p.args):
+        return piecewise_fold(rv)
     return rv
 
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -442,6 +442,22 @@ def test_piecewise_integrate5_independent_conditions():
     assert integrate(p, (x, 1, 3)) == Piecewise((0, Eq(y, 0)), (4*y, True))
 
 
+def test_issue_22917():
+    p = (Piecewise((0, ITE((x - y > 1) | (2 * x - 2 * y > 1), False,
+                           ITE(x - y > 1, 2 * y - 2 < -1, 2 * x - 2 * y > 1))),
+                   (Piecewise((0, ITE(x - y > 1, True, 2 * x - 2 * y > 1)),
+                              (2 * Piecewise((0, x - y > 1), (y, True)), True)), True))
+         + 2 * Piecewise((1, ITE((x - y > 1) | (2 * x - 2 * y > 1), False,
+                                 ITE(x - y > 1, 2 * y - 2 < -1, 2 * x - 2 * y > 1))),
+                         (Piecewise((1, ITE(x - y > 1, True, 2 * x - 2 * y > 1)),
+                                    (2 * Piecewise((1, x - y > 1), (x, True)), True)), True)))
+    assert piecewise_fold(p) == Piecewise((2, (x - y > S.Half) | (x - y > 1)),
+                                          (2*y + 4, x - y > 1),
+                                          (4*x + 2*y, True))
+    assert piecewise_fold(p > 1).rewrite(ITE) == ITE((x - y > S.Half) | (x - y > 1), True,
+                                                     ITE(x - y > 1, 2*y + 4 > 1, 4*x + 2*y > 1))
+
+
 def test_piecewise_simplify():
     p = Piecewise(((x**2 + 1)/x**2, Eq(x*(1 + x) - x**2, 0)),
                   ((-1)**x*(-1), True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #22917

#### Brief description of what is fixed or changed

In some situation, `piecewise_fold` requires a second execution. This checks if there are any Piecewise left inside a Piecewise and if so applies `piecewise_fold` again. It may be that this should happen for other situations as well, e..g. check if `len(atoms(Piecewise)) > 1`?

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `piecewise_fold` is applied recursively to always fold fully.
<!-- END RELEASE NOTES -->
