### PR TITLE
Use explicit keyword argument in Intersection.__new__

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -702,7 +702,7 @@ Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
-Jay Patankar <patankarjays@gmail.com>
+Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -702,6 +702,7 @@ Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
+Jay Patankar <patankarjays@gmail.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1475,8 +1475,8 @@ class Intersection(Set, LatticeOp):
         return S.EmptySet
 
     def __new__(cls, *args , evaluate=None):
-        if evaluate==None:
-            evaluate=global_parameters.evaluate
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
 
         # flatten inputs to merge intersections and iterables
         args = list(ordered(set(_sympify(args))))

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1474,8 +1474,9 @@ class Intersection(Set, LatticeOp):
     def zero(self):
         return S.EmptySet
 
-    def __new__(cls, *args, **kwargs):
-        evaluate = kwargs.get('evaluate', global_parameters.evaluate)
+    def __new__(cls, *args , evaluate=None):
+        if evaluate==None:
+            evaluate=global_parameters.evaluate
 
         # flatten inputs to merge intersections and iterables
         args = list(ordered(set(_sympify(args))))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

See #14030 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


Removed the **kwargs from the function signature of new(), replacing it with an equivalent default argument.




#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * `Intersection.__new__` now accepts only an explicit keyword-only argument `evaluate` rather than `**kwargs`.


<!-- END RELEASE NOTES -->
