### PR TITLE
New debug function with lazy formatting

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -33,7 +33,7 @@ from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import RootSum
 from sympy.utilities.exceptions import (
     sympy_deprecation_warning, SymPyDeprecationWarning, ignore_warnings)
-from sympy.utilities.misc import debug
+from sympy.utilities.misc import debug, debugf
 
 
 def _simplifyconds(expr, s, a):
@@ -140,14 +140,14 @@ def _laplace_transform_integration(f, t, s_, simplify=True):
     such that `f` is to an addition anymore.
     """
     s = Dummy('s')
-    debug('[LT _l_t_i ] started with (%s, %s, %s)'%(f, t, s))
-    debug('[LT _l_t_i ]     and simplify=%s'%(simplify, ))
+    debugf('[LT _l_t_i ] started with (%s, %s, %s)', (f, t, s))
+    debugf('[LT _l_t_i ]     and simplify=%s', (simplify, ))
 
     if f.has(DiracDelta):
         return None
 
     F = integrate(f*exp(-s*t), (t, S.Zero, S.Infinity))
-    debug('[LT _l_t_i ]     integrated: %s'%(F, ))
+    debugf('[LT _l_t_i ]     integrated: %s', (F, ))
 
     if not F.has(Integral):
         return _simplify(F.subs(s, s_), simplify), S.NegativeInfinity, S.true
@@ -488,7 +488,7 @@ def _laplace_rule_timescale(f, t, s):
         ma2 = arg.match(a*t)
         if ma2 and ma2[a].is_positive and not ma2[a]==1:
             debug('_laplace_apply_prog rules match:')
-            debug('      f:    %s _ %s, %s )'%(f, ma1, ma2))
+            debugf('      f:    %s _ %s, %s )', (f, ma1, ma2))
             debug('      rule: time scaling (4.1.4)')
             r, pr, cr = _laplace_transform(1/ma2[a]*ma1[g].func(t),
                                            t, s/ma2[a], simplify=False)
@@ -518,14 +518,14 @@ def _laplace_rule_heaviside(f, t, s):
         ma2 = ma1[y].match(t-a)
         if ma2 and ma2[a].is_positive:
             debug('_laplace_apply_prog_rules match:')
-            debug('      f:    %s ( %s, %s )'%(f, ma1, ma2))
+            debugf('      f:    %s ( %s, %s )', (f, ma1, ma2))
             debug('      rule: time shift (4.1.4)')
             r, pr, cr = _laplace_transform(ma1[g].subs(t, t+ma2[a]), t, s,
                                            simplify=False)
             return (exp(-ma2[a]*s)*r, pr, cr)
         if ma2 and ma2[a].is_negative:
             debug('_laplace_apply_prog_rules match:')
-            debug('      f:    %s ( %s, %s )'%(f, ma1, ma2))
+            debugf('      f:    %s ( %s, %s )', (f, ma1, ma2))
             debug('      rule: Heaviside factor with negative time shift (4.1.4)')
             r, pr, cr = _laplace_transform(ma1[g], t, s, simplify=False)
             return (r, pr, cr)
@@ -548,7 +548,7 @@ def _laplace_rule_exp(f, t, s):
         ma2 = ma1[y].collect(t).match(a*t)
         if ma2:
             debug('_laplace_apply_prog_rules match:')
-            debug('      f:    %s ( %s, %s )'%(f, ma1, ma2))
+            debugf('      f:    %s ( %s, %s )', (f, ma1, ma2))
             debug('      rule: multiply with exp (4.1.5)')
             r, pr, cr = _laplace_transform(ma1[z], t, s-ma2[a],
                                            simplify=False)
@@ -575,7 +575,7 @@ def _laplace_rule_delta(f, t, s):
         ma2 = ma1[y].collect(t).match(b*t-a)
         if ma2:
             debug('_laplace_apply_prog_rules match:')
-            debug('      f:    %s ( %s, %s )'%(f, ma1, ma2))
+            debugf('      f:    %s ( %s, %s )', (f, ma1, ma2))
             debug('      rule: multiply with DiracDelta')
             loc = ma2[a]/ma2[b]
             if re(loc)>=0 and im(loc)==0:
@@ -623,8 +623,8 @@ def _laplace_rule_trig(f, t, s, doit=True, **hints):
             ma2 = ma1[y].collect(t).match(a*t)
             if ma2:
                 debug('_laplace_apply_rules match:')
-                debug('      f:    %s ( %s, %s )'%(f, ma1, ma2))
-                debug('      rule: multiply with %s (%s)'%(fm.func, nu))
+                debugf('      f:    %s ( %s, %s )', (f, ma1, ma2))
+                debugf('      rule: multiply with %s (%s)', (fm.func, nu))
                 r, pr, cr = _laplace_transform(ma1[z], t, s, simplify=False)
                 if sd==1:
                     cp_shift = Abs(re(ma2[a]))
@@ -650,7 +650,7 @@ def _laplace_rule_diff(f, t, s, doit=True, **hints):
     ma1 = f.match(a*Derivative(g, (t, n)))
     if ma1 and ma1[g].args[0] == t and ma1[n].is_integer:
         debug('_laplace_apply_rules match:')
-        debug('      f, n: %s, %s'%(f, ma1[n]))
+        debugf('      f, n: %s, %s', (f, ma1[n]))
         debug('      rule: time derivative (4.1.8)')
         d = []
         for k in range(ma1[n]):
@@ -686,7 +686,7 @@ def _laplace_rule_sdiff(f, t, s, doit=True, **hints):
             N = len(pc)
             if N>1:
                 debug('_laplace_apply_rules match:')
-                debug('      f, n: %s, %s'%(f, pfac))
+                debugf('      f, n: %s, %s', (f, pfac))
                 debug('      rule: frequency derivative (4.1.6)')
                 oex = prod(ofac)
                 r_, p_, c_ = _laplace_transform(oex, t, s, simplify=False)
@@ -779,9 +779,9 @@ def _laplace_apply_simple_rules(f, t, s):
                 continue
             if c==True:
                 debug('_laplace_apply_simple_rules match:')
-                debug('      f:     %s'%(f,))
-                debug('      rule:  %s o---o %s'%(t_dom, s_dom))
-                debug('      match: %s'%(ma, ))
+                debugf('      f:     %s', (f,))
+                debugf('      rule:  %s o---o %s', (t_dom, s_dom))
+                debugf('      match: %s', (ma, ))
                 return (s_dom.xreplace(ma).subs({s_: s}),
                         plane.xreplace(ma), S.true)
     return None
@@ -792,7 +792,7 @@ def _laplace_transform(fn, t_, s_, simplify=True):
     Front-end function of the Laplace transform. It tries to apply all known
     rules recursively, and if everything else fails, it tries to integrate.
     """
