### PR TITLE
Fix enum antipattern practices for `galois_group`

### DIFF
--- a/sympy/combinatorics/galois.py
+++ b/sympy/combinatorics/galois.py
@@ -11,7 +11,7 @@ class, and then have to do extra work to determine which group it is, by
 checking various properties.
 
 Names are instances of ``Enum`` classes defined in this module. With a name in
-hand, the name's ``get_perm_group`` method can then be used to retrieve a
+hand, ``get_perm_group`` function can then be used to retrieve a
 :py:class:`~.PermutationGroup`.
 
 The names used for groups in this module are taken from [1].
@@ -22,8 +22,9 @@ References
 .. [1] Cohen, H. *A Course in Computational Algebraic Number Theory*.
 
 """
-
+from __future__ import annotations
 from collections import defaultdict
+from collections.abc import Callable
 from enum import Enum
 import itertools
 
@@ -33,6 +34,7 @@ from sympy.combinatorics.named_groups import (
 )
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.permutations import Permutation
+from sympy.core.cache import cacheit
 
 
 class S1TransitiveSubgroups(Enum):
@@ -41,18 +43,12 @@ class S1TransitiveSubgroups(Enum):
     """
     S1 = "S1"
 
-    def get_perm_group(self):
-        return SymmetricGroup(1)
-
 
 class S2TransitiveSubgroups(Enum):
     """
     Names for the transitive subgroups of S2.
     """
     S2 = "S2"
-
-    def get_perm_group(self):
-        return SymmetricGroup(2)
 
 
 class S3TransitiveSubgroups(Enum):
@@ -61,12 +57,6 @@ class S3TransitiveSubgroups(Enum):
     """
     A3 = "A3"
     S3 = "S3"
-
-    def get_perm_group(self):
-        if self == self.A3:
-            return AlternatingGroup(3)
-        elif self == self.S3:
-            return SymmetricGroup(3)
 
 
 class S4TransitiveSubgroups(Enum):
@@ -79,18 +69,6 @@ class S4TransitiveSubgroups(Enum):
     A4 = "A4"
     S4 = "S4"
 
-    def get_perm_group(self):
-        if self == self.C4:
-            return CyclicGroup(4)
-        elif self == self.V:
-            return four_group()
-        elif self == self.D4:
-            return DihedralGroup(4)
-        elif self == self.A4:
-            return AlternatingGroup(4)
-        elif self == self.S4:
-            return SymmetricGroup(4)
-
 
 class S5TransitiveSubgroups(Enum):
     """
@@ -101,18 +79,6 @@ class S5TransitiveSubgroups(Enum):
     M20 = "M20"
     A5 = "A5"
     S5 = "S5"
-
-    def get_perm_group(self):
-        if self == self.C5:
-            return CyclicGroup(5)
-        elif self == self.D5:
-            return DihedralGroup(5)
-        elif self == self.M20:
-            return M20()
-        elif self == self.A5:
-            return AlternatingGroup(5)
-        elif self == self.S5:
-            return SymmetricGroup(5)
 
 
 class S6TransitiveSubgroups(Enum):
@@ -136,39 +102,56 @@ class S6TransitiveSubgroups(Enum):
     A6 = "A6"
     S6 = "S6"
 
