### PR TITLE
Relax input requirements on polys in algebraic number theory functions

### DIFF
--- a/sympy/polys/numberfields/basis.py
+++ b/sympy/polys/numberfields/basis.py
@@ -4,7 +4,6 @@ from sympy.polys.polytools import Poly
 from sympy.polys.domains.algebraicfield import AlgebraicField
 from sympy.polys.domains.integerring import ZZ
 from sympy.polys.domains.rationalfield import QQ
-from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import public
 from .modules import ModuleEndomorphism, ModuleHomomorphism, PowerBasis
 from .utilities import extract_fundamental_discriminant

--- a/sympy/polys/numberfields/basis.py
+++ b/sympy/polys/numberfields/basis.py
@@ -100,8 +100,8 @@ def round_two(T, radicals=None):
     Explanation
     ===========
 
-    Carry out Zassenhaus's "Round 2" algorithm on a monic irreducible
-    polynomial *T* over :ref:`ZZ`. This computes an integral basis and the
+    Carry out Zassenhaus's "Round 2" algorithm on an irreducible polynomial
+    *T* over :ref:`ZZ` or :ref:`QQ`. This computes an integral basis and the
     discriminant for the field $K = \mathbb{Q}[x]/(T(x))$.
 
     Alternatively, you may pass an :py:class:`~.AlgebraicField` instance, in
@@ -153,9 +153,9 @@ def round_two(T, radicals=None):
     ==========
 
     T : :py:class:`~.Poly`, :py:class:`~.AlgebraicField`
-        Either (1) the irreducible monic polynomial over :ref:`ZZ` defining the
-        number field, or (2) an :py:class:`~.AlgebraicField` representing the
-        number field itself.
+        Either (1) the irreducible polynomial over :ref:`ZZ` or :ref:`QQ`
+        defining the number field, or (2) an :py:class:`~.AlgebraicField`
+        representing the number field itself.
 
     radicals : dict, optional
         This is a way for any $p$-radicals (if computed) to be returned by
@@ -191,16 +191,11 @@ def round_two(T, radicals=None):
     K = None
     if isinstance(T, AlgebraicField):
         K, T = T, T.ext.minpoly_of_element()
-    if T.domain == QQ:
-        try:
-            T = Poly(T, domain=ZZ)
-        except CoercionFailed:
-            pass  # Let the error be raised by the next clause.
     if (   not T.is_univariate
         or not T.is_irreducible
-        or not T.is_monic
-        or not T.domain == ZZ):
-        raise ValueError('Round 2 requires a monic irreducible univariate polynomial over ZZ.')
+        or T.domain not in [ZZ, QQ]):
+        raise ValueError('Round 2 requires an irreducible univariate polynomial over ZZ or QQ.')
+    T, _ = T.make_monic_over_integers_by_scaling_roots()
     n = T.degree()
     D = T.discriminant()
     D_modulus = ZZ.from_sympy(abs(D))

--- a/sympy/polys/numberfields/galoisgroups.py
+++ b/sympy/polys/numberfields/galoisgroups.py
@@ -563,7 +563,7 @@ def galois_group(f, *gens, by_name=False, max_tries=30, randomize=False, **args)
     ==========
 
     f : Expr
-        Irreducible, monic polynomial over :ref:`ZZ`, whose Galois group
+        Irreducible polynomial over :ref:`ZZ` or :ref:`QQ`, whose Galois group
         is to be determined.
     gens : optional list of symbols
         For converting *f* to Poly, and will be passed on to the

--- a/sympy/polys/numberfields/tests/test_basis.py
+++ b/sympy/polys/numberfields/tests/test_basis.py
@@ -10,10 +10,9 @@ from sympy.testing.pytest import raises
 
 
 def test_round_two():
-    # Poly must be monic, irreducible, and over ZZ:
-    raises(ValueError, lambda: round_two(Poly(3 * x ** 2 + 1)))
+    # Poly must be irreducible, and over ZZ or QQ:
     raises(ValueError, lambda: round_two(Poly(x ** 2 - 1)))
-    raises(ValueError, lambda: round_two(Poly(x ** 2 + QQ(1, 2))))
+    raises(ValueError, lambda: round_two(Poly(x ** 2 + sqrt(2))))
 
     # Test on many fields:
     cases = (
@@ -59,6 +58,10 @@ def test_round_two():
         (x**3 + 9 * x**2 + 6 * x - 8, DM([(1, 0, 0), (0, (1, 2), (1, 2)), (0, 0, 1)], QQ).transpose(), 3969),
         # F = 2^2 * 3^2 * 7
         (x**3 + 15 * x**2 - 9 * x + 13, DM([((1, 6), (1, 3), (1, 6)), (0, 1, 0), (0, 0, 1)], QQ).transpose(), -5292),
+        # Polynomial need not be monic
+        (5*x**3 + 5*x**2 - 10 * x + 40, DM([[1, 0, 0], [0, 1, 0], [0, (1, 2), (1, 2)]], QQ).transpose(), -503),
+        # Polynomial can have non-integer rational coeffs
+        (QQ(5, 3)*x**3 + QQ(5, 3)*x**2 - QQ(10, 3)*x + QQ(40, 3), DM([[1, 0, 0], [0, 1, 0], [0, (1, 2), (1, 2)]], QQ).transpose(), -503),
     )
     for f, B_exp, d_exp in cases:
         K = QQ.alg_field_from_poly(f)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The `round_two()` function (for computing an integral basis of a number field) has required
a monic, irreducible poly over ZZ. We relax this to accept any irreducible poly over ZZ or QQ.

The `galois_group()` function was already so relaxed, but its docstring failed to say so;
that is also corrected.





#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
