### PR TITLE
Time-derivative rule implemented for the inverse Laplace transform

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -644,23 +644,24 @@ def _laplace_rule_diff(f, t, s, doit=True, **hints):
     """
 
     a = Wild('a', exclude=[t])
-    y = Wild('y')
     n = Wild('n', exclude=[t])
-    g = WildFunction('g', nargs=1)
+    g = WildFunction('g')
     ma1 = f.match(a*Derivative(g, (t, n)))
-    if ma1 and ma1[g].args[0] == t and ma1[n].is_integer:
-        debug('_laplace_apply_rules match:')
-        debugf('      f, n: %s, %s', (f, ma1[n]))
-        debug('      rule: time derivative (4.1.8)')
-        d = []
-        for k in range(ma1[n]):
-            if k==0:
-                y = ma1[g].func(t).subs(t, 0)
-            else:
-                y = Derivative(ma1[g].func(t), (t, k)).subs(t, 0)
-            d.append(s**(ma1[n]-k-1)*y)
-        r, pr, cr = _laplace_transform(ma1[g].func(t), t, s, simplify=False)
-        return (ma1[a]*(s**ma1[n]*r - Add(*d)),  pr, cr)
+    if ma1 and ma1[n].is_integer:
+        m = [ z.has(t) for z in ma1[g].args ]
+        if sum(m)==1:
+            debug('_laplace_apply_rules match:')
+            debugf('      f, n: %s, %s', (f, ma1[n]))
+            debug('      rule: time derivative (4.1.8)')
+            d = []
+            for k in range(ma1[n]):
+                if k==0:
+                    y = ma1[g].subs(t, 0)
+                else:
+                    y = Derivative(ma1[g], (t, k)).subs(t, 0)
+                d.append(s**(ma1[n]-k-1)*y)
+            r, pr, cr = _laplace_transform(ma1[g], t, s, simplify=False)
+            return (ma1[a]*(s**ma1[n]*r - Add(*d)),  pr, cr)
     return None
 
 

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -644,24 +644,23 @@ def _laplace_rule_diff(f, t, s, doit=True, **hints):
     """
 
     a = Wild('a', exclude=[t])
+    y = Wild('y')
     n = Wild('n', exclude=[t])
-    g = WildFunction('g')
+    g = WildFunction('g', nargs=1)
     ma1 = f.match(a*Derivative(g, (t, n)))
-    if ma1 and ma1[n].is_integer:
-        m = [ z.has(t) for z in ma1[g].args ]
-        if sum(m)==1:
-            debug('_laplace_apply_rules match:')
-            debugf('      f, n: %s, %s', (f, ma1[n]))
-            debug('      rule: time derivative (4.1.8)')
-            d = []
-            for k in range(ma1[n]):
-                if k==0:
-                    y = ma1[g].subs(t, 0)
-                else:
-                    y = Derivative(ma1[g], (t, k)).subs(t, 0)
-                d.append(s**(ma1[n]-k-1)*y)
-            r, pr, cr = _laplace_transform(ma1[g], t, s, simplify=False)
-            return (ma1[a]*(s**ma1[n]*r - Add(*d)),  pr, cr)
+    if ma1 and ma1[g].args[0] == t and ma1[n].is_integer:
+        debug('_laplace_apply_rules match:')
+        debugf('      f, n: %s, %s', (f, ma1[n]))
+        debug('      rule: time derivative (4.1.8)')
+        d = []
+        for k in range(ma1[n]):
+            if k==0:
+                y = ma1[g].func(t).subs(t, 0)
+            else:
+                y = Derivative(ma1[g].func(t), (t, k)).subs(t, 0)
+            d.append(s**(ma1[n]-k-1)*y)
+        r, pr, cr = _laplace_transform(ma1[g].func(t), t, s, simplify=False)
+        return (ma1[a]*(s**ma1[n]*r - Add(*d)),  pr, cr)
     return None
 
 
@@ -1132,6 +1131,7 @@ def _inverse_laplace_build_rules():
     _ILT_rules = [
         (a/s, a, S.true, same, 1),
         (b*(s+a)**(-c), t**(c-1)*exp(-a*t)/gamma(c), c>0, same, 1),
+        (1/(s**2+a**2)**2, (sin(a*t) - a*t*cos(a*t))/(2*a**3), S.true, same, 1)
     ]
     return _ILT_rules, s, t
 
@@ -1204,11 +1204,31 @@ def _inverse_laplace_time_shift(F, s, t, plane):
     return None
 
 
