### PR TITLE
Remove deprecated Enum `member.member` access

### DIFF
--- a/sympy/combinatorics/galois.py
+++ b/sympy/combinatorics/galois.py
@@ -63,9 +63,9 @@ class S3TransitiveSubgroups(Enum):
     S3 = "S3"
 
     def get_perm_group(self):
-        if self == self.A3:
+        if self == S3TransitiveSubgroups.A3:
             return AlternatingGroup(3)
-        elif self == self.S3:
+        elif self == S3TransitiveSubgroups.S3:
             return SymmetricGroup(3)
 
 
@@ -80,15 +80,15 @@ class S4TransitiveSubgroups(Enum):
     S4 = "S4"
 
     def get_perm_group(self):
-        if self == self.C4:
+        if self == S4TransitiveSubgroups.C4:
             return CyclicGroup(4)
-        elif self == self.V:
+        elif self == S4TransitiveSubgroups.V:
             return four_group()
-        elif self == self.D4:
+        elif self == S4TransitiveSubgroups.D4:
             return DihedralGroup(4)
-        elif self == self.A4:
+        elif self == S4TransitiveSubgroups.A4:
             return AlternatingGroup(4)
-        elif self == self.S4:
+        elif self == S4TransitiveSubgroups.S4:
             return SymmetricGroup(4)
 
 
@@ -103,15 +103,15 @@ class S5TransitiveSubgroups(Enum):
     S5 = "S5"
 
     def get_perm_group(self):
-        if self == self.C5:
+        if self == S5TransitiveSubgroups.C5:
             return CyclicGroup(5)
-        elif self == self.D5:
+        elif self == S5TransitiveSubgroups.D5:
             return DihedralGroup(5)
-        elif self == self.M20:
+        elif self == S5TransitiveSubgroups.M20:
             return M20()
-        elif self == self.A5:
+        elif self == S5TransitiveSubgroups.A5:
             return AlternatingGroup(5)
-        elif self == self.S5:
+        elif self == S5TransitiveSubgroups.S5:
             return SymmetricGroup(5)
 
 
@@ -137,37 +137,37 @@ class S6TransitiveSubgroups(Enum):
     S6 = "S6"
 
     def get_perm_group(self):
-        if self == self.C6:
+        if self == S6TransitiveSubgroups.C6:
             return CyclicGroup(6)
-        elif self == self.S3:
+        elif self == S6TransitiveSubgroups.S3:
             return S3_in_S6()
-        elif self == self.D6:
+        elif self == S6TransitiveSubgroups.D6:
             return DihedralGroup(6)
-        elif self == self.A4:
+        elif self == S6TransitiveSubgroups.A4:
             return A4_in_S6()
-        elif self == self.G18:
+        elif self == S6TransitiveSubgroups.G18:
             return G18()
-        elif self == self.A4xC2:
+        elif self == S6TransitiveSubgroups.A4xC2:
             return A4xC2()
-        elif self == self.S4m:
+        elif self == S6TransitiveSubgroups.S4m:
             return S4m()
-        elif self == self.S4p:
+        elif self == S6TransitiveSubgroups.S4p:
             return S4p()
-        elif self == self.G36m:
+        elif self == S6TransitiveSubgroups.G36m:
             return G36m()
-        elif self == self.G36p:
+        elif self == S6TransitiveSubgroups.G36p:
             return G36p()
-        elif self == self.S4xC2:
+        elif self == S6TransitiveSubgroups.S4xC2:
             return S4xC2()
-        elif self == self.PSL2F5:
+        elif self == S6TransitiveSubgroups.PSL2F5:
             return PSL2F5()
-        elif self == self.G72:
+        elif self == S6TransitiveSubgroups.G72:
             return G72()
-        elif self == self.PGL2F5:
+        elif self == S6TransitiveSubgroups.PGL2F5:
             return PGL2F5()
-        elif self == self.A6:
+        elif self == S6TransitiveSubgroups.A6:
             return AlternatingGroup(6)
-        elif self == self.S6:
+        elif self == S6TransitiveSubgroups.S6:
             return SymmetricGroup(6)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24782 


#### Brief description of what is fixed or changed

Replaces `self == self.X` tests in enum instance methods with `self == ClassName.X`.




#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
