### PR TITLE
[GSoC PR4.2] Implemented leading term and nseries methods for the frac function

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -150,14 +150,7 @@ class floor(RoundFunction):
             r = floor(arg0)
         if arg0.is_finite:
             if arg0 == r:
-                if cdir == 0:
-                    ndirl = arg.dir(x, cdir=-1)
-                    ndir = arg.dir(x, cdir=1)
-                    if ndir != ndirl:
-                        raise ValueError("Two sided limit of %s around 0"
-                                    "does not exist" % self)
-                else:
-                    ndir = arg.dir(x, cdir=cdir)
+                ndir = arg.dir(x, cdir=cdir)
                 return r - 1 if ndir.is_negative else r
             else:
                 return r
@@ -315,14 +308,7 @@ class ceiling(RoundFunction):
             r = ceiling(arg0)
         if arg0.is_finite:
             if arg0 == r:
-                if cdir == 0:
-                    ndirl = arg.dir(x, cdir=-1)
-                    ndir = arg.dir(x, cdir=1)
-                    if ndir != ndirl:
-                        raise ValueError("Two sided limit of %s around 0"
-                                    "does not exist" % self)
-                else:
-                    ndir = arg.dir(x, cdir=cdir)
+                ndir = arg.dir(x, cdir=cdir)
                 return r if ndir.is_negative else r + 1
             else:
                 return r
@@ -586,6 +572,43 @@ class frac(Function):
                     return S.true
             if other.is_integer and other.is_positive:
                 return S.true
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.calculus.accumulationbounds import AccumBounds
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+        r = self.subs(x, 0)
+
+        if arg0.is_finite:
+            if r.is_zero:
+                ndir = arg.dir(x, cdir=cdir)
+                if ndir.is_negative:
+                    return S.One
+                return (arg - arg0).as_leading_term(x, logx=logx, cdir=cdir)
+            else:
+                return r
+        elif arg0 in (S.ComplexInfinity, S.Infinity, S.NegativeInfinity):
+            return AccumBounds(0, 1)
+        return arg.as_leading_term(x, logx=logx, cdir=cdir)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.series.order import Order
+        arg = self.args[0]
+        arg0 = arg.subs(x, 0)
+        r = self.subs(x, 0)
+
+        if arg0.is_infinite:
+            from sympy.calculus.accumulationbounds import AccumBounds
+            o = Order(1, (x, 0)) if n <= 0 else AccumBounds(0, 1) + Order(x**n, (x, 0))
+            return o
+        else:
+            res = (arg - arg0)._eval_nseries(x, n, logx=logx, cdir=cdir)
+            if r.is_zero:
+                ndir = arg.dir(x, cdir=cdir)
+                res += S.One if ndir.is_negative else S.Zero
+            else:
+                res += r
+            return res
 
 
 @dispatch(frac, Basic)  # type:ignore

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -582,6 +582,20 @@ def test_issue_14355():
     assert ceiling((x**3 + x)/(x**2 - x)).series(x, 0, 100, cdir = -1) == 0
 
 
+def test_frac_leading_term():
+    assert frac(x).as_leading_term(x) == x
+    assert frac(x).as_leading_term(x, cdir = 1) == x
+    assert frac(x).as_leading_term(x, cdir = -1) == 1
+    assert frac(x + S.Half).as_leading_term(x, cdir = 1) == S.Half
+    assert frac(x + S.Half).as_leading_term(x, cdir = -1) == S.Half
+    assert frac(-2*x + 1).as_leading_term(x, cdir = 1) == S.One
+    assert frac(-2*x + 1).as_leading_term(x, cdir = -1) == -2*x
+    assert frac(sin(x) + 5).as_leading_term(x, cdir = 1) == x
+    assert frac(sin(x) + 5).as_leading_term(x, cdir = -1) == S.One
+    assert frac(sin(x**2) + 5).as_leading_term(x, cdir = 1) == x**2
+    assert frac(sin(x**2) + 5).as_leading_term(x, cdir = -1) == x**2
+
+
 @XFAIL
 def test_issue_4149():
     assert floor(3 + pi*I + y*I) == 3 + floor(pi + y)*I

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -244,6 +244,22 @@ def test_ceiling_requires_robust_assumptions():
     assert limit(ceiling(5 + cos(x)), x, 0, "-") == 6
 
 
+def test_frac():
+    assert limit(frac(x), x, oo) == AccumBounds(0, 1)
+    assert limit(frac(x)**(1/x), x, oo) == AccumBounds(0, 1)
+    assert limit(frac(x)**(1/x), x, -oo) == AccumBounds(1, oo)
+    assert limit(frac(x)**x, x, oo) == AccumBounds(0, oo)  # wolfram gives (0, 1)
+    assert limit(frac(sin(x)), x, 0, "+") == 0
+    assert limit(frac(sin(x)), x, 0, "-") == 1
+    assert limit(frac(cos(x)), x, 0, "+-") == 1
+    assert limit(frac(x**2), x, 0, "+-") == 0
+    raises(ValueError, lambda: limit(frac(x), x, 0, '+-'))
+    assert limit(frac(-2*x + 1), x, 0, "+") == 1
+    assert limit(frac(-2*x + 1), x, 0, "-") == 0
+    assert limit(frac(x + S.Half), x, 0, "+-") == 1/2
+    assert limit(frac(1/x), x, 0) == AccumBounds(0, 1)
+
+
 def test_issue_14355():
     assert limit(floor(sin(x)/x), x, 0, '+') == 0
     assert limit(floor(sin(x)/x), x, 0, '-') == 0
