### PR TITLE
iterables: topological sort uses natural value as default parameter

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -785,7 +785,7 @@ def postfixes(seq):
         yield seq[n - i - 1:]
 
 
-def topological_sort(graph, key=None):
+def topological_sort(graph, key=lambda value : value):
     r"""
     Topological sort of graph's vertices.
 
@@ -796,7 +796,7 @@ def topological_sort(graph, key=None):
         A tuple consisting of a list of vertices and a list of edges of
         a graph to be sorted topologically.
 
-    key : callable[T] (optional)
+    key : callable[T], optional (default: lambda value : value)
         Ordering key for vertices on the same level. By default the natural
         (e.g. lexicographic) ordering is used (in this case the base type
         must implement ordering relations).
@@ -864,9 +864,6 @@ def topological_sort(graph, key=None):
 
     for v, u in E:
         S.discard(u)
-
-    if key is None:
-        key = lambda value: value
 
     S = sorted(S, key=key, reverse=True)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Topological sort used `None` as a default argument on the key field as a way to set a default like this `lambda value: value`. This can be achieved in a simpler way, by simply passing the default lambda as a default argument instead of none-checking.
#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
   *  iterables: topological sort takes natural value as default parameter, instead of getting it as None
<!-- END RELEASE NOTES -->
