### PR TITLE
Issue #24304 fix (2nd try with pull request)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -487,6 +487,7 @@ Demian Wassermann <demian@bwh.harvard.edu>
 Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>
 Denis Ivanenko <ivanenko@ucu.edu.ua> LilJohny <ivanenko@ucu.edu.ua>
 Denis Rykov <rykovd@gmail.com>
+Denis Shuvalov <shuvalovds@gmail.com>
 Dennis Meckel <meckel@datenschuppen.de>
 Dennis Sweeney <sweeney.427@osu.edu> sweeneyde <sweeney.427@osu.edu>
 Denys Rybalka <rybalka.denis@gmail.com>

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -64,7 +64,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     imagesize = 'tight'
     offset = "0cm,0cm"
     resolution = round(150*scale)
-    dvi = r"-T %s -D %d -bg %s -fg %s -O %s" % (
+    dvi = r"-T %s -D %d -bg %s -fg %s -O %s --nogs" % (
         imagesize, resolution, backcolor, forecolor, offset)
     dvioptions = dvi.split()
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -64,7 +64,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     imagesize = 'tight'
     offset = "0cm,0cm"
     resolution = round(150*scale)
-    dvi = r"-T %s -D %d -bg %s -fg %s -O %s --nogs" % (
+    dvi = r"-T %s -D %d -bg %s -fg %s -O %s --nogs " % (
         imagesize, resolution, backcolor, forecolor, offset)
     dvioptions = dvi.split()
 

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -14,6 +14,7 @@ from .latex import latex
 
 __doctest_requires__ = {('preview',): ['pyglet']}
 
+CALLS_TIMEOUT = 10.0  # Time-out system command calls
 
 def _check_output_no_window(*args, **kwargs):
     # Avoid showing a cmd.exe window when running this
@@ -22,7 +23,7 @@ def _check_output_no_window(*args, **kwargs):
         creation_flag = 0x08000000 # CREATE_NO_WINDOW
     else:
         creation_flag = 0 # Default value
-    return check_output(*args, creationflags=creation_flag, **kwargs)
+    return check_output(*args, creationflags=creation_flag, timeout=CALLS_TIMEOUT, **kwargs)
 
 
 def system_default_viewer(fname, fmt):
@@ -346,7 +347,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                     raise RuntimeError("%s is not installed" % cmd_variants[0])
 
             defaultoptions = {
-                "dvipng": ["-T", "tight", "-z", "9", "--truecolor"],
+                "dvipng": ["-T", "tight", "--nogs", "-z", "9", "--truecolor"],
                 "dvisvgm": ["--no-fonts"],
             }
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Issue #24304 fix

#### Brief description of what is fixed or changed
"-nogs" option for dvipng calls
timeout for subprocess call

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Call dvipng with "-nogs" option to avoid its stuck on Windows
  * Implement 10s time-out for any sub-process call
<!-- END RELEASE NOTES -->
