### PR TITLE
Provide a sparse `symmetrize()` method

### DIFF
--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -1,15 +1,15 @@
 """High-level polynomials manipulation functions. """
 
 
-from sympy.core import S, Basic, Add, Mul, symbols, Dummy
+from sympy.core import S, Basic, symbols, Dummy
 from sympy.polys.polyerrors import (
     PolificationFailed, ComputationFailed,
     MultivariatePolynomialError, OptionError)
-from sympy.polys.polyoptions import allowed_flags
-from sympy.polys.polytools import (
-    poly_from_expr, parallel_poly_from_expr, Poly)
+from sympy.polys.polyoptions import allowed_flags, build_options
+from sympy.polys.polytools import poly_from_expr, Poly
 from sympy.polys.specialpolys import (
     symmetric_poly, interpolating_poly)
+from sympy.polys.rings import sring
 from sympy.utilities import numbered_symbols, take, public
 
 @public
@@ -53,81 +53,20 @@ def symmetrize(F, *gens, **args):
         iterable = False
         F = [F]
 
-    try:
-        F, opt = parallel_poly_from_expr(F, *gens, **args)
-    except PolificationFailed as exc:
-        result = []
+    R, F = sring(F, *gens, **args)
+    gens = R.symbols
 
-        for expr in exc.exprs:
-            if expr.is_Number:
-                result.append((expr, S.Zero))
-            else:
-                raise ComputationFailed('symmetrize', len(F), exc)
-
-        if not iterable:
-            result, = result
-
-        if not exc.opt.formal:
-            return result
-        else:
-            if iterable:
-                return result, []
-            else:
-                return result + ([],)
-
-    polys, symbols = [], opt.symbols
-    gens, dom = opt.gens, opt.domain
-
-    for i in range(len(gens)):
-        poly = symmetric_poly(i + 1, gens, polys=True)
-        polys.append((next(symbols), poly.set_domain(dom)))
-
-    indices = list(range(len(gens) - 1))
-    weights = list(range(len(gens), 0, -1))
+    opt = build_options(gens, args)
+    symbols = opt.symbols
+    symbols = [next(symbols) for i in range(len(gens))]
 
     result = []
 
     for f in F:
-        symmetric = []
+        p, r, m = f.symmetrize()
+        result.append((p.as_expr(*symbols), r.as_expr(*gens)))
 
-        if not f.is_homogeneous:
-            symmetric.append(f.TC())
-            f -= f.TC().as_poly(f.gens)
-
-        while f:
-            _height, _monom, _coeff = -1, None, None
-
-            for i, (monom, coeff) in enumerate(f.terms()):
-                if all(monom[i] >= monom[i + 1] for i in indices):
-                    height = max([n*m for n, m in zip(weights, monom)])
-
-                    if height > _height:
-                        _height, _monom, _coeff = height, monom, coeff
-
-            if _height != -1:
-                monom, coeff = _monom, _coeff
-            else:
-                break
-
-            exponents = []
-
-            for m1, m2 in zip(monom, monom[1:] + (0,)):
-                exponents.append(m1 - m2)
-
-            term = [s**n for (s, _), n in zip(polys, exponents)]
-            poly = [p**n for (_, p), n in zip(polys, exponents)]
-
-            symmetric.append(Mul(coeff, *term))
-            product = poly[0].mul(coeff)
-
-            for p in poly[1:]:
-                product = product.mul(p)
-
-            f -= product
-
-        result.append((Add(*symmetric), f.as_expr()))
-
-    polys = [(s, p.as_expr()) for s, p in polys]
+    polys = [(s, g.as_expr()) for s, (_, g) in zip(symbols, m)]
 
     if not opt.formal:
         for i, (sym, non_sym) in enumerate(result):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -629,10 +629,13 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             return new_ring.from_dict(self, self.ring.domain)
 
     def as_expr(self, *symbols):
-        if symbols and len(symbols) != self.ring.ngens:
-            raise ValueError("not enough symbols, expected %s got %s" % (self.ring.ngens, len(symbols)))
-        else:
+        if not symbols:
             symbols = self.ring.symbols
