### PR TITLE
Fix issues with numpydoc formatting

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1478,9 +1478,12 @@ class Quaternion(Expr):
         Parameters
         ==========
 
-        q1 : a pure Quaternion.
-        q2 : a pure Quaternion.
-        q3 : a pure Quaternion.
+        q1
+            A pure Quaternion.
+        q2
+            A pure Quaternion.
+        q3
+            A pure Quaternion.
 
         Returns
         =======

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -122,7 +122,7 @@ class Quaternion(Expr):
             return obj
 
     def set_norm(self, norm):
-        """Sets norm of an already instantiated quaternion.:
+        """Sets norm of an already instantiated quaternion.
 
         Parameters
         ==========
@@ -1143,7 +1143,7 @@ class Quaternion(Expr):
         return (pout.b, pout.c, pout.d)
 
     def to_axis_angle(self):
-        """Returns the axis and angle of rotation of a quaternion
+        """Returns the axis and angle of rotation of a quaternion.
 
         Returns
         =======

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -609,8 +609,6 @@ def remove_handler(key, handler):
     """
     Removes a handler from the ask system.
 
-    Same syntax as register_handler
-
     .. deprecated:: 1.8.
         Use multipledispatch handler instead. See :obj:`~.Predicate`.
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -607,7 +607,9 @@ def register_handler(key, handler):
 
 def remove_handler(key, handler):
     """
-    Removes a handler from the ask system. Same syntax as register_handler
+    Removes a handler from the ask system.
+
+    Same syntax as register_handler
 
     .. deprecated:: 1.8.
         Use multipledispatch handler instead. See :obj:`~.Predicate`.

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -381,14 +381,14 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     Parameters
     ==========
 
-    proposition : Any boolean expression.
+    proposition : Boolean
         Proposition which will be evaluated to boolean value. If this is
         not ``AppliedPredicate``, it will be wrapped by ``Q.is_true``.
 
-    assumptions : Any boolean expression, optional.
+    assumptions : Boolean, optional
         Local assumptions to evaluate the *proposition*.
 
-    context : AssumptionsContext, optional.
+    context : AssumptionsContext, optional
         Default assumptions to evaluate the *proposition*. By default,
         this is ``sympy.assumptions.global_assumptions`` variable.
 

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -634,9 +634,9 @@ class AccumulationBounds(Expr):
         Parameters
         ==========
 
-        other: AccumulationBounds
-             Another AccumulationBounds object with which the intersection
-             has to be computed.
+        other : AccumulationBounds
+            Another AccumulationBounds object with which the intersection
+            has to be computed.
 
         Returns
         =======

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -12,7 +12,8 @@ from sympy.sets.sets import FiniteSet
 
 
 class AccumulationBounds(Expr):
-    r"""
+    r"""An accumulation bounds.
+
     # Note AccumulationBounds has an alias: AccumBounds
 
     AccumulationBounds represent an interval `[a, b]`, which is always closed

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -228,7 +228,7 @@ def function_range(f, symbol, domain):
 def not_empty_in(finset_intersection, *syms):
     """
     Finds the domain of the functions in ``finset_intersection`` in which the
-    ``finite_set`` is not-empty
+    ``finite_set`` is not-empty.
 
     Parameters
     ==========

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -234,10 +234,10 @@ def not_empty_in(finset_intersection, *syms):
     ==========
 
     finset_intersection : Intersection of FiniteSet
-                        The unevaluated intersection of FiniteSet containing
-                        real-valued functions with Union of Sets
+        The unevaluated intersection of FiniteSet containing
+        real-valued functions with Union of Sets
     syms : Tuple of symbols
-            Symbol for which domain is to be found
+        Symbol for which domain is to be found
 
     Raises
     ======
@@ -344,7 +344,7 @@ def periodicity(f, symbol, check=False):
     Parameters
     ==========
 
-    f : :py:class:`~.Expr`.
+    f : :py:class:`~.Expr`
         The concerned function.
     symbol : :py:class:`~.Symbol`
         The variable for which the period is to be determined.

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -272,6 +272,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
     def eval_zeta_function(self, f, limits):
         """
         Check whether the function matches with the zeta function.
+
         If it matches, then return a `Piecewise` expression because
         zeta function does not converge unless `s > 1` and `q > 0`
         """

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -396,7 +396,6 @@ class Add(Expr, AssocOp):
 
     @classmethod
     def class_key(cls):
-        """Nice order of classes"""
         return 3, 1, cls.__name__
 
     @property
@@ -987,7 +986,7 @@ class Add(Expr, AssocOp):
 
     def as_real_imag(self, deep=True, **hints):
         """
