### PR TITLE
doc: fix space typos around inline literals.

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -530,7 +530,7 @@ Example::
 but for SymPy we don’t actually use ``srepr()`` for ``__repr__`` because it’s
 is so verbose, it is unlikely that anyone would want it called by default.
 Another reason is that lists call repr on their elements, like ``print([a, b, c])``
-calls ``repr(a)``, ``repr(b)``, ``repr(c)``. So if we used srepr for `` __repr__`` any list with
+calls ``repr(a)``, ``repr(b)``, ``repr(c)``. So if we used srepr for ``__repr__`` any list with
 SymPy objects would include the srepr form, even if we used ``str()`` or ``print()``.
 
 

--- a/doc/src/modules/rewriting.rst
+++ b/doc/src/modules/rewriting.rst
@@ -89,7 +89,7 @@ in the ``cse`` function. Examples::
     ⎝[(x₀, (x - y)⋅(-y + z))], ⎣╲╱ x₀  + x₀⎦⎠
 
 Optimizations to be performed before and after common subexpressions
-elimination can be passed in the``optimizations`` optional argument. A set of
+elimination can be passed in the ``optimizations`` optional argument. A set of
 predefined basic optimizations can be applied by passing
 ``optimizations='basic'``::
 


### PR DESCRIPTION
Found those while working on a new error detector for sphinxlint.

Before the fix those inline literals were not interepted as so, leaking double backticks in the rendered doc :

![Capture d’écran du 2022-10-05 22-08-08](https://user-images.githubusercontent.com/239510/194154601-0d612be0-e213-47eb-8692-2eb93b574abb.png)
![Capture d’écran du 2022-10-05 22-07-40](https://user-images.githubusercontent.com/239510/194154604-76385a92-e668-4509-b2a3-fc1739f8b624.png)

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->