### PR TITLE
Changed convention in rotation matrices to right hand rule

### DIFF
--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -590,6 +590,21 @@ Matrix Functions
 
 .. autofunction:: sympy.matrices.dense::randMatrix
 
+Rotation matrices in 3D
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: sympy.matrices.dense::rot_axis1
+
+.. autofunction:: sympy.matrices.dense::rot_axis2
+
+.. autofunction:: sympy.matrices.dense::rot_axis3
+
+.. autofunction:: sympy.matrices.dense::rot_ccw_axis1
+
+.. autofunction:: sympy.matrices.dense::rot_ccw_axis2
+
+.. autofunction:: sympy.matrices.dense::rot_ccw_axis3
+
 Numpy Utility Functions
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -598,11 +613,5 @@ Numpy Utility Functions
 .. autofunction:: sympy.matrices.dense::matrix2numpy
 
 .. autofunction:: sympy.matrices.dense::symarray
-
-.. autofunction:: sympy.matrices.dense::rot_axis1
-
-.. autofunction:: sympy.matrices.dense::rot_axis2
-
-.. autofunction:: sympy.matrices.dense::rot_axis3
 
 .. autofunction:: a2idx

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -192,7 +192,7 @@ from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         Adjoint, hadamard_product, HadamardProduct, HadamardPower,
         Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
         DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
-        PermutationMatrix, MatrixPermute, Permanent, per, rot_rh_axis1, 
+        PermutationMatrix, MatrixPermute, Permanent, per, rot_rh_axis1,
         rot_rh_axis2, rot_rh_axis3)
 
 from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -192,8 +192,8 @@ from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         Adjoint, hadamard_product, HadamardProduct, HadamardPower,
         Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
         DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
