### PR TITLE
Make SMT Printer warning logs more pythonic.

### DIFF
--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -1,5 +1,4 @@
 import typing
-import warnings
 
 import sympy
 from sympy.core import Add, Mul
@@ -213,7 +212,8 @@ def smtlib_code(
     precision=None,
     symbol_table=None,
     known_types=None, known_constants=None, known_functions=None,
-    prefix_expressions=None, suffix_expressions=None
+    prefix_expressions=None, suffix_expressions=None,
+    log_warn=None
 ):
     r"""Converts ``expr`` to a string of smtlib code.
 
@@ -247,25 +247,24 @@ def smtlib_code(
         A list of lists of ``str`` and/or expressions to convert into SMTLib and prefix to the output.
     suffix_expressions: list, optional
         A list of lists of ``str`` and/or expressions to convert into SMTLib and postfix to the output.
+    log_warn: lambda function, optional
+        A function to record all warnings during potentially risky operations.
+        Soundness is a core value in SMT solving, so it is good to log all assumptions made.
 
     Examples
     ========
-    >>> import warnings
-    >>> default_showwarning = warnings.showwarning
-    >>> warnings.showwarning = (lambda m, *_: print(repr(m)))
-
     >>> from sympy import smtlib_code, symbols, sin, Eq
     >>> x = symbols('x')
-    >>> smtlib_code(sin(x).series(x).removeO())
-    UserWarning('Could not infer type of `x`. Defaulting to float.')
-    UserWarning('Non-Boolean expression `x**5/120 - x**3/6 + x` will not be asserted. Converting to SMTLib verbatim.')
+    >>> smtlib_code(sin(x).series(x).removeO(), log_warn=print)
+    Could not infer type of `x`. Defaulting to float.
+    Non-Boolean expression `x**5/120 - x**3/6 + x` will not be asserted. Converting to SMTLib verbatim.
     '(declare-const x Real)\n(+ x (* (/ -1 6) (pow x 3)) (* (/ 1 120) (pow x 5)))'
 
     >>> from sympy import Rational
     >>> x, y, tau = symbols("x, y, tau")
-    >>> smtlib_code((2*tau)**Rational(7, 2))
-    UserWarning('Could not infer type of `tau`. Defaulting to float.')
-    UserWarning('Non-Boolean expression `8*sqrt(2)*tau**(7/2)` will not be asserted. Converting to SMTLib verbatim.')
+    >>> smtlib_code((2*tau)**Rational(7, 2), log_warn=print)
+    Could not infer type of `tau`. Defaulting to float.
+    Non-Boolean expression `8*sqrt(2)*tau**(7/2)` will not be asserted. Converting to SMTLib verbatim.
     '(declare-const tau Real)\n(* 8 (pow 2 (/ 1 2)) (pow tau (/ 7 2)))'
 
     ``Piecewise`` expressions are implemented with ``ite`` expressions by default.
@@ -275,7 +274,7 @@ def smtlib_code(
 
     >>> from sympy import Piecewise
     >>> pw = Piecewise((x + 1, x > 0), (x, True))
-    >>> smtlib_code(Eq(pw, 3), symbol_table={x: float})
+    >>> smtlib_code(Eq(pw, 3), symbol_table={x: float}, log_warn=print)
     '(declare-const x Real)\n(assert (= (ite (> x 0) (+ 1 x) x) 3))'
 
     Custom printing can be defined for certain types by passing a dictionary of
@@ -292,12 +291,12 @@ def smtlib_code(
     >>> user_def_funcs = {  # functions defined by the user must have their types specified explicitly
     ...   g: Callable[[int], float],
     ... }
-    >>> smtlib_code(f(x) + g(x), symbol_table=user_def_funcs, known_functions=smt_builtin_funcs)
-    UserWarning('Non-Boolean expression `f(x) + g(x)` will not be asserted. Converting to SMTLib verbatim.')
+    >>> smtlib_code(f(x) + g(x), symbol_table=user_def_funcs, known_functions=smt_builtin_funcs, log_warn=print)
+    Non-Boolean expression `f(x) + g(x)` will not be asserted. Converting to SMTLib verbatim.
     '(declare-const x Int)\n(declare-fun g (Int) Real)\n(sum (existing_smtlib_fcn x) (g x))'
-
-    >>> warnings.showwarning = default_showwarning
     """
