### PR TITLE
Clean up numpydoc upstream errors

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1219,21 +1219,6 @@ class Quaternion(Expr):
 
         Generates a 4x4 transformation matrix (used for rotation about a point
         other than the origin) if the point(v) is passed as an argument.
-
-        Examples
-        ========
-
-        >>> from sympy import Quaternion
-        >>> from sympy import symbols, trigsimp, cos, sin
-        >>> x = symbols('x')
-        >>> q = Quaternion(cos(x/2), 0, 0, sin(x/2))
-        >>> trigsimp(q.to_rotation_matrix((1, 1, 1)))
-         Matrix([
-        [cos(x), -sin(x), 0,  sin(x) - cos(x) + 1],
-        [sin(x),  cos(x), 0, -sin(x) - cos(x) + 1],
-        [     0,       0, 1,                    0],
-        [     0,       0, 0,                    1]])
-
         """
 
         q = self

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -678,9 +678,6 @@ class CodeBlock(CodegenAST):
         This is a class constructor so that the default constructor for
         CodeBlock can error when variables are used before they are assigned.
 
-        Examples
-        ========
-
         >>> from sympy import symbols
         >>> from sympy.codegen.ast import CodeBlock, Assignment
         >>> x, y, z = symbols('x y z')

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -440,8 +440,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         See Also
         ========
 
-        Sum.is_absolutely_convergent()
-        sympy.concrete.products.Product.is_convergent()
+        Sum.is_absolutely_convergent
+        sympy.concrete.products.Product.is_convergent
         """
         p, q, r = symbols('p q r', cls=Wild)
 
@@ -686,7 +686,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         See Also
         ========
 
-        Sum.is_convergent()
+        Sum.is_convergent
         """
         return Sum(abs(self.function), self.limits).is_convergent()
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -193,7 +193,7 @@ class Add(Expr, AssocOp):
 
         NB: the removal of 0 is already handled by AssocOp.__new__
 
-        See also
+        See Also
         ========
 
         sympy.core.mul.Mul.flatten

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1843,8 +1843,8 @@ class Expr(Basic, EvalfMixin):
 
         separatevars
         expand_log
-        Add.as_two_terms
-        Mul.as_two_terms
+        sympy.core.add.Add.as_two_terms
+        sympy.core.mul.Mul.as_two_terms
         as_coeff_mul
         """
         from .symbol import Symbol

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1840,8 +1840,12 @@ class Expr(Basic, EvalfMixin):
 
         See Also
         ========
-        .separatevars(), .expand(log=True), sympy.core.add.Add.as_two_terms(),
-        sympy.core.mul.Mul.as_two_terms(), .as_coeff_add(), .as_coeff_mul()
+
+        separatevars
+        expand_log
+        Add.as_two_terms
+        Mul.as_two_terms
+        as_coeff_mul
         """
         from .symbol import Symbol
         from .add import _unevaluated_Add
@@ -2813,7 +2817,8 @@ class Expr(Basic, EvalfMixin):
 
         See Also
         ========
-        is_rational_function()
+
+        is_rational_function
 
         References
         ==========

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2092,25 +2092,6 @@ class Subs(Expr):
         A point or list of evaluation points
         corresponding to those variables.
 
-    Notes
-    =====
-
-    ``Subs`` objects are generally useful to represent unevaluated derivatives
-    calculated at a point.
-
-    The variables may be expressions, but they are subjected to the limitations
-    of subs(), so it is usually a good practice to use only symbols for
-    variables, since in that case there can be no ambiguity.
-
-    There's no automatic expansion - use the method .doit() to effect all
-    possible substitutions of the object and also of objects inside the
-    expression.
-
-    When evaluating derivatives at a point that is not a symbol, a Subs object
-    is returned. One is also able to calculate derivatives of Subs objects - in
-    this case the expression is always expanded (for the unevaluated form, use
-    Derivative()).
-
     Examples
     ========
 
@@ -2139,6 +2120,22 @@ class Subs(Expr):
 
     Notes
     =====
+
+    ``Subs`` objects are generally useful to represent unevaluated derivatives
+    calculated at a point.
+
+    The variables may be expressions, but they are subjected to the limitations
+    of subs(), so it is usually a good practice to use only symbols for
+    variables, since in that case there can be no ambiguity.
+
+    There's no automatic expansion - use the method .doit() to effect all
+    possible substitutions of the object and also of objects inside the
+    expression.
+
+    When evaluating derivatives at a point that is not a symbol, a Subs object
+    is returned. One is also able to calculate derivatives of Subs objects - in
+    this case the expression is always expanded (for the unevaluated form, use
+    Derivative()).
 
     In order to allow expressions to combine before doit is done, a
     representation of the Subs expression is used internally to make

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -350,8 +350,8 @@ class Application(Basic, metaclass=FunctionClass):
         (possible of some other class), or if the class cls should be
         unmodified, return None.
 
-        Examples of eval() for the function "sign"
-        ---------------------------------------------
+        Examples of eval for the function "sign"
+        ----------------------------------------
 
         .. code-block:: python
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -345,13 +345,12 @@ class Application(Basic, metaclass=FunctionClass):
         Explanation
         ===========
 
-        The eval() method is called when the class cls is about to be
+        The ``eval()`` method is called when the class ``cls`` is about to be
         instantiated and it should return either some simplified instance
-        (possible of some other class), or if the class cls should be
+        (possible of some other class), or if the class ``cls`` should be
         unmodified, return None.
 
-        Examples of eval for the function "sign"
-        ----------------------------------------
+        Examples of ``eval()`` for the function "sign"
 
         .. code-block:: python
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2869,8 +2869,7 @@ class AlgebraicNumber(Expr):
         See Also
         ========
 
-        .AlgebraicNumber.__new__()
-
+        AlgebraicNumber
         """
         return AlgebraicNumber(
             (self.minpoly, self.root), coeffs=coeffs, alias=self.alias)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2333,9 +2333,6 @@ class acos(InverseTrigonometricFunction):
 
     A purely imaginary argument will be rewritten to asinh.
 
