### PR TITLE
Remove qdots from KanesMethod.forcing

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -375,8 +375,8 @@ class KanesMethod(_Methods):
         uauxdot = [diff(i, t) for i in self._uaux]
         uauxdot_zero = {i: 0 for i in uauxdot}
         # Dictionary of q' and q'' to u and u'
-        q_ddot_u_map = {k.diff(t): v.diff(t) for (k, v) in
-                self._qdot_u_map.items()}
+        q_ddot_u_map = {k.diff(t): v.diff(t).xreplace(
+            self._qdot_u_map) for (k, v) in self._qdot_u_map.items()}
         q_ddot_u_map.update(self._qdot_u_map)
 
         # Fill up the list of partials: format is a list with num elements

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -4,7 +4,7 @@ from sympy.core.backend import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
 from sympy.simplify.simplify import simplify
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
-                                     dot)
+                                     dot, find_dynamicsymbols)
 from sympy.testing.pytest import raises
 from sympy.core.backend import USE_SYMENGINE
 
@@ -530,3 +530,29 @@ def test_implicit_kinematics():
     lambda_0_sol = solve(config_cons[0], q_att_vec[0])[1]
     lhs_candidate = simplify(mass_matrix_kin_implicit * qdot_candidate).subs({q_att_vec[0]: lambda_0_sol})
     assert lhs_candidate == forcing_kin_implicit
+
+def test_issue_24887():
+    # Spherical pendulum
+    g, l, m, c = symbols('g l m c')
+    q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1:4 u1:4')
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+    A.orient_body_fixed(N, (q1, q2, q3), 'zxy')
+    N_w_A = A.ang_vel_in(N)
+    # A.set_ang_vel(N, u1 * A.x + u2 * A.y + u3 * A.z)
+    kdes = [N_w_A.dot(A.x) - u1, N_w_A.dot(A.y) - u2, N_w_A.dot(A.z) - u3]
+    O = Point('O')
+    O.set_vel(N, 0)
+    Po = O.locatenew('Po', -l * A.y)
+    Po.set_vel(A, 0)
+    P = Particle('P', Po, m)
+    kane = KanesMethod(N, [q1, q2, q3], [u1, u2, u3], kdes, bodies=[P],
+                       forcelist=[(Po, -m * g * N.y)])
+    kane.kanes_equations()
+    expected_md = m * l ** 2 * Matrix([[1, 0, 0], [0, 0, 0], [0, 0, 1]])
+    expected_fd = Matrix([
+        [l*m*(g*(sin(q1)*sin(q3) - sin(q2)*cos(q1)*cos(q3)) - l*u2*u3)],
+        [0], [l*m*(-g*(sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)) + l*u1*u2)]])
+    assert find_dynamicsymbols(kane.forcing).issubset({q1, q2, q3, u1, u2, u3})
+    assert simplify(kane.mass_matrix - expected_md) == zeros(3, 3)
+    assert simplify(kane.forcing - expected_fd) == zeros(3, 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24887

#### Brief description of what is fixed or changed
Fixed a bug with `KanesMethod.forcing`, which could formerly contain derivatives of the generalized coordinates.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Fixed a bug with `KanesMethod.forcing`, which could formerly contain derivatives of the generalized coordinates.
<!-- END RELEASE NOTES -->
