### PR TITLE
Fix evaluate=False parameter to parse_expr is ignored for relationals

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1109,6 +1109,12 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.BitOr: 'Or',
         ast.BitAnd: 'And',
         ast.BitXor: 'Not',
+        ast.Equality:'Eq', 
+        ast.Unequality:'Ne',
+        ast.StrictLessThan:'Lt',
+        ast.LessThan:'Le',
+        ast.StrictGreaterThan:'Gt',
+        ast.GreaterThan:'Ge',
     }
     functions = (
         'Abs', 'im', 're', 'sign', 'arg', 'conjugate',


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes(#24288).
<!-- If this pull request fixes an issue, write "Fixes #24288" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The PR implements a changes in `parse_expr(evaluate=False)` works by handling specific types of nodes when parsing, but it doesn't currently have any support for inequalities.
In: `parse_expr('1 < 2', evaluate=False)`
Out: `True`
Expected : `1<2`
I added the relational inequalities in this PR now it support the inequalities


#### Other comments


#### Release Notes 


<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
    • parsing
           • Added inequalities in the `parse_expr`

<!-- END RELEASE NOTES -->
