### PR TITLE
Corrected the treatment of `Heaviside(t)`, added two simple rules

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1327,7 +1327,15 @@ def _inverse_laplace_build_rules():
     _ILT_rules = [
         (a/s, a, S.true, same, 1),
         (b*(s+a)**(-c), t**(c-1)*exp(-a*t)/gamma(c), c>0, same, 1),
-        (1/(s**2+a**2)**2, (sin(a*t) - a*t*cos(a*t))/(2*a**3), S.true, same, 1)
+        (1/(s**2+a**2)**2, (sin(a*t) - a*t*cos(a*t))/(2*a**3),
+         S.true, same, 1),
+        # The next two rules must be there in that order. For the second
+        # one, the condition would be a != 0 or, respectively, to take the
+        # limit a -> 0 after the transform if a == 0. It is much simpler if
+        # the case a == 0 has its own rule.
+        (1/(s**b), t**(b - 1)/gamma(b), S.true, same, 1),
+        (1/(s*(s+a)**b), lowergamma(b, a*t)/(a**b*gamma(b)),
+          S.true, same, 1)
     ]
     return _ILT_rules, s, t
 
@@ -1362,7 +1370,6 @@ def _inverse_laplace_apply_simple_rules(f, s, t):
                 debugf('      rule: %s o---o %s', (s_dom, t_dom))
                 debugf('      ma:   %s', (ma,))
                 return Heaviside(t)*t_dom.xreplace(ma).subs({t_: t}), S.true
-
     return None
 
 
@@ -1416,7 +1423,10 @@ def _inverse_laplace_time_diff(F, s, t, plane):
         debugf('      ma:   %s', (ma1,))
         r, c = _inverse_laplace_transform(ma1[g], s, t, plane)
         r = r.replace(Heaviside(t), 1)
-        return diff(r, t, ma1[n]), c
+        if r.has(InverseLaplaceTransform):
+            return diff(r, t, ma1[n]), c
+        else:
+            return Heaviside(t)*diff(r, t, ma1[n]), c
     return None
 
 

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1370,6 +1370,7 @@ def _inverse_laplace_apply_simple_rules(f, s, t):
                 debugf('      rule: %s o---o %s', (s_dom, t_dom))
                 debugf('      ma:   %s', (ma,))
                 return Heaviside(t)*t_dom.xreplace(ma).subs({t_: t}), S.true
+
     return None
 
 

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -402,6 +402,11 @@ def test_inverse_laplace_transform():
     assert ILT(1/s, s, t) == Heaviside(t)
     assert ILT(a/(a + s), s, t) == a*exp(-a*t)*Heaviside(t)
     assert ILT(s/(a + s), s, t) == -a*exp(-a*t)*Heaviside(t) + DiracDelta(t)
+    assert ILT(s/(a + s)**3, s, t) == t*(-a*t + 4)*exp(-a*t)*Heaviside(t)/2
+    assert ILT(1/(s*(a + s)**3), s, t) == (
+        -a**2*t**2 - 4*a*t + 4*exp(a*t) - 4)*exp(-a*t)*Heaviside(t)/(2*a**3)
+    assert ILT(1/(s*(a + s)**n), s, t) == (
+        Heaviside(t)*lowergamma(n, a*t)/(a**n*gamma(n)))
     assert ILT((s-a)**(-b), s, t) == t**(b - 1)*exp(a*t)*Heaviside(t)/gamma(b)
     assert ILT((a + s)**(-2), s, t) == t*exp(-a*t)*Heaviside(t)
     assert ILT((a + s)**(-5), s, t) == t**4*exp(-a*t)*Heaviside(t)/24
@@ -465,10 +470,9 @@ def test_inverse_laplace_transform():
     # Test time_diff rule
     assert ILT(s**42*f(s), s, t) ==\
         Derivative(InverseLaplaceTransform(f(s), s, t, None), (t, 42))
-    assert ILT((b*s**2 + d)/(a**2 + s**2)**2, s, t) ==\
-        (a**3*b*t*cos(a*t) + 4*a**2*b*sin(a*t)*Heaviside(t) +\
-         a**2*b*sin(a*t) - a*d*t*cos(a*t)*Heaviside(t) +\
-             d*sin(a*t)*Heaviside(t))/(2*a**3)
+    assert ILT((b*s**2 + d)/(a**2 + s**2)**2, s, t) == (
+        a**3*b*t*cos(a*t) + 5*a**2*b*sin(a*t) - a*d*t*cos(a*t) +
+        d*sin(a*t))*Heaviside(t)/(2*a**3)
     assert ILT(cos(s), s, t) == InverseLaplaceTransform(cos(s), s, t, None)
     # Rules for testing different DiracDelta cases
     assert ILT(2, s, t) == 2*DiracDelta(t)


### PR DESCRIPTION
#### References to other Issues or PRs

Part of #24561
Hot fix for #24579

#### Brief description of what is fixed or changed

There was a small error in how `Heaviside(t)` was treated in `_inverse_laplace_time_diff`. It manifested when `s/(s+a**3)` was transformed. I also added two simple rules, which now completes all the rules in Section 5.2 of Bateman54 (ILT of rational functions).

#### Other comments

I do not provide release notes because this is a bug fix on a PR that is not in a release yet, #24579

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
