### PR TITLE
Use Generalisation of Lucas' Theorem for binomial(n, m) mod q

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -821,6 +821,7 @@ Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Laura Domine <temigo@gmx.com>
 Lauren Glattly <laurenglattly@gmail.com>
+Laurence Warne <laurencewarne@gmail.com>
 Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
 Lee Johnston <lee.johnston.100@gmail.com>
 Lejla Metohajrova <l.metohajrova@gmail.com>

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -26,6 +26,18 @@ class Mod(Function):
     The convention used is the same as Python's: the remainder always has the
     same sign as the divisor.
 
+    Many objects can be evaluated modulo ``n`` much faster than they can be
+    evaluated directly (or at all).  For this, ``evaluate=False`` is
+    necessary to prevent eager evaluation:
+
+    >>> from sympy import binomial, factorial, Mod, Pow
+    >>> Mod(Pow(2, 10**16, evaluate=False), 97)
+    61
+    >>> Mod(factorial(10**9, evaluate=False), 10**9 + 9)
+    712524808
+    >>> Mod(binomial(10**18, 10**12, evaluate=False), (10**5 + 3)**2)
+    3744312326
+
     Examples
     ========
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -9,6 +9,7 @@ from sympy.core.numbers import Integer, pi, I
 from sympy.core.relational import Eq
 from sympy.external.gmpy import HAS_GMPY, gmpy
 from sympy.ntheory import sieve
+from sympy.ntheory.residue_ntheory import binomial_mod
 from sympy.polys.polytools import Poly
 
 from math import factorial as _factorial, prod, sqrt as _sqrt
@@ -887,11 +888,27 @@ class binomial(CombinatorialFunction):
     >>> expand_func(binomial(n, 3))
     n*(n - 2)*(n - 1)/6
 
+    In many cases, we can also compute binomial coefficients modulo a
+    prime p quickly using Lucas' Theorem [2]_, though we need to include
+    `evaluate=False` to postpone evaluation:
+
+    >>> from sympy import Mod
+    >>> Mod(binomial(156675, 4433, evaluate=False), 10**5 + 3)
+    28625
+
+    Using a generalisation of Lucas's Theorem given by Granville [3]_,
+    we can extend this to arbitrary n:
+
+    >>> Mod(binomial(10**18, 10**12, evaluate=False), (10**5 + 3)**2)
+    3744312326
+
     References
     ==========
 
     .. [1] https://www.johndcook.com/blog/binomial_coefficients/
