### PR TITLE
Tensor module: add matches methods for TensAdd, TensMul, and Tensor

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2401,8 +2401,8 @@ class TensExpr(Expr, ABC):
 
         #Since canon_bp may be expensive, we first check for exact equality.
         diff = self - expr
-        if (diff == 0 or
-            diff.canon_bp() == 0
+        if (diff == S.Zero or
+            diff.canon_bp() == S.Zero
             ):
             return repl_dict
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4106,6 +4106,8 @@ class TensMul(TensExpr, AssocOp):
 
         if repl_dict is None:
             repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
 
         # handle simple patterns
         if self == expr:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4304,10 +4304,9 @@ class TensMul(TensExpr, AssocOp):
             matched_this = []
             for e in expr_sifted["Tensor"]:
                 m = q_tensor.matches(e)
-                if m is not None:
-                    matched_this.append((e,m))
+                if m is None:
+                    continue
 
-            for e,m in matched_this:
                 rem_query = self.func(*[a for a in self.args if a != q_tensor]).doit()
                 rem_expr = expr.func(*[a for a in expr.args if a != e]).doit()
                 tmp_repl = dict()

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4202,7 +4202,7 @@ class TensMul(TensExpr, AssocOp):
             temp_repl.update(m)
 
         from sympy import Wild, WildFunction
-        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, (WildTensor, WildTensorIndex, Wild, WildFunction))])
+        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, (WildTensor, WildTensorIndex, Wild, WildFunction, WildTensorHead))])
         repl_dict.update(temp_repl)
         return repl_dict
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4102,6 +4102,11 @@ class TensMul(TensExpr, AssocOp):
         Match assuming all tensors commute. But note that we are not assuming anything about their symmetry under index permutations.
         """
 
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
         if isinstance(self, TensExpr) and not isinstance(expr, TensExpr):
             return None
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4108,11 +4108,10 @@ class TensMul(TensExpr, AssocOp):
         else:
             repl_dict = repl_dict.copy()
 
-        if isinstance(self, TensExpr) and not isinstance(expr, TensExpr):
-            return None
-
         #Take care of the various possible types for expr.
-        if isinstance(expr, Tensor):
+        if not not isinstance(expr, TensExpr):
+            return None
+        elif isinstance(expr, Tensor):
             expr = TensMul(expr)
         elif isinstance(expr, TensAdd):
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4120,7 +4120,7 @@ class TensMul(TensExpr, AssocOp):
             """
             Replaces all internally contracted indices in tensmul by WildTensorIndex instances.
             """
-            dummy = [i for i in tensmul.get_indices() if i not in tensmul.get_free_indices() and isinstance(i,TensorIndex) and not isinstance(i,WildTensorIndex)]
+            dummy = [i for i in tensmul.get_indices() if i not in tensmul.get_free_indices() and not isinstance(i,WildTensorIndex)]
             dummies_to_wilds = {}
             for i in dummy:
                 if -i not in dummies_to_wilds.keys():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4215,7 +4215,7 @@ class TensMul(TensExpr, AssocOp):
             return None
 
         #Try to match the non-tensorial coefficient
-        m = self.coeff.matches(expr.coeff)
+        m = self.coeff.matches(expr.coeff, old=old)
         if m is None:
             return None
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2985,6 +2985,41 @@ class Tensor(TensExpr):
                 indices.append(index)
         return self.head(*indices)
 
+    def matches(self, expr, repl_dict=None, old=False):
+        expr = sympify(expr)
+
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
+        #simple checks
+        if self == expr:
+            return repl_dict
+        if not isinstance(expr, Tensor):
+            return None
+        if self.head != expr.head:
+            return None
+
+        s_indices = self.get_indices()
+        e_indices = expr.get_indices()
+
+        if len(s_indices) != len(e_indices):
+            return None
+
+        for i in range(len(s_indices)):
+            s_ind = s_indices[i]
+            m = s_ind.matches(e_indices[i])
+            if (
+                (m is None)
+                or (-s_ind in repl_dict.keys() and -repl_dict[-s_ind] != m[s_ind])
+                ):
+                return None
+            else:
+                repl_dict.update(m)
+
+        return repl_dict
+
     def __call__(self, *indices):
         deprecate_call()
         free_args = self.free_args

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4146,8 +4146,12 @@ class TensMul(TensExpr, AssocOp):
                     all_indices_match=True
                     d = {}
                     for i in range(len(q_tensor.indices)):
-                        m = q_tensor.indices[i].matches(e_tensor.indices[i])
-                        if m is None:
+                        q_ind = q_tensor.indices[i]
+                        m = q_ind.matches(e_tensor.indices[i])
+                        if (
+                            (m is None)
+                            or (-q_ind in temp_repl.keys() and -temp_repl[-q_ind] != m[q_ind])
+                            ):
                             all_indices_match = False
                             break
                         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4121,7 +4121,7 @@ class TensMul(TensExpr, AssocOp):
 
         free = set(self.get_free_indices())
         query_sifted = sift(self.args, siftkey)
-        expr_sifted = sift(self.args, siftkey)
+        expr_sifted = sift(expr.args, siftkey)
 
         query_sifted["Tensor"] = sift(query_sifted["Tensor"], lambda x: x.component)
         expr_sifted["Tensor"] = sift(expr_sifted["Tensor"], lambda x: x.component)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4268,14 +4268,11 @@ class TensMul(TensExpr, AssocOp):
             return None
         #The code that follows assumes expr is a TensMul
 
-        def get_wilds(expr):
-            return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) ]
-
         # handle simple patterns
         if self == expr:
             return repl_dict
 
-        if len(get_wilds(self)) == 0:
+        if len(_get_wilds(self)) == 0:
             return self._matches_simple(expr, repl_dict, old)
 
         def siftkey(arg):
@@ -5155,6 +5152,10 @@ def _expand(expr, **kwargs):
         return expr._expand(**kwargs)
     else:
         return expr.expand(**kwargs)
+
+
+def _get_wilds(expr):
+    return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) ]
 
 
 def get_postprocessor(cls):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3120,9 +3120,6 @@ class Tensor(TensExpr):
         return new_perms
 
     def matches(self, expr, repl_dict=None, old=False):
-        """
-        TODO: A problem with moving the symmetry matching here is that TensMul._matches_commutative now sometimes fails if q_tensor is initially matched in such a way that dummies are broken.
-        """
         expr = sympify(expr)
 
         if repl_dict is None:
@@ -3134,7 +3131,6 @@ class Tensor(TensExpr):
         if self == expr:
             return repl_dict
         if not isinstance(expr, Tensor):
-            #TODO: This might be a problem if the tensor gained a minus sign due to a symmetry. But I guess that should be handled in TensMul.matches.
             return None
         if self.head != expr.head:
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4111,10 +4111,6 @@ class TensMul(TensExpr, AssocOp):
         if isinstance(self, TensExpr) and not isinstance(expr, TensExpr):
             return None
 
-        # handle simple patterns
-        if self == expr:
-            return repl_dict
-
         #Take care of the various possible types for expr.
         if isinstance(expr, Tensor):
             expr = TensMul(expr)
@@ -4122,15 +4118,20 @@ class TensMul(TensExpr, AssocOp):
             return None
         #The code that follows assumes expr is a TensMul
 
-        #If there are no Wilds in self, we can depend on canon_bp to tell us whether self and expr are equivalent.
         def get_nondummy_wilds(expr):
             dummy_indices = set(expr.get_indices()) - set(expr.get_free_indices())
             return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) if a not in dummy_indices ]
+
+        # handle simple patterns
+        if self == expr:
+            return repl_dict
 
         if len(get_nondummy_wilds(self)) == 0:
             if set(self.get_free_indices()) != set(expr.get_free_indices()):
                 #If there are no wilds and the free indices are not the same, they cannot match.
                 return None
+
+            #If there are no Wilds in self, we can depend on canon_bp to tell us whether self and expr are equivalent.
             diff = self.as_dummy() - expr.as_dummy()
             if diff == 0 or diff.canon_bp() == 0:
                 return repl_dict

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3507,8 +3507,7 @@ class TensMul(TensExpr, AssocOp):
                     dummy_name = dummy_name_gen(index_type)
                     if dummy_name not in free_names:
                         break
-                #We use WildTensorIndex below so that, e.g. K(p)*V(-p) will match V(-p)*K(p). Otherwise, a lot of hackery is needed in TensMul.matches().
-                dummy = WildTensorIndex(dummy_name, index_type, is_up=True, ignore_updown=True)
+                dummy = old_index.func(dummy_name, index_type, *old_index.args[2:])
                 replacements[pos1cov][old_index] = dummy
                 replacements[pos1contra][-old_index] = -dummy
                 indices[pos2cov] = dummy

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4165,7 +4165,7 @@ class TensMul(TensExpr, AssocOp):
                 return None
 
             #If there are no Wilds in self, we can depend on canon_bp to tell us whether self and expr are equivalent.
-            diff = self.as_dummy() - expr.as_dummy()
+            diff = self.doit() - expr.doit()
             if diff == 0 or diff.canon_bp() == 0:
                 return repl_dict
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3362,7 +3362,8 @@ class TensMul(TensExpr, AssocOp):
                     dummy_name = dummy_name_gen(index_type)
                     if dummy_name not in free_names:
                         break
-                dummy = TensorIndex(dummy_name, index_type, True)
+                #We use WildTensorIndex below so that, e.g. K(p)*V(-p) will match V(-p)*K(p). Otherwise, a lot of hackery is needed in TensMul.matches().
+                dummy = WildTensorIndex(dummy_name, index_type, is_up=True, ignore_updown=True)
                 replacements[pos1cov][old_index] = dummy
                 replacements[pos1contra][-old_index] = -dummy
                 indices[pos2cov] = dummy

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4185,16 +4185,15 @@ class TensMul(TensExpr, AssocOp):
 
         tensors_matched = TensMul(*temp_repl.values()).atoms(Tensor)
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in tensors_matched]
-        if len(remaining_e_tensors) > 0:
-            if len(indexless_wilds) > 0:
-                #If there are any remaining tensors, match them with the indexless WildTensor
-                m =  indexless_wilds[0].matches( TensMul(*remaining_e_tensors).doit() )
-                if m is None:
-                    return None
-                else:
-                    temp_repl.update(m)
-            else:
+        if len(indexless_wilds) > 0:
+            #If there are any remaining tensors, match them with the indexless WildTensor
+            m =  indexless_wilds[0].matches( TensMul(1,*remaining_e_tensors).doit() )
+            if m is None:
                 return None
+            else:
+                temp_repl.update(m)
+        elif len(remaining_e_tensors) > 0:
+            return None
 
         m = self.coeff.matches(expr.coeff)
         if m is None:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4310,14 +4310,18 @@ class TensMul(TensExpr, AssocOp):
             for e,m in matched_this:
                 rem_query = self.func(*[a for a in self.args if a != q_tensor]).doit()
                 rem_expr = expr.func(*[a for a in expr.args if a != e]).doit()
-                rem_m = rem_query.matches(rem_expr, repl_dict=m)
+                tmp_repl = dict()
+                tmp_repl.update(repl_dict)
+                tmp_repl.update(m)
+                rem_m = rem_query.matches(rem_expr, repl_dict=tmp_repl)
                 if rem_m is not None:
                     #Check that contracted indices are not mapped to different indices.
                     internally_consistent = True
                     for k in rem_m.keys():
-                        if isinstance(k,TensorIndex) and -k in rem_m.keys() and rem_m[-k] != -rem_m[k]:
-                            internally_consistent = False
-                            break
+                        if isinstance(k,TensorIndex):
+                            if -k in rem_m.keys() and rem_m[-k] != -rem_m[k]:
+                                internally_consistent = False
+                                break
                     if internally_consistent:
                         repl_dict.update(rem_m)
                         return repl_dict

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4318,6 +4318,9 @@ class TensMul(TensExpr, AssocOp):
             return None
         #The code that follows assumes expr is a TensMul
 
+        #Find the non-tensor part of expr. This need not be the same as expr.coeff when expr.doit() has not been called.
+        expr_coeff = reduce(lambda a, b: a*b, [arg for arg in expr.args if not isinstance(arg, TensExpr)], S.One)
+
         # handle simple patterns
         if self == expr:
             return repl_dict
@@ -4341,7 +4344,7 @@ class TensMul(TensExpr, AssocOp):
             if TensMul(*query_sifted["coeff"]).doit() != self.coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {query_sifted['coeff']}")
         if "coeff" in expr_sifted.keys():
-            if TensMul(*expr_sifted["coeff"]).doit() != expr.coeff:
+            if TensMul(*expr_sifted["coeff"]).doit() != expr_coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
 
         query_tens_heads = set(tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]) #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
@@ -4430,7 +4433,7 @@ class TensMul(TensExpr, AssocOp):
             return None
 
         #Try to match the non-tensorial coefficient
-        m = self.coeff.matches(expr.coeff, old=old)
+        m = self.coeff.matches(expr_coeff, old=old)
         if m is None:
             return None
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4371,7 +4371,7 @@ class TensMul(TensExpr, AssocOp):
                     if m is None:
                         continue
 
-                    rem_query = sign*self.func(*[a for a in self.args if a != q_tensor]).doit(deep=False)
+                    rem_query = self.func(sign, *[a for a in self.args if a != q_tensor]).doit(deep=False)
                     rem_expr = expr.func(*[a for a in expr.args if a != e]).doit(deep=False)
                     tmp_repl = {}
                     tmp_repl.update(repl_dict)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3097,6 +3097,28 @@ class Tensor(TensExpr):
                 indices.append(index)
         return self.head(*indices)
 
+    def _get_symmetrized_forms(self):
+        """
+        Return a list giving all possible permutations of self that are allowed by its symmetries.
+        """
+        comp = self.component
+        gens = comp.symmetry.generators
+        rank = comp.rank
+
+        old_perms = None
+        new_perms = set([self])
+        while new_perms != old_perms:
+            old_perms = new_perms.copy()
+            for tens in old_perms:
+                for gen in gens:
+                    inds = tens.get_indices()
+                    per = [gen.apply(i) for i in range(0,rank)]
+                    sign = (-1)**(gen.apply(rank) - rank)
+                    ind_map = { k:v for k,v in zip(inds, [inds[i] for i in per]) }
+                    new_perms.add( sign * tens._replace_indices(ind_map) )
+
+        return new_perms
+
     def matches(self, expr, repl_dict=None, old=False):
         expr = sympify(expr)
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4099,7 +4099,7 @@ class TensMul(TensExpr, AssocOp):
 
     def _matches_commutative(self, expr, repl_dict=None, old=False):
         """
