### PR TITLE
B(1) = +½ set 8: Espinosa–Moll polygamma

### DIFF
--- a/doc/src/contributing/docstring.rst
+++ b/doc/src/contributing/docstring.rst
@@ -497,8 +497,8 @@ Here is an example of a correctly formatted docstring::
 
         >>> from sympy import series
         >>> series(gamma(x), x, 0, 3)
-        1/x - EulerGamma + x*(EulerGamma**2/2 + pi**2/12) + x**2*(-EulerGamma*pi**2/12 +
-        polygamma(2, 1)/6 - EulerGamma**3/6) + O(x**3)
+        1/x - EulerGamma + x*(EulerGamma**2/2 + pi**2/12) +
+        x**2*(-EulerGamma*pi**2/12 - zeta(3)/3 - EulerGamma**3/6) + O(x**3)
 
         We can numerically evaluate the ``gamma`` function to arbitrary
         precision on the whole complex plane:

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -843,10 +843,11 @@ class harmonic(Function):
     polygamma(0, n + 1) + EulerGamma
 
     >>> harmonic(n,3).rewrite(polygamma)
-    polygamma(2, n + 1)/2 - polygamma(2, 1)/2
+    polygamma(2, n + 1)/2 + zeta(3)
 
-    >>> harmonic(n,m).rewrite(polygamma)
-    (-1)**m*(polygamma(m - 1, 1) - polygamma(m - 1, n + 1))/gamma(m)
+    >>> simplify(harmonic(n,m).rewrite(polygamma))
+    Piecewise((polygamma(0, n + 1) + EulerGamma, Eq(m, 1)),
+    (-(-1)**m*polygamma(m - 1, n + 1)/factorial(m - 1) + zeta(m), True))
 
     Integer offsets in the argument can be pulled out:
 
@@ -869,7 +870,7 @@ class harmonic(Function):
     pi**2/6
 
     >>> limit(harmonic(n, 3), n, oo)
-    -polygamma(2, 1)/2
+    zeta(3)
 
     >>> limit(harmonic(n, m+1), n, oo) # does not hold for m == 1
     zeta(m + 1)
@@ -923,7 +924,9 @@ class harmonic(Function):
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):
         from sympy.functions.special.gamma_functions import gamma, polygamma
         if m.is_integer and m.is_positive:
-            return S.NegativeOne**m * (polygamma(m-1, 1) - polygamma(m-1, n+1)) / gamma(m)
+            return Piecewise((polygamma(0, n+1) + S.EulerGamma, Eq(m, 1)),
+                    (S.NegativeOne**m * (polygamma(m-1, 1) - polygamma(m-1, n+1)) /
+                    gamma(m), True))
 
     def _eval_rewrite_as_digamma(self, n, m=1, **kwargs):
         from sympy.functions.special.gamma_functions import polygamma

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -329,6 +329,7 @@ def test_harmonic_evalf():
     assert harmonic(-2.0, 2.0).evalf() is S.NaN
 
 def test_harmonic_rewrite():
+    from sympy.functions.elementary.piecewise import Piecewise
     n = Symbol("n")
     m = Symbol("m", integer=True, positive=True)
 
@@ -337,7 +338,7 @@ def test_harmonic_rewrite():
     assert harmonic(n).rewrite(polygamma) == polygamma(0, n + 1) + EulerGamma
 
     assert harmonic(n,3).rewrite(polygamma) == polygamma(2, n + 1)/2 - polygamma(2, 1)/2
-    assert harmonic(n,m).rewrite(polygamma) == (-1)**m * (polygamma(m-1, 1) - polygamma(m-1, n+1)) / gamma(m)
+    assert isinstance(harmonic(n,m).rewrite(polygamma), Piecewise)
 
     assert expand_func(harmonic(n+4)) == harmonic(n) + 1/(n + 4) + 1/(n + 3) + 1/(n + 2) + 1/(n + 1)
     assert expand_func(harmonic(n-4)) == harmonic(n) - 1/(n - 1) - 1/(n - 2) - 1/(n - 3) - 1/n

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import (I, Rational, nan, oo, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol)
 from sympy.functions.combinatorial.factorials import factorial
-from sympy.functions.combinatorial.numbers import bernoulli, harmonic
+from sympy.functions.combinatorial.numbers import harmonic
 from sympy.functions.elementary.complexes import (Abs, conjugate, im, re)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import tanh

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -250,6 +250,7 @@ def test_polygamma():
 
     assert polygamma(0, -9) is zoo
     assert polygamma(0, -1) is zoo
+    assert polygamma(Rational(3, 2), -1) is zoo
 
     assert polygamma(0, 0) is zoo
 
@@ -356,6 +357,7 @@ def test_polygamma():
 
     assert str(polygamma(pi, 3).evalf(n=10)) == "0.1169314564"
     assert str(polygamma(2.3, 1.0).evalf(n=10)) == "-3.003302909"
