### PR TITLE
codeprinter: fix typos and add additional tests

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -434,9 +434,11 @@ class AssignmentBase(CodegenAST):
         from sympy.matrices.expressions.matexpr import (
             MatrixElement, MatrixSymbol)
         from sympy.tensor.indexed import Indexed
+        from sympy.tensor.array.expressions import ArrayElement
 
         # Tuple of things that can be on the lhs of an assignment
-        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable)
+        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable,
+                ArrayElement)
         if not isinstance(lhs, assignable):
             raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
 

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -431,7 +431,7 @@ class FCodePrinter(CodePrinter):
         body = self._print(expr.body)
         return ('do {target} = {start}, {stop}, {step}\n'
                 '{body}\n'
-                'end do').format(target=target, start=start, stop=stop,
+                'end do').format(target=target, start=start, stop=stop - 1,
                         step=step, body=body)
 
     def _print_Type(self, type_):
@@ -773,3 +773,9 @@ class FCodePrinter(CodePrinter):
     def _print_ArrayConstructor(self, ac):
         fmtstr = "[%s]" if self._settings["standard"] >= 2003 else '(/%s/)'
         return fmtstr % ', '.join(map(lambda arg: self._print(arg), ac.elements))
+
+    def _print_ArrayElement(self, elem):
+        return '{symbol}({idxs})'.format(
+            symbol=self._print(elem.name),
+            idxs=', '.join(map(lambda arg: self._print(arg), elem.indices))
+        )

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -261,9 +261,8 @@ class RCodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
         body = self._print(expr.body)
-        return ('for ({target} = {start}; {target} < {stop}; {target} += '
-                '{step}) {{\n{body}\n}}').format(target=target, start=start,
-                stop=stop, step=step, body=body)
+        return 'for({target} in seq(from={start}, to={stop}, by={step}){{\n{body}\n}}'.format(target=target, start=start,
+                stop=stop-1, step=step, body=body)
 
 
     def indent_code(self, code):

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -1,4 +1,5 @@
 from sympy.core.add import Add
+from sympy.core.expr import Expr
 from sympy.core.function import (Function, Lambda, diff)
 from sympy.core.mod import Mod
 from sympy.core import (Catalan, EulerGamma, GoldenRatio)
@@ -649,17 +650,14 @@ def test_element_like_objects():
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = fcode(Assignment(e.lhs, e.rhs))
-    print(code0)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
-    from sympy.core.expr import Expr
     class ElementExpr(Element, Expr):
         pass
 
     e = e.subs((a, ElementExpr(a.name, a.indices)) for a in e.atoms(ArrayElement)  )
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = fcode(Assignment(e.lhs, e.rhs))
-    print(code0)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
 

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -19,13 +19,14 @@ from sympy.sets.fancysets import Range
 from sympy.codegen import For, Assignment, aug_assign
 from sympy.codegen.ast import Declaration, Variable, float32, float64, \
         value_const, real, bool_, While, FunctionPrototype, FunctionDefinition, \
-        integer, Return
+        integer, Return, Element
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or, Not, Equivalent, Xor
 from sympy.matrices import Matrix, MatrixSymbol
 from sympy.printing.fortran import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
+from sympy.tensor.array.expressions import ArraySymbol, ArrayElement
 from sympy.utilities.lambdify import implemented_function
 from sympy.testing.pytest import raises
 
@@ -628,6 +629,7 @@ def test_dummy_loops():
     code = fcode(x[i], assign_to=y[i], source_format='free')
     assert code == expected
 
+
 def test_fcode_Indexed_without_looking_for_contraction():
     len_y = 5
     y = IndexedBase('y', shape=(len_y,))
@@ -636,6 +638,28 @@ def test_fcode_Indexed_without_looking_for_contraction():
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = fcode(e.rhs, assign_to=e.lhs, contract=False)
+    assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
+
+
+def test_element_like_objects():
+    len_y = 5
+    y = ArraySymbol('y', shape=(len_y,))
+    x = ArraySymbol('x', shape=(len_y,))
+    Dy = ArraySymbol('Dy', shape=(len_y-1,))
+    i = Idx('i', len_y-1)
+    e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
+    code0 = fcode(Assignment(e.lhs, e.rhs))
+    print(code0)
+    assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
+
+    from sympy.core.expr import Expr
+    class ElementExpr(Element, Expr):
+        pass
+
+    e = e.subs((a, ElementExpr(a.name, a.indices)) for a in e.atoms(ArrayElement)  )
+    e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
+    code0 = fcode(Assignment(e.lhs, e.rhs))
+    print(code0)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
 
@@ -751,7 +775,7 @@ def test_fcode_For():
 
     f = For(x, Range(0, 10, 2), [Assignment(y, x * y)])
     sol = fcode(f)
-    assert sol == ("      do x = 0, 10, 2\n"
+    assert sol == ("      do x = 0, 9, 2\n"
                    "         y = x*y\n"
                    "      end do")
 

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -458,7 +458,7 @@ def test_rcode_Assignment():
 def test_rcode_For():
     f = For(x, Range(0, 10, 2), [aug_assign(y, '*', x)])
     sol = rcode(f)
-    assert sol == ("for (x = 0; x < 10; x += 2) {\n"
+    assert sol == ("for(x in seq(from=0, to=9, by=2){\n"
                    "   y *= x;\n"
                    "}")
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Several of the less controversial problems brought up in #23998 are addressed.

#### Brief description of what is fixed or changed
`ArrayElement`s now print with `()` instead of `[]` in fortran.
Typos in the R and Fortran printers were fixed for `For` loops.
Tests were added for the above changes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
