### PR TITLE
Numerical error on conversion of coulomb to statcoulomb 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -209,6 +209,7 @@ Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>
 Achal Jain <2achaljain@gmail.com>
 Adam Bloomston <adam@glitterfram.es> <mail@adambloomston>

--- a/sympy/physics/units/systems/cgs.py
+++ b/sympy/physics/units/systems/cgs.py
@@ -57,15 +57,15 @@ cgs_gauss.set_quantity_scale_factor(maxwell, sqrt(centimeter**3*gram)/second)
 
 # SI units expressed in CGS-gaussian units:
 cgs_gauss.set_quantity_scale_factor(coulomb, 10*speed_of_light*statcoulomb)
-cgs_gauss.set_quantity_scale_factor(ampere, speed_of_light*statcoulomb/second/10)
-cgs_gauss.set_quantity_scale_factor(volt, speed_of_light*statvolt/10**6)
+cgs_gauss.set_quantity_scale_factor(ampere, 10*speed_of_light*statcoulomb/second)
+cgs_gauss.set_quantity_scale_factor(volt, 10**6/speed_of_light*statvolt)
 cgs_gauss.set_quantity_scale_factor(weber, 10**8*maxwell)
 cgs_gauss.set_quantity_scale_factor(tesla, 10**4*gauss)
 cgs_gauss.set_quantity_scale_factor(debye, One/10**18*statcoulomb*centimeter)
 cgs_gauss.set_quantity_scale_factor(oersted, sqrt(gram/centimeter)/second)
-cgs_gauss.set_quantity_scale_factor(ohm, 10**9/speed_of_light**2*second/centimeter)
-cgs_gauss.set_quantity_scale_factor(farad, One/10**9*speed_of_light**2*centimeter)
-cgs_gauss.set_quantity_scale_factor(henry, 10**9/speed_of_light**2/centimeter*second**2)
+cgs_gauss.set_quantity_scale_factor(ohm, 10**5/speed_of_light**2*second/centimeter)
+cgs_gauss.set_quantity_scale_factor(farad, One/10**5*speed_of_light**2*centimeter)
+cgs_gauss.set_quantity_scale_factor(henry, 10**5/speed_of_light**2/centimeter*second**2)
 
 # Coulomb's constant:
 cgs_gauss.set_quantity_dimension(coulomb_constant, 1)

--- a/sympy/physics/units/systems/cgs.py
+++ b/sympy/physics/units/systems/cgs.py
@@ -56,7 +56,7 @@ cgs_gauss.set_quantity_dimension(maxwell, magnetic_flux)
 cgs_gauss.set_quantity_scale_factor(maxwell, sqrt(centimeter**3*gram)/second)
 
 # SI units expressed in CGS-gaussian units:
-cgs_gauss.set_quantity_scale_factor(coulomb, speed_of_light*statcoulomb/10)
+cgs_gauss.set_quantity_scale_factor(coulomb, 10*speed_of_light*statcoulomb)
 cgs_gauss.set_quantity_scale_factor(ampere, speed_of_light*statcoulomb/second/10)
 cgs_gauss.set_quantity_scale_factor(volt, speed_of_light*statvolt/10**6)
 cgs_gauss.set_quantity_scale_factor(weber, 10**8*maxwell)

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -11,7 +11,6 @@ from sympy.physics.units.systems.cgs import cgs_gauss
 
 def test_conversion_to_from_si():
     try:
-    
         assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
         assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
         assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -32,34 +32,6 @@ def test_conversion_to_from_si():
     assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
 
 