-    def get_perm_group(self):
-        if self == self.C6:
-            return CyclicGroup(6)
-        elif self == self.S3:
-            return S3_in_S6()
-        elif self == self.D6:
-            return DihedralGroup(6)
-        elif self == self.A4:
-            return A4_in_S6()
-        elif self == self.G18:
-            return G18()
-        elif self == self.A4xC2:
-            return A4xC2()
-        elif self == self.S4m:
-            return S4m()
-        elif self == self.S4p:
-            return S4p()
-        elif self == self.G36m:
-            return G36m()
-        elif self == self.G36p:
-            return G36p()
-        elif self == self.S4xC2:
-            return S4xC2()
-        elif self == self.PSL2F5:
-            return PSL2F5()
-        elif self == self.G72:
-            return G72()
-        elif self == self.PGL2F5:
-            return PGL2F5()
-        elif self == self.A6:
-            return AlternatingGroup(6)
-        elif self == self.S6:
-            return SymmetricGroup(6)
+
+TransitiveSubgroups = (
+    S1TransitiveSubgroups | S2TransitiveSubgroups | S3TransitiveSubgroups |
+    S4TransitiveSubgroups | S5TransitiveSubgroups | S6TransitiveSubgroups
+)
+
+
+@cacheit
+def get_perm_group_table() -> dict[TransitiveSubgroups, Callable[[], PermutationGroup]]:
+    r"""Get the permutation group table for transitive subgroup names."""
+    return {
+        S1TransitiveSubgroups.S1: lambda: SymmetricGroup(1),
+        S2TransitiveSubgroups.S2: lambda: SymmetricGroup(2),
+        S3TransitiveSubgroups.A3: lambda: AlternatingGroup(3),
+        S3TransitiveSubgroups.S3: lambda: SymmetricGroup(3),
+
+        S4TransitiveSubgroups.C4: lambda: CyclicGroup(4),
+        S4TransitiveSubgroups.V: lambda: four_group(),
+        S4TransitiveSubgroups.D4: lambda: DihedralGroup(4),
+        S4TransitiveSubgroups.A4: lambda: AlternatingGroup(4),
+        S4TransitiveSubgroups.S4: lambda: SymmetricGroup(4),
+
+        S5TransitiveSubgroups.C5: lambda: CyclicGroup(5),
+        S5TransitiveSubgroups.D5: lambda: DihedralGroup(5),
+        S5TransitiveSubgroups.M20: lambda: M20(),
+        S5TransitiveSubgroups.A5: lambda: AlternatingGroup(5),
+        S5TransitiveSubgroups.S5: lambda: SymmetricGroup(5),
+
+        S6TransitiveSubgroups.C6: lambda: CyclicGroup(6),
+        S6TransitiveSubgroups.S3: lambda: S3_in_S6(),
+        S6TransitiveSubgroups.D6: lambda: DihedralGroup(6),
+        S6TransitiveSubgroups.A4: lambda: A4_in_S6(),
+        S6TransitiveSubgroups.G18: lambda: G18(),
+        S6TransitiveSubgroups.A4xC2: lambda: A4xC2(),
+        S6TransitiveSubgroups.S4m: lambda: S4m(),
+        S6TransitiveSubgroups.S4p: lambda: S4p(),
+        S6TransitiveSubgroups.G36m: lambda: G36m(),
+        S6TransitiveSubgroups.G36p: lambda: G36p(),
+        S6TransitiveSubgroups.S4xC2: lambda: S4xC2(),
+        S6TransitiveSubgroups.PSL2F5: lambda: PSL2F5(),
+        S6TransitiveSubgroups.G72: lambda: G72(),
+        S6TransitiveSubgroups.PGL2F5: lambda: PGL2F5(),
+        S6TransitiveSubgroups.A6: lambda: AlternatingGroup(6),
+        S6TransitiveSubgroups.S6: lambda: SymmetricGroup(6),
+    }
+
+
+def get_perm_group(name: TransitiveSubgroups) -> PermutationGroup:
+    r"""Get the permutation group from the transitive subgroup names."""
+    return get_perm_group_table()[name]()
 
 
 def four_group():

--- a/sympy/combinatorics/galois.py
+++ b/sympy/combinatorics/galois.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from enum import Enum
 import itertools