-
+    .. [2] https://en.wikipedia.org/wiki/Lucas%27s_theorem
+    .. [3] Binomial coefficients modulo prime powers, Andrew Granville,
+        Available: https://web.archive.org/web/20170202003812/http://www.dms.umontreal.ca/~andrew/PDF/BinCoeff.pdf
     """
 
     def fdiff(self, argindex=1):
@@ -1009,6 +1026,9 @@ class binomial(CombinatorialFunction):
 
                     res *= pow(kf*df % aq, aq - 2, aq)
                     res %= aq
+
+            elif _sqrt(q) < k and q != 1:
+                res = binomial_mod(n, k, q)
 
             else:
                 # Binomial Factorization is performed by calculating the

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -534,6 +534,9 @@ def test_binomial_Mod():
     # binomial factorize
     assert Mod(binomial(253, 113, evaluate=False), r) == Mod(binomial(253, 113), r)
 
+    # using Granville's generalisation of Lucas' Theorem
+    assert Mod(binomial(10**18, 10**12, evaluate=False), p*p) == 3744312326
+
 
 @slow
 def test_binomial_Mod_slow():

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -9,6 +9,7 @@ from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence
 from .primetest import isprime
 from .factor_ import factorint, trailing, totient, multiplicity, perfect_power
+from .modular import crt
 from sympy.utilities.misc import as_int
 from sympy.core.random import _randint, randint
 
@@ -1571,3 +1572,167 @@ def polynomial_congruence(expr, m):
         lambda p: _polynomial_congruence_prime(coefficients, p),
         lambda root, p: _diff_poly(root, coefficients, p),
         lambda root, p: _val_poly(root, coefficients, p))
+
+
+def binomial_mod(n, m, k):
+    """Compute ``binomial(n, m) % k``.
+
+    Explanation
+    ===========
+
+    Returns ``binomial(n, m) % k`` using a generalization of Lucas'
+    Theorem for prime powers given by Granville [1]_, in conjunction with
+    the Chinese Remainder Theorem.  The residue for each prime power
+    is calculated in time O(log^2(n) + q^4*log(n)log(p) + q^4*p*log^3(p)).
+
+    Parameters
+    ==========
+
+    n : an integer
+    m : an integer
+    k : a positive integer
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.residue_ntheory import binomial_mod
+    >>> binomial_mod(10, 2, 6)  # binomial(10, 2) = 45
+    3
+    >>> binomial_mod(17, 9, 10)  # binomial(17, 9) = 24310
+    0
+
+    References
+    ==========
+
+    .. [1] Binomial coefficients modulo prime powers, Andrew Granville,
+        Available: https://web.archive.org/web/20170202003812/http://www.dms.umontreal.ca/~andrew/PDF/BinCoeff.pdf
+    """
+    if k < 1: raise ValueError('k is required to be positive')
+    # We decompose q into a product of prime powers and apply
+    # the generalization of Lucas' Theorem given by Granville
+    # to obtain binomial(n, k) mod p^e, and then use the Chinese
+    # Remainder Theorem to obtain the result mod q
+    if n < 0 or m < 0 or m > n: return 0
+    factorisation = factorint(k)
+    residues = [_binomial_mod_prime_power(n, m, p, e) for p, e in factorisation.items()]
+    return crt([p**pw for p, pw in factorisation.items()], residues, check=False)[0]
+
+
+def _binomial_mod_prime_power(n, m, p, q):
+    """Compute ``binomial(n, m) % p**q`` for a prime ``p``.
+
+    Parameters
+    ==========
+
+    n : positive integer
+    m : a nonnegative integer
+    p : a prime
+    q : a positive integer (the prime exponent)
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.residue_ntheory import _binomial_mod_prime_power
+    >>> _binomial_mod_prime_power(10, 2, 3, 2)  # binomial(10, 2) = 45
+    0
+    >>> _binomial_mod_prime_power(17, 9, 2, 4)  # binomial(17, 9) = 24310
+    6
+
+    References
+    ==========
+
+    .. [1] Binomial coefficients modulo prime powers, Andrew Granville,
+        Available: https://web.archive.org/web/20170202003812/http://www.dms.umontreal.ca/~andrew/PDF/BinCoeff.pdf
+    """
+    # Function/variable naming within this function follows Ref.[1]
+    # n!_p will be used to denote the product of integers <= n not divisible by
+    # p, with binomial(n, m)_p the same as binomial(n, m), but defined using
+    # n!_p in place of n!
+    modulo = pow(p, q)
+
+    def up_factorial(u):
+        """Compute (u*p)!_p modulo p^q."""
+        r = q // 2
+        fac = prod = 1
+        if r == 1 and p == 2 or 2*r + 1 in (p, p*p):
+            if q % 2 == 1: r += 1
+            modulo, div = pow(p, 2*r), pow(p, 2*r - q)
+        else:
+            modulo, div = pow(p, 2*r + 1), pow(p, (2*r + 1) - q)
+        for j in range(1, r + 1):
+            for mul in range((j - 1)*p + 1, j*p):  # ignore jp itself
+                fac *= mul
+                fac %= modulo
+            bj_ = bj(u, j, r)
+            if bj_ < 0: prod *= pow(mod_inverse(fac, modulo), -bj_, modulo)
+            else: prod *= pow(fac, bj_, modulo)
+            prod %= modulo
+        if p == 2:
+            sm = u // 2
+            for j in range(1, r + 1): sm += j//2 * bj(u, j, r)
+            if sm % 2 == 1: prod *= -1
+        prod %= modulo//div
+        return prod % modulo
+
+    def bj(u, j, r):
+        """Compute the exponent of (j*p)!_p in the calculation of (u*p)!_p."""
+        prod = u
+        for i in range(1, r + 1):
+            if i != j: prod *= u*u - i*i
+        for i in range(1, r + 1):
+            if i != j: prod //= j*j - i*i
+        return prod // j
+
+    def up_plus_v_binom(u, v):
+        """Compute binomial(u*p + v, v)_p modulo p^q."""
+        prod = div = 1
+        for i in range(1, v + 1):
+            div *= i
+            div %= modulo
+        div = mod_inverse(div, modulo)
+        for j in range(1, q):
+            b = div
+            for v_ in range(j*p + 1, j*p + v + 1):
+                b *= v_
+                b %= modulo
+            aj = u
+            for i in range(1, q):
+                if i != j: aj *= u - i
+            for i in range(1, q):
+                if i != j: aj //= j - i
+            aj //= j
+            if aj < 0: b, aj = mod_inverse(b, modulo), -aj
+            prod *= pow(b, aj, modulo)
+            prod %= modulo
+        return prod
+
+    factorials = [1]
+    def factorial(v):
+        """Compute v! modulo p^q."""
+        if len(factorials) <= v:
+            for i in range(len(factorials), v + 1):
+                factorials.append(factorials[-1]*i % modulo)
+        return factorials[v]
+
+    def factorial_p(n):
+        """Compute n!_p modulo p^q."""
+        u, v = divmod(n, p)
+        return (factorial(v) * up_factorial(u) * up_plus_v_binom(u, v)) % modulo
+
+    prod = 1
+    Nj, Mj, Rj = n, m, n - m
+    # e0 will be the p-adic valuation of binomial(n, m) at p
+    e0 = carry = eq_1 = j = 0
+    while Nj:
+        numerator = factorial_p(Nj % modulo)
+        denominator = factorial_p(Mj % modulo) * factorial_p(Rj % modulo) % modulo
+        Nj, (Mj, mj), (Rj, rj) = Nj//p, divmod(Mj, p), divmod(Rj, p)
+        carry = (mj + rj + carry) // p
+        e0 += carry
+        if j >= q - 1: eq_1 += carry
+        prod *= numerator * mod_inverse(denominator, modulo)
+        prod %= modulo
+        j += 1
+
+    mul = pow(1 if p == 2 and q >= 3 else -1, eq_1, modulo)
+    return (pow(p, e0, modulo) * mul * prod) % modulo


### PR DESCRIPTION
Hi!  This PR implements a generalisation of Lucas' Theorem described in https://web.archive.org/web/20170202003812/http://www.dms.umontreal.ca/~andrew/PDF/BinCoeff.pdf to speed up computation of `binomial(n, m) modulo p^q` (specifically in the `binomial` class' `_eval_Mod` method).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The method allows us to compute `binomial(n, m) mod p^q` in `O(log^2(n) + q^4*log(n)log(p) + q^4*p*log^3(p))` (then for all integers, we can first factorise and then use the Chinese Remainder Theorem after applying the new method for each prime power).  For example we can compute:

```python
>>> Mod(binomial(10**50, 10**25, evaluate=False), 2**45))
0
>>> Mod(binomial(10**50, 10**25, evaluate=False), 2**46))
35184372088832
```
(Checks out since `v_2(binomial(10^50, 10^25)) = 45` using Kummer's Theorem).

#### Other comments

This method may not be fastest  if `p` and or `q` are large, currently the new method is used only if `n < sqrt(modulo)`, so many of the cases where binomial factorization was used remain.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Use Lucas' Theorem Generalization to calculate binomial coefficients modulo `n`.
* ntheory
  * Created functions `binomial_mod` and `_binomial_mod_prime_power` which can
    be used to calculate large binomial coefficients modulo arbitrary numbers
<!-- END RELEASE NOTES -->
