### PR TITLE
Fixes wrong result of a Matrix with quantum operators

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1959,7 +1959,12 @@ class MatrixOperations(MatrixRequired):
         return sum(self[i, i] for i in range(self.rows))
 
     def _eval_transpose(self):
-        return self._new(self.cols, self.rows, lambda i, j: self[j, i])
+        def func(i, j):
+            if hasattr(self[j, i], "transpose"):
+                return self[j, i].transpose()
+            return self[j, i]
+
+        return self._new(self.cols, self.rows, func)
 
     def adjoint(self):
         """Conjugate transpose or Hermitian conjugation."""

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -920,6 +920,8 @@ def sdm_transpose(M):
     MT = {}
     for i, Mi in M.items():
         for j, Mij in Mi.items():
+            if hasattr(Mij, "transpose"):
+                Mij =  Mij.transpose()
             try:
                 MT[j][i] = Mij
             except KeyError:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24671 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 
<!-- END RELEASE NOTES -->
