### PR TITLE
minor fix on ntheory.ecm

### DIFF
--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -53,8 +53,8 @@ class Point:
         """
         if self.a_24 != other.a_24 or self.mod != other.mod:
             return False
-        return self.x_cord * mod_inverse(self.z_cord, self.mod) % self.mod ==\
-            other.x_cord * mod_inverse(other.z_cord, self.mod) % self.mod
+        return self.x_cord * other.z_cord % self.mod ==\
+            other.x_cord * self.z_cord % self.mod
 
     def add(self, Q, diff):
         """
@@ -109,8 +109,8 @@ class Point:
         >>> p2.z_cord
         10
         """
-        u, v = self.x_cord + self.z_cord, self.x_cord - self.z_cord
-        u, v = u*u, v*v
+        u = pow(self.x_cord + self.z_cord, 2, self.mod)
+        v = pow(self.x_cord - self.z_cord, 2, self.mod)
         diff = u - v
         x_cord = u*v % self.mod
         z_cord = diff*(v + self.a_24*diff) % self.mod
@@ -203,16 +203,13 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
 
     from sympy.functions.elementary.miscellaneous import sqrt
     from sympy.polys.polytools import gcd
-    curve = 0
     D = int(sqrt(B2))
     beta = [0]*(D + 1)
     S = [0]*(D + 1)
     k = 1
     for p in sieve.primerange(1, B1 + 1):
         k *= pow(p, integer_log(B1, p)[0])
-    while(curve <= max_curve):
-        curve += 1
-
+    for _ in range(max_curve):
         #Suyama's Parametrization
         sigma = rgen.randint(6, n - 1)
         u = (sigma*sigma - 5) % n
@@ -223,8 +220,12 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
         try:
             C = (pow(diff, 3, n)*(3*u + v)*mod_inverse(4*u_3*v, n) - 2) % n
         except ValueError:
-            #If the mod_inverse(4*u_3*v, n) doesn't exist
-            return gcd(4*u_3*v, n)
+            #If the mod_inverse(4*u_3*v, n) doesn't exist (i.e., g != 1)
+            g = gcd(4*u_3*v, n)
+            #If g = n, try another curve
+            if g == n:
+                continue
+            return g
 
         a24 = (C + 2)*mod_inverse(4, n) % n
         Q = Point(u_3, pow(v, 3, n), a24, n)


### PR DESCRIPTION
(1) We don't need to compute X1/Z1 = X2/Z2 to check if two points are equal. We just need to check
if X1Z2 = X2Z1. No mod_inverse calculation required.

(2) Use pow function.

(3) I changed the loop from while to for.

(4) Although very rare, some values of sigma can
lead to u = 0. The current code doesn't return the wrong value, but it would be more efficient
to try another curve.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
