### PR TITLE
Type analysis for `strategies.core`

### DIFF
--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -24,7 +24,14 @@ def exhaust(rule: Callable[[_T], _T]) -> Callable[[_T], _T]:
 
 
 def memoize(rule: Callable[[_S], _T]) -> Callable[[_S], _T]:
-    """ Memoized version of a rule """
+    """Memoized version of a rule
+
+    Notes
+    =====
+
+    This cache can grow infinitely, so it is not recommended to use this
+    than ``functools.lru_cache`` unless you need very heavy computation.
+    """
     cache: dict[_S, _T] = {}
     def memoized_rl(expr: _S) -> _T:
         if expr in cache:

--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -1,20 +1,32 @@
 """ Generic SymPy-Independent Strategies """
+from __future__ import annotations
+from collections.abc import Callable, Mapping
+from typing import TypeVar
+from sys import stdout
 
-identity = lambda x: x
 
-def exhaust(rule):
+_S = TypeVar('_S')
+_T = TypeVar('_T')
+
+
+def identity(x: _T) -> _T:
+    return x
+
+
+def exhaust(rule: Callable[[_T], _T]) -> Callable[[_T], _T]:
     """ Apply a rule repeatedly until it has no effect """
-    def exhaustive_rl(expr):
+    def exhaustive_rl(expr: _T) -> _T:
         new, old = rule(expr), expr
         while new != old:
             new, old = rule(new), new
         return new
     return exhaustive_rl
 
-def memoize(rule):
+
+def memoize(rule: Callable[[_S], _T]) -> Callable[[_S], _T]:
     """ Memoized version of a rule """
-    cache = {}
-    def memoized_rl(expr):
+    cache: dict[_S, _T] = {}
+    def memoized_rl(expr: _S) -> _T:
         if expr in cache:
             return cache[expr]
         else:
@@ -23,29 +35,32 @@ def memoize(rule):
             return result
     return memoized_rl
 
-def condition(cond, rule):
+
+def condition(
+    cond: Callable[[_T], bool], rule: Callable[[_T], _T]
+) -> Callable[[_T], _T]:
     """ Only apply rule if condition is true """
-    def conditioned_rl(expr):
+    def conditioned_rl(expr: _T) -> _T:
         if cond(expr):
             return rule(expr)
-        else:
-            return expr
+        return expr
     return conditioned_rl
 
-def chain(*rules):
+
+def chain(*rules: Callable[[_T], _T]) -> Callable[[_T], _T]:
     """
     Compose a sequence of rules so that they apply to the expr sequentially
     """
-    def chain_rl(expr):
+    def chain_rl(expr: _T) -> _T:
         for rule in rules:
             expr = rule(expr)
         return expr
     return chain_rl
 
+
 def debug(rule, file=None):
     """ Print out before and after expressions each time rule is used """
     if file is None:
-        from sys import stdout
         file = stdout
     def debug_rl(*args, **kwargs):
         expr = args[0]
@@ -56,28 +71,30 @@ def debug(rule, file=None):
         return result
     return debug_rl
 
-def null_safe(rule):
+
+def null_safe(rule: Callable[[_T], _T | None]) -> Callable[[_T], _T]:
     """ Return original expr if rule returns None """
-    def null_safe_rl(expr):
+    def null_safe_rl(expr: _T) -> _T:
         result = rule(expr)
         if result is None:
             return expr
-        else:
-            return result
+        return result
     return null_safe_rl
 
-def tryit(rule, exception):
+
+def tryit(rule: Callable[[_T], _T], exception) -> Callable[[_T], _T]:
     """ Return original expr if rule raises exception """
-    def try_rl(expr):
+    def try_rl(expr: _T) -> _T:
         try:
             return rule(expr)
         except exception:
             return expr
     return try_rl
 
-def do_one(*rules):
+
+def do_one(*rules: Callable[[_T], _T]) -> Callable[[_T], _T]:
     """ Try each of the rules until one works. Then stop. """
-    def do_one_rl(expr):
+    def do_one_rl(expr: _T) -> _T:
         for rl in rules:
             result = rl(expr)
             if result != expr:
@@ -85,14 +102,28 @@ def do_one(*rules):
         return expr
     return do_one_rl
 
-def switch(key, ruledict):
+
+def switch(
+    key: Callable[[_S], _T],
+    ruledict: Mapping[_T, Callable[[_S], _S]]
+) -> Callable[[_S], _S]:
     """ Select a rule based on the result of key called on the function """
-    def switch_rl(expr):
+    def switch_rl(expr: _S) -> _S:
         rl = ruledict.get(key(expr), identity)
         return rl(expr)
     return switch_rl
 
