### PR TITLE
core: remove all metaclasses from Basic

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,8 +76,23 @@ SymPy deprecation warnings.
 
 ## Version 1.12
 
+(managedproperties)=
+### The ``ManagedProperties`` metaclass
+
+The ``ManagedProperties`` metaclass was previously the metaclass for ``Basic``.
+Now ``Basic`` does not use metaclasses and so its metaclass is just ``type``.
+Any code that previously subclassed ``Basic`` and wanted to do anything with
+metaclasses would have needed to subclass ``ManagedProperties`` to make the
+relevant metaclass. The only relevant method of ``ManagedProperties`` has been
+moved to ``Basic.__init_subclass__``. Since ``ManagedProperties`` is not used
+as the metaclass for ``Basic`` any more and no longer does anything useful it
+should be possible for such code to just subclass ``type`` instead for any
+metaclass.
+
+
 (deprecated-mechanics-joint-coordinate-format)=
 ### New Joint coordinate format
+
 The format, i.e. type and auto generated name, of the generalized coordinates
 and generalized speeds of the joints in the ``sympy.physics.mechanics`` module
 has changed. The data type has changed from ``list`` to ``Matrix``, which is the

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -1166,7 +1166,7 @@ assumptions system. Briefly these are:
    efficiently applying the implication rules. This happens once when SymPy is
    imported before even the :class:`~.Basic` class is defined.
 
-2. The :meth`~.Basic.__init_subclass__` method will post-process every
+2. The :meth:`~.Basic.__init_subclass__` method will post-process every
    :class:`~.Basic` subclass to add the relevant properties needed for
    assumptions queries. This also adds the ``default_assumptions`` attribute
    to the class. This happens each time a :class:`~.Basic` subclass is

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -1166,11 +1166,11 @@ assumptions system. Briefly these are:
    efficiently applying the implication rules. This happens once when SymPy is
    imported before even the :class:`~.Basic` class is defined.
 
-2. The ``ManagedProperties`` metaclass is defined which is the metaclass for
-   all :class:`~.Basic` subclasses. This class will post-process every
+2. The :meth`~.Basic.__init_subclass__` method will post-process every
    :class:`~.Basic` subclass to add the relevant properties needed for
-   assumptions queries.  This also adds the ``default_assumptions`` attribute
-   to the class. This happens each time a :class:`~.Basic` subclass is defined.
+   assumptions queries. This also adds the ``default_assumptions`` attribute
+   to the class. This happens each time a :class:`~.Basic` subclass is
+   defined (when its containing module is imported).
 
 3. Every :class:`~.Basic` instance initially uses the ``default_assumptions`` class
    attribute. When an assumptions query is made on a :class:`~.Basic` instance
@@ -1223,7 +1223,7 @@ object directly like (full output omitted):
       ('composite', False),
       ...
 
-The ``ManagedProperties`` metaclass will inspect the attributes of each
+The ``Basic.__init_subclass__`` method will inspect the attributes of each
 ``Basic`` class to see if any assumptions related attributes are defined. An
 example of these is the ``is_extended_nonnegative = True`` attribute defined
 in the ``expreal`` class. The implications of any such attributes will be

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -1166,7 +1166,7 @@ assumptions system. Briefly these are:
    efficiently applying the implication rules. This happens once when SymPy is
    imported before even the :class:`~.Basic` class is defined.
 
-2. The :meth:`~.Basic.__init_subclass__` method will post-process every
+2. The ``Basic.__init_subclass__`` method will post-process every
    :class:`~.Basic` subclass to add the relevant properties needed for
    assumptions queries. This also adds the ``default_assumptions`` attribute
    to the class. This happens each time a :class:`~.Basic` subclass is

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -2,7 +2,6 @@
 
 from contextlib import contextmanager
 import inspect
-from sympy.core.assumptions import ManagedProperties
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean, false, true
@@ -172,7 +171,7 @@ class AppliedPredicate(Boolean):
         return set()
 
 
-class PredicateMeta(ManagedProperties):
+class PredicateMeta(type):
     def __new__(cls, clsname, bases, dct):
         # If handler is not defined, assign empty dispatcher.
         if "handler" not in dct:

