### PR TITLE
[GSoC] Revert JointAxisMixin

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/multi_degree_freedom_holonomic_system.rst
+++ b/doc/src/modules/physics/mechanics/examples/multi_degree_freedom_holonomic_system.rst
@@ -40,9 +40,9 @@ kinematics. ::
 
     >>> slider = PrismaticJoint('J1', wall, block, coordinates=q1, speeds=u1)
     >>> rev1 = PinJoint('J2', block, compound_pend, coordinates=q2, speeds=u2,
-    ...                 joint_axis=compound_pend.z, child_point=l*2/3*compound_pend.y)
+    ...                 joint_axis=block.z, child_point=l*2/3*compound_pend.y)
     >>> rev2 = PinJoint('J3', compound_pend, simple_pend, coordinates=q3, speeds=u3,
-    ...                 joint_axis=simple_pend.z, parent_point=-l/3*compound_pend.y,
+    ...                 joint_axis=compound_pend.z, parent_point=-l/3*compound_pend.y,
     ...                 child_point=l*simple_pend.y)
 
     >>> joints = (slider, rev1, rev2)

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -524,33 +524,7 @@ class Joint(ABC):
         return Matrix(generated_coordinates)
 
 
-class _JointAxisMixin:
-    """Mixin class, which provides joint axis support methods.
-
-    This class is strictly only to be inherited by joint types that have a joint
-    axis. This is because the methods of this class assume that the object has
-    a joint_axis attribute.
-    """
-
-    __slots__ = ()
-
-    def _express_joint_axis(self, frame):
-        """Helper method to express the joint axis in a specified frame."""
-        try:
-            ax_mat = self.joint_axis.to_matrix(self.parent_interframe)
-        except ValueError:
-            ax_mat = self.joint_axis.to_matrix(self.child_interframe)
-        try:
-            self.parent_interframe.dcm(frame)  # Check if connected
-        except ValueError:
-            self.child_interframe.dcm(frame)  # Should be connected
-            int_frame = self.child_interframe
-        else:
-            int_frame = self.parent_interframe
-        return self._to_vector(ax_mat, int_frame).express(frame)
-
-
-class PinJoint(Joint, _JointAxisMixin):
+class PinJoint(Joint):
     """Pin (Revolute) Joint.
 
     .. image:: PinJoint.svg
@@ -799,11 +773,9 @@ class PinJoint(Joint, _JointAxisMixin):
         return self._fill_coordinate_list(speed, 1, 'u')
 
     def _orient_frames(self):
-        self._joint_axis = self._axis(
-            self.joint_axis, self.parent_interframe, self.child_interframe)
-        axis = self._express_joint_axis(self.parent_interframe)
+        self._joint_axis = self._axis(self.joint_axis, self.parent_interframe)
         self.child_interframe.orient_axis(
-            self.parent_interframe, axis, self.coordinates[0])
+            self.parent_interframe, self.joint_axis, self.coordinates[0])
 
     def _set_angular_velocity(self):
         self.child_interframe.set_ang_vel(self.parent_interframe, self.speeds[
@@ -817,7 +789,7 @@ class PinJoint(Joint, _JointAxisMixin):
                                           self.parent.frame, self.child.frame)
 
 
-class PrismaticJoint(Joint, _JointAxisMixin):
+class PrismaticJoint(Joint):
     """Prismatic (Sliding) Joint.
 
     .. image:: PrismaticJoint.svg
@@ -1064,10 +1036,9 @@ class PrismaticJoint(Joint, _JointAxisMixin):
         return self._fill_coordinate_list(speed, 1, 'u')
 
     def _orient_frames(self):
-        self._joint_axis = self._axis(
-            self.joint_axis, self.parent_interframe, self.child_interframe)
-        axis = self._express_joint_axis(self.parent_interframe)
-        self.child_interframe.orient_axis(self.parent_interframe, axis, 0)
+        self._joint_axis = self._axis(self.joint_axis, self.parent_interframe)
+        self.child_interframe.orient_axis(
+            self.parent_interframe, self.joint_axis, 0)
 
     def _set_angular_velocity(self):
         self.child_interframe.set_ang_vel(self.parent_interframe, 0)
@@ -1081,7 +1052,7 @@ class PrismaticJoint(Joint, _JointAxisMixin):
         self.child.masscenter.set_vel(self.parent.frame, self.speeds[0] * axis)
 
 
