### PR TITLE
Fix MatMul(x, OneMatrix).diff(x) RecursionError

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1537,3 +1537,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Blair Azzopardi <blairuk@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -391,6 +391,7 @@ Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>
 Bill Flynn <wflynny@gmail.com>
 Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
+Blair Azzopardi <blairuk@gmail.com>
 Blair Azzopardi <bsdz@users.noreply.github.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
@@ -1537,4 +1538,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Blair Azzopardi <blairuk@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -391,8 +391,7 @@ Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>
 Bill Flynn <wflynny@gmail.com>
 Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
-Blair Azzopardi <blairuk@gmail.com>
-Blair Azzopardi <bsdz@users.noreply.github.com>
+Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -554,7 +554,7 @@ Marcel Stimberg <marcel.stimberg@ens.fr>
 Alexey Pakhocmhik <cool.Bakov@yandex.ru>
 Tommy Olofsson <tommy.olofsson.90@gmail.com>
 Zulfikar <zulfikar97@gmail.com>
-Blair Azzopardi <bsdz@users.noreply.github.com>
+Blair Azzopardi <blairuk@gmail.com>
 Danny Hermes <daniel.j.hermes@gmail.com>
 Sergey Pestov <pestov-sa@yandex.ru>
 Mohit Chandra <mohit.chandra@research.iiit.ac.in>

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -86,7 +86,7 @@ def test_matrix_derivative_by_scalar():
 
 
 def test_one_matrix():
-    assert MatMul(x.T, OneMatrix(k, 1)).diff(x) == OneMatrix(k, 1) 
+    assert MatMul(x.T, OneMatrix(k, 1)).diff(x) == OneMatrix(k, 1)
 
 
 def test_matrix_derivative_non_matrix_result():

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -85,6 +85,10 @@ def test_matrix_derivative_by_scalar():
     assert expr.diff(x) == 2*mu*Identity(k)
 
 
+def test_one_matrix():
+    assert MatMul(x.T, OneMatrix(k, 1)).diff(x) == OneMatrix(k, 1) 
+
+
 def test_matrix_derivative_non_matrix_result():
     # This is a 4-dimensional array:
     I = Identity(k)

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -6,7 +6,7 @@ from sympy.core.singleton import S
 from sympy.matrices.expressions.hadamard import HadamardProduct
 from sympy.matrices.expressions.inverse import Inverse
 from sympy.matrices.expressions.matexpr import (MatrixExpr, MatrixSymbol)
-from sympy.matrices.expressions.special import Identity
+from sympy.matrices.expressions.special import Identity, OneMatrix
 from sympy.matrices.expressions.transpose import Transpose
 from sympy.combinatorics.permutations import _af_invert
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
@@ -81,6 +81,11 @@ def _(expr: MatrixSymbol, x: _ArrayExpr):
 
 @array_derive.register(Identity)
 def _(expr: Identity, x: _ArrayExpr):
+    return ZeroArray(*(x.shape + expr.shape))
+
+
+@array_derive.register(OneMatrix)
+def _(expr: OneMatrix, x: _ArrayExpr):
     return ZeroArray(*(x.shape + expr.shape))
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24637.

#### Brief description of what is fixed or changed
Add array_derive registration for OneMatrix similar to Identity

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Fix RecursionError when differentiating a product with OneMatrix expression.


<!-- END RELEASE NOTES -->
