### PR TITLE
expand AddWithLimits expr using force hint

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -884,8 +884,8 @@ Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank <54908605+mayankray2020@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
-Megan Ly <megan.ly@learnosity.com>
-Megan Ly <megan@artcompiler.com> Megan Ly <meganly@MacBook-Pro.local>
+Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
+Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -832,7 +832,7 @@ arooshiverma <av22@iitbbs.ac.in>
 Christoph Gohle <ctg@mpq.mpg.de>
 Charalampos Tsiagkalis <ctsiagkalis@uth.gr>
 Daniel Sears <highpost@users.noreply.github.com>
-Megan Ly <megan@artcompiler.com>
+Megan Ly <megan.ly@learnosity.com>
 Sean P. Cornelius <spcornelius@gmail.com>
 Erik R. Gomez <gomez@kth.se>
 Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -592,8 +592,9 @@ class AddWithLimits(ExprWithLimits):
 
     def _eval_expand_basic(self, **hints):
         summand = self.function.expand(**hints)
-        if (summand.is_Add and summand.is_commutative and
-                self.has_finite_limits is not False):
+        force = hints.get('force', False)
+        if (summand.is_Add and (force or summand.is_commutative and
+                 self.has_finite_limits is not False)):
             return Add(*[self.func(i, *self.limits) for i in summand.args])
         elif isinstance(summand, MatrixBase):
             return summand.applyfunc(lambda x: self.func(x, *self.limits))

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -947,6 +947,8 @@ def test_factor_expand_subs():
         == Sum(n*x*x**n + x*x**n, (n, -1, oo))
     assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand(power_exp=False) \
         == Sum(n*x**(n + 1) + x**(n + 1), (n, -1, oo))
+    assert Sum(x**(n + 1)*(n + 1), (n, -1, oo)).expand(force=True) \
+           == Sum(x*x**n, (n, -1, oo)) + Sum(n*x*x**n, (n, -1, oo))
     assert Sum(a*n+a*n**2,(n,0,4)).expand() \
         == Sum(a*n,(n,0,4)) + Sum(a*n**2,(n,0,4))
     assert Sum(x**a*x**n,(x,0,3)) \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -804,6 +804,10 @@ def test_subs7():
 def test_expand():
     e = Integral(f(x)+f(x**2), (x, 1, y))
     assert e.expand() == Integral(f(x), (x, 1, y)) + Integral(f(x**2), (x, 1, y))
+    e = Integral(f(x)+f(x**2), (x, 1, oo))
+    assert e.expand() == e
+    assert e.expand(force=True) == Integral(f(x), (x, 1, oo)) + \
+           Integral(f(x**2), (x, 1, oo))
 
 
 def test_integration_variable():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Implements feedback from #23996 

#### Brief description of what is fixed or changed
Expand does not split sums or integrals if the summand is not commutative or the expression has infinite limits.  The force=True hint can now be used to split the sum/integral regardless of the assumptions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * Permitted expand to split sums and integrals with the force hint.
<!-- END RELEASE NOTES -->
