### PR TITLE
Use a separate RNG for the core assumptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -683,6 +683,7 @@ James Harrop <ebc121@gmail.com>
 James Pearson <xiong.chiamiov@gmail.com>
 James Taylor <user234683@tutanota.com>
 Jan Kruse <janckruse@t-online.de>
+Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>
 Jaroslaw Tworek <dev.jrx@gmail.com>
 Jashanpreet Singh <jashansingh.4398@gmail.com>

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -214,7 +214,7 @@ from .facts import FactRules, FactKB
 from .core import BasicMeta
 from .sympify import sympify
 
-from sympy.core.random import shuffle
+from sympy.core.random import _assumptions_shuffle as shuffle
 from sympy.core.assumptions_generated import generated_assumptions as _assumptions
 
 def _load_pre_generated_assumption_rules():

--- a/sympy/core/random.py
+++ b/sympy/core/random.py
@@ -32,9 +32,19 @@ choice = rng.choice
 random = rng.random
 randint = rng.randint
 randrange = rng.randrange
-seed = rng.seed
+sample = rng.sample
+# seed = rng.seed
 shuffle = rng.shuffle
 uniform = rng.uniform
+
+_assumptions_rng = _random.Random()
+_assumptions_shuffle = _assumptions_rng.shuffle
+
+
+def seed(a=None, version=2):
+    rng.seed(a=a, version=version)
+    _assumptions_rng.seed(a=a, version=version)
+
 
 def random_complex_number(a=2, b=-1, c=3, d=1, rational=False, tolerance=None):
     """

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -10,6 +10,9 @@ from sympy.core.assumptions import (assumptions, check_assumptions,
     failing_assumptions, common_assumptions, _generate_assumption_rules,
     _load_pre_generated_assumption_rules)
 from sympy.core.facts import InconsistentAssumptions
+from sympy.core.random import seed
+from sympy.combinatorics import Permutation
+from sympy.combinatorics.perm_groups import PermutationGroup
 
 from sympy.testing.pytest import raises, XFAIL
 
@@ -1301,3 +1304,18 @@ def test_pre_generated_assumption_rules_are_valid():
     pre_generated_assumptions =_load_pre_generated_assumption_rules()
     generated_assumptions =_generate_assumption_rules()
     assert pre_generated_assumptions._to_python() == generated_assumptions._to_python(), "pre-generated assumptions are invalid, see sympy.core.assumptions._generate_assumption_rules"
+
+
+def test_ask_shuffle():
+    grp = PermutationGroup(Permutation(1, 0, 2), Permutation(2, 1, 3))
+
+    seed(123)
+    first = grp.random()
+    seed(123)
+    simplify(I)
+    second = grp.random()
+    seed(123)
+    simplify(-I)
+    third = grp.random()
+
+    assert first == second == third

--- a/sympy/core/tests/test_random.py
+++ b/sympy/core/tests/test_random.py
@@ -1,7 +1,9 @@
 import random
+from sympy.core.random import random as rand, seed, shuffle, _assumptions_shuffle
 from sympy.core.symbol import Symbol, symbols
 from sympy.functions.elementary.trigonometric import sin, acos
 from sympy.abc import x
+
 
 def test_random():
     random.seed(42)
@@ -28,3 +30,32 @@ def test_random():
     for i in range(4):
         z += sin(random.uniform(-10,10) * x)
     assert y == z
+
+
+def test_seed():
+    assert rand() < 1
+    seed(1)
+    a = rand()
+    b = rand()
+    seed(1)
+    c = rand()
+    d = rand()
+    assert a == c
+    if not c == d:
+        assert a != b
+    else:
+        assert a == b
+
+    abc = 'abc'
+    first = list(abc)
+    second = list(abc)
+    third = list(abc)
+
+    seed(123)
+    shuffle(first)
+
+    seed(123)
+    shuffle(second)
+    _assumptions_shuffle(third)
+
+    assert first == second == third


### PR DESCRIPTION
fix of issue #22592

#### References to other Issues or PRs
Fixes #22592


#### Brief description of what is fixed or changed

added assumption rng to `sympy.core.random` to separate from general rng to avoid side effects on random states by assumption testing.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
   * Fixed a bug where the core assumptions system would sometimes alter the random seed during assumptions queries. Now assumptions queries use a separate RNG.

<!-- END RELEASE NOTES -->
