### PR TITLE
Add support for linting with Ruff

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,13 +22,16 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath flake8 flake8-comprehensions
+      - run: pip install mpmath flake8 flake8-comprehensions ruff
 
       - name: Basic code quality tests
         run: bin/test quality
 
       - name: Run flake8 on the sympy package
         run: flake8 sympy
+
+      - name: Run Ruff on the sympy package
+        run: ruff check .
 
       - name: Detect invalid escapes like '\e'
         run: python -We:invalid -We::SyntaxWarning -m compileall -f -q sympy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[tool.ruff]
+# Enable Pyflakes `E` and `F` codes by default.
+select = ["E", "F"]
+
+# Ignore rules that currently fail on the SymPy codebase
+ignore = [
+    "E401",  # Multiple imports on one line
+    "E402",  # Module level import not at top of file
+    "E501",  # Line too long (<LENGTH> > 88 characters)
+    "E701",  # Multiple statements on one line (colon)
+    "E702",  # Multiple statements on one line (semicolon)
+    "E703",  # Statement ends with an unnecessary semicolon
+    "E711",  # Comparison to `None` should be `cond is not None`
+    "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
+    "E713",  # Test for membership should be `not in`
+    "E714",  # Test for object identity should be `is not`
+    "E721",  # Do not compare types, use `isinstance()`
+    "E722",  # Do not use bare `except`
+    "E731",  # Do not assign a `lambda` expression, use a `def`
+    "E741",  # Ambiguous variable name: `<VARIABLE>`
+    "E743",  # Ambiguous function name: `<FUNCTION>`
+    "F401",  # `<TYPE>` imported but unused
+    "F403",  # `from <MODULE> import *` used; unable to detect undefined names
+    "F405",  # `<TYPE>` may be undefined, or defined from star imports: `<MODULE>`
+    "F523",  # `.format` call has unused arguments at position(s): <INDEX>
+    "F601",  # Dictionary key literal `'<KEY>'` repeated
+    "F811",  # Redefinition of unused `<VARIABLE>` from line <LINE>
+    "F821",  # Undefined name `VARIABLE`
+    "F823",  # Local variable `VARIABLE` referenced before assignment
+    "F841",  # Local variable `VARIABLE` is assigned to but never used
+]
+
+# Exclude paths currently excluded in the flake8 configuration
+exclude = [
+    "sympy/parsing/latex/_antlr/*",
+    "sympy/parsing/autolev/_antlr/*",
+    "sympy/parsing/autolev/test-examples/*",
+    "sympy/integrals/rubi/*",
+]
+
+# Black default, although irrelevant with E501 ignored
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Per-file ignores currently specified in the flake8 configuration
+[tool.ruff.per-file-ignores]
+"sympy/interactive/session.py" = ["F821"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
-select = ["E", "F"]
+select = ["C4", "E", "F"]
 
 # Ignore rules that currently fail on the SymPy codebase
 ignore = [
@@ -32,6 +32,8 @@ ignore = [
 
 # Exclude paths currently excluded in the flake8 configuration
 exclude = [
+    "sympy/assumptions/*generated.py",
+    "sympy/core/*_generated.py",
     "sympy/parsing/latex/_antlr/*",
     "sympy/parsing/autolev/_antlr/*",
     "sympy/parsing/autolev/test-examples/*",


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Issue https://github.com/sympy/sympy/issues/24508 discusses migration from flake8 to [Ruff](https://github.com/charliermarsh/ruff).

#### Brief description of what is fixed or changed
This PR introduces a `pyproject.toml` that contains Ruff configuration equivalent to the flake8 configuration currently present in `setup.cfg`. It also introduces an additional step to the `code-quality` job in `runtests.yml` that runs `ruff check .`.

#### Other comments
The configuration currently contains a long list of rules that are being ignored by Ruff. These are all of the rules that SymPy currently violates. The idea would be to gradually decide on rules that we'd like to enforce on a rule-by-rule basis and remove these one at a time. A PR per rule removal that also fixes all violations would probably be the best way to keep PRs small enough to review.

Enforcement of some rules will be reasonably straightforward (e.g. [E722](https://beta.ruff.rs/docs/rules/bare-except/)) while others will require greater discussion and thought (e.g. [E501](https://beta.ruff.rs/docs/rules/#pycodestyle-e-w)).

Ruff is near instantaneous to run on the whole SymPy repo so it could be a practical way to enforce a more consistent code style in SymPy. Also, if flake8 can be replaced by Ruff then the runtime of the `code-quality` job in CI will reduce by >80%.

Introduction of a `pyproject.toml` file could also help begin migration towards [PEP 621](https://peps.python.org/pep-0621/) compliance.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
