### PR TITLE
Cleanup Basic metaclass

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -614,8 +614,6 @@ def _ask(fact, obj):
 class ManagedProperties(BasicMeta):
     """Metaclass for classes with old-style assumptions"""
     def __init__(cls, *args, **kws):
-        BasicMeta.__init__(cls, *args, **kws)
-
         local_defs = {}
         for k in _assume_defined:
             attrname = as_property(k)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from itertools import chain, zip_longest
 
-from .assumptions import ManagedProperties
+from .assumptions import as_property, _assume_defined, StdFactKB, make_property
 from .cache import cacheit
 from .core import BasicMeta
 from .sympify import _sympify, sympify, SympifyError, _external_converter
@@ -33,7 +33,63 @@ def as_Basic(expr):
             expr))
 
 
-class Basic(Printable, metaclass=ManagedProperties):
+# This must be a base class of Basic so that __init_subclass__ applies to Basic
+class _BasicBase:
+    __slots__ = ('_mhash',              # hash value
+                 '_args',               # arguments
+                 '_assumptions'
+                )
+
+    def __init_subclass__(cls):
+        local_defs = {}
+        for k in _assume_defined:
+            attrname = as_property(k)
+            v = cls.__dict__.get(attrname, '')
+            if isinstance(v, (bool, int, type(None))):
+                if v is not None:
+                    v = bool(v)
+                local_defs[k] = v
+
+        defs = {}
+        for base in reversed(cls.__bases__):
+            assumptions = getattr(base, '_explicit_class_assumptions', None)
+            if assumptions is not None:
+                defs.update(assumptions)
+        defs.update(local_defs)
+
+        cls._explicit_class_assumptions = defs
+        cls.default_assumptions = StdFactKB(defs)
+
+        cls._prop_handler = {}
+        for k in _assume_defined:
+            eval_is_meth = getattr(cls, '_eval_is_%s' % k, None)
+            if eval_is_meth is not None:
+                cls._prop_handler[k] = eval_is_meth
+
+        # Put definite results directly into the class dict, for speed
+        for k, v in cls.default_assumptions.items():
+            setattr(cls, as_property(k), v)
+
+        # protection e.g. for Integer.is_even=F <- (Rational.is_integer=F)
+        derived_from_bases = set()
+        for base in cls.__bases__:
+            default_assumptions = getattr(base, 'default_assumptions', None)
+            # is an assumption-aware class
+            if default_assumptions is not None:
+                derived_from_bases.update(default_assumptions)
+
+        for fact in derived_from_bases - set(cls.default_assumptions):
+            pname = as_property(fact)
+            if pname not in cls.__dict__:
+                setattr(cls, pname, make_property(fact))
+
+        # Finally, add any missing automagic property (e.g. for Basic)
+        for fact in _assume_defined:
+            pname = as_property(fact)
+            if not hasattr(cls, pname):
+                setattr(cls, pname, make_property(fact))
+
+class Basic(_BasicBase, Printable, metaclass=BasicMeta):
     """
     Base class for all SymPy objects.
 
@@ -77,10 +133,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         >>> isinstance(B, Basic)
         True
     """
-    __slots__ = ('_mhash',              # hash value
-                 '_args',               # arguments
-                 '_assumptions'
-                )
+    __slots__ = ()
 
     _args: tuple[Basic, ...]
     _mhash: int | None

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -85,6 +85,10 @@ class Basic(Printable, metaclass=ManagedProperties):
     _args: tuple[Basic, ...]
     _mhash: int | None
 
+    @property
+    def __sympy__(self):
+        return True
+
     # To be overridden with True in the appropriate subclasses
     is_number = False
     is_Atom = False

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -62,9 +62,6 @@ class Registry:
 
 
 class BasicMeta(type):
-    def __init__(cls, *args, **kws):
-        cls.__sympy__ = property(lambda self: True)
-
     def __cmp__(cls, other):
         # If the other object is not a Basic subclass, then we are not equal to
         # it.


### PR DESCRIPTION
The goal is to eventually remove the metaclass from `Basic`, but I don't plan to actually remove `BasicMeta` here because that's hard (c.f. #19907).

I've moved the `ManagedProperties` logic into `__init_subclass__`. This is primarily a proof-of-concept for now. If we decide that we want to do this, we should apply some cleanups to this. For example:

- ManagedProperties is still used in some other places in the codebase.
- We can probably replace _BasicBase with just moving some of the
  `__init_subclass__` logic into `Basic.__init__`

I'm curious if this has any impact on performance, but it's hard to tell since
we still have the BasicMeta metaclass (with the ordering of classes), which is
harder to remove.<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/24633

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
