### PR TITLE
ruff-PIE802: optimize any all with generators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ select = [
     "C4",
     "E",
     "F",
+    "PIE802",
 ]
 
 # Ignore rules that currently fail on the SymPy codebase

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -34,7 +34,7 @@ def is_nilpotent_number(n):
     is_nilpotent = True
     for p_j, a_j in prime_factors:
         for p_i, a_i in prime_factors:
-            if any([Mod(Pow(p_i, k), p_j) == 1 for k in range(1, a_i + 1)]):
+            if any(Mod(Pow(p_i, k), p_j) == 1 for k in range(1, a_i + 1)):
                 is_nilpotent = False
                 break
         if not is_nilpotent:

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -69,9 +69,9 @@ def test_functional_diffgeom_ch3():
     series = intcurve_series(circ, t, R2_r.point([1, 0]), coeffs=True)
     series_x, series_y = zip(*series)
     assert all(
-        [term == cos(t).taylor_term(i, t) for i, term in enumerate(series_x)])
+        term == cos(t).taylor_term(i, t) for i, term in enumerate(series_x))
     assert all(
-        [term == sin(t).taylor_term(i, t) for i, term in enumerate(series_y)])
+        term == sin(t).taylor_term(i, t) for i, term in enumerate(series_y))
 
 
 def test_functional_diffgeom_ch4():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1174,7 +1174,7 @@ def test_relational_simplification_patterns_numerically():
                     [Xor, _simplify_patterns_xor()]]
     valuelist = list(set(combinations(list(range(-2, 3))*3, 3)))
     # Skip combinations of +/-2 and 0, except for all 0
-    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
+    valuelist = [v for v in valuelist if any(w % 2 for w in v) or not any(v)]
     for func, patternlist in patternlists:
         for pattern in patternlist:
             original = func(*pattern[0].args)
@@ -1326,7 +1326,7 @@ def test_relational_threeterm_simplification_patterns_numerically():
     patternlists = [[And, _simplify_patterns_and3()]]
     valuelist = list(set(combinations(list(range(-2, 3))*3, 3)))
     # Skip combinations of +/-2 and 0, except for all 0
-    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
+    valuelist = [v for v in valuelist if any(w % 2 for w in v) or not any(v)]
     for func, patternlist in patternlists:
         for pattern in patternlist:
             original = func(*pattern[0].args)

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -132,5 +132,5 @@ def test_Equality():
 def test_integrate():
     intIM = integrate(IM, x)
     assert intIM.shape == IM.shape
-    assert all([intIM[i, j] == (1 + j + 3*i)*x for i, j in
-                product(range(3), range(3))])
+    assert all(intIM[i, j] == (1 + j + 3*i)*x for i, j in
+                product(range(3), range(3)))

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -4,12 +4,12 @@ from sympy.testing.pytest import raises
 
 
 def test_digits():
-    assert all([digits(n, 2)[1:] == [int(d) for d in format(n, 'b')]
-                for n in range(20)])
-    assert all([digits(n, 8)[1:] == [int(d) for d in format(n, 'o')]
-                for n in range(20)])
-    assert all([digits(n, 16)[1:] == [int(d, 16) for d in format(n, 'x')]
-                for n in range(20)])
+    assert all(digits(n, 2)[1:] == [int(d) for d in format(n, 'b')]
+                for n in range(20))
+    assert all(digits(n, 8)[1:] == [int(d) for d in format(n, 'o')]
+                for n in range(20))
+    assert all(digits(n, 16)[1:] == [int(d, 16) for d in format(n, 'x')]
+                for n in range(20))
     assert digits(2345, 34) == [34, 2, 0, 33]
     assert digits(384753, 71) == [71, 1, 5, 23, 4]
     assert digits(93409, 10) == [10, 9, 3, 4, 0, 9]

