### PR TITLE
tensor module: TensMul.contract_metric: handle case where expr.canon_bp() == 0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -781,6 +781,7 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3771,11 +3771,8 @@ class TensMul(TensExpr, AssocOp):
         """
         expr = self.expand()
         if self != expr:
-            expr = expr.canon_bp()
-            if expr == S.Zero:
-                return expr
-            else:
-                return expr.contract_metric(g)
+            expr = canon_bp(expr)
+            return contract_metric(expr, g)
         pos_map = self._get_indices_to_args_pos()
         args = list(self.args)
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3772,7 +3772,10 @@ class TensMul(TensExpr, AssocOp):
         expr = self.expand()
         if self != expr:
             expr = expr.canon_bp()
-            return expr.contract_metric(g)
+            if expr == S.Zero:
+                return expr
+            else:
+                return expr.contract_metric(g)
         pos_map = self._get_indices_to_args_pos()
         args = list(self.args)
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -992,6 +992,18 @@ def test_metric_contract3():
     assert _is_equal(t1, B(-a2,a1)*psi(-a1))
 
 
+def test_contract_metric4():
+    R3 = TensorIndexType('R3', dim=3)
+    p, q, r = tensor_indices("p q r", R3)
+    delta = R3.delta
+    eps = R3.epsilon
+    K = TensorHead("K", [R3])
+
+    #Check whether contract_metric chokes on an expandable expression which becomes zero on canonicalization.
+    expr = eps(p,q,r)*( K(-p)*K(-q) + delta(-p,-q) )
+    assert expr.contract_metric(delta) == 0
+
+
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_name='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -999,7 +999,7 @@ def test_contract_metric4():
     eps = R3.epsilon
     K = TensorHead("K", [R3])
 
-    #Check whether contract_metric chokes on an expandable expression which becomes zero on canonicalization.
+    #Check whether contract_metric chokes on an expandable expression which becomes zero on canonicalization (issue #24354)
     expr = eps(p,q,r)*( K(-p)*K(-q) + delta(-p,-q) )
     assert expr.contract_metric(delta) == 0
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24354


#### Brief description of what is fixed or changed
If called on an expression which becomes zero during canonicalization (`canon_bp`), , contract_metric would earlier crash. This PR modifies TensMul.contract_metric to handle that case, and adds a test.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
