### PR TITLE
[GSoC] Implement auto coordinate generation helper for the joints framework

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -78,13 +78,14 @@ SymPy deprecation warnings.
 
 (deprecated-mechanics-joint-coordinate-format)=
 ### New Joint coordinate format
-The format of the generalized coordinates and generalized speeds of the joints
-in the ``sympy.physics.mechanics`` module has changed. The data type of has
-changed to from ``list`` to ``Matrix``, which is the same as the type for the
-generalized coordinates within the ``KanesMethod``. The auto naming of the
-generalized coordinates and generalized speeds of the ``PinJoint`` and
-``PrismaticJoint`` have also changed to ``q_<joint.name>`` and
-``u_<joint.name>``. Before this was unique for each of the joint types.
+The format, i.e. type and auto generated name, of the generalized coordinates
+and generalized speeds of the joints in the ``sympy.physics.mechanics`` module
+has changed. The data type has changed from ``list`` to ``Matrix``, which is the
+same as the type for the generalized coordinates within the ``KanesMethod``.
+The auto naming of the generalized coordinates and generalized speeds of the
+``PinJoint`` and ``PrismaticJoint`` have also changed to ``q_<joint.name>`` and
+``u_<joint.name>``. Previously each of those joints had an unique template for
+auto generating these names.
 
 (deprecated-mechanics-joint-axis)=
 ### New Joint intermediate frames

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,11 +76,21 @@ SymPy deprecation warnings.
 
 ## Version 1.12
 
+(deprecated-mechanics-joint-coordinate-format)=
+### New Joint coordinate format
+The format of the generalized coordinates and generalized speeds of the joints
+in the ``sympy.physics.mechanics`` module has changed. The data type of has
+changed to from ``list`` to ``Matrix``, which is the same as the type for the
+generalized coordinates within the ``KanesMethod``. The auto naming of the
+generalized coordinates and generalized speeds of the ``PinJoint`` and
+``PrismaticJoint`` have also changed to ``q_<joint.name>`` and
+``u_<joint.name>``. Before this was unique for each of the joint types.
+
 (deprecated-mechanics-joint-axis)=
 ### New Joint intermediate frames
 
-The definition of the joint axis in the ``sympy.physics.mechanics`` has changed.
-Instead of using the arguments ``parent_axis`` and ``child_axis`` to
+The definition of the joint axis in the ``sympy.physics.mechanics`` module has
+changed. Instead of using the arguments ``parent_axis`` and ``child_axis`` to
 automatically determine the joint axis and an intermediate reference frame, the
 joints now use an intermediate frame argument for both the parent and the child
 body, i.e. ``parent_interframe`` and ``child_interframe``. This means that you
@@ -102,9 +112,9 @@ joint was:
 ...                child_axis=-child.z)   # doctest: +SKIP
 >>> parent.dcm(child)   # doctest: +SKIP
 Matrix([
-[-cos(theta_pin(t)), -sin(theta_pin(t)),  0],
-[-sin(theta_pin(t)),  cos(theta_pin(t)),  0],
-[                 0,                  0, -1]])
+[-cos(q_pin(t)), -sin(q_pin(t)),  0],
+[-sin(q_pin(t)),  cos(q_pin(t)),  0],
+[             0,              0, -1]])
 ```
 
 When inspecting this matrix you will notice that for ``theta_pin = 0`` the child
@@ -122,9 +132,9 @@ this exact rotation:
 ...                child_interframe=int_frame)
 >>> parent.dcm(child)
 Matrix([
-[-cos(theta_pin(t)), -sin(theta_pin(t)),  0],
-[-sin(theta_pin(t)),  cos(theta_pin(t)),  0],
-[                 0,                  0, -1]])
+[-cos(q_pin(t)), -sin(q_pin(t)),  0],
+[-sin(q_pin(t)),  cos(q_pin(t)),  0],
+[             0,              0, -1]])
 ```
 
 However if you liked the fact that the deprecated arguments aligned the frames
