### PR TITLE
Quantum IdentityOperator operates from right and IdentityGate speed up

### DIFF
--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -628,6 +628,16 @@ class IdentityGate(OneQubitGate):
     gate_name = '1'
     gate_name_latex = '1'
 
+    # Short cut version of gate._apply_operator_Qubit
+    def _apply_operator_Qubit(self, qubits, **options):
+        # Check number of qubits this gate acts on (see gate._apply_operator_Qubit)
+        if qubits.nqubits < self.min_qubits:
+            raise QuantumError(
+                'Gate needs a minimum of %r qubits to act on, got: %r' %
+                (self.min_qubits, qubits.nqubits)
+            )
+        return qubits # no computation required for IdentityGate
+
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('eye2', format)
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -296,6 +296,9 @@ class IdentityOperator(Operator):
     def _apply_operator(self, ket, **options):
         return ket
 
+    def _apply_from_right_to(self, bra, **options):
+        return bra
+
     def _eval_power(self, exp):
         return self
 

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -9,7 +9,7 @@ from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import H, XGate
-from sympy.physics.quantum.operator import Operator
+from sympy.physics.quantum.operator import Operator, IdentityOperator
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -145,3 +145,5 @@ def test_issue24158_ket_times_op():
     P2 = QubitBra(0) * QubitBra(0) * Qubit(0) * XGate(0) # 'forgot' to set brackets
     P2 = qapply(P2, dagger = True) # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
     assert qapply(P2, dagger = True) == QubitBra(1) # qapply(P1) -> 0 before fix
+    # Pull Request 24237: IdentityOperator from the right without dagger=True option
+    assert qapply(QubitBra(1)*IdentityOperator()) == QubitBra(1)

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -8,7 +8,7 @@ from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.gate import H, XGate
+from sympy.physics.quantum.gate import H, XGate, IdentityGate
 from sympy.physics.quantum.operator import Operator, IdentityOperator
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
@@ -147,3 +147,4 @@ def test_issue24158_ket_times_op():
     assert qapply(P2, dagger = True) == QubitBra(1) # qapply(P1) -> 0 before fix
     # Pull Request 24237: IdentityOperator from the right without dagger=True option
     assert qapply(QubitBra(1)*IdentityOperator()) == QubitBra(1)
+    assert qapply(IdentityGate(0)*(Qubit(0) + Qubit(1))) == Qubit(0) + Qubit(1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
1.) The IdentityOperator has the following unexpected behavior with qapply:
``` 
from sympy.physics.quantum.operator import *
from sympy.physics.quantum.state import *
Id = IdentityOperator()
x = qapply(Id * Ket(1)) # ->  |1>
x = qapply(Bra(1) * Id, dagger = True) #  ->  <1|
x = qapply(Bra(1) * Id) # -> <1|*I   unexpected for Identity
```
`qapply` has the `dagger=True` option that invokes `Dagger(Dagger(b)*Dagger(a))` if the product `a*b` doesn't compute. Most `operators` in quantum have code only for operating on `kets` from the right, and require the dagger=True in qapply option to compute  `bra*op`. However for IdentityOperator this makes no sense: no options should be required to make the identity act as identity.
The change is just to add the method  `_apply_from_right_to()` to the` IdentityOperator` that mimics the already existing `_apply_operator()` for operation from the left.

2.) The implementation of `IdentityGate` (i.e. the quantum gate that implements identity on a qubit, see sympy.physics.quantum.gate.py) just invokes the generic gate application method `gate._apply_operator_Qubit` which creates a huge overhead. 
The change is to override the generic method by a short cut that just returns the input.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * IdentityOperator applied more stringently in qapply and speed up of IdentityGate 
<!-- END RELEASE NOTES -->
