### PR TITLE
Remove deprecated a2idx and classof

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1284,13 +1284,3 @@ Matrix([
 [0, x, 1, 0, 0],
 [0, 0, x, 1, 0]])
 ```
-
-## Version 1.3
-
-(deprecated-sympy-matrices-classof-a2idx)=
-### Importing `classof` and `a2idx` from `sympy.matrices.matrices`
-
-The functions `sympy.matrices.matrices.classof` and
-`sympy.matrices.matrices.a2idx` were duplicates of the same functions in
-`sympy.matrices.common`. The two functions should be used from the
-`sympy.matrices.common` module instead.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -26,7 +26,7 @@ from sympy.utilities.misc import as_int, filldedent
 
 from .common import (
     MatrixCommon, MatrixError, NonSquareMatrixError, NonInvertibleMatrixError,
-    ShapeError, MatrixKind)
+    ShapeError, MatrixKind, a2idx)
 
 from .utilities import _iszero, _is_zero_after_expand_mul, _simplify
 
@@ -1774,8 +1774,6 @@ class MatrixBase(MatrixDeprecated,
 
         key2ij
         """
-        from sympy.matrices.common import a2idx as a2idx_ # Remove this line after deprecation of a2idx from matrices.py
-
         islice, jslice = [isinstance(k, slice) for k in keys]
         if islice:
             if not self.rows:
@@ -1783,7 +1781,7 @@ class MatrixBase(MatrixDeprecated,
             else:
                 rlo, rhi = keys[0].indices(self.rows)[:2]
         else:
-            rlo = a2idx_(keys[0], self.rows)
+            rlo = a2idx(keys[0], self.rows)
             rhi = rlo + 1
         if jslice:
             if not self.cols:
@@ -1791,7 +1789,7 @@ class MatrixBase(MatrixDeprecated,
             else:
                 clo, chi = keys[1].indices(self.cols)[:2]
         else:
-            clo = a2idx_(keys[1], self.cols)
+            clo = a2idx(keys[1], self.cols)
             chi = clo + 1
         return rlo, rhi, clo, chi
 
@@ -1805,17 +1803,15 @@ class MatrixBase(MatrixDeprecated,
 
         key2bounds
         """
-        from sympy.matrices.common import a2idx as a2idx_ # Remove this line after deprecation of a2idx from matrices.py
-
         if is_sequence(key):
             if not len(key) == 2:
                 raise TypeError('key must be a sequence of length 2')
-            return [a2idx_(i, n) if not isinstance(i, slice) else i
+            return [a2idx(i, n) if not isinstance(i, slice) else i
                     for i, n in zip(key, self.shape)]
         elif isinstance(key, slice):
             return key.indices(len(self))[:2]
         else:
-            return divmod(a2idx_(key, len(self)), self.cols)
+            return divmod(a2idx(key, len(self)), self.cols)
 
     def normalized(self, iszerofunc=_iszero):
         """Return the normalized version of ``self``.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -21,7 +21,6 @@ from sympy.polys import cancel
 from sympy.printing import sstr
 from sympy.printing.defaults import Printable
 from sympy.printing.str import StrPrinter
-from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import flatten, NotIterable, is_sequence, reshape
 from sympy.utilities.misc import as_int, filldedent
 
@@ -2234,28 +2233,3 @@ class MatrixBase(MatrixDeprecated,
         _strongly_connected_components.__doc__
     strongly_connected_components_decomposition.__doc__ = \
         _strongly_connected_components_decomposition.__doc__
-
-
-@deprecated(
-    """
-    sympy.matrices.matrices.classof is deprecated. Use
-    sympy.matrices.common.classof instead.
-    """,
-    deprecated_since_version="1.3",
-    active_deprecations_target="deprecated-sympy-matrices-classof-a2idx",
-)
-def classof(A, B):
-    from sympy.matrices.common import classof as classof_
-    return classof_(A, B)
-
-@deprecated(
-    """
-    sympy.matrices.matrices.a2idx is deprecated. Use
-    sympy.matrices.common.a2idx instead.
-    """,
-    deprecated_since_version="1.3",
-    active_deprecations_target="deprecated-sympy-matrices-classof-a2idx",
-)
-def a2idx(j, n=None):
-    from sympy.matrices.common import a2idx as a2idx_
-    return a2idx_(j, n)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2993,17 +2993,6 @@ def test_issue_19809():
             future = executor.submit(f)
             assert future.result()
 
-def test_deprecated_classof_a2idx():
-    with warns_deprecated_sympy():
-        from sympy.matrices.matrices import classof
-        M = Matrix([[1, 2], [3, 4]])
-        IM = ImmutableMatrix([[1, 2], [3, 4]])
-        assert classof(M, IM) == ImmutableDenseMatrix
-
-    with warns_deprecated_sympy():
-        from sympy.matrices.matrices import a2idx
-        assert a2idx(-1, 3) == 2
-
 
 def test_issue_23276():
     M = Matrix([x, y])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15109

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:




See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - BREAKING: Removed deprecated functions `a2idx` and `classof` from `sympy.matrices`. This had been deprecated and giving out `DeprecationWarning` since SymPy 1.3.
<!-- END RELEASE NOTES -->
