### PR TITLE
Tensor module: TensMul: fix index conflicts when using subs, xreplace, or doit.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -781,6 +781,7 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3268,7 +3268,7 @@ class TensMul(TensExpr, AssocOp):
             free_this = set(get_free_indices(arg))
             if len(dum_this.intersection(free)) > 0:
                 exclude = free_this.union(free, dum_other)
-                newarg = TensMul._dedupe_indices(arg, exclude, arg._index_structure)
+                newarg = TensMul._dedupe_indices(arg, exclude)
             else:
                 newarg = arg
             newargs.append(newarg)
@@ -4021,11 +4021,10 @@ class TensMul(TensExpr, AssocOp):
             return self.data.__iter__()
 
     @staticmethod
-    def _dedupe_indices(new, exclude, index_structure):
+    def _dedupe_indices(new, exclude):
         """
         exclude: set
         new: TensExpr
-        index_structure: _IndexStructure (required to generate new dummy indices)
 
         If ``new`` has any dummy indices that are in ``exclude``, return a version
         of new with those indices replaced. If no replacements are needed,
@@ -4046,7 +4045,7 @@ class TensMul(TensExpr, AssocOp):
         """
         exclude.update(dums_new)
         self_args_free = [(i, None) for i in exclude]
-        gen = index_structure._get_generator_for_dummy_indices(self_args_free)
+        gen = _IndexStructure._get_generator_for_dummy_indices(self_args_free)
         repl = {}
         for d in conflicts:
             if -d in repl.keys():
@@ -4078,7 +4077,7 @@ class TensMul(TensExpr, AssocOp):
         exclude.update(index_rules.keys())
         exclude.update(index_rules.values())
         for old, new in other_rules.items():
-            new_renamed = TensMul._dedupe_indices(new, exclude, self._index_structure)
+            new_renamed = TensMul._dedupe_indices(new, exclude)
             if old == new or new_renamed is None:
                 newrule[old] = new
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4033,6 +4033,7 @@ class TensMul(TensExpr, AssocOp):
         """
         exclude = set(exclude)
         dums_new = set(get_dummy_indices(new))
+        free_new = set(get_free_indices(new))
 
         conflicts = dums_new.intersection(exclude)
         if len(conflicts) == 0:
@@ -4044,6 +4045,7 @@ class TensMul(TensExpr, AssocOp):
         set it as ``None`` here.
         """
         exclude.update(dums_new)
+        exclude.update(free_new)
         exclude_for_gen = [(i, None) for i in exclude]
         gen = _IndexStructure._get_generator_for_dummy_indices(exclude_for_gen)
         repl = {}

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4061,6 +4061,22 @@ class TensMul(TensExpr, AssocOp):
                 exclude.update(get_indices(new_renamed))
         return newrule
 
+    def _eval_subs(self, old, new):
+        """
+        This handles the fact that if a dummy index in new is the same as an
+        index in self (which is not present in old), the dummy index in new
+        must be renamed.
+        """
+
+        if not isinstance(new, TensExpr):
+            return None
+
+        new_renamed = self._dedupe_indices(new, self.get_indices())
+        if new_renamed is None:
+            return None
+        else:
+            return self.subs({old: new_renamed})
+
     def _eval_rewrite_as_Indexed(self, *args):
         from sympy.concrete.summations import Sum
         index_symbols = [i.args[0] for i in self.get_indices()]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3401,6 +3401,17 @@ class TensMul(TensExpr, AssocOp):
         deep = hints.get('deep', True)
         if deep:
             args = [arg.doit(**hints) for arg in self.args]
+
+            """
+            There may now be conflicts between dummy indices of different args
+            (each arg's doit method does not have any information about which
+            dummy indices are already used in the other args), so we
+            deduplicate them.
+            """
+            rule = dict(zip(self.args, args))
+            rule = self._dedupe_indices_in_rule(rule)
+            args = [rule[a] for a in self.args]
+
         else:
             args = self.args
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4064,7 +4064,8 @@ class TensMul(TensExpr, AssocOp):
         """
         rule: dict
 
-        This applies self._dedupe_indices on all values of rule.
+        This applies TensMul._dedupe_indices on all values of rule.
+
         """
         index_rules = {k:v for k,v in rule.items() if isinstance(k, TensorIndex)}
         other_rules = {k:v for k,v in rule.items() if k not in index_rules.keys()}

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4039,13 +4039,13 @@ class TensMul(TensExpr, AssocOp):
             return None
 
         """
-        ``self_args_free`` is to be passed to ``_IndexStructure._get_generator_for_dummy_indices()``.
+        ``exclude_for_gen`` is to be passed to ``_IndexStructure._get_generator_for_dummy_indices()``.
         Since the latter does not use the index position for anything, we just
         set it as ``None`` here.
         """
         exclude.update(dums_new)
