### PR TITLE
Deprecate source function

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -210,6 +210,14 @@ parent_frame.x
 
 ## Version 1.11
 
+(deprecated-conv-array-expr-module-names)=
+### Modules `sympy.tensor.array.expressions.conv_*` renamed to `sympy.tensor.array.expressions.from_*`
+
+In order to avoid possible naming and tab-completion conflicts with
+functions with similar names to the names of the modules, all modules whose
+name starts with `conv_*` in `sympy.tensor.array.expressions` have been renamed
+to `from_*`.
+
 (mathematica-parser-new)=
 ### New Mathematica code parser
 
@@ -1303,41 +1311,6 @@ Matrix([
 
 ## Version 1.3
 
-(deprecated-source)=
-### The `source()` function
-
-The ``source`` function is deprecated. Use
-[`inspect.getsource(obj)`](https://docs.python.org/3/library/inspect.html#inspect.getsource)
-instead, or if you are in IPython or Jupyter, use `obj??`.
-
-(deprecated-quantity-dimension-scale-factor)=
-### The `dimension` and `scale_factor` arguments to `sympy.physics.units.Quanitity`
-
-The `dimension` and `scale_factor` arguments to
-{class}`sympy.physics.units.quantities.Quantity` are deprecated.
-
-The problem with these arguments is that **dimensions** are **not** an
-**absolute** association to a quantity. For example:
-
-- in natural units length and time are the same dimension (so you can sum
-  meters and seconds).
-
-- SI and cgs units have different dimensions for the same quantities.
-
-At this point a problem arises for scale factor as well: while it is always
-true that `kilometer / meter == 1000`, some other quantities may have a
-relative scale factor or not depending on which unit system is currently being
-used.
-
-Instead, things should be managed on the {class}`~.DimensionSystem` class. The
-`DimensionSystem.set_quantity_dimension()` method should be used instead of the
-`dimension` argument, and the
-`DimensionSystem.set_quantity_scale_factor()` method should be used
-instead of the `scale_factor` argument.
-
-See issue [#14318](https://github.com/sympy/sympy/issues/14318) for more
-details. See also {ref}`deprecated-quantity-methods` above.
-
 (deprecated-sympy-matrices-classof-a2idx)=
 ### Importing `classof` and `a2idx` from `sympy.matrices.matrices`
 
@@ -1345,81 +1318,3 @@ The functions `sympy.matrices.matrices.classof` and
 `sympy.matrices.matrices.a2idx` were duplicates of the same functions in
 `sympy.matrices.common`. The two functions should be used from the
 `sympy.matrices.common` module instead.
-
-## Version 1.2
-
-(deprecated-matrix-dot-non-vector)=
-### Dot product of non-row/column vectors
-
-The [`Matrix.dot()`](sympy.matrices.matrices.MatrixBase.dot) method has
-confusing behavior where `A.dot(B)` returns a list corresponding to
-`flatten(A.T*B.T)` when `A` and `B` are matrices that are not vectors (i.e.,
-neither dimension is size 1). This is confusing. The purpose of `Matrix.dot()`
-is to perform a mathematical dot product, which should only be defined for
-vectors (i.e., either a $n\times 1$ or $1\times n$ matrix), but in a way that
-works regardless of whether each argument is a row or column vector.
-Furthermore, returning a list here was much less useful than a matrix would
-be, and resulted in a polymorphic return type depending on the shapes of the
-inputs.
-
-This behavior is deprecated. `Matrix.dot` should only be used to do a
-mathematical dot product, which operates on row or column vectors. Use the
-`*` or `@` operators to do matrix multiplication.
-
-```py
->>> from sympy import Matrix
->>> A = Matrix([[1, 2], [3, 4]])
->>> B = Matrix([[2, 3], [1, 2]])
->>> A*B
-Matrix([
-[ 4,  7],
-[10, 17]])
->>> A@B
-Matrix([
-[ 4,  7],
-[10, 17]])
-```
-
-(deprecated-line3d-equation-k)=
-### `sympy.geometry.Line3D.equation` no longer needs the `k` argument
-
-The `k` argument to {meth}`sympy.geometry.line.Line3D.equation()` method is
-deprecated.
-
-Previously, the function `Line3D.equation` returned `(X, Y, Z, k)` which was
-changed to `(Y-X, Z-X)` (here `X`, `Y` and `Z` are expressions of `x`, `y` and
-`z` respectively). As in 2D an equation is returned relating `x` and `y` just
-like that in 3D two equations will be returned relating `x`, `y` and `z`.
-
-So in the new `Line3D.equation` the `k` argument is not needed anymore. Now
-the `k` argument is effectively ignored. A `k` variable is temporarily formed
-inside `equation()` and then gets substituted using `subs()` in terms of `x`
-and then `(Y-X, Z-X)` is returned.
-
-Previously:
-
-```py
->>> from sympy import Point3D,Line3D
->>> p1,p2 = Point3D(1, 2, 3), Point3D(5, 6, 7)
->>> l = Line3D(p1, p2)
->>> l.equation() # doctest: +SKIP
-(x/4 - 1/4, y/4 - 1/2, z/4 - 3/4, k)
-```
-
-Now:
-
-```py
->>> from sympy import Point3D, Line3D, solve
->>> p1,p2 = Point3D(1, 2, 3), Point3D(5, 6, 7)
->>> l = Line3D(p1,p2)
->>> l.equation()
-(-x + y - 1, -x + z - 2)
-```
-
-(deprecated-conv-array-expr-module-names)=
-### Modules `sympy.tensor.array.expressions.conv_*` renamed to `sympy.tensor.array.expressions.from_*`
-
-In order to avoid possible naming and tab-completion conflicts with
-functions with similar names to the names of the modules, all modules whose
-name starts with `conv_*` in `sympy.tensor.array.expressions` have been renamed
-to `from_*`.

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1306,7 +1306,7 @@ Matrix([
 (deprecated-source)=
 ### The `source()` function
 
-The {func}`~.source` function is deprecated. Use
+The ``source`` function is deprecated. Use
 [`inspect.getsource(obj)`](https://docs.python.org/3/library/inspect.html#inspect.getsource)
 instead, or if you are in IPython or Jupyter, use `obj??`.
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1087,30 +1087,6 @@ The `tensorhead()` function is deprecated in favor of {func}`~.tensor_heads`.
 `symbols()` or `TensorIndex` and `tensor_indices()`). It also does not use
 Young tableau to denote symmetries.
 
-(deprecated-quantity-methods)=
-### Methods to `sympy.physics.units.Quantity`
-
-The following methods of
-{class}`sympy.physics.units.quantities.Quantity` are deprecated.
-
-- `Quantity.set_dimension()`. This should be replaced with
-  `unit_system.set_quantity_dimension` or
-  `Quantity.set_global_dimension()`.
-
-- `Quantity.set_scale_factor()`. This should be replaced with
-  `unit_system.set_quantity_scale_factor` or {meth}`.Quantity.set_global_relative_scale_factor`
-
-- `Quantity.get_dimensional_expr()`. This is now associated with
-  {class}`~.UnitSystem` objects. The dimensional relations depend on the unit
-  system used. Use `unit_system.get_dimensional_expr()` instead.
-
-- `Quantity._collect_factor_and_dimension`. This has been moved to the
-  {class}`~.UnitSystem` class. Use
-  `unit_system._collect_factor_and_dimension(expr)` instead.
-
-See {ref}`deprecated-quantity-dimension-scale-factor` below for the motivation
-for this change.
-
 (deprecated-is-emptyset)=
 ### The `is_EmptySet` attribute of sets
 

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -814,28 +814,3 @@ These will give you the function parameters and docstring for
 .. module:: sympy.simplify.simplify
 .. autofunction:: powsimp
    :noindex:
-
-source()
---------
-
-Another useful option is the :func:`~.source` function.  This will print
-the source code of a function, including any docstring that it may have.
-You can also do ``function??`` in :command:`ipython`.  For example,
-from SymPy 0.6.5:
-
-    >>> source(simplify)  # simplify() is actually only 2 lines of code. #doctest: +SKIP
-    In file: ./sympy/simplify/simplify.py
-    def simplify(expr):
-        """Naively simplifies the given expression.
-           ...
-           Simplification is not a well defined term and the exact strategies
-           this function tries can change in the future versions of SymPy. If
-           your algorithm relies on "simplification" (whatever it is), try to
-           determine what you need exactly  -  is it powsimp()? radsimp()?
-           together()?, logcombine()?, or something else? And use this particular
-           function directly, because those are well defined and thus your algorithm
-           will be robust.
-           ...
-        """
-        expr = Poly.cancel(powsimp(expr))
-        return powsimp(together(expr.expand()), combine='exp', deep=True)

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -203,7 +203,7 @@ from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
 from .utilities import (flatten, group, take, subsets, variations,
         numbered_symbols, cartes, capture, dict_merge, prefixes, postfixes,
         sift, topological_sort, unflatten, has_dups, has_variety, reshape,
-        rotations, filldedent, lambdify, source,
+        rotations, filldedent, lambdify,
         threaded, xthreaded, public, memoize_property, timed)
 
 from .integrals import (integrate, Integral, line_integrate, mellin_transform,
@@ -440,7 +440,7 @@ __all__ = [
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
     'cartes', 'capture', 'dict_merge', 'prefixes', 'postfixes', 'sift',
     'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
-    'rotations', 'filldedent', 'lambdify', 'source', 'threaded', 'xthreaded',
+    'rotations', 'filldedent', 'lambdify', 'threaded', 'xthreaded',
     'public', 'memoize_property', 'timed',
 
     # sympy.integrals

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -10,8 +10,6 @@ from .misc import filldedent
 
 from .lambdify import lambdify
 
-from .source import source
-
 from .decorator import threaded, xthreaded, public, memoize_property
 
 from .timeutils import timed
@@ -25,8 +23,6 @@ __all__ = [
     'filldedent',
 
     'lambdify',
-
-    'source',
 
     'threaded', 'xthreaded', 'public', 'memoize_property',
 

--- a/sympy/utilities/source.py
+++ b/sympy/utilities/source.py
@@ -2,31 +2,6 @@
 This module adds several functions for interactive source code inspection.
 """
 
-from sympy.utilities.decorator import deprecated
-
-import inspect
-
-@deprecated(
-    """
-    The source() function is deprecated. Use inspect.getsource() instead, or
-    if you are in IPython or Jupyter, the ?? feature.
-    """,
-    deprecated_since_version="1.3",
-    active_deprecations_target="deprecated-source",
-)
-def source(object):
-    """
-    Prints the source code of a given object.
-
-    .. deprecated:: 1.3
-
-       The ``source()`` function is deprecated. Use ``inspect.getsource()`` or
-       ``??`` in IPython/Jupyter instead.
-
-    """
-    print('In file: %s' % inspect.getsourcefile(object))
-    print(inspect.getsource(object))
-
 
 def get_class(lookup_view):
     """

--- a/sympy/utilities/tests/test_source.py
+++ b/sympy/utilities/tests/test_source.py
@@ -1,24 +1,5 @@
-import sys
+from sympy.utilities.source import get_mod_func, get_class
 
-from sympy.utilities.source import get_mod_func, get_class, source
-from sympy.testing.pytest import warns_deprecated_sympy
-from sympy.geometry import point
-
-def test_source():
-    # Dummy stdout
-    class StdOut:
-        def write(self, x):
-            pass
-
-    # Test SymPyDeprecationWarning from source()
-    with warns_deprecated_sympy():
-        # Redirect stdout temporarily so print out is not seen
-        stdout = sys.stdout
-        try:
-            sys.stdout = StdOut()
-            source(point)
-        finally:
-            sys.stdout = stdout
 
 def test_get_mod_func():
     assert get_mod_func(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #14905

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- utilities
  - BREAKING: Removed deprecated `source` function. This had been deprecated and giving out DeprecationWarning since SymPy 1.3.

<!-- END RELEASE NOTES -->
