### PR TITLE
tensor: fix printing of TensMul with imaginary coefficients

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -787,6 +787,7 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3629,7 +3629,7 @@ class TensMul(TensExpr, AssocOp):
 
     def _get_args_for_traditional_printer(self):
         args = list(self.args)
-        if (self.coeff < 0) == True:
+        if self.coeff.is_real and (self.coeff < 0):
             # expressions like "-A(a)"
             sign = "-"
             if self.coeff == S.NegativeOne:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3629,10 +3629,10 @@ class TensMul(TensExpr, AssocOp):
 
     def _get_args_for_traditional_printer(self):
         args = list(self.args)
-        if self.coeff.is_real and (self.coeff < 0):
+        if self.coeff.could_extract_minus_sign():
             # expressions like "-A(a)"
             sign = "-"
-            if self.coeff == S.NegativeOne:
+            if args[0] == S.NegativeOne:
                 args = args[1:]
             else:
                 args[0] = -args[0]

--- a/sympy/tensor/tests/test_printing.py
+++ b/sympy/tensor/tests/test_printing.py
@@ -1,0 +1,13 @@
+from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorHead
+from sympy import I
+
+def test_printing_TensMul():
+    R3 = TensorIndexType('R3', dim=3)
+    p, q = tensor_indices("p q", R3)
+    K = TensorHead("K", [R3])
+
+    assert repr(2*K(p)) == "2*K(p)"
+    assert repr(-K(p)) == "-K(p)"
+    assert repr(-2*K(p)*K(q)) == "-2*K(p)*K(q)"
+    assert repr(-I*K(p)) == "-I*K(p)"
+    assert repr(I*K(p)) == "I*K(p)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24473


#### Brief description of what is fixed or changed
To find the sign of the coefficient, earlier the code would just compare it to zero, leading to an error for an imaginary coefficient. Now, it uses `could_extract_minus_sign`.

#### Other comments

After this PR:
```
>>> print(-I*K(p))
-I*K(p)
>>> print(I*K(p))
I*K(p)
>>> print(K(p))
K(p)
>>> print(-K(p))
-K(p)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* tensor
    * Fixed bug in printing TensMul.

<!-- END RELEASE NOTES -->
