### PR TITLE
Remove deprecations in physics.units

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -7,9 +7,6 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.physics.units.dimensions import _QuantityMapper
 from sympy.physics.units.prefixes import Prefix
-from sympy.utilities.exceptions import (sympy_deprecation_warning,
-                                        SymPyDeprecationWarning,
-                                        ignore_warnings)
 
 
 class Quantity(AtomicExpr):
@@ -24,7 +21,7 @@ class Quantity(AtomicExpr):
     is_physical_constant = False
     _diff_wrt = True
 
-    def __new__(cls, name, abbrev=None, dimension=None, scale_factor=None,
+    def __new__(cls, name, abbrev=None,
                 latex_repr=None, pretty_unicode_repr=None,
                 pretty_ascii_repr=None, mathml_presentation_repr=None,
                 is_prefixed=False,
@@ -32,33 +29,6 @@ class Quantity(AtomicExpr):
 
         if not isinstance(name, Symbol):
             name = Symbol(name)
-
-        # For Quantity(name, dim, scale, abbrev) to work like in the
-        # old version of SymPy:
-        if not isinstance(abbrev, str) and not \
-                   isinstance(abbrev, Symbol):
-            dimension, scale_factor, abbrev = abbrev, dimension, scale_factor
-
-        if dimension is not None:
-            sympy_deprecation_warning(
-                """
-                The 'dimension' argument to to Quantity() is deprecated.
-                Instead use the unit_system.set_quantity_dimension() method.
-                """,
-                deprecated_since_version="1.3",
-                active_deprecations_target="deprecated-quantity-dimension-scale-factor"
-            )
-
-        if scale_factor is not None:
-            sympy_deprecation_warning(
-                """
-                The 'scale_factor' argument to to Quantity() is deprecated.
-                Instead use the unit_system.set_quantity_scale_factors()
-                method.
-                """,
-                deprecated_since_version="1.3",
-                active_deprecations_target="deprecated-quantity-dimension-scale-factor"
-            )
 
         if abbrev is None:
             abbrev = name
@@ -76,46 +46,7 @@ class Quantity(AtomicExpr):
         obj._ascii_repr = pretty_ascii_repr
         obj._mathml_repr = mathml_presentation_repr
         obj._is_prefixed = is_prefixed
-
-        if dimension is not None:
-            # TODO: remove after deprecation:
-            with ignore_warnings(SymPyDeprecationWarning):
-                obj.set_dimension(dimension)
-
-        if scale_factor is not None:
-            # TODO: remove after deprecation:
-            with ignore_warnings(SymPyDeprecationWarning):
-                obj.set_scale_factor(scale_factor)
-
         return obj
-
-    def set_dimension(self, dimension, unit_system="SI"):
-        sympy_deprecation_warning(
-            f"""
-            Quantity.set_dimension() is deprecated. Use either
-            unit_system.set_quantity_dimension() or
-            {self}.set_global_dimension() instead.
-            """,
-            deprecated_since_version="1.5",
-            active_deprecations_target="deprecated-quantity-methods",
-        )
-        from sympy.physics.units import UnitSystem
-        unit_system = UnitSystem.get_unit_system(unit_system)
-        unit_system.set_quantity_dimension(self, dimension)
-
-    def set_scale_factor(self, scale_factor, unit_system="SI"):
-        sympy_deprecation_warning(
-            f"""
-            Quantity.set_scale_factor() is deprecated. Use either
-            unit_system.set_quantity_scale_factors() or
-            {self}.set_global_relative_scale_factor() instead.
-            """,
-            deprecated_since_version="1.5",
-            active_deprecations_target="deprecated-quantity-methods",
-        )
-        from sympy.physics.units import UnitSystem
-        unit_system = UnitSystem.get_unit_system(unit_system)
-        unit_system.set_quantity_scale_factor(self, scale_factor)
 
     def set_global_dimension(self, dimension):
         _QuantityMapper._quantity_dimension_global[self] = dimension
@@ -177,38 +108,6 @@ class Quantity(AtomicExpr):
     def _eval_subs(self, old, new):
         if isinstance(new, Quantity) and self != old:
             return self
-
-    @staticmethod
-    def get_dimensional_expr(expr, unit_system="SI"):
-        sympy_deprecation_warning(
-            """
-            Quantity.get_dimensional_expr() is deprecated. It is now
-            associated with UnitSystem objects. The dimensional relations
-            depend on the unit system used. Use
-            unit_system.get_dimensional_expr() instead.
-            """,
-            deprecated_since_version="1.5",
-            active_deprecations_target="deprecated-quantity-methods",
-        )
-        from sympy.physics.units import UnitSystem
-        unit_system = UnitSystem.get_unit_system(unit_system)
-        return unit_system.get_dimensional_expr(expr)
-
-    @staticmethod
-    def _collect_factor_and_dimension(expr, unit_system="SI"):
-        """Return tuple with scale factor expression and dimension expression."""
-        sympy_deprecation_warning(
-            """
-            Quantity._collect_factor_and_dimension() is deprecated. This
-            method has been moved to the UnitSystem class. Use
-            unit_system._collect_factor_and_dimension(expr) instead.
-            """,
-            deprecated_since_version="1.5",
-            active_deprecations_target="deprecated-quantity-methods",
-        )
-        from sympy.physics.units import UnitSystem
-        unit_system = UnitSystem.get_unit_system(unit_system)
-        return unit_system._collect_factor_and_dimension(expr)
 
     def _latex(self, printer):
         if self._latex_repr:

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -27,7 +27,7 @@ from sympy.physics.units.definitions.dimension_definitions import (
 from sympy.physics.units.prefixes import PREFIXES, kilo
 from sympy.physics.units.quantities import PhysicalConstant, Quantity
 from sympy.physics.units.systems import SI
-from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
+from sympy.testing.pytest import raises
 
 k = PREFIXES["k"]
 
@@ -86,11 +86,6 @@ def test_Quantity_definition():
 
     assert v.dimension == length
     assert v.scale_factor == 5000
-
-    with warns_deprecated_sympy():
-        Quantity('invalid', 'dimension', 1)
-    with warns_deprecated_sympy():
-        Quantity('mismatch', dimension=length, scale_factor=kg)
 
 
 def test_abbrev():
@@ -164,10 +159,6 @@ def test_quantity_abs():
     assert SI.get_dimensional_expr(v_w1) == (length/time).name
 
     Dq = Dimension(SI.get_dimensional_expr(expr))
-
-    with warns_deprecated_sympy():
-        Dq1 = Dimension(Quantity.get_dimensional_expr(expr))
-        assert Dq == Dq1
 
     assert SI.get_dimension_system().get_dimensional_dependencies(Dq) == {
         length: 1,
@@ -376,19 +367,6 @@ def test_factor_and_dimension():
     assert ((Rational(3, 2))**Rational(4, 3), (length/time)**Rational(4, 3)) == \
         SI._collect_factor_and_dimension(expr)
 
-    with warns_deprecated_sympy():
-        assert (3000, Dimension(1)) == Quantity._collect_factor_and_dimension(3000)
-
-
-@XFAIL
-def test_factor_and_dimension_with_Abs():
-    with warns_deprecated_sympy():
-        v_w1 = Quantity('v_w1', length/time, Rational(3, 2)*meter/second)
-    v_w1.set_global_relative_scale_factor(Rational(3, 2), meter/second)
-    expr = v_w1 - Abs(v_w1)
-    with warns_deprecated_sympy():
-        assert (0, length/time) == Quantity._collect_factor_and_dimension(expr)
-
 
 def test_dimensional_expr_of_derivative():
     l = Quantity('l')
@@ -498,14 +476,6 @@ def test_issue_14547():
     e = foot + 1
     assert e.is_Add and set(e.args) == {foot, 1}
 
-
-def test_deprecated_quantity_methods():
-    step = Quantity("step")
-    with warns_deprecated_sympy():
-        step.set_dimension(length)
-        step.set_scale_factor(2*meter)
-        assert convert_to(step, centimeter) == 200*centimeter
-        assert convert_to(1000*step/second, kilometer/second) == 2*kilometer/second
 
 def test_issue_22164():
     warnings.simplefilter("error")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #14319

#### Brief description of what is fixed or changed



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- physics.units
  - BREAKING: Removed deprecated arguments `dimension, scale_factor` for `Quantity`. These have been deprecated and giving out DeprecationWarning since SymPy 1.3.
  - BREAKING: Removed deprecated methods `set_dimension, set_scale_factor, get_dimensional_expr`, `collect_factor_and_dimension` from `Quantity`. These have been deprecated and giving out DeprecationWarning since SymPy 1.5.

<!-- END RELEASE NOTES -->
