### PR TITLE
fix(dsolve): handle simple DAE systems in dsolve

### DIFF
--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -2157,7 +2157,8 @@ def constant_renumber(expr, variables=None, newconstants=None):
                 *[_constant_renumber(x) for x in expr.args])
         else:
             sortedargs = list(expr.args)
-            sortedargs.sort(key=sort_key)
+            if type(expr) in (Mul, Add) and expr.is_commutative:
+                sortedargs.sort(key=sort_key)
             return expr.func(*[_constant_renumber(x) for x in sortedargs])
     expr = _constant_renumber(expr)
 

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -241,8 +241,7 @@ from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.core.sympify import sympify
 from sympy.core.traversal import preorder_traversal
 
-from sympy.logic.boolalg import (BooleanAtom, BooleanTrue,
-                                BooleanFalse)
+from sympy.logic.boolalg import BooleanTrue, BooleanFalse
 from sympy.functions import exp, log, sqrt
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.integrals.integrals import Integral
@@ -789,15 +788,10 @@ def solve_ics(sols, funcs, constants, ics):
 
         for sol in S:
             if sol.has(matching_func):
-                sol2 = sol
-                sol2 = sol2.subs(x, x0)
+                sol2 = sol.subs(x, x0)
                 sol2 = sol2.subs(funcarg, value)
-                # This check is necessary because of issue #15724
-                if not isinstance(sol2, BooleanAtom) or not subs_sols:
-                    subs_sols = [s for s in subs_sols if not isinstance(s, BooleanAtom)]
-                    subs_sols.append(sol2)
+                subs_sols.append(sol2)
 
-    # TODO: Use solveset here
     try:
         solved_constants = solve(subs_sols, constants, dict=True)
     except NotImplementedError:
@@ -806,7 +800,7 @@ def solve_ics(sols, funcs, constants, ics):
     # XXX: We can't differentiate between the solution not existing because of
     # invalid initial conditions, and not existing because solve is not smart
     # enough. If we could use solveset, this might be improvable, but for now,
-    # we use NotImplementedError in this case.
+    # we use ValueError in this case.
     if not solved_constants:
         raise ValueError("Couldn't solve for initial conditions")
 

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1267,6 +1267,8 @@ class _DummyFunc(Expr):
     #   >>> Function(Dummy('x')).free_symbols
     #   set()
     #
+    is_commutative = True
+
     @classmethod
     def new(cls, arg):
         return cls(Dummy(), arg)

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1238,10 +1238,18 @@ def _add_parameters_solve(solution, derivatives, t):
     derivative_map = {}
     new_solution = {}
 
+    all_rhs = Tuple(*solution.values())
+
     for derivative in derivatives:
         if derivative in solution:
             new_solution[derivative] = solution[derivative]
         else:
+            # Replace g'' = C1(t) with g = C1(t) if g does not appear in any
+            # other equations.
+            if derivative.is_Derivative:
+                function = derivative.args[0]
+                if not all_rhs.has_xfree({derivative}):
+                    derivative = function
             new_solution[derivative] = derivative
             derivative_map[derivative] = _DummyFunc.new(t)
 

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1107,7 +1107,7 @@ def _solve_reduce_derivatives(eqs, funcs, t):
     highest_derivatives = [func.diff(t, order[func]) for func in funcs]
 
     # There is no point in attempting any of the things below if the equations
-    # are already in explicit form.
+    # are already in explicit form. Maybe just use linsolve here?
     derivs_found = []
     derivs_set = set(highest_derivatives)
     for eq in eqs:

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1016,11 +1016,6 @@ def test_issue_15913():
     assert checkodesol(eq, sol, f(x)) == (True, 0)
 
 
-def test_issue_16146():
-    raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x), g(x), h(x)]))
-    raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x)]))
-
-
 def test_dsolve_remove_redundant_solutions():
 
     eq = (f(x)-2)*f(x).diff(x)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2103,7 +2103,7 @@ def test_dsolve_dae():
 
     eqs5 = [f(x).diff(x)*g(x)]
     sol5 = [
-        [Eq(f(x), C2 + Integral(C1f(x), x)), Eq(g(x), 0)],
+        [Eq(f(x), C1f(x)), Eq(g(x), 0)],
         [Eq(f(x), C1), Eq(g(x), C2f(x))],
     ]
     assert dsolve(eqs5, funcs) == sol5

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2131,14 +2131,13 @@ def test_dsolve_dae():
     assert dsolve(eqs8, funcs) == sol8
     assert checksysodesol(eqs8, sol8) == (True, [0])
 
-
     # Check that function symbols do not clobber existing symbols or functions.