-        Match assuming all tensors commute.
+        Match assuming all tensors commute. But note that we are not assuming anything about their symmetry under index permutations.
         """
 
         if isinstance(self, TensExpr) and not isinstance(expr, TensExpr):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2813,10 +2813,9 @@ class TensAdd(TensExpr, AssocOp):
                 m = w.matches(e)
                 if m is not None:
                     matched_e_tensors.append(e)
-                    if w in repl_dict.keys():
-                        repl_dict[w] += m.pop(w)
+                    if w.component in repl_dict.keys():
+                        repl_dict[w.component] += m.pop(w.component)
                     repl_dict.update(m)
-                    break
 
         remaining_e_tensors = [t for t in expr_sifted["nonwild"] if t not in matched_e_tensors]
         for w in query_sifted["indexless_wildtensor"]:
@@ -2824,10 +2823,9 @@ class TensAdd(TensExpr, AssocOp):
                 m = w.matches(e)
                 if m is not None:
                     matched_e_tensors.append(e)
-                    if w in repl_dict.keys():
-                        repl_dict[w] += m.pop(w)
+                    if w.component in repl_dict.keys():
+                        repl_dict[w.component] += m.pop(w.component)
                     repl_dict.update(m)
-                    break
 
         remaining_e_tensors = [t for t in expr_sifted["nonwild"] if t not in matched_e_tensors]
         if len(remaining_e_tensors) > 0:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4133,7 +4133,6 @@ class TensMul(TensExpr, AssocOp):
         return
 
     def matches(self, expr, repl_dict=None, old=False):
-        print(f"({self})._matches({expr}) called") #debug
         expr = sympify(expr)
 
         return self._matches_commutative(expr, repl_dict, old)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4167,9 +4167,10 @@ class TensMul(TensExpr, AssocOp):
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in temp_repl.values()]
         indexless_wilds, wilds = sift(query_sifted["WildTensor"], lambda x: len(x.get_free_indices()) == 0, binary=True)
         for w in wilds:
-            free_this_wild = set(w.get_free_indices()).intersection(free)
+            free_this_wild = set(w.get_free_indices())
+            tensors_to_try = [t for t in remaining_e_tensors if set(t.get_free_indices()).issubset(free_this_wild) ]
 
-            m = w.matches(TensMul(*remaining_e_tensors).doit() )
+            m = w.matches(TensMul(*tensors_to_try).doit() )
             if m is None:
                 return None
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4109,7 +4109,7 @@ class TensMul(TensExpr, AssocOp):
             repl_dict = repl_dict.copy()
 
         #Take care of the various possible types for expr.
-        if not not isinstance(expr, TensExpr):
+        if not isinstance(expr, TensExpr):
             return None
         elif isinstance(expr, Tensor):
             expr = TensMul(expr)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4181,7 +4181,7 @@ class TensMul(TensExpr, AssocOp):
         if len(remaining_e_tensors) > 0:
             if len(indexless_wilds) > 0:
                 #If there are any remaining tensors, match them with the indexless WildTensor
-                temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors)
+                temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors).doit()
             else:
                 return None
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -38,15 +38,16 @@ from abc import abstractmethod, ABC
 from collections import defaultdict
 import operator
 import itertools
-from sympy.core import Wild, WildFunction
+
 from sympy.core.numbers import (Integer, Rational)
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
 from sympy.core.containers import Tuple, Dict
+from sympy.core.function import WildFunction
 from sympy.core.sorting import default_sort_key
-from sympy.core.symbol import Symbol, symbols
+from sympy.core.symbol import Symbol, symbols, Wild
 from sympy.core.sympify import CantSympify, _sympify
 from sympy.core.operations import AssocOp
 from sympy.external.gmpy import SYMPY_INTS

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4114,6 +4114,13 @@ class TensMul(TensExpr, AssocOp):
         if self == expr:
             return repl_dict
 
+        #Take care of the various possible types for expr.
+        if isinstance(expr, Tensor):
+            expr = TensMul(expr)
+        elif isinstance(expr, TensAdd):
+            return None
+        #The code that follows assumes expr is a TensMul
+
         query_wild_tensor_indices = self.atoms(WildTensorIndex)
         free = set(self.get_free_indices())
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4142,11 +4142,19 @@ class TensMul(TensExpr, AssocOp):
                 return "WildTensor"
             elif isinstance(arg, Tensor):
                 return "Tensor"
+            elif isinstance(arg, TensExpr):
+                return "TensExpr"
             else:
                 return "coeff"
 
         query_sifted = sift(self.args, siftkey)
         expr_sifted = sift(expr.args, siftkey)
+
+        #Sanity checks
+        if "TensExpr" in query_sifted.keys():
+            raise NotImplementedError(f"Found a TensExpr that we do not know to handle: {query_sifted['TensExpr']}")
+        if "TensExpr" in expr_sifted.keys():
+            raise NotImplementedError(f"Found a TensExpr that we do not know to handle: {expr_sifted['TensExpr']}")
 
         query_tens_heads = set(x.head for x in query_sifted["Tensor"])
         expr_tens_heads = set(x.head for x in expr_sifted["Tensor"])

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2399,9 +2399,12 @@ class TensExpr(Expr, ABC):
                 #If there are no wilds and the free indices are not the same, they cannot match.
                 return None
 
-        #If there are no Wilds in self, we can depend on canon_bp to tell us whether self and expr are equivalent.
-        diff = self.doit().canon_bp() - expr.doit().canon_bp()
-        if diff == 0 or diff.canon_bp() == 0:
+        #Below, we try some cheaper things before trying doit, since the latter may be quite expensive.
+        diff = self - expr
+        if (diff == 0 or
+            diff.canon_bp() == 0 or
+            diff.doit().canon_bp() == 0
+            ):
             return repl_dict
         else:
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2399,11 +2399,7 @@ class TensExpr(Expr, ABC):
                 #If there are no wilds and the free indices are not the same, they cannot match.
                 return None
 
-        #Since canon_bp may be expensive, we first check for exact equality.
-        diff = self - expr
-        if (diff == S.Zero or
-            diff.canon_bp() == S.Zero
-            ):
+        if canon_bp(self - expr) == S.Zero:
             return repl_dict
         else:
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2403,8 +2403,8 @@ class TensExpr(Expr, ABC):
         diff = self - expr
         if (diff == 0 or
             diff.canon_bp() == 0 or
-            #TODO: We should try to avoid an indiscriminate doit, as it can slow things down a lot when, e.g., there is an Integral in diff.
-            diff.doit().canon_bp() == 0
+            #TODO: We should try to avoid an indiscriminate doit, as it can slow things down a lot when, e.g., there is an Integral in diff. Currently we just exclude integrals, but that feels somewhat hacky. The reason we need doit is because TensExpr and subclasses require it for relabelling dummy indices, collecting terms with common coeffs, and flattening.
+            diff.doit(integrals=False).canon_bp() == 0
             ):
             return repl_dict
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4344,8 +4344,8 @@ class TensMul(TensExpr, AssocOp):
             if TensMul(*expr_sifted["coeff"]).doit(deep=False) != expr_coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
 
-        query_tens_heads = set(tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]) #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
-        expr_tens_heads = set(tuple(getattr(x, "components", [])) for x in expr_sifted["Tensor"])
+        query_tens_heads = {tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]} #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
+        expr_tens_heads = {tuple(getattr(x, "components", [])) for x in expr_sifted["Tensor"]}
         if not query_tens_heads.issubset(expr_tens_heads):
             #Some tensorheads in self are not present in the expr
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4342,10 +4342,10 @@ class TensMul(TensExpr, AssocOp):
 
         #Sanity checks
         if "coeff" in query_sifted.keys():
-            if TensMul(*query_sifted["coeff"]).doit() != self.coeff:
+            if TensMul(*query_sifted["coeff"]).doit(deep=False) != self.coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {query_sifted['coeff']}")
         if "coeff" in expr_sifted.keys():
-            if TensMul(*expr_sifted["coeff"]).doit() != expr_coeff:
+            if TensMul(*expr_sifted["coeff"]).doit(deep=False) != expr_coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
 
         query_tens_heads = set(tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]) #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
@@ -4375,8 +4375,8 @@ class TensMul(TensExpr, AssocOp):
                     if m is None:
                         continue
 
-                    rem_query = sign*self.func(*[a for a in self.args if a != q_tensor]).doit()
-                    rem_expr = expr.func(*[a for a in expr.args if a != e]).doit()
+                    rem_query = sign*self.func(*[a for a in self.args if a != q_tensor]).doit(deep=False)
+                    rem_expr = expr.func(*[a for a in expr.args if a != e]).doit(deep=False)
                     tmp_repl = dict()
                     tmp_repl.update(repl_dict)
                     tmp_repl.update(m)
@@ -4413,7 +4413,7 @@ class TensMul(TensExpr, AssocOp):
                 if shares_indices_with_wild:
                     tensors_to_try.append(t)
 
-            m = w.matches(TensMul(*tensors_to_try).doit() )
+            m = w.matches(TensMul(*tensors_to_try).doit(deep=False) )
             if m is None:
                 return None
             else:
@@ -4425,7 +4425,7 @@ class TensMul(TensExpr, AssocOp):
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in matched_e_tensors]
         if len(indexless_wilds) > 0:
             #If there are any remaining tensors, match them with the indexless WildTensor
-            m =  indexless_wilds[0].matches( TensMul(1,*remaining_e_tensors).doit() )
+            m =  indexless_wilds[0].matches( TensMul(1,*remaining_e_tensors).doit(deep=False) )
             if m is None:
                 return None
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4154,7 +4154,7 @@ class TensMul(TensExpr, AssocOp):
             #Some tensorheads in self are not present in the expr
             return None
 
-        #Try to match all non-wild tensors of the query with tensors that compose the expression
+        #Try to match all non-wild tensors of self with tensors that compose expr
         matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in the query.
         for q_tensor in query_sifted["Tensor"]:
             matched_this_q = False

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4373,7 +4373,7 @@ class TensMul(TensExpr, AssocOp):
 
                     rem_query = sign*self.func(*[a for a in self.args if a != q_tensor]).doit(deep=False)
                     rem_expr = expr.func(*[a for a in expr.args if a != e]).doit(deep=False)
-                    tmp_repl = dict()
+                    tmp_repl = {}
                     tmp_repl.update(repl_dict)
                     tmp_repl.update(m)
                     rem_m = rem_query.matches(rem_expr, repl_dict=tmp_repl)
@@ -4403,7 +4403,7 @@ class TensMul(TensExpr, AssocOp):
                 free = t.get_free_indices()
                 shares_indices_with_wild = True
                 for i in free:
-                    if all([j.matches(i) is None for j in free_this_wild]):
+                    if all(j.matches(i) is None for j in free_this_wild):
                         #The index i matches none of the indices in free_this_wild
                         shares_indices_with_wild = False
                 if shares_indices_with_wild:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4446,7 +4446,7 @@ class TensMul(TensExpr, AssocOp):
         else:
             repl_dict = repl_dict.copy()
 
-        commute = all([arg.component.comm == 0 for arg in expr.args if isinstance(arg, Tensor)])
+        commute = all(arg.component.comm == 0 for arg in expr.args if isinstance(arg, Tensor))
         if commute:
             return self._matches_commutative(expr, repl_dict, old)
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2393,6 +2393,7 @@ class TensExpr(Expr, ABC):
 
         if not isinstance(expr, TensExpr):
             if len(self.get_free_indices()) > 0:
+                #self has indices, but expr does not.
                 return None
         else:
             if set(self.get_free_indices()) != set(expr.get_free_indices()):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3138,11 +3138,11 @@ class Tensor(TensExpr):
         #Now consider all index symmetries of expr, and see if any of them allow a match.
         for new_expr in expr._get_symmetrized_forms():
             m = self._matches(new_expr, repl_dict, old=old)
-            if m is None:
-                return None
-            else:
+            if m is not None:
                 repl_dict.update(m)
                 return repl_dict
+
+        return None
 
     def _matches(self, expr, repl_dict=None, old=False):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4135,7 +4135,7 @@ class TensMul(TensExpr, AssocOp):
         query_tens_sift_heads = sift(query_sifted["Tensor"], lambda x: x.component)
         expr_tens_sift_heads = sift(expr_sifted["Tensor"], lambda x: x.component)
 
-        #First check which tensors are the same in both query and expression
+        #Try to match all non-wild tensors of the query with tensors that compose the expression
         matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in the query.
         for head in query_tens_sift_heads.keys():
             if head not in expr_tens_sift_heads.keys():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4144,13 +4144,14 @@ class TensMul(TensExpr, AssocOp):
         for w in wilds:
             free_this_wild = set(w.get_free_indices()).intersection(free)
 
-            m = w.matches(TensMul(*[e for e in remaining_e_tensors if len(free_this_wild) == 0 or len( set(e.get_free_indices()).intersection(free_this_wild) ) != 0]).doit() )
+            m = w.matches(TensMul(*remaining_e_tensors).doit() )
             if m is None:
                 return None
             else:
                 temp_repl.update(m)
 
-        remaining_e_tensors = [t for t in itertools.chain(*expr_sifted["Tensor"].values()) if t not in temp_repl.values()]
+        tensors_matched = TensMul(*temp_repl.values()).atoms(Tensor)
+        remaining_e_tensors = [t for t in itertools.chain(*expr_sifted["Tensor"].values()) if t not in tensors_matched]
         if len(remaining_e_tensors) > 0:
             if len(indexless_wilds) > 0:
                 #If there are any remaining tensors, match them with the indexless WildTensor

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4142,7 +4142,7 @@ class TensMul(TensExpr, AssocOp):
         for w in wilds:
             free_this_wild = set(w.get_free_indices()).intersection(free)
 
-            m = w.matches(TensMul(*[e for e in remaining_e_tensors if len( set(e.get_free_indices()).intersection(free_this_wild) ) != 0]))
+            m = w.matches(TensMul(*[e for e in remaining_e_tensors if len(free_this_wild) == 0 or len( set(e.get_free_indices()).intersection(free_this_wild) ) != 0]).doit() )
             if m is None:
                 return None
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4120,7 +4120,7 @@ class TensMul(TensExpr, AssocOp):
             """
             Replaces all internally contracted indices in tensmul by WildTensorIndex instances.
             """
-            dummy = [i for i in tensmul.get_indices() if i not in tensmul.get_free_indices()]
+            dummy = [i for i in tensmul.get_indices() if i not in tensmul.get_free_indices() and isinstance(i,TensorIndex) and not isinstance(i,WildTensorIndex)]
             dummies_to_wilds = {}
             for i in dummy:
                 if -i not in dummies_to_wilds.keys():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2403,6 +2403,7 @@ class TensExpr(Expr, ABC):
         diff = self - expr
         if (diff == 0 or
             diff.canon_bp() == 0 or
+            #TODO: We should try to avoid an indiscriminate doit, as it can slow things down a lot when, e.g., there is an Integral in diff.
             diff.doit().canon_bp() == 0
             ):
             return repl_dict

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4162,6 +4162,7 @@ class TensMul(TensExpr, AssocOp):
         if m is not None:
             temp_repl.update(m)
 
+        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, WildTensor)])
         repl_dict.update(temp_repl)
         return repl_dict
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4117,26 +4117,6 @@ class TensMul(TensExpr, AssocOp):
         query_wild_tensor_indices = self.atoms(WildTensorIndex)
         free = set(self.get_free_indices())
 
-        def wildify_dummies(tensmul, map=False):
-            """
-            Replaces all internally contracted indices in tensmul by WildTensorIndex instances.
-            """
-            dummy = [i for i in tensmul.get_indices() if i not in tensmul.get_free_indices() and not isinstance(i,WildTensorIndex)]
-            dummies_to_wilds = {}
-            for i in dummy:
-                if -i not in dummies_to_wilds.keys():
-                    dummies_to_wilds[i] = WildTensorIndex(True, i.tensor_index_type, is_up=i.is_up, ignore_updown=True)
-                else:
-                    #Preserve the fact that this index is contracted with another one.
-                    dummies_to_wilds[i] = -dummies_to_wilds[-i]
-
-            ret = tensmul.subs(dummies_to_wilds)
-            if map:
-                return ret, dummies_to_wilds
-            else:
-                return ret
-
-        self, dummies_to_wilds = wildify_dummies(self, map=True)
 
         def siftkey(arg):
             if isinstance(arg, WildTensor):
@@ -4201,8 +4181,7 @@ class TensMul(TensExpr, AssocOp):
         else:
             temp_repl.update(m)
 
-        wilds_to_dummies = {v:k for k,v in dummies_to_wilds.items()}
-        temp_repl = dict([(k.subs(wilds_to_dummies),v) for k,v in temp_repl.items() if isinstance(k, WildTensor) or k in query_wild_tensor_indices])
+        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, (WildTensor, WildTensorIndex))])
         repl_dict.update(temp_repl)
         return repl_dict
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4126,7 +4126,6 @@ class TensMul(TensExpr, AssocOp):
                 for w in reversed(wild_part):
                     d1 = w.matches(last_op, repl_dict)
                     if d1 is not None:
-                        print(f"{d1 = }")
                         d2 = self.xreplace(d1).matches(expr, d1)
                         if d2 is not None:
                             return d2

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4160,7 +4160,9 @@ class TensMul(TensExpr, AssocOp):
                 return None
 
         m = self.coeff.matches(expr.coeff)
-        if m is not None:
+        if m is None:
+            return None
+        else:
             temp_repl.update(m)
 
         temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, WildTensor)])

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4312,10 +4312,11 @@ class TensMul(TensExpr, AssocOp):
             repl_dict = repl_dict.copy()
 
         #Take care of the various possible types for expr.
-        if isinstance(expr, Tensor):
-            expr = TensMul(expr)
-        elif not isinstance(expr, TensMul):
-            return None
+        if not isinstance(expr, TensMul):
+            if isinstance(expr, (TensExpr, Expr)):
+                expr = TensMul(expr)
+            else:
+                return None
         #The code that follows assumes expr is a TensMul
 
         #Find the non-tensor part of expr. This need not be the same as expr.coeff when expr.doit() has not been called.

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4181,7 +4181,11 @@ class TensMul(TensExpr, AssocOp):
         if len(remaining_e_tensors) > 0:
             if len(indexless_wilds) > 0:
                 #If there are any remaining tensors, match them with the indexless WildTensor
-                temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors).doit()
+                m =  indexless_wilds[0].matches( TensMul(*remaining_e_tensors).doit() )
+                if m is None:
+                    return None
+                else:
+                    temp_repl.update(m)
             else:
                 return None
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4135,6 +4135,7 @@ class TensMul(TensExpr, AssocOp):
         query_tens_sift_heads = sift(query_sifted["Tensor"], lambda x: x.component)
         expr_tens_sift_heads = sift(expr_sifted["Tensor"], lambda x: x.component)
 
+        #First check which tensors are the same in both query and expression
         matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in the query.
         for head in query_tens_sift_heads.keys():
             if head not in expr_tens_sift_heads.keys():
@@ -4168,6 +4169,7 @@ class TensMul(TensExpr, AssocOp):
                 if not matched_this_q:
                     return None
 
+        #Try to match WildTensor instances which have indices
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in matched_e_tensors]
         indexless_wilds, wilds = sift(query_sifted["WildTensor"], lambda x: len(x.get_free_indices()) == 0, binary=True)
         for w in wilds:
@@ -4180,6 +4182,7 @@ class TensMul(TensExpr, AssocOp):
             else:
                 repl_dict.update(m)
 
+        #Try to match indexless WildTensor instances
         tensors_matched = TensMul(*[repl_dict[w.component] for w in wilds], *matched_e_tensors).atoms(Tensor)
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in tensors_matched]
         if len(indexless_wilds) > 0:
@@ -4192,6 +4195,7 @@ class TensMul(TensExpr, AssocOp):
         elif len(remaining_e_tensors) > 0:
             return None
 
+        #Try to match the non-tensorial coefficient
         m = self.coeff.matches(expr.coeff)
         if m is None:
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2395,8 +2395,7 @@ class TensExpr(Expr, ABC):
             if len(self.get_free_indices()) > 0:
                 #self has indices, but expr does not.
                 return None
-        else:
-            if set(self.get_free_indices()) != set(expr.get_free_indices()):
+        elif set(self.get_free_indices()) != set(expr.get_free_indices()):
                 #If there are no wilds and the free indices are not the same, they cannot match.
                 return None
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3135,6 +3135,34 @@ class Tensor(TensExpr):
         if self.head != expr.head:
             return None
 
+        #Now consider all index symmetries of expr, and see if any of them allow a match.
+        for new_expr in expr._get_symmetrized_forms():
+            m = self._matches(new_expr, repl_dict, old=old)
+            if m is None:
+                return None
+            else:
+                repl_dict.update(m)
+                return repl_dict
+
+    def _matches(self, expr, repl_dict=None, old=False):
+        """
+        This does not account for index symmetries of expr
+        """
+        expr = sympify(expr)
+
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
+        #simple checks
+        if self == expr:
+            return repl_dict
+        if not isinstance(expr, Tensor):
+            return None
+        if self.head != expr.head:
+            return None
+
         s_indices = self.get_indices()
         e_indices = expr.get_indices()
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4268,15 +4268,14 @@ class TensMul(TensExpr, AssocOp):
             return None
         #The code that follows assumes expr is a TensMul
 
-        def get_nondummy_wilds(expr):
-            dummy_indices = set(expr.get_indices()) - set(expr.get_free_indices())
-            return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) if a not in dummy_indices ]
+        def get_wilds(expr):
+            return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) ]
 
         # handle simple patterns
         if self == expr:
             return repl_dict
 
-        if len(get_nondummy_wilds(self)) == 0:
+        if len(get_wilds(self)) == 0:
             return self._matches_simple(expr, repl_dict, old)
 
         def siftkey(arg):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4149,11 +4149,12 @@ class TensMul(TensExpr, AssocOp):
                 temp_repl.update(m)
 
         remaining_e_tensors = [t for t in itertools.chain(*expr_sifted["Tensor"].values()) if t not in temp_repl.values()]
-        if len(indexless_wilds) > 0:
-            #If there are any remaining tensors, match them with the indexless WildTensor
-            temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors)
-        else:
-            return None
+        if len(remaining_e_tensors) > 0:
+            if len(indexless_wilds) > 0:
+                #If there are any remaining tensors, match them with the indexless WildTensor
+                temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors)
+            else:
+                return None
 
         m = self.coeff.matches(expr.coeff)
         if m is not None:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -56,7 +56,6 @@ from sympy.utilities.exceptions import (sympy_deprecation_warning,
                                         ignore_warnings)
 from sympy.utilities.decorator import memoize_property, deprecated
 from sympy.utilities.iterables import sift
-import itertools
 
 
 def deprecate_data():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4335,28 +4335,6 @@ class TensMul(TensExpr, AssocOp):
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in matched_e_tensors]
         indexless_wilds, wilds = sift(query_sifted["WildTensor"], lambda x: len(x.get_free_indices()) == 0, binary=True)
 
-        def _eq(ind1, ind2):
-            """
-            ind1, ind2: either WildTensorIndex or TensorIndex
-
-            Check for equality of name and tensor_index_type. If neither of the two have ignore_updown=True, equality of is_up is also checked
-            """
-            if ind1.name != ind2.name:
-                return False
-            if ind1.tensor_index_type != ind2.tensor_index_type:
-                return False
-            if hasattr(ind2, "ignore_updown") and not hasattr(ind1, "ignore_updown"):
-                #Swap so that if only one index has this attribute, it is ind1
-                tmp = ind1
-                ind1 = ind2
-                ind2 = tmp
-            if hasattr(ind1, "ignore_updown"):
-                return True
-            if ind1.is_up == ind2.is_up:
-                return True
-            else:
-                return False
-
         for w in wilds:
             free_this_wild = set(w.get_free_indices())
             tensors_to_try = []
@@ -4364,7 +4342,7 @@ class TensMul(TensExpr, AssocOp):
                 free = t.get_free_indices()
                 shares_indices_with_wild = True
                 for i in free:
-                    if not any([_eq(i, j) for j in free_this_wild]):
+                    if all([j.matches(i) is None for j in free_this_wild]):
                         #The index i matches none of the indices in free_this_wild
                         shares_indices_with_wild = False
                 if shares_indices_with_wild:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3010,10 +3010,9 @@ class Tensor(TensExpr):
         for i in range(len(s_indices)):
             s_ind = s_indices[i]
             m = s_ind.matches(e_indices[i])
-            if (
-                (m is None)
-                or (-s_ind in repl_dict.keys() and -repl_dict[-s_ind] != m[s_ind])
-                ):
+            if m is None:
+                return None
+            elif -s_ind in repl_dict.keys() and -repl_dict[-s_ind] != m[s_ind]:
                 return None
             else:
                 repl_dict.update(m)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4187,7 +4187,7 @@ class TensMul(TensExpr, AssocOp):
         def siftkey(arg):
             if isinstance(arg, WildTensor):
                 return "WildTensor"
-            elif isinstance(arg, (Tensor, TensMul)):
+            elif isinstance(arg, (Tensor, TensExpr)):
                 return "Tensor"
             else:
                 return "coeff"
@@ -4203,8 +4203,8 @@ class TensMul(TensExpr, AssocOp):
             if TensMul(*expr_sifted["coeff"]).doit() != expr.coeff:
                 raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
 
-        query_tens_heads = set(tuple(x.components) for x in query_sifted["Tensor"])
-        expr_tens_heads = set(tuple(x.components) for x in expr_sifted["Tensor"])
+        query_tens_heads = set(tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]) #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
+        expr_tens_heads = set(tuple(getattr(x, "components", [])) for x in expr_sifted["Tensor"])
         if not query_tens_heads.issubset(expr_tens_heads):
             #Some tensorheads in self are not present in the expr
             return None

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2766,7 +2766,7 @@ class TensAdd(TensExpr, AssocOp):
             wildatom_types = sift(wildatoms, type)
             if len(wildatoms) == 0:
                 return "nonwild"
-            elif "WildTensor" in wildatom_types.keys():
+            elif WildTensor in wildatom_types.keys():
                 for w in wildatom_types["WildTensor"]:
                     if len(w.get_indices()) == 0:
                         return "indexless_wildtensor"

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4136,8 +4136,11 @@ class TensMul(TensExpr, AssocOp):
         for head in query_tens_sift_heads.keys():
             if head not in expr_tens_sift_heads.keys():
                 return None
+            matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in the query.
             for q_tensor in query_tens_sift_heads[head]:
                 for e_tensor in expr_tens_sift_heads[head]:
+                    if e_tensor in matched_e_tensors:
+                        continue
                     if len(q_tensor.indices) != len(e_tensor.indices):
                         continue
                     all_indices_match=True
@@ -4153,6 +4156,8 @@ class TensMul(TensExpr, AssocOp):
                     if all_indices_match:
                         temp_repl[q_tensor] = e_tensor
                         temp_repl.update(d)
+                        matched_e_tensors.append(e_tensor)
+                        break
                 if q_tensor not in temp_repl.keys():
                     return None
         remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in temp_repl.values()]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3175,7 +3175,6 @@ class Tensor(TensExpr):
             if m is None:
                 return None
             elif -s_ind in repl_dict.keys() and -repl_dict[-s_ind] != m[s_ind]:
-                #TODO: Might move all such dummy breakage tests to TensorIndex.matches.
                 return None
             else:
                 repl_dict.update(m)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3120,6 +3120,9 @@ class Tensor(TensExpr):
         return new_perms
 
     def matches(self, expr, repl_dict=None, old=False):
+        """
+        TODO: A problem with moving the symmetry matching here is that TensMul._matches_commutative now sometimes fails if q_tensor is initially matched in such a way that dummies are broken.
+        """
         expr = sympify(expr)
 
         if repl_dict is None:
@@ -3131,6 +3134,7 @@ class Tensor(TensExpr):
         if self == expr:
             return repl_dict
         if not isinstance(expr, Tensor):
+            #TODO: This might be a problem if the tensor gained a minus sign due to a symmetry. But I guess that should be handled in TensMul.matches.
             return None
         if self.head != expr.head:
             return None
@@ -3175,6 +3179,7 @@ class Tensor(TensExpr):
             if m is None:
                 return None
             elif -s_ind in repl_dict.keys() and -repl_dict[-s_ind] != m[s_ind]:
+                #TODO: Might move all such dummy breakage tests to TensorIndex.matches.
                 return None
             else:
                 repl_dict.update(m)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4105,11 +4105,6 @@ class TensMul(TensExpr, AssocOp):
         if isinstance(self, TensExpr) and not isinstance(expr, TensExpr):
             return None
 
-        if repl_dict is None:
-            repl_dict = {}
-        else:
-            repl_dict = repl_dict.copy()
-
         # handle simple patterns
         if self == expr:
             return repl_dict
@@ -4206,6 +4201,11 @@ class TensMul(TensExpr, AssocOp):
 
     def matches(self, expr, repl_dict=None, old=False):
         expr = sympify(expr)
+
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
 
         commute = all([arg.component.comm == 0 for arg in expr.args if isinstance(arg, Tensor)])
         if commute:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2399,12 +2399,10 @@ class TensExpr(Expr, ABC):
                 #If there are no wilds and the free indices are not the same, they cannot match.
                 return None
 
-        #Below, we try some cheaper things before trying doit, since the latter may be quite expensive.
+        #Since canon_bp may be expensive, we first check for exact equality.
         diff = self - expr
         if (diff == 0 or
-            diff.canon_bp() == 0 or
-            #TODO: We should try to avoid an indiscriminate doit, as it can slow things down a lot when, e.g., there is an Integral in diff. Currently we just exclude integrals, but that feels somewhat hacky. The reason we need doit is because TensExpr and subclasses require it for relabelling dummy indices, collecting terms with common coeffs, and flattening.
-            diff.doit(integrals=False).canon_bp() == 0
+            diff.canon_bp() == 0
             ):
             return repl_dict
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4121,10 +4121,6 @@ class TensMul(TensExpr, AssocOp):
             return None
         #The code that follows assumes expr is a TensMul
 
-        query_wild_tensor_indices = self.atoms(WildTensorIndex)
-        free = set(self.get_free_indices())
-
-
         def siftkey(arg):
             if isinstance(arg, WildTensor):
                 return "WildTensor"

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -55,6 +55,7 @@ from sympy.utilities.exceptions import (sympy_deprecation_warning,
                                         ignore_warnings)
 from sympy.utilities.decorator import memoize_property, deprecated
 from sympy.utilities.iterables import sift
+import itertools
 
 
 def deprecate_data():
@@ -4136,7 +4137,7 @@ class TensMul(TensExpr, AssocOp):
                         temp_repl[q_tensor] = e_tensor
                 if q_tensor not in temp_repl.keys():
                     return None
-        remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in temp_repl.items()]
+        remaining_e_tensors = [t for t in itertools.chain(*expr_sifted["Tensor"].values()) if t not in temp_repl.values()]
         indexless_wilds, wilds = sift(query_sifted["WildTensor"], lambda x: len(x.get_free_indices()) == 0, binary=True)
         for w in wilds:
             free_this_wild = set(w.get_free_indices()).intersection(free)
@@ -4147,7 +4148,7 @@ class TensMul(TensExpr, AssocOp):
             else:
                 temp_repl.update(m)
 
-        remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in temp_repl.items()]
+        remaining_e_tensors = [t for t in itertools.chain(*expr_sifted["Tensor"].values()) if t not in temp_repl.values()]
         if len(indexless_wilds) > 0:
             #If there are any remaining tensors, match them with the indexless WildTensor
             temp_repl[indexless_wilds[0]] = TensMul(*remaining_e_tensors)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4134,7 +4134,11 @@ class TensMul(TensExpr, AssocOp):
     def matches(self, expr, repl_dict=None, old=False):
         expr = sympify(expr)
 
-        return self._matches_commutative(expr, repl_dict, old)
+        commute = all([arg.component.comm == 0 for arg in expr.args if isinstance(arg, Tensor)])
+        if commute:
+            return self._matches_commutative(expr, repl_dict, old)
+        else:
+            raise NotImplementedError("Tensor matching not implemented for non-commuting tensors")
 
 class TensorElement(TensExpr):
     """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4142,8 +4142,6 @@ class TensMul(TensExpr, AssocOp):
                 return "WildTensor"
             elif isinstance(arg, Tensor):
                 return "Tensor"
