### PR TITLE
Cleanup numpydoc builder lint errors

### DIFF
--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -1,13 +1,12 @@
 """
 Extract reference documentation from the NumPy source tree.
 """
-
+from __future__ import annotations
 import inspect
 import textwrap
 import re
 import pydoc
 from collections.abc import Mapping
-import sys
 
 
 class Reader:
@@ -465,7 +464,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = str(inspect.signature(func))
                 argspec = argspec.replace('*', r'\*')
                 signature = '{}{}'.format(func_name, argspec)
-            except TypeError as e:
+            except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -480,8 +479,7 @@ class FunctionDoc(NumpyDocString):
     def __str__(self):
         out = ''
 
-        func, func_name = self.get_func()
-        signature = self['Signature'].replace('*', r'\*')
+        _, func_name = self.get_func()
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -1,11 +1,9 @@
-import sys
+from __future__ import annotations
 import re
 import inspect
 import textwrap
 import pydoc
 import sphinx
-import collections
-
 from docscrape import NumpyDocString, FunctionDoc, ClassDoc
 
 

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -16,8 +16,7 @@ It will:
 .. [1] https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
 """
-
-import sys
+from __future__ import annotations
 import re
 import pydoc
 import sphinx
@@ -47,10 +46,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
-        if sys.version_info[0] >= 3:
-            doc = str(doc)
-        else:
-            doc = unicode(doc)
+        doc = str(doc)
         lines[:] = doc.split(u_NL)
 
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
@@ -132,12 +128,13 @@ def setup(app, get_doc_object_=get_doc_object):
 # ------------------------------------------------------------------------------
 
 from docutils.statemachine import ViewList
+from sphinx.domains import Domain
 from sphinx.domains.c import CDomain
 from sphinx.domains.python import PythonDomain
 
 
-class ManglingDomainBase:
-    directive_mangling_map = {}
+class ManglingDomainBase(Domain):
+    directive_mangling_map: dict[str, str] = {}
 
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I fixed some lint errors for numpydoc, and python 2 workarounds.
I think that the linter is not applied to utilities scripts though.

I think that we need to maintain the old docstring builder somehow to make it 'lint' about bad formatting, 
adapt the changes from numpydoc upstream that can solve some bugs,
or implement some customized features for sympy.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
