### PR TITLE
Added two option to Quaternion.to_euler

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -535,6 +535,7 @@ Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
 Evandro <15084103+evbernardes@users.noreply.github.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
 Evgenia Karunus <lakesare@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -534,7 +534,7 @@ Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
-Evandro <15084103+evbernardes@users.noreply.github.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -11,7 +11,6 @@ from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.core.sympify import sympify, _sympify
 from sympy.core.expr import Expr
 from sympy.core.logic import fuzzy_not, fuzzy_or
-from sympy.core.numbers import pi
 
 from mpmath.libmp.libmpf import prec_to_dps
 
@@ -278,14 +277,12 @@ class Quaternion(Expr):
             angles[1] = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
 
         # Check for singularities in numerical cases
-        angle_test = angles[1].evalf()
+        angle_test = angles[1]
         case = 0
-        pi_f = pi.evalf()
         if angle_test.is_number:
-            eps = 10e-7
-            if abs(angle_test) <= eps:
+            if angle_test.equals(S.Zero):
                 case = 1
-            elif abs(angle_test - pi_f) <= eps:
+            if angle_test.equals(S.Pi):
                 case = 2
 
         if case == 0:
@@ -307,7 +304,7 @@ class Quaternion(Expr):
 
         # for Tait-Bryan angles
         if not symmetric:
-            angles[1] -= pi / 2
+            angles[1] -= S.Pi / 2
             angles[0] *= sign
 
         if extrinsic:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -272,7 +272,8 @@ class Quaternion(Expr):
             a, b, c, d = a - c, b + d, c + a, d - b
 
         if avoid_square_root:
-            angles[1] = acos((a*a + b*b - c*c - d*d) / (a*a + b*b + c*c + d*d))
+            n2 = self.norm()**2 if symmetric else 2 * self.norm()**2
+            angles[1] = acos((a*a + b*b - c*c - d*d) / n2)
         else:
             angles[1] = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -287,18 +287,6 @@ class Quaternion(Expr):
             elif abs(angle_test - pi_f) <= eps:
                 case = 2
 
-        # if case1:
-
-        # elif case2:
-
-        if extrinsic:
-            angle_first = 0
-            angle_third = 2
-        else:
-            seq = seq[::-1]
-            angle_first = 2
-            angle_third = 0
-
         if case == 0:
             if angle_addition:
                 angles[0] = atan2(b, a) + atan2(d, c)

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -266,7 +266,7 @@ class Quaternion(Expr):
             a, b, c, d = a - c, b + d, c + a, d - b
 
         if avoid_square_root:
-            angle_j = acos((a*a + b*b - c*c - d*d) / self.norm()**2)
+            angle_j = acos((a*a + b*b - c*c - d*d) / (a*a + b*b + c*c + d*d))
         else:
             angle_j = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -177,7 +177,7 @@ class Quaternion(Expr):
             return trigsimp(qi * qj * qk)
 
     def to_euler(self, seq, angle_addition=True, avoid_square_root=False):
-        """Returns Euler angles representing same rotation as the quaternion,
+        r"""Returns Euler angles representing same rotation as the quaternion,
         in the sequence given by `seq`. This implements the method described
         in [1]_.
 
@@ -194,18 +194,19 @@ class Quaternion(Expr):
         angle_addition : bool
             Default : True
             When True, first and third angles are given as an addition and
-            subtraction of two simpler `atan2` expressions. When False, the first
-            and third angles are each given by a single more complicated
+            subtraction of two simpler `atan2` expressions. When False, the
+            first and third angles are each given by a single more complicated
             `atan2` expression. This equivalent is given by:
 
             --math::
+
                 \operatorname{atan_2} (b,a) \pm \operatorname{atan_2} (d,c) =
                 \operatorname{atan_2} (bc\pm ad, ac\mp bd)
 
         avoid_square_root : bool
             Default : False
