### PR TITLE
Solve printing issues in Stats with matrix expressions by adding 'is_commutative'.

### DIFF
--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -26,6 +26,7 @@ from sympy.functions.special.zeta_functions import zeta
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (Equivalent, false, true, Xor)
 from sympy.matrices.dense import Matrix
+from sympy.matrices.expressions import Identity
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices import SparseMatrix
@@ -33,6 +34,8 @@ from sympy.polys.polytools import factor
 from sympy.series.limits import Limit
 from sympy.series.order import O
 from sympy.sets.sets import (Complement, FiniteSet, Interval, SymmetricDifference)
+from sympy.stats import (Covariance, Expectation, Probability, Variance)
+from sympy.stats.rv import RandomSymbol
 from sympy.external import import_module
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, \
     Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback
@@ -1173,3 +1176,17 @@ def test_printing_str_array_expressions():
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)
     assert sstr(ArrayElement(M*N, [x, 0])) == "(M*N)[x, 0]"
+
+
+def test_printing_stats():
+    # issue 24132
+    x = RandomSymbol("x")
+    y = RandomSymbol("y")
+    z1 = Probability(x > 0)*Identity(2)
+    z2 = Expectation(x)*Identity(2)
+    z3 = Variance(x)*Identity(2)
+    z4 = Covariance(x, y) * Identity(2)
+    assert str(z1) == "Probability(x > 0)*I"
+    assert str(z2) == "Expectation(x)*I"
+    assert str(z3) == "Variance(x)*I"
+    assert str(z4) ==  "Covariance(x, y)*I"

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -59,7 +59,9 @@ class Probability(Expr):
     >>> prob.evaluate_integral()
     sqrt(2)*(-sqrt(2)*sqrt(pi)*erf(sqrt(2)/2) + sqrt(2)*sqrt(pi))/(4*sqrt(pi))
     """
+
     is_commutative = True
+
     def __new__(cls, prob, condition=None, **kwargs):
         prob = _sympify(prob)
         if condition is None:

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -59,6 +59,7 @@ class Probability(Expr):
     >>> prob.evaluate_integral()
     sqrt(2)*(-sqrt(2)*sqrt(pi)*erf(sqrt(2)/2) + sqrt(2)*sqrt(pi))/(4*sqrt(pi))
     """
+    is_commutative = True
     def __new__(cls, prob, condition=None, **kwargs):
         prob = _sympify(prob)
         if condition is None:
@@ -197,7 +198,7 @@ class Expectation(Expr):
     >>> Expectation(X + Expectation(Y)).doit(deep=False)
     mu + Expectation(Expectation(Y))
     >>> Expectation(X + Expectation(Y + Expectation(2*X))).doit(deep=False)
-    mu + Expectation(Expectation(Y + Expectation(2*X)))
+    mu + Expectation(Expectation(Expectation(2*X) + Y))
 
     """
 
@@ -215,6 +216,9 @@ class Expectation(Expr):
             obj = Expr.__new__(cls, expr, condition)
         obj._condition = condition
         return obj
+
+    def _eval_is_commutative(self):
+        return self.args[0].is_commutative
 
     def expand(self, **hints):
         expr = self.args[0]
@@ -385,6 +389,9 @@ class Variance(Expr):
         obj._condition = condition
         return obj
 
+    def _eval_is_commutative(self):
+        return self.args[0].is_commutative
+
     def expand(self, **hints):
         arg = self.args[0]
         condition = self._condition
@@ -498,6 +505,9 @@ class Covariance(Expr):
             obj = Expr.__new__(cls, arg1, arg2, condition)
         obj._condition = condition
         return obj
+
+    def _eval_is_commutative(self):
+        return self.args[0].is_commutative
 
     def expand(self, **hints):
         arg1 = self.args[0]
@@ -651,7 +661,7 @@ class CentralMoment(Expr):
     Rewrite the CentralMoment expression in terms of Expectation:
 
     >>> CM.rewrite(Expectation)
-    Expectation((X - Expectation(X))**4)
+    Expectation((-Expectation(X) + X)**4)
 
     Rewrite the CentralMoment expression in terms of Probability:
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24132 

#### Brief description of what is fixed or changed
Added `is_commutative` assumption as class variable for Probability and `eval_is_commutative()` method for Expectation, Variance, Covariance classes.

```
>>> from sympy import *
>>> from sympy.stats import Expectation
>>> from sympy.stats.rv import RandomSymbol
>>> z = Expectation(RandomSymbol("x")) * Identity(2)
>>> print(z)  
NotImplementedError: noncommutative scalars in MatMul are not supported. # On master

>>> z = Expectation(RandomSymbol("x")) * Identity(2)
>>> print(z)
Expectation(x)*I  # On branch
```


#### Other comments
Initial changes to fix the issue were introduced by @KuldeepBorkar but they lacked testing and had multiple `doctest` failures. Those have been resolved here. I will add him as co-author to the commit, once this is close to merging.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Fixed failing print for Probability, Expectation, Variance and Covariance.
<!-- END RELEASE NOTES -->
