### PR TITLE
Adding support for Si(x) in lambdify() via SciPyPrinter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1201,6 +1201,7 @@ Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>
 Sean Ge <seange727@gmail.com>
 Sean P. Cornelius <spcornelius@gmail.com>
@@ -1533,4 +1534,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Sayan Mitra <ee18b156@smail.iitm.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -1533,3 +1533,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -427,6 +427,15 @@ class SciPyPrinter(NumPyPrinter):
                 self._print(e.args[0]),
                 limit_str)
 
+    def _print_Si(self, expr):
+        return "{}({})[0]".format(
+                self._module_format("scipy.special.sici"),
+                self._print(expr.args[0]))
+
+    def _print_Ci(self, expr):
+        return "{}({})[1]".format(
+                self._module_format("scipy.special.sici"),
+                self._print(expr.args[0]))
 
 for func in _scipy_known_functions:
     setattr(SciPyPrinter, f'_print_{func}', _print_known_func)

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -5,6 +5,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.gamma_functions import polygamma
+from sympy.functions.special.error_functions import (Si, Ci)
 from sympy.matrices.expressions.blockmatrix import BlockMatrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
@@ -346,3 +347,5 @@ def test_scipy_print_methods():
     k = Symbol('k', integer=True, nonnegative=True)
     x = Symbol('x', real=True)
     assert prntr.doprint(polygamma(k, x)) == "scipy.special.polygamma(k, x)"
+    assert prntr.doprint(Si(x)) == "scipy.special.sici(x)[0]"
+    assert prntr.doprint(Ci(x)) == "scipy.special.sici(x)[1]"

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -172,7 +172,7 @@ def _import(module, reload=False):
     # contrast to abs().
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
-    
+
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -184,6 +184,16 @@ def _import(module, reload=False):
         except ImportError:
             pass
 
+    # Adding support for Ci(x) for the lambdify function (issue 24175)
+    if 'Ci' not in namespace:
+        try:
+            _import("scipy")
+            def _ci(x):
+                from scipy.special import sici
+                return sici(x)[1]
+            namespace['Ci'] = _ci
+        except ImportError:
+            pass
 
 # Used for dynamically generated filenames that are inserted into the
 # linecache.

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -104,7 +104,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
-    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *; from scipy.special import sici",)),
+    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -104,7 +104,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
-    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
+    "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *; from scipy.special import sici",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
@@ -176,6 +176,7 @@ def _import(module, reload=False):
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:
+            _import("scipy")
             def _si(x):
                 from scipy.special import sici
                 return sici(x)[0]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -172,6 +172,17 @@ def _import(module, reload=False):
     # contrast to abs().
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
+    
+    # Adding support for Si(x) for the lambdify function (issue 24175)
+    if 'Si' not in namespace:
+        try:
+            _import("scipy")
+            def _si(x):
+                import scipy
+                return scipy.special.sici(x)[0]
+            namespace['Si'] = _si
+        except ImportError:
+            pass
 
 
 # Used for dynamically generated filenames that are inserted into the

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -173,27 +173,6 @@ def _import(module, reload=False):
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
 
-    # Adding support for Si(x) for the lambdify function (issue 24175)
-    if 'Si' not in namespace:
-        try:
-            _import("scipy")
-            def _si(x):
-                from scipy.special import sici
-                return sici(x)[0]
-            namespace['Si'] = _si
-        except ImportError:
-            pass
-
-    # Adding support for Ci(x) for the lambdify function (issue 24175)
-    if 'Ci' not in namespace:
-        try:
-            _import("scipy")
-            def _ci(x):
-                return sici(x)[1]
-            namespace['Ci'] = _ci
-        except ImportError:
-            pass
-
 # Used for dynamically generated filenames that are inserted into the
 # linecache.
 _lambdify_generated_counter = 1

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -176,10 +176,9 @@ def _import(module, reload=False):
     # Adding support for Si(x) for the lambdify function (issue 24175)
     if 'Si' not in namespace:
         try:
-            _import("scipy")
             def _si(x):
-                import scipy
-                return scipy.special.sici(x)[0]
+                from scipy.special import sici
+                return sici(x)[0]
             namespace['Si'] = _si
         except ImportError:
             pass

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -189,7 +189,6 @@ def _import(module, reload=False):
         try:
             _import("scipy")
             def _ci(x):
-                from scipy.special import sici
                 return sici(x)[1]
             namespace['Ci'] = _ci
         except ImportError:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -23,7 +23,7 @@ from sympy.functions.elementary.trigonometric import (acos, cos, cot, sin,
 from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely)
 from sympy.functions.special.beta_functions import (beta, betainc, betainc_regularized)
 from sympy.functions.special.delta_functions import (Heaviside)
-from sympy.functions.special.error_functions import (Ei, erf, erfc, fresnelc, fresnels)
+from sympy.functions.special.error_functions import (Ei, erf, erfc, fresnelc, fresnels, Si, Ci)
 from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma, polygamma)
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (And, false, ITE, Not, Or, true)
@@ -1094,10 +1094,10 @@ def test_scipy_fns():
     if not scipy:
         skip("scipy not installed")
 
-    single_arg_sympy_fns = [Ei, erf, erfc, factorial, gamma, loggamma, digamma]
+    single_arg_sympy_fns = [Ei, erf, erfc, factorial, gamma, loggamma, digamma, Si, Ci]
     single_arg_scipy_fns = [scipy.special.expi, scipy.special.erf, scipy.special.erfc,
         scipy.special.factorial, scipy.special.gamma, scipy.special.gammaln,
-                            scipy.special.psi]
+                            scipy.special.psi, scipy.special.sici, scipy.special.sici]
     numpy.random.seed(0)
     for (sympy_fn, scipy_fn) in zip(single_arg_sympy_fns, single_arg_scipy_fns):
         f = lambdify(x, sympy_fn(x), modules="scipy")
@@ -1117,8 +1117,15 @@ def test_scipy_fns():
             if sympy_fn == digamma:
                 tv = numpy.real(tv)
             sympy_result = sympy_fn(tv).evalf()
+            scipy_result = scipy_fn(tv)
+            # SciPy's sici returns a tuple with both Si and Ci present in it
+            # which needs to be unpacked
+            if sympy_fn == Si:
+                scipy_result = scipy_fn(tv)[0]
+            if sympy_fn == Ci:
+                scipy_result = scipy_fn(tv)[1]
             assert abs(f(tv) - sympy_result) < 1e-13*(1 + abs(sympy_result))
-            assert abs(f(tv) - scipy_fn(tv)) < 1e-13*(1 + abs(sympy_result))
+            assert abs(f(tv) - scipy_result) < 1e-13*(1 + abs(sympy_result))
 
     double_arg_sympy_fns = [RisingFactorial, besselj, bessely, besseli,
                             besselk, polygamma]


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24175 
#24568 


#### Brief description of what is fixed or changed
Added print method for `Si` and `Ci` in `SciPyPrinter`

#### Other comments
Method name - `_print_Si` and `_print_Ci`

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Added support for Si(x) and Ci(x) for using lambdify()
<!-- END RELEASE NOTES -->
