### PR TITLE
Remove usage of numpy.distutils

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -785,20 +785,17 @@ ufunc${ind} = PyUFunc_FromFuncAndData(${funcname}_funcs, ${funcname}_data, ${fun
     Py_DECREF(ufunc${ind});""")
 
 _ufunc_setup = Template("""\
-def configuration(parent_package='', top_path=None):
-    import numpy
-    from numpy.distutils.misc_util import Configuration
+from setuptools.extension import Extension
+from setuptools import setup
 
-    config = Configuration('',
-                           parent_package,
-                           top_path)
-    config.add_extension('${module}', sources=['${module}.c', '${filename}.c'])
-
-    return config
+from numpy import get_include
 
 if __name__ == "__main__":
-    from numpy.distutils.core import setup
-    setup(configuration=configuration)""")
+    setup(ext_modules=[
+        Extension('${module}',
+                  sources=['${module}.c', '${filename}.c'],
+                  include_dirs=[get_include()])])
+""")
 
 
 class UfuncifyCodeWrapper(CodeWrapper):


### PR DESCRIPTION
It was only used in ufuncify, and can easily be replaced by pure setuptools.

Fixes #24360.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - Remove the use of the deprecated `numpy.distutils` in `ufuncify`. 
<!-- END RELEASE NOTES -->