### PR TITLE
Implemented homogeneous option to Quaternion.to_rotation_matrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -534,6 +534,7 @@ Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
+Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
 Evgenia Karunus <lakesare@gmail.com>
 Fabian Ball <fabian.ball@kit.edu>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -856,7 +856,7 @@ class Quaternion(Expr):
 
         return t
 
-    def to_rotation_matrix(self, v=None, homogeneous=False):
+    def to_rotation_matrix(self, v=None, normal=False):
         """Returns the equivalent rotation transformation matrix of the quaternion
         which represents rotation about the origin if v is not passed.
 
@@ -865,10 +865,10 @@ class Quaternion(Expr):
 
         v : tuple or None
             Default value: None
-        homogeneous : bool
-            When True, gives uses a slightly different formula for the rotation
-            matrix. For numerical values, the matrix is the same. For symbolic
-            values, this formula can be slightly simpler.
+        normal : bool
+            When True, gives an expression that may be more efficient for
+            symbolic calculations but less so for direct evaluation. Both
+            formulas are mathematically equivalent.
             Default value: False
 
         Returns
@@ -912,26 +912,25 @@ class Quaternion(Expr):
 
         q = self
         s = q.norm()**-2
-        if homogeneous:
+
+        # diagonal elements are different according to parameter normal
+        if normal:
             m00 = s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
+            m11 = s*(q.a**2 - q.b**2 + q.c**2 - q.d**2)
+            m22 = s*(q.a**2 - q.b**2 - q.c**2 + q.d**2)
         else:
             m00 = 1 - 2*s*(q.c**2 + q.d**2)
+            m11 = 1 - 2*s*(q.b**2 + q.d**2)
+            m22 = 1 - 2*s*(q.b**2 + q.c**2)
+
         m01 = 2*s*(q.b*q.c - q.d*q.a)
         m02 = 2*s*(q.b*q.d + q.c*q.a)
 
         m10 = 2*s*(q.b*q.c + q.d*q.a)
-        if homogeneous:
-            m11 = s*(q.a**2 - q.b**2 + q.c**2 - q.d**2)
-        else:
-            m11 = 1 - 2*s*(q.b**2 + q.d**2)
         m12 = 2*s*(q.c*q.d - q.b*q.a)
 
         m20 = 2*s*(q.b*q.d - q.c*q.a)
         m21 = 2*s*(q.c*q.d + q.b*q.a)
-        if homogeneous:
-            m22 = s*(q.a**2 - q.b**2 - q.c**2 + q.d**2)
-        else:
-            m22 = 1 - 2*s*(q.b**2 + q.c**2)
 
         if not v:
             return Matrix([[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]])

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -50,9 +50,8 @@ class Quaternion(Expr):
 
     is_commutative = False
 
-    def __new__(cls, a=0, b=0, c=0, d=0, real_field=True, norm=None):
+    def __new__(cls, a=0, b=0, c=0, d=0, real_field=True):
         a, b, c, d = map(sympify, (a, b, c, d))
-        norm = sympify(norm)
 
         if any(i.is_commutative is False for i in [a, b, c, d]):
             raise ValueError("arguments have to be commutative")
@@ -63,7 +62,6 @@ class Quaternion(Expr):
             obj._c = c
             obj._d = d
             obj._real_field = real_field
-            obj._norm = norm
             return obj
 
     @property
@@ -378,13 +376,10 @@ class Quaternion(Expr):
 
     def norm(self):
         """Returns the norm of the quaternion."""
-        if self._norm is not None:
-            return self._norm
-        else:
-            q = self
-            # trigsimp is used to simplify sin(x)^2 + cos(x)^2 (these terms
-            # arise when from_axis_angle is used).
-            return sqrt(trigsimp(q.a**2 + q.b**2 + q.c**2 + q.d**2))
+        q = self
+        # trigsimp is used to simplify sin(x)^2 + cos(x)^2 (these terms
+        # arise when from_axis_angle is used).
+        return sqrt(trigsimp(q.a**2 + q.b**2 + q.c**2 + q.d**2))
 
     def normalize(self):
         """Returns the normalized form of the quaternion."""
@@ -734,7 +729,7 @@ class Quaternion(Expr):
         q = self
         s = q.norm()**-2
         if homogeneous:
-            m00 = 2*s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
+            m00 = s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
         else:
             m00 = 1 - 2*s*(q.c**2 + q.d**2)
         m01 = 2*s*(q.b*q.c - q.d*q.a)
@@ -742,7 +737,7 @@ class Quaternion(Expr):
 
         m10 = 2*s*(q.b*q.c + q.d*q.a)
         if homogeneous:
-            m00 = 2*s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
+            m11 = s*(q.a**2 - q.b**2 + q.c**2 - q.d**2)
         else:
             m11 = 1 - 2*s*(q.b**2 + q.d**2)
         m12 = 2*s*(q.c*q.d - q.b*q.a)
@@ -750,7 +745,7 @@ class Quaternion(Expr):
         m20 = 2*s*(q.b*q.d - q.c*q.a)
         m21 = 2*s*(q.c*q.d + q.b*q.a)
         if homogeneous:
-            m00 = 2*s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
+            m22 = s*(q.a**2 - q.b**2 - q.c**2 + q.d**2)
         else:
             m22 = 1 - 2*s*(q.b**2 + q.c**2)
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -866,6 +866,9 @@ class Quaternion(Expr):
         v : tuple or None
             Default value: None
         homogeneous : bool
+            When True, gives uses a slightly different formula for the rotation
+            matrix. For numerical values, the matrix is the same. For symbolic
+            values, this formula can be slightly simpler.
             Default value: False
 
         Returns

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -856,7 +856,7 @@ class Quaternion(Expr):
 
         return t
 
-    def to_rotation_matrix(self, v=None, normal=False):
+    def to_rotation_matrix(self, v=None, homogeneous=True):
         """Returns the equivalent rotation transformation matrix of the quaternion
         which represents rotation about the origin if v is not passed.
 