--- a/sympy/assumptions/tests/test_wrapper.py
+++ b/sympy/assumptions/tests/test_wrapper.py
@@ -1,7 +1,14 @@
 from sympy.assumptions.ask import Q
-from sympy.core.symbol import Symbol
 from sympy.assumptions.wrapper import (AssumptionsWrapper, is_infinite,
     is_extended_real)
+from sympy.core.symbol import Symbol
+from sympy.core.assumptions import _assume_defined
+
+
+def test_all_predicates():
+    for fact in _assume_defined:
+        method_name = f'_eval_is_{fact}'
+        assert hasattr(AssumptionsWrapper, method_name)
 
 
 def test_AssumptionsWrapper():

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -44,7 +44,6 @@ False
 """
 
 from sympy.assumptions import ask, Q
-from sympy.core.assumptions import _assume_defined, as_property
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
 

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -44,20 +44,9 @@ False
 """
 
 from sympy.assumptions import ask, Q
-from sympy.core.assumptions import (_assume_defined, as_property,
-    ManagedProperties)
+from sympy.core.assumptions import _assume_defined, as_property
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
-
-class AssumptionsWrapperMeta(ManagedProperties):
-    """
-    Metaclass to give _eval_is_[...] attributes to AssumptionsWrapper
-    """
-    def __init__(cls, *args, **kws):
-        for fact in _assume_defined:
-            pname = "_eval_%s" % as_property(fact)
-            setattr(cls, pname, make_eval_method(fact))
-        super().__init__(cls, *args, **kws)
 
 
 def make_eval_method(fact):
@@ -72,7 +61,7 @@ def make_eval_method(fact):
 
 
 # we subclass Basic to use the fact deduction and caching
-class AssumptionsWrapper(Basic, metaclass=AssumptionsWrapperMeta):
+class AssumptionsWrapper(Basic):
     """
     Wrapper over ``Basic`` instances to call predicate query by
     ``.is_[...]`` property
@@ -125,6 +114,38 @@ class AssumptionsWrapper(Basic, metaclass=AssumptionsWrapperMeta):
         obj.expr = expr
         obj.assumptions = assumptions
         return obj
+
+    _eval_is_algebraic = make_eval_method("algebraic")
+    _eval_is_antihermitian = make_eval_method("antihermitian")
+    _eval_is_commutative = make_eval_method("commutative")
+    _eval_is_complex = make_eval_method("complex")
+    _eval_is_composite = make_eval_method("composite")
+    _eval_is_even = make_eval_method("even")
+    _eval_is_extended_negative = make_eval_method("extended_negative")
+    _eval_is_extended_nonnegative = make_eval_method("extended_nonnegative")
+    _eval_is_extended_nonpositive = make_eval_method("extended_nonpositive")
+    _eval_is_extended_nonzero = make_eval_method("extended_nonzero")
+    _eval_is_extended_positive = make_eval_method("extended_positive")
+    _eval_is_extended_real = make_eval_method("extended_real")
+    _eval_is_finite = make_eval_method("finite")
+    _eval_is_hermitian = make_eval_method("hermitian")
+    _eval_is_imaginary = make_eval_method("imaginary")
+    _eval_is_infinite = make_eval_method("infinite")
+    _eval_is_integer = make_eval_method("integer")
+    _eval_is_irrational = make_eval_method("irrational")
+    _eval_is_negative = make_eval_method("negative")
+    _eval_is_noninteger = make_eval_method("noninteger")
+    _eval_is_nonnegative = make_eval_method("nonnegative")
+    _eval_is_nonpositive = make_eval_method("nonpositive")
+    _eval_is_nonzero = make_eval_method("nonzero")
+    _eval_is_odd = make_eval_method("odd")
+    _eval_is_polar = make_eval_method("polar")
+    _eval_is_positive = make_eval_method("positive")
+    _eval_is_prime = make_eval_method("prime")
+    _eval_is_rational = make_eval_method("rational")
+    _eval_is_real = make_eval_method("real")
+    _eval_is_transcendental = make_eval_method("transcendental")
+    _eval_is_zero = make_eval_method("zero")
 
 
 # one shot functions which are faster than AssumptionsWrapper

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -210,6 +210,8 @@ References
 
 """
 
