### PR TITLE
test_autowrap: Change to directory before testing relative writes

### DIFF
--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -261,12 +261,16 @@ def test_autowrap_store_files():
 def test_autowrap_store_files_issue_gh12939():
     x, y = symbols('x y')
     tmp = './tmp'
+    saved_cwd = os.getcwd()
+    temp_cwd = tempfile.mkdtemp()
     try:
+        os.chdir(temp_cwd)
         f = autowrap(x + y, backend='dummy', tempdir=tmp)
         assert f() == str(x + y)
         assert os.access(tmp, os.F_OK)
     finally:
-        shutil.rmtree(tmp)
+        os.chdir(saved_cwd)
+        shutil.rmtree(temp_cwd)
 
 
 def test_binary_function():


### PR DESCRIPTION




<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #24075


#### Brief description of what is fixed or changed
Change to a temporary directory before testing writes to relative paths, to avoid permissions errors if the current directory is not writable.

#### Other comments


#### Release Notes


<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
