### PR TITLE
Fix documentation on singular_value_decomposition

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1130,7 +1130,7 @@ def _singular_value_decomposition(A):
     Explanation
     ===========
 
-    A Singular Value decomposition is a decomposition in the form $A = U \Sigma V$
+    A Singular Value decomposition is a decomposition in the form $A = U \Sigma V^H$
     where
 
     - $U, V$ are column orthogonal matrix.


### PR DESCRIPTION
#### References to other Issues or PRs

None

#### Brief description of what is fixed or changed

It's incorrect to say that A was decomposed as U * S * V where U and V are **column-orthogonal** matrices.
In that case we should write the decomposition as U * S * V.H

The sample code a few lines below already confirms it:

```python
>>> U, S, V = A.singular_value_decomposition()

>>> A == U * S * V.H
    True
```

#### Other comments

No further comments.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
