### PR TITLE
Implement an abstract class for bodies

### DIFF
--- a/doc/src/modules/physics/mechanics/api/part_bod.rst
+++ b/doc/src/modules/physics/mechanics/api/part_bod.rst
@@ -4,8 +4,13 @@
 Masses, Inertias & Particles, RigidBodys (Docstrings)
 =====================================================
 
-.. automodule:: sympy.physics.mechanics.particle
+.. autoclass:: sympy.physics.mechanics.particle.Particle
    :members:
+   :inherited-members:
+
+.. autoclass:: sympy.physics.mechanics.rigidbody.RigidBody
+   :members:
+   :inherited-members:
 
 .. automodule:: sympy.physics.mechanics.rigidbody
    :members:

--- a/doc/src/modules/physics/mechanics/api/part_bod.rst
+++ b/doc/src/modules/physics/mechanics/api/part_bod.rst
@@ -12,9 +12,6 @@ Masses, Inertias & Particles, RigidBodys (Docstrings)
    :members:
    :inherited-members:
 
-.. automodule:: sympy.physics.mechanics.rigidbody
-   :members:
-
 .. autofunction:: sympy.physics.mechanics.functions.inertia
 
 .. autofunction:: sympy.physics.mechanics.functions.inertia_of_point_mass

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,6 +1,7 @@
 from sympy.core.backend import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame, Dyadic
 from sympy.physics.mechanics import RigidBody, Particle, inertia
+from sympy.physics.mechanics.body_base import BodyBase
 
 __all__ = ['Body']
 
@@ -99,7 +100,6 @@ class Body(RigidBody, Particle):  # type: ignore
     def __init__(self, name, masscenter=None, mass=None, frame=None,
                  central_inertia=None):
 
-        self.name = name
         self._loads = []
 
         if frame is None:
@@ -129,13 +129,21 @@ class Body(RigidBody, Particle):  # type: ignore
 
         # If user passes masscenter and mass then a particle is created
         # otherwise a rigidbody. As a result a body may or may not have inertia.
+        # Note: BodyBase.__init__ is used to prevent problems with super() calls in
+        # Particle and RigidBody arising due to multiple inheritance.
         if central_inertia is None and mass is not None:
+            BodyBase.__init__(self, name, masscenter, _mass)
             self.frame = frame
-            self.masscenter = masscenter
-            Particle.__init__(self, name, masscenter, _mass)
             self._central_inertia = Dyadic(0)
         else:
-            RigidBody.__init__(self, name, masscenter, frame, _mass, _inertia)
+            BodyBase.__init__(self, name, masscenter, _mass)
+            self.frame = frame
+            self.inertia = _inertia
+
+    def __repr__(self):
+        if self.is_rigidbody:
+            return RigidBody.__repr__(self)
+        return Particle.__repr__(self)
 
     @property
     def loads(self):

--- a/sympy/physics/mechanics/body_base.py
+++ b/sympy/physics/mechanics/body_base.py
@@ -1,0 +1,94 @@
+from abc import ABC, abstractmethod
+from sympy.core.backend import Symbol, sympify
+from sympy.physics.vector import Point
+
+__all__ = ['BodyBase']
+
+
+class BodyBase(ABC):
+    """Abstract class for body type objects."""
+    def __init__(self, name, masscenter=None, mass=None):
+        # Note: If frame=None, no auto-generated frame is created, because a
+        # Particle does not need to have a frame by default.
+        if not isinstance(name, str):
+            raise TypeError('Supply a valid name.')
+        self._name = name
+        if mass is None:
+            mass = Symbol(f'{name}_mass')
+        if masscenter is None:
+            masscenter = Point(f'{name}_masscenter')
+        self.mass = mass
+        self.masscenter = masscenter
+        self.potential_energy = 0
+        self.points = []
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}({repr(self.name)}, masscenter='
+                f'{repr(self.masscenter)}, mass={repr(self.mass)})')
+
+    @property
+    def name(self):
+        """The name of the body."""
+        return self._name
+
+    @property
+    def masscenter(self):
+        """The body's center of mass."""
+        return self._masscenter
+
+    @masscenter.setter
+    def masscenter(self, point):
+        if not isinstance(point, Point):
+            raise TypeError("The body's center of mass must be a Point object.")
+        self._masscenter = point
+
+    @property
+    def mass(self):
+        """The body's mass."""
+        return self._mass
+
+    @mass.setter
+    def mass(self, mass):
+        self._mass = sympify(mass)
+
+    @property
+    def potential_energy(self):
+        """The potential energy of the body.
+
+        Examples
+        ========
+
+        >>> from sympy.physics.mechanics import Particle, Point
+        >>> from sympy import symbols
+        >>> m, g, h = symbols('m g h')
+        >>> O = Point('O')
+        >>> P = Particle('P', O, m)
+        >>> P.potential_energy = m * g * h
+        >>> P.potential_energy
+        g*h*m
+
+        """
+        return self._potential_energy
+
+    @potential_energy.setter
+    def potential_energy(self, scalar):
+        self._potential_energy = sympify(scalar)
+
+    @abstractmethod
+    def kinetic_energy(self, frame):
+        pass
+
+    @abstractmethod
+    def linear_momentum(self, frame):
+        pass
+
+    @abstractmethod
+    def angular_momentum(self, point, frame):
+        pass
+
+    @abstractmethod
+    def parallel_axis(self, point, frame):
+        pass

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,5 +1,4 @@
 from sympy.core.backend import sympify
