### PR TITLE
B(1) = +½ set 6: alternating Hurwitz zeta

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1361,6 +1361,10 @@ class genocchi(Function):
             return 2 * (1-S(2)**n) * bernoulli(n)
         return 2 * (bernoulli(n, x) - 2**n * bernoulli(n, (x+1) / 2))
 
+    def _eval_rewrite_as_dirichlet_eta(self, n, x=1, **kwargs):
+        from sympy.functions.special.zeta_functions import dirichlet_eta
+        return -2*n * dirichlet_eta(1-n, x)
+
     def _eval_is_integer(self):
         if len(self.args) > 1 and self.args[1] != 1:
             return

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -15,7 +15,7 @@ from sympy.series.limits import limit
 from sympy.functions import (
     bernoulli, harmonic, bell, fibonacci, tribonacci, lucas, euler, catalan,
     genocchi, partition, motzkin, binomial, gamma, sqrt, cbrt, hyper, log, digamma,
-    trigamma, polygamma, factorial, sin, cos, cot, zeta)
+    trigamma, polygamma, factorial, sin, cos, cot, zeta, dirichlet_eta)
 from sympy.functions.combinatorial.numbers import _nT
 
 from sympy.core.expr import unchanged
@@ -491,6 +491,9 @@ def test_genocchi():
     assert str(genocchi(-2).evalf(n=10)) == '3.606170709'
     assert str(genocchi(1.3, 3.7).evalf(n=10)) == '-1.847375373'
     assert str(genocchi(I, 1.0).evalf(n=10)) == '-0.3161917278 - 1.45311955*I'
+
+    n = Symbol('n')
+    assert genocchi(n, x).rewrite(dirichlet_eta) == -2*n * dirichlet_eta(1-n, x)
 
 
 @nocache_fail

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.zeta_functions import (dirichlet_eta, lerchphi, polylog, riemann_xi, stieltjes, zeta)
 from sympy.series.order import O
 from sympy.core.function import ArgumentIndexError
-from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
+from sympy.functions.combinatorial.numbers import bernoulli, factorial, genocchi, harmonic
 from sympy.testing.pytest import raises
 from sympy.core.random import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically)
@@ -88,8 +88,12 @@ def test_dirichlet_eta_eval():
     assert dirichlet_eta(0) == S.Half
     assert dirichlet_eta(-1) == Rational(1, 4)
     assert dirichlet_eta(1) == log(2)
+    assert dirichlet_eta(1, S.Half).simplify() == pi/2
+    assert dirichlet_eta(1, 2) == 1 - log(2)
     assert dirichlet_eta(2) == pi**2/12
     assert dirichlet_eta(4) == pi**4*Rational(7, 720)
+    assert str(dirichlet_eta(I).evalf(n=10)) == '0.5325931818 + 0.2293848577*I'
+    assert str(dirichlet_eta(I, I).evalf(n=10)) == '3.462349253 + 0.220285771*I'
 
 
 def test_riemann_xi_eval():
@@ -101,10 +105,13 @@ def test_riemann_xi_eval():
 
 
 def test_rewriting():
-    assert dirichlet_eta(x).rewrite(zeta) == (1 - 2**(1 - x))*zeta(x)
+    from sympy.functions.elementary.piecewise import Piecewise
+    assert isinstance(dirichlet_eta(x).rewrite(zeta), Piecewise)
+    assert isinstance(dirichlet_eta(x).rewrite(genocchi), Piecewise)
     assert zeta(x).rewrite(dirichlet_eta) == dirichlet_eta(x)/(1 - 2**(1 - x))
     assert zeta(x).rewrite(dirichlet_eta, a=2) == zeta(x)
     assert verify_numerically(dirichlet_eta(x), dirichlet_eta(x).rewrite(zeta), x)
+    assert verify_numerically(dirichlet_eta(x), dirichlet_eta(x).rewrite(genocchi), x)
     assert verify_numerically(zeta(x), zeta(x).rewrite(dirichlet_eta), x)
 
     assert zeta(x, a).rewrite(lerchphi) == lerchphi(1, x, a)

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -3,12 +3,14 @@
 from sympy.core.add import Add
 from sympy.core import Function, S, sympify, pi, I
 from sympy.core.function import ArgumentIndexError, expand_mul
+from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy
-from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
+from sympy.functions.combinatorial.numbers import bernoulli, factorial, genocchi, harmonic
 from sympy.functions.elementary.complexes import re, unpolarify, Abs, polar_lift
 from sympy.functions.elementary.exponential import log, exp_polar, exp
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys.polytools import Poly
 
 ###############################################################################
@@ -568,22 +570,31 @@ class dirichlet_eta(Function):
     Explanation
     ===========
 
-    For $\operatorname{Re}(s) > 0$, this function is defined as
+    For $\operatorname{Re}(s) > 0$ and $0 < x \le 1$, this function is defined as
 
-    .. math:: \eta(s) = \sum_{n=1}^\infty \frac{(-1)^{n-1}}{n^s}.
+    .. math:: \eta(s, a) = \sum_{n=0}^\infty \frac{(-1)^n}{(n+a)^s}.
 