-    Examples
-    ========
-
     >>> from sympy import acos, oo
     >>> acos(1)
     0

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2319,10 +2319,10 @@ class acos(InverseTrigonometricFunction):
     r"""
     The inverse cosine function.
 
-    Returns the arc cosine of x (measured in radians).
+    Explanation
+    ===========
 
-    Examples
-    ========
+    Returns the arc cosine of x (measured in radians).
 
     ``acos(x)`` will evaluate automatically in the cases
     $x \in \{\infty, -\infty, 0, 1, -1\}$ and for some instances when
@@ -2332,6 +2332,9 @@ class acos(InverseTrigonometricFunction):
     (see note in :class:`sympy.functions.elementary.trigonometric.asec`)
 
     A purely imaginary argument will be rewritten to asinh.
+
+    Examples
+    ========
 
     >>> from sympy import acos, oo
     >>> acos(1)

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -219,11 +219,6 @@ class LinearEntity(GeometrySet):
 
         angle : angle in radians
 
-        See Also
-        ========
-
-        angle_between, is_perpendicular, Ray2D.closing_angle
-
         Examples
         ========
 
@@ -235,7 +230,8 @@ class LinearEntity(GeometrySet):
 
         See Also
         ========
-        angle_between, Ray2D.closing_angle
+
+        angle_between, is_perpendicular, Ray2D.closing_angle
         """
         if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
             raise TypeError('Must pass only LinearEntity objects')
@@ -1909,18 +1905,6 @@ class LinearEntity2D(LinearEntity):
     def perpendicular_line(self, p):
         """Create a new Line perpendicular to this linear entity which passes
         through the point `p`.
-
-        Examples
-        ========
-
-        >>> from sympy import Point, Line
-        >>> p1, p2, p3 = Point(0, 0), Point(2, 3), Point(-2, 2)
-        >>> l1 = Line(p1, p2)
-        >>> l2 = l1.perpendicular_line(p3)
-        >>> p3 in l2
-        True
-        >>> l1.is_perpendicular(l2)
-        True
 
         Parameters
         ==========

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -868,7 +868,7 @@ class HolonomicFunction:
         See Also
         ========
 
-        .integrate()
+        integrate
         """
         kwargs.setdefault('evaluate', True)
         if args:
@@ -1200,7 +1200,7 @@ class HolonomicFunction:
         See Also
         ========
 
-        from_hyper()
+        from_hyper
         """
 
         R = self.annihilator.parent
@@ -1283,7 +1283,7 @@ class HolonomicFunction:
         See Also
         ========
 
-        HolonomicFunction.series()
+        HolonomicFunction.series
 
         References
         ==========

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1674,7 +1674,7 @@ class HolonomicFunction:
         See Also
         ========
 
-        HolonomicFunction.to_sequence()
+        HolonomicFunction.to_sequence
         """
 
         if _recur is None:
@@ -2143,7 +2143,7 @@ class HolonomicFunction:
         See Also
         ========
 
-        to_hyper()
+        to_hyper
         """
 
         # convert to hypergeometric first

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -556,7 +556,8 @@ class MatrixShaping(MatrixRequired):
 
         See Also
         ========
-        diag - to create a diagonal matrix
+
+        diag
         """
         rv = []
         k = as_int(k)
