### PR TITLE
tensor: Fix dispatch bug in array_derivates.py

### DIFF
--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -112,7 +112,7 @@ class ArrayDerivative(Derivative):
                 return None
         else:
             # Both `expr` and `v` are some array/matrix type:
-            if isinstance(expr, MatrixCommon) or isinstance(expr, MatrixCommon):
+            if isinstance(expr, MatrixCommon) or isinstance(v, MatrixCommon):
                 result = derive_by_array(expr, v)
             elif isinstance(expr, MatrixExpr) and isinstance(v, MatrixExpr):
                 result = cls._call_derive_default(expr, v)

--- a/sympy/tensor/array/tests/test_array_derivatives.py
+++ b/sympy/tensor/array/tests/test_array_derivatives.py
@@ -48,5 +48,5 @@ def test_array_derivative_construction():
     d = ArrayDerivative(M.as_explicit(), (N.as_explicit(), 2), evaluate=False)
     assert d.doit().shape == (4, 3, 4, 3, 3, 2)
     expr = d.doit()
-    assert isinstance(expr, ArrayDerivative)
+    assert isinstance(expr, NDimArray)
     assert expr.shape == (4, 3, 4, 3, 3, 2)


### PR DESCRIPTION
This bug prevent simplification of the array expr when possible.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes bug in array_derivatives dispatch. Fix #24742 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * fix bug in array_derivatives dispatch logic that prevented simplification of array exprs.
<!-- END RELEASE NOTES -->
