### PR TITLE
Unify quantum Operator**0 to give IdentityOperator() instead of 1  

### DIFF
--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -92,7 +92,7 @@ class Operator(QExpr):
         >>> A.inv()
         A**(-1)
         >>> A*A.inv()
-        I
+        IdentityOperator()
 
     References
     ==========

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -348,9 +348,9 @@ class IdentityOperator(Operator):
         if not self.N or self.N == oo:
             raise NotImplementedError('Cannot represent infinite dimensional' +
                                       ' identity operator as a matrix')
-                                      
+
         format = options.get('format', 'sympy')
-        return self._format_represent(eye(self.N), format)    
+        return self._format_represent(eye(self.N), format)
 
 
 class OuterProduct(Operator):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -203,11 +203,11 @@ class Operator(QExpr):
     #    handling exponent == 0 and passing on all other to the original super()._pow()
     #    unmodified.
 
-    def Operator__pow(self, exponent):
+    def _pow(self, exponent):
         if exponent == 0 or exponent == S.Zero:
-            return IdentityOperator()     #Operator class has no dimension, so return dimensionless IdentityOperator()
+            return IdentityOperator()     # Operator class has no dimension, so return dimensionless IdentityOperator()
         else:
-            return super()._pow(exponent) #maintains classic behaviour for exp != 0
+            return super()._pow(self, exponent) # maintains classic behaviour for exp != 0
 
 
 class HermitianOperator(Operator):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -206,9 +206,13 @@ class Operator(QExpr):
     def _pow(self, exponent):
         from sympy.core.singleton import S
         if exponent == 0 or exponent == S.Zero:
-            return IdentityOperator()     # Operator class has no dimension, so return dimensionless IdentityOperator()
+            try:
+                dim = self.hilbert_space.dimension # will raise "Not Implemented" for std Operator class!
+                return IdentityOperator(dim)
+            except NotImplementedError:
+                return IdentityOperator()  # if self has no dimension, so return dimensionless IdentityOperator()
         else:
-            return super()._pow(exponent) # maintains classic behaviour for exp != 0
+            return super()._pow(exponent)  # maintains classic behaviour for exp != 0
 
 
 class HermitianOperator(Operator):
@@ -339,17 +343,14 @@ class IdentityOperator(Operator):
 
         return Mul(self, other)
 
+
     def _represent_default_basis(self, **options):
         if not self.N or self.N == oo:
             raise NotImplementedError('Cannot represent infinite dimensional' +
                                       ' identity operator as a matrix')
-
+        
         format = options.get('format', 'sympy')
-        if format != 'sympy':
-            raise NotImplementedError('Representation in format ' +
-                                      '%s not implemented.' % format)
-
-        return eye(self.N)
+        return self._format_represent(eye(self.N), format)    
 
 
 class OuterProduct(Operator):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -204,10 +204,11 @@ class Operator(QExpr):
     #    unmodified.
 
     def _pow(self, exponent):
+        from sympy.core.singleton import S
         if exponent == 0 or exponent == S.Zero:
             return IdentityOperator()     # Operator class has no dimension, so return dimensionless IdentityOperator()
         else:
-            return super()._pow(self, exponent) # maintains classic behaviour for exp != 0
+            return super()._pow(exponent) # maintains classic behaviour for exp != 0
 
 
 class HermitianOperator(Operator):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -348,7 +348,7 @@ class IdentityOperator(Operator):
         if not self.N or self.N == oo:
             raise NotImplementedError('Cannot represent infinite dimensional' +
                                       ' identity operator as a matrix')
-        
+                                      
         format = options.get('format', 'sympy')
         return self._format_represent(eye(self.N), format)    
 

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -10,6 +10,7 @@ from sympy.physics.quantum.operator import (Operator, UnitaryOperator,
                                             HermitianOperator, OuterProduct,
                                             DifferentialOperator,
                                             IdentityOperator)
+from sympy.physics.quantum.gate import (XGate, TGate, PhaseGate)
 from sympy.physics.quantum.state import Ket, Bra, Wavefunction
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.represent import represent
@@ -231,3 +232,25 @@ def test_differential_operator():
     assert diff(d, th) == \
         DifferentialOperator(Derivative(d.expr, th), f(r, th))
     assert qapply(d*w) == Wavefunction(3*sin(th), r, (th, 0, pi))
+
+
+# Issue 24153: Test if pow(U, 0) == IdentityOperator(), U*U.inv() == IdentityOperator()
+def test_issue24153_mulopop1():
+    U = Operator('U')
+    n = symbols('n')
+    In = IdentityOperator()
+    assert U ** n == pow(U, n) # actually, pow(U,n) is alias to Expr.__pow__(U,n) := U**n
+    assert U ** 0 == In
+    assert pow(U,  0)  == In
+    assert Pow(U,  0)  == 1    # this is hard coded in Pow for exponent == 0
+    assert pow(U, -1)  == U.inv()
+    assert U ** -1     == U.inv()
+    assert U * U ** -1 == In
+    assert Mul(U, U ** -1) == In
+    assert XGate(0) ** 2   == In  # this calls ._eval_power()
+    assert TGate(0) ** 4 * TGate(0).inv() ** 2 * TGate(0) ** -2  == In
+    #assert TGate(0) ** 8 == IdentityOperator()   # tbd: add this identity to TGate
+    #assert PhaseGate(0) ** 4 == IdentityOperator()   # tbd: add this identity to PhaseGate
+    P = TensorProduct(XGate(0), TGate(0)) * TensorProduct(XGate(0), In)
+    assert qapply(P) == TensorProduct(In, TGate(0)) # I x T  (classic: 1xT)
+    assert TensorProduct(U * U ** -1, pow(U, n) * U ** -n) == TensorProduct(In, In) #classic: 1x1

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -1,5 +1,6 @@
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.mul import Mul
+from sympy.core import Pow
 from sympy.core.numbers import (Integer, pi)
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.trigonometric import sin
@@ -10,12 +11,13 @@ from sympy.physics.quantum.operator import (Operator, UnitaryOperator,
                                             HermitianOperator, OuterProduct,
                                             DifferentialOperator,
                                             IdentityOperator)
-from sympy.physics.quantum.gate import (XGate, TGate, PhaseGate)
+from sympy.physics.quantum.gate import (XGate, TGate)
 from sympy.physics.quantum.state import Ket, Bra, Wavefunction
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.spin import JzKet, JzBra
 from sympy.physics.quantum.trace import Tr
+from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.matrices import eye
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24153

#### Brief description of what is fixed or changed
The fix modifies the behaviour of quantum operators for expressions like `Operator**0`, `pow(Operator, 0)` or `Operator * Operator.inv()`: This will now return `IdentityOperator()` instead of `1`. This makes the behavior more consistent with that of other operator classes especially Matrix or MatrixSymbol, and more consistent with usual mathematical notation. See #24153 for examples.
The fix hooks into `._pow()` and explicitly affects exponents == 0 only.
 
#### Other comments
`Pow(base, 0) `will continue to return `1` for most type of bases, as this is hard coded in `Pow()`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Result of expressions like `Operator**0`, `pow(Operator, 0)` or `Operator * Operator.inv()` has been modified to `IdentityOperator()` instead of unusual scalar `1`
<!-- END RELEASE NOTES -->
