### PR TITLE
fix(core): make symbol thread-safe

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -179,16 +179,15 @@ will return values and update the dictionary.
 For a :class:`~.Symbol`, there are two locations for assumptions that may
 be of interest. The ``assumptions0`` attribute gives the full set of
 assumptions derived from a given set of initial assumptions. The
-latter assumptions are stored as ``Symbol._assumptions.generator``
+latter assumptions are stored as ``Symbol._assumptions_orig``
 
-    >>> Symbol('x', prime=True, even=True)._assumptions.generator
+    >>> Symbol('x', prime=True, even=True)._assumptions_orig
     {'even': True, 'prime': True}
 
-The ``generator`` is not necessarily canonical nor is it filtered
-in any way: it records the assumptions used to instantiate a Symbol
-and (for storage purposes) represents a more compact representation
-of the assumptions needed to recreate the full set in
-``Symbol.assumptions0``.
+The ``_assumptions_orig`` are not necessarily canonical nor are they filtered
+in any way: they records the assumptions used to instantiate a Symbol and (for
+storage purposes) represent a more compact representation of the assumptions
+needed to recreate the full set in ``Symbol.assumptions0``.
 
 
 References

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -224,7 +224,7 @@ class Symbol(AtomicExpr, Boolean):
 
     is_comparable = False
 
-    __slots__ = ('name',)
+    __slots__ = ('name', '_assumptions_orig', '_assumptions0')
 
     name: str
 
@@ -300,24 +300,45 @@ class Symbol(AtomicExpr, Boolean):
         if not isinstance(name, str):
             raise TypeError("name should be a string, not %s" % repr(type(name)))
 
+        # This is retained purely so that srepr can include commutative=True if
+        # that was explicitly specified but not if it was not. Ideally srepr
+        # should not distinguish these cases because the symbols otherwise
+        # compare equal and are considered equivalent.
+        #
+        # See https://github.com/sympy/sympy/issues/8873
+        #
+        assumptions_orig = assumptions.copy()
+
+        # The only assumption that is assumed by default is comutative=True:
+        assumptions.setdefault('commutative', True)
+
+        assumptions_kb = StdFactKB(assumptions)
+        assumptions0 = dict(assumptions_kb)
+
         obj = Expr.__new__(cls)
         obj.name = name
 
-        # TODO: Issue #8873: Forcing the commutative assumption here means
-        # later code such as ``srepr()`` cannot tell whether the user
-        # specified ``commutative=True`` or omitted it.  To workaround this,
-        # we keep a copy of the assumptions dict, then create the StdFactKB,
-        # and finally overwrite its ``._generator`` with the dict copy.  This
-        # is a bit of a hack because we assume StdFactKB merely copies the
-        # given dict as ``._generator``, but future modification might, e.g.,
-        # compute a minimal equivalent assumption set.
-        tmp_asm_copy = assumptions.copy()
+        obj._assumptions = assumptions_kb
+        obj._assumptions_orig = assumptions_orig
+        obj._assumptions0 = assumptions0
 
-        # be strict about commutativity
-        is_commutative = fuzzy_bool(assumptions.get('commutative', True))
-        assumptions['commutative'] = is_commutative
-        obj._assumptions = StdFactKB(assumptions)
-        obj._assumptions._generator = tmp_asm_copy  # Issue #8873
+        # The three assumptions dicts are all a little different:
+        #
+        #   >>> from sympy import Symbol
+        #   >>> x = Symbol('x', finite=True)
+        #   >>> x.is_positive  # query an assumption
+        #   >>> x._assumptions
+        #   {'finite': True, 'infinite': False, 'commutative': True, 'positive': None}
+        #   >>> x._assumptions0
+        #   {'finite': True, 'infinite': False, 'commutative': True}
+        #   >>> x._assumptions_orig
+        #   {'finite': True}
+        #
+        # Two symbols with the same name are equal if their _assumptions0 are
+        # the same. Arguably it should be _assumptions_orig that is being
+        # compared because that is more transparent to the user (it is
+        # what was passed to the constructor modulo changes made by _sanitize).
+
         return obj
 
     @staticmethod
@@ -326,7 +347,7 @@ class Symbol(AtomicExpr, Boolean):
         return Symbol.__xnew__(cls, name, **assumptions)
 
     def __getnewargs_ex__(self):
-        return ((self.name,), self.assumptions0)
+        return ((self.name,), self._assumptions_orig)
 
     # NOTE: __setstate__ is not needed for pickles created by __getnewargs_ex__
     # but was used before Symbol was changed to use __getnewargs_ex__ in v1.9.
@@ -351,8 +372,7 @@ class Symbol(AtomicExpr, Boolean):
 
     @property
     def assumptions0(self):
