### PR TITLE
Fix auto_int_to_Integer in the qtconsole

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -153,7 +153,7 @@ def enable_automatic_int_sympification(shell):
             pass
         else:
             cell = int_to_Integer(cell)
-        old_run_cell(cell, *args, **kwargs)
+        return old_run_cell(cell, *args, **kwargs)
 
     shell.run_cell = my_run_cell
 


### PR DESCRIPTION
Previously the monkeypatched function was returning None.

Fixes #24280

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- interactive
  - Fix auto_int_to_Integer in the qtconsole.
<!-- END RELEASE NOTES -->
