### PR TITLE
make test_perm_groups more PEP-8 compliant

### DIFF
--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -201,7 +201,7 @@ def test_coset_rank():
         h1 = G.coset_unrank(rk, af=True)
         assert h == h1
         i += 1
-    assert G.coset_unrank(48) == None
+    assert G.coset_unrank(48) is None
     assert G.coset_unrank(G.coset_rank(gens[0])) == gens[0]
 
 
@@ -499,7 +499,7 @@ def test_is_alt_sym():
     # A dry-running test to check if it looks up for the updated cache.
     G = DihedralGroup(6)
     G.is_alt_sym()
-    assert G.is_alt_sym() == False
+    assert G.is_alt_sym() is False
 
 
 def test_minimal_block():
@@ -526,7 +526,7 @@ def test_minimal_blocks():
     assert P.minimal_blocks() == [[0]*5]
 
     P = PermutationGroup(Permutation(0, 3))
-    assert P.minimal_blocks() == False
+    assert P.minimal_blocks() is False
 
 
 def test_max_div():
@@ -812,8 +812,8 @@ def test_elements():
 
 
 def test_is_group():
-    assert PermutationGroup(Permutation(1,2), Permutation(2,4)).is_group == True
-    assert SymmetricGroup(4).is_group == True
+    assert PermutationGroup(Permutation(1,2), Permutation(2,4)).is_group is True
+    assert SymmetricGroup(4).is_group is True
 
 
 def test_PermutationGroup():
@@ -870,7 +870,8 @@ def test_sylow_subgroup():
     S = P.sylow_subgroup(3)
     assert S.order() == 3
 
-    P = PermutationGroup(Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5), Permutation(0, 2))
+    P = PermutationGroup(
+        Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5), Permutation(0, 2))
     S = P.sylow_subgroup(3)
     assert S.order() == 9
     S = P.sylow_subgroup(2)
@@ -941,7 +942,8 @@ def test_presentation():
     P = SymmetricGroup(5)
     assert _test(P)
 
-    P = PermutationGroup([Permutation(0,3,1,2), Permutation(3)(0,1), Permutation(0,1)(2,3)])
+    P = PermutationGroup(
+        [Permutation(0,3,1,2), Permutation(3)(0,1), Permutation(0,1)(2,3)])
     assert _strong_test(P)
 
     P = DihedralGroup(6)
@@ -958,38 +960,38 @@ def test_polycyclic():
     a = Permutation([0, 1, 2])
     b = Permutation([2, 1, 0])
     G = PermutationGroup([a, b])
-    assert G.is_polycyclic == True
+    assert G.is_polycyclic is True
 
     a = Permutation([1, 2, 3, 4, 0])
     b = Permutation([1, 0, 2, 3, 4])
     G = PermutationGroup([a, b])
-    assert G.is_polycyclic == False
+    assert G.is_polycyclic is False
 
 
 def test_elementary():
     a = Permutation([1, 5, 2, 0, 3, 6, 4])
     G = PermutationGroup([a])
-    assert G.is_elementary(7) == False
+    assert G.is_elementary(7) is False
 
     a = Permutation(0, 1)(2, 3)
     b = Permutation(0, 2)(3, 1)
     G = PermutationGroup([a, b])
-    assert G.is_elementary(2) == True
+    assert G.is_elementary(2) is True
     c = Permutation(4, 5, 6)
     G = PermutationGroup([a, b, c])
-    assert G.is_elementary(2) == False
+    assert G.is_elementary(2) is False
 
     G = SymmetricGroup(4).sylow_subgroup(2)
-    assert G.is_elementary(2) == False
+    assert G.is_elementary(2) is False
     H = AlternatingGroup(4).sylow_subgroup(2)
-    assert H.is_elementary(2) == True
+    assert H.is_elementary(2) is True
 
 
 def test_perfect():
     G = AlternatingGroup(3)
-    assert G.is_perfect == False
+    assert G.is_perfect is False
     G = AlternatingGroup(5)
-    assert G.is_perfect == True
+    assert G.is_perfect is True
 
 
 def test_index():
@@ -1167,15 +1169,15 @@ def test_composition_series():
 def test_is_symmetric():
     a = Permutation(0, 1, 2)
     b = Permutation(0, 1, size=3)
-    assert PermutationGroup(a, b).is_symmetric == True
+    assert PermutationGroup(a, b).is_symmetric is True
 
     a = Permutation(0, 2, 1)
     b = Permutation(1, 2, size=3)
-    assert PermutationGroup(a, b).is_symmetric == True
+    assert PermutationGroup(a, b).is_symmetric is True
 
     a = Permutation(0, 1, 2, 3)
     b = Permutation(0, 3)(1, 2)
-    assert PermutationGroup(a, b).is_symmetric == False
+    assert PermutationGroup(a, b).is_symmetric is False
 
 def test_conjugacy_class():
     S = SymmetricGroup(4)
@@ -1207,7 +1209,8 @@ def test_coset_class():
     assert not rht_coset.is_left_coset
     #Creating list representation of coset
     list_repr = rht_coset.as_list()
-    expected = [Permutation(0, 2), Permutation(0, 2, 1), Permutation(1, 2), Permutation(2), Permutation(2)(0, 1), Permutation(0, 1, 2)]
+    expected = [Permutation(0, 2), Permutation(0, 2, 1), Permutation(1, 2),
+                Permutation(2), Permutation(2)(0, 1), Permutation(0, 1, 2)]
     for ele in list_repr:
         assert ele in expected
     #Creating left coset


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Improving PEP-8 compliance

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