-        Returns a tuple representing a complex number
+        Return a tuple representing a complex number.
 
         Examples
         ========

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -987,7 +987,7 @@ class Add(Expr, AssocOp):
 
     def as_real_imag(self, deep=True, **hints):
         """
-        returns a tuple representing a complex number
+        Returns a tuple representing a complex number
 
         Examples
         ========

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1267,7 +1267,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         return self._has(iterargs, *patterns)
 
     def has_xfree(self, s: set[Basic]):
-        """return True if self has any of the patterns in s as a
+        """Return True if self has any of the patterns in s as a
         free argument, else False. This is like `Basic.has_free`
         but this will only report exact argument matches.
 
@@ -1295,7 +1295,7 @@ class Basic(Printable, metaclass=ManagedProperties):
 
     @cacheit
     def has_free(self, *patterns):
-        """return True if self has object(s) ``x`` as a free expression
+        """Return True if self has object(s) ``x`` as a free expression
         else False.
 
         Examples
@@ -1781,7 +1781,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         return m
 
     def count_ops(self, visual=None):
-        """wrapper for count_ops that returns the operation count."""
+        """Wrapper for count_ops that returns the operation count."""
         from .function import count_ops
         return count_ops(self, visual)
 
@@ -1857,11 +1857,12 @@ class Basic(Printable, metaclass=ManagedProperties):
         Parameters
         ==========
 
-        args : *rule*, or *pattern* and *rule*.
+        args : Expr
+            A *rule*, or *pattern* and *rule*.
             - *pattern* is a type or an iterable of types.
             - *rule* can be any object.
 
-        deep : bool, optional.
+        deep : bool, optional
             If ``True``, subexpressions are recursively transformed. Default is
             ``True``.
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1632,7 +1632,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         return (rv, mapping) if map else rv
 
     def find(self, query, group=False):
-        """Find all subexpressions matching a query. """
+        """Find all subexpressions matching a query."""
         query = _make_find_query(query)
         results = list(filter(query, _preorder_traversal(self)))
 
@@ -1650,7 +1650,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             return groups
 
     def count(self, query):
-        """Count the number of matching subexpressions. """
+        """Count the number of matching subexpressions."""
         query = _make_find_query(query)
         return sum(bool(query(sub)) for sub in _preorder_traversal(self))
 
@@ -1812,12 +1812,12 @@ class Basic(Printable, metaclass=ManagedProperties):
             return self
 
     def simplify(self, **kwargs):
-        """See the simplify function in sympy.simplify"""
+        """See the simplify function with :func:`sympy.simplify`."""
         from sympy.simplify.simplify import simplify
         return simplify(self, **kwargs)
 
     def refine(self, assumption=True):
-        """See the refine function in sympy.assumptions"""
+        """See the refine function with :func:`sympy.assumptions`."""
         from sympy.assumptions.refine import refine
         return refine(self, assumption)
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1812,12 +1812,12 @@ class Basic(Printable, metaclass=ManagedProperties):
             return self
 
     def simplify(self, **kwargs):
-        """See the simplify function with :func:`sympy.simplify`."""
+        """See the simplify function with sympy.simplify"""
         from sympy.simplify.simplify import simplify
         return simplify(self, **kwargs)
 
     def refine(self, assumption=True):
-        """See the refine function with :func:`sympy.assumptions`."""
+        """See the refine function with sympy.assumptions"""
         from sympy.assumptions.refine import refine
         return refine(self, assumption)
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -295,7 +295,7 @@ class Basic(Printable, metaclass=ManagedProperties):
 
     @classmethod
     def class_key(cls):
-        """Nice order of classes. """
+        """Nice order of classes."""
         return 5, 0, cls.__name__
 
     @cacheit

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1812,12 +1812,12 @@ class Basic(Printable, metaclass=ManagedProperties):
             return self
 
     def simplify(self, **kwargs):
-        """See the simplify function with sympy.simplify"""
+        """See the simplify function in sympy.simplify"""
         from sympy.simplify.simplify import simplify
         return simplify(self, **kwargs)
 
     def refine(self, assumption=True):
-        """See the refine function with sympy.assumptions"""
+        """See the refine function in sympy.assumptions"""
         from sympy.assumptions.refine import refine
         return refine(self, assumption)
 

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -166,7 +166,7 @@ def cached_property(func):
 
 
 def lazy_function(module : str, name : str) -> Callable:
-    """ Create a lazy proxy for a function in a module
+    """Create a lazy proxy for a function in a module.
 
     The module containing the function is not imported until the function is used.
 

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -119,8 +119,8 @@ class Tuple(Basic):
 
     # XXX: Basic defines count() as something different, so we can't
     # redefine it here. Originally this lead to cse() test failure.
-    def tuple_count(self, value):
-        """T.count(value) -> integer -- return number of occurrences of value"""
+    def tuple_count(self, value) -> int:
+        """Return number of occurrences of value."""
         return self.args.count(value)
 
     def index(self, value, start=None, stop=None):
@@ -216,7 +216,7 @@ def tuple_wrapper(method):
 
 class Dict(Basic):
     """