-from sympy.physics.vector import Point
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.utilities.exceptions import sympy_deprecation_warning
 

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,12 +1,12 @@
 from sympy.core.backend import sympify
 from sympy.physics.vector import Point
-
+from sympy.physics.mechanics.body_base import BodyBase
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['Particle']
 
 
-class Particle:
+class Particle(BodyBase):
     """A particle.
 
     Explanation
@@ -41,40 +41,10 @@ class Particle:
     >>> pa.point = po
 
     """
+    point = BodyBase.masscenter
 
-    def __init__(self, name, point, mass):
-        if not isinstance(name, str):
-            raise TypeError('Supply a valid name.')
-        self._name = name
-        self.mass = mass
-        self.point = point
-        self.potential_energy = 0
-
-    def __str__(self):
-        return self._name
-
-    def __repr__(self):
-        return self.__str__()
-
-    @property
-    def mass(self):
-        """Mass of the particle."""
-        return self._mass
-
-    @mass.setter
-    def mass(self, value):
-        self._mass = sympify(value)
-
-    @property
-    def point(self):
-        """Point of the particle."""
-        return self._point
-
-    @point.setter
-    def point(self, p):
-        if not isinstance(p, Point):
-            raise TypeError("Particle point attribute must be a Point object.")
-        self._point = p
+    def __init__(self, name, point=None, mass=None):
+        super().__init__(name, point, mass)
 
     def linear_momentum(self, frame):
         """Linear momentum of the particle.
@@ -197,50 +167,6 @@ class Particle:
 
         return (self.mass / sympify(2) * self.point.vel(frame) &
                 self.point.vel(frame))
-
-    @property
-    def potential_energy(self):
-        """The potential energy of the Particle.
-
-        Examples
-        ========
-
-        >>> from sympy.physics.mechanics import Particle, Point
-        >>> from sympy import symbols
-        >>> m, g, h = symbols('m g h')
-        >>> O = Point('O')
-        >>> P = Particle('P', O, m)
-        >>> P.potential_energy = m * g * h
-        >>> P.potential_energy
-        g*h*m
-
-        """
-
-        return self._pe
-
-    @potential_energy.setter
-    def potential_energy(self, scalar):
-        """Used to set the potential energy of the Particle.
-
-        Parameters
-        ==========
-
-        scalar : Sympifyable
-            The potential energy (a scalar) of the Particle.
-
-        Examples
-        ========
-
-        >>> from sympy.physics.mechanics import Particle, Point
-        >>> from sympy import symbols
-        >>> m, g, h = symbols('m g h')
-        >>> O = Point('O')
-        >>> P = Particle('P', O, m)
-        >>> P.potential_energy = m * g * h
-
-        """
-
-        self._pe = sympify(scalar)
 
     def set_potential_energy(self, scalar):
         sympy_deprecation_warning(

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,12 +1,12 @@
-from sympy.core.backend import sympify
+from sympy.core.backend import sympify, Symbol
 from sympy.physics.vector import Point, ReferenceFrame, Dyadic
-
+from sympy.physics.mechanics.body_base import BodyBase
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['RigidBody']
 
 
-class RigidBody:
+class RigidBody(BodyBase):
     """An idealized rigid body.
 
     Explanation
