### PR TITLE
Changed the default to `simplify=False` in LT and ILT

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1086,11 +1086,11 @@ class LaplaceTransform(IntegralTransform):
         Standard hints are the following:
         - ``noconds``:  if True, do not return convergence conditions. The
         default setting is `True`.
-        - ``simplify``: if True, it simplifies the final result. This is the
-        default behaviour
+        - ``simplify``: if True, it simplifies the final result. The
+        default setting is `False`.
         """
         _noconds = hints.get('noconds', True)
-        _simplify = hints.get('simplify', True)
+        _simplify = hints.get('simplify', False)
 
         debugf('[LT doit] (%s, %s, %s)', (self.function,
                                           self.function_variable,
@@ -1168,8 +1168,8 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
     >>> laplace_transform(t**4, t, s)
     (24/s**5, 0, True)
     >>> laplace_transform(t**a, t, s)
-    (s**(-a - 1)*gamma(a + 1), 0, re(a) > -1)
-    >>> laplace_transform(DiracDelta(t)-a*exp(-a*t), t, s)
+    (gamma(a + 1)/(s*s**a), 0, re(a) > -1)
+    >>> laplace_transform(DiracDelta(t)-a*exp(-a*t), t, s, simplify=True)
     (s/(a + s), -re(a), True)
 
     References
@@ -1188,7 +1188,7 @@ def laplace_transform(f, t, s, legacy_matrix=True, **hints):
     """
 
     _noconds = hints.get('noconds', False)
-    _simplify = hints.get('simplify', True)
+    _simplify = hints.get('simplify', False)
 
     if isinstance(f, MatrixBase) and hasattr(f, 'applyfunc'):
 
@@ -1642,11 +1642,11 @@ class InverseLaplaceTransform(IntegralTransform):
         Standard hints are the following:
         - ``noconds``:  if True, do not return convergence conditions. The
         default setting is `True`.
-        - ``simplify``: if True, it simplifies the final result. This is the
-        default behaviour
+        - ``simplify``: if True, it simplifies the final result. The
+        default setting is `False`.
         """
         _noconds = hints.get('noconds', True)
-        _simplify = hints.get('simplify', True)
+        _simplify = hints.get('simplify', False)
 
         debugf('[ILT doit] (%s, %s, %s)', (self.function,
                                            self.function_variable,

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -645,13 +645,14 @@ def test_messy():
     from sympy.functions.special.bessel import besselj
     from sympy.functions.special.error_functions import (Chi, E1, Shi, Si)
     from sympy.integrals.transforms import (fourier_transform, laplace_transform)
-    assert laplace_transform(Si(x), x, s) == ((-atan(s) + pi/2)/s, 0, True)
+    assert (laplace_transform(Si(x), x, s, simplify=True) ==
+            ((-atan(s) + pi/2)/s, 0, True))
 
-    assert laplace_transform(Shi(x), x, s) == (
+    assert laplace_transform(Shi(x), x, s, simplify=True) == (
         acoth(s)/s, -oo, s**2 > 1)
 
     # where should the logs be simplified?
-    assert laplace_transform(Chi(x), x, s) == (
+    assert laplace_transform(Chi(x), x, s, simplify=True) == (
         (log(s**(-2)) - log(1 - 1/s**2))/(2*s), -oo, s**2 > 1)
 
     # TODO maybe simplify the inequalities? when the simplification

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2914,7 +2914,7 @@ def test_Y2():
     t = symbols('t', positive=True)
     w = symbols('w', real=True)
     s = symbols('s')
-    f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
+    f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t, simplify=True)
     assert f == cos(t*(w - 1))
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561 

#### Brief description of what is fixed or changed
The default of the hint `simplify` is changed to `simplify=False` in the Laplace transform and the inverse Laplace transform. Test cases and doc examples have been adapted accordingly. Mathematically, nothing changes, and the previous behaviour can be forced by giving the hint `simplify=True`.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * The default of the hint `simplify` is changed to `simplify=False` in the Laplace transform and the inverse Laplace transform.
<!-- END RELEASE NOTES -->
