### PR TITLE
Implement Inertia object

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -74,6 +74,32 @@ will need to either add a `warnings` filter as above or use pytest to filter
 SymPy deprecation warnings.
 ```
 
+## Version 1.13
+
+(moved-mechanics-functions)=
+### Moved mechanics functions
+With the introduction of some new objects like the ``Inertia`` object in the
+``sympy.physics.mechanics`` module, some functions from
+``sympy.physics.mechanics.functions`` have been moved to new modules. This
+removes some circular import errors and makes it easier to navigate through the
+source code, due to the parity between function names and module names. The
+following functions were moved:
+- ``inertia`` has been moved to ``sympy.physics.mechanics.inertia``
+- ``inertia_of_point_mass`` has been moved to ``sympy.physics.mechanics.inertia``
+
+Previously you could import the functions from
+``sympy.physics.mechanics.functions``:
+
+```py
+>>> from sympy.physics.mechanics.functions import inertia, inertia_of_point_mass
+```
+
+Now they should be imported from ``sympy.physics.mechanics``:
+
+```py
+>>> from sympy.physics.mechanics import inertia, inertia_of_point_mass
+```
+
 ## Version 1.12
 
 (deprecated-mechanics-joint-coordinate-format)=
@@ -196,7 +222,7 @@ parent_frame.x
 Or
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint, Point
+>>> from sympy.physics.mechanics import Body, PinJoint
 >>> parent, child = Body('parent'), Body('child')
 >>> parent_point = parent.masscenter.locatenew('parent_point', parent.frame.x)
 >>> child_point = child.masscenter.locatenew('child_point', -child.frame.x)

--- a/doc/src/modules/physics/mechanics/api/part_bod.rst
+++ b/doc/src/modules/physics/mechanics/api/part_bod.rst
@@ -4,17 +4,29 @@
 Masses, Inertias & Particles, RigidBodys (Docstrings)
 =====================================================
 
-.. automodule:: sympy.physics.mechanics.particle
+Bodies
+======
+
+.. autoclass:: sympy.physics.mechanics.particle.Particle
    :members:
    :inherited-members:
 
-.. automodule:: sympy.physics.mechanics.rigidbody
+.. autoclass:: sympy.physics.mechanics.rigidbody.RigidBody
    :members:
    :inherited-members:
 
-.. autofunction:: sympy.physics.mechanics.functions.inertia
+Inertias
+========
 
-.. autofunction:: sympy.physics.mechanics.functions.inertia_of_point_mass
+.. autoclass:: sympy.physics.mechanics.inertia.Inertia
+   :members:
+
+.. autofunction:: sympy.physics.mechanics.inertia.inertia
+
+.. autofunction:: sympy.physics.mechanics.inertia.inertia_of_point_mass
+
+Other Functions
+===============
 
 .. autofunction:: sympy.physics.mechanics.functions.linear_momentum
 

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -67,7 +67,7 @@ the center of mass is given below in the 'Rigid Body' section. The
    >>> A = ReferenceFrame('A')
    >>> P = Point('P')
    >>> Inertia(P, outer(A.x, A.x))
-   Inertia((A.x|A.x), P)
+   ((A.x|A.x), P)
 
 
 Inertia (Dyadics)

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -37,6 +37,39 @@ The associated point contains the position, velocity and acceleration of the
 particle. :mod:`sympy.physics.mechanics` allows one to perform kinematic
 analysis of points separate from their association with masses.
 
+Inertia
+=======
+
+Inertia consists out of two parts: a quantity and a reference. The quantity is
+expressed as a :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` and the
+reference is a :class:`Point<sympy.physics.vector.point.Point>`. The
+:class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` can be defined as the outer
+product between two vectors, which returns the juxtaposition of these vectors.
+See the 'Dyadic' section under the advanced documentation in the
+:mod:`sympy.physics.vector` module. Another more intuitive method to define the
+:class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` is to use the
+:func:`~.inertia` function as described below in the section
+'Inertia (Dyadics)'. The :class:`Point<sympy.physics.vector.point.Point>` about
+which the :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` is specified can
+be any point, as long as it is defined with respect to the center of mass. The
+most common reference point is of course the center of mass itself.
+
+The inertia of a body can be specified using either an :class:`~.Inertia` object
+or a ``tuple``. If a ``tuple`` is used, then it should have a length of two,
+with the first entry being a :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>`
+and the second entry being a :class:`Point<sympy.physics.vector.point.Point>`
+about which the inertia dyadic is defined. Internally this ``tuple`` gets
+converted to an :class:`~.Inertia` object. An example of using a ``tuple`` about
+the center of mass is given below in the 'Rigid Body' section. The
+:class:`~.Inertia` object can be created as follows.::
+
+   >>> from sympy.physics.mechanics import ReferenceFrame, Point, outer, Inertia
+   >>> A = ReferenceFrame('A')
+   >>> P = Point('P')
+   >>> Inertia(P, outer(A.x, A.x))
+   Inertia((A.x|A.x), P)
+
+
 Inertia (Dyadics)
 =================
 