-        PermutationMatrix, MatrixPermute, Permanent, per, rot_rh_axis1,
-        rot_rh_axis2, rot_rh_axis3)
+        PermutationMatrix, MatrixPermute, Permanent, per, rot_ccw_axis1,
+        rot_ccw_axis2, rot_ccw_axis3)
 
 from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         Segment2D, Ray2D, Line3D, Segment3D, Ray3D, Plane, Ellipse, Circle,

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -428,7 +428,8 @@ __all__ = [
     'HadamardPower', 'Determinant', 'det', 'diagonalize_vector', 'DiagMatrix',
     'DiagonalMatrix', 'DiagonalOf', 'trace', 'DotProduct',
     'kronecker_product', 'KroneckerProduct', 'PermutationMatrix',
-    'MatrixPermute', 'Permanent', 'per',
+    'MatrixPermute', 'Permanent', 'per', 'rot_ccw_axis1', 'rot_ccw_axis2',
+    'rot_ccw_axis3',
 
     # sympy.geometry
     'Point', 'Point2D', 'Point3D', 'Line', 'Ray', 'Segment', 'Line2D',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -192,7 +192,8 @@ from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         Adjoint, hadamard_product, HadamardProduct, HadamardPower,
         Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
         DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
-        PermutationMatrix, MatrixPermute, Permanent, per)
+        PermutationMatrix, MatrixPermute, Permanent, per, rot_rh_axis1, 
+        rot_rh_axis2, rot_rh_axis3)
 
 from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         Segment2D, Ray2D, Line3D, Segment3D, Ray3D, Plane, Ellipse, Circle,

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -7,8 +7,8 @@ from .common import ShapeError, NonSquareMatrixError, MatrixKind
 from .dense import (
     GramSchmidt, casoratian, diag, eye, hessian, jordan_cell,
     list2numpy, matrix2numpy, matrix_multiply_elementwise, ones,
-    randMatrix, rot_axis1, rot_axis2, rot_axis3, rot_rh_axis1,
-    rot_rh_axis2, rot_rh_axis3, symarray, wronskian, zeros)
+    randMatrix, rot_axis1, rot_axis2, rot_axis3, rot_ccw_axis1,
+    rot_ccw_axis2, rot_ccw_axis3, symarray, wronskian, zeros)
 from .dense import MutableDenseMatrix
 from .matrices import DeferredVector, MatrixBase
 

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -39,7 +39,7 @@ __all__ = [
     'GramSchmidt', 'casoratian', 'diag', 'eye', 'hessian', 'jordan_cell',
     'list2numpy', 'matrix2numpy', 'matrix_multiply_elementwise', 'ones',
     'randMatrix', 'rot_axis1', 'rot_axis2', 'rot_axis3', 'symarray',
-    'wronskian', 'zeros',
+    'wronskian', 'zeros', 'rot_ccw_axis1', 'rot_ccw_axis2', 'rot_ccw_axis3',
 
     'MutableDenseMatrix',
 

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -7,7 +7,7 @@ from .common import ShapeError, NonSquareMatrixError, MatrixKind
 from .dense import (
     GramSchmidt, casoratian, diag, eye, hessian, jordan_cell,
     list2numpy, matrix2numpy, matrix_multiply_elementwise, ones,
-    randMatrix, rot_axis1, rot_axis2, rot_axis3, rot_rh_axis1, 
+    randMatrix, rot_axis1, rot_axis2, rot_axis3, rot_rh_axis1,
     rot_rh_axis2, rot_rh_axis3, symarray, wronskian, zeros)
 from .dense import MutableDenseMatrix
 from .matrices import DeferredVector, MatrixBase

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -7,8 +7,8 @@ from .common import ShapeError, NonSquareMatrixError, MatrixKind
 from .dense import (
     GramSchmidt, casoratian, diag, eye, hessian, jordan_cell,
     list2numpy, matrix2numpy, matrix_multiply_elementwise, ones,
-    randMatrix, rot_axis1, rot_axis2, rot_axis3, symarray, wronskian,
-    zeros)
+    randMatrix, rot_axis1, rot_axis2, rot_axis3, rot_rh_axis1, 
+    rot_rh_axis2, rot_rh_axis3, symarray, wronskian, zeros)
 from .dense import MutableDenseMatrix
 from .matrices import DeferredVector, MatrixBase
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -166,7 +166,10 @@ def matrix2numpy(m, dtype=object):  # pragma: no cover
 
 def rot_axis3(theta):
     """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 3-axis.
+    the 3-axis in the left-hand convention.
+
+    For the more usual right-hand convention, use:
+        rot_axis3(-theta)
 
     Examples
     ========
@@ -178,17 +181,17 @@ def rot_axis3(theta):
     >>> theta = pi/3
     >>> rot_axis3(theta)
     Matrix([
-    [      1/2, -sqrt(3)/2, 0],
-    [sqrt(3)/2,        1/2, 0],
-    [        0,          0, 1]])
+    [       1/2, sqrt(3)/2, 0],
+    [-sqrt(3)/2,       1/2, 0],
+    [         0,         0, 1]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis3(pi/2)
     Matrix([
-    [0, -1, 0],
-    [1,  0, 0],
-    [0,  0, 1]])
+    [ 0, 1, 0],
+    [-1, 0, 0],
+    [ 0, 0, 1]])
 
     See Also
     ========
@@ -200,15 +203,18 @@ def rot_axis3(theta):
     """
     ct = cos(theta)
     st = sin(theta)
