### PR TITLE
Implement Inertia object

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,7 +76,29 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
-There are no deprecations yet for SymPy 1.13.
+(moved-mechanics-functions)=
+### Moved mechanics functions
+With the introduction of some new objects like the ``Inertia`` and load objects
+in the ``sympy.physics.mechanics`` module, some functions from
+``sympy.physics.mechanics.functions`` have been moved to new modules. This
+removes some circular import errors and makes it easier to navigate through the
+source code, due to the parity between function names and module names. The
+following functions were moved:
+- ``inertia`` has been moved to ``sympy.physics.mechanics.inertia``
+- ``inertia_of_point_mass`` has been moved to ``sympy.physics.mechanics.inertia``
+
+Previously you could import the functions from
+``sympy.physics.mechanics.functions``:
+
+```py
+>>> from sympy.physics.mechanics.functions import inertia, inertia_of_point_mass, gravity
+```
+
+Now they should be imported from ``sympy.physics.mechanics``:
+
+```py
+>>> from sympy.physics.mechanics import inertia, inertia_of_point_mass
+```
 
 ## Version 1.12
 

--- a/doc/src/modules/physics/mechanics/api/part_bod.rst
+++ b/doc/src/modules/physics/mechanics/api/part_bod.rst
@@ -1,8 +1,11 @@
 .. _part_bod:
 
-=====================================================
-Masses, Inertias & Particles, RigidBodys (Docstrings)
-=====================================================
+======================================================
+Bodies, Inertias & Other Functions (Docstrings)
+======================================================
+
+Bodies
+======
 
 .. autoclass:: sympy.physics.mechanics.particle.Particle
    :members:
@@ -12,9 +15,18 @@ Masses, Inertias & Particles, RigidBodys (Docstrings)
    :members:
    :inherited-members:
 
-.. autofunction:: sympy.physics.mechanics.functions.inertia
+Inertias
+========
 
-.. autofunction:: sympy.physics.mechanics.functions.inertia_of_point_mass
+.. autoclass:: sympy.physics.mechanics.inertia.Inertia
+   :members:
+
+.. autofunction:: sympy.physics.mechanics.inertia.inertia
+
+.. autofunction:: sympy.physics.mechanics.inertia.inertia_of_point_mass
+
+Other Functions
+===============
 
 .. autofunction:: sympy.physics.mechanics.functions.linear_momentum
 

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -40,15 +40,88 @@ analysis of points separate from their association with masses.
 Inertia
 =======
 
