### PR TITLE
maint: unpin scipy version under pypy

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.9', '3.10', '3.11', 'pypy3.8']
         experimental: [false]
         # Maybe use this to add 3.12 when the time comes:
         #include:
@@ -194,23 +194,17 @@ jobs:
       - if: ${{ contains(matrix.python-version, '3.11') }}
         run: pip install git+https://github.com/scipy/scipy@main
 
-      # SciPy 1.9.0 and 1.9.1 fail to compile under PyPy:
-      #
-      # https://github.com/FFY00/meson-python/issues/121
-      - if: ${{ matrix.python-version == 'pypy-3.8' }}
-        run: pip install 'scipy<1.9.0'
-
       # dependencies to install in all Python versions:
       - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
                          aesara wurlitzer autowrap                            \
                          'antlr4-python3-runtime==4.11.*'
 
       # These are not available for pypy
-      - if: ${{ matrix.python-version != 'pypy-3.8' }}
+      - if: ${{ ! contains(matrix.python-version, 'pypy') }}
         run: pip install gmpy2 jax jaxlib
 
       # These are not available for pypy and cannot be installed in 3.11 (yet)
-      - if: ${{ matrix.python-version != 'pypy-3.8' && ! contains(matrix.python-version, '3.11') }}
+      - if: ${{ ! contains(matrix.python-version, 'pypy') && ! contains(matrix.python-version, '3.11') }}
         run: pip install symengine llvmlite numba pymc
 
       # Test external imports


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

The SciPy version was pinned in the optional dependency CI job for PyPy. This was due to the following upstream issues that should now be fixed:

https://github.com/scipy/scipy/issues/16737#issuecomment-1353502769
https://github.com/mesonbuild/meson-python/issues/121

This commit unpins the SciPy version to test with latest SciPy.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
