### PR TITLE
Apply ruff SIM101 rule: merge isinstance calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ select = [
     "E",
     "F",
     "PIE802",
+    "SIM101",
 ]
 
 # Ignore rules that currently fail on the SymPy codebase

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -775,8 +775,7 @@ class Diagram(Basic):
                         Diagram._add_morphism_closure(
                             conclusions, morphism, empty, add_identities=False,
                             recurse_composites=False)
-            elif isinstance(conclusions_arg, dict) or \
-                    isinstance(conclusions_arg, Dict):
+            elif isinstance(conclusions_arg, (dict, Dict)):
                 # The user has supplied a dictionary of morphisms and
                 # their properties.
                 for morphism, props in conclusions_arg.items():

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1423,8 +1423,7 @@ class Derivative(Expr):
                 expr = expr.xreplace({old_v: v})
                 # Derivatives and UndefinedFunctions are independent
                 # of all others
-                clashing = not (isinstance(old_v, Derivative) or \
-                    isinstance(old_v, AppliedUndef))
+                clashing = not (isinstance(old_v, (Derivative, AppliedUndef)))
                 if v not in expr.free_symbols and not clashing:
                     return expr.diff(v)  # expr's version of 0
                 if not old_v.is_scalar and not hasattr(
@@ -3231,11 +3230,7 @@ def count_ops(expr, visual=False):
                 # count the args
                 ops.append(o*(len(a.args) - 1))
             elif a.args and (
-                    a.is_Pow or
-                    a.is_Function or
-                    isinstance(a, Derivative) or
-                    isinstance(a, Integral) or
-                    isinstance(a, Sum)):
+                    a.is_Pow or a.is_Function or isinstance(a, (Derivative, Integral, Sum))):
                 # if it's not in the list above we don't
                 # consider a.func something to count, e.g.
                 # Tuple, MatrixSymbol, etc...

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1941,9 +1941,7 @@ cancel_rule = rewriter(
 
 distribute_expand_rule = rewriter(
     lambda integrand, symbol: (
-        all(arg.is_Pow or arg.is_polynomial(symbol) for arg in integrand.args)
-        or isinstance(integrand, Pow)
-        or isinstance(integrand, Mul)),
+        isinstance(integrand, (Pow, Mul)) or all(arg.is_Pow or arg.is_polynomial(symbol) for arg in integrand.args)),
     lambda integrand, symbol: integrand.expand())
 
 trig_expand_rule = rewriter(

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -964,9 +964,7 @@ class MatrixBase(MatrixDeprecated,
                     and not isinstance(args[0], DeferredVector):
                 dat = list(args[0])
                 ismat = lambda i: isinstance(i, MatrixBase) and (
-                    evaluate or
-                    isinstance(i, BlockMatrix) or
-                    isinstance(i, MatrixSymbol))
+                    evaluate or isinstance(i, (BlockMatrix, MatrixSymbol)))
                 raw = lambda i: is_sequence(i) and not ismat(i)
                 evaluate = kwargs.get('evaluate', True)
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -98,8 +98,7 @@ def operators_to_state(operators, **options):
     |psi>
     """
 
-    if not (isinstance(operators, Operator)
-            or isinstance(operators, set) or issubclass(operators, Operator)):
+    if not (isinstance(operators, (Operator, set)) or issubclass(operators, Operator)):
         raise NotImplementedError("Argument is not an Operator or a set!")
 
     if isinstance(operators, set):

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -622,9 +622,7 @@ class Lambdifier:
             # XXX debug: print funcname
             args_dict = {}
             for a in expr.args:
-                if (isinstance(a, Symbol) or
-                    isinstance(a, NumberSymbol) or
-                        a in [I, zoo, oo]):
+                if (isinstance(a, (Symbol, NumberSymbol)) or a in [I, zoo, oo]):
                     continue
                 else:
                     args_dict.update(cls.sympy_expression_namespace(a))

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -229,7 +229,7 @@ def test_quantifier_extensions():
             }
 
         def __new__(cls, *args):
-            limits = [sympify(a) for a in args if isinstance(a, tuple) or isinstance(a, Tuple)]
+            limits = [sympify(a) for a in args if isinstance(a, (tuple, Tuple))]
             function = [sympify(a) for a in args if isinstance(a, Boolean)]
             assert len(limits) + len(function) == len(args)
             assert len(function) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Merges isinstance calls and turns on SIM101 ruff check. This coding style is more readable and more performant.

#### Other comments
I will look into turning out flake8-SIM checks on in the future.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
