### PR TITLE
quality: remove unchecked type hints

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from functools import wraps
 
-from sympy.core import Add, Expr, Mul, Pow, S, sympify, Float
+from sympy.core import Add, Mul, Pow, S, sympify, Float
 from sympy.core.basic import Basic
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.function import Lambda
@@ -158,7 +158,7 @@ class CodePrinter(StrPrinter):
         # keep a set of expressions that are not strictly translatable to Code
         # and number constants that must be declared and initialized
         self._not_supported = set()
-        self._number_symbols: set[tuple[Expr, Float]] = set()
+        self._number_symbols = set()
 
         lines = self._print(expr).splitlines()
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1706,7 +1706,7 @@ class LatexPrinter(Printer):
     def _print_MatrixBase(self, expr):
         out_str = self._print_matrix_contents(expr)
         if self._settings['mat_delim']:
-            left_delim: str = self._settings['mat_delim']
+            left_delim = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
             out_str = r'\left' + left_delim + out_str + \
                       r'\right' + right_delim

--- a/sympy/stats/tests/test_symbolic_multivariate.py
+++ b/sympy/stats/tests/test_symbolic_multivariate.py
@@ -88,7 +88,7 @@ def test_multivariate_expectation():
 def test_multivariate_variance():
     raises(ShapeError, lambda: Variance(A))
 
-    expr = Variance(a)  # type: VarianceMatrix
+    expr = Variance(a)
     assert expr == Variance(a) == VarianceMatrix(a)
     assert expr.expand() == ZeroMatrix(k, k)
     expr = Variance(a.T)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -4,7 +4,7 @@ from collections import defaultdict, Counter
 from functools import reduce
 import itertools
 from itertools import accumulate
-from typing import Optional, List, Dict as tDict, Tuple as tTuple
+from typing import Optional, List, Tuple as tTuple
 
 import typing
 
@@ -779,7 +779,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
             rank2 = len(diagonal_indices)
             rank3 = rank1 - rank2
             inv_permutation = []
-            counter1: int = 0
+            counter1 = 0
             indices_down = ArrayDiagonal._push_indices_down(diagonal_indices_short, list(range(rank1)), get_rank(expr))
             for i in indices_down:
                 if i in trivial_pos:
@@ -1154,8 +1154,8 @@ class ArrayContraction(_CodegenArrayAbstract):
             # Also consider the case of diagonal matrices being contracted:
             current_dimension = self.expr.shape[links[0]]
 
-            not_vectors: tTuple[_ArgE, int] = []
-            vectors: tTuple[_ArgE, int] = []
+            not_vectors = []
+            vectors = []
             for arg_ind, rel_ind in positions:
                 arg = editor.args_with_ind[arg_ind]
                 mat = arg.element
@@ -1702,12 +1702,12 @@ class _EditArrayContraction:
         return self.number_of_contraction_indices - 1
 
     def refresh_indices(self):
-        updates: tDict[int, int] = {}
+        updates = {}
         for arg_with_ind in self.args_with_ind:
             updates.update({i: -1 for i in arg_with_ind.indices if i is not None})
         for i, e in enumerate(sorted(updates)):
             updates[e] = i
-        self.number_of_contraction_indices: int = len(updates)
+        self.number_of_contraction_indices = len(updates)
         for arg_with_ind in self.args_with_ind:
             arg_with_ind.indices = [updates.get(i, None) for i in arg_with_ind.indices]
 
@@ -1847,8 +1847,8 @@ class _EditArrayContraction:
     def track_permutation_start(self):
         permutation = []
         perm_diag = []
-        counter: int = 0
-        counter2: int = -1
+        counter = 0
+        counter2 = -1
         for arg_with_ind in self.args_with_ind:
             perm = []
             for i in arg_with_ind.indices:

--- a/sympy/tensor/array/expressions/from_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/from_array_to_indexed.py
@@ -16,7 +16,7 @@ def convert_array_to_indexed(expr, indices):
 class _ConvertArrayToIndexed:
 
     def __init__(self):
-        self.count_dummies: int = 0
+        self.count_dummies = 0
 
     def do_convert(self, expr, indices):
         if isinstance(expr, ArrayTensorProduct):

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -81,7 +81,7 @@ def _support_function_tp1_recognize(contraction_indices, args):
     editor.track_permutation_start()
 
     while True:
-        flag_stop: bool = True
+        flag_stop = True
         for i, arg_with_ind in enumerate(editor.args_with_ind):
             if not isinstance(arg_with_ind.element, MatrixExpr):
                 continue
@@ -808,7 +808,7 @@ def identify_hadamard_products(expr: tUnion[ArrayContraction, ArrayDiagonal]):
 def identify_removable_identity_matrices(expr):
     editor = _EditArrayContraction(expr)
 
-    flag: bool = True
+    flag = True
     while flag:
         flag = False
         for arg_with_ind in editor.args_with_ind:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2246,7 +2246,7 @@ class TensExpr(Expr, metaclass=_TensorMetaclass):
 
         # Raise indices:
         for pos in pos2up:
-            index_type_pos = index_types1[pos]  # type: TensorIndexType
+            index_type_pos = index_types1[pos]
             if index_type_pos not in replacement_dict:
                 raise ValueError("No metric provided to lower index")
             metric = replacement_dict[index_type_pos]
@@ -2254,7 +2254,7 @@ class TensExpr(Expr, metaclass=_TensorMetaclass):
             array = TensExpr._contract_and_permute_with_metric(metric_inverse, array, pos, len(free_ind1))
         # Lower indices:
         for pos in pos2down:
