### PR TITLE
tensor module: deduplicate dummy indices when using subs/xreplace/doit on TensMul

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -781,6 +781,7 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1961,6 +1961,21 @@ def test_rewrite_tensor_to_Indexed():
     assert b2.rewrite(Indexed) == Sum(Indexed(Symbol("B"), L_1)*Indexed(Symbol("A"), L_0, L_0, i2, L_1), (L_0, 0, 3), (L_1, 0, 3))
 
 
+def test_TensMul_subs():
+    """
+    Test subs and xreplace in TensMul
+    """
+    R3 = TensorIndexType('R3', dim=3)
+    p, q, r = tensor_indices("p q r", R3)
+    K = TensorHead("K", [R3])
+    V = TensorHead("V", [R3])
+    C0 = TensorIndex(R3.dummy_name + "_0", R3, True)
+
+    assert ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
+    assert ( K(p)*V(r)*K(-p) ).xreplace({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
+    assert ( K(p)*V(r) ).xreplace({p: C0, V(r): K(q)*K(-q)}) == K(C0)*K(q)*K(-q)
+
+
 def test_tensorsymmetry():
     with warns_deprecated_sympy():
         tensorsymmetry([1]*2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs
If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
When using `subs`, `xreplace`, or `doit(deep=True)` on a TensMul, sometimes we need to deduplicate dummy indices. Otherwise, the resulting TensMul becomes invalid due to repeated indices.

This PR
- adds _eval_subs and _xreplace methods to TensMul to handle
this.
- fixes a similar issue in TensMul.doit()
- adds a test

#### Other comments
After this PR:
```
>>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorHead
>>> R3 = TensorIndexType('R3', dim=3)
>>> p, q, r = tensor_indices("p q r", R3)
>>> K = TensorHead("K", [R3])
>>> V = TensorHead("V", [R3])
>>> ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)})
K(R_0)*K(R_1)*K(-R_1)*K(-R_0)
```

Before this PR (sympy built from master):
```
>>> ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/sympy/core/basic.py", line 1005, in subs
    rv = rv._subs(old, new, **kwargs)
  File "/usr/lib/python3.10/site-packages/sympy/core/cache.py", line 72, in wrapper
    retval = cfunc(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/sympy/core/basic.py", line 1119, in _subs
    rv = fallback(self, old, new)
  File "/usr/lib/python3.10/site-packages/sympy/core/basic.py", line 1096, in fallback
    rv = self.func(*args)
  File "/usr/lib/python3.10/site-packages/sympy/tensor/tensor.py", line 3260, in __new__
    args, indices, free, dum = TensMul._tensMul_contract_indices(args, replace_indices=False)
  File "/usr/lib/python3.10/site-packages/sympy/tensor/tensor.py", line 3344, in _tensMul_contract_indices
    indices, free, free_names, dummy_data = TensMul._indices_to_free_dum(args_indices)
  File "/usr/lib/python3.10/site-packages/sympy/tensor/tensor.py", line 3320, in _indices_to_free_dum
    raise ValueError("Repeated index: %s" % index)
ValueError: Repeated index: R_0
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fix index conflicts when using subs or xreplace on TensMul
<!-- END RELEASE NOTES -->