-See the Inertia (Dyadics) section in 'Advanced Topics' part of
-:mod:`sympy.physics.vector` docs.
+Inertia consists out of two parts: a quantity and a reference. The quantity is
+expressed as a :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` and the
+reference is a :class:`Point<sympy.physics.vector.point.Point>`. The
+:class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` can be defined as the outer
+product between two vectors, which returns the juxtaposition of these vectors.
+See the 'Dyadic' section under the advanced documentation in the
+:mod:`sympy.physics.vector` module. Another more intuitive method to define the
+:class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` is to use the
+:func:`~.inertia` function as described below in the section
+'Inertia (Dyadics)'. The :class:`Point<sympy.physics.vector.point.Point>` about
+which the :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` is specified can
+be any point, as long as it is defined with respect to the center of mass. The
+most common reference point is of course the center of mass itself.
+
+The inertia of a body can be specified using either an :class:`~.Inertia` object
+or a ``tuple``. If a ``tuple`` is used, then it should have a length of two,
+with the first entry being a :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>`
+and the second entry being a :class:`Point<sympy.physics.vector.point.Point>`
+about which the inertia dyadic is defined. Internally this ``tuple`` gets
+converted to an :class:`~.Inertia` object. An example of using a ``tuple`` about
+the center of mass is given below in the 'Rigid Body' section. The
+:class:`~.Inertia` object can be created as follows.::
+
+   >>> from sympy.physics.mechanics import ReferenceFrame, Point, outer, Inertia
+   >>> A = ReferenceFrame('A')
+   >>> P = Point('P')
+   >>> Inertia(P, outer(A.x, A.x))
+   ((A.x|A.x), P)
+
+
+Inertia (Dyadics)
+=================
+
+A dyadic tensor is a second order tensor formed by the juxtaposition of a pair
+of vectors. There are various operations defined with respect to dyadics,
+which have been implemented in :obj:`~.sympy.physics.vector` in the form of
+class :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>`. To know more, refer
+to the :obj:`sympy.physics.vector.dyadic.Dyadic` and
+:obj:`sympy.physics.vector.vector.Vector` class APIs. Dyadics are used to
+define the inertia of bodies within :mod:`sympy.physics.mechanics`. Inertia
+dyadics can be defined explicitly using the outer product, but the
+:func:`~.inertia` function is typically much more convenient for the user.::
+
+  >>> from sympy.physics.mechanics import ReferenceFrame, inertia
+  >>> N = ReferenceFrame('N')
+
+  Supply a reference frame and the moments of inertia if the object
+  is symmetrical:
+
+  >>> inertia(N, 1, 2, 3)
+  (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
+
+  Supply a reference frame along with the products and moments of inertia
+  for a general object:
+
+  >>> inertia(N, 1, 2, 3, 4, 5, 6)
+  (N.x|N.x) + 4*(N.x|N.y) + 6*(N.x|N.z) + 4*(N.y|N.x) + 2*(N.y|N.y) + 5*(N.y|N.z) + 6*(N.z|N.x) + 5*(N.z|N.y) + 3*(N.z|N.z)
+
+Notice that the :func:`~.inertia` function returns a dyadic with each component
+represented as two unit vectors separated by a ``|`` (outer product). Refer to
+the :obj:`sympy.physics.vector.dyadic.Dyadic` section for more information about
+dyadics.
+
+Inertia is often expressed in a matrix, or tensor, form, especially for
+numerical purposes. Since the matrix form does not contain any information
+about the reference frame(s) the inertia dyadic is defined in, you must provide
+one or two reference frames to extract the measure numbers from the dyadic.
+There is a convenience function to do this::
+
+  >>> inertia(N, 1, 2, 3, 4, 5, 6).to_matrix(N)
+  Matrix([
+  [1, 4, 6],
+  [4, 2, 5],
+  [6, 5, 3]])
 
 Rigid Body
 ==========
 
 Rigid bodies are created in a similar fashion as particles. The
 :class:`~.RigidBody` class generates objects with four attributes: mass, center
-of mass, a reference frame, and an inertia tuple::
+of mass, a reference frame, and an :class:`~.Inertia` (a ``tuple`` can be parsed
+as well).::
 
   >>> from sympy import Symbol
   >>> from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
@@ -64,102 +137,6 @@ The mass is specified exactly as is in a particle. Similar to the
 :class:`~.Particle`'s ``.point``, the :class:`~.RigidBody`'s center of mass,
 ``.masscenter`` must be specified. The reference frame is stored in an analogous
 fashion and holds information about the body's orientation and angular velocity.
-Finally, the inertia for a rigid body needs to be specified about a point. In
-:mod:`sympy.physics.mechanics`, you are allowed to specify any point for this. The most
-common is the center of mass, as shown in the above code. If a point is selected
-which is not the center of mass, ensure that the position between the point and
-the center of mass has been defined. The inertia is specified as a tuple of length
-two with the first entry being a ``Dyadic`` and the second entry being a
-``Point`` of which the inertia dyadic is defined about.
-
-.. _Dyadic:
-
-Dyadic
-======
-
-In :mod:`sympy.physics.mechanics`, dyadics are used to represent inertia ([Kane1985]_,
-[WikiDyadics]_, [WikiDyadicProducts]_). A dyadic is a linear polynomial of
-component unit dyadics, similar to a vector being a linear polynomial of
-component unit vectors. A dyadic is the outer product between two vectors which
-returns a new quantity representing the juxtaposition of these two vectors. For
-example:
-
-.. math::
-  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{a}_x} &= \mathbf{\hat{a}_x}
-  \mathbf{\hat{a}_x}\\
-  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{a}_y} &= \mathbf{\hat{a}_x}
-  \mathbf{\hat{a}_y}\\
-
-Where :math:`\mathbf{\hat{a}_x}\mathbf{\hat{a}_x}` and
-`\mathbf{\hat{a}_x}\mathbf{\hat{a}_y}` are the outer products obtained by
-multiplying the left side as a column vector by the right side as a row vector.
-Note that the order is significant.
-
-Some additional properties of a dyadic are:
-
-.. math::
-  (x \mathbf{v}) \otimes \mathbf{w} &= \mathbf{v} \otimes (x \mathbf{w}) = x
-  (\mathbf{v} \otimes \mathbf{w})\\
-  \mathbf{v} \otimes (\mathbf{w} + \mathbf{u}) &= \mathbf{v} \otimes \mathbf{w}
-  + \mathbf{v} \otimes \mathbf{u}\\
-  (\mathbf{v} + \mathbf{w}) \otimes \mathbf{u} &= \mathbf{v} \otimes \mathbf{u}
-  + \mathbf{w} \otimes \mathbf{u}\\
-
-A vector in a reference frame can be represented as
-:math:`\begin{bmatrix}a\\b\\c\end{bmatrix}` or :math:`a \mathbf{\hat{i}} + b
-\mathbf{\hat{j}} + c \mathbf{\hat{k}}`. Similarly, a dyadic can be represented
-in tensor form:
-
-.. math::
-  \begin{bmatrix}
-  a_{11} & a_{12} & a_{13} \\
-  a_{21} & a_{22} & a_{23} \\
-  a_{31} & a_{32} & a_{33}
-  \end{bmatrix}\\
-
-or in dyadic form:
-
-.. math::
-  a_{11} \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} +
-  a_{12} \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} +
-  a_{13} \mathbf{\hat{a}_x}\mathbf{\hat{a}_z} +
-  a_{21} \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} +
-  a_{22} \mathbf{\hat{a}_y}\mathbf{\hat{a}_y} +
-  a_{23} \mathbf{\hat{a}_y}\mathbf{\hat{a}_z} +
-  a_{31} \mathbf{\hat{a}_z}\mathbf{\hat{a}_x} +
-  a_{32} \mathbf{\hat{a}_z}\mathbf{\hat{a}_y} +
-  a_{33} \mathbf{\hat{a}_z}\mathbf{\hat{a}_z}\\
-
-Just as with vectors, the later representation makes it possible to keep track
-of which frames the dyadic is defined with respect to. Also, the two
-components of each term in the dyadic need not be in the same frame. The
-following is valid:
-
-.. math::
-  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{b}_y} = \mathbf{\hat{a}_x}
-  \mathbf{\hat{b}_y}
-
-Dyadics can also be crossed and dotted with vectors; again, order matters:
-
-.. math::
-  \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x} &=
-  \mathbf{\hat{a}_x}\\
-  \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x} &=
-  \mathbf{\hat{a}_y}\\
-  \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} \cdot \mathbf{\hat{a}_x} &= 0\\
-  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} &=
-  \mathbf{\hat{a}_x}\\
-  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} &=
-  \mathbf{\hat{a}_y}\\
-  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} &= 0\\
-  \mathbf{\hat{a}_x} \times \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} &=
-  \mathbf{\hat{a}_z}\mathbf{\hat{a}_x}\\
-  \mathbf{\hat{a}_x} \times \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} &= 0\\
-  \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} \times \mathbf{\hat{a}_z} &=
-  - \mathbf{\hat{a}_y}\mathbf{\hat{a}_y}\\
-
-One can also take the time derivative of dyadics or express them in different
-frames, just like with vectors.
 
 Linear Momentum
 ===============

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -45,8 +45,9 @@ expressed as a :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` and the
 reference is a :class:`Point<sympy.physics.vector.point.Point>`. The
 :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` can be defined as the outer
 product between two vectors, which returns the juxtaposition of these vectors.
