### PR TITLE
Add transformation matrix to LLL

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -82,7 +82,7 @@ from .dense import (
         )
 
 from sympy.polys.domains import QQ
-from .lll import ddm_lll
+from .lll import ddm_lll, ddm_lll_transform
 
 
 class DDM(list):
@@ -486,8 +486,11 @@ class DDM(list):
         zero = self.domain.zero
         return all(Mij == zero for i, Mi in enumerate(self) for Mij in Mi[i+1:])
 
-    def lll(A, delta=QQ(3, 4)) -> 'DDM':
-        return ddm_lll(A, delta)
+    def lll(A, delta=QQ(3, 4)):
+        return ddm_lll(A, delta=delta)
+
+    def lll_transform(A, delta=QQ(3, 4)):
+        return ddm_lll_transform(A, delta=delta)
 
 
 from .sdm import SDM

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1691,7 +1691,7 @@ class DomainMatrix:
             A, B = A.unify(B)
         return A == B
 
-    def lll(A, delta=QQ(3, 4)) -> 'DomainMatrix':
+    def lll(A, delta=QQ(3, 4)):
         """
         Performs the Lenstra–Lenstra–Lovász (LLL) basis reduction algorithm.
         See [1]_ and [2]_.
@@ -1739,6 +1739,10 @@ class DomainMatrix:
         and 4.4 of [3]_ (pp.68-69). It uses the efficient method of only calculating
         state updates as they are required.
 
+        See also
+        ========
+
+        lll_transform
 
         References
         ==========
@@ -1749,3 +1753,39 @@ class DomainMatrix:
 
         """
         return DomainMatrix.from_rep(A.rep.lll(delta=delta))
+
+    def lll_transform(A, delta=QQ(3, 4)):
+        """
+        Performs the Lenstra–Lenstra–Lovász (LLL) basis reduction algorithm
+        and returns the reduced basis and transformation matrix.
+
+        Explanation
+        ===========
+
+        Parameters, algorithm and basis are the same as for :meth:`lll` except that
+        the return value is a tuple `(B, T)` with `B` the reduced basis and
+        `T` a transformation matrix. The original basis `A` is transformed to
+        `B` with `T*A == B`. If only `B` is needed then :meth:`lll` should be
+        used as it is a little faster.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.domains import ZZ, QQ
+        >>> from sympy.polys.matrices import DM
+        >>> X = DM([[1, 0, 0, 0, -20160],
+        ...         [0, 1, 0, 0, 33768],
+        ...         [0, 0, 1, 0, 39578],
+        ...         [0, 0, 0, 1, 47757]], ZZ)
+        >>> B, T = X.lll_transform(delta=QQ(5, 6))
+        >>> T * X == B
+        True
+
+        See also
+        ========
+
+        lll
+
+        """
+        reduced, transform = A.rep.lll_transform(delta=delta)
+        return DomainMatrix.from_rep(reduced), DomainMatrix.from_rep(transform)

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -12,7 +12,7 @@ from sympy.utilities.iterables import _strongly_connected_components
 from .exceptions import DMBadInputError, DMDomainError, DMShapeError
 
 from .ddm import DDM
-from .lll import ddm_lll
+from .lll import ddm_lll, ddm_lll_transform
 from sympy.polys.domains import QQ
 
 
