### PR TITLE
Improve efficiency of orient body fixed and space fixed

### DIFF
--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -238,12 +238,12 @@ def test_pin_joint_interframe():
     Pint.orient_body_fixed(N, (pi / 4, pi, pi / 3), 'xyz')
     PinJoint('J', P, C, q, u, parent_point=N.x, child_point=-C.y,
              parent_interframe=Pint, joint_axis=Pint.x)
-    assert _simplify_matrix(N.dcm(A)) == Matrix([
+    assert _simplify_matrix(N.dcm(A)) - Matrix([
         [-1 / 2, sqrt(3) * cos(q) / 2, -sqrt(3) * sin(q) / 2],
         [sqrt(6) / 4, sqrt(2) * (2 * sin(q) + cos(q)) / 4,
          sqrt(2) * (-sin(q) + 2 * cos(q)) / 4],
         [sqrt(6) / 4, sqrt(2) * (-2 * sin(q) + cos(q)) / 4,
-         -sqrt(2) * (sin(q) + 2 * cos(q)) / 4]])
+         -sqrt(2) * (sin(q) + 2 * cos(q)) / 4]]) == zeros(3)
     assert A.ang_vel_in(N) == u * Pint.x
     assert C.masscenter.pos_from(P.masscenter) == N.x + A.y
     assert C.masscenter.vel(N) == u * A.z

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -10,7 +10,7 @@ from sympy.physics.mechanics import (dynamicsymbols, Body, PinJoint,
                                      PlanarJoint)
 from sympy.physics.mechanics.joint import Joint
 from sympy.physics.vector import Vector, ReferenceFrame, Point
-from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 Vector.simp = True
@@ -220,7 +220,6 @@ def test_pin_joint_chaos_pendulum():
                                        (h/4 + lB/2)*omega)*A.x
 
 
-@XFAIL
 def test_pin_joint_interframe():
     q, u = dynamicsymbols('q, u')
     # Check not connected

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -829,6 +829,10 @@ class ReferenceFrame:
 
         .. _Euler and Tait-Bryan Angles: https://en.wikipedia.org/wiki/Euler_angles
 
+        The computed angular velocity in this method is by default expressed in
+        the child's frame, so it is most preferable to use ``u1 * child.x + u2 *
+        child.y + u3 * child.z`` as generalized speeds.
+
         Parameters
         ==========
 
@@ -920,6 +924,10 @@ class ReferenceFrame:
         by right hand rotating through three successive space fixed simple axis
         rotations. Each subsequent axis of rotation is about the "space fixed"
         unit vectors of the parent reference frame.
+
+        The computed angular velocity in this method is by default expressed in
+        the child's frame, so it is most preferable to use ``u1 * child.x + u2 *
+        child.y + u3 * child.z`` as generalized speeds.
 
         Parameters
         ==========

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -474,11 +474,84 @@ def test_orient_body():
     assert B.dcm(A) == Matrix([[cos(1), sin(1)**2, -sin(1)*cos(1)], [0, cos(1), sin(1)], [sin(1), -sin(1)*cos(1), cos(1)**2]])
 
 
+def test_orient_body_advanced():
+    q1, q2, q3 = dynamicsymbols('q1:4')
+    c1, c2, c3 = symbols('c1:4')
+    u1, u2, u3 = dynamicsymbols('q1:4', 1)
+
+    # Test with everything as dynamicsymbols
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_body_fixed(A, (q1, q2, q3), 'zxy')
+    assert A.dcm(B) == Matrix([
+        [-sin(q1) * sin(q2) * sin(q3) + cos(q1) * cos(q3), -sin(q1) * cos(q2),
+         sin(q1) * sin(q2) * cos(q3) + sin(q3) * cos(q1)],
+        [sin(q1) * cos(q3) + sin(q2) * sin(q3) * cos(q1), cos(q1) * cos(q2),
+         sin(q1) * sin(q3) - sin(q2) * cos(q1) * cos(q3)],
+        [-sin(q3) * cos(q2), sin(q2), cos(q2) * cos(q3)]])
+    assert B.ang_vel_in(A).to_matrix(B) == Matrix([
+        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2], [sin(q2) * u1 + u3],
+        [sin(q3) * u2 + cos(q2) * cos(q3) * u1]])
+
+    # Test with constant symbol
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_body_fixed(A, (q1, c2, q3), 131)
+    assert A.dcm(B) == Matrix([
+        [cos(c2), -sin(c2) * cos(q3), sin(c2) * sin(q3)],
+        [sin(c2) * cos(q1), -sin(q1) * sin(q3) + cos(c2) * cos(q1) * cos(q3),
+         -sin(q1) * cos(q3) - sin(q3) * cos(c2) * cos(q1)],
+        [sin(c2) * sin(q1), sin(q1) * cos(c2) * cos(q3) + sin(q3) * cos(q1),
+         -sin(q1) * sin(q3) * cos(c2) + cos(q1) * cos(q3)]])
+    assert B.ang_vel_in(A).to_matrix(B) == Matrix([
+        [cos(c2) * u1 + u3], [-sin(c2) * cos(q3) * u1],
+        [sin(c2) * sin(q3) * u1]])
+
+    # Test all symbols not time dependent
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_body_fixed(A, (c1, c2, c3), 123)
+    assert B.ang_vel_in(A) == Vector(0)
+
+
+def test_orient_space_advanced():
+    # space fixed is in the end like body fixed only in opposite order
+    q1, q2, q3 = dynamicsymbols('q1:4')
+    c1, c2, c3 = symbols('c1:4')
+    u1, u2, u3 = dynamicsymbols('q1:4', 1)
+
+    # Test with everything as dynamicsymbols
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_space_fixed(A, (q3, q2, q1), 'yxz')
+    assert A.dcm(B) == Matrix([
+        [-sin(q1) * sin(q2) * sin(q3) + cos(q1) * cos(q3), -sin(q1) * cos(q2),
+         sin(q1) * sin(q2) * cos(q3) + sin(q3) * cos(q1)],
+        [sin(q1) * cos(q3) + sin(q2) * sin(q3) * cos(q1), cos(q1) * cos(q2),
+         sin(q1) * sin(q3) - sin(q2) * cos(q1) * cos(q3)],
+        [-sin(q3) * cos(q2), sin(q2), cos(q2) * cos(q3)]])
+    assert B.ang_vel_in(A).to_matrix(B) == Matrix([
+        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2], [sin(q2) * u1 + u3],
+        [sin(q3) * u2 + cos(q2) * cos(q3) * u1]])
+
+    # Test with constant symbol
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_space_fixed(A, (q3, c2, q1), 131)
+    assert A.dcm(B) == Matrix([
+        [cos(c2), -sin(c2) * cos(q3), sin(c2) * sin(q3)],
+        [sin(c2) * cos(q1), -sin(q1) * sin(q3) + cos(c2) * cos(q1) * cos(q3),
+         -sin(q1) * cos(q3) - sin(q3) * cos(c2) * cos(q1)],
+        [sin(c2) * sin(q1), sin(q1) * cos(c2) * cos(q3) + sin(q3) * cos(q1),
+         -sin(q1) * sin(q3) * cos(c2) + cos(q1) * cos(q3)]])
+    assert B.ang_vel_in(A).to_matrix(B) == Matrix([
+        [cos(c2) * u1 + u3], [-sin(c2) * cos(q3) * u1],
+        [sin(c2) * sin(q3) * u1]])
+
+    # Test all symbols not time dependent
+    A, B = ReferenceFrame('A'), ReferenceFrame('B')
+    B.orient_space_fixed(A, (c1, c2, c3), 123)
+    assert B.ang_vel_in(A) == Vector(0)
+
+
 def test_orient_body_simple_ang_vel():