-    Wrapper around the builtin dict object
+    Wrapper around the builtin dict object.
 
     Explanation
     ===========

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3548,11 +3548,11 @@ class Expr(Basic, EvalfMixin):
         return c, e
 
     def as_coeff_Mul(self, rational: bool = False) -> tuple['Number', Expr]:
-        """Efficiently extract the coefficient of a product. """
+        """Efficiently extract the coefficient of a product """
         return S.One, self
 
     def as_coeff_Add(self, rational=False) -> tuple['Number', Expr]:
-        """Efficiently extract the coefficient of a summation. """
+        """Efficiently extract the coefficient of a summation."""
         return S.Zero, self
 
     def fps(self, x=None, x0=0, dir=1, hyper=True, order=4, rational=True,

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3548,7 +3548,7 @@ class Expr(Basic, EvalfMixin):
         return c, e
 
     def as_coeff_Mul(self, rational: bool = False) -> tuple['Number', Expr]:
-        """Efficiently extract the coefficient of a product """
+        """Efficiently extract the coefficient of a product."""
         return S.One, self
 
     def as_coeff_Add(self, rational=False) -> tuple['Number', Expr]:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1273,7 +1273,6 @@ class Expr(Basic, EvalfMixin):
         raise NotImplementedError('not sure of order of %s' % o)
 
     def count_ops(self, visual=None):
-        """wrapper for count_ops that returns the operation count."""
         from .function import count_ops
         return count_ops(self, visual)
 
@@ -2166,7 +2165,9 @@ class Expr(Basic, EvalfMixin):
         return S.One, self
 
     def as_numer_denom(self):
-        """ expression -> a/b -> a, b
+        """Return the numerator and the denominator of an expression.
+
+        expression -> a/b -> a, b
 
         This is just a stub that should be defined by
         an object's class methods to get anything else.
@@ -2180,7 +2181,9 @@ class Expr(Basic, EvalfMixin):
         return self, S.One
 
     def normal(self):
-        """ expression -> a/b
+        """Return the expression as a fraction.
+
+        expression -> a/b
 
         See Also
         ========
@@ -3426,7 +3429,8 @@ class Expr(Basic, EvalfMixin):
         return limit(self, x, xlim, dir)
 
     def compute_leading_term(self, x, logx=None):
-        """
+        """Deprecated function to compute the leading term of a series.
+
         as_leading_term is only allowed for results of .series()
         This is a wrapper to compute a series first.
         """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -826,13 +826,13 @@ class Number(AtomicExpr):
         return S.Zero, (self,)
 
     def as_coeff_Mul(self, rational=False):
-        """Efficiently extract the coefficient of a product. """
+        """Efficiently extract the coefficient of a product."""
         if rational and not self.is_Rational:
             return S.One, self
         return (self, S.One) if self else (S.One, self)
 
     def as_coeff_Add(self, rational=False):
-        """Efficiently extract the coefficient of a summation. """
+        """Efficiently extract the coefficient of a summation."""
         if not rational:
             return self, S.Zero
         return S.Zero, self
@@ -2037,11 +2037,11 @@ class Rational(Number):
         return S.One, self
 
     def as_coeff_Mul(self, rational=False):
-        """Efficiently extract the coefficient of a product. """
+        """Efficiently extract the coefficient of a product."""
         return self, S.One
 
     def as_coeff_Add(self, rational=False):
-        """Efficiently extract the coefficient of a summation. """
+        """Efficiently extract the coefficient of a summation."""
         return self, S.Zero
 
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -494,7 +494,8 @@ class LatticeOp(AssocOp):
     >>> my_join(1, 2)
     2
 
-    References:
+    References
+    ==========
 
     .. [1] https://en.wikipedia.org/wiki/Lattice_%28order%29
     """

--- a/sympy/core/sorting.py
+++ b/sympy/core/sorting.py
@@ -49,7 +49,6 @@ def default_sort_key(item, order=None):
     >>> default_sort_key(2)
     ((1, 0, 'Number'), (0, ()), (), 2)
 
-
     While sort_key is a method only defined for SymPy objects,
     default_sort_key will accept anything as an argument so it is
     more robust as a sorting key. For the following, using key=
@@ -69,8 +68,8 @@ def default_sort_key(item, order=None):
     >>> min(a, key=default_sort_key)
     2
 
-    Note
-    ----
+    Notes
+    =====
 
     The key returned is useful for getting items into a canonical order
     that will be the same across platforms. It is not directly useful for

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -899,8 +899,8 @@ class Rem(Function):
 
     @classmethod
     def eval(cls, p, q):
-        """ the function remainder if both p,q are numbers
-            and q is not zero
+        """Return the function remainder if both $p, q$ are numbers
+        and $q$ is not zero.
         """
 
         if q.is_zero:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -899,8 +899,8 @@ class Rem(Function):
 
     @classmethod
     def eval(cls, p, q):
-        """Return the function remainder if both $p, q$ are numbers
-        and $q$ is not zero.
+        """Return the function remainder if both p, q are numbers and q is not
+        zero.
         """
 
         if q.is_zero:

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -302,7 +302,8 @@ class LinearEntity(GeometrySet):
         Parameters
         ==========
 
-        lines : a sequence of linear entities.
+        lines
+            A sequence of linear entities.
 
         Returns
         =======

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -505,7 +505,7 @@ class Plane(GeometryEntity):
 
 
     def is_perpendicular(self, l):
-        """is the given geometric entity perpendicualar to the given plane?
+        """Is the given geometric entity perpendicualar to the given plane?
 
         Parameters
         ==========

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -863,7 +863,8 @@ class Point2D(Point):
     Parameters
     ==========
 
-    coords : sequence of 2 coordinate values.
+    coords
+        A sequence of 2 coordinate values.
 
     Attributes
     ==========
@@ -1075,7 +1076,8 @@ class Point3D(Point):
     Parameters
     ==========
 
-    coords : sequence of 3 coordinate values.
+    coords
+        A sequence of 3 coordinate values.
 
     Attributes
     ==========

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -31,13 +31,12 @@ class Polygon(GeometrySet):
     Parameters
     ==========
 
-    vertices : sequence of Points
+    vertices
+        A sequence of points.
 
-    Optional parameters
-    ==========
-
-    n : If > 0, an n-sided RegularPolygon is created. See below.
-        Default value is 0.
+    n : int, optional
+        If $> 0$, an n-sided RegularPolygon is created.
+        Default value is $0$.
 
     Attributes
     ==========

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -285,7 +285,8 @@ def closest_points(*args):
     Parameters
     ==========
 
-    args : a collection of Points on 2D plane.
+    args
+        A collection of Points on 2D plane.
 
     Notes
     =====
@@ -476,7 +477,8 @@ def farthest_points(*args):
     Parameters
     ==========
 
-    args : a collection of Points on 2D plane.
+    args
+        A collection of Points on 2D plane.
 
     Notes
     =====

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2761,7 +2761,7 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
     Parameters
     ==========
 
-    expr : Boolean expression
+    expr : Boolean
 
     form : string (``'cnf'`` or ``'dnf'``) or ``None`` (default).
         If ``'cnf'`` or ``'dnf'``, the simplest expression in the corresponding
@@ -2780,7 +2780,7 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
         made. By setting ``force`` to ``True``, this limit is removed. Be
         aware that this can lead to very long simplification times.
 
-    dontcare : Boolean expression
+    dontcare : Boolean
         Optimize expression under the assumption that inputs where this
         expression is true are don't care. This is useful in e.g. Piecewise
         conditions, where later conditions do not need to consider inputs that

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2450,7 +2450,7 @@ class MatrixOperations(MatrixRequired):
         return self.applyfunc(lambda x: trigsimp(x, **opts))
 
     def upper_triangular(self, k=0):
-        """returns the elements on and above the kth diagonal of a matrix.
+        """Return the elements on and above the kth diagonal of a matrix.
         If k is not specified then simply returns upper-triangular portion
         of a matrix
 
@@ -2489,7 +2489,7 @@ class MatrixOperations(MatrixRequired):
 
 
     def lower_triangular(self, k=0):
-        """returns the elements on and below the kth diagonal of a matrix.
+        """Return the elements on and below the kth diagonal of a matrix.
         If k is not specified then simply returns lower-triangular portion
         of a matrix
 

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1563,7 +1563,7 @@ def _QRdecomposition(M):
     return _QRdecomposition_optional(M, normalize=True)
 
 def _upper_hessenberg_decomposition(A):
-    """Converts a matrix into Hessenberg matrix H
+    """Converts a matrix into Hessenberg matrix H.
 
     Returns 2 matrices H, P s.t.
     $P H P^{T} = A$, where H is an upper hessenberg matrix

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -247,7 +247,7 @@ class MatrixExpr(Expr):
         return adjoint(self)
 
     def as_coeff_Mul(self, rational=False):
-        """Efficiently extract the coefficient of a product. """
+        """Efficiently extract the coefficient of a product."""
         return S.One, self
 
     def conjugate(self):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -66,7 +66,7 @@ from .inverse import (
 
 
 class DeferredVector(Symbol, NotIterable):
-    """A vector whose components are deferred (e.g. for use with lambdify)
+    """A vector whose components are deferred (e.g. for use with lambdify).
 
     Examples
     ========
@@ -671,7 +671,7 @@ class MatrixDeprecated(MatrixCommon):
         return _det_bareiss(self)
 
     def det_LU_decomposition(self):
-        """Compute matrix determinant using LU decomposition
+        """Compute matrix determinant using LU decomposition.
 
 
         Note that this method fails if the LU decomposition itself
@@ -1182,7 +1182,7 @@ class MatrixBase(MatrixDeprecated,
             return
 
     def add(self, b):
-        """Return self + b """
+        """Return self + b."""
         return self + b
 
     def condition_number(self):
@@ -1406,7 +1406,9 @@ class MatrixBase(MatrixDeprecated,
         return (mat * b)[0]
 
     def dual(self):
-        """Returns the dual of a matrix, which is:
+        """Returns the dual of a matrix.
+
+        A dual of a matrix is:
 
         ``(1/2)*levicivita(i, j, k, l)*M(k, l)`` summed over indices `k` and `l`
 
@@ -1579,8 +1581,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     def exp(self):
-
-        """Return the exponential of a square matrix
+        """Return the exponential of a square matrix.
 
         Examples
         ========
@@ -1654,7 +1655,7 @@ class MatrixBase(MatrixDeprecated,
         return self.__class__(banded(size, bands))
 
     def log(self, simplify=cancel):
-        """Return the logarithm of a square matrix
+        """Return the logarithm of a square matrix.
 
         Parameters
         ==========
@@ -1854,6 +1855,7 @@ class MatrixBase(MatrixDeprecated,
 
     def norm(self, ord=None):
         """Return the Norm of a Matrix or Vector.
+
         In the simplest case this is the geometric size of the vector
         Other norms can be specified by the ord parameter
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -90,7 +90,7 @@ def _primitive_root_prime_iter(p):
 
 def primitive_root(p):
     """
-    Returns the smallest primitive root or None
+    Returns the smallest primitive root or None.
 
     Parameters
     ==========
@@ -156,7 +156,7 @@ def primitive_root(p):
 
 def is_primitive_root(a, p):
     """
-    Returns True if ``a`` is a primitive root of ``p``
+    Returns True if ``a`` is a primitive root of ``p``.
 
     ``a`` is said to be the primitive root of ``p`` if gcd(a, p) == 1 and
     totient(p) is the smallest positive number s.t.
@@ -219,7 +219,7 @@ def _sqrt_mod_tonelli_shanks(a, p):
 
 def sqrt_mod(a, p, all_roots=False):
     """
-    Find a root of ``x**2 = a mod p``
+    Find a root of ``x**2 = a mod p``.
 
     Parameters
     ==========
@@ -304,7 +304,7 @@ def _product(*iters):
 
 def sqrt_mod_iter(a, p, domain=int):
     """
-    Iterate over solutions to ``x**2 = a mod p``
+    Iterate over solutions to ``x**2 = a mod p``.
 
     Parameters
     ==========
@@ -581,7 +581,12 @@ def _sqrt_mod1(a, p, n):
 def is_quad_residue(a, p):
     """
     Returns True if ``a`` (mod ``p``) is in the set of squares mod ``p``,
-    i.e a % p in set([i**2 % p for i in range(p)]). If ``p`` is an odd
+    i.e a % p in set([i**2 % p for i in range(p)]).
+
+    Examples
+    ========
+
+    If ``p`` is an odd
     prime, an iterative method is used to make the determination:
 
     >>> from sympy.ntheory import is_quad_residue
@@ -809,7 +814,7 @@ def _nthroot_mod_composite(a, n, m):
 
 def nthroot_mod(a, n, p, all_roots=False):
     """
-    Find the solutions to ``x**n = a mod p``
+    Find the solutions to ``x**n = a mod p``.
 
     Parameters
     ==========
@@ -1361,11 +1366,16 @@ def discrete_log(n, a, b, order=None, prime_order=None):
 
 def quadratic_congruence(a, b, c, p):
     """
-    Find the solutions to ``a x**2 + b x + c = 0 mod p
-    a : integer
-    b : integer
-    c : integer
-    p : positive integer
+    Find the solutions to ``a x**2 + b x + c = 0 mod p.
+
+    Parameters
+    ==========
+
+    a : int
+    b : int
+    c : int
+    p : int
+        A positive integer.
     """
     a = as_int(a)
     b = as_int(b)

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -912,7 +912,7 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
                transformations: tUnion[tTuple[TRANS, ...], str] \
                    = standard_transformations,
                global_dict: Optional[DICT] = None, evaluate=True):
-    """Converts the string ``s`` to a SymPy expression, in ``local_dict``
+    """Converts the string ``s`` to a SymPy expression, in ``local_dict``.
 
     Parameters
     ==========

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -122,7 +122,7 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
             return K1.convert(a.LC(), K0.dom)
 
     def log(self, a, b):
-        r"""logarithm of *a* to the base *b*
+        r"""Logarithm of *a* to the base *b*.
 
         Parameters
         ==========

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -17,7 +17,7 @@ from sympy.ntheory.factor_ import multiplicity
 
 def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
     """
-    reduces expression by combining powers with similar bases and exponents.
+    Reduce expression by combining powers with similar bases and exponents.
 
     Explanation
     ===========

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -500,7 +500,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
     For system of ordinary differential equations
     =============================================
 
-   **Usage**
+    **Usage**
         ``dsolve(eq, func)`` -> Solve a system of ordinary differential
         equations ``eq`` for ``func`` being list of functions including
         `x(t)`, `y(t)`, `z(t)` where number of functions in the list depends

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -18,7 +18,7 @@ class SolveFailed(Exception):
 
 def solve_poly_system(seq, *gens, strict=False, **args):
     """
-    returns a list of solutions for the system of polynomial equations
+    Return a list of solutions for the system of polynomial equations
     or else None.
 
     Parameters

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2913,9 +2913,9 @@ def _return_conditionset(eqs, symbols):
 def substitution(system, symbols, result=[{}], known_symbols=[],
                  exclude=[], all_symbols=None):
     r"""
-     Solves the `system` using substitution method. It is used in
-     :func:`~.nonlinsolve`. This will be called from :func:`~.nonlinsolve` when any
-     equation(s) is non polynomial equation.
+    Solves the `system` using substitution method. It is used in
+    :func:`~.nonlinsolve`. This will be called from :func:`~.nonlinsolve` when any
+    equation(s) is non polynomial equation.
 
     Parameters
     ==========

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -130,10 +130,6 @@ class DenseNDimArray(NDimArray):
 
 
 class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray): # type: ignore
-    """
-
-    """
-
     def __new__(cls, iterable, shape=None, **kwargs):
         return cls._new(iterable, shape, **kwargs)
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -84,7 +84,7 @@ class ArrayKind(Kind):
 
 
 class NDimArray(Printable):
-    """
+    """N-dimensional array.
 
     Examples
     ========

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -149,11 +149,11 @@ class BasisDependent(Expr):
     factor.__doc__ += fctr.__doc__  # type: ignore
 
     def as_coeff_Mul(self, rational=False):
-        """Efficiently extract the coefficient of a product. """
+        """Efficiently extract the coefficient of a product."""
         return (S.One, self)
 
     def as_coeff_add(self, *deps):
-        """Efficiently extract the coefficient of a summation. """
+        """Efficiently extract the coefficient of a summation."""
         l = [x * self.components[x] for x in self.components]
         return 0, tuple(l)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

It fixes the issues with 'SS01', 'SS02', 'SS04'` about summaries missing, not capitalized, or indented in wrong way.

I try to fix other issues with summaries/parameters not ending with period, or badly formatted, but it may need to take some time.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
