### PR TITLE
Repair `PermutationGroup.is_cyclic`

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3219,17 +3219,15 @@ class PermutationGroup(Basic):
                 self._is_abelian = True
                 return True
 
-        for p in factors:
-            pgens = []
-            for g in self.generators:
-                pgens.append(g**p)
-            if self.index(self.subgroup(pgens)) != p:
-                self._is_cyclic = False
-                return False
+        if not self.is_abelian:
+            self._is_cyclic = False
+            return False
 
-        self._is_cyclic = True
-        self._is_abelian = True
-        return True
+        self._is_cyclic = all(
+            any(g**(order//p) != self.identity for g in self.generators)
+            for p in factors
+        )
+        return self._is_cyclic
 
     @property
     def is_dihedral(self):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3225,7 +3225,7 @@ class PermutationGroup(Basic):
 
         self._is_cyclic = all(
             any(g**(order//p) != self.identity for g in self.generators)
-            for p in factors
+            for p, e in factors.items() if e > 1
         )
         return self._is_cyclic
 

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1046,6 +1046,9 @@ def test_cyclic():
     assert G.is_cyclic
     assert G._is_abelian
 
+    G = PermutationGroup(*SymmetricGroup(3).generators)
+    assert G.is_cyclic is False
+
 
 def test_dihedral():
     G = SymmetricGroup(2)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1046,7 +1046,23 @@ def test_cyclic():
     assert G.is_cyclic
     assert G._is_abelian
 
+    # Non-abelian and therefore not cyclic
     G = PermutationGroup(*SymmetricGroup(3).generators)
+    assert G.is_cyclic is False
+
+    # Abelian and cyclic
+    G = PermutationGroup(
+        Permutation(0, 1, 2, 3),
+        Permutation(4, 5, 6)
+    )
+    assert G.is_cyclic
+
+    # Abelian but not cyclic
+    G = PermutationGroup(
+        Permutation(0, 1),
+        Permutation(2, 3),
+        Permutation(4, 5, 6)
+    )
     assert G.is_cyclic is False
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24432 

#### Brief description of what is fixed or changed

Repair the test for whether a `PermutationGroup` is cyclic or not.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fix a bug in checking whether a PermutationGroup is cyclic. Previously this would return True incorrectly in some cases.

<!-- END RELEASE NOTES -->
