### PR TITLE
removed incorrect statement in is_extra_strong_lucas_prp doc

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -425,7 +425,7 @@ def is_strong_lucas_prp(n):
 
 def is_extra_strong_lucas_prp(n):
     """Extra Strong Lucas compositeness test.  Returns False if n is
-    definitely composite, and True if n is a "extra strong" Lucas probable
+    definitely composite, and True if n is an "extra strong" Lucas probable
     prime.
 
     The parameters are selected using P = 3, Q = 1, then incrementing P until
@@ -434,8 +434,7 @@ def is_extra_strong_lucas_prp(n):
     used in OEIS A217719, Perl's Math::Prime::Util, and the Lucas pseudoprime
     page on Wikipedia.
 
-    With these parameters, there are no counterexamples below 2^64 nor any
-    known above that range.  It is 20-50% faster than the strong test.
+    It is 20-50% faster than the strong test.
 
     Because of the different parameters selected, there is no relationship
     between the strong Lucas pseudoprimes and extra strong Lucas pseudoprimes.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24476.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