-            elif isinstance(arg, TensExpr):
-                return "TensExpr"
             else:
                 return "coeff"
 
@@ -4151,10 +4149,12 @@ class TensMul(TensExpr, AssocOp):
         expr_sifted = sift(expr.args, siftkey)
 
         #Sanity checks
-        if "TensExpr" in query_sifted.keys():
-            raise NotImplementedError(f"Found a TensExpr that we do not know to handle: {query_sifted['TensExpr']}")
-        if "TensExpr" in expr_sifted.keys():
-            raise NotImplementedError(f"Found a TensExpr that we do not know to handle: {expr_sifted['TensExpr']}")
+        if "coeff" in query_sifted.keys():
+            if TensMul(*query_sifted["coeff"]).doit() != self.coeff:
+                raise NotImplementedError(f"Found something that we do not know to handle: {query_sifted['coeff']}")
+        if "coeff" in expr_sifted.keys():
+            if TensMul(*expr_sifted["coeff"]).doit() != expr.coeff:
+                raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
 
         query_tens_heads = set(x.head for x in query_sifted["Tensor"])
         expr_tens_heads = set(x.head for x in expr_sifted["Tensor"])

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4202,7 +4202,8 @@ class TensMul(TensExpr, AssocOp):
         else:
             temp_repl.update(m)
 
