### PR TITLE
Implement compatibility of Particle and RigidBody with the joints framework

### DIFF
--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -1,5 +1,6 @@
 from sympy.physics.mechanics import (Body, Lagrangian, KanesMethod, LagrangesMethod,
                                     RigidBody, Particle)
+from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.method import _Methods
 from sympy.core.backend import Matrix
 
@@ -76,7 +77,7 @@ class JointsMethod(_Methods):
     """
 
     def __init__(self, newtonion, *joints):
-        if isinstance(newtonion, Body):
+        if isinstance(newtonion, BodyBase):
             self.frame = newtonion.frame
         else:
             self.frame = newtonion
@@ -152,7 +153,8 @@ class JointsMethod(_Methods):
     def _generate_loadlist(self):
         load_list = []
         for body in self.bodies:
-            load_list.extend(body.loads)
+            if isinstance(body, Body):
+                load_list.extend(body.loads)
         return load_list
 
     def _generate_q(self):
@@ -183,6 +185,9 @@ class JointsMethod(_Methods):
         # Convert `Body` to `Particle` and `RigidBody`
         bodylist = []
         for body in self.bodies:
+            if not isinstance(body, Body):
+                bodylist.append(body)
+                continue
             if body.is_rigidbody:
                 rb = RigidBody(body.name, body.masscenter, body.frame, body.mass,
                     (body.central_inertia, body.masscenter))

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -3,8 +3,9 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
 from sympy.simplify.trigsimp import trigsimp
-from sympy.physics.mechanics import (PinJoint, JointsMethod, Body, KanesMethod,
-                                    PrismaticJoint, LagrangesMethod, inertia)
+from sympy.physics.mechanics import (
+    PinJoint, JointsMethod, RigidBody, Particle,Body, KanesMethod,
+    PrismaticJoint, LagrangesMethod, inertia)
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
 from sympy.testing.pytest import raises
 from sympy.core.backend import zeros
@@ -34,6 +35,22 @@ def test_jointsmethod():
     assert method.forcing_full == Matrix([[u], [0]])
     assert method.mass_matrix_full == Matrix([[1, 0], [0, C_ixx]])
     assert isinstance(method.method, KanesMethod)
+
+
+def test_rigid_body_particle_compatibility():
+    l, m, g = symbols('l m g')
+    C = RigidBody('C')
+    b = Particle('b', mass=m)
+    b.add_frame()
+    q, u = dynamicsymbols('q u')
+    P = PinJoint('P', C, b, coordinates=q, speeds=u,
+                 child_point=-l * b.x, joint_axis=C.z)
+    method = JointsMethod(C, P)
+    method.loads.append((b.masscenter, m * g * C.x))
+    method.form_eoms()
+    rhs = method.rhs()
+    assert rhs[1] == -g*sin(q)/l
+
 
 def test_jointmethod_duplicate_coordinates_speeds():
     P = Body('P')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR is part of the mechanics experimental development (#24234)

#### Brief description of what is fixed or changed
This PR implements a revised bodies structure, where `Particle` and `RigidBody` both inherit from an abstract base class `BodyBase`. This improves the similarity between the objects, so they will also be usable in the joints framework.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Added compatibility of `Particle` and `RigidBody` with the joints framework.
<!-- END RELEASE NOTES -->