--- a/sympy/polys/matrices/lll.py
+++ b/sympy/polys/matrices/lll.py
@@ -81,8 +81,8 @@ def _ddm_lll(x, delta=QQ(3, 4), return_transform=False):
             if return_transform:
                 T[k], T[k - 1] = T[k - 1], T[k]
             k = max(k - 1, 1)
-    assert all([lovasz_condition(i) for i in range(1, m)])
-    assert all([mu_small(i, j) for i in range(m) for j in range(i)])
+    assert all(lovasz_condition(i) for i in range(1, m))
+    assert all(mu_small(i, j) for i in range(m) for j in range(i))
     return y, T
 
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -230,7 +230,7 @@ def test_roots_quartic():
     z = symbols('z', negative=True)
     eq = x**4 + 2*x**3 + 3*x**2 + x*(z + 11) + 5
     zans = roots_quartic(Poly(eq, x))
-    assert all([verify_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans])
+    assert all(verify_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans)
     # but some are (see also issue 4989)
     # it's ok if the solution is not Piecewise, but the tests below should pass
     eq = Poly(y*x**4 + x**3 - x + z, x)
@@ -242,7 +242,7 @@ def test_roots_quartic():
         {"y": Rational(-1, 3), "z": -2})  # 0 real
     for rep in reps:
         sol = roots_quartic(Poly(eq.subs(rep), x))
-        assert all([verify_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol)])
+        assert all(verify_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol))
 
 
 def test_issue_21287():

--- a/sympy/solvers/ode/tests/test_riccati.py
+++ b/sympy/solvers/ode/tests/test_riccati.py
@@ -724,8 +724,8 @@ def check_dummy_sol(eq, solse, dummy_sym):
     C1 = Dummy('C1')
     sols = [sol.subs(C1, dummy_sym) for sol in sols]
 
-    assert all([x[0] for x in checkodesol(eq, sols)])
-    assert all([s1.dummy_eq(s2, dummy_sym) for s1, s2 in zip(sols, solse)])
+    assert all(x[0] for x in checkodesol(eq, sols))
+    assert all(s1.dummy_eq(s2, dummy_sym) for s1, s2 in zip(sols, solse))
 
 
 def test_solve_riccati():

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -779,7 +779,7 @@ def identify_hadamard_products(expr: tUnion[ArrayContraction, ArrayDiagonal]):
             return x == sorted(x)
 
         # Check if expression is a trace:
-        if all([map_ind_to_inds[j] == len(v) and j >= 0 for j in k]) and all([j >= 0 for j in k]):
+        if all(map_ind_to_inds[j] == len(v) and j >= 0 for j in k) and all(j >= 0 for j in k):
             # This is a trace
             make_trace = True
             first_element = v[0].element
@@ -886,7 +886,7 @@ def remove_identity_matrices(expr: ArrayContraction):
         non_identity = [i for i in args if not isinstance(i.element, Identity)][0]
         # Check that all identity matrices have at least one free index
         # (otherwise they would be contractions to some other elements)
-        if any([None not in i.indices for i in identity_matrices]):
+        if any(None not in i.indices for i in identity_matrices):
             continue
         # Mark the identity matrices for removal:
         for i in identity_matrices:

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1194,7 +1194,7 @@ def test_hash():
     assert hash(t4.func(*t4.args)) == hash(t4)
 
     def check_all(obj):
-        return all([isinstance(_, Basic) for _ in obj.args])
+        return all(isinstance(_, Basic) for _ in obj.args)
 
     assert check_all(a)
     assert check_all(Lorentz)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Optimize code to remove unnecessary list comprehensions in any/all builtin functions call. The builtin function calls will shortcircuiting when reading a generator, but the entire list has to be generated first when using a list comprehension. I've also enabled the proper ruff check. There is a flake8 plugin, but it is deprecated and recommends transitioning into the ruff plugin (although not all rules are ported over to it). As such, I have enabled the ruff rule corresponding to this fix.

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* All any/all builtins that previously used a list comprehension now use a generator.

#### Other comments
* This is more performant than the existing code and the check encourages better coding style going forward.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
