### PR TITLE
(fix) update coverage_doctest.py remove print statement  [python:S3699]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1544,4 +1544,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-Dayne Sorvisto <daynesorvisto@yahoo.ca>
+DayneSorvisto <daynesorvisto@yahoo.ca>

--- a/.mailmap
+++ b/.mailmap
@@ -1544,3 +1544,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+Dayne Sorvisto <daynesorvisto@yahoo.ca>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1208,3 +1208,4 @@ Charles Harris <erdos4d@gmail.com>
 Tejaswini Sanapathi <sastejaswini2002@gmail.com>
 Devansh <be19b002@smail.iitm.ac.in>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
+DayneSorvisto <daynesorvisto@yahoo.ca>

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -400,7 +400,7 @@ def process_class(c_name, obj, c_skip, c_missing_doc, c_missing_doctest, c_indir
         c_skip.append(c_name)
         return False, False, None
     else:
-        raise TypeError('Current doc type of ', print(obj), ' is ', type(doc), '. Docstring must be a string, property , or none')
+        raise TypeError('Current doc type of ', repr(obj), ' is ', type(doc), '. Docstring must be a string, property , or none')
 
     in_sphinx = False
     if sphinx:


### PR DESCRIPTION
The output of functions that don't return anything should not be used [python:S3699]

#### Brief description of what is fixed or changed

If a function does not return anything, it makes no sense to use its output. Specifically, passing it to another function, or assigning its "result" to a variable is probably a bug because such functions return nothing, which is probably not what was intended.


#### Other comments

Replaced print(obj) with repr(obj)  

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

Updated line 403 of bin/coverage_doctest.py to remove print since doesn't return anything in context.
* solvers
  * testing
     * improve solving of trig equations
<!-- END RELEASE NOTES -->
