### PR TITLE
Added is_Boolean = True to relationals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1508,3 +1508,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Maurice Hendrix <52317399+MauriceHendrix@users.noreply.github.com>

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -144,6 +144,7 @@ class Relational(Boolean, EvalfMixin):
     ValidRelationOperator = {}  # type: tDict[tUnion[str, None], Type[Relational]]
 
     is_Relational = True
+    is_Boolean = True
 
     # ValidRelationOperator - Defined below, because the necessary classes
     #   have not yet been defined


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #24086


#### Brief description of what is fixed or changed
Added is_Boolean = True to reationals to fix issue where booleans in equations being passed to Piecewise cause error `AttributeError: 'BooleanTrue' object has no attribute 'as_coeff_Add' ` as suggested by @oscarbenjamin


#### Other comments
- I tested the issue with sympy 1.9, 1.10.1 and 1.11.1 it does not happen in 1.9 but does in 1.10.1 and 1.11.1
- We are working on a project getting equations form MathML in an xml file (cellml). https://github.com/ModellingWebLab/cellmlmanip


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in Relational where booleans in equations being passed to Piecewise cause error.
<!-- END RELEASE NOTES -->
