### PR TITLE
Fix erroring test in `sympy/printing/tests/test_aesaracode.py`

### DIFF
--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -238,8 +238,8 @@ class AesaraPrinter(Printer):
         return aet.switch(p_cond, p_e, p_remaining)
 
     def _print_Rational(self, expr, **kwargs):
-        return aet.true_div(self._print(expr.p, **kwargs),
-                            self._print(expr.q, **kwargs))
+        return aet.true_divide(self._print(expr.p, **kwargs),
+                               self._print(expr.q, **kwargs))
 
     def _print_Integer(self, expr, **kwargs):
         return expr.p

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -76,8 +76,6 @@ if aesara:
             sympy.Transpose: DimShuffle((False, False), [1, 0]),
     }
 
-    aesara_version = tuple(getattr(aesara, '__version__').split('.'))
-
 
 class AesaraPrinter(Printer):
     """ Code printer which creates Aesara symbolic expression graphs.

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -17,6 +17,13 @@ if aesara:
     from aesara.tensor.elemwise import Elemwise
     from aesara.tensor.elemwise import DimShuffle
 
+    # `true_divide` replaced `true_div` in Aesara 2.8.11 (released 2023) to
+    # match NumPy
+    # XXX: Remove this when not needed to support older versions.
+    true_divide = getattr(aet, 'true_divide', None)
+    if true_divide is None:
+        true_divide = aet.true_div
+
     mapping = {
             sympy.Add: aet.add,
             sympy.Mul: aet.mul,
@@ -240,11 +247,6 @@ class AesaraPrinter(Printer):
         return aet.switch(p_cond, p_e, p_remaining)
 
     def _print_Rational(self, expr, **kwargs):
-        # `true_divide` replaced `true_div` in Aesara 2.8.11 to match NumPy
-        if aesara_version >= ('2', '8', '11'):
-            true_divide = aet.true_divide
-        else:
-            true_divide = aet.true_div
         return true_divide(self._print(expr.p, **kwargs),
                            self._print(expr.q, **kwargs))
 

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -69,6 +69,8 @@ if aesara:
             sympy.Transpose: DimShuffle((False, False), [1, 0]),
     }
 
+    aesara_version = tuple(getattr(aesara, '__version__').split('.'))
+
 
 class AesaraPrinter(Printer):
     """ Code printer which creates Aesara symbolic expression graphs.
@@ -238,8 +240,13 @@ class AesaraPrinter(Printer):
         return aet.switch(p_cond, p_e, p_remaining)
 
     def _print_Rational(self, expr, **kwargs):
-        return aet.true_divide(self._print(expr.p, **kwargs),
-                               self._print(expr.q, **kwargs))
+        # `true_divide` replaced `true_div` in Aesara 2.8.11 to match NumPy
+        if aesara_version >= ('2', '8', '11'):
+            true_divide = aet.true_divide
+        else:
+            true_divide = aet.true_div
+        return true_divide(self._print(expr.p, **kwargs),
+                           self._print(expr.q, **kwargs))
 
     def _print_Integer(self, expr, **kwargs):
         return expr.p

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -264,8 +264,8 @@ def test_MatAdd():
 
 
 def test_Rationals():
-    assert theq(aesara_code_(sy.Integer(2) / 3), aet.true_div(2, 3))
-    assert theq(aesara_code_(S.Half), aet.true_div(1, 2))
+    assert theq(aesara_code_(sy.Integer(2) / 3), aet.true_divide(2, 3))
+    assert theq(aesara_code_(S.Half), aet.true_divide(1, 2))
 
 def test_Integers():
     assert aesara_code_(sy.Integer(3)) == 3

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -30,7 +30,7 @@ if aesara:
     from aesara.tensor.elemwise import Elemwise, DimShuffle
     from aesara.tensor.math import Dot
 
-    from sympy.printing.aesara_code import true_divide
+    from sympy.printing.aesaracode import true_divide
 
     xt, yt, zt = [aet.scalar(name, 'floatX') for name in 'xyz']
     Xt, Yt, Zt = [aet.tensor('floatX', (False, False), name=n) for n in 'XYZ']

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -30,6 +30,8 @@ if aesara:
     from aesara.tensor.elemwise import Elemwise, DimShuffle
     from aesara.tensor.math import Dot
 
+    aesara_version = tuple(getattr(aesara, '__version__').split('.'))
+
     xt, yt, zt = [aet.scalar(name, 'floatX') for name in 'xyz']
     Xt, Yt, Zt = [aet.tensor('floatX', (False, False), name=n) for n in 'XYZ']
 else:
@@ -264,8 +266,13 @@ def test_MatAdd():
 
 
 def test_Rationals():
-    assert theq(aesara_code_(sy.Integer(2) / 3), aet.true_divide(2, 3))
-    assert theq(aesara_code_(S.Half), aet.true_divide(1, 2))
+    # `true_divide` replaced `true_div` in Aesara 2.8.11 to match NumPy
+    if aesara_version >= ('2', '8', '11'):
+        true_divide = aet.true_divide
+    else:
+        true_divide = aet.true_div
+    assert theq(aesara_code_(sy.Integer(2) / 3), true_divide(2, 3))
+    assert theq(aesara_code_(S.Half), true_divide(1, 2))
 
 def test_Integers():
     assert aesara_code_(sy.Integer(3)) == 3

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -30,7 +30,7 @@ if aesara:
     from aesara.tensor.elemwise import Elemwise, DimShuffle
     from aesara.tensor.math import Dot
 
-    aesara_version = tuple(getattr(aesara, '__version__').split('.'))
+    from sympy.printing.aesara_code import true_divide
 
     xt, yt, zt = [aet.scalar(name, 'floatX') for name in 'xyz']
     Xt, Yt, Zt = [aet.tensor('floatX', (False, False), name=n) for n in 'XYZ']
@@ -266,11 +266,6 @@ def test_MatAdd():
 
 
 def test_Rationals():
-    # `true_divide` replaced `true_div` in Aesara 2.8.11 to match NumPy
-    if aesara_version >= ('2', '8', '11'):
-        true_divide = aet.true_divide
-    else:
-        true_divide = aet.true_div
     assert theq(aesara_code_(sy.Integer(2) / 3), true_divide(2, 3))
     assert theq(aesara_code_(S.Half), true_divide(1, 2))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24746 

#### Brief description of what is fixed or changed
Use Aesara `true_divide` function in place of deprecated `true_div`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
