### PR TITLE
Refactoring of `primitive_root`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -211,7 +211,8 @@ def primitive_root(p, smallest=True):
     if p <= 4:
         return p - 1
     if not smallest:
-        if p%2:
+        p_even = p%2 == 0
+        if not p_even:
             q = p  # p is odd
         elif p%4:
             q = p//2  # p had 1 factor of 2
@@ -226,7 +227,7 @@ def primitive_root(p, smallest=True):
             q, e = m
             if not isprime(q):
                 return None
-        if t:
+        if p_even:
             return next(_primitive_root_prime_power2_iter(q, e))
         return next(_primitive_root_prime_power_iter(q, e))
     f = factorint(p)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -181,7 +181,7 @@ def _primitive_root_prime_power2_iter(p, e):
 
 def primitive_root(p, smallest=True):
     """
-    Returns the primitive root or None.
+    Returns a primitive root of p or None.
 
     Parameters
     ==========
@@ -211,10 +211,12 @@ def primitive_root(p, smallest=True):
     if p <= 4:
         return p - 1
     if not smallest:
-        t = trailing(p)
-        if t > 1:
-            return None
-        q = p >> t
+        if p%2:
+            q = p  # p is odd
+        elif p%4:
+            q = p//2  # p had 1 factor of 2
+        else:
+            return None  # p had more than one factor of 2
         if isprime(q):
             e = 1
         else:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -108,7 +108,7 @@ def _primitive_root_prime_iter(p):
             # 2 is the smallest primitive root of p = 5,11,13,19,29,37
             g = 2
     else:
-        v = [(p - 1) // i for i in sorted(factorint(p - 1))]
+        v = [(p - 1) // i for i in factorint(p - 1).keys()]
         for g in range(2, p):
             if all(pow(g, pw, p) != 1 for pw in v):
                 break

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -68,7 +68,7 @@ def n_order(a, n):
     return order
 
 
-def _primitive_root_prime_iter(p):
+def _primitive_root_prime_iter(p, ordered=True):
     """
     Generates the primitive roots for a prime ``p``
 
@@ -76,6 +76,7 @@ def _primitive_root_prime_iter(p):
     ==========
 
     p : odd prime
+    ordered : if True, return in order
 
     Examples
     ========
@@ -91,10 +92,36 @@ def _primitive_root_prime_iter(p):
 
     """
     # it is assumed that p is an int
-    v = [(p - 1) // i for i in factorint(p - 1).keys()]
-    for g in range(2, p):
-        if all(pow(g, pw, p) != 1 for pw in v):
-            yield g
+    if p == 3:
+        yield 2
+        return
+    qs = sorted(factorint(p - 1).keys())
+    if p < 41:
+        # small case
+        if p == 23:
+            g = 5
+        elif p == 7 or p % 7 == 3:
+            # 3 is the smallest primitive root of p = 7,17,31
+            g = 3
+        else:
+            # 2 is the smallest primitive root of p = 5,11,13,19,29,37
+            g = 2
+    else:
+        v = [(p - 1) // i for i in qs]
+        for g in range(2, p):
+            if all(pow(g, pw, p) != 1 for pw in v):
+                break
+    yield g
+    # g**k is the primitive root of p iff gcd(p - 1, k) = 1
+    sieve = [True] * ((p - 3) // 2)
+    for q in qs[1:]:
+        for k in range((q - 3) // 2, len(sieve), q):
+            sieve[k] = False
+    gs = (pow(g, 2 * i + 3, p) for i, v in enumerate(sieve) if v)
+    if ordered:
+        yield from sorted(gs)
+    else:
+        yield from gs
 
 
 def _primitive_root_prime_power_iter(p, e, ordered=True):

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -68,7 +68,7 @@ def n_order(a, n):
     return order
 
 
-def _primitive_root_prime_iter(p, ordered=True):
+def _primitive_root_prime_iter(p):
     """
     Generates the primitive roots for a prime ``p``
 
@@ -76,7 +76,6 @@ def _primitive_root_prime_iter(p, ordered=True):
     ==========
 
     p : odd prime
-    ordered : if True, return in order
 
     Examples
     ========
@@ -107,7 +106,7 @@ def _primitive_root_prime_iter(p, ordered=True):
             # 2 is the smallest primitive root of p = 5,11,13,19,29,37
             g = 2
     else:
