### PR TITLE
Correct doc-string argument names and formatting in utilities

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -297,7 +297,7 @@ class Variable:
             When not given, the data type will be guessed based on the
             assumptions on the symbol argument.
 
-        dimension : sequence containing tupes, optional
+        dimensions : sequence containing tuples, optional
             If present, the argument is interpreted as an array, where this
             sequence of tuples specifies (lower, upper) bounds for each
             index of the array.
@@ -315,7 +315,7 @@ class Variable:
                             "instance of the DataType class.")
         if dimensions and not isinstance(dimensions, (tuple, list)):
             raise TypeError(
-                "The dimension argument must be a sequence of tuples")
+                "The dimensions argument must be a sequence of tuples")
 
         self._name = name
         self._datatype = {
@@ -419,7 +419,7 @@ class OutputArgument(Argument, ResultBase):
             When not given, the data type will be guessed based on the
             assumptions on the symbol argument.
 
-        dimension : sequence containing tupes, optional
+        dimensions : sequence containing tuples, optional
             If present, the argument is interpreted as an array, where this
             sequence of tuples specifies (lower, upper) bounds for each
             index of the array.
@@ -491,7 +491,7 @@ class Result(Variable, ResultBase):
             When not given, the data type will be guessed based on the
             assumptions on the expr argument.
 
-        dimension : sequence containing tupes, optional
+        dimensions : sequence containing tuples, optional
             If present, this variable is interpreted as an array,
             where this sequence of tuples specifies (lower, upper)
             bounds for each index of the array.
@@ -1991,7 +1991,7 @@ def get_code_generator(language, project=None, standard=None, printer = None):
 
 def codegen(name_expr, language=None, prefix=None, project="project",
             to_files=False, header=True, empty=True, argument_sequence=None,
-            global_vars=None, standard=None, code_gen=None, printer = None):
+            global_vars=None, standard=None, code_gen=None, printer=None):
     """Generate source code for expressions in a given language.
 
     Parameters
@@ -2042,10 +2042,13 @@ def codegen(name_expr, language=None, prefix=None, project="project",
         Sequence of global variables used by the routine.  Variables
         listed here will not show up as function arguments.
 
-    standard : string
+    standard : string, optional
 
-    code_gen : CodeGen instance
+    code_gen : CodeGen instance, optional
         An instance of a CodeGen subclass. Overrides ``language``.
+
+    printer : Printer instance, optional
+        An instance of a Printer subclass.
 
     Examples
     ========

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -668,7 +668,7 @@ class MultisetPartitionTraverser():
         Parameters
         ==========
 
-         part
+        part
             part to be decremented (topmost part on the stack)
 
         ub

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -110,8 +110,7 @@ def sympy_deprecation_warning(message, *, deprecated_since_version,
     Parameters
     ==========
 
-    message: str
-
+    message : str
          The deprecation message. This may span multiple lines and contain
          code examples. Messages should be wrapped to 80 characters. The
          message is automatically dedented and leading and trailing whitespace
@@ -120,8 +119,7 @@ def sympy_deprecation_warning(message, *, deprecated_since_version,
          arbitrary, as it might be huge and make the warning message
          unreadable.
 
-    deprecated_since_version: str
-
+    deprecated_since_version : str
          The version of SymPy the feature has been deprecated since. For new
          deprecations, this should be the version in `sympy/release.py
          <https://github.com/sympy/sympy/blob/master/sympy/release.py>`_
@@ -131,8 +129,7 @@ def sympy_deprecation_warning(message, *, deprecated_since_version,
          argument is required and must be passed as a keyword argument.
          (example:  ``deprecated_since_version="1.10"``).
 
-    active_deprecations_target: str
-
+    active_deprecations_target : str
         The Sphinx target corresponding to the section for the deprecation in
         the :ref:`active-deprecations` document (see
         ``doc/src/explanation/active-deprecations.md``). This is used to
@@ -140,8 +137,7 @@ def sympy_deprecation_warning(message, *, deprecated_since_version,
         argument is required and must be passed as a keyword argument.
         (example: ``active_deprecations_target="deprecated-feature-abc"``)
 
-    stacklevel: int (default: 3)
-
+    stacklevel : int, default: 3
         The ``stacklevel`` parameter that is passed to ``warnings.warn``. If
         you create a wrapper that calls this function, this should be
         increased so that the warning message shows the user line of code that

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -525,6 +525,12 @@ def numbered_symbols(prefix='x', cls=None, start=0, exclude=(), *args, **assumpt
     start : int, optional
         The start number.  By default, it is 0.
 
+    exclude : list, tuple, set of cls, optional
+        Symbols to be excluded.
+
+    *args, **kwargs
+        Additional positional and keyword arguments are passed to the *cls* class.
+
     Returns
     =======
 
@@ -896,7 +902,7 @@ def strongly_connected_components(G):
     Parameters
     ==========
 
-    graph : tuple[list, list[tuple[T, T]]
+    G : tuple[list, list[tuple[T, T]]
         A tuple consisting of a list of vertices and a list of edges of
         a graph whose strongly connected components are to be found.
 
@@ -1050,7 +1056,7 @@ def connected_components(G):
     Parameters
     ==========
 
-    graph : tuple[list, list[tuple[T, T]]
+    G : tuple[list, list[tuple[T, T]]
         A tuple consisting of a list of vertices and a list of edges of
         a graph whose connected components are to be found.
 
@@ -1592,20 +1598,21 @@ def multiset_partitions(multiset, m=None):
 def partitions(n, m=None, k=None, size=False):
     """Generate all partitions of positive integer, n.
 
