### PR TITLE
Decompose partition utility from `kbins`

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2754,7 +2754,6 @@ def sequence_partitions(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]
 
     This is modified version of EnricoGiampieri's partition generator
     from https://stackoverflow.com/questions/13131491/
-    partition-n-items-into-k-bins-in-python-lazily
 
     See Also
     ========

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2785,7 +2785,7 @@ def sequence_partitions_empty(l: Sequence[_T], n: int) -> Iterator[List[Sequence
         \{(s_1, \cdots, s_n) | s_1 \in V^*, \cdots, s_n \in V^*,
         s_1 \cdots s_n = l_1 \cdots l_m\}
 
-    There are more combinations than :func:`sequence_partition` because
+    There are more combinations than :func:`sequence_partitions` because
     empty sequence can fill everywhere, so we try to provide different
     utility for this.
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2732,7 +2732,7 @@ def sequence_partitions(l, n):
     Yields
     ======
 
-    out : Sequence[T]
+    out : list[Sequence[T]]
         A list of sequences with concatenation equals $l$.
         This should conform with the type of $l$.
 
@@ -2798,7 +2798,7 @@ def sequence_partitions_empty(l, n):
     Yields
     ======
 
-    out : Sequence[T]
+    out : list[Sequence[T]]
         A list of sequences with concatenation equals $l$.
         This should conform with the type of $l$.
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -3,7 +3,6 @@ from itertools import (
     chain, combinations, combinations_with_replacement, cycle, islice,
     permutations, product
 )
-from typing import TypeVar, Sequence, List, Iterator
 # For backwards compatibility
 from itertools import product as cartes # noqa: F401
 from operator import gt
@@ -2706,10 +2705,7 @@ def runs(seq, op=gt):
     return cycles
 
 
-_T = TypeVar('_T')
-
-
-def sequence_partitions(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]:
+def sequence_partitions(l, n):
     r"""Returns the partition of sequence $l$ into $n$ bins
 
     Explanation
@@ -2727,17 +2723,18 @@ def sequence_partitions(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]
     Parameters
     ==========
 
-    l
+    l : Sequence[T]
         A nonempty sequence of any Python objects
 
-    n
+    n : int
         A positive integer
 
     Yields
     ======
 
-    out
-        A list of sequences with concatenation equals $l$
+    out : Sequence[T]
+        A list of sequences with concatenation equals $l$.
+        This should conform with the type of $l$.
 
     Examples
     ========
@@ -2769,7 +2766,7 @@ def sequence_partitions(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]
             yield [l[:i]] + part
 
 
-def sequence_partitions_empty(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]:
+def sequence_partitions_empty(l, n):
     r"""Returns the partition of sequence $l$ into $n$ bins with
     empty sequence
 
@@ -2792,17 +2789,18 @@ def sequence_partitions_empty(l: Sequence[_T], n: int) -> Iterator[List[Sequence
     Parameters
     ==========
 
-    l
+    l : Sequence[T]
         A sequence of any Python objects (can be possibly empty)
 
-    n
+    n : int
         A positive integer
 
     Yields
     ======
 
-    out
-        A list of sequences with concatenation equals $l$
+    out : Sequence[T]
+        A list of sequences with concatenation equals $l$.
+        This should conform with the type of $l$.
 
     Examples
     ========

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -3,7 +3,7 @@ from itertools import (
     chain, combinations, combinations_with_replacement, cycle, islice,
     permutations, product
 )
-
+from typing import TypeVar, Sequence, List, Iterator
 # For backwards compatibility
 from itertools import product as cartes # noqa: F401
 from operator import gt
@@ -2706,6 +2706,132 @@ def runs(seq, op=gt):
     return cycles
 
 
+T = TypeVar('T')
+
+
+def sequence_partitions(l: Sequence[T], n: int) -> Iterator[List[Sequence[T]]]:
+    r"""Returns the partition of sequence $l$ into $n$ bins
+
+    Explanation
+    ===========
+
+    Given the sequence $l_1 \cdots l_m \in V^+$ where
+    $V^+$ is the Kleene plus of $V$
+
+    The set of $n$ partitions of $l$ is defined as:
+
+    .. math::
+        \{(s_1, \cdots, s_n) | s_1 \in V^+, \cdots, s_n \in V^+,
+        s_1 \cdots s_n = l_1 \cdots l_m\}
+
+    Parameters
+    ==========
+
+    l
+        A nonempty sequence of any Python objects
+
+    n
+        A positive integer
+
+    Yields
+    ======
+
+    out
+        A list of sequences with concatenation equals $l$
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import sequence_partitions
+    >>> for out in sequence_partitions([1, 2, 3, 4], 2):
+    ...     print(out)
+    [[1], [2, 3, 4]]
+    [[1, 2], [3, 4]]
+    [[1, 2, 3], [4]]
+
+    Notes
+    =====
+
+    This is modified version of EnricoGiampieri's partition generator
+    from https://stackoverflow.com/questions/13131491/
+    partition-n-items-into-k-bins-in-python-lazily
+
+    See Also
+    ========
+
+    sequence_partitions_empty
+    """
+    # Asserting l is nonempty is done only for sanity check
+    if n == 1 and l:
+        yield [l]
+        return
+    for i in range(1, len(l)):
+        for part in sequence_partitions(l[i:], n - 1):
+            yield [l[:i]] + part
+
+
+def sequence_partitions_empty(l: Sequence[T], n: int) -> Iterator[List[Sequence[T]]]:
+    r"""Returns the partition of sequence $l$ into $n$ bins with
+    empty sequence
+
+    Explanation
+    ===========
+
+    Given the sequence $l_1 \cdots l_m \in V^*$ where
+    $V^*$ is the Kleene star of $V$
+
+    The set of $n$ partitions of $l$ is defined as:
+
+    .. math::
+        \{(s_1, \cdots, s_n) | s_1 \in V^*, \cdots, s_n \in V^*,
+        s_1 \cdots s_n = l_1 \cdots l_m\}
+
+    There are more combinations than :func:`sequence_partition` because
+    empty sequence can fill everywhere, so we try to provide different
+    utility for this.
+
+    Parameters
+    ==========
+
+    l
+        A sequence of any Python objects (can be possibly empty)
+
+    n
+        A positive integer
+
+    Yields
+    ======
+
+    out
+        A list of sequences with concatenation equals $l$
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import sequence_partitions_empty
+    >>> for out in sequence_partitions_empty([1, 2, 3, 4], 2):
+    ...     print(out)
+    [[], [1, 2, 3, 4]]
+    [[1], [2, 3, 4]]
+    [[1, 2], [3, 4]]
+    [[1, 2, 3], [4]]
+    [[1, 2, 3, 4], []]
+
+    See Also
+    ========
+
+    sequence_partitions
+    """
+    if n < 1:
+        return
+    if n == 1:
+        yield [l]
+        return
+    for i in range(0, len(l) + 1):
+        for part in sequence_partitions_empty(l[i:], n - 1):
+            yield [l[:i]] + part
+
+
 def kbins(l, k, ordered=None):
     """
     Return sequence ``l`` partitioned into ``k`` bins.
@@ -2787,24 +2913,12 @@ def kbins(l, k, ordered=None):
     partitions, multiset_partitions
 
     """
-    def partition(lista, bins):
-        #  EnricoGiampieri's partition generator from
-        #  https://stackoverflow.com/questions/13131491/
-        #  partition-n-items-into-k-bins-in-python-lazily
-        if len(lista) == 1 or bins == 1:
-            yield [lista]
-        elif len(lista) > 1 and bins > 1:
-            for i in range(1, len(lista)):
-                for part in partition(lista[i:], bins - 1):
-                    if len([lista[:i]] + part) == bins:
-                        yield [lista[:i]] + part
-
     if ordered is None:
-        yield from partition(l, k)
+        yield from sequence_partitions(l, k)
     elif ordered == 11:
         for pl in multiset_permutations(l):
             pl = list(pl)
-            yield from partition(pl, k)
+            yield from sequence_partitions(pl, k)
     elif ordered == 00:
         yield from multiset_partitions(l, k)
     elif ordered == 10:

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2706,10 +2706,10 @@ def runs(seq, op=gt):
     return cycles
 
 
-T = TypeVar('T')
+_T = TypeVar('_T')
 
 
-def sequence_partitions(l: Sequence[T], n: int) -> Iterator[List[Sequence[T]]]:
+def sequence_partitions(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]:
     r"""Returns the partition of sequence $l$ into $n$ bins
 
     Explanation
@@ -2770,7 +2770,7 @@ def sequence_partitions(l: Sequence[T], n: int) -> Iterator[List[Sequence[T]]]:
             yield [l[:i]] + part
 
 
-def sequence_partitions_empty(l: Sequence[T], n: int) -> Iterator[List[Sequence[T]]]:
+def sequence_partitions_empty(l: Sequence[_T], n: int) -> Iterator[List[Sequence[_T]]]:
     r"""Returns the partition of sequence $l$ into $n$ bins with
     empty sequence
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2705,7 +2705,7 @@ def runs(seq, op=gt):
     return cycles
 
 
-def sequence_partitions(l, n):
+def sequence_partitions(l, n, /):
     r"""Returns the partition of sequence $l$ into $n$ bins
 
     Explanation
@@ -2766,7 +2766,7 @@ def sequence_partitions(l, n):
             yield [l[:i]] + part
 
 
-def sequence_partitions_empty(l, n):
+def sequence_partitions_empty(l, n, /):
     r"""Returns the partition of sequence $l$ into $n$ bins with
     empty sequence
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -19,7 +19,8 @@ from sympy.utilities.iterables import (
     prefixes, reshape, rotate_left, rotate_right, runs, sift,
     strongly_connected_components, subsets, take, topological_sort, unflatten,
     uniq, variations, ordered_partitions, rotations, is_palindromic, iterable,
-    NotIterable, multiset_derangements)
+    NotIterable, multiset_derangements,
+    sequence_partitions, sequence_partitions_empty)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -885,3 +886,51 @@ def test_iterable():
         _iterable = False
 
     assert iterable(Test6()) is False
+
+
+def test_sequence_partitions():
+    assert list(sequence_partitions([1], 1)) == [[[1]]]
+    assert list(sequence_partitions([1, 2], 1)) == [[[1, 2]]]
+    assert list(sequence_partitions([1, 2], 2)) == [[[1], [2]]]
+    assert list(sequence_partitions([1, 2, 3], 1)) == [[[1, 2, 3]]]
+    assert list(sequence_partitions([1, 2, 3], 2)) == \
+        [[[1], [2, 3]], [[1, 2], [3]]]
+    assert list(sequence_partitions([1, 2, 3], 3)) == [[[1], [2], [3]]]
+
+    # Exceptional cases
+    assert list(sequence_partitions([], 0)) == []
+    assert list(sequence_partitions([], 1)) == []
+    assert list(sequence_partitions([1, 2], 0)) == []
+    assert list(sequence_partitions([1, 2], 3)) == []
+
+
+def test_sequence_partitions_empty():
+    assert list(sequence_partitions_empty([], 1)) == [[[]]]
+    assert list(sequence_partitions_empty([], 2)) == [[[], []]]
+    assert list(sequence_partitions_empty([], 3)) == [[[], [], []]]
+    assert list(sequence_partitions_empty([1], 1)) == [[[1]]]
+    assert list(sequence_partitions_empty([1], 2)) == [[[], [1]], [[1], []]]
+    assert list(sequence_partitions_empty([1], 3)) == \
+        [[[], [], [1]], [[], [1], []], [[1], [], []]]
+    assert list(sequence_partitions_empty([1, 2], 1)) == [[[1, 2]]]
+    assert list(sequence_partitions_empty([1, 2], 2)) == \
+        [[[], [1, 2]], [[1], [2]], [[1, 2], []]]
+    assert list(sequence_partitions_empty([1, 2], 3)) == [
+        [[], [], [1, 2]], [[], [1], [2]], [[], [1, 2], []],
+        [[1], [], [2]], [[1], [2], []], [[1, 2], [], []]
+    ]
+    assert list(sequence_partitions_empty([1, 2, 3], 1)) == [[[1, 2, 3]]]
+    assert list(sequence_partitions_empty([1, 2, 3], 2)) == \
+        [[[], [1, 2, 3]], [[1], [2, 3]], [[1, 2], [3]], [[1, 2, 3], []]]
+    assert list(sequence_partitions_empty([1, 2, 3], 3)) == [
+        [[], [], [1, 2, 3]], [[], [1], [2, 3]],
+        [[], [1, 2], [3]], [[], [1, 2, 3], []],
+        [[1], [], [2, 3]], [[1], [2], [3]],
+        [[1], [2, 3], []], [[1, 2], [], [3]],
+        [[1, 2], [3], []], [[1, 2, 3], [], []]
+    ]
+
+    # Exceptional cases
+    assert list(sequence_partitions([], 0)) == []
+    assert list(sequence_partitions([1], 0)) == []
+    assert list(sequence_partitions([1, 2], 0)) == []


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There are lots of utilities under name 'partition', but I find none of them are useful for some purpose, so I try to implement this and hope that this effort is not duplicated.
I also implemented `sequence_partitions_empty` because it is needed for parsing, unification, pattern matching with empty sequences.
I've also removed some redundant length check. This can make things little bit faster, but there could more faster algorithm to use, but at least it is not the responsibility for now

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - Added `sequence_partitions`, `sequence_partitions_empty` for generic partitioning of sequence into bins, with the option to partition into empty sequence respectively.
<!-- END RELEASE NOTES -->