-See the 'Dyadic' section under the advanced documentation in the
-:mod:`sympy.physics.vector` module. Another more intuitive method to define the
+For further information, please refer to the :ref:`Dyadic` section in the
+advanced documentation of the :mod:`sympy.physics.vector` module. Another more
+intuitive method to define the
 :class:`Dyadic<sympy.physics.vector.dyadic.Dyadic>` is to use the
 :func:`~.inertia` function as described below in the section
 'Inertia (Dyadics)'. The :class:`Point<sympy.physics.vector.point.Point>` about
@@ -120,7 +121,7 @@ Rigid Body
 
 Rigid bodies are created in a similar fashion as particles. The
 :class:`~.RigidBody` class generates objects with four attributes: mass, center
-of mass, a reference frame, and an :class:`~.Inertia` (a ``tuple`` can be parsed
+of mass, a reference frame, and an :class:`~.Inertia` (a ``tuple`` can be passed
 as well).::
 
   >>> from sympy import Symbol

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -8,49 +8,94 @@ the features that will be implemented in the future will also be covered, along
 with unanswered questions about proper functionality. Also, common problems
 will be discussed, along with some solutions.
 
-Inertia (Dyadics)
-=================
+.. _Dyadic:
 
-A dyadic tensor is a second order tensor formed by the juxtaposition of a pair
-of vectors. There are various operations defined with respect to dyadics,
-which have been implemented in :obj:`~.sympy.physics.vector` in the form of
-class :obj:`sympy.physics.vector.dyadic.Dyadic`. To know more, refer to the
-:obj:`sympy.physics.vector.dyadic.Dyadic` and
-:obj:`sympy.physics.vector.vector.Vector` class APIs. Dyadics are used to
-define the inertia of bodies within :mod:`sympy.physics.mechanics`. Inertia
-dyadics can be defined explicitly but the ``inertia`` function is typically
-much more convenient for the user::
+Dyadic
+======
 
-  >>> from sympy.physics.mechanics import ReferenceFrame, inertia
-  >>> N = ReferenceFrame('N')
+In :mod:`sympy.physics.mechanics`, dyadics are used to represent inertia ([Kane1985]_,
+[WikiDyadics]_, [WikiDyadicProducts]_). A dyadic is a linear polynomial of
+component unit dyadics, similar to a vector being a linear polynomial of
+component unit vectors. A dyadic is the outer product between two vectors which
+returns a new quantity representing the juxtaposition of these two vectors. For
+example:
 
-  Supply a reference frame and the moments of inertia if the object
-  is symmetrical:
+.. math::
+  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{a}_x} &= \mathbf{\hat{a}_x}
+  \mathbf{\hat{a}_x}\\
+  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{a}_y} &= \mathbf{\hat{a}_x}
+  \mathbf{\hat{a}_y}\\
 