+    log_warn = log_warn or (lambda _: None)
+
     if not isinstance(expr, list): expr = [expr]
     expr = [
         sympy.sympify(_, strict=True, evaluate=False, convert_xor=False)
@@ -338,7 +337,7 @@ def smtlib_code(
                 sym not in p._known_constants and
                 sym not in p.symbol_table
             ):
-                warnings.warn(f"Could not infer type of `{sym}`. Defaulting to float.")
+                log_warn(f"Could not infer type of `{sym}`. Defaulting to float.")
                 p.symbol_table[sym] = float
             if (
                 sym.is_Function and
@@ -358,16 +357,16 @@ def smtlib_code(
                      if type(fnc) not in p._known_functions and not fnc.is_Piecewise}
         declarations = \
             [
-                _auto_declare_smtlib(sym, p)
+                _auto_declare_smtlib(sym, p, log_warn)
                 for sym in constants.values()
             ] + [
-                _auto_declare_smtlib(fnc, p)
+                _auto_declare_smtlib(fnc, p, log_warn)
                 for fnc in functions.values()
             ]
         declarations = [decl for decl in declarations if decl]
 
     if auto_assert:
-        expr = [_auto_assert_smtlib(e, p) for e in expr]
+        expr = [_auto_assert_smtlib(e, p, log_warn) for e in expr]
 
     # return SMTLibPrinter().doprint(expr)
     return '\n'.join([
@@ -394,7 +393,7 @@ def smtlib_code(
     ])
 
 
-def _auto_declare_smtlib(sym: typing.Union[Symbol, Function], p: SMTLibPrinter):
+def _auto_declare_smtlib(sym: typing.Union[Symbol, Function], p: SMTLibPrinter, log_warn: typing.Callable[[str], None]):
     if sym.is_Symbol:
         type_signature = p.symbol_table[sym]
         assert isinstance(type_signature, type)
@@ -411,11 +410,11 @@ def _auto_declare_smtlib(sym: typing.Union[Symbol, Function], p: SMTLibPrinter):
         return p._s_expr('declare-fun', [type(sym), params_signature, return_signature])
 
     else:
-        warnings.warn(f"Non-Symbol/Function `{sym}` will not be declared.")
+        log_warn(f"Non-Symbol/Function `{sym}` will not be declared.")
         return None
 
 
-def _auto_assert_smtlib(e: Expr, p: SMTLibPrinter):
+def _auto_assert_smtlib(e: Expr, p: SMTLibPrinter, log_warn: typing.Callable[[str], None]):
     if isinstance(e, Boolean) or (
         e in p.symbol_table and p.symbol_table[e] == bool
     ) or (
@@ -425,7 +424,7 @@ def _auto_assert_smtlib(e: Expr, p: SMTLibPrinter):
     ):
         return p._s_expr('assert', [e])
     else:
-        warnings.warn(f"Non-Boolean expression `{e}` will not be asserted. Converting to SMTLib verbatim.")
+        log_warn(f"Non-Boolean expression `{e}` will not be asserted. Converting to SMTLib verbatim.")
         return e
 
 

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -1,4 +1,3 @@
-import builtins
 import typing
 import warnings
 

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -251,6 +251,7 @@ def smtlib_code(
     Examples
     ========
     >>> import warnings
+    >>> default_showwarning = warnings.showwarning
     >>> warnings.showwarning = (lambda m, *_: print(repr(m)))
 
     >>> from sympy import smtlib_code, symbols, sin, Eq
@@ -294,6 +295,8 @@ def smtlib_code(
     >>> smtlib_code(f(x) + g(x), symbol_table=user_def_funcs, known_functions=smt_builtin_funcs)
     UserWarning('Non-Boolean expression `f(x) + g(x)` will not be asserted. Converting to SMTLib verbatim.')
     '(declare-const x Int)\n(declare-fun g (Int) Real)\n(sum (existing_smtlib_fcn x) (g x))'
+
+    >>> warnings.showwarning = default_showwarning
     """
     if not isinstance(expr, list): expr = [expr]
     expr = [

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -1,4 +1,9 @@
+import contextlib
+import itertools
+import re
+import typing
 import warnings
+from enum import Enum
 from typing import Callable
 
 import sympy
@@ -8,154 +13,186 @@ from sympy.core import (S, pi, symbols, Function, Rational, Integer,
                         Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, exp, sin, cos
 from sympy.printing.smtlib import smtlib_code
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, Failed
 
 x, y, z = symbols('x,y,z')
 
 
+class _W(Enum):
+    DEFAULTING_TO_FLOAT = re.compile("Could not infer type of `.+`. Defaulting to float.", re.I)
+    WILL_NOT_DECLARE = re.compile("Non-Symbol/Function `.+` will not be declared.", re.I)
+    WILL_NOT_ASSERT = re.compile("Non-Boolean expression `.+` will not be asserted. Converting to SMTLib verbatim.", re.I)
+
+
+@contextlib.contextmanager
+def _smtlib_warns(expected: typing.Iterable[_W]):
+    # based on sympy.testing.pytest.warns()
+
+    # Absorbs all warnings in warnrec
+    with warnings.catch_warnings(record=True) as warnrec:
+        # Any warning other than the one we are looking for is an error
+        warnings.simplefilter("error")
+        warnings.filterwarnings("always", category=UserWarning)
+        # Now run the test
+        yield warnrec
+
+    errors = []
+    for i, (w, e) in enumerate(itertools.zip_longest(warnrec, expected)):
+        if not e:
+            errors += [f"[{i}] Received unexpected warning `{w.message}`."]
+        elif not w:
+            errors += [f"[{i}] Did not receive expected warning `{e.name}`."]
+        elif not e.value.match(str(w.message)):
+            errors += [f"[{i}] Warning `{w.message}` does not match expected {e.name}."]
+
+    if errors: raise Failed('\n'.join(errors))
+
+
 def test_Integer():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(Integer(67)) == "67"
-    assert smtlib_code(Integer(-1)) == "-1"
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.WILL_NOT_ASSERT] * 2):
+        assert smtlib_code(Integer(67)) == "67"
+        assert smtlib_code(Integer(-1)) == "-1"
 
 
 def test_Rational():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(Rational(3, 7)) == "(/ 3 7)"
-    assert smtlib_code(Rational(18, 9)) == "2"
-    assert smtlib_code(Rational(3, -7)) == "(/ -3 7)"
-    assert smtlib_code(Rational(-3, -7)) == "(/ 3 7)"
-    assert smtlib_code(x + Rational(3, 7), auto_declare=False) == "(+ (/ 3 7) x)"
-    assert smtlib_code(Rational(3, 7) * x) == "(declare-const x Real)\n" \
-                                              "(* (/ 3 7) x)"
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.WILL_NOT_ASSERT] * 4):
+        assert smtlib_code(Rational(3, 7)) == "(/ 3 7)"
+        assert smtlib_code(Rational(18, 9)) == "2"
+        assert smtlib_code(Rational(3, -7)) == "(/ -3 7)"
+        assert smtlib_code(Rational(-3, -7)) == "(/ 3 7)"
+
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT] * 2):
+        assert smtlib_code(x + Rational(3, 7), auto_declare=False) == "(+ (/ 3 7) x)"
+        assert smtlib_code(Rational(3, 7) * x) == "(declare-const x Real)\n" \
+                                                  "(* (/ 3 7) x)"
 
 
 def test_Relational():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(Eq(x, y), auto_declare=False) == "(assert (= x y))"
-    assert smtlib_code(Ne(x, y), auto_declare=False) == "(assert (not (= x y)))"
-    assert smtlib_code(Le(x, y), auto_declare=False) == "(assert (<= x y))"
-    assert smtlib_code(Lt(x, y), auto_declare=False) == "(assert (< x y))"
-    assert smtlib_code(Gt(x, y), auto_declare=False) == "(assert (> x y))"
-    assert smtlib_code(Ge(x, y), auto_declare=False) == "(assert (>= x y))"
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT] * 12):
+        assert smtlib_code(Eq(x, y), auto_declare=False) == "(assert (= x y))"
+        assert smtlib_code(Ne(x, y), auto_declare=False) == "(assert (not (= x y)))"
+        assert smtlib_code(Le(x, y), auto_declare=False) == "(assert (<= x y))"
+        assert smtlib_code(Lt(x, y), auto_declare=False) == "(assert (< x y))"
+        assert smtlib_code(Gt(x, y), auto_declare=False) == "(assert (> x y))"
+        assert smtlib_code(Ge(x, y), auto_declare=False) == "(assert (>= x y))"
 
 
 def test_Function():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(sin(x) ** cos(x), auto_declare=False) == "(pow (sin x) (cos x))"
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(sin(x) ** cos(x), auto_declare=False) == "(pow (sin x) (cos x))"
 
-    assert smtlib_code(
-        abs(x),
-        symbol_table={x: int, y: bool},
-        known_types={int: "INTEGER_TYPE"},
-        known_functions={sympy.Abs: "ABSOLUTE_VALUE_OF"}
-    ) == "(declare-const x INTEGER_TYPE)\n" \
-         "(ABSOLUTE_VALUE_OF x)"
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            abs(x),
+            symbol_table={x: int, y: bool},
+            known_types={int: "INTEGER_TYPE"},
+            known_functions={sympy.Abs: "ABSOLUTE_VALUE_OF"}
+        ) == "(declare-const x INTEGER_TYPE)\n" \
+             "(ABSOLUTE_VALUE_OF x)"
 
     my_fun1 = Function('f1')
-    assert smtlib_code(
-        my_fun1(x),
-        symbol_table={my_fun1: Callable[[bool], float]},
-    ) == "(declare-const x Bool)\n" \
-         "(declare-fun f1 (Bool) Real)\n" \
-         "(f1 x)"
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            my_fun1(x),
+            symbol_table={my_fun1: Callable[[bool], float]},
+        ) == "(declare-const x Bool)\n" \
+             "(declare-fun f1 (Bool) Real)\n" \
+             "(f1 x)"
 
-    assert smtlib_code(
-        my_fun1(x),
-        symbol_table={my_fun1: Callable[[bool], bool]},
-    ) == "(declare-const x Bool)\n" \
-         "(declare-fun f1 (Bool) Bool)\n" \
-         "(assert (f1 x))"
+    with _smtlib_warns([]):
+        assert smtlib_code(
+            my_fun1(x),
+            symbol_table={my_fun1: Callable[[bool], bool]},
+        ) == "(declare-const x Bool)\n" \
+             "(declare-fun f1 (Bool) Bool)\n" \
+             "(assert (f1 x))"
 
-    assert smtlib_code(
-        Eq(my_fun1(x, z), y),
-        symbol_table={my_fun1: Callable[[int, bool], bool]},
-    ) == "(declare-const x Int)\n" \
-         "(declare-const y Bool)\n" \
-         "(declare-const z Bool)\n" \
-         "(declare-fun f1 (Int Bool) Bool)\n" \
-         "(assert (= (f1 x z) y))"
+        assert smtlib_code(
+            Eq(my_fun1(x, z), y),
+            symbol_table={my_fun1: Callable[[int, bool], bool]},
+        ) == "(declare-const x Int)\n" \
+             "(declare-const y Bool)\n" \
+             "(declare-const z Bool)\n" \
+             "(declare-fun f1 (Int Bool) Bool)\n" \
+             "(assert (= (f1 x z) y))"
 
-    assert smtlib_code(
-        Eq(my_fun1(x, z), y),
-        symbol_table={my_fun1: Callable[[int, bool], bool]},
-        known_functions={my_fun1: "MY_KNOWN_FUN", Eq: '=='}
-    ) == "(declare-const x Int)\n" \
-         "(declare-const y Bool)\n" \
-         "(declare-const z Bool)\n" \
-         "(assert (== (MY_KNOWN_FUN x z) y))"
+        assert smtlib_code(
+            Eq(my_fun1(x, z), y),
+            symbol_table={my_fun1: Callable[[int, bool], bool]},
+            known_functions={my_fun1: "MY_KNOWN_FUN", Eq: '=='}
+        ) == "(declare-const x Int)\n" \
+             "(declare-const y Bool)\n" \
+             "(declare-const z Bool)\n" \
+             "(assert (== (MY_KNOWN_FUN x z) y))"
 
-    assert smtlib_code(
-        Eq(my_fun1(x, z), y),
-        known_functions={my_fun1: "MY_KNOWN_FUN", Eq: '=='}
-    ) == "(declare-const x Real)\n" \
-         "(declare-const y Real)\n" \
-         "(declare-const z Real)\n" \
-         "(assert (== (MY_KNOWN_FUN x z) y))"
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT] * 3):
+        assert smtlib_code(
+            Eq(my_fun1(x, z), y),
+            known_functions={my_fun1: "MY_KNOWN_FUN", Eq: '=='}
+        ) == "(declare-const x Real)\n" \
+             "(declare-const y Real)\n" \
+             "(declare-const z Real)\n" \
+             "(assert (== (MY_KNOWN_FUN x z) y))"
 
 
 def test_Pow():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(x ** 3, auto_declare=False) == "(pow x 3)"
-    assert smtlib_code(x ** (y ** 3), auto_declare=False) == "(pow x (pow y 3))"
-    assert smtlib_code(x ** Rational(2, 3), auto_declare=False) == '(pow x (/ 2 3))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(x ** 3, auto_declare=False) == "(pow x 3)"
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(x ** (y ** 3), auto_declare=False) == "(pow x (pow y 3))"
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(x ** Rational(2, 3), auto_declare=False) == '(pow x (/ 2 3))'
 
-    a = Symbol('a', integer=True)
-    b = Symbol('b', real=True)
-    c = Symbol('c')
+        a = Symbol('a', integer=True)
+        b = Symbol('b', real=True)
+        c = Symbol('c')
 
-    def g(x): return 2 * x
+        def g(x): return 2 * x
 
-    # if x=1, y=2, then expr=2.333...
-    expr = 1 / (g(a) * 3.5) ** (a - b ** a) / (a ** 2 + b)
+        # if x=1, y=2, then expr=2.333...
+        expr = 1 / (g(a) * 3.5) ** (a - b ** a) / (a ** 2 + b)
 
-    assert smtlib_code([
-        Eq(a < 2, c),
-        Eq(b > a, c),
-        c & True,
-        Eq(expr, 2 + Rational(1, 3))
-    ]) == '(declare-const a Int)\n' \
-          '(declare-const b Real)\n' \
-          '(declare-const c Bool)\n' \
-          '(assert (= (< a 2) c))\n' \
-          '(assert (= (> b a) c))\n' \
-          '(assert c)\n' \
-          '(assert (= ' \
-          '(* (pow (* 7. a) (+ (pow b a) (* -1 a))) (pow (+ b (pow a 2)) -1)) ' \
-          '(/ 7 3)' \
-          '))'
+    with _smtlib_warns([]):
+        assert smtlib_code([
+            Eq(a < 2, c),
+            Eq(b > a, c),
+            c & True,
+            Eq(expr, 2 + Rational(1, 3))
+        ]) == '(declare-const a Int)\n' \
+              '(declare-const b Real)\n' \
+              '(declare-const c Bool)\n' \
+              '(assert (= (< a 2) c))\n' \
+              '(assert (= (> b a) c))\n' \
+              '(assert c)\n' \
+              '(assert (= ' \
+              '(* (pow (* 7. a) (+ (pow b a) (* -1 a))) (pow (+ b (pow a 2)) -1)) ' \
+              '(/ 7 3)' \
+              '))'
 
-    assert smtlib_code(
-        Mul(-2, c, Pow(Mul(b, b, evaluate=False), -1, evaluate=False), evaluate=False)
-    ) == '(declare-const b Real)\n' \
-         '(declare-const c Real)\n' \
-         '(* -2 c (pow (* b b) -1))'
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Mul(-2, c, Pow(Mul(b, b, evaluate=False), -1, evaluate=False), evaluate=False)
+        ) == '(declare-const b Real)\n' \
+             '(declare-const c Real)\n' \
+             '(* -2 c (pow (* b b) -1))'
 
 
 def test_basic_ops():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(x * y, auto_declare=False) == "(* x y)"
-    assert smtlib_code(x + y, auto_declare=False) == "(+ x y)"
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(x * y, auto_declare=False) == "(* x y)"
+
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(x + y, auto_declare=False) == "(+ x y)"
+
+    # with _smtlib_warns([_SmtlibWarnings.DEFAULTING_TO_FLOAT, _SmtlibWarnings.DEFAULTING_TO_FLOAT, _SmtlibWarnings.WILL_NOT_ASSERT]):
     # todo: implement re-write, currently does '(+ x (* -1 y))' instead
     # assert smtlib_code(x - y, auto_declare=False) == "(- x y)"
-    assert smtlib_code(-x, auto_declare=False) == "(* -1 x)"
-    warnings.filters = warning_filters
+
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(-x, auto_declare=False) == "(* -1 x)"
 
 
 def test_quantifier_extensions():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
     from sympy.logic.boolalg import Boolean
     from sympy import Interval, Tuple, sympify
 
@@ -204,170 +241,177 @@ def test_quantifier_extensions():
     # end For-All Quantifier class example
 
     f = Function('f')
-    assert smtlib_code(
-        ForAll((x, -42, +21), Eq(f(x), f(x))),
-        symbol_table={f: Callable[[float], float]}
-    ) == '(assert (forall ( (x Real [-42, 21])) true))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT]):
+        assert smtlib_code(
+            ForAll((x, -42, +21), Eq(f(x), f(x))),
+            symbol_table={f: Callable[[float], float]}
+        ) == '(assert (forall ( (x Real [-42, 21])) true))'
 
-    assert smtlib_code(
-        ForAll(
-            (x, -42, +21), (y, -100, 3),
-            Implies(Eq(x, y), Eq(f(x), f(y)))
-        ),
-        symbol_table={f: Callable[[float], float]}
-    ) == '(declare-fun f (Real) Real)\n' \
-         '(assert (' \
-         'forall ( (x Real [-42, 21]) (y Real [-100, 3])) ' \
-         '(=> (= x y) (= (f x) (f y)))' \
-         '))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT] * 2):
+        assert smtlib_code(
+            ForAll(
+                (x, -42, +21), (y, -100, 3),
+                Implies(Eq(x, y), Eq(f(x), f(y)))
+            ),
+            symbol_table={f: Callable[[float], float]}
+        ) == '(declare-fun f (Real) Real)\n' \
+             '(assert (' \
+             'forall ( (x Real [-42, 21]) (y Real [-100, 3])) ' \
+             '(=> (= x y) (= (f x) (f y)))' \
+             '))'
 
     a = Symbol('a', integer=True)
     b = Symbol('b', real=True)
     c = Symbol('c')
 
-    assert smtlib_code(
-        ForAll(
-            (a, 2, 100), ForAll(
-                (b, 2, 100),
-                Implies(a < b, sqrt(a) < b) | c
-            ))
-    ) == '(declare-const c Bool)\n' \
-         '(assert (forall ( (a Int [2, 100]) (b Real [2, 100])) ' \
-         '(or c (=> (< a b) (< (pow a (/ 1 2)) b)))' \
-         '))'
-    warnings.filters = warning_filters
+    with _smtlib_warns([]):
+        assert smtlib_code(
+            ForAll(
+                (a, 2, 100), ForAll(
+                    (b, 2, 100),
+                    Implies(a < b, sqrt(a) < b) | c
+                ))
+        ) == '(declare-const c Bool)\n' \
+             '(assert (forall ( (a Int [2, 100]) (b Real [2, 100])) ' \
+             '(or c (=> (< a b) (< (pow a (/ 1 2)) b)))' \
+             '))'
 
 
 def test_mix_number_mult_symbols():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(
-        1 / pi,
-        known_constants={pi: "MY_PI"}
-    ) == '(pow MY_PI -1)'
-
-    assert smtlib_code(
-        [
-            Eq(pi, 3.14, evaluate=False),
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
             1 / pi,
-        ],
-        known_constants={pi: "MY_PI"}
-    ) == '(assert (= MY_PI 3.14))\n' \
-         '(pow MY_PI -1)'
+            known_constants={pi: "MY_PI"}
+        ) == '(pow MY_PI -1)'
 
-    assert smtlib_code(
-        Add(S.Zero, S.One, S.NegativeOne, S.Half,
-            S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
-        known_constants={
-            S.Pi: 'p', S.GoldenRatio: 'g',
-            S.Exp1: 'e'
-        },
-        known_functions={
-            Add: 'plus',
-            exp: 'exp'
-        },
-        precision=3
-    ) == '(plus 0 1 -1 (/ 1 2) (exp 1) p g)'
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            [
+                Eq(pi, 3.14, evaluate=False),
+                1 / pi,
+            ],
+            known_constants={pi: "MY_PI"}
+        ) == '(assert (= MY_PI 3.14))\n' \
+             '(pow MY_PI -1)'
 
-    assert smtlib_code(
-        Add(S.Zero, S.One, S.NegativeOne, S.Half,
-            S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
-        known_constants={
-            S.Pi: 'p'
-        },
-        known_functions={
-            Add: 'plus',
-            exp: 'exp'
-        },
-        precision=3
-    ) == '(plus 0 1 -1 (/ 1 2) (exp 1) p 1.62)'
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Add(S.Zero, S.One, S.NegativeOne, S.Half,
+                S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
+            known_constants={
+                S.Pi: 'p', S.GoldenRatio: 'g',
+                S.Exp1: 'e'
+            },
+            known_functions={
+                Add: 'plus',
+                exp: 'exp'
+            },
+            precision=3
+        ) == '(plus 0 1 -1 (/ 1 2) (exp 1) p g)'
 
-    assert smtlib_code(
-        Add(S.Zero, S.One, S.NegativeOne, S.Half,
-            S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
-        known_functions={Add: 'plus'},
-        precision=3
-    ) == '(plus 0 1 -1 (/ 1 2) 2.72 3.14 1.62)'
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Add(S.Zero, S.One, S.NegativeOne, S.Half,
+                S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
+            known_constants={
+                S.Pi: 'p'
+            },
+            known_functions={
+                Add: 'plus',
+                exp: 'exp'
+            },
+            precision=3
+        ) == '(plus 0 1 -1 (/ 1 2) (exp 1) p 1.62)'
 
-    assert smtlib_code(
-        Add(S.Zero, S.One, S.NegativeOne, S.Half,
-            S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
-        known_constants={S.Exp1: 'e'},
-        known_functions={Add: 'plus'},
-        precision=3
-    ) == '(plus 0 1 -1 (/ 1 2) e 3.14 1.62)'
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Add(S.Zero, S.One, S.NegativeOne, S.Half,
+                S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
+            known_functions={Add: 'plus'},
+            precision=3
+        ) == '(plus 0 1 -1 (/ 1 2) 2.72 3.14 1.62)'
+
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Add(S.Zero, S.One, S.NegativeOne, S.Half,
+                S.Exp1, S.Pi, S.GoldenRatio, evaluate=False),
+            known_constants={S.Exp1: 'e'},
+            known_functions={Add: 'plus'},
+            precision=3
+        ) == '(plus 0 1 -1 (/ 1 2) e 3.14 1.62)'
 
 
 def test_boolean():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(x & y) == '(declare-const x Bool)\n' \
-                                 '(declare-const y Bool)\n' \
-                                 '(assert (and x y))'
-    assert smtlib_code(x | y) == '(declare-const x Bool)\n' \
-                                 '(declare-const y Bool)\n' \
-                                 '(assert (or x y))'
-    assert smtlib_code(~x) == '(declare-const x Bool)\n' \
-                              '(assert (not x))'
-
-    assert smtlib_code(x & y & z) == '(declare-const x Bool)\n' \
+    with _smtlib_warns([]):
+        assert smtlib_code(x & y) == '(declare-const x Bool)\n' \
                                      '(declare-const y Bool)\n' \
-                                     '(declare-const z Bool)\n' \
-                                     '(assert (and x y z))'
-    assert smtlib_code((x & ~y) | (z > 3)) == '(declare-const x Bool)\n' \
-                                              '(declare-const y Bool)\n' \
-                                              '(declare-const z Real)\n' \
-                                              '(assert (or (> z 3) (and x (not y))))'
+                                     '(assert (and x y))'
+        assert smtlib_code(x | y) == '(declare-const x Bool)\n' \
+                                     '(declare-const y Bool)\n' \
+                                     '(assert (or x y))'
+        assert smtlib_code(~x) == '(declare-const x Bool)\n' \
+                                  '(assert (not x))'
+        assert smtlib_code(x & y & z) == '(declare-const x Bool)\n' \
+                                         '(declare-const y Bool)\n' \
+                                         '(declare-const z Bool)\n' \
+                                         '(assert (and x y z))'
+
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT]):
+        assert smtlib_code((x & ~y) | (z > 3)) == '(declare-const x Bool)\n' \
+                                                  '(declare-const y Bool)\n' \
+                                                  '(declare-const z Real)\n' \
+                                                  '(assert (or (> z 3) (and x (not y))))'
 
     f = Function('f')
     g = Function('g')
     h = Function('h')
-    assert smtlib_code([
-        Gt(f(x), y),
-        Lt(y, g(z))
-    ], symbol_table={
-        f: Callable[[bool], int], g: Callable[[bool], int],
-    }) == '(declare-const x Bool)\n' \
-          '(declare-const y Real)\n' \
-          '(declare-const z Bool)\n' \
-          '(declare-fun f (Bool) Int)\n' \
-          '(declare-fun g (Bool) Int)\n' \
-          '(assert (> (f x) y))\n' \
-          '(assert (< y (g z)))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT]):
+        assert smtlib_code([
+            Gt(f(x), y),
+            Lt(y, g(z))
+        ], symbol_table={
+            f: Callable[[bool], int], g: Callable[[bool], int],
+        }) == '(declare-const x Bool)\n' \
+              '(declare-const y Real)\n' \
+              '(declare-const z Bool)\n' \
+              '(declare-fun f (Bool) Int)\n' \
+              '(declare-fun g (Bool) Int)\n' \
+              '(assert (> (f x) y))\n' \
+              '(assert (< y (g z)))'
 
-    assert smtlib_code([
-        Eq(f(x), y),
-        Lt(y, g(z))
-    ], symbol_table={
-        f: Callable[[bool], int], g: Callable[[bool], int],
-    }) == '(declare-const x Bool)\n' \
-          '(declare-const y Int)\n' \
-          '(declare-const z Bool)\n' \
-          '(declare-fun f (Bool) Int)\n' \
-          '(declare-fun g (Bool) Int)\n' \
-          '(assert (= (f x) y))\n' \
-          '(assert (< y (g z)))'
+    with _smtlib_warns([]):
+        assert smtlib_code([
+            Eq(f(x), y),
+            Lt(y, g(z))
+        ], symbol_table={
+            f: Callable[[bool], int], g: Callable[[bool], int],
+        }) == '(declare-const x Bool)\n' \
+              '(declare-const y Int)\n' \
+              '(declare-const z Bool)\n' \
+              '(declare-fun f (Bool) Int)\n' \
+              '(declare-fun g (Bool) Int)\n' \
+              '(assert (= (f x) y))\n' \
+              '(assert (< y (g z)))'
 
-    assert smtlib_code(
-        [Eq(f(x), y),
-         Eq(g(f(x)), z),
-         Eq(h(g(f(x))), x)],
-        symbol_table={
-            f: Callable[[float], int],
-            g: Callable[[int], bool],
-            h: Callable[[bool], float]
-        }
-    ) == '(declare-const x Real)\n' \
-         '(declare-const y Int)\n' \
-         '(declare-const z Bool)\n' \
-         '(declare-fun f (Real) Int)\n' \
-         '(declare-fun g (Int) Bool)\n' \
-         '(declare-fun h (Bool) Real)\n' \
-         '(assert (= (f x) y))\n' \
-         '(assert (= (g (f x)) z))\n' \
-         '(assert (= (h (g (f x))) x))'
-    warnings.filters = warning_filters
+    with _smtlib_warns([]):
+        assert smtlib_code(
+            [Eq(f(x), y),
+             Eq(g(f(x)), z),
+             Eq(h(g(f(x))), x)],
+            symbol_table={
+                f: Callable[[float], int],
+                g: Callable[[int], bool],
+                h: Callable[[bool], float]
+            }
+        ) == '(declare-const x Real)\n' \
+             '(declare-const y Int)\n' \
+             '(declare-const z Bool)\n' \
+             '(declare-fun f (Real) Int)\n' \
+             '(declare-fun g (Int) Bool)\n' \
+             '(declare-fun h (Bool) Real)\n' \
+             '(assert (= (f x) y))\n' \
+             '(assert (= (g (f x)) z))\n' \
+             '(assert (= (h (g (f x))) x))'
 
 
 # todo: make smtlib_code support arrays
@@ -382,42 +426,42 @@ def test_boolean():
 #     # scalar, matrix, empty matrix and empty list
 #     assert julia_code((1, eye(3), Matrix(0, 0, []), [])) == "(1, [1 0 0;\n0 1 0;\n0 0 1], zeros(0, 0), Any[])"
 
-
 def test_smtlib_piecewise():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(
-        Piecewise((x, x < 1),
-                  (x ** 2, True)),
-        auto_declare=False
-    ) == '(ite (< x 1) x (pow x 2))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Piecewise((x, x < 1),
+                      (x ** 2, True)),
+            auto_declare=False
+        ) == '(ite (< x 1) x (pow x 2))'
 
-    assert smtlib_code(
-        Piecewise((x ** 2, x < 1),
-                  (x ** 3, x < 2),
-                  (x ** 4, x < 3),
-                  (x ** 5, True)),
-        auto_declare=False
-    ) == '(ite (< x 1) (pow x 2) ' \
-         '(ite (< x 2) (pow x 3) ' \
-         '(ite (< x 3) (pow x 4) ' \
-         '(pow x 5))))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(
+            Piecewise((x ** 2, x < 1),
+                      (x ** 3, x < 2),
+                      (x ** 4, x < 3),
+                      (x ** 5, True)),
+            auto_declare=False
+        ) == '(ite (< x 1) (pow x 2) ' \
+             '(ite (< x 2) (pow x 3) ' \
+             '(ite (< x 3) (pow x 4) ' \
+             '(pow x 5))))'
 
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x ** 2, x > 1), (sin(x), x > 0))
-    raises(AssertionError, lambda: smtlib_code(expr))
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        raises(AssertionError, lambda: smtlib_code(expr))
 
 
 def test_smtlib_piecewise_times_const():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
     pw = Piecewise((x, x < 1), (x ** 2, True))
-    assert smtlib_code(2 * pw) == '(declare-const x Real)\n(* 2 (ite (< x 1) x (pow x 2)))'
-    assert smtlib_code(pw / x) == '(declare-const x Real)\n(* (pow x -1) (ite (< x 1) x (pow x 2)))'
-    assert smtlib_code(pw / (x * y)) == '(declare-const x Real)\n(declare-const y Real)\n(* (pow x -1) (pow y -1) (ite (< x 1) x (pow x 2)))'
-    assert smtlib_code(pw / 3) == '(declare-const x Real)\n(* (/ 1 3) (ite (< x 1) x (pow x 2)))'
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(2 * pw) == '(declare-const x Real)\n(* 2 (ite (< x 1) x (pow x 2)))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(pw / x) == '(declare-const x Real)\n(* (pow x -1) (ite (< x 1) x (pow x 2)))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(pw / (x * y)) == '(declare-const x Real)\n(declare-const y Real)\n(* (pow x -1) (pow y -1) (ite (< x 1) x (pow x 2)))'
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        assert smtlib_code(pw / 3) == '(declare-const x Real)\n(* (/ 1 3) (ite (< x 1) x (pow x 2)))'
 
 
 # todo: make smtlib_code support arrays / matrices ?
@@ -434,7 +478,6 @@ def test_smtlib_piecewise_times_const():
 #     assert julia_code(A, assign_to=B) == "B = [3]"
 #     raises(ValueError, lambda: julia_code(A, assign_to=C))
 
-
 # def test_julia_matrix_elements():
 #     A = Matrix([[x, 2, x * y]])
 #     assert julia_code(A[0, 0] ** 2 + A[0, 1] + A[0, 2]) == "x .^ 2 + x .* y + 2"
@@ -444,23 +487,19 @@ def test_smtlib_piecewise_times_const():
 #            "sin(AA[1,2]) + AA[1,1] .^ 2 + AA[1,3]"
 #     assert julia_code(sum(A)) == "AA[1,1] + AA[1,2] + AA[1,3]"
 
-
 def test_smtlib_boolean():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
-    assert smtlib_code(True, auto_assert=False) == 'true'
-    assert smtlib_code(True) == '(assert true)'
-    assert smtlib_code(S.true) == '(assert true)'
-    assert smtlib_code(S.false) == '(assert false)'
-    assert smtlib_code(False) == '(assert false)'
-    assert smtlib_code(False, auto_assert=False) == 'false'
-    warnings.filters = warning_filters
+    with _smtlib_warns([]):
+        assert smtlib_code(True, auto_assert=False) == 'true'
+        assert smtlib_code(True) == '(assert true)'
+        assert smtlib_code(S.true) == '(assert true)'
+        assert smtlib_code(S.false) == '(assert false)'
+        assert smtlib_code(False) == '(assert false)'
+        assert smtlib_code(False, auto_assert=False) == 'false'
 
 
 def test_not_supported():
-    warning_filters = list(warnings.filters)
-    warnings.simplefilter('ignore')
     f = Function('f')
-    raises(KeyError, lambda: smtlib_code(f(x).diff(x), symbol_table={f: Callable[[float], float]}))
-    raises(KeyError, lambda: smtlib_code(S.ComplexInfinity))
-    warnings.filters = warning_filters
+    with _smtlib_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]):
+        raises(KeyError, lambda: smtlib_code(f(x).diff(x), symbol_table={f: Callable[[float], float]}))
+    with _smtlib_warns([_W.WILL_NOT_ASSERT]):
+        raises(KeyError, lambda: smtlib_code(S.ComplexInfinity))

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -25,12 +25,12 @@ class _W(Enum):
 
 @contextlib.contextmanager
 def _check_warns(expected: typing.Iterable[_W]):
-    warnings = []
-    log_warn = warnings.append
+    warns: typing.List[str] = []
+    log_warn = warns.append
     yield log_warn
 
     errors = []
-    for i, (w, e) in enumerate(itertools.zip_longest(warnings, expected)):
+    for i, (w, e) in enumerate(itertools.zip_longest(warns, expected)):
         if not e:
             errors += [f"[{i}] Received unexpected warning `{w}`."]
         elif not w:

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable
 
 import sympy
@@ -13,11 +14,16 @@ x, y, z = symbols('x,y,z')
 
 
 def test_Integer():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(Integer(67)) == "67"
     assert smtlib_code(Integer(-1)) == "-1"
+    warnings.filters = warning_filters
 
 
 def test_Rational():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(Rational(3, 7)) == "(/ 3 7)"
     assert smtlib_code(Rational(18, 9)) == "2"
     assert smtlib_code(Rational(3, -7)) == "(/ -3 7)"
@@ -25,18 +31,24 @@ def test_Rational():
     assert smtlib_code(x + Rational(3, 7), auto_declare=False) == "(+ (/ 3 7) x)"
     assert smtlib_code(Rational(3, 7) * x) == "(declare-const x Real)\n" \
                                               "(* (/ 3 7) x)"
+    warnings.filters = warning_filters
 
 
 def test_Relational():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(Eq(x, y), auto_declare=False) == "(assert (= x y))"
     assert smtlib_code(Ne(x, y), auto_declare=False) == "(assert (not (= x y)))"
     assert smtlib_code(Le(x, y), auto_declare=False) == "(assert (<= x y))"
     assert smtlib_code(Lt(x, y), auto_declare=False) == "(assert (< x y))"
     assert smtlib_code(Gt(x, y), auto_declare=False) == "(assert (> x y))"
     assert smtlib_code(Ge(x, y), auto_declare=False) == "(assert (>= x y))"
+    warnings.filters = warning_filters
 
 
 def test_Function():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(sin(x) ** cos(x), auto_declare=False) == "(pow (sin x) (cos x))"
 
     assert smtlib_code(
@@ -87,9 +99,12 @@ def test_Function():
          "(declare-const y Real)\n" \
          "(declare-const z Real)\n" \
          "(assert (== (MY_KNOWN_FUN x z) y))"
+    warnings.filters = warning_filters
 
 
 def test_Pow():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(x ** 3, auto_declare=False) == "(pow x 3)"
     assert smtlib_code(x ** (y ** 3), auto_declare=False) == "(pow x (pow y 3))"
     assert smtlib_code(x ** Rational(2, 3), auto_declare=False) == '(pow x (/ 2 3))'
@@ -124,17 +139,23 @@ def test_Pow():
     ) == '(declare-const b Real)\n' \
          '(declare-const c Real)\n' \
          '(* -2 c (pow (* b b) -1))'
+    warnings.filters = warning_filters
 
 
 def test_basic_ops():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(x * y, auto_declare=False) == "(* x y)"
     assert smtlib_code(x + y, auto_declare=False) == "(+ x y)"
     # todo: implement re-write, currently does '(+ x (* -1 y))' instead
     # assert smtlib_code(x - y, auto_declare=False) == "(- x y)"
     assert smtlib_code(-x, auto_declare=False) == "(* -1 x)"
+    warnings.filters = warning_filters
 
 
 def test_quantifier_extensions():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     from sympy.logic.boolalg import Boolean
     from sympy import Interval, Tuple, sympify
 
@@ -214,9 +235,12 @@ def test_quantifier_extensions():
          '(assert (forall ( (a Int [2, 100]) (b Real [2, 100])) ' \
          '(or c (=> (< a b) (< (pow a (/ 1 2)) b)))' \
          '))'
+    warnings.filters = warning_filters
 
 
 def test_mix_number_mult_symbols():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(
         1 / pi,
         known_constants={pi: "MY_PI"}
@@ -272,9 +296,12 @@ def test_mix_number_mult_symbols():
         known_functions={Add: 'plus'},
         precision=3
     ) == '(plus 0 1 -1 (/ 1 2) e 3.14 1.62)'
+    warnings.filters = warning_filters
 
 
 def test_boolean():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(x & y) == '(declare-const x Bool)\n' \
                                  '(declare-const y Bool)\n' \
                                  '(assert (and x y))'
@@ -340,6 +367,7 @@ def test_boolean():
          '(assert (= (f x) y))\n' \
          '(assert (= (g (f x)) z))\n' \
          '(assert (= (h (g (f x))) x))'
+    warnings.filters = warning_filters
 
 
 # todo: make smtlib_code support arrays
@@ -356,6 +384,8 @@ def test_boolean():
 
 
 def test_smtlib_piecewise():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(
         Piecewise((x, x < 1),
                   (x ** 2, True)),
@@ -376,14 +406,18 @@ def test_smtlib_piecewise():
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x ** 2, x > 1), (sin(x), x > 0))
     raises(AssertionError, lambda: smtlib_code(expr))
+    warnings.filters = warning_filters
 
 
 def test_smtlib_piecewise_times_const():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     pw = Piecewise((x, x < 1), (x ** 2, True))
     assert smtlib_code(2 * pw) == '(declare-const x Real)\n(* 2 (ite (< x 1) x (pow x 2)))'
     assert smtlib_code(pw / x) == '(declare-const x Real)\n(* (pow x -1) (ite (< x 1) x (pow x 2)))'
     assert smtlib_code(pw / (x * y)) == '(declare-const x Real)\n(declare-const y Real)\n(* (pow x -1) (pow y -1) (ite (< x 1) x (pow x 2)))'
     assert smtlib_code(pw / 3) == '(declare-const x Real)\n(* (/ 1 3) (ite (< x 1) x (pow x 2)))'
+    warnings.filters = warning_filters
 
 
 # todo: make smtlib_code support arrays / matrices ?
@@ -412,15 +446,21 @@ def test_smtlib_piecewise_times_const():
 
 
 def test_smtlib_boolean():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     assert smtlib_code(True, auto_assert=False) == 'true'
     assert smtlib_code(True) == '(assert true)'
     assert smtlib_code(S.true) == '(assert true)'
     assert smtlib_code(S.false) == '(assert false)'
     assert smtlib_code(False) == '(assert false)'
     assert smtlib_code(False, auto_assert=False) == 'false'
+    warnings.filters = warning_filters
 
 
 def test_not_supported():
+    warning_filters = list(warnings.filters)
+    warnings.simplefilter('ignore')
     f = Function('f')
     raises(KeyError, lambda: smtlib_code(f(x).diff(x), symbol_table={f: Callable[[float], float]}))
     raises(KeyError, lambda: smtlib_code(S.ComplexInfinity))
+    warnings.filters = warning_filters


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fix https://github.com/sympy/sympy/pull/23961.


#### Brief description of what is fixed or changed
Made SMT printer tests not send logs to STDOUT and instead use python `warnings` module as noted here: https://github.com/sympy/sympy/pull/23961#issuecomment-1235844014


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
