### PR TITLE
Added test for float('inf') in test_sympify

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -2,7 +2,7 @@ from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda)
 from sympy.core.mul import Mul
-from sympy.core.numbers import (Float, I, Integer, Rational, pi)
+from sympy.core.numbers import (Float, I, Integer, Rational, pi, oo)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
@@ -780,6 +780,11 @@ def test_issue_16759():
 def test_issue_17811():
     a = Function('a')
     assert sympify('a(x)*5', evaluate=False) == Mul(a(x), 5, evaluate=False)
+
+
+def test_issue_8439():
+    assert x + float('inf') == x + oo
+    assert S(float('inf')) == oo
 
 
 def test_issue_14706():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -783,6 +783,7 @@ def test_issue_17811():
 
 
 def test_issue_8439():
+    assert sympify(float('inf')) == oo
     assert x + float('inf') == x + oo
     assert S(float('inf')) == oo
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1005,6 +1005,10 @@ def test_issue_8373():
     x = Symbol('x', real=True)
     assert simplify(Or(x < 1, x >= 1)) == S.true
 
+def test_issue_8439():
+    assert x + float('inf') == x + oo
+    assert S(float('inf')) == oo
+
 
 def test_issue_7950():
     expr = And(Eq(x, 1), Eq(x, 2))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1005,10 +1005,6 @@ def test_issue_8373():
     x = Symbol('x', real=True)
     assert simplify(Or(x < 1, x >= 1)) == S.true
 
-def test_issue_8439():
-    assert x + float('inf') == x + oo
-    assert S(float('inf')) == oo
-
 
 def test_issue_7950():
     expr = And(Eq(x, 1), Eq(x, 2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #8439

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