-        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, (WildTensor, WildTensorIndex))])
+        from sympy import Wild, WildFunction
+        temp_repl = dict([(k,v) for k,v in temp_repl.items() if isinstance(k, (WildTensor, WildTensorIndex, Wild, WildFunction))])
         repl_dict.update(temp_repl)
         return repl_dict
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4165,7 +4165,7 @@ class TensMul(TensExpr, AssocOp):
                 return None
 
             #If there are no Wilds in self, we can depend on canon_bp to tell us whether self and expr are equivalent.
-            diff = self.doit() - expr.doit()
+            diff = self.doit().canon_bp() - expr.doit().canon_bp()
             if diff == 0 or diff.canon_bp() == 0:
                 return repl_dict
             else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -5156,7 +5156,7 @@ def _expand(expr, **kwargs):
 
 
 def _get_wilds(expr):
-    return [ a for a in expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead) ]
+    return list(expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead))
 
 
 def get_postprocessor(cls):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4155,7 +4155,7 @@ class TensMul(TensExpr, AssocOp):
             return None
 
         #Try to match all non-wild tensors of self with tensors that compose expr
-        matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in the query.
+        matched_e_tensors = [] #Used to make sure that the same tensor in expr is not matched with more than one tensor in self.
         for q_tensor in query_sifted["Tensor"]:
             matched_this_q = False
             for e_tensor in expr_sifted["Tensor"]:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2758,11 +2758,11 @@ class TensAdd(TensExpr, AssocOp):
         if not isinstance(expr, TensAdd):
             return None
 
