### PR TITLE
Fix bug (variable name mistake)

### DIFF
--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -258,8 +258,10 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
             alpha = (R.x_cord*R.z_cord) % n
             for q in sieve.primerange(r + 2, r + 2*D + 1):
                 delta = (q - r) // 2
-                f = (R.x_cord - S[d].x_cord)*(R.z_cord + S[d].z_cord) -\
-                alpha + beta[delta]
+                # We want to calculate
+                # f = R.x_cord * S[delta].z_cord - S[delta].x_cord * R.z_cord
+                f = (R.x_cord - S[delta].x_cord)*\
+                    (R.z_cord + S[delta].z_cord) - alpha + beta[delta]
                 g = (g*f) % n
             #Swap
             T, R = R, R.add(S[D], T)


### PR DESCRIPTION
The variable name is `delta`, not `d`.
Added comment.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
