### PR TITLE
tensor module: TensAdd.doit: fix bug in handling args which are == 0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -781,6 +781,7 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2481,14 +2481,14 @@ class TensAdd(TensExpr, AssocOp):
         else:
             args = self.args
 
+        # if any of the args are zero (after doit), drop them. Otherwise, _tensAdd_check will complain about non-matching indices, even though the TensAdd is correctly formed.
+        args = [arg for arg in args if arg != 0]
+
         if not args:
             return S.Zero
 
         if len(args) == 1 and not isinstance(args[0], TensExpr):
             return args[0]
-
-        # if any of the args are zero (after doit), drop them. Otherwise, the next step will complain about non-matching indices, even though the TensAdd is correctly formed.
-        args = [arg for arg in args if arg != 0]
 
         # now check that all addends have the same indices:
         TensAdd._tensAdd_check(args)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2487,6 +2487,9 @@ class TensAdd(TensExpr, AssocOp):
         if len(args) == 1 and not isinstance(args[0], TensExpr):
             return args[0]
 
+        # if any of the args are zero (after doit), drop them. Otherwise, the next step will complain about non-matching indices, even though the TensAdd is correctly formed.
+        args = [arg for arg in args if arg != 0]
+
         # now check that all addends have the same indices:
         TensAdd._tensAdd_check(args)
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2482,7 +2482,7 @@ class TensAdd(TensExpr, AssocOp):
             args = self.args
 
         # if any of the args are zero (after doit), drop them. Otherwise, _tensAdd_check will complain about non-matching indices, even though the TensAdd is correctly formed.
-        args = [arg for arg in args if arg != 0]
+        args = [arg for arg in args if arg != S.Zero]
 
         if not args:
             return S.Zero

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2487,26 +2487,11 @@ class TensAdd(TensExpr, AssocOp):
         if not args:
             return S.Zero
 
-        if len(args) == 1 and not isinstance(args[0], TensExpr):
+        if len(args) == 1:
             return args[0]
 
         # now check that all addends have the same indices:
         TensAdd._tensAdd_check(args)
-
-        # if TensAdd has only 1 element in its `args`:
-        if len(args) == 1:  # and isinstance(args[0], TensMul):
-            return args[0]
-
-        # Remove zeros:
-        args = [x for x in args if x]
-
-        # if there are no more args (i.e. have cancelled out),
-        # just return zero:
-        if not args:
-            return S.Zero
-
-        if len(args) == 1:
-            return args[0]
 
         # Collect terms appearing more than once, differing by their coefficients:
         args = TensAdd._tensAdd_collect_terms(args)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2484,10 +2484,9 @@ class TensAdd(TensExpr, AssocOp):
         # if any of the args are zero (after doit), drop them. Otherwise, _tensAdd_check will complain about non-matching indices, even though the TensAdd is correctly formed.
         args = [arg for arg in args if arg != S.Zero]
 
-        if not args:
+        if len(args) == 0:
             return S.Zero
-
-        if len(args) == 1:
+        elif len(args) == 1:
             return args[0]
 
         # now check that all addends have the same indices:

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -600,6 +600,8 @@ def test_add1():
     assert t1 != t2
     assert t2 != TensMul.from_data(0, [], [], [])
 
+    #Test whether doit chokes on subterms that are zero.
+    assert TensAdd(p(a), TensMul(0, p(a)) ).doit() == p(a)
 
 def test_special_eq_ne():
     # test special equality cases:

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -600,7 +600,7 @@ def test_add1():
     assert t1 != t2
     assert t2 != TensMul.from_data(0, [], [], [])
 
-    #Test whether doit chokes on subterms that are zero.
+    #Test whether TensAdd.doit chokes on subterms that are zero.
     assert TensAdd(p(a), TensMul(0, p(a)) ).doit() == p(a)
 
 def test_special_eq_ne():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs
 If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
If an arg of `TensAdd` becomes zero while applying `doit`, one gets an error about mismatching indices.

Demonstration (sympy built from master):

```
>>> from sympy.tensor.tensor import TensorIndexType, TensorHead, TensorIndex, TensAdd, TensMul
>>> R3 = TensorIndexType('R3', dim=3)
>>> K = TensorHead('K', [R3])
>>> p = TensorIndex('p', R3)
>>> expr = TensAdd(K(p), TensMul(0, K(p)) )
>>> expr.doit()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/sympy/tensor/tensor.py", line 2491, in doit
    TensAdd._tensAdd_check(args)
  File "/usr/lib/python3.10/site-packages/sympy/tensor/tensor.py", line 2554, in _tensAdd_check
    raise ValueError('all tensors must have the same indices')
ValueError: all tensors must have the same indices
>>>
```

After the changes in this PR:
```
>>> expr.doit()
K(p)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
