### PR TITLE
Correct rebuilding of objects to use all args in CSE

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -510,7 +510,7 @@ def opt_cse(exprs, order='canonical'):
 
         list(map(_find_opts, expr.args))
 
-        if expr.could_extract_minus_sign():
+        if not isinstance(expr, MatrixExpr) and expr.could_extract_minus_sign():
             neg_expr = -expr
             if not neg_expr.is_Atom:
                 opt_subs[expr] = Unevaluated(Mul, (S.NegativeOne, neg_expr))

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -639,7 +639,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
             return expr
 
         if iterable(expr):
-            new_args = [_rebuild(arg) for arg in expr]
+            new_args = [_rebuild(arg) for arg in expr.args]
             return expr.func(*new_args)
 
         if expr in subs:

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import symbols, Symbol
 from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                             SparseMatrix, ImmutableSparseMatrix)
 from sympy.matrices.expressions import (MatrixExpr, MatrixSymbol, MatMul,
-                                        MatAdd, MatPow)
+                                        MatAdd, MatPow, Inverse)
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.polys.rootoftools import RootOf
 from sympy.utilities.iterables import numbered_symbols, sift, \
@@ -522,6 +522,10 @@ def opt_cse(exprs, order='canonical'):
 
         elif isinstance(expr, (Add, MatAdd)):
             adds.add(expr)
+
+        elif isinstance(expr, Inverse):
+            # Do not want to treat `Inverse` as a `MatPow`
+            pass
 
         elif isinstance(expr, (Pow, MatPow)):
             base, exp = expr.base, expr.exp

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -2,6 +2,7 @@ from functools import reduce
 import itertools
 from operator import add
 
+from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import Function
@@ -16,6 +17,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
+from sympy.matrices.expressions import Inverse, MatMul
 from sympy.polys.rootoftools import CRootOf
 from sympy.series.order import O
 from sympy.simplify.cse_main import cse
@@ -604,3 +606,26 @@ def test_issue_18991():
 def test_unevaluated_Mul():
     m = [Mul(1, 2, evaluate=False)]
     assert cse(m) == ([], m)
+
+
+def test_cse_matrix_expression_inverse():
+    A = Matrix(symbols('A:4')).reshape(2, 2)
+    x = Inverse(A)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [Inverse(A)])
+
+
+def test_cse_matrix_expression_matmul_inverse():
+    A = Matrix(symbols('A:4')).reshape(2, 2)
+    b = Matrix(symbols('b:2'))
+    x = MatMul(Inverse(A), b)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [x])
+
+
+def test_cse_matrix_expression_matrix_solve():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    b = ImmutableDenseMatrix(symbols('b:2'))
+    x = MatrixSolve(A, b)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [x])

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
-from sympy.matrices.expressions import Inverse, MatAdd, MatMul, MatPow, Transpose
+from sympy.matrices.expressions import Inverse, MatAdd, MatMul, Transpose
 from sympy.polys.rootoftools import CRootOf
 from sympy.series.order import O
 from sympy.simplify.cse_main import cse

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
-from sympy.matrices.expressions import Inverse, MatMul
+from sympy.matrices.expressions import Inverse, MatAdd, MatMul, MatPow, Transpose
 from sympy.polys.rootoftools import CRootOf
 from sympy.series.order import O
 from sympy.simplify.cse_main import cse
@@ -609,18 +609,72 @@ def test_unevaluated_Mul():
 
 
 def test_cse_matrix_expression_inverse():
-    A = Matrix(symbols('A:4')).reshape(2, 2)
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
     x = Inverse(A)
     cse_expr = cse(x)
     assert cse_expr == ([], [Inverse(A)])
 
 
 def test_cse_matrix_expression_matmul_inverse():
-    A = Matrix(symbols('A:4')).reshape(2, 2)
-    b = Matrix(symbols('b:2'))
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    b = ImmutableDenseMatrix(symbols('b:2'))
     x = MatMul(Inverse(A), b)
     cse_expr = cse(x)
     assert cse_expr == ([], [x])
+
+
+def test_cse_matrix_negate_matrix():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    x = MatMul(S.NegativeOne, A)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [x])
+
+
+def test_cse_matrix_negate_matmul_not_extracted():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    B = ImmutableDenseMatrix(symbols('B:4')).reshape(2, 2)
+    x = MatMul(S.NegativeOne, A, B)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [x])
+
+
+@XFAIL  # No simplification rule for nested associative operations
+def test_cse_matrix_nested_matmul_collapsed():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    B = ImmutableDenseMatrix(symbols('B:4')).reshape(2, 2)
+    x = MatMul(S.NegativeOne, MatMul(A, B))
+    cse_expr = cse(x)
+    assert cse_expr == ([], [MatMul(S.NegativeOne, A, B)])
+
+
+def test_cse_matrix_optimize_out_single_argument_mul():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    x = MatMul(MatMul(MatMul(A)))
+    cse_expr = cse(x)
+    assert cse_expr == ([], [A])
+
+
+@XFAIL  # Multiple simplification passed not supported in CSE
+def test_cse_matrix_optimize_out_single_argument_mul_combined():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    x = MatAdd(MatMul(MatMul(MatMul(A))), MatMul(MatMul(A)), MatMul(A), A)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [MatMul(4, A)])
+
+
+def test_cse_matrix_optimize_out_single_argument_add():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    x = MatAdd(MatAdd(MatAdd(MatAdd(A))))
+    cse_expr = cse(x)
+    assert cse_expr == ([], [A])
+
+
+@XFAIL  # Multiple simplification passed not supported in CSE
+def test_cse_matrix_optimize_out_single_argument_add_combined():
+    A = ImmutableDenseMatrix(symbols('A:4')).reshape(2, 2)
+    x = MatMul(MatAdd(MatAdd(MatAdd(A))), MatAdd(MatAdd(A)), MatAdd(A), A)
+    cse_expr = cse(x)
+    assert cse_expr == ([], [MatMul(4, A)])
 
 
 def test_cse_matrix_expression_matrix_solve():
