### PR TITLE
Added test case for syntax error on lambdify

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,6 +1,7 @@
 from itertools import product
 import math
 import inspect
+import numpy
 
 import mpmath
 from sympy.testing.pytest import raises, warns_deprecated_sympy

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,7 +1,7 @@
 from itertools import product
 import math
 import inspect
-import numpy
+
 
 import mpmath
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -1658,6 +1658,7 @@ def test_deprecated_set():
         lambdify({x, y}, x + y)
 
 def test_issue_13881():
+    import numpy
 
     X = MatrixSymbol('X', 3, 1)
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,7 +1,6 @@
 from itertools import product
 import math
 import inspect
-import numpy
 
 import mpmath
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -49,7 +48,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma
-from sympy import MatrixSymbol, lambdify
+
 
 import sympy
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,6 +1,7 @@
 from itertools import product
 import math
 import inspect
+import numpy
 
 import mpmath
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -48,6 +49,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma
+from sympy import MatrixSymbol, lambdify
 
 import sympy
 
@@ -1654,6 +1656,24 @@ def test_lambdify_cse():
 def test_deprecated_set():
     with warns_deprecated_sympy():
         lambdify({x, y}, x + y)
+
+def test_issue_13881():
+
+    X = MatrixSymbol('X', 3, 1)
+
+    f = lambdify(X, X.T*X, 'numpy')
+    assert f(numpy.array([1, 2, 3])) == 14
+    assert f(numpy.array([3, 2, 1])) == 14
+
+    f = lambdify(X, X*X.T, 'numpy')
+    assert f(numpy.array([1, 2, 3])) == 14
+    assert f(numpy.array([3, 2, 1])) == 14
+
+    f = lambdify(X, (X*X.T)*X, 'numpy')
+    arr1 = numpy.array([[1], [2], [3]])
+    arr2 = numpy.array([[14],[28],[42]])
+
+    assert numpy.array_equal(f(arr1), arr2)
 
 
 def test_23536_lambdify_cse_dummy():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -3,6 +3,7 @@ import math
 import inspect
 
 
+
 import mpmath
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.concrete.summations import Sum
@@ -1658,7 +1659,8 @@ def test_deprecated_set():
         lambdify({x, y}, x + y)
 
 def test_issue_13881():
-    import numpy
+    if not numpy:
+        skip("numpy not installed.")
 
     X = MatrixSymbol('X', 3, 1)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #13881 


#### Brief description of what is fixed or changed
Add test case that this works just fine:
```python
>>> from sympy import MatrixSymbol, lambdify
>>> x = MatrixSymbol('x', 3, 1)
>>> f = lambdify(x, x.T*x)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
