### PR TITLE
Particle and RigidBody compatibility with the joints framework

### DIFF
--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -5,7 +5,8 @@ Masses, Inertias, Particles and Rigid Bodies in Physics/Mechanics
 =================================================================
 
 This document will describe how to represent masses and inertias in
-:mod:`sympy.physics.mechanics` and use of the ``RigidBody`` and ``Particle`` classes.
+:mod:`sympy.physics.mechanics` and use of the :class:`~.RigidBody` and
+:class:`~.Particle` classes.
 
 It is assumed that the reader is familiar with the basics of these topics, such
 as finding the center of mass for a system of particles, how to manipulate an
@@ -21,9 +22,9 @@ expression. Keep in mind that masses can be time varying.
 Particle
 ========
 
-Particles are created with the class ``Particle`` in :mod:`sympy.physics.mechanics`.
-A ``Particle`` object has an associated point and an associated mass which are
-the only two attributes of the object.::
+Particles are created with the class :class:`~.Particle` in
+:mod:`sympy.physics.mechanics`. A :class:`~.Particle` object has an associated
+point and an associated mass which are the only two attributes of the object.::
 
   >>> from sympy.physics.mechanics import Particle, Point
   >>> from sympy import Symbol
@@ -33,8 +34,8 @@ the only two attributes of the object.::
   >>> pa = Particle('pa', po, m)
 
 The associated point contains the position, velocity and acceleration of the
-particle. :mod:`sympy.physics.mechanics` allows one to perform kinematic analysis of points
-separate from their association with masses.
+particle. :mod:`sympy.physics.mechanics` allows one to perform kinematic
+analysis of points separate from their association with masses.
 
 Inertia
 =======
@@ -45,9 +46,9 @@ See the Inertia (Dyadics) section in 'Advanced Topics' part of
 Rigid Body
 ==========
 
-Rigid bodies are created in a similar fashion as particles. The ``RigidBody``
-class generates objects with four attributes: mass, center of mass, a reference
-frame, and an inertia tuple::
+Rigid bodies are created in a similar fashion as particles. The
+:class:`~.RigidBody` class generates objects with four attributes: mass, center
+of mass, a reference frame, and an inertia tuple::
 
   >>> from sympy import Symbol
   >>> from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
@@ -60,10 +61,10 @@ frame, and an inertia tuple::
   >>> B = RigidBody('B', P, A, m, (I, P))
 
 The mass is specified exactly as is in a particle. Similar to the
-``Particle``'s ``.point``, the ``RigidBody``'s center of mass, ``.masscenter``
-must be specified. The reference frame is stored in an analogous fashion and
-holds information about the body's orientation and angular velocity. Finally,
-the inertia for a rigid body needs to be specified about a point. In
+:class:`~.Particle`'s ``.point``, the :class:`~.RigidBody`'s center of mass,
+``.masscenter`` must be specified. The reference frame is stored in an analogous
+fashion and holds information about the body's orientation and angular velocity.
+Finally, the inertia for a rigid body needs to be specified about a point. In
 :mod:`sympy.physics.mechanics`, you are allowed to specify any point for this. The most
 common is the center of mass, as shown in the above code. If a point is selected
 which is not the center of mass, ensure that the position between the point and

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -385,13 +385,13 @@ class Joint(ABC):
         with ``parent.y + parent.z`` can be created as follows:
 
         >>> from sympy.physics.mechanics.joint import Joint
-        >>> from sympy.physics.mechanics import Body
-        >>> parent = Body('parent')
+        >>> from sympy.physics.mechanics import RigidBody
+        >>> parent = RigidBody('parent')
         >>> parent_interframe = Joint._create_aligned_interframe(
         ...     parent, parent.y + parent.z)
         >>> parent_interframe
         parent_int_frame