-        if len(_get_nondummy_wilds(self)) == 0:
+        if len(_get_wilds(self)) == 0:
             return self._matches_simple(expr, repl_dict, old)
 
         def siftkey(arg):
-            wildatoms = _get_nondummy_wilds(arg)
+            wildatoms = _get_wilds(arg)
             wildatom_types = sift(wildatoms, type)
             if len(wildatoms) == 0:
                 return "nonwild"

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3102,7 +3102,7 @@ class Tensor(TensExpr):
         rank = comp.rank
 
         old_perms = None
-        new_perms = set([self])
+        new_perms = {self}
         while new_perms != old_perms:
             old_perms = new_perms.copy()
             for tens in old_perms:
@@ -3110,7 +3110,7 @@ class Tensor(TensExpr):
                     inds = tens.get_indices()
                     per = [gen.apply(i) for i in range(0,rank)]
                     sign = (-1)**(gen.apply(rank) - rank)
-                    ind_map = { k:v for k,v in zip(inds, [inds[i] for i in per]) }
+                    ind_map = dict(zip(inds, [inds[i] for i in per]))
                     new_perms.add( sign * tens._replace_indices(ind_map) )
 
         return new_perms

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4310,11 +4310,17 @@ class TensMul(TensExpr, AssocOp):
             for e,m in matched_this:
                 rem_query = self.func(*[a for a in self.args if a != q_tensor]).doit()
                 rem_expr = expr.func(*[a for a in expr.args if a != e]).doit()
