### PR TITLE
Partially fix rewrite trigonometric functions to more general functions

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -799,6 +799,7 @@ def test_cot_rewrite():
     assert cot(sin(x)).rewrite(Pow) == cot(sin(x))
     assert cot(pi*Rational(2, 5), evaluate=False).rewrite(sqrt) == (Rational(-1, 4) + sqrt(5)/4)/\
                                                         sqrt(sqrt(5)/8 + Rational(5, 8))
+    assert cot(x).rewrite(hyper) == (2/pi)*hyper((1, -(x/pi), (x/pi)), (1 - (x/pi), (x/pi) + 1), 1) - (1/x)
 
 
 def test_cot_subs():
@@ -1721,6 +1722,9 @@ def test_sec_rewrite():
     assert sec(x).rewrite(sin) == 1 / sin(x + pi / 2, evaluate=False)
     assert sec(x).rewrite(tan) == (tan(x / 2)**2 + 1) / (-tan(x / 2)**2 + 1)
     assert sec(x).rewrite(csc) == csc(-x + pi/2, evaluate=False)
+    assert sec(x).rewrite(hyper) == [((4*pi)/((pi**2) - 4*(x**2)))
+        *hyper((1, 3/2, (1/2) - (x/pi), (x/pi) + (1/2)), (1/2, (3/2) - (x/pi), (x/pi) + (3/2)), -1),
+        1/hyper([], (1/2,), -(x**2)/4)]
 
 
 def test_sec_fdiff():
@@ -1908,6 +1912,8 @@ def test_csc_rewrite():
     assert csc(x).rewrite(cot) == (cot(x/2)**2 + 1)/(2*cot(x/2))
     assert csc(x).rewrite(cos) == 1/cos(x - pi/2, evaluate=False)
     assert csc(x).rewrite(sec) == sec(-x + pi/2, evaluate=False)
+    assert csc(x).rewrite(hyper) == [(2/x)*hyper((1, -(x/pi), x/pi), (1 - (x/pi), (x/pi) + 1), -1) - (1/x),
+        1/(x*hyper([], (3/2,), -(x**2)/4))]
 
     # issue 17349
     assert csc(1 - exp(-besselj(I, I))).rewrite(cos) == \

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -10,11 +10,12 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.complexes import (arg, conjugate, im, re)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (acoth, asinh, atanh, cosh, coth, sinh, tanh)
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import (sqrt, cbrt)
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, atan2,
                                                       cos, cot, csc, sec, sin, sinc, tan)
 from sympy.functions.special.bessel import (besselj, jn)
 from sympy.functions.special.delta_functions import Heaviside
+from sympy.functions.special.hyper import hyper
 from sympy.matrices.dense import Matrix
 from sympy.polys.polytools import (cancel, gcd)
 from sympy.series.limits import limit
@@ -216,6 +217,13 @@ def test_sin_rewrite():
     assert sin(x).rewrite(csc) == 1/csc(x)
     assert sin(x).rewrite(cos) == cos(x - pi / 2, evaluate=False)
     assert sin(x).rewrite(sec) == 1 / sec(x - pi / 2, evaluate=False)
+    assert sin(x).rewrite(hyper) == [x*hyper([], (3/2,), -(x**2)/4),
+        hyper([], (1/2,), -(1/4)*(x - (pi/2))**2),
+        sqrt((1/2)*hyper([], (1/2,), -(x - (pi/2))**2) + (1/2)),
+        cbrt((3/4)*hyper([], (1/2,), -(1/4)*(x - (pi/2))) + (1/4)*hyper([], (1/2,), -(9/4)*(x - pi/2)**2)),
+        x * hyper((x/pi, x/pi, x/pi), (1, 1), -1)
+            - ((2*(x**3))/(pi**2))*hyper(((x/pi) + 1, (x/pi) + 1, (x/pi) + 1), (2, 2), -1),
+        sqrt((x**2)*hyper((1,), (2, (3/2)), -(x**2)))]
     assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
 
 
@@ -439,6 +447,13 @@ def test_cos_rewrite():
     assert cos(x).rewrite(sec) == 1/sec(x)
     assert cos(x).rewrite(sin) == sin(x + pi/2, evaluate=False)
     assert cos(x).rewrite(csc) == 1/csc(-x + pi/2, evaluate=False)
+    assert cos(x).rewrite(hyper) == [hyper([], (1/2,), -(x**2)/4),
+        -(x - (pi/2))*hyper([], (3/2,), -(1/4)*(x - (pi/2))**2),
+        sqrt((1/2) + (1/2)*hyper([], (1/2,), -x**2)),
+        cbrt((3/4)*hyper([], (1/2,), -(x**2)/4) + (1/4)*hyper([], (1/2,), -(9*x**2)/4)),
+        ((pi/2) - x)*hyper(((x/pi) - (1/2), (x/pi) - (1/2), (x/pi) - (1/2)), (1, 1), -1)
+        - (2/pi**2)*(((pi/2) - x)**3)*hyper(((x/pi) + (1/2), (x/pi) + (1/2), (x/pi) + (1/2)), (2, 2), -1),
+        sqrt(((x - (pi/2))**2)*hyper((1,), (2, (3/2)), -((x - (pi/2))**2)))]
     assert cos(sin(x)).rewrite(Pow) == cos(sin(x))
 
 
@@ -610,6 +625,7 @@ def test_tan_rewrite():
     assert tan(sin(x)).rewrite(Pow) == tan(sin(x))
     assert tan(pi*Rational(2, 5), evaluate=False).rewrite(sqrt) == sqrt(sqrt(5)/8 +
                Rational(5, 8))/(Rational(-1, 4) + sqrt(5)/4)
