### PR TITLE
Revert particle frame attribute, while keeping compatibility with Joint

### DIFF
--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -132,10 +132,12 @@ class Body(RigidBody, Particle):  # type: ignore
         # Note: BodyBase.__init__ is used to prevent problems with super() calls in
         # Particle and RigidBody arising due to multiple inheritance.
         if central_inertia is None and mass is not None:
-            BodyBase.__init__(self, name, masscenter, frame, _mass)
+            BodyBase.__init__(self, name, masscenter, _mass)
+            self.frame = frame
             self._central_inertia = Dyadic(0)
         else:
-            BodyBase.__init__(self, name, masscenter, frame, _mass)
+            BodyBase.__init__(self, name, masscenter, _mass)
+            self.frame = frame
             self.inertia = _inertia
 
     def __repr__(self):

--- a/sympy/physics/mechanics/body_base.py
+++ b/sympy/physics/mechanics/body_base.py
@@ -8,7 +8,7 @@ __all__ = ['BodyBase']
 
 class BodyBase(ABC):
     """Abstract class for body type objects."""
-    def __init__(self, name, masscenter=None, frame=None, mass=None):
+    def __init__(self, name, masscenter=None, mass=None):
         # Note: If frame=None, no auto-generated frame is created, because a
         # Particle does not need to have a frame by default.
         if not isinstance(name, str):
@@ -20,7 +20,6 @@ class BodyBase(ABC):
             masscenter = Point(f'{name}_masscenter')
         self.mass = mass
         self.masscenter = masscenter
-        self.frame = frame
         self.potential_energy = 0
         self.points = []
 
@@ -29,24 +28,12 @@ class BodyBase(ABC):
 
     def __repr__(self):
         return (f'{self.__class__.__name__}({repr(self.name)}, masscenter='
-                f'{repr(self.masscenter)}, frame={repr(self.frame)}, mass='
-                f'{repr(self.mass)})')
+                f'{repr(self.masscenter)}, mass={repr(self.mass)})')
 
     @property
     def name(self):
         """The name of the body."""
         return self._name
-
-    @property
-    @abstractmethod
-    def frame(self):
-        """The ReferenceFrame fixed to the body."""
-        pass
-
-    @frame.setter
-    @abstractmethod
-    def frame(self, frame):
-        pass
 
     @property
     def masscenter(self):
@@ -67,21 +54,6 @@ class BodyBase(ABC):
     @mass.setter
     def mass(self, mass):
         self._mass = sympify(mass)
-
-    @property
-    def x(self):
-        """The basis Vector for the body, in the x direction. """
-        return self.frame.x
-
-    @property
-    def y(self):
-        """The basis Vector for the body, in the y direction. """
-        return self.frame.y
-
-    @property
-    def z(self):
-        """The basis Vector for the body, in the z direction. """
-        return self.frame.z
 
     @property
     def potential_energy(self):

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -149,18 +149,45 @@ class Joint(ABC):
             raise TypeError('Child must be a body.')
         self._child = child
 
-        # Add frames to bodies if necessary
-        for body in (self._parent, self._child):
-            if isinstance(body, Particle):
-                body.add_frame()
+        if parent_axis is not None or child_axis is not None:
+            sympy_deprecation_warning(
+                """
+                The parent_axis and child_axis arguments for the Joint classes
+                are deprecated. Instead use parent_interframe, child_interframe.
+                """,
+                deprecated_since_version="1.12",
+                active_deprecations_target="deprecated-mechanics-joint-axis",
+                stacklevel=4
+            )
+            if parent_interframe is None:
+                parent_interframe = parent_axis
+            if child_interframe is None:
+                child_interframe = child_axis
 
-        self._coordinates = self._generate_coordinates(coordinates)
-        self._speeds = self._generate_speeds(speeds)
-        _validate_coordinates(self.coordinates, self.speeds)
-        self._kdes = self._generate_kdes()
+        # Set parent and child frame attributes
+        if hasattr(self._parent, 'frame'):
+            self._parent_frame = self._parent.frame
+        else:
+            if isinstance(parent_interframe, ReferenceFrame):
+                self._parent_frame = parent_interframe
+            else:
+                self._parent_frame = ReferenceFrame(
+                    f'{self.name}_{self._parent.name}_frame')
+        if hasattr(self._child, 'frame'):
+            self._child_frame = self._child.frame
+        else:
+            if isinstance(child_interframe, ReferenceFrame):
+                self._child_frame = child_interframe
+            else:
+                self._child_frame = ReferenceFrame(
+                    f'{self.name}_{self._child.name}_frame')
 