-    """orient_body_fixed() uses kinematic_equations() internally and solves
-    those equations for the measure numbers of the angular velocity. This test
-    ensures that the simplest form of that linear system solution is returned,
-    thus the == for the expression comparison."""
+    """This test ensures that the simplest form of that linear system solution
+    is returned, thus the == for the expression comparison."""
 
     psi, theta, phi = dynamicsymbols('psi, theta, varphi')
     t = dynamicsymbols._t

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -489,7 +489,8 @@ def test_orient_body_advanced():
          sin(q1) * sin(q3) - sin(q2) * cos(q1) * cos(q3)],
         [-sin(q3) * cos(q2), sin(q2), cos(q2) * cos(q3)]])
     assert B.ang_vel_in(A).to_matrix(B) == Matrix([
-        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2], [sin(q2) * u1 + u3],
+        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2],
+        [sin(q2) * u1 + u3],
         [sin(q3) * u2 + cos(q2) * cos(q3) * u1]])
 
     # Test with constant symbol
@@ -502,7 +503,8 @@ def test_orient_body_advanced():
         [sin(c2) * sin(q1), sin(q1) * cos(c2) * cos(q3) + sin(q3) * cos(q1),
          -sin(q1) * sin(q3) * cos(c2) + cos(q1) * cos(q3)]])
     assert B.ang_vel_in(A).to_matrix(B) == Matrix([
-        [cos(c2) * u1 + u3], [-sin(c2) * cos(q3) * u1],
+        [cos(c2) * u1 + u3],
+        [-sin(c2) * cos(q3) * u1],
         [sin(c2) * sin(q3) * u1]])
 
     # Test all symbols not time dependent
@@ -527,7 +529,8 @@ def test_orient_space_advanced():
          sin(q1) * sin(q3) - sin(q2) * cos(q1) * cos(q3)],
         [-sin(q3) * cos(q2), sin(q2), cos(q2) * cos(q3)]])
     assert B.ang_vel_in(A).to_matrix(B) == Matrix([
-        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2], [sin(q2) * u1 + u3],
+        [-sin(q3) * cos(q2) * u1 + cos(q3) * u2],
+        [sin(q2) * u1 + u3],
         [sin(q3) * u2 + cos(q2) * cos(q3) * u1]])
 
     # Test with constant symbol
@@ -540,7 +543,8 @@ def test_orient_space_advanced():
         [sin(c2) * sin(q1), sin(q1) * cos(c2) * cos(q3) + sin(q3) * cos(q1),
          -sin(q1) * sin(q3) * cos(c2) + cos(q1) * cos(q3)]])
     assert B.ang_vel_in(A).to_matrix(B) == Matrix([
-        [cos(c2) * u1 + u3], [-sin(c2) * cos(q3) * u1],
+        [cos(c2) * u1 + u3],
+        [-sin(c2) * cos(q3) * u1],
         [sin(c2) * sin(q3) * u1]])
 
     # Test all symbols not time dependent


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Changed the computation behind `ReferenceFrame.orient_body_fixed` and `ReferenceFrame.orient_space_fixed` to be more efficient. It now directly computes the simplified angular velocity instead of solving the kinematic equations and simplifying those. Another advantage is that it makes these methods compatible with the symengine (see #22304).
Lastly, there have been added a few more tests.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
