### PR TITLE
Small errors in _laplace_rule_exp and _laplace_rule_trig corrected

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -707,6 +707,10 @@ def test_laplace_transform():
     assert inverse_laplace_transform(
         f(w), w, t, plane=0) == InverseLaplaceTransform(f(w), w, t, 0)
     assert LT(f(t)*g(t), t, s) == LaplaceTransform(f(t)*g(t), t, s)
+    # Issue #24294
+    assert LT(b*f(a*t), t, s) == b*LaplaceTransform(f(t), t, s/a)/a
+    assert LT(3*exp(t)*Heaviside(t), t, s) == (3/(s - 1), 1, True)
+    assert LT(2*sin(t)*Heaviside(t), t, s) == (2/(s**2 + 1), 0, True)
 
     # additional basic tests from wikipedia
     assert LT((t - a)**b*exp(-c*(t - a))*Heaviside(t - a), t, s) == \

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1654,9 +1654,9 @@ def _laplace_rule_exp(f, t, s, doit=True, **hints):
             L = _laplace_apply_rules(ma1[z], t, s-ma2[a], doit=doit, **hints)
             try:
                 r, p, c = L
-                return (r, p+ma2[a], c)
+                return (k*r, p+ma2[a], c)
             except TypeError:
-                return L
+                return k*L
     return None
 
 def _laplace_rule_trig(f, t, s, doit=True, **hints):
@@ -1700,15 +1700,15 @@ def _laplace_rule_trig(f, t, s, doit=True, **hints):
                         cp_shift = Abs(ma2[a])
                     else:
                         cp_shift = 0
-                    return ((s1*(r.subs(s, s-sd*ma2[a])+\
+                    return (k*(s1*(r.subs(s, s-sd*ma2[a])+\
                                     s2*r.subs(s, s+sd*ma2[a]))).simplify()/2,
                             p+cp_shift, c)
                 except TypeError:
                     if doit==True and _simplify==True:
-                        return (s1*(L.subs(s, s-sd*ma2[a])+\
+                        return k*(s1*(L.subs(s, s-sd*ma2[a])+\
                                     s2*L.subs(s, s+sd*ma2[a]))).simplify()/2
                     else:
-                        return (s1*(L.subs(s, s-sd*ma2[a])+\
+                        return k*(s1*(L.subs(s, s-sd*ma2[a])+\
                                     s2*L.subs(s, s+sd*ma2[a])))/2
     return None
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1598,7 +1598,7 @@ def _laplace_rule_timescale(f, t, s, doit=True, **hints):
                 L = _laplace_apply_rules(ma1[g].func(t), t, s/ma2[b],
                                          doit=doit, **hints)
                 noconds = hints.get('noconds', False)
-                if noconds:
+                if not noconds and type(L) is tuple:
                     r, p, c = L
                     return (1/ma2[b]*r, p, c)
                 else:


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes  #24294

#### Brief description of what is fixed or changed

The functions _laplace_rule_exp and _laplace_rule_trig did not return the
constant factors of their expressions.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * corrected small errors in Laplace transform rules
<!-- END RELEASE NOTES -->
