### PR TITLE
Remove redundant `all_classes` from BasicMeta

### DIFF
--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -60,14 +60,9 @@ class Registry:
     def __delattr__(self, name):
         delattr(self.__class__, name)
 
-#A set containing all SymPy class objects
-all_classes = set()
-
 
 class BasicMeta(type):
-
     def __init__(cls, *args, **kws):
-        all_classes.add(cls)
         cls.__sympy__ = property(lambda self: True)
 
     def __cmp__(cls, other):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1258,12 +1258,7 @@ def test_undef_fcn_float_issue_6938():
 
 def test_undefined_function_eval():
     # Issue 15170. Make sure UndefinedFunction with eval defined works
-    # properly. The issue there was that the hash was determined before _nargs
-    # was set, which is included in the hash, hence changing the hash. The
-    # class is added to sympy.core.core.all_classes before the hash is
-    # changed, meaning "temp in all_classes" would fail, causing sympify(temp(t))
-    # to give a new class. We will eventually remove all_classes, but make
-    # sure this continues to work.
+    # properly.
 
     fdiff = lambda self, argindex=1: cos(self.args[argindex - 1])
     eval = classmethod(lambda cls, t: None)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I find that `all_classes` is not used anywhere, but it can possibly cause some garbage collection problem with functions.
Unfortunately, I don't think that the problem is fixed entirely, but we can remove some redundancy at least

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