-        self._parent_axis = self._axis(parent_axis, parent.frame)
-        self._child_axis = self._axis(child_axis, child.frame)
+        self._parent_interframe = self._locate_joint_frame(
+            self._parent, parent_interframe, self._parent_frame)
+        self._child_interframe = self._locate_joint_frame(
+            self._child, child_interframe, self._child_frame)
+        self._parent_axis = self._axis(parent_axis, self._parent_frame)
+        self._child_axis = self._axis(child_axis, self._child_frame)
 
         if parent_joint_pos is not None or child_joint_pos is not None:
             sympy_deprecation_warning(
@@ -176,26 +203,15 @@ class Joint(ABC):
                 parent_point = parent_joint_pos
             if child_point is None:
                 child_point = child_joint_pos
-        self._parent_point = self._locate_joint_pos(parent, parent_point)
-        self._child_point = self._locate_joint_pos(child, child_point)
-        if parent_axis is not None or child_axis is not None:
-            sympy_deprecation_warning(
-                """
-                The parent_axis and child_axis arguments for the Joint classes
-                are deprecated. Instead use parent_interframe, child_interframe.
-                """,
-                deprecated_since_version="1.12",
-                active_deprecations_target="deprecated-mechanics-joint-axis",
-                stacklevel=4
-            )
-            if parent_interframe is None:
-                parent_interframe = parent_axis
-            if child_interframe is None:
-                child_interframe = child_axis
-        self._parent_interframe = self._locate_joint_frame(parent,
-                                                           parent_interframe)
-        self._child_interframe = self._locate_joint_frame(child,
-                                                          child_interframe)
+        self._parent_point = self._locate_joint_pos(
+            self._parent, parent_point, self._parent_frame)
+        self._child_point = self._locate_joint_pos(
+            self._child, child_point, self._child_frame)
+
+        self._coordinates = self._generate_coordinates(coordinates)
+        self._speeds = self._generate_speeds(speeds)
+        _validate_coordinates(self.coordinates, self.speeds)
+        self._kdes = self._generate_kdes()
 
         self._orient_frames()
         self._set_angular_velocity()
@@ -453,8 +469,10 @@ class Joint(ABC):
             kdes.append(-self.coordinates[i].diff(t) + self.speeds[i])
         return Matrix(kdes)
 
-    def _locate_joint_pos(self, body, joint_pos):
+    def _locate_joint_pos(self, body, joint_pos, body_frame=None):
         """Returns the attachment point of a body."""
+        if body_frame is None:
+            body_frame = body.frame
         if joint_pos is None:
             return body.masscenter
         if not isinstance(joint_pos, (Point, Vector)):
@@ -462,22 +480,24 @@ class Joint(ABC):
         if isinstance(joint_pos, Vector):
             point_name = f'{self.name}_{body.name}_joint'
             joint_pos = body.masscenter.locatenew(point_name, joint_pos)
-        if not joint_pos.pos_from(body.masscenter).dt(body.frame) == 0:
+        if not joint_pos.pos_from(body.masscenter).dt(body_frame) == 0:
             raise ValueError('Attachment point must be fixed to the associated '
                              'body.')
         return joint_pos
 
-    def _locate_joint_frame(self, body, interframe):
+    def _locate_joint_frame(self, body, interframe, body_frame=None):
         """Returns the attachment frame of a body."""
+        if body_frame is None:
+            body_frame = body.frame
         if interframe is None:
-            return body.frame
+            return body_frame
         if isinstance(interframe, Vector):
             interframe = Joint._create_aligned_interframe(
-                body, interframe,
+                body_frame, interframe,
                 frame_name=f'{self.name}_{body.name}_int_frame')
         elif not isinstance(interframe, ReferenceFrame):
             raise TypeError('Interframe must be a ReferenceFrame.')
-        if not interframe.ang_vel_in(body.frame) == 0:
+        if not interframe.ang_vel_in(body_frame) == 0:
             raise ValueError(f'Interframe {interframe} is not fixed to body '
                              f'{body}.')
         body.masscenter.set_vel(interframe, 0)  # Fixate interframe to body
@@ -678,9 +698,9 @@ class PinJoint(Joint):
     Matrix([[q_PC(t)]])
     >>> joint.speeds
     Matrix([[u_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,             0,            0],
     [0,  cos(q_PC(t)), sin(q_PC(t))],
@@ -792,10 +812,10 @@ class PinJoint(Joint):
 
     def _set_linear_velocity(self):
         self.child_point.set_pos(self.parent_point, 0)
-        self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.child.frame, 0)
+        self.parent_point.set_vel(self._parent_frame, 0)
+        self.child_point.set_vel(self._child_frame, 0)
         self.child.masscenter.v2pt_theory(self.parent_point,
-                                          self.parent.frame, self.child.frame)
+                                          self._parent_frame, self._child_frame)
 
 
 class PrismaticJoint(Joint):
@@ -940,9 +960,9 @@ class PrismaticJoint(Joint):
     Matrix([[q_PC(t)]])
     >>> joint.speeds
     Matrix([[u_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     0
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -1055,10 +1075,10 @@ class PrismaticJoint(Joint):
     def _set_linear_velocity(self):
         axis = self.joint_axis.normalize()
         self.child_point.set_pos(self.parent_point, self.coordinates[0] * axis)
-        self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.child.frame, 0)
-        self.child_point.set_vel(self.parent.frame, self.speeds[0] * axis)
-        self.child.masscenter.set_vel(self.parent.frame, self.speeds[0] * axis)
+        self.parent_point.set_vel(self._parent_frame, 0)
+        self.child_point.set_vel(self._child_frame, 0)
+        self.child_point.set_vel(self._parent_frame, self.speeds[0] * axis)
+        self.child.masscenter.set_vel(self._parent_frame, self.speeds[0] * axis)
 
 
 class CylindricalJoint(Joint):
@@ -1200,9 +1220,9 @@ class CylindricalJoint(Joint):
     Matrix([
     [u0_PC(t)],
     [u1_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u0_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,              0,             0],
     [0,  cos(q0_PC(t)), sin(q0_PC(t))],
@@ -1349,12 +1369,12 @@ class CylindricalJoint(Joint):
         self.child_point.set_pos(
             self.parent_point,
             self.translation_coordinate * self.joint_axis.normalize())
-        self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.child.frame, 0)
+        self.parent_point.set_vel(self._parent_frame, 0)
+        self.child_point.set_vel(self._child_frame, 0)
         self.child_point.set_vel(
-            self.parent.frame,
+            self._parent_frame,
             self.translation_speed * self.joint_axis.normalize())
-        self.child.masscenter.v2pt_theory(self.child_point, self.parent.frame,
+        self.child.masscenter.v2pt_theory(self.child_point, self._parent_frame,
                                           self.child_interframe)
 
 
@@ -1530,9 +1550,9 @@ class PlanarJoint(Joint):
     [u0_PC(t)],
     [u1_PC(t)],
     [u2_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u0_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,              0,             0],
     [0,  cos(q0_PC(t)), sin(q0_PC(t))],
@@ -1711,10 +1731,10 @@ class PlanarJoint(Joint):
         self.parent_point.set_vel(self.parent_interframe, 0)
         self.child_point.set_vel(self.child_interframe, 0)
         self.child_point.set_vel(
-            self.parent.frame, self.planar_speeds[0] * self.planar_vectors[0] +
+            self._parent_frame, self.planar_speeds[0] * self.planar_vectors[0] +
             self.planar_speeds[1] * self.planar_vectors[1])
-        self.child.masscenter.v2pt_theory(self.child_point, self.parent.frame,
-                                          self.child.frame)
+        self.child.masscenter.v2pt_theory(self.child_point, self._parent_frame,
+                                          self._child_frame)
 
 
 class SphericalJoint(Joint):
@@ -1962,10 +1982,10 @@ class SphericalJoint(Joint):
 
     def _set_linear_velocity(self):
         self.child_point.set_pos(self.parent_point, 0)
-        self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.child.frame, 0)
-        self.child.masscenter.v2pt_theory(self.parent_point, self.parent.frame,
-                                          self.child.frame)
+        self.parent_point.set_vel(self._parent_frame, 0)
+        self.child_point.set_vel(self._child_frame, 0)
+        self.child.masscenter.v2pt_theory(self.parent_point, self._parent_frame,
+                                          self._child_frame)
 
 
 class WeldJoint(Joint):
@@ -2073,9 +2093,9 @@ class WeldJoint(Joint):
     Matrix(0, 0, [])
     >>> joint.speeds
     Matrix(0, 0, [])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     0
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -2164,6 +2184,6 @@ class WeldJoint(Joint):
 
     def _set_linear_velocity(self):
         self.child_point.set_pos(self.parent_point, 0)
-        self.parent_point.set_vel(self.parent.frame, 0)
-        self.child_point.set_vel(self.child.frame, 0)
-        self.child.masscenter.set_vel(self.parent.frame, 0)
+        self.parent_point.set_vel(self._parent_frame, 0)
+        self.child_point.set_vel(self._child_frame, 0)
+        self.child.masscenter.set_vel(self._parent_frame, 0)

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 
 from sympy.core.backend import pi, AppliedUndef, Derivative, Matrix
 from sympy.physics.mechanics.body_base import BodyBase
-from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.functions import _validate_coordinates
 from sympy.physics.vector import (Vector, dynamicsymbols, cross, Point,
                                   ReferenceFrame)

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import S
-from sympy.physics.vector import ReferenceFrame, cross, dot
+from sympy.physics.vector import cross, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.inertia import inertia_of_point_mass
 from sympy.utilities.exceptions import sympy_deprecation_warning

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -42,47 +42,12 @@ class Particle(BodyBase):
     >>> # Or you could change these later
     >>> pa.mass = m
     >>> pa.point = po
-    >>> # It is possible to attach a frame to a Particle if desired
-    >>> pa.add_frame()
-    pa_frame
 
     """
     point = BodyBase.masscenter
 
-    def __init__(self, name, point=None, mass=None, frame=None):
-        super().__init__(name, point, frame, mass)
-
-    def __repr__(self):
-        return (f'{self.__class__.__name__}({repr(self.name)}, masscenter='
-                f'{repr(self.masscenter)}, frame={repr(self._frame)}, mass='
-                f'{repr(self.mass)})')
-
-    @property
-    def frame(self):
-        """The optional ReferenceFrame fixed to the Particle."""
-        if self._frame is None:
-            raise AttributeError("Particle has no attached frame.")
-        return self._frame
-
-    @frame.setter
-    def frame(self, frame):
-        if frame is None:
-            self._frame = None
-            return
-        elif isinstance(frame, ReferenceFrame):
-            self._frame = frame
-        else:
-            raise ValueError('Frame must be an instance of ReferenceFrame.')
-        self.point.set_vel(frame, 0)
-
-    def add_frame(self, frame=None):
-        """Method to attach a frame to the particle."""
-        if frame is None:
-            if self._frame is not None:
-                return self.frame
-            frame = ReferenceFrame(f'{self.name}_frame')
-        self.frame = frame
-        return self.frame
+    def __init__(self, name, point=None, mass=None):
+        super().__init__(name, point, mass)
 
     def linear_momentum(self, frame):
         """Linear momentum of the particle.

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -56,9 +56,10 @@ class RigidBody(BodyBase):
 
     def __init__(self, name, masscenter=None, frame=None, mass=None,
                  inertia=None):
+        super().__init__(name, masscenter, mass)
         if frame is None:
             frame = ReferenceFrame(f'{name}_frame')
-        super().__init__(name, masscenter, frame, mass)
+        self.frame = frame
         if inertia is None:
             ixx = Symbol(f'{name}_ixx')
             iyy = Symbol(f'{name}_iyy')
@@ -85,6 +86,21 @@ class RigidBody(BodyBase):
         if not isinstance(F, ReferenceFrame):
             raise TypeError("RigidBody frame must be a ReferenceFrame object.")
         self._frame = F
+
+    @property
+    def x(self):
+        """The basis Vector for the body, in the x direction. """
+        return self.frame.x
+
+    @property
+    def y(self):
+        """The basis Vector for the body, in the y direction. """
+        return self.frame.y
+
+    @property
+    def z(self):
+        """The basis Vector for the body, in the z direction. """
+        return self.frame.z
 
     @property
     def inertia(self):

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -144,16 +144,17 @@ def test_particle_compatibility():
     m, l = symbols('m l')
     C_frame = ReferenceFrame('C')
     P = Particle('P')
-    C = Particle('C', mass=m, frame=C_frame)
+    C = Particle('C', mass=m)
     q, u = dynamicsymbols('q, u')
-    PinJoint('J', P, C, q, u, child_point=l * C_frame.y)
-    assert C.frame == C_frame
-    assert P.frame.name == 'P_frame'
-    assert C.masscenter.pos_from(P.masscenter) == -l * C.y
-    assert C.frame.dcm(P.frame) == Matrix([[1, 0, 0],
-                                           [0, cos(q), sin(q)],
-                                           [0, -sin(q), cos(q)]])
-    assert C.masscenter.vel(P.frame) == -l * u * C.z
+    J = PinJoint('J', P, C, q, u, child_interframe=C_frame,
+                 child_point=l * C_frame.y)
+    assert J.child_interframe == C_frame
+    assert J.parent_interframe.name == 'J_P_frame'
+    assert C.masscenter.pos_from(P.masscenter) == -l * C_frame.y
+    assert C_frame.dcm(J.parent_interframe) == Matrix([[1, 0, 0],
+                                                       [0, cos(q), sin(q)],
+                                                       [0, -sin(q), cos(q)]])
+    assert C.masscenter.vel(J.parent_interframe) == -l * u * C_frame.z
 
 
 def test_body_compatibility():

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -41,10 +41,10 @@ def test_rigid_body_particle_compatibility():
     l, m, g = symbols('l m g')
     C = RigidBody('C')
     b = Particle('b', mass=m)
-    b.add_frame()
+    b_frame = ReferenceFrame('b_frame')
     q, u = dynamicsymbols('q u')
-    P = PinJoint('P', C, b, coordinates=q, speeds=u,
-                 child_point=-l * b.x, joint_axis=C.z)
+    P = PinJoint('P', C, b, coordinates=q, speeds=u, child_interframe=b_frame,
+                 child_point=-l * b_frame.x, joint_axis=C.z)
     method = JointsMethod(C, P)
     method.loads.append((b.masscenter, m * g * C.x))
     method.form_eoms()

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,5 +1,4 @@
 from sympy.core.backend import symbols, Symbol
-from sympy.physics.vector import Vector
 from sympy.physics.mechanics import Point, Particle, ReferenceFrame, inertia
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -57,32 +56,6 @@ def test_particle():
     assert p.kinetic_energy(
         N) in [m2 * (v1 ** 2 + v2 ** 2 + v3 ** 2) / 2,
                m2 * v1 ** 2 / 2 + m2 * v2 ** 2 / 2 + m2 * v3 ** 2 / 2]
-
-
-def test_particle_frame():
-    p = Particle('P')
-    # Test adding frames in various ways
-    p.add_frame()
-    frame = p.frame
-    assert frame.name == 'P_frame'
-    assert p.point.vel(frame) == Vector(0)
-    N = ReferenceFrame('N')
-    p.frame = N
-    assert p.frame == N
-    assert p.point.vel(N) == Vector(0)
-    p.add_frame()  # Should not overwrite the frame
-    assert p.frame == N
-    p.add_frame(frame)  # Should overwrite the frame
-    assert p.frame == frame
-    # Remove frame
-    p.frame = None
-    raises(AttributeError, lambda: p.frame)
-    # Test invalid frame type
-    with raises(ValueError):
-        p.frame = 'a'
-    # Test parse frame in __init__
-    p = Particle('P', frame=N)
-    assert p.frame.name == 'N'
 
 
 def test_parallel_axis():

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -12,8 +12,8 @@ def test_particle_default():
     assert p.masscenter.name == 'P_masscenter'
     assert p.potential_energy == 0
     assert p.__str__() == 'P'
-    assert p.__repr__() == ("Particle('P', masscenter=P_masscenter, frame=None,"
-                            " mass=P_mass)")
+    assert p.__repr__() == ("Particle('P', masscenter=P_masscenter, "
+                            "mass=P_mass)")
     raises(AttributeError, lambda: p.frame)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR is part of the mechanics experimental development (#24234).
It reverts a part of #24238 by modifying the implementation from #24550.

#### Brief description of what is fixed or changed
This PR reverts the added frame attribute to joint, while keeping its compatibility with joint by using the intermediate frame.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
