### PR TITLE
Adding support for Si(x) in lambdify()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1201,6 +1201,7 @@ Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>
 Sean Ge <seange727@gmail.com>
 Sean P. Cornelius <spcornelius@gmail.com>
@@ -1533,4 +1534,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Sayan Mitra <ee18b156@smail.iitm.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -1533,3 +1533,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -172,7 +172,7 @@ def _import(module, reload=False):
     # contrast to abs().
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
-    
+
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -104,7 +104,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
-    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
+    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *; from scipy.special import sici",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
@@ -176,6 +176,7 @@ def _import(module, reload=False):
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:
+            _import("scipy")
             def _si(x):
                 from scipy.special import sici
                 return sici(x)[0]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -172,6 +172,17 @@ def _import(module, reload=False):
     # contrast to abs().
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
+    
+    # Adding support for Si(x) for the lambdify function (issue 24175)
+    if 'Si' not in namespace:
+        try:
+            _import("scipy")
+            def _si(x):
+                import scipy
+                return scipy.special.sici(x)[0]
+            namespace['Si'] = _si
+        except ImportError:
+            pass
 
 
 # Used for dynamically generated filenames that are inserted into the

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -176,10 +176,9 @@ def _import(module, reload=False):
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:
-            _import("scipy")
             def _si(x):
-                import scipy
-                return scipy.special.sici(x)[0]
+                from scipy.special import sici
+                return sici(x)[0]
             namespace['Si'] = _si
         except ImportError:
             pass


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24175


#### Brief description of what is fixed or changed
As per the discussion on the thread, added support for Si(x) in lambdify() using the scipy library.


#### Other comments
Helper function _si(x) that gives the first element of sici(from scipy)

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added support for Si(x) in lambdify.py
<!-- END RELEASE NOTES -->
