### PR TITLE
Corrected small bug in solvers/solvers.py

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -271,7 +271,7 @@ def checksol(f, symbol, sol=None, **flags):
             if not f.is_Boolean:
                 return
         else:
-            f = f.rewrite(Add, evaluate=False)
+            f = f.rewrite(Add, evaluate=False, deep=False)
 
     if isinstance(f, BooleanAtom):
         return bool(f)
@@ -945,7 +945,7 @@ def solve(f, *symbols, **flags):
                             is True or False.
                         '''))
                 else:
-                    fi = fi.rewrite(Add, evaluate=False)
+                    fi = fi.rewrite(Add, evaluate=False, deep=False)
             f[i] = fi
 
         # *** dispatch and handle as a system of relationals

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -375,12 +375,13 @@ def test_issue_21004():
     f_diff = f.diff(x)
     assert solve(f_diff, x) == []
 
+
 def test_issue_24650():
     x = symbols('x')
     r = solve(Eq(Piecewise((x, Eq(x, 0) | (x > 1))), 0))
     assert r == [0]
     r = checksol(Eq(Piecewise((x, Eq(x, 0) | (x > 1))), 0), x, sol=0)
-    assert r == True
+    assert r is True
 
 
 def test_linear_system():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -375,6 +375,13 @@ def test_issue_21004():
     f_diff = f.diff(x)
     assert solve(f_diff, x) == []
 
+def test_issue_24650():
+    x = symbols('x')
+    r = solve(Eq(Piecewise((x, Eq(x, 0) | (x > 1))), 0))
+    assert r == [0]
+    r = checksol(Eq(Piecewise((x, Eq(x, 0) | (x > 1))), 0), x, sol=0)
+    assert r == True
+
 
 def test_linear_system():
     x, y, z, t, n = symbols('x, y, z, t, n')


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24650

#### Brief description of what is fixed or changed
Two instances of `.rewrite(Add)` that are supposed to rewrite an `Eq()` now have the flag `deep=False` set. Two test cases adde, one for each code path that is fixed.

#### Other comments
No release notes as this does not change anything except preventing some errors.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
