### PR TITLE
Remove `BasicMeta`

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -211,7 +211,6 @@ References
 """
 
 from .facts import FactRules, FactKB
-from .core import BasicMeta
 from .sympify import sympify
 
 from sympy.core.random import _assumptions_shuffle as shuffle
@@ -611,10 +610,10 @@ def _ask(fact, obj):
     return None
 
 
-class ManagedProperties(BasicMeta):
+class ManagedProperties(type):
     """Metaclass for classes with old-style assumptions"""
     def __init__(cls, *args, **kws):
-        BasicMeta.__init__(cls, *args, **kws)
+        cls.__sympy__ = property(lambda self: True)
 
         local_defs = {}
         for k in _assume_defined:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,6 +7,7 @@ from itertools import chain, zip_longest
 
 from .assumptions import ManagedProperties
 from .cache import cacheit
+from .core import old_compare
 from .sympify import _sympify, sympify, SympifyError, _external_converter
 from .sorting import ordered
 from .kind import Kind, UndefinedKind
@@ -227,7 +228,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             return 0
         n1 = self.__class__
         n2 = other.__class__
-        c = (n1 > n2) - (n1 < n2)
+        c = old_compare(n1, n2)
         if c:
             return c
         #

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,7 +7,7 @@ from itertools import chain, zip_longest
 
 from .assumptions import ManagedProperties
 from .cache import cacheit
-from .core import old_compare
+from .core import ordering_of_classes
 from .sympify import _sympify, sympify, SympifyError, _external_converter
 from .sorting import ordered
 from .kind import Kind, UndefinedKind
@@ -31,6 +31,30 @@ def as_Basic(expr):
         raise TypeError(
             'Argument must be a Basic object, not `%s`' % func_name(
             expr))
+
+
+def _old_compare(x: type, y: type) -> int:
+    # If the other object is not a Basic subclass, then we are not equal to it.
+    if not issubclass(y, Basic):
+        return -1
+
+    n1 = x.__name__
+    n2 = y.__name__
+    if n1 == n2:
+        return 0
+
+    UNKNOWN = len(ordering_of_classes) + 1
+    try:
+        i1 = ordering_of_classes.index(n1)
+    except ValueError:
+        i1 = UNKNOWN
+    try:
+        i2 = ordering_of_classes.index(n2)
+    except ValueError:
+        i2 = UNKNOWN
+    if i1 == UNKNOWN and i2 == UNKNOWN:
+        return (n1 > n2) - (n1 < n2)
+    return (i1 > i2) - (i1 < i2)
 
 
 class Basic(Printable, metaclass=ManagedProperties):
@@ -228,7 +252,7 @@ class Basic(Printable, metaclass=ManagedProperties):
             return 0
         n1 = self.__class__
         n2 = other.__class__
-        c = old_compare(n1, n2)
+        c = _old_compare(n1, n2)
         if c:
             return c
         #

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -44,31 +44,6 @@ ordering_of_classes = [
 ]
 
 
-def old_compare(x: type, y: type) -> int:
-    from sympy.core.basic import Basic
-    # If the other object is not a Basic subclass, then we are not equal to it.
-    if not issubclass(y, Basic):
-        return -1
-
-    n1 = x.__name__
-    n2 = y.__name__
-    if n1 == n2:
-        return 0
-
-    UNKNOWN = len(ordering_of_classes) + 1
-    try:
-        i1 = ordering_of_classes.index(n1)
-    except ValueError:
-        i1 = UNKNOWN
-    try:
-        i2 = ordering_of_classes.index(n2)
-    except ValueError:
-        i2 = UNKNOWN
-    if i1 == UNKNOWN and i2 == UNKNOWN:
-        return (n1 > n2) - (n1 < n2)
-    return (i1 > i2) - (i1 < i2)
-
-
 class Registry:
     """
     Base class for registry objects.

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -1,4 +1,6 @@
 """ The core's core. """
+from __future__ import annotations
+
 
 # used for canonical ordering of symbolic sequences
 # via __cmp__ method:
@@ -42,6 +44,31 @@ ordering_of_classes = [
 ]
 
 