+    assert str(polygamma(-1, 1).evalf(n=10)) == "-0.9189385332" # not zero
     assert str(polygamma(I, 1).evalf(n=10)) == "-3.109856569 + 1.89089016*I"
     assert str(polygamma(1, I).evalf(n=10)) == "-0.5369999034 - 0.7942335428*I"
     assert str(polygamma(I, I).evalf(n=10)) == "6.332362889 + 45.92828268*I"

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -1,15 +1,15 @@
-from sympy.core.function import expand_func
+from sympy.core.function import expand_func, Subs
 from sympy.core import EulerGamma
 from sympy.core.numbers import (I, Rational, nan, oo, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol)
 from sympy.functions.combinatorial.factorials import factorial
-from sympy.functions.combinatorial.numbers import harmonic
+from sympy.functions.combinatorial.numbers import bernoulli, harmonic
 from sympy.functions.elementary.complexes import (Abs, conjugate, im, re)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.trigonometric import (cos, sin, atan)
 from sympy.functions.special.error_functions import (Ei, erf, erfc)
 from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma, lowergamma, multigamma, polygamma, trigamma, uppergamma)
 from sympy.functions.special.zeta_functions import zeta
@@ -316,7 +316,7 @@ def test_polygamma():
     assert polygamma(k, exp_polar(2*I*pi)*x).args == (k, exp_polar(2*I*pi)*x)
 
     # Polygamma of order -1 is loggamma:
-    assert polygamma(-1, x) == loggamma(x)
+    assert polygamma(-1, x) == loggamma(x) - log(2*pi) / 2
 
     # But smaller orders are iterated integrals and don't have a special name
     assert polygamma(-2, x).func is polygamma
@@ -342,20 +342,23 @@ def test_polygamma():
     assert polygamma(I, 3).is_negative is None
 
     # issue 17350
-    assert polygamma(pi, 3).evalf() == polygamma(pi, 3)
     assert (I*polygamma(I, pi)).as_real_imag() == \
            (-im(polygamma(I, pi)), re(polygamma(I, pi)))
     assert (tanh(polygamma(I, 1))).rewrite(exp) == \
            (exp(polygamma(I, 1)) - exp(-polygamma(I, 1)))/(exp(polygamma(I, 1)) + exp(-polygamma(I, 1)))
     assert (I / polygamma(I, 4)).rewrite(exp) == \
-           I*sqrt(re(polygamma(I, 4))**2 + im(polygamma(I, 4))**2)\
-           /((re(polygamma(I, 4)) + I*im(polygamma(I, 4)))*Abs(polygamma(I, 4)))
-    assert unchanged(polygamma, 2.3, 1.0)
+           I*exp(-I*atan(im(polygamma(I, 4))/re(polygamma(I, 4))))/Abs(polygamma(I, 4))
 
     # issue 12569
     assert unchanged(im, polygamma(0, I))
     assert polygamma(Symbol('a', positive=True), Symbol('b', positive=True)).is_real is True
     assert polygamma(0, I).is_real is None
+
+    assert str(polygamma(pi, 3).evalf(n=10)) == "0.1169314564"
+    assert str(polygamma(2.3, 1.0).evalf(n=10)) == "-3.003302909"
+    assert str(polygamma(I, 1).evalf(n=10)) == "-3.109856569 + 1.89089016*I"
+    assert str(polygamma(1, I).evalf(n=10)) == "-0.5369999034 - 0.7942335428*I"
+    assert str(polygamma(I, I).evalf(n=10)) == "6.332362889 + 45.92828268*I"
 
 
 def test_polygamma_expand_func():
@@ -401,6 +404,13 @@ def test_polygamma_expand_func():
     assert e.expand(func=True) == e
     e = polygamma(3, x + y + Rational(3, 4))
     assert e.expand(func=True, basic=False) == e
+
+    assert polygamma(-1, x, evaluate=False).expand(func=True) == \
+        loggamma(x) - log(pi)/2 - log(2)/2
+    p2 = polygamma(-2, x).expand(func=True) + x**2/2 - x/2 + S(1)/12
+    assert isinstance(p2, Subs)
+    assert p2.point == (-1,)
+
 
 def test_digamma():
     assert digamma(nan) == nan


### PR DESCRIPTION
#### References to other Issues or PRs

Part 8 of the changes formerly included in #23926 (and the last part committed there before I started splitting it into several PRs), building upon #23985.

#### Brief description of what is fixed or changed

This PR generalises `polygamma()` to the generalised polygamma function described in Espinosa and Moll:
$$\psi(s,z)=\frac{\zeta'(s+1,z)+(\psi(-s)+\gamma)\zeta(s+1,z)}{\Gamma(-s)}$$

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
    * `polygamma()` now accepts complex arguments, implementing the generalised polygamma function described in [Espinosa and Moll (2004)](http://www.math.tulane.edu/~vhm/papers_html/genoff.pdf).
    * BREAKING: As a result of using the Espinosa–Moll generalisation, `polygamma(-1, x)` now differs from `loggamma(x)` by a constant instead of being the same.
<!-- END RELEASE NOTES -->