-            When True, the second angle is calculated with an expression based on
-            `acos`, which is slightly more complicated but avoids a square
+            When True, the second angle is calculated with an expression based
+            on acos`, which is slightly more complicated but avoids a square
             root. When False, second angle is calculated with `atan2`, which
             is simpler and can be better for numerical reasons (some
             numerical implementations of `acos` have problems near zero).

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -281,7 +281,7 @@ class Quaternion(Expr):
         angle_test = angles[1].evalf()
         case = 0
         pi_f = pi.evalf()
-        if angle_test.is_Number:
+        if angle_test.is_number:
             eps = 10e-7
             if abs(angle_test) <= eps:
                 case = 1

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1,6 +1,7 @@
 import warnings
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
+from sympy.core.relational import is_eq
 from sympy.functions.elementary.complexes import (conjugate, im, re, sign)
 from sympy.functions.elementary.exponential import (exp, log as ln)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -280,9 +281,9 @@ class Quaternion(Expr):
         angle_test = angles[1]
         case = 0
         if angle_test.is_number:
-            if angle_test.equals(S.Zero):
+            if is_eq(angle_test, S.Zero):
                 case = 1
-            if angle_test.equals(S.Pi):
+            if is_eq(angle_test, S.Pi):
                 case = 2
 
         if case == 0:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -236,6 +236,9 @@ class Quaternion(Expr):
         .. [1] https://doi.org/10.1371/journal.pone.0276302
 
         """
+        if self.is_zero_quaternion():
+            raise ValueError('Cannot convert a quaternion with norm 0.')
+
         extrinsic = _is_extrinsic(seq)
         i, j, k = seq.lower()
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -14,7 +14,6 @@ from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
 from itertools import permutations
 import random
-from numpy.testing import assert_allclose
 
 w, x, y, z = symbols('w:z')
 phi = symbols('phi')

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -343,4 +343,3 @@ def test_to_euler_options():
                     q = Quaternion(*elements)
                     if not q.is_zero_quaternion():
                         test_one_case(q)
-

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,4 +1,3 @@
-import random
 import pytest
 from sympy.core.function import diff
 from sympy.core.numbers import (E, I, Rational, pi)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,4 +1,3 @@
-import pytest
 from sympy.core.function import diff
 from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.singleton import S
@@ -12,7 +11,7 @@ from sympy.matrices.dense import Matrix
 from sympy.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.algebras.quaternion import Quaternion
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns
 from itertools import permutations, product
 
 w, x, y, z = symbols('w:z')
@@ -304,7 +303,7 @@ def test_to_euler_numerical_singilarities():
 
     def test_one_case(angles, seq):
         q = Quaternion.from_euler(angles, seq)
-        with pytest.warns(UserWarning, match="Singularity"):
+        with warns(UserWarning, match='Singularity', test_stacklevel=False):
             assert q.to_euler(seq) == angles
 
     # symmetric

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -287,16 +287,13 @@ def test_to_euler():
     q = Quaternion(w, x, y, z)
     q_normalized = q.normalize()
 
-    for xyz in ('xyz', 'XYZ'):
-        for seq_tuple in permutations(xyz):
-            for symmetric in (True, False):
-                if symmetric:
-                    seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-                else:
-                    seq = ''.join(seq_tuple)
-                euler_from_q = q.to_euler(seq)
-                q_back = simplify(Quaternion.from_euler(euler_from_q, seq))
-                assert q_back == q_normalized
+    seqs = ['zxy', 'zyx', 'zyz', 'zxz']
+    seqs += [seq.upper() for seq in seqs]
+
+    for seq in seqs:
+        euler_from_q = q.to_euler(seq)
+        q_back = simplify(Quaternion.from_euler(euler_from_q, seq))
+        assert q_back == q_normalized
 
 
 def test_to_euler_numerical_singilarities():

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,3 +1,5 @@
+import random
+import pytest
 from sympy.core.function import diff
 from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.singleton import S
@@ -13,7 +15,6 @@ from sympy.simplify.trigsimp import trigsimp
 from sympy.algebras.quaternion import Quaternion
 from sympy.testing.pytest import raises
 from itertools import permutations
-import random
 
 w, x, y, z = symbols('w:z')
 phi = symbols('phi')
@@ -298,6 +299,26 @@ def test_to_euler():
                 euler_from_q = q.to_euler(seq)
                 q_back = simplify(Quaternion.from_euler(euler_from_q, seq))
                 assert q_back == q_normalized
+
+
+def test_to_euler_numerical_singilarities():
+
+    def test_one_case(angles, seq):
+        q = Quaternion.from_euler(angles, seq)
+        with pytest.warns(UserWarning, match="Singularity"):
+            assert q.to_euler(seq) == angles
+
+    # symmetric
+    test_one_case((pi/2,  0, 0), 'zyz')
+    test_one_case((pi/2,  0, 0), 'ZYZ')
+    test_one_case((pi/2,  pi, 0), 'zyz')
+    test_one_case((pi/2,  pi, 0), 'ZYZ')
+
+    # asymmetric
+    test_one_case((pi/2,  pi/2, 0), 'zyx')
+    test_one_case((pi/2,  -pi/2, 0), 'zyx')
+    test_one_case((pi/2,  pi/2, 0), 'ZYX')
+    test_one_case((pi/2,  -pi/2, 0), 'ZYX')
 
 
 def test_to_euler_options():


### PR DESCRIPTION
#### References to other Issues or PRs
Little follow up to PR #24358


#### Brief description of what is fixed or changed
Added two options to `to_euler`.

The first uses $\operatorname{atan_2} (b,a) \pm \operatorname{atan_2} (d,c) = \operatorname{atan_2} (bc\pm ad, ac\mp bd)$ to assemble the first and third angles into single `atan2` expressions instead of a sum or difference of two `atan2` expressions. Can be useful to compare with existing conversion formulas on the internet.

The second one uses an equivalent formula for the second angle that uses `acos2`. The only advantage this has it to avoid the use of square roots.
#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added two options to Quaternion.to_euler.
<!-- END RELEASE NOTES -->