-        return {key: value for key, value
-                in self._assumptions.items() if value is not None}
+        return self._assumptions0.copy()
 
     @cacheit
     def sort_key(self, order=None):
@@ -442,7 +462,7 @@ class Dummy(Symbol):
         return obj
 
     def __getnewargs_ex__(self):
-        return ((self.name, self.dummy_index), self.assumptions0)
+        return ((self.name, self.dummy_index), self._assumptions_orig)
 
     @cacheit
     def sort_key(self, order=None):

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -7,7 +7,7 @@ from sympy.core.symbol import (Dummy, Symbol, Wild, symbols)
 from sympy.core.sympify import sympify  # can't import as S yet
 from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, skip
 from sympy.core.symbol import disambiguate
 
 
@@ -398,6 +398,13 @@ def test_disambiguate():
 
 
 def test_issue_gh_16734():
+    try:
+        import pyodide_js
+    except ImportError:
+        pass
+    else:
+        skip('Cannot create threads under pyodide')
+
     # https://github.com/sympy/sympy/issues/16734
 
     syms = list(symbols('x, y'))

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,3 +1,5 @@
+import threading
+
 from sympy.core.function import Function, UndefinedFunction
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import (GreaterThan, LessThan, StrictGreaterThan, StrictLessThan)
@@ -8,12 +10,14 @@ from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 from sympy.testing.pytest import raises
 from sympy.core.symbol import disambiguate
 
+
 def test_Str():
     a1 = Str('a')
     a2 = Str('a')
     b = Str('b')
     assert a1 == a2 != b
     raises(TypeError, lambda: Str())
+
 
 def test_Symbol():
     a = Symbol("a")
@@ -391,3 +395,26 @@ def test_disambiguate():
     assert disambiguate(*t7) == (y*y_1, y_1)
     assert disambiguate(Dummy('x_1'), Dummy('x_1')
         ) == (x_1, Symbol('x_1_1'))
+
+
+def test_issue_gh_16734():
+    # https://github.com/sympy/sympy/issues/16734
+
+    syms = list(symbols('x, y'))
+
+    def thread1():
+        for n in range(100):
+            syms[0], syms[1] = symbols(f'x{n}, y{n}')
+            syms[0].is_positive # Check an assumption in this thread.
+        syms[0] = None
+
+    def thread2():
+        while syms[0] is not None:
+            # Compare the symbol in this thread.
+            result = (syms[0] == syms[1])
+
+    # Previously this would be very likely to raise an exception:
+    thread = threading.Thread(target=thread1)
+    thread.start()
+    thread2()
+    thread.join()

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -399,7 +399,7 @@ def test_disambiguate():
 
 def test_issue_gh_16734():
     try:
-        import pyodide_js
+        import pyodide_js  # noqa
     except ImportError:
         pass
     else:

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -403,7 +403,7 @@ def test_issue_gh_16734():
     syms = list(symbols('x, y'))
 
     def thread1():
-        for n in range(100):
+        for n in range(1000):
             syms[0], syms[1] = symbols(f'x{n}, y{n}')
             syms[0].is_positive # Check an assumption in this thread.
         syms[0] = None
@@ -411,7 +411,7 @@ def test_issue_gh_16734():
     def thread2():
         while syms[0] is not None:
             # Compare the symbol in this thread.
-            result = (syms[0] == syms[1])
+            result = (syms[0] == syms[1])  # noqa
 
     # Previously this would be very likely to raise an exception:
     thread = threading.Thread(target=thread1)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -224,7 +224,7 @@ class ReprPrinter(Printer):
         return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
     def _print_Symbol(self, expr):
-        d = expr._assumptions.generator
+        d = expr._assumptions_orig
         # print the dummy_index like it was an assumption
         if expr.is_Dummy:
             d['dummy_index'] = expr.dummy_index

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -17,7 +17,7 @@ from sympy.tensor.array import Array
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
     PermuteDims, ArrayDiagonal
 from sympy.printing.numpy import JaxPrinter, _jax_known_constants, _jax_known_functions
-from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
+from sympy.tensor.array.expressions.from_matrix_to_array import convert_matrix_to_array
 
 from sympy.testing.pytest import skip, raises
 from sympy.external import import_module


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/16734

Make symbol use a separate dict for .assumptions0 to avoid iterating over ._assumptions while it might be modified in another thread.

#### Other comments

The change related to gh-8873 should be reverted I think.

Perhaps it would be better if symbol equality was determined by `_assumptions_orig` (with `commutative=True` included) rather than `.assumptions0`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * A rare bug from using Symbol in multithreaded code was fixed. Previously an exception might be raised when comparing two symbols while querying an assumption in a parallel thread.
   * Symbols with assumptions are now encoded more efficiently in pickles reducing the number of bytes needed for each symbol.
<!-- END RELEASE NOTES -->