-def minimize(*rules, objective=identity):
+
+# XXX Untyped default argument for minimize function
+# where python requires SupportsRichComparison type
+def _identity(x):
+    return x
+
+
+def minimize(
+    *rules: Callable[[_S], _T],
+    objective=_identity
+) -> Callable[[_S], _T]:
     """ Select result of rules that minimizes objective
 
     >>> from sympy.strategies import minimize
@@ -106,7 +137,6 @@ def minimize(*rules, objective=identity):
     >>> rl(4)
     5
     """
-
-    def minrule(expr):
+    def minrule(expr: _S) -> _T:
         return min([rule(expr) for rule in rules], key=objective)
     return minrule

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sympy.core.singleton import S
 from sympy.core.basic import Basic
 from sympy.strategies.core import (

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -1,26 +1,42 @@
 from sympy.core.singleton import S
-from sympy.strategies.core import (null_safe, exhaust, memoize, condition,
-        chain, tryit, do_one, debug, switch, minimize)
+from sympy.core.basic import Basic
+from sympy.strategies.core import (
+    null_safe, exhaust, memoize, condition,
+    chain, tryit, do_one, debug, switch, minimize)
+from io import StringIO
+
+
+def posdec(x: int) -> int:
+    if x > 0:
+        return x - 1
+    return x
+
+
+def inc(x: int) -> int:
+    return x + 1
+
+
+def dec(x: int) -> int:
+    return x - 1
+
 
 def test_null_safe():
-    def rl(expr):
+    def rl(expr: int) -> int | None:
         if expr == 1:
             return 2
+        return None
+
     safe_rl = null_safe(rl)
     assert rl(1) == safe_rl(1)
-
-    assert      rl(3) == None
+    assert rl(3) == None
     assert safe_rl(3) == 3
 
-def posdec(x):
-    if x > 0:
-        return x-1
-    else:
-        return x
+
 def test_exhaust():
     sink = exhaust(posdec)
     assert sink(5) == 0
     assert sink(10) == 0
+
 
 def test_memoize():
     rl = memoize(posdec)
@@ -28,35 +44,47 @@ def test_memoize():
     assert rl(5) == posdec(5)
     assert rl(-2) == posdec(-2)
 
+
 def test_condition():
-    rl = condition(lambda x: x%2 == 0, posdec)
+    rl = condition(lambda x: x % 2 == 0, posdec)
     assert rl(5) == 5
     assert rl(4) == 3
+
 
 def test_chain():
     rl = chain(posdec, posdec)
     assert rl(5) == 3
     assert rl(1) == 0
 
+
 def test_tryit():
-    def rl(expr):
+    def rl(expr: Basic) -> Basic:
         assert False
+
     safe_rl = tryit(rl, AssertionError)
-    assert safe_rl(S(1)) == 1
+    assert safe_rl(S(1)) == S(1)
+
 
 def test_do_one():
     rl = do_one(posdec, posdec)
     assert rl(5) == 4
 
-    rl1 = lambda x: 2 if x == 1 else x
-    rl2 = lambda x: 3 if x == 2 else x
+    def rl1(x: int) -> int:
+        if x == 1:
+            return 2
+        return x
+
+    def rl2(x: int) -> int:
+        if x == 2:
+            return 3
+        return x
 
     rule = do_one(rl1, rl2)
     assert rule(1) == 2
     assert rule(rule(1)) == 3
 
+
 def test_debug():
-    from io import StringIO
     file = StringIO()
     rl = debug(posdec, file)
     rl(5)
@@ -67,21 +95,23 @@ def test_debug():
     assert '5' in log
     assert '4' in log
 
-def test_switch():
-    inc = lambda x: x + 1
-    dec = lambda x: x - 1
-    key = lambda x: x % 3
-    rl = switch(key, {0: inc, 1: dec})
 
+def test_switch():
+    def key(x: int) -> int:
+        return x % 3
+
+    rl = switch(key, {0: inc, 1: dec})
     assert rl(3) == 4
     assert rl(4) == 3
     assert rl(5) == 5
 
+
 def test_minimize():
-    inc = lambda x: x + 1
-    dec = lambda x: x - 1
+    def key(x: int) -> int:
+        return -x
+
     rl = minimize(inc, dec)
     assert rl(4) == 3
 
-    rl = minimize(inc, dec, objective=lambda x: -x)
+    rl = minimize(inc, dec, objective=key)
     assert rl(4) == 5


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

For higher order functional programming library like `sympy.strategies`, 
type annotations are helpful because type inference is often the only way to logically assert their runtime behavior.
I'd try to modernize the library because some functions of it are used in places of sympy.
I only leave `debug`, `minimize` untyped because they would need weird type signature.

#### Other comments

I removed redundant test file `test_strat.py`.
I think that a lot of features in `strategies.core` relies on symbolic identity check `==` than `try-except` or `is None`. 

I'm not sure if it is the best solution because symbolic identity check grows linearly as much as the structure of the object becomes complicated, but I'd leave it now until it becomes some performance bottleneck in the future.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- strategies
  - Added type annotations for functions in `strategies.core`.
  
<!-- END RELEASE NOTES -->