+from sympy.utilities.exceptions import sympy_deprecation_warning
+
 from .facts import FactRules, FactKB
 from .sympify import sympify
 
@@ -610,6 +612,62 @@ def _ask(fact, obj):
     return None
 
 
+def _prepare_class_assumptions(cls):
+    """Precompute class level assumptions and generate handlers.
+
+    This is called by Basic.__init_subclass__ each time a Basic subclass is
+    defined.
+    """
+
+    local_defs = {}
+    for k in _assume_defined:
+        attrname = as_property(k)
+        v = cls.__dict__.get(attrname, '')
+        if isinstance(v, (bool, int, type(None))):
+            if v is not None:
+                v = bool(v)
+            local_defs[k] = v
+
+    defs = {}
+    for base in reversed(cls.__bases__):
+        assumptions = getattr(base, '_explicit_class_assumptions', None)
+        if assumptions is not None:
+            defs.update(assumptions)
+    defs.update(local_defs)
+
+    cls._explicit_class_assumptions = defs
+    cls.default_assumptions = StdFactKB(defs)
+
+    cls._prop_handler = {}
+    for k in _assume_defined:
+        eval_is_meth = getattr(cls, '_eval_is_%s' % k, None)
+        if eval_is_meth is not None:
+            cls._prop_handler[k] = eval_is_meth
+
+    # Put definite results directly into the class dict, for speed
+    for k, v in cls.default_assumptions.items():
+        setattr(cls, as_property(k), v)
+
+    # protection e.g. for Integer.is_even=F <- (Rational.is_integer=F)
+    derived_from_bases = set()
+    for base in cls.__bases__:
+        default_assumptions = getattr(base, 'default_assumptions', None)
+        # is an assumption-aware class
+        if default_assumptions is not None:
+            derived_from_bases.update(default_assumptions)
+
+    for fact in derived_from_bases - set(cls.default_assumptions):
+        pname = as_property(fact)
+        if pname not in cls.__dict__:
+            setattr(cls, pname, make_property(fact))
+
+    # Finally, add any missing automagic property (e.g. for Basic)
+    for fact in _assume_defined:
+        pname = as_property(fact)
+        if not hasattr(cls, pname):
+            setattr(cls, pname, make_property(fact))
+
+
 # XXX: ManagedProperties used to be the metaclass for Basic but now Basic does
 # not use a metaclass. We leave this here for backwards compatibility for now
 # in case someone has been using the ManagedProperties class in downstream
@@ -617,7 +675,19 @@ def _ask(fact, obj):
 # class and wanting to use a metaclass the metaclass must be a subclass of the
 # metaclass for the class that is being subclassed. Anyone wanting to subclass
 # Basic and use a metclass in their subclass would have needed to subclass
-# ManagedProperties. Here ManagedProperties is still the metaclass for Basic
-# but it is just type because that is the metaclass when metaclasses are not
-# being used.
-ManagedProperties = type
+# ManagedProperties. Here ManagedProperties is not the metaclass for Basic any
+# more but it should still be usable as a metaclass for Basic subclasses since
+# it is a subclass of type which is now the metaclass for Basic.
+class ManagedProperties(type):
+    def __init__(cls, *args, **kwargs):
+        msg = ("The ManagedProperties metaclass. "
+               "Basic does not use metaclasses any more")
+        sympy_deprecation_warning(msg,
+            deprecated_since_version="1.12",
+            active_deprecations_target='managedproperties')
+
+        # Here we still call this function in case someone is using
+        # ManagedProperties for something that is not a Basic subclass. For
+        # Basic subclasses this function is now called by __init_subclass__ and
+        # so this metaclass is not needed any more.
+        _prepare_class_assumptions(cls)

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -674,7 +674,7 @@ def _prepare_class_assumptions(cls):
 # code. The reason that it might have been used is that when subclassing a
 # class and wanting to use a metaclass the metaclass must be a subclass of the
 # metaclass for the class that is being subclassed. Anyone wanting to subclass
