### PR TITLE
Bug Fix: Error on all limits with Piecewise #24127

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -60,6 +60,7 @@ class ExprCondPair(Tuple):
     def _eval_simplify(self, **kwargs):
         return self.func(*[a.simplify(**kwargs) for a in self.args])
 
+
 class Piecewise(Function):
     """
     Represents a piecewise function.
@@ -236,6 +237,32 @@ class Piecewise(Function):
 
     def _eval_evalf(self, prec):
         return self.func(*[(e._evalf(prec), c) for e, c in self.args])
+
+    def _eval_is_meromorphic(self, x, a):
+        # Conditions often implicitly assume that the argument is real.
+        # Hence, there needs to be some check for as_set.
+        if not a.is_real:
+            return None
+
+        a_real = a.is_real
+        # First, let's check if a is real. If not return ValueError.
+        if a_real is False:
+            raise ValueError("A piecewise function is defined only on the real line.")
+        if a_real is None:
+            return None
+
+        # Then, scan ExprCondPairs in the given order to find a piece that would contain a,
+        # possibly as a boundary point.
+        for e, c in self.args:
+            cond = c.subs(x, a)
+
+            if cond.is_Relational:
+                return None
+            if a in c.as_set().boundary:
+                return None
+            # Apply expression if a is an interior point of the domain of e.
+            if cond:
+                return e._eval_is_meromorphic(x, a)
 
     def piecewise_integrate(self, x, **kwargs):
         """Return the Piecewise with each expression being

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -244,13 +244,6 @@ class Piecewise(Function):
         if not a.is_real:
             return None
 
-        a_real = a.is_real
-        # First, let's check if a is real. If not return ValueError.
-        if a_real is False:
-            raise ValueError("A piecewise function is defined only on the real line.")
-        if a_real is None:
-            return None
-
         # Then, scan ExprCondPairs in the given order to find a piece that would contain a,
         # possibly as a boundary point.
         for e, c in self.args:

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1553,3 +1553,16 @@ def test_issue_22533():
 def test_issue_24072():
     assert Piecewise((1, x > 1), (2, x <= 1), (3, x <= 1)
         ) == Piecewise((1, x > 1), (2, True))
+
+
+def test_piecewise__eval_is_meromorphic():
+    """ Issue 24127: Tests eval_is_meromorphic auxiliary method """
+    x = symbols('x', real=True)
+    f = Piecewise((1, x < 0), (sqrt(1 - x), True))
+    assert f.is_meromorphic(x, I) is None
+    assert f.is_meromorphic(x, -1) == True
+    assert f.is_meromorphic(x, 0) == None
+    assert f.is_meromorphic(x, 1) == False
+    assert f.is_meromorphic(x, 2) == True
+    assert f.is_meromorphic(x, Symbol('a')) == None
+    assert f.is_meromorphic(x, Symbol('a', real=True)) == None


### PR DESCRIPTION
#### References to other Issues or PRs
Partial fix for #24127.

#### Brief description of what is fixed or changed
Error in #24127 was exactly what it said in the label: `Piecewise` class was missing attribute `_eval_is_meromorphic`. This attribute has been added and the reproduction script should now work.

#### Other comments
I will work on accuracy of the result. Not sure if this is correct:

```
In [9]: f1.limit(x,x0)
Out[9]: 1/2
```

If you think the result above is incorrect please let me know and I will get that rectified.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added `_eval_is_meromorphic` tot the `Piecewise` class.
<!-- END RELEASE NOTES -->
