### PR TITLE
Fix MatrixSolve not sympifying the vector argument

### DIFF
--- a/sympy/codegen/matrix_nodes.py
+++ b/sympy/codegen/matrix_nodes.py
@@ -60,6 +60,7 @@ class MatrixSolve(Token, MatrixExpr):
     __slots__ = _fields = ('matrix', 'vector')
 
     _construct_matrix = staticmethod(sympify)
+    _construct_vector = staticmethod(sympify)
 
     @property
     def shape(self):

--- a/sympy/codegen/tests/test_matrix_nodes.py
+++ b/sympy/codegen/tests/test_matrix_nodes.py
@@ -1,0 +1,9 @@
+from sympy.core.symbol import symbols
+from sympy.matrices.dense import Matrix
+from sympy.codegen.matrix_nodes import MatrixSolve
+
+
+def test_matrix_solve_24862():
+    A = Matrix(3, 3, symbols('a:9'))
+    b = Matrix(3, 1, symbols('b:3'))
+    hash(MatrixSolve(A, b))

--- a/sympy/codegen/tests/test_matrix_nodes.py
+++ b/sympy/codegen/tests/test_matrix_nodes.py
@@ -3,7 +3,7 @@ from sympy.matrices.dense import Matrix
 from sympy.codegen.matrix_nodes import MatrixSolve
 
 
-def test_matrix_solve_24862():
+def test_matrix_solve_issue_24862():
     A = Matrix(3, 3, symbols('a:9'))
     b = Matrix(3, 1, symbols('b:3'))
     hash(MatrixSolve(A, b))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24862

#### Brief description of what is fixed or changed
Sympify the `vector` argument of `MatrixSolve`, solving #24862.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
