### PR TITLE
Fix various typos

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1463,7 +1463,7 @@ kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
-luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
+luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@pm.me>
 mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1463,7 +1463,7 @@ kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
-luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@pm.me>
+luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
 mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1463,7 +1463,7 @@ kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
-luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@users.noreply.github.com>
+luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
 mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1464,6 +1464,7 @@ klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
 luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
+luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@users.noreply.github.com>
 mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>

--- a/bin/strip_whitespace
+++ b/bin/strip_whitespace
@@ -9,7 +9,7 @@ def strip_file(filename, write, report):
     # .readlines() retains \n chars, while .read().splitlines() does not.
     # Assuming that whitespace errors will be few, we will thus only need
     # to re-add \n to a few right-stripped lines. The hit flag will keep us
-    # from unecessarily re-writing files with no changes.
+    # from unnecessarily re-writing files with no changes.
 
     # newline="" keeps current line endings
     with open(filename, newline="") as f:

--- a/bin/test_sphinx.sh
+++ b/bin/test_sphinx.sh
@@ -7,7 +7,7 @@ cd doc
 make html
 make man
 make latexpdf LATEXMKOPTS="-halt-on-error -xelatex -silent" || {
-    echo "An error had occured during the LaTeX build";
+    echo "An error had occurred during the LaTeX build";
     tail -n 1000 _build/latex/*.log;
     sleep 1; # A guard against the CI running tail concurrently.
     exit 1;

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -404,7 +404,7 @@ intersphinx_mapping = {
 # to something from matplotlib.
 intersphinx_disabled_reftypes = ['*']
 
-# Requried for linkcode extension.
+# Required for linkcode extension.
 # Get commit hash from the external file.
 commit_hash_filepath = '../commit_hash.txt'
 commit_hash = None

--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -178,7 +178,7 @@ into an evaluable numeric function.
 In principle, `lambdify` can interface with any external library if the user
 passes in an appropriate namespace dictionary as the third argument, but by
 default, `lambdify` is aware of several popular numeric Python libraries.
-These libraries are enabled as backends in `lambdify` with build-in
+These libraries are enabled as backends in `lambdify` with built-in
 translations to convert SymPy expressions into the appropriate functions for
 those libraries.
 

--- a/doc/src/contributing/dev-setup.rst
+++ b/doc/src/contributing/dev-setup.rst
@@ -117,7 +117,7 @@ To run tests for modules, use:
 
 This will run tests for the ``core`` and ``utilities`` modules.
 
-Similary, run quality tests with:
+Similarly, run quality tests with:
 
 .. code-block:: bash
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -748,7 +748,7 @@ Several parts of {mod}`sympy.diffgeom` have been updated to no longer be
 mutable, which better matches the immutable design used in the rest of SymPy.
 
 - Passing strings for symbol names in {class}`~.CoordSystem` is deprecated.
-  Instead you should be explicit and pass symbols with the appropiate
+  Instead you should be explicit and pass symbols with the appropriate
   assumptions, for instance, instead of
 
   ```py

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -113,7 +113,7 @@ interpreted as meaning that the result is *unknown*.
 
 .. note:: We need to use ``print`` in the above examples because the special
           value ``None`` does not display by default in the Python
-          interpretter.
+          interpreter.
 
 There are several reasons why an assumptions query might give ``None``. It is
 possible that the query is *unknowable* as in the case of ``x`` above. Since

--- a/doc/src/guides/custom-functions.md
+++ b/doc/src/guides/custom-functions.md
@@ -28,7 +28,7 @@ class, such as {class}`~.Boolean`, {class}`~.MatrixExpr`, {class}`~.Expr`, or
 Before digging into the more advanced functionality for custom functions, we
 should mention two common cases, the case where the function is fully
 symbolic, and the case where the function is fully evaluated. Both of these
-cases have much simpler alternatives than the full mechanisms described in ths
+cases have much simpler alternatives than the full mechanisms described in this
 guide.
 
 (custom-functions-fully-symbolic)=

--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -86,7 +86,7 @@ a drop-in replacement for numpy.
      -0.05440211]
 
 JAX is a similar alternative to CuPy that provides GPU and TPU acceleration via
-just-in-time compliation to XLA. It too, can in some cases, be used as a drop-in
+just-in-time compilation to XLA. It too, can in some cases, be used as a drop-in
 replacement for numpy.
 
     >>> f = lambdify(x, expr, "jax")

--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -33,7 +33,7 @@ functions to generate partitions that can be used as low-level tools for
 routines:  ``partitions`` and ``multiset_partitions``. The former gives
 integer partitions, and the latter gives enumerated partitions of elements.
 There is also a routine ``kbins`` that will give a variety of permutations
-of partions. And to obtain partitions as a list instead of a dictionary, there
+of partitions. And to obtain partitions as a list instead of a dictionary, there
 is the ``ordered_partition`` function which is quite fast. Finally, to simply
 obtain a count of the number of partitions without enumerating them, there
 is the ``nT`` function.

--- a/doc/src/modules/vector/intro.rst
+++ b/doc/src/modules/vector/intro.rst
@@ -59,7 +59,7 @@ units of measurement, the expression of vectorial and scalar quantities
 differs according to the coordinate system a certain observer deals with.
 
 Consider two points :math:`P` and :math:`Q` in space. Assuming units to
-be common throughtout, the distance between these points remains
+be common throughout, the distance between these points remains
 the same regardless of the coordinate system in which the measurements are
 being made. However, the 3-D coordinates of each of the two points, as well
 as the position vector of any of the points with respect to the other,

--- a/doc/src/tutorials/intro-tutorial/manipulation.rst
+++ b/doc/src/tutorials/intro-tutorial/manipulation.rst
@@ -545,7 +545,7 @@ evaluations:
     >>> UnevaluatedExpr(sympify("x + x", evaluate=False)) + y
     y + (x + x)
 
-``UnevalutedExpr`` is supported by SymPy printers and can be used to print the
+``UnevaluatedExpr`` is supported by SymPy printers and can be used to print the
 result in different output forms. For example
 
     >>> from sympy import latex

--- a/examples/beginner/plot_examples.py
+++ b/examples/beginner/plot_examples.py
@@ -30,7 +30,7 @@ g[0].surface_color = lambda x, y: sin(x)
 param_line_2d = plot_parametric((x*cos(x), x*sin(x), (x, 0, 15)), (1.1*x*cos(x), 1.1*x*sin(x), (x, 0, 15)), show=False)
 param_line_2d[0].line_color = lambda u: sin(u)  # parametric
 param_line_2d[1].line_color = lambda u, v: u**2 + v**2  # coordinates
-param_line_2d.title = 'The inner one is colored by parameter and the outher one by coordinates'
+param_line_2d.title = 'The inner one is colored by parameter and the outer one by coordinates'
 
 param_line_3d = plot3d_parametric_line((x*cos(x), x*sin(x), x, (x, 0, 15)),
                      (1.5*x*cos(x), 1.5*x*sin(x), x, (x, 0, 15)),

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -142,7 +142,7 @@ class AppliedPredicate(Boolean):
         """
         Return the predicate.
         """
-        # Will be changed to self.args[0] after args overridding is removed
+        # Will be changed to self.args[0] after args overriding is removed
         return self._args[0]
 
     @property
@@ -150,7 +150,7 @@ class AppliedPredicate(Boolean):
         """
         Return the arguments which are applied to the predicate.
         """
-        # Will be changed to self.args[1:] after args overridding is removed
+        # Will be changed to self.args[1:] after args overriding is removed
         return self._args[1:]
 
     def _eval_ask(self, assumptions):

--- a/sympy/assumptions/relation/binrel.py
+++ b/sympy/assumptions/relation/binrel.py
@@ -95,7 +95,7 @@ class BinaryRelation(Predicate):
     def _compare_reflexive(self, lhs, rhs):
         # quick exit for structurally same arguments
         # do not check != here because it cannot catch the
-        # equivalent arguements with different structures.
+        # equivalent arguments with different structures.
 
         # reflexivity does not hold to NaN
         if lhs is S.NaN or rhs is S.NaN:

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -209,7 +209,7 @@ def get_relevant_clsfacts(exprs, relevant_facts=None):
 
     Here, we will see how facts relevant to ``Abs(x*y)`` are recursively
     extracted. On the first run, set containing the expression is passed
-    without pre-discovered relevant facts. The result is a set containig
+    without pre-discovered relevant facts. The result is a set containing
     candidates for next run, and ``CNF()`` instance containing facts
     which are relevant to ``Abs`` and its argument.
 

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -4,7 +4,7 @@ query with same syntax.
 
 In SymPy, there are two assumption systems. Old assumption system is
 defined in sympy/core/assumptions, and it can be accessed by attribute
-such as ``x.is_even``. New assumption system is definded in
+such as ``x.is_even``. New assumption system is defined in
 sympy/assumptions, and it can be accessed by predicates such as
 ``Q.even(x)``.
 

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -199,7 +199,7 @@ class Token(CodegenAST):
     @classmethod
     def _construct(cls, attr, arg):
         """ Construct an attribute value from argument passed to ``__new__()``. """
-        # arg may be ``NoneToken()``, so comparation is done using == instead of ``is`` operator
+        # arg may be ``NoneToken()``, so comparison is done using == instead of ``is`` operator
         if arg == None:
             return cls.defaults.get(attr, none)
         else:
@@ -1792,7 +1792,7 @@ class FunctionPrototype(Node):
     @classmethod
     def from_FunctionDefinition(cls, func_def):
         if not isinstance(func_def, FunctionDefinition):
-            raise TypeError("func_def is not an instance of FunctionDefiniton")
+            raise TypeError("func_def is not an instance of FunctionDefinition")
         return cls(**func_def.kwargs(exclude=('body',)))
 
 

--- a/sympy/codegen/fnodes.py
+++ b/sympy/codegen/fnodes.py
@@ -340,7 +340,7 @@ def array(symbol, dim, intent=None, *, attrs=(), value=None, type=None):
     symbol : symbol
     dim : Attribute or iterable
         If dim is an ``Attribute`` it need to have the name 'dimension'. If it is
-        not an ``Attribute``, then it is passsed to :func:`dimension` as ``*dim``
+        not an ``Attribute``, then it is passed to :func:`dimension` as ``*dim``
     intent : str
         One of: 'in', 'out', 'inout' or None
     \\*\\*kwargs:

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -340,8 +340,8 @@ class IntegerPartition(Basic):
         """
         Generates a new IntegerPartition object from a list or dictionary.
 
-        Explantion
-        ==========
+        Explanation
+        ===========
 
         The partition can be given as a list of positive integers or a
         dictionary of (integer, multiplicity) items. If the partition is

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1947,7 +1947,7 @@ class PermutationGroup(Basic):
             The criterion for the incorrect ``False`` return.
 
         perms : list[Permutation], optional
-            If explicitly given, it tests over the given candidats
+            If explicitly given, it tests over the given candidates
             for testing.
 
             If ``None``, it randomly computes ``N_eps`` and chooses

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1705,7 +1705,7 @@ class Permutation(Atom):
 
         This function is similar to the ``__call__`` magic, however,
         ``__call__`` magic already has some other applications like
-        permuting an array or attatching new cycles, which would
+        permuting an array or attaching new cycles, which would
         not always be mathematically consistent.
 
         This also guarantees that the return type is a SymPy integer,

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -30,7 +30,7 @@ def test_schur_partition():
         for item in result:
             _sum_free_test(item)
             """
-            Checks if the occurance of all numbers  is exactly one
+            Checks if the occurrence of all numbers is exactly one
             """
             t += len(item)
             for l in item:

--- a/sympy/combinatorics/testutil.py
+++ b/sympy/combinatorics/testutil.py
@@ -219,7 +219,7 @@ def canonicalize_naive(g, dummies, sym, *v):
     msym : Symmetry of the metric.
     v : A list of (base_i, gens_i, n_i, sym_i) for tensors of type `i`.
         base_i, gens_i BSGS for tensors of this type
-        n_i  number ot tensors of type `i`
+        n_i  number of tensors of type `i`
 
     Returns
     =======

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -337,7 +337,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         to work with SymPy should be handled directly in the __eq__ methods
         of the `Basic` classes it could equate to and not be converted. Note
         that after conversion, `==`  is used again since it is not
-        neccesarily clear whether `self` or `other`'s __eq__ method needs
+        necessarily clear whether `self` or `other`'s __eq__ method needs
         to be used."""
         for superclass in type(other).__mro__:
             conv = _external_converter.get(superclass)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -158,7 +158,7 @@ class Expr(Basic, EvalfMixin):
     # ***************
     # * Arithmetics *
     # ***************
-    # Expr and its sublcasses use _op_priority to determine which object
+    # Expr and its subclasses use _op_priority to determine which object
     # passed to a binary special method (__mul__, etc.) will handle the
     # operation. In general, the 'call_highest_priority' decorator will choose
     # the object with the highest _op_priority to handle the call.

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -921,7 +921,7 @@ def _gcd_terms(terms, isprimitive=False, fraction=True):
     isprimitive : boolean, optional
         If ``isprimitive`` is True then the call to primitive
         for an Add will be skipped. This is useful when the
-        content has already been extrated.
+        content has already been extracted.
 
     fraction : boolean, optional
         If ``fraction`` is True then the expression will appear over a common

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -263,7 +263,7 @@ class FunctionClass(ManagedProperties):
         return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
     def _valid_nargs(self, n : int) -> bool:
-        """ Return True if the specified interger is a valid number of arguments
+        """ Return True if the specified integer is a valid number of arguments
 
         The number of arguments n is guaranteed to be an integer and positive
 

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -55,7 +55,7 @@ class Kind(object, metaclass=KindMeta):
 
     Kind of every object must be carefully selected so that it shows the
     intention of design. Expressions may have different kind according
-    to the kind of its arguements. For example, arguements of ``Add``
+    to the kind of its arguments. For example, arguments of ``Add``
     must have common kind since addition is group operator, and the
     resulting ``Add()`` has the same kind.
 
@@ -167,7 +167,7 @@ class _BooleanKind(Kind):
     Kind for boolean objects.
 
     SymPy's ``S.true``, ``S.false``, and built-in ``True`` and ``False``
-    have this kind. Boolean number ``1`` and ``0`` are not relevent.
+    have this kind. Boolean number ``1`` and ``0`` are not relevant.
 
     Examples
     ========

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1361,7 +1361,7 @@ class Mul(Expr, AssocOp):
                     assert not e.is_zero
                     return # sign of e unknown -> self.is_integer unknown
                 else:
-                    # x**2, 2**x, or x**y with x and y int-unknown -> unknonwn
+                    # x**2, 2**x, or x**y with x and y int-unknown -> unknown
                     return
             else:
                 return

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -253,7 +253,7 @@ class Symbol(AtomicExpr, Boolean):
 
     @staticmethod
     def _sanitize(assumptions, obj=None):
-        """Remove None, covert values to bool, check commutativity *in place*.
+        """Remove None, convert values to bool, check commutativity *in place*.
         """
 
         # be strict about commutativity: cannot be None

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4322,7 +4322,7 @@ def test_sympy__series__sequences__SeqBase():
 
 
 def test_sympy__series__sequences__EmptySequence():
-    # Need to imort the instance from series not the class from
+    # Need to import the instance from series not the class from
     # series.sequence
     from sympy.series import EmptySequence
     assert _test_args(EmptySequence)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2227,7 +2227,7 @@ def test_denest_add_mul():
     eq = Mul(eq, 2, evaluate=False)
     eq = Mul(eq, 2, evaluate=False)
     assert Mul(*eq.args) == 8*x
-    # but don't let them denest unecessarily
+    # but don't let them denest unnecessarily
     eq = Mul(-2, x - 2, evaluate=False)
     assert 2*eq == Mul(-4, x - 2, evaluate=False)
     assert -eq == Mul(2, x - 2, evaluate=False)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -681,7 +681,7 @@ def test_evalf_with_bounded_error():
         (2 - 3 * I, Rational(1, 1000), None),
         # very large eps
         (2 - 3 * I, Rational(1000), None),
-        # case where x already small, hence some cancelation in p = m + n - 1
+        # case where x already small, hence some cancellation in p = m + n - 1
         (Rational(1234, 10**8), Rational(1, 10**12), None),
     ]
     for x0, eps, m in cases:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -246,7 +246,7 @@ def test_igcd_lehmer():
     assert igcd_lehmer(a*c, b*c) == c
     # big divisor
     assert igcd_lehmer(a, 10**1000) == 1
-    # swapping argmument
+    # swapping argument
     assert igcd_lehmer(1, 2) == igcd_lehmer(2, 1)
 
 

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2009,7 +2009,7 @@ def decipher_rsa(i, key, factors=None):
         very large cases (Like 2048-bit RSA keys) since the
         overhead of using pure Python implementation of
         :meth:`sympy.ntheory.modular.crt` may overcompensate the
-        theoritical speed advantage.
+        theoretical speed advantage.
 
     Notes
     =====
@@ -2544,7 +2544,7 @@ def elgamal_private_key(digit=10, seed=None):
     Explanation
     ===========
 
-    Elgamal encryption is based on the mathmatical problem
+    Elgamal encryption is based on the mathematical problem
     called the Discrete Logarithm Problem (DLP). For example,
 
     `a^{b} \equiv c \pmod p`

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -174,7 +174,7 @@ class CoordSystem(Basic):
     assumptions of coordinate symbols of the coordinate system. If not passed,
     these symbols are generated automatically and are assumed to be real valued.
 
-    By passing *relations* parameter, user can define the tranform relations of
+    By passing *relations* parameter, user can define the transform relations of
     coordinate systems. Inverse transformation and indirect transformation can
     be found automatically. If this parameter is not passed, coordinate
     transformation cannot be done.
@@ -1653,7 +1653,7 @@ class CovarDerivativeOp(Expr):
                              'was not a vector field.')
         christoffel = ImmutableDenseNDimArray(christoffel)
         obj = super().__new__(cls, wrt, christoffel)
-        # deprecated assigments
+        # deprecated assignments
         obj._wrt = wrt
         obj._christoffel = christoffel
         return obj

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2468,7 +2468,7 @@ def nD(i=None, brute=None, *, n=None, m=None):
 
     By default, a brute-force enumeration and count of multiset permutations
     is only done if there are fewer than 9 elements. There may be cases when
-    there is high multiplicty with few unique elements that will benefit
+    there is high multiplicity with few unique elements that will benefit
     from a brute-force enumeration, too. For this reason, the `brute`
     keyword (default None) is provided. When False, the brute-force
     enumeration will never be used. When True, it will always be used.

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -853,7 +853,7 @@ class cos(TrigonometricFunction):
         from sympy.functions.special.polynomials import chebyshevt
 
         def migcdex(x):
-            # recursive calcuation of gcd and linear combination
+            # recursive calculation of gcd and linear combination
             # for a sequence of integers.
             # Given  (x1, x2, x3)
             # Returns (y1, y1, y3, g)

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -592,7 +592,7 @@ class Heaviside(Function):
         Explanation
         ===========
 
-        The value of Heaviside(0) must be 1/2 for rewritting as sign to be
+        The value of Heaviside(0) must be 1/2 for rewriting as sign to be
         strictly equivalent. For easier usage, we also allow this rewriting
         when Heaviside(0) is undefined.
 

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -831,7 +831,7 @@ class LinearEntity(GeometrySet):
     def perpendicular_segment(self, p):
         """Create a perpendicular line segment from `p` to this line.
 
-        The enpoints of the segment are ``p`` and the closest point in
+        The endpoints of the segment are ``p`` and the closest point in
         the line containing self. (If self is not a line, the point might
         not be in self.)
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1026,7 +1026,7 @@ class Polygon(GeometrySet):
             if compare > 0:
                 if not prev:
                     # if previous point lies below the line, the intersection
-                    # point of the polygon egde and the line has to be included
+                    # point of the polygon edge and the line has to be included
                     edge = Line(point, prev_point)
                     new_point = edge.intersection(line)
                     upper_vertices.append(new_point[0])

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -666,7 +666,7 @@ class HolonomicFunction:
                 return HolonomicFunction(sol, self.x, self.x0, y0)
 
             else:
-                # change the intiial conditions to a same point
+                # change the initial conditions to a same point
                 selfat0 = self.annihilator.is_singular(0)
                 otherat0 = other.annihilator.is_singular(0)
 

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -327,7 +327,7 @@ def test_evalf_euler():
     s = '0.699525841805253'  # approx. equal to log(2) i.e. 0.693147180559945
     assert sstr(p.evalf(r, method='Euler')[-1]) == s
 
-    # path taken is a traingle 0-->1+i-->2
+    # path taken is a triangle 0-->1+i-->2
     r = [0.1 + 0.1*I]
     for i in range(9):
         r.append(r[-1]+0.1+0.1*I)
@@ -404,7 +404,7 @@ def test_evalf_rk4():
     s = '0.693146363174626'  # approx. equal to log(2) i.e. 0.693147180559945
     assert sstr(p.evalf(r)[-1]) == s
 
-    # path taken is a traingle 0-->1+i-->2
+    # path taken is a triangle 0-->1+i-->2
     r = [0.1 + 0.1*I]
     for i in range(9):
         r.append(r[-1]+0.1+0.1*I)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -619,7 +619,7 @@ class Integral(AddWithLimits):
 
             final = hints.get('final', True)
             # dotit may be iterated but floor terms making atan and acot
-            # continous should only be added in the final round
+            # continuous should only be added in the final round
             if (final and not isinstance(antideriv, Integral) and
                 antideriv is not None):
                 for atan_term in antideriv.atoms(atan):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -361,7 +361,7 @@ def test_issue_3679():
     assert NS(Integral(1/(x**2 - 8*x + 17), (x, 2, 4))) == '1.10714871779409'
 
 
-def test_issue_3686():  # remove this when fresnel itegrals are implemented
+def test_issue_3686():  # remove this when fresnel integrals are implemented
     from sympy.core.function import expand_func
     from sympy.functions.special.error_functions import fresnels
     assert expand_func(integrate(sin(x**2), x)) == \

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -759,7 +759,7 @@ def test_laplace_transform():
     Ms = Matrix([[    1/(s - 1), (s + 1)**(-2)],
                  [(s + 1)**(-2),     1/(s - 1)]])
 
-    # The default behaviour for Laplace tranform of a Matrix returns a Matrix
+    # The default behaviour for Laplace transform of a Matrix returns a Matrix
     # of Tuples and is deprecated:
     with warns_deprecated_sympy():
         Ms_conds = Matrix([[(1/(s - 1), 1, True), ((s + 1)**(-2),

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1185,7 +1185,7 @@ def _laplace_deep_collect(f, t):
 def _laplace_build_rules(t, s):
     """
     This is an internal helper function that returns the table of Laplace
-    transfrom rules in terms of the time variable `t` and the frequency
+    transform rules in terms of the time variable `t` and the frequency
     variable `s`.  It is used by `_laplace_apply_rules`.
     """
     a = Wild('a', exclude=[t])
@@ -1854,7 +1854,7 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
     auxiliary convergence conditions.
 
     The implementation is rule-based, and if you are interested in which
-    rules are applied, and whether integration is attemped, you can switch
+    rules are applied, and whether integration is attempted, you can switch
     debug information on by setting ``sympy.SYMPY_DEBUG=True``.
 
     The lower bound is `0-`, meaning that this bound should be approached

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2149,7 +2149,7 @@ def _convert_to_varsANF(term, variables):
     Parameters
     ==========
 
-    term : list of 1's and 0's (complementation patter)
+    term : list of 1's and 0's (complementation pattern)
     variables : list of variables
 
     """
@@ -2517,7 +2517,7 @@ def ANFform(variables, truthvalues):
 
     The variables must be given as the first argument.
 
-    Return True, False, logical :py:class:`~.And` funciton (i.e., the
+    Return True, False, logical :py:class:`~.And` function (i.e., the
     "Zhegalkin monomial") or logical :py:class:`~.Xor` function (i.e.,
     the "Zhegalkin polynomial"). When True and False
     are represented by 1 and 0, respectively, then
@@ -2638,7 +2638,7 @@ def bool_minterm(k, variables):
     Parameters
     ==========
 
-    k : int or list of 1's and 0's (complementation patter)
+    k : int or list of 1's and 0's (complementation pattern)
     variables : list of variables
 
     Examples
@@ -2710,7 +2710,7 @@ def bool_monomial(k, variables):
     Each boolean function can be uniquely represented by a
     Zhegalkin Polynomial (Algebraic Normal Form). The Zhegalkin
     Polynomial of the boolean function with `n` variables can contain
-    up to `2^n` monomials. We can enumarate all the monomials.
+    up to `2^n` monomials. We can enumerate all the monomials.
     Each monomial is fully specified by the presence or absence
     of each variable.
 
@@ -2784,7 +2784,7 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
         Optimize expression under the assumption that inputs where this
         expression is true are don't care. This is useful in e.g. Piecewise
         conditions, where later conditions do not need to consider inputs that
-        are convered by previous conditions. For example, if a previous
+        are converted by previous conditions. For example, if a previous
         condition is ``And(A, B)``, the simplification of expr can be made
         with don't cares for ``And(A, B)``.
 

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -721,7 +721,7 @@ def _LUdecomposition_Simple(M, iszerofunc=_iszero, simpfunc=None,
         If the original matrix is a $m, n$ matrix:
 
         *lu* is a $m, n$ matrix, which contains result of the
-        decomposition in a compresed form. See the notes section
+        decomposition in a compressed form. See the notes section
         to see how the matrix is compressed.
 
         *row_swaps* is a $m$-element list where each element is a
@@ -1145,7 +1145,7 @@ def _singular_value_decomposition(A):
     For matrices which are not square or are rank-deficient, it is
     sufficient to return a column orthogonal matrix because augmenting
     them may introduce redundant computations.
-    In condensed Singular Value Decomposition we only return column orthognal
+    In condensed Singular Value Decomposition we only return column orthogonal
     matrices because of this reason
 
     If you want to augment the results to return a full orthogonal
@@ -1153,7 +1153,7 @@ def _singular_value_decomposition(A):
 
     - Augment the $U, V$ matrices with columns that are orthogonal to every
       other columns and make it square.
-    - Augument the $\Sigma$ matrix with zero rows to make it have the same
+    - Augment the $\Sigma$ matrix with zero rows to make it have the same
       shape as the original matrix.
 
     The procedure will be illustrated in the examples section.
@@ -1408,7 +1408,7 @@ def _QRdecomposition(M):
 
     - Augment the $Q$ matrix with columns that are orthogonal to every
       other columns and make it square.
-    - Augument the $R$ matrix with zero rows to make it have the same
+    - Augment the $R$ matrix with zero rows to make it have the same
       shape as the original matrix.
 
     The procedure will be illustrated in the examples section.

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -660,7 +660,7 @@ def _det(M, method="bareiss", iszerofunc=None):
 
     dets = []
     for b in M.strongly_connected_components():
-        if method == "domain-ge": # uses DomainMatrix to evalute determinant
+        if method == "domain-ge": # uses DomainMatrix to evaluate determinant
             det = _det_DOM(M[b, b])
         elif method == "bareiss":
             det = M[b, b]._eval_det_bareiss(iszerofunc=iszerofunc)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -409,7 +409,7 @@ def test_derivatives_elementwise_applyfunc():
     _check_derivative_with_explicit_matrix(expr, x, expr.diff(x))
 
     expr = x.applyfunc(sin).T*y
-    # TODO: restore (currently returning the traspose):
+    # TODO: restore (currently returning the transpose):
     #  assert expr.diff(x).dummy_eq(DiagMatrix(x.applyfunc(cos))*y)
     _check_derivative_with_explicit_matrix(expr, x, expr.diff(x))
 

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -122,7 +122,7 @@ class Trace(Expr):
     def _normalize(self):
         # Normalization of trace of matrix products. Use transposition and
         # cyclic properties of traces to make sure the arguments of the matrix
-        # product are sorted and the first argument is not a trasposition.
+        # product are sorted and the first argument is not a transposition.
         from sympy.matrices.expressions.matmul import MatMul
         from sympy.matrices.expressions.transpose import Transpose
         trace_arg = self.arg

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -36,7 +36,7 @@ def _diagonal_solve(M, rhs):
     if not M.is_diagonal():
         raise TypeError("Matrix should be diagonal")
     if rhs.rows != M.rows:
-        raise TypeError("Size mis-match")
+        raise TypeError("Size mismatch")
 
     return M._new(
         rhs.rows, rhs.cols, lambda i, j: rhs[i, j] / M[i, i])

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -102,7 +102,7 @@ def _initialize_first_polynomial(N, M, factor_base, idx_1000, idx_5000, seed=Non
     """This step is the initialization of the 1st sieve polynomial.
     Here `a` is selected as a product of several primes of the factor_base
     such that `a` is about to ``sqrt(2*N) / M``. Other initial values of
-    factor_base elem are also intialized which includes a_inv, b_ainv, soln1,
+    factor_base elem are also initialized which includes a_inv, b_ainv, soln1,
     soln2 which are used when the sieve polynomial is changed. The b_ainv
     is required for fast polynomial change as we do not have to calculate
     `2*b*mod_inverse(a, prime)` every time.
@@ -115,8 +115,8 @@ def _initialize_first_polynomial(N, M, factor_base, idx_1000, idx_5000, seed=Non
     N : Number to be factored
     M : sieve interval
     factor_base : factor_base primes
-    idx_1000 : index of prime numbe in the factor_base near 1000
-    idx_5000 : index of primenumber in the factor_base near to 5000
+    idx_1000 : index of prime number in the factor_base near 1000
+    idx_5000 : index of prime number in the factor_base near to 5000
     seed : Generate pseudoprime numbers
     """
     if seed is not None:
@@ -447,7 +447,7 @@ def qs(N, prime_bound, M, ERROR_TERM=25, seed=1234):
     these relations then we can form ``(t1*t2...ti)**2 = u1*u2...ui modN`` such that
     the right hand side is a square, thus we found a relation of ``X**2 = Y**2 modN``.
 
-    Here, several optimizations are done like using muliple polynomials for
+    Here, several optimizations are done like using multiple polynomials for
     sieving, fast changing between polynomials and using partial relations.
     The use of partial relations can speeds up the factoring by 2 times.
 

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -32,8 +32,8 @@ to use the features of this module.
 Clang: The C and C++ compiler which is used to extract an AST from the provided
 C source code.
 
-Refrences
-=========
+References
+==========
 
 .. [1] https://github.com/sympy/sympy/issues
 .. [2] https://clang.llvm.org/docs/
@@ -121,7 +121,7 @@ if cin:
 
             It takes the filename as an attribute and creates a Clang AST
             Translation Unit parsing the file.
-            Then the transformation function is called on the transaltion unit,
+            Then the transformation function is called on the translation unit,
             whose reults are collected into a list which is returned by the
             function.
 
@@ -161,7 +161,7 @@ if cin:
 
             It takes the source code as an attribute, stores it in a temporary
             file and creates a Clang AST Translation Unit parsing the file.
-            Then the transformation function is called on the transaltion unit,
+            Then the transformation function is called on the translation unit,
             whose reults are collected into a list which is returned by the
             function.
 

--- a/sympy/parsing/fortran/fortran_parser.py
+++ b/sympy/parsing/fortran/fortran_parser.py
@@ -45,8 +45,8 @@ if lfortran:
     LFortran : Required to parse Fortran source code into ASR
 
 
-    Refrences
-    =========
+    References
+    ==========
 
     .. [1] https://github.com/sympy/sympy/issues
     .. [2] https://gitlab.com/lfortran/lfortran
@@ -99,7 +99,7 @@ if lfortran:
             NotImplementedError() when called for Numeric assignments or Arrays
 
             """
-            # TODO: Arithmatic Assignment
+            # TODO: Arithmetic Assignment
             if isinstance(node.target, asr.Variable):
                 target = node.target
                 value = node.value

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -52,7 +52,7 @@ class SymPyExpression:  # type: ignore
     Declaration(Variable(c, type=float32, value=2.0)),
     Declaration(Variable(d, type=float32, value=4.0))]
 
-    An example of variable definiton:
+    An example of variable definition:
 
     >>> from sympy.parsing.sym_expr import SymPyExpression
     >>> src2 = '''

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2121,8 +2121,8 @@ class Beam:
             for plotting loads.
             Given a right handed coordinate system with XYZ coordinates,
             the beam's length is assumed to be along the positive X axis.
-            The draw function recognizes positve loads(with n>-2) as loads
-            acting along negative Y direction and positve moments acting
+            The draw function recognizes positive loads(with n>-2) as loads
+            acting along negative Y direction and positive moments acting
             along positive Z direction.
 
         Parameters
@@ -2236,7 +2236,7 @@ class Beam:
             elif load[2] >= 0:
                 # `fill` will be assigned only when higher order loads are present
                 value, start, order, end = load
-                # Positive loads have their seperate equations
+                # Positive loads have their separate equations
                 if(value>0):
                     plus = 1
                 # if pictorial is True we remake the load equation again with

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -503,7 +503,7 @@ def test_MIMOSeries_construction():
     # arg cannot contain SISO as well as MIMO systems.
     raises(TypeError, lambda: MIMOSeries(tfm_1, tf_1))
 
-    # for all the adjascent transfer function matrices:
+    # for all the adjacent transfer function matrices:
     # no. of inputs of first TFM must be equal to the no. of outputs of the second TFM.
     raises(ValueError, lambda: MIMOSeries(tfm_1, tfm_2, -tfm_1))
 

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -1,7 +1,7 @@
 #TODO:
 # -Implement Clebsch-Gordan symmetries
 # -Improve simplification method
-# -Implement new simpifications
+# -Implement new simplifications
 """Clebsch-Gordon Coefficients."""
 
 from sympy.concrete.summations import Sum

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -192,7 +192,7 @@ class Gate(UnitaryOperator):
     #-------------------------------------------------------------------------
 
     def get_target_matrix(self, format='sympy'):
-        """The matrix represenation of the target part of the gate.
+        """The matrix representation of the target part of the gate.
 
         Parameters
         ----------

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2593,7 +2593,7 @@ def _get_ordered_dummies(mul, verbose=False):
     Strategy
     --------
 
-    The canoncial order is given by an arbitrary sorting rule.  A sort key
+    The canonical order is given by an arbitrary sorting rule.  A sort key
     is determined for each dummy as a tuple that depends on all factors where
     the index is present.  The dummies are thereby sorted according to the
     contraction structure of the term, instead of sorting based solely on the

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1521,7 +1521,7 @@ class MatplotlibBackend(BaseBackend):
         if parent.fill:
             ax.fill_between(**parent.fill)
 
-        # xlim and ylim shoulld always be set at last so that plot limits
+        # xlim and ylim should always be set at last so that plot limits
         # doesn't get altered during the process.
         if parent.xlim:
             ax.set_xlim(parent.xlim)
@@ -1676,7 +1676,7 @@ def plot(*args, show=True, **kwargs):
         The last argument is a 3-tuple denoting the range of the free
         variable. e.g. ``(x, 0, 5)``
 
-        Typical usage examples are in the followings:
+        Typical usage examples are in the following:
 
         - Plotting a single expression with a single range.
             ``plot(expr, range, **kwargs)``

--- a/sympy/polys/distributedmodules.py
+++ b/sympy/polys/distributedmodules.py
@@ -149,7 +149,7 @@ def sdm_monomial_divides(A, B):
 # The actual distributed modules code.
 
 def sdm_LC(f, K):
-    """Returns the leading coeffcient of ``f``. """
+    """Returns the leading coefficient of ``f``. """
     if not f:
         return K.zero
     else:

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1083,7 +1083,7 @@ class DomainMatrix:
         return A.from_rep(A.rep.mul_elementwise(B.rep))
 
     def __truediv__(A, lamda):
-        """ Method for Scalar Divison"""
+        """ Method for Scalar Division"""
         if isinstance(lamda, int) or ZZ.of_type(lamda):
             lamda = DomainScalar(ZZ(lamda), ZZ)
 

--- a/sympy/polys/numberfields/tests/test_primes.py
+++ b/sympy/polys/numberfields/tests/test_primes.py
@@ -149,7 +149,7 @@ def test_decomp_5():
 
 def test_decomp_6():
     # Another case where 2 divides the index. This is Dedekind's example of
-    # an essential discriminant divisor. (See Cohen, Excercise 6.10.)
+    # an essential discriminant divisor. (See Cohen, Exercise 6.10.)
     T = Poly(x ** 3 + x ** 2 - 2 * x + 8)
     rad = {}
     ZK, dK = round_two(T, radicals=rad)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1722,7 +1722,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         raise ValueError("expected a monomial, got %s" % element)
 
     def const(self):
-        """Returns the constant coeffcient. """
+        """Returns the constant coefficient. """
         return self._get_coeff(self.ring.zero_monom)
 
     @property

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -208,7 +208,7 @@ def solve_lin_sys(eqs, ring, _raw=True):
         PolynomialRing (assumed equal to zero).
     ring: PolynomialRing
         The polynomial ring from which eqs are drawn. The generators of this
-        ring are the unkowns to be solved for and the domain of the ring is
+        ring are the unknowns to be solved for and the domain of the ring is
         the domain of the coefficients of the system of equations.
     _raw: bool
         If *_raw* is False, the keys and values in the returned dictionary

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -205,7 +205,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
     You may also enter ``'file'`` for the viewer argument. Doing so will cause
     this function to return a file object in read-only mode, if ``filename``
-    is unset. However, if it was set, then 'preview' writes the genereted
+    is unset. However, if it was set, then 'preview' writes the generated
     file to this filename instead.
 
     There is also support for writing to a ``io.BytesIO`` like object, which

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -24,7 +24,7 @@ from sympy.external import import_module
 
 # Unlike NumPy which will aggressively promote operands to double precision,
 # jax always uses single precision. Double precision in jax can be
-# configured before the call to `import jax`, however this must be explicity
+# configured before the call to `import jax`, however this must be explicitly
 # configured and is not fully supported. Thus, the tests here have been modified
 # from the tests in test_numpy.py, only in the fact that they assert lambdify
 # function accuracy to only single precision accuracy.

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -314,7 +314,7 @@ def mrv(e, x):
         args = [ss.do_subs(x[1]) for x in l]
         return s, e.func(*args)
     elif e.is_Derivative:
-        raise NotImplementedError("MRV set computation for derviatives"
+        raise NotImplementedError("MRV set computation for derivatives"
                                   " not implemented yet.")
     raise NotImplementedError(
         "Don't know how to calculate the mrv of '%s'" % e)

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -131,7 +131,7 @@ def test_powerset_method():
 
 def test_is_subset():
     # covers line 101-102
-    # initalize powerset(1), which is a subset of powerset(1,2)
+    # initialize powerset(1), which is a subset of powerset(1,2)
     subset = PowerSet(FiniteSet(1))
     pset = PowerSet(FiniteSet(1, 2))
     bad_set = PowerSet(FiniteSet(2, 3))

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -78,7 +78,7 @@ def test_same_setexprs_are_not_identical():
     b = SetExpr(FiniteSet(0, 1))
     assert (a + b).set == FiniteSet(0, 1, 2)
 
-    # Cannont detect the set being the same:
+    # Cannot detect the set being the same:
     # assert (a + a).set == FiniteSet(0, 2)
 
 

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -450,7 +450,7 @@ def trigsimp(expr, **opts):
         algorithm. If ``'fu'``, run the collection of trigonometric
         transformations described by Fu, et al. (see the
         :py:func:`~sympy.simplify.fu.fu` docstring). If ``'old'``, the original
-        SymPy trig simplication function is run.
+        SymPy trig simplification function is run.
     opts :
         Optional keyword arguments passed to the method. See each method's
         function docstring for details.

--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -273,7 +273,7 @@ def _solve_lambert(f, symbol, gens):
             sols.extend(_solve_lambert(plhs, symbol, gens))
         # uniq is needed for a case like
         # 2*log(t) - log(-z**2) + log(z + log(x) + log(z))
-        # where subtituting t with +/-x gives all the same solution;
+        # where substituting t with +/-x gives all the same solution;
         # uniq, rather than list(set()), is used to maintain canonical
         # order
         return list(uniq(sols))

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1648,7 +1648,7 @@ def diop_solve(eq, param=symbols("t", integer=True)):
 
     if eq_type is not None and eq_type not in diop_known:
             raise ValueError(filldedent('''
-    Alhough this type of equation was identified, it is not yet
+    Although this type of equation was identified, it is not yet
     handled. It should, however, be listed in `diop_known` at the
     top of this file. Developers should see comments at the end of
     `classify_diop`.

--- a/sympy/solvers/ode/nonhomogeneous.py
+++ b/sympy/solvers/ode/nonhomogeneous.py
@@ -409,7 +409,7 @@ def _undetermined_coefficients_match(expr, x, func=None, eq_homogeneous=S.Zero):
 
     def is_homogeneous_solution(term):
         r""" This function checks whether the given trialset contains any root
-            of homogenous equation"""
+            of homogeneous equation"""
         return expand(sub_func_doit(eq_homogeneous, func, term)).is_zero
 
     retdict['test'] = _test_term(expr, x)

--- a/sympy/solvers/ode/riccati.py
+++ b/sympy/solvers/ode/riccati.py
@@ -62,7 +62,7 @@ of the algorithm, a few definitions to understand are -
     `\infty` if `a(\frac{1}{x})` has a pole at 0.
 
 Every pole is associated with an order that is equal to the multiplicity
-of its appearence as a root of `T(x)`. A pole is called a simple pole if
+of its appearance as a root of `T(x)`. A pole is called a simple pole if
 it has an order 1. Similarly, a pole is called a multiple pole if it has
 an order `\ge` 2.
 
@@ -124,7 +124,7 @@ to get the solution correctly.
 Implementation
 ==============
 
-In this implementatin, we use ``Poly`` to represent a rational function
+In this implementation, we use ``Poly`` to represent a rational function
 rather than using ``Expr`` since ``Poly`` is much faster. Since we cannot
 represent rational functions directly using ``Poly``, we instead represent
 a rational function with 2 ``Poly`` objects - one for its numerator and
@@ -153,7 +153,7 @@ the number of poles be `n`. Also find the valuation of `a(x)` at
 NOTE: Although the algorithm considers `\infty` as a pole, it is
 not mentioned if it a part of the set of finite poles. `\infty`
 is NOT a part of the set of finite poles. If a pole exists at
-`\infty`, we use its multiplicty to find the laurent series of
+`\infty`, we use its multiplicity to find the laurent series of
 `a(x)` about `\infty`.
 
 Step 6 : Find `n` c-vectors (one for each pole) and 1 d-vector using

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -690,7 +690,7 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False,
     Explanation
     ===========
 
-    This solver solves the system of ODEs of the follwing form:
+    This solver solves the system of ODEs of the following form:
 
     .. math::
         X'(t) = A(t) X(t) +  b(t)
@@ -2090,7 +2090,7 @@ def dsolve_system(eqs, funcs=None, t=None, ics=None, doit=False, simplify=True):
 
     if t is not None and not isinstance(t, Symbol):
         raise ValueError(filldedent('''
-            The indepedent variable must be of type Symbol
+            The independent variable must be of type Symbol
         '''))
 
     if t is None:

--- a/sympy/solvers/ode/tests/test_riccati.py
+++ b/sympy/solvers/ode/tests/test_riccati.py
@@ -657,7 +657,7 @@ def test_rational_laurent_series():
     4. mul - Multiplicity of x0 if x0 is a pole of
        the rational function (0 otherwise).
     5. n - Number of terms upto which the series
-       is to be calcuated.
+       is to be calculated.
     """
     tests = [
     # Laurent series about simple pole (Multiplicity = 1)
@@ -667,7 +667,7 @@ def test_rational_laurent_series():
         S(1), 1, 6,
         {1: 7, 0: -8, -1: 9, -2: -9, -3: 9, -4: -9}
     ),
-    # Laurent series about multiple pole (Multiplicty > 1)
+    # Laurent series about multiple pole (Multiplicity > 1)
     (
         Poly(64*x**3 - 1728*x + 1216, x, extension=True),
         Poly(64*x**4 - 80*x**3 - 831*x**2 + 1809*x - 972, x, extension=True),

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -360,7 +360,7 @@ def test__classify_linear_system():
     assert _classify_linear_system(eq4, funcs, t) == sol4
 
 
-    # Multiple matchs
+    # Multiple matches
 
     f, g = symbols("f g", cls=Function)
     y, t_ = symbols("y t_")

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1403,7 +1403,7 @@ def _solve(f, *symbols, **flags):
                     v = cond.subs(symbol, candidate)
                     _eval_simplify = getattr(v, '_eval_simplify', None)
                     if _eval_simplify is not None:
-                        # unconditionally take the simpification of v
+                        # unconditionally take the simplification of v
                         v = _eval_simplify(ratio=2, measure=lambda x: 1)
                 except TypeError:
                     # incompatible type with condition(s)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1219,7 +1219,7 @@ def _invert_modular(modterm, rhs, n, symbol):
     1. If a is symbol then  m*n + rhs is the required solution.
 
     2. If a is an instance of ``Add`` then we try to find two symbol independent
-       parts of a and the symbol independent part gets tranferred to the other
+       parts of a and the symbol independent part gets transferred to the other
        side and again the ``_invert_modular`` is called on the symbol
        dependent part.
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -187,7 +187,7 @@ def test_solve_args():
     assert solve(x**2 - pi, pi) == [x**2]
     # no equations
     assert solve([], [x]) == []
-    # nonlinear systen
+    # nonlinear system
     assert solve((x**2 - 4, y - 2), x, y) == [(-2, 2), (2, 2)]
     assert solve((x**2 - 4, y - 2), y, x) == [(2, -2), (2, 2)]
     assert solve((x**2 - 4 + z, y - 2 - z), a, z, y, x, set=True

--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -76,7 +76,7 @@ class CompoundPSpace(PSpace):
         new_pspace = self._transform_pspace(self.symbol, parent_dist, func)
         if new_pspace is not None:
             return new_pspace
-        message = ("Compound Distribution for %s is not implemeted yet" % str(parent_dist))
+        message = ("Compound Distribution for %s is not implemented yet" % str(parent_dist))
         raise NotImplementedError(message)
 
     def _transform_pspace(self, sym, dist, pdf):
@@ -159,7 +159,7 @@ class CompoundDistribution(Distribution, NamedArgsMixin):
     def __new__(cls, dist):
         if not isinstance(dist, (ContinuousDistribution,
                 SingleFiniteDistribution, DiscreteDistribution)):
-            message = "Compound Distribution for %s is not implemeted yet" % str(dist)
+            message = "Compound Distribution for %s is not implemented yet" % str(dist)
             raise NotImplementedError(message)
         if not cls._compound_check(dist):
             return dist

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2305,7 +2305,7 @@ class LevyDistribution(SingleContinuousDistribution):
     @staticmethod
     def check(mu, c):
         _value_check(c > 0, "c (scale parameter) must be positive")
-        _value_check(mu.is_real, "mu (location paramater) must be real")
+        _value_check(mu.is_real, "mu (location parameter) must be real")
 
     def pdf(self, x):
         mu, c = self.mu, self.c
@@ -3487,7 +3487,7 @@ def PowerFunction(name, alpha, a, b):
     Parameters
     ==========
 
-    alpha : Positive number, `0 < \alpha`, the shape paramater
+    alpha : Positive number, `0 < \alpha`, the shape parameter
     a : Real number, :math:`-\infty < a`, the left boundary
     b : Real number, :math:`a < b < \infty`, the right boundary
 

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -349,7 +349,7 @@ def Coin(name, p=S.Half):
     Parameters
     ==========
 
-    p : Rational Numeber between 0 and 1
+    p : Rational Number between 0 and 1
       Represents probability of getting "Heads", by default is Half
 
     Examples

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -837,7 +837,7 @@ def Multinomial(syms, n, *p):
 
     n : Positive integer
         Represents number of trials
-    p : List of event probabilites
+    p : List of event probabilities
         Must be in the range of $[0, 1]$.
 
     Returns
@@ -910,7 +910,7 @@ def NegativeMultinomial(syms, k0, *p):
 
     k0 : positive integer
         Represents number of failures before the experiment is stopped
-    p : List of event probabilites
+    p : List of event probabilities
         Must be in the range of $[0, 1]$
 
     Returns

--- a/sympy/stats/random_matrix_models.py
+++ b/sympy/stats/random_matrix_models.py
@@ -288,7 +288,7 @@ def CircularEnsemble(sym, dim):
 
 def CircularUnitaryEnsemble(sym, dim):
     """
-    Represents Cicular Unitary Ensembles.
+    Represents Circular Unitary Ensembles.
 
     Examples
     ========
@@ -303,7 +303,7 @@ def CircularUnitaryEnsemble(sym, dim):
     ====
 
     As can be seen above in the example, density of CiruclarUnitaryEnsemble
-    is not evaluated becuase the exact definition is based on haar measure of
+    is not evaluated because the exact definition is based on haar measure of
     unitary group which is not unique.
     """
     sym, dim = _symbol_converter(sym), _sympify(dim)
@@ -313,7 +313,7 @@ def CircularUnitaryEnsemble(sym, dim):
 
 def CircularOrthogonalEnsemble(sym, dim):
     """
-    Represents Cicular Orthogonal Ensembles.
+    Represents Circular Orthogonal Ensembles.
 
     Examples
     ========
@@ -328,7 +328,7 @@ def CircularOrthogonalEnsemble(sym, dim):
     ====
 
     As can be seen above in the example, density of CiruclarOrthogonalEnsemble
-    is not evaluated becuase the exact definition is based on haar measure of
+    is not evaluated because the exact definition is based on haar measure of
     unitary group which is not unique.
     """
     sym, dim = _symbol_converter(sym), _sympify(dim)
@@ -338,7 +338,7 @@ def CircularOrthogonalEnsemble(sym, dim):
 
 def CircularSymplecticEnsemble(sym, dim):
     """
-    Represents Cicular Symplectic Ensembles.
+    Represents Circular Symplectic Ensembles.
 
     Examples
     ========
@@ -353,7 +353,7 @@ def CircularSymplecticEnsemble(sym, dim):
     ====
 
     As can be seen above in the example, density of CiruclarSymplecticEnsemble
-    is not evaluated becuase the exact definition is based on haar measure of
+    is not evaluated because the exact definition is based on haar measure of
     unitary group which is not unique.
     """
     sym, dim = _symbol_converter(sym), _sympify(dim)

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -449,7 +449,7 @@ def median(X, evaluate=True, **kwargs):
         x = Dummy('x')
         result = solveset(piecewise_fold(cdf(x) - Rational(1, 2)), x, pspace(X).set)
         return result
-    raise NotImplementedError("The median of %s is not implemeted."%str(pspace(X)))
+    raise NotImplementedError("The median of %s is not implemented."%str(pspace(X)))
 
 
 def coskewness(X, Y, Z, condition=None, **kwargs):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1621,7 +1621,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     independent Bernoulli process trials with the same parameter `p`.
     It's assumed that the probability `p` applies to every
     trial and that the outcomes of each trial
-    are independent of all the rest. Therefore Bernoulli Processs
+    are independent of all the rest. Therefore Bernoulli Process
     is Discrete State and Discrete Time Stochastic Process.
 
     Parameters

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -280,7 +280,7 @@ def get_indices(expr):
             return set(), {}
         elif isinstance(expr, Function):
             # Support ufunc like behaviour by returning indices from arguments.
-            # Functions do not interpret repeated indices across argumnts
+            # Functions do not interpret repeated indices across arguments
             # as summation
             ind0 = set()
             for arg in expr.args:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4178,7 +4178,7 @@ def get_lines(ex, index_type):
     Returns ``(lines, traces, rest)`` for an index type,
     where ``lines`` is the list of list of positions of a matrix line,
     ``traces`` is the list of list of traced matrix lines,
-    ``rest`` is the rest of the elements ot the tensor.
+    ``rest`` is the rest of the elements of the tensor.
     """
     def _join_lines(a):
         i = 0

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -42,7 +42,7 @@ from sympy.external.gmpy import GROUND_TYPES, HAS_GMPY
 IS_WINDOWS = (os.name == 'nt')
 ON_CI = os.getenv('CI', None)
 
-# emperically generated list of the proportion of time spent running
+# empirically generated list of the proportion of time spent running
 # an even split of tests.  This should periodically be regenerated.
 # A list of [.6, .1, .3] would mean that if the tests are evenly split
 # into '1/3', '2/3', '3/3', the first split would take 60% of the time,

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -27,7 +27,7 @@ class CompileError (Exception):
 
 
 def get_abspath(path, cwd='.'):
-    """ Returns the aboslute path.
+    """ Returns the absolute path.
 
     Parameters
     ==========

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -226,7 +226,7 @@ class Routine:
     def result_variables(self):
         """Returns a list of OutputArgument, InOutArgument and Result.
 
-        If return values are present, they are at the end ot the list.
+        If return values are present, they are at the end of the list.
         """
         args = [arg for arg in self.arguments if isinstance(
             arg, (OutputArgument, InOutArgument))]
@@ -251,7 +251,7 @@ default_datatypes = {
     "complex": DataType("double", "COMPLEX*16", "complex", "", "", "float") #FIXME:
        # complex is only supported in fortran, python, julia, and octave.
        # So to not break c or rust code generation, we stick with double or
-       # float, respecitvely (but actually should raise an exception for
+       # float, respectively (but actually should raise an exception for
        # explicitly complex variables (x.is_complex==True))
 }
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1366,7 +1366,7 @@ def _partition(seq, vector, m=None):
 
 
 def _set_partitions(n):
-    """Cycle through all partions of n elements, yielding the
+    """Cycle through all partitions of n elements, yielding the
     current number of partitions, ``m``, and a mutable list, ``q``
     such that ``element[i]`` is in part ``q[i]`` of the partition.
 
@@ -2290,7 +2290,7 @@ def multiset_derangements(s):
         b = take[0][0]  # last element to be placed
         b_ct = take[0][1]
 
-        # split the indexes of the not-already-assigned elemements of rv into
+        # split the indexes of the not-already-assigned elements of rv into
         # three categories
         forced_a = []  # positions which must have an a
         forced_b = []  # positions which must have a b

--- a/sympy/utilities/mathml/data/mmltex.xsl
+++ b/sympy/utilities/mathml/data/mmltex.xsl
@@ -1920,7 +1920,7 @@ priority="2">
 			<xsl:text>}</xsl:text>
 		</xsl:when>
 		<xsl:otherwise>
-		<!-- number of argumnets is not 2 - code 25 -->
+		<!-- number of arguments is not 2 - code 25 -->
 			<xsl:message>exception 25:</xsl:message>
 			<xsl:text>\text{exception 25:}</xsl:text>
 		</xsl:otherwise>

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1498,7 +1498,7 @@ def test_cupy_array_arg():
 
 def test_cupy_array_arg_using_numpy():
     # numpy functions can be run on cupy arrays
-    # unclear if we can "officialy" support this,
+    # unclear if we can "officially" support this,
     # depends on numpy __array_function__ support
     if not cupy:
         skip("CuPy not installed")

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -98,7 +98,7 @@ class ImplicitRegion(Basic):
         ==========
 
         - Erik Hillgarter, "Rational Points on Conics", Diploma Thesis, RISC-Linz,
-          J. Kepler Universitat Linz, 1996. Availaible:
+          J. Kepler Universitat Linz, 1996. Available:
           https://www3.risc.jku.at/publications/download/risc_1355/Rational%20Points%20on%20Conics.pdf
 
         """
@@ -342,7 +342,7 @@ class ImplicitRegion(Basic):
 
     def rational_parametrization(self, parameters=('t', 's'), reg_point=None):
         """
-        Returns the rational parametrization of implict region.
+        Returns the rational parametrization of implicit region.
 
         Examples
         ========


### PR DESCRIPTION
Found via `codespell -q 3 -L aboves,aline,ans,aother,arithmetics,assum,atleast,braket,clen,declar,declars,dorder,dum,enew,fo,fro,inout,iself,ist,ket,lamda,lightyear,lightyears,nd,numer,numers,orderd,ot,pring,rcall,rever,ro,ser,siz,splitted,sring,supercedes,te,tht,unequality,upto,vas,versin,whet`

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->