### PR TITLE
physics/continuum_mechanics: Added sympy functions for cos and sin instead of using the math module

### DIFF
--- a/sympy/physics/continuum_mechanics/tests/test_truss.py
+++ b/sympy/physics/continuum_mechanics/tests/test_truss.py
@@ -1,5 +1,6 @@
 from sympy.core.symbol import Symbol, symbols
 from sympy.physics.continuum_mechanics.truss import Truss
+from sympy import sqrt
 
 
 def test_truss():
@@ -99,10 +100,9 @@ def test_truss():
 
     # testing the solve method
     t.solve()
-    assert t.reaction_loads['R_A_x']/P - (-1.4142135623731) < 1e-10
-    assert t.reaction_loads['R_A_y']/P - (-2.41421356237309) < 1e-10
-    assert t.reaction_loads['R_D_y']/P - (-0.5) < 1e-10
-    assert t.internal_forces[AB]/P < 1e-10
-    assert t.internal_forces[CD] < 1e-10
-    assert t.internal_forces[AC] < 1e-10
-    # assert t.internal_forces == {AB: 3.06161699786838e-17*P, CD: 0, AC: 0}
+    assert t.reaction_loads['R_A_x'] == -sqrt(2)*P
+    assert t.reaction_loads['R_A_y'] == -sqrt(2)*P - P
+    assert t.reaction_loads['R_D_y'] == -P/2
+    assert t.internal_forces[AB]/P == 0
+    assert t.internal_forces[CD] == 0
+    assert t.internal_forces[AC] == 0

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -11,7 +11,7 @@ from sympy.core.sympify import sympify
 from sympy import Matrix, pi
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import zeros
-import math
+from sympy import sin, cos
 
 
 
@@ -657,9 +657,9 @@ class Truss:
         >>> t.apply_support("node_2", type="roller")
         >>> t.solve()
         >>> t.reaction_loads
-        {'R_node_1_x': 0, 'R_node_1_y': 6.66666666666667, 'R_node_2_y': 3.33333333333333}
+        {'R_node_1_x': 0, 'R_node_1_y': 20/3, 'R_node_2_y': 10/3}
         >>> t.internal_forces
-        {'member_1': 6.66666666666666, 'member_2': 6.66666666666667, 'member_3': -6.66666666666667*sqrt(2), 'member_4': -3.33333333333333*sqrt(5), 'member_5': 10.0}
+        {'member_1': 20/3, 'member_2': 20/3, 'member_3': -20*sqrt(2)/3, 'member_4': -10*sqrt(5)/3, 'member_5': 10}
         """
         count_reaction_loads = 0
         for node in self._nodes:
@@ -677,8 +677,8 @@ class Truss:
             if node[0] in list(self._loads):
                 for load in self._loads[node[0]]:
                     if load[0]!=Symbol('R_'+str(node[0])+'_x') and load[0]!=Symbol('R_'+str(node[0])+'_y'):
-                        load_matrix[load_matrix_row] -= load[0]*math.cos(pi*load[1]/180)
-                        load_matrix[load_matrix_row + 1] -= load[0]*math.sin(pi*load[1]/180)
+                        load_matrix[load_matrix_row] -= load[0]*cos(pi*load[1]/180)
+                        load_matrix[load_matrix_row + 1] -= load[0]*sin(pi*load[1]/180)
             load_matrix_row += 2
         cols = 0
         row = 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24038

#### Brief description of what is fixed or changed
Replaced `math.sin` and `math.cos` by their respective SymPy functions. This way Symbolic functions are used for calculations in the `solve` method. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Added Symbolic Functions in the `solve` method for calculations instead of the `math` module
<!-- END RELEASE NOTES -->