@@ -865,11 +865,11 @@ class Quaternion(Expr):
 
         v : tuple or None
             Default value: None
-        normal : bool
+        homogeneous : bool
             When True, gives an expression that may be more efficient for
             symbolic calculations but less so for direct evaluation. Both
             formulas are mathematically equivalent.
-            Default value: False
+            Default value: True
 
         Returns
         =======
@@ -914,7 +914,7 @@ class Quaternion(Expr):
         s = q.norm()**-2
 
         # diagonal elements are different according to parameter normal
-        if normal:
+        if homogeneous:
             m00 = s*(q.a**2 + q.b**2 - q.c**2 - q.d**2)
             m11 = s*(q.a**2 - q.b**2 + q.c**2 - q.d**2)
             m22 = s*(q.a**2 - q.b**2 - q.c**2 + q.d**2)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -233,9 +233,9 @@ def test_quaternion_conversions():
                [0,           0,          0,  1]])
 
 
-def test_rotation_matrix_normal():
+def test_rotation_matrix_homogeneous():
     q = Quaternion(w, x, y, z)
-    R1 = q.to_rotation_matrix(normal=True) * q.norm()**2
+    R1 = q.to_rotation_matrix(homogeneous=True) * q.norm()**2
     R2 = simplify(q.to_rotation_matrix() * q.norm()**2)
     assert R1 == R2
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -233,9 +233,9 @@ def test_quaternion_conversions():
                [0,           0,          0,  1]])
 
 
-def test_rotation_matrix_homogeneous():
+def test_rotation_matrix_normal():
     q = Quaternion(w, x, y, z)
-    R1 = q.to_rotation_matrix(homogeneous=True) * q.norm()**2
+    R1 = q.to_rotation_matrix(normal=True) * q.norm()**2
     R2 = simplify(q.to_rotation_matrix() * q.norm()**2)
     assert R1 == R2
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -8,6 +8,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, cos, sin, atan2, atan)
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import Matrix
+from sympy.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
@@ -229,6 +230,13 @@ def test_quaternion_conversions():
                [sin(theta),  cos(theta), 0, -sin(theta) - cos(theta) + 1],
                [0,           0,          1,  0],
                [0,           0,          0,  1]])
+
+
+def test_rotation_matrix_homogeneous():
+    q = Quaternion(w, x, y, z)
+    R1 = q.to_rotation_matrix(homogeneous=True) * q.norm()**2
+    R2 = simplify(q.to_rotation_matrix() * q.norm()**2)
+    assert R1 == R2
 
 
 def test_quaternion_rotation_iss1593():


### PR DESCRIPTION

#### Brief description of what is fixed or changed
Added a bool parameter called `homogeneous` defaulting to `False`.

When `homogeneous == True`, a slightly different but equivalent definition of the rotation matrix is given.

#### Other comments
This is another one in a series of small quality-of-life contributions I'm making to `Quaternion`.

The "homogeneous" version of the rotation matrix can be slightly better for symbolic manipulation (its formula can be seen [here](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation)). 

To demonstrate this, the test function I implemented shows that the homogeneous version is equivalent to the original non-homogeneous version after being passed to `simplify`.

As an interesting observation, the homogeneous version also has the property of being equivalent to a rotation + a scaling when the quaternion norm is ignored. If the norm is ignored in the non-homogeneous version, the rotation does not correctly represent anything.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Implemented homogeneous option to Quaternion.to_rotation_matrix
<!-- END RELEASE NOTES -->
