### PR TITLE
Implemented functions for skew-symmetric form of cross product

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1313,7 +1313,7 @@ class MatrixBase(MatrixDeprecated,
         """
 
         if not (self.shape == (3, 3)):
-            raise ShapeError("Dimensions incorrect, expected (3, 1), got " +
+            raise ShapeError("Dimensions incorrect, expected (3, 3), got " +
                              str(self.shape))
         elif self.T != -self:
             raise ValueError("Matrix is not skew-symmetric")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1262,7 +1262,6 @@ class MatrixBase(MatrixDeprecated,
                 (self[2] * b[0] - self[0] * b[2]),
                 (self[0] * b[1] - self[1] * b[0])))
 
-    @property
     def hat(self):
         r"""
         Return the skew-symmetric matrix representing the cross product,
@@ -1292,11 +1291,10 @@ class MatrixBase(MatrixDeprecated,
                  z,  0, -x,
                 -y,  x,  0))
 
-    @property
     def vee(self):
         r"""
         Return a 3x1 vector from a skew-symmetric matrix representing the cross product,
-        so that ``self * b`` is equivalent to  ``self.vee.cross(b)``.
+        so that ``self * b`` is equivalent to  ``self.vee().cross(b)``.
 
         Parameters
         ==========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1267,10 +1267,6 @@ class MatrixBase(MatrixDeprecated,
         Return the skew-symmetric matrix representing the cross product,
         so that ``self.hat() * b`` is equivalent to  ``self.cross(b)``.
 
-        Parameters
-        ==========
-            b : 3x1 Matrix
-
         See Also
         ========
 
@@ -1295,10 +1291,6 @@ class MatrixBase(MatrixDeprecated,
         r"""
         Return a 3x1 vector from a skew-symmetric matrix representing the cross product,
         so that ``self * b`` is equivalent to  ``self.vee().cross(b)``.
-
-        Parameters
-        ==========
-            b : 3x3 Skew-symmetric Matrix
 
         See Also
         ========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1277,7 +1277,7 @@ class MatrixBase(MatrixDeprecated,
         multiply_elementwise
         """
 
-        if not (self.shape == (3, 1)):
+        if self.shape != (3, 1):
             raise ShapeError("Dimensions incorrect, expected (3, 1), got " +
                              str(self.shape))
         else:
@@ -1302,7 +1302,7 @@ class MatrixBase(MatrixDeprecated,
         multiply_elementwise
         """
 
-        if not (self.shape == (3, 3)):
+        if self.shape != (3, 3):
             raise ShapeError("Dimensions incorrect, expected (3, 3), got " +
                              str(self.shape))
         elif not self.is_anti_symmetric():

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1375,11 +1375,6 @@ class MatrixBase(MatrixDeprecated,
         [                      0],
         [Derivative(theta(t), t)]])
 
