### PR TITLE
Fix the Ket*Op -> Op*Ket Bug in qapply and _apply_operator

### DIFF
--- a/sympy/physics/quantum/boson.py
+++ b/sympy/physics/quantum/boson.py
@@ -157,7 +157,7 @@ class BosonFockKet(Ket):
     def _eval_innerproduct_BosonFockBra(self, bra, **hints):
         return KroneckerDelta(self.n, bra.n)
 
-    def _apply_operator_BosonOp(self, op, **options):
+    def _apply_from_right_to_BosonOp(self, op, **options):
         if op.is_annihilation:
             return sqrt(self.n) * BosonFockKet(self.n - 1)
         else:
@@ -223,7 +223,7 @@ class BosonCoherentKet(Ket):
         else:
             return exp(-(abs(self.alpha)**2 + abs(bra.alpha)**2 - 2 * conjugate(bra.alpha) * self.alpha)/2)
 
-    def _apply_operator_BosonOp(self, op, **options):
+    def _apply_from_right_to_BosonOp(self, op, **options):
         if op.is_annihilation:
             return self.alpha * self
         else:

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -141,7 +141,7 @@ class FermionFockKet(Ket):
     def _eval_innerproduct_FermionFockBra(self, bra, **hints):
         return KroneckerDelta(self.n, bra.n)
 
-    def _apply_operator_FermionOp(self, op, **options):
+    def _apply_from_right_to_FermionOp(self, op, **options):
         if op.is_annihilation:
             if self.n == 1:
                 return FermionFockKet(0)

--- a/sympy/physics/quantum/pauli.py
+++ b/sympy/physics/quantum/pauli.py
@@ -457,25 +457,25 @@ class SigmaZKet(Ket):
     def _eval_innerproduct_SigmaZBra(self, bra, **hints):
         return KroneckerDelta(self.n, bra.n)
 
-    def _apply_operator_SigmaZ(self, op, **options):
+    def _apply_from_right_to_SigmaZ(self, op, **options):
         if self.n == 0:
             return self
         else:
             return S.NegativeOne * self
 
-    def _apply_operator_SigmaX(self, op, **options):
+    def _apply_from_right_to_SigmaX(self, op, **options):
         return SigmaZKet(1) if self.n == 0 else SigmaZKet(0)
 
-    def _apply_operator_SigmaY(self, op, **options):
+    def _apply_from_right_to_SigmaY(self, op, **options):
         return I * SigmaZKet(1) if self.n == 0 else (-I) * SigmaZKet(0)
 
-    def _apply_operator_SigmaMinus(self, op, **options):
+    def _apply_from_right_to_SigmaMinus(self, op, **options):
         if self.n == 0:
             return SigmaZKet(1)
         else:
             return S.Zero
 
-    def _apply_operator_SigmaPlus(self, op, **options):
+    def _apply_from_right_to_SigmaPlus(self, op, **options):
         if self.n == 0:
             return S.Zero
         else:

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -182,7 +182,7 @@ def qapply_Mul(e, **options):
         result = lhs._apply_operator(rhs, **options)
     except (NotImplementedError, AttributeError):
         try:
-            result = rhs._apply_operator(lhs, **options)
+            result = rhs._apply_from_right_to(lhs, **options)
         except (NotImplementedError, AttributeError):
             if isinstance(lhs, BraBase) and isinstance(rhs, KetBase):
                 result = InnerProduct(lhs, rhs)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -254,26 +254,26 @@ class KetBase(StateBase):
         """
         return dispatch_method(self, '_eval_innerproduct', bra, **hints)
 
-    def _apply_operator(self, op, **options):
-        """Apply an Operator to this Ket.
+    def _apply_from_right_to(self, op, **options):
+        """Apply an Operator to this Ket as Operator*Ket
 
         This method will dispatch to methods having the format::
 
-            ``def _apply_operator_OperatorName(op, **options):``
+            ``def _apply_from_right_to_OperatorName(op, **options):``
 
         Subclasses should define these methods (one for each OperatorName) to
-        teach the Ket how operators act on it.
+        teach the Ket how to implement OperatorName*Ket
 
         Parameters
         ==========
 
         op : Operator
-            The Operator that is acting on the Ket.
+            The Operator that is acting on the Ket as op*Ket
         options : dict
             A dict of key/value pairs that control how the operator is applied
             to the Ket.
         """
-        return dispatch_method(self, '_apply_operator', op, **options)
+        return dispatch_method(self, '_apply_from_right_to', op, **options)
 
 
 class BraBase(StateBase):

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -8,7 +8,7 @@ from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.gate import H
+from sympy.physics.quantum.gate import H, XGate
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
@@ -128,3 +128,19 @@ def test_issue3044():
     result = Mul(S.NegativeOne, Rational(1, 4), 2**S.Half, hbar**2)
     result *= TensorProduct(JzKet(2,-1), JzKet(S.Half,S.Half))
     assert qapply(expr1) == result