-    It admits a unique analytic continuation to all of $\mathbb{C}$.
-    It is an entire, unbranched function.
+    It admits a unique analytic continuation to all of $\mathbb{C}$ for any
+    fixed $a$ not a nonpositive integer. It is an entire, unbranched function.
+
+    It can be expressed using the Hurwitz zeta function as
+
+    .. math:: \eta(s, a) = \zeta(s,a) - 2^{1-s} \zeta\left(s, \frac{a+1}{2}\right)
+
+    and using the generalized Genocchi function as
+
+    .. math:: \eta(s, a) = \frac{G(1-s, a)}{2(s-1)}.
+
+    In both cases the limiting value of $\log2 - \psi(a) + \psi\left(\frac{a+1}{2}\right)$
+    is used when $s = 1$.
 
     Examples
     ========
 
-    The Dirichlet eta function is closely related to the Riemann zeta function:
-
     >>> from sympy import dirichlet_eta, zeta
     >>> from sympy.abc import s
     >>> dirichlet_eta(s).rewrite(zeta)
-    (1 - 2**(1 - s))*zeta(s)
+    Piecewise((log(2), Eq(s, 1)), ((1 - 2**(1 - s))*zeta(s), True))
 
     See Also
     ========
@@ -594,19 +605,45 @@ class dirichlet_eta(Function):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Dirichlet_eta_function
+    .. [2] Peter Luschny, "An introduction to the Bernoulli function",
+           https://arxiv.org/abs/2009.06743
 
     """
 
     @classmethod
-    def eval(cls, s):
-        if s == 1:
-            return log(2)
-        z = zeta(s)
-        if not z.has(zeta):
-            return (1 - 2**(1 - s))*z
+    def eval(cls, s, a=None):
+        if a is S.One:
+            return cls(s)
+        if a is None:
+            if s == 1:
+                return log(2)
+            z = zeta(s)
+            if not z.has(zeta):
+                return (1 - 2**(1-s)) * z
+            return
+        elif s == 1:
+            from sympy.functions.special.gamma_functions import digamma
+            return log(2) - digamma(a) + digamma((a+1)/2)
+        z1 = zeta(s, a)
+        z2 = zeta(s, (a+1)/2)
+        if not z1.has(zeta) and not z2.has(zeta):
+            return z1 - 2**(1-s) * z2
 
-    def _eval_rewrite_as_zeta(self, s, **kwargs):
-        return (1 - 2**(1 - s)) * zeta(s)
+    def _eval_rewrite_as_zeta(self, s, a=1, **kwargs):
+        from sympy.functions.special.gamma_functions import digamma
+        if a == 1:
+            return Piecewise((log(2), Eq(s, 1)), ((1 - 2**(1-s)) * zeta(s), True))
+        return Piecewise((log(2) - digamma(a) + digamma((a+1)/2), Eq(s, 1)),
+                (zeta(s, a) - 2**(1-s) * zeta(s, (a+1)/2), True))
+
+    def _eval_rewrite_as_genocchi(self, s, a=S.One, **kwargs):
+        from sympy.functions.special.gamma_functions import digamma
+        return Piecewise((log(2) - digamma(a) + digamma((a+1)/2), Eq(s, 1)),
+                (genocchi(1-s, a) / (2 * (s-1)), True))
+
+    def _eval_evalf(self, prec):
+        if all(i.is_number for i in self.args):
+            return self.rewrite(zeta)._eval_evalf(prec)
 
 
 class riemann_xi(Function):

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -496,7 +496,7 @@ def test_specfun():
 
     # Automatic rewrite
     assert octave_code(Ei(x)) == 'logint(exp(x))'
-    assert octave_code(dirichlet_eta(x)) == '(1 - 2.^(1 - x)).*zeta(x)'
+    assert octave_code(dirichlet_eta(x)) == '((x == 1).*(log(2)) + (~(x == 1)).*((1 - 2.^(1 - x)).*zeta(x)))'
     assert octave_code(riemann_xi(x)) == 'pi.^(-x/2).*x.*(x - 1).*gamma(x/2).*zeta(x)/2'
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

Part 6 of the changes formerly included in #23926, building upon #23989. Calling this part 6 is only a formality though – I came up with the idea for this PR _after_ I started splitting #23926 into smaller PRs.

#### Brief description of what is fixed or changed

So far we know the following things:

* The pole at $s = 1$ of the Hurwitz zeta function can be removed by a multiplication, yielding the (generalised) Bernoulli function.
* The ordinary Genocchi function is related to the ordinary Bernoulli function by a multiplication by $2(1-2^s)$.
* The Dirichlet eta function is related to the Riemann zeta function by a multiplication by $1-2^{1-s}$.

All this suggests the existence of a similarly generalised Dirichlet eta function closing the loop of two-argument functions below:
```
zeta ---- bernoulli
  |           |
  |           |
  |           |
 eta ---- genocchi
```
And indeed this fourth function exists, as indicated by Luschny:
> Reduced to lowest terms, [the alternating Bernoulli numbers] have the denominator 2 and... are **half the Genocchi numbers**.

This eventually leads to the following equivalences:
$$\eta(s,a)=\zeta(s,a)-2^{1-s}\zeta\left(s,\frac{a+1}2\right)=\frac{G(1-s,a)}{2(s-1)}$$
$$G(s,a)=-2s\eta(1-s,a)$$

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
    * `dirichlet_eta()` now accepts two complex arguments.
<!-- END RELEASE NOTES -->