### PR TITLE
perf(core): reduce assumption checking in Mul(x,y)

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -282,7 +282,7 @@ class Mul(Expr, AssocOp):
                 a, b = b, a
                 seq = [a, b]
             assert a is not S.One
-            if not a.is_zero and a.is_Rational:
+            if a.is_Rational and not a.is_zero:
                 r, b = b.as_coeff_Mul()
                 if b.is_Add:
                     if r is not S.One:  # 2-arg hack


### PR DESCRIPTION
A common case for Mul is a 2-arg Mul as this arises from any code using e.g. a*b. The Mul.flatten function tries to special case this to distribute a rational into an Add if either arg is a rational. This was tested for in a suboptimal order as

    if not a.is_zero and a.is_Rational:

With large expressions a.is_zero can be expensive as it invokes the core assumption system which causes many different assumption handles to run. By constrast a.is_Rational is always a plain attribute look up giving True or False so checking it first in order to shortcut checking for a.is_zero obviously makes sense. Better than that though in the case that a.is_Rational is True then a.is_zero is trivial so reversing the order here eliminates all nontrivial is_zero assumption queries from this line. Since every call to a*b goes through this line of code this can give a significant speed boost for some macro benchmarks.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

I came across this while profiling the det_div_free function from https://github.com/sympy/sympy/issues/24780#issuecomment-1462349131. Here are timings with master using that function:
```python
In [1]: edit det_div_free.py
Editing... done. Executing edited code...

In [2]: for _ in range(10):
   ...:     M = randMatrix(5)*x + randMatrix(5)*y
   ...:     %time ok = det_div_free(M)
   ...:     del ok
   ...: 
CPU times: user 252 ms, sys: 1.01 ms, total: 253 ms
Wall time: 253 ms
CPU times: user 237 ms, sys: 587 µs, total: 238 ms
Wall time: 238 ms
CPU times: user 237 ms, sys: 546 µs, total: 237 ms
Wall time: 238 ms
CPU times: user 226 ms, sys: 402 µs, total: 226 ms
Wall time: 226 ms
CPU times: user 231 ms, sys: 559 µs, total: 231 ms
Wall time: 232 ms
CPU times: user 288 ms, sys: 1.11 ms, total: 289 ms
Wall time: 290 ms
CPU times: user 313 ms, sys: 1.55 ms, total: 315 ms
Wall time: 317 ms
CPU times: user 242 ms, sys: 353 µs, total: 242 ms
Wall time: 243 ms
CPU times: user 234 ms, sys: 464 µs, total: 234 ms
Wall time: 235 ms
CPU times: user 237 ms, sys: 373 µs, total: 237 ms
Wall time: 238 ms
```
Here are timings with the PR:
```python
In [2]: for _ in range(10):
   ...:     M = randMatrix(5)*x + randMatrix(5)*y
   ...:     %time ok = det_div_free(M)
   ...:     del ok
   ...: 
CPU times: user 97.6 ms, sys: 512 µs, total: 98.2 ms
Wall time: 98.2 ms
CPU times: user 94.3 ms, sys: 434 µs, total: 94.7 ms
Wall time: 94.9 ms
CPU times: user 89.2 ms, sys: 210 µs, total: 89.4 ms
Wall time: 89.5 ms
CPU times: user 86.2 ms, sys: 207 µs, total: 86.4 ms
Wall time: 86.5 ms
CPU times: user 99.1 ms, sys: 736 µs, total: 99.8 ms
Wall time: 101 ms
CPU times: user 87.1 ms, sys: 857 µs, total: 88 ms
Wall time: 88.7 ms
CPU times: user 88.7 ms, sys: 1.07 ms, total: 89.7 ms
Wall time: 90.5 ms
CPU times: user 94.9 ms, sys: 1.35 ms, total: 96.2 ms
Wall time: 97.6 ms
CPU times: user 97.6 ms, sys: 1.66 ms, total: 99.3 ms
Wall time: 101 ms
CPU times: user 95.3 ms, sys: 1.37 ms, total: 96.6 ms
Wall time: 98 ms
```
For that benchmark this PR gives a 2.5x speed up. The operation that is being timed here is basically multiplication of matrices with large expressions. In the matrix product `C = A*B` the expression for `C[i, j]` is computed as
```python
C[i, j] = Add(*(Mul(A[i, k], B[k, j]) for k in range(n)))
```
So clearly the lowest level operation is multiplication and it is always a 2-arg multiply. There are various places in Mul.flatten that can trigger an assumptions query but most are for unusual cases but the line changed here applies to every 2-arg Mul.

1. This is the one that this PR changes and every 2-arg Mul goes here:
    https://github.com/sympy/sympy/blob/ee255925dca1ac582644b8c88ebfcf89ef9bcf1f/sympy/core/mul.py#L285
2. This `is_zero` check is gated on `is_Number` which ensures that it is always fast because `Number` (Rational, Float, +-oo) always has a static `is_zero` attribute. There are many others gated on `is_Number` as well or equivalents like `is_Rational` etc.
    https://github.com/sympy/sympy/blob/ee255925dca1ac582644b8c88ebfcf89ef9bcf1f/sympy/core/mul.py#L360-L361
3. This one only applies to the coefficient which is always Number or nan or zoo or something so is quick:
    https://github.com/sympy/sympy/blob/ee255925dca1ac582644b8c88ebfcf89ef9bcf1f/sympy/core/mul.py#L684

It is important when wanting to reduce assumptions queries to try as much as possible not to query a single property on any given object. Just one query like `is_positive` will trigger almost every handler that the object has as well as many recursive assumptions queries to the args of the expression. For example `if x.is_positive` would result in calling something like `x._eval_is_prime()` because if `is_prime` is True then so is `is_positive` in turn `Mul._eval_is_prime` will make many assumptions queries to the args of the Mul and so on. After that query most possible assumption queries will have been computed and cached so subsequent queries are not so problematic but the difference between making zero queries or making at least one query is significant.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Multiplication of large expressions was made faster by reducing unnecessary assumptions queries.
<!-- END RELEASE NOTES -->
