### PR TITLE
Fix collect_factor_and_dimension dimension comparison

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -561,6 +561,22 @@ def test_issue_24062():
     exp_expr = 1 + exp(expr)
     assert SI._collect_factor_and_dimension(exp_expr) == (1 + E, Dimension(1))
 
+def test_issue_24211():
+    from sympy.physics.units import time, velocity, acceleration, second, meter
+    V1 = Quantity('V1')
+    SI.set_quantity_dimension(V1, velocity)
+    SI.set_quantity_scale_factor(V1, 1 * meter / second)
+    A1 = Quantity('A1')
+    SI.set_quantity_dimension(A1, acceleration)
+    SI.set_quantity_scale_factor(A1, 1 * meter / second**2)
+    T1 = Quantity('T1')
+    SI.set_quantity_dimension(T1, time)
+    SI.set_quantity_scale_factor(T1, 1 * second)
+
+    expr = A1*T1 + V1
+    # should not throw ValueError here
+    SI._collect_factor_and_dimension(expr)
+
 
 def test_prefixed_property():
     assert not meter.is_prefixed

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -175,7 +175,7 @@ class UnitSystem(_QuantityMapper):
             for addend in expr.args[1:]:
                 addend_factor, addend_dim = \
                     self._collect_factor_and_dimension(addend)
-                if dim != addend_dim:
+                if not self.get_dimension_system().equivalent_dims(dim, addend_dim):
                     raise ValueError(
                         'Dimension of "{}" is {}, '
                         'but it should be {}'.format(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24211


#### Brief description of what is fixed or changed
_collect_factor_and_dimensions was updated to compare dimensions with equivalent_dims instead of direct comparison.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Changed _collect_factor_and_dimension dimension comparison to equivalent_dims instead of strict equality

<!-- END RELEASE NOTES -->