+def _inverse_laplace_time_diff(F, s, t, plane):
+    """
+    Helper function for the class InverseLaplaceTransform.
+    """
+    n = Wild('n', exclude=[s])
+    g = Wild('g')
+
+    ma1 = F.match(s**n*g)
+    if ma1 and ma1[n].is_integer and ma1[n].is_positive:
+        debug('_inverse_laplace_time_diff match:')
+        debugf('      f:    %s', (F,))
+        debug('      rule: s**n*F(s) o---o diff(f(t), t, n)')
+        debugf('      ma:   %s', (ma1,))
+        r, c = _inverse_laplace_transform(ma1[g], s, t, plane)
+        r = r.replace(Heaviside(t), 1)
+        return diff(r, t, ma1[n]), c
+    return None
+
+
 def _inverse_laplace_apply_prog_rules(F, s, t, plane):
     """
     Helper function for the class InverseLaplaceTransform.
     """
-    prog_rules = [_inverse_laplace_time_shift]
+    prog_rules = [_inverse_laplace_time_shift,
+                  _inverse_laplace_time_diff]
 
     for p_rule in prog_rules:
         if (r := p_rule(F, s, t, plane)) is not None:

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -271,6 +271,10 @@ def test_laplace_transform():
         s**3*LaplaceTransform(f(t), t, s) - s**2*f(0) -\
             s*Subs(Derivative(f(t), t), t, 0) -\
             Subs(Derivative(f(t), (t, 2)), t, 0)
+    # Issue #7219
+    assert LT(diff(f(x, t, w), t, 2), t, s) ==\
+        (s**2*LaplaceTransform(f(x, t, w), t, s) - s*f(x, 0, w) -\
+         Subs(Derivative(f(x, t, w), t), t, 0), -oo, True)
     # Issue #23307
     assert LT(10*diff(f(t), (t, 1)), t, s, noconds=True) ==\
         10*s*LaplaceTransform(f(t), t, s) - 10*f(0)

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -271,10 +271,6 @@ def test_laplace_transform():
         s**3*LaplaceTransform(f(t), t, s) - s**2*f(0) -\
             s*Subs(Derivative(f(t), t), t, 0) -\
             Subs(Derivative(f(t), (t, 2)), t, 0)
-    # Issue #7219
-    assert LT(diff(f(x, t, w), t, 2), t, s) ==\
-        (s**2*LaplaceTransform(f(x, t, w), t, s) - s*f(x, 0, w) -\
-         Subs(Derivative(f(x, t, w), t), t, 0), -oo, True)
     # Issue #23307
     assert LT(10*diff(f(t), (t, 1)), t, s, noconds=True) ==\
         10*s*LaplaceTransform(f(t), t, s) - 10*f(0)
@@ -372,6 +368,7 @@ def test_inverse_laplace_transform():
     a, b, c, d = symbols('a b c d', positive=True)
     r = Symbol('r', real=True)
     t, z = symbols('t z')
+    f = Function('f')
 
     def simp_hyp(expr):
         return factor_terms(expand_mul(expr)).rewrite(sin)
@@ -439,6 +436,13 @@ def test_inverse_laplace_transform():
         c*(a*exp(b*t) - b*exp(a*t))*exp(-t*(a + b))*Heaviside(t)/(a - b)
     assert ILT(c*s/(d**2*(s+a)**2+b**2), s, t) ==\
         c*(-a*d*sin(b*t/d) + b*cos(b*t/d))*exp(-a*t)*Heaviside(t)/(b*d**2)
+    # Test time_diff rule
+    assert ILT(s**42*f(s), s, t) ==\
+        Derivative(InverseLaplaceTransform(f(s), s, t, None), (t, 42))
+    assert ILT((b*s**2 + d)/(a**2 + s**2)**2, s, t) ==\
+        (a**3*b*t*cos(a*t) + 4*a**2*b*sin(a*t)*Heaviside(t) +\
+         a**2*b*sin(a*t) - a*d*t*cos(a*t)*Heaviside(t) +\
+             d*sin(a*t)*Heaviside(t))/(2*a**3)
     # Rules for testing different DiracDelta cases
     assert ILT(2, s, t) == 2*DiracDelta(t)
     assert ILT(2*exp(3*s) - 5*exp(-7*s), s, t) == \


### PR DESCRIPTION
#### References to other Issues or PRs

Part of #24561

#### Brief description of what is fixed or changed

This change implements the time-derivative rule of the inverse Laplace transform (ILT) and one more simple rule such that the ILT now covers everything required for system theory.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Time-derivative rule implemented for the inverse Laplace transform
<!-- END RELEASE NOTES -->
