### PR TITLE
Printing: Fixes UnevaluatedExpr.is_commutative is None 

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4062,6 +4062,9 @@ class UnevaluatedExpr(Expr):
         else:
             return self.args[0]
 
+    def _eval_is_commutative(self):
+        return self.args[0].is_commutative
+
 
 
 def unchanged(func, *args):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4062,10 +4062,6 @@ class UnevaluatedExpr(Expr):
         else:
             return self.args[0]
 
-    def _eval_is_commutative(self):
-        return self.args[0].is_commutative
-
-
 
 def unchanged(func, *args):
     """Return True if `func` applied to the `args` is unchanged.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2088,6 +2088,7 @@ def test_held_expression_UnevaluatedExpr():
     x2 = UnevaluatedExpr(2)*2
     assert type(x2) is Mul
     assert x2.args == (2, UnevaluatedExpr(2))
+    assert str(1/UnevaluatedExpr(sqrt(pi))) == '1/(sqrt(pi))'
 
 def test_round_exception_nostr():
     # Don't use the string form of the expression in the round exception, as

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2067,7 +2067,7 @@ class PrettyPrinter(Printer):
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
-        if power.is_commutative :
+        if power.is_commutative:
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1994,7 +1994,7 @@ class PrettyPrinter(Printer):
 
         # Gather terms for numerator/denominator
         for item in args:
-            if item.is_commutative is not False and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
+            if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
@@ -2067,7 +2067,7 @@ class PrettyPrinter(Printer):
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
-        if power.is_commutative is not False:
+        if power.is_commutative:
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1994,7 +1994,7 @@ class PrettyPrinter(Printer):
 
         # Gather terms for numerator/denominator
         for item in args:
-            if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
+            if item.is_commutative is not False and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
@@ -2067,7 +2067,7 @@ class PrettyPrinter(Printer):
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
-        if power.is_commutative:
+        if power.is_commutative is not False:
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2067,7 +2067,7 @@ class PrettyPrinter(Printer):
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
-        if power.is_commutative is not False:
+        if power.is_commutative :
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -342,7 +342,7 @@ class StrPrinter(Printer):
                 return i.func(b, e, evaluate=False)
             return i.func(e, evaluate=False)
         for item in args:
-            if (item.is_commutative is not False and
+            if (item.is_commutative and
                     isinstance(item, Pow) and
                     bool(item.exp.as_coeff_Mul()[0] < 0)):
                 if item.exp is not S.NegativeOne:
@@ -649,7 +649,7 @@ class StrPrinter(Printer):
         if expr.exp is S.Half and not rational:
             return "sqrt(%s)" % self._print(expr.base)
 
-        if expr.is_commutative is not False:
+        if expr.is_commutative:
             if -expr.exp is S.Half and not rational:
                 # Note: Don't test "expr.exp == -S.Half" here, because that will
                 # match -0.5, which we don't want.

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -342,7 +342,7 @@ class StrPrinter(Printer):
                 return i.func(b, e, evaluate=False)
             return i.func(e, evaluate=False)
         for item in args:
-            if (item.is_commutative and
+            if (item.is_commutative is not False and
                     isinstance(item, Pow) and
                     bool(item.exp.as_coeff_Mul()[0] < 0)):
                 if item.exp is not S.NegativeOne:
@@ -649,7 +649,7 @@ class StrPrinter(Printer):
         if expr.exp is S.Half and not rational:
             return "sqrt(%s)" % self._print(expr.base)
 
-        if expr.is_commutative:
+        if expr.is_commutative is not False:
             if -expr.exp is S.Half and not rational:
                 # Note: Don't test "expr.exp == -S.Half" here, because that will
                 # match -0.5, which we don't want.

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1155,6 +1155,10 @@ def test_diffgeom():
     b = BaseScalarField(rect, 0)
     assert str(b) == "x"
 
+def test_issue_19345():
+    assert str(1/UnevaluatedExpr(sqrt(pi))) == '1/(sqrt(pi))'
+
+
 def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=True) == '1.00000000000000'
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -224,6 +224,9 @@ def test_AccumBounds():
     assert str(AccumBounds(0, a)) == "AccumBounds(0, a)"
     assert str(AccumBounds(0, 1)) == "AccumBounds(0, 1)"
 
+def test_issue_19435():
+    assert str(1/UnevaluatedExpr(sqrt(pi))) == '1/(sqrt(pi))'
+
 
 def test_Lambda():
     assert str(Lambda(d, d**2)) == "Lambda(_d, _d**2)"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1155,10 +1155,6 @@ def test_diffgeom():
     b = BaseScalarField(rect, 0)
     assert str(b) == "x"
 
-def test_issue_19345():
-    assert str(1/UnevaluatedExpr(sqrt(pi))) == '1/(sqrt(pi))'
-
-
 def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=True) == '1.00000000000000'
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -161,7 +161,7 @@ def test_latex_printing():
                             '\\hat{k}_{N}}\\right)')
 
 def test_issue_23058():
-    from sympy import symbols, sin, cos, pi, UnevaluatedExpr
+    from sympy import symbols, sin, cos, pi
 
     delop = Del()
     CC_   = CoordSys3D("C")

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -198,9 +198,8 @@ def test_issue_23058():
     assert upretty(vecB) == vecB_str
     assert upretty(vecE) == vecE_str
 
-    ten = UnevaluatedExpr(10)
+    ten = symbols('10', commutative=False)
     eps, mu = 4*pi*ten**(-11), ten**(-5)
-
     Bx = 2 * ten**(-4) * cos(ten**5 * t) * sin(ten**(-3) * y)
     vecB = Bx * xhat
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19435 


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 
<!-- END RELEASE NOTES -->