+    assert tan(x).rewrite(hyper) == (8*x)/((pi**2) - (4 * (x**2)))*hyper((1, (1/2) - (x/pi), (x/pi) + (1/2)), ((3/2) - (x/pi), (x/pi) + (3/2)), 1)
 
 
 def test_tan_subs():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1608,6 +1608,10 @@ class cot(TrigonometricFunction):
             return None
         return y
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        return (2/pi)*hyper((1, -(arg/pi), (arg/pi)), (1 - (arg/pi), (arg/pi) + 1), 1) - (1/arg)
+
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.functions.elementary.complexes import re
@@ -1863,6 +1867,12 @@ class sec(ReciprocalTrigonometricFunction):
     def _eval_rewrite_as_csc(self, arg, **kwargs):
         return csc(pi/2 - arg, evaluate=False)
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        return [((4*pi)/((pi**2) - 4*(arg**2)))
+            *hyper((1, 3/2, (1/2) - (arg/pi), (arg/pi) + (1/2)), (1/2, (3/2) - (arg/pi), (arg/pi) + (3/2)), -1),
+            1/hyper([], (1/2,), -(arg**2)/4)]
+
     def fdiff(self, argindex=1):
         if argindex == 1:
             return tan(self.args[0])*sec(self.args[0])
@@ -1963,6 +1973,11 @@ class csc(ReciprocalTrigonometricFunction):
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
         return (1/sin(arg).rewrite(tan))
+
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        return [(2/arg)*hyper((1, -(arg/pi), arg/pi), (1 - (arg/pi), (arg/pi) + 1), -1) - (1/arg),
+            1/(arg*hyper([], (3/2,), -(arg**2)/4))]
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -943,6 +943,10 @@ class cos(TrigonometricFunction):
     def _eval_rewrite_as_csc(self, arg, **kwargs):
         return 1/sec(arg).rewrite(csc)
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        return hyper([], (1,), ((-arg**2)/4,))
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -945,7 +945,11 @@ class cos(TrigonometricFunction):
 
     def _eval_rewrite_as_hyper(self, arg, **kwargs):
         from sympy.functions.special.hyper import hyper
-        return hyper([], (1,), ((-arg**2)/4,))
+        from sympy import cbrt
+        return [hyper([], (1/2,), -(arg**2)/4),
+            -(arg - (pi/2))*hyper([], (3/2,), -(1/4)*(arg - (pi/2))**2),
+            sqrt((1/2) + (1/2)*hyper([], (1/2,), -arg**2)),
+            cbrt((3/4)*hyper([], (1/2,), -(arg**2)/4) + (1/4)*hyper([], (1/2,), -(9*arg**2)/4))]
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -532,6 +532,17 @@ class sin(TrigonometricFunction):
     def _eval_rewrite_as_sinc(self, arg, **kwargs):
         return arg*sinc(arg)
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        from sympy import cbrt
+        return [arg*hyper([], (3/2,), -(arg**2)/4),
+            hyper([], (1/2,), -(1/4)*(arg - (pi/2))**2),
+            sqrt((1/2)*hyper([], (1/2,), -(arg - (pi/2))**2) + (1/2)),
+            cbrt((3/4)*hyper([], (1/2,), -(1/4)*(arg - (pi/2))) + (1/4)*hyper([], (1/2,), -(9/4)*(arg - pi/2)**2)),
+            arg * hyper((arg/pi, arg/pi, arg/pi), (1, 1), -1)
+                - ((2*(arg**3))/(pi**2))*hyper(((arg/pi) + 1, (arg/pi) + 1, (arg/pi) + 1), (2, 2), -1),
+            sqrt((arg**2)*hyper((1,), (2, (3/2)), -(arg**2)))]
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
@@ -1308,6 +1319,10 @@ class tan(TrigonometricFunction):
         if y.has(cos):
             return None
         return y
+
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.functions.special.hyper import hyper
+        return (8*arg)/((pi**2) - (4 * (arg**2)))*hyper((1, (1/2) - (arg/pi), (arg/pi) + (1/2)), ((3/2) - (arg/pi), (arg/pi) + (3/2)), 1)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         from sympy.calculus.accumulationbounds import AccumBounds

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -949,7 +949,10 @@ class cos(TrigonometricFunction):
         return [hyper([], (1/2,), -(arg**2)/4),
             -(arg - (pi/2))*hyper([], (3/2,), -(1/4)*(arg - (pi/2))**2),
             sqrt((1/2) + (1/2)*hyper([], (1/2,), -arg**2)),
-            cbrt((3/4)*hyper([], (1/2,), -(arg**2)/4) + (1/4)*hyper([], (1/2,), -(9*arg**2)/4))]
+            cbrt((3/4)*hyper([], (1/2,), -(arg**2)/4) + (1/4)*hyper([], (1/2,), -(9*arg**2)/4)),
+            ((pi/2) - arg)*hyper(((arg/pi) - (1/2), (arg/pi) - (1/2), (arg/pi) - (1/2)), (1, 1), -1)
+                - (2/pi**2)*(((pi/2) - arg)**3)*hyper(((arg/pi) + (1/2), (arg/pi) + (1/2), (arg/pi) + (1/2)), (2, 2), -1),
+            sqrt(((arg - (pi/2))**2)*hyper((1,), (2, (3/2)), -((arg - (pi/2))**2)))]
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())


### PR DESCRIPTION
#### References to other Issues or PRs
Partially fixes #24176

#### Brief description of what is fixed or changed
Implemented hypergeometric rewrites for sin, cos, tan, csc, sec, and cot. Formulas were sourced from ex. https://functions.wolfram.com/ElementaryFunctions/Cos/26/01/.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Implemented hypergeometric rewrites for sin, cos, tan, csc, sec, and cot.
<!-- END RELEASE NOTES -->