### PR TITLE
Subset Construction Algorithm for Finite State Machine

### DIFF
--- a/doc/src/modules/combinatorics/fsm.rst
+++ b/doc/src/modules/combinatorics/fsm.rst
@@ -1,0 +1,78 @@
+Finite State Machine
+====================
+
+.. module:: sympy.combinatorics.rewritingsystem_fsm
+
+Finite State Machine Representation
+-----------------------------------
+
+Given:
+
+- Type of state symbols $N$
+- Type of input symbols $T$
+
+We make two definitions of finite state machines below:
+
+Nondeterministic Finite State Machine
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A transition table for nondeterministic finite state machine is defined as a
+mapping:
+
+.. math::
+    \delta: N \to (T \to 2^N)
+
+Where each state symbols maps to a mapping between input symbols and the set
+of state symbols.
+
+If the current state is $A \in N$ and the input alphabet is $a \in T$,
+and if $B \in \delta(A)(a)$, then it is possible to make a transition
+from $A$ to $B$ in the finite state machine when the input symbol is $a$.
+
+Similarly, a transition table for nondeterministic finite state machine with
+empty input ($\epsilon$) is defined as a mapping:
+
+.. math::
+    \delta: N \to ((T | \epsilon) \to 2^N)
+
+Where the singleton type for $\epsilon$ is appended to the types of
+input symbols.
+
+If the current state is $A \in N$ and if $B \in \delta(A)(\epsilon)$,
+it is possible to make a transition from $A$ to $B$ without taking any input
+symbol.
+
+Deterministic Finite State Machine
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A transition table for deterministic finite state machine is defined as a
+mapping:
+
+.. math::
+    \delta: N \to (T \to N)
+
+If $A \in N$ is the current state symbol and if $a \in T$ is the input symbol,
+$a$ should exist in the domain of $\delta(A)$ for it to be possible to make any
+transition. And for each $a$ in the domain, there is only one symbol
+$B = \delta(A)(a)$ for the transition.
+
+NFA to DFA Conversion
+---------------------
+
+.. autofunction:: epsilon_closure
+
+.. autofunction:: instructions
+
+.. autofunction:: subset_construction
+
+.. autofunction:: subset_construction_epsilon
+
+TODO
+----
+
+There is an educational framework of finite state machine to have reference
+implementation like
+http://www.cs.um.edu.mt/gordon.pace/Research/Software/Relic/
+
+If you want to fill in some nontrivial computation of finite state machine to
+use in generic symbolic computation, things can be added here.

--- a/doc/src/modules/combinatorics/index.rst
+++ b/doc/src/modules/combinatorics/index.rst
@@ -25,3 +25,4 @@ Contents
    tensor_can.rst
    fp_groups.rst
    pc_groups.rst
