### PR TITLE
Remove type comparison for `meijerint`

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -32,6 +32,7 @@ import itertools
 from sympy import SYMPY_DEBUG
 from sympy.core import S, Expr
 from sympy.core.add import Add
+from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.exprtools import factor_terms
@@ -41,7 +42,7 @@ from sympy.core.mul import Mul
 from sympy.core.numbers import ilcm, Rational, pi
 from sympy.core.relational import Eq, Ne, _canonical_coeff
 from sympy.core.sorting import default_sort_key, ordered
-from sympy.core.symbol import Dummy, symbols, Wild
+from sympy.core.symbol import Dummy, symbols, Wild, Symbol
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (re, im, arg, Abs, sign,
@@ -295,19 +296,13 @@ from sympy.utilities.timeutils import timethis
 timeit = timethis('meijerg')
 
 
-def _mytype(f, x):
+def _mytype(f: Basic, x: Symbol) -> tuple[str, ...]:
     """ Create a hashable entity describing the type of f. """
     if x not in f.free_symbols:
         return ()
     elif f.is_Function:
-        return (type(f),)
-    else:
-        types = [_mytype(a, x) for a in f.args]
-        res = []
-        for t in types:
-            res += list(t)
-        res.sort()
-        return tuple(res)
+        return str(type(f)),
+    return tuple(sorted(t for a in f.args for t in _mytype(a, x)))
 
 
 class _CoeffExpValueError(ValueError):

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -296,13 +296,16 @@ from sympy.utilities.timeutils import timethis
 timeit = timethis('meijerg')
 
 
-def _mytype(f: Basic, x: Symbol) -> tuple[str, ...]:
+def _mytype(f: Basic, x: Symbol) -> tuple[type[Basic], ...]:
     """ Create a hashable entity describing the type of f. """
+    def key(x: type[Basic]) -> tuple[int, int, str]:
+        return x.class_key()
+
     if x not in f.free_symbols:
         return ()
     elif f.is_Function:
-        return str(type(f)),
-    return tuple(sorted(t for a in f.args for t in _mytype(a, x)))
+        return type(f),
+    return tuple(sorted((t for a in f.args for t in _mytype(a, x)), key=key))
 
 
 class _CoeffExpValueError(ValueError):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is some portion of work from #13059
I think that `frozenset` trick is not working in recent version somehow
so I'd try other way around of using `class_key`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
