### PR TITLE
Add an `equal_valued` function to compare Float and Rational

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -168,6 +168,9 @@ numbers
 
 .. autofunction:: mod_inverse
 
+.. autofunction:: equal_valued
+
+
 power
 -----
 .. module:: sympy.core.power

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -4,6 +4,7 @@ from sympy.core import Pow, S
 from sympy.core.function import diff, expand_mul
 from sympy.core.kind import NumberKind
 from sympy.core.mod import Mod
+from sympy.core.numbers import equal_valued
 from sympy.core.relational import Relational
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.sympify import _sympify
@@ -480,9 +481,8 @@ def periodicity(f, symbol, check=False):
 
     elif f.is_Mul:
         coeff, g = f.as_independent(symbol, as_Add=False)
-        if isinstance(g, TrigonometricFunction) or coeff != 1:
+        if isinstance(g, TrigonometricFunction) or not equal_valued(coeff, 1):
             period = periodicity(g, symbol)
-
         else:
             period = _periodicity(g.args, symbol)
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -8,7 +8,7 @@ from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
 from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
-from .numbers import ilcm, igcd
+from .numbers import ilcm, igcd, equal_valued
 from .expr import Expr
 from .kind import UndefinedKind
 from sympy.utilities.iterables import is_sequence, sift
@@ -496,7 +496,7 @@ class Add(Expr, AssocOp):
                 for i in c:
                     if abs(i) >= big:
                         big = abs(i)
-                if big > 0 and big != 1:
+                if big > 0 and not equal_valued(big, 1):
                     from sympy.functions.elementary.complexes import sign
                     bigs = (big, -big)
                     c = [sign(i) if i in bigs else i/big for i in c]

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1057,7 +1057,7 @@ def evalf_alg_num(a: 'AlgebraicNumber', prec: int, options: OPT_DICT) -> TMP_RES
 def as_mpmath(x: Any, prec: int, options: OPT_DICT) -> tUnion[mpc, mpf]:
     from .numbers import Infinity, NegativeInfinity, Zero
     x = sympify(x)
-    if isinstance(x, Zero) or x == 0:
+    if isinstance(x, Zero) or x == 0.0:
         return mpf(0)
     if isinstance(x, Infinity):
         return mpf('inf')
