### PR TITLE
Use sum/fsum & prod/fprod in some python related printers

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -23,7 +23,7 @@ class LambdaPrinter(PythonCodePrinter):
     lambdify.
     """
     printmethod = "_lambdacode"
-
+    _default_settings = dict(PythonCodePrinter._default_settings, fully_qualified_modules=False)
 
     def _print_And(self, expr):
         result = ['(']

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -65,14 +65,21 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
 
     def _print_Add(self, e):
         if len(e.args) >= self._settings['num_terms_sum']:
-            return '{}({}, axis=0)'.format(self._module_format(self._module + '.sum'),
-                                   self._print_seq(e.args))
+            bcast = '{}({})'.format(
+                self._module_format(self._module + '.broadcast_arrays'),
+                ', '.join(map(self._print, e.args))
+            )
+            return '{}({}, axis=0)'.format(self._module_format(self._module + '.sum'), bcast)
         return super()._print_Add(e)
 
     def _print_Mul(self, e):
         if len(e.args) >= self._settings['num_factors_prod']:
-            return '{}({})'.format(self._module_format(self._module + '.prod'),
-                                   self._print_seq(e.args))
+            bcast = '{}({})'.format(
+                self._module_format(self._module + '.broadcast_arrays'),
+                ', '.join(map(self._print, e.args))
+            )
+            return '{}({}, axis=0)'.format(self._module_format(self._module + '.prod'),
+                                           bcast)
         return super()._print_Mul(e)
 
     def _print_MatMul(self, expr):

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -65,7 +65,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
 
     def _print_Add(self, e):
         if len(e.args) >= self._settings['num_terms_sum']:
-            return '{}({})'.format(self._module_format(self._module + '.sum'),
+            return '{}({}, axis=0)'.format(self._module_format(self._module + '.sum'),
                                    self._print_seq(e.args))
         return super()._print_Add(e)
 

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -64,12 +64,16 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return '({},)'.format(delimiter.join(self._print(item) for item in seq))
 
     def _print_Add(self, e):
-        return '{}({})'.format(self._module_format(self._module + '.sum'),
-            self._print_seq(e.args))
+        if len(e.args) >= self._settings['num_terms_sum']:
+            return '{}({})'.format(self._module_format(self._module + '.sum'),
+                                   self._print_seq(e.args))
+        return super()._print_Add(e)
 
     def _print_Mul(self, e):
-        return '{}({})'.format(self._module_format(self._module + '.prod'),
-            self._print_seq(e.args))
+        if len(e.args) >= self._settings['num_factors_prod']:
+            return '{}({})'.format(self._module_format(self._module + '.prod'),
+                                   self._print_seq(e.args))
+        return super()._print_Mul(e)
 
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -63,6 +63,14 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         delimiter=', '
         return '({},)'.format(delimiter.join(self._print(item) for item in seq))
 
+    def _print_Add(self, e):
+        return '{}({})'.format(self._module_format(self._module + '.sum'),
+            self._print_seq(e.args))
+
+    def _print_Mul(self, e):
+        return '{}({})'.format(self._module_format(self._module + '.prod'),
+            self._print_seq(e.args))
+
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"
         if expr.as_coeff_matrices()[0] is not S.One:

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -194,7 +194,8 @@ class AbstractPythonCodePrinter(CodePrinter):
         # is already better served by the mpmath printer. And finally, subclassing and
         # overriding this remains an option.
         if len(expr.args) >= self._settings['num_terms_sum']:
-            return 'sum([%s], start=%s)' % (
+            return '%s([%s], start=%s)' % (
+                self._module_format("builtins.sum"),
                 ', '.join(map(self._print, expr.args[1:])),
                 self._print(expr.args[0])
             )
@@ -275,7 +276,8 @@ class AbstractPythonCodePrinter(CodePrinter):
                 a=self._print(a),
                 b=self._print(b))
             for i, a, b in expr.limits)
-        return '(builtins.sum({function} {loops}))'.format(
+        return '(%s({function} {loops}))'.format(
+            self._module_format("builtins.sum"),
             function=self._print(expr.function),
             loops=' '.join(loops))
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -276,7 +276,7 @@ class AbstractPythonCodePrinter(CodePrinter):
                 a=self._print(a),
                 b=self._print(b))
             for i, a, b in expr.limits)
-        return '(%s({function} {loops}))'.format(
+        return '({}({function} {loops}))'.format(
             self._module_format("builtins.sum"),
             function=self._print(expr.function),
             loops=' '.join(loops))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -68,6 +68,14 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Min(x, y)) == "min(x, y)"
     assert prntr.doprint(Max(x, y)) == "max(x, y)"
 
+    prntr2 = PythonCodePrinter({'num_terms_sum': 3, 'num_factors_prod': 4})
+    assert prntr2.doprint(x+y) == "x + y"
+    assert prntr2.doprint(x+y+z) == "sum([y, z], start=x)"
+    assert prntr2.doprint(x*y*z) == "x*y*z"
+    w = symbols('w')
+    assert prntr2.doprint(w*x*y*z) == "math.prod([x, y, z], start=w)"
+
+
 
 def test_PythonCodePrinter_standard():
     prntr = PythonCodePrinter()

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -70,7 +70,7 @@ def test_PythonCodePrinter():
 
     prntr2 = PythonCodePrinter({'num_terms_sum': 3, 'num_factors_prod': 4})
     assert prntr2.doprint(x+y) == "x + y"
-    assert prntr2.doprint(x+y+z) == "sum([y, z], start=x)"
+    assert prntr2.doprint(x+y+z) == "builtins.sum([y, z], start=x)"
     assert prntr2.doprint(x*y*z) == "x*y*z"
     w = symbols('w')
     assert prntr2.doprint(w*x*y*z) == "math.prod([x, y, z], start=w)"

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -102,7 +102,7 @@ NUMEXPR_TRANSLATIONS: dict[str, str] = {}
 # Available modules:
 MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
-    "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
+    "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("import mpmath; from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -563,3 +563,14 @@ def as_int(n, strict=True):
         if n != result:
             raise ValueError('%s is not an integer' % (n,))
         return result
+
+class adjusted_recursion_limit:
+    def __init__(self, new_limit):
+        self._ori_limit = sys.getrecursionlimit()
+        self._new_limit = new_limit
+
+    def __enter__(self):
+        sys.setrecursionlimit(self._new_limit)
+
+    def __exit__(self, exc_t, exc_v, exc_tb):
+        sys.setrecursionlimit(self._ori_limit)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -6,6 +6,7 @@ import sys
 import operator
 
 import mpmath
+from sympy.printing.pycode import PythonCodePrinter
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.concrete.summations import Sum
 from sympy.core.add import Add
@@ -1737,4 +1738,14 @@ def test_24673_recursion_error():
             arr_4 = numpy.arange(4)
             arr_3_4 = numpy.arange(12).reshape((3, 4))
             arr_5_3_4 = numpy.arange(3*4*5).reshape((5, 3, 4))
-            assert f(arr_4, arr_5_3_4, arr_3_4) == functools.reduce(op, [arr_5_3_4 + arr_4 + arr_3_4])
+            ref = functools.reduce(op, [arr_5_3_4, arr_4, arr_3_4])
+            ans = f(arr_4, arr_5_3_4, arr_3_4)
+            assert numpy.all(ans == ref)
+
+    nterms = PythonCodePrinter._default_settings['num_terms_sum'] + 1
+    expr = sum([x**i for i in range(nterms)])
+    res1 = lambdify(x, expr)(1.01)
+    # we don't want builtins.sum here, only sum
+    res2 = eval(lambdastr(x, expr, dummify=True))(1.01)
+    err = res1 - res2
+    assert abs(err) < abs(res1)*4e-16

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,7 +2,6 @@ from itertools import product
 import functools
 import math
 import inspect
-import sys
 import operator
 
 import mpmath

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1723,14 +1723,14 @@ def test_23536_lambdify_cse_dummy():
 def test_24673_recursion_error_108k_ops():
     class adjusted_recursion_limit:
         def __init__(self, new_limit):
-            self._ori_limit = sys.gettrecursionlimit()
+            self._ori_limit = sys.getrecursionlimit()
             self._new_limit = new_limit
 
         def __enter__(self):
-            sys.setrecursionlimit(self.new_limit)
+            sys.setrecursionlimit(self._new_limit)
 
         def __exit__(self, exc_t, exc_v, exc_tb):
-            sys.setrecursionlimit(self.new_limit)
+            sys.setrecursionlimit(self._ori_limit)
 
     # TODO, reproduce using a smaller expression. (this takes too long...)
     a, b, c, x, y, z = symbols('a, b, c, x, y, z')


### PR DESCRIPTION
Tentative fix for recusion error when using lambdify.

#### References to other Issues or PRs
Fixes #24673

#### Brief description of what is fixed or changed


#### Other comments
Perhaps this needs to be opt-in with some printer setting for backwards compatibility. (`lambdify` can then use that setting by default). Also, I have found `functools.reduce(operators.add, [...])` to be a better replacement for `sum` in generic python code (but of course I can't remember an example right now).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