@@ -340,7 +356,6 @@ def test_series_AccumBounds():
     t2 = Mul(AccumBounds(-1 + sin(1)/2, sin(1)/2 + 1), 1/(1 - cos(1)))
     assert limit(simplify(Sum(sin(n).rewrite(exp), (n, 0, k)).doit().rewrite(sin)), k, oo) == t2
 
-    assert limit(frac(x)**x, x, oo) == AccumBounds(0, oo)  # wolfram gives (0, 1)
     assert limit(((sin(x) + 1)/2)**x, x, oo) == AccumBounds(0, oo)  # wolfram says 0
 
     # https://github.com/sympy/sympy/issues/12312

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -1,3 +1,4 @@
+from sympy.calculus.util import AccumBounds
 from sympy.core.function import (Derivative, PoleError)
 from sympy.core.numbers import (E, I, Integer, Rational, pi)
 from sympy.core.singleton import S
@@ -5,7 +6,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (acosh, acoth, asinh, atanh, cosh, coth, sinh, tanh)
-from sympy.functions.elementary.integers import (ceiling, floor)
+from sympy.functions.elementary.integers import (ceiling, floor, frac)
 from sympy.functions.elementary.miscellaneous import (cbrt, sqrt)
 from sympy.functions.elementary.trigonometric import (asin, cos, cot, sin, tan)
 from sympy.series.limits import limit
@@ -442,6 +443,20 @@ def test_floor():
 
     x = Symbol('x', negative=True)
     assert floor(x + 1.5).series(x) == 1
+
+
+def test_frac():
+    assert frac(x).series(x, cdir=1) == x
+    assert frac(x).series(x, cdir=-1) == 1 + x
+    assert frac(2*x + 1).series(x, cdir=1) == 2*x
+    assert frac(2*x + 1).series(x, cdir=-1) == 1 + 2*x
+    assert frac(x**2).series(x, cdir=1) == x**2
+    assert frac(x**2).series(x, cdir=-1) == x**2
+    assert frac(sin(x) + 5).series(x, cdir=1) == x - x**3/6 + x**5/120 + O(x**6)
+    assert frac(sin(x) + 5).series(x, cdir=-1) == 1 + x - x**3/6 + x**5/120 + O(x**6)
+    assert frac(sin(x) + S.Half).series(x) == S.Half + x - x**3/6 + x**5/120 + O(x**6)
+    assert frac(x**8).series(x, cdir=1) == O(x**6)
+    assert frac(1/x).series(x) == AccumBounds(0, 1) + O(x**6)
 
 
 def test_ceiling():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The `frac` function performs quite poorly while calculating limits . Some wrong results returned from master are as follows

```
>>> x =Symbol('x')
>>> limit(frac(x), x, 0, '+')
frac(_w)
>>> limit(frac(x), x, 0, '-')
0
>>> limit(frac(x + 1), x, 0, '-')
0
>>> limit(frac(-x), x, 0, '+')
0
>>> limit(frac(-x), x, 0, '-')
frac(-_w)
>>> limit(frac(-2*x + 1), x, 0, '+')
0
>>> limit(frac(x), x, 0, '+-')
Traceback (most recent call last):
    raise ValueError("The limit does not exist since "
ValueError: The limit does not exist since left hand limit = 0 and right hand limit = frac(_w)
```
All these have been been fixed , also I have implemented the `_eval_nseries` method for `frac` 
On master we had , which isn't wrong but not what one would expect either
```
>>> frac(x).series(x, 0, 6, cdir=1)
x*Subs(Derivative(frac(x), x), x, 0) + x**2*Subs(Derivative(frac(x), (x, 2)), x, 0)/2 + x**3*Subs(Derivative(frac(x), (x, 3)), x, 0)/6 + x**4*Subs(Derivative(frac(x), (x, 4)), x, 0)/24 + x**5*Subs(Derivative(frac(x), (x, 5)), x, 0)/120 + O(x**6)
```
The results for `series/nseries` of `frac` function heavily depend on the direction/`cdir` in which the `series/nseries` is being calculated , hence tests like the following will also be added, for the same.
```
>>> frac(x).series(x)
x + O(x**6)
>>> frac(x)._eval_nseries(x, 6, logx = None, cdir = 1)
x + O(x**6)
>>> frac(x)._eval_nseries(x, 6, logx = None, cdir = 0)
x + O(x**6)
>>> frac(x)._eval_nseries(x, 6, logx = None, cdir = -1)
1 + x + O(x**6)
>>> frac(2*x + 1)._eval_nseries(x, 6, logx = None, cdir = 1)
2*x + O(x**6)
>>> frac(2*x + 2)._eval_nseries(x, 6, logx = None, cdir = 1)
2*x + O(x**6)
>>> frac(x**2)._eval_nseries(x, 6, logx = None, cdir = 1)
x**2 + O(x**6)
>>> frac(x**2)._eval_nseries(x, 6, logx = None, cdir = -1)
x**2 + O(x**6)
>>> frac(x**3 - 1)._eval_nseries(x, 6, logx = None, cdir = -1)
1 + x**3 + O(x**6)
>>> frac(x**3 - 1)._eval_nseries(x, 6, logx = None, cdir = 1)
x**3 + O(x**6)
>>> 
>>> frac(1/x).series(x, 0, 6)
AccumBounds(0, 1) + O(x**6)
>>> frac(1/x).series(x, 0, 0)
O(1)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Implemented leading term and nseries methods for the frac function
<!-- END RELEASE NOTES -->
