### PR TITLE
Reformat flake8 and Ruff configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
-select = ["C4", "E", "F"]
+select = [
+    "C4",
+    "E",
+    "F",
+]
 
 # Ignore rules that currently fail on the SymPy codebase
 ignore = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,19 @@ long_description_content_type = text/markdown
 
 [flake8]
 doctests = True
-ignore = F403
-select = C4,F,E722
-exclude = sympy/assumptions/*generated.py,
-          sympy/core/*_generated.py,
-          sympy/parsing/autolev/_antlr/*,
-          sympy/parsing/autolev/test-examples/*,
-          sympy/parsing/latex/_antlr/*,
-          sympy/polys/numberfields/resolvent_lookup.py
+ignore =
+    F403,
+select =
+    C4,
+    E722,
+    F,
+exclude =
+    sympy/assumptions/*generated.py,
+    sympy/core/*_generated.py,
+    sympy/parsing/autolev/_antlr/*,
+    sympy/parsing/autolev/test-examples/*,
+    sympy/parsing/latex/_antlr/*,
+    sympy/polys/numberfields/resolvent_lookup.py,
 per-file-ignores = sympy/interactive/session.py:F821
 
 # Global mypy settings:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to issue https://github.com/sympy/sympy/issues/24508 and PR https://github.com/sympy/sympy/pull/24729.

#### Brief description of what is fixed or changed
This PR reformats the flake8 configuration in `setup.cfg` and Ruff configuration in `pyproject.toml`. This reformatting is done so that individual rule codes, filepaths etc. are on individual lines. This will allow me to submit multiple PRs in parallel that will bring the flake8 and Ruff configuration in line with each other (for the entire SymPy repo) without introducing merge conflicts meaning that we can more easily decide which rule enforcements we want on a case-by-case basis.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
