### PR TITLE
Fix bug that coordinates could be general functions

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -738,6 +738,7 @@ def _f_list_parser(fl, ref_frame):
 
 def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
                           is_dynamicsymbols=True):
+    t_set = {dynamicsymbols._t}
     # Convert input to iterables
     if coordinates is None:
         coordinates = []
@@ -757,10 +758,12 @@ def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
                              'generalized speeds should be unique.')
     if is_dynamicsymbols:  # Check whether all coordinates are dynamicsymbols
         for coordinate in coordinates:
-            if not isinstance(coordinate, (AppliedUndef, Derivative)):
+            if not (isinstance(coordinate, (AppliedUndef, Derivative)) and
+                    coordinate.free_symbols == t_set):
                 raise ValueError(f'Generalized coordinate "{coordinate}" is not'
                                  f' a dynamicsymbol.')
         for speed in speeds:
-            if not isinstance(speed, (AppliedUndef, Derivative)):
+            if not (isinstance(speed, (AppliedUndef, Derivative)) and
+                    speed.free_symbols == t_set):
                 raise ValueError(f'Generalized speed "{speed}" is not a '
                                  f'dynamicsymbol.')

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import sin, cos, tan, pi, symbols, Matrix, S
+from sympy.core.backend import sin, cos, tan, pi, symbols, Matrix, S, Function
 from sympy.physics.mechanics import (Particle, Point, ReferenceFrame,
                                      RigidBody)
 from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
@@ -277,3 +277,14 @@ def test_validate_coordinates():
     _validate_coordinates([s1 + s2 + s3, q1], [0, u1], is_dynamicsymbols=False)
     raises(ValueError, lambda: _validate_coordinates(
         [s1 + s2 + s3, q1], [0, u1], is_dynamicsymbols=True))
+    # Test normal function
+    t = dynamicsymbols._t
+    a = symbols('a')
+    f1, f2 = symbols('f1:3', cls=Function)
+    _validate_coordinates([f1(a), f2(a)], is_dynamicsymbols=False)
+    raises(ValueError, lambda: _validate_coordinates([f1(a), f2(a)]))
+    raises(ValueError, lambda: _validate_coordinates(speeds=[f1(a), f2(a)]))
+    dynamicsymbols._t = a
+    _validate_coordinates([f1(a), f2(a)])
+    raises(ValueError, lambda: _validate_coordinates([f1(t), f2(t)]))
+    dynamicsymbols._t = t


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Noticed that find_dynamicsymbols also checked whether the function is a function of dynamicsymbols._t, so this PR adds this check also to the _validate_coordinates function.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