-
-
-
-
-
         See Also
         ========
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1313,7 +1313,7 @@ class MatrixBase(MatrixDeprecated,
         if not (self.shape == (3, 3)):
             raise ShapeError("Dimensions incorrect, expected (3, 3), got " +
                              str(self.shape))
-        elif self.T != -self:
+        elif not self.is_anti_symmetric():
             raise ValueError("Matrix is not skew-symmetric")
         else:
             return self._new(3, 1, (

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1242,6 +1242,8 @@ class MatrixBase(MatrixDeprecated,
         ========
 
         dot
+        hat
+        vee
         multiply
         multiply_elementwise
         """
@@ -1259,6 +1261,67 @@ class MatrixBase(MatrixDeprecated,
                 (self[1] * b[2] - self[2] * b[1]),
                 (self[2] * b[0] - self[0] * b[2]),
                 (self[0] * b[1] - self[1] * b[0])))
+
+    @property
+    def hat(self):
+        r"""
+        Return the skew-symmetric matrix representing the cross product,
+        so that ``self.hat() * b`` is equivalent to  ``self.cross(b)``.
+
+        Parameters
+        ==========
+            b : 3x1 Matrix
+
+        See Also
+        ========
+
+        dot
+        cross
+        vee
+        multiply
+        multiply_elementwise
+        """
+
+        if not (self.shape == (3, 1)):
+            raise ShapeError("Dimensions incorrect, expected (3, 1), got " +
+                             str(self.shape))
+        else:
+            x, y, z = self
+            return self._new(3, 3, (
+                 0, -z,  y,
+                 z,  0, -x,
+                -y,  x,  0))
+
+    @property
+    def vee(self):
+        r"""
+        Return a 3x1 vector from a skew-symmetric matrix representing the cross product,
+        so that ``self * b`` is equivalent to  ``self.vee.cross(b)``.
+
+        Parameters
+        ==========
+            b : 3x3 Skew-symmetric Matrix
+
+        See Also
+        ========
+
+        dot
+        cross
+        hat
+        multiply
+        multiply_elementwise
+        """
+
+        if not (self.shape == (3, 3)):
+            raise ShapeError("Dimensions incorrect, expected (3, 1), got " +
+                             str(self.shape))
+        elif self.T != -self:
+            raise ValueError("Matrix is not skew-symmetric")
+        else:
+            return self._new(3, 1, (
+                 self[2, 1],
+                 self[0, 2],
+                 self[1, 0]))
 
     @property
     def D(self):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1267,6 +1267,36 @@ class MatrixBase(MatrixDeprecated,
         Return the skew-symmetric matrix representing the cross product,
         so that ``self.hat() * b`` is equivalent to  ``self.cross(b)``.
 
+        Examples
+        ========
+
+        Calling `hat` creates a skew-symmetric Matrix:
+
+        >>> from sympy import Matrix
+        >>> a = Matrix([1, 2, 3])
+        >>> a.hat()
+        Matrix([
+        [ 0, -3,  2],
+        [ 3,  0, -1],
+        [-2,  1,  0]])
+
+        Multiplying it with another Matrix calculates the cross product:
+
+        >>> b = Matrix([3, 2, 1])
+        >>> a.hat() * b
+        Matrix([
+        [-4],
+        [ 8],
+        [-4]])
+
+        Which is equivalent to calling the `cross` method:
+
+        >>> a.cross(b)
+        Matrix([
+        [-4],
+        [ 8],
+        [-4]])
+
         See Also
         ========
 
@@ -1291,6 +1321,64 @@ class MatrixBase(MatrixDeprecated,
         r"""
         Return a 3x1 vector from a skew-symmetric matrix representing the cross product,
         so that ``self * b`` is equivalent to  ``self.vee().cross(b)``.
+
+        Examples
+        ========
+
+        Calling `vee` creates a vector from a skew-symmetric Matrix:
+
+        >>> from sympy import Matrix
+        >>> A = Matrix([[0, -3, 2], [3, 0, -1], [-2, 1, 0]])
+        >>> a = A.vee()
+        >>> a
+        Matrix([
+        [1],
+        [2],
+        [3]])
+
+        Calculating the matrix product of the original matrix with a vector
+        is equivalent to a cross product:
+
+        >>> b = Matrix([3, 2, 1])
+        >>> A * b
+        Matrix([
+        [-4],
+        [ 8],
+        [-4]])
+
+        >>> a.cross(b)
+        Matrix([
+        [-4],
+        [ 8],
+        [-4]])
+
+        `vee` can also be used to retrieve angular velocity expressions.
+        Defining a rotation matrix:
+
+        >>> from sympy import rot_ccw_axis3, trigsimp
+        >>> from sympy.physics.mechanics import dynamicsymbols
+        >>> theta = dynamicsymbols('theta')
+        >>> R = rot_ccw_axis3(theta)
+        >>> R
+        Matrix([
+        [cos(theta(t)), -sin(theta(t)), 0],
+        [sin(theta(t)),  cos(theta(t)), 0],
+        [            0,              0, 1]])
+
+        We can retrive the angular velocity:
+
+        >>> Omega = R.T * R.diff()
+        >>> Omega = trigsimp(Omega)
+        >>> Omega.vee()
+        Matrix([
+        [                      0],
+        [                      0],
+        [Derivative(theta(t), t)]])
+
+
+
+
+
 
         See Also
         ========

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2552,7 +2552,7 @@ def test_hat_vee():
     v1 = Matrix([x, y, z])
     v2 = Matrix([a, b, c])
     assert v1.hat() * v2 == v1.cross(v2)
-    assert v1.hat().T == -v1.hat()
+    assert v1.hat().is_anti_symmetric()
     assert v1.hat().vee() == v1
 
 def test_hash():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2548,6 +2548,12 @@ def test_cross():
     raises(ShapeError, lambda:
         Matrix(1, 2, [1, 1]).cross(Matrix(1, 2, [1, 1])))
 
+def test_hat_vee():
+    v1 = Matrix([x, y, z])
+    v2 = Matrix([a, b, c])
+    assert v1.hat * v2 == v1.cross(v2)
+    assert v1.hat.T == -v1.hat
+    assert v1.hat.vee == v1
 
 def test_hash():
     for cls in classes[-2:]:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2551,9 +2551,9 @@ def test_cross():
 def test_hat_vee():
     v1 = Matrix([x, y, z])
     v2 = Matrix([a, b, c])
-    assert v1.hat * v2 == v1.cross(v2)
-    assert v1.hat.T == -v1.hat
-    assert v1.hat.vee == v1
+    assert v1.hat() * v2 == v1.cross(v2)
+    assert v1.hat().T == -v1.hat()
+    assert v1.hat().vee() == v1
 
 def test_hash():
     for cls in classes[-2:]:


### PR DESCRIPTION
#### References to other Issues or PRs
Added `hat` and `vee` convenient functions for matrices.
`hat` transforms a `3 x 1` Matrix into a `3 x 3` skew-symmetric matrix, and `vee` does the inverse operation.

I'm open to changing the names of the functions to something more descriptive if needed, these are just the names I'm more used to use when studying Lie theory, as seen for example in [this library](https://github.com/artivis/manif).

#### Brief description of what is fixed or changed
The cross product $\pmb v_1 \times \pmb v_2$ can be expressed instead by $\widehat{\pmb v}_1  \pmb v_2$, where $\widehat{\pmb v}_1$ is a `3 x 3` skew symmetric matrix with the property that $(\widehat{\pmb v}_1)^T = -\widehat{\pmb v}_1$.

For convenience, the inverse operation is also implemented.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Implemented `hat` and `vee` operations for matrices.
<!-- END RELEASE NOTES -->