### PR TITLE
Remove type checking for BasicMeta

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,7 +7,6 @@ from itertools import chain, zip_longest
 
 from .assumptions import ManagedProperties
 from .cache import cacheit
-from .core import BasicMeta
 from .sympify import _sympify, sympify, SympifyError, _external_converter
 from .sorting import ordered
 from .kind import Kind, UndefinedKind
@@ -1343,7 +1342,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         type_set = set()  # only types
         p_set = set()  # hashable non-types
         for p in patterns:
-            if isinstance(p, BasicMeta):
+            if isinstance(p, type) and issubclass(p, Basic):
                 type_set.add(p)
                 continue
             if not isinstance(p, Basic):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from sympy.core.mul import Mul
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
-from sympy.core.core import BasicMeta
 from sympy.core.assumptions import ManagedProperties
 
 
@@ -358,8 +357,9 @@ class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):
         if not latexname:
             latexname = name
-        return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
-                                 {'gate_name': name, 'gate_name_latex': latexname})
+        return ManagedProperties.__new__(
+            mcl, name + "Gate", (OneQubitGate,),
+            {'gate_name': name, 'gate_name_latex': latexname})
 
 def CreateCGate(name, latexname=None):
     """Use a lexical closure to make a controlled gate.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -218,7 +218,6 @@ from functools import cmp_to_key, update_wrapper
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 
-from sympy.core.core import BasicMeta
 from sympy.core.function import AppliedUndef, UndefinedFunction, Function
 
 
@@ -305,9 +304,9 @@ class Printer:
             # If the printer defines a name for a printing method
             # (Printer.printmethod) and the object knows for itself how it
             # should be printed, use that method.
-            if (self.printmethod and hasattr(expr, self.printmethod)
-                    and not isinstance(expr, BasicMeta)):
-                return getattr(expr, self.printmethod)(self, **kwargs)
+            if self.printmethod and hasattr(expr, self.printmethod):
+                if not (isinstance(expr, type) and issubclass(expr, Basic)):
+                    return getattr(expr, self.printmethod)(self, **kwargs)
 
             # See if the class of expr is known, or if one of its super
             # classes is known, and use that print function


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This attempts to adapt `BasicMeta` type checking in library code for preparation to remove BasicMeta

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
