### PR TITLE
Added test for simplified Piecewise is missing conditions

### DIFF
--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -5,6 +5,7 @@ from sympy.core.containers import Tuple
 from sympy.core.expr import unchanged
 from sympy.core.function import (Function, diff, expand)
 from sympy.core.mul import Mul
+from sympy.core.mod import Mod
 from sympy.core.numbers import (Float, I, Rational, oo, pi, zoo)
 from sympy.core.relational import (Eq, Ge, Gt, Ne)
 from sympy.core.singleton import S
@@ -1338,6 +1339,31 @@ def test_issue_14787():
     x = Symbol('x')
     f = Piecewise((x, x < 1), ((S(58) / 7), True))
     assert str(f.evalf()) == "Piecewise((x, x < 1), (8.28571428571429, True))"
+
+def test_issue_21481():
+    b, e = symbols('b e')
+    A = Piecewise((1, Eq(b, 1) | Eq(e, 0) | (Eq(b, -1) & Eq(Mod(e, 2), 0))),
+                    (0, Eq(b, 0) & (e > 0)), (-1, Eq(b, -1) & Eq(Mod(e, 2), 1)),
+                    (Piecewise((2, ((b > 1) & (e > 0)) | ((b > 0) & (b < 1) & (e < 0)) |
+                            ((e >= 2) & (b < -1) & Eq(Mod(e, 2), 0)) |
+                            ((e <= -2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
+                            (S.Half, ((b > 1) & (e < 0)) | ((b > 0) & (e > 0) & (b < 1)) |
+                            ((e <= -2) & (b < -1) & Eq(Mod(e, 2), 0)) |
+                            ((e >= 2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
+                            (-S.Half, Eq(Mod(e, 2), 1) & (((e <= -1) & (b < -1)) |
+                            ((e >= 1) & (b > -1) & (b < 0)))),
+                                (-2, ((e >= 1) & (b < -1) & Eq(Mod(e, 2), 1)) |
+                                ((e <= -1) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 1)))),
+                    Eq(im(b), 0) & Eq(im(e), 0)))
+    B = piecewise_fold(A)
+    sa = A.simplify()
+    sb = B.simplify()
+    v = Tuple(-2, -1, -0.5, 0, 0.5, 1, 2)
+    for i in v:
+        for j in v:
+            r = {b:i, e:j}
+            ok = [k.xreplace(r) for k in (A, B, sa, sb)]
+            assert len(set(ok)) == 1
 
 
 def test_issue_8458():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1342,23 +1342,37 @@ def test_issue_14787():
 
 def test_issue_21481():
     b, e = symbols('b e')
-    A = Piecewise((1, Eq(b, 1) | Eq(e, 0) | (Eq(b, -1) & Eq(Mod(e, 2), 0))),
-                    (0, Eq(b, 0) & (e > 0)), (-1, Eq(b, -1) & Eq(Mod(e, 2), 1)),
-                    (Piecewise((2, ((b > 1) & (e > 0)) | ((b > 0) & (b < 1) & (e < 0)) |
-                            ((e >= 2) & (b < -1) & Eq(Mod(e, 2), 0)) |
-                            ((e <= -2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
-                            (S.Half, ((b > 1) & (e < 0)) | ((b > 0) & (e > 0) & (b < 1)) |
-                            ((e <= -2) & (b < -1) & Eq(Mod(e, 2), 0)) |
-                            ((e >= 2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
-                            (-S.Half, Eq(Mod(e, 2), 1) & (((e <= -1) & (b < -1)) |
-                            ((e >= 1) & (b > -1) & (b < 0)))),
-                                (-2, ((e >= 1) & (b < -1) & Eq(Mod(e, 2), 1)) |
-                                ((e <= -1) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 1)))),
-                    Eq(im(b), 0) & Eq(im(e), 0)))
+
+    C = Piecewise(
+        (2,
+        ((b > 1) & (e > 0)) |
+        ((b > 0) & (b < 1) & (e < 0)) |
+        ((e >= 2) & (b < -1) & Eq(Mod(e, 2), 0)) |
+        ((e <= -2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
+        (S.Half,
+        ((b > 1) & (e < 0)) |
+        ((b > 0) & (e > 0) & (b < 1)) |
+        ((e <= -2) & (b < -1) & Eq(Mod(e, 2), 0)) |
+        ((e >= 2) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 0))),
+        (-S.Half,
+        Eq(Mod(e, 2), 1) &
+        (((e <= -1) & (b < -1)) | ((e >= 1) & (b > -1) & (b < 0)))),
+        (-2,
+        ((e >= 1) & (b < -1) & Eq(Mod(e, 2), 1)) |
+        ((e <= -1) & (b > -1) & (b < 0) & Eq(Mod(e, 2), 1)))
+    )
+    A = Piecewise(
+        (1, Eq(b, 1) | Eq(e, 0) | (Eq(b, -1) & Eq(Mod(e, 2), 0))),
+        (0, Eq(b, 0) & (e > 0)),
+        (-1, Eq(b, -1) & Eq(Mod(e, 2), 1)),
+        (C, Eq(im(b), 0) & Eq(im(e), 0))
+    )
+
+
     B = piecewise_fold(A)
     sa = A.simplify()
     sb = B.simplify()
-    v = Tuple(-2, -1, -0.5, 0, 0.5, 1, 2)
+    v = tuple([-2, -1, -S.Half, 0, S.Half, 1, 2])
     for i in v:
         for j in v:
             r = {b:i, e:j}

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1342,7 +1342,6 @@ def test_issue_14787():
 
 def test_issue_21481():
     b, e = symbols('b e')
-
     C = Piecewise(
         (2,
         ((b > 1) & (e > 0)) |
@@ -1368,11 +1367,10 @@ def test_issue_21481():
         (C, Eq(im(b), 0) & Eq(im(e), 0))
     )
 
-
     B = piecewise_fold(A)
     sa = A.simplify()
     sb = B.simplify()
-    v = tuple([-2, -1, -S.Half, 0, S.Half, 1, 2])
+    v = (-2, -1, -S.Half, 0, S.Half, 1, 2)
     for i in v:
         for j in v:
             r = {b:i, e:j}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21481

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
