### PR TITLE
backward_diff discretization of cont. transfer function

### DIFF
--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -32,3 +32,5 @@ lti
    :members:
 
 .. autofunction:: bilinear
+
+.. autofunction::backward_diff

--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -33,4 +33,4 @@ lti
 
 .. autofunction:: bilinear
 
-.. autofunction::backward_diff
+.. autofunction:: backward_diff

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -7,7 +7,7 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','bilinear',
-    'pole_zero_numerical_data',
+    'backward_diff', 'pole_zero_numerical_data',
     'pole_zero_plot', 'step_response_numerical_data', 'step_response_plot',
     'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,5 +1,5 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
-    Feedback, MIMOFeedback, TransferFunctionMatrix, bilinear)
+    Feedback, MIMOFeedback, TransferFunctionMatrix, bilinear, backward_diff)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -58,11 +58,11 @@ def bilinear(tf, sample_per):
         [2*L + R*T, -2*L + R*T]
         """
 
-        
+
         T = sample_per  # and sample period T
         s = tf.var
         z =  s # dummy discrete variable z
-        
+
         np = tf.num.as_poly(s).all_coeffs()
         dp = tf.den.as_poly(s).all_coeffs()
 
@@ -101,7 +101,7 @@ def backward_diff(tf, sample_per):
         >>> denZ
         [L + R*T, -L]
         """
-        
+
         T = sample_per  # and sample period T
         s = tf.var
         z =  s         # dummy discrete variable z

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -58,10 +58,11 @@ def bilinear(tf, sample_per):
         [2*L + R*T, -2*L + R*T]
         """
 
-        z = Symbol('z') # discrete variable z
+        
         T = sample_per  # and sample period T
         s = tf.var
-
+        z =  s # dummy discrete variable z
+        
         np = tf.num.as_poly(s).all_coeffs()
         dp = tf.den.as_poly(s).all_coeffs()
 
@@ -100,10 +101,10 @@ def backward_diff(tf, sample_per):
         >>> denZ
         [L + R*T, -L]
         """
-
-        z = Symbol('z') # discrete variable z
+        
         T = sample_per  # and sample period T
         s = tf.var
+        z =  s         # dummy discrete variable z
 
         np = tf.num.as_poly(s).all_coeffs()
         dp = tf.den.as_poly(s).all_coeffs()

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -45,7 +45,6 @@ def bilinear(tf, sample_per):
         Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
         as [a, b], [c, d].
 
-
         Examples
         ========
 
@@ -78,16 +77,14 @@ def bilinear(tf, sample_per):
 
 
 def backward_diff(tf, sample_per):
-
         """
-
         Returns falling coefficients of H(z) from numerator and denominator.
         Where H(z) is the corresponding discretized transfer function,
         discretized with the backward difference transform method.
         H(z) is obtained from the continuous transfer function H(s)
         by substituting s(z) =  (z-1)/(T*z) into H(s), where T is the
         sample period.
-        H(z) corresponds to the difference equation of the by backward difference scheme.
+        H(z) corresponds to the difference equation of the backward difference scheme.
         Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
         as [a, b], [c, d].
 
@@ -119,7 +116,6 @@ def backward_diff(tf, sample_per):
 
         num_coefs = num.as_poly(z).all_coeffs()
         den_coefs = den.as_poly(z).all_coeffs()
-
 
         return num_coefs, den_coefs
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -41,7 +41,6 @@ def bilinear(tf, sample_per):
         H(z) is obtained from the continuous transfer function H(s)
         by substituting s(z) = 2/T * (z-1)/(z+1) into H(s), where T is the
         sample period.
-        H(z) corresponds to the difference equation of the trapezoidal scheme.
         Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
         as [a, b], [c, d].
 
@@ -85,7 +84,6 @@ def backward_diff(tf, sample_per):
         H(z) is obtained from the continuous transfer function H(s)
         by substituting s(z) =  (z-1)/(T*z) into H(s), where T is the
         sample period.
-        H(z) corresponds to the difference equation of the backward difference scheme.
         Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
         as [a, b], [c, d].
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,7 +22,7 @@ from sympy.series import limit
 from mpmath.libmp.libmpf import prec_to_dps
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel',
-    'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'bilinear']
+    'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'bilinear', 'backward_diff']
 
 
 def _roots(poly, var):
@@ -35,12 +35,13 @@ def _roots(poly, var):
 
 def bilinear(tf, sample_per):
         """
-        Returns falling coeffs of H(z) from numerator and denominator.
-        H(z) is the corresponding discretized transfer function,
+        Returns falling coefficients of H(z) from numerator and denominator.
+        Where H(z) is the corresponding discretized transfer function,
         discretized with the bilinear transform method.
         H(z) is obtained from the continuous transfer function H(s)
         by substituting s(z) = 2/T * (z-1)/(z+1) into H(s), where T is the
         sample period.
+        H(z) corresponds to the difference equation of the trapezoidal scheme.
         Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
         as [a, b], [c, d].
 
