### PR TITLE
Deprecate old issue for Line3D

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2564,7 +2564,7 @@ class Line3D(LinearEntity3D, Line):
 
         return LinearEntity3D.__new__(cls, p1, pt, **kwargs)
 
-    def equation(self, x='x', y='y', z='z', k=None):
+    def equation(self, x='x', y='y', z='z'):
         """Return the equations that define the line in 3D.
 
         Parameters
@@ -2576,9 +2576,6 @@ class Line3D(LinearEntity3D, Line):
             The name to use for the y-axis, default value is 'y'.
         z : str, optional
             The name to use for the z-axis, default value is 'z'.
-        k : str, optional
-            .. deprecated:: 1.2
-               The ``k`` flag is deprecated. It does nothing.
 
         Returns
         =======
@@ -2596,17 +2593,7 @@ class Line3D(LinearEntity3D, Line):
         (-3*x + 4*y + 3, z)
         >>> solve(eq.subs(z, 0), (x, y, z))
         {x: 4*y/3 + 1}
-
         """
-        if k is not None:
-            sympy_deprecation_warning(
-                """
-                The 'k' argument to Line3D.equation() is deprecated. Is
-                currently has no effect, so it may be omitted.
-                """,
-                deprecated_since_version="1.2",
-                active_deprecations_target='deprecated-line3d-equation-k',
-            )
         x, y, z, k = [_symbol(i, real=True) for i in (x, y, z, 'k')]
         p1, p2 = self.points
         d1, d2, d3 = p1.direction_ratio(p2)

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -38,7 +38,6 @@ from sympy.sets.sets import Intersection
 from sympy.simplify.simplify import simplify
 from sympy.solvers.solvers import solve
 from sympy.solvers.solveset import linear_coeffs
-from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import Undecidable, filldedent
 
 

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -475,10 +475,6 @@ def test_equation():
     assert Line3D(Point(1, 2, 3), Point(2, 2, 3)
         ).equation() == (y - 2, z - 3)
 
-    with warns_deprecated_sympy():
-        assert Line3D(Point(1, 2, 3), Point(2, 2, 3)
-        ).equation(k='k') == (y - 2, z - 3)
-
 
 def test_intersection_2d():
     p1 = Point(0, 0)

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -13,7 +13,7 @@ from sympy.geometry import (Circle, GeometryError, Line, Point, Ray,
 from sympy.geometry.line import Undecidable
 from sympy.geometry.polygon import _asa as asa
 from sympy.utilities.iterables import cartes
-from sympy.testing.pytest import raises, warns, warns_deprecated_sympy
+from sympy.testing.pytest import raises, warns
 
 
 x = Symbol('x', real=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #13742

#### Brief description of what is fixed or changed




#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Removed the `'k'` argument to `Line3D.equation` after following deprecation policy.

<!-- END RELEASE NOTES -->
