### PR TITLE
sympify inner product of OrthoKet to Integer instead of int

### DIFF
--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -659,12 +659,12 @@ class OrthogonalKet(OrthogonalState, KetBase):
             is_zero = diff.is_zero
 
             if is_zero is False:
-                return 0
+                return S.Zero # i.e. Integer(0)
 
             if is_zero is None:
                 return None
 
-        return 1
+        return S.One # i.e. Integer(1)
 
 
 class OrthogonalBra(OrthogonalState, BraBase):


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The evaluation of the inner product of OrthogonalBra and OrthogonalKet is now sympified to return S.One resp. S.Zero. Before it returned int 1 or 0 which is not a Sympy Expr and which could break further computation in SymPy.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * For `OrthogonalBra` / `OrthogonalKet` computing their inner product returns a correctly sympified result now   
<!-- END RELEASE NOTES -->
