### PR TITLE
added Matrix conversions to Quaternion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -535,6 +535,7 @@ Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
 Evandro <15084103+evbernardes@users.noreply.github.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
 Evgenia Karunus <lakesare@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -534,7 +534,7 @@ Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
-Evandro <15084103+evbernardes@users.noreply.github.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -177,10 +177,18 @@ class Quaternion(Expr):
         a + b*i + c*j + d*k
 
         >>> q.to_Matrix()
-        Matrix([[a], [b], [c], [d]])
+        Matrix([
+        [a],
+        [b],
+        [c],
+        [d]])
+
 
         >>> q.to_Matrix(vector_only=True)
-        Matrix([[x], [y], [z]])
+        Matrix([
+        [b],
+        [c],
+        [d]])
 
         """
         if vector_only:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -269,7 +269,6 @@ class Quaternion(Expr):
     @classmethod
     def from_Matrix(cls, elements):
         """Returns quaternion from elements of a column vector`.
-        If a
         If vector_only is True, returns only imaginary part as a Matrix of
         length 3.
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -112,6 +112,127 @@ class Quaternion(Expr):
     def real_field(self):
         return self._real_field
 
+    @property
+    def product_matrix_left(self):
+        """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
+        left. This can be useful when treating quaternion elements as column
+        vectors:
+            q1.product_matrix_left * q2.to_Matrix()
+        is equivalent to:
+            (q1 * q2).to_Matrix()
+
+        """
+        return Matrix([
+                [self.a, -self.b, -self.c, -self.d],
+                [self.b, self.a, -self.d, self.c],
+                [self.c, self.d, self.a, -self.b],
+                [self.d, -self.c, self.b, self.a]])
+
+    @property
+    def product_matrix_right(self):
+        """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
+        right. This can be useful when treating quaternion elements as column
+        vectors:
+            q2.product_matrix_right * q1.to_Matrix()
+        is equivalent to:
+            (q1 * q2).to_Matrix()
+
+        Note the switched arguments: this represents the quaternion on the
+        right, but still considered as a matrix multiplication from the left.
+
+        """
+        return Matrix([
+                [self.a, -self.b, -self.c, -self.d],
+                [self.b, self.a, self.d, -self.c],
+                [self.c, -self.d, self.a, self.b],
+                [self.d, self.c, -self.b, self.a]])
+
+    def to_Matrix(self, vector_only=False):
+        """Returns elements of quaternion as a column vector`.
+        By default, a Matrix of length 4 is returned, with the real part as the
+        first element.
+        If vector_only is True, returns only imaginary part as a Matrix of
+        length 3.
+
+        Parameters
+        ==========
+
+        vector_only : bool
+            If True, only imaginary part is returned.
+            Default : False
+
+        Returns
+        =======
+
+        Matrix
+            A column vector constructed by the elements of the quaternion.
+
+        Examples
+        ========
+
+        >>> from sympy import Quaternion
+        >>> from sympy.abc import a, b, c, d
+        >>> q = Quaternion(a, b, c, d)
+        >>> q
+        a + b*i + c*j + d*k
+
+        >>> q.to_Matrix()
+        Matrix([[a], [b], [c], [d]])
+
+        >>> q.to_Matrix(vector_only=True)
+        Matrix([[x], [y], [z]])
+
+        """
+        if vector_only:
+            return Matrix(self.args[1:])
+        else:
+            return Matrix(self.args)
+
+    @classmethod
+    def from_Matrix(cls, elements):
+        """Returns quaternion from elements of a column vector`.
+        If a
+        If vector_only is True, returns only imaginary part as a Matrix of
+        length 3.
+
+        Parameters
+        ==========
+
+        elements : Matrix of shape (4, 1) or (3, 1), or list/tuple of length 3
+            or 4.
+            If length is 3, assume real part is zero.
+            Default : False
+
+        Returns
+        =======
+
+        Quaternion
+            A quaternions created from the input elements.
+
+        Examples
+        ========
+
+        >>> from sympy import Quaternion
+        >>> from sympy.abc import a, b, c, d
+        >>> q = Quaternion.from_Matrix([a, b, c, d])
+        >>> q
+        a + b*i + c*j + d*k
+
+        >>> q = Quaternion.from_Matrix([b, c, d])
+        >>> q
+        0 + b*i + c*j + d*k
+
+        """
+        length = len(elements)
+        if length != 3 and length != 4:
+            raise ValueError("Input elements must have length 3 or 4, got {} "
+                             "elements".format(length))
+
+        if length == 3:
+            return Quaternion(0, *elements)
+        else:
+            return Quaternion(*elements)
+
     @classmethod
     def from_euler(cls, angles, seq):
         """Returns quaternion equivalent to rotation represented by the Euler

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -114,17 +114,17 @@ class Quaternion(Expr):
 
     @property
     def product_matrix_left(self):
-        """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
+        r"""Returns 4 x 4 Matrix equivalent to a Hamilton product from the
         left. This can be useful when treating quaternion elements as column
         vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
         are real numbers, the product matrix from the left is:
 
-        ::
+        .. math::
 
-                  [a  -b  -c  -d]
-            M  =  [b   a  -d   c]
-                  [c   d   a  -b]
-                  [d  -c   b   a]
+            M  =  \begin{bmatrix} a  &-b  &-c  &-d \\
+                                  b  & a  &-d  & c \\
+                                  c  & d  & a  &-b \\
+                                  d  &-c  & b  & a \end{bmatrix}
 
         Examples
         ========
@@ -164,17 +164,18 @@ class Quaternion(Expr):
 
     @property
     def product_matrix_right(self):
-        """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
+        r"""Returns 4 x 4 Matrix equivalent to a Hamilton product from the
         right. This can be useful when treating quaternion elements as column
         vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
         are real numbers, the product matrix from the left is:
 
-        ::
+        .. math::
 
-                  [a  -b  -c  -d]
-            M  =  [b   a   d  -c]
-                  [c  -d   a   b]
-                  [d   c  -b   a]
+            M  =  \begin{bmatrix} a  &-b  &-c  &-d \\
+                                  b  & a  & d  &-c \\
+                                  c  &-d  & a  & b \\
+                                  d  & c  &-b  & a \end{bmatrix}
+
 
         Examples
         ========

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -119,13 +119,12 @@ class Quaternion(Expr):
         vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
         are real numbers, the product matrix from the left is:
 
-        .. math::
-            \left[\begin{matrix}
-                a & - b & - c & - d \\
-                b & a & - d & c \\
-                c & d & a & - b \\
-                d & - c & b & a
-            \end{matrix}\right]
+        ::
+
+                  [a  -b  -c  -d]
+            M  =  [b   a  -d   c]
+                  [c   d   a  -b]
+                  [d  -c   b   a]
 
         Examples
         ========
@@ -170,13 +169,12 @@ class Quaternion(Expr):
         vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
         are real numbers, the product matrix from the left is:
 
-        .. math::
-            \left[\begin{matrix}
-                a & - b & - c & - d\\
-                b & a & d & - c\\
-                c & - d & a & b\\
-                d & c & - b & a
-            \end{matrix}\right]
+        ::
+
+                  [a  -b  -c  -d]
+            M  =  [b   a   d  -c]
+                  [c  -d   a   b]
+                  [d   c  -b   a]
 
         Examples
         ========

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -116,11 +116,46 @@ class Quaternion(Expr):
     def product_matrix_left(self):
         """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
         left. This can be useful when treating quaternion elements as column
-        vectors:
-            q1.product_matrix_left * q2.to_Matrix()
-        is equivalent to:
-            (q1 * q2).to_Matrix()
+        vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
+        are real numbers, the product matrix from the left is:
 
+        .. math::
+            \left[\begin{matrix}
+                a & - b & - c & - d \\
+                b & a & - d & c \\
+                c & d & a & - b \\
+                d & - c & b & a
+            \end{matrix}\right]
+
+        Examples
+        ========
+
+        >>> from sympy import Quaternion
+        >>> from sympy.abc import a, b, c, d
+        >>> q1 = Quaternion(1, 0, 0, 1)
+        >>> q2 = Quaternion(a, b, c, d)
+        >>> q1.product_matrix_left
+        Matrix([
+        [1, 0,  0, -1],
+        [0, 1, -1,  0],
+        [0, 1,  1,  0],
+        [1, 0,  0,  1]])
+
+        >>> q1.product_matrix_left * q2.to_Matrix()
+        Matrix([
+        [a - d],
+        [b - c],
+        [b + c],
+        [a + d]])
+
+        This is equivalent to:
+
+        >>> (q1 * q2).to_Matrix()
+        Matrix([
+        [a - d],
+        [b - c],
+        [b + c],
+        [a + d]])
         """
         return Matrix([
                 [self.a, -self.b, -self.c, -self.d],
@@ -132,14 +167,50 @@ class Quaternion(Expr):
     def product_matrix_right(self):
         """Returns 4 x 4 Matrix equivalent to a Hamilton product from the
         right. This can be useful when treating quaternion elements as column
-        vectors:
-            q2.product_matrix_right * q1.to_Matrix()
-        is equivalent to:
-            (q1 * q2).to_Matrix()
+        vectors. Given a quaternion $q = a + bi + cj + dk$ where a, b, c and d
+        are real numbers, the product matrix from the left is:
 
-        Note the switched arguments: this represents the quaternion on the
-        right, but still considered as a matrix multiplication from the left.
+        .. math::
+            \left[\begin{matrix}
+                a & - b & - c & - d\\
+                b & a & d & - c\\
+                c & - d & a & b\\
+                d & c & - b & a
+            \end{matrix}\right]
 
+        Examples
+        ========
+
+        >>> from sympy import Quaternion
+        >>> from sympy.abc import a, b, c, d
+        >>> q1 = Quaternion(a, b, c, d)
+        >>> q2 = Quaternion(1, 0, 0, 1)
+        >>> q2.product_matrix_right
+        Matrix([
+        [1, 0, 0, -1],
+        [0, 1, 1, 0],
+        [0, -1, 1, 0],
+        [1, 0, 0, 1]])
+
+        Note the switched arguments: the matrix represents the quaternion on
+        the right, but is still considered as a matrix multiplication from the
+        left.
+
+        >>> q2.product_matrix_right * q1.to_Matrix()
+        Matrix([
+        [ a - d],
+        [ b + c],
+        [-b + c],
+        [ a + d]])
+
+        This is equivalent to:
+
+        >>> (q1 * q2).to_Matrix()
+        Matrix([
+        [ a - d],
+        [ b + c],
+        [-b + c],
+        [ a + d]])
         """
         return Matrix([
                 [self.a, -self.b, -self.c, -self.d],
@@ -148,7 +219,7 @@ class Quaternion(Expr):
                 [self.d, self.c, -self.b, self.a]])
 
     def to_Matrix(self, vector_only=False):
-        """Returns elements of quaternion as a column vector`.
+        """Returns elements of quaternion as a column vector.
         By default, a Matrix of length 4 is returned, with the real part as the
         first element.
         If vector_only is True, returns only imaginary part as a Matrix of
@@ -206,16 +277,15 @@ class Quaternion(Expr):
         Parameters
         ==========
 
-        elements : Matrix of shape (4, 1) or (3, 1), or list/tuple of length 3
-            or 4.
-            If length is 3, assume real part is zero.
+        elements : Matrix, list or tuple of length 3 or 4. If length is 3,
+            assume real part is zero.
             Default : False
 
         Returns
         =======
 
         Quaternion
-            A quaternions created from the input elements.
+            A quaternion created from the input elements.
 
         Examples
         ========

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -34,6 +34,24 @@ def test_quaternion_construction():
     raises(ValueError, lambda: Quaternion(w, x, nc, z))
 
 
+def test_to_and_from_Matrix():
+    q = Quaternion(w, x, y, z)
+    q_full = Quaternion.from_Matrix(q.to_Matrix())
+    q_vect = Quaternion.from_Matrix(q.to_Matrix(True))
+    assert (q - q_full).is_zero_quaternion()
+    assert (q.vector_part() - q_vect).is_zero_quaternion()
+
+
+def test_product_matrices():
+    q1 = Quaternion(w, x, y, z)
+    q2 = Quaternion(*(symbols("a:d")))
+    assert (q1 * q2).to_Matrix() == q1.product_matrix_left * q2.to_Matrix()
+    assert (q1 * q2).to_Matrix() == q2.product_matrix_right * q1.to_Matrix()
+
+    R1 = (q1.product_matrix_left * q1.product_matrix_right.T)[1:, 1:]
+    R2 = simplify(q1.to_rotation_matrix()*q1.norm()**2)
+    assert R1 == R2
+
 def test_quaternion_axis_angle():
 
     test_data = [ # axis, angle, expected_quaternion

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -52,6 +52,7 @@ def test_product_matrices():
     R2 = simplify(q1.to_rotation_matrix()*q1.norm()**2)
     assert R1 == R2
 
+
 def test_quaternion_axis_angle():
 
     test_data = [ # axis, angle, expected_quaternion


### PR DESCRIPTION
#### References to other Issues or PRs
This is a followup to PR #24380, and the discussion I had with @oscarbenjamin.

#### Brief description of what is fixed or changed

Added two conversion methods: one taking an instance of `Quaternion` and returning its elements as a column vector (3x1 or 4x1, according to an optional parameter) and another method doing the inverse operation.

Added two properties: one returns a matrix equivalent of the Hamilton product from the left, and the other returns the equivalent of the Hamilton product from the right.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * added Matrix conversions to Quaternion.
<!-- END RELEASE NOTES -->
