### PR TITLE
Override `_eval_subs` for matrix expressions

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -464,6 +464,9 @@ class MatrixExpr(Expr):
         from .applyfunc import ElementwiseApplyFunction
         return ElementwiseApplyFunction(func, self)
 
+    def _eval_subs(self, old, new):
+        return None
+
 
 @dispatch(MatrixExpr, Expr)
 def _eval_is_eq(lhs, rhs): # noqa:F811

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -56,3 +56,14 @@ def test_shape_error():
 
     A = MatrixSymbol('A', 3, 2)
     raises(ShapeError, lambda: MatAdd(A, B))
+
+
+def test_subs():
+    M1 = MatrixSymbol("M1", 2, 2)
+    M2 = MatrixSymbol("M2", 2, 2)
+    M3 = MatrixSymbol("M3", 2, 2)
+
+    assert (M1 + M2).subs(M1 + M2, M3) == M3
+    # TODO Dry run assertion because possibly it could handle associativity in
+    # the future
+    assert (M1 + M2 + M3).subs(M1 + M2, M3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fixes to #24131

#### Brief description of what is fixed or changed

I'm not sure if this is the best fix, but partially correct fix because we can keep `Add._eval_subs` or `Mul._eval_subs` getting called from MatrixExpr to keep some runtime errors not happen.
There is still a basic capability to substitute without taking account of associativity/commutativity, even if there is nothing implemented under `MatrixExpr._eval_subs`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