@@ -1221,7 +1221,8 @@ def check_convergence(numer: 'Expr', denom: 'Expr', n: 'Symbol') -> tTuple[int, 
     if rate:
         return rate, None, None
     constant = dpol.LC() / npol.LC()
-    if abs(constant) != 1:
+    from .numbers import equal_valued
+    if not equal_valued(abs(constant), 1):
         return rate, constant, None
     if npol.degree() == dpol.degree() == 0:
         return rate, constant, 0
@@ -1237,7 +1238,7 @@ def hypsum(expr: 'Expr', n: 'Symbol', start: int, prec: int) -> mpf:
     quotient between successive terms must be a quotient of integer
     polynomials.
     """
-    from .numbers import Float
+    from .numbers import Float, equal_valued
     from sympy.simplify.simplify import hypersimp
 
     if prec == float('inf'):
@@ -1277,7 +1278,7 @@ def hypsum(expr: 'Expr', n: 'Symbol', start: int, prec: int) -> mpf:
         alt = g < 0
         if abs(g) < 1:
             raise ValueError("Sum diverges like (%i)^n" % abs(1/g))
-        if p < 1 or (p == 1 and not alt):
+        if p < 1 or (equal_valued(p, 1) and not alt):
             raise ValueError("Sum diverges like n^%i" % (-p))
         # We have polynomial convergence: use Richardson extrapolation
         vold = None
@@ -1492,7 +1493,7 @@ def evalf(x: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
         re, im = as_real_imag()
         if re.has(re_) or im.has(im_):
             raise NotImplementedError
-        if re == 0:
+        if re == 0.0:
             re = None
             reprec = None
         elif re.is_number:
@@ -1500,7 +1501,7 @@ def evalf(x: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
             reprec = prec
         else:
             raise NotImplementedError
-        if im == 0:
+        if im == 0.0:
             im = None
             imprec = None
         elif im.is_number:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2374,8 +2374,8 @@ class Expr(Basic, EvalfMixin):
             co = self
             diff = co - c
             # XXX should we match types? i.e should 3 - .1 succeed?
-            if (co > 0 and diff > 0 and diff < co or
-                    co < 0 and diff < 0 and diff > co):
+            if (co > 0 and diff >= 0 and diff < co or
+                    co < 0 and diff <= 0 and diff > co):
                 return diff
             return None
 

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -7,7 +7,7 @@ from .basic import Basic
 from .expr import Expr
 from .function import expand_power_exp
 from .sympify import sympify
-from .numbers import Rational, Integer, Number, I
+from .numbers import Rational, Integer, Number, I, equal_valued
 from .singleton import S
 from .sorting import default_sort_key, ordered
 from .symbol import Dummy
@@ -382,9 +382,9 @@ class Factors:
                             factors[I] = S.One
                         elif a.is_Pow:
                             factors[a.base] = factors.get(a.base, S.Zero) + a.exp
-                        elif a == 1:
+                        elif equal_valued(a, 1):
                             factors[a] = S.One
-                        elif a == -1:
+                        elif equal_valued(a, -1):
                             factors[-a] = S.One
                             factors[S.NegativeOne] = S.One
                         else:

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -4,6 +4,7 @@ from .function import Function
 from .kind import NumberKind
 from .logic import fuzzy_and, fuzzy_not
 from .mul import Mul
+from .numbers import equal_valued
 from .singleton import S
 
 
@@ -164,7 +165,7 @@ class Mod(Function):
         # extract gcd; any further simplification should be done by the user
         try:
             G = gcd(p, q)
-            if G != 1:
+            if not equal_valued(G, 1):
                 p, q = [gcd_terms(i/G, clear=False, fraction=False)
                         for i in (p, q)]
         except PolynomialError:  # issue 21373
@@ -193,7 +194,7 @@ class Mod(Function):
             ok = False
             if not cp.is_Rational or not cq.is_Rational:
                 r = cp % cq
-                if r == 0:
+                if equal_valued(r, 0):
                     G *= cq
                     p *= int(cp/cq)
                     ok = True
@@ -211,10 +212,10 @@ class Mod(Function):
             return rv*G
 
         # put 1.0 from G on inside
-        if G.is_Float and G == 1:
+        if G.is_Float and equal_valued(G, 1):
             p *= G
             return cls(p, q, evaluate=False)
-        elif G.is_Mul and G.args[0].is_Float and G.args[0] == 1:
+        elif G.is_Mul and G.args[0].is_Float and equal_valued(G.args[0], 1):
             p = G.args[0]*p
             G = Mul._from_args(G.args[1:])
         return G*cls(p, q, evaluate=(p, q) != (pwas, qwas))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4446,48 +4446,52 @@ def equal_valued(x, y):
     Examples
     ========
 
-    >>> from sympy import S
+    >>> from sympy import S, symbols, Integer, Rational, Float
     >>> from sympy.core.numbers import equal_valued
     >>> equal_valued(1, 2)
     False
     >>> equal_valued(1, 1)
     True
 
-    Comparing SymPy numbers with ``a == b`` gives ``False`` if they are not of
-    the same type. With ``equal_valued`` if either argument is a ``Float``
-    then it will be treated as an exact rational number for comparison with the
-    other argument.
+    In SymPy expressions with Floats compare unequal to corresponding
+    expressions with rationals:
 
-    >>> S(1) == S(1.0)
+    >>> x = symbols('x')
+    >>> x**2 == x**2.0
     False
-    >>> equal_valued(1, 1.0)
-    True
-    >>> S.Half == 0.5
-    False
-    >>> equal_valued(S.Half, 0.5)
+
+    However an individual Float compares equal to a Rational:
+
+    >>> Rational(1, 2) == Float(0.5)
     True
 
-    Comparing two Floats with ``a == b`` gives ``False`` if they do not have
-    the same precision. With ``equal_valued`` the precision of Floats is
-    ignored.
+    In a future version of SymPy this might change so that Rational and Float
+    compare unequal. This function is provided in to provide the behaviour
+    currently expected of ``==`` so that it could still be used if the
+    behaviour of ``==`` were to change.
 
-    >>> S(1).n(3) == S(1).n(5)
-    False
-    >>> equal_valued(S(1).n(3), S(1).n(5))
+    >>> equal_valued(1, 1.0) # Float vs Rational
+    True
+    >>> equal_valued(S(1).n(3), S(1).n(5)) # Floats of different precision
     True
 
     Explanation
     ===========
 
-    Since Float and Rational compare unequal and floats with different
-    precisions compare unequal a function is needed that can check if a number
-    is equal to 1 or 0 etc. The idea is that instead of testing ``if x == 1:``
-    if we want to accept floats like ``1.0`` as well then the test can be
-    written as ``if equal_valued(x, 1):`` or ``if equal_valued(x, 2):``.
-    Since this function is expected to be used in situations where one or both
-    operands are expected to be concrete numbers like 1 or 0 the function does
-    not recurse through the args of any compound expression to compare any
-    nested floats.
+    In future SymPy verions Float and Rational might compare unequal and floats
+    with different precisions might compare unequal. In that context a function
+    is needed that can check if a number is equal to 1 or 0 etc. The idea is
+    that instead of testing ``if x == 1:`` if we want to accept floats like
+    ``1.0`` as well then the test can be written as ``if equal_valued(x, 1):``
+    or ``if equal_valued(x, 2):``. Since this function is intended to be used
+    in situations where one or both operands are expected to be concrete
+    numbers like 1 or 0 the function does not recurse through the args of any
+    compound expression to compare any nested floats.
+
+    References
+    ==========
+
+    .. [1] https://github.com/sympy/sympy/pull/20033
     """
     x = _sympify(x)
     y = _sympify(y)
@@ -4527,10 +4531,10 @@ def equal_valued(x, y):
         # y non-integer. Need p == man and q == 2**-exp
         if p != man:
             return False
-        exp = -exp
-        if q.bit_length() - 1 != exp:
+        neg_exp = -exp
+        if q.bit_length() - 1 != neg_exp:
             return False
-        return (1 << exp) == q
+        return (1 << neg_exp) == q
 
 
 @dispatch(Tuple, Number) # type:ignore

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4466,8 +4466,8 @@ def equal_valued(x, y):
     True
 
     In a future version of SymPy this might change so that Rational and Float
-    compare unequal. This function provides the behaviour currently expected of
-    ``==`` so that it could still be used if the behaviour of ``==`` were to
+    compare unequal. This function provides the behavior currently expected of
+    ``==`` so that it could still be used if the behavior of ``==`` were to
     change in future.
 
     >>> equal_valued(1, 1.0) # Float vs Rational

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4466,9 +4466,9 @@ def equal_valued(x, y):
     True
 
     In a future version of SymPy this might change so that Rational and Float
-    compare unequal. This function is provided in to provide the behaviour
-    currently expected of ``==`` so that it could still be used if the
-    behaviour of ``==`` were to change.
+    compare unequal. This function provides the behaviour currently expected of
+    ``==`` so that it could still be used if the behaviour of ``==`` were to
+    change in future.
 
     >>> equal_valued(1, 1.0) # Float vs Rational
     True

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1336,7 +1336,7 @@ class Float(Number):
         (-p)**r -> exp(r*log(-p)) -> exp(r*(log(p) + I*Pi)) ->
                   -> p**r*(sin(Pi*r) + cos(Pi*r)*I)
         """
-        if self == 0:
+        if equal_valued(self, 0):
             if expt.is_extended_positive:
                 return self
             if expt.is_extended_negative:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4446,7 +4446,7 @@ def equal_valued(x, y):
     Examples
     ========
 
-    >>> from sympy import S, symbols, Integer, Rational, Float
+    >>> from sympy import S, symbols, Rational, Float
     >>> from sympy.core.numbers import equal_valued
     >>> equal_valued(1, 2)
     False

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -9,7 +9,7 @@ from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import (mpf_norm, mod_inverse, igcd, seterr,
     igcd_lehmer, Integer, I, pi, comp, ilcm, Rational, E, nan, igcd2,
-    oo, AlgebraicNumber, igcdex, Number, Float, zoo)
+    oo, AlgebraicNumber, igcdex, Number, Float, zoo, equal_valued)
 from sympy.core.power import Pow
 from sympy.core.relational import Ge, Gt, Le, Lt
 from sympy.core.singleton import S
@@ -2232,3 +2232,35 @@ def test_exponentiation_of_0():
     x = Symbol('x', zero=True)
     assert 0**-x == S.One
     assert 0**x == S.One
+
+
+def test_equal_valued():
+    x = Symbol('x')
+
+    equal_values = [
+        [1, 1.0, S(1), S(1.0), S(1).n(5)],
+        [2, 2.0, S(2), S(2.0), S(2).n(5)],
+        [-1, -1.0, -S(1), -S(1.0), -S(1).n(5)],
+        [0.5, S(0.5), S(1)/2],
+        [-0.5, -S(0.5), -S(1)/2],
+        [0, 0.0, S(0), S(0.0), S(0).n()],
+        [pi], [pi.n()],           # <-- not equal
+        [S(1)/10], [0.1, S(0.1)], # <-- not equal
+        [S(0.1).n(5)],
+        [oo],
+        [cos(x/2)], [cos(0.5*x)], # <-- no recursion
+    ]
+
+    for m, values_m in enumerate(equal_values):
+        for value_i in values_m:
+
+            # All values in same list equal
+            for value_j in values_m:
+                assert equal_valued(value_i, value_j) is True
+
+            # Not equal to anything in any other list:
+            for n, values_n in enumerate(equal_values):
+                if n == m:
+                    continue
+                for value_j in values_n:
+                    assert equal_valued(value_i, value_j) is False

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -213,7 +213,7 @@ def test_harmonic():
     assert harmonic(n, 0) == n
     assert harmonic(n).evalf() == harmonic(n)
     assert harmonic(n, 1) == harmonic(n)
-    assert harmonic(1, n).evalf() == harmonic(1, n)
+    assert harmonic(1, n) == 1
 
     assert harmonic(0, 1) == 0
     assert harmonic(1, 1) == 1

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -5,7 +5,7 @@ from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
 from sympy.core.mod import Mod
-from sympy.core.numbers import Rational, pi, Integer, Float
+from sympy.core.numbers import Rational, pi, Integer, Float, equal_valued
 from sympy.core.relational import Ne, Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
@@ -218,7 +218,7 @@ def _pi_coeff(arg: Expr, cycles: int = 1) -> tUnion[Expr, None]:
                     m = 2**p
                     cm = c*m
                     i = int(cm)
-                    if i == cm:
+                    if equal_valued(i, cm):
                         c = Rational(i, m)
                         cx = c*x
                 else:

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -4,7 +4,8 @@ various operations on them.
 """
 
 from sympy.core import Add, Mul, Pow
-from sympy.core.numbers import NaN, Infinity, NegativeInfinity, Float, I, pi
+from sympy.core.numbers import (NaN, Infinity, NegativeInfinity, Float, I, pi,
+        equal_valued)
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
@@ -1481,7 +1482,7 @@ class HolonomicFunction:
             rootstoconsider = []
             for i in ordered(self.y0.keys()):
                 for j in ordered(indicialroots.keys()):
-                    if j == i:
+                    if equal_valued(j, i):
                         rootstoconsider.append(i)
 
         elif allpos and allint:

--- a/sympy/physics/quantum/identitysearch.py
+++ b/sympy/physics/quantum/identitysearch.py
@@ -4,7 +4,7 @@ from sympy.core.random import randint
 from sympy.external import import_module
 from sympy.core.basic import Basic
 from sympy.core.mul import Mul
-from sympy.core.numbers import Number
+from sympy.core.numbers import Number, equal_valued
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.physics.quantum.represent import represent
@@ -155,7 +155,7 @@ def is_scalar_nonsparse_matrix(circuit, nqubits, identity_only, eps=None):
                                  if not identity_only
                                  else matrix_trace)
 