-  >>> inertia(N, 1, 2, 3)
-  (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
+Where :math:`\mathbf{\hat{a}_x}\mathbf{\hat{a}_x}` and
+`\mathbf{\hat{a}_x}\mathbf{\hat{a}_y}` are the outer products obtained by
+multiplying the left side as a column vector by the right side as a row vector.
+Note that the order is significant.
 
-  Supply a reference frame along with the products and moments of inertia
-  for a general object:
+Some additional properties of a dyadic are:
 
-  >>> inertia(N, 1, 2, 3, 4, 5, 6)
-  (N.x|N.x) + 4*(N.x|N.y) + 6*(N.x|N.z) + 4*(N.y|N.x) + 2*(N.y|N.y) + 5*(N.y|N.z) + 6*(N.z|N.x) + 5*(N.z|N.y) + 3*(N.z|N.z)
+.. math::
+  (x \mathbf{v}) \otimes \mathbf{w} &= \mathbf{v} \otimes (x \mathbf{w}) = x
+  (\mathbf{v} \otimes \mathbf{w})\\
+  \mathbf{v} \otimes (\mathbf{w} + \mathbf{u}) &= \mathbf{v} \otimes \mathbf{w}
+  + \mathbf{v} \otimes \mathbf{u}\\
+  (\mathbf{v} + \mathbf{w}) \otimes \mathbf{u} &= \mathbf{v} \otimes \mathbf{u}
+  + \mathbf{w} \otimes \mathbf{u}\\
 
-Notice that the ``inertia`` function returns a dyadic with each component
-represented as two unit vectors separated by a ``|``. Refer to the
-:obj:`sympy.physics.vector.dyadic.Dyadic` section for more information about dyadics.
+A vector in a reference frame can be represented as
+:math:`\begin{bmatrix}a\\b\\c\end{bmatrix}` or :math:`a \mathbf{\hat{i}} + b
+\mathbf{\hat{j}} + c \mathbf{\hat{k}}`. Similarly, a dyadic can be represented
+in tensor form:
 
-Inertia is often expressed in a matrix, or tensor, form, especially for
-numerical purposes. Since the matrix form does not contain any information
-about the reference frame(s) the inertia dyadic is defined in, you must provide
-one or two reference frames to extract the measure numbers from the dyadic.
-There is a convenience function to do this::
+.. math::
+  \begin{bmatrix}
+  a_{11} & a_{12} & a_{13} \\
+  a_{21} & a_{22} & a_{23} \\
+  a_{31} & a_{32} & a_{33}
+  \end{bmatrix}\\
 
-  >>> inertia(N, 1, 2, 3, 4, 5, 6).to_matrix(N)
-  Matrix([
-  [1, 4, 6],
-  [4, 2, 5],
-  [6, 5, 3]])
+or in dyadic form:
+
+.. math::
+  a_{11} \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} +
+  a_{12} \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} +
+  a_{13} \mathbf{\hat{a}_x}\mathbf{\hat{a}_z} +
+  a_{21} \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} +
+  a_{22} \mathbf{\hat{a}_y}\mathbf{\hat{a}_y} +
+  a_{23} \mathbf{\hat{a}_y}\mathbf{\hat{a}_z} +
+  a_{31} \mathbf{\hat{a}_z}\mathbf{\hat{a}_x} +
+  a_{32} \mathbf{\hat{a}_z}\mathbf{\hat{a}_y} +
+  a_{33} \mathbf{\hat{a}_z}\mathbf{\hat{a}_z}\\
+
+Just as with vectors, the later representation makes it possible to keep track
+of which frames the dyadic is defined with respect to. Also, the two
+components of each term in the dyadic need not be in the same frame. The
+following is valid:
+
+.. math::
+  \mathbf{\hat{a}_x} \otimes \mathbf{\hat{b}_y} = \mathbf{\hat{a}_x}
+  \mathbf{\hat{b}_y}
+
+Dyadics can also be crossed and dotted with vectors; again, order matters:
+
+.. math::
+  \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x} &=
+  \mathbf{\hat{a}_x}\\
+  \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x} &=
+  \mathbf{\hat{a}_y}\\
+  \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} \cdot \mathbf{\hat{a}_x} &= 0\\
+  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} &=
+  \mathbf{\hat{a}_x}\\
+  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_x}\mathbf{\hat{a}_y} &=
+  \mathbf{\hat{a}_y}\\
+  \mathbf{\hat{a}_x} \cdot \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} &= 0\\
+  \mathbf{\hat{a}_x} \times \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} &=
+  \mathbf{\hat{a}_z}\mathbf{\hat{a}_x}\\
+  \mathbf{\hat{a}_x} \times \mathbf{\hat{a}_x}\mathbf{\hat{a}_x} &= 0\\
+  \mathbf{\hat{a}_y}\mathbf{\hat{a}_x} \times \mathbf{\hat{a}_z} &=
+  - \mathbf{\hat{a}_y}\mathbf{\hat{a}_y}\\
+
+One can also take the time derivative of dyadics or express them in different
+frames, just like with vectors.
 
 Common Issues
 =============

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -12,9 +12,11 @@ __all__ = [
 
     'RigidBody',
 
-    'inertia', 'inertia_of_point_mass', 'linear_momentum', 'angular_momentum',
-    'kinetic_energy', 'potential_energy', 'Lagrangian', 'mechanics_printing',
-    'mprint', 'msprint', 'mpprint', 'mlatex', 'msubs', 'find_dynamicsymbols',
+    'linear_momentum', 'angular_momentum', 'kinetic_energy', 'potential_energy',
+    'Lagrangian', 'mechanics_printing', 'mprint', 'msprint', 'mpprint',
+    'mlatex', 'msubs', 'find_dynamicsymbols',
+
+    'inertia', 'inertia_of_point_mass', 'Inertia',
 
     'Particle',
 
@@ -45,10 +47,12 @@ from .kane import KanesMethod
 
 from .rigidbody import RigidBody
 
-from .functions import (inertia, inertia_of_point_mass, linear_momentum,
-        angular_momentum, kinetic_energy, potential_energy, Lagrangian,
-        mechanics_printing, mprint, msprint, mpprint, mlatex, msubs,
-        find_dynamicsymbols)
+from .functions import (linear_momentum, angular_momentum, kinetic_energy,
+                        potential_energy, Lagrangian, mechanics_printing,
+                        mprint, msprint, mpprint, mlatex, msubs,
+                        find_dynamicsymbols)
+
+from .inertia import inertia, inertia_of_point_mass, Inertia
 
 from .particle import Particle
 

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,6 +1,6 @@
 from sympy.core.backend import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame, Dyadic
-from sympy.physics.mechanics import RigidBody, Particle, inertia
+from sympy.physics.mechanics import RigidBody, Particle, Inertia
 from sympy.physics.mechanics.body_base import BodyBase
 
 __all__ = ['Body']
@@ -115,8 +115,8 @@ class Body(RigidBody, Particle):  # type: ignore
             izx = Symbol(name + '_izx')
             ixy = Symbol(name + '_ixy')
             iyz = Symbol(name + '_iyz')
-            _inertia = (inertia(frame, ixx, iyy, izz, ixy, iyz, izx),
-                        masscenter)
+            _inertia = Inertia.from_inertia_scalars(masscenter, frame, ixx, iyy,
+                                                    izz, ixy, iyz, izx)
         else:
             _inertia = (central_inertia, masscenter)
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -7,12 +7,13 @@ from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
-from sympy.core.backend import (Matrix, sympify, Mul, Derivative, sin, cos,
-                                tan, AppliedUndef, S)
+from sympy.core.backend import (Matrix, Mul, Derivative, sin, cos, tan,
+                                AppliedUndef, S)
+from sympy.physics.mechanics.inertia import (inertia as _inertia,
+    inertia_of_point_mass as _inertia_of_point_mass)
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
-__all__ = ['inertia',
-           'inertia_of_point_mass',
-           'linear_momentum',
+__all__ = ['linear_momentum',
            'angular_momentum',
            'kinetic_energy',
            'potential_energy',
@@ -46,91 +47,27 @@ mechanics_printing.__doc__ = init_vprinting.__doc__
 
 
 def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
-    """Simple way to create inertia Dyadic object.
-
-    Explanation
-    ===========
-
-    If you do not know what a Dyadic is, just treat this like the inertia
-    tensor. Then, do the easy thing and define it in a body-fixed frame.
-
-    Parameters
-    ==========
-
-    frame : ReferenceFrame
-        The frame the inertia is defined in
-    ixx : Sympifyable
-        the xx element in the inertia dyadic
-    iyy : Sympifyable
-        the yy element in the inertia dyadic
-    izz : Sympifyable
-        the zz element in the inertia dyadic
-    ixy : Sympifyable
-        the xy element in the inertia dyadic
-    iyz : Sympifyable
-        the yz element in the inertia dyadic
-    izx : Sympifyable
-        the zx element in the inertia dyadic
-
-    Examples
-    ========
-
-    >>> from sympy.physics.mechanics import ReferenceFrame, inertia
-    >>> N = ReferenceFrame('N')
-    >>> inertia(N, 1, 2, 3)
-    (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
-
-    """
-
-    if not isinstance(frame, ReferenceFrame):
-        raise TypeError('Need to define the inertia in a frame')
-    ixx = sympify(ixx)
-    ixy = sympify(ixy)
-    iyy = sympify(iyy)
-    iyz = sympify(iyz)
-    izx = sympify(izx)
-    izz = sympify(izz)
-    ol = ixx * (frame.x | frame.x)
-    ol += ixy * (frame.x | frame.y)
-    ol += izx * (frame.x | frame.z)
-    ol += ixy * (frame.y | frame.x)
-    ol += iyy * (frame.y | frame.y)
-    ol += iyz * (frame.y | frame.z)
-    ol += izx * (frame.z | frame.x)
-    ol += iyz * (frame.z | frame.y)
-    ol += izz * (frame.z | frame.z)
-    return ol
+    sympy_deprecation_warning(
+        """
+        The inertia function has been moved.
+        Import it from "sympy.physics.mechanics".
+        """,
+        deprecated_since_version="1.13",
+        active_deprecations_target="moved-mechanics-functions"
+    )
+    return _inertia(frame, ixx, iyy, izz, ixy, iyz, izx)
 
 
 def inertia_of_point_mass(mass, pos_vec, frame):
-    """Inertia dyadic of a point mass relative to point O.
-
-    Parameters
-    ==========
-
-    mass : Sympifyable
-        Mass of the point mass
-    pos_vec : Vector
-        Position from point O to point mass
-    frame : ReferenceFrame
-        Reference frame to express the dyadic in
-
-    Examples
-    ========
-
-    >>> from sympy import symbols
-    >>> from sympy.physics.mechanics import ReferenceFrame, inertia_of_point_mass
-    >>> N = ReferenceFrame('N')
-    >>> r, m = symbols('r m')
-    >>> px = r * N.x
-    >>> inertia_of_point_mass(m, px, N)
-    m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
-
-    """
-
-    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
-                   (frame.z | frame.z)) * (pos_vec & pos_vec) -
-                   (pos_vec | pos_vec))
+    sympy_deprecation_warning(
+        """
+        The inertia_of_point_mass function has been moved.
+        Import it from "sympy.physics.mechanics".
+        """,
+        deprecated_since_version="1.13",
+        active_deprecations_target="moved-mechanics-functions"
+    )
+    return _inertia_of_point_mass(mass, pos_vec, frame)
 
 
 def linear_momentum(frame, *body):

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -1,0 +1,184 @@
+from sympy.core.backend import sympify
+from sympy.physics.vector import Point, Dyadic, ReferenceFrame
+from collections import namedtuple
+
+__all__ = ['inertia', 'inertia_of_point_mass', 'Inertia']
+
+
+def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
+    """Simple way to create inertia Dyadic object.
+
+    Explanation
+    ===========
+
+    If you do not know what a Dyadic is, just treat this like the inertia
+    tensor. Then, do the easy thing and define it in a body-fixed frame.
+
+    Parameters
+    ==========
+
+    frame : ReferenceFrame
+        The frame the inertia is defined in
+    ixx : Sympifyable
+        the xx element in the inertia dyadic
+    iyy : Sympifyable
+        the yy element in the inertia dyadic
+    izz : Sympifyable
+        the zz element in the inertia dyadic
+    ixy : Sympifyable
+        the xy element in the inertia dyadic
+    iyz : Sympifyable
+        the yz element in the inertia dyadic
+    izx : Sympifyable
+        the zx element in the inertia dyadic
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, inertia
+    >>> N = ReferenceFrame('N')
+    >>> inertia(N, 1, 2, 3)
+    (N.x|N.x) + 2*(N.y|N.y) + 3*(N.z|N.z)
+
+    """
+
+    if not isinstance(frame, ReferenceFrame):
+        raise TypeError('Need to define the inertia in a frame')
+    ixx = sympify(ixx)
+    ixy = sympify(ixy)
+    iyy = sympify(iyy)
+    iyz = sympify(iyz)
+    izx = sympify(izx)
+    izz = sympify(izz)
+    ol = ixx * (frame.x | frame.x)
+    ol += ixy * (frame.x | frame.y)
+    ol += izx * (frame.x | frame.z)
+    ol += ixy * (frame.y | frame.x)
+    ol += iyy * (frame.y | frame.y)
+    ol += iyz * (frame.y | frame.z)
+    ol += izx * (frame.z | frame.x)
+    ol += iyz * (frame.z | frame.y)
+    ol += izz * (frame.z | frame.z)
+    return ol
+
+
+def inertia_of_point_mass(mass, pos_vec, frame):
+    """Inertia dyadic of a point mass relative to point O.
+
+    Parameters
+    ==========
+
+    mass : Sympifyable
+        Mass of the point mass
+    pos_vec : Vector
+        Position from point O to point mass
+    frame : ReferenceFrame
+        Reference frame to express the dyadic in
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> from sympy.physics.mechanics import ReferenceFrame, inertia_of_point_mass
+    >>> N = ReferenceFrame('N')
+    >>> r, m = symbols('r m')
+    >>> px = r * N.x
+    >>> inertia_of_point_mass(m, px, N)
+    m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
+
+    """
+
+    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
+                    (frame.z | frame.z)) * (pos_vec & pos_vec) -
+                   (pos_vec | pos_vec))
+
+
+class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
+    """Inertia object consisting of a Dyadic and a Point of reference.
+
+    Explanation
+    ===========
+
+    This is a simple class to store the Point and Dyadic, belonging to an
+    inertia.
+
+    Attributes
+    ==========
+
+    dyadic : Dyadic
+        The dyadic of the inertia.
+    point : Point
+        The reference point of the inertia.
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, Point, Inertia
+    >>> N = ReferenceFrame('N')
+    >>> Po = Point('Po')
+    >>> Inertia(N.x.outer(N.x) + N.y.outer(N.y) + N.z.outer(N.z), Po)
+    ((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+
+    In the example above the Dyadic was created manually, one can however also
+    use the ``inertia`` function for this or the class method ``from_tensor`` as
+    shown below.
+
+    >>> Inertia.from_inertia_scalars(Po, N, 1, 1, 1)
+    ((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
+
+    """
+    def __new__(cls, dyadic, point):
+        # Switch order if given in the wrong order
+        if isinstance(dyadic, Point) and isinstance(point, Dyadic):
+            point, dyadic = dyadic, point
+        if not isinstance(point, Point):
+            raise TypeError('Reference point should be of type Point')
+        if not isinstance(dyadic, Dyadic):
+            raise TypeError('Inertia value should be expressed as a Dyadic')
+        return super().__new__(cls, dyadic, point)
+
+    @classmethod
+    def from_inertia_scalars(cls, point, frame, ixx, iyy, izz, ixy=0, iyz=0,
+                             izx=0):
+        """Simple way to create an Inertia object based on the tensor values.
+
+        Explanation
+        ===========
+
+        This class method uses the ``inertia`` function to create the Dyadic
+        based on the tensor values.
+
+        Examples
+        ========
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, Point, Inertia
+        >>> ixx, iyy, izz, ixy, iyz, izx = symbols('ixx iyy izz ixy iyz izx')
+        >>> N = ReferenceFrame('N')
+        >>> P = Point('P')
+        >>> I = Inertia.from_inertia_scalars(P, N, ixx, iyy, izz, ixy, iyz, izx)
+
+        The tensor values can easily be seen when converting the dyadic to a
+        matrix.
+
+        >>> I.dyadic.to_matrix(N)
+        Matrix([
+        [ixx, ixy, izx],
+        [ixy, iyy, iyz],
+        [izx, iyz, izz]])
+
+        """
+        return cls(inertia(frame, ixx, iyy, izz, ixy, iyz, izx), point)
+
+    def __add__(self, other):
+        raise TypeError(f"unsupported operand type(s) for +: "
+                        f"'{self.__class__.__name__}' and "
+                        f"'{other.__class__.__name__}'")
+
+    def __mul__(self, other):
+        raise TypeError(f"unsupported operand type(s) for *: "
+                        f"'{self.__class__.__name__}' and "
+                        f"'{other.__class__.__name__}'")
+
+    __radd__ = __add__
+    __rmul__ = __mul__

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -11,26 +11,26 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
     Explanation
     ===========
 
