### PR TITLE
Remove `Basic.compare` from physics and printing

### DIFF
--- a/doc/man/isympy.1
+++ b/doc/man/isympy.1
@@ -112,7 +112,7 @@ in the printed expression will have no canonical order
 Example: isympy -o rev-lax
 
 \fIORDER\fR must be one of 'lex', 'rev-lex', 'grlex',
-\&'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.
+\&'rev-grlex', 'grevlex', 'rev-grevlex', or 'none'.
 .TP
 \*(T<\fB\-q\fR\*(T>, \*(T<\fB\-\-quiet\fR\*(T>
 Print only Python's and SymPy's versions to stdout at startup, and nothing else.

--- a/doc/man/isympy.xml
+++ b/doc/man/isympy.xml
@@ -249,7 +249,7 @@ this will generate isympy.1 in the current directory. -->
 					<para>Example: isympy -o rev-lax</para>
 
                     <para><replaceable class="parameter">ORDER</replaceable> must be one of 'lex', 'rev-lex', 'grlex',
-                    'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.</para>
+                    'rev-grlex', 'grevlex', 'rev-grevlex', or 'none'.</para>
 				</listitem>
             </varlistentry>
             <varlistentry>

--- a/isympy.py
+++ b/isympy.py
@@ -75,7 +75,7 @@ COMMAND LINE OPTIONS
         $isympy -o rev-lex
 
     ORDER must be one of 'lex', 'rev-lex', 'grlex', 'rev-grlex',
-    'grevlex', 'rev-grevlex', 'old', or 'none'.
+    'grevlex', 'rev-grevlex', or 'none'.
 
     Note that for very large expressions, ORDER='none' may speed up
     printing considerably but the terms will have no canonical order.
@@ -231,7 +231,7 @@ def main() -> None:
         default=None,
         metavar='ORDER',
         choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
-        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none; defaults to lex')
+        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | none; defaults to lex')
 
     parser.add_argument(
         '-q', '--quiet',
@@ -329,6 +329,8 @@ def main() -> None:
         args['pretty_print'] = False
 
     if options.order is not None:
+        if options.order == 'old':
+            parser.error('-o old is no longer supported')
         args['order'] = options.order
 
     args['quiet'] = options.quiet

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -344,10 +344,10 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         printer.
     order : string or None, default='lex'
         There are a few different settings for this parameter:
+        ``'none'``, which does not attempt to order the expressions;
         ``'lex'`` (default), which is lexographic order;
         ``'grlex'``, which is graded lexographic order;
         ``'grevlex'``, which is reversed graded lexographic order;
-        ``'none'``, which does not attempt to order the expressions;
         ``None``, which sets it to lex.
     use_unicode : bool or None, default=None
         If ``True``, use unicode characters;
@@ -431,18 +431,18 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> init_printing(use_unicode=False) # doctest: +SKIP
     >>> theta # doctest: +SKIP
     theta
-    >>> init_printing(order='lex') # doctest: +SKIP
-    >>> str(y + x + y**2 + x**2) # doctest: +SKIP
+    >>> init_printing(order='none', pretty_print=False) # doctest: +SKIP
+    >>> x**2 + y**2 + x + y # doctest: +SKIP
+    x + y + x**2 + y**2
+    >>> init_printing(order='lex', pretty_print=False) # doctest: +SKIP
+    >>> y + x + y**2 + x**2 # doctest: +SKIP
     x**2 + x + y**2 + y
-    >>> init_printing(order='grlex') # doctest: +SKIP
-    >>> str(y + x + y**2 + x**2) # doctest: +SKIP
-    x**2 + x + y**2 + y
-    >>> init_printing(order='grevlex') # doctest: +SKIP
-    >>> str(y * x**2 + x * y**2) # doctest: +SKIP
+    >>> init_printing(order='grlex', pretty_print=False) # doctest: +SKIP
+    >>> y + x + y**2 + x**2 # doctest: +SKIP
+    x**2 + y**2 + x + y
+    >>> init_printing(order='grevlex', pretty_print=False) # doctest: +SKIP
+    >>> y * x**2 + x * y**2 # doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_printing(order='none') # doctest: +SKIP
-    >>> str(x**2 + y**2 + x + y) # doctest: +SKIP
-    x**2 + x + y**2 + y
     >>> init_printing(num_columns=10) # doctest: +SKIP
     >>> x**2 + x + y**2 + y # doctest: +SKIP
     x + y +

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -347,6 +347,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         ``'lex'`` (default), which is lexographic order;
         ``'grlex'``, which is graded lexographic order;
         ``'grevlex'``, which is reversed graded lexographic order;
+        ``'none'``, which does not attempt to order the expressions;
         ``None``, which sets it to lex.
     use_unicode : bool or None, default=None
         If ``True``, use unicode characters;
@@ -439,6 +440,9 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> init_printing(order='grevlex') # doctest: +SKIP
     >>> str(y * x**2 + x * y**2) # doctest: +SKIP
     x**2*y + x*y**2
+    >>> init_printing(order='none') # doctest: +SKIP
+    >>> str(x**2 + y**2 + x + y) # doctest: +SKIP
+    x**2 + x + y**2 + y
     >>> init_printing(num_columns=10) # doctest: +SKIP
     >>> x**2 + x + y**2 + y # doctest: +SKIP
     x + y +

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -347,7 +347,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         ``'lex'`` (default), which is lexographic order;
         ``'grlex'``, which is graded lexographic order;
         ``'grevlex'``, which is reversed graded lexographic order;
-        ``'old'``, which is used for compatibility reasons and for long expressions;
         ``None``, which sets it to lex.
     use_unicode : bool or None, default=None
         If ``True``, use unicode characters;
@@ -440,9 +439,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> init_printing(order='grevlex') # doctest: +SKIP
     >>> str(y * x**2 + x * y**2) # doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_printing(order='old') # doctest: +SKIP
-    >>> str(x**2 + y**2 + x + y) # doctest: +SKIP
-    x**2 + x + y**2 + y
     >>> init_printing(num_columns=10) # doctest: +SKIP
     >>> x**2 + x + y**2 + y # doctest: +SKIP
     x + y +

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -317,6 +317,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
+        none, which does not attempt to order the expressions;
         None, which sets it to lex.
     use_unicode: boolean or None
         If True, use unicode characters;
@@ -381,6 +382,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
     >>> init_session(order='grevlex') #doctest: +SKIP
     >>> y * x**2 + x * y**2 #doctest: +SKIP
     x**2*y + x*y**2
+    >>> init_session(order='none') # doctest: +SKIP
+    >>> x**2 + y**2 + x + y #doctest: +SKIP
+    x**2 + x + y**2 + y
     >>> theta = Symbol('theta') #doctest: +SKIP
     >>> theta #doctest: +SKIP
     theta

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -317,7 +317,6 @@ def init_session(ipython=None, pretty_print=True, order=None,
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
-        old, which is used for compatibility reasons and for long expressions;
         None, which sets it to lex.
     use_unicode: boolean or None
         If True, use unicode characters;
@@ -382,9 +381,6 @@ def init_session(ipython=None, pretty_print=True, order=None,
     >>> init_session(order='grevlex') #doctest: +SKIP
     >>> y * x**2 + x * y**2 #doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_session(order='old') #doctest: +SKIP
-    >>> x**2 + y**2 + x + y #doctest: +SKIP
-    x + y + x**2 + y**2
     >>> theta = Symbol('theta') #doctest: +SKIP
     >>> theta #doctest: +SKIP
     theta

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -376,15 +376,15 @@ def init_session(ipython=None, pretty_print=True, order=None,
     sqrt(5)
     >>> y + x + y**2 + x**2 #doctest: +SKIP
     x**2 + x + y**2 + y
+    >>> init_session(order='none') # doctest: +SKIP
+    >>> x**2 + y**2 + x + y #doctest: +SKIP
+    x + y + x**2 + y**2
     >>> init_session(order='grlex') #doctest: +SKIP
     >>> y + x + y**2 + x**2 #doctest: +SKIP
     x**2 + y**2 + x + y
     >>> init_session(order='grevlex') #doctest: +SKIP
     >>> y * x**2 + x * y**2 #doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_session(order='none') # doctest: +SKIP
-    >>> x**2 + y**2 + x + y #doctest: +SKIP
-    x**2 + x + y**2 + y
     >>> theta = Symbol('theta') #doctest: +SKIP
     >>> theta #doctest: +SKIP
     theta

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -4,6 +4,7 @@ from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer
 from sympy.core.singleton import S
+from sympy.core.sorting import default_sort_key
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.operator import Operator
@@ -105,7 +106,7 @@ class AntiCommutator(Expr):
 
         # Canonical ordering of arguments
         #The Commutator [A,B] is on canonical form if A < B.
-        if a.compare(b) == 1:
+        if sorted([a, b], key=default_sort_key) != [a, b]:
             return cls(b, a)
 
     def doit(self, **hints):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from sympy.core.mul import Mul
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
-from sympy.core.core import BasicMeta
 from sympy.core.assumptions import ManagedProperties
 
 
@@ -358,8 +357,9 @@ class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):
         if not latexname:
             latexname = name
-        return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
-                                 {'gate_name': name, 'gate_name_latex': latexname})
+        return ManagedProperties.__new__(
+            mcl, name + "Gate", (OneQubitGate,),
+            {'gate_name': name, 'gate_name_latex': latexname})
 
 def CreateCGate(name, latexname=None):
     """Use a lexical closure to make a controlled gate.

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -5,6 +5,7 @@ from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
+from sympy.core.sorting import default_sort_key
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.dagger import Dagger
@@ -119,7 +120,7 @@ class Commutator(Expr):
 
         # Canonical ordering of arguments
         # The Commutator [A, B] is in canonical form if A < B.
-        if a.compare(b) == 1:
+        if sorted([a, b], key=default_sort_key) != [a, b]:
             return S.NegativeOne*cls(b, a)
 
     def _expand_pow(self, A, B, sign):

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -1239,10 +1239,10 @@ def gate_sort(circuit):
                 first_base, first_exp = circ_array[i].as_base_exp()
                 second_base, second_exp = circ_array[i + 1].as_base_exp()
 
-                # Use SymPy's hash based sorting. This is not mathematical
-                # sorting, but is rather based on comparing hashes of objects.
-                # See Basic.compare for details.
-                if first_base.compare(second_base) > 0:
+                # Use sympy's canonical sorting. This is not mathematical
+                # sorting, but an arbitrary canonical sorting of the
+                # expression trees.
+                if sorted([first_base, second_base], key=default_sort_key) != [first_base, second_base]:
                     if Commutator(first_base, second_base).doit() == 0:
                         new_args = (circuit.args[:i] + (circuit.args[i + 1],) +
                                    (circuit.args[i],) + circuit.args[i + 2:])

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -838,18 +838,16 @@ def test_big_expr():
     sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B')))),Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
 
     assert str(e2) == '-[A + B,Jz**2]*{Dagger(D)*Dagger(C),E**(-2)}*[J2,Jz]'
-    ascii_str = \
-"""\
- [          2] / +  +  -2\ [ 2   ]\n\
--[A + B,/J \ ]*<D *C ,E  >*[J ,J ]\n\
- [      \ z/ ] \         / [    z]\
-"""
-    ucode_str = \
-"""\
- ⎡          2⎤ ⎧ †  †  -2⎫ ⎡ 2   ⎤\n\
--⎢A + B,⎛J ⎞ ⎥⋅⎨D ⋅C ,E  ⎬⋅⎢J ,J ⎥\n\
- ⎣      ⎝ z⎠ ⎦ ⎩         ⎭ ⎣    z⎦\
-"""
+    ascii_str = "\n".join([
+        r" [          2] / +  +  -2\ [ 2   ]",
+        r"-[A + B,/J \ ]*<D *C ,E  >*[J ,J ]",
+        r" [      \ z/ ] \         / [    z]"
+    ])
+    ucode_str = "\n".join([
+        " ⎡          2⎤ ⎧ †  †  -2⎫ ⎡ 2   ⎤",
+        "-⎢A + B,⎛J ⎞ ⎥⋅⎨D ⋅C ,E  ⎬⋅⎢J ,J ⎥",
+        " ⎣      ⎝ z⎠ ⎦ ⎩         ⎭ ⎣    z⎦"
+    ])
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == \

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -815,46 +815,47 @@ def test_big_expr():
     e3 = Wigner3j(1, 2, 3, 4, 5, 6)*TensorProduct(Commutator(Operator('A') + Dagger(Operator('B')), Operator('C') + Operator('D')), Jz - J2)*Dagger(OuterProduct(Dagger(JzBra(1, 1)), JzBra(1, 0)))*TensorProduct(JzKetCoupled(1, 1, (1, 1)) + JzKetCoupled(1, 0, (1, 1)), JzKetCoupled(1, -1, (1, 1)))
     e4 = (ComplexSpace(1)*ComplexSpace(2) + FockSpace()**2)*(L2(Interval(
         0, oo)) + HilbertSpace())
-    assert str(e1) == '(Jz**2)x(Dagger(A) + Dagger(B))*{Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3,Dagger(A) + Dagger(B)}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
-    ascii_str = \
-"""\
-                 /                                      3        \\                                 \n\
-                 |/                                   +\\         |                                 \n\
-    2  / +    +\\ <|                    /d            \\ |   +    +>                                 \n\
-/J \\ x \\A  + B /*||DifferentialOperator|--(f(x)),f(x)| | ,A  + B |*(<1,0| + <1,1|)*(|0,0> + |1,-1>)\n\
-\\ z/             \\\\                    \\dx           / /         /                                 \
-"""
-    ucode_str = \
-"""\
-                 ⎧                                      3        ⎫                                 \n\
-                 ⎪⎛                                   †⎞         ⎪                                 \n\
-    2  ⎛ †    †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
-⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
-⎝ z⎠             ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
-"""
+    assert str(e1) == '(Jz**2)x(Dagger(A) + Dagger(B))*{Dagger(A) + Dagger(B),Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
+    ascii_str = "\n".join([
+        '                 /                                              3\\                                 ',
+        '                 |        /                                   +\\ |                                 ',
+        '    2  / +    +\\ < +    + |                    /d            \\ | >                                 ',
+        '/J \\ x \\A  + B /*|A  + B ,|DifferentialOperator|--(f(x)),f(x)| | |*(<1,0| + <1,1|)*(|0,0> + |1,-1>)',
+        '\\ z/             \\        \\                    \\dx           / / /                                 '
+    ])
+    ucode_str = "\n".join([
+        '                 ⎧                                              3⎫                                 ',
+        '                 ⎪        ⎛                                   †⎞ ⎪                                 ',
+        '    2  ⎛ †    †⎞ ⎨ †    † ⎜                    ⎛d            ⎞ ⎟ ⎬                                 ',
+        '⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪A  + B ,⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)',
+        '⎝ z⎠             ⎩        ⎝                    ⎝dx           ⎠ ⎠ ⎭                                 '
+    ])
+
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
-    sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
-    assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
+        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{A^{\dagger} + B^{\dagger},\left(DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)^{\dagger}\right)^{3}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+    sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B')))),Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
+
+    assert str(e2) == '-[A + B,Jz**2]*{Dagger(D)*Dagger(C),E**(-2)}*[J2,Jz]'
     ascii_str = \
 """\
-[    2      ] / -2  +  +\\ [ 2   ]\n\
-[/J \\ ,A + B]*<E  ,D *C >*[J ,J ]\n\
-[\\ z/       ] \\         / [    z]\
+ [          2] / +  +  -2\ [ 2   ]\n\
+-[A + B,/J \ ]*<D *C ,E  >*[J ,J ]\n\
+ [      \ z/ ] \         / [    z]\
 """
     ucode_str = \
 """\
-⎡    2      ⎤ ⎧ -2  †  †⎫ ⎡ 2   ⎤\n\
-⎢⎛J ⎞ ,A + B⎥⋅⎨E  ,D ⋅C ⎬⋅⎢J ,J ⎥\n\
-⎣⎝ z⎠       ⎦ ⎩         ⎭ ⎣    z⎦\
+ ⎡          2⎤ ⎧ †  †  -2⎫ ⎡ 2   ⎤\n\
+-⎢A + B,⎛J ⎞ ⎥⋅⎨D ⋅C ,E  ⎬⋅⎢J ,J ⎥\n\
+ ⎣      ⎝ z⎠ ⎦ ⎩         ⎭ ⎣    z⎦\
 """
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == \
-        r'\left[J_z^{2},A + B\right] \left\{E^{-2},D^{\dagger} C^{\dagger}\right\} \left[J^2,J_z\right]'
-    sT(e2, "Mul(Commutator(Pow(JzOp(Symbol('J')), Integer(2)),Add(Operator(Symbol('A')), Operator(Symbol('B')))), AntiCommutator(Pow(Operator(Symbol('E')), Integer(-2)),Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C'))))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
+        r'- \left[A + B,J_z^{2}\right] \left\{D^{\dagger} C^{\dagger},E^{-2}\right\} \left[J^2,J_z\right]'
+    sT(e2, "Mul(Integer(-1), Commutator(Add(Operator(Symbol('A')), Operator(Symbol('B'))),Pow(JzOp(Symbol('J')), Integer(2))), AntiCommutator(Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C')))),Pow(Operator(Symbol('E')), Integer(-2))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
+
     assert str(e3) == \
         "Wigner3j(1, 2, 3, 4, 5, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x|1,-1,j1=1,j2=1>"
     ascii_str = \

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -527,8 +527,8 @@ class CodePrinter(StrPrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order=self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -138,8 +138,8 @@ class JuliaCodePrinter(CodePrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order=self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -523,8 +523,8 @@ class LatexPrinter(Printer):
             if not expr.is_Mul:
                 return str(self._print(expr))
             else:
-                if self.order not in ('old', 'none'):
-                    args = expr.as_ordered_factors()
+                if self.order != 'none':
+                    args = expr.as_ordered_factors(order=self.order)
                 else:
                     args = list(expr.args)
 
@@ -2979,7 +2979,7 @@ def latex(expr, **settings):
     order: string, optional
         Any of the supported monomial orderings (currently ``'lex'``,
         ``'grlex'``, or ``'grevlex'``), and ``'none'``. This parameter does
-        nothing for `~.Mul` objects. For ery large expressions, set the
+        nothing for `~.Mul` objects. For very large expressions, set the
         ``order`` keyword to ``'none'`` if speed is a concern.
     symbol_names : dictionary of strings mapped to symbols, optional
         Dictionary of symbols and the custom strings they should be emitted as.

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2978,11 +2978,9 @@ def latex(expr, **settings):
         ``'ldot'``, ``'dot'``, or ``'times'``.
     order: string, optional
         Any of the supported monomial orderings (currently ``'lex'``,
-        ``'grlex'``, or ``'grevlex'``), ``'old'``, and ``'none'``. This
-        parameter does nothing for `~.Mul` objects. Setting order to ``'old'``
-        uses the compatibility ordering for ``~.Add`` defined in Printer. For
-        very large expressions, set the ``order`` keyword to ``'none'`` if
-        speed is a concern.
+        ``'grlex'``, or ``'grevlex'``), and ``'none'``. This parameter does
+        nothing for `~.Mul` objects. For ery large expressions, set the
+        ``order`` keyword to ``'none'`` if speed is a concern.
     symbol_names : dictionary of strings mapped to symbols, optional
         Dictionary of symbols and the custom strings they should be emitted as.
     root_notation : boolean, optional

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -156,8 +156,8 @@ class OctaveCodePrinter(CodePrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order=self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1983,8 +1983,8 @@ class PrettyPrinter(Printer):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        if self.order not in ('old', 'none'):
-            args = product.as_ordered_factors()
+        if self.order != 'none':
+            args = product.as_ordered_factors(order=self.order)
         else:
             args = list(product.args)
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -213,11 +213,7 @@ import sys
 from typing import Any, Type
 import inspect
 from contextlib import contextmanager
-from functools import cmp_to_key, update_wrapper
-
-from sympy.core.add import Add
-from sympy.core.basic import Basic
-
+from functools import update_wrapper
 from sympy.core.core import BasicMeta
 from sympy.core.function import AppliedUndef, UndefinedFunction, Function
 
@@ -341,10 +337,7 @@ class Printer:
     def _as_ordered_terms(self, expr, order=None):
         """A compatibility function for ordering terms in Add. """
         order = order or self.order
-
-        if order == 'old':
-            return sorted(Add.make_args(expr), key=cmp_to_key(Basic._compare_pretty))
-        elif order == 'none':
+        if order in ('old', 'none'):
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -337,7 +337,9 @@ class Printer:
     def _as_ordered_terms(self, expr, order=None):
         """A compatibility function for ordering terms in Add. """
         order = order or self.order
-        if order in ('old', 'none'):
+        if order == 'old':
+            raise ValueError("'old' ordering has been removed")
+        if order == 'none':
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -193,8 +193,8 @@ class ReprPrinter(Printer):
         return "nan"
 
     def _print_Mul(self, expr, order=None):
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order=self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -321,8 +321,8 @@ class StrPrinter(Printer):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order=self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -206,12 +206,12 @@ def test_latex_basic():
     k = ZZ.cyclotomic_field(5)
     assert latex(k.ext.field_element([1, 2, 3, 4])) == \
         r"\zeta^{3} + 2 \zeta^{2} + 3 \zeta + 4"
-    assert latex(k.ext.field_element([1, 2, 3, 4]), order='old') == \
-        r"4 + 3 \zeta + 2 \zeta^{2} + \zeta^{3}"
+    assert latex(k.ext.field_element([1, 2, 3, 4]), order='none') == \
+        r"4 + \zeta^{3} + 2 \zeta^{2} + 3 \zeta"
     assert latex(k.primes_above(19)[0]) == \
         r"\left(19, \zeta^{2} + 5 \zeta + 1\right)"
-    assert latex(k.primes_above(19)[0], order='old') == \
-           r"\left(19, 1 + 5 \zeta + \zeta^{2}\right)"
+    assert latex(k.primes_above(19)[0], order='none') == \
+        r"\left(19, 1 + \zeta^{2} + 5 \zeta\right)"
     assert latex(k.primes_above(7)[0]) == r"\left(7\right)"
 
     assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -59,7 +59,7 @@ def test_printmethod():
 def test_Add():
     sT(x + y, "Add(Symbol('x'), Symbol('y'))")
     assert srepr(x**2 + 1, order='lex') == "Add(Pow(Symbol('x'), Integer(2)), Integer(1))"
-    assert srepr(x**2 + 1, order='old') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
+    assert srepr(x**2 + 1, order='none') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
     assert srepr(sympify('x + 3 - 2', evaluate=False), order='none') == "Add(Symbol('x'), Integer(3), Mul(Integer(-1), Integer(2)))"
 
 
@@ -231,7 +231,7 @@ def test_settins():
 
 def test_Mul():
     sT(3*x**3*y, "Mul(Integer(3), Pow(Symbol('x'), Integer(3)), Symbol('y'))")
-    assert srepr(3*x**3*y, order='old') == "Mul(Integer(3), Symbol('y'), Pow(Symbol('x'), Integer(3)))"
+    assert srepr(3*x**3*y, order='none') == "Mul(Integer(3), Symbol('y'), Pow(Symbol('x'), Integer(3)))"
     assert srepr(sympify('(x+4)*2*x*7', evaluate=False), order='none') == "Mul(Add(Symbol('x'), Integer(4)), Integer(2), Symbol('x'), Integer(7))"
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is more redux from #19907 to only handle the issues with physics and printing.
I just nullified the keyword 'old' from printing

Also some ordering in physics.physics are changed I assume, 
but I think that it is better than the changes in #19907 about physics because I flipped the sorting such that it correctly sorts things alphabetical at least
for example, `Commutator(A, B)` is canonical and it isn't wrongly written as `-Commutator(B, A)`

#### Other comments

I also recognize that `order=None` and `order='none'` are different and confusing options for printing, maybe this is abused and can cause some buggy behavior, so I'm not sure 'old' have to be removed and it can replace 'none' instead.

I only see that `old` exists to do some more redundant computation
https://github.com/sympy/sympy/blob/1d2de06782fe1f46f1fb9b211b406431f666d221/sympy/printing/printer.py#L345-L346
so removing this wont be difficult
so I'll leave 'old' keyword should be something like we 'dont care' about how it is printed in the future.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- interactive
  - BREAKING: The legacy option `order='old'` is deprecated in `init_printing, init_session`. Use `order='none'` instead.
- printing
  - BREAKING: The legacy option `order='old'` is deprecated in all printers. Use `order='none'` instead.
<!-- END RELEASE NOTES -->
