### PR TITLE
Refactoring of `is_primitive_root`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -201,11 +201,9 @@ def is_primitive_root(a, p):
         raise ValueError("The two numbers should be relatively prime")
     # Primitive root of p exist only for
     # p = 2, 4, q**e, 2*q**e (q is odd prime)
-    if p == 2:
-        # 1 is a primitive root of 2
-        return True
-    elif p == 4:
-        return a == 3
+    if p <= 4:
+        # The primitive root is only p-1.
+        return a == p - 1
     t = trailing(p)
     if t > 1:
         return False


### PR DESCRIPTION
(1) Added docstring
(2) Raises an error when p <= 1
(3) Since there are only a limited number of `p` for which primitive roots exist, factorization of `p` can be simplified.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
