### PR TITLE
Use zero and one for generic matrix identity

### DIFF
--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -10,7 +10,7 @@ from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, flatten, sort, condition,
     exhaust, do_one, glom)
 from sympy.matrices.expressions.matexpr import MatrixExpr
-from sympy.matrices.expressions.special import ZeroMatrix, GenericZeroMatrix
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.matrices.expressions._shape import validate_matadd_integer as validate
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import sympy_deprecation_warning
@@ -32,8 +32,6 @@ class MatAdd(MatrixExpr, Add):
     A + B + C
     """
     is_MatAdd = True
-
-    identity = GenericZeroMatrix()
 
     def __new__(cls, *args, evaluate=False, check=None, _sympify=True):
         if not args:

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -37,8 +37,6 @@ class MatMul(MatrixExpr, Mul):
     """
     is_MatMul = True
 
-    identity = GenericIdentity()
-
     def __new__(cls, *args, evaluate=False, check=None, _sympify=True):
         if not args:
             return cls.identity

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -17,7 +17,7 @@ from .matexpr import MatrixExpr
 from .matpow import MatPow
 from .transpose import transpose
 from .permutation import PermutationMatrix
-from .special import ZeroMatrix, Identity, GenericIdentity, OneMatrix
+from .special import ZeroMatrix, Identity, OneMatrix
 
 
 # XXX: MatMul should perhaps not subclass directly from Mul

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -8,7 +8,7 @@ from sympy.combinatorics import Permutation
 from sympy.concrete.summations import Sum
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.core.symbol import symbols, Symbol
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
@@ -471,3 +471,10 @@ def test_derivatives_of_hadamard_expressions():
 
     expr = hadamard_power(a.T*X*b, S.Half)
     assert expr.diff(X) == a/(2*sqrt(a.T*X*b))*b.T
+
+
+def test_issue_23364():
+    Q = MatrixSymbol('Q', 4, 4)
+    l = Symbol('l')
+    expr = (l * Q)**2
+    assert expr.diff(l) == MatMul(2 / l, (l * Q)**2)

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -6,8 +6,10 @@ from sympy.core import Add, Basic, S
 from sympy.core.add import add
 from sympy.testing.pytest import XFAIL, raises
 
+
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 2)
+
 
 def test_evaluate():
     assert MatAdd(X, X, evaluate=True) == add(X, X, evaluate=True) == MatAdd(X, X).doit()
@@ -56,3 +58,10 @@ def test_shape_error():
 
     A = MatrixSymbol('A', 3, 2)
     raises(ShapeError, lambda: MatAdd(A, B))
+
+
+def test_issue_24131():
+    A = MatrixSymbol("A", 2, 2)
+    B = MatrixSymbol("B", 2, 2)
+    C = MatrixSymbol("C", 2, 2)
+    assert (A + B + C).subs(A + B, C) == MatAdd(C, C)

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -37,8 +37,8 @@ def test_doit_args():
 
 
 def test_generic_identity():
-    assert MatAdd.identity == GenericZeroMatrix()
-    assert MatAdd.identity != S.Zero
+    assert MatAdd.identity != GenericZeroMatrix()
+    assert MatAdd.identity == S.Zero
 
 
 def test_zero_matrix_add():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -119,7 +119,7 @@ def test_addition():
     raises(TypeError, lambda: 5 - A)
 
     assert A + ZeroMatrix(n, m) - A == ZeroMatrix(n, m)
-    raises(TypeError, lambda: ZeroMatrix(n, m) + S.Zero)
+    assert ZeroMatrix(n, m) + S.Zero == ZeroMatrix(n, m)
 
 
 def test_multiplication():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -167,8 +167,7 @@ def test_construction_with_mul():
     assert mul(C, D) != MatMul(D, C)
 
 def test_generic_identity():
-    assert MatMul.identity == GenericIdentity()
-    assert MatMul.identity != S.One
+    assert MatMul.identity == S.One
 
 
 def test_issue_23519():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -5,7 +5,6 @@ from sympy.matrices.common import ShapeError
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
 from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
-from sympy.matrices.expressions.special import GenericIdentity
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, combine_powers, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe

--- a/sympy/matrices/expressions/tests/test_special.py
+++ b/sympy/matrices/expressions/tests/test_special.py
@@ -48,8 +48,7 @@ def test_generic_zero_matrix():
     raises(TypeError, lambda: z.rows)
     raises(TypeError, lambda: z.cols)
 
-    assert MatAdd() == z
-    assert MatAdd(z, A) == MatAdd(A)
+    assert MatAdd() == 0
     # Make sure it is hashable
     hash(z)
 
@@ -85,8 +84,7 @@ def test_generic_identity():
     raises(TypeError, lambda: I.rows)
     raises(TypeError, lambda: I.cols)
 
-    assert MatMul() == I
-    assert MatMul(I, A) == MatMul(A)
+    assert MatMul() == 1
     # Make sure it is hashable
     hash(I)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#24131

#### Brief description of what is fixed or changed

This is experiment with switching S.Zero and S.One with generic matrix identities.
Although this may look a bit unsound fix, I'm taking a serious consideration at making `S.Zero` as the universal identity of matrix addition than `GenericZeroMatrix` because of the reasons below

- Since matrix inherits from `Expr`, lots of parent methods from sympy try to shove in `S.Zero`. Probably we shouldn't have inherited matrix from `Expr` itself, because but it is too late to change that.
- "Generic" matrix doesn't seem like having better runtime behavior than `S.Zero` or `S.One` anyway because of shape problems.

So if the generic matrices becomes pointless, we can let `S.Zero, S.One` become the universal identities for matrix expressions
I think that `S.Zero` and `S.One` could rather have better runtime behavior because they match the garbage inputs that parent classes throws.

I think that this fixes the problems of #24131 and #23364

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
