### PR TITLE
Implementation derivative support for MatrixSolve

### DIFF
--- a/sympy/codegen/matrix_nodes.py
+++ b/sympy/codegen/matrix_nodes.py
@@ -65,3 +65,8 @@ class MatrixSolve(Token, MatrixExpr):
     @property
     def shape(self):
         return self.vector.shape
+
+    def _eval_derivative(self, x):
+        return MatrixSolve(
+            self.matrix, self.vector.diff(x) - self.matrix.diff(
+                x) * MatrixSolve(self.matrix, self.vector))

--- a/sympy/codegen/matrix_nodes.py
+++ b/sympy/codegen/matrix_nodes.py
@@ -67,6 +67,5 @@ class MatrixSolve(Token, MatrixExpr):
         return self.vector.shape
 
     def _eval_derivative(self, x):
-        return MatrixSolve(
-            self.matrix, self.vector.diff(x) - self.matrix.diff(
-                x) * MatrixSolve(self.matrix, self.vector))
+        A, b = self.matrix, self.vector
+        return MatrixSolve(A, b.diff(x) - A.diff(x) * MatrixSolve(A, b))

--- a/sympy/codegen/tests/test_matrix_nodes.py
+++ b/sympy/codegen/tests/test_matrix_nodes.py
@@ -1,9 +1,51 @@
 from sympy.core.symbol import symbols
+from sympy.core.function import Function
 from sympy.matrices.dense import Matrix
+from sympy.matrices.dense import zeros
+from sympy.simplify.simplify import simplify
 from sympy.codegen.matrix_nodes import MatrixSolve
+from sympy.utilities.lambdify import lambdify
+from sympy.printing.numpy import NumPyPrinter
+from sympy.testing.pytest import skip
+from sympy.external import import_module
 
 
 def test_matrix_solve_issue_24862():
     A = Matrix(3, 3, symbols('a:9'))
     b = Matrix(3, 1, symbols('b:3'))
     hash(MatrixSolve(A, b))
+
+
+def test_matrix_solve_derivative_exact():
+    q = symbols('q')
+    a11, a12, a21, a22, b1, b2 = (
+        f(q) for f in symbols('a11 a12 a21 a22 b1 b2', cls=Function))
+    A = Matrix([[a11, a12], [a21, a22]])
+    b = Matrix([b1, b2])
+    x_lu = A.LUsolve(b)
+    dxdq_lu = A.LUsolve(b.diff(q) - A.diff(q) * A.LUsolve(b))
+    assert simplify(x_lu.diff(q) - dxdq_lu) == zeros(2, 1)
+    # dxdq_ms is the MatrixSolve equivalent of dxdq_lu
+    dxdq_ms = MatrixSolve(A, b.diff(q) - A.diff(q) * MatrixSolve(A, b))
+    assert MatrixSolve(A, b).diff(q) == dxdq_ms
+
+
+def test_matrix_solve_derivative_numpy():
+    np = import_module('numpy')
+    if not np:
+        skip("numpy not installed.")
+    q = symbols('q')
+    a11, a12, a21, a22, b1, b2 = (
+        f(q) for f in symbols('a11 a12 a21 a22 b1 b2', cls=Function))
+    A = Matrix([[a11, a12], [a21, a22]])
+    b = Matrix([b1, b2])
+    dx_lu = A.LUsolve(b).diff(q)
+    subs = {a11.diff(q): 0.2, a12.diff(q): 0.3, a21.diff(q): 0.1,
+            a22.diff(q): 0.5, b1.diff(q): 0.4, b2.diff(q): 0.9,
+            a11: 1.3, a12: 0.5, a21: 1.2, a22: 4, b1: 6.2, b2: 3.5}
+    p, p_vals = zip(*subs.items())
+    dx_sm = MatrixSolve(A, b).diff(q)
+    np.testing.assert_allclose(
+        lambdify(p, dx_sm, printer=NumPyPrinter)(*p_vals),
+        lambdify(p, dx_lu, printer=NumPyPrinter)(*p_vals))
+

--- a/sympy/codegen/tests/test_matrix_nodes.py
+++ b/sympy/codegen/tests/test_matrix_nodes.py
@@ -48,4 +48,3 @@ def test_matrix_solve_derivative_numpy():
     np.testing.assert_allclose(
         lambdify(p, dx_sm, printer=NumPyPrinter)(*p_vals),
         lambdify(p, dx_lu, printer=NumPyPrinter)(*p_vals))
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Implements #24864

#### Brief description of what is fixed or changed
Implement the support of taking a derivative of a `MatrixSolve` node.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Implemented diff support for `MatrixSolve`.
<!-- END RELEASE NOTES -->
