### PR TITLE
sympygh-24140: fix broken links to eqworld

### DIFF
--- a/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
+++ b/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
@@ -284,11 +284,13 @@ Mathematical Equivalents
 |                       | sm.Matrix([1,2,3]).   | computation related   |
 |                       | reshape(3, 1), x),    | to polynomials and    |
 |                       | x)``                  | roots refer to        |
-|                       |                       | `mpmath/calculus. <htt|
-|                       |                       | p://docs.s            |
-|                       |                       | ympy.org/0.7.6/module |
-|                       |                       | s/mpmath/calculus/pol |
-|                       |                       | ynomials.html>`_      |
+|                       |                       | `mpmath/calculus. <ht |
+|                       |                       | tps://web.archive.org |
+|                       |                       | /web/20180731093609/h |
+|                       |                       | ttp://docs.sympy.org/ |
+|                       |                       | 0.7.6/modules/mpmath/ |
+|                       |                       | calculus/polynomials. |
+|                       |                       | html>`_               |
 +-----------------------+-----------------------+-----------------------+
 | ``Solve(A, x1, x2)``  | ``sm.linsolve(A,      | For more information  |
 |                       | (x1, x2))``           | refer to              |

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1179,7 +1179,7 @@ def classify_sysode(eq, funcs=None, **kwargs):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode-toc1.htm
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode-toc1.htm
     -A. D. Polyanin and A. V. Manzhirov, Handbook of Mathematics for Engineers and Scientists
 
     Examples
@@ -3302,7 +3302,7 @@ def _nonlinear_3eq_order1_type1(x, y, z, t, eq):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode0401.pdf
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode0401.pdf
 
     """
     C1, C2 = get_numbered_constants(eq, num=2)
@@ -3356,7 +3356,7 @@ def _nonlinear_3eq_order1_type2(x, y, z, t, eq):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode0402.pdf
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode0402.pdf
 
     """
     C1, C2 = get_numbered_constants(eq, num=2)
@@ -3413,7 +3413,7 @@ def _nonlinear_3eq_order1_type3(x, y, z, t, eq):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode0404.pdf
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode0404.pdf
 
     """
     C1 = get_numbered_constants(eq, num=1)
@@ -3473,7 +3473,7 @@ def _nonlinear_3eq_order1_type4(x, y, z, t, eq):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode0405.pdf
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode0405.pdf
 
     """
     C1 = get_numbered_constants(eq, num=1)
@@ -3523,7 +3523,7 @@ def _nonlinear_3eq_order1_type5(x, y, z, t, eq):
 
     References
     ==========
-    -http://eqworld.ipmnet.ru/en/solutions/sysode/sode0406.pdf
+    -https://eqworld.ipmnet.ru/en/solutions/sysode/sode0406.pdf
 
     """
     C1 = get_numbered_constants(eq, num=1)

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -944,8 +944,8 @@ class RiccatiSpecial(SinglePatternODESolver):
     ==========
 
     - http://www.maplesoft.com/support/help/Maple/view.aspx?path=odeadvisor/Riccati
-    - http://eqworld.ipmnet.ru/en/solutions/ode/ode0106.pdf -
-      http://eqworld.ipmnet.ru/en/solutions/ode/ode0123.pdf
+    - https://eqworld.ipmnet.ru/en/solutions/ode/ode0106.pdf -
+      https://eqworld.ipmnet.ru/en/solutions/ode/ode0123.pdf
     """
     hint = "Riccati_special_minus2"
     has_integral = False
@@ -1075,7 +1075,7 @@ class SecondNonlinearAutonomousConserved(SinglePatternODESolver):
     References
     ==========
 
-    - http://eqworld.ipmnet.ru/en/solutions/ode/ode0301.pdf
+    - https://eqworld.ipmnet.ru/en/solutions/ode/ode0301.pdf
     """
     hint = "2nd_nonlinear_autonomous_conserved"
     has_integral = True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Links to eqworld were broken, but it was fixed by chaning all occurrencies of `http` to `https`
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#24140 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
