### PR TITLE
Remove the rewrite(exp) from solve()

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3159,16 +3159,12 @@ def _invert(eq, *symbols, **kwargs):
             if any(_ispow(i) for i in (ad, bd)):
                 a_base, a_exp = ad.as_base_exp()
                 b_base, b_exp = bd.as_base_exp()
-                if a_base == b_base:
-                    # a = -b
-                    lhs = powsimp(powdenest(ad/bd))
-                    rhs = -bi/ai
-                else:
-                    rat = ad/bd
-                    _lhs = powsimp(ad/bd)
-                    if _lhs != rat:
-                        lhs = _lhs
-                        rhs = -bi/ai
+                simp = powsimp(powdenest(ad/bd))
+                if not isinstance(simp, Pow):
+                    ad = exp(a_exp*log(a_base))
+                    bd = exp(b_exp*log(b_base))
+                lhs = powsimp(powdenest(ad/bd))
+                rhs = -bi/ai
             elif ai == -bi:
                 if isinstance(ad, Function) and ad.func == bd.func:
                     if len(ad.args) == len(bd.args) == 1:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3163,8 +3163,11 @@ def _invert(eq, *symbols, **kwargs):
                 if not isinstance(simp, Pow):
                     ad = exp(a_exp*log(a_base))
                     bd = exp(b_exp*log(b_base))
-                lhs = powsimp(powdenest(ad/bd))
-                rhs = -bi/ai
+                rat = ad/bd
+                _lhs = powsimp(rat)
+                if _lhs != rat:
+                    lhs = _lhs
+                    rhs = -bi/ai
             elif ai == -bi:
                 if isinstance(ad, Function) and ad.func == bd.func:
                     if len(ad.args) == len(bd.args) == 1:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3079,7 +3079,7 @@ def _invert(eq, *symbols, **kwargs):
     >>> invert(sqrt(x) + y, y)
     (-sqrt(x), y)
     >>> invert(sqrt(x) + y, x, y)
-    (0, sqrt(x) + y)
+    (-1, y/sqrt(x))
 
     If there is more than one symbol in a power's base and the exponent
     is not an Integer, then the principal root will be used for the

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2747,9 +2747,6 @@ def _tsolve(eq, sym, **flags):
             elif lhs.func == LambertW:
                 return _vsolve(lhs.args[0] - rhs*exp(rhs), sym, **flags)
 
-        rewrite = lhs.rewrite(exp)
-        if rewrite != lhs:
-            return _vsolve(rewrite - rhs, sym, **flags)
     except NotImplementedError:
         pass
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2747,7 +2747,7 @@ def _tsolve(eq, sym, **flags):
             elif lhs.func == LambertW:
                 return _vsolve(lhs.args[0] - rhs*exp(rhs), sym, **flags)
 
-        rewrite = lhs.rewrite([TrigonometricFunction, HyperbolicFunction], exp, evaluate=True)
+        rewrite = lhs.rewrite([TrigonometricFunction, HyperbolicFunction], exp)
         if rewrite != lhs:
             return _vsolve(rewrite - rhs, sym, **flags)
     except NotImplementedError:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2747,6 +2747,9 @@ def _tsolve(eq, sym, **flags):
             elif lhs.func == LambertW:
                 return _vsolve(lhs.args[0] - rhs*exp(rhs), sym, **flags)
 
+        rewrite = lhs.rewrite([TrigonometricFunction, HyperbolicFunction], exp, evaluate=True)
+        if rewrite != lhs:
+            return _vsolve(rewrite - rhs, sym, **flags)
     except NotImplementedError:
         pass
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -209,7 +209,7 @@ def test_solve_args():
     assert solve(True, x) == []
     assert solve([x - 1, False], [x], set=True) == ([], set())
     assert solve([-y*(x + y - 1)/2, (y - 1)/x/y + 1/y],
-        set=True, check=False) == ([x, y], {(1 - y, y), (x, 0)})
+        set=True) == ([x], {(1 - y,)})
     # ordering should be canonical, fastest to order by keys instead
     # of by size
     assert list(solve((y - 1, x - sqrt(3)*z)).keys()) == [x, y]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -211,7 +211,7 @@ def test_solve_args():
     assert solve(True, x) == []
     assert solve([x - 1, False], [x], set=True) == ([], set())
     assert solve([-y*(x + y - 1)/2, (y - 1)/x/y + 1/y],
-        set=True) == ([x], {(1 - y,)})
+        set=True, check=False) == ([x, y], {(1 - y, y), (x, 0)})
     # ordering should be canonical, fastest to order by keys instead
     # of by size
     assert list(solve((y - 1, x - sqrt(3)*z)).keys()) == [x, y]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,6 +3,7 @@ from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.mul import Mul
+from sympy.core.mod import Mod
 from sympy.core import (GoldenRatio, TribonacciConstant)
 from sympy.core.numbers import (E, Float, I, Rational, oo, pi)
 from sympy.core.relational import (Eq, Gt, Lt, Ne)
@@ -13,6 +14,7 @@ from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.complexes import (Abs, arg, conjugate, im, re)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (atanh, cosh, sinh, tanh)
+from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import (cbrt, root, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, atan2, cos, sec, sin, tan)
@@ -2588,3 +2590,11 @@ def test_solve_undetermined_coeffs_issue_23927():
         phi: 2*atan((A + sqrt(A**2 + B**2))/B),
         r: (A**2 + A*sqrt(A**2 + B**2) + B**2)/(A + sqrt(A**2 + B**2))/-1
         }]
+
+def test_issue_24368():
+    # Ideally these would produce a solution, but for now just check that they
+    # don't fail with a RuntimeError
+    raises(NotImplementedError, lambda: solve(Mod(x**2, 49), x))
+    s2 = Symbol('s2', integer=True, positive=True)
+    f = floor(s2/2 - S(1)/2)
+    raises(NotImplementedError, lambda: solve((Mod(f**2/(f + 1) + 2*f/(f + 1) + 1/(f + 1), 1))*f + Mod(f**2/(f + 1) + 2*f/(f + 1) + 1/(f + 1), 1), s2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/24368
Alternative to #24549

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - Fix recursion error issues with solve().
<!-- END RELEASE NOTES -->
