### PR TITLE
Fix doc-strings in combinatorics.util

### DIFF
--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -134,13 +134,12 @@ def _distribute_gens_by_base(base, gens):
 
     Returns
     =======
-
-    List of length `k`, where `k` is
-    the length of ``base``. The `i`-th entry contains those elements in
-    ``gens`` which fix the first `i` elements of ``base`` (so that the
-    `0`-th entry is equal to ``gens`` itself). If no element fixes the first
-    `i` elements of ``base``, the `i`-th element is set to a list containing
-    the identity element.
+    list
+        List of length `k`, where `k` is the length of *base*. The `i`-th entry
+        contains those elements in *gens* which fix the first `i` elements of
+        *base* (so that the `0`-th entry is equal to *gens* itself). If no
+        element fixes the first `i` elements of *base*, the `i`-th element is
+        set to a list containing the identity element.
 
     Examples
     ========
@@ -196,20 +195,19 @@ def _handle_precomputed_bsgs(base, strong_gens, transversals=None,
     Parameters
     ==========
 
-    ``base`` - the base
-    ``strong_gens`` - the strong generators
-    ``transversals`` - basic transversals
-    ``basic_orbits`` - basic orbits
-    ``strong_gens_distr`` - strong generators distributed by membership in basic
-    stabilizers
+    base : the base
+    strong_gens : the strong generators
+    transversals : basic transversals
+    basic_orbits : basic orbits
+    strong_gens_distr : strong generators distributed by membership in basic stabilizers
 
     Returns
     =======
 
-    ``(transversals, basic_orbits, strong_gens_distr)`` where ``transversals``
-    are the basic transversals, ``basic_orbits`` are the basic orbits, and
-    ``strong_gens_distr`` are the strong generators distributed by membership
-    in basic stabilizers.
+    (transversals, basic_orbits, strong_gens_distr)
+        where *transversals* are the basic transversals, *basic_orbits* are the
+        basic orbits, and *strong_gens_distr* are the strong generators distributed
+        by membership in basic stabilizers.
 
     Examples
     ========
@@ -262,13 +260,12 @@ def _orbits_transversals_from_bsgs(base, strong_gens_distr,
     Parameters
     ==========
 
-    ``base`` - The base.
-    ``strong_gens_distr`` - Strong generators distributed by membership in basic
-    stabilizers.
-    ``transversals_only`` - bool
+    base : The base.
+    strong_gens_distr : Strong generators distributed by membership in basic stabilizers.
+    transversals_only : bool, default: False
         A flag switching between returning only the
         transversals and both orbits and transversals.
-    ``slp`` -
+    slp : bool, default: False
         If ``True``, return a list of dictionaries containing the
         generator presentations of the elements of the transversals,
         i.e. the list of indices of generators from ``strong_gens_distr[i]``
@@ -319,11 +316,10 @@ def _remove_gens(base, strong_gens, basic_orbits=None, strong_gens_distr=None):
     Parameters
     ==========
 
-    ``base`` - a base
-    ``strong_gens`` - a strong generating set relative to ``base``
-    ``basic_orbits`` - basic orbits
-    ``strong_gens_distr`` - strong generators distributed by membership in basic
-    stabilizers
+    base : a base
+    strong_gens : a strong generating set relative to *base*
+    basic_orbits : basic orbits
+    strong_gens_distr : strong generators distributed by membership in basic stabilizers
 
     Returns
     =======
@@ -406,15 +402,16 @@ def _strip(g, base, orbits, transversals):
     Parameters
     ==========
 
-    ``g`` - permutation to be decomposed
-    ``base`` - sequence of points
-    ``orbits`` - a list in which the ``i``-th entry is an orbit of ``base[i]``
-    under some subgroup of the pointwise stabilizer of `
-    `base[0], base[1], ..., base[i - 1]``. The groups themselves are implicit
-    in this function since the only information we need is encoded in the orbits
-    and transversals
-    ``transversals`` - a list of orbit transversals associated with the orbits
-    ``orbits``.
+    g : permutation to be decomposed
+    base : sequence of points
+    orbits : list
+        A list in which the ``i``-th entry is an orbit of ``base[i]``
+        under some subgroup of the pointwise stabilizer of `
+        `base[0], base[1], ..., base[i - 1]``. The groups themselves are implicit
+        in this function since the only information we need is encoded in the orbits
+        and transversals
+    transversals : list
+        A list of orbit transversals associated with the orbits *orbits*.
 
     Examples
     ========
@@ -503,8 +500,7 @@ def _strong_gens_from_distr(strong_gens_distr):
     Parameters
     ==========
 
-    ``strong_gens_distr`` - strong generators distributed by membership in basic
-    stabilizers
+    strong_gens_distr : strong generators distributed by membership in basic stabilizers
 
     Examples
     ========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fix formatting of doc-strings. Far from perfect (as I do not really understand the functions), but at least a step in the right direction when it comes to numpydoc etc.

#### Other comments

One may question if these functions should be in the documentation build.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
