### PR TITLE
Getting rid of some micro optimizations in `ddm_irref`

### DIFF
--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -132,10 +132,9 @@ def ddm_irref(a, _partial_pivot=False):
 
         # normalise row
         u = a[i]
-        aij_inv = u[j]**-1
         for l in range(j + 1, n):
-            u[l] *= aij_inv # ai[j] = one
-        u[j] *= aij_inv
+            u[l] /= u[j]
+        u[j] /= u[j]
 
         # eliminate above and below to the right
         for k, v in enumerate(a):

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -131,18 +131,19 @@ def ddm_irref(a, _partial_pivot=False):
                 continue
 
         # normalise row
-        aij_inv = a[i][j]**-1
+        u = a[i]
+        aij_inv = u[j]**-1
         for l in range(j + 1, n):
-            a[i][l] *= aij_inv # ai[j] = one
-        a[i][j] *= aij_inv
+            u[l] *= aij_inv # ai[j] = one
+        u[j] *= aij_inv
 
         # eliminate above and below to the right
-        for k, r in enumerate(a):
+        for k, v in enumerate(a):
             if k == i:
                 continue
             for l in range(j + 1, n):
-                r[l] -= r[j] * a[i][l]
-            r[j] -= r[j]
+                v[l] -= v[j] * u[l]
+            v[j] -= v[j]
 
         # next row
         pivots.append(j)

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -131,18 +131,18 @@ def ddm_irref(a, _partial_pivot=False):
                 continue
 
         # normalise row
-        u = a[i]
+        ai = a[i]
         for l in range(j + 1, n):
-            u[l] /= u[j]
-        u[j] /= u[j]
+            ai[l] /= ai[j]
+        ai[j] /= ai[j]
 
         # eliminate above and below to the right
-        for k, v in enumerate(a):
+        for k, ak in enumerate(a):
             if k == i:
                 continue
             for l in range(j + 1, n):
-                v[l] -= v[j] * u[l]
-            v[j] -= v[j]
+                ak[l] -= ak[j] * ai[l]
+            ak[j] -= ak[j]
 
         # next row
         pivots.append(j)

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -131,17 +131,18 @@ def ddm_irref(a, _partial_pivot=False):
                 continue
 
         # normalise row
+        aij_inv = a[i][j]**-1
         for l in range(j + 1, n):
-            a[i][l] /= a[i][j] # ai[j] = one
-        a[i][j] /= a[i][j]
+            a[i][l] *= aij_inv # ai[j] = one
+        a[i][j] *= aij_inv
 
         # eliminate above and below to the right
-        for k in range(len(a)):
+        for k, r in enumerate(a):
             if k == i:
                 continue
-            for l in range(j+1, n):
-                a[k][l] -= a[k][j] * a[i][l]
-            a[k][j] -= a[k][j]
+            for l in range(j + 1, n):
+                r[l] -= r[j] * a[i][l]
+            r[j] -= r[j]
 
         # next row
         pivots.append(j)

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -136,14 +136,12 @@ def ddm_irref(a, _partial_pivot=False):
         a[i][j] /= a[i][j]
 
         # eliminate above and below to the right
-        for k, ak in enumerate(a):
-            if k == i or not ak[j]:
+        for k in range(len(a)):
+            if k == i:
                 continue
-
-            # ak[j] = zero
             for l in range(j+1, n):
-                ak[l] -= ak[j] * a[i][l]
-            ak[j] -= ak[j]
+                a[k][l] -= a[k][j] * a[i][l]
+            a[k][j] -= a[k][j]
 
         # next row
         pivots.append(j)

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -116,38 +116,34 @@ def ddm_irref(a, _partial_pivot=False):
         # domain is RR or CC. It uses partial (row) pivoting based on the
         # absolute value of the pivot candidates.
         if _partial_pivot:
-            ip = max(range(i, m), key=lambda ip: abs(a[ip][j]))
-            a[i], a[ip] = a[ip], a[i]
-
-        # pivot
-        aij = a[i][j]
+            p = max(range(i, m), key=lambda ip: abs(a[ip][j]))
+            a[i], a[p] = a[p], a[i]
 
         # zero-pivot
-        if not aij:
-            for ip in range(i+1, m):
-                aij = a[ip][j]
+        if not a[i][j]:
+            for p in range(i+1, m):
                 # row-swap
-                if aij:
-                    a[i], a[ip] = a[ip], a[i]
+                if a[p][j]:
+                    a[i], a[p] = a[p], a[i]
                     break
             else:
                 # next column
                 continue
 
         # normalise row
-        ai = a[i]
-        aijinv = aij**-1
-        for l in range(j, n):
-            ai[l] *= aijinv # ai[j] = one
+        for l in range(j + 1, n):
+            a[i][l] /= a[i][j] # ai[j] = one
+        a[i][j] /= a[i][j]
 
         # eliminate above and below to the right
         for k, ak in enumerate(a):
             if k == i or not ak[j]:
                 continue
-            akj = ak[j]
-            ak[j] -= akj # ak[j] = zero
+
+            # ak[j] = zero
             for l in range(j+1, n):
-                ak[l] -= akj * ai[l]
+                ak[l] -= ak[j] * a[i][l]
+            ak[j] -= ak[j]
 
         # next row
         pivots.append(j)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that old sympy code used a lot of micro-optimizing, like assigning attributes to variable before loop
I'm testing out how such micro optimizations are worth it, by testing out `100 x 100` matrix
```
rng = Random(0)

def f():
    return Fraction(rng.randint(-10, 10), rng.randint(1, 10))

M = [[f() for _ in range(100)] for _ in range(100)]
%prun -s cumulative out = ddm_irref(M)
```
But I don't see there is any improvement even in 3.8, maybe because most of the times are dominated by `Fraction` and also

Especially after python 3.11, these kind of optimizations are likely be outdated because of specializing adapters
https://peps.python.org/pep-0659/
so things like `exquo = K.exquo` are going to be bad practice the future.

Maybe things like efficiently looping with both the key and the items, like `enumerate` or `dict.items` can still be valid in the future, and it wouldn't hurt the readability.
But generally, having too many variables, and abusing the variables make it hard to track down each state what they denote and how they mutate, so we need to get rid of something too trivial like `aij = a[i][j], aijinv = aij**-1, ...`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