-# Basic and use a metclass in their subclass would have needed to subclass
+# Basic and use a metaclass in their subclass would have needed to subclass
 # ManagedProperties. Here ManagedProperties is not the metaclass for Basic any
 # more but it should still be usable as a metaclass for Basic subclasses since
 # it is a subclass of type which is now the metaclass for Basic.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from itertools import chain, zip_longest
 
-from .assumptions import as_property, _assume_defined, StdFactKB, make_property
+from .assumptions import _prepare_class_assumptions
 from .cache import cacheit
 from .core import ordering_of_classes
 from .sympify import _sympify, sympify, SympifyError, _external_converter
@@ -33,63 +33,6 @@ def as_Basic(expr):
             expr))
 
 
-# This must be a base class of Basic so that __init_subclass__ applies to Basic
-class _BasicBase:
-    __slots__ = ('_mhash',              # hash value
-                 '_args',               # arguments
-                 '_assumptions'
-                )
-
-    def __init_subclass__(cls):
-        local_defs = {}
-        for k in _assume_defined:
-            attrname = as_property(k)
-            v = cls.__dict__.get(attrname, '')
-            if isinstance(v, (bool, int, type(None))):
-                if v is not None:
-                    v = bool(v)
-                local_defs[k] = v
-
-        defs = {}
-        for base in reversed(cls.__bases__):
-            assumptions = getattr(base, '_explicit_class_assumptions', None)
-            if assumptions is not None:
-                defs.update(assumptions)
-        defs.update(local_defs)
-
-        cls._explicit_class_assumptions = defs
-        cls.default_assumptions = StdFactKB(defs)
-
-        cls._prop_handler = {}
-        for k in _assume_defined:
-            eval_is_meth = getattr(cls, '_eval_is_%s' % k, None)
-            if eval_is_meth is not None:
-                cls._prop_handler[k] = eval_is_meth
-
-        # Put definite results directly into the class dict, for speed
-        for k, v in cls.default_assumptions.items():
-            setattr(cls, as_property(k), v)
-
-        # protection e.g. for Integer.is_even=F <- (Rational.is_integer=F)
-        derived_from_bases = set()
-        for base in cls.__bases__:
-            default_assumptions = getattr(base, 'default_assumptions', None)
-            # is an assumption-aware class
-            if default_assumptions is not None:
-                derived_from_bases.update(default_assumptions)
-
-        for fact in derived_from_bases - set(cls.default_assumptions):
-            pname = as_property(fact)
-            if pname not in cls.__dict__:
-                setattr(cls, pname, make_property(fact))
-
-        # Finally, add any missing automagic property (e.g. for Basic)
-        for fact in _assume_defined:
-            pname = as_property(fact)
-            if not hasattr(cls, pname):
-                setattr(cls, pname, make_property(fact))
-
-
 def _old_compare(x: type, y: type) -> int:
     # If the other object is not a Basic subclass, then we are not equal to it.
     if not issubclass(y, Basic):
@@ -114,7 +57,7 @@ def _old_compare(x: type, y: type) -> int:
     return (i1 > i2) - (i1 < i2)
 
 
-class Basic(_BasicBase, Printable):
+class Basic(Printable):
     """
     Base class for all SymPy objects.
 
@@ -158,7 +101,10 @@ class Basic(_BasicBase, Printable):
         >>> isinstance(B, Basic)
         True
     """
-    __slots__ = ()
+    __slots__ = ('_mhash',              # hash value
+                 '_args',               # arguments
+                 '_assumptions'
+                )
 
     _args: tuple[Basic, ...]
     _mhash: int | None
@@ -166,6 +112,13 @@ class Basic(_BasicBase, Printable):
     @property
     def __sympy__(self):
         return True
+
+    def __init_subclass__(cls):
+        # Initialize the default_assumptions FactKB and also any assumptions
+        # property methods. This method will only be called for subclasses of
+        # Basic but not for Basic itself so we call
+        # _prepare_class_assumptions(Basic) below the class definition.
+        _prepare_class_assumptions(cls)
 
     # To be overridden with True in the appropriate subclasses
     is_number = False