@@ -51,21 +51,29 @@ class RigidBody:
 
     """
 
-    def __init__(self, name, masscenter, frame, mass, inertia):
-        if not isinstance(name, str):
-            raise TypeError('Supply a valid name.')
-        self._name = name
-        self.masscenter = masscenter
-        self.mass = mass
+    def __init__(self, name, masscenter=None, frame=None, mass=None,
+                 inertia=None):
+        # circular import issue (will soon be removed)
+        from sympy.physics.mechanics.functions import inertia as inertia_f
+        super().__init__(name, masscenter, mass)
+        if frame is None:
+            frame = ReferenceFrame(f'{name}_frame')
         self.frame = frame
+        if inertia is None:
+            ixx = Symbol(f'{name}_ixx')
+            iyy = Symbol(f'{name}_iyy')
+            izz = Symbol(f'{name}_izz')
+            izx = Symbol(f'{name}_izx')
+            ixy = Symbol(f'{name}_ixy')
+            iyz = Symbol(f'{name}_iyz')
+            inertia = (inertia_f(frame, ixx, iyy, izz, ixy, iyz, izx),
+                       self.masscenter)
         self.inertia = inertia
-        self.potential_energy = 0
-
-    def __str__(self):
-        return self._name
 
     def __repr__(self):
-        return self.__str__()
+        return (f'{self.__class__.__name__}({repr(self.name)}, masscenter='
+                f'{repr(self.masscenter)}, frame={repr(self.frame)}, mass='
+                f'{repr(self.mass)}), inertia={repr(self.inertia)}))')
 
     @property
     def frame(self):
@@ -79,24 +87,19 @@ class RigidBody:
         self._frame = F
 
     @property
-    def masscenter(self):
-        """The body's center of mass."""
-        return self._masscenter
-
-    @masscenter.setter
-    def masscenter(self, p):
-        if not isinstance(p, Point):
-            raise TypeError("RigidBody center of mass must be a Point object.")
-        self._masscenter = p
+    def x(self):
+        """The basis Vector for the body, in the x direction. """
+        return self.frame.x
 
     @property
-    def mass(self):
-        """The body's mass."""
-        return self._mass
+    def y(self):
+        """The basis Vector for the body, in the y direction. """
+        return self.frame.y
 
-    @mass.setter
-    def mass(self, m):
-        self._mass = sympify(m)
+    @property
+    def z(self):
+        """The basis Vector for the body, in the z direction. """
+        return self.frame.z
 
     @property
     def inertia(self):
@@ -273,57 +276,6 @@ class RigidBody:
             self.masscenter.vel(frame)) / sympify(2))
 
         return rotational_KE + translational_KE
-
-    @property
-    def potential_energy(self):
-        """The potential energy of the RigidBody.
-
-        Examples
-        ========
-
-        >>> from sympy.physics.mechanics import RigidBody, Point, outer, ReferenceFrame
-        >>> from sympy import symbols
-        >>> M, g, h = symbols('M g h')
-        >>> b = ReferenceFrame('b')
-        >>> P = Point('P')
-        >>> I = outer (b.x, b.x)
-        >>> Inertia_tuple = (I, P)
-        >>> B = RigidBody('B', P, b, M, Inertia_tuple)
-        >>> B.potential_energy = M * g * h
-        >>> B.potential_energy
-        M*g*h
-
-        """
-
-        return self._pe
-
-    @potential_energy.setter
-    def potential_energy(self, scalar):
-        """Used to set the potential energy of this RigidBody.
-
-        Parameters
-        ==========
-
-        scalar: Sympifyable
-            The potential energy (a scalar) of the RigidBody.
-
-        Examples
-        ========
-
-        >>> from sympy.physics.mechanics import Point, outer
-        >>> from sympy.physics.mechanics import RigidBody, ReferenceFrame
-        >>> from sympy import symbols
-        >>> b = ReferenceFrame('b')
-        >>> M, g, h = symbols('M g h')
-        >>> P = Point('P')
-        >>> I = outer (b.x, b.x)
-        >>> Inertia_tuple = (I, P)
-        >>> B = RigidBody('B', P, b, M, Inertia_tuple)
-        >>> B.potential_energy = M * g * h
-
-        """
-
-        self._pe = sympify(scalar)
 
     def set_potential_energy(self, scalar):
         sympy_deprecation_warning(

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,15 +1,29 @@
-from sympy.core.symbol import symbols
+from sympy.core.backend import symbols
 from sympy.physics.mechanics import Point, Particle, ReferenceFrame, inertia
-
+from sympy.physics.mechanics.body_base import BodyBase
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
+def test_particle_default():
+    # Test default
+    p = Particle('P')
+    assert p.name == 'P'
+    assert p.mass == symbols('P_mass')
+    assert p.masscenter.name == 'P_masscenter'
+    assert p.potential_energy == 0
+    assert p.__str__() == 'P'
+    assert p.__repr__() == ("Particle('P', masscenter=P_masscenter, "
+                            "mass=P_mass)")
+    raises(AttributeError, lambda: p.frame)
+
+
 def test_particle():
+    # Test initializing with parameters
     m, m2, v1, v2, v3, r, g, h = symbols('m m2 v1 v2 v3 r g h')
     P = Point('P')
     P2 = Point('P2')
     p = Particle('pa', P, m)
-    assert p.__str__() == 'pa'
+    assert isinstance(p, BodyBase)
     assert p.mass == m
     assert p.point == P
     # Test the mass setter
@@ -26,7 +40,7 @@ def test_particle():
     raises(TypeError, lambda: Particle(P, P, m))
     raises(TypeError, lambda: Particle('pa', m, m))
     assert p.linear_momentum(N) == m2 * v1 * N.x
-    assert p.angular_momentum(O, N) == -m2 * r *v1 * N.z
+    assert p.angular_momentum(O, N) == -m2 * r * v1 * N.z
     P2.set_vel(N, v2 * N.y)
     assert p.linear_momentum(N) == m2 * v2 * N.y
     assert p.angular_momentum(O, N) == 0
@@ -40,8 +54,8 @@ def test_particle():
     assert p.potential_energy == m * g * h
     # TODO make the result not be system-dependent
     assert p.kinetic_energy(
-        N) in [m2*(v1**2 + v2**2 + v3**2)/2,
-        m2 * v1**2 / 2 + m2 * v2**2 / 2 + m2 * v3**2 / 2]
+        N) in [m2 * (v1 ** 2 + v2 ** 2 + v3 ** 2) / 2,
+               m2 * v1 ** 2 / 2 + m2 * v2 ** 2 / 2 + m2 * v3 ** 2 / 2]
 
 
 def test_parallel_axis():