-            index_type_pos = index_types1[pos]  # type: TensorIndexType
+            index_type_pos = index_types1[pos]
             if index_type_pos not in replacement_dict:
                 raise ValueError("No metric provided to lower index")
             metric = replacement_dict[index_type_pos]
@@ -2548,8 +2548,8 @@ class TensAdd(TensExpr, AssocOp):
                 return set(x.get_free_indices())
             return set()
 
-        indices0: set[TensorIndex] = get_indices_set(args[0])
-        list_indices: list[set[TensorIndex]] = [get_indices_set(arg) for arg in args[1:]]
+        indices0 = get_indices_set(args[0])
+        list_indices = [get_indices_set(arg) for arg in args[1:]]
         if not all(x == indices0 for x in list_indices):
             raise ValueError('all tensors must have the same indices')
 

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -3,9 +3,7 @@ from sympy.core.numbers import Number
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
-from sympy.tensor.tensor import (Tensor, TensExpr, TensAdd, TensMul,
-                                 TensorIndex)
+from sympy.tensor.tensor import Tensor, TensExpr, TensAdd, TensMul
 
 
 class PartialDerivative(TensExpr):
@@ -242,8 +240,8 @@ class PartialDerivative(TensExpr):
             dim_after = len(array.shape)
             dim_increase = dim_after - dim_before
             array = permutedims(array, [i + dim_increase for i in range(dim_before)] + list(range(dim_increase)))
-            array: MutableDenseNDimArray = array.as_mutable()
-            varindex: TensorIndex = var_indices[0]
+            array = array.as_mutable()
+            varindex = var_indices[0]
             # Remove coefficients of base vector:
             coeff_index = [0] + [slice(None) for i in range(len(indices))]
             for i, coeff in enumerate(coeff_array):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -777,7 +777,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
             raise TypeError("numexpr must be the only item in 'modules'")
         namespaces += list(modules)
     # fill namespace with first having highest priority
-    namespace = {} # type: tDict[str, Any]
+    namespace = {}
     for m in namespaces[::-1]:
         buf = _get_namespace(m)
         namespace.update(buf)
@@ -850,7 +850,7 @@ or tuple for the function arguments.
     # Create the function definition code and execute it
     funcname = '_lambdifygenerated'
     if _module_present('tensorflow', namespaces):
-        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify) # type: _EvaluatorPrinter
+        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify)
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
@@ -882,7 +882,7 @@ or tuple for the function arguments.
     # Provide lambda expression with builtins, and compatible implementation of range
     namespace.update({'builtins':builtins, 'range':range})
 
-    funclocals = {} # type: tDict[str, Any]
+    funclocals = {}
     global _lambdify_generated_counter
     filename = '<lambdifygenerated-%s>' % _lambdify_generated_counter
     _lambdify_generated_counter += 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Removes unchecked type hints.

Currently (since a recent release of mypy) running `mypy sympy` gives warnings. These warnings are mixed up with any errors reported making it hard to see the errors e.g. (from #24428):
```console
$ mypy sympy
sympy/utilities/lambdify.py:780: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/utilities/lambdify.py:853: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/utilities/lambdify.py:885: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/printing/codeprinter.py:161: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/printing/latex.py:1709: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/tensor.py:2249: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/tensor.py:2257: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/tensor.py:2551: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/tensor.py:2552: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:782: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:[11](https://github.com/sympy/sympy/actions/runs/3780990659/jobs/6427535182#step:6:12)57: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:1158: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:1705: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:1710: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:1850: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/array_expressions.py:1851: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/from_array_to_matrix.py:84: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/from_array_to_matrix.py:811: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/array/expressions/from_array_to_indexed.py:19: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/toperators.py:245: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/tensor/toperators.py:246: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
sympy/utilities/tests/test_lambdify.py:1697: error: Type application targets a non-generic function or class  [misc]
sympy/utilities/tests/test_lambdify.py:1698: error: Type application targets a non-generic function or class  [misc]
sympy/utilities/tests/test_lambdify.py:1700: error: Type application targets a non-generic function or class  [misc]
sympy/utilities/tests/test_lambdify.py:1701: error: Type application targets a non-generic function or class  [misc]
sympy/utilities/tests/test_lambdify.py:1703: error: Type application targets a non-generic function or class  [misc]
sympy/utilities/tests/test_lambdify.py:1704: error: Type application targets a non-generic function or class  [misc]
sympy/stats/tests/test_symbolic_multivariate.py:91: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 6 errors in 1 file (checked [14](https://github.com/sympy/sympy/actions/runs/3780990659/jobs/6427535182#step:6:15)[15](https://github.com/sympy/sympy/actions/runs/3780990659/jobs/6427535182#step:6:16) source files)
```
This PR removes the hints that cause the warnings. The reason for the warning is something like this:
```python
# t.py
def f():
    x: int = 1
```
```console
$ mypy t.py 
t.py:2: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 1 source file
```
Here `x` has a type hint but since `f` does not have type hints in its signature mypy will not check the body of `f` and the hint for `x` is effectively ignored.

Using `--check-untyped-defs` is not currently an option:
```console
$ mypy --check-untyped-defs sympy
...
Found 10196 errors in 649 files (checked 1415 source files)
```
I don't want to fix those 10000 errors right now but we also shouldn't have unchecked type hints. Also some of these particular hints are useless anyway.

It would be good to be able to make those warnings be errors so that new ones don't creep in in future but it doesn't seem to be possible to do that with mypy (https://github.com/python/mypy/issues/962#issuecomment-1365284798).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