@@ -629,3 +683,53 @@ def test_cse_matrix_expression_matrix_solve():
     x = MatrixSolve(A, b)
     cse_expr = cse(x)
     assert cse_expr == ([], [x])
+
+
+def test_cse_matrix_matrix_expression():
+    X = ImmutableDenseMatrix(symbols('X:4')).reshape(2, 2)
+    y = ImmutableDenseMatrix(symbols('y:2'))
+    b = MatMul(Inverse(MatMul(Transpose(X), X)), Transpose(X), y)
+    cse_expr = cse(b)
+    x0 = MatrixSymbol('x0', 2, 2)
+    reduced_expr_expected = MatMul(Inverse(MatMul(x0, X)), x0, y)
+    assert cse_expr == ([(x0, Transpose(X))], [reduced_expr_expected])
+
+
+def test_cse_matrix_kalman_filter():
+    """Kalman Filter example from Matthew Rocklin's SciPy 2013 talk.
+
+    Talk titled: "Matrix Expressions and BLAS/LAPACK; SciPy 2013 Presentation"
+
+    Video: https://pyvideo.org/scipy-2013/matrix-expressions-and-blaslapack-scipy-2013-pr.html
+
+    Notes
+    =====
+
+    Equations are:
+
+    new_mu = mu + Sigma*H.T * (R + H*Sigma*H.T).I * (H*mu - data)
+           = MatAdd(mu, MatMul(Sigma, Transpose(H), Inverse(MatAdd(R, MatMul(H, Sigma, Transpose(H)))), MatAdd(MatMul(H, mu), MatMul(S.NegativeOne, data))))
+    new_Sigma = Sigma - Sigma*H.T * (R + H*Sigma*H.T).I * H * Sigma
+              = MatAdd(Sigma, MatMul(S.NegativeOne, Sigma, Transpose(H)), Inverse(MatAdd(R, MatMul(H*Sigma*Transpose(H)))), H, Sigma))
+
+    """
+    N = 2
+    mu = ImmutableDenseMatrix(symbols(f'mu:{N}'))
+    Sigma = ImmutableDenseMatrix(symbols(f'Sigma:{N * N}')).reshape(N, N)
+    H = ImmutableDenseMatrix(symbols(f'H:{N * N}')).reshape(N, N)
+    R = ImmutableDenseMatrix(symbols(f'R:{N * N}')).reshape(N, N)
+    data = ImmutableDenseMatrix(symbols(f'data:{N}'))
+    new_mu = MatAdd(mu, MatMul(Sigma, Transpose(H), Inverse(MatAdd(R, MatMul(H, Sigma, Transpose(H)))), MatAdd(MatMul(H, mu), MatMul(S.NegativeOne, data))))
+    new_Sigma = MatAdd(Sigma, MatMul(S.NegativeOne, Sigma, Transpose(H), Inverse(MatAdd(R, MatMul(H, Sigma, Transpose(H)))), H, Sigma))
+    cse_expr = cse([new_mu, new_Sigma])
+    x0 = MatrixSymbol('x0', N, N)
+    x1 = MatrixSymbol('x1', N, N)
+    replacements_expected = [
+        (x0, Transpose(H)),
+        (x1, Inverse(MatAdd(R, MatMul(H, Sigma, x0)))),
+    ]
+    reduced_exprs_expected = [
+        MatAdd(mu, MatMul(Sigma, x0, x1, MatAdd(MatMul(H, mu), MatMul(S.NegativeOne, data)))),
+        MatAdd(Sigma, MatMul(S.NegativeOne, Sigma, x0, x1, H, Sigma)),
+    ]
+    assert cse_expr == (replacements_expected, reduced_exprs_expected)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR addresses issues #24689, #24696, and #24697.

#### Brief description of what is fixed or changed
- Ensure all arguments are used correctly when rebuilding expressions in `tree_cse`.
- Ensure that `Inverse` is not optimised to a `MatPow` in `opt_cse`.
- Improved performance of CSE of matrix expressions.
- Add optimisations for collapsing nested multinary matrix operations with single operands.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fixed a bug with rebuilding of expressions that involve matrix expressions of matrices in CSE.
  * Improved performance of CSE of matrix expressions.
  * Added optimisations for collapsing nested multinary matrix operations with single operands.
<!-- END RELEASE NOTES -->