+   fsm.rst

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+from typing import TypeVar, Mapping, Collection, DefaultDict
+
+
 class State:
     '''
     A representation of a state managed by a ``StateMachine``.
@@ -58,3 +62,433 @@ class StateMachine:
 
     def __repr__(self):
         return "%s" % (self.name)
+
+
+_N = TypeVar('_N')
+_T = TypeVar('_T')
+
+
+def epsilon_closure(
+    transition: Mapping[_N, Mapping[_T, Collection[_N]]],
+    epsilon: _T,
+    states: Collection[_N]
+) -> set[_N]:
+    r"""Compute the $\epsilon$ closure for a nondeterministic finite state
+    machine.
+
+    Explanation
+    ===========
+
+    Given a transition table for nondeterministic finite state machine with
+    $\epsilon$ is defined as a mapping:
+
+    .. math::
+        N \to ((T | \epsilon) \to 2^N)
+
+    And given the initial set $S$ of states in $2^N$,
+    the $\epsilon$ closure is defined as a set of all states reachable by the
+    elements of $S$ by $\epsilon$ transitions in zero or finite number of
+    steps.
+
+    Parameters
+    ==========
+
+    transition: Mapping[N, Mapping[T, Collection[N]]]
+        A transition table of nondeterministic finite machine in the type
+        $N \to ((T | \epsilon) \to 2^N)$ represented as a dictionary of
+        dictionaries of sets.
+
+    epsilon: T
+        An empty transition symbol $\epsilon$.
+
+    states: Collection[N]
+        A set of initial states of type $2^N$.
+
+    Returns
+    =======
+
+    set[N]
+        A set of states of type $2^N$ which is reflexively-transitively closed
+        under $\epsilon$ transition.
+
+    Examples
+    ========
+
+    Computing the $\epsilon$ closure of a nondeterministic finite state machine
+    for a single state:
+
+    >>> from sympy.combinatorics.rewritingsystem_fsm import epsilon_closure
+
+    >>> transition = {
+    ...     0: {'e': {1, 7}},
+    ...     1: {'e': {2, 4}},
+    ...     2: {'a': {3}},
+    ...     3: {'e': {6}},
+    ...     4: {'b': {5}},
+    ...     5: {'e': {6}},
+    ...     6: {'e': {1, 7}},
+    ...     7: {'a': {8}},
+    ...     8: {'b': {9}},
+    ...     9: {'b': {10}},
+    ... }
+    >>> epsilon_closure(transition, 'e', {0})
+    {0, 1, 2, 4, 7}
+
+    Computing the $\epsilon$ closure of a nondeterministic finite state machine
+    for multiple states:
+
+    >>> epsilon_closure(transition, 'e', {3, 8})
+    {1, 2, 3, 4, 6, 7, 8}
+
+    References
+    ==========
+
+    .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
+       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+    """
+    stack: list[_N] = list(states)
+    closure = set(stack)
+
+    while stack:
+        state = stack.pop()
+        if state not in transition:
+            continue
+
+        if epsilon not in transition[state]:
+            continue
+
+        for new_state in transition[state][epsilon]:
+            if new_state not in closure:
+                closure.add(new_state)
+                stack.append(new_state)
+
+    return closure
+
+
+def instructions(
+    transition: Mapping[_N, Mapping[_T, Collection[_N]]],
+    states: Collection[_N],
+) -> DefaultDict[_T, set[_N]]:
+    r"""Compute the union of instructions from the given set of input states.
+
+    Explanation
+    ===========
+
+    Given a transition table for nondeterministic finite state machine defined
+    as a mapping:
+
+    .. math::
+        \delta: N \to (T \to 2^N)
+
+    And given the initial set $S$ of states in $2^N$,
+    the instructions from $S$ is defined as a mapping:
+
+    .. math::
+        \delta': T \to 2^N
+
+    where
+
+    .. math::
+        \delta'(a) = \bigcup_{A \in S} \delta(A)(a)
+
+    Parameters
+    ==========
+
+    transition: Mapping[N, Mapping[T, Collection[N]]]
+        A transition table of nondeterministic finite machine in the type
+        $N \to (T \to 2^N)$ represented as a dictionary of
+        dictionaries of sets.
+
+    states: Collection[N]
+        A set of initial states of type $2^N$.
+
+    Returns
+    =======
+
+    defaultdict[T, set[N]]
+        A instruction table of type $T \to 2^N$ represented as a dictionary
+        of sets.
+
+    Examples
+    ========
+
+    >>> from sympy.combinatorics.rewritingsystem_fsm import instructions
+
+    >>> transition = {
+    ...     0: {'e': {1, 7}},
+    ...     1: {'e': {2, 4}},
+    ...     2: {'a': {3}},
+    ...     3: {'e': {6}},
+    ...     4: {'b': {5}},
+    ...     5: {'e': {6}},
+    ...     6: {'e': {1, 7}},
+    ...     7: {'a': {8}},
+    ...     8: {'b': {9}},
+    ...     9: {'b': {10}},
+    ... }
+
+    Computing all possible transitions that is reachable by the state $2$ for
+    each input symbols:
+
+    >>> instructions(transition, {2})
+    {'a': {3}}
+
+    Computing all possible transitions that is reachable by the states
+    $\{0, 1, 2, 4, 7\}$ for each input symbols:
+
+    >>> instructions(transition, {0, 1, 2, 4, 7})
+    {'a': {3, 8}, 'b': {5}, 'e': {1, 2, 4, 7}}
+
+    References
+    ==========
+
+    .. [*] Johnson, J.H., Wood, D. (1997). Instruction computation in subset
+       construction. In: Raymond, D., Wood, D., Yu, S. (eds) Automata
+       Implementation. WIA 1996. Lecture Notes in Computer Science, vol 1260.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-63174-7_6
+    """
+    out: DefaultDict[_T, set[_N]] = DefaultDict(set)
+    for state in states:
+        if state not in transition:
+            continue
+        for enter in transition[state]:
+            out[enter] |= set(transition[state][enter])
+    return out
+
+
+def subset_construction(
+    transition: Mapping[_N, Mapping[_T, Collection[_N]]],
+    start: Collection[_N]
+) -> dict[frozenset[_N], dict[_T, frozenset[_N]]]:
+    r"""Convert the nondeterministic finite state machine without $\epsilon$
+    to a deterministic finite state machine.
+
+    Explanation
+    ===========
+
+    Given a transition table for nondeterministic finite state machine defined
+    as a mapping:
+
+    .. math::
+        N \to (T \to 2^N)
+
+    An equivalent deterministic finite state machine can be computed as a
+    mapping from the set of instructions to the set of instructions:
+
+    .. math::
+        2^N \to (T \to 2^N)
+
+    Parameters
+    ==========
+
+    transition: Mapping[N, Mapping[T, Collection[N]]]
+        A transition table of nondeterministic finite state machine of the type
+        $N \to (T \to 2^N)$ represented as a dictionary of
+        dictionaries of sets.
+
+    start: Collection[N]
+        The initial $\epsilon$ closure of the set of start symbols.
+
+    Returns
+    =======
+
+    dict[frozenset[N], dict[T, frozenset[N]]]
+        The transition table of the deterministic finite state machine of the
+        type $2^N \to (T \to 2^N)$ represented as a dictionary of
+        dictionaries of frozen sets.
+
+    Examples
+    ========
+
+    Compute the table for deterministic finite state machine without $\epsilon$
+    from the initial state $1$:
+
+    >>> from sympy.combinatorics.rewritingsystem_fsm import subset_construction
+
+    >>> transition = {
+    ...     0: {'e': {1, 7}},
+    ...     1: {'e': {2, 4}},
+    ...     2: {'a': {3}},
+    ...     3: {'e': {6}},
+    ...     4: {'b': {5}},
+    ...     5: {'e': {6}},
+    ...     6: {'e': {1, 7}},
+    ...     7: {'a': {8}},
+    ...     8: {'b': {9}},
+    ...     9: {'b': {10}},
+    ... }
+    >>> dfa = subset_construction(transition, {0})
+    >>> for A in dfa:
+    ...     for x in dfa[A]:
+    ...         B = dfa[A][x]
+    ...         print(f"{set(A)}, {x} -> {set(B)}")
+    {0}, e -> {1, 7}
+    {1, 7}, e -> {2, 4}
+    {1, 7}, a -> {8}
+    {8}, b -> {9}
+    {9}, b -> {10}
+    {2, 4}, a -> {3}
+    {2, 4}, b -> {5}
+    {5}, e -> {6}
+    {6}, e -> {1, 7}
+    {3}, e -> {6}
+
+    Notes
+    =====
+
+    Although accepting the set of start symbols is has computationally
+    well-defined behavior, it may be ambiguous generalization for users,
+    and in most applications, supplying a single element set like ``{'A'}``
+    is sufficient.
+
+    The interface is designed such that it aligns with the inteface of
+    :func:`subset_construction_epsilon`.
+
+    References
+    ==========
+
+    .. [*] Gertjan van Noord; Treatment of Epsilon Moves in Subset
+       Construction. Computational Linguistics 2000; 26 (1): 61–76.
+       doi: https://doi.org/10.1162/089120100561638
+
+    .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
+       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+    """
+    _start = frozenset(start)
+    stack: list[frozenset[_N]] = [_start]
+    out: dict[frozenset[_N], dict[_T, frozenset[_N]]] = {}
+
+    while stack:
+        state = stack.pop()
+        for enter, _new_state in instructions(transition, state).items():
+            new_state = frozenset(_new_state)
+            if state not in out:
+                out[state] = {}
+            out[state][enter] = new_state
+            if new_state not in out:
+                stack.append(new_state)
+
+    return out
+
+
+def subset_construction_epsilon(
+    transition: Mapping[_N, Mapping[_T, Collection[_N]]],
+    epsilon: _T,
+    start: Collection[_N]
+) -> dict[frozenset[_N], dict[_T, frozenset[_N]]]:
+    r"""Convert the nondeterministic finite state machine without $\epsilon$
+    to a deterministic finite state machine.
+
+    Explanation
+    ===========
+
+    Given a transition table for nondeterministic finite state machine defined
+    as a mapping:
+
+    .. math::
+        N \to ((T | \epsilon) \to 2^N)
+
+    An equivalent deterministic finite state machine can be computed as a
+    mapping from the set of instructions to the set of instructions:
+
+    .. math::
+        2^N \to (T \to 2^N)
+
+    Parameters
+    ==========
+
+    transition: Mapping[N, Mapping[T, Collection[N]]]
+        A transition table of nondeterministic finite state machine of the type
+        $N \to ((T | \epsilon) \to 2^N)$ represented as a dictionary of
+        dictionaries of sets.
+
+    start: Collection[N]
+        The initial $\epsilon$ closure of the set of start symbols.
+        We warn that asserting the $\epsilon$ closure is assumed for users
+        composing the function :func:`epsilon_closure` in priori, and not done
+        here automatically to avoid some redundancy of computation and bring
+        some symmetry of implementation.
+
+    epsilon: T
+        The symbol for $\epsilon$ transition.
+
+    Returns
+    =======
+
+    dict[frozenset[N], dict[T, frozenset[N]]]
+        The transition table of the deterministic finite state machine
+
+    Examples
+    ========
+
+    Compute the table for deterministic finite state machine with $\epsilon$
+    from the initial state $1$:
+
+    >>> from sympy.combinatorics.rewritingsystem_fsm import (
+    ...     epsilon_closure, subset_construction_epsilon)
+
+    >>> transition = {
+    ...     0: {'e': {1, 7}},
+    ...     1: {'e': {2, 4}},
+    ...     2: {'a': {3}},
+    ...     3: {'e': {6}},
+    ...     4: {'b': {5}},
+    ...     5: {'e': {6}},
+    ...     6: {'e': {1, 7}},
+    ...     7: {'a': {8}},
+    ...     8: {'b': {9}},
+    ...     9: {'b': {10}},
+    ... }
+    >>> start = epsilon_closure(transition, 'e', {0})
+    >>> dfa = subset_construction_epsilon(transition, 'e', start)
+    >>> for A in dfa:
+    ...     for x in dfa[A]:
+    ...         B = dfa[A][x]
+    ...         print(f"{set(A)}, {x} -> {set(B)}")
+    {0, 1, 2, 4, 7}, a -> {1, 2, 3, 4, 6, 7, 8}
+    {0, 1, 2, 4, 7}, b -> {1, 2, 4, 5, 6, 7}
+    {1, 2, 4, 5, 6, 7}, a -> {1, 2, 3, 4, 6, 7, 8}
+    {1, 2, 4, 5, 6, 7}, b -> {1, 2, 4, 5, 6, 7}
+    {1, 2, 3, 4, 6, 7, 8}, a -> {1, 2, 3, 4, 6, 7, 8}
+    {1, 2, 3, 4, 6, 7, 8}, b -> {1, 2, 4, 5, 6, 7, 9}
+    {1, 2, 4, 5, 6, 7, 9}, a -> {1, 2, 3, 4, 6, 7, 8}
+    {1, 2, 4, 5, 6, 7, 9}, b -> {1, 2, 4, 5, 6, 7, 10}
+    {1, 2, 4, 5, 6, 7, 10}, a -> {1, 2, 3, 4, 6, 7, 8}
+    {1, 2, 4, 5, 6, 7, 10}, b -> {1, 2, 4, 5, 6, 7}
+
+    Notes
+    =====
+
+    Deterministic finite state machine shouldn't use $\epsilon$ transition,
+    so the type for $\epsilon$ can be removed from the output, however, because
+    of the limitations of type checking libraries of python, it may not be
+    able to automatically infer such type.
+
+    References
+    ==========
+
+    .. [*] Gertjan van Noord; Treatment of Epsilon Moves in Subset
+       Construction. Computational Linguistics 2000; 26 (1): 61–76.
+       doi: https://doi.org/10.1162/089120100561638
+
+    .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
+       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+    """
+    _start = frozenset(start)
+    stack: list[frozenset[_N]] = [_start]
+    out: dict[frozenset[_N], dict[_T, frozenset[_N]]] = {}
+
+    while stack:
+        state = stack.pop()
+        for enter, _new_state in instructions(transition, state).items():
+            if enter == epsilon:
+                continue
+
+            new_state = frozenset(epsilon_closure(transition, epsilon, _new_state))
+            if state not in out:
+                out[state] = {}
+            out[state][enter] = new_state
+            if new_state not in out:
+                stack.append(new_state)
+
+    return out

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -144,7 +144,7 @@ def epsilon_closure(
     ==========
 
     .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
-       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+       "Compilers: Principles, Techniques, and Tools (2nd Edition)." (2006).
     """
     stack: list[_N] = list(states)
     closure = set(stack)
@@ -348,11 +348,11 @@ def subset_construction(
     ==========
 
     .. [*] Gertjan van Noord; Treatment of Epsilon Moves in Subset
-       Construction. Computational Linguistics 2000; 26 (1): 61–76.
+       Construction. Computational Linguistics 2000; 26 (1): 61-76.
        doi: https://doi.org/10.1162/089120100561638
 
     .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
-       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+       "Compilers: Principles, Techniques, and Tools (2nd Edition)." (2006).
     """
     _start = frozenset(start)
     stack: list[frozenset[_N]] = [_start]
@@ -468,11 +468,11 @@ def subset_construction_epsilon(
     ==========
 
     .. [*] Gertjan van Noord; Treatment of Epsilon Moves in Subset
-       Construction. Computational Linguistics 2000; 26 (1): 61–76.
+       Construction. Computational Linguistics 2000; 26 (1): 61-76.
        doi: https://doi.org/10.1162/089120100561638
 
     .. [*] Aho, Alfred V., Monica S. Lam, Ravi Sethi and Jeffrey D. Ullman.
-       “Compilers: Principles, Techniques, and Tools (2nd Edition).” (2006).
+       "Compilers: Principles, Techniques, and Tools (2nd Edition)." (2006).
     """
     _start = frozenset(start)
     stack: list[frozenset[_N]] = [_start]

--- a/sympy/combinatorics/tests/test_fsm.py
+++ b/sympy/combinatorics/tests/test_fsm.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from sympy.combinatorics.rewritingsystem_fsm import (
+    epsilon_closure, instructions,
+    subset_construction, subset_construction_epsilon)
+
+
+def test_doctest_copies() -> None:
+    transition: dict[int, dict[str, set[int]]]  = {
+        0: {'e': {1, 7}},
+        1: {'e': {2, 4}},
+        2: {'a': {3}},
+        3: {'e': {6}},
+        4: {'b': {5}},
+        5: {'e': {6}},
+        6: {'e': {1, 7}},
+        7: {'a': {8}},
+        8: {'b': {9}},
+        9: {'b': {10}},
+    }
+    epsilon = 'e'
+
+    assert epsilon_closure(transition, epsilon, {0}) == {0, 1, 2, 4, 7}
+    assert epsilon_closure(transition, epsilon, {5}) == {1, 2, 4, 5, 6, 7}
+    assert epsilon_closure(transition, epsilon, {3, 8}) == {1, 2, 3, 4, 6, 7, 8}
+    assert instructions(transition, {0, 1, 2, 4, 7}) == {
+        'a': {8, 3}, 'b': {5}, 'e': {1, 2, 4, 7}}
+
+    assert subset_construction(transition, {0}) == {
+        frozenset({0}): {'e': frozenset({1, 7})},
+        frozenset({1, 7}): {'e': frozenset({2, 4}), 'a': frozenset({8})},
+        frozenset({8}): {'b': frozenset({9})},
+        frozenset({9}): {'b': frozenset({10})},
+        frozenset({2, 4}): {'a': frozenset({3}), 'b': frozenset({5})},
+        frozenset({5}): {'e': frozenset({6})},
+        frozenset({6}): {'e': frozenset({1, 7})},
+        frozenset({3}): {'e': frozenset({6})}
+    }
+    assert subset_construction_epsilon(
+        transition, 'e', epsilon_closure(transition, 'e', {0})
+    ) == {
+        frozenset({0, 1, 2, 4, 7}): {
+            'a': frozenset({1, 2, 3, 4, 6, 7, 8}),
+            'b': frozenset({1, 2, 4, 5, 6, 7})},
+        frozenset({1, 2, 4, 5, 6, 7}): {
+            'a': frozenset({1, 2, 3, 4, 6, 7, 8}),
+            'b': frozenset({1, 2, 4, 5, 6, 7})},
+        frozenset({1, 2, 3, 4, 6, 7, 8}): {
+            'a': frozenset({1, 2, 3, 4, 6, 7, 8}),
+            'b': frozenset({1, 2, 4, 5, 6, 7, 9})},
+        frozenset({1, 2, 4, 5, 6, 7, 9}): {
+            'a': frozenset({1, 2, 3, 4, 6, 7, 8}),
+            'b': frozenset({1, 2, 4, 5, 6, 7, 10})},
+        frozenset({1, 2, 4, 5, 6, 7, 10}): {
+            'a': frozenset({1, 2, 3, 4, 6, 7, 8}),
+            'b': frozenset({1, 2, 4, 5, 6, 7})
+        }
+    }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is some subproduct of my attempt to define some lexical analysis for symbolic computation.
Although lexical analysis of strings is very trivial because it can be already done by `regex`.
But I find that `regex` can just be made more general than just working on strings.

I believe that 'variadic arguments' are used a lot of symbolic computation for syntactic convenience,
And to give more formalization of such variadic functions, a regular expression of symbolic objects can be the natural approach, and it can generalize the primitive list generic types (`list[T]`) or positional arguments (`first: S, ..., *args: T`) that are overly restrictive to use in matching of arguments like `a variable list of coefficient followed by a variable list of symbols`, without losing much efficiency or decidability.

The project to define some formal grammar for objects of sympy, are a bit long road to achieve, however, I introduce some partial implementations that people in the community can play with, and these sort of things can be assembled to have a library for regular expression for pattern matching of general symbolic objects.

I've also generalized the type system such that it can work for any sympy object or any python object.
without having to force users to use a certain set of objects/classes to use this.

There is already some class based designs in the `rewritingsystem_fsm.py`, but I can't figure out how to make it work because it has no examples documented or tested. But if I can provide some adapter between the functional approaches and the class based legacy, it can be good.

People who have some basic knowledge about finite state machines in may be able to review this,
but even without the correctness review, I've at least done the type analysis completely, so there would not likely be any 'shape errors' of objects.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Added `epsilon_closure`, `subset_construction`, `subset_construction_epsilon` utility functions for converting nondeterministic finite automata to deterministic finite automata.
<!-- END RELEASE NOTES -->
