### PR TITLE
Laplace transform: New trig rules for products of trig functions

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -636,7 +636,6 @@ def _laplace_rule_trig(fn, t_, s, doit=True, **hints):
 
     # Convert the product of trigonometric functions to a sum of exponentials
     x1 = f.rewrite(exp).expand()
-    xa = [k.simplify() for k in Add.make_args(x1)]
 
     xm = []  # all p*exp(a*t+b) matches
     xn = []  # expressions that do not match -> LT
@@ -645,7 +644,7 @@ def _laplace_rule_trig(fn, t_, s, doit=True, **hints):
     conditions = [True]  # All convergenge conditions
     results = []
 
-    for term in xa:
+    for term in Add.make_args(x1):
         if (r := term.match(p*exp(m))) is not None:
             mc = r[m].as_poly(t).all_coeffs()
             if len(mc) == 2:
@@ -655,7 +654,7 @@ def _laplace_rule_trig(fn, t_, s, doit=True, **hints):
         else:
             xn.append(term)
 
-    if g == 1:
+    if not g.has(t):
         # Search for complex conjugate poles and symmetric real poles. The
         # order is vital, if we have four poles in a square layout, then
         # collecting the conjugate-complex poles first always gives simpler

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -368,7 +368,7 @@ def _laplace_build_rules():
     (log(a*t)**2, (log(exp(S.EulerGamma)*s/a)**2+pi**2/6)/s,
      a>0, S.Zero, dco), # 4.6.13
     (sin(omega*t), omega/(s**2+omega**2),
-      S.true, Abs(im(omega)), dco), # 4,7,1
+     S.true, Abs(im(omega)), dco), # 4,7,1
     (Abs(sin(omega*t)), omega/(s**2+omega**2)*coth(pi*s/2/omega),
      omega>0, S.Zero, dco), # 4.7.2
     (sin(omega*t)/t, atan(omega/s),

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -729,7 +729,7 @@ def _laplace_trig_ltex(xm, t, s):
         i_pointsym = None
         # The following code checks all remaining poles. If t1 is a pole at
         # a+b*I, then we check for a-b*I, -a+b*I, and -a-b*I, and
-        # assign the respectiove indices to i_imagsym, i_realsym, i_pointsym.
+        # assign the respective indices to i_imagsym, i_realsym, i_pointsym.
         # -a-b*I / i_pointsym only applies if both a and b are != 0.
         for i in range(len(xm)):
             real_eq = t1[re] == xm[i][re]
@@ -749,7 +749,7 @@ def _laplace_trig_ltex(xm, t, s):
         # cc:     a+b*I, a-b*I (a may be zero)
         # quad:   a+b*I, -a+b*I (b may be zero)
         # point:  a+b*I, -a-b*I (a!=0 and b!=0 is needed, but that has been
-        #                        asserted when finiding i_pointsym above.)
+        #                        asserted when finding i_pointsym above.)
         # If none apply, then t1 is a simple pole.
         if (
                 i_imagsym is not None and i_realsym is not None

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1009,7 +1009,7 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
     >>> laplace_transform(t**a, t, s)
     (s**(-a - 1)*gamma(a + 1), 0, re(a) > -1)
     >>> laplace_transform(DiracDelta(t)-a*exp(-a*t), t, s)
-    (s/(a + s), -a, True)
+    (s/(a + s), -re(a), True)
 
     References
     ==========

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -736,7 +736,6 @@ def _laplace_trig_ltex(xm, t, s):
             realsym = t1[re] == -xm[i][re]
             imag_eq = t1[im] == xm[i][im]
             imagsym = t1[im] == -xm[i][im]
-            debug('----', t1, xm[i], realsym, imagsym)
             if realsym and imagsym and t1[re] != 0 and t1[im] != 0:
                 i_pointsym = i
             elif realsym and imag_eq and t1[re] != 0:

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -382,7 +382,7 @@ def _laplace_build_rules():
     (sin(2*sqrt(a*t))/t, pi*erf(sqrt(a/s)),
      S.true, S.Zero, dco), # 4.7.34
     (cos(omega*t), s/(s**2+omega**2),
-      S.true, Abs(im(omega)), dco), # 4.7.43
+     S.true, Abs(im(omega)), dco), # 4.7.43
     (cos(omega*t)**2, (s**2+2*omega**2)/(s**2+4*omega**2)/s,
      S.true, 2*Abs(im(omega)), dco), # 4.7.45
     (sqrt(t)*cos(2*sqrt(a*t)), sqrt(pi)/2*s**(-S(5)/2)*(s-2*a)*exp(-a/s),

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -592,7 +592,9 @@ def _laplace_trig_split(fn):
     trigs = [S.One]
     other = [S.One]
     for term in Mul.make_args(fn):
-        if term.has(sin) or term.has(cos) or term.has(sinh) or term.has(cosh):
+        if (
+                term.has(sin) or term.has(cos) or term.has(sinh) or
+                term.has(cosh) or term.has(exp)):
             trigs.append(term)
         else:
             other.append(term)

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -389,10 +389,20 @@ def _laplace_build_rules():
      S.true, S.Zero, dco), # 4.7.66
     (cos(2*sqrt(a*t))/sqrt(t), sqrt(pi/s)*exp(-a/s),
      S.true, S.Zero, dco), # 4.7.67
+    (sin(a*t)*sin(b*t), 2*a*b*s/(s**2+(a+b)**2)/(s**2+(a-b)**2),
+     S.true, Abs(im(a))+Abs(im(b)), dco), # 4.7.78
+    (cos(a*t)*sin(b*t), b*(s**2-a**2+b**2)/(s**2+(a+b)**2)/(s**2+(a-b)**2),
+     S.true, Abs(im(a))+Abs(im(b)), dco), # 4.7.79
+    (cos(a*t)*cos(b*t), s*(s**2+a**2+b**2)/(s**2+(a+b)**2)/(s**2+(a-b)**2),
+     S.true, Abs(im(a))+Abs(im(b)), dco), # 4.7.80
     (sinh(a*t), a/(s**2-a**2),
      S.true, Abs(re(a)), dco), # 4.9.1
     (cosh(a*t), s/(s**2-a**2),
      S.true, Abs(re(a)), dco), # 4.9.2
+    (sinh(a*t)**2, 2*a**2/(s**3-4*a**2*s),
+     S.true, 2*Abs(re(a)), dco), # 4.9.3
+    (cosh(a*t)**2, (s**2-2*a**2)/(s**3-4*a**2*s),
+     S.true, 2*Abs(re(a)), dco), # 4.9.4
     (sinh(a*t)/t, log((s+a)/(s-a))/2,
      S.true, Abs(re(a)), dco), # 4.9.12
     (t**n*sinh(a*t), gamma(n+1)/2*((s-a)**(-n-1)-(s+a)**(-n-1)),

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -165,14 +165,14 @@ def test_laplace_transform():
     assert LT(cos(2*sqrt(a*t))/sqrt(t), t, s) ==\
         (sqrt(pi)*sqrt(1/s)*exp(-a/s), 0, True)
     assert LT(sin(a*t)*sin(b*t), t, s) == (
-        2*a*b*s/(a**4 - 2*a**2*b**2 + 2*a**2*s**2 + b**4 + 2*b**2*s**2 + s**4),
+        2*a*b*s/((s**2 + (a - b)**2)*(s**2 + (a + b)**2)),
         0, True)
     assert LT(cos(a*t)*sin(b*t), t, s) == (
-        b*(-a**2 + b**2 + s**2)/(a**4 - 2*a**2*b**2 + 2*a**2*s**2 +
-                                 b**4 + 2*b**2*s**2 + s**4), 0, True)
+        b*(-a**2 + b**2 + s**2)/((s**2 + (a - b)**2)*(s**2 + (a + b)**2)),
+        0, True)
     assert LT(cos(a*t)*cos(b*t), t, s) == (
-        s*(a**2 + b**2 + s**2)/(a**4 - 2*a**2*b**2 + 2*a**2*s**2 +
-                                b**4 + 2*b**2*s**2 + s**4), 0, True)
+        s*(a**2 + b**2 + s**2)/((s**2 + (a - b)**2)*(s**2 + (a + b)**2)),
+        0, True)
     assert LT(-a*t*cos(a*t) + sin(a*t), t, s, simplify=True) ==\
         (2*a**3/(a**4 + 2*a**2*s**2 + s**4), 0, True)
     assert LT(c*exp(-b*t)*sin(a*t), t, s) == (a*c/(a**2 + (b + s)**2), -b, True)

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -232,7 +232,7 @@ def test_laplace_transform():
         (a*LaplaceTransform(f(t), t, s)*exp(-s), -oo, True)
     assert LT(b*f(t/a), t, s) == (a*b*LaplaceTransform(f(t), t, a*s),
                                   -oo, True)