+        elif len(symbols) != self.ring.ngens:
+            raise ValueError(
+                "Wrong number of symbols, expected %s got %s" %
+                (self.ring.ngens, len(symbols))
+            )
 
         return expr_from_dict(self.as_expr_dict(), *symbols)
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -28,7 +28,7 @@ from sympy.polys.polyoptions import (Domain as DomainOpt,
 from sympy.polys.polyutils import (expr_from_dict, _dict_reorder,
                                    _parallel_dict_from_expr)
 from sympy.printing.defaults import DefaultPrinting
-from sympy.utilities import public
+from sympy.utilities import public, subsets
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.magic import pollute
 
@@ -551,6 +551,19 @@ class PolyRing(DefaultPrinting, IPolys):
         """Add the elements of ``symbols`` as generators to ``self``"""
         syms = set(self.symbols).union(set(symbols))
         return self.clone(symbols=list(syms))
+
+    def symmetric_poly(self, n):
+        """Return the symmetric poly of given degree over this ring's gens."""
+        if n < 0 or n > self.ngens:
+            raise ValueError("Cannot generate symmetric polynomial of order %s for %s" % (n, self.gens))
+        elif not n:
+            return self.one
+        else:
+            poly = self.zero
+            for s in subsets(range(self.ngens), int(n)):
+                monom = tuple(int(i in s) for i in range(self.ngens))
+                poly += self.term_new(monom, self.domain.one)
+            return poly
 
 
 class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
@@ -2370,6 +2383,104 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
                         poly[monom] = coeff
 
             return poly
+
+    def symmetrize(self):
+        r"""
+        Rewrite *self* in terms of elementary symmetric polynomials.
+
+        Explanation
+        ===========
+
+        If this :py:class:`~.PolyElement` belongs to a ring of $n$ variables,
+        we can try to write it as a function of the elementary symmetric
+        polynomials on $n$ variables. We compute a symmetric part, and a
+        remainder for any part we were not able to symmetrize.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.rings import ring
+        >>> from sympy.polys.domains import ZZ
+        >>> R, x, y = ring("x,y", ZZ)
+
+        >>> f = x**2 + y**2
+        >>> f.symmetrize()
+        (x**2 - 2*y, 0, [(x, x + y), (y, x*y)])
+
+        >>> f = x**2 - y**2
+        >>> f.symmetrize()
+        (x**2 - 2*y, -2*y**2, [(x, x + y), (y, x*y)])
+
+        Returns
+        =======
+
+        Triple ``(p, r, m)``
+            ``p`` is a :py:class:`~.PolyElement` that represents our attempt
+            to express *self* as a function of elementary symmetric
+            polynomials. Each variable in ``p`` stands for one of the
+            elementary symmetric polynomials. The correspondence is given
+            by ``m``.
+
+            ``r`` is the remainder.
+
+            ``m`` is a list of pairs, giving the mapping from variables in
+            ``p`` to elementary symmetric polynomials.
+
+            The triple satisfies the equation ``p.compose(m) + r == self``.
+            If the remainder ``r`` is zero, *self* is symmetric. If it is
+            nonzero, we were not able to represent *self* as symmetric.
+
+        See Also
+        ========
+
+        sympy.polys.polyfuncs.symmetrize
+
+        """
+        f = self.copy()
+        ring = f.ring
+        n = ring.ngens
+        polys = [ring.symmetric_poly(i+1) for i in range(n)]
+
+        poly_powers = {}
+        def get_poly_power(i, n):
+            if (i, n) not in poly_powers:
+                poly_powers[(i, n)] = polys[i]**n
+            return poly_powers[(i, n)]
+
+        indices = list(range(n - 1))
+        weights = list(range(n, 0, -1))
+
+        symmetric = ring.zero
+
+        while f:
+            _height, _monom, _coeff = -1, None, None
+
+            for i, (monom, coeff) in enumerate(f.terms()):
+                if all(monom[i] >= monom[i + 1] for i in indices):
+                    height = max([n*m for n, m in zip(weights, monom)])
+
+                    if height > _height:
+                        _height, _monom, _coeff = height, monom, coeff
+
+            if _height != -1:
+                monom, coeff = _monom, _coeff
+            else:
+                break
+
+            exponents = []
+            for m1, m2 in zip(monom, monom[1:] + (0,)):
+                exponents.append(m1 - m2)
+
+            symmetric += ring.term_new(tuple(exponents), coeff)
+
+            product = coeff
+            for i, n in enumerate(exponents):
+                product *= get_poly_power(i, n)
+            f -= product
+
+        mapping = list(zip(ring.gens, polys))
+
+        return symmetric, f, mapping
 
     def compose(f, x, a=None):
         ring = f.ring

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2439,6 +2439,10 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         f = self.copy()
         ring = f.ring
         n = ring.ngens
+
+        if not n:
+            return f, ring.zero, []
+
         polys = [ring.symmetric_poly(i+1) for i in range(n)]
 
         poly_powers = {}

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -150,6 +150,18 @@ def test_PolyRing_mul():
 
     assert R.mul([2, 3, 5]) == 30
 
+def test_PolyRing_symmetric_poly():
+    R, x, y, z, t = ring("x,y,z,t", ZZ)
+
+    raises(ValueError, lambda: R.symmetric_poly(-1))
+    raises(ValueError, lambda: R.symmetric_poly(5))
+
+    assert R.symmetric_poly(0) == R.one
+    assert R.symmetric_poly(1) == x + y + z + t
+    assert R.symmetric_poly(2) == x*y + x*z + x*t + y*z + y*t + z*t
+    assert R.symmetric_poly(3) == x*y*z + x*y*t + x*z*t + y*z*t
+    assert R.symmetric_poly(4) == x*y*z*t
+
 def test_sring():
     x, y, z, t = symbols("x,y,z,t")
 
@@ -1192,6 +1204,33 @@ def test_PolyElement_subs():
     raises(CoercionFailed, lambda: f.subs([(x, 1), (y, QQ(1,7))]))
     raises(CoercionFailed, lambda: f.subs([(x, QQ(1,7)), (y, 1)]))
     raises(CoercionFailed, lambda: f.subs([(x, QQ(1,7)), (y, QQ(1,7))]))
+
+def test_PolyElement_symmetrize():
+    R, x, y = ring("x,y", ZZ)
+
+    # Homogeneous, symmetric
+    f = x**2 + y**2
+    sym, rem, m = f.symmetrize()
+    assert rem == 0
+    assert sym.compose(m) + rem == f
+
+    # Homogeneous, asymmetric
+    f = x**2 - y**2
+    sym, rem, m = f.symmetrize()
+    assert rem != 0
+    assert sym.compose(m) + rem == f
+
+    # Inhomogeneous, symmetric
+    f = x*y + 7
+    sym, rem, m = f.symmetrize()
+    assert rem == 0
+    assert sym.compose(m) + rem == f
+
+    # Inhomogeneous, asymmetric
+    f = y + 7
+    sym, rem, m = f.symmetrize()
+    assert rem != 0
+    assert sym.compose(m) + rem == f
 
 def test_PolyElement_compose():
     R, x = ring("x", ZZ)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -271,11 +271,11 @@ def test_PolyElement_as_expr():
     assert f != g
     assert f.as_expr() == g
 
-    X, Y, Z = symbols("x,y,z")
-    g = 3*X**2*Y - X*Y*Z + 7*Z**3 + 1
+    U, V, W = symbols("u,v,w")
+    g = 3*U**2*V - U*V*W + 7*W**3 + 1
 
     assert f != g
-    assert f.as_expr(X, Y, Z) == g
+    assert f.as_expr(U, V, W) == g
 
     raises(ValueError, lambda: f.as_expr(X))
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1232,6 +1232,18 @@ def test_PolyElement_symmetrize():
     assert rem != 0
     assert sym.compose(m) + rem == f
 
+    # Constant
+    f = R.from_expr(3)
+    sym, rem, m = f.symmetrize()
+    assert rem == 0
+    assert sym.compose(m) + rem == f
+
+    # Constant constructed from sring
+    R, f = sring(3)
+    sym, rem, m = f.symmetrize()
+    assert rem == 0
+    assert sym.compose(m) + rem == f
+
 def test_PolyElement_compose():
     R, x = ring("x", ZZ)
     f = x**3 + 4*x**2 + 2*x + 3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

We give the `PolyElement` class a `symmetrize()` method. This attempts to render the instance as a function of elementary symmetric polynomials.

#### Other comments

This is significantly faster than the existing `sympy.polys.polyfuncs.symmetrize()` function, which operates on a polynomial given as an `Expr`.

For example, from the following script,

```python
import time

from sympy.combinatorics.perm_groups import PermutationGroup
from sympy.combinatorics.permutations import Permutation
from sympy.core.symbol import symbols
from sympy.polys.domains import ZZ
from sympy.polys.orderings import lex
from sympy.polys.polyfuncs import symmetrize
from sympy.polys.rings import xring
from sympy.polys.specialpolys import symmetric_poly
from sympy.utilities.lambdify import lambdify

# Example is based on Galois resolvent for deg 6 polynomials

print('\nSetup...')

R, X = xring("X0,X1,X2,X3,X4,X5", ZZ, lex)

# H = PGL2F5()
H = PermutationGroup(
    Permutation(0, 1, 2, 3, 4), Permutation(0, 5)(1, 2)(3, 4))

term0 = X[0] ** 2 * X[5] ** 2 * (X[1] * X[4] + X[2] * X[3])
terms = set(term0.compose(list(zip(X, s(X)))) for s in H.elements)
F = sum(terms)
s = [Permutation(5)] + [Permutation(5)(0, n) for n in range(1, 6)]

root_forms = [
    F.compose(list(zip(X, sigma(X))))
    for sigma in s
]

Y = symbols("Y0,Y1,Y2,Y3,Y4,Y5")

C3_form = lambdify(Y, symmetric_poly(3, *Y))
C3 = C3_form(*root_forms)
E3 = C3.as_expr()

print(f'\nPoly is degree {C3.degree()} and has {len(C3)} terms.')

print('\nPolyElement.symmetrize...')
t0 = time.time()
p, r, m = C3.symmetrize()
t1 = time.time()
print(f'  Remainder: {r} (zero means poly was symmetric)')
print(f'  Took {t1 - t0:.2f}s')

print('\nsympy.polys.polyfuncs.symmetrize...')
t0 = time.time()
p, r, m = symmetrize(E3, formal=True)
t1 = time.time()
print(f'  Remainder: {r} (zero means poly was symmetric)')
print(f'  Took {t1 - t0:.2f}s')
```

I get the results,

```
Poly is degree 6 and has 8321 terms.

PolyElement.symmetrize...
  Remainder: 0 (zero means poly was symmetric)
  Took 1.04s

sympy.polys.polyfuncs.symmetrize...
  Remainder: 0 (zero means poly was symmetric)
  Took 28.71s
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added a `PolyElement.symmetrize()` method for sparse symmetrization.
<!-- END RELEASE NOTES -->
