### PR TITLE
`decompose_power` more canonical (4**x -> 2**(2*x))

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -229,10 +229,18 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
     (x, 1)
     >>> decompose_power(x**2)
     (x, 2)
+    >>> decompose_power(x**(2*y))
+    (x**y, 2)
+    >>> decompose_power(x**(2*y/3))
+    (x**(y/3), 2)
     >>> decompose_power(exp(2*y/3))
     (exp(y/3), 2)
+    >>> decompose_power(4**x)
+    (2**x, 2)
 
     """
+    from sympy.ntheory.factor_ import perfect_power
+
     base, exp = expr.as_base_exp()
 
     if exp.is_Number:
@@ -243,6 +251,21 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
         else:
             base, e = expr, 1
     else:
+        if base.is_Rational and not exp.is_Rational:
+            if base.is_Integer:
+                pp = perfect_power(base)
+                if pp:
+                    base, _exp = pp
+                    exp *= _exp
+            else:
+                npp = perfect_power(base.p)
+                if npp:
+                    n, _exp = npp
+                    dpp = perfect_power(base.q, [_exp])
+                    if dpp:
+                        d, _ = dpp
+                        base = Rational(n, d, gcd=1)
+                        exp *= _exp
         exp, tail = exp.as_coeff_Mul(rational=True)
 
         if exp is S.NegativeOne:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -258,10 +258,10 @@ def decompose_power(expr: Expr) -> tTuple[Expr, int]:
                     base, _exp = pp
                     exp *= _exp
             else:
-                npp = perfect_power(base.p)
+                npp = perfect_power(base.p)  # type: ignore
                 if npp:
                     n, _exp = npp
-                    dpp = perfect_power(base.q, [_exp])
+                    dpp = perfect_power(base.q, [_exp])  # type: ignore
                     if dpp:
                         d, _ = dpp
                         base = Rational(n, d, gcd=1)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -33,6 +33,7 @@ def test_decompose_power():
     assert decompose_power(x**(2*y)) == (x**y, 2)
     assert decompose_power(x**(2*y/3)) == (x**(y/3), 2)
     assert decompose_power(x**(y*Rational(2, 3))) == (x**(y/3), 2)
+    assert decompose_power(81**x) == (3**x, 4)
 
 
 def test_Factors():

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -211,7 +211,7 @@ def _parallel_dict_from_expr_if_gens(exprs, opt):
                         monom[indices[base]] = exp
                     except KeyError:
                         if not factor.has_free(*opt.gens):
-                            coeff.append(factor)
+                            coeff.append(base**exp)
                         else:
                             raise PolynomialError("%s contains an element of "
                                                   "the set of generators." % factor)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2542,6 +2542,7 @@ def test_issue_21276():
     eq = (2*x*(y - z) - y*erf(y - z) - y + z*erf(y - z) + z)**2
     assert solveset(eq.expand(), y) == FiniteSet(z, z + erfinv(2*x - 1))
 
+
 # exponential tests
 def test_exponential_real():
     from sympy.abc import y

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -731,6 +731,7 @@ def test_frechet():
     assert density(X)(x) == a*((x - m)/s)**(-a - 1)*exp(-((x - m)/s)**(-a))/s
     assert cdf(X)(x) == Piecewise((exp(-((-m + x)/s)**(-a)), m <= x), (0, True))
 
+
 @slow
 def test_gamma():
     k = Symbol("k", positive=True)
@@ -759,8 +760,8 @@ def test_gamma():
 
     Y = Gamma('y', 2*k, 3*theta)
     assert coskewness(X, theta*X + Y, k*X + Y).simplify() == \
-        2*531441**(-k)*sqrt(k)*theta*(3*3**(12*k) - 2*531441**k) \
-        /(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
+        2*sqrt(k)*theta/(sqrt(k**2 + 18)*sqrt(theta**2 + 18))
+
 
 def test_gamma_inverse():
     a = Symbol("a", positive=True)
@@ -771,6 +772,7 @@ def test_gamma_inverse():
     assert characteristic_function(X)(x) == 2 * (-I*b*x)**(a/2) \
             * besselk(a, 2*sqrt(b)*sqrt(-I*x))/gamma(a)
     raises(NotImplementedError, lambda: moment_generating_function(X))
+
 
 def test_gompertz():
     b = Symbol("b", positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
When the base is rational, `decompose_power` will now reduce it as much as possible so `4**x` decomposes as `(2**x, 2)` instead of `(4**x, 1)`. This is preferable to pushing an integer coefficient in the exponent onto the base since it will then allow powers of an exponential to be identified by `Poly`, e.g. `Poly(4**x + 2**x) -> Poly(y**2 + y, y)` where `y=2**x`.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * decompose_power gives a more canonical base and exponent when the base is a perfect power
<!-- END RELEASE NOTES -->
