### PR TITLE
Removed warning from quaternion

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1,4 +1,3 @@
-import warnings
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.relational import is_eq
@@ -554,7 +553,6 @@ class Quaternion(Expr):
                 angles[2] = atan2(b*c - a*d, a*c + b*d)
 
         else:  # any degenerate case
-            warnings.warn('Singularity case, setting third angle to zero')
             angles[2 * (not extrinsic)] = sympify(0)
             if case == 1:
                 angles[2 * extrinsic] = 2 * atan2(b, a)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -12,7 +12,7 @@ from sympy.matrices.dense import Matrix
 from sympy.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.algebras.quaternion import Quaternion
-from sympy.testing.pytest import raises, warns
+from sympy.testing.pytest import raises
 from itertools import permutations, product
 
 w, x, y, z = symbols('w:z')
@@ -339,16 +339,14 @@ def test_to_euler_iss24504():
     See issue 24504 for reference.
     """
     q = Quaternion.from_euler((phi, 0, 0), 'zyz')
-    with warns(UserWarning, match='Singularity', test_stacklevel=False):
-        assert trigsimp(q.to_euler('zyz'), inverse=True) == (phi, 0, 0)
+    assert trigsimp(q.to_euler('zyz'), inverse=True) == (phi, 0, 0)
 
 
 def test_to_euler_numerical_singilarities():
 
     def test_one_case(angles, seq):
         q = Quaternion.from_euler(angles, seq)
-        with warns(UserWarning, match='Singularity', test_stacklevel=False):
-            assert q.to_euler(seq) == angles
+        assert q.to_euler(seq) == angles
 
     # symmetric
     test_one_case((pi/2,  0, 0), 'zyz')


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24604 

#### Brief description of what is fixed or changed
Removed warning from degenerate cases in `Quaternion.to_euler`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