-        is_identity = matrix[0] == 1.0 if identity_only else True
+        is_identity = equal_valued(matrix[0], 1) if identity_only else True
 
         has_correct_trace = adjusted_matrix_trace == pow(2, nqubits)
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -4,7 +4,7 @@ from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import Function
-from sympy.core.numbers import oo
+from sympy.core.numbers import oo, equal_valued
 from sympy.core.singleton import S
 from sympy.functions.elementary.complexes import conjugate
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -926,7 +926,7 @@ class Wavefunction(Function):
 
         """
 
-        return (self.norm == 1.0)
+        return equal_valued(self.norm, 1)
 
     @property  # type: ignore
     @cacheit

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -15,7 +15,7 @@ from sympy.core.evalf import (
     pure_complex, evalf, fastlog, _evalf_with_bounded_error, quad_to_mpmath)
 from sympy.core.function import Derivative
 from sympy.core.mul import Mul, _keep_coeff
-from sympy.core.numbers import ilcm, I, Integer
+from sympy.core.numbers import ilcm, I, Integer, equal_valued
 from sympy.core.relational import Relational, Equality
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
@@ -5632,7 +5632,7 @@ def terms_gcd(f, *gens, **args):
         coeff = S.One
 
     term = Mul(*[x**j for x, j in zip(f.gens, J)])
-    if coeff == 1:
+    if equal_valued(coeff, 1):
         coeff = S.One
         if term == 1:
             return orig

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -18,6 +18,7 @@ from functools import wraps
 from itertools import chain
 
 from sympy.core import S
+from sympy.core.numbers import equal_valued
 from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
@@ -281,10 +282,10 @@ class C89CodePrinter(CodePrinter):
             return self._print_Function(expr)
         PREC = precedence(expr)
         suffix = self._get_func_suffix(real)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             literal_suffix = self._get_literal_suffix(real)
             return '1.0%s/%s' % (literal_suffix, self.parenthesize(expr.base, PREC))
-        elif expr.exp == 0.5:
+        elif equal_valued(expr.exp, 0.5):
             return '%ssqrt%s(%s)' % (self._ns, suffix, self._print(expr.base))
         elif expr.exp == S.One/3 and self.standard != 'C89':
             return '%scbrt%s(%s)' % (self._ns, suffix, self._print(expr.base))

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -35,6 +35,7 @@ from sympy.codegen.fnodes import (
 )
 from sympy.core import S, Add, N, Float, Symbol
 from sympy.core.function import Function
+from sympy.core.numbers import equal_valued
 from sympy.core.relational import Eq
 from sympy.sets import Range
 from sympy.printing.codeprinter import CodePrinter
@@ -340,12 +341,12 @@ class FCodePrinter(CodePrinter):
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             return '%s/%s' % (
                 self._print(literal_dp(1)),
                 self.parenthesize(expr.base, PREC)
             )
-        elif expr.exp == 0.5:
+        elif equal_valued(expr.exp, 0.5):
             if expr.base.is_integer:
                 # Fortran intrinsic sqrt() does not accept integer argument
                 if expr.base.is_Number:

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sympy.core import Basic, S
 from sympy.core.function import Lambda
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
 from functools import reduce
@@ -281,9 +282,9 @@ class GLSLPrinter(CodePrinter):
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             return '1.0/%s' % (self.parenthesize(expr.base, PREC))
-        elif expr.exp == 0.5:
+        elif equal_valued(expr.exp, 0.5):
             return 'sqrt(%s)' % self._print(expr.base)
         else:
             try:

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from sympy.core import S
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 
@@ -98,9 +99,9 @@ class JavascriptCodePrinter(CodePrinter):
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             return '1/%s' % (self.parenthesize(expr.base, PREC))
-        elif expr.exp == 0.5:
+        elif equal_valued(expr.exp, 0.5):
             return 'Math.sqrt(%s)' % self._print(expr.base)
         elif expr.exp == S.One/3:
             return 'Math.cbrt(%s)' % self._print(expr.base)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from sympy.core import Mul, Pow, S, Rational
 from sympy.core.mul import _keep_coeff
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search
@@ -202,14 +203,14 @@ class JuliaCodePrinter(CodePrinter):
 
         PREC = precedence(expr)
 
-        if expr.exp == S.Half:
+        if equal_valued(expr.exp, 0.5):
             return "sqrt(%s)" % self._print(expr.base)
 
         if expr.is_commutative:
-            if expr.exp == -S.Half:
+            if equal_valued(expr.exp, -0.5):
                 sym = '/' if expr.base.is_number else './'
                 return "1 %s sqrt(%s)" % (sym, self._print(expr.base))
-            if expr.exp == -S.One:
+            if equal_valued(expr.exp, -1):
                 sym = '/' if expr.base.is_number else './'
                 return  "1 %s %s" % (sym, self.parenthesize(expr.base, PREC))
 

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -9,7 +9,7 @@ FIXME: This module is still under actively developed. Some functions may be not 
 """
 
 from sympy.core import S
