### PR TITLE
Deprecate monotonicity_helper

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,7 +76,15 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
-There are no deprecations yet for SymPy 1.13.
+(monotonicity-helper)=
+### The ``calculus.singularities.monotonicity_helper`` function
+
+The ``calculus.singularities.monotonicity_helper`` is considered private. Instead use
+the required check directly through the provided functions
+* {func}`~sympy.calculus.singularities.is_increasing`
+* {func}`~sympy.calculus.singularities.is_strictly_increasing`
+* {func}`~sympy.calculus.singularities.is_decreasing`
+* {func}`~sympy.calculus.singularities.is_strictly_decreasing`
 
 ## Version 1.12
 

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -21,6 +21,7 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.trigonometric import sec, csc, cot, tan, cos
+from sympy.utilities.decorator import deprecated
 from sympy.utilities.misc import filldedent
 
 
@@ -109,9 +110,20 @@ def singularities(expression, symbol, domain=None):
 ###########################################################################
 
 
+@deprecated(
+    "monotonicity_helper is considered a private function, use the direct"
+    " function for checking instead", deprecated_since_version="1.13",
+    active_deprecations_target="monotonicity-helper"
+)
 def monotonicity_helper(expression, predicate, interval=S.Reals, symbol=None):
     """
     Helper function for functions checking function monotonicity.
+
+    .. deprecated:: 1.13
+
+    It returns a boolean indicating whether the interval in which
+    the function's derivative satisfies given predicate is a superset
+    of the given interval.
 
     Parameters
     ==========
@@ -128,14 +140,43 @@ def monotonicity_helper(expression, predicate, interval=S.Reals, symbol=None):
     symbol : Symbol, optional
         The symbol present in expression which gets varied over the given range.
 
+    Returns
+    =======
+
+    bool
+        True if ``predicate`` is true for all the derivatives when ``symbol``
+        is varied in ``range``, False otherwise.
+
+    """
+    return _monotonicity_helper(expression, predicate, interval=interval, symbol=symbol)
+
+def _monotonicity_helper(expression, predicate, interval=S.Reals, symbol=None):
+    """
+    Helper function for functions checking function monotonicity.
+
     It returns a boolean indicating whether the interval in which
     the function's derivative satisfies given predicate is a superset
     of the given interval.
 
+    Parameters
+    ==========
+
+    expression : Expr
+        The target function which is being checked
+    predicate : function
+        The property being tested for. The function takes in an integer
+        and returns a boolean. The integer input is the derivative and
+        the boolean result should be true if the property is being held,
+        and false otherwise.
+    interval : Set, optional
+        The range of values in which we are testing, defaults to all reals.
+    symbol : Symbol, optional
+        The symbol present in expression which gets varied over the given range.
+
     Returns
     =======
 
-    Boolean
+    bool
         True if ``predicate`` is true for all the derivatives when ``symbol``
         is varied in ``range``, False otherwise.
 
@@ -176,7 +217,7 @@ def is_increasing(expression, interval=S.Reals, symbol=None):
     Returns
     =======
 
-    Boolean
+    bool
         True if ``expression`` is increasing (either strictly increasing or
         constant) in the given ``interval``, False otherwise.
 
@@ -198,7 +239,7 @@ def is_increasing(expression, interval=S.Reals, symbol=None):
     True
 
     """
-    return monotonicity_helper(expression, lambda x: x >= 0, interval, symbol)
+    return _monotonicity_helper(expression, lambda x: x >= 0, interval, symbol)
 
 
 def is_strictly_increasing(expression, interval=S.Reals, symbol=None):
@@ -219,7 +260,7 @@ def is_strictly_increasing(expression, interval=S.Reals, symbol=None):
     Returns
     =======
 
-    Boolean
+    bool
         True if ``expression`` is strictly increasing in the given ``interval``,
         False otherwise.
 
@@ -241,7 +282,7 @@ def is_strictly_increasing(expression, interval=S.Reals, symbol=None):
     False
 
     """
-    return monotonicity_helper(expression, lambda x: x > 0, interval, symbol)
+    return _monotonicity_helper(expression, lambda x: x > 0, interval, symbol)
 
 
 def is_decreasing(expression, interval=S.Reals, symbol=None):
@@ -262,7 +303,7 @@ def is_decreasing(expression, interval=S.Reals, symbol=None):
     Returns
     =======
 
-    Boolean
+    bool
         True if ``expression`` is decreasing (either strictly decreasing or
         constant) in the given ``interval``, False otherwise.
 
@@ -288,7 +329,7 @@ def is_decreasing(expression, interval=S.Reals, symbol=None):
     False
 
     """
-    return monotonicity_helper(expression, lambda x: x <= 0, interval, symbol)
+    return _monotonicity_helper(expression, lambda x: x <= 0, interval, symbol)
 
 
 def is_strictly_decreasing(expression, interval=S.Reals, symbol=None):
@@ -309,7 +350,7 @@ def is_strictly_decreasing(expression, interval=S.Reals, symbol=None):
     Returns
     =======
 
-    Boolean
+    bool
         True if ``expression`` is strictly decreasing in the given ``interval``,
         False otherwise.
 
@@ -331,7 +372,7 @@ def is_strictly_decreasing(expression, interval=S.Reals, symbol=None):
     False
 
     """
-    return monotonicity_helper(expression, lambda x: x < 0, interval, symbol)
+    return _monotonicity_helper(expression, lambda x: x < 0, interval, symbol)
 
 
 def is_monotonic(expression, interval=S.Reals, symbol=None):
@@ -352,7 +393,7 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
     Returns
     =======
 
-    Boolean
+    bool
         True if ``expression`` is monotonic in the given ``interval``,
         False otherwise.
 

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -9,10 +9,11 @@ from sympy.calculus.singularities import (
     is_strictly_increasing,
     is_decreasing,
     is_strictly_decreasing,
-    is_monotonic
+    is_monotonic,
+    monotonicity_helper
 )
 from sympy.sets import Interval, FiniteSet
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.abc import x, y
 
 
@@ -101,3 +102,7 @@ def test_issue_23401():
     x = Symbol('x')
     expr = (x + 1)/(-1.0e-3*x**2 + 0.1*x + 0.1)
     assert is_increasing(expr, Interval(1,2), x)
+
+def test_monotonicity_helper_is_deprecated():
+    with warns_deprecated_sympy():
+        monotonicity_helper(1, lambda x: x >= 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to the discusssion in #23037

#### Brief description of what is fixed or changed
This is a typical example of what I believe should be "private". Currently, this function is in the documentation leading to that there is yet another function listed that a user shouldn't really need to access directly (and the list of functions that a user should access is quite long as it is).

Here, this function is well abstracted and well documented.

#### Other comments
This clearly only has a minor impact on the whole issue (and the user experience), but there are quite a few functions and methods like this in the code base. Things that probably should have been private to start with.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * BREAKING CHANGE: `monotonicity_helper` is deprecated. 
<!-- END RELEASE NOTES -->
