### PR TITLE
added as_list property to Quaternion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -533,6 +533,7 @@ Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
+Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
 Evgenia Karunus <lakesare@gmail.com>
 Fabian Ball <fabian.ball@kit.edu>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -81,6 +81,10 @@ class Quaternion(Expr):
         return self._d
 
     @property
+    def as_list(self):
+        return [self._a, self._b, self._c, self._d]
+
+    @property
     def real_field(self):
         return self._real_field
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Added a very simple property to get ordered elements of Quaternion as a list of length 4.

#### Other comments

I have done this operation multiple times, in particular, when treating the quaternion as a 4-vector in order to define other operations to the quaternion as a Matrix x Vector multiplication:
```
qv = Matrix(q.as_list)
```

This can be useful, for example, for a very straight forward implementation of the Hamilton product in the same way as a cross product can be rewritten as a multiplication between a skew-symmetric matrix and a vector:
```
(q1 * q2).as_list
```
Would be equivalent to this:
```
Q1 * Matrix(q2.as_list)
```
Where `Q1` represents the Hamilton product from the left:
```
Q1 = Matrix([
            [+q1.a,-q1.b,-q1.c,-q1.d],
            [+q1.b,+q1.a,-q1.d,+q1.c],
            [+q1.c,+q1.d,+q1.a,-q1.b],
            [+q1.d,-q1.c,+q1.b,+q1.a]])
```
Alternatively, a separate `as_4vector` property could be added returning `Matrix(self.as_list)`.



#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added `as_list` property to Quaternion
<!-- END RELEASE NOTES -->