### PR TITLE
Removed unused variables

### DIFF
--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -214,20 +214,21 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
         sigma = rgen.randint(6, n - 1)
         u = (sigma*sigma - 5) % n
         v = (4*sigma) % n
-        diff = v - u
         u_3 = pow(u, 3, n)
 
         try:
-            C = (pow(diff, 3, n)*(3*u + v)*mod_inverse(4*u_3*v, n) - 2) % n
+            # We use elliptic curve y**2 = x**3 + a*x**2 + x
+            # where a = pow(v - u, 3, n)*(3*u + v)*mod_inverse(4*u_3*v, n) - 2
+            # It is not necessary to retain a, only a24.
+            a24 = pow(v - u, 3, n)*(3*u + v)*mod_inverse(16*u_3*v, n) % n
         except ValueError:
-            #If the mod_inverse(4*u_3*v, n) doesn't exist (i.e., g != 1)
-            g = gcd(4*u_3*v, n)
+            #If the mod_inverse(16*u_3*v, n) doesn't exist (i.e., g != 1)
+            g = gcd(16*u_3*v, n)
             #If g = n, try another curve
             if g == n:
                 continue
             return g
 
-        a24 = (C + 2)*mod_inverse(4, n) % n
         Q = Point(u_3, pow(v, 3, n), a24, n)
         Q = Q.mont_ladder(k)
         g = gcd(Q.z_cord, n)

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -217,9 +217,10 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
         u_3 = pow(u, 3, n)
 
         try:
-            # We use elliptic curve y**2 = x**3 + a*x**2 + x
+            # We use the elliptic curve y**2 = x**3 + a*x**2 + x
             # where a = pow(v - u, 3, n)*(3*u + v)*mod_inverse(4*u_3*v, n) - 2
-            # It is not necessary to retain a, only a24.
+            # However, we do not declare a because it is more convenient
+            # to use a24 = (a + 2)*mod_inverse(4, n) in the calculation.
             a24 = pow(v - u, 3, n)*(3*u + v)*mod_inverse(16*u_3*v, n) % n
         except ValueError:
             #If the mod_inverse(16*u_3*v, n) doesn't exist (i.e., g != 1)


### PR DESCRIPTION
Variable C is an important parameter that determines the elliptic curve, but is not required for the calculation.
It is also likely that the variable name C was used from [1]. In [1], the elliptic curve is defined as y^2=x^3+Cx^2+Ax+B. Since this docstring uses a, it would be better to unify it with a.

[1]  Carl Pomerance and Richard Crandall "Prime Numbers: A Computational Perspective" (2nd Ed.), page 344

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