@@ -47,8 +80,8 @@ class :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>`. To know more, refer
 to the :obj:`sympy.physics.vector.dyadic.Dyadic` and
 :obj:`sympy.physics.vector.vector.Vector` class APIs. Dyadics are used to
 define the inertia of bodies within :mod:`sympy.physics.mechanics`. Inertia
-dyadics can be defined explicitly but the :func:`~.inertia` function is
-typically much more convenient for the user::
+dyadics can be defined explicitly using the outer product, but the
+:func:`~.inertia` function is typically much more convenient for the user.::
 
   >>> from sympy.physics.mechanics import ReferenceFrame, inertia
   >>> N = ReferenceFrame('N')
@@ -66,8 +99,8 @@ typically much more convenient for the user::
   (N.x|N.x) + 4*(N.x|N.y) + 6*(N.x|N.z) + 4*(N.y|N.x) + 2*(N.y|N.y) + 5*(N.y|N.z) + 6*(N.z|N.x) + 5*(N.z|N.y) + 3*(N.z|N.z)
 
 Notice that the :func:`~.inertia` function returns a dyadic with each component
-represented as two unit vectors separated by a ``|``. Refer to the
-:obj:`sympy.physics.vector.dyadic.Dyadic` section for more information about
+represented as two unit vectors separated by a ``|`` (outer product). Refer to
+the :obj:`sympy.physics.vector.dyadic.Dyadic` section for more information about
 dyadics.
 
 Inertia is often expressed in a matrix, or tensor, form, especially for
@@ -87,7 +120,8 @@ Rigid Body
 
 Rigid bodies are created in a similar fashion as particles. The
 :class:`~.RigidBody` class generates objects with four attributes: mass, center
-of mass, a reference frame, and an inertia tuple::
+of mass, a reference frame, and an :class:`~.Inertia` (a ``tuple`` can be parsed
+as well).::
 
   >>> from sympy import Symbol
   >>> from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
@@ -100,7 +134,7 @@ of mass, a reference frame, and an inertia tuple::
   >>> B = RigidBody('B', P, A, m, (I, P))
 
 The mass is specified exactly as is in a particle. Similar to the
-:class:`~.Particle`'s ``.point``, the :class:`~.RigidBody`'s center of mass,
+:class:`~.Particle`'s ``.point``, the :class:`RigidBody`'s center of mass,
 ``.masscenter`` must be specified. The reference frame is stored in an analogous
 fashion and holds information about the body's orientation and angular velocity.
 

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -134,7 +134,7 @@ as well).::
   >>> B = RigidBody('B', P, A, m, (I, P))
 
 The mass is specified exactly as is in a particle. Similar to the
-:class:`~.Particle`'s ``.point``, the :class:`RigidBody`'s center of mass,
+:class:`~.Particle`'s ``.point``, the :class:`~.RigidBody`'s center of mass,
 ``.masscenter`` must be specified. The reference frame is stored in an analogous
 fashion and holds information about the body's orientation and angular velocity.
 

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -12,9 +12,11 @@ __all__ = [
 
     'RigidBody',
 
-    'inertia', 'inertia_of_point_mass', 'linear_momentum', 'angular_momentum',
-    'kinetic_energy', 'potential_energy', 'Lagrangian', 'mechanics_printing',
-    'mprint', 'msprint', 'mpprint', 'mlatex', 'msubs', 'find_dynamicsymbols',
+    'linear_momentum', 'angular_momentum', 'kinetic_energy', 'potential_energy',
+    'Lagrangian', 'mechanics_printing', 'mprint', 'msprint', 'mpprint',
+    'mlatex', 'msubs', 'find_dynamicsymbols',
+
+    'inertia', 'inertia_of_point_mass', 'Inertia',
 
     'Particle',
 
@@ -45,10 +47,12 @@ from .kane import KanesMethod
 
 from .rigidbody import RigidBody
 
-from .functions import (inertia, inertia_of_point_mass, linear_momentum,
-        angular_momentum, kinetic_energy, potential_energy, Lagrangian,
-        mechanics_printing, mprint, msprint, mpprint, mlatex, msubs,
-        find_dynamicsymbols)
+from .functions import (linear_momentum, angular_momentum, kinetic_energy,
+                        potential_energy, Lagrangian, mechanics_printing,
+                        mprint, msprint, mpprint, mlatex, msubs,
+                        find_dynamicsymbols)
+
+from .inertia import inertia, inertia_of_point_mass, Inertia
 
 from .particle import Particle
 

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -115,8 +115,8 @@ class Body(RigidBody, Particle):  # type: ignore
             izx = Symbol(name + '_izx')
             ixy = Symbol(name + '_ixy')
             iyz = Symbol(name + '_iyz')
-            _inertia = Inertia.from_tensor(masscenter, frame, ixx, iyy, izz,
-                                           ixy, iyz, izx)
+            _inertia = Inertia.from_inertia_scalars(masscenter, frame, ixx, iyy, izz,
+                                                    ixy, iyz, izx)
         else:
             _inertia = (central_inertia, masscenter)
 

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,6 +1,6 @@
 from sympy.core.backend import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame, Dyadic
-from sympy.physics.mechanics import RigidBody, Particle, inertia
+from sympy.physics.mechanics import RigidBody, Particle, Inertia
 from sympy.physics.mechanics.body_base import BodyBase
 
 __all__ = ['Body']
@@ -115,8 +115,8 @@ class Body(RigidBody, Particle):  # type: ignore
             izx = Symbol(name + '_izx')
             ixy = Symbol(name + '_ixy')
             iyz = Symbol(name + '_iyz')
-            _inertia = (inertia(frame, ixx, iyy, izz, ixy, iyz, izx),
-                        masscenter)
+            _inertia = Inertia.from_tensor(masscenter, frame, ixx, iyy, izz,
+                                           ixy, iyz, izx)
         else:
             _inertia = (central_inertia, masscenter)
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -7,12 +7,10 @@ from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
-from sympy.core.backend import (Matrix, sympify, Mul, Derivative, sin, cos,
-                                tan, AppliedUndef, S)
+from sympy.core.backend import (Matrix, Mul, Derivative, sin, cos, tan,
+                                AppliedUndef, S)
 
-__all__ = ['inertia',
-           'inertia_of_point_mass',
-           'linear_momentum',
+__all__ = ['linear_momentum',
            'angular_momentum',
            'kinetic_energy',
            'potential_energy',
@@ -42,95 +40,8 @@ def mechanics_printing(**kwargs):
 
     init_vprinting(**kwargs)
 
+
 mechanics_printing.__doc__ = init_vprinting.__doc__
-
-
-def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
-    """Simple way to create inertia Dyadic object.
-
-    Explanation
-    ===========
-
-    If you do not know what a Dyadic is, just treat this like the inertia
-    tensor. Then, do the easy thing and define it in a body-fixed frame.
-
-    Parameters
-    ==========
-
-    frame : ReferenceFrame
-        The frame the inertia is defined in
-    ixx : Sympifyable
-        the xx element in the inertia dyadic
-    iyy : Sympifyable
-        the yy element in the inertia dyadic
-    izz : Sympifyable
-        the zz element in the inertia dyadic
-    ixy : Sympifyable
-        the xy element in the inertia dyadic
-    iyz : Sympifyable
-        the yz element in the inertia dyadic
-    izx : Sympifyable
-        the zx element in the inertia dyadic
-
-    Examples
-    ========
-
-    >>> from sympy.physics.mechanics import ReferenceFrame, inertia
-    >>> N = ReferenceFrame('N')
-    >>> inertia(N, 1, 2, 3)
-    (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
-
-    """
-
-    if not isinstance(frame, ReferenceFrame):
-        raise TypeError('Need to define the inertia in a frame')
-    ixx = sympify(ixx)
-    ixy = sympify(ixy)
-    iyy = sympify(iyy)
-    iyz = sympify(iyz)
-    izx = sympify(izx)
-    izz = sympify(izz)
-    ol = ixx * (frame.x | frame.x)
-    ol += ixy * (frame.x | frame.y)
-    ol += izx * (frame.x | frame.z)
-    ol += ixy * (frame.y | frame.x)
-    ol += iyy * (frame.y | frame.y)
-    ol += iyz * (frame.y | frame.z)
-    ol += izx * (frame.z | frame.x)
-    ol += iyz * (frame.z | frame.y)
-    ol += izz * (frame.z | frame.z)
-    return ol
-
-
-def inertia_of_point_mass(mass, pos_vec, frame):
-    """Inertia dyadic of a point mass relative to point O.
-
-    Parameters
-    ==========
-
-    mass : Sympifyable
-        Mass of the point mass
-    pos_vec : Vector
-        Position from point O to point mass
-    frame : ReferenceFrame
-        Reference frame to express the dyadic in
-
-    Examples
-    ========
-
-    >>> from sympy import symbols
-    >>> from sympy.physics.mechanics import ReferenceFrame, inertia_of_point_mass
-    >>> N = ReferenceFrame('N')
-    >>> r, m = symbols('r m')
-    >>> px = r * N.x
-    >>> inertia_of_point_mass(m, px, N)
-    m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
-
-    """
-
-    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
-                   (frame.z | frame.z)) * (pos_vec & pos_vec) -
-                   (pos_vec | pos_vec))
 
 
 def linear_momentum(frame, *body):

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -9,6 +9,9 @@ from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
 from sympy.core.backend import (Matrix, Mul, Derivative, sin, cos, tan,
                                 AppliedUndef, S)
+from sympy.physics.mechanics.inertia import (inertia as _inertia,
+    inertia_of_point_mass as _inertia_of_point_mass)
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['linear_momentum',
            'angular_momentum',
@@ -42,6 +45,30 @@ def mechanics_printing(**kwargs):
 
 
 mechanics_printing.__doc__ = init_vprinting.__doc__
+
+
+def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
+    sympy_deprecation_warning(
+        """
+        The inertia function has been moved.
+        Import it from "sympy.physics.mechanics".
+        """,
+        deprecated_since_version="1.13",
+        active_deprecations_target="moved-mechanics-functions"
+    )
+    return _inertia(frame, ixx, iyy, izz, ixy, iyz, izx)
+
+
+def inertia_of_point_mass(mass, pos_vec, frame):
+    sympy_deprecation_warning(
+        """
+        The inertia_of_point_mass function has been moved.
+        Import it from "sympy.physics.mechanics".
+        """,
+        deprecated_since_version="1.13",
+        active_deprecations_target="moved-mechanics-functions"
+    )
+    return _inertia_of_point_mass(mass, pos_vec, frame)
 
 
 def linear_momentum(frame, *body):

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -122,7 +122,7 @@ class Inertia:
     use the ``inertia`` function for this or the class method ``from_tensor`` as
     shown below.
 
-    >>> Inertia.from_tensor(Po, N, 1, 1, 1)
+    >>> Inertia.from_inertia_scalars(Po, N, 1, 1, 1)
     Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     """
@@ -138,7 +138,8 @@ class Inertia:
         self._point = point
 
     @classmethod
-    def from_tensor(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
+    def from_inertia_scalars(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0,
+                             izx=0):
         """Simple way to create an Inertia object based on the tensor values.
 
         Explanation
@@ -155,7 +156,7 @@ class Inertia:
         >>> ixx, iyy, izz, ixy, iyz, izx = symbols('ixx iyy izz ixy iyz izx')
         >>> N = ReferenceFrame('N')
         >>> P = Point('P')
-        >>> I = Inertia.from_tensor(P, N, ixx, iyy, izz, ixy, iyz, izx)
+        >>> I = Inertia.from_inertia_scalars(P, N, ixx, iyy, izz, ixy, iyz, izx)
 
         The tensor values can easily be seen when converting the dyadic to a
         matrix.
@@ -171,10 +172,12 @@ class Inertia:
 
     @property
     def point(self):
+        """Reference point of the inertia."""
         return self._point
 
     @property
     def dyadic(self):
+        """Inertia dyadic."""
         return self._dyadic
 
     def __repr__(self):

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -117,14 +117,14 @@ class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
     >>> N = ReferenceFrame('N')
     >>> Po = Point('Po')
     >>> Inertia(N.x.outer(N.x) + N.y.outer(N.y) + N.z.outer(N.z), Po)
-    Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+    ((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     In the example above the Dyadic was created manually, one can however also
     use the ``inertia`` function for this or the class method ``from_tensor`` as
     shown below.
 
     >>> Inertia.from_inertia_scalars(Po, N, 1, 1, 1)
-    Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+    ((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     """
     def __new__(cls, dyadic, point):

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -145,11 +145,26 @@ class Inertia:
         ===========
 
         This class method uses the ``inertia`` function to create the Dyadic
-        based on the tensor values in the form:
+        based on the tensor values.
 
-            ``[[ixx, ixy, ixz],
-               [ixy, iyy, iyz],
-               [izx, iyz, izz]]``
+        Examples
+        ========
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, Point, Inertia
+        >>> ixx, iyy, izz, ixy, iyz, izx = symbols('ixx iyy izz ixy iyz izx')
+        >>> N = ReferenceFrame('N')
+        >>> P = Point('P')
+        >>> I = Inertia.from_tensor(P, N, ixx, iyy, izz, ixy, iyz, izx)
+
+        The tensor values can easily be seen when converting the dyadic to a
+        matrix.
+
+        >>> I.dyadic.to_matrix(N)
+        Matrix([
+        [ixx, ixy, izx],
+        [ixy, iyy, iyz],
+        [izx, iyz, izz]])
 
         """
         return cls(inertia(frame, ixx, iyy, izz, ixy, iyz, izx), point)

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -1,0 +1,180 @@
+from sympy.core.backend import sympify
+from sympy.physics.vector import Point, Dyadic, ReferenceFrame
+
+__all__ = ['inertia', 'inertia_of_point_mass', 'Inertia']
+
+
+def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
+    """Simple way to create inertia Dyadic object.
+
+    Explanation
+    ===========
+
+    If you do not know what a Dyadic is, just treat this like the inertia
+    tensor. Then, do the easy thing and define it in a body-fixed frame.
+
+    Parameters
+    ==========
+
+    frame : ReferenceFrame
+        The frame the inertia is defined in
+    ixx : Sympifyable
+        the xx element in the inertia dyadic
+    iyy : Sympifyable
+        the yy element in the inertia dyadic
+    izz : Sympifyable
+        the zz element in the inertia dyadic
+    ixy : Sympifyable
+        the xy element in the inertia dyadic
+    iyz : Sympifyable
+        the yz element in the inertia dyadic
+    izx : Sympifyable
+        the zx element in the inertia dyadic
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, inertia
+    >>> N = ReferenceFrame('N')
+    >>> inertia(N, 1, 2, 3)
+    (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
+
+    """
+
+    if not isinstance(frame, ReferenceFrame):
+        raise TypeError('Need to define the inertia in a frame')
+    ixx = sympify(ixx)
+    ixy = sympify(ixy)
+    iyy = sympify(iyy)
+    iyz = sympify(iyz)
+    izx = sympify(izx)
+    izz = sympify(izz)
+    ol = ixx * (frame.x | frame.x)
+    ol += ixy * (frame.x | frame.y)
+    ol += izx * (frame.x | frame.z)
+    ol += ixy * (frame.y | frame.x)
+    ol += iyy * (frame.y | frame.y)
+    ol += iyz * (frame.y | frame.z)
+    ol += izx * (frame.z | frame.x)
+    ol += iyz * (frame.z | frame.y)
+    ol += izz * (frame.z | frame.z)
+    return ol
+
+
+def inertia_of_point_mass(mass, pos_vec, frame):
+    """Inertia dyadic of a point mass relative to point O.
+
+    Parameters
+    ==========
+
+    mass : Sympifyable
+        Mass of the point mass
+    pos_vec : Vector
+        Position from point O to point mass
+    frame : ReferenceFrame
+        Reference frame to express the dyadic in
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> from sympy.physics.mechanics import ReferenceFrame, inertia_of_point_mass
+    >>> N = ReferenceFrame('N')
+    >>> r, m = symbols('r m')
+    >>> px = r * N.x
+    >>> inertia_of_point_mass(m, px, N)
+    m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
+
+    """
+
+    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
+                    (frame.z | frame.z)) * (pos_vec & pos_vec) -
+                   (pos_vec | pos_vec))
+
+
+class Inertia:
+    """Inertia object consisting of a Dyadic and a Point of reference.
+
+    Explanation
+    ===========
+
+    This is a simple class to store the Point and Dyadic, belonging to an
+    inertia.
+
+    Attributes
+    ==========
+
+    dyadic : Dyadic
+        The dyadic of the inertia.
+    point : Point
+        The reference point of the inertia.
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, Point, Inertia
+    >>> N = ReferenceFrame('N')
+    >>> Po = Point('Po')
+    >>> Inertia(N.x.outer(N.x) + N.y.outer(N.y) + N.z.outer(N.z), Po)
+    Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+
+    In the example above the Dyadic was created manually, one can however also
+    use the ``inertia`` function for this or the class method ``from_tensor`` as
+    shown below.
+
+    >>> Inertia.from_tensor(Po, N, 1, 1, 1)
+    Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+
+    """
+    def __init__(self, dyadic, point):
+        # Switch order if given in the wrong order
+        if isinstance(dyadic, Point) and isinstance(point, Dyadic):
+            point, dyadic = dyadic, point
+        if not isinstance(point, Point):
+            raise TypeError('Reference point should be of type Point')
+        if not isinstance(dyadic, Dyadic):
+            raise TypeError('Inertia value should be expressed as a Dyadic')
+        self._dyadic = dyadic
+        self._point = point
+
+    @classmethod
+    def from_tensor(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
+        """Simple way to create an Inertia object based on the tensor values.
+
+        Explanation
+        ===========
+
+        This class method uses the ``inertia`` function to create the Dyadic
+        based on the tensor values in the form:
+
+            ``[[ixx, ixy, ixz],
+               [ixy, iyy, iyz],
+               [izx, iyz, izz]]``
+
+        """
+        return cls(inertia(frame, ixx, iyy, izz, ixy, iyz, izx), point)
+
+    @property
+    def point(self):
+        return self._point
+
+    @property
+    def dyadic(self):
+        return self._dyadic
+
+    def __repr__(self):
+        return f'Inertia({self.dyadic}, {self.point})'
+
+    def __getitem__(self, item):
+        if item == 0 or item == -2:
+            return self.dyadic
+        elif item == 1 or item == -1:
+            return self.point
+        raise IndexError('Inertia index out of range.')
+
+    def __eq__(self, other):
+        if isinstance(other, Inertia):
+            return self.point == other.point and self.dyadic == other.dyadic
+        if isinstance(other, tuple) and len(other) == 2:
+            return self[0] == other[0] and self[1] == other[1]
+        return False

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -92,7 +92,7 @@ def inertia_of_point_mass(mass, pos_vec, frame):
                    (pos_vec | pos_vec))
 
 
-class Inertia:
+class Inertia(tuple):
     """Inertia object consisting of a Dyadic and a Point of reference.
 
     Explanation
@@ -126,7 +126,7 @@ class Inertia:
     Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     """
-    def __init__(self, dyadic, point):
+    def __new__(cls, point, dyadic):
         # Switch order if given in the wrong order
         if isinstance(dyadic, Point) and isinstance(point, Dyadic):
             point, dyadic = dyadic, point
@@ -134,8 +134,7 @@ class Inertia:
             raise TypeError('Reference point should be of type Point')
         if not isinstance(dyadic, Dyadic):
             raise TypeError('Inertia value should be expressed as a Dyadic')
-        self._dyadic = dyadic
-        self._point = point
+        return super().__new__(cls, (dyadic, point))
 
     @classmethod
     def from_inertia_scalars(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0,
@@ -173,26 +172,25 @@ class Inertia:
     @property
     def point(self):
         """Reference point of the inertia."""
-        return self._point
+        return self[1]
 
     @property
     def dyadic(self):
         """Inertia dyadic."""
-        return self._dyadic
+        return self[0]
 
     def __repr__(self):
         return f'Inertia({self.dyadic}, {self.point})'
 
-    def __getitem__(self, item):
-        if item == 0 or item == -2:
-            return self.dyadic
-        elif item == 1 or item == -1:
-            return self.point
-        raise IndexError('Inertia index out of range.')
+    def __add__(self, other):
+        raise TypeError(f"unsupported operand type(s) for +: "
+                        f"'{self.__class__.__name__}' and "
+                        f"'{other.__class__.__name__}'")
 
-    def __eq__(self, other):
-        if isinstance(other, Inertia):
-            return self.point == other.point and self.dyadic == other.dyadic
-        if isinstance(other, tuple) and len(other) == 2:
-            return self[0] == other[0] and self[1] == other[1]
-        return False
+    def __mul__(self, other):
+        raise TypeError(f"unsupported operand type(s) for *: "
+                        f"'{self.__class__.__name__}' and "
+                        f"'{other.__class__.__name__}'")
+
+    __radd__ = __add__
+    __rmul__ = __mul__

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -126,7 +126,7 @@ class Inertia(tuple):
     Inertia((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     """
-    def __new__(cls, point, dyadic):
+    def __new__(cls, dyadic, point):
         # Switch order if given in the wrong order
         if isinstance(dyadic, Point) and isinstance(point, Dyadic):
             point, dyadic = dyadic, point

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -1,5 +1,6 @@
 from sympy.core.backend import sympify
 from sympy.physics.vector import Point, Dyadic, ReferenceFrame
+from collections import namedtuple
 
 __all__ = ['inertia', 'inertia_of_point_mass', 'Inertia']
 
@@ -92,7 +93,7 @@ def inertia_of_point_mass(mass, pos_vec, frame):
                    (pos_vec | pos_vec))
 
 
-class Inertia(tuple):
+class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
     """Inertia object consisting of a Dyadic and a Point of reference.
 
     Explanation
@@ -134,7 +135,7 @@ class Inertia(tuple):
             raise TypeError('Reference point should be of type Point')
         if not isinstance(dyadic, Dyadic):
             raise TypeError('Inertia value should be expressed as a Dyadic')
-        return super().__new__(cls, (dyadic, point))
+        return super().__new__(cls, dyadic, point)
 
     @classmethod
     def from_inertia_scalars(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0,
@@ -168,19 +169,6 @@ class Inertia(tuple):
 
         """
         return cls(inertia(frame, ixx, iyy, izz, ixy, iyz, izx), point)
-
-    @property
-    def point(self):
-        """Reference point of the inertia."""
-        return self[1]
-
-    @property
-    def dyadic(self):
-        """Inertia dyadic."""
-        return self[0]
-
-    def __repr__(self):
-        return f'Inertia({self.dyadic}, {self.point})'
 
     def __add__(self, other):
         raise TypeError(f"unsupported operand type(s) for +: "

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import S
-from sympy.physics.vector import Point, ReferenceFrame, cross, dot
+from sympy.physics.vector import ReferenceFrame, cross, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.inertia import inertia_of_point_mass
 from sympy.utilities.exceptions import sympy_deprecation_warning

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,6 +1,7 @@
 from sympy.core.backend import S
-from sympy.physics.vector import ReferenceFrame, cross, dot
+from sympy.physics.vector import Point, ReferenceFrame, cross, dot
 from sympy.physics.mechanics.body_base import BodyBase
+from sympy.physics.mechanics.inertia import inertia_of_point_mass
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['Particle']
@@ -239,7 +240,5 @@ method is deprecated. Instead use
             point and frame.
 
         """
-        # circular import issue
-        from sympy.physics.mechanics import inertia_of_point_mass
         return inertia_of_point_mass(self.mass, self.point.pos_from(point),
                                      frame)

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -66,8 +66,8 @@ class RigidBody(BodyBase):
             izx = Symbol(f'{name}_izx')
             ixy = Symbol(f'{name}_ixy')
             iyz = Symbol(f'{name}_iyz')
-            inertia = Inertia.from_tensor(self.masscenter, self.frame, ixx, iyy,
-                                          izz, ixy, iyz, izx)
+            inertia = Inertia.from_inertia_scalars(self.masscenter, self.frame, ixx, iyy,
+                                                   izz, ixy, iyz, izx)
         self.inertia = inertia
 
     def __repr__(self):

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,6 +1,7 @@
 from sympy.core.backend import Symbol, S
 from sympy.physics.vector import Point, ReferenceFrame, Dyadic, dot
 from sympy.physics.mechanics.body_base import BodyBase
+from sympy.physics.mechanics.inertia import inertia_of_point_mass, Inertia
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['RigidBody']
@@ -55,8 +56,6 @@ class RigidBody(BodyBase):
 
     def __init__(self, name, masscenter=None, frame=None, mass=None,
                  inertia=None):
-        # This import will be removed with the introduction of InertiaTuple
-        from sympy.physics.mechanics.functions import inertia as f_inertia
         if frame is None:
             frame = ReferenceFrame(f'{name}_frame')
         super().__init__(name, masscenter, frame, mass)
@@ -67,8 +66,8 @@ class RigidBody(BodyBase):
             izx = Symbol(f'{name}_izx')
             ixy = Symbol(f'{name}_ixy')
             iyz = Symbol(f'{name}_iyz')
-            inertia = (f_inertia(self.frame, ixx, iyy, izz, ixy, iyz, izx),
-                       self.masscenter)
+            inertia = Inertia.from_tensor(self.masscenter, self.frame, ixx, iyy,
+                                          izz, ixy, iyz, izx)
         self.inertia = inertia
 
     def __repr__(self):
@@ -90,20 +89,14 @@ class RigidBody(BodyBase):
     @property
     def inertia(self):
         """The body's inertia about a point; stored as (Dyadic, Point)."""
-        return (self._inertia, self._inertia_point)
+        return self._inertia
 
     @inertia.setter
     def inertia(self, I):
-        if not isinstance(I[0], Dyadic):
-            raise TypeError("RigidBody inertia must be a Dyadic object.")
-        if not isinstance(I[1], Point):
-            raise TypeError("RigidBody inertia must be about a Point.")
-        self._inertia = I[0]
-        self._inertia_point = I[1]
+        self._inertia = Inertia(I[0], I[1])
         # have I S/O, want I S/S*
         # I S/O = I S/S* + I S*/O; I S/S* = I S/O - I S*/O
         # I_S/S* = I_S/O - I_S*/O
-        from sympy.physics.mechanics.functions import inertia_of_point_mass
         I_Ss_O = inertia_of_point_mass(self.mass,
                                        self.masscenter.pos_from(I[1]),
                                        self.frame)
@@ -118,7 +111,7 @@ class RigidBody(BodyBase):
     def central_inertia(self, I):
         if not isinstance(I, Dyadic):
             raise TypeError("RigidBody inertia must be a Dyadic object.")
-        self.inertia = (I, self.masscenter)
+        self.inertia = Inertia(I, self.masscenter)
 
     def linear_momentum(self, frame):
         """ Linear momentum of the rigid body.
@@ -295,8 +288,6 @@ method is deprecated. Instead use
             point.
 
         """
-        # circular import issue
-        from sympy.physics.mechanics.functions import inertia_of_point_mass
         if frame is None:
             frame = self.frame
         return self.central_inertia + inertia_of_point_mass(

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import Symbol, S
-from sympy.physics.vector import Point, ReferenceFrame, Dyadic, dot
+from sympy.physics.vector import ReferenceFrame, Dyadic, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.inertia import inertia_of_point_mass, Inertia
 from sympy.utilities.exceptions import sympy_deprecation_warning

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -8,7 +8,7 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
 
 from sympy.physics.mechanics.functions import (gravity, center_of_mass,
                                                _validate_coordinates)
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
@@ -233,3 +233,14 @@ def test_validate_coordinates():
     _validate_coordinates([s1 + s2 + s3, q1], [0, u1], is_dynamicsymbols=False)
     raises(ValueError, lambda: _validate_coordinates(
         [s1 + s2 + s3, q1], [0, u1], is_dynamicsymbols=True))
+
+
+def test_deprecated_moved_functions():
+    from sympy.physics.mechanics.functions import inertia, inertia_of_point_mass
+    N = ReferenceFrame('N')
+    with warns_deprecated_sympy():
+        assert inertia(N, 0, 1, 0, 1) == (N.x | N.y) + (N.y | N.x) + (N.y | N.y)
+    with warns_deprecated_sympy():
+        assert inertia_of_point_mass(1, N.x + N.y, N) == (
+            (N.x | N.x) + (N.y | N.y) + 2 * (N.z | N.z) -
+            (N.x | N.y) - (N.y | N.x))

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -2,7 +2,6 @@ from sympy.core.backend import sin, cos, tan, pi, symbols, Matrix, S
 from sympy.physics.mechanics import (Particle, Point, ReferenceFrame,
                                      RigidBody)
 from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
-                                     inertia, inertia_of_point_mass,
                                      kinetic_energy, linear_momentum,
                                      outer, potential_energy, msubs,
                                      find_dynamicsymbols, Lagrangian)
@@ -17,49 +16,6 @@ N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])
 B = A.orientnew('B', 'Axis', [q2, A.x])
 C = B.orientnew('C', 'Axis', [q3, B.y])
-
-
-def test_inertia():
-    N = ReferenceFrame('N')
-    ixx, iyy, izz = symbols('ixx iyy izz')
-    ixy, iyz, izx = symbols('ixy iyz izx')
-    assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
-            (N.y | N.y) + izz * (N.z | N.z))
-    assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
-    raises(TypeError, lambda: inertia(0, 0, 0, 0))
-    assert inertia(N, ixx, iyy, izz, ixy, iyz, izx) == (ixx * (N.x | N.x) +
-            ixy * (N.x | N.y) + izx * (N.x | N.z) + ixy * (N.y | N.x) + iyy *
-        (N.y | N.y) + iyz * (N.y | N.z) + izx * (N.z | N.x) + iyz * (N.z |
-            N.y) + izz * (N.z | N.z))
-
-
-def test_inertia_of_point_mass():
-    r, s, t, m = symbols('r s t m')
-    N = ReferenceFrame('N')
-
-    px = r * N.x
-    I = inertia_of_point_mass(m, px, N)
-    assert I == m * r**2 * (N.y | N.y) + m * r**2 * (N.z | N.z)
-
-    py = s * N.y
-    I = inertia_of_point_mass(m, py, N)
-    assert I == m * s**2 * (N.x | N.x) + m * s**2 * (N.z | N.z)
-
-    pz = t * N.z
-    I = inertia_of_point_mass(m, pz, N)
-    assert I == m * t**2 * (N.x | N.x) + m * t**2 * (N.y | N.y)
-
-    p = px + py + pz
-    I = inertia_of_point_mass(m, p, N)
-    assert I == (m * (s**2 + t**2) * (N.x | N.x) -
-                 m * r * s * (N.x | N.y) -
-                 m * r * t * (N.x | N.z) -
-                 m * r * s * (N.y | N.x) +
-                 m * (r**2 + t**2) * (N.y | N.y) -
-                 m * s * t * (N.y | N.z) -
-                 m * r * t * (N.z | N.x) -
-                 m * s * t * (N.z | N.y) +
-                 m * (r**2 + s**2) * (N.z | N.z))
 
 
 def test_linear_momentum():

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -53,6 +53,7 @@ def test_inertia_object():
     ixx, iyy, izz = symbols('ixx iyy izz')
     I_dyadic = ixx * (N.x | N.x) + iyy * (N.y | N.y) + izz * (N.z | N.z)
     I = Inertia(inertia(N, ixx, iyy, izz), O)
+    assert isinstance(I, tuple)
     assert I.__repr__() == ('Inertia(ixx*(N.x|N.x) + iyy*(N.y|N.y) + '
                             'izz*(N.z|N.z), O)')
     assert I.dyadic == I_dyadic
@@ -63,3 +64,8 @@ def test_inertia_object():
     raises(TypeError, lambda: I != (O, I_dyadic))  # Incorrect tuple order
     assert I == Inertia(O, I_dyadic)  # Parse changed argument order
     assert I == Inertia.from_inertia_scalars(O, N, ixx, iyy, izz)
+    # Test invalid tuple operations
+    raises(TypeError, lambda: I + (1, 2))
+    raises(TypeError, lambda: (1, 2) + I)
+    raises(TypeError, lambda: I * 2)
+    raises(TypeError, lambda: 2 * I)

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -1,0 +1,65 @@
+from sympy.core.backend import symbols
+from sympy.testing.pytest import raises
+from sympy.physics.mechanics import (inertia, inertia_of_point_mass,
+                                     Inertia, ReferenceFrame, Point)
+
+
+def test_inertia_dyadic():
+    N = ReferenceFrame('N')
+    ixx, iyy, izz = symbols('ixx iyy izz')
+    ixy, iyz, izx = symbols('ixy iyz izx')
+    assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
+            (N.y | N.y) + izz * (N.z | N.z))
+    assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
+    raises(TypeError, lambda: inertia(0, 0, 0, 0))
+    assert inertia(N, ixx, iyy, izz, ixy, iyz, izx) == (ixx * (N.x | N.x) +
+            ixy * (N.x | N.y) + izx * (N.x | N.z) + ixy * (N.y | N.x) + iyy *
+        (N.y | N.y) + iyz * (N.y | N.z) + izx * (N.z | N.x) + iyz * (N.z |
+            N.y) + izz * (N.z | N.z))
+
+
+def test_inertia_of_point_mass():
+    r, s, t, m = symbols('r s t m')
+    N = ReferenceFrame('N')
+
+    px = r * N.x
+    I = inertia_of_point_mass(m, px, N)
+    assert I == m * r**2 * (N.y | N.y) + m * r**2 * (N.z | N.z)
+
+    py = s * N.y
+    I = inertia_of_point_mass(m, py, N)
+    assert I == m * s**2 * (N.x | N.x) + m * s**2 * (N.z | N.z)
+
+    pz = t * N.z
+    I = inertia_of_point_mass(m, pz, N)
+    assert I == m * t**2 * (N.x | N.x) + m * t**2 * (N.y | N.y)
+
+    p = px + py + pz
+    I = inertia_of_point_mass(m, p, N)
+    assert I == (m * (s**2 + t**2) * (N.x | N.x) -
+                 m * r * s * (N.x | N.y) -
+                 m * r * t * (N.x | N.z) -
+                 m * r * s * (N.y | N.x) +
+                 m * (r**2 + t**2) * (N.y | N.y) -
+                 m * s * t * (N.y | N.z) -
+                 m * r * t * (N.z | N.x) -
+                 m * s * t * (N.z | N.y) +
+                 m * (r**2 + s**2) * (N.z | N.z))
+
+
+def test_inertia_object():
+    N = ReferenceFrame('N')
+    O = Point('O')
+    ixx, iyy, izz = symbols('ixx iyy izz')
+    I_dyadic = ixx * (N.x | N.x) + iyy * (N.y | N.y) + izz * (N.z | N.z)
+    I = Inertia(inertia(N, ixx, iyy, izz), O)
+    assert I.__repr__() == ('Inertia(ixx*(N.x|N.x) + iyy*(N.y|N.y) + '
+                            'izz*(N.z|N.z), O)')
+    assert I.dyadic == I_dyadic
+    assert I.point == O
+    assert I[0] == I_dyadic
+    assert I[1] == O
+    assert I == (I_dyadic, O)  # Test tuple equal
+    raises(TypeError, lambda: I != (O, I_dyadic))  # Incorrect tuple order
+    assert I == Inertia(O, I_dyadic)  # Parse changed argument order
+    assert I == Inertia.from_tensor(O, N, ixx, iyy, izz)

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -54,8 +54,8 @@ def test_inertia_object():
     I_dyadic = ixx * (N.x | N.x) + iyy * (N.y | N.y) + izz * (N.z | N.z)
     I = Inertia(inertia(N, ixx, iyy, izz), O)
     assert isinstance(I, tuple)
-    assert I.__repr__() == ('Inertia(ixx*(N.x|N.x) + iyy*(N.y|N.y) + '
-                            'izz*(N.z|N.z), O)')
+    assert I.__repr__() == ('Inertia(dyadic=ixx*(N.x|N.x) + iyy*(N.y|N.y) + '
+                            'izz*(N.z|N.z), point=O)')
     assert I.dyadic == I_dyadic
     assert I.point == O
     assert I[0] == I_dyadic

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -62,4 +62,4 @@ def test_inertia_object():
     assert I == (I_dyadic, O)  # Test tuple equal
     raises(TypeError, lambda: I != (O, I_dyadic))  # Incorrect tuple order
     assert I == Inertia(O, I_dyadic)  # Parse changed argument order
-    assert I == Inertia.from_tensor(O, N, ixx, iyy, izz)
+    assert I == Inertia.from_inertia_scalars(O, N, ixx, iyy, izz)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,5 +1,5 @@
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
-from sympy.physics.mechanics import dynamicsymbols, outer, inertia
+from sympy.physics.mechanics import dynamicsymbols, outer, inertia, Inertia
 from sympy.physics.mechanics import inertia_of_point_mass
 from sympy.core.backend import expand, zeros, _simplify_matrix, symbols, Symbol
 
@@ -19,11 +19,12 @@ def test_rigidbody_default():
     assert b.__str__() == 'B'
     assert b.__repr__() == (
         "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass), "
-        "inertia=(B_ixx*(B_frame.x|B_frame.x) + B_ixy*(B_frame.x|B_frame.y) + "
-        "B_izx*(B_frame.x|B_frame.z) + B_ixy*(B_frame.y|B_frame.x) + "
-        "B_iyy*(B_frame.y|B_frame.y) + B_iyz*(B_frame.y|B_frame.z) + "
-        "B_izx*(B_frame.z|B_frame.x) + B_iyz*(B_frame.z|B_frame.y) + "
-        "B_izz*(B_frame.z|B_frame.z), B_masscenter)))")
+        "inertia=Inertia(B_ixx*(B_frame.x|B_frame.x) + "
+        "B_ixy*(B_frame.x|B_frame.y) + B_izx*(B_frame.x|B_frame.z) + "
+        "B_ixy*(B_frame.y|B_frame.x) + B_iyy*(B_frame.y|B_frame.y) + "
+        "B_iyz*(B_frame.y|B_frame.z) + B_izx*(B_frame.z|B_frame.x) + "
+        "B_iyz*(B_frame.z|B_frame.y) + B_izz*(B_frame.z|B_frame.z), "
+        "B_masscenter)))")
 
 
 def test_rigidbody():
@@ -53,8 +54,7 @@ def test_rigidbody():
     assert B.frame == A2
     assert B.masscenter == P2
     assert B.inertia == (I2, B.masscenter)
-    assert B.masscenter == P2
-    assert B.inertia == (I2, B.masscenter)
+    assert isinstance(B.inertia, Inertia)
 
     # Testing linear momentum function assuming A2 is the inertial frame
     N = ReferenceFrame('N')
@@ -80,6 +80,7 @@ def test_rigidbody2():
     B.potential_energy = M * g * h
     assert B.potential_energy == M * g * h
     assert expand(2 * B.kinetic_energy(N)) == omega**2 + M * v**2
+
 
 def test_rigidbody3():
     q1, q2, q3, q4 = dynamicsymbols('q1:5')
@@ -142,6 +143,7 @@ def test_rigidbody_inertia():
     R = RigidBody('R', o, N, m, (Io, p))
     I_check = inertia(N, Ix - b ** 2 * m, Iy - a ** 2 * m,
                       Iz - m * (a ** 2 + b ** 2), m * a * b)
+    assert isinstance(R.inertia, Inertia)
     assert R.inertia == (Io, p)
     assert R.central_inertia == I_check
     R.central_inertia = Io
@@ -150,6 +152,9 @@ def test_rigidbody_inertia():
     R.inertia = (Io, p)
     assert R.inertia == (Io, p)
     assert R.central_inertia == I_check
+    # parse Inertia object
+    R.inertia = Inertia(Io, o)
+    assert R.inertia == (Io, o)
 
 
 def test_parallel_axis():

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -19,12 +19,12 @@ def test_rigidbody_default():
     assert b.__str__() == 'B'
     assert b.__repr__() == (
         "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass), "
-        "inertia=Inertia(B_ixx*(B_frame.x|B_frame.x) + "
+        "inertia=Inertia(dyadic=B_ixx*(B_frame.x|B_frame.x) + "
         "B_ixy*(B_frame.x|B_frame.y) + B_izx*(B_frame.x|B_frame.z) + "
         "B_ixy*(B_frame.y|B_frame.x) + B_iyy*(B_frame.y|B_frame.y) + "
         "B_iyz*(B_frame.y|B_frame.z) + B_izx*(B_frame.z|B_frame.x) + "
         "B_iyz*(B_frame.z|B_frame.y) + B_izz*(B_frame.z|B_frame.z), "
-        "B_masscenter)))")
+        "point=B_masscenter)))")
 
 
 def test_rigidbody():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR is part of the mechanics experimental development (#24234) implementing the changes suggested in #24257.

#### Brief description of what is fixed or changed
This PR implements an `Inertia` object that stores the quantity (Dyadic) and the reference (Point) of an inertia. This is a replacement of the tuple, which is currently being used. Besides that the functions associated with inertia are moved to a separate inertia.py file removing some circular import issues.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