-                rem_m = rem_query.matches(rem_expr)
+                rem_m = rem_query.matches(rem_expr, repl_dict=m)
                 if rem_m is not None:
-                    repl_dict.update(m)
-                    repl_dict.update(rem_m)
-                    return repl_dict
+                    #Check that contracted indices are not mapped to different indices.
+                    internally_consistent = True
+                    for k in rem_m.keys():
+                        if isinstance(k,TensorIndex) and -k in rem_m.keys() and rem_m[-k] != -rem_m[k]:
+                            internally_consistent = False
+                            break
+                    if internally_consistent:
+                        repl_dict.update(rem_m)
+                        return repl_dict
 
             return None
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3517,6 +3517,13 @@ class TensMul(TensExpr, AssocOp):
                 arg._replace_indices(repl) if isinstance(arg, TensExpr) else arg
                 for arg, repl in zip(args, replacements)]
 
+            """
+            The order of indices might've changed due to the replacements (e.g. if one of the args is a TensAdd, replacing an index can change the sort order of the terms, thus changing the order of indices returned by its get_indices() method).
+            To stay on the safe side, we calculate these quantities again.
+            """
+            args_indices = [get_indices(arg) for arg in args]
+            indices, free, free_names, dummy_data = TensMul._indices_to_free_dum(args_indices)
+
         dum = TensMul._dummy_data_to_dum(dummy_data)
         return args, indices, free, dum
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4260,11 +4260,9 @@ class TensMul(TensExpr, AssocOp):
             repl_dict = repl_dict.copy()
 
         #Take care of the various possible types for expr.
