### PR TITLE
updated trignometric.py to fix incorrect result for cos function

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -390,9 +390,8 @@ def test_cos():
     assert cos(2*k*pi) == 1
     assert cos(0, evaluate=False).is_zero is False
     assert cos(Rational(1, 2)).is_zero is False
-    # The following test will return None as the result, but 
-    # really it should be True even if it is not always 
-    # possible to resolve an assumptions query.
+    # The following test will return None as the result, but really it should
+    # be True even if it is not always possible to resolve an assumptions query.
     assert cos(asin(-1, evaluate=False), evaluate=False).is_zero is None
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -388,9 +388,10 @@ def test_cos():
 
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1
-    assert cos(0, evaluate=False).simplify() == 1
+    assert cos(0, evaluate=False).is_zero is False
     assert cos(Rational(1, 2)).is_zero is False
-    assert cos(asin(-1, evaluate=False), evaluate=False).simplify() == 0
+    #The following test will return None as the result, but really it should be True even if it is not always possible to resolve an assumptions query.
+    assert cos(asin(-1, evaluate=False), evaluate=False).is_zero is None
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):
             x = n*pi/d

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -391,7 +391,6 @@ def test_cos():
     assert cos(0, evaluate=False).simplify() == 1
     assert cos(Rational(1, 2)).is_zero is False
     assert cos(asin(-1, evaluate=False), evaluate=False).simplify() == 0
-    
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):
             x = n*pi/d

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -391,6 +391,7 @@ def test_cos():
     assert cos(0, evaluate=False).simplify() == 1
     assert cos(Rational(1, 2)).is_zero is False
     assert cos(asin(-1, evaluate=False), evaluate=False).simplify() == 0
+    
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):
             x = n*pi/d

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -390,7 +390,9 @@ def test_cos():
     assert cos(2*k*pi) == 1
     assert cos(0, evaluate=False).is_zero is False
     assert cos(Rational(1, 2)).is_zero is False
-    #The following test will return None as the result, but really it should be True even if it is not always possible to resolve an assumptions query.
+    #The following test will return None as the result, 
+    #but really it should be True even if it is not always 
+    #possible to resolve an assumptions query.
     assert cos(asin(-1, evaluate=False), evaluate=False).is_zero is None
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -388,7 +388,9 @@ def test_cos():
 
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1
-
+    assert cos(0, evaluate=False).simplify() == 1
+    assert cos(Rational(1, 2)).is_zero is False
+    assert cos(asin(-1, evaluate=False), evaluate=False).simplify() == 0
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):
             x = n*pi/d

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -390,9 +390,9 @@ def test_cos():
     assert cos(2*k*pi) == 1
     assert cos(0, evaluate=False).is_zero is False
     assert cos(Rational(1, 2)).is_zero is False
-    #The following test will return None as the result, 
-    #but really it should be True even if it is not always 
-    #possible to resolve an assumptions query.
+    # The following test will return None as the result, but 
+    # really it should be True even if it is not always 
+    # possible to resolve an assumptions query.
     assert cos(asin(-1, evaluate=False), evaluate=False).is_zero is None
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(2*d + 1):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1003,10 +1003,8 @@ class cos(TrigonometricFunction):
 
     def _eval_is_zero(self):
         rest, pi_mult = _peeloff_pi(self.args[0])
-        if pi_mult:
-            return fuzzy_and([(pi_mult - S.Half).is_integer, rest.is_zero])
-        else:
-            return rest.is_zero
+        if rest.is_zero and pi_mult:
+            return (pi_mult - S.Half).is_integer
 
 
 class tan(TrigonometricFunction):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #24208 

#### Brief description of what is fixed or changed
Changes proposed by @oscarbenjamin in #24208 were made to trignometric.py to get correct result for cos function

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * A bug in `cos.is_zero` was fixed. Previously `is_zero` would give incorrect results in some cases.
<!-- END RELEASE NOTES -->