-    If you do not know what a Dyadic is, just treat this like the inertia
-    tensor. Then, do the easy thing and define it in a body-fixed frame.
+    Creates an inertia Dyadic based on the given tensor values and a body-fixed
+    reference frame.
 
     Parameters
     ==========
 
     frame : ReferenceFrame
-        The frame the inertia is defined in
+        The frame the inertia is defined in.
     ixx : Sympifyable
-        the xx element in the inertia dyadic
+        The xx element in the inertia dyadic.
     iyy : Sympifyable
-        the yy element in the inertia dyadic
+        The yy element in the inertia dyadic.
     izz : Sympifyable
-        the zz element in the inertia dyadic
+        The zz element in the inertia dyadic.
     ixy : Sympifyable
-        the xy element in the inertia dyadic
+        The xy element in the inertia dyadic.
     iyz : Sympifyable
-        the yz element in the inertia dyadic
+        The yz element in the inertia dyadic.
     izx : Sympifyable
-        the zx element in the inertia dyadic
+        The zx element in the inertia dyadic.
 
     Examples
     ========
@@ -44,22 +44,13 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
 
     if not isinstance(frame, ReferenceFrame):
         raise TypeError('Need to define the inertia in a frame')
-    ixx = sympify(ixx)
-    ixy = sympify(ixy)
-    iyy = sympify(iyy)
-    iyz = sympify(iyz)
-    izx = sympify(izx)
-    izz = sympify(izz)
-    ol = ixx * (frame.x | frame.x)
-    ol += ixy * (frame.x | frame.y)
-    ol += izx * (frame.x | frame.z)
-    ol += ixy * (frame.y | frame.x)
-    ol += iyy * (frame.y | frame.y)
-    ol += iyz * (frame.y | frame.z)
-    ol += izx * (frame.z | frame.x)
-    ol += iyz * (frame.z | frame.y)
-    ol += izz * (frame.z | frame.z)
-    return ol
+    ixx, iyy, izz = sympify(ixx), sympify(iyy), sympify(izz)
+    ixy, iyz, izx = sympify(ixy), sympify(iyz), sympify(izx)
+    return (ixx * (frame.x | frame.x) + ixy * (frame.x | frame.y) +
+            izx * (frame.x | frame.z) + ixy * (frame.y | frame.x) +
+            iyy * (frame.y | frame.y) + iyz * (frame.y | frame.z) +
+            izx * (frame.z | frame.x) + iyz * (frame.z | frame.y) +
+            izz * (frame.z | frame.z))
 
 
 def inertia_of_point_mass(mass, pos_vec, frame):
