### PR TITLE
Implemented inverse option for trigsimp

### DIFF
--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -508,13 +508,8 @@ def test_trigsimp_inverse():
 
     funcs = [(sin, asin), (cos, acos), (sec, asec), (csc, acsc),
              (tan, atan), (cot, acot)]
-
     for func, funcinv in funcs:
         assert alpha == trigsimp(funcinv(func(alpha)), inverse=True)
-
-    # test asin(sin(alpha)) and acos(cos(alpha))
-    assert alpha == trigsimp(acos(c), inverse=True)
-    assert alpha == trigsimp(asin(s), inverse=True)
 
     # test atan2(cos, sin), atan2(sin, cos), etc...
     for a, b in [[c, s], [s, c]]:

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
-from sympy.functions.elementary.trigonometric import (sec, asec, csc, acsc)
+from sympy.functions.elementary.trigonometric import (asec, acsc)
 from sympy.functions.elementary.trigonometric import (acot, atan)
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import Matrix
@@ -506,10 +506,9 @@ def test_trigsimp_inverse():
     alpha = symbols('alpha')
     s, c = sin(alpha), cos(alpha)
 
-    funcs = [(sin, asin), (cos, acos), (sec, asec), (csc, acsc),
-             (tan, atan), (cot, acot)]
-    for func, funcinv in funcs:
-        assert alpha == trigsimp(funcinv(func(alpha)), inverse=True)
+    for finv in [asin, acos, asec, acsc, atan, acot]:
+        f = finv.inverse(None)
+        assert alpha == trigsimp(finv(f(alpha)), inverse=True)
 
     # test atan2(cos, sin), atan2(sin, cos), etc...
     for a, b in [[c, s], [s, c]]:

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -9,6 +9,8 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
+from sympy.functions.elementary.trigonometric import (sec, asec, csc, acsc)
+from sympy.functions.elementary.trigonometric import (acot, atan)
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import Matrix
 from sympy.simplify.simplify import simplify
@@ -503,6 +505,12 @@ def test_trigsimp_old():
 def test_trigsimp_inverse():
     alpha = symbols('alpha')
     s, c = sin(alpha), cos(alpha)
+
+    funcs = [(sin, asin), (cos, acos), (sec, asec), (csc, acsc),
+             (tan, atan), (cot, acot)]
+
+    for func, funcinv in funcs:
+        assert alpha == trigsimp(funcinv(func(alpha)), inverse=True)
 
     # test asin(sin(alpha)) and acos(cos(alpha))
     assert alpha == trigsimp(acos(c), inverse=True)

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -1,3 +1,4 @@
+from itertools import product
 from sympy.core.function import (Subs, count_ops, diff, expand)
 from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.singleton import S
@@ -7,6 +8,7 @@ from sympy.functions.elementary.hyperbolic import (cosh, coth, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
+from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import Matrix
 from sympy.simplify.simplify import simplify
@@ -496,3 +498,21 @@ def test_trigsimp_old():
     assert trigsimp(sin(x)/cos(x), old=True, method='groebner', hints=[tan]) == tan(x)
 
     assert trigsimp(1-sin(sin(x)**2+cos(x)**2)**2, old=True, deep=True) == cos(1)**2
+
+
+def test_trigsimp_inverse():
+    alpha = symbols('alpha')
+    s, c = sin(alpha), cos(alpha)
+
+    # test asin(sin(alpha)) and acos(cos(alpha))
+    assert alpha == trigsimp(acos(c), inverse=True)
+    assert alpha == trigsimp(asin(s), inverse=True)
+
+    # test atan2(cos, sin), atan2(sin, cos), etc...
+    for a, b in [[c, s], [s, c]]:
+        for i, j in product([-1, 1], repeat=2):
+            angle = atan2(i*b, j*a)
+            angle_inverted = trigsimp(angle, inverse=True)
+            assert angle_inverted != angle  # assures simplification happened
+            assert sin(angle_inverted) == trigsimp(sin(angle))
+            assert cos(angle_inverted) == trigsimp(cos(angle))

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -11,7 +11,7 @@ from sympy.core.sorting import _nodes
 from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.functions import sin, cos, exp, cosh, tanh, sinh, tan, cot, coth
-from sympy.functions import asin, acos, sec, asec, csc, acsc, acot, atan, atan2
+from sympy.functions import atan2
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.polys import Poly, factor, cancel, parallel_poly_from_expr
@@ -428,9 +428,6 @@ _trigs = (TrigonometricFunction, HyperbolicFunction)
 
 def _trigsimp_inverse(rv):
 
-    funcs = [(sin, asin), (cos, acos), (sec, asec), (csc, acsc),
-             (tan, atan), (cot, acot)]
-
     def check_args(x, y):
         try:
             return x.args[0] == y.args[0]
@@ -439,12 +436,13 @@ def _trigsimp_inverse(rv):
 
     def f(rv):
         # for simple functions
-        for func, funcinv in funcs:
-            if isinstance(rv, funcinv) and isinstance(rv.args[0], func):
-                return f(rv.args[0].args[0])
+        g = getattr(rv, 'inverse', None)
+        if (g is not None and isinstance(rv.args[0], g()) and
+                isinstance(g()(1), TrigonometricFunction)):
+            return rv.args[0].args[0]
 
         # for atan2 simplifications, harder because atan2 has 2 args
-        if type(rv) is atan2:
+        if isinstance(rv, atan2):
             y, x = rv.args
             if _coeff_isneg(y):
                 return -f(atan2(-y, x))

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -23,7 +23,6 @@ from sympy.strategies.core import identity
 from sympy.strategies.tree import greedy
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
-from itertools import product
 
 def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
                       polynomial=False):


### PR DESCRIPTION
#### References to other Issues or PRs
Implements a part of #24391. 

#### Brief description of what is fixed or changed
Added a `inverse` option to `simplify.trigsimp` in order to simplify the following expressions:

1. $\operatorname{asin}(\sin(x)) = x$
2. $\operatorname{asin}(\cos(x)) = x$
3. $\operatorname{atan_2}(\pm \sin(x), \pm \cos(x))$
4. $\operatorname{atan_2}(\pm \cos(x), \pm \sin(x))$

This ignores the set*, just like like calling `simplify.simplify` with `inverse=True` (it performs both 1. and 2.).

* in theory, for example, $\operatorname{atan_2}(\sin(x), \cos(x)) = \left((x - \pi)\mod 2 \pi\right) + \pi $, but in this implementation we just get $\operatorname{atan_2}(\sin(x), \cos(x)) = x$

#### Other comments

Since I am not familiar with how an addition to `trigsimp` should be structured, I created a separate private function that is called at the very end of `def trigsimp` only if `inverse=True`.

Surely there's a better way to implement this, if someone is interested in helping. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Implemented inverse option for trigsimp
<!-- END RELEASE NOTES -->