@@ -72,6 +73,54 @@ def bilinear(tf, sample_per):
 
         num_coefs = num.as_poly(z).all_coeffs()
         den_coefs = den.as_poly(z).all_coeffs()
+
+        return num_coefs, den_coefs
+
+
+def backward_diff(tf, sample_per):
+
+        """
+
+        Returns falling coefficients of H(z) from numerator and denominator.
+        Where H(z) is the corresponding discretized transfer function,
+        discretized with the backward difference transform method.
+        H(z) is obtained from the continuous transfer function H(s)
+        by substituting s(z) =  (z-1)/(T*z) into H(s), where T is the
+        sample period.
+        H(z) corresponds to the difference equation of the by backward difference scheme.
+        Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+        as [a, b], [c, d].
+
+        Examples
+
+        ========
+
+        >>> from sympy.physics.control.lti import TransferFunction, bilinear
+        >>> from sympy.abc import s, L, R, T
+        >>> tf = TransferFunction(1, s*L + R, s)
+        >>> numZ, denZ = bilinear(tf, T)
+        >>> numZ
+        [T, 0]
+        >>> denZ
+        [L + R*T, -L]
+        """
+
+        z = Symbol('z') # discrete variable z
+        T = sample_per  # and sample period T
+        s = tf.var
+
+        np = tf.num.as_poly(s).all_coeffs()
+        dp = tf.den.as_poly(s).all_coeffs()
+
+        # The next line results from multiplying H(z) with z^N/z^N
+
+        N = max(len(np), len(dp)) - 1
+        num = Add(*[ T**(N-i)*c*(z-1)**i*(z)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
+        den = Add(*[ T**(N-i)*c*(z-1)**i*(z)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
+
+        num_coefs = num.as_poly(z).all_coeffs()
+        den_coefs = den.as_poly(z).all_coeffs()
+
 
         return num_coefs, den_coefs
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -92,7 +92,6 @@ def backward_diff(tf, sample_per):
         as [a, b], [c, d].
 
         Examples
-
         ========
 
         >>> from sympy.physics.control.lti import TransferFunction, backward_diff

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -95,10 +95,10 @@ def backward_diff(tf, sample_per):
 
         ========
 
-        >>> from sympy.physics.control.lti import TransferFunction, bilinear
+        >>> from sympy.physics.control.lti import TransferFunction, backward_diff
         >>> from sympy.abc import s, L, R, T
         >>> tf = TransferFunction(1, s*L + R, s)
-        >>> numZ, denZ = bilinear(tf, T)
+        >>> numZ, denZ = backward_diff(tf, T)
         >>> numZ
         [T, 0]
         >>> denZ

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -14,7 +14,8 @@ from sympy.simplify.simplify import simplify
 from sympy.core.containers import Tuple
 from sympy.matrices import ImmutableMatrix, Matrix
 from sympy.physics.control import (TransferFunction, Series, Parallel,
-    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback, bilinear)
+    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
+    bilinear, backward_diff)
 from sympy.testing.pytest import raises
 
 a, x, b, s, g, d, p, k, a0, a1, a2, b0, b1, b2, tau, zeta, wn, T = symbols('a, x, b, s, g, d, p, k,\
@@ -1229,5 +1230,16 @@ def test_TransferFunction_bilinear():
     tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
     tf_test_manual = TransferFunction(s*T+T, s*(T*b+2*a)+T*b-2*a, s)
+
+    assert S.Zero == (tf_test_bilinear-tf_test_manual).simplify().num
+
+def test_TransferFunction_backward_diff():
+    # simple transfer function, e.g. ohms law
+    tf = TransferFunction(1, a*s+b, s)
+    numZ, denZ = backward_diff(tf, T)
+    # discretized transfer function with coefs from tf.bilinear()
+    tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
+    # corresponding tf with manually calculated coefs
+    tf_test_manual = TransferFunction(s*T, s*(T*b+a)-a, s)
 
     assert S.Zero == (tf_test_bilinear-tf_test_manual).simplify().num


### PR DESCRIPTION
# Added backward difference discretization method to physics.control.lti

#### References to other Issues or PRs

It is a 1 to 1 extension of [PR 24558](https://github.com/sympy/sympy/pull/24558)


#### Brief description of what is fixed or changed

Added function

```
backward_diff(tf, sample_per)
```

In full analogy of 

```
bilinear(tf, sample_per)
```

In practical use of contiuous transfer function $H(s)$  (corresponding to differential eq.)one eventually needs the dicsretized version $H(z)$ (corresponding to difference eq.).

* bilinear renders coefficients for trapezoidal integration scheme
* backward_diff renders coefficients for backward difference integration scheme 

Both methdos preserve the stability of the continuous input transfer function.

#### Other comments

SymPy would obtain more than one symbolic discretizatin methods of continuous transfer functions.

As the numerical counterparts from the scientific computing with python eco system

https://python-control.readthedocs.io/en/latest/generated/control.sample_system.html

https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.cont2discrete.html#scipy.signal.cont2discrete

#### Release Notes


<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