+def old_compare(x: type, y: type) -> int:
+    from sympy.core.basic import Basic
+    # If the other object is not a Basic subclass, then we are not equal to it.
+    if not issubclass(y, Basic):
+        return -1
+
+    n1 = x.__name__
+    n2 = y.__name__
+    if n1 == n2:
+        return 0
+
+    UNKNOWN = len(ordering_of_classes) + 1
+    try:
+        i1 = ordering_of_classes.index(n1)
+    except ValueError:
+        i1 = UNKNOWN
+    try:
+        i2 = ordering_of_classes.index(n2)
+    except ValueError:
+        i2 = UNKNOWN
+    if i1 == UNKNOWN and i2 == UNKNOWN:
+        return (n1 > n2) - (n1 < n2)
+    return (i1 > i2) - (i1 < i2)
+
+
 class Registry:
     """
     Base class for registry objects.
@@ -59,41 +86,3 @@ class Registry:
 
     def __delattr__(self, name):
         delattr(self.__class__, name)
-
-
-class BasicMeta(type):
-    def __init__(cls, *args, **kws):
-        cls.__sympy__ = property(lambda self: True)
-
-    def __cmp__(cls, other):
-        # If the other object is not a Basic subclass, then we are not equal to
-        # it.
-        if not isinstance(other, BasicMeta):
-            return -1
-        n1 = cls.__name__
-        n2 = other.__name__
-        if n1 == n2:
-            return 0
-
-        UNKNOWN = len(ordering_of_classes) + 1
-        try:
-            i1 = ordering_of_classes.index(n1)
-        except ValueError:
-            i1 = UNKNOWN
-        try:
-            i2 = ordering_of_classes.index(n2)
-        except ValueError:
-            i2 = UNKNOWN
-        if i1 == UNKNOWN and i2 == UNKNOWN:
-            return (n1 > n2) - (n1 < n2)
-        return (i1 > i2) - (i1 < i2)
-
-    def __lt__(cls, other):
-        if cls.__cmp__(other) == -1:
-            return True
-        return False
-
-    def __gt__(cls, other):
-        if cls.__cmp__(other) == 1:
-            return True
-        return False

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -6,16 +6,22 @@ from typing import Any
 
 from sympy.integrals.meijerint import _create_lookup_table
 from sympy.core.add import Add
+from sympy.core.basic import Basic
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
 from sympy.printing.latex import latex
 
-t: dict[tuple[type, ...], list[Any]] = {}
+t: dict[tuple[type[Basic], ...], list[Any]] = {}
 _create_lookup_table(t)
 
-doc = ""
 
-for about, category in sorted(t.items()):
+def key(item: tuple[tuple[type[Basic], ...], list[Any]]):
+    about, category = item
+    return tuple(map(lambda x: x.class_key(), about)), category
+
+
+doc = ""
+for about, category in sorted(t.items(), key=key):
     if about == ():
         doc += 'Elementary functions:\n\n'
     else:

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -15,13 +15,8 @@ t: dict[tuple[type[Basic], ...], list[Any]] = {}
 _create_lookup_table(t)
 
 
-def key(item: tuple[tuple[type[Basic], ...], list[Any]]):
-    about, category = item
-    return tuple(map(lambda x: x.class_key(), about)), category
-
-
 doc = ""
-for about, category in sorted(t.items(), key=key):
+for about, category in t.items():
     if about == ():
         doc += 'Elementary functions:\n\n'
     else:

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -342,7 +342,7 @@ def test_lookup_table():
     from sympy.integrals.meijerint import z as z_dummy
     table = {}
     _create_lookup_table(table)
-    for _, l in sorted(table.items()):
+    for _, l in table.items():
         for formula, terms, cond, hint in sorted(l, key=default_sort_key):
             subs = {}
             for ai in list(formula.free_symbols) + [z_dummy]:

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -6,8 +6,8 @@ from sympy.physics.units import meter
 
 from sympy.testing.pytest import XFAIL, raises
 
+from sympy.core.assumptions import ManagedProperties
 from sympy.core.basic import Atom, Basic
-from sympy.core.core import BasicMeta
 from sympy.core.singleton import SingletonRegistry
 from sympy.core.symbol import Str, Dummy, Symbol, Wild
 from sympy.core.numbers import (E, I, pi, oo, zoo, nan, Integer,
@@ -58,7 +58,7 @@ def check(a, exclude=[], check_attr=True):
             continue
 
         if callable(protocol):
-            if isinstance(a, BasicMeta):
+            if isinstance(a, ManagedProperties):
                 # Classes can't be copied, but that's okay.
                 continue
             b = protocol(a)
@@ -97,7 +97,7 @@ def test_core_basic():
     for c in (Atom, Atom(),
               Basic, Basic(),
               # XXX: dynamically created types are not picklable
-              # BasicMeta, BasicMeta("test", (), {}),
+              # ManagedProperties, ManagedProperties("test", (), {}),
               SingletonRegistry, S):
         check(c)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments

This is a redux of work from #19907.
I simply pulled out the old comparison as function than metaclass, but didn't change the sorting logic yet, such that we can easily isolate the effort to maintain the old behavior.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
