### PR TITLE
Documented gymbal lock cases

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -442,6 +442,9 @@ class Quaternion(Expr):
         in the sequence given by `seq`. This implements the method described
         in [1]_.
 
+        For degenerate cases (gymbal lock cases), the third angle is
+        set to zero.
+
         Parameters
         ==========
 
@@ -553,7 +556,7 @@ class Quaternion(Expr):
                 angles[2] = atan2(b*c - a*d, a*c + b*d)
 
         else:  # any degenerate case
-            angles[2 * (not extrinsic)] = sympify(0)
+            angles[2 * (not extrinsic)] = S.Zero
             if case == 1:
                 angles[2 * extrinsic] = 2 * atan2(b, a)
             else:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -456,7 +456,6 @@ class Quaternion(Expr):
             must be from the set ``{'X', 'Y', 'Z'}``
 
         angle_addition : bool
-            Default : True
             When True, first and third angles are given as an addition and
             subtraction of two simpler ``atan2`` expressions. When False, the
             first and third angles are each given by a single more complicated
@@ -467,13 +466,15 @@ class Quaternion(Expr):
                 \operatorname{atan_2} (b,a) \pm \operatorname{atan_2} (d,c) =
                 \operatorname{atan_2} (bc\pm ad, ac\mp bd)
 
+            Default : True
+
         avoid_square_root : bool
-            Default : False
             When True, the second angle is calculated with an expression based
             on ``acos``, which is slightly more complicated but avoids a square
             root. When False, second angle is calculated with ``atan2``, which
             is simpler and can be better for numerical reasons (some
             numerical implementations of ``acos`` have problems near zero).
+            Default : False
 
 
         Returns

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -376,7 +376,7 @@ class Quaternion(Expr):
     @classmethod
     def from_euler(cls, angles, seq):
         """Returns quaternion equivalent to rotation represented by the Euler
-        angles, in the sequence defined by `seq`.
+        angles, in the sequence defined by ``seq``.
 
         Parameters
         ==========
@@ -386,9 +386,9 @@ class Quaternion(Expr):
         seq : string of length 3
             Represents the sequence of rotations.
             For intrinsic rotations, seq must be all lowercase and its elements
-            must be from the set `{'x', 'y', 'z'}`
+            must be from the set ``{'x', 'y', 'z'}``
             For extrinsic rotations, seq must be all uppercase and its elements
-            must be from the set `{'X', 'Y', 'Z'}`
+            must be from the set ``{'X', 'Y', 'Z'}``
 
         Returns
         =======
@@ -458,7 +458,7 @@ class Quaternion(Expr):
         angle_addition : bool
             Default : True
             When True, first and third angles are given as an addition and
-            subtraction of two simpler `atan2` expressions. When False, the
+            subtraction of two simpler ``atan2`` expressions. When False, the
             first and third angles are each given by a single more complicated
             ``atan2`` expression. This equivalent expression is given by:
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -439,7 +439,7 @@ class Quaternion(Expr):
 
     def to_euler(self, seq, angle_addition=True, avoid_square_root=False):
         r"""Returns Euler angles representing same rotation as the quaternion,
-        in the sequence given by `seq`. This implements the method described
+        in the sequence given by ``seq``. This implements the method described
         in [1]_.
 
         For degenerate cases (gymbal lock cases), the third angle is

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -293,7 +293,7 @@ class Quaternion(Expr):
 
         vector_only : bool
             If True, only imaginary part is returned.
-            Default : False
+            Default value: False
 
         Returns
         =======
@@ -341,7 +341,7 @@ class Quaternion(Expr):
 
         elements : Matrix, list or tuple of length 3 or 4. If length is 3,
             assume real part is zero.
-            Default : False
+            Default value: False
 
         Returns
         =======
@@ -466,7 +466,7 @@ class Quaternion(Expr):
                 \operatorname{atan_2} (b,a) \pm \operatorname{atan_2} (d,c) =
                 \operatorname{atan_2} (bc\pm ad, ac\mp bd)
 
-            Default : True
+            Default value: True
 
         avoid_square_root : bool
             When True, the second angle is calculated with an expression based
@@ -474,7 +474,7 @@ class Quaternion(Expr):
             root. When False, second angle is calculated with ``atan2``, which
             is simpler and can be better for numerical reasons (some
             numerical implementations of ``acos`` have problems near zero).
-            Default : False
+            Default value: False
 
 
         Returns

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -451,18 +451,18 @@ class Quaternion(Expr):
         seq : string of length 3
             Represents the sequence of rotations.
             For intrinsic rotations, seq must be all lowercase and its elements
-            must be from the set `{'x', 'y', 'z'}`
+            must be from the set ``{'x', 'y', 'z'}``
             For extrinsic rotations, seq must be all uppercase and its elements
-            must be from the set `{'X', 'Y', 'Z'}`
+            must be from the set ``{'X', 'Y', 'Z'}``
 
         angle_addition : bool
             Default : True
             When True, first and third angles are given as an addition and
             subtraction of two simpler `atan2` expressions. When False, the
             first and third angles are each given by a single more complicated
-            `atan2` expression. This equivalent is given by:
+            ``atan2`` expression. This equivalent expression is given by:
 
-            --math::
+            .. math::
 
                 \operatorname{atan_2} (b,a) \pm \operatorname{atan_2} (d,c) =
                 \operatorname{atan_2} (bc\pm ad, ac\mp bd)
@@ -470,10 +470,10 @@ class Quaternion(Expr):
         avoid_square_root : bool
             Default : False
             When True, the second angle is calculated with an expression based
-            on acos`, which is slightly more complicated but avoids a square
-            root. When False, second angle is calculated with `atan2`, which
+            on ``acos``, which is slightly more complicated but avoids a square
+            root. When False, second angle is calculated with ``atan2``, which
             is simpler and can be better for numerical reasons (some
-            numerical implementations of `acos` have problems near zero).
+            numerical implementations of ``acos`` have problems near zero).
 
 
         Returns


### PR DESCRIPTION
#### References to other Issues or PRs
Follow up to #24604 and #24605.

#### Brief description of what is fixed or changed
Modified docstring of `Quaternion.to_euler` to explain how degenerate cases are dealt with.

As another minor edit, replaced `sympify(0)` with `S.Zero`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