+
+
+# Issue 24158: Tests whether qapply incorrectly evaluates some ket*op as op*ket
+def test_issue24158_ket_times_op():
+    P = BosonFockKet(0) * BosonOp("a") # undefined term
+    # Does lhs._apply_operator_BosonOp(rhs) still evaluate ket*op as op*ket?
+    assert qapply(P) == P   # qapply(P) -> BosonOp("a")*BosonFockKet(0) = 0 before fix
+    P = Qubit(1) * XGate(0) # undefined term
+    # Does rhs._apply_operator_Qubit(lhs) still evaluate ket*op as op*ket?
+    assert qapply(P) == P   # qapply(P) -> Qubit(0) before fix
+    P1 = Mul(QubitBra(0), Mul(QubitBra(0), Qubit(0)), XGate(0)) # legal expr <0| * (<1|*|1>) * X
+    assert qapply(P1) == QubitBra(0) * XGate(0)     # qapply(P1) -> 0 before fix
+    assert qapply(P1, dagger = True) == QubitBra(1) # qapply(P1, dagger=True) -> 0 before fix
+    P2 = QubitBra(0) * QubitBra(0) * Qubit(0) * XGate(0) # 'forgot' to set brackets
+    assert qapply(P2, dagger = True) == QubitBra(1) # qapply(P1) -> 0 before fix
+

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -15,7 +15,7 @@ from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
 from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.state import Ket
 from sympy.physics.quantum.density import Density
-from sympy.physics.quantum.qubit import Qubit
+from sympy.physics.quantum.qubit import Qubit, QubitBra
 from sympy.physics.quantum.boson import BosonOp, BosonFockKet, BosonFockBra
 
 

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -143,4 +143,3 @@ def test_issue24158_ket_times_op():
     assert qapply(P1, dagger = True) == QubitBra(1) # qapply(P1, dagger=True) -> 0 before fix
     P2 = QubitBra(0) * QubitBra(0) * Qubit(0) * XGate(0) # 'forgot' to set brackets
     assert qapply(P2, dagger = True) == QubitBra(1) # qapply(P1) -> 0 before fix
-

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -140,6 +140,8 @@ def test_issue24158_ket_times_op():
     assert qapply(P) == P   # qapply(P) -> Qubit(0) before fix
     P1 = Mul(QubitBra(0), Mul(QubitBra(0), Qubit(0)), XGate(0)) # legal expr <0| * (<1|*|1>) * X
     assert qapply(P1) == QubitBra(0) * XGate(0)     # qapply(P1) -> 0 before fix
+    P1 = qapply(P1, dagger = True)  # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
     assert qapply(P1, dagger = True) == QubitBra(1) # qapply(P1, dagger=True) -> 0 before fix
     P2 = QubitBra(0) * QubitBra(0) * Qubit(0) * XGate(0) # 'forgot' to set brackets
+    P2 = qapply(P2, dagger = True) # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
     assert qapply(P2, dagger = True) == QubitBra(1) # qapply(P1) -> 0 before fix


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24158

#### Brief description of what is fixed or changed
See issue #24158. It might also fix #6073 (not tested).
qapply may wrongly associate kets to operators from the left, e.g. |1> X -> |0>, which leads to wrong results. Note in the example Qubit(1)=|1>,  QubitBra(1)=<1|  and XGate(0)=X the CNOT gate:
```
from sympy import Mul
from sympy.physics.quantum.qubit import Qubit, QubitBra
from sympy.physics.quantum.gate import XGate
from sympy.physics.quantum.qapply import qapply
P0 = Qubit(0)*XGate(0) # |0>*X is undefined
print(qapply(P0)) 
#result:  |1>  !!  qapply actually computed X*|0> !
P1 = Mul(QubitBra(0), Mul(QubitBra(0), Qubit(0)), XGate(0)) #legal expr <0| * (<1|*|1>) * X
print(qapply(P1))
#result:  0   !! expected: <0| * (<0|*|0>) * X = <0| * X = <1| = QubitBra(1)
P2 = QubitBra(0) * QubitBra(0)*Qubit(0) * XGate(0)  # 'forgot' to set brackets
print(qapply(P2))
#result:  0   !! expected: <1| as above 
```
You might consider P2 posed unclearly, but expression P1 is perfectly legal and may easily come up when building expressions in code.
### Assessment ###
P0 already demonstrates the core issue: From the code analysis it seems that qapply has been written to accept and automatically 'correct' the (undefined) term `Ket*Operator` to `Operator*Ket`. However as shown above this behaviour may lead to fatally wrong results and should be removed.

### Modifications ###

See #24158 for a technical description of the situation and the required modifications. In a nut shell:

In some Ket-classes the incorrect definitions of and calls to `Ket._apply_operator(op)` to compute `Ket*op` - which is undefined but returned `op*Ket` instead - are renamed to `_apply_from_right_to()` so qapply (which is also patched) will call them in the correct context of `op*Ket` only.

#### Other comments

`._apply_operator_*` and `._apply_from_right_to_*`  are related to each other as is `.__mul__` to `.__rmul__ `.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * In certain cases `qapply` would evaluate  `Ket * Operator` in expressions as `Operator * Ket`. This behavior could lead to incorrect results and has been removed. 
<!-- END RELEASE NOTES -->