-    lil = ((ct, -st, 0),
-           (st, ct, 0),
+    lil = ((ct, st, 0),
+           (-st, ct, 0),
            (0, 0, 1))
     return Matrix(lil)
 
 
 def rot_axis2(theta):
     """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 2-axis.
+    the 2-axis in the left-hand convention.
+
+    For the more usual right-hand convention, use:
+        rot_axis2(-theta)
 
     Examples
     ========
@@ -220,17 +226,17 @@ def rot_axis2(theta):
     >>> theta = pi/3
     >>> rot_axis2(theta)
     Matrix([
-    [       1/2, 0, sqrt(3)/2],
-    [         0, 1,         0],
-    [-sqrt(3)/2, 0,       1/2]])
+    [      1/2, 0, -sqrt(3)/2],
+    [        0, 1,          0],
+    [sqrt(3)/2, 0,        1/2]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis2(pi/2)
     Matrix([
-    [ 0, 0, 1],
-    [ 0, 1, 0],
-    [-1, 0, 0]])
+    [0, 0, -1],
+    [0, 1,  0],
+    [1, 0,  0]])
 
     See Also
     ========
@@ -242,15 +248,18 @@ def rot_axis2(theta):
     """
     ct = cos(theta)
     st = sin(theta)
-    lil = ((ct, 0, st),
+    lil = ((ct, 0, -st),
            (0, 1, 0),
-           (-st, 0, ct))
+           (st, 0, ct))
     return Matrix(lil)
 
 
 def rot_axis1(theta):
     """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 1-axis.
+    the 1-axis in the left-hand convention.
+
+    For the more usual right-hand convention, use:
+        rot_axis1(-theta)
 
     Examples
     ========
@@ -262,17 +271,17 @@ def rot_axis1(theta):
     >>> theta = pi/3
     >>> rot_axis1(theta)
     Matrix([
-    [1,          0,          0],
-    [0,        1/2, -sqrt(3)/2],
-    [0,  sqrt(3)/2,        1/2]])
+    [1,          0,         0],
+    [0,        1/2, sqrt(3)/2],
+    [0, -sqrt(3)/2,       1/2]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis1(pi/2)
     Matrix([
-    [1, 0,  0],
-    [0, 0, -1],
-    [0, 1,  0]])
+    [1,  0, 0],
+    [0,  0, 1],
+    [0, -1, 0]])
 
     See Also
     ========
@@ -285,8 +294,8 @@ def rot_axis1(theta):
     ct = cos(theta)
     st = sin(theta)
     lil = ((1, 0, 0),
-           (0, ct, -st),
-           (0, st, ct))
+           (0, ct, st),
+           (0, -st, ct))
     return Matrix(lil)
 
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -299,6 +299,132 @@ def rot_axis1(theta):
     return Matrix(lil)
 
 
+def rot_rh_axis3(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) about
+    the 3-axis in the right-hand convention.
+
+    For the less usual less-hand convention, use:
+        rot_rh_axis3(-theta)
+    Or:
+        rot_axis3(theta)
+
+    Examples
+    ========
+
+    >>> from sympy import pi, rot_rh_axis3
+
+    A rotation of pi/3 (60 degrees):
+
+    >>> theta = pi/3
+    >>> rot_rh_axis3(theta)
+    Matrix([
+    [      1/2, -sqrt(3)/2, 0],
+    [sqrt(3)/2,        1/2, 0],
+    [        0,          0, 1]])
+
+    If we rotate by pi/2 (90 degrees):
+
+    >>> rot_rh_axis3(pi/2)
+    Matrix([
+    [0, -1, 0],
+    [1,  0, 0],
+    [0,  0, 1]])
+
+    See Also
+    ========
+
+    rot_rh_axis1: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 1-axis
+    rot_rh_axis2: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 2-axis
+    """
+    return rot_axis3(-theta)
+
+
+def rot_rh_axis2(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) about
+    the 2-axis in the right-hand convention.
+
+    For the less usual less-hand convention, use:
+        rot_rh_axis2(-theta)
+    Or:
+        rot_axis2(theta)
+
+    Examples
+    ========
+
+    >>> from sympy import pi, rot_rh_axis2
+
+    A rotation of pi/3 (60 degrees):
+
+    >>> theta = pi/3
+    >>> rot_rh_axis2(theta)
+    Matrix([
+    [       1/2, 0, sqrt(3)/2],
+    [         0, 1,         0],
+    [-sqrt(3)/2, 0,       1/2]])
+
+    If we rotate by pi/2 (90 degrees):
+
+    >>> rot_rh_axis2(pi/2)
+    Matrix([
+    [ 0,  0,  1],
+    [ 0,  1,  0],
+    [-1,  0,  0]])
+
+    See Also
+    ========
+
+    rot_rh_axis1: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 1-axis
+    rot_rh_axis3: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 3-axis
+    """
+    return rot_axis2(-theta)
+
+
+def rot_rh_axis1(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) about
+    the 1-axis in the right-hand convention.
+
+    For the less usual less-hand convention, use:
+        rot_rh_axis1(-theta)
+    Or:
+        rot_axis1(theta)
+
+    Examples
+    ========
+
+    >>> from sympy import pi, rot_rh_axis1
+
+    A rotation of pi/3 (60 degrees):
+
+    >>> theta = pi/3
+    >>> rot_rh_axis1(theta)
+    Matrix([
+    [1,         0,          0],
+    [0,       1/2, -sqrt(3)/2],
+    [0, sqrt(3)/2,        1/2]])
+
+    If we rotate by pi/2 (90 degrees):
+
+    >>> rot_rh_axis1(pi/2)
+    Matrix([
+    [1, 0,  0],
+    [0, 0, -1],
+    [0, 1,  0]])
+
+    See Also
+    ========
+
+    rot_rh_axis2: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 2-axis
+    rot_rh_axis3: Returns a rotation matrix for a rotation of theta (in radians)
+        about the 3-axis
+    """
+    return rot_axis1(-theta)
+
+
 @doctest_depends_on(modules=('numpy',))
 def symarray(prefix, shape, **kwargs):  # pragma: no cover
     r"""Create a numpy ndarray of symbols (as an object array).

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -129,7 +129,7 @@ MutableMatrix = Matrix = MutableDenseMatrix
 
 ###########
 # Numpy Utility Functions:
-# list2numpy, matrix2numpy, symmarray, rot_axis[123]
+# list2numpy, matrix2numpy, symmarray
 ###########
 
 
@@ -207,6 +207,12 @@ def rot_axis3(theta):
            (-st, ct, 0),
            (0, 0, 1))
     return Matrix(lil)
+
+
+###########
+# Rotation matrices in 3D:
+# rot_axis[123], rot_ccw_axis[123]
+###########
 
 
 def rot_axis2(theta):

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -165,10 +165,10 @@ def matrix2numpy(m, dtype=object):  # pragma: no cover
 
 
 def rot_axis3(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 3-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     clockwise rotation.
 
     Examples
@@ -210,10 +210,10 @@ def rot_axis3(theta):
 
 
 def rot_axis2(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 2-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     clockwise rotation.
 
     Examples
@@ -255,10 +255,10 @@ def rot_axis2(theta):
 
 
 def rot_axis1(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 1-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     clockwise rotation.
 
     Examples
@@ -300,10 +300,10 @@ def rot_axis1(theta):
 
 
 def rot_ccw_axis3(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 3-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     counterclockwise rotation.
 
     Examples
@@ -340,10 +340,10 @@ def rot_ccw_axis3(theta):
 
 
 def rot_ccw_axis2(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 2-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     counterclockwise rotation.
 
     Examples
@@ -380,10 +380,10 @@ def rot_ccw_axis2(theta):
 
 
 def rot_ccw_axis1(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) 
+    """Returns a rotation matrix for a rotation of theta (in radians)
     about the 1-axis.
 
-    For a right-handed coordinate system, this corresponds to a 
+    For a right-handed coordinate system, this corresponds to a
     counterclockwise rotation.
 
     Examples

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -165,11 +165,11 @@ def matrix2numpy(m, dtype=object):  # pragma: no cover
 
 
 def rot_axis3(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 3-axis in the left-hand convention.
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 3-axis.
 
-    For the more usual right-hand convention, use:
-        rot_axis3(-theta)
+    For a right-handed coordinate system, this corresponds to a 
+    clockwise rotation.
 
     Examples
     ========
@@ -210,11 +210,11 @@ def rot_axis3(theta):
 
 
 def rot_axis2(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 2-axis in the left-hand convention.
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 2-axis.
 
-    For the more usual right-hand convention, use:
-        rot_axis2(-theta)
+    For a right-handed coordinate system, this corresponds to a 
+    clockwise rotation.
 
     Examples
     ========
@@ -255,11 +255,11 @@ def rot_axis2(theta):
 
 
 def rot_axis1(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 1-axis in the left-hand convention.
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 1-axis.
 
-    For the more usual right-hand convention, use:
-        rot_axis1(-theta)
+    For a right-handed coordinate system, this corresponds to a 
+    clockwise rotation.
 
     Examples
     ========
@@ -299,24 +299,22 @@ def rot_axis1(theta):
     return Matrix(lil)
 
 
-def rot_rh_axis3(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 3-axis in the right-hand convention.
+def rot_ccw_axis3(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 3-axis.
 
-    For the less usual less-hand convention, use:
-        rot_rh_axis3(-theta)
-    Or:
-        rot_axis3(theta)
+    For a right-handed coordinate system, this corresponds to a 
+    counterclockwise rotation.
 
     Examples
     ========
 
-    >>> from sympy import pi, rot_rh_axis3
+    >>> from sympy import pi, rot_ccw_axis3
 
     A rotation of pi/3 (60 degrees):
 
     >>> theta = pi/3
-    >>> rot_rh_axis3(theta)
+    >>> rot_ccw_axis3(theta)
     Matrix([
     [      1/2, -sqrt(3)/2, 0],
     [sqrt(3)/2,        1/2, 0],
@@ -324,7 +322,7 @@ def rot_rh_axis3(theta):
 
     If we rotate by pi/2 (90 degrees):
 
-    >>> rot_rh_axis3(pi/2)
+    >>> rot_ccw_axis3(pi/2)
     Matrix([
     [0, -1, 0],
     [1,  0, 0],
@@ -333,32 +331,30 @@ def rot_rh_axis3(theta):
     See Also
     ========
 
-    rot_rh_axis1: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis1: Returns a rotation matrix for a rotation of theta (in radians)
         about the 1-axis
-    rot_rh_axis2: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis2: Returns a rotation matrix for a rotation of theta (in radians)
         about the 2-axis
     """
     return rot_axis3(-theta)
 
 
-def rot_rh_axis2(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 2-axis in the right-hand convention.
+def rot_ccw_axis2(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 2-axis.
 
-    For the less usual less-hand convention, use:
-        rot_rh_axis2(-theta)
-    Or:
-        rot_axis2(theta)
+    For a right-handed coordinate system, this corresponds to a 
+    counterclockwise rotation.
 
     Examples
     ========
 
-    >>> from sympy import pi, rot_rh_axis2
+    >>> from sympy import pi, rot_ccw_axis2
 
     A rotation of pi/3 (60 degrees):
 
     >>> theta = pi/3
-    >>> rot_rh_axis2(theta)
+    >>> rot_ccw_axis2(theta)
     Matrix([
     [       1/2, 0, sqrt(3)/2],
     [         0, 1,         0],
@@ -366,7 +362,7 @@ def rot_rh_axis2(theta):
 
     If we rotate by pi/2 (90 degrees):
 
-    >>> rot_rh_axis2(pi/2)
+    >>> rot_ccw_axis2(pi/2)
     Matrix([
     [ 0,  0,  1],
     [ 0,  1,  0],
@@ -375,32 +371,30 @@ def rot_rh_axis2(theta):
     See Also
     ========
 
-    rot_rh_axis1: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis1: Returns a rotation matrix for a rotation of theta (in radians)
         about the 1-axis
-    rot_rh_axis3: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis3: Returns a rotation matrix for a rotation of theta (in radians)
         about the 3-axis
     """
     return rot_axis2(-theta)
 
 
-def rot_rh_axis1(theta):
-    """Returns a rotation matrix for a rotation of theta (in radians) about
-    the 1-axis in the right-hand convention.
+def rot_ccw_axis1(theta):
+    """Returns a rotation matrix for a rotation of theta (in radians) 
+    about the 1-axis.
 
-    For the less usual less-hand convention, use:
-        rot_rh_axis1(-theta)
-    Or:
-        rot_axis1(theta)
+    For a right-handed coordinate system, this corresponds to a 
+    counterclockwise rotation.
 
     Examples
     ========
 
-    >>> from sympy import pi, rot_rh_axis1
+    >>> from sympy import pi, rot_ccw_axis1
 
     A rotation of pi/3 (60 degrees):
 
     >>> theta = pi/3
-    >>> rot_rh_axis1(theta)
+    >>> rot_ccw_axis1(theta)
     Matrix([
     [1,         0,          0],
     [0,       1/2, -sqrt(3)/2],
@@ -408,7 +402,7 @@ def rot_rh_axis1(theta):
 
     If we rotate by pi/2 (90 degrees):
 
-    >>> rot_rh_axis1(pi/2)
+    >>> rot_ccw_axis1(pi/2)
     Matrix([
     [1, 0,  0],
     [0, 0, -1],
@@ -417,9 +411,9 @@ def rot_rh_axis1(theta):
     See Also
     ========
 
-    rot_rh_axis2: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis2: Returns a rotation matrix for a rotation of theta (in radians)
         about the 2-axis
-    rot_rh_axis3: Returns a rotation matrix for a rotation of theta (in radians)
+    rot_ccw_axis3: Returns a rotation matrix for a rotation of theta (in radians)
         about the 3-axis
     """
     return rot_axis1(-theta)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -178,17 +178,17 @@ def rot_axis3(theta):
     >>> theta = pi/3
     >>> rot_axis3(theta)
     Matrix([
-    [       1/2, sqrt(3)/2, 0],
-    [-sqrt(3)/2,       1/2, 0],
-    [         0,         0, 1]])
+    [      1/2, -sqrt(3)/2, 0],
+    [sqrt(3)/2,        1/2, 0],
+    [        0,          0, 1]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis3(pi/2)
     Matrix([
-    [ 0, 1, 0],
-    [-1, 0, 0],
-    [ 0, 0, 1]])
+    [0, -1, 0],
+    [1,  0, 0],
+    [0,  0, 1]])
 
     See Also
     ========
@@ -200,8 +200,8 @@ def rot_axis3(theta):
     """
     ct = cos(theta)
     st = sin(theta)
-    lil = ((ct, st, 0),
-           (-st, ct, 0),
+    lil = ((ct, -st, 0),
+           (st, ct, 0),
            (0, 0, 1))
     return Matrix(lil)
 
@@ -220,17 +220,17 @@ def rot_axis2(theta):
     >>> theta = pi/3
     >>> rot_axis2(theta)
     Matrix([
-    [      1/2, 0, -sqrt(3)/2],
-    [        0, 1,          0],
-    [sqrt(3)/2, 0,        1/2]])
+    [       1/2, 0, sqrt(3)/2],
+    [         0, 1,         0],
+    [-sqrt(3)/2, 0,       1/2]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis2(pi/2)
     Matrix([
-    [0, 0, -1],
-    [0, 1,  0],
-    [1, 0,  0]])
+    [ 0, 0, 1],
+    [ 0, 1, 0],
+    [-1, 0, 0]])
 
     See Also
     ========
@@ -242,9 +242,9 @@ def rot_axis2(theta):
     """
     ct = cos(theta)
     st = sin(theta)
-    lil = ((ct, 0, -st),
+    lil = ((ct, 0, st),
            (0, 1, 0),
-           (st, 0, ct))
+           (-st, 0, ct))
     return Matrix(lil)
 
 
@@ -262,17 +262,17 @@ def rot_axis1(theta):
     >>> theta = pi/3
     >>> rot_axis1(theta)
     Matrix([
-    [1,          0,         0],
-    [0,        1/2, sqrt(3)/2],
-    [0, -sqrt(3)/2,       1/2]])
+    [1,          0,          0],
+    [0,        1/2, -sqrt(3)/2],
+    [0,  sqrt(3)/2,        1/2]])
 
     If we rotate by pi/2 (90 degrees):
 
     >>> rot_axis1(pi/2)
     Matrix([
-    [1,  0, 0],
-    [0,  0, 1],
-    [0, -1, 0]])
+    [1, 0,  0],
+    [0, 0, -1],
+    [0, 1,  0]])
 
     See Also
     ========
@@ -285,8 +285,8 @@ def rot_axis1(theta):
     ct = cos(theta)
     st = sin(theta)
     lil = ((1, 0, 0),
-           (0, ct, st),
-           (0, -st, ct))
+           (0, ct, -st),
+           (0, st, ct))
     return Matrix(lil)
 
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -27,7 +27,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
-    MatrixSymbol, dotprodsimp)
+    MatrixSymbol, dotprodsimp, rot_rh_axis1, rot_rh_axis2, rot_rh_axis3)
 from sympy.matrices.utilities import _dotprodsimp_state
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -2313,6 +2313,10 @@ def test_rotation_matrices():
     assert rot_axis1(- pi / 2) == q1.to_rotation_matrix()
     assert rot_axis2(- pi / 2) == q2.to_rotation_matrix()
     assert rot_axis3(- pi / 2) == q3.to_rotation_matrix()
+    # Check right-hand convention
+    assert rot_rh_axis1(+ pi / 2) == q1.to_rotation_matrix()
+    assert rot_rh_axis2(+ pi / 2) == q2.to_rotation_matrix()
+    assert rot_rh_axis3(+ pi / 2) == q3.to_rotation_matrix()
 
 
 def test_DeferredVector():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -39,6 +39,7 @@ from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
 from sympy.external import import_module
+from sympy.algebras import Quaternion
 
 from sympy.abc import a, b, c, d, x, y, z, t
 
@@ -2303,6 +2304,15 @@ def test_rotation_matrices():
     assert rot_axis1(0) == eye(3)
     assert rot_axis2(0) == eye(3)
     assert rot_axis3(0) == eye(3)
+
+    # Check right-hand convention
+    # see Issue #24529
+    q1 = Quaternion.from_axis_angle([1, 0, 0], pi / 2)
+    q2 = Quaternion.from_axis_angle([0, 1, 0], pi / 2)
+    q3 = Quaternion.from_axis_angle([0, 0, 1], pi / 2)
+    assert rot_axis1(pi / 2) == q1.to_rotation_matrix()
+    assert rot_axis2(pi / 2) == q2.to_rotation_matrix()
+    assert rot_axis3(pi / 2) == q3.to_rotation_matrix()
 
 
 def test_DeferredVector():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2305,14 +2305,14 @@ def test_rotation_matrices():
     assert rot_axis2(0) == eye(3)
     assert rot_axis3(0) == eye(3)
 
-    # Check right-hand convention
+    # Check left-hand convention
     # see Issue #24529
     q1 = Quaternion.from_axis_angle([1, 0, 0], pi / 2)
     q2 = Quaternion.from_axis_angle([0, 1, 0], pi / 2)
     q3 = Quaternion.from_axis_angle([0, 0, 1], pi / 2)
-    assert rot_axis1(pi / 2) == q1.to_rotation_matrix()
-    assert rot_axis2(pi / 2) == q2.to_rotation_matrix()
-    assert rot_axis3(pi / 2) == q3.to_rotation_matrix()
+    assert rot_axis1(- pi / 2) == q1.to_rotation_matrix()
+    assert rot_axis2(- pi / 2) == q2.to_rotation_matrix()
+    assert rot_axis3(- pi / 2) == q3.to_rotation_matrix()
 
 
 def test_DeferredVector():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -27,7 +27,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
-    MatrixSymbol, dotprodsimp, rot_rh_axis1, rot_rh_axis2, rot_rh_axis3)
+    MatrixSymbol, dotprodsimp, rot_ccw_axis1, rot_ccw_axis2, rot_ccw_axis3)
 from sympy.matrices.utilities import _dotprodsimp_state
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -2314,9 +2314,9 @@ def test_rotation_matrices():
     assert rot_axis2(- pi / 2) == q2.to_rotation_matrix()
     assert rot_axis3(- pi / 2) == q3.to_rotation_matrix()
     # Check right-hand convention
-    assert rot_rh_axis1(+ pi / 2) == q1.to_rotation_matrix()
-    assert rot_rh_axis2(+ pi / 2) == q2.to_rotation_matrix()
-    assert rot_rh_axis3(+ pi / 2) == q3.to_rotation_matrix()
+    assert rot_ccw_axis1(+ pi / 2) == q1.to_rotation_matrix()
+    assert rot_ccw_axis2(+ pi / 2) == q2.to_rotation_matrix()
+    assert rot_ccw_axis3(+ pi / 2) == q3.to_rotation_matrix()
 
 
 def test_DeferredVector():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24528

#### Brief description of what is fixed or changed
Changed the convention in rotation matrix functions in `matrices.dense`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added 3D rotation matrices for counterclockwise rotation.
<!-- END RELEASE NOTES -->
