### PR TITLE
correct piecewise eval

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1300,9 +1300,7 @@ def _piecewise_collapse_arguments(_args):
                 newargs[-1] = ExprCondPair(expr, orcond)
                 continue
             elif newargs[-1].cond == cond:
-                newargs[-1] = ExprCondPair(expr, cond)
                 continue
-
         newargs.append(ExprCondPair(expr, cond))
     return newargs
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1548,3 +1548,8 @@ def test_issue_22533():
     x = Symbol('x', real=True)
     f = Piecewise((-1 / x, x <= 0), (1 / x, True))
     assert integrate(f, x) == Piecewise((-log(x), x <= 0), (log(x), True))
+
+
+def test_issue_24072():
+    assert Piecewise((1, x > 1), (2, x <= 1), (3, x <= 1)
+        ) == Piecewise((1, x > 1), (2, True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #24072

#### Brief description of what is fixed or changed

#### Other comments

A test identifying the root cause was added, but the correct answer for the OP is also given:

```python
>>> expr
Piecewise((1, a <= 1), (0, True)) + Piecewise((1, a <= 1), (0, True))/(2*a) + Piecewise((1, a > 1), (0, True))/a
>>> piecewise_fold(_)
Piecewise((1/a, a > 1), (1 + 1/(2*a), True))
>>> _.subs(a,1)
3/2
```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * a bug selecting later expression when two successive conditions matched was fixed
<!-- END RELEASE NOTES -->