@@ -853,8 +853,12 @@ class SDM(dict):
         """
         return all(i >= j for i, row in self.items() for j in row)
 
-    def lll(A, delta=QQ(3, 4)) -> 'SDM':
-        return A.from_ddm(ddm_lll(A.to_ddm(), delta))
+    def lll(A, delta=QQ(3, 4)):
+        return A.from_ddm(ddm_lll(A.to_ddm(), delta=delta))
+
+    def lll_transform(A, delta=QQ(3, 4)):
+        reduced, transform = ddm_lll_transform(A.to_ddm(), delta=delta)
+        return A.from_ddm(reduced), A.from_ddm(transform)
 
 
 def binop_dict(A, B, fab, fa, fb):

--- a/sympy/polys/matrices/tests/test_lll.py
+++ b/sympy/polys/matrices/tests/test_lll.py
@@ -2,7 +2,7 @@ from sympy.polys.domains import ZZ, QQ
 from sympy.polys.matrices import DM
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.matrices.exceptions import DMRankError, DMValueError, DMShapeError, DMDomainError
-from sympy.polys.matrices.lll import ddm_lll
+from sympy.polys.matrices.lll import _ddm_lll, ddm_lll, ddm_lll_transform
 from sympy.testing.pytest import raises
 
 
@@ -36,14 +36,43 @@ def test_lll():
                 [-54, 34, 55, 678],
                 [-189, 3077, -184, -223]], ZZ)
         )
-
     ]
     delta = QQ(5, 6)
     for basis_dm, reduced_dm in normal_test_data:
-        assert ddm_lll(basis_dm.rep, delta=delta) == reduced_dm.rep
-        assert basis_dm.rep.lll(delta=delta) == reduced_dm.rep
-        assert basis_dm.rep.to_sdm().lll(delta=delta) == reduced_dm.rep.to_sdm()
-        assert basis_dm.lll(delta=delta) == reduced_dm
+        reduced = _ddm_lll(basis_dm.rep, delta=delta)[0]
+        assert reduced == reduced_dm.rep
+
+        reduced = ddm_lll(basis_dm.rep, delta=delta)
+        assert reduced == reduced_dm.rep
+
+        reduced, transform = _ddm_lll(basis_dm.rep, delta=delta, return_transform=True)
+        assert reduced == reduced_dm.rep
+        assert transform.matmul(basis_dm.rep) == reduced_dm.rep
+
+        reduced, transform = ddm_lll_transform(basis_dm.rep, delta=delta)
+        assert reduced == reduced_dm.rep
+        assert transform.matmul(basis_dm.rep) == reduced_dm.rep
+
+        reduced = basis_dm.rep.lll(delta=delta)
+        assert reduced == reduced_dm.rep
+
+        reduced, transform = basis_dm.rep.lll_transform(delta=delta)
+        assert reduced == reduced_dm.rep
+        assert transform.matmul(basis_dm.rep) == reduced_dm.rep
+
+        reduced = basis_dm.rep.to_sdm().lll(delta=delta)
+        assert reduced == reduced_dm.rep.to_sdm()
+
+        reduced, transform = basis_dm.rep.to_sdm().lll_transform(delta=delta)
+        assert reduced == reduced_dm.rep.to_sdm()
+        assert transform.matmul(basis_dm.rep.to_sdm()) == reduced_dm.rep.to_sdm()
+
+        reduced = basis_dm.lll(delta=delta)
+        assert reduced == reduced_dm
+
+        reduced, transform = basis_dm.lll_transform(delta=delta)
+        assert reduced == reduced_dm
+        assert transform.matmul(basis_dm) == reduced_dm
 
 
 def test_lll_linear_dependent():
@@ -61,32 +90,56 @@ def test_lll_linear_dependent():
             [10, -4, 2]], ZZ)
     ]
     for not_basis in linear_dependent_test_data:
+        raises(DMRankError, lambda: _ddm_lll(not_basis.rep))
         raises(DMRankError, lambda: ddm_lll(not_basis.rep))
         raises(DMRankError, lambda: not_basis.rep.lll())
         raises(DMRankError, lambda: not_basis.rep.to_sdm().lll())
         raises(DMRankError, lambda: not_basis.lll())
+        raises(DMRankError, lambda: _ddm_lll(not_basis.rep, return_transform=True))
+        raises(DMRankError, lambda: ddm_lll_transform(not_basis.rep))
+        raises(DMRankError, lambda: not_basis.rep.lll_transform())
+        raises(DMRankError, lambda: not_basis.rep.to_sdm().lll_transform())
+        raises(DMRankError, lambda: not_basis.lll_transform())
 
 
 def test_lll_wrong_delta():
     dummy_matrix = DomainMatrix.ones((3, 3), ZZ)
     for wrong_delta in [QQ(-1, 4), QQ(0, 1), QQ(1, 4), QQ(1, 1), QQ(100, 1)]:
+        raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta))
         raises(DMValueError, lambda: ddm_lll(dummy_matrix.rep, delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.lll(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.lll(delta=wrong_delta))
+        raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta, return_transform=True))
+        raises(DMValueError, lambda: ddm_lll_transform(dummy_matrix.rep, delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.rep.lll_transform(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll_transform(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.lll_transform(delta=wrong_delta))
 
 
 def test_lll_wrong_shape():
     wrong_shape_matrix = DomainMatrix.ones((4, 3), ZZ)
+    raises(DMShapeError, lambda: _ddm_lll(wrong_shape_matrix.rep))
     raises(DMShapeError, lambda: ddm_lll(wrong_shape_matrix.rep))
     raises(DMShapeError, lambda: wrong_shape_matrix.rep.lll())
     raises(DMShapeError, lambda: wrong_shape_matrix.rep.to_sdm().lll())
     raises(DMShapeError, lambda: wrong_shape_matrix.lll())
+    raises(DMShapeError, lambda: _ddm_lll(wrong_shape_matrix.rep, return_transform=True))
+    raises(DMShapeError, lambda: ddm_lll_transform(wrong_shape_matrix.rep))
+    raises(DMShapeError, lambda: wrong_shape_matrix.rep.lll_transform())
+    raises(DMShapeError, lambda: wrong_shape_matrix.rep.to_sdm().lll_transform())
+    raises(DMShapeError, lambda: wrong_shape_matrix.lll_transform())
 
 
 def test_lll_wrong_domain():
     wrong_domain_matrix = DomainMatrix.ones((3, 3), QQ)
+    raises(DMDomainError, lambda: _ddm_lll(wrong_domain_matrix.rep))
     raises(DMDomainError, lambda: ddm_lll(wrong_domain_matrix.rep))
     raises(DMDomainError, lambda: wrong_domain_matrix.rep.lll())
     raises(DMDomainError, lambda: wrong_domain_matrix.rep.to_sdm().lll())
     raises(DMDomainError, lambda: wrong_domain_matrix.lll())
+    raises(DMDomainError, lambda: _ddm_lll(wrong_domain_matrix.rep, return_transform=True))
+    raises(DMDomainError, lambda: ddm_lll_transform(wrong_domain_matrix.rep))
+    raises(DMDomainError, lambda: wrong_domain_matrix.rep.lll_transform())
+    raises(DMDomainError, lambda: wrong_domain_matrix.rep.to_sdm().lll_transform())
+    raises(DMDomainError, lambda: wrong_domain_matrix.lll_transform())


### PR DESCRIPTION
#### References to other Issues or PRs
See recent pull request adding LLL [here](https://github.com/sympy/sympy/pull/24572)

#### Brief description of what is fixed or changed
Add the transformation matrix as an optional output to the lll methods added in the above pull request. The matrix is only computed if explicitly requested.

#### Other comments
Refactoring ideas are welcome. I don't like returning multiple objects from functions, but I don't know how to make this cleaner, since the transformation matrix needs to be computed at the same time as the reduced basis, for efficiency.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