-        self_args_free = [(i, None) for i in exclude]
-        gen = _IndexStructure._get_generator_for_dummy_indices(self_args_free)
+        exclude_for_gen = [(i, None) for i in exclude]
+        gen = _IndexStructure._get_generator_for_dummy_indices(exclude_for_gen)
         repl = {}
         for d in conflicts:
             if -d in repl.keys():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4050,29 +4050,6 @@ class TensMul(TensExpr, AssocOp):
         new_renamed = new._replace_indices(repl)
         return new_renamed
 
-    def _dedupe_indices_in_rule(self, rule):
-        """
-        rule: dict
-
-        This applies TensMul._dedupe_indices on all values of rule.
-
-        """
-        index_rules = {k:v for k,v in rule.items() if isinstance(k, TensorIndex)}
-        other_rules = {k:v for k,v in rule.items() if k not in index_rules.keys()}
-        exclude = set(self.get_indices())
-
-        newrule = {}
-        newrule.update(index_rules)
-        exclude.update(index_rules.keys())
-        exclude.update(index_rules.values())
-        for old, new in other_rules.items():
-            new_renamed = TensMul._dedupe_indices(new, exclude)
-            if old == new or new_renamed is None:
-                newrule[old] = new
-            else:
-                newrule[old] = new_renamed
-                exclude.update(get_indices(new_renamed))
-        return newrule
 
     def _eval_rewrite_as_Indexed(self, *args):
         from sympy.concrete.summations import Sum

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3255,7 +3255,8 @@ class TensMul(TensExpr, AssocOp):
         args = list(map(_sympify, args))
 
         """
-        If the internal dummy indices in one arg conflict with the free indices of the remaining args, we need to rename those internal dummy indices.
+        If the internal dummy indices in one arg conflict with the free indices
+        of the remaining args, we need to rename those internal dummy indices.
         """
         free = [get_free_indices(arg) for arg in args]
         free = set(itertools.chain(*free)) #flatten free

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4027,6 +4027,29 @@ class TensMul(TensExpr, AssocOp):
         new_renamed = new._replace_indices(repl)
         return new_renamed
 
+    def _dedupe_indices_in_rule(self, rule):
+        """
+        rule: dict
+
+        This applies self._dedupe_indices on all values of rule.
+        """
+        index_rules = {k:v for k,v in rule.items() if isinstance(k, TensorIndex)}
+        other_rules = {k:v for k,v in rule.items() if k not in index_rules.keys()}
+        exclude = set(self.get_indices())
+
+        newrule = {}
+        newrule.update(index_rules)
+        exclude.update(index_rules.keys())
+        exclude.update(index_rules.values())
+        for old, new in other_rules.items():
+            new_renamed = self._dedupe_indices(new, exclude)
+            if old == new or new_renamed is None:
+                newrule[old] = new
+            else:
+                newrule[old] = new_renamed
+                exclude.update(get_indices(new_renamed))
+        return newrule
+
     def _eval_rewrite_as_Indexed(self, *args):
         from sympy.concrete.summations import Sum
         index_symbols = [i.args[0] for i in self.get_indices()]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4305,6 +4305,12 @@ def get_indices(t):
         return ()
     return t.get_indices()
 
+def get_dummy_indices(t):
+    if not isinstance(t, TensExpr):
+        return ()
+    inds = t.get_indices()
+    free = t.get_free_indices()
+    return [i for i in inds if i not in free]
 
 def get_index_structure(t):
     if isinstance(t, TensExpr):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4030,10 +4030,10 @@ class TensMul(TensExpr, AssocOp):
         of new with those indices replaced. If no replacements are needed,
         return None
         """
-        inds_self = set(exclude)
+        exclude = set(exclude)
         dums_new = set(get_dummy_indices(new))
 
-        conflicts = dums_new.intersection(inds_self)
+        conflicts = dums_new.intersection(exclude)
         if len(conflicts) == 0:
             return None
 
@@ -4042,8 +4042,8 @@ class TensMul(TensExpr, AssocOp):
         Since the latter does not use the index position for anything, we just
         set it as ``None`` here.
         """
-        inds_self.update(dums_new)
-        self_args_free = [(i, None) for i in inds_self]
+        exclude.update(dums_new)
+        self_args_free = [(i, None) for i in exclude]
         gen = index_structure._get_generator_for_dummy_indices(self_args_free)
         repl = {}
         for d in conflicts:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4030,6 +4030,7 @@ class TensMul(TensExpr, AssocOp):
         If ``new`` has any dummy indices that are in ``exclude``, return a version
         of new with those indices replaced. If no replacements are needed,
         return None