-    eqs10 = [f(x).diff(x) - g(x).diff(x) - C1f(x) - C2f(x)]
-    sol10 = [
+    eqs9 = [f(x).diff(x) - g(x).diff(x) - C1f(x) - C2f(x)]
+    sol9 = [
         Eq(f(x), C3 + Integral(C1f(x) + C2f(x) + C4f(x), x)),
         Eq(g(x), C5 + Integral(C4f(x), x)),
     ]
-    assert dsolve(eqs10, funcs) == sol10
+    assert dsolve(eqs9, funcs) == sol9
 
     eqs10 = [f(x).diff(x) - g(x).diff(x) - C1 - C2]
     sol10 = [
@@ -2250,13 +2249,12 @@ def test_dsolve_dae_bad():
     sol2_bad = [Eq(f(x), 0), Eq(g(x), 0)]
     sol2_good = [
         [Eq(f(x), 0), Eq(g(x), 0)],
-        [Eq(f(x), C1 + C2*x), Eq(g(x), C3f(x))],
+        [Eq(f(x), C1 + C2*x), Eq(g(x), C1 + C2*x)],
     ]
     assert dsolve(eqs2, [f(x), g(x)]) == sol2_bad
     assert checksysodesol(eqs2, sol2_bad) == (True, [0, 0])
-    assert checksysodesol(eqs2, sol2_good[0]) == (True, [0, 0])
-    # XXX: checksysodesol does not know how to handle C3(x).
-    # assert checksysodesol(eqs2, sol2_good[1]) == (True, [0, 0])
+    for sol2i in sol2_good:
+        assert checksysodesol(eqs2, sol2i) == (True, [0, 0])
 
     # XXX: This one should be easy but fails because solve cannot handle the
     # equations:
@@ -2268,6 +2266,10 @@ def test_dsolve_dae_bad():
     sol16 = [Eq(f(x), x), Eq(g(x), C1f(x))]
     raises(NotImplementedError, lambda: dsolve(eqs16, [f(x), g(x)]))
     assert checksysodesol(eqs16, sol16) == (True, [0, 0])
+
+    # This fails because it falls back to classify_sysode which rejects a
+    # single equation:
+    # dsolve([f(x).diff(x)-exp(x)*h(x)/f(x)], [f(x), g(x), h(x)])
 
 
 def test_dsolve_dae_issue_gh24841():

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2202,8 +2202,6 @@ def test_dsolve_dae():
 
 def test_dsolve_dae_bad():
     C1f = Function('C1')
-    C2f = Function('C2')
-    C3f = Function('C3')
 
     eqs = [Eq(f(x).diff(x), f(x) + g(x)), Eq(g(x).diff(x), f(x) + g(x))]
     sol = [
@@ -2239,7 +2237,7 @@ def test_dsolve_dae_bad():
     #   >>> g1, f1, fp1 = symbols('g1, f1, fp1')
     #   >>> g2, f2, fp2 = g(x), f(x), f(x).diff(x)
     #   >>> solve([g1*fp1, g1-f1], [f1, g1, fp1], dict=True)
-    #   [{f₁: 0, g₁: 0}, {f₁: g₁, fp₁: 0}]
+    #   [{f1: 0, g1: 0}, {f1: g1, fp1: 0}]
     #   >>> solve([g2*fp2, g2-f2], [f2, g2, fp2], dict=True)
     #   [{f(x): 0, g(x): 0}]
     #

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2084,14 +2084,10 @@ def test_dsolve_dae():
     assert dsolve(eqs123, funcs, ics=ics2) == sol2
 
     # With DAEs it is possible that the initial conditions are inconsistent and
-    # so the existence of a solution to an IVP is not guaranteed.
-    #
-    # This example should raise but does not due to this line ignoring False:
-    #
-    #    https://github.com/sympy/sympy/blob/481bb7bdb6bc35d18d15aabfe86c0ea95e2bf301/sympy/solvers/ode/ode.py#L787
-    #
-    # ics3 = {f(0):1, g(0): 1}
-    # raises(ValueError, lambda: dsolve(eqs123, funcs, ics=ics3))
+    # so the existence of a solution to an IVP is not guaranteed. Here the
+    # initial condition for g contradicts the algebraic equation for g:
+    ics3 = {f(0):1, g(0): 1}
+    raises(ValueError, lambda: dsolve(eqs123, funcs, ics=ics3))
 
     # Purely algebraic equations should be handled at least if linear. Really
     # something like this should use solve/linsolve et al butsimple cases can

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2181,6 +2181,16 @@ def test_dsolve_dae():
     for sol15i in sol15:
         assert checksysodesol(eqs15, sol15i) == (True, [0, 0])
 
+    eqs16 = [f(x).diff(x, 2), f(x).diff(x)]
+    sol16 = [Eq(f(x), C1)]
+    assert dsolve(eqs16, [f(x)]) == sol16
+    assert checksysodesol(eqs16, sol16) == (True, [0, 0])
+
+    eqs17 = [f(x).diff(x, 2), f(x).diff(x), f(x)]
+    sol17 = [Eq(f(x), 0)]
+    assert dsolve(eqs17, [f(x)]) == sol17
+    assert checksysodesol(eqs17, sol17) == (True, [0, 0, 0])
+
 
 def test_dsolve_dae_bad():
     C1f = Function('C1')

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2117,16 +2117,16 @@ def test_dsolve_dae():
 
     eqs7 = [f(x).diff(x) - g(x).diff(x)]
     sol7 = [
-        Eq(f(x), C2 + Integral(C1f(x), x)),
-        Eq(g(x), C3 + Integral(C1f(x), x)),
+        Eq(f(x), C1 + Integral(C2f(x), x)),
+        Eq(g(x), C3 + Integral(C2f(x), x)),
     ]
     assert dsolve(eqs7, funcs) == sol7
     assert checksysodesol(eqs7, sol7) == (True, [0])
 
     eqs8 = [f(x).diff(x) - g(x)]
     sol8 = [
-        Eq(f(x), C2 + Integral(C1f(x), x)),
-        Eq(g(x), C1f(x)),
+        Eq(f(x), C1 + Integral(C2f(x), x)),
+        Eq(g(x), C2f(x)),
     ]
     assert dsolve(eqs8, funcs) == sol8
     assert checksysodesol(eqs8, sol8) == (True, [0])
@@ -2135,15 +2135,15 @@ def test_dsolve_dae():
     # Check that function symbols do not clobber existing symbols or functions.
     eqs10 = [f(x).diff(x) - g(x).diff(x) - C1f(x) - C2f(x)]
     sol10 = [
-        Eq(f(x), C4 + Integral(C1f(x) + C2f(x) + C3f(x), x)),
-        Eq(g(x), C5 + Integral(C3f(x), x)),
+        Eq(f(x), C3 + Integral(C1f(x) + C2f(x) + C4f(x), x)),
+        Eq(g(x), C5 + Integral(C4f(x), x)),
     ]
     assert dsolve(eqs10, funcs) == sol10
 
     eqs10 = [f(x).diff(x) - g(x).diff(x) - C1 - C2]
     sol10 = [
-        Eq(f(x), C4 + x*(C1 + C2) + Integral(C3f(x), x)),
-        Eq(g(x), C5 + Integral(C3f(x), x)),
+        Eq(f(x), C3 + x*(C1 + C2) + Integral(C4f(x), x)),
+        Eq(g(x), C5 + Integral(C4f(x), x)),
     ]
     assert dsolve(eqs10, funcs) == sol10
 
@@ -2190,6 +2190,15 @@ def test_dsolve_dae():
     sol17 = [Eq(f(x), 0)]
     assert dsolve(eqs17, [f(x)]) == sol17
     assert checksysodesol(eqs17, sol17) == (True, [0, 0, 0])
+
+    eqs18 = [f(x).diff(x) - g(x)*h(x) - 1, g(x).diff(x)]
+    sol18 = [
+        Eq(f(x), C1 + C2*Integral(C3f(x), x) + x),
+        Eq(g(x), C2),
+        Eq(h(x), C3f(x))
+    ]
+    assert dsolve(eqs18, [f(x), g(x), h(x)]) == sol18
+    assert checksysodesol(eqs18, sol18) == (True, [0, 0])
 
 
 def test_dsolve_dae_bad():

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -2183,10 +2183,10 @@ def test_dsolve_dae_bad():
 
     # XXX: This one is not handled properly. It is similar to the above but
     # this time solve decides that the equations are inconsistent. The
-    # equations imply that g(x) = 0 but g(x).diff(x) is the highest derivative
-    # of g so that is what solve cwis askedattempts to solve for. Since g(x) is
-    # treated as algebraically independent by solve the conclusion is that the
-    # system is inconsistent.
+    # equations imply that g(x) = 0 but g'(x) is the highest derivative of g so
+    # that is what solve is asked to solve for. Since g(x) is treated as
+    # algebraically independent by solve the conclusion is that the system is
+    # inconsistent.
     eqs2 = [f(x).diff(x), f(x).diff(x) + g(x), g(x).diff(x)]
     sol2_good = [Eq(f(x), C1), Eq(g(x), 0)]
     sol2_bad = []


### PR DESCRIPTION
Fixes gh-24841

A mixture of algebraic and differential equations is known as a system of differential algebraic equations. The machinery in dsolve_system can handle simple cases of this but needs to take care not to misconstrue them as a system of ODEs.

This commit changes it so that:

- `_classify_linear_system` no longer incorrectly identifies a system containing algebraic equations as being first order. On its own this prevents a wrong result for DAEs but would mean that dsolve cannot solve them.

- Teaches `dsolve_system`'s strong component solver to recognise algebraic equations that are already in solution form like `x(t) = sin(t)` etc. Nothing special is needed to solve these but the solver needs to check for that case before trying to classify as a system of ODEs.

- Fixes a few other places that assume that all the functions to be solved for will appear as derivatives in the equations.

Note: The case of inconsistent initial conditions is not correctly handled yet due to buggy code in `solve_ics`:
https://github.com/sympy/sympy/blob/481bb7bdb6bc35d18d15aabfe86c0ea95e2bf301/sympy/solvers/ode/ode.py#L785-L789
That check discards the case where the initial conditions are unsatisfiable (substituting into the equation gives False).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
    * A bug meaning that dsolve would return wrong results in the case of some simple linear differential algebraic systems was fixed.
<!-- END RELEASE NOTES -->