### PR TITLE
Add missing argument **options to method _apply_operator_xxx of various Ket types

### DIFF
--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -55,10 +55,10 @@ class XOp(HermitianOperator):
     def _eval_commutator_PxOp(self, other):
         return I*hbar
 
-    def _apply_operator_XKet(self, ket):
+    def _apply_operator_XKet(self, ket, **options):
         return ket.position*ket
 
-    def _apply_operator_PositionKet3D(self, ket):
+    def _apply_operator_PositionKet3D(self, ket, **options):
         return ket.position_x*ket
 
     def _represent_PxKet(self, basis, *, index=1, **options):
@@ -82,7 +82,7 @@ class YOp(HermitianOperator):
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
-    def _apply_operator_PositionKet3D(self, ket):
+    def _apply_operator_PositionKet3D(self, ket, **options):
         return ket.position_y*ket
 
 
@@ -97,7 +97,7 @@ class ZOp(HermitianOperator):
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
-    def _apply_operator_PositionKet3D(self, ket):
+    def _apply_operator_PositionKet3D(self, ket, **options):
         return ket.position_z*ket
 
 #-------------------------------------------------------------------------
@@ -116,7 +116,7 @@ class PxOp(HermitianOperator):
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
-    def _apply_operator_PxKet(self, ket):
+    def _apply_operator_PxKet(self, ket, **options):
         return ket.momentum*ket
 
     def _represent_XKet(self, basis, *, index=1, **options):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -615,7 +615,7 @@ class DifferentialOperator(Operator):
 
         return self.expr.free_symbols
 
-    def _apply_operator_Wavefunction(self, func):
+    def _apply_operator_Wavefunction(self, func, **options):
         from sympy.physics.quantum.state import Wavefunction
         var = self.variables
         wf_vars = func.args[1:]

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -116,7 +116,7 @@ class RaisingOp(SHOOp):
     def _eval_commutator_NumberOp(self, other):
         return S.NegativeOne*self
 
-    def _apply_operator_SHOKet(self, ket):
+    def _apply_operator_SHOKet(self, ket, **options):
         temp = ket.n + S.One
         return sqrt(temp)*SHOKet(temp)
 
@@ -254,7 +254,7 @@ class LoweringOp(SHOOp):
     def _eval_commutator_NumberOp(self, other):
         return self
 
-    def _apply_operator_SHOKet(self, ket):
+    def _apply_operator_SHOKet(self, ket, **options):
         temp = ket.n - Integer(1)
         if ket.n is S.Zero:
             return S.Zero
@@ -369,7 +369,7 @@ class NumberOp(SHOOp):
     def _eval_rewrite_as_H(self, *args, **kwargs):
         return H/(hbar*omega) - S.Half
 
-    def _apply_operator_SHOKet(self, ket):
+    def _apply_operator_SHOKet(self, ket, **options):
         return ket.n*ket
 
     def _eval_commutator_Hamiltonian(self, other):
@@ -481,7 +481,7 @@ class Hamiltonian(SHOOp):
     def _eval_rewrite_as_N(self, *args, **kwargs):
         return hbar*omega*(N + S.Half)
 
-    def _apply_operator_SHOKet(self, ket):
+    def _apply_operator_SHOKet(self, ket, **options):
         return (hbar*omega*(ket.n + S.Half))*ket
 
     def _eval_commutator_NumberOp(self, other):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -659,12 +659,12 @@ class OrthogonalKet(OrthogonalState, KetBase):
             is_zero = diff.is_zero
 
             if is_zero is False:
-                return 0
+                return S.Zero # i.e. Integer(0)
 
             if is_zero is None:
                 return None
 
-        return 1
+        return S.One # i.e. Integer(1)
 
 
 class OrthogonalBra(OrthogonalState, BraBase):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Many operators types in quantum have the method `_apply_operator_<Ket>()` to teach the operator how to act on a `Ket` of type `<ket>`.  This methods takes three arguments `self, ket` and `**options`. For some operators the argument `**options` had been omitted from the method instance definition so calls to the method with `options!={}` failed. The missing arguments have been fixed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * A missing argument has been fixed in the method `_apply_operator_<ket>()` of some operators
<!-- END RELEASE NOTES -->
