### PR TITLE
`collect` should not use `print` for debug messages

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
 
-from sympy import SYMPY_DEBUG
-
 from sympy.core import sympify, S, Mul, Derivative, Pow
 from sympy.core.add import _unevaluated_Add, Add
 from sympy.core.assumptions import assumptions

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -421,18 +421,10 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         small_first = True
 
         for symbol in syms:
-            if SYMPY_DEBUG:
-                print("DEBUG: parsing of expression %s with symbol %s " % (
-                    str(terms), str(symbol))
-                )
-
             if isinstance(symbol, Derivative) and small_first:
                 terms = list(reversed(terms))
                 small_first = not small_first
             result = parse_expression(terms, symbol)
-
-            if SYMPY_DEBUG:
-                print("DEBUG: returned %s" % str(result))
 
             if result is not None:
                 if not symbol.is_commutative:


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed
`collect` used `print` instead of `debug` when `SYMPY_DEBUG` was `True`. In addition, these debug messages were not useful for users, they must have been leftovers from development.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