-        if not isinstance(expr, TensExpr):
-            return None
-        elif isinstance(expr, Tensor):
+        if isinstance(expr, Tensor):
             expr = TensMul(expr)
-        elif isinstance(expr, TensAdd):
+        elif not isinstance(expr, TensMul):
             return None
         #The code that follows assumes expr is a TensMul
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import Integer
 from sympy.matrices.dense import (Matrix, eye)
 from sympy.tensor.indexed import Indexed
 from sympy.combinatorics import Permutation
-from sympy.core import S, Rational, Symbol, Basic, Add
+from sympy.core import S, Rational, Symbol, Basic, Add, Wild
 from sympy.core.containers import Tuple
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2056,10 +2056,7 @@ def test_TensMul_matching():
     W = WildTensorHead('W', unordered_indices=True)
     U = WildTensorHead('U')
 
-    assert(
-        ( wi*K(p) ).matches( K(p) )
-        == {wi: 1}
-        )
+    assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
     check_tens_eq(
         (K(p) * V(-p)).replace( W(a) * V(-a), 1),
         1

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2036,15 +2036,6 @@ def test_TensMul_matching():
     """
     Test match and replace with the pattern being a TensMul
     """
-    def check_tens_eq(expr1, expr2):
-        """
-        Canonicalizes the two given tensor expressions and checks equality.
-        """
-        diff = expr1 - expr2
-        if diff != 0:
-            diff = diff.canon_bp().simplify()
-        assert diff == 0
-
     R3 = TensorIndexType('R3', dim=3)
     p, q, r, s, t = tensor_indices("p q r s t", R3)
     wi = Wild("wi")
@@ -2057,52 +2048,37 @@ def test_TensMul_matching():
     U = WildTensorHead('U')
 
     assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
-    check_tens_eq(
-        (K(p) * V(-p)).replace( W(a) * V(-a), 1),
-        1
+    assert (K(p) * V(-p)).replace( W(a) * V(-a), 1) == 1
+    assert ( K(q) * K(p) * V(-p) ).replace( W(q,a) * V(-a), 1) == 1
+    assert ( K(p) * V(-p) ).replace( K(-a)* V(a), 1 ) == 1
+    assert ( K(q) * K(p) * V(-p) ).replace( W(q)* U(p) * V(-p), 1) == 1
+    assert (
+        (K(p)*V(q)).replace(W()*K(p)*V(q), W()*V(p)*V(q)).doit()
+        == V(p)*V(q)
         )
-    check_tens_eq(
-        ( K(q) * K(p) * V(-p) ).replace( W(q,a) * V(-a), 1),
-        1
+    assert (
+        ( eps(r,p,q)*eps(-r,-s,-t) ).replace(
+            eps(e,a,b)*eps(-e,c,d),
+            delta(a,c)*delta(b,d) - delta(a,d)*delta(b,c),
+            ).doit()
+        == delta(p,-s)*delta(q,-t) - delta(p,-t)*delta(q,-s)
         )
-    check_tens_eq(
-        ( K(p) * V(-p) ).replace( K(-a)* V(a), 1 ),
-        1
-        )
-    check_tens_eq(
-        ( K(q) * K(p) * V(-p) ).replace( W(q)* U(p) * V(-p), 1),
-        1
-        )
-    check_tens_eq(
-        (K(p)*V(q)).replace(
-            W()*K(p)*V(q),
-            W()*V(p)*V(q),
-            ),
-        V(p)*V(q)
-        )
-    check_tens_eq(
-        ( eps(r,p,q) * eps(-r, -s, -t) ).replace(
-            eps(e, a, b) * eps(-e, c, d),
-            delta(a, c)*delta(b, d) - delta(a, d)*delta(b, c),
-            ),
-        delta(p,-s)*delta(q,-t) - delta(p,-t)*delta(q,-s)
-        )
-    check_tens_eq(
-        ( eps(r,p,q) * eps(-r, -p, -q) ).replace(
-            eps(c, a, b) * eps(-c, d, f),
-            delta(a, d)*delta(b, f) - delta(a, f)*delta(b, d),
-            ).contract_delta(delta),
-        6,
+    assert (
+        ( eps(r,p,q)*eps(-r,-p,-q) ).replace(
+            eps(c,a,b)*eps(-c,d,f),
+            delta(a,d)*delta(b,f) - delta(a,f)*delta(b,d),
+            ).contract_delta(delta).doit()
+        == 6
         )
 
     #Multiple occurrence of WildTensor in value
-    check_tens_eq(
-        ( K(p)*V(q) ).replace(W(q)*K(p), W(p)*W(q)),
-        V(p)*V(q)
+    assert (
+        ( K(p)*V(q) ).replace(W(q)*K(p), W(p)*W(q))
+        == V(p)*V(q)
         )
-    check_tens_eq(
-        ( K(p)*V(q)*V(r) ).replace(W(q,r)*K(p), W(p,r)*W(q,s)*V(-s) ),
-        V(p)*V(r)*V(q)*V(s)*V(-s)
+    assert (
+        ( K(p)*V(q)*V(r) ).replace(W(q,r)*K(p), W(p,r)*W(q,s)*V(-s) )
+        == V(p)*V(r)*V(q)*V(s)*V(-s)
         )
 
 def test_TensMul_subs():

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2058,6 +2058,15 @@ def test_tensor_matching():
         6,
         )
 
+    #With TensAdd as query
+    check_tens_eq(
+        ( K(p)*K(q) + V(p)*V(q) + K(p)*V(q) + K(q)*V(p) ).replace(
+            W(p,q) + K(p)*K(q) + V(p)*V(q),
+            W(p,q) + 3*K(p)*V(q)
+            ),
+        K(p)*V(q) + K(q)*V(p) + 3*K(p)*V(q)
+        )
+
     #Multiple occurrence of WildTensor in value
     check_tens_eq(
         ( K(p)*V(q) ).replace(W(q)*K(p), W(p)*W(q)),

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2050,7 +2050,7 @@ def test_TensMul_matching():
         ( eps(r,p,q)*eps(-r,-s,-t) ).replace(
             eps(e,a,b)*eps(-e,c,d),
             delta(a,c)*delta(b,d) - delta(a,d)*delta(b,c),
-            ).doit()
+            ).doit().canon_bp()
         == delta(p,-s)*delta(q,-t) - delta(p,-t)*delta(q,-s)
         )
     assert (

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2036,10 +2036,10 @@ def test_TensMul_matching():
     U = WildTensorHead('U')
 
     assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
-    assert (K(p) * V(-p)).replace( W(a) * V(-a), 1) == 1
-    assert ( K(q) * K(p) * V(-p) ).replace( W(q,a) * V(-a), 1) == 1
-    assert ( K(p) * V(-p) ).replace( K(-a)* V(a), 1 ) == 1
-    assert ( K(q) * K(p) * V(-p) ).replace( W(q)* U(p) * V(-p), 1) == 1
+    assert ( K(p)*V(-p) ).replace( W(a)*V(-a), 1) == 1
+    assert ( K(q)*K(p)*V(-p) ).replace( W(q,a)*V(-a), 1) == 1
+    assert ( K(p)*V(-p) ).replace( K(-a)*V(a), 1 ) == 1
+    assert ( K(q)*K(p)*V(-p) ).replace( W(q)*U(p)*V(-p), 1) == 1
     assert (
         (K(p)*V(q)).replace(W()*K(p)*V(q), W()*V(p)*V(q)).doit()
         == V(p)*V(q)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1997,6 +1997,7 @@ def test_tensor_matching():
     assert eps(p,-a,a).matches( eps(p,q,r) ) == None
     assert eps(p,-b,a).matches( eps(p,q,r) ) == {a: r, -b: q}
     assert eps(p,-q,r).replace(eps(a,b,c), 1) == 1
+    assert eps(p,q,r).matches(eps(q,r,p)) == dict()
     assert W().matches( K(p)*V(q) ) == {W(): K(p)*V(q)}
     assert W(a).matches( K(p) ) == {a:p, W(a).head: _WildTensExpr(K(p))}
     assert W(a,p).matches( K(p)*V(q) ) == {a:q, W(a,p).head: _WildTensExpr(K(p)*V(q))}

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1997,7 +1997,7 @@ def test_tensor_matching():
     assert eps(p,-a,a).matches( eps(p,q,r) ) == None
     assert eps(p,-b,a).matches( eps(p,q,r) ) == {a: r, -b: q}
     assert eps(p,-q,r).replace(eps(a,b,c), 1) == 1
-    assert eps(p,q,r).matches(eps(q,r,p)) == dict()
+    assert eps(p,q,r).matches(eps(q,r,p)) == {}
     assert W().matches( K(p)*V(q) ) == {W(): K(p)*V(q)}
     assert W(a).matches( K(p) ) == {a:p, W(a).head: _WildTensExpr(K(p))}
     assert W(a,p).matches( K(p)*V(q) ) == {a:q, W(a,p).head: _WildTensExpr(K(p)*V(q))}

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2035,6 +2035,7 @@ def test_TensMul_matching():
     V = TensorHead("V", [R3])
     W = WildTensorHead('W', unordered_indices=True)
     U = WildTensorHead('U')
+    k = Symbol("K")
 
     assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
     assert ( wi * eps(p,q,r) ).matches(eps(p,r,q)) == {wi:-1}
@@ -2061,6 +2062,7 @@ def test_TensMul_matching():
         == 6
         )
     assert ( V(-p)*V(q)*V(-q) ).replace( wi*W()*V(a)*V(-a), wi*W() ).doit() == V(-p)
+    assert ( k**4*K(r)*K(-r) ).replace( wi*W()*K(a)*K(-a), wi*W()*k**2 ).doit() == k**6
 
     #Multiple occurrence of WildTensor in value
     assert (

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2009,28 +2009,16 @@ def test_TensAdd_matching():
     """
     Test match and replace with the pattern being a TensAdd
     """
-    def check_tens_eq(expr1, expr2):
-        """
-        Canonicalizes the two given tensor expressions and checks equality.
-        """
-        diff = expr1 - expr2
-        if diff != 0:
-            diff = diff.canon_bp().simplify()
-        assert diff == 0
-
     R3 = TensorIndexType('R3', dim=3)
     p, q = tensor_indices("p q", R3)
     K = TensorHead("K", [R3])
     V = TensorHead("V", [R3])
     W = WildTensorHead('W', unordered_indices=True)
 
-    check_tens_eq(
-        ( K(p)*K(q) + V(p)*V(q) + K(p)*V(q) + K(q)*V(p) ).replace(
+    assert ( K(p)*K(q) + V(p)*V(q) + K(p)*V(q) + K(q)*V(p) ).replace(
             W(p,q) + K(p)*K(q) + V(p)*V(q),
             W(p,q) + 3*K(p)*V(q)
-            ),
-        K(p)*V(q) + K(q)*V(p) + 3*K(p)*V(q)
-        )
+            ) == K(p)*V(q) + K(q)*V(p) + 3*K(p)*V(q)
 
 def test_TensMul_matching():
     """

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2016,9 +2016,9 @@ def test_TensAdd_matching():
     W = WildTensorHead('W', unordered_indices=True)
 
     assert ( K(p)*K(q) + V(p)*V(q) + K(p)*V(q) + K(q)*V(p) ).replace(
-            W(p,q) + K(p)*K(q) + V(p)*V(q),
-            W(p,q) + 3*K(p)*V(q)
-            ) == K(p)*V(q) + K(q)*V(p) + 3*K(p)*V(q)
+        W(p,q) + K(p)*K(q) + V(p)*V(q),
+        W(p,q) + 3*K(p)*V(q)
+        ).doit() == K(p)*V(q) + K(q)*V(p) + 3*K(p)*V(q)
 
 def test_TensMul_matching():
     """

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1990,7 +1990,6 @@ def test_tensor_matching():
     W = WildTensorHead('W', unordered_indices=True)
     U = WildTensorHead('U')
 
-    #Matching wild objects
     assert a.matches(q) == {a:q}
     assert a.matches(-q) == {a:-q}
     assert g.matches(-q) == None

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2074,6 +2074,12 @@ def test_TensMul_matching():
         == V(p)*V(r)*V(q)*V(s)*V(-s)
         )
 
+    #Edge case involving automatic index relabelling
+    D0, D1, D2, D3 = tensor_indices("R_0 R_1 R_2 R_3", R3)
+    expr = delta(-D0, -D1)*K(D2)*K(D3)*K(-D3)
+    m = ( W()*K(a)*K(-a) ).matches(expr)
+    assert D2 not in m.values()
+
 def test_TensMul_subs():
     """
     Test subs and xreplace in TensMul. See bug #24337

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2037,6 +2037,7 @@ def test_TensMul_matching():
     U = WildTensorHead('U')
 
     assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
+    assert ( wi * eps(p,q,r) ).matches(eps(p,r,q)) == {wi:-1}
     assert ( K(p)*V(-p) ).replace( W(a)*V(-a), 1) == 1
     assert ( K(q)*K(p)*V(-p) ).replace( W(q,a)*V(-a), 1) == 1
     assert ( K(p)*V(-p) ).replace( K(-a)*V(a), 1 ) == 1

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2058,6 +2058,7 @@ def test_TensMul_matching():
             ).contract_delta(delta).doit()
         == 6
         )
+    assert ( V(-p)*V(q)*V(-q) ).replace( wi*W()*V(a)*V(-a), wi*W() ).doit() == V(-p)
 
     #Multiple occurrence of WildTensor in value
     assert (


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- 
#### References to other Issues or PRs
-->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds `matches` routines for `TensMul` and `TensAdd`. This is needed in order to match subexpressions properly (similar to Add and Mul in sympy core).
I have also added a `matches` method for `Tensor` that takes index symmetries into account.

#### Other comments
The `matches` method I have implemented for `TensMul` only supports commutative tensors (will raise an error if it is used with non-commutative ones).

It is now possible to do things like

```

$isympy
In [1]: from sympy.tensor.tensor import TensorIndexType, tensor_indices, WildTensorInd
   ...: ex, TensorHead, WildTensorHead
In [2]: from sympy import Wild, Symbol
In [3]: R3 = TensorIndexType('R3', dim=3)
In [4]: r = tensor_indices("r", R3)
In [5]: wi = Wild("wi")
In [6]: a = symbols("a", cls = WildTensorIndex, tensor_index_type=R3, ignore_updown=Tr
   ...: ue)
In [7]: K = TensorHead("K", [R3])
In [8]: W = WildTensorHead('W', unordered_indices=True)
In [9]: k = Symbol("K")
In [10]: ( k**4*K(r)*K(-r) ).replace( wi*W()*K(a)*K(-a), wi*W()*k**2 ).doit()
Out[10]: 
 6
K
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Implemented matching for TensAdd
  * Implemented matching for TensMul when its arguments are commutative.
  * Matching for Tensor now takes index symmetries into account.
<!-- END RELEASE NOTES -->
