### PR TITLE
maint(ci): fix branchnames for 1.12 benchmarks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ name: release
 on:
   push:
     branches:
-      - '1.11'
+      - '1.12'
   pull_request:
     branches:
-      - '1.11'
+      - '1.12'
 env:
-  release_branch: '1.11'
-  release_version: '1.11rc1'
-  previous_version: '1.10'
+  release_branch: '1.12'
+  release_version: '1.12rc1'
+  previous_version: '1.11'
 
 jobs:
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -433,7 +433,7 @@ jobs:
         # well.
 
       - run: git remote add upstream https://github.com/sympy/sympy.git
-      - run: git fetch upstream master
+      - run: git fetch upstream 1.12
       - run: git fetch upstream 1.11
 
       - name: Configure benchmarks
@@ -446,8 +446,8 @@ jobs:
         # Output benchmark results
       - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 | tee pr_vs_master.txt
       - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 --only-changed | tee pr_vs_master_changed.txt
-      - run: asv compare upstream/1.11 upstream/master --config asv.conf.actions.json --factor 1.5 | tee master_vs_release.txt
-      - run: asv compare upstream/1.11 upstream/master --config asv.conf.actions.json --factor 1.5 --only-changed | tee master_vs_release_changed.txt
+      - run: asv compare upstream/1.11 upstream/1.12 --config asv.conf.actions.json --factor 1.5 | tee master_vs_release.txt
+      - run: asv compare upstream/1.11 upstream/1.12 --config asv.conf.actions.json --factor 1.5 --only-changed | tee master_vs_release_changed.txt
 
         # This workflow does not have write permissions for the repository so
         # we save all outputs as artifacts that can be accessed by the

--- a/asv.conf.actions.json
+++ b/asv.conf.actions.json
@@ -22,7 +22,7 @@
 
     // This list needs to be updated after each release of sympy. The branch to
     // be checked should always be the previous release.
-    "branches": ["upstream/1.11", "upstream/master", "HEAD"], // for git
+    "branches": ["upstream/1.11", "upstream/1.12", "HEAD"], // for git
     // "branches": ["tip"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "1.12.dev"
+__version__ = "1.12rc1"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Issue for releasing 1.12: #24601

#### Brief description of what is fixed or changed

On the release branch benchmarks should not compare with the release branch rather than master.

Also updates release.yml so that the release workflow runs on this branch.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
