### PR TITLE
Fix documentation about singular_value_decomposition()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1296,6 +1296,7 @@ Stephen Loo <shikil@yahoo.com>
 Steve Anton <anxuiz.nx@gmail.com>
 Steve Kieffer <sk@skieffer.info>
 Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
+Steven Burns <royalstream@hotmail.com>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1295,8 +1295,8 @@ Stephan Seitz <stephan.seitz@fau.de>
 Stephen Loo <shikil@yahoo.com>
 Steve Anton <anxuiz.nx@gmail.com>
 Steve Kieffer <sk@skieffer.info>
-Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
 Steven Burns <royalstream@hotmail.com>
+Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1130,7 +1130,7 @@ def _singular_value_decomposition(A):
     Explanation
     ===========
 
-    A Singular Value decomposition is a decomposition in the form $A = U \Sigma V$
+    A Singular Value decomposition is a decomposition in the form $A = U \Sigma V^H$
     where
 
     - $U, V$ are column orthogonal matrix.


### PR DESCRIPTION
#### References to other Issues or PRs

None

#### Brief description of what is fixed or changed

It's incorrect to say that A was decomposed as U * S * V where U and V are **column-orthogonal** matrices.
In that case we should write the decomposition as U * S * V.H

The sample code a few lines below already confirms it:

```python
>>> U, S, V = A.singular_value_decomposition()

>>> A == U * S * V.H
    True
```

#### Other comments

No further comments.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
