### PR TITLE
Fix simplify Cos 0

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1006,7 +1006,7 @@ class cos(TrigonometricFunction):
         if pi_mult:
             return fuzzy_and([(pi_mult - S.Half).is_integer, rest.is_zero])
         else:
-            return rest.is_zero
+            return (rest - S.Half).is_zero
 
 
 class tan(TrigonometricFunction):


### PR DESCRIPTION
Fix simplify Cos 0


#### Fix cos(0, evaluate=False).simplify() will get 0 which is equal to 1


<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug with simplify Cos 0

<!-- END RELEASE NOTES -->
