### PR TITLE
Remove deprecated features in `jordan_block` and `is_diagonalizable`

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1244,15 +1244,6 @@ design flaw and not consistent with how the rest of SymPy works.
 Instead, the {meth}`.TensExpr.replace_with_arrays` method should be
 used.
 
-(deprecated-matrix-is_diagonalizable-cache)=
-### The `clear_cache` and `clear_subproducts` keywords to `Matrix.is_diagonalizable`
-
-The `clear_cache` and `clear_subproducts` keywords to
-[`Matrix.is_diagonalizable()`](sympy.matrices.matrices.MatrixEigen.is_diagonalizable)
-are deprecated. These used to clear cached entries, but this cache was removed
-because it was not actually safe given that `Matrix` is mutable. The keywords
-now do nothing.
-
 (deprecated-matrix-jordan_block-rows-cols)=
 ### The `rows` and `cols` keyword arguments to `Matrix.jordan_block`
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1243,35 +1243,3 @@ design flaw and not consistent with how the rest of SymPy works.
 
 Instead, the {meth}`.TensExpr.replace_with_arrays` method should be
 used.
-
-(deprecated-matrix-jordan_block-rows-cols)=
-### The `rows` and `cols` keyword arguments to `Matrix.jordan_block`
-
-The `rows` and `cols` keywords to
-[`Matrix.jordan_block`](sympy.matrices.common.MatrixCommon.jordan_block) are
-deprecated. The `size` parameter should be used to specify the (square) number
-of rows and columns.
-
-The non-square matrices created by setting `rows` and `cols` are not
-mathematically Jordan block matrices, which only make sense as square
-matrices.
-
-To emulate the deprecated `jordan_block(rows=n, cols=m)` behavior, use a
-general banded matrix constructor, like
-
-```py
->>> from sympy import Matrix, symbols
->>> eigenvalue = symbols('x')
->>> def entry(i, j):
-...     if i == j:
-...         return eigenvalue
-...     elif i + 1 == j: # use j + 1 == i for band='lower'
-...         return 1
-...     return 0
->>> # the same as the deprecated Matrix.jordan_block(rows=3, cols=5, eigenvalue=x)
->>> Matrix(3, 5, entry)
-Matrix([
-[x, 1, 0, 0, 0],
-[0, x, 1, 0, 0],
-[0, 0, x, 1, 0]])
-```

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -22,7 +22,6 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.complexes import Abs, re, im
 from .utilities import _dotprodsimp, _simplify
 from sympy.polys.polytools import Poly
-from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import flatten, is_sequence
 from sympy.utilities.misc import as_int, filldedent
 from sympy.tensor.array import NDimArray

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -799,7 +799,7 @@ class MatrixSpecial(MatrixRequired):
         return cls._new(rows, cols, vals, copy=False)
 
     @classmethod
-    def _eval_jordan_block(cls, rows, cols, eigenvalue, band='upper'):
+    def _eval_jordan_block(cls, size: int, eigenvalue, band='upper'):
         if band == 'lower':
             def entry(i, j):
                 if i == j:
@@ -814,7 +814,7 @@ class MatrixSpecial(MatrixRequired):
                 elif i + 1 == j:
                     return cls.one
                 return cls.zero
-        return cls._new(rows, cols, entry)
+        return cls._new(size, size, entry)
 
     @classmethod
     def _eval_ones(cls, rows, cols):
@@ -1032,15 +1032,6 @@ class MatrixSpecial(MatrixRequired):
             If it is not specified, the class type where the method is
             being executed on will be returned.
 
-        rows, cols : Integer, optional
-            Specifies the shape of the Jordan block matrix. See Notes
-            section for the details of how these key works.
-
-            .. deprecated:: 1.4
-                The rows and cols parameters are deprecated and will be
-                removed in a future version.
-
-
         Returns
         =======
 
@@ -1087,68 +1078,12 @@ class MatrixSpecial(MatrixRequired):
         [0, 0, x, 1],
         [0, 0, 0, x]])
 