@@ -2097,6 +2050,12 @@ class Basic(_BasicBase, Printable):
 
     def could_extract_minus_sign(self):
         return False  # see Expr.could_extract_minus_sign
+
+
+# For all Basic subclasses _prepare_class_assumptions is called by
+# Basic.__init_subclass__ but that method is not called for Basic itself so we
+# call the function here instead.
+_prepare_class_assumptions(Basic)
 
 
 class Atom(Basic):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -109,6 +109,10 @@ class Basic(Printable, metaclass=ManagedProperties):
     _args: tuple[Basic, ...]
     _mhash: int | None
 
+    @property
+    def __sympy__(self):
+        return True
+
     # To be overridden with True in the appropriate subclasses
     is_number = False
     is_Atom = False

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -35,7 +35,6 @@ from typing import Any
 from collections.abc import Iterable
 
 from .add import Add
-from .assumptions import ManagedProperties
 from .basic import Basic, _atomic
 from .cache import cacheit
 from .containers import Tuple, Dict
@@ -151,7 +150,7 @@ def arity(cls):
         lambda p:p.default == p.empty, binary=True))
     return no if not yes else tuple(range(no, no + yes + 1))
 
-class FunctionClass(ManagedProperties):
+class FunctionClass(type):
     """
     Base class for function classes. FunctionClass is a subclass of type.
 
@@ -194,8 +193,6 @@ class FunctionClass(ManagedProperties):
             namespace = args[2]
             if 'eval' in namespace and not isinstance(namespace['eval'], classmethod):
                 raise TypeError("eval on Function subclasses should be a class method (defined with @classmethod)")
-
-        super().__init__(*args, **kwargs)
 
     @property
     def __signature__(self):

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -2,7 +2,6 @@
 
 
 from .core import Registry
-from .assumptions import ManagedProperties
 from .sympify import sympify
 
 
@@ -131,7 +130,7 @@ class SingletonRegistry(Registry):
 S = SingletonRegistry()
 
 
-class Singleton(ManagedProperties):
+class Singleton(type):
     """
     Metaclass for singleton classes.
 
@@ -162,14 +161,8 @@ class Singleton(ManagedProperties):
     Instance creation is delayed until the first time the value is accessed.
     (SymPy versions before 1.0 would create the instance during class
     creation time, which would be prone to import cycles.)
-
-    This metaclass is a subclass of ManagedProperties because that is the
-    metaclass of many classes that need to be Singletons (Python does not allow
-    subclasses to have a different metaclass than the superclass, except the
-    subclass may use a subclassed metaclass).
     """
     def __init__(cls, *args, **kwargs):
-        super().__init__(cls, *args, **kwargs)
         cls._instance = obj = Basic.__new__(cls)
         cls.__new__ = lambda cls: obj
         cls.__getnewargs__ = lambda obj: ()

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.functions.special.gamma_functions import gamma
 from sympy.integrals.integrals import Integral
 from sympy.functions.elementary.exponential import exp
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 b1 = Basic()
 b2 = Basic(b1)
@@ -294,3 +294,26 @@ def test_replace_exceptions():
     raises(TypeError, lambda: e.replace(b*c, c.is_real))
     raises(TypeError, lambda: e.replace(b.is_real, 1))
     raises(TypeError, lambda: e.replace(lambda d: d.is_Number, 1))
+
+
+def test_ManagedProperties():
+    # ManagedProperties is now deprecated. Here we do our best to check that if
+    # someone is using it then it does work in the way that it previously did
+    # but gives a deprecation warning.
+    from sympy.core.assumptions import ManagedProperties
+
+    myclasses = []
+
+    class MyMeta(ManagedProperties):
+        def __init__(cls, *args, **kwargs):
+            myclasses.append('executed')
+            super().__init__(*args, **kwargs)
+
+    code = """
+class MySubclass(Basic, metaclass=MyMeta):
+    pass
+"""
+    with warns_deprecated_sympy():
+        exec(code)
+
+    assert myclasses == ['executed']

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from sympy.core.mul import Mul
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
-from sympy.core.assumptions import ManagedProperties
 
 
 __all__ = [
@@ -353,12 +352,11 @@ class Mx(OneQubitGate):
     gate_name='Mx'
     gate_name_latex='M_x'
 
-class CreateOneQubitGate(ManagedProperties):
+class CreateOneQubitGate(type):
     def __new__(mcl, name, latexname=None):
         if not latexname:
             latexname = name
-        return ManagedProperties.__new__(
-            mcl, name + "Gate", (OneQubitGate,),
+        return type(name + "Gate", (OneQubitGate,),
             {'gate_name': name, 'gate_name_latex': latexname})
 
 def CreateCGate(name, latexname=None):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -34,7 +34,7 @@ from typing import Any
 from functools import reduce
 from math import prod
 
-from abc import abstractmethod, ABCMeta
+from abc import abstractmethod, ABC
 from collections import defaultdict
 import operator
 import itertools
@@ -1964,11 +1964,7 @@ def tensor_heads(s, index_types, symmetry=None, comm=0):
     return thlist
 
 
-class _TensorMetaclass(ABCMeta):
-    pass
-
-
-class TensExpr(Expr, metaclass=_TensorMetaclass):
+class TensExpr(Expr, ABC):
     """
     Abstract base class for tensor expressions
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -43,7 +43,6 @@ from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
-from sympy.core.assumptions import ManagedProperties
 from sympy.core.containers import Tuple, Dict
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Symbol, symbols
@@ -1965,7 +1964,7 @@ def tensor_heads(s, index_types, symmetry=None, comm=0):
     return thlist
 
 
