### PR TITLE
Support for powm1 from scipy.special in codegen

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -43,7 +43,7 @@ from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.power import Pow
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
-from sympy.codegen.scipy_nodes import cosm1
+from sympy.codegen.scipy_nodes import cosm1, powm1
 from sympy.core.mul import Mul
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.utilities.iterables import sift
@@ -274,6 +274,7 @@ class FuncMinusOneOptim(ReplaceOptim):
 
 expm1_opt = FuncMinusOneOptim(exp, expm1)
 cosm1_opt = FuncMinusOneOptim(cos, cosm1)
+powm1_opt = FuncMinusOneOptim(Pow, powm1)
 
 log1p_opt = ReplaceOptim(
     lambda e: isinstance(e, log),
@@ -353,4 +354,4 @@ optims_c99 = (expm1_opt, log1p_opt, exp2_opt, log2_opt, log2const_opt)
 
 optims_numpy = optims_c99 + (logaddexp_opt, logaddexp2_opt,) + sinc_opts
 
-optims_scipy = (cosm1_opt,)
+optims_scipy = (cosm1_opt, powm1_opt)

--- a/sympy/codegen/scipy_nodes.py
+++ b/sympy/codegen/scipy_nodes.py
@@ -1,5 +1,7 @@
 from sympy.core.function import Add, ArgumentIndexError, Function
+from sympy.core.power import Pow
 from sympy.core.singleton import S
+from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.trigonometric import cos, sin
 
 
@@ -30,9 +32,48 @@ class cosm1(Function):
     def _eval_evalf(self, *args, **kwargs):
         return self.rewrite(cos).evalf(*args, **kwargs)
 
-    def _eval_simplify(self, x, **kwargs):
+    def _eval_simplify(self, **kwargs):
+        x, = self.args
         candidate = _cosm1(x.simplify(**kwargs))
         if candidate != _cosm1(x, evaluate=False):
             return candidate
         else:
             return cosm1(x)
+
+
+def _powm1(x, y, *, evaluate=True):
+    return Add(Pow(x, y, evaluate=evaluate), -S.One, evaluate=evaluate)
+
+
+class powm1(Function):
+    """ Minus one plus x to the power of y, i.e. x**y - 1. For use when x is close to one or y is close to zero.
+
+    Helper class for use with e.g. scipy.special.powm1
+    See: https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.powm1.html
+    """
+    nargs = 2
+
+    def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of this function.
+        """
+        if argindex == 1:
+            return Pow(self.args[0], self.args[1])*self.args[1]/self.args[0]
+        elif argindex == 2:
+            return log(self.args[0])*Pow(*self.args)
+        else:
+            raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_Pow(self, x, y, **kwargs):
+        return _powm1(x, y)
+
+    def _eval_evalf(self, *args, **kwargs):
+        return self.rewrite(Pow).evalf(*args, **kwargs)
+
+    def _eval_simplify(self, **kwargs):
+        x, y = self.args
+        candidate = _powm1(x.simplify(**kwargs), y.simplify(**kwargs))
+        if candidate != _powm1(x, y, evaluate=False):
+            return candidate
+        else:
+            return powm1(x, y)

--- a/sympy/codegen/tests/test_scipy_nodes.py
+++ b/sympy/codegen/tests/test_scipy_nodes.py
@@ -1,8 +1,10 @@
 from itertools import product
+from sympy.core.power import Pow
 from sympy.core.symbol import symbols
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.trigonometric import cos
 from sympy.core.numbers import pi
-from sympy.codegen.scipy_nodes import cosm1
+from sympy.codegen.scipy_nodes import cosm1, powm1
 
 x, y, z = symbols('x y z')
 
@@ -19,3 +21,24 @@ def test_cosm1():
     expr_minus2 = cosm1(pi)
     assert expr_minus2.rewrite(cos) == -2
     assert cosm1(3.14).simplify() == cosm1(3.14)  # cannot simplify with 3.14
+    assert cosm1(pi/2).simplify() == -1
+    assert (1/cos(x) - 1 + cosm1(x)/cos(x)).simplify() == 0
+
+
+def test_powm1():
+    cases = {
+            powm1(x, y): x**y - 1,
+            powm1(x*y, z): (x*y)**z - 1,
+            powm1(x, y*z): x**(y*z)-1,
+            powm1(x*y*z, x*y*z): (x*y*z)**(x*y*z)-1
+    }
+    for pm1_e, ref_e in cases.items():
+        for wrt, deriv_order in product([x, y, z], range(3)):
+            der = pm1_e.diff(wrt, deriv_order)
+            ref = ref_e.diff(wrt, deriv_order)
+            delta = (der - ref).rewrite(Pow)
+            assert delta.simplify() == 0
+
+    eulers_constant_m1 = powm1(x, 1/log(x))
+    assert eulers_constant_m1.rewrite(Pow) == exp(1) - 1
+    assert eulers_constant_m1.simplify() == exp(1) - 1

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -496,6 +496,12 @@ def test_sympy__codegen__scipy_nodes__cosm1():
     from sympy.codegen.scipy_nodes import cosm1
     assert _test_args(cosm1(x))
 
+
+def test_sympy__codegen__scipy_nodes__powm1():
+    from sympy.codegen.scipy_nodes import powm1
+    assert _test_args(powm1(x, y))
+
+
 def test_sympy__codegen__abstract_nodes__List():
     from sympy.codegen.abstract_nodes import List
     assert _test_args(List(1, 2, 3))

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -286,6 +286,7 @@ _known_functions_scipy_special = {
     'besseli': 'iv',
     'besselk': 'kv',
     'cosm1': 'cosm1',
+    'powm1': 'powm1',
     'factorial': 'factorial',
     'gamma': 'gamma',
     'loggamma': 'gammaln',


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
NIL

#### Brief description of what is fixed or changed
Upcoming scipy 1.10.0 has support for [powm1](https://scipy.github.io/devdocs/reference/generated/scipy.special.powm1.html), so does the boost c++ library since long. This PR adds a `Function` subclass for this entity and rewrite rules for it.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * `powm1` is now available for this enhanced precision math function.
<!-- END RELEASE NOTES -->
