### PR TITLE
Fix - Cannot parse Greek characters (and possibly others) in parse_mathematica

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1400,6 +1400,7 @@ Yuki Matsuda <yuki.matsuda.w@gmail.com>
 Yuri Karadzhov <yuri.karadzhov@gmail.com>
 Yuriy Demidov <iurii.demidov@gmail.com>
 Yury G. Kudryashov <urkud.urkud@gmail.com>
+Yves Tumushimire <yvestumushimire@gmail.com>
 Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
 Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
 Zach Raines <raineszm@gmail.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -663,7 +663,7 @@ class MathematicaParser:
         # Remove newlines at the end
         while tokens and tokens[-1] == "\n":
             tokens.pop(-1)
-            
+
         return tokens
 
     def _is_op(self, token: tUnion[str, list]) -> bool:

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -654,7 +654,7 @@ class MathematicaParser:
             code_splits[i] = code_split
 
         # Tokenize the input strings with a regular expression:
-        token_lists = [tokenizer.findall(i) if isinstance(i, str) else [i] for i in code_splits]
+        token_lists = [tokenizer.findall(i) if isinstance(i, str) and i.isascii() else [i] for i in code_splits]
         tokens = [j for i in token_lists for j in i]
 
         # Remove newlines at the beginning
@@ -663,7 +663,7 @@ class MathematicaParser:
         # Remove newlines at the end
         while tokens and tokens[-1] == "\n":
             tokens.pop(-1)
-
+            
         return tokens
 
     def _is_op(self, token: tUnion[str, list]) -> bool:

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -15,6 +15,7 @@ def test_mathematica():
         'x+y': 'x+y',
         '355/113': '355/113',
         '2.718281828': '2.718281828',
+        'Cos(1/2 * π)': 'Cos(π/2)',
         'Sin[12]': 'sin(12)',
         'Exp[Log[4]]': 'exp(log(4))',
         '(x+1)(x+3)': '(x+1)*(x+3)',
@@ -94,6 +95,7 @@ def test_parser_mathematica_tokenizer():
     assert chain("+x") == "x"
     assert chain("-1") == "-1"
     assert chain("- 3") == "-3"
+    assert chain("α") == "α"
     assert chain("+Sin[x]") == ["Sin", "x"]
     assert chain("-Sin[x]") == ["Times", "-1", ["Sin", "x"]]
     assert chain("x(a+1)") == ["Times", "x", ["Plus", "a", "1"]]

--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -48,6 +48,8 @@ unicode_whitelist = [
 
 unicode_strict_whitelist = [
     r'*/sympy/parsing/latex/_antlr/__init__.py',
+    # test_mathematica.py uses some unicode for testing Greek characters are working #24055
+    r'*/sympy/parsing/tests/test_mathematica.py',
 ]
 
 


### PR DESCRIPTION
Fix Cannot parse Greek characters (and possibly others) in parse_mathematica

#### References to other Issues or PRs
Fixes #24055 

#### Brief description of what is fixed or changed
Skipping non ascii letters in `tokeneziner.findall()`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  *  Fix a bug with parsing Greek characters (and possibly others)
<!-- END RELEASE NOTES -->
