### PR TITLE
Support increased verbosity in the doctest runner

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -614,8 +614,9 @@ def doctest(*paths, subprocess=True, rerun=0, **kwargs):
     >>> sympy.doctest(split='1/2')  # doctest: +SKIP
 
     The ``subprocess`` and ``verbose`` options are the same as with the function
-    ``test()``.  See the docstring of that function for more information.
-
+    ``test()`` (see the docstring of that function for more information) except
+    that ``verbose`` may also be set equal to ``2`` in order to print
+    individual doctest lines, as they are being tested.
     """
     # count up from 0, do not print 0
     print_counter = lambda i : (print("rerun %d" % (rerun-i))
@@ -1439,12 +1440,13 @@ class SymPyDocTests:
                     self._reporter.test_skip(v=str(e))
                     continue
 
-            runner = SymPyDocTestRunner(optionflags=pdoctest.ELLIPSIS |
+            runner = SymPyDocTestRunner(verbose=self._reporter._verbose==2,
+                    optionflags=pdoctest.ELLIPSIS |
                     pdoctest.NORMALIZE_WHITESPACE |
                     pdoctest.IGNORE_EXCEPTION_DETAIL)
             runner._checker = SymPyOutputChecker()
             old = sys.stdout
-            new = StringIO()
+            new = old if self._reporter._verbose==2 else StringIO()
             sys.stdout = new
             # If the testing is normal, the doctests get importing magic to
             # provide the global namespace. If not normal (the default) then


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I found it can be hard to track down a hanging doctest, even using the existing `verbose=True` option.
That gives something like this:

```
>>> sympy.doctest("sympy/solvers/solvers.py", verbose=True)

sympy/solvers/solvers.py[12] 
sympy.solvers.solvers.unrad ok
sympy.solvers.solvers._invert ok
sympy.solvers.solvers.nsolve ok
sympy.solvers.solvers._tsolve ok
sympy.solvers.solvers.solve_linear_system_LU ok
sympy.solvers.solvers.solve_undetermined_coeffs ok
sympy.solvers.solvers.solve_linear_system ok
sympy.solvers.solvers.solve_linear ok

sympy.solvers.solvers.solve ^C interrupted by user
```

but you don't learn which exact line within a given docstring is the culprit. Some docstrings contain a lot of tests (98 in this example). This PR makes it so that setting `verbose=2` results in output like this:

```
Trying:
    expr = root(x, 3) - root(x, 5)
Expecting nothing
ok
Trying:
    expr1 = root(x, 3, 1) - root(x, 5, 1)
Expecting nothing
ok
Trying:
    v = expr1.subs(x, -3)
Expecting nothing
ok
Trying:
    eq = Eq(expr, v); eq1 = Eq(expr1, v)
Expecting nothing
ok
Trying:
    solve(eq, check=False), solve(eq1, check=False)
Expecting:
    ([], [])
^C interrupted by user
```


#### Other comments

Don't know if there's a good way to add a unit test for this.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* testing
  * Support increased verbosity in the doctest runner

<!-- END RELEASE NOTES -->
