### PR TITLE
Implement derivative support for BlockMatrix

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -223,6 +223,9 @@ class BlockMatrix(MatrixExpr):
 
         return (BlockMatrix(real_matrices), BlockMatrix(im_matrices))
 
+    def _eval_derivative(self, x):
+        return BlockMatrix(self.blocks.diff(x))
+
     def transpose(self):
         """Return transpose of matrix.
 

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -8,8 +8,8 @@ from sympy.matrices.expressions import (MatrixSymbol, Identity,
         Inverse, trace, Transpose, det, ZeroMatrix, OneMatrix)
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import (
-    Matrix, ImmutableMatrix, ImmutableSparseMatrix)
-from sympy.core import Tuple, symbols, Expr, S
+    Matrix, ImmutableMatrix, ImmutableSparseMatrix, zeros)
+from sympy.core import Tuple, symbols, Expr, S, Function
 from sympy.functions import transpose, im, re
 
 i, j, k, l, m, n, p = symbols('i:n, p', integer=True)
@@ -443,3 +443,10 @@ def test_adjoint_and_special_matrices():
     assert re(X) == X
     assert X2.adjoint() == BlockMatrix([[A, ZeroMatrix(3, 2)], [-S.ImaginaryUnit*OneMatrix(2, 3), D]])
     assert im(X2) == BlockMatrix([[ZeroMatrix(3, 3), OneMatrix(3, 2)], [ZeroMatrix(2, 3), ZeroMatrix(2, 2)]])
+
+
+def test_block_matrix_derivative():
+    x = symbols('x')
+    A = Matrix(3, 3, [Function(f'a{i}')(x) for i in range(9)])
+    bc = BlockMatrix([[A[:2, :2], A[:2, 2]], [A[2, :2], A[2:, 2]]])
+    assert Matrix(bc.diff(x)) - A.diff(x) == zeros(3, 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Implements derivative support for `BlockMatrix`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Implemented diff support for `BlockMatrix`.
<!-- END RELEASE NOTES -->