-class CylindricalJoint(_JointAxisMixin, Joint):
+class CylindricalJoint(Joint):
     """Cylindrical Joint.
 
     .. image:: CylindricalJoint.svg
@@ -1356,11 +1327,9 @@ class CylindricalJoint(_JointAxisMixin, Joint):
         return self._fill_coordinate_list(speeds, 2, 'u')
 
     def _orient_frames(self):
-        self._joint_axis = self._axis(
-            self.joint_axis, self.parent_interframe, self.child_interframe)
-        axis = self._express_joint_axis(self.parent_interframe)
+        self._joint_axis = self._axis(self.joint_axis, self.parent_interframe)
         self.child_interframe.orient_axis(
-            self.parent_interframe, axis, self.rotation_coordinate)
+            self.parent_interframe, self.joint_axis, self.rotation_coordinate)
 
     def _set_angular_velocity(self):
         self.child_interframe.set_ang_vel(

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -237,7 +237,7 @@ def test_pin_joint_interframe():
     Pint = ReferenceFrame('Pint')
     Pint.orient_body_fixed(N, (pi / 4, pi, pi / 3), 'xyz')
     PinJoint('J', P, C, q, u, parent_point=N.x, child_point=-C.y,
-             parent_interframe=Pint, joint_axis=C.x)
+             parent_interframe=Pint, joint_axis=Pint.x)
     assert _simplify_matrix(N.dcm(A)) == Matrix([
         [-1 / 2, sqrt(3) * cos(q) / 2, -sqrt(3) * sin(q) / 2],
         [sqrt(6) / 4, sqrt(2) * (2 * sin(q) + cos(q)) / 4,
@@ -277,7 +277,7 @@ def test_pin_joint_interframe():
     Cint.orient_body_fixed(A, (2 * pi / 3, -pi, pi / 2), 'xyz')
     PinJoint('J', P, C, q, u, parent_point=N.x - N.y, child_point=-C.z,
              parent_interframe=Pint, child_interframe=Cint,
-             joint_axis=Cint.x + Cint.z)
+             joint_axis=Pint.x + Pint.z)
     assert _simplify_matrix(N.dcm(A)) == Matrix([
         [cos(q), (sqrt(2) + sqrt(6)) * -sin(q) / 4,
          (-sqrt(2) + sqrt(6)) * sin(q) / 4],
@@ -312,20 +312,6 @@ def test_pin_joint_joint_axis():
     assert pin.joint_axis == Pint.y
     assert N.dcm(A) == Matrix([[-sin(q), 0, cos(q)], [0, -1, 0],
                                [cos(q), 0, sin(q)]])
-    # Check child_interframe as reference
-    N, A, P, C, Pint, Cint = _generate_body(True)
-    pin = PinJoint('J', P, C, q, u, parent_interframe=Pint,
-                   child_interframe=Cint, joint_axis=Cint.y)
-    assert pin.joint_axis == Cint.y
-    assert N.dcm(A) == Matrix([[-sin(q), 0, cos(q)], [0, -1, 0],
-                               [cos(q), 0, sin(q)]])
-    # Check child as reference
-    N, A, P, C, Pint, Cint = _generate_body(True)
-    pin = PinJoint('J', P, C, q, u, parent_interframe=Pint,
-                   child_interframe=Cint, joint_axis=C.y)
-    assert pin.joint_axis == C.y
-    assert N.dcm(A) == Matrix([[-sin(q), 0, cos(q)], [0, -1, 0],
-                               [cos(q), 0, sin(q)]])
     # Check combination of joint_axis with interframes supplied as vectors (2x)
     N, A, P, C = _generate_body()
     pin = PinJoint('J', P, C, q, u, parent_interframe=N.z,
@@ -343,6 +329,8 @@ def test_pin_joint_joint_axis():
     N, A, P, C, Pint, Cint = _generate_body(True)
     raises(ValueError, lambda: PinJoint('J', P, C,
                                         joint_axis=cos(q) * N.x + sin(q) * N.y))
+    # Check joint_axis provided in child frame
+    raises(ValueError, lambda: PinJoint('J', P, C, joint_axis=C.x))
     # Check some invalid combinations
     raises(ValueError, lambda: PinJoint('J', P, C, joint_axis=P.x + C.y))
     raises(ValueError, lambda: PinJoint(
@@ -355,16 +343,13 @@ def test_pin_joint_joint_axis():
     N, A, P, C, Pint, Cint = _generate_body(True)
     PinJoint('J', P, C, parent_interframe=Pint, child_interframe=Cint,
              joint_axis=Pint.x + P.y)
-    N, A, P, C, Pint, Cint = _generate_body(True)
-    PinJoint('J', P, C, parent_interframe=Pint, child_interframe=Cint,
-             joint_axis=Cint.x + C.y)
     # Check invalid zero vector
     raises(Exception, lambda: PinJoint(
         'J', P, C, parent_interframe=Pint, child_interframe=Cint,
         joint_axis=Vector(0)))
-    raises(ValueError, lambda: PinJoint(
+    raises(Exception, lambda: PinJoint(
         'J', P, C, parent_interframe=Pint, child_interframe=Cint,
-        joint_axis=C.z - Cint.x))
+        joint_axis=P.y + Pint.y))
 
 
 def test_pin_joint_arbitrary_axis():
@@ -545,14 +530,6 @@ def test_pin_joint_axis():
     N, A, P, C, Pint, Cint = _generate_body(True)
     PinJoint('J', P, C, q, u, parent_interframe=Pint, child_interframe=Cint,
              joint_axis=-Pint.z)
-    assert N.dcm(A) == N_R_A
-    N, A, P, C, Pint, Cint = _generate_body(True)
-    PinJoint('J', P, C, q, u, parent_interframe=Pint, child_interframe=Cint,
-             joint_axis=-Cint.z)
-    assert N.dcm(A) == N_R_A
-    N, A, P, C, Pint, Cint = _generate_body(True)
-    PinJoint('J', P, C, q, u, parent_interframe=Pint, child_interframe=Cint,
-             joint_axis=A.x)
     assert N.dcm(A) == N_R_A
     # Test time varying joint axis
     N, A, P, C, Pint, Cint = _generate_body(True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Reduces the flexibility of the `joint_axis` introduced in #23920, namely the option to provide the `joint_axis` expressed in the `child` body. This feature is removed, because as for `ReferenceFrame.orient_axis` you also ought to supply the rotation axis expressed in the parent. Besides this it is also favorable to keep the code base less complex for future features as implementing constraints. 

#### Other comments
Nothing is put in the release notes, since this PR reduces undocumented redundant functionality of #23920

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
