### PR TITLE
doc: fix quote used instead of backtick in hyperlink reference.

### DIFF
--- a/doc/src/contributing/dev-setup.rst
+++ b/doc/src/contributing/dev-setup.rst
@@ -91,7 +91,7 @@ Now activate the environment:
 Run the Tests
 --------------
 
-There are several ways of running SymPy tests but the easiest is to use the ``bin/test`` script, consult 'the wiki details on running tests <https://github.com/sympy/sympy/wiki/Running-tests>`_.
+There are several ways of running SymPy tests but the easiest is to use the ``bin/test`` script, consult `the wiki details on running tests <https://github.com/sympy/sympy/wiki/Running-tests>`_.
 
 The script takes a number of options and arguments and then passes them to ``sympy.test(*paths, **kwargs)``. Run ``bin/test --help`` for all supported arguments.
 


### PR DESCRIPTION
Before the fix it gets rendered as:

![Screenshot 2022-10-07 at 11-29-27 Development Environment Setup - SymPy 1 11 documentation](https://user-images.githubusercontent.com/239510/194521847-a4eb4938-304b-4a8f-9e4f-a3377dcfe54d.png)

(Yes this will be detected in the next release of sphinx-lint, that's how I found it ;))

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->