### PR TITLE
manualintegrate: don't substitute existing denom to 0

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1896,10 +1896,11 @@ def substitution_rule(integral):
                 continue
 
             if simplify(c - 1) != 0:
-                _, denom = c.as_numer_denom()
-                if subrule:
-                    subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
+                numer, denom = c.as_numer_denom()
+                subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
 
+                # e.g. integrand = E**(a*x), c = 1/a, we should treat a = 0 differently
+                # But for E**(a*x)/a, we already know a != 0
                 if denom.free_symbols:
                     piecewise = []
                     could_be_zero = []
@@ -1910,7 +1911,7 @@ def substitution_rule(integral):
                         could_be_zero.append(denom)
 
                     for expr in could_be_zero:
-                        if not fuzzy_not(expr.is_zero):
+                        if not fuzzy_not(expr.is_zero) and not integrand.has_free(Pow(expr, S.NegativeOne)):
                             substep = integral_steps(manual_subs(integrand, expr, 0), symbol)
 
                             if substep:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.function import (Derivative, Function, diff, expand)
-from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.numbers import (I, Rational, pi, oo)
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
@@ -599,6 +599,11 @@ def test_issue_23566():
     i = Integral(1/sqrt(x**2 - 1), (x, -2, -1)).doit(manual=True)
     assert i == -log(4 - 2*sqrt(3)) + log(2)
     assert str(i.n()) == '1.31695789692482'
+
+
+def test_issue_24781():
+    assert manualintegrate(exp(-y**2)*Integral(y*exp(-z**2/(2*x**2))/x, (z, -oo, oo)), y) == \
+        -exp(-y**2)*Integral(exp(-z**2/(2*x**2)), (z, -oo, oo))/(2*x)
 
 
 def test_nested_pow():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24781 
#### Brief description of what is fixed or changed

Before substituting denom to 0, check whether it already exists as denom in original integrand.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug in manual integration (substitution gives NaN)
<!-- END RELEASE NOTES -->
