### PR TITLE
Fixed test_rotation_matrix_homogeneous

### DIFF
--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -266,7 +266,7 @@ def test_quaternion_conversions():
 def test_rotation_matrix_homogeneous():
     q = Quaternion(w, x, y, z)
     R1 = q.to_rotation_matrix(homogeneous=True) * q.norm()**2
-    R2 = simplify(q.to_rotation_matrix() * q.norm()**2)
+    R2 = simplify(q.to_rotation_matrix(homogeneous=False) * q.norm()**2)
     assert R1 == R2
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Follow up to #24382 

#### Brief description of what is fixed or changed
Minor fix to the test comparing both options of `Quaternion.to_rotation_matrix`.

With the change making `homogeneous=True` by default, without this fix, the test passes because it is comparing the same two matrices.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
