### PR TITLE
Simplified middle angle in Quaternion.to_euler for asymmetric sequences

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -536,10 +536,10 @@ class Quaternion(Expr):
         if avoid_square_root:
             if symmetric:
                 n2 = self.norm()**2
-                angles[1] = acos(factor((a*a + b*b - c*c - d*d) / n2))
+                angles[1] = acos(factor((a * a + b * b - c * c - d * d) / n2))
             else:
                 n2 = 2 * self.norm()**2
-                angles[1] = asin(factor((c*c + d*d - a*a - b*b) / n2))
+                angles[1] = asin(factor((c * c + d * d - a * a - b * b) / n2))
         else:
             angles[1] = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
             if not symmetric:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -4,8 +4,10 @@ from sympy.core.relational import is_eq
 from sympy.functions.elementary.complexes import (conjugate, im, re, sign)
 from sympy.functions.elementary.exponential import (exp, log as ln)
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (acos, cos, sin, atan2)
+from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
+from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.simplify.trigsimp import trigsimp
+from sympy.simplify.simplify import factor
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.core.sympify import sympify, _sympify
@@ -532,10 +534,16 @@ class Quaternion(Expr):
             a, b, c, d = a - c, b + d, c + a, d - b
 
         if avoid_square_root:
-            n2 = self.norm()**2 if symmetric else 2 * self.norm()**2
-            angles[1] = acos((a*a + b*b - c*c - d*d) / n2)
+            if symmetric:
+                n2 = self.norm()**2
+                angles[1] = acos((a*a + b*b - c*c - d*d) / n2)
+            else:
+                n2 = 2 * self.norm()**2
+                angles[1] = asin(factor((c*c + d*d - a*a - b*b) / n2))
         else:
             angles[1] = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
+            if not symmetric:
+                angles[1] -= S.Pi / 2
 
         # Check for singularities in numerical cases
         case = 0
@@ -562,7 +570,6 @@ class Quaternion(Expr):
 
         # for Tait-Bryan angles
         if not symmetric:
-            angles[1] -= S.Pi / 2
             angles[0] *= sign
 
         if extrinsic:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -536,7 +536,7 @@ class Quaternion(Expr):
         if avoid_square_root:
             if symmetric:
                 n2 = self.norm()**2
-                angles[1] = acos((a*a + b*b - c*c - d*d) / n2)
+                angles[1] = acos(factor((a*a + b*b - c*c - d*d) / n2))
             else:
                 n2 = 2 * self.norm()**2
                 angles[1] = asin(factor((c*c + d*d - a*a - b*b) / n2))

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -7,7 +7,6 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.simplify.trigsimp import trigsimp
-from sympy.simplify.simplify import factor
 from sympy.integrals.integrals import integrate
 from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.core.sympify import sympify, _sympify
@@ -536,10 +535,10 @@ class Quaternion(Expr):
         if avoid_square_root:
             if symmetric:
                 n2 = self.norm()**2
-                angles[1] = acos(factor((a * a + b * b - c * c - d * d) / n2))
+                angles[1] = acos((a * a + b * b - c * c - d * d) / n2)
             else:
                 n2 = 2 * self.norm()**2
-                angles[1] = asin(factor((c * c + d * d - a * a - b * b) / n2))
+                angles[1] = asin((c * c + d * d - a * a - b * b) / n2)
         else:
             angles[1] = 2 * atan2(sqrt(c * c + d * d), sqrt(a * a + b * b))
             if not symmetric:


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Two simplifications are made for the option `avoid_square_root=True`.
First, I put a call to `simplify.factor` inside the formula for the middle angle, so that running:
```python
Quaternion(a, b, c, d, norm=1).to_euler('zyx', avoid_square_root=True)[1]
```
Gives this:
```math
\operatorname{acos}{\left( 2 \, (b d - a c) \right)}- \frac{\pi}{2}
```
Instead of this:
```math
\operatorname{acos}{\left(\frac{\left(a - c\right)^{2}}{2} - \frac{\left(a + c\right)^{2}}{2} - \frac{\left(- b + d\right)^{2}}{2} + \frac{\left(b + d\right)^{2}}{2} \right)} - \frac{\pi}{2}
```

Second, I used the fact that $\cos(\theta + \pi / 2) = -\sin(\theta)$ to simplify $\operatorname{acos}(x) - \pi / 2 = \operatorname{asin}(- x)$ for asymmetric sequences, further simplifying the result to:
```math
\operatorname{asin}{\left(2 \left(a c - b d\right) \right)}
```

This has one big advantage: it is consistent with a formula for the pitch angle that is widely implemented.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