-
+from typing import Union
 from sympy.combinatorics.named_groups import (
     SymmetricGroup, AlternatingGroup, CyclicGroup, DihedralGroup,
     set_symmetric_group_properties, set_alternating_group_properties,
@@ -103,10 +103,10 @@ class S6TransitiveSubgroups(Enum):
     S6 = "S6"
 
 
-TransitiveSubgroups = (
-    S1TransitiveSubgroups | S2TransitiveSubgroups | S3TransitiveSubgroups |
-    S4TransitiveSubgroups | S5TransitiveSubgroups | S6TransitiveSubgroups
-)
+TransitiveSubgroups = Union[
+    S1TransitiveSubgroups, S2TransitiveSubgroups, S3TransitiveSubgroups,
+    S4TransitiveSubgroups, S5TransitiveSubgroups, S6TransitiveSubgroups
+]
 
 
 @cacheit

--- a/sympy/combinatorics/tests/test_galois.py
+++ b/sympy/combinatorics/tests/test_galois.py
@@ -2,7 +2,7 @@
 
 from sympy.combinatorics.galois import (
     S4TransitiveSubgroups, S5TransitiveSubgroups, S6TransitiveSubgroups,
-    find_transitive_subgroups_of_S6,
+    find_transitive_subgroups_of_S6, get_perm_group
 )
 from sympy.combinatorics.homomorphisms import is_isomorphic
 from sympy.combinatorics.named_groups import (
@@ -11,7 +11,7 @@ from sympy.combinatorics.named_groups import (
 
 
 def test_four_group():
-    G = S4TransitiveSubgroups.V.get_perm_group()
+    G = get_perm_group(S4TransitiveSubgroups.V)
     A4 = AlternatingGroup(4)
     assert G.is_subgroup(A4)
     assert G.degree == 4
@@ -21,7 +21,7 @@ def test_four_group():
 
 
 def test_M20():
-    G = S5TransitiveSubgroups.M20.get_perm_group()
+    G = get_perm_group(S5TransitiveSubgroups.M20)
     S5 = SymmetricGroup(5)
     A5 = AlternatingGroup(5)
     assert G.is_subgroup(S5)
@@ -41,7 +41,7 @@ if INCLUDE_SEARCH_REPS:
 
 
 def get_versions_of_S6_subgroup(name):
-    vers = [name.get_perm_group()]
+    vers = [get_perm_group(name)]
     if INCLUDE_SEARCH_REPS:
         vers.append(S6_randomized[name])
     return vers

--- a/sympy/polys/numberfields/galoisgroups.py
+++ b/sympy/polys/numberfields/galoisgroups.py
@@ -546,10 +546,11 @@ def galois_group(f, *gens, by_name=False, max_tries=30, randomize=False, **args)
     >>> print(G_name)
     S4TransitiveSubgroups.V
 
-    The group itself can then be obtained by calling the name's
-    ``get_perm_group()`` method:
+    The group itself can then be obtained by calling ``get_perm_group()``
+    function:
 
-    >>> G_name.get_perm_group()
+    >>> from sympy.combinatorics.galois import get_perm_group
+    >>> get_perm_group(G_name)
     PermutationGroup([
     (0 1)(2 3),
     (0 2)(1 3)])

--- a/sympy/polys/numberfields/tests/test_galoisgroups.py
+++ b/sympy/polys/numberfields/tests/test_galoisgroups.py
@@ -4,6 +4,7 @@ from sympy.abc import x
 from sympy.combinatorics.galois import (
     S1TransitiveSubgroups, S2TransitiveSubgroups, S3TransitiveSubgroups,
     S4TransitiveSubgroups, S5TransitiveSubgroups, S6TransitiveSubgroups,
+    get_perm_group
 )
 from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.numberfields.galoisgroups import (
@@ -111,7 +112,7 @@ def test_galois_group_not_by_name():
     for deg in range(1, 7):
         T, G_name, _ = test_polys_by_deg[deg][0]
         G, _ = galois_group(T)
-        assert G == G_name.get_perm_group()
+        assert G == get_perm_group(G_name)
 
 
 def test_galois_group_not_monic_over_ZZ():

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3960,7 +3960,8 @@ class Poly(Basic):
         else:
             g, _ = f.make_monic_over_integers_by_scaling_roots()
             name, alt = gg[n](g, max_tries=max_tries, randomize=randomize)
-        G = name if by_name else name.get_perm_group()
+        from sympy.combinatorics.galois import get_perm_group
+        G = name if by_name else get_perm_group(name)
         return G, alt
 
     @property


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24782

#### Brief description of what is fixed or changed

I'm changing the structure of galois group table to be functional than object-oriented, 
such that it is not using some antipattern practices that is getting warned by Python 3.12

I'm not sure that using 'enum' with custom methods is pro-pattern, and the only feature we all need is some lazy table of constants, so we can just use dictionary for the purpose.
since this is before the release, we have time to reorganize the public API without deprecation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