@@ -924,10 +925,10 @@ class MatrixSpecial(MatrixRequired):
         See Also
         ========
         eye
-        diagonal - to extract a diagonal
+        diagonal
         .dense.diag
         .expressions.blockmatrix.BlockMatrix
-        .sparsetools.banded - to create multi-diagonal matrices
+        .sparsetools.banded
        """
         from sympy.matrices.matrices import MatrixBase
         from sympy.matrices.dense import Matrix
@@ -983,8 +984,8 @@ class MatrixSpecial(MatrixRequired):
     def eye(kls, rows, cols=None, **kwargs):
         """Returns an identity matrix.
 
-        Args
-        ====
+        Parameters
+        ==========
 
         rows : rows of the matrix
         cols : cols of the matrix (if None, cols=rows)
@@ -1105,8 +1106,8 @@ class MatrixSpecial(MatrixRequired):
     def ones(kls, rows, cols=None, **kwargs):
         """Returns a matrix of ones.
 
-        Args
-        ====
+        Parameters
+        ==========
 
         rows : rows of the matrix
         cols : cols of the matrix (if None, cols=rows)
@@ -1126,8 +1127,8 @@ class MatrixSpecial(MatrixRequired):
     def zeros(kls, rows, cols=None, **kwargs):
         """Returns a matrix of zeros.
 
-        Args
-        ====
+        Parameters
+        ==========
 
         rows : rows of the matrix
         cols : cols of the matrix (if None, cols=rows)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -783,7 +783,7 @@ def diag(*values, strict=True, unpack=False, **kwargs):
     See Also
     ========
     .common.MatrixCommon.eye
-    .common.MatrixCommon.diagonal - to extract a diagonal
+    .common.MatrixCommon.diagonal
     .common.MatrixCommon.diag
     .expressions.blockmatrix.BlockMatrix
     """

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -269,9 +269,9 @@ class JointsMethod(_Methods):
         See Also
         ========
 
-        sympy.physics.mechanics.kane.KanesMethod.rhs():
+        sympy.physics.mechanics.kane.KanesMethod.rhs:
             KanesMethod's rhs function.
-        sympy.physics.mechanics.lagrange.LagrangesMethod.rhs():
+        sympy.physics.mechanics.lagrange.LagrangesMethod.rhs:
             LagrangesMethod's rhs function.
 
         """

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -448,7 +448,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         See Also
         ========
 
-        integral_basis()
+        integral_basis
 
         """
         if self._maximal_order is None:
@@ -496,10 +496,9 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         See Also
         ========
 
-        to_sympy()
-        to_alg_num()
-        maximal_order()
-
+        to_sympy
+        to_alg_num
+        maximal_order
         """
         ZK = self.maximal_order()
         M = ZK.QQ_matrix

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -52,9 +52,8 @@ def approximants(l, X=Symbol('x'), simplify=False):
     See Also
     ========
 
-    See function sympy.concrete.guess.guess_generating_function_rational and
-    function mpmath.pade
-
+    sympy.concrete.guess.guess_generating_function_rational
+    mpmath.pade
     """
     from sympy.simplify import simplify as simp
     from sympy.simplify.radsimp import denom

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1307,6 +1307,12 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     True then permutations of the base solution and/or permutations of the
     signs of the values will be returned when applicable.
 
+    Details
+    =======
+
+    ``eq`` should be an expression which is assumed to be zero.
+    ``t`` is the parameter to be used in the solution.
+
     Examples
     ========
 
@@ -1317,15 +1323,6 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     {(2, 3)}
     >>> diophantine(eq, permute=True)
     {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
-
-    Details
-    =======
-
-    ``eq`` should be an expression which is assumed to be zero.
-    ``t`` is the parameter to be used in the solution.
-
-    Examples
-    ========
 
     >>> from sympy.abc import x, y, z
     >>> diophantine(x**2 - y**2)
@@ -1339,7 +1336,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     See Also
     ========
 
-    diop_solve()
+    diop_solve
     sympy.utilities.iterables.permute_signs
     sympy.utilities.iterables.signed_permutations
     """

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -774,7 +774,7 @@ class MultisetPartitionTraverser():
         See Also
         ========
 
-        multiset_partitions_taocp():
+        multiset_partitions_taocp:
             which provides the same result as this method, but is
             about twice as fast.  Hence, enum_all is primarily useful
             for testing.  Also see the function for a discussion of


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I've tested the build of upstream numpydoc and I notice that there is weird behavior for "see also" sections
That writing functions as calls `()` tries to execute some code around it and gets broken for it

So we may need to ban these stuff for docstring. I'm not sure if those were linked correctly before though.

I also remove duplicate examples because upstream numpydoc become more sensitive about building it

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
