### PR TITLE
B(1) = +½ set 7: ζ–B function fuzzing

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -546,6 +546,8 @@ class bernoulli(Function):
         elif n.is_zero:
             return S.One
         elif n.is_integer is False or n.is_nonnegative is False:
+            if x is not None and x.is_Integer and x.is_nonpositive:
+                return S.NaN
             return
         # Bernoulli numbers
         elif x is None:
@@ -781,7 +783,7 @@ class harmonic(Function):
       ``harmonic(n) == harmonic(n, 1)``
 
     This function can be extended to complex `n` and `m` where `n` is not a
-    negative integer as
+    negative integer or `m` is a nonpositive integer as
 
     .. math:: \operatorname{H}_{n,m} = \begin{cases} \zeta(m) - \zeta(m, n+1)
             & m \ne 1 \\ \psi(n+1) + \gamma & m = 1 \end{cases}
@@ -871,7 +873,10 @@ class harmonic(Function):
     >>> limit(harmonic(n, 3), n, oo)
     -polygamma(2, 1)/2
 
-    >>> limit(harmonic(n, m+1), n, oo) # does not hold for m == 1
+    For `m > 1`, `H_{n,m}` tends to `\zeta(m)` in the limit of infinite `n`:
+
+    >>> m = Symbol("m", positive=True)
+    >>> limit(harmonic(n, m+1), n, oo)
     zeta(m + 1)
 
     See Also
@@ -887,10 +892,6 @@ class harmonic(Function):
     .. [3] http://functions.wolfram.com/GammaBetaErf/HarmonicNumber2/
 
     """
-
-    # Generate one memoized Harmonic number-generating function for each
-    # order and store it in a dictionary
-    _functions = {}  # type: tDict[Integer, Callable[[int], Rational]]
 
     @classmethod
     def eval(cls, n, m=None):
@@ -910,15 +911,13 @@ class harmonic(Function):
                 return S.Infinity
             elif is_gt(m, S.One):
                 return zeta(m)
+        elif m.is_Integer and m.is_nonpositive:
+            return (bernoulli(1-m, n+1) - bernoulli(1-m)) / (1-m)
         elif n.is_Integer:
-            if n.is_negative:
-                return S.NaN
-            elif m not in cls._functions:
-                @recurrence_memo([0])
-                def f(n, prev):
-                    return prev[-1] + S.One / n**m
-                cls._functions[m] = f
-            return cls._functions[m](int(n))
+            if n.is_negative and (m.is_integer is False or m.is_nonpositive is False):
+                return S.ComplexInfinity if m is S.One else S.NaN
+            if n.is_nonnegative:
+                return sum(k**(-m) for k in range(1, int(n)+1))
 
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):
         from sympy.functions.special.gamma_functions import gamma, polygamma

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -8,7 +8,7 @@ the separate 'factorials' module.
 """
 from math import prod
 from collections import defaultdict
-from typing import Callable, Dict as tDict, Tuple as tTuple
+from typing import Tuple as tTuple
 
 from sympy.core import S, Symbol, Add, Dummy
 from sympy.core.cache import cacheit

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -917,7 +917,7 @@ class harmonic(Function):
             if n.is_negative and (m.is_integer is False or m.is_nonpositive is False):
                 return S.ComplexInfinity if m is S.One else S.NaN
             if n.is_nonnegative:
-                return sum(k**(-m) for k in range(1, int(n)+1))
+                return Add(*(k**(-m) for k in range(1, int(n)+1)))
 
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):
         from sympy.functions.special.gamma_functions import gamma, polygamma

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -246,8 +246,12 @@ def test_harmonic():
     assert harmonic(oo, 1 + ip) is zeta(1 + ip)
 
     assert harmonic(0, m) == 0
+    assert harmonic(-1, -1) == 0
+    assert harmonic(-1, 0) == -1
+    assert harmonic(-1, 1) is S.ComplexInfinity
     assert harmonic(-1, 2) is S.NaN
-    assert harmonic(-2, n) is S.NaN
+    assert harmonic(-3, -2) == -5
+    assert harmonic(-3, -3) == 9
 
 
 def test_harmonic_rational():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -517,9 +517,10 @@ class zeta(Function):
         elif a is S.One:
             if sint and s.is_even:
                 return -(2*pi*I)**s * bernoulli(s) / (2*factorial(s))
-        elif sint and a.is_Integer:
-            if a.is_positive:
-                return cls(s) - harmonic(a-1, s)
+        elif sint and a.is_Integer and a.is_positive:
+            return cls(s) - harmonic(a-1, s)
+        elif a.is_Integer and a.is_nonpositive and \
+                (s.is_integer is False or s.is_nonpositive is False):
             return S.NaN
 
     def _eval_rewrite_as_bernoulli(self, s, a=1, **kwargs):


### PR DESCRIPTION
#### References to other Issues or PRs

Most of this PR is a response to @oscarbenjamin's script at https://github.com/sympy/sympy/pull/23926#issuecomment-1233954899, but its original purpose was to clarify [a piece of documentation](https://github.com/sympy/sympy/pull/23985#discussion_r960383091) that I realised was unclear only after #23985 was merged. Ultimately this PR is associated with the changes originally in #23926.

#### Brief description of what is fixed or changed

Some fuzzing of `zeta()`, `bernoulli()` and the functions depending on them, so that they evaluate consistently across rewrites.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->