### PR TITLE
Mentioned that Float cannot represent negative zero

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1015,7 +1015,7 @@ class Float(Number):
     -oo
     >>> _.is_Float
     False
-    
+
     Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
     """
     __slots__ = ('_mpf_', '_prec')

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -855,6 +855,7 @@ class Number(AtomicExpr):
 
 class Float(Number):
     """Represent a floating-point number of arbitrary precision.
+    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
 
     Examples
     ========

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -855,7 +855,6 @@ class Number(AtomicExpr):
 
 class Float(Number):
     """Represent a floating-point number of arbitrary precision.
-    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
 
     Examples
     ========
@@ -926,6 +925,7 @@ class Float(Number):
 
     Floats are inexact by their nature unless their value is a binary-exact
     value.
+    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
 
     >>> approx, exact = Float(.1, 1), Float(.125, 1)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1016,7 +1016,8 @@ class Float(Number):
     >>> _.is_Float
     False
 
-    Zero in Float only has a single value. Values are not separate for positive and negative zeroes.
+    Zero in Float only has a single value. Values are not separate for
+    positive and negative zeroes.
     """
     __slots__ = ('_mpf_', '_prec')
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -925,7 +925,6 @@ class Float(Number):
 
     Floats are inexact by their nature unless their value is a binary-exact
     value.
-    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
 
     >>> approx, exact = Float(.1, 1), Float(.125, 1)
 
@@ -1016,6 +1015,8 @@ class Float(Number):
     -oo
     >>> _.is_Float
     False
+    
+    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
     """
     __slots__ = ('_mpf_', '_prec')
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1016,7 +1016,7 @@ class Float(Number):
     >>> _.is_Float
     False
 
-    Zero in Float only has a single value. Values are not seperate for positive and neghative zeroes.
+    Zero in Float only has a single value. Values are not separate for positive and negative zeroes.
     """
     __slots__ = ('_mpf_', '_prec')
 


### PR DESCRIPTION
####  Fixed #24088 
<!--  -->


#### Improved documentation of float to include that Float cannot represent negative zero.


#### Release Notes



<!-- BEGIN RELEASE NOTES -->

- other
  - an addition to documentation about Float.

<!-- END RELEASE NOTES -->
