### PR TITLE
Fix as_coeff_Mul for Float(0.0)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -827,9 +827,9 @@ class Number(AtomicExpr):
 
     def as_coeff_Mul(self, rational=False):
         """Efficiently extract the coefficient of a product."""
-        if rational and not self.is_Rational:
-            return S.One, self
-        return (self, S.One) if self else (S.One, self)
+        if not rational:
+            return self, S.One
+        return S.One, self
 
     def as_coeff_Add(self, rational=False):
         """Efficiently extract the coefficient of a summation."""

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1660,6 +1660,7 @@ def test_as_coeff_Mul():
     assert Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
     assert Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
     assert Float(5.0).as_coeff_Mul() == (Float(5.0), Integer(1))
+    assert Float(0.0).as_coeff_Mul() == (Float(0.0), Integer(1))
 
     assert (Integer(3)*x).as_coeff_Mul() == (Integer(3), x)
     assert (Rational(3, 4)*x).as_coeff_Mul() == (Rational(3, 4), x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
As `as_coeff_Mul` should return `(0.0, 1)` instead of `(1, 0.0)` for `Float(0.0)` similar to how `S.Zero._as_coeff_Mul()` is `(0, 1)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fix `as_coeff_Mul` to return `(0.0, 1)` for `Float(0.0)`
<!-- END RELEASE NOTES -->
