### PR TITLE
Added tests in test_refine to simplify piecewise function

### DIFF
--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -192,6 +192,12 @@ def test_func_args():
     x.my_member = "A very important value"
     assert x.my_member == refine(x).my_member
 
+def test_issue_refine_9384():
+    assert refine(Piecewise((1, x < 0), (0, True)), Q.positive(x)) == 0
+    assert refine(Piecewise((1, x < 0), (0, True)), Q.negative(x)) == 1
+    assert refine(Piecewise((1, x > 0), (0, True)), Q.positive(x)) == 1
+    assert refine(Piecewise((1, x > 0), (0, True)), Q.negative(x)) == 0
+
 
 def test_eval_refine():
     class MockExpr(Expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #9384

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 
<!-- END RELEASE NOTES -->