-    assert LT(exp(-f(x)*t), t, s) == (1/(s + f(x)), -f(x), True)
+    assert LT(exp(-f(x)*t), t, s) == (1/(s + f(x)), -re(f(x)), True)
     assert LT(exp(-a*t)*f(t), t, s) ==\
         (LaplaceTransform(f(t), t, a + s), -oo, True)
     assert LT(exp(-a*t)*erfc(sqrt(b/t)/2), t, s) ==\
@@ -257,6 +257,13 @@ def test_laplace_transform():
          LaplaceTransform(f(t), t, I*a + s)/2, -oo, True)
     assert LT(cos(a*t)*t, t, s, simplify=True) ==\
         ((-a**2 + s**2)/(a**4 + 2*a**2*s**2 + s**4), 0, True)
+    L, plane, _ = LT(sin(a*t)**3*cosh(b*t), t, s, simplify=False)
+    assert plane == b
+    assert (
+        -L -3*a/(8*(9*a**2 + b**2 + 2*b*s + s**2)) -
+        3*a/(8*(9*a**2 + b**2 - 2*b*s + s**2)) +
+        3*a/(8*(a**2 + b**2 + 2*b*s + s**2)) +
+        3*a/(8*(a**2 + b**2 - 2*b*s + s**2))).simplify() == 0
     assert LT(t**2*exp(-t**2), t, s) ==\
         (sqrt(pi)*s**2*exp(s**2/4)*erfc(s/2)/8 - s/4 +\
          sqrt(pi)*exp(s**2/4)*erfc(s/2)/4, 0, True)

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -8,7 +8,7 @@ from sympy.core.numbers import I, oo, pi
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, symbols
 from sympy.simplify.simplify import simplify
