### PR TITLE
Make ShapeError more readable

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1143,6 +1143,7 @@ Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
 S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
+S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -252,7 +252,8 @@ class MatrixShaping(MatrixRequired):
 
         if self.rows != other.rows:
             raise ShapeError(
-                "`self` and `other` must have the same number of rows.")
+                "The matrices have incompatible number of rows ({} and {})"
+                .format(self.rows, other.rows))
 
         return self._eval_col_insert(pos, other)
 
@@ -284,7 +285,8 @@ class MatrixShaping(MatrixRequired):
 
         if self.cols != other.cols:
             raise ShapeError(
-                "`self` and `other` must have the same number of columns.")
+                "The matrices have incompatible number of columns ({} and {})"
+                .format(self.cols, other.cols))
         return self._eval_col_join(other)
 
     def col(self, j):
@@ -488,7 +490,8 @@ class MatrixShaping(MatrixRequired):
 
         if self.cols != other.cols:
             raise ShapeError(
-                "`self` and `other` must have the same number of columns.")
+                "The matrices have incompatible number of columns ({} and {})"
+                .format(self.cols, other.cols))
 
         return self._eval_row_insert(pos, other)
 
@@ -519,7 +522,8 @@ class MatrixShaping(MatrixRequired):
 
         if self.rows != other.rows:
             raise ShapeError(
-                "`self` and `rhs` must have the same number of rows.")
+                "The matrices have incompatible number of rows ({} and {})"
+                .format(self.rows, other.rows))
         return self._eval_row_join(other)
 
     def diagonal(self, k=0):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24160

#### Brief description of what is fixed or changed

I have replaced all occurrences of ``ShapeError`` and there are only four of these that have the problem.
I had to pick whether it is a good option to print out the full variables or not,
But I recently found that users are allowed to use other frameworks to inspect local variables (https://stackoverflow.com/questions/19514288/locals-and-globals-in-stack-trace-on-exception-python)
And it is automatically done in like pdb, pytest, ..., so there wouldn't be a need to print out full Matrix object at all.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Made ``ShapeError`` messages more readable for users.
<!-- END RELEASE NOTES -->
