### PR TITLE
Fix unevaluated printing of negative sum in numerator

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -287,8 +287,8 @@ class StrPrinter(Printer):
 
             pre = []
             # don't parenthesize first factor if negative
-            if n and n[0].could_extract_minus_sign():
-                pre = [str(n.pop(0))]
+            if n and not n[0].is_Add and n[0].could_extract_minus_sign():
+                pre = [self._print(n.pop(0))]
 
             nfactors = pre + [self.parenthesize(a, prec, strict=False)
                 for a in n]
@@ -297,7 +297,7 @@ class StrPrinter(Printer):
 
             # don't parenthesize first of denominator unless singleton
             if len(d) > 1 and d[0].could_extract_minus_sign():
-                pre = [str(d.pop(0))]
+                pre = [self._print(d.pop(0))]
             else:
                 pre = []
             dfactors = pre + [self.parenthesize(a, prec, strict=False)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -286,6 +286,10 @@ def test_Mul():
     # issue 21537
     assert str(Mul(x, Pow(1/y, -1, evaluate=False), evaluate=False)) == 'x/(1/y)'
 
+    # Issue 24108
+    from sympy.core.parameters import evaluate
+    with evaluate(False):
+        assert str(Mul(Pow(Integer(2), Integer(-1)), Add(Integer(-1), Mul(Integer(-1), Integer(1))))) == "(-1 - 1*1)/2"
 
     class CustomClass1(Expr):
         is_commutative = True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24108 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Fix str of numerator consisting of a sum where a minus signs can be extracted.
<!-- END RELEASE NOTES -->