-    debug('[LT _l_t] (%s, %s, %s)'%(fn, t_, s_))
+    debugf('[LT _l_t] (%s, %s, %s)', (fn, t_, s_))
 
     terms = Add.make_args(fn)
     terms_s = []
@@ -883,9 +883,9 @@ class LaplaceTransform(IntegralTransform):
         _noconds = hints.get('noconds', True)
         _simplify = hints.get('simplify', True)
 
-        debug('[LT doit] (%s, %s, %s)'%(self.function,
-                                        self.function_variable,
-                                        self.transform_variable))
+        debugf('[LT doit] (%s, %s, %s)', (self.function,
+                                          self.function_variable,
+                                          self.transform_variable))
 
         t_ = self.function_variable
         s_ = self.transform_variable
@@ -1141,8 +1141,8 @@ def _inverse_laplace_apply_simple_rules(f, s, t):
     """
     if f==1:
         debug('_inverse_laplace_apply_simple_rules match:')
-        debug('      f:    %s'%(1,))
-        debug('      rule: 1 o---o DiracDelta(%s)'%(t,))
+        debugf('      f:    %s', (1,))
+        debugf('      rule: 1 o---o DiracDelta(%s)', (t,))
         return DiracDelta(t), S.true
 
     _ILT_rules, s_, t_ = _inverse_laplace_build_rules()
@@ -1161,9 +1161,9 @@ def _inverse_laplace_apply_simple_rules(f, s, t):
                 continue
             if c:
                 debug('_inverse_laplace_apply_simple_rules match:')
-                debug('      f:    %s'%(f,))
-                debug('      rule: %s o---o %s'%(s_dom, t_dom))
-                debug('      ma:   %s'%(ma,))
+                debugf('      f:    %s', (f,))
+                debugf('      rule: %s o---o %s', (s_dom, t_dom))
+                debugf('      ma:   %s', (ma,))
                 return Heaviside(t)*t_dom.xreplace(ma).subs({t_: t}), S.true
     return None
 
@@ -1181,9 +1181,9 @@ def _inverse_laplace_time_shift(F, s, t, plane):
     if ma1:
         if ma1[a].is_negative:
             debug('_inverse_laplace_time_shift match:')
-            debug('      f:    %s'%(F,))
+            debugf('      f:    %s', (F,))
             debug('      rule: exp(-a*s) o---o DiracDelta(t-a)')
-            debug('      ma:   %s'%(ma1,))
+            debugf('      ma:   %s', (ma1,))
             return DiracDelta(t+ma1[a]), S.true
         else:
             debug('_inverse_laplace_time_shift match: negative time shift')
@@ -1193,9 +1193,9 @@ def _inverse_laplace_time_shift(F, s, t, plane):
     if ma1:
         if ma1[a].is_negative:
             debug('_inverse_laplace_time_shift match:')
-            debug('      f:    %s'%(F,))
+            debugf('      f:    %s', (F,))
             debug('      rule: exp(-a*s)*F(s) o---o Heaviside(t-a)*f(t-a)')
-            debug('      ma:   %s'%(ma1,))
+            debugf('      ma:   %s', (ma1,))
             return _inverse_laplace_transform(ma1[g], s, t+ma1[a], plane)
         else:
             debug('_inverse_laplace_time_shift match: negative time shift')
@@ -1241,7 +1241,7 @@ def _inverse_laplace_rational(fn, s, t, plane, simplify):
     """
     Helper function for the class InverseLaplaceTransform.
     """
-    debug('[ILT _i_l_r] (%s, %s, %s)'%(fn, s, t))
+    debugf('[ILT _i_l_r] (%s, %s, %s)', (fn, s, t))
     x_ = symbols('x_')
     f = fn.apart(s)
     terms = Add.make_args(f)
@@ -1288,7 +1288,7 @@ def _inverse_laplace_rational(fn, s, t, plane, simplify):
     result = Add(*terms_t)
     if simplify:
         result = result.simplify(doit=False)
-    debug('[ILT _i_l_r]   returns %s'%(result,))
+    debugf('[ILT _i_l_r]   returns %s', (result,))
     return result, And(*conditions)
 
 
@@ -1301,7 +1301,7 @@ def _inverse_laplace_transform(fn, s_, t_, plane, simplify=True, dorational=True
     terms_t = []
     conditions = []
 
-    debug('[ILT _i_l_t] (%s, %s, %s)'%(fn, s_, t_))
+    debugf('[ILT _i_l_t] (%s, %s, %s)', (fn, s_, t_))
 
     for term in terms:
         k, f = term.as_independent(s_, as_Add=False)
@@ -1387,9 +1387,9 @@ class InverseLaplaceTransform(IntegralTransform):
         _noconds = hints.get('noconds', True)
         _simplify = hints.get('simplify', True)
 
-        debug('[ILT doit] (%s, %s, %s)'%(self.function,
-                                         self.function_variable,
-                                         self.transform_variable))
+        debugf('[ILT doit] (%s, %s, %s)', (self.function,
+                                           self.function_variable,
+                                           self.transform_variable))
 
         s_ = self.function_variable
         t_ = self.transform_variable

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -68,6 +68,7 @@ from sympy.logic.boolalg import And, Or, BooleanAtom, Not, BooleanFunction
 from sympy.polys import cancel, factor
 from sympy.utilities.iterables import multiset_partitions
 from sympy.utilities.misc import debug as _debug
+from sympy.utilities.misc import debugf as _debugf
 
 # keep this at top for easy reference
 z = Dummy('z')
@@ -802,12 +803,15 @@ def _check_antecedents_1(g, x, helper=False):
     def debug(*msg):
         _debug(*msg)
 
+    def debugf(string, arg):
+        _debugf(string, arg)
+
     debug('Checking antecedents for 1 function:')
-    debug('  delta=%s, eta=%s, m=%s, n=%s, p=%s, q=%s'
-          % (delta, eta, m, n, p, q))
-    debug('  ap = %s, %s' % (list(g.an), list(g.aother)))
-    debug('  bq = %s, %s' % (list(g.bm), list(g.bother)))
-    debug('  cond_3=%s, cond_3*=%s, cond_4=%s' % (cond_3, cond_3_star, cond_4))
+    debugf('  delta=%s, eta=%s, m=%s, n=%s, p=%s, q=%s',
+           (delta, eta, m, n, p, q))
+    debugf('  ap = %s, %s', (list(g.an), list(g.aother)))
+    debugf('  bq = %s, %s', (list(g.bm), list(g.bother)))
+    debugf('  cond_3=%s, cond_3*=%s, cond_4=%s', (cond_3, cond_3_star, cond_4))
 
     conds = []
 
@@ -1006,11 +1010,11 @@ def _check_antecedents(g1, g2, x):
     theta = (pi*(v - s - t) + Abs(unbranched_argument(sigma)))/(v - u)
 
     _debug('Checking antecedents:')
-    _debug('  sigma=%s, s=%s, t=%s, u=%s, v=%s, b*=%s, rho=%s'
-           % (sigma, s, t, u, v, bstar, rho))
-    _debug('  omega=%s, m=%s, n=%s, p=%s, q=%s, c*=%s, mu=%s,'
-           % (omega, m, n, p, q, cstar, mu))
-    _debug('  phi=%s, eta=%s, psi=%s, theta=%s' % (phi, eta, psi, theta))
+    _debugf('  sigma=%s, s=%s, t=%s, u=%s, v=%s, b*=%s, rho=%s',
+            (sigma, s, t, u, v, bstar, rho))
+    _debugf('  omega=%s, m=%s, n=%s, p=%s, q=%s, c*=%s, mu=%s,',
+            (omega, m, n, p, q, cstar, mu))
+    _debugf('  phi=%s, eta=%s, psi=%s, theta=%s', (phi, eta, psi, theta))
 
     def _c1():
         for g in [g1, g2]:
@@ -1121,13 +1125,13 @@ def _check_antecedents(g1, g2, x):
     for cond, i in [(c1, 1), (c2, 2), (c3, 3), (c4, 4), (c5, 5), (c6, 6),
                     (c7, 7), (c8, 8), (c9, 9), (c10, 10), (c11, 11),
                     (c12, 12), (c13, 13), (c14, 14), (c15, 15)]:
-        _debug('  c%s:' % i, cond)
+        _debugf('  c%s: %s', (i, cond))
 
     # We will return Or(*conds)
     conds = []
 
     def pr(count):
-        _debug('  case %s:' % count, conds[-1])
+        _debugf('  case %s: %s', (count, conds[-1]))
     conds += [And(m*n*s*t != 0, bstar.is_positive is True, cstar.is_positive is True, c1, c2, c3, c10,
                   c12)]  # 1
     pr(1)
@@ -1372,9 +1376,9 @@ def _check_antecedents_inversion(g, x):
         epsilon = S.NaN
     theta = ((1 - sigma)/2 + Add(*g.bq) - Add(*g.ap))/sigma
     delta = g.delta
-    _debug('  m=%s, n=%s, p=%s, q=%s, tau=%s, nu=%s, rho=%s, sigma=%s' % (
-        m, n, p, q, tau, nu, rho, sigma))
-    _debug('  epsilon=%s, theta=%s, delta=%s' % (epsilon, theta, delta))
+    _debugf('  m=%s, n=%s, p=%s, q=%s, tau=%s, nu=%s, rho=%s, sigma=%s',
+            (m, n, p, q, tau, nu, rho, sigma))
+    _debugf('  epsilon=%s, theta=%s, delta=%s', (epsilon, theta, delta))
 
     # First check if the computation is valid.
     if not (g.delta >= e/2 or (p >= 1 and p >= q)):
@@ -1804,7 +1808,7 @@ def meijerint_definite(f, x, a, b):
     #
     # There are usually several ways of doing this, and we want to try all.
     # This function does (1), calls _meijerint_definite_2 for step (2).
-    _debug('Integrating', f, 'wrt %s from %s to %s.' % (x, a, b))
+    _debugf('Integrating %s wrt %s from %s to %s.', (f, x, a, b))
     f = sympify(f)
     if f.has(DiracDelta):
         _debug('Integrand has DiracDelta terms - giving up.')
@@ -1872,7 +1876,7 @@ def meijerint_definite(f, x, a, b):
         if b is S.Infinity:
             for split in _find_splitting_points(f, x):
                 if (a - split >= 0) == True:
-                    _debug('Trying x -> x + %s' % split)
+                    _debugf('Trying x -> x + %s', split)
                     res = _meijerint_definite_2(f.subs(x, x + split)
                                                 *Heaviside(x + split - a), x)
                     if res:
@@ -2067,9 +2071,9 @@ def _meijerint_definite_4(f, x, only_double=False):
                 break
             cond = _my_unpolarify(cond)
             if cond == False:
-                _debug('But cond is always False (full_pb=%s).' % full_pb)
+                _debugf('But cond is always False (full_pb=%s).', full_pb)
             else:
-                _debug('Result before branch substitutions is:', res)
+                _debugf('Result before branch substitutions is: %s', (res, ))
                 if only_double:
                     return res, cond
                 return _my_unpolarify(hyperexpand(res)), cond

--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import Rational
 from sympy.polys import cancel, ComputationFailed, parallel_poly_from_expr, reduced, Poly
 from sympy.polys.monomials import Monomial, monomial_div
 from sympy.polys.polyerrors import DomainError, PolificationFailed
-from sympy.utilities.misc import debug
+from sympy.utilities.misc import debug, debugf
 
 def ratsimp(expr):
     """
