### PR TITLE
avoid call to setup.py (backport to 1.12)

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -161,8 +161,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: python -m pip install --upgrade pip
+      - run: pip install build
       - run: wget -qO- https://github.com/pyodide/pyodide/releases/download/0.20.1a1/pyodide-build-0.20.1a1.tar.bz2 | tar xjf -
-      - run: python3 setup.py bdist_wheel
+      - run: python -m build --wheel
       - run: node bin/test_pyodide.mjs --split=${{ matrix.split }} 2>/dev/null  # ignore node exception
 
   # -------------------- Optional dependency tests ----------------- #
@@ -405,7 +410,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: python setup.py sdist
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build --sdist
       - run: release/compare_tar_against_git.py dist/*.tar.gz .
 
   # -------- Run benchmarks against master and previous release ---- #

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To install SymPy from GitHub source, first clone SymPy using `git`:
 
 Then, in the `sympy` repository that you cloned, simply run:
 
-    $ python setup.py install
+    $ pip install .
 
 See <https://docs.sympy.org/dev/install.html> for more information.
 

--- a/release/ci_release_script.sh
+++ b/release/ci_release_script.sh
@@ -10,7 +10,7 @@
 
 doc/aptinstall.sh
 
-pip install --upgrade setuptools pip wheel
+pip install --upgrade setuptools pip wheel build
 pip install -r doc/requirements.txt
 pip install .
 

--- a/release/releasecheck.py
+++ b/release/releasecheck.py
@@ -7,8 +7,8 @@ def main(version, prevversion, outdir):
     check_version(version, outdir)
     run_stage(['bin/mailmap_check.py', '--update-authors'])
     run_stage(['mkdir', '-p', outdir])
-    build_release_files('bdist_wheel', 'sympy-%s-py3-none-any.whl', outdir, version)
-    build_release_files('sdist', 'sympy-%s.tar.gz', outdir, version)
+    build_release_files('--wheel', 'sympy-%s-py3-none-any.whl', outdir, version)
+    build_release_files('--sdist', 'sympy-%s.tar.gz', outdir, version)
     run_stage(['release/compare_tar_against_git.py', join(outdir, 'sympy-%s.tar.gz' % (version,)), '.'])
     run_stage(['release/build_docs.py', version, outdir])
     run_stage(['release/sha256.py', version, outdir])
@@ -44,7 +44,7 @@ def run_stage(cmd):
 
 def build_release_files(cmd, fname, outdir, version):
     fname = fname % (version,)
-    run_stage(['python', 'setup.py', '-q', cmd])
+    run_stage(['python', '-m', 'build', cmd])
     src = join('dist', fname)
     dst = join(outdir, fname)
     run_stage(['mv', src, dst])

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ python mechanism for installing packages.
 For the easiest installation just type the command (you'll probably need
 root privileges for that):
 
-    python setup.py install
+    pip install .
 
 This will install the library in the default location. For instructions on
-how to customize the install procedure read the output of:
+how to customize the installation procedure read the output of:
 
-    python setup.py --help install
+    pip install --help
 
 In addition, there are some other commands:
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-24840

#### Brief description of what is fixed or changed

Don't use setup.py in examples or release scripts.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