@@ -140,9 +150,9 @@ given vector:
 ...                child_interframe=-child.z)
 >>> parent.dcm(child)
 Matrix([
-[-cos(theta_pin(t)), -sin(theta_pin(t)),  0],
-[-sin(theta_pin(t)),  cos(theta_pin(t)),  0],
-[                 0,                  0, -1]])
+[-cos(q_pin(t)), -sin(q_pin(t)),  0],
+[-sin(q_pin(t)),  cos(q_pin(t)),  0],
+[             0,              0, -1]])
 ```
 
 (deprecated-mechanics-joint-pos)=

--- a/doc/src/modules/physics/mechanics/api/PinJoint.svg
+++ b/doc/src/modules/physics/mechanics/api/PinJoint.svg
@@ -29,7 +29,7 @@
         <text fill="#FF0000"
               font-family="Calibri,Calibri_MSFontService,sans-serif"
               font-weight="400" font-size="83"
-              transform="matrix(1 0 0 1 3259.58 1576)">θ, ω<tspan font-size="83"
+              transform="matrix(1 0 0 1 3259.58 1576)">q, u<tspan font-size="83"
                                                                   x="-42.585"
                                                                   y="395">joint_axis</tspan>
             <tspan fill="#008000" font-size="83" x="-1704.28" y="-33">parent.masscenter</tspan></text>

--- a/doc/src/modules/physics/mechanics/api/PrismaticJoint.svg
+++ b/doc/src/modules/physics/mechanics/api/PrismaticJoint.svg
@@ -47,7 +47,7 @@
         <text fill="#FF0000"
               font-family="Calibri,Calibri_MSFontService,sans-serif"
               font-weight="400" font-size="64"
-              transform="matrix(1 0 0 1 2447.49 1370)">q1, u1<tspan
+              transform="matrix(1 0 0 1 2447.49 1370)">q, u<tspan
                 fill="#008000" font-size="64" x="-1301.45" y="2">parent.masscenter</tspan>
             <tspan fill="#0070C0" font-size="64" x="-132.069" y="-529">child.masscenter</tspan>
             <tspan fill="#008000" font-size="64" x="-1085.66" y="-232">parent_point</tspan>

--- a/doc/src/modules/physics/mechanics/joints.rst
+++ b/doc/src/modules/physics/mechanics/joints.rst
@@ -76,7 +76,7 @@ body's frame. ::
    ...     child_point=-3 * child.frame.x,
    ...     joint_axis=parent.frame.z)
    >>> joint.kdes
-   [u - q']
+   Matrix([[u - q']])
    >>> joint.parent_point.pos_from(parent.masscenter)
    3*parent_frame.x
    >>> joint.parent_interframe

--- a/doc/src/modules/physics/mechanics/joints.rst
+++ b/doc/src/modules/physics/mechanics/joints.rst
@@ -46,8 +46,8 @@ the joint axis is defined in the ``parent_interframe`` as $2\hat{p}_x +
 4\hat{p}_y + 3\hat{p}_z$, then this will also be $2\hat{c}_x + 4\hat{c}_y +
 3\hat{c}_z$ in the ``child_interframe``. Practically this means that in the case
 of the :class:`~.PinJoint`, also shown below, the ``joint_axis`` is the axis of
-rotation, with the generalized coordinate :math:`\theta` as the angle of
-rotation and the generalized speed :math:`\omega` as the angular velocity.
+rotation, with the generalized coordinate :math:`q` as the angle of
+rotation and the generalized speed :math:`u` as the angular velocity.
 
 .. image:: api/PinJoint.svg
    :align: center
@@ -67,16 +67,16 @@ body's frame. ::
 
    >>> from sympy.physics.mechanics import *
    >>> mechanics_printing(pretty_print=False)
-   >>> theta, omega = dynamicsymbols('theta, omega')
+   >>> q, u = dynamicsymbols('q, u')
    >>> parent = Body('parent')
    >>> child = Body('child')
    >>> joint = PinJoint(
-   ...     'hinge', parent, child, coordinates=theta, speeds=omega,
+   ...     'hinge', parent, child, coordinates=q, speeds=u,
    ...     parent_point=3 * parent.frame.x,
    ...     child_point=-3 * child.frame.x,
    ...     joint_axis=parent.frame.z)
    >>> joint.kdes
-   [omega - theta']
+   [u - q']
    >>> joint.parent_point.pos_from(parent.masscenter)
    3*parent_frame.x
    >>> joint.parent_interframe
@@ -86,7 +86,7 @@ body's frame. ::
    >>> child.masscenter.pos_from(parent.masscenter)
    3*parent_frame.x + 3*child_frame.x
    >>> child.masscenter.vel(parent.frame)
-   3*omega*child_frame.y
+   3*u*child_frame.y
 
 JointsMethod in Physics/Mechanics
 =================================
@@ -101,6 +101,6 @@ In the code below we form the equations of motion of the single
 
    >>> method = JointsMethod(parent, joint)
    >>> method.form_eoms()
-   Matrix([[-(child_izz + 9*child_mass)*omega']])
+   Matrix([[-(child_izz + 9*child_mass)*u']])
    >>> type(method.method)  # The method working in the backend
    <class 'sympy.physics.mechanics.kane.KanesMethod'>

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -502,7 +502,7 @@ class Joint(ABC):
             return dynamicsymbols(f'{label}{number}_{self.name}')
 
         name = 'generalized coordinate' if label == 'q' else 'generalized speed'
-        coords = []
+        generated_coordinates = []
         if coordinates is None:
             coordinates = []
         elif isinstance(coordinates, (AppliedUndef, Derivative)):
@@ -510,18 +510,18 @@ class Joint(ABC):
         # Supports more iterables, also Matrix
         for i, coord in enumerate(coordinates):
             if coord is None:
-                coords.append(create_symbol(i + offset))
+                generated_coordinates.append(create_symbol(i + offset))
             elif isinstance(coord, (AppliedUndef, Derivative)):
-                coords.append(coord)
+                generated_coordinates.append(coord)
             else:
                 raise TypeError(f'The {name} {coord} should have been a '
                                 f'dynamicsymbol.')
         for i in range(len(coordinates) + offset, n_coords + offset):
-            coords.append(create_symbol(i))
-        if len(coords) != n_coords:
+            generated_coordinates.append(create_symbol(i))
+        if len(generated_coordinates) != n_coords:
             raise ValueError(f'{len(coordinates)} {name}s have been provided. '
                              f'The maximum number of {name}s is {n_coords}.')
-        return Matrix(coords)
+        return Matrix(generated_coordinates)
 
 
 class _JointAxisMixin:

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -40,9 +40,9 @@ class Joint(ABC):
         The parent body of joint.
     child : Body
         The child body of joint.
-    coordinates: List of dynamicsymbols, optional
+    coordinates: iterable of dynamicsymbols, optional
         Generalized coordinates of the joint.
-    speeds : List of dynamicsymbols, optional
+    speeds : iterable of dynamicsymbols, optional
         Generalized speeds of joint.
     parent_point : Point or Vector, optional
         Attachment point where the joint is fixed to the parent body. If a
@@ -96,10 +96,10 @@ class Joint(ABC):
         The joint's parent body.
     child : Body
         The joint's child body.
-    coordinates : list
-        List of the joint's generalized coordinates.
-    speeds : list
-        List of the joint's generalized speeds.
+    coordinates : Matrix
+        Matrix of the joint's generalized coordinates.
+    speeds : Matrix
+        Matrix of the joint's generalized speeds.
     parent_point : Point
         Attachment point where the joint is fixed to the parent body.
     child_point : Point
@@ -114,7 +114,7 @@ class Joint(ABC):
     child_interframe : ReferenceFrame
         Intermediate frame of the child body with respect to which the joint
         transformation is formulated.
-    kdes : list
+    kdes : Matrix
         Kinematical differential equations of the joint.
 
     Notes
@@ -215,12 +215,12 @@ class Joint(ABC):
 
     @property
     def coordinates(self):
-        """List generalized coordinates of the joint."""
+        """Matrix of the joint's generalized coordinates."""
         return self._coordinates
 
     @property
     def speeds(self):
-        """List generalized coordinates of the joint.."""
+        """Matrix of the joint's generalized speeds."""
         return self._speeds
 
     @property
@@ -260,12 +260,12 @@ class Joint(ABC):
 
     @abstractmethod
     def _generate_coordinates(self, coordinates):
-        """Generate list generalized coordinates of the joint."""
+        """Generate Matrix of the joint's generalized coordinates."""
         pass
 
     @abstractmethod
     def _generate_speeds(self, speeds):
-        """Generate list generalized speeds of the joint."""
+        """Generate Matrix of the joint's generalized speeds."""
         pass
 
     @abstractmethod
@@ -474,25 +474,30 @@ class Joint(ABC):
         body.masscenter.set_vel(interframe, 0)  # Fixate interframe to body
         return interframe
 
-    def _fill_coordinate_list(self, coordinates, n_coords, label='q', offset=0):
+    def _fill_coordinate_list(self, coordinates, n_coords, label='q', offset=0,
+                              number_single=False):
         """Helper method for _generate_coordinates and _generate_speeds.
 
         Parameters
         ==========
 
-        coordinates : List
-            List of coordinates or speeds that have been provided.
+        coordinates : iterable
+            Iterable of coordinates or speeds that have been provided.
         n_coords : Integer
             Number of coordinates that should be returned.
         label : String, optional
-            Coordinate type either 'q' (coordinates) or 'u' (speeds).
+            Coordinate type either 'q' (coordinates) or 'u' (speeds). The
+            Default is 'q'.
         offset : Integer
-            Count offset when creating new dynamicsymbols.
+            Count offset when creating new dynamicsymbols. The default is 0.
+        number_single : Boolean
+            Boolean whether if n_coords == 1, number should still be used. The
+            default is False.
 
         """
 
         def create_symbol(number):
-            if n_coords == 1:
+            if n_coords == 1 and not number_single:
                 return dynamicsymbols(f'{label}_{self.name}')
             return dynamicsymbols(f'{label}{number}_{self.name}')
 
@@ -514,7 +519,7 @@ class Joint(ABC):
         for i in range(len(coordinates) + offset, n_coords + offset):
             coords.append(create_symbol(i))
         if len(coords) != n_coords:
-            raise ValueError(f'{len(coordinates)} {name} have been provided. '
+            raise ValueError(f'{len(coordinates)} {name}s have been provided. '
                              f'The maximum number of {name}s is {n_coords}.')
         return Matrix(coords)
 
@@ -630,10 +635,12 @@ class PinJoint(Joint, _JointAxisMixin):
         The joint's parent body.
     child : Body
         The joint's child body.
-    coordinates : list
-        List of the joint's generalized coordinates.
-    speeds : list
-        List of the joint's generalized speeds.
+    coordinates : Matrix
+        Matrix of the joint's generalized coordinates. The default value is
+        ``dynamicsymbols(f'q_{joint.name}')``.
+    speeds : Matrix
+        Matrix of the joint's generalized speeds. The default value is
+        ``dynamicsymbols(f'u_{joint.name}')``.
     parent_point : Point
         Attachment point where the joint is fixed to the parent body.
     child_point : Point
@@ -651,7 +658,7 @@ class PinJoint(Joint, _JointAxisMixin):
     joint_axis : Vector
         The axis about which the rotation occurs. Note that the components of
         this axis are the same in the parent_interframe and child_interframe.
-    kdes : list
+    kdes : Matrix
         Kinematical differential equations of the joint.
 
     Examples
@@ -837,9 +844,11 @@ class PrismaticJoint(Joint, _JointAxisMixin):
     child : Body
         The child body of joint.
     coordinates: dynamicsymbol, optional
-        Generalized coordinates of the joint.
+        Generalized coordinates of the joint. The default value is
+        ``dynamicsymbols(f'q_{joint.name}')``.
     speeds : dynamicsymbol, optional
-        Generalized speeds of joint.
+        Generalized speeds of joint. The default value is
+        ``dynamicsymbols(f'u_{joint.name}')``.
     parent_point : Point or Vector, optional
         Attachment point where the joint is fixed to the parent body. If a
         vector is provided, then the attachment point is computed by adding the
@@ -895,10 +904,10 @@ class PrismaticJoint(Joint, _JointAxisMixin):
         The joint's parent body.
     child : Body
         The joint's child body.
-    coordinates : list
-        List of the joint's generalized coordinates.
-    speeds : list
-        List of the joint's generalized speeds.
+    coordinates : Matrix
+        Matrix of the joint's generalized coordinates.
+    speeds : Matrix
+        Matrix of the joint's generalized speeds.
     parent_point : Point
         Attachment point where the joint is fixed to the parent body.
     child_point : Point
@@ -913,7 +922,7 @@ class PrismaticJoint(Joint, _JointAxisMixin):
     child_interframe : ReferenceFrame
         Intermediate frame of the child body with respect to which the joint
         transformation is formulated.
-    kdes : list
+    kdes : Matrix
         Kinematical differential equations of the joint.
 
     Examples

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -490,13 +490,13 @@ class Joint(ABC):
             Count offset when creating new dynamicsymbols.
 
         """
-        name = 'generalized coordinate' if label == 'q' else 'generalized speed'
 
         def create_symbol(number):
             if n_coords == 1:
                 return dynamicsymbols(f'{label}_{self.name}')
             return dynamicsymbols(f'{label}{number}_{self.name}')
 
+        name = 'generalized coordinate' if label == 'q' else 'generalized speed'
         coords = []
         if coordinates is None:
             coordinates = []
@@ -514,7 +514,7 @@ class Joint(ABC):
         for i in range(len(coordinates) + offset, n_coords + offset):
             coords.append(create_symbol(i))
         if len(coords) != n_coords:
-            raise ValueError(f'{len(coordinates)} {name}s have been provided. '
+            raise ValueError(f'{len(coordinates)} {name} have been provided. '
                              f'The maximum number of {name}s is {n_coords}.')
         return Matrix(coords)
 

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from sympy.core.backend import pi, AppliedUndef, Derivative
+from sympy.core.backend import pi, AppliedUndef, Derivative, Matrix
 from sympy.physics.mechanics.body import Body
 from sympy.physics.vector import (Vector, dynamicsymbols, cross, Point,
                                   ReferenceFrame)
@@ -442,7 +442,7 @@ class Joint(ABC):
         t = dynamicsymbols._t
         for i in range(len(self.coordinates)):
             kdes.append(-self.coordinates[i].diff(t) + self.speeds[i])
-        return kdes
+        return Matrix(kdes)
 
     def _locate_joint_pos(self, body, joint_pos):
         """Returns the attachment point of a body."""
@@ -516,7 +516,7 @@ class Joint(ABC):
         if len(coords) != n_coords:
             raise ValueError(f'{len(coordinates)} {name}s have been provided. '
                              f'The maximum number of {name}s is {n_coords}.')
-        return coords
+        return Matrix(coords)
 
 
 class _JointAxisMixin:
@@ -685,9 +685,9 @@ class PinJoint(Joint, _JointAxisMixin):
     >>> joint.child_axis
     C_frame.x
     >>> joint.coordinates
-    [q_PC(t)]
+    Matrix([[q_PC(t)]])
     >>> joint.speeds
-    [u_PC(t)]
+    Matrix([[u_PC(t)]])
     >>> joint.child.frame.ang_vel_in(joint.parent.frame)
     u_PC(t)*P_frame.x
     >>> joint.child.frame.dcm(joint.parent.frame)
@@ -947,9 +947,9 @@ class PrismaticJoint(Joint, _JointAxisMixin):
     >>> joint.child_axis
     C_frame.x
     >>> joint.coordinates
-    [q_PC(t)]
+    Matrix([[q_PC(t)]])
     >>> joint.speeds
-    [u_PC(t)]
+    Matrix([[u_PC(t)]])
     >>> joint.child.frame.ang_vel_in(joint.parent.frame)
     0
     >>> joint.child.frame.dcm(joint.parent.frame)

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -1,6 +1,7 @@
 from sympy.physics.mechanics import (Body, Lagrangian, KanesMethod, LagrangesMethod,
                                     RigidBody, Particle)
 from sympy.physics.mechanics.method import _Methods
+from sympy.core.backend import Matrix
 
 __all__ = ['JointsMethod']
 
@@ -161,7 +162,7 @@ class JointsMethod(_Methods):
                 if coordinate in q_ind:
                     raise ValueError('Coordinates of joints should be unique.')
                 q_ind.append(coordinate)
-        return q_ind
+        return Matrix(q_ind)
 
     def _generate_u(self):
         u_ind = []
@@ -170,12 +171,12 @@ class JointsMethod(_Methods):
                 if speed in u_ind:
                     raise ValueError('Speeds of joints should be unique.')
                 u_ind.append(speed)
-        return u_ind
+        return Matrix(u_ind)
 
     def _generate_kdes(self):
-        kd_ind = []
+        kd_ind = Matrix([])
         for joint in self._joints:
-            kd_ind.extend(joint.kdes)
+            kd_ind = kd_ind.col_join(joint.kdes)
         return kd_ind
 
     def _convert_bodies(self):

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -174,7 +174,7 @@ class JointsMethod(_Methods):
         return Matrix(u_ind)
 
     def _generate_kdes(self):
-        kd_ind = Matrix([])
+        kd_ind = Matrix(1, 0, []).T
         for joint in self._joints:
             kd_ind = kd_ind.col_join(joint.kdes)
         return kd_ind

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -8,10 +8,9 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
                                      find_dynamicsymbols, Lagrangian)
 
 from sympy.physics.mechanics.functions import gravity, center_of_mass
-from sympy.physics.vector.vector import Vector
 from sympy.testing.pytest import raises
 
-Vector.simp = True
+
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
 N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -41,25 +41,26 @@ def test_coordinate_generation():
     # Using PinJoint to access Joint's coordinate generation method
     J = PinJoint('J', P, C)
     # Test single given
-    assert J._fill_coordinate_list(q, 1) == [q]
-    assert J._fill_coordinate_list([u], 1) == [u]
-    assert J._fill_coordinate_list([u], 1, offset=2) == [u]
+    assert J._fill_coordinate_list(q, 1) == Matrix([q])
+    assert J._fill_coordinate_list([u], 1) == Matrix([u])
+    assert J._fill_coordinate_list([u], 1, offset=2) == Matrix([u])
     # Test None
-    assert J._fill_coordinate_list(None, 1) == [qj]
-    assert J._fill_coordinate_list([None], 1) == [qj]
-    assert J._fill_coordinate_list([q0, None], 3) == [q0, q1j, q2j]
+    assert J._fill_coordinate_list(None, 1) == Matrix([qj])
+    assert J._fill_coordinate_list([None], 1) == Matrix([qj])
+    assert J._fill_coordinate_list([q0, None], 3) == Matrix([q0, q1j, q2j])
     # Test autofill
-    assert J._fill_coordinate_list(None, 3) == [q0j, q1j, q2j]
-    assert J._fill_coordinate_list([], 3) == [q0j, q1j, q2j]
+    assert J._fill_coordinate_list(None, 3) == Matrix([q0j, q1j, q2j])
+    assert J._fill_coordinate_list([], 3) == Matrix([q0j, q1j, q2j])
     # Test offset
-    assert J._fill_coordinate_list([], 3, offset=1) == [q1j, q2j, q3j]
-    assert J._fill_coordinate_list(q1, 3, offset=1) == [q1, q2j, q3j]
-    assert J._fill_coordinate_list([q1, None, q3], 3, offset=1) == [q1, q2j, q3]
-    assert J._fill_coordinate_list(None, 2, offset=2) == [q2j, q3j]
+    assert J._fill_coordinate_list([], 3, offset=1) == Matrix([q1j, q2j, q3j])
+    assert J._fill_coordinate_list(q1, 3, offset=1) == Matrix([q1, q2j, q3j])
+    assert J._fill_coordinate_list([q1, None, q3], 3, offset=1) == Matrix(
+        [q1, q2j, q3])
+    assert J._fill_coordinate_list(None, 2, offset=2) == Matrix([q2j, q3j])
     # Test label
-    assert J._fill_coordinate_list(None, 1, 'u') == [uj]
-    assert J._fill_coordinate_list([], 3, 'u') == [u0j, u1j, u2j]
-    assert J._fill_coordinate_list([u0], 3, 'u', 1) == [u0, u2j, u3j]
+    assert J._fill_coordinate_list(None, 1, 'u') == Matrix([uj])
+    assert J._fill_coordinate_list([], 3, 'u') == Matrix([u0j, u1j, u2j])
+    assert J._fill_coordinate_list([u0], 3, 'u', 1) == Matrix([u0, u2j, u3j])
 
 
 def test_pin_joint():
@@ -71,9 +72,9 @@ def test_pin_joint():
     assert Pj.name == 'J'
     assert Pj.parent == P
     assert Pj.child == C
-    assert Pj.coordinates == [q]
-    assert Pj.speeds == [u]
-    assert Pj.kdes == [u - q.diff(t)]
+    assert Pj.coordinates == Matrix([q])
+    assert Pj.speeds == Matrix([u])
+    assert Pj.kdes == Matrix([u - q.diff(t)])
     assert Pj.joint_axis == P.frame.x
     assert Pj.child_point.pos_from(C.masscenter) == Vector(0)
     assert Pj.parent_point.pos_from(P.masscenter) == Vector(0)
@@ -150,8 +151,8 @@ def test_pin_joint_double_pendulum():
     assert B.ang_vel_in(N) == u1 * N.z + u2 * A.z
 
     # Check kde
-    assert J1.kdes == [u1 - q1.diff(t)]
-    assert J2.kdes == [u2 - q2.diff(t)]
+    assert J1.kdes == Matrix([u1 - q1.diff(t)])
+    assert J2.kdes == Matrix([u2 - q2.diff(t)])
 
     # Check Linear Velocity
     assert PartP.masscenter.vel(N) == l*u1*A.y
@@ -193,8 +194,8 @@ def test_pin_joint_chaos_pendulum():
     assert N.ang_vel_in(B) == -omega*N.y - alpha*A.z
 
     # Check kde
-    assert J1.kdes == [omega - theta.diff(t)]
-    assert J2.kdes == [alpha - phi.diff(t)]
+    assert J1.kdes == Matrix([omega - theta.diff(t)])
+    assert J2.kdes == Matrix([alpha - phi.diff(t)])
 
     # Check pos of masscenters
     assert C.masscenter.pos_from(rod.masscenter) == lA*A.z
@@ -607,9 +608,9 @@ def test_sliding_joint():
     assert S.name == 'S'
     assert S.parent == P
     assert S.child == C
-    assert S.coordinates == [q]
-    assert S.speeds == [u]
-    assert S.kdes == [u - q.diff(t)]
+    assert S.coordinates == Matrix([q])
+    assert S.speeds == Matrix([u])
+    assert S.kdes == Matrix([u - q.diff(t)])
     assert S.joint_axis == P.frame.x
     assert S.child_point.pos_from(C.masscenter) == Vector(0)
     assert S.parent_point.pos_from(P.masscenter) == Vector(0)

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -62,6 +62,10 @@ def test_coordinate_generation():
     assert J._fill_coordinate_list(None, 1, 'u') == Matrix([uj])
     assert J._fill_coordinate_list([], 3, 'u') == Matrix([u0j, u1j, u2j])
     assert J._fill_coordinate_list([u0], 3, 'u', 1) == Matrix([u0, u2j, u3j])
+    # Test single numbering
+    assert J._fill_coordinate_list(None, 1, number_single=True) == Matrix([q0j])
+    assert J._fill_coordinate_list([], 1, 'u', 2, True) == Matrix([u2j])
+    assert J._fill_coordinate_list([], 3, 'q') == Matrix([q0j, q1j, q2j])
 
 
 def test_pin_joint():
@@ -359,7 +363,7 @@ def test_pin_joint_joint_axis():
 def test_pin_joint_arbitrary_axis():
     q, u = dynamicsymbols('q_J, u_J')
 
-    # When the bodies are attached though masscenters but axess are opposite.
+    # When the bodies are attached though masscenters but axes are opposite.
     N, A, P, C = _generate_body()
     PinJoint('J', P, C, child_interframe=-A.x)
 

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -66,6 +66,12 @@ def test_coordinate_generation():
     assert J._fill_coordinate_list(None, 1, number_single=True) == Matrix([q0j])
     assert J._fill_coordinate_list([], 1, 'u', 2, True) == Matrix([u2j])
     assert J._fill_coordinate_list([], 3, 'q') == Matrix([q0j, q1j, q2j])
+    # Test too many coordinates supplied
+    raises(ValueError, lambda: J._fill_coordinate_list([q0, q1], 1))
+    raises(ValueError, lambda: J._fill_coordinate_list([u0, u1, None], 2, 'u'))
+    # Test incorrect coordinate type
+    raises(TypeError, lambda: J._fill_coordinate_list([q0, symbols('q1')], 2))
+    raises(TypeError, lambda: J._fill_coordinate_list([q0 + q1, q1], 2))
 
 
 def test_pin_joint():

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -3,14 +3,15 @@ from sympy.core.numbers import pi
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
-from sympy.matrices.dense import Matrix
-from sympy.core.backend import _simplify_matrix
+from sympy.core.backend import Matrix, _simplify_matrix
 from sympy.core.symbol import symbols
 from sympy.physics.mechanics import dynamicsymbols, Body, PinJoint, PrismaticJoint
 from sympy.physics.mechanics.joint import Joint
 from sympy.physics.vector import Vector, ReferenceFrame, Point
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
+
+Vector.simp = True
 t = dynamicsymbols._t # type: ignore
 
 

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -366,8 +366,8 @@ def test_pin_joint_arbitrary_axis():
     assert (-A.x).angle_between(N.x) == 0
     assert -A.x.express(N) == N.x
     assert A.dcm(N) == Matrix([[-1, 0, 0],
-                            [0, -cos(q), -sin(q)],
-                            [0, -sin(q), cos(q)]])
+                               [0, -cos(q), -sin(q)],
+                               [0, -sin(q), cos(q)]])
     assert A.ang_vel_in(N) == u*N.x
     assert A.ang_vel_in(N).magnitude() == sqrt(u**2)
     assert C.masscenter.pos_from(P.masscenter) == 0

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -26,15 +26,15 @@ def test_jointsmethod():
     assert method.frame == P.frame
     assert method.bodies == [C, P]
     assert method.loads == [(P.masscenter, g*P.frame.y)]
-    assert method.q == [q]
-    assert method.u == [u]
-    assert method.kdes == [u - q.diff()]
+    assert method.q == Matrix([q])
+    assert method.u == Matrix([u])
+    assert method.kdes == Matrix([u - q.diff()])
     soln = method.form_eoms()
     assert soln == Matrix([[-C_ixx*u.diff()]])
     assert method.forcing_full == Matrix([[u], [0]])
     assert method.mass_matrix_full == Matrix([[1, 0], [0, C_ixx]])
     assert isinstance(method.method, KanesMethod)
-
+test_jointsmethod()
 def test_jointmethod_duplicate_coordinates_speeds():
     P = Body('P')
     C = Body('C')

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -20,18 +20,18 @@ def test_jointsmethod():
     C = Body('C')
     Pin = PinJoint('P1', P, C)
     C_ixx, g = symbols('C_ixx g')
-    theta, omega = dynamicsymbols('theta_P1, omega_P1')
+    q, u = dynamicsymbols('q_P1, u_P1')
     P.apply_force(g*P.y)
     method = JointsMethod(P, Pin)
     assert method.frame == P.frame
     assert method.bodies == [C, P]
     assert method.loads == [(P.masscenter, g*P.frame.y)]
-    assert method.q == [theta]
-    assert method.u == [omega]
-    assert method.kdes == [omega - theta.diff()]
+    assert method.q == [q]
+    assert method.u == [u]
+    assert method.kdes == [u - q.diff()]
     soln = method.form_eoms()
-    assert soln == Matrix([[-C_ixx*omega.diff()]])
-    assert method.forcing_full == Matrix([[omega], [0]])
+    assert soln == Matrix([[-C_ixx*u.diff()]])
+    assert method.forcing_full == Matrix([[u], [0]])
     assert method.mass_matrix_full == Matrix([[1, 0], [0, C_ixx]])
     assert isinstance(method.method, KanesMethod)
 

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -34,7 +34,7 @@ def test_jointsmethod():
     assert method.forcing_full == Matrix([[u], [0]])
     assert method.mass_matrix_full == Matrix([[1, 0], [0, C_ixx]])
     assert isinstance(method.method, KanesMethod)
-test_jointsmethod()
+
 def test_jointmethod_duplicate_coordinates_speeds():
     P = Body('P')
     C = Body('C')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23933.


#### Brief description of what is fixed or changed
This PR adds a `Joint` method that functions as a helper to generate the coordinates for every type of joint in a generic way.

#### Other comments
There is a slide change in the generated name of the generalized coordinates and speeds for the `PinJoint` and `PrismaticJoint`, so they suite the new standard.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Introduce a more flexible generalized coordinates/speeds parser to the joints framework.
  * BREAKING: Generalize the formatting of the generalized coordinates/speeds in the joints framework.
<!-- END RELEASE NOTES -->