-def test_ohm_cgs_gauss():
-
-    assert convert_to(ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
-    assert convert_to(1*ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
-    assert convert_to(2*ohm,second/centimeter,cgs_gauss) == 50000*second/(22468879468420441*centimeter)
-    assert NS(convert_to(ohm,second/centimeter,cgs_gauss)) == '1.11265005605362e-12*second/centimeter'
-    assert NS(convert_to(2*ohm,second/centimeter,cgs_gauss)) == '2.22530011210724e-12*second/centimeter'
-
-def test_henry_cgs_gauss():
-    assert convert_to(henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
-    assert convert_to(1*henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
-    assert convert_to(2*henry,second**2/centimeter,cgs_gauss) == 50000*second**2/(22468879468420441*centimeter)
-    assert NS(convert_to(henry,second**2/centimeter,cgs_gauss)) == '1.11265005605362e-12*second**2/centimeter'
-    assert NS(convert_to(2*henry,second**2/centimeter,cgs_gauss)) == '2.22530011210724e-12*second**2/centimeter'
-
-def test_volt_cgs_gauss():
-    assert convert_to(volt,statvolt,cgs_gauss) == 10**6*statvolt/299792458
-    assert convert_to(1*volt,statvolt,cgs_gauss) == 10**6*statvolt/299792458
-    assert convert_to(2*volt,statvolt,cgs_gauss) == 2*10**6*statvolt/299792458
-
-def test_farad_cgs_gauss():
-
-   assert convert_to(farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
-   assert convert_to(1*farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
-   assert convert_to(2*farad,centimeter,cgs_gauss) == 2*299792458**2*centimeter/10**5
-
-
-
 def test_cgs_gauss_convert_constants():
 
     assert convert_to(speed_of_light, centimeter/second, cgs_gauss) == 29979245800*centimeter/second
@@ -74,3 +46,9 @@ def test_cgs_gauss_convert_constants():
     assert convert_to(elementary_charge, statcoulomb, cgs_gauss)
     assert convert_to(gravitational_constant, dyne*centimeter**2/gram**2, cgs_gauss)
     assert NS(convert_to(planck, erg*second, cgs_gauss)) == '6.62607015e-27*erg*second'
+
+    spc = 25000*second/(22468879468420441*centimeter)
+    assert convert_to(ohm, second/centimeter, cgs_gauss) == spc
+    assert convert_to(henry, second**2/centimeter, cgs_gauss) == spc*second
+    assert convert_to(volt, statvolt, cgs_gauss) == 10**6*statvolt/299792458
+    assert convert_to(farad, centimeter, cgs_gauss) == 299792458**2*centimeter/10**5

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -4,7 +4,7 @@ from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.physics.units import convert_to, coulomb_constant, elementary_charge, gravitational_constant, planck
 from sympy.physics.units.definitions.unit_definitions import statcoulomb, coulomb, second, gram, centimeter, erg, \
-    newton, joule, dyne, speed_of_light, meter
+    newton, joule, dyne, speed_of_light, meter, farad, henry, statvolt, volt, ohm
 from sympy.physics.units.systems import SI
 from sympy.physics.units.systems.cgs import cgs_gauss
 
@@ -29,7 +29,33 @@ def test_conversion_to_from_si():
     assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
     assert convert_to(newton, dyne, SI) == 10**5*dyne
     assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
+    
+def test_ohm_cgs_gauss(): 
+    assert convert_to(ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
+    assert convert_to(1*ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
+    assert convert_to(2*ohm,second/centimeter,cgs_gauss) == 50000*second/(22468879468420441*centimeter)
+    assert NS(convert_to(ohm,second/centimeter,cgs_gauss)) == '1.11265005605362e-12*second/centimeter'
+    assert NS(convert_to(2*ohm,second/centimeter,cgs_gauss)) == '2.22530011210724e-12*second/centimeter'
 
+def test_henry_cgs_gauss(): 
+    assert convert_to(henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
+    assert convert_to(1*henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
+    assert convert_to(2*henry,second**2/centimeter,cgs_gauss) == 50000*second**2/(22468879468420441*centimeter)
+    assert NS(convert_to(henry,second**2/centimeter,cgs_gauss)) == '1.11265005605362e-12*second**2/centimeter'
+    assert NS(convert_to(2*henry,second**2/centimeter,cgs_gauss)) == '2.22530011210724e-12*second**2/centimeter'
+
+def test_volt_cgs_gauss():
+    assert convert_to(volt,statvolt,cgs_gauss) == 10**6*statvolt/299792458
+    assert convert_to(1*volt,statvolt,cgs_gauss) == 10**6*statvolt/299792458
+    assert convert_to(2*volt,statvolt,cgs_gauss) == 2*10**6*statvolt/299792458
+
+def test_farad_cgs_gauss():
+   
+   assert convert_to(farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
+   assert convert_to(1*farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
+   assert convert_to(2*farad,centimeter,cgs_gauss) == 2*299792458**2*centimeter/10**5
+
+    
 
 def test_cgs_gauss_convert_constants():
 
@@ -41,7 +67,7 @@ def test_cgs_gauss_convert_constants():
     assert convert_to(coulomb_constant, dyne*centimeter**2/statcoulomb**2, cgs_gauss) == centimeter**2*dyne/statcoulomb**2
     assert convert_to(coulomb_constant, 1, SI) == coulomb_constant
     assert NS(convert_to(coulomb_constant, newton*meter**2/coulomb**2, SI)) == '8987551787.36818*meter**2*newton/coulomb**2'
-
+    
     assert convert_to(elementary_charge, statcoulomb, cgs_gauss)
     assert convert_to(gravitational_constant, dyne*centimeter**2/gram**2, cgs_gauss)
     assert NS(convert_to(planck, erg*second, cgs_gauss)) == '6.62607015e-27*erg*second'

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -11,8 +11,8 @@ from sympy.physics.units.systems.cgs import cgs_gauss
 
 def test_conversion_to_from_si():
 
-    assert convert_to(statcoulomb, coulomb, cgs_gauss) == 5*coulomb/149896229
-    assert convert_to(coulomb, statcoulomb, cgs_gauss) == 149896229*statcoulomb/5
+    assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
+    assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
     assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second
     assert convert_to(coulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == 149896229*centimeter**(S(3)/2)*sqrt(gram)/(5*second)
 

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -10,28 +10,25 @@ from sympy.physics.units.systems.cgs import cgs_gauss
 
 
 def test_conversion_to_from_si():
-    try:
-        assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
-        assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
-        assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second
-        assert convert_to(coulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == 149896229*centimeter**(S(3)/2)*sqrt(gram)/(5*second)
+    assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
+    assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
+    assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second
+    assert convert_to(coulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == 2997924580*centimeter**(S(3)/2)*sqrt(gram)/second
 
     # SI units have an additional base unit, no conversion in case of electromagnetism:
-        assert convert_to(coulomb, statcoulomb, SI) == coulomb
-        assert convert_to(statcoulomb, coulomb, SI) == statcoulomb
+    assert convert_to(coulomb, statcoulomb, SI) == coulomb
+    assert convert_to(statcoulomb, coulomb, SI) == statcoulomb
 
     # SI without electromagnetism:
-        assert convert_to(erg, joule, SI) == joule/10**7
-        assert convert_to(erg, joule, cgs_gauss) == joule/10**7
-        assert convert_to(joule, erg, SI) == 10**7*erg
-        assert convert_to(joule, erg, cgs_gauss) == 10**7*erg
+    assert convert_to(erg, joule, SI) == joule/10**7
+    assert convert_to(erg, joule, cgs_gauss) == joule/10**7
+    assert convert_to(joule, erg, SI) == 10**7*erg
+    assert convert_to(joule, erg, cgs_gauss) == 10**7*erg
 
-        assert convert_to(dyne, newton, SI) == newton/10**5
-        assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
-        assert convert_to(newton, dyne, SI) == 10**5*dyne
-        assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
-    except AssertionError as msg:
-        return msg
+    assert convert_to(dyne, newton, SI) == newton/10**5
+    assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
+    assert convert_to(newton, dyne, SI) == 10**5*dyne
+    assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
 
 
 def test_cgs_gauss_convert_constants():
@@ -39,7 +36,7 @@ def test_cgs_gauss_convert_constants():
     assert convert_to(speed_of_light, centimeter/second, cgs_gauss) == 29979245800*centimeter/second
 
     assert convert_to(coulomb_constant, 1, cgs_gauss) == 1
-    assert convert_to(coulomb_constant, newton*meter**2/coulomb**2, cgs_gauss) == 22468879468420441*meter**2*newton/(25000000000*coulomb**2)
+    assert convert_to(coulomb_constant, newton*meter**2/coulomb**2, cgs_gauss) == 22468879468420441*meter**2*newton/(2500000*coulomb**2)
     assert convert_to(coulomb_constant, newton*meter**2/coulomb**2, SI) == 22468879468420441*meter**2*newton/(2500000*coulomb**2)
     assert convert_to(coulomb_constant, dyne*centimeter**2/statcoulomb**2, cgs_gauss) == centimeter**2*dyne/statcoulomb**2
     assert convert_to(coulomb_constant, 1, SI) == coulomb_constant

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -10,26 +10,29 @@ from sympy.physics.units.systems.cgs import cgs_gauss
 
 
 def test_conversion_to_from_si():
-
-    assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
-    assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
-    assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second
-    assert convert_to(coulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == 149896229*centimeter**(S(3)/2)*sqrt(gram)/(5*second)
+    try:
+    
+        assert convert_to(statcoulomb, coulomb, cgs_gauss) == coulomb/2997924580
+        assert convert_to(coulomb, statcoulomb, cgs_gauss) == 2997924580*statcoulomb
+        assert convert_to(statcoulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == centimeter**(S(3)/2)*sqrt(gram)/second
+        assert convert_to(coulomb, sqrt(gram*centimeter**3)/second, cgs_gauss) == 149896229*centimeter**(S(3)/2)*sqrt(gram)/(5*second)
 
     # SI units have an additional base unit, no conversion in case of electromagnetism:
-    assert convert_to(coulomb, statcoulomb, SI) == coulomb
-    assert convert_to(statcoulomb, coulomb, SI) == statcoulomb
+        assert convert_to(coulomb, statcoulomb, SI) == coulomb
+        assert convert_to(statcoulomb, coulomb, SI) == statcoulomb
 
     # SI without electromagnetism:
-    assert convert_to(erg, joule, SI) == joule/10**7
-    assert convert_to(erg, joule, cgs_gauss) == joule/10**7
-    assert convert_to(joule, erg, SI) == 10**7*erg
-    assert convert_to(joule, erg, cgs_gauss) == 10**7*erg
+        assert convert_to(erg, joule, SI) == joule/10**7
+        assert convert_to(erg, joule, cgs_gauss) == joule/10**7
+        assert convert_to(joule, erg, SI) == 10**7*erg
+        assert convert_to(joule, erg, cgs_gauss) == 10**7*erg
 
-    assert convert_to(dyne, newton, SI) == newton/10**5
-    assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
-    assert convert_to(newton, dyne, SI) == 10**5*dyne
-    assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
+        assert convert_to(dyne, newton, SI) == newton/10**5
+        assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
+        assert convert_to(newton, dyne, SI) == 10**5*dyne
+        assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
+    except AssertionError as msg:
+        return msg
 
 
 def test_cgs_gauss_convert_constants():

--- a/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
+++ b/sympy/physics/units/tests/test_unit_system_cgs_gauss.py
@@ -25,19 +25,22 @@ def test_conversion_to_from_si():
     assert convert_to(joule, erg, SI) == 10**7*erg
     assert convert_to(joule, erg, cgs_gauss) == 10**7*erg
 
+
     assert convert_to(dyne, newton, SI) == newton/10**5
     assert convert_to(dyne, newton, cgs_gauss) == newton/10**5
     assert convert_to(newton, dyne, SI) == 10**5*dyne
     assert convert_to(newton, dyne, cgs_gauss) == 10**5*dyne
-    
-def test_ohm_cgs_gauss(): 
+
+
+def test_ohm_cgs_gauss():
+
     assert convert_to(ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
     assert convert_to(1*ohm,second/centimeter,cgs_gauss) == 25000*second/(22468879468420441*centimeter)
     assert convert_to(2*ohm,second/centimeter,cgs_gauss) == 50000*second/(22468879468420441*centimeter)
     assert NS(convert_to(ohm,second/centimeter,cgs_gauss)) == '1.11265005605362e-12*second/centimeter'
     assert NS(convert_to(2*ohm,second/centimeter,cgs_gauss)) == '2.22530011210724e-12*second/centimeter'
 
-def test_henry_cgs_gauss(): 
+def test_henry_cgs_gauss():
     assert convert_to(henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
     assert convert_to(1*henry,second**2/centimeter,cgs_gauss) == 25000*second**2/(22468879468420441*centimeter)
     assert convert_to(2*henry,second**2/centimeter,cgs_gauss) == 50000*second**2/(22468879468420441*centimeter)
@@ -50,12 +53,12 @@ def test_volt_cgs_gauss():
     assert convert_to(2*volt,statvolt,cgs_gauss) == 2*10**6*statvolt/299792458
 
 def test_farad_cgs_gauss():
-   
+
    assert convert_to(farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
    assert convert_to(1*farad,centimeter,cgs_gauss) == 299792458**2*centimeter/10**5
    assert convert_to(2*farad,centimeter,cgs_gauss) == 2*299792458**2*centimeter/10**5
 
-    
+
 
 def test_cgs_gauss_convert_constants():
 
@@ -67,7 +70,7 @@ def test_cgs_gauss_convert_constants():
     assert convert_to(coulomb_constant, dyne*centimeter**2/statcoulomb**2, cgs_gauss) == centimeter**2*dyne/statcoulomb**2
     assert convert_to(coulomb_constant, 1, SI) == coulomb_constant
     assert NS(convert_to(coulomb_constant, newton*meter**2/coulomb**2, SI)) == '8987551787.36818*meter**2*newton/coulomb**2'
-    
+
     assert convert_to(elementary_charge, statcoulomb, cgs_gauss)
     assert convert_to(gravitational_constant, dyne*centimeter**2/gram**2, cgs_gauss)
     assert NS(convert_to(planck, erg*second, cgs_gauss)) == '6.62607015e-27*erg*second'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
fixes #24319 ,#24381 ,#24281
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
fixes numerical error in the conversion of `coulomb` and `statcoulomb` 




#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

or if no release note(s) should be included use:



See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
     *  fixed numerical error in conversion of statcoulomb and coulomb

<!-- END RELEASE NOTES -->