@@ -51,13 +65,14 @@ def test_parallel_axis():
     p = o.locatenew('p', a * N.x + b * N.y)
     P = Particle('P', o, m)
     Ip = P.parallel_axis(p, N)
-    Ip_expected = inertia(N, m * b**2, m * a**2, m * (a**2 + b**2),
+    Ip_expected = inertia(N, m * b ** 2, m * a ** 2, m * (a ** 2 + b ** 2),
                           ixy=-m * a * b)
     assert Ip == Ip_expected
+
 
 def test_deprecated_set_potential_energy():
     m, g, h = symbols('m g h')
     P = Point('P')
     p = Particle('pa', P, m)
     with warns_deprecated_sympy():
-        p.set_potential_energy(m*g*h)
+        p.set_potential_energy(m * g * h)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,10 +1,29 @@
-from sympy.core.symbol import symbols
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
 from sympy.physics.mechanics import dynamicsymbols, outer, inertia
 from sympy.physics.mechanics import inertia_of_point_mass
-from sympy.core.backend import expand, zeros, _simplify_matrix
-
+from sympy.core.backend import expand, zeros, _simplify_matrix, symbols
 from sympy.testing.pytest import raises, warns_deprecated_sympy
+
+
+def test_rigidbody_default():
+    # Test default
+    b = RigidBody('B')
+    I = inertia(b.frame, *symbols('B_ixx B_iyy B_izz B_ixy B_iyz B_izx'))
+    assert b.name == 'B'
+    assert b.mass == symbols('B_mass')
+    assert b.masscenter.name == 'B_masscenter'
+    assert b.inertia == (I, b.masscenter)
+    assert b.central_inertia == I
+    assert b.frame.name == 'B_frame'
+    assert b.__str__() == 'B'
+    assert b.__repr__() == (
+        "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass), "
+        "inertia=(B_ixx*(B_frame.x|B_frame.x) + "
+        "B_ixy*(B_frame.x|B_frame.y) + B_izx*(B_frame.x|B_frame.z) + "
+        "B_ixy*(B_frame.y|B_frame.x) + B_iyy*(B_frame.y|B_frame.y) + "
+        "B_iyz*(B_frame.y|B_frame.z) + B_izx*(B_frame.z|B_frame.x) + "
+        "B_iyz*(B_frame.z|B_frame.y) + B_izz*(B_frame.z|B_frame.z), "
+        "B_masscenter)))")
 
 
 def test_rigidbody():
@@ -61,6 +80,7 @@ def test_rigidbody2():
     B.potential_energy = M * g * h
     assert B.potential_energy == M * g * h
     assert expand(2 * B.kinetic_energy(N)) == omega**2 + M * v**2
+
 
 def test_rigidbody3():
     q1, q2, q3, q4 = dynamicsymbols('q1:5')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Output of the mechanics experimental development (#24234)
Implements parts of #24238 and #24699

#### Brief description of what is fixed or changed
This PR implements a revised bodies structure, where `Particle` and `RigidBody` both inherit from an abstract base class `BodyBase`. This improves the similarity between the objects and is a first step to make `Particle` and `RigidBody` compatible with the joints framework.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