-from sympy.functions.elementary.complexes import Abs, re, im
+from sympy.functions.elementary.complexes import Abs, re
 from sympy.functions.elementary.exponential import exp, log, exp_polar
 from sympy.functions.elementary.hyperbolic import cosh, sinh, coth, asinh
 from sympy.functions.elementary.miscellaneous import sqrt

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -257,6 +257,11 @@ def test_laplace_transform():
          LaplaceTransform(f(t), t, I*a + s)/2, -oo, True)
     assert LT(cos(a*t)*t, t, s, simplify=True) ==\
         ((-a**2 + s**2)/(a**4 + 2*a**2*s**2 + s**4), 0, True)
+    L, plane, _ = LT(sin(a*t+b)**2*f(t), t, s)
+    assert plane == 0
+    assert (
+        -L -LaplaceTransform(f(t), t, -2*I*a + s)*exp(2*I*b)/4 -
+        LaplaceTransform(f(t), t, 2*I*a + s)*exp(-2*I*b)/4 + 1/(2*s)) == 0
     L, plane, _ = LT(sin(a*t)**3*cosh(b*t), t, s, simplify=False)
     assert plane == b
     assert (


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561 

#### Brief description of what is fixed or changed
The old trig rules of the Laplace transform implemented a few tabularised rules by pattern matching. The new rules rewrite trigonometric expressions as exponentials and combines exprssions with complex conjugate or symmetric real poles to obtain real-valued expressions if the original coefficients were also real-valued.

Three simple rules were changed, their planes were wrong for complex arguments.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * The Laplace transform now has better rules for dealing with trigonometric functions and their products.
<!-- END RELEASE NOTES -->