+
         """
         exclude = set(exclude)
         dums_new = set(get_dummy_indices(new))

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3422,17 +3422,6 @@ class TensMul(TensExpr, AssocOp):
         deep = hints.get('deep', True)
         if deep:
             args = [arg.doit(**hints) for arg in self.args]
-
-            """
-            There may now be conflicts between dummy indices of different args
-            (each arg's doit method does not have any information about which
-            dummy indices are already used in the other args), so we
-            deduplicate them.
-            """
-            rule = dict(zip(self.args, args))
-            rule = self._dedupe_indices_in_rule(rule)
-            args = [rule[a] for a in self.args]
-
         else:
             args = self.args
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3422,6 +3422,17 @@ class TensMul(TensExpr, AssocOp):
         deep = hints.get('deep', True)
         if deep:
             args = [arg.doit(**hints) for arg in self.args]
+
+            """
+            There may now be conflicts between dummy indices of different args
+            (each arg's doit method does not have any information about which
+            dummy indices are already used in the other args), so we
+            deduplicate them.
+            """
+            rule = dict(zip(self.args, args))
+            rule = self._dedupe_indices_in_rule(rule)
+            args = [rule[a] for a in self.args]
+
         else:
             args = self.args
 
@@ -4050,6 +4061,29 @@ class TensMul(TensExpr, AssocOp):
         new_renamed = new._replace_indices(repl)
         return new_renamed
 
+    def _dedupe_indices_in_rule(self, rule):
+        """
+        rule: dict
+
+        This applies TensMul._dedupe_indices on all values of rule.
+
+        """
+        index_rules = {k:v for k,v in rule.items() if isinstance(k, TensorIndex)}
+        other_rules = {k:v for k,v in rule.items() if k not in index_rules.keys()}
+        exclude = set(self.get_indices())
+
+        newrule = {}
+        newrule.update(index_rules)
+        exclude.update(index_rules.keys())
+        exclude.update(index_rules.values())
+        for old, new in other_rules.items():
+            new_renamed = TensMul._dedupe_indices(new, exclude)
+            if old == new or new_renamed is None:
+                newrule[old] = new
+            else:
+                newrule[old] = new_renamed
+                exclude.update(get_indices(new_renamed))
+        return newrule
 
     def _eval_rewrite_as_Indexed(self, *args):
         from sympy.concrete.summations import Sum

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1961,6 +1961,21 @@ def test_rewrite_tensor_to_Indexed():
     assert b2.rewrite(Indexed) == Sum(Indexed(Symbol("B"), L_1)*Indexed(Symbol("A"), L_0, L_0, i2, L_1), (L_0, 0, 3), (L_1, 0, 3))
 
 
+def test_TensMul_subs():
+    """
+    Test subs and xreplace in TensMul
+    """
+    R3 = TensorIndexType('R3', dim=3)
+    p, q, r = tensor_indices("p q r", R3)
+    K = TensorHead("K", [R3])
+    V = TensorHead("V", [R3])
+    C0 = TensorIndex(R3.dummy_name + "_0", R3, True)
+
+    assert ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
+    assert ( K(p)*V(r)*K(-p) ).xreplace({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
+    assert ( K(p)*V(r) ).xreplace({p: C0, V(r): K(q)*K(-q)}) == K(C0)*K(q)*K(-q)
+
+
 def test_tensorsymmetry():
     with warns_deprecated_sympy():
         tensorsymmetry([1]*2)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1969,11 +1969,13 @@ def test_TensMul_subs():
     p, q, r = tensor_indices("p q r", R3)
     K = TensorHead("K", [R3])
     V = TensorHead("V", [R3])
+    A = TensorHead("A", [R3, R3])
     C0 = TensorIndex(R3.dummy_name + "_0", R3, True)
 
     assert ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
     assert ( K(p)*V(r)*K(-p) ).xreplace({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
     assert ( K(p)*V(r) ).xreplace({p: C0, V(r): K(q)*K(-q)}) == K(C0)*K(q)*K(-q)
+    assert ( K(p)*A(q,-q)*K(-p) ).doit() == K(p)*A(q,-q)*K(-p)
 
 
 def test_tensorsymmetry():

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1963,7 +1963,7 @@ def test_rewrite_tensor_to_Indexed():
 
 def test_TensMul_subs():
     """
-    Test subs and xreplace in TensMul
+    Test subs and xreplace in TensMul. See bug #24337
     """
     R3 = TensorIndexType('R3', dim=3)
     p, q, r = tensor_indices("p q r", R3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24337
Fixes #23434


#### Brief description of what is fixed or changed
When internally contracted (dummy) indices are renamed in `TensMul`, they are automatically chosen such that they are unique within the particular `TensMul`. However, when a `TensMul` is inserted into another `TensMul` using `xreplace` or `subs`, it is possible for the names of the dummy indices to clash. A similar issue can happen when using `doit(deep=True)`.

This PR modifies `TensMul.__new__` to deduplicate the dummy indices in such cases (where the `TensMul` can still be unambiguously interpreted). Similarly, `TensMul.doit` has also been modified.

Tests have also been added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
   * Fix index conflicts when using subs, xreplace, or doit on a TensMul
<!-- END RELEASE NOTES -->
