### PR TITLE
Speed up `Point.mont_ladder`

### DIFF
--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -139,15 +139,37 @@ class Point:
         >>> p3.z_cord
         17
         """
-        Q = self
+        Q = Point(self.x_cord, self.z_cord, self.a_24, self.mod)
         R = self.double()
         for i in bin(k)[3:]:
+            q_plus = Q.x_cord + Q.z_cord
+            q_minus = Q.x_cord - Q.z_cord
+            r_plus = R.x_cord + R.z_cord
+            r_minus = R.x_cord - R.z_cord
+            u = r_minus*q_plus % self.mod
+            v = r_plus*q_minus % self.mod
+            add = u + v
+            subt = u - v
             if  i  == '1':
-                Q = R.add(Q, self)
-                R = R.double()
+                # We want to calculate
+                # Q, R = R.add(Q, self), R.double()
+                u2 = pow(r_plus, 2, self.mod)
+                v2 = pow(r_minus, 2, self.mod)
+                diff = u2 - v2
+                Q.x_cord = self.z_cord * add * add % self.mod
+                Q.z_cord = self.x_cord * subt * subt % self.mod
+                R.x_cord = u2*v2 % self.mod
+                R.z_cord = diff*(v2 + self.a_24*diff) % self.mod
             else:
-                R = Q.add(R, self)
-                Q = Q.double()
+                # We want to calculate
+                # Q, R = Q.double(), Q.add(R, self)
+                u2 = pow(q_plus, 2, self.mod)
+                v2 = pow(q_minus, 2, self.mod)
+                diff = u2 - v2
+                R.x_cord = self.z_cord * add * add % self.mod
+                R.z_cord = self.x_cord * subt * subt % self.mod
+                Q.x_cord = u2*v2 % self.mod
+                Q.z_cord = diff*(v2 + self.a_24*diff) % self.mod
         return Q
 
 


### PR DESCRIPTION
When calculating `Point.mont_ladder`, we call `add()` and `double()`, which creates an instance each time. This overhead becomes non-negligible as k grows. Inlining the `add()` and `double()` processes reduces readability, but speeds up the process.

For example, the following code can be executed in about 70% of the time compared to the current code.

`Point(2**30, 3**30, 5**30, 2**107-1).mont_ladder(3**300)`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
