### PR TITLE
Stats: Fixed variance of sum of poisson distribution RVs when parameter is a float

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -10,7 +10,7 @@ from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import Derivative, expand
 from sympy.core.mul import Mul
-from sympy.core.numbers import Float, _illegal
+from sympy.core.numbers import _illegal
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1278,22 +1278,12 @@ def _eval_sum_hyper(f, i, a):
     if hs is None:
         return None
 
-    if isinstance(hs, Float):
-        from sympy.simplify.simplify import nsimplify
-        hs = nsimplify(hs)
-    if hs.args:
-        for arg in hs.args:
-            if isinstance(arg, Float):
-                from sympy.simplify.simplify import nsimplify
-                hs = nsimplify(hs)
-                break
-
     from sympy.simplify.combsimp import combsimp
     from sympy.simplify.hyperexpand import hyperexpand
     from sympy.simplify.radsimp import fraction
     numer, denom = fraction(factor(hs))
-    top, topl = numer.as_coeff_mul(i)
-    bot, botl = denom.as_coeff_mul(i)
+    top, topl = numer.as_coeff_mul(i,rational=False)
+    bot, botl = denom.as_coeff_mul(i,rational=False)
     ab = [top, bot]
     factors = [topl, botl]
     params = [[], []]

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1281,6 +1281,12 @@ def _eval_sum_hyper(f, i, a):
     if isinstance(hs, Float):
         from sympy.simplify.simplify import nsimplify
         hs = nsimplify(hs)
+    if hs.args:
+        for arg in hs.args:
+            if isinstance(arg, Float):
+                from sympy.simplify.simplify import nsimplify
+                hs = nsimplify(hs)
+                break
 
     from sympy.simplify.combsimp import combsimp
     from sympy.simplify.hyperexpand import hyperexpand

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -297,7 +297,8 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()
-    assert result == 99999.0
+    from sympy import N
+    assert N(result,10) == 99999.0
     assert result.is_Float
 
     result = Sum(S.Half**n, (n, 1, oo)).doit()

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1674,7 +1674,7 @@ def try_shifted_sum(func, z):
     nbq = [x - k for x in nbq]
 
     ops = []
-    for n in range(r - 1):
+    for n in range(int(r) - 1):
         ops.append(ShiftA(n + 1))
     ops.reverse()
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -439,3 +439,12 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
+
+def test_issue_20669():
+    from sympy import N
+    X1 = Poisson("X1", 5.2)
+    X2 = Poisson("X2", 5.2)
+    X3 = Poisson("X3", 5)
+    assert N(variance(X1 + X2), 7) == N(variance(X1) + variance(X2), 7)
+    assert N(E(X1*X2), 7) == N(E(X1) * E(X2), 7)
+    assert N(E(X1*X3), 7) == N(E(X1) * E(X3), 7)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20669


#### Brief description of what is fixed or changed
-> Earlier, the variance of sum of two random variables (poison specifically) gave an error when the parameter was a float. This has been fixed and a regression test has been added.
-> The problem lay in the summations.py file present in the concrete module, where the existing code could only detect if the number was a float. It could not check for float numbers present in a fraction like (7.5)/x+1.  The same has been fixed.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
