### PR TITLE
Remove gap filling in coordinate generation

### DIFF
--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -6,7 +6,7 @@ from sympy.core.backend import pi, AppliedUndef, Derivative, Matrix
 from sympy.physics.mechanics.body import Body
 from sympy.physics.vector import (Vector, dynamicsymbols, cross, Point,
                                   ReferenceFrame)
-
+from sympy.utilities.iterables import iterable
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['Joint', 'PinJoint', 'PrismaticJoint', 'CylindricalJoint',
@@ -506,8 +506,11 @@ class Joint(ABC):
         generated_coordinates = []
         if coordinates is None:
             coordinates = []
-        elif isinstance(coordinates, (AppliedUndef, Derivative)):
+        elif not iterable(coordinates):
             coordinates = [coordinates]
+        if not (len(coordinates) == 0 or len(coordinates) == n_coords):
+            raise ValueError(f'Expected {n_coords} {name}s, instead got '
+                             f'{len(coordinates)} {name}s.')
         # Supports more iterables, also Matrix
         for i, coord in enumerate(coordinates):
             if coord is None:
@@ -519,9 +522,6 @@ class Joint(ABC):
                                 f'dynamicsymbol.')
         for i in range(len(coordinates) + offset, n_coords + offset):
             generated_coordinates.append(create_symbol(i))
-        if len(generated_coordinates) != n_coords:
-            raise ValueError(f'{len(coordinates)} {name}s have been provided. '
-                             f'The maximum number of {name}s is {n_coords}.')
         return Matrix(generated_coordinates)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In the previous implementation one can supply less coordinates than requested, causing a magical auto generation of the missing coordinates. This PR removes this option, that was introduced in #24028.

#### Other comments
While this does change the behaviour, it is not worth deprecating since there has not been a sympy release with this feature yet.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