-        >>> parent.dcm(parent_interframe)
+        >>> parent.frame.dcm(parent_interframe)
         Matrix([
         [        0, -sqrt(2)/2, -sqrt(2)/2],
         [sqrt(2)/2,        1/2,       -1/2],
@@ -669,11 +669,11 @@ class PinJoint(Joint):
     A single pin joint is created from two bodies and has the following basic
     attributes:
 
-    >>> from sympy.physics.mechanics import Body, PinJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, PinJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = PinJoint('PC', parent, child)
@@ -697,9 +697,9 @@ class PinJoint(Joint):
     Matrix([[q_PC(t)]])
     >>> joint.speeds
     Matrix([[u_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,             0,            0],
     [0,  cos(q_PC(t)), sin(q_PC(t))],
@@ -712,15 +712,15 @@ class PinJoint(Joint):
     created as follows.
 
     >>> from sympy import symbols, trigsimp
-    >>> from sympy.physics.mechanics import Body, PinJoint
+    >>> from sympy.physics.mechanics import RigidBody, PinJoint
     >>> l1, l2 = symbols('l1 l2')
 
     First create bodies to represent the fixed ceiling and one to represent
     each pendulum bob.
 
-    >>> ceiling = Body('C')
-    >>> upper_bob = Body('U')
-    >>> lower_bob = Body('L')
+    >>> ceiling = RigidBody('C')
+    >>> upper_bob = RigidBody('U')
+    >>> lower_bob = RigidBody('L')
 
     The first joint will connect the upper bob to the ceiling by a distance of
     ``l1`` and the joint axis will be about the Z axis for each body.
@@ -931,11 +931,11 @@ class PrismaticJoint(Joint):
     A single prismatic joint is created from two bodies and has the following
     basic attributes:
 
-    >>> from sympy.physics.mechanics import Body, PrismaticJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, PrismaticJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = PrismaticJoint('PC', parent, child)
@@ -959,9 +959,9 @@ class PrismaticJoint(Joint):
     Matrix([[q_PC(t)]])
     >>> joint.speeds
     Matrix([[u_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     0
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -974,14 +974,14 @@ class PrismaticJoint(Joint):
     to the moving body. about the X axis of each connected body can be created
     as follows.
 
-    >>> from sympy.physics.mechanics import PrismaticJoint, Body
+    >>> from sympy.physics.mechanics import PrismaticJoint, RigidBody
 
     First create bodies to represent the fixed ceiling and one to represent
     a particle.
 
-    >>> wall = Body('W')
-    >>> Part1 = Body('P1')
-    >>> Part2 = Body('P2')
+    >>> wall = RigidBody('W')
+    >>> Part1 = RigidBody('P1')
+    >>> Part2 = RigidBody('P2')
 
     The first joint will connect the particle to the ceiling and the
     joint axis will be about the X axis for each body.
@@ -997,13 +997,13 @@ class PrismaticJoint(Joint):
     be accessed. First the direction cosine matrices of Part relative
     to the ceiling are found:
 
-    >>> Part1.dcm(wall)
+    >>> Part1.frame.dcm(wall.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
     [0, 0, 1]])
 
-    >>> Part2.dcm(wall)
+    >>> Part2.frame.dcm(wall.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -1020,16 +1020,16 @@ class PrismaticJoint(Joint):
     The angular velocities of the two particle links can be computed with
     respect to the ceiling.
 
-    >>> Part1.ang_vel_in(wall)
+    >>> Part1.frame.ang_vel_in(wall.frame)
     0
 
-    >>> Part2.ang_vel_in(wall)
+    >>> Part2.frame.ang_vel_in(wall.frame)
     0
 
     And finally, the linear velocities of the two particles can be computed
     with respect to the ceiling.
 
-    >>> Part1.masscenter_vel(wall)
+    >>> Part1.masscenter.vel(wall.frame)
     u_J1(t)*W_frame.x
 
     >>> Part2.masscenter.vel(wall.frame)
@@ -1187,11 +1187,11 @@ class CylindricalJoint(Joint):
     A single cylindrical joint is created between two bodies and has the
     following basic attributes:
 
-    >>> from sympy.physics.mechanics import Body, CylindricalJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, CylindricalJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = CylindricalJoint('PC', parent, child)
@@ -1219,9 +1219,9 @@ class CylindricalJoint(Joint):
     Matrix([
     [u0_PC(t)],
     [u1_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u0_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,              0,             0],
     [0,  cos(q0_PC(t)), sin(q0_PC(t))],
@@ -1235,7 +1235,7 @@ class CylindricalJoint(Joint):
     two cylindrical joints perpendicular to each other can be created as follows.
 
     >>> from sympy import symbols
-    >>> from sympy.physics.mechanics import Body, CylindricalJoint
+    >>> from sympy.physics.mechanics import RigidBody, CylindricalJoint
     >>> r, l, w = symbols('r l w')
 
     First create bodies to represent the fixed floor with a fixed pole on it.
@@ -1243,9 +1243,9 @@ class CylindricalJoint(Joint):
     body represents a solid flag freely translating along and rotating around
     the Y axis of the tube.
 
-    >>> floor = Body('floor')
-    >>> tube = Body('tube')
-    >>> flag = Body('flag')
+    >>> floor = RigidBody('floor')
+    >>> tube = RigidBody('tube')
+    >>> flag = RigidBody('flag')
 
     The first joint will connect the first tube to the floor with it translating
     along and rotating around the Z axis of both bodies.
@@ -1266,12 +1266,12 @@ class CylindricalJoint(Joint):
     be accessed. First the direction cosine matrices of both the body and the
     flag relative to the floor are found:
 
-    >>> tube.dcm(floor)
+    >>> tube.frame.dcm(floor.frame)
     Matrix([
     [ cos(q0_C1(t)), sin(q0_C1(t)), 0],
     [-sin(q0_C1(t)), cos(q0_C1(t)), 0],
     [             0,             0, 1]])
-    >>> flag.dcm(floor)
+    >>> flag.frame.dcm(floor.frame)
     Matrix([
     [cos(q0_C1(t))*cos(q0_C2(t)), sin(q0_C1(t))*cos(q0_C2(t)), -sin(q0_C2(t))],
     [             -sin(q0_C1(t)),               cos(q0_C1(t)),              0],
@@ -1285,9 +1285,9 @@ class CylindricalJoint(Joint):
     The angular velocities of the two tubes can be computed with respect to the
     floor.
 
-    >>> tube.ang_vel_in(floor)
+    >>> tube.frame.ang_vel_in(floor.frame)
     u0_C1(t)*floor_frame.z
-    >>> flag.ang_vel_in(floor)
+    >>> flag.frame.ang_vel_in(floor.frame)
     u0_C1(t)*floor_frame.z + u0_C2(t)*tube_frame.y
 
     Finally, the linear velocities of the two tube centers of mass can be
@@ -1503,11 +1503,11 @@ class PlanarJoint(Joint):
     A single planar joint is created between two bodies and has the following
     basic attributes:
 
-    >>> from sympy.physics.mechanics import Body, PlanarJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, PlanarJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = PlanarJoint('PC', parent, child)
@@ -1549,9 +1549,9 @@ class PlanarJoint(Joint):
     [u0_PC(t)],
     [u1_PC(t)],
     [u2_PC(t)]])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     u0_PC(t)*P_frame.x
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1,              0,             0],
     [0,  cos(q0_PC(t)), sin(q0_PC(t))],
@@ -1565,13 +1565,13 @@ class PlanarJoint(Joint):
     block sliding on a slope, can be created as follows.
 
     >>> from sympy import symbols
-    >>> from sympy.physics.mechanics import PlanarJoint, Body, ReferenceFrame
+    >>> from sympy.physics.mechanics import PlanarJoint, RigidBody, ReferenceFrame
     >>> a, d, h = symbols('a d h')
 
     First create bodies to represent the slope and the block.
 
-    >>> ground = Body('G')
-    >>> block = Body('B')
+    >>> ground = RigidBody('G')
+    >>> block = RigidBody('B')
 
     To define the slope you can either define the plane by specifying the
     ``planar_vectors`` or/and the ``rotation_axis``. However it is advisable to
@@ -1602,7 +1602,7 @@ class PlanarJoint(Joint):
     The direction cosine matrix of the block with respect to the ground can be
     found with:
 
-    >>> block.dcm(ground)
+    >>> block.frame.dcm(ground.frame)
     Matrix([
     [              cos(a),              0,              -sin(a)],
     [sin(a)*sin(q0_PC(t)),  cos(q0_PC(t)), sin(q0_PC(t))*cos(a)],
@@ -1611,7 +1611,7 @@ class PlanarJoint(Joint):
     The angular velocity of the block can be computed with respect to the
     ground.
 
-    >>> block.ang_vel_in(ground)
+    >>> block.frame.ang_vel_in(ground.frame)
     u0_PC(t)*A.x
 
     The position of the block's center of mass can be found with:
@@ -1637,15 +1637,15 @@ class PlanarJoint(Joint):
     between the provided vector and the 'x' axis.
 
     >>> from sympy import symbols, cos, sin
-    >>> from sympy.physics.mechanics import PlanarJoint, Body
+    >>> from sympy.physics.mechanics import PlanarJoint, RigidBody
     >>> a, d, h = symbols('a d h')
-    >>> ground = Body('G')
-    >>> block = Body('B')
+    >>> ground = RigidBody('G')
+    >>> block = RigidBody('B')
     >>> joint = PlanarJoint(
     ...     'PC', ground, block, parent_point=d * ground.x,
     ...     child_point=-h * block.x, child_interframe=block.x,
     ...     parent_interframe=cos(a) * ground.x + sin(a) * ground.z)
-    >>> block.dcm(ground).simplify()
+    >>> block.frame.dcm(ground.frame).simplify()
     Matrix([
     [               cos(a),              0,               sin(a)],
     [-sin(a)*sin(q0_PC(t)),  cos(q0_PC(t)), sin(q0_PC(t))*cos(a)],
@@ -1730,10 +1730,10 @@ class PlanarJoint(Joint):
         self.parent_point.set_vel(self.parent_interframe, 0)
         self.child_point.set_vel(self.child_interframe, 0)
         self.child_point.set_vel(
-            self.parent.frame, self.planar_speeds[0] * self.planar_vectors[0] +
+            self._parent_frame, self.planar_speeds[0] * self.planar_vectors[0] +
             self.planar_speeds[1] * self.planar_vectors[1])
-        self.child.masscenter.v2pt_theory(self.child_point, self.parent.frame,
-                                          self.child.frame)
+        self.child.masscenter.v2pt_theory(self.child_point, self._parent_frame,
+                                          self._child_frame)
 
 
 class SphericalJoint(Joint):
@@ -1847,11 +1847,11 @@ class SphericalJoint(Joint):
     A single spherical joint is created from two bodies and has the following
     basic attributes:
 
-    >>> from sympy.physics.mechanics import Body, SphericalJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, SphericalJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = SphericalJoint('PC', parent, child)
@@ -1898,13 +1898,13 @@ class SphericalJoint(Joint):
     spherical joint with a ZXZ rotation can be created as follows.
 
     >>> from sympy import symbols
-    >>> from sympy.physics.mechanics import Body, SphericalJoint
+    >>> from sympy.physics.mechanics import RigidBody, SphericalJoint
     >>> l1 = symbols('l1')
 
     First create bodies to represent the fixed floor and a pendulum bob.
 
-    >>> floor = Body('F')
-    >>> bob = Body('B')
+    >>> floor = RigidBody('F')
+    >>> bob = RigidBody('B')
 
     The joint will connect the bob to the floor, with the joint located at a
     distance of ``l1`` from the child's center of mass and the rotation set to a
@@ -2068,11 +2068,11 @@ class WeldJoint(Joint):
     A single weld joint is created from two bodies and has the following basic
     attributes:
 
-    >>> from sympy.physics.mechanics import Body, WeldJoint
-    >>> parent = Body('P')
+    >>> from sympy.physics.mechanics import RigidBody, WeldJoint
+    >>> parent = RigidBody('P')
     >>> parent
     P
-    >>> child = Body('C')
+    >>> child = RigidBody('C')
     >>> child
     C
     >>> joint = WeldJoint('PC', parent, child)
@@ -2092,9 +2092,9 @@ class WeldJoint(Joint):
     Matrix(0, 0, [])
     >>> joint.speeds
     Matrix(0, 0, [])
-    >>> joint.child.frame.ang_vel_in(joint.parent.frame)
+    >>> child.frame.ang_vel_in(parent.frame)
     0
-    >>> joint.child.frame.dcm(joint.parent.frame)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
@@ -2106,13 +2106,13 @@ class WeldJoint(Joint):
     bodies rotated by a quarter turn about the Y axis can be created as follows:
 
     >>> from sympy import symbols, pi
-    >>> from sympy.physics.mechanics import ReferenceFrame, Body, WeldJoint
+    >>> from sympy.physics.mechanics import ReferenceFrame, RigidBody, WeldJoint
     >>> l1, l2 = symbols('l1 l2')
 
     First create the bodies to represent the parent and rotated child body.
 
-    >>> parent = Body('P')
-    >>> child = Body('C')
+    >>> parent = RigidBody('P')
+    >>> child = RigidBody('C')
 
     Next the intermediate frame specifying the fixed rotation with respect to
     the parent can be created.
@@ -2132,7 +2132,7 @@ class WeldJoint(Joint):
     accessed. The direction cosine matrix of the child body with respect to the
     parent can be found:
 
-    >>> child.dcm(parent)
+    >>> child.frame.dcm(parent.frame)
     Matrix([
     [0, 0, -1],
     [0, 1,  0],
@@ -2152,7 +2152,7 @@ class WeldJoint(Joint):
     The angular velocity of the child with respect to the parent is 0 as one
     would expect.
 
-    >>> child.ang_vel_in(parent)
+    >>> child.frame.ang_vel_in(parent.frame)
     0
 
     """

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -1,5 +1,6 @@
 from sympy.physics.mechanics import (Body, Lagrangian, KanesMethod, LagrangesMethod,
                                     RigidBody, Particle)
+from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.method import _Methods
 from sympy.core.backend import Matrix
 
@@ -76,7 +77,7 @@ class JointsMethod(_Methods):
     """
 
     def __init__(self, newtonion, *joints):
-        if isinstance(newtonion, Body):
+        if isinstance(newtonion, BodyBase):
             self.frame = newtonion.frame
         else:
             self.frame = newtonion
@@ -152,7 +153,8 @@ class JointsMethod(_Methods):
     def _generate_loadlist(self):
         load_list = []
         for body in self.bodies:
-            load_list.extend(body.loads)
+            if isinstance(body, Body):
+                load_list.extend(body.loads)
         return load_list
 
     def _generate_q(self):
@@ -183,6 +185,9 @@ class JointsMethod(_Methods):
         # Convert `Body` to `Particle` and `RigidBody`
         bodylist = []
         for body in self.bodies:
+            if not isinstance(body, Body):
+                bodylist.append(body)
+                continue
             if body.is_rigidbody:
                 rb = RigidBody(body.name, body.masscenter, body.frame, body.mass,
                     (body.central_inertia, body.masscenter))

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,4 +1,5 @@
-from sympy.core.backend import sympify
+from sympy.core.backend import S
+from sympy.physics.vector import cross, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
@@ -24,8 +25,10 @@ class Particle(BodyBase):
     point : Point
         A physics/mechanics Point which represents the position, velocity, and
         acceleration of this Particle
-    mass : sympifyable
+    mass : Sympifyable
         A SymPy expression representing the Particle's mass
+    potential_energy : Sympifyable
+        The potential energy of the Particle.
 
     Examples
     ========
@@ -126,7 +129,8 @@ class Particle(BodyBase):
 
         """
 
-        return self.point.pos_from(point) ^ (self.mass * self.point.vel(frame))
+        return cross(self.point.pos_from(point),
+                     self.mass * self.point.vel(frame))
 
     def kinetic_energy(self, frame):
         """Kinetic energy of the particle.
@@ -164,8 +168,8 @@ class Particle(BodyBase):
 
         """
 
-        return (self.mass / sympify(2) * self.point.vel(frame) &
-                self.point.vel(frame))
+        return S.Half * self.mass * dot(self.point.vel(frame),
+                                        self.point.vel(frame))
 
     def set_potential_energy(self, scalar):
         sympy_deprecation_warning(

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -5,9 +5,9 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.core.backend import Matrix, _simplify_matrix, eye, zeros
 from sympy.core.symbol import symbols
-from sympy.physics.mechanics import (dynamicsymbols, Body, JointsMethod,
-                                     PinJoint, PrismaticJoint, CylindricalJoint,
-                                     PlanarJoint, SphericalJoint, WeldJoint)
+from sympy.physics.mechanics import (
+    dynamicsymbols, RigidBody, Particle, JointsMethod, PinJoint, PrismaticJoint,
+    CylindricalJoint, PlanarJoint, SphericalJoint, WeldJoint, Body)
 from sympy.physics.mechanics.joint import Joint
 from sympy.physics.vector import Vector, ReferenceFrame, Point
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -20,8 +20,8 @@ t = dynamicsymbols._t # type: ignore
 def _generate_body(interframe=False):
     N = ReferenceFrame('N')
     A = ReferenceFrame('A')
-    P = Body('P', frame=N)
-    C = Body('C', frame=A)
+    P = RigidBody('P', frame=N)
+    C = RigidBody('C', frame=A)
     if interframe:
         Pint, Cint = ReferenceFrame('P_int'), ReferenceFrame('C_int')
         Pint.orient_axis(N, N.x, pi)
@@ -31,8 +31,8 @@ def _generate_body(interframe=False):
 
 
 def test_Joint():
-    parent = Body('parent')
-    child = Body('child')
+    parent = RigidBody('parent')
+    child = RigidBody('child')
     raises(TypeError, lambda: Joint('J', parent, child))
 
 
@@ -84,8 +84,8 @@ def test_coordinate_generation():
 
 
 def test_pin_joint():
-    P = Body('P')
-    C = Body('C')
+    P = RigidBody('P')
+    C = RigidBody('C')
     l, m = symbols('l m')
     q, u = dynamicsymbols('q_J, u_J')
     Pj = PinJoint('J', P, C)
@@ -104,8 +104,8 @@ def test_pin_joint():
     assert Pj.child_interframe == C.frame
     assert Pj.__str__() == 'PinJoint: J  parent: P  child: C'
 
-    P1 = Body('P1')
-    C1 = Body('C1')
+    P1 = RigidBody('P1')
+    C1 = RigidBody('C1')
     Pint = ReferenceFrame('P_int')
     Pint.orient_axis(P1.frame, P1.y, pi / 2)
     J1 = PinJoint('J1', P1, C1, parent_point=l*P1.frame.x,
@@ -140,6 +140,95 @@ def test_pin_joint():
     assert J.child_interframe == Cint
 
 
+def test_particle_compatibility():
+    m, l = symbols('m l')
+    C_frame = ReferenceFrame('C')
+    P = Particle('P')
+    C = Particle('C', mass=m)
+    q, u = dynamicsymbols('q, u')
+    J = PinJoint('J', P, C, q, u, child_interframe=C_frame,
+                 child_point=l * C_frame.y)
+    assert J.child_interframe == C_frame
+    assert J.parent_interframe.name == 'J_P_frame'
+    assert C.masscenter.pos_from(P.masscenter) == -l * C_frame.y
+    assert C_frame.dcm(J.parent_interframe) == Matrix([[1, 0, 0],
+                                                       [0, cos(q), sin(q)],
+                                                       [0, -sin(q), cos(q)]])
+    assert C.masscenter.vel(J.parent_interframe) == -l * u * C_frame.z
+    # Test with specified joint axis
+    P_frame = ReferenceFrame('P')
+    C_frame = ReferenceFrame('C')
+    P = Particle('P')
+    C = Particle('C', mass=m)
+    q, u = dynamicsymbols('q, u')
+    J = PinJoint('J', P, C, q, u, parent_interframe=P_frame,
+                 child_interframe=C_frame, child_point=l * C_frame.y,
+                 joint_axis=P_frame.z)
+    assert J.joint_axis == J.parent_interframe.z
+    assert C_frame.dcm(J.parent_interframe) == Matrix([[cos(q), sin(q), 0],
+                                                       [-sin(q), cos(q), 0],
+                                                       [0, 0, 1]])
+    assert P.masscenter.vel(J.parent_interframe) == 0
+    assert C.masscenter.vel(J.parent_interframe) == l * u * C_frame.x
+    q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1:4 u1:4')
+    qdot_to_u = {qi.diff(t): ui for qi, ui in ((q1, u1), (q2, u2), (q3, u3))}
+    # Test compatibility for prismatic joint
+    P, C = Particle('P'), Particle('C')
+    J = PrismaticJoint('J', P, C, q, u)
+    assert J.parent_interframe.dcm(J.child_interframe) == eye(3)
+    assert C.masscenter.pos_from(P.masscenter) == q * J.parent_interframe.x
+    assert P.masscenter.vel(J.parent_interframe) == 0
+    assert C.masscenter.vel(J.parent_interframe) == u * J.parent_interframe.x
+    # Test compatibility for cylindrical joint
+    P, C = Particle('P'), Particle('C')
+    P_frame = ReferenceFrame('P_frame')
+    J = CylindricalJoint('J', P, C, q1, q2, u1, u2, parent_interframe=P_frame,
+                         parent_point=l * P_frame.x, joint_axis=P_frame.y)
+    assert J.parent_interframe.dcm(J.child_interframe) == Matrix([
+        [cos(q1), 0, sin(q1)], [0, 1, 0], [-sin(q1), 0, cos(q1)]])
+    assert C.masscenter.pos_from(P.masscenter) == l * P_frame.x + q2 * P_frame.y
+    assert C.masscenter.vel(J.parent_interframe) == u2 * P_frame.y
+    assert P.masscenter.vel(J.child_interframe).xreplace(qdot_to_u) == (
+        -u2 * P_frame.y - l * u1 * P_frame.z)
+    # Test compatibility for planar joint
+    P, C = Particle('P'), Particle('C')
+    C_frame = ReferenceFrame('C_frame')
+    J = PlanarJoint('J', P, C, q1, [q2, q3], u1, [u2, u3],
+                    child_interframe=C_frame, child_point=l * C_frame.z)
+    P_frame = J.parent_interframe
+    assert J.parent_interframe.dcm(J.child_interframe) == Matrix([
+        [1, 0, 0], [0, cos(q1), -sin(q1)], [0, sin(q1), cos(q1)]])
+    assert C.masscenter.pos_from(P.masscenter) == (
+        -l * C_frame.z + q2 * P_frame.y + q3 * P_frame.z)
+    assert C.masscenter.vel(J.parent_interframe) == (
+        l * u1 * C_frame.y + u2 * P_frame.y + u3 * P_frame.z)
+    # Test compatibility for weld joint
+    P, C = Particle('P'), Particle('C')
+    C_frame, P_frame = ReferenceFrame('C_frame'), ReferenceFrame('P_frame')
+    J = WeldJoint('J', P, C, parent_interframe=P_frame,
+                  child_interframe=C_frame, parent_point=l * P_frame.x,
+                  child_point=l * C_frame.y)
+    assert P_frame.dcm(C_frame) == eye(3)
+    assert C.masscenter.pos_from(P.masscenter) == l * P_frame.x - l * C_frame.y
+    assert C.masscenter.vel(J.parent_interframe) == 0
+
+
+def test_body_compatibility():
+    m, l = symbols('m l')
+    C_frame = ReferenceFrame('C')
+    P = Body('P')
+    C = Body('C', mass=m, frame=C_frame)
+    q, u = dynamicsymbols('q, u')
+    PinJoint('J', P, C, q, u, child_point=l * C_frame.y)
+    assert C.frame == C_frame
+    assert P.frame.name == 'P_frame'
+    assert C.masscenter.pos_from(P.masscenter) == -l * C.y
+    assert C.frame.dcm(P.frame) == Matrix([[1, 0, 0],
+                                           [0, cos(q), sin(q)],
+                                           [0, -sin(q), cos(q)]])
+    assert C.masscenter.vel(P.frame) == -l * u * C.z
+
+
 def test_pin_joint_double_pendulum():
     q1, q2 = dynamicsymbols('q1 q2')
     u1, u2 = dynamicsymbols('u1 u2')
@@ -147,9 +236,9 @@ def test_pin_joint_double_pendulum():
     N = ReferenceFrame('N')
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    C = Body('C', frame=N)  # ceiling
-    PartP = Body('P', frame=A, mass=m)
-    PartR = Body('R', frame=B, mass=m)
+    C = RigidBody('C', frame=N)  # ceiling
+    PartP = RigidBody('P', frame=A, mass=m)
+    PartR = RigidBody('R', frame=B, mass=m)
 
     J1 = PinJoint('J1', C, PartP, speeds=u1, coordinates=q1,
                   child_point=-l*A.x, joint_axis=C.frame.z)
@@ -188,9 +277,9 @@ def test_pin_joint_chaos_pendulum():
     B = ReferenceFrame('B')
     lA = (lB - h / 2) / 2
     lC = (lB/2 + h/4)
-    rod = Body('rod', frame=A, mass=mA)
-    plate = Body('plate', mass=mB, frame=B)
-    C = Body('C', frame=N)
+    rod = RigidBody('rod', frame=A, mass=mA)
+    plate = RigidBody('plate', mass=mB, frame=B)
+    C = RigidBody('C', frame=N)
     J1 = PinJoint('J1', C, rod, coordinates=theta, speeds=omega,
                   child_point=lA*A.z, joint_axis=N.y)
     J2 = PinJoint('J2', rod, plate, coordinates=phi, speeds=alpha,
@@ -597,7 +686,7 @@ def test_locate_joint_frame():
            lambda: PinJoint('J', P, C, child_interframe=child_interframe))
 
 
-def test_sliding_joint():
+def test_prismatic_joint():
     _, _, P, C = _generate_body()
     q, u = dynamicsymbols('q_S, u_S')
     S = PrismaticJoint('S', P, C)
@@ -613,8 +702,8 @@ def test_sliding_joint():
     assert S.parent_point.pos_from(S.child_point) == - q * P.frame.x
     assert P.masscenter.pos_from(C.masscenter) == - q * P.frame.x
     assert C.masscenter.vel(P.frame) == u * P.frame.x
-    assert P.ang_vel_in(C) == 0
-    assert C.ang_vel_in(P) == 0
+    assert P.frame.ang_vel_in(C.frame) == 0
+    assert C.frame.ang_vel_in(P.frame) == 0
     assert S.__str__() == 'PrismaticJoint: S  parent: P  child: C'
 
     N, A, P, C = _generate_body()
@@ -629,11 +718,11 @@ def test_sliding_joint():
     assert S.child_point.pos_from(C.masscenter) == m * C.frame.y
     assert S.parent_point.pos_from(P.masscenter) == l * P.frame.x
     assert S.parent_point.pos_from(S.child_point) == - q * P.frame.z
-    assert P.masscenter.pos_from(C.masscenter) == - l*N.x - q*N.z + m*A.y
+    assert P.masscenter.pos_from(C.masscenter) == - l * N.x - q * N.z + m * A.y
     assert C.masscenter.vel(P.frame) == u * P.frame.z
     assert P.masscenter.vel(Pint) == Vector(0)
-    assert C.ang_vel_in(P) == 0
-    assert P.ang_vel_in(C) == 0
+    assert C.frame.ang_vel_in(P.frame) == 0
+    assert P.frame.ang_vel_in(C.frame) == 0
 
     _, _, P, C = _generate_body()
     Pint = ReferenceFrame('P_int')
@@ -647,11 +736,11 @@ def test_sliding_joint():
     assert S.parent_point.pos_from(S.child_point) == - q * P.frame.z
     assert P.masscenter.pos_from(C.masscenter) == (-l - q)*P.frame.z + m*C.frame.x
     assert C.masscenter.vel(P.frame) == u * P.frame.z
-    assert C.ang_vel_in(P) == 0
-    assert P.ang_vel_in(C) == 0
+    assert C.frame.ang_vel_in(P.frame) == 0
+    assert P.frame.ang_vel_in(C.frame) == 0
 
 
-def test_sliding_joint_arbitrary_axis():
+def test_prismatic_joint_arbitrary_axis():
     q, u = dynamicsymbols('q_S, u_S')
 
     N, A, P, C = _generate_body()
@@ -892,10 +981,10 @@ def test_spherical_joint():
     assert S.parent_point.pos_from(S.child_point) == Vector(0)
     assert P.masscenter.pos_from(C.masscenter) == Vector(0)
     assert C.masscenter.vel(N) == Vector(0)
-    assert P.ang_vel_in(C) == (-u0 * cos(q1) * cos(q2) - u1 * sin(q2)) * A.x + (
+    assert N.ang_vel_in(A) == (-u0 * cos(q1) * cos(q2) - u1 * sin(q2)) * A.x + (
             u0 * sin(q2) * cos(q1) - u1 * cos(q2)) * A.y + (
                    -u0 * sin(q1) - u2) * A.z
-    assert C.ang_vel_in(P) == (u0 * cos(q1) * cos(q2) + u1 * sin(q2)) * A.x + (
+    assert A.ang_vel_in(N) == (u0 * cos(q1) * cos(q2) + u1 * sin(q2)) * A.x + (
             -u0 * sin(q2) * cos(q1) + u1 * cos(q2)) * A.y + (
                    u0 * sin(q1) + u2) * A.z
     assert S.__str__() == 'SphericalJoint: S  parent: P  child: C'
@@ -914,7 +1003,7 @@ def test_spherical_joint_speeds_as_derivative_terms():
     assert S.coordinates == Matrix([q0, q1, q2])
     assert S.speeds == Matrix([u0, u1, u2])
     assert S.kdes == Matrix([0, 0, 0])
-    assert P.ang_vel_in(C) == (-u0 * cos(q1) * cos(q2) - u1 * sin(q2)) * A.x + (
+    assert N.ang_vel_in(A) == (-u0 * cos(q1) * cos(q2) - u1 * sin(q2)) * A.x + (
         u0 * sin(q2) * cos(q1) - u1 * cos(q2)) * A.y + (
                -u0 * sin(q1) - u2) * A.z
 
@@ -1075,14 +1164,14 @@ def test_weld_joint():
     assert W.coordinates == Matrix()
     assert W.speeds == Matrix()
     assert W.kdes == Matrix(1, 0, []).T
-    assert P.dcm(C) == eye(3)
+    assert P.frame.dcm(C.frame) == eye(3)
     assert W.child_point.pos_from(C.masscenter) == Vector(0)
     assert W.parent_point.pos_from(P.masscenter) == Vector(0)
     assert W.parent_point.pos_from(W.child_point) == Vector(0)
     assert P.masscenter.pos_from(C.masscenter) == Vector(0)
     assert C.masscenter.vel(P.frame) == Vector(0)
-    assert P.ang_vel_in(C) == 0
-    assert C.ang_vel_in(P) == 0
+    assert P.frame.ang_vel_in(C.frame) == 0
+    assert C.frame.ang_vel_in(P.frame) == 0
     assert W.__str__() == 'WeldJoint: W  parent: P  child: C'
 
     N, A, P, C = _generate_body()
@@ -1098,8 +1187,8 @@ def test_weld_joint():
     assert P.masscenter.pos_from(C.masscenter) == - l * N.x + m * A.y
     assert C.masscenter.vel(P.frame) == Vector(0)
     assert P.masscenter.vel(Pint) == Vector(0)
-    assert C.ang_vel_in(P) == 0
-    assert P.ang_vel_in(C) == 0
+    assert C.frame.ang_vel_in(P.frame) == 0
+    assert P.frame.ang_vel_in(C.frame) == 0
     assert P.x == A.z
 
     JointsMethod(P, W)  # Tests #10770

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -3,8 +3,9 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
 from sympy.simplify.trigsimp import trigsimp
-from sympy.physics.mechanics import (PinJoint, JointsMethod, Body, KanesMethod,
-                                    PrismaticJoint, LagrangesMethod, inertia)
+from sympy.physics.mechanics import (
+    PinJoint, JointsMethod, RigidBody, Particle,Body, KanesMethod,
+    PrismaticJoint, LagrangesMethod, inertia)
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
 from sympy.testing.pytest import raises
 from sympy.core.backend import zeros
@@ -34,6 +35,22 @@ def test_jointsmethod():
     assert method.forcing_full == Matrix([[u], [0]])
     assert method.mass_matrix_full == Matrix([[1, 0], [0, C_ixx]])
     assert isinstance(method.method, KanesMethod)
+
+
+def test_rigid_body_particle_compatibility():
+    l, m, g = symbols('l m g')
+    C = RigidBody('C')
+    b = Particle('b', mass=m)
+    b_frame = ReferenceFrame('b_frame')
+    q, u = dynamicsymbols('q u')
+    P = PinJoint('P', C, b, coordinates=q, speeds=u, child_interframe=b_frame,
+                 child_point=-l * b_frame.x, joint_axis=C.z)
+    method = JointsMethod(C, P)
+    method.loads.append((b.masscenter, m * g * C.x))
+    method.form_eoms()
+    rhs = method.rhs()
+    assert rhs[1] == -g*sin(q)/l
+
 
 def test_jointmethod_duplicate_coordinates_speeds():
     P = Body('P')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Output of the mechanics experimental development (#24234)
Implements parts of #24550 and #24699

#### Brief description of what is fixed or changed
Make `Particle` and `RigidBody` compatible with the joints framework.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Make `Particle` and `RigidBody` compatible with the joints framework.
<!-- END RELEASE NOTES -->
