### PR TITLE
maint(ci): don't test git versions of dependencies

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -188,12 +188,6 @@ jobs:
       - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
       - run: python -m pip install --upgrade pip wheel setuptools
 
-      # Use various libs from git for Python 3.11
-      - if: ${{ contains(matrix.python-version, '3.11') }}
-        run: pip install git+https://github.com/cython/cython@master
-      - if: ${{ contains(matrix.python-version, '3.11') }}
-        run: pip install git+https://github.com/scipy/scipy@main
-
       # dependencies to install in all Python versions:
       - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
                          aesara wurlitzer autowrap                            \
@@ -201,11 +195,7 @@ jobs:
 
       # These are not available for pypy
       - if: ${{ ! contains(matrix.python-version, 'pypy') }}
-        run: pip install gmpy2 jax jaxlib
-
-      # These are not available for pypy and cannot be installed in 3.11 (yet)
-      - if: ${{ ! contains(matrix.python-version, 'pypy') && ! contains(matrix.python-version, '3.11') }}
-        run: pip install symengine llvmlite numba pymc
+        run: pip install gmpy2 jax jaxlib symengine llvmlite numba pymc
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -185,7 +185,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Install the non-Python dependencies
-      - run: sudo apt install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev
       - run: python -m pip install --upgrade pip wheel setuptools
 
       # dependencies to install in all Python versions:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -193,9 +193,13 @@ jobs:
                          aesara wurlitzer autowrap                            \
                          'antlr4-python3-runtime==4.11.*'
 
+      # Not available in pypy or cpython 3.11 (yet).
+      - if: ${{ ! contains(matrix.python-version, 'pypy') && ! contains(matrix.python-version, '3.11') }}
+        run: pip install llvmlite numba
+
       # These are not available for pypy
       - if: ${{ ! contains(matrix.python-version, 'pypy') }}
-        run: pip install gmpy2 jax jaxlib symengine llvmlite numba pymc
+        run: pip install gmpy2 jax jaxlib symengine pymc
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/doc/aptinstall.sh
+++ b/doc/aptinstall.sh
@@ -12,8 +12,8 @@
 
 set -o errexit
 
-sudo apt update
-sudo apt install\
+sudo apt-get update
+sudo apt-get install\
   texlive-latex-recommended\
   texlive-fonts-recommended\
   texlive-fonts-extra\


### PR DESCRIPTION
When CPython 3.11 was added to the test matrix it used git versions of dependencies like scipy because they otherwise did not build on 3.11. Now it should be possible to just use the latest public release.

Probably it is a good idea to add a 3.12 job.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
