### PR TITLE
[GSoC PR4.3] Implemented some series methods for gamma and error functions

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1405,6 +1405,18 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.functions.special.gamma_functions import digamma
+        nu, z = self.args
+        if nu.is_real and nu >= 1:
+            term_one = (-z)**(nu - 1)/factorial(nu - 1) * (digamma(nu) - log(z))
+            term_two = 1/(nu - 1)
+            if nu == 1:
+                term_two = z/(2 - nu)
+            arg = Add(*[term_one, term_two]).as_leading_term(x, logx=logx)
+            return arg
+        return super(expint, self)._eval_as_leading_term(x, logx, cdir)
+
     def _eval_nseries(self, x, n, logx, cdir=0):
         if not self.args[0].has(x):
             nu = self.args[0]
@@ -1889,6 +1901,19 @@ class Si(TrigonometricIntegral):
         from sympy.integrals.integrals import Integral
         t = Symbol('t', Dummy=True)
         return Integral(sinc(t), (t, 0, z))
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        arg = self.args[0].as_leading_term(x)
+        arg0 = arg.subs(x, 0)
+
+        if arg0 is S.NaN:
+            arg0 = arg.limit(x, 0, dir='-' if re(cdir).is_negative else '+')
+        if arg0.is_zero:
+            return arg
+        elif not arg0.is_infinite:
+            return self.func(arg0)
+        else:
+            return self
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.series.order import Order

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -383,11 +383,17 @@ class lowergamma(Function):
     def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
 
+    def _eval_rewrite_as_tractable(self, s, x, **kwargs):
+        return self.rewrite(uppergamma)
+
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         if s.is_integer and s.is_nonpositive:
             return self
         return self.rewrite(uppergamma).rewrite(expint)
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        return self.rewrite(uppergamma)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_is_zero(self):
         x = self.args[1]
@@ -555,6 +561,10 @@ class uppergamma(Function):
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         return expint(1 - s, x)*x**s
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.functions.special.error_functions import expint
+        return self.rewrite(expint)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
 
 ###############################################################################

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, as
                                                       atan, cos, cot, csc, sec, sin, tan)
 from sympy.functions.special.bessel import (besseli, bessely, besselj, besselk)
 from sympy.functions.special.error_functions import (Ei, erf, erfc, erfi, fresnelc, fresnels)
-from sympy.functions.special.gamma_functions import (digamma, gamma, uppergamma)
+from sympy.functions.special.gamma_functions import (digamma, gamma, lowergamma, uppergamma)
 from sympy.functions.special.hyper import meijerg
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.series.limits import (Limit, limit)
@@ -371,6 +371,16 @@ def test_bessel_functions_at_infinity():
 
     # test issue 14874
     assert limit(besselk(0, x), x, oo) == 0
+
+
+def test_lowergamma_at_origin():
+    a, x = symbols('a x')
+    assert limit(lowergamma(a, x), a, 0) == oo
+    assert limit(lowergamma(a, x), a, 0, '-') == -oo
+    assert limit(lowergamma(I*a, x), a, 0) == -oo*I
+    assert limit(lowergamma(I*a, x), a, 0, '-') == oo*I
+    assert limit(lowergamma(a, 1), a, 0) == oo
+    assert limit(x*lowergamma(x, 1)/gamma(x + 1), x, 0) == 1
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
While implementing leading term for `expint(nu, z)` function, we don't really have to take care of cases where `nu < 1` and as the already implemented `_eval_nseries` method shows  we essentially only need to focus on cases where nu >=1.
Because expint(nu, z) when nu < 1 will be rewritten in forms of exponentials.
```
>>> expint(0, x)
exp(-x)/x
>>> expint(-1, x)
exp(-x)/x + exp(-x)/x**2
>>> expint(-2, x)
exp(-x)/x + 2*exp(-x)/x**2 + 2*exp(-x)/x**3
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Implemented leading term methods for expint and Si function.
  * Implemented leading term methods for uppergamma and lowergamma fucntion.
<!-- END RELEASE NOTES -->
