### PR TITLE
Changed the order of expand / prog_rules in ILT; added test cases

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1539,9 +1539,9 @@ def _inverse_laplace_transform(fn, s_, t_, plane, simplify=True, dorational=True
             pass
         elif (r := _inverse_laplace_apply_simple_rules(f, s_, t_)) is not None:
             pass
-        elif (r := _inverse_laplace_apply_prog_rules(f, s_, t_, plane)) is not None:
-            pass
         elif (r := _inverse_laplace_expand(f, s_, t_, plane)) is not None:
+            pass
+        elif (r := _inverse_laplace_apply_prog_rules(f, s_, t_, plane)) is not None:
             pass
         elif any(undef.has(s_) for undef in f.atoms(AppliedUndef)):
             # If there are undefined functions f(t) then integration is

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -483,6 +483,12 @@ def test_inverse_laplace_transform():
     assert ILT(exp(2*s), s, t) == InverseLaplaceTransform(exp(2*s), s, t, None)
     r = Symbol('r', real=True)
     assert ILT(exp(r*s), s, t) == InverseLaplaceTransform(exp(r*s), s, t, None)
+    # Rules for testing whether Heaviside(t) is treated properly in diff rule
+    assert ILT(s**2/(a**2 + s**2), s, t) == (
+        -a*sin(a*t)*Heaviside(t) + DiracDelta(t))
+    assert ILT(s**2*(f(s) + 1/(a**2 + s**2)), s, t) == (
+        -a*sin(a*t)*Heaviside(t) + DiracDelta(t) +
+        Derivative(InverseLaplaceTransform(f(s), s, t, None), (t, 2)))
     # Rules from the previous test_inverse_laplace_transform_delta_cond():
     assert ILT(exp(r*s), s, t, noconds=False) ==\
         (InverseLaplaceTransform(exp(r*s), s, t, None), True)


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561
Hot fix for #24579

#### Brief description of what is fixed or changed
This continues #24728 where one aspect was overlooked: the order in which expansion and program-rule application was done was wrong. This would only have become apparent in terms like `s**2*(a+b)`, which triggers the differentiation rule, where the ILT of `a` can be computed and the ILT of `b` cannot be computed. This is now fixed, and a test is added to catch it.

#### Other comments
No release notes as it is a bug fix on an un-released PR.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