-class _TensorMetaclass(ManagedProperties, ABCMeta):
+class _TensorMetaclass(ABCMeta):
     pass
 
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -6,7 +6,6 @@ from sympy.physics.units import meter
 
 from sympy.testing.pytest import XFAIL, raises
 
-from sympy.core.assumptions import ManagedProperties
 from sympy.core.basic import Atom, Basic
 from sympy.core.singleton import SingletonRegistry
 from sympy.core.symbol import Str, Dummy, Symbol, Wild
@@ -58,7 +57,7 @@ def check(a, exclude=[], check_attr=True):
             continue
 
         if callable(protocol):
-            if isinstance(a, ManagedProperties):
+            if isinstance(a, type):
                 # Classes can't be copied, but that's okay.
                 continue
             b = protocol(a)
@@ -97,7 +96,7 @@ def test_core_basic():
     for c in (Atom, Atom(),
               Basic, Basic(),
               # XXX: dynamically created types are not picklable
-              # ManagedProperties, ManagedProperties("test", (), {}),
+              # type, type("test", (), {}),
               SingletonRegistry, S):
         check(c)
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -93,11 +93,7 @@ def check(a, exclude=[], check_attr=True):
 
 
 def test_core_basic():
-    for c in (Atom, Atom(),
-              Basic, Basic(),
-              # XXX: dynamically created types are not picklable
-              # type, type("test", (), {}),
-              SingletonRegistry, S):
+    for c in (Atom, Atom(), Basic, Basic(), SingletonRegistry, S):
         check(c)
 
 def test_core_Str():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Builds on #24634 after #24657 was merged.

#### Brief description of what is fixed or changed

The ManagedProperties metaclass is removed meaning that Basic no longer uses a metaclass. Some subclasses such as Function still use metaclasses though.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `Basic` no longer uses the `ManagedProperties` and `BasicMeta` metaclasses and is now just an ordinary class whose metaclass is type.
    * DEPRECATION: The `ManagedProperties` metaclass is now deprecated. This used to be the metaclass for `Basic` but is no longer needed since `Basic` does not use metaclasses. Any code using this must be making metaclasses and should just subclass `type` instead of `ManagedProperties`.
    * BREAKING CHANGE: The `BasicMeta` metaclass was removed. There has never been a good reason for downstream code to use this metaclass since `ManagedProperties` was the metaclass for `Basic`. Now `Basic` does not use any metaclasses so any downstream code that wants to use metaclasses should just use `type` rather than `ManagedProperties`.
<!-- END RELEASE NOTES -->