-        Notes
-        =====
-
-        .. deprecated:: 1.4
-            This feature is deprecated and will be removed in a future
-            version.
-
-        The keyword arguments ``size``, ``rows``, ``cols`` relates to
-        the Jordan block size specifications.
-
-        If you want to create a square Jordan block, specify either
-        one of the three arguments.
-
-        If you want to create a rectangular Jordan block, specify
-        ``rows`` and ``cols`` individually.
-
-        +--------------------------------+---------------------+
-        |        Arguments Given         |     Matrix Shape    |
-        +----------+----------+----------+----------+----------+
-        |   size   |   rows   |   cols   |   rows   |   cols   |
-        +==========+==========+==========+==========+==========+
-        |   size   |         Any         |   size   |   size   |
-        +----------+----------+----------+----------+----------+
-        |          |        None         |     ValueError      |
-        |          +----------+----------+----------+----------+
-        |   None   |   rows   |   None   |   rows   |   rows   |
-        |          +----------+----------+----------+----------+
-        |          |   None   |   cols   |   cols   |   cols   |
-        +          +----------+----------+----------+----------+
-        |          |   rows   |   cols   |   rows   |   cols   |
-        +----------+----------+----------+----------+----------+
-
         References
         ==========
 
         .. [1] https://en.wikipedia.org/wiki/Jordan_matrix
         """
-        if 'rows' in kwargs or 'cols' in kwargs:
-            msg = """
-                The 'rows' and 'cols' keywords to Matrix.jordan_block() are
-                deprecated. Use the 'size' parameter instead.
-                """
-            if 'rows' in kwargs and 'cols' in kwargs:
-                msg += f"""\
-                To get a non-square Jordan block matrix use a more generic
-                banded matrix constructor, like
-
-                def entry(i, j):
-                    if i == j:
-                        return eigenvalue
-                    elif {"i + 1 == j" if band == 'upper' else "j + 1 == i"}:
-                        return 1
-                    return 0
-
-                Matrix({kwargs['rows']}, {kwargs['cols']}, entry)
-                """
-            sympy_deprecation_warning(msg, deprecated_since_version="1.4",
-                active_deprecations_target="deprecated-matrix-jordan_block-rows-cols")
-
         klass = kwargs.pop('cls', kls)
-        rows = kwargs.pop('rows', None)
-        cols = kwargs.pop('cols', None)
 
         eigenval = kwargs.get('eigenval', None)
         if eigenvalue is None and eigenval is None:
@@ -1161,19 +1096,11 @@ class MatrixSpecial(MatrixRequired):
             if eigenval is not None:
                 eigenvalue = eigenval
 
-        if (size, rows, cols) == (None, None, None):
+        if size is None:
             raise ValueError("Must supply a matrix size")
 
-        if size is not None:
-            rows, cols = size, size
-        elif rows is not None and cols is None:
-            cols = rows
-        elif cols is not None and rows is None:
-            rows = cols
-
-        rows, cols = as_int(rows), as_int(cols)
-
-        return klass._eval_jordan_block(rows, cols, eigenvalue, band)
+        size = as_int(size)
+        return klass._eval_jordan_block(size, eigenvalue, band)
 
     @classmethod
     def ones(kls, rows, cols=None, **kwargs):

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -501,29 +501,6 @@ def _is_diagonalizable(M, reals_only=False, **kwargs):
     is_diagonal
     diagonalize
     """
-
-    if 'clear_cache' in kwargs:
-        sympy_deprecation_warning(
-            """
-            The 'clear_cache' keyword to Matrix.is_diagonalizable is
-            deprecated. It does nothing and should be omitted.
-            """,
-            deprecated_since_version="1.4",
-            active_deprecations_target="deprecated-matrix-is_diagonalizable-cache",
-            stacklevel=4,
-        )
-
-    if 'clear_subproducts' in kwargs:
-        sympy_deprecation_warning(
-            """
-            The 'clear_subproducts' keyword to Matrix.is_diagonalizable is
-            deprecated. It does nothing and should be omitted.
-            """,
-            deprecated_since_version="1.4",
-            active_deprecations_target="deprecated-matrix-is_diagonalizable-cache",
-            stacklevel=4,
-        )
-
     if not M.is_square:
         return False
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -14,7 +14,6 @@ from sympy.polys import roots, CRootOf, ZZ, QQ, EX
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.eigen import dom_eigenvects, dom_eigenvects_to_sympy
 from sympy.polys.polytools import gcd
-from sympy.utilities.exceptions import sympy_deprecation_warning
 
 from .common import MatrixError, NonSquareMatrixError
 from .determinant import _find_reasonable_pivot

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -20,7 +20,7 @@ from sympy.matrices import (Matrix, diag, eye,
     ImmutableSparseMatrix)
 from sympy.polys.polytools import Poly
 from sympy.utilities.iterables import flatten
-from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+from sympy.testing.pytest import raises, XFAIL
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray as Array
 
 from sympy.abc import x, y, z

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1018,29 +1018,6 @@ def test_jordan_block():
     lambda: SpecialOnlyMatrix.jordan_block(
         eigenvalue=2, eigenval=4))
 
-    # Deprecated feature
-    with warns_deprecated_sympy():
-        assert (SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) ==
-                SpecialOnlyMatrix(3, 3, (2, 1, 0, 0, 2, 1, 0, 0, 2)))
-
-    with warns_deprecated_sympy():
-        assert (SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2) ==
-                SpecialOnlyMatrix(3, 3, (2, 1, 0, 0, 2, 1, 0, 0, 2)))
-
-    with warns_deprecated_sympy():
-        assert SpecialOnlyMatrix.jordan_block(3, 2) == \
-            SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) == \
-            SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2)
-
-    with warns_deprecated_sympy():
-        assert SpecialOnlyMatrix.jordan_block(
-            rows=4, cols=3, eigenvalue=2) == \
-            Matrix([
-                [2, 1, 0],
-                [0, 2, 1],
-                [0, 0, 2],
-                [0, 0, 0]])
-
     # Using alias keyword
     assert SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) == \
         SpecialOnlyMatrix.jordan_block(size=3, eigenval=2)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1586,13 +1586,6 @@ def test_issue_15887():
     a[1, 0] = 0
     raises(MatrixError, lambda: a.diagonalize())
 
-    # Test deprecated cache and kwargs
-    with warns_deprecated_sympy():
-        a.is_diagonalizable(clear_cache=True)
-
-    with warns_deprecated_sympy():
-        a.is_diagonalizable(clear_subproducts=True)
-
 
 def test_jordan_form():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16163
Fixes #16208

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Removed `clear_cache, clear_subproduct` keyword argument from `is_diagonalizable` which was deprecated after SymPy 1.4.
  - Removed `rows, cols` keyword argument from `jordan_block` which was deprecated after SymPy 1.4.
 
<!-- END RELEASE NOTES -->