-from sympy.core.numbers import Integer, IntegerConstant
+from sympy.core.numbers import Integer, IntegerConstant, equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 
@@ -130,11 +130,11 @@ class MapleCodePrinter(CodePrinter):
 
     def _print_Pow(self, expr, **kwargs):
         PREC = precedence(expr)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             return '1/%s' % (self.parenthesize(expr.base, PREC))
-        elif expr.exp in (0.5, S.Half):
+        elif equal_valued(expr.exp, 0.5):
             return 'sqrt(%s)' % self._print(expr.base)
-        elif expr.exp in (-0.5, -S.Half):
+        elif equal_valued(expr.exp, -0.5):
             return '1/sqrt(%s)' % self._print(expr.base)
         else:
             return '{base}^{exp}'.format(

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from sympy.core import Mul, Pow, S, Rational
 from sympy.core.mul import _keep_coeff
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search
@@ -220,14 +221,14 @@ class OctaveCodePrinter(CodePrinter):
 
         PREC = precedence(expr)
 
-        if expr.exp == S.Half:
+        if equal_valued(expr.exp, 0.5):
             return "sqrt(%s)" % self._print(expr.base)
 
         if expr.is_commutative:
-            if expr.exp == -S.Half:
+            if equal_valued(expr.exp, -0.5):
                 sym = '/' if expr.base.is_number else './'
                 return "1" + sym + "sqrt(%s)" % self._print(expr.base)
-            if expr.exp == -S.One:
+            if equal_valued(expr.exp, -1):
                 sym = '/' if expr.base.is_number else './'
                 return "1" + sym + "%s" % self.parenthesize(expr.base, PREC)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1673,7 +1673,7 @@ class PrettyPrinter(Printer):
 
     def _print_Heaviside(self, e):
         func_name = greek_unicode['theta'] if self._use_unicode else 'Heaviside'
-        if e.args[1]==1/2:
+        if e.args[1] is S.Half:
             pform = prettyForm(*self._print(e.args[0]).parens())
             pform = prettyForm(*pform.left(func_name))
             return pform

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -11,6 +11,7 @@ using the functions defined in math.h where possible.
 from __future__ import annotations
 from typing import Any
 
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from sympy.sets.fancysets import Range
@@ -144,9 +145,9 @@ class RCodePrinter(CodePrinter):
         if "Pow" in self.known_functions:
             return self._print_Function(expr)
         PREC = precedence(expr)
-        if expr.exp == -1:
+        if equal_valued(expr.exp, -1):
             return '1.0/%s' % (self.parenthesize(expr.base, PREC))
-        elif expr.exp == 0.5:
+        elif equal_valued(expr.exp, 0.5):
             return 'sqrt(%s)' % self._print(expr.base)
         else:
             return '%s^%s' % (self.parenthesize(expr.base, PREC),

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 from typing import Any
 
 from sympy.core import S, Rational, Float, Lambda
+from sympy.core.numbers import equal_valued
 from sympy.printing.codeprinter import CodePrinter
 
 # Rust's methods for integer and float can be found at here :
@@ -69,11 +70,11 @@ known_functions = {
     # "": "is_sign_positive",
     # "": "is_sign_negative",
     # "": "mul_add",
-    "Pow": [(lambda base, exp: exp == -S.One, "recip", 2),           # 1.0/x
-            (lambda base, exp: exp == S.Half, "sqrt", 2),            # x ** 0.5
-            (lambda base, exp: exp == -S.Half, "sqrt().recip", 2),   # 1/(x ** 0.5)
+    "Pow": [(lambda base, exp: equal_valued(exp, -1), "recip", 2),   # 1.0/x
+            (lambda base, exp: equal_valued(exp, 0.5), "sqrt", 2),   # x ** 0.5
+            (lambda base, exp: equal_valued(exp, -0.5), "sqrt().recip", 2),   # 1/(x ** 0.5)
             (lambda base, exp: exp == Rational(1, 3), "cbrt", 2),    # x ** (1/3)
-            (lambda base, exp: base == S.One*2, "exp2", 3),          # 2 ** x
+            (lambda base, exp: equal_valued(base, 2), "exp2", 3),    # 2 ** x
             (lambda base, exp: exp.is_integer, "powi", 1),           # x ** y, for i32
             (lambda base, exp: not exp.is_integer, "powf", 1)],      # x ** y, for f64
     "exp": [(lambda exp: True, "exp", 2)],   # e ** x

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -687,7 +687,7 @@ def test_issue_6052():
 def test_issue_7224():
     expr = sqrt(x)*besseli(1,sqrt(8*x))
     assert limit(x*diff(expr, x, x)/expr, x, 0) == 2
-    assert limit(x*diff(expr, x, x)/expr, x, 1).evalf(n=2) == 2.0
+    assert limit(x*diff(expr, x, x)/expr, x, 1).evalf() == 2.0
 
 
 def test_issue_8208():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -233,10 +233,11 @@ def test_issue_12791():
     expr = (-beta**2*varphi*sin(theta) + beta**2*cos(theta) + \
         beta*varphi*sin(theta) - beta*cos(theta) - beta + 1)/(beta*cos(theta) - 1)**2
 
-    sol = 0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta)\
-        - 1.0)**2 + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)\
-        + 0.25*cos(2*theta) + 1.25)/(0.5*cos(theta) - 1.0)**3\
-        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - S.Half)**2, (beta, S.Half))
+    sol = (0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta) - 1.0)**2
+        + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)
+        + 0.25*cos(2*theta) + 1.25)/((0.5*cos(theta) - 1.0)**2*(0.5*cos(theta) - 1.0))
+        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2
+        + O((beta - S.Half)**2, (beta, S.Half)))
 
     assert expr.series(beta, 0.5, 2).trigsimp() == sol
 

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -233,11 +233,10 @@ def test_issue_12791():
     expr = (-beta**2*varphi*sin(theta) + beta**2*cos(theta) + \
         beta*varphi*sin(theta) - beta*cos(theta) - beta + 1)/(beta*cos(theta) - 1)**2
 
-    sol = (0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta) - 1.0)**2
-        + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)
-        + 0.25*cos(2*theta) + 1.25)/((0.5*cos(theta) - 1.0)**2*(0.5*cos(theta) - 1.0))
-        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2
-        + O((beta - S.Half)**2, (beta, S.Half)))
+    sol = 0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta)\
+        - 1.0)**2 + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)\
+        + 0.25*cos(2*theta) + 1.25)/(0.5*cos(theta) - 1.0)**3\
+        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - S.Half)**2, (beta, S.Half))
 
     assert expr.series(beta, 0.5, 2).trigsimp() == sol
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Extracting part of #20033
See the explanation at https://github.com/sympy/sympy/pull/20033#issuecomment-1407429811

#### Brief description of what is fixed or changed

Add a function `equal_valued` whose purpose is to compare expressions where it might be expected that a Rational should compare equal to a Float. As it stands this function doesn't do anything but if something like #20033 was ever merged then this function would be able to preserve the current behaviour of `==` comparison for expressions including Float and Rational. If it was ever intended to merge #20033 then it would be useful if this function had already existed in a number of SymPy releases.

A few other places that use floats inconsistently are also changed.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