@@ -88,9 +79,9 @@ def inertia_of_point_mass(mass, pos_vec, frame):
 
     """
 
-    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
-                    (frame.z | frame.z)) * (pos_vec & pos_vec) -
-                   (pos_vec | pos_vec))
+    return mass * (
+        ((frame.x | frame.x) + (frame.y | frame.y) + (frame.z | frame.z)) *
+        (pos_vec & pos_vec) - (pos_vec | pos_vec))
 
 
 class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
@@ -145,8 +136,28 @@ class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
         Explanation
         ===========
 
-        This class method uses the ``inertia`` function to create the Dyadic
-        based on the tensor values.
+        This class method uses the :func`~.inertia` to create the Dyadic based
+        on the tensor values.
+
+        Parameters
+        ==========
+
+        point : Point
+            The reference point of the inertia.
+        frame : ReferenceFrame
+            The frame the inertia is defined in.
+        ixx : Sympifyable
+            The xx element in the inertia dyadic.
+        iyy : Sympifyable
+            The yy element in the inertia dyadic.
+        izz : Sympifyable
+            The zz element in the inertia dyadic.
+        ixy : Sympifyable
+            The xy element in the inertia dyadic.
+        iyz : Sympifyable
+            The yz element in the inertia dyadic.
+        izx : Sympifyable
+            The zx element in the inertia dyadic.
 
         Examples
         ========

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -2,14 +2,13 @@ from sympy.core.backend import sin, cos, tan, pi, symbols, Matrix, S, Function
 from sympy.physics.mechanics import (Particle, Point, ReferenceFrame,
                                      RigidBody)
 from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
-                                     inertia, inertia_of_point_mass,
                                      kinetic_energy, linear_momentum,
                                      outer, potential_energy, msubs,
                                      find_dynamicsymbols, Lagrangian)
 
 from sympy.physics.mechanics.functions import (gravity, center_of_mass,
                                                _validate_coordinates)
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
@@ -17,49 +16,6 @@ N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])
 B = A.orientnew('B', 'Axis', [q2, A.x])
 C = B.orientnew('C', 'Axis', [q3, B.y])
-
-
-def test_inertia():
-    N = ReferenceFrame('N')
-    ixx, iyy, izz = symbols('ixx iyy izz')
-    ixy, iyz, izx = symbols('ixy iyz izx')
-    assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
-            (N.y | N.y) + izz * (N.z | N.z))
-    assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
-    raises(TypeError, lambda: inertia(0, 0, 0, 0))
-    assert inertia(N, ixx, iyy, izz, ixy, iyz, izx) == (ixx * (N.x | N.x) +
-            ixy * (N.x | N.y) + izx * (N.x | N.z) + ixy * (N.y | N.x) + iyy *
-        (N.y | N.y) + iyz * (N.y | N.z) + izx * (N.z | N.x) + iyz * (N.z |
-            N.y) + izz * (N.z | N.z))
-
-
-def test_inertia_of_point_mass():
-    r, s, t, m = symbols('r s t m')
-    N = ReferenceFrame('N')
-
-    px = r * N.x
-    I = inertia_of_point_mass(m, px, N)
-    assert I == m * r**2 * (N.y | N.y) + m * r**2 * (N.z | N.z)
-
-    py = s * N.y
-    I = inertia_of_point_mass(m, py, N)
-    assert I == m * s**2 * (N.x | N.x) + m * s**2 * (N.z | N.z)
-
-    pz = t * N.z
-    I = inertia_of_point_mass(m, pz, N)
-    assert I == m * t**2 * (N.x | N.x) + m * t**2 * (N.y | N.y)
-
-    p = px + py + pz
-    I = inertia_of_point_mass(m, p, N)
-    assert I == (m * (s**2 + t**2) * (N.x | N.x) -
-                 m * r * s * (N.x | N.y) -
-                 m * r * t * (N.x | N.z) -
-                 m * r * s * (N.y | N.x) +
-                 m * (r**2 + t**2) * (N.y | N.y) -
-                 m * s * t * (N.y | N.z) -
-                 m * r * t * (N.z | N.x) -
-                 m * s * t * (N.z | N.y) +
-                 m * (r**2 + s**2) * (N.z | N.z))
 
 
 def test_linear_momentum():
@@ -290,3 +246,14 @@ def test_validate_coordinates():
     _validate_coordinates([f1(a), f2(a)])
     raises(ValueError, lambda: _validate_coordinates([f1(t), f2(t)]))
     dynamicsymbols._t = t
+
+
+def test_deprecated_moved_functions():
+    from sympy.physics.mechanics.functions import inertia, inertia_of_point_mass
+    N = ReferenceFrame('N')
+    with warns_deprecated_sympy():
+        assert inertia(N, 0, 1, 0, 1) == (N.x | N.y) + (N.y | N.x) + (N.y | N.y)
+    with warns_deprecated_sympy():
+        assert inertia_of_point_mass(1, N.x + N.y, N) == (
+            (N.x | N.x) + (N.y | N.y) + 2 * (N.z | N.z) -
+            (N.x | N.y) - (N.y | N.x))

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -8,7 +8,6 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
 
 from sympy.physics.mechanics.functions import (
     gravity, center_of_mass, _validate_coordinates, _parse_linear_solver)
-from sympy.testing.pytest import raises
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -1,0 +1,71 @@
+from sympy.core.backend import symbols
+from sympy.testing.pytest import raises
+from sympy.physics.mechanics import (inertia, inertia_of_point_mass,
+                                     Inertia, ReferenceFrame, Point)
+
+
+def test_inertia_dyadic():
+    N = ReferenceFrame('N')
+    ixx, iyy, izz = symbols('ixx iyy izz')
+    ixy, iyz, izx = symbols('ixy iyz izx')
+    assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
+            (N.y | N.y) + izz * (N.z | N.z))
+    assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
+    raises(TypeError, lambda: inertia(0, 0, 0, 0))
+    assert inertia(N, ixx, iyy, izz, ixy, iyz, izx) == (ixx * (N.x | N.x) +
+            ixy * (N.x | N.y) + izx * (N.x | N.z) + ixy * (N.y | N.x) + iyy *
+        (N.y | N.y) + iyz * (N.y | N.z) + izx * (N.z | N.x) + iyz * (N.z |
+            N.y) + izz * (N.z | N.z))
+
+
+def test_inertia_of_point_mass():
+    r, s, t, m = symbols('r s t m')
+    N = ReferenceFrame('N')
+
+    px = r * N.x
+    I = inertia_of_point_mass(m, px, N)
+    assert I == m * r**2 * (N.y | N.y) + m * r**2 * (N.z | N.z)
+
+    py = s * N.y
+    I = inertia_of_point_mass(m, py, N)
+    assert I == m * s**2 * (N.x | N.x) + m * s**2 * (N.z | N.z)
+
+    pz = t * N.z
+    I = inertia_of_point_mass(m, pz, N)
+    assert I == m * t**2 * (N.x | N.x) + m * t**2 * (N.y | N.y)
+
+    p = px + py + pz
+    I = inertia_of_point_mass(m, p, N)
+    assert I == (m * (s**2 + t**2) * (N.x | N.x) -
+                 m * r * s * (N.x | N.y) -
+                 m * r * t * (N.x | N.z) -
+                 m * r * s * (N.y | N.x) +
+                 m * (r**2 + t**2) * (N.y | N.y) -
+                 m * s * t * (N.y | N.z) -
+                 m * r * t * (N.z | N.x) -
+                 m * s * t * (N.z | N.y) +
+                 m * (r**2 + s**2) * (N.z | N.z))
+
+
+def test_inertia_object():
+    N = ReferenceFrame('N')
+    O = Point('O')
+    ixx, iyy, izz = symbols('ixx iyy izz')
+    I_dyadic = ixx * (N.x | N.x) + iyy * (N.y | N.y) + izz * (N.z | N.z)
+    I = Inertia(inertia(N, ixx, iyy, izz), O)
+    assert isinstance(I, tuple)
+    assert I.__repr__() == ('Inertia(dyadic=ixx*(N.x|N.x) + iyy*(N.y|N.y) + '
+                            'izz*(N.z|N.z), point=O)')
+    assert I.dyadic == I_dyadic
+    assert I.point == O
+    assert I[0] == I_dyadic
+    assert I[1] == O
+    assert I == (I_dyadic, O)  # Test tuple equal
+    raises(TypeError, lambda: I != (O, I_dyadic))  # Incorrect tuple order
+    assert I == Inertia(O, I_dyadic)  # Parse changed argument order
+    assert I == Inertia.from_inertia_scalars(O, N, ixx, iyy, izz)
+    # Test invalid tuple operations
+    raises(TypeError, lambda: I + (1, 2))
+    raises(TypeError, lambda: (1, 2) + I)
+    raises(TypeError, lambda: I * 2)
+    raises(TypeError, lambda: 2 * I)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,5 +1,5 @@
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
-from sympy.physics.mechanics import dynamicsymbols, outer, inertia
+from sympy.physics.mechanics import dynamicsymbols, outer, inertia, Inertia
 from sympy.physics.mechanics import inertia_of_point_mass
 from sympy.core.backend import expand, zeros, _simplify_matrix, symbols
 from sympy.testing.pytest import raises, warns_deprecated_sympy
@@ -18,12 +18,12 @@ def test_rigidbody_default():
     assert b.__str__() == 'B'
     assert b.__repr__() == (
         "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass), "
-        "inertia=(B_ixx*(B_frame.x|B_frame.x) + "
+        "inertia=Inertia(dyadic=B_ixx*(B_frame.x|B_frame.x) + "
         "B_ixy*(B_frame.x|B_frame.y) + B_izx*(B_frame.x|B_frame.z) + "
         "B_ixy*(B_frame.y|B_frame.x) + B_iyy*(B_frame.y|B_frame.y) + "
         "B_iyz*(B_frame.y|B_frame.z) + B_izx*(B_frame.z|B_frame.x) + "
         "B_iyz*(B_frame.z|B_frame.y) + B_izz*(B_frame.z|B_frame.z), "
-        "B_masscenter)))")
+        "point=B_masscenter)))")
 
 
 def test_rigidbody():
@@ -53,8 +53,7 @@ def test_rigidbody():
     assert B.frame == A2
     assert B.masscenter == P2
     assert B.inertia == (I2, B.masscenter)
-    assert B.masscenter == P2
-    assert B.inertia == (I2, B.masscenter)
+    assert isinstance(B.inertia, Inertia)
 
     # Testing linear momentum function assuming A2 is the inertial frame
     N = ReferenceFrame('N')
@@ -143,6 +142,7 @@ def test_rigidbody_inertia():
     R = RigidBody('R', o, N, m, (Io, p))
     I_check = inertia(N, Ix - b ** 2 * m, Iy - a ** 2 * m,
                       Iz - m * (a ** 2 + b ** 2), m * a * b)
+    assert isinstance(R.inertia, Inertia)
     assert R.inertia == (Io, p)
     assert R.central_inertia == I_check
     R.central_inertia = Io
@@ -151,6 +151,9 @@ def test_rigidbody_inertia():
     R.inertia = (Io, p)
     assert R.inertia == (Io, p)
     assert R.central_inertia == I_check
+    # parse Inertia object
+    R.inertia = Inertia(Io, o)
+    assert R.inertia == (Io, o)
 
 
 def test_parallel_axis():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Output of the mechanics experimental development (#24234)
Implements #24588

#### Brief description of what is fixed or changed
This PR implements an `Inertia` object that stores the quantity (Dyadic) and the reference (Point) of an inertia. This is a replacement of the tuple, which is currently being used. Besides that the functions associated with inertia are moved to a separate `inertia.py` file removing some circular import issues.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Implemented `Inertia`, an object to store the quantity and reference of an inertia.
  * BREAKING: moved the inertia functions from `physics.mechanics.functions.py` to `physics.mechanics.inertia.py`
<!-- END RELEASE NOTES -->
