### PR TITLE
passthrough unknown objects through Dagger

### DIFF
--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -22,6 +22,8 @@ class Dagger(adjoint):
 
     arg : Expr
         The SymPy expression that we want to take the dagger of.
+    evaluate : bool
+        Whether the resulting expression should be directly evaluated.
 
     Examples
     ========
@@ -77,10 +79,10 @@ class Dagger(adjoint):
     .. [2] https://en.wikipedia.org/wiki/Hermitian_transpose
     """
 
-    def __new__(cls, arg):
-        if hasattr(arg, 'adjoint'):
+    def __new__(cls, arg, evaluate=True):
+        if hasattr(arg, 'adjoint') and evaluate:
             return arg.adjoint()
-        elif hasattr(arg, 'conjugate') and hasattr(arg, 'transpose'):
+        elif hasattr(arg, 'conjugate') and hasattr(arg, 'transpose') and evaluate:
             return arg.conjugate().transpose()
         return Expr.__new__(cls, sympify(arg))
 

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -1,6 +1,6 @@
 """Hermitian conjugation."""
 
-from sympy.core import Expr, Mul
+from sympy.core import Expr, Mul, sympify
 from sympy.functions.elementary.complexes import adjoint
 
 __all__ = [
@@ -79,12 +79,10 @@ class Dagger(adjoint):
 
     def __new__(cls, arg):
         if hasattr(arg, 'adjoint'):
-            obj = arg.adjoint()
+            return arg.adjoint()
         elif hasattr(arg, 'conjugate') and hasattr(arg, 'transpose'):
-            obj = arg.conjugate().transpose()
-        if obj is not None:
-            return obj
-        return Expr.__new__(cls, arg)
+            return arg.conjugate().transpose()
+        return Expr.__new__(cls, sympify(arg))
 
     def __mul__(self, other):
         from sympy.physics.quantum import IdentityOperator

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -81,3 +81,13 @@ def test_scipy_sparse_dagger():
     a = sparse.csr_matrix([[1.0 + 0.0j, 2.0j], [-1.0j, 2.0 + 0.0j]])
     adag = a.copy().transpose().conjugate()
     assert np.linalg.norm((Dagger(a) - adag).todense()) == 0.0
+
+
+def test_unknown():
+    """Check treatment of unknown objects.
+    Objects without adjoint or conjugate/transpose methods
+    are sympified and wrapped in dagger.
+    """
+    x = symbols("x")
+    result = Dagger(x)
+    assert result.args == (x,) and isinstance(result, adjoint)

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -91,3 +91,12 @@ def test_unknown():
     x = symbols("x")
     result = Dagger(x)
     assert result.args == (x,) and isinstance(result, adjoint)
+
+
+def test_unevaluated():
+    """Check that evaluate=False returns unevaluated Dagger.
+    """
+    x = symbols("x", real=True)
+    assert Dagger(x) == x
+    result = Dagger(x, evaluate=False)
+    assert result.args == (x,) and isinstance(result, adjoint)


### PR DESCRIPTION
I've made `sympy.physics.quantum.Dagger` wrap unrecognized objects without complaining.

#### References to other Issues or PRs
closes #24664

#### Brief description of what is fixed or changed

Mainly just clean up a runaway `UnboundLocalError`

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Allowed `Dagger` to treat unrecognized inputs and stay unevaluated.
<!-- END RELEASE NOTES -->