@@ -145,7 +145,7 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
 
             M1 = staircase(N)
             M2 = staircase(D)
-            debug('%s / %s: %s, %s' % (N, D, M1, M2))
+            debugf('%s / %s: %s, %s', (N, D, M1, M2))
 
             Cs = symbols("c:%d" % len(M1), cls=Dummy)
             Ds = symbols("d:%d" % len(M2), cls=Dummy)
@@ -204,7 +204,7 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
     c, d, allsol = _ratsimpmodprime(
         Poly(num, opt.gens, domain=opt.domain), Poly(denom, opt.gens, domain=opt.domain), [])
     if not quick and allsol:
-        debug('Looking for best minimal solution. Got: %s' % len(allsol))
+        debugf('Looking for best minimal solution. Got: %s', len(allsol))
         newsol = []
         for c_hat, d_hat, S, ng in allsol:
             sol = solve(S, ng, particular=True, quick=False)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -257,8 +257,8 @@ def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
         """
         # First parse the hints
         n, funcs, iterables, extragens = parse_hints(hints)
-        debug('n=%s' % n, 'funcs:', funcs, 'iterables:',
-              iterables, 'extragens:', extragens)
+        debug('n=%s   funcs: %s   iterables: %s    extragens: %s',
+              (funcs, iterables, extragens))
 
         # We just add the extragens to gens and analyse them as before
         gens = list(gens)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -47,7 +47,7 @@ from sympy.polys import roots, cancel, factor, Poly
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
 from sympy.utilities.lambdify import lambdify
-from sympy.utilities.misc import filldedent, debug
+from sympy.utilities.misc import filldedent, debugf
 from sympy.utilities.iterables import (connected_components,
     generate_bell, uniq, iterable, is_sequence, subsets, flatten)
 from sympy.utilities.decorator import conserve_mpmath_dps
@@ -2216,7 +2216,7 @@ def minsolve_linear_system(system, *symbols, **flags):
         bestsol = minsolve_linear_system(system, *symbols, quick=True)
         n0 = len([x for x in bestsol.values() if x != 0])
         for n in range(n0 - 1, 1, -1):
-            debug('minsolve: %s' % n)
+            debugf('minsolve: %s', n)
             thissol = None
             for nonzeros in combinations(range(N), n):
                 subm = Matrix([system.col(i).T for i in nonzeros] + [system.col(-1).T]).T

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -249,6 +249,16 @@ def debug(*args):
         print(*args, file=sys.stderr)
 
 
+def debugf(string, args):
+    """
+    Print ``string%args`` if SYMPY_DEBUG is True, else do nothing. This is
+    intended for debug messages using formatted strings.
+    """
+    from sympy import SYMPY_DEBUG
+    if SYMPY_DEBUG:
+        print(string%args, file=sys.stderr)
+
+
 def find_executable(executable, path=None):
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561 

#### Brief description of what is fixed or changed
Introduced a new debug function, `debugf`, that can print `str%args`, but will only do the formatting if debugging is switched on. Inserted it in all places where I found a `debug(str % args)` in the code base. This does not make any functional changes, it just saves computation power.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
