### PR TITLE
don't split sums and integrals with infinite limits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -884,6 +884,7 @@ Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank <54908605+mayankray2020@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
+Megan Ly <megan.ly@learnosity.com>
 Megan Ly <megan@artcompiler.com> Megan Ly <meganly@MacBook-Pro.local>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -592,7 +592,8 @@ class AddWithLimits(ExprWithLimits):
 
     def _eval_expand_basic(self, **hints):
         summand = self.function.expand(**hints)
-        if summand.is_Add and summand.is_commutative:
+        if (summand.is_Add and summand.is_commutative and
+                self.has_finite_limits is not False):
             return Add(*[self.func(i, *self.limits) for i in summand.args])
         elif isinstance(summand, MatrixBase):
             return summand.applyfunc(lambda x: self.func(x, *self.limits))

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -944,9 +944,9 @@ def test_factor_expand_subs():
     assert Sum(x+1,(x,1,y)).expand() == Sum(x,(x,1,y)) + Sum(1,(x,1,y))
     assert Sum(x+a*x**2,(x,1,y)).expand() == Sum(x,(x,1,y)) + Sum(a*x**2,(x,1,y))
     assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand() \
-        == Sum(x*x**n, (n, -1, oo)) + Sum(n*x*x**n, (n, -1, oo))
+        == Sum(n*x*x**n + x*x**n, (n, -1, oo))
     assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand(power_exp=False) \
-        == Sum(n*x**(n+1), (n, -1, oo)) + Sum(x**(n+1), (n, -1, oo))
+        == Sum(n*x**(n + 1) + x**(n + 1), (n, -1, oo))
     assert Sum(a*n+a*n**2,(n,0,4)).expand() \
         == Sum(a*n,(n,0,4)) + Sum(a*n**2,(n,0,4))
     assert Sum(x**a*x**n,(x,0,3)) \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21151 

#### Brief description of what is fixed or changed
Fixes expand so it does not split sums and integrals with infinite limits.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * Fixed expand to not split sums and integrals with infinite limits.
<!-- END RELEASE NOTES -->