-        v = [(p - 1) // i for i in qs]
+        v = [(p - 1) // q for q in qs]
         for g in range(2, p):
             if all(pow(g, pw, p) != 1 for pw in v):
                 break
@@ -117,14 +116,10 @@ def _primitive_root_prime_iter(p, ordered=True):
     for q in qs[1:]:
         for k in range((q - 3) // 2, len(sieve), q):
             sieve[k] = False
-    gs = (pow(g, 2 * i + 3, p) for i, v in enumerate(sieve) if v)
-    if ordered:
-        yield from sorted(gs)
-    else:
-        yield from gs
+    yield from sorted(pow(g, 2 * i + 3, p) for i, v in enumerate(sieve) if v)
 
 
-def _primitive_root_prime_power_iter(p, e, ordered=True):
+def _primitive_root_prime_power_iter(p, e):
     """
     Generates the primitive roots of ``p**e``
 
@@ -136,28 +131,20 @@ def _primitive_root_prime_power_iter(p, e, ordered=True):
 
     p : odd prime
     e : positive integer
-    ordered : if True, return in order
 
     """
     p2 = p**2
     if e == 1:
         yield from _primitive_root_prime_iter(p)
-    elif ordered:
+    else:
         for m in range(0, p**e, p2):
             for k in range(0, p2, p):
                 for g in _primitive_root_prime_iter(p):
                     if (g - mod_inverse(pow(g, p - 2, p2), p2)) % p2 != k:
                         yield g + k + m
-    else:
-        for g in _primitive_root_prime_iter(p):
-            t = (g - mod_inverse(pow(g, p - 2, p2), p2)) % p2
-            for k in range(0, p2, p):
-                if k != t:
-                    for m in range(0, p**e, p2):
-                        yield g + k + m
 
 
-def _primitive_root_prime_power2_iter(p, e, ordered=True):
+def _primitive_root_prime_power2_iter(p, e):
     """
     Generates the primitive roots of ``2*p**e``
 
@@ -169,18 +156,14 @@ def _primitive_root_prime_power2_iter(p, e, ordered=True):
 
     p : odd prime
     e : positive integer
-    ordered : if True, return in order
 
     """
     store = []
-    for g in _primitive_root_prime_power_iter(p, e, ordered=ordered):
+    for g in _primitive_root_prime_power_iter(p, e):
         if g % 2 == 1:
             yield g
         else:
-            if ordered:
-                store.append(g + p**e)
-            else:
-                yield g + p**e
+            store.append(g + p**e)
     yield from store
 
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -97,7 +97,6 @@ def _primitive_root_prime_iter(p):
     if p == 3:
         yield 2
         return
-    qs = sorted(factorint(p - 1).keys())
     if p < 41:
         # small case
         if p == 23:
@@ -109,7 +108,7 @@ def _primitive_root_prime_iter(p):
             # 2 is the smallest primitive root of p = 5,11,13,19,29,37
             g = 2
     else:
-        v = [(p - 1) // i for i in qs]
+        v = [(p - 1) // i for i in sorted(factorint(p - 1))]
         for g in range(2, p):
             if all(pow(g, pw, p) != 1 for pw in v):
                 break

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -33,8 +33,10 @@ def test_residue():
     raises(ValueError, lambda: is_primitive_root(3, 6))
 
     for p in primerange(3, 100):
-        it = _primitive_root_prime_iter(p)
-        assert len(list(it)) == totient(totient(p))
+        li = list(_primitive_root_prime_iter(p))
+        li2 = list(_primitive_root_prime_iter(p, False))
+        assert len(li) == totient(totient(p))
+        assert li == sorted(li2)
     for p in primerange(3, 50):
         for k in range(2, 4):
             li = list(_primitive_root_prime_power_iter(p, k))

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -33,17 +33,12 @@ def test_residue():
     raises(ValueError, lambda: is_primitive_root(3, 6))
 
     for p in primerange(3, 100):
-        li = list(_primitive_root_prime_iter(p))
-        li2 = list(_primitive_root_prime_iter(p, False))
-        assert len(li) == totient(totient(p))
-        assert li == sorted(li2)
+        it = _primitive_root_prime_iter(p)
+        assert len(list(it)) == totient(totient(p))
     for p in primerange(3, 50):
         for k in range(2, 4):
             li = list(_primitive_root_prime_power_iter(p, k))
-            li2 = list(_primitive_root_prime_power_iter(p, k, False))
-            li3 = list(_primitive_root_prime_power2_iter(p, k))
-            li4 = list(_primitive_root_prime_power2_iter(p, k, False))
-            assert li == sorted(li2) and li3 == sorted(li4)
+            li2 = list(_primitive_root_prime_power2_iter(p, k))
             assert len(li) == len(li2) == totient(totient(p**k))
     assert primitive_root(97) == 5
     assert primitive_root(97**2) == 5

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -9,6 +9,7 @@ from sympy.ntheory import n_order, is_primitive_root, is_quad_residue, \
     sqrt_mod_iter, mobius, discrete_log, quadratic_congruence, \
     polynomial_congruence
 from sympy.ntheory.residue_ntheory import _primitive_root_prime_iter, \
+    _primitive_root_prime_power_iter, _primitive_root_prime_power2_iter, \
     _discrete_log_trial_mul, _discrete_log_shanks_steps, \
     _discrete_log_pollard_rho, _discrete_log_pohlig_hellman
 from sympy.polys.domains import ZZ
@@ -34,6 +35,14 @@ def test_residue():
     for p in primerange(3, 100):
         it = _primitive_root_prime_iter(p)
         assert len(list(it)) == totient(totient(p))
+    for p in primerange(3, 50):
+        for k in range(2, 4):
+            li = list(_primitive_root_prime_power_iter(p, k))
+            li2 = list(_primitive_root_prime_power_iter(p, k, False))
+            li3 = list(_primitive_root_prime_power2_iter(p, k))
+            li4 = list(_primitive_root_prime_power2_iter(p, k, False))
+            assert li == sorted(li2) and li3 == sorted(li4)
+            assert len(li) == len(li2) == totient(totient(p**k))
     assert primitive_root(97) == 5
     assert primitive_root(97**2) == 5
     assert primitive_root(40487) == 5

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -33,24 +33,36 @@ def test_residue():
     raises(ValueError, lambda: is_primitive_root(3, 6))
 
     for p in primerange(3, 100):
-        it = _primitive_root_prime_iter(p)
-        assert len(list(it)) == totient(totient(p))
-    for p in primerange(3, 50):
-        for k in range(2, 4):
-            li = list(_primitive_root_prime_power_iter(p, k))
-            li2 = list(_primitive_root_prime_power2_iter(p, k))
-            assert len(li) == len(li2) == totient(totient(p**k))
+        li = list(_primitive_root_prime_iter(p))
+        assert li[0] == min(li)
+        for g in li:
+            assert n_order(g, p) == p - 1
+        assert len(li) == totient(totient(p))
+        for e in range(1, 4):
+            li_power = list(_primitive_root_prime_power_iter(p, e))
+            li_power2 = list(_primitive_root_prime_power2_iter(p, e))
+            assert len(li_power) == len(li_power2) == totient(totient(p**e))
     assert primitive_root(97) == 5
+    assert n_order(primitive_root(97, False), 97) == totient(97)
     assert primitive_root(97**2) == 5
+    assert n_order(primitive_root(97**2, False), 97**2) == totient(97**2)
     assert primitive_root(40487) == 5
+    assert n_order(primitive_root(40487, False), 40487) == totient(40487)
     # note that primitive_root(40487) + 40487 = 40492 is a primitive root
     # of 40487**2, but it is not the smallest
     assert primitive_root(40487**2) == 10
+    assert n_order(primitive_root(40487**2, False), 40487**2) == totient(40487**2)
     assert primitive_root(82) == 7
+    assert n_order(primitive_root(82, False), 82) == totient(82)
     p = 10**50 + 151
     assert primitive_root(p) == 11
+    assert n_order(primitive_root(p, False), p) == totient(p)
     assert primitive_root(2*p) == 11
+    assert n_order(primitive_root(2*p, False), 2*p) == totient(2*p)
     assert primitive_root(p**2) == 11
+    assert n_order(primitive_root(p**2, False), p**2) == totient(p**2)
+    assert primitive_root(4 * 11) is None and primitive_root(4 * 11, False) is None
+    assert primitive_root(15) is None and primitive_root(15, False) is None
     raises(ValueError, lambda: primitive_root(-3))
 
     assert is_quad_residue(3, 7) is False


### PR DESCRIPTION
p into two patterns and made them independent as a function.

* `_primitive_root_prime_iter`
Generates the primitive roots of `p`. Once one primitive root `g` is found, the other primitive roots are represented by powers of `g`. In this case, the exponent and `p-1` are relatively prime. Therefore, there is no need to perform power calculations to determine the primitive roots every time.

* `_primitive_root_prime_power_iter`
Generates the primitive roots of `p**e`. Let `g` (`0 < g < p`) be the primitive root of `p`. If `pow(g+s*p,p-1,p**2)!=1`, then `g+s*p` is primitive root of `p**e`. There is always one integer `s` (`0 <= s < p`) per `g` that does not satisfy this condition, and the other `p-1` are primitive roots. Thus, we find `totient(p)*(p-1)` primitive roots of `p**2`, which is consistent with `totient(totient(p**2))`. The primitive roots of `p**3` are all numbers congruent to the primitive roots of `p**2` by `p`. The same is true for `p**e` (`e > 3`), which is consistent with the `totient(totient(p**e))`. From the above, we see that `g+(k+m*p)*p` is all of the primitive roots of `p**e`. Where `g` is primitive root of `p` (`0<g<p`), `0 <= k < p`, `0 <= m < p**(e-2)`, `g**(p-1)+(p-1)*g**(p-2)*k*p % p**2 != 1`.

* `_primitive_root_prime_power2_iter`
Generates the primitive roots of `2*p**e`. If `g` is the primitive root of `p**e`, then the odd one of `g` and `g+p**e` is the primitive root of `2*p**e`. Since `totient(totient(2*p**e))=totient(totient(p**e))`, this is all the primitive roots of `2*p**e`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added `smallest` option to `primitive_root`
<!-- END RELEASE NOTES -->
