### PR TITLE
Replace deprecated .isSet() method with .is_set()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -422,6 +422,7 @@ Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@us
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Conley <chrisconley15@gmail.com>
+Chris Kerr <chris.kerr@mykolab.ch>
 Chris Smith <smichr@gmail.com>
 Chris Smith <smichr@gmail.com> <Donna Smith@.(none)>
 Chris Swierczewski <cswiercz@gmail.com>

--- a/sympy/plotting/pygletplot/plot_mode_base.py
+++ b/sympy/plotting/pygletplot/plot_mode_base.py
@@ -269,7 +269,7 @@ class PlotModeBase(PlotMode):
         self._calculate_cverts()
 
     def _calculate_verts(self):
-        if self._calculating_verts.isSet():
+        if self._calculating_verts.is_set():
             return
         self._calculating_verts.set()
         try:
@@ -280,9 +280,9 @@ class PlotModeBase(PlotMode):
             self.bounds_callback()
 
     def _calculate_cverts(self):
-        if self._calculating_verts.isSet():
+        if self._calculating_verts.is_set():
             return
-        while self._calculating_cverts.isSet():
+        while self._calculating_cverts.is_set():
             sleep(0)  # wait for previous calculation
         self._calculating_cverts.set()
         try:
@@ -291,7 +291,7 @@ class PlotModeBase(PlotMode):
             self._calculating_cverts.clear()
 
     def _get_calculating_verts(self):
-        return self._calculating_verts.isSet()
+        return self._calculating_verts.is_set()
 
     def _get_calculating_verts_pos(self):
         return self._calculating_verts_pos
@@ -300,7 +300,7 @@ class PlotModeBase(PlotMode):
         return self._calculating_verts_len
 
     def _get_calculating_cverts(self):
-        return self._calculating_cverts.isSet()
+        return self._calculating_cverts.is_set()
 
     def _get_calculating_cverts_pos(self):
         return self._calculating_cverts_pos


### PR DESCRIPTION


#### References to other Issues or PRs
Fixes #24074

#### Brief description of what is fixed or changed

Change pyglet threading code to use `Event.is_set()` which is the approved replacement for `Event.isSet()`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


<!-- BEGIN RELEASE NOTES -->

* plotting
  * Replace use of deprecated `Event.isSet()` method
 
<!-- END RELEASE NOTES -->
