### PR TITLE
fix(polys): fix printing elements of EX[x]

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -805,7 +805,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             else:
                 if negative:
                     coeff = -coeff
-                if coeff != self.ring.one:
+                if coeff != self.ring.domain.one:
                     scoeff = printer.parenthesize(coeff, prec_mul, strict=True)
                 else:
                     scoeff = ''

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -228,6 +228,17 @@ def test_PolyElement__lt_le_gt_ge__():
     assert x**3 > x**2 > x > R(1)
     assert x**3 >= x**2 >= x >= R(1)
 
+def test_PolyElement__str__():
+    x, y = symbols('x, y')
+
+    for dom in [ZZ, QQ, ZZ[x], ZZ[x,y], ZZ[x][y]]:
+        R, t = ring('t', dom)
+        assert str(2*t**2 + 1) == '2*t**2 + 1'
+
+    for dom in [EX, EX[x]]:
+        R, t = ring('t', dom)
+        assert str(2*t**2 + 1) == 'EX(2)*t**2 + EX(1)'
+
 def test_PolyElement_copy():
     R, x, y, z = ring("x,y,z", ZZ)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

On master printing elements of a ring with `EX` domain fails:
```python
In [1]: str(EX[x].from_sympy(x))
---------------------------------------------------------------------------
SympifyError
```
This is due to `PolyElement.str` attempting to compare an element of the ground domain with an element of the ring. In the case of `EX` comparing with a `PolyElement` raises. Possibly that should be fixed but at least here we make sure that we are comparing elements of the same domain in `str`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * A bug that prevented printing elements of polynomial rings over the `EX` domain was fixed.
<!-- END RELEASE NOTES -->