-    Parameters
-    ==========
-
-    m : integer (default gives partitions of all sizes)
-        limits number of parts in partition (mnemonic: m, maximum parts)
-    k : integer (default gives partitions number from 1 through n)
-        limits the numbers that are kept in the partition (mnemonic: k, keys)
-    size : bool (default False, only partition is returned)
-        when ``True`` then (M, P) is returned where M is the sum of the
-        multiplicities and P is the generated partition.
-
     Each partition is represented as a dictionary, mapping an integer
     to the number of copies of that integer in the partition.  For example,
     the first partition of 4 returned is {4: 1}, "4: one of them".
+
+    Parameters
+    ==========
+    n : int
+    m : int, optional
+        limits number of parts in partition (mnemonic: m, maximum parts)
+    k : int, optional
+        limits the numbers that are kept in the partition (mnemonic: k, keys)
+    size : bool, default: False
+        If ``True``, (M, P) is returned where M is the sum of the
+        multiplicities and P is the generated partition.
+        If ``False``, only the generated partition is returned.
 
     Examples
     ========
@@ -1721,18 +1728,18 @@ def partitions(n, m=None, k=None, size=False):
 
 
 def ordered_partitions(n, m=None, sort=True):
-    """Generates ordered partitions of integer ``n``.
+    """Generates ordered partitions of integer *n*.
 
     Parameters
     ==========
-
-    m : integer (default None)
+    n : int
+    m : int, optional
         The default value gives partitions of all sizes else only
-        those with size m. In addition, if ``m`` is not None then
+        those with size m. In addition, if *m* is not None then
         partitions are generated *in place* (see examples).
-    sort : bool (default True)
+    sort : bool, default: True
         Controls whether partitions are
-        returned in sorted order when ``m`` is not None; when False,
+        returned in sorted order when *m* is not None; when False,
         the partitions are returned as fast as possible with elements
         sorted, but when m|n the partitions will not be in
         ascending lexicographical order.
@@ -1858,7 +1865,7 @@ def ordered_partitions(n, m=None, sort=True):
 
 def binary_partitions(n):
     """
-    Generates the binary partition of n.
+    Generates the binary partition of *n*.
 
     A binary partition consists only of numbers that are
     powers of two. Each step reduces a `2^{k+1}` to `2^k` and


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fix some incorrect argument names and a bit of formatting issues.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
