### PR TITLE
Fix infinite recursion issues for cse for unevaluated expression

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -513,7 +513,8 @@ def opt_cse(exprs, order='canonical'):
 
         if not isinstance(expr, MatrixExpr) and expr.could_extract_minus_sign():
             # XXX -expr does not always work rigorously for some expressions
-            # Issue https://github.com/sympy/sympy/issues/24818
+            # containing UnevaluatedExpr.
+            # https://github.com/sympy/sympy/issues/24818
             if isinstance(expr, Add):
                 neg_expr = Add(*(-i for i in expr.args))
             else:

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -512,7 +512,13 @@ def opt_cse(exprs, order='canonical'):
         list(map(_find_opts, expr.args))
 
         if not isinstance(expr, MatrixExpr) and expr.could_extract_minus_sign():
-            neg_expr = -expr
+            # XXX -expr does not always work rigorously for some expressions
+            # Issue https://github.com/sympy/sympy/issues/24818
+            if isinstance(expr, Add):
+                neg_expr = Add(*(-i for i in expr.args))
+            else:
+                neg_expr = -expr
+
             if not neg_expr.is_Atom:
                 opt_subs[expr] = Unevaluated(Mul, (S.NegativeOne, neg_expr))
                 seen_subexp.add(neg_expr)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -546,7 +546,7 @@ def test_cse_unevaluated():
         assert red == (-1 + x0) / (1 + x0)
     else:
         msg = f'Expected common subexpression {xp1} or {-xp1}, instead got {ue}'
-        raise ValueError(msg)
+        assert False, msg
 
 
 def test_cse__performance():

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -545,7 +545,8 @@ def test_cse_unevaluated():
     elif ue == -xp1:
         assert red == (-1 + x0) / (1 + x0)
     else:
-        raise ValueError("Unexpected common subexpression found")
+        msg = f'Expected common subexpression {xp1} or {-xp1}, instead got {ue}'
+        raise ValueError(msg)
 
 
 def test_cse__performance():

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -5,6 +5,7 @@ from operator import add
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
+from sympy.core.expr import UnevaluatedExpr
 from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
@@ -533,6 +534,19 @@ def test_cse_ignore_issue_15002():
     substs, reduced = cse(l, ignore=(x,))
     rl = [e.subs(reversed(substs)) for e in reduced]
     assert rl == l
+
+
+def test_cse_unevaluated():
+    xp1 = UnevaluatedExpr(x + 1)
+    # This used to cause RecursionError
+    [(x0, ue)], [red] = cse([(-1 - xp1) / (1 - xp1)])
+    if ue == xp1:
+        assert red == (-1 - x0) / (1 - x0)
+    elif ue == -xp1:
+        assert red == (-1 + x0) / (1 + x0)
+    else:
+        raise ValueError("Unexpected common subexpression found")
+
 
 def test_cse__performance():
     nexprs, nterms = 3, 20


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24818

#### Brief description of what is fixed or changed

`-expr` does not work rigorously unevaluated expression.
I'm not sure if there's a counterpart for `could_extract_minus_sign` to negate the expression that does not rely on `-expr`
But I think that the fix sounds minimal and it could be responsible for `cse` to implement something different than relying on adhoc negation because I notice it has perfomance issues with matrix expressions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
