### PR TITLE
Fix commutation issue of matrix adjoint, transpose, inverse

### DIFF
--- a/sympy/matrices/expressions/adjoint.py
+++ b/sympy/matrices/expressions/adjoint.py
@@ -1,6 +1,5 @@
 from sympy.core import Basic
 from sympy.functions import adjoint, conjugate
-from sympy.matrices.expressions.transpose import transpose
 from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
@@ -50,12 +49,12 @@ class Adjoint(MatrixExpr):
     def _eval_adjoint(self):
         return self.arg
 
+    def _eval_transpose(self):
+        return self.arg.conjugate()
+
     def _eval_conjugate(self):
-        return transpose(self.arg)
+        return self.arg.transpose()
 
     def _eval_trace(self):
         from sympy.matrices.expressions.trace import Trace
         return conjugate(Trace(self.arg))
-
-    def _eval_transpose(self):
-        return conjugate(self.arg)

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -795,8 +795,8 @@ def bc_dist(expr):
 
 def bc_matmul(expr):
     if isinstance(expr, MatPow):
-        if expr.args[1].is_Integer:
-            factor, matrices = (1, [expr.args[0]]*expr.args[1])
+        if expr.args[1].is_Integer and expr.args[1] > 0:
+            factor, matrices = 1, [expr.args[0]]*expr.args[1]
         else:
             return expr
     else:

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -54,6 +54,15 @@ class Inverse(MatPow):
     def _eval_inverse(self):
         return self.arg
 
+    def _eval_transpose(self):
+        return Inverse(self.arg.transpose())
+
+    def _eval_adjoint(self):
+        return Inverse(self.arg.adjoint())
+
+    def _eval_conjugate(self):
+        return Inverse(self.arg.conjugate())
+
     def _eval_determinant(self):
         from sympy.matrices.expressions.determinant import det
         return 1/det(self.arg)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -89,7 +89,15 @@ class MatPow(MatrixExpr):
 
     def _eval_transpose(self):
         base, exp = self.args
-        return MatPow(base.T, exp)
+        return MatPow(base.transpose(), exp)
+
+    def _eval_adjoint(self):
+        base, exp = self.args
+        return MatPow(base.adjoint(), exp)
+
+    def _eval_conjugate(self):
+        base, exp = self.args
+        return MatPow(base.conjugate(), exp)
 
     def _eval_derivative(self, x):
         return Pow._eval_derivative(self, x)

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -4,12 +4,18 @@ from sympy.matrices.expressions.blockmatrix import (
     block_collapse, bc_matmul, bc_block_plus_ident, BlockDiagMatrix,
     BlockMatrix, bc_dist, bc_matadd, bc_transpose, bc_inverse,
     blockcut, reblock_2x2, deblock)
-from sympy.matrices.expressions import (MatrixSymbol, Identity,
-        Inverse, trace, Transpose, det, ZeroMatrix, OneMatrix)
+from sympy.matrices.expressions import (
+    MatrixSymbol, Identity, trace, det, ZeroMatrix, OneMatrix)
+from sympy.matrices.expressions.inverse import Inverse
+from sympy.matrices.expressions.matpow import MatPow
+from sympy.matrices.expressions.transpose import Transpose
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import (
     Matrix, ImmutableMatrix, ImmutableSparseMatrix, zeros)
 from sympy.core import Tuple, symbols, Expr, S, Function
+    Matrix, ImmutableMatrix, ImmutableSparseMatrix)
+from sympy.core import Tuple, Expr, S
+from sympy.core.symbol import Symbol, symbols
 from sympy.functions import transpose, im, re
 
 i, j, k, l, m, n, p = symbols('i:n, p', integer=True)
@@ -450,3 +456,16 @@ def test_block_matrix_derivative():
     A = Matrix(3, 3, [Function(f'a{i}')(x) for i in range(9)])
     bc = BlockMatrix([[A[:2, :2], A[:2, 2]], [A[2, :2], A[2:, 2]]])
     assert Matrix(bc.diff(x)) - A.diff(x) == zeros(3, 3)
+
+
+def test_transpose_inverse_commute():
+    n = Symbol('n')
+    I = Identity(n)
+    Z = ZeroMatrix(n, n)
+    A = BlockMatrix([[I, Z], [Z, I]])
+
+    assert block_collapse(A.transpose().inverse()) == A
+    assert block_collapse(A.inverse().transpose()) == A
+
+    assert block_collapse(MatPow(A.transpose(), -2)) == MatPow(A, -2)
+    assert block_collapse(MatPow(A, -2).transpose()) == MatPow(A, -2)

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -12,9 +12,7 @@ from sympy.matrices.expressions.transpose import Transpose
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import (
     Matrix, ImmutableMatrix, ImmutableSparseMatrix, zeros)
-from sympy.core import Tuple, symbols, Expr, S, Function
-    Matrix, ImmutableMatrix, ImmutableSparseMatrix)
-from sympy.core import Tuple, Expr, S
+from sympy.core import Tuple, Expr, S, Function
 from sympy.core.symbol import Symbol, symbols
 from sympy.functions import transpose, im, re
 

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -60,3 +60,10 @@ def test_inverse_matpow_canonicalization():
 def test_nonsquare_error():
     A = MatrixSymbol('A', 3, 4)
     raises(NonSquareMatrixError, lambda: Inverse(A))
+
+
+def test_adjoint_trnaspose_conjugate():
+    A = MatrixSymbol('A', n, n)
+    assert A.transpose().inverse() == A.inverse().transpose()
+    assert A.conjugate().inverse() == A.inverse().conjugate()
+    assert A.adjoint().inverse() == A.inverse().adjoint()

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -1,6 +1,4 @@
 from sympy.core.basic import Basic
-from sympy.functions import adjoint, conjugate
-
 from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
@@ -53,10 +51,10 @@ class Transpose(MatrixExpr):
         return self.arg._entry(j, i, expand=expand, **kwargs)
 
     def _eval_adjoint(self):
-        return conjugate(self.arg)
+        return self.arg.conjugate()
 
     def _eval_conjugate(self):
-        return adjoint(self.arg)
+        return self.arg.adjoint()
 
     def _eval_transpose(self):
         return self.arg


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24735

#### Brief description of what is fixed or changed

I added a guard for `bc_matmul` for matrix power because `list` multiplied with negative integer gives empty list, which can be causing some bugs when `MatPow` is used with negative integer.

So this fixes more general issues with matrix power with negative integer `block_collapse(MatPow(A.transpose(), -2))`

This also fixes more general problem of `adjoint, transpose, conjugate` not giving same result as `inverse`
For example,
```
A = MatrixSymbol('A', n, n)

A.transpose().inverse() == A.inverse().transpose()
A.conjugate().inverse() == A.inverse().conjugate()
A.adjoint().inverse() == A.inverse().adjoint()
```
because each methods had used different code path.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `block_collapse` giving wrong result for `Inverse`
  - Fixed an issue of `adjoint`, `transpose`, `conjugate` not commuting with `inverse` for matrix expressions. For example, `A.transpose().inverse()` and `A.inverse().transpose()` will give same result.
<!-- END RELEASE NOTES -->
