### PR TITLE
Backport various fixes to 1.12

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -179,16 +179,15 @@ will return values and update the dictionary.
 For a :class:`~.Symbol`, there are two locations for assumptions that may
 be of interest. The ``assumptions0`` attribute gives the full set of
 assumptions derived from a given set of initial assumptions. The
-latter assumptions are stored as ``Symbol._assumptions.generator``
+latter assumptions are stored as ``Symbol._assumptions_orig``
 
-    >>> Symbol('x', prime=True, even=True)._assumptions.generator
+    >>> Symbol('x', prime=True, even=True)._assumptions_orig
     {'even': True, 'prime': True}
 
-The ``generator`` is not necessarily canonical nor is it filtered
-in any way: it records the assumptions used to instantiate a Symbol
-and (for storage purposes) represents a more compact representation
-of the assumptions needed to recreate the full set in
-``Symbol.assumptions0``.
+The ``_assumptions_orig`` are not necessarily canonical nor are they filtered
+in any way: they records the assumptions used to instantiate a Symbol and (for
+storage purposes) represent a more compact representation of the assumptions
+needed to recreate the full set in ``Symbol.assumptions0``.
 
 
 References

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -224,7 +224,7 @@ class Symbol(AtomicExpr, Boolean):
 
     is_comparable = False
 
-    __slots__ = ('name',)
+    __slots__ = ('name', '_assumptions_orig', '_assumptions0')
 
     name: str
 
@@ -300,24 +300,45 @@ class Symbol(AtomicExpr, Boolean):
         if not isinstance(name, str):
             raise TypeError("name should be a string, not %s" % repr(type(name)))
 
+        # This is retained purely so that srepr can include commutative=True if
+        # that was explicitly specified but not if it was not. Ideally srepr
+        # should not distinguish these cases because the symbols otherwise
+        # compare equal and are considered equivalent.
+        #
+        # See https://github.com/sympy/sympy/issues/8873
+        #
+        assumptions_orig = assumptions.copy()
+
+        # The only assumption that is assumed by default is comutative=True:
+        assumptions.setdefault('commutative', True)
+
+        assumptions_kb = StdFactKB(assumptions)
+        assumptions0 = dict(assumptions_kb)
+
         obj = Expr.__new__(cls)
         obj.name = name
 
-        # TODO: Issue #8873: Forcing the commutative assumption here means
-        # later code such as ``srepr()`` cannot tell whether the user
-        # specified ``commutative=True`` or omitted it.  To workaround this,
-        # we keep a copy of the assumptions dict, then create the StdFactKB,
-        # and finally overwrite its ``._generator`` with the dict copy.  This
-        # is a bit of a hack because we assume StdFactKB merely copies the
-        # given dict as ``._generator``, but future modification might, e.g.,
-        # compute a minimal equivalent assumption set.
-        tmp_asm_copy = assumptions.copy()
+        obj._assumptions = assumptions_kb
+        obj._assumptions_orig = assumptions_orig
+        obj._assumptions0 = assumptions0
 
-        # be strict about commutativity
-        is_commutative = fuzzy_bool(assumptions.get('commutative', True))
-        assumptions['commutative'] = is_commutative
-        obj._assumptions = StdFactKB(assumptions)
-        obj._assumptions._generator = tmp_asm_copy  # Issue #8873
+        # The three assumptions dicts are all a little different:
+        #
+        #   >>> from sympy import Symbol
+        #   >>> x = Symbol('x', finite=True)
+        #   >>> x.is_positive  # query an assumption
+        #   >>> x._assumptions
+        #   {'finite': True, 'infinite': False, 'commutative': True, 'positive': None}
+        #   >>> x._assumptions0
+        #   {'finite': True, 'infinite': False, 'commutative': True}
+        #   >>> x._assumptions_orig
+        #   {'finite': True}
+        #
+        # Two symbols with the same name are equal if their _assumptions0 are
+        # the same. Arguably it should be _assumptions_orig that is being
+        # compared because that is more transparent to the user (it is
+        # what was passed to the constructor modulo changes made by _sanitize).
+
         return obj
 
     @staticmethod
@@ -326,7 +347,7 @@ class Symbol(AtomicExpr, Boolean):
         return Symbol.__xnew__(cls, name, **assumptions)
 
     def __getnewargs_ex__(self):
-        return ((self.name,), self.assumptions0)
+        return ((self.name,), self._assumptions_orig)
 
     # NOTE: __setstate__ is not needed for pickles created by __getnewargs_ex__
     # but was used before Symbol was changed to use __getnewargs_ex__ in v1.9.
@@ -351,8 +372,7 @@ class Symbol(AtomicExpr, Boolean):
 
     @property
     def assumptions0(self):
-        return {key: value for key, value
-                in self._assumptions.items() if value is not None}
+        return self._assumptions0.copy()
 
     @cacheit
     def sort_key(self, order=None):
@@ -442,7 +462,7 @@ class Dummy(Symbol):
         return obj
 
     def __getnewargs_ex__(self):
-        return ((self.name, self.dummy_index), self.assumptions0)
+        return ((self.name, self.dummy_index), self._assumptions_orig)
 
     @cacheit
     def sort_key(self, order=None):

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -5,8 +5,9 @@ from sympy.core.symbol import (Dummy, Symbol, Wild, symbols)
 from sympy.core.sympify import sympify  # can't import as S yet
 from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, skip_under_pyodide
 from sympy.core.symbol import disambiguate
+
 
 def test_Str():
     a1 = Str('a')
@@ -14,6 +15,7 @@ def test_Str():
     b = Str('b')
     assert a1 == a2 != b
     raises(TypeError, lambda: Str())
+
 
 def test_Symbol():
     a = Symbol("a")
@@ -391,3 +393,27 @@ def test_disambiguate():
     assert disambiguate(*t7) == (y*y_1, y_1)
     assert disambiguate(Dummy('x_1'), Dummy('x_1')
         ) == (x_1, Symbol('x_1_1'))
+
+
+@skip_under_pyodide("Cannot create threads under pyodide.")
+def test_issue_gh_16734():
+    # https://github.com/sympy/sympy/issues/16734
+
+    syms = list(symbols('x, y'))
+
+    def thread1():
+        for n in range(1000):
+            syms[0], syms[1] = symbols(f'x{n}, y{n}')
+            syms[0].is_positive # Check an assumption in this thread.
+        syms[0] = None
+
+    def thread2():
+        while syms[0] is not None:
+            # Compare the symbol in this thread.
+            result = (syms[0] == syms[1])  # noqa
+
+    # Previously this would be very likely to raise an exception:
+    thread = threading.Thread(target=thread1)
+    thread.start()
+    thread2()
+    thread.join()

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,3 +1,5 @@
+import threading
+
 from sympy.core.function import Function, UndefinedFunction
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import (GreaterThan, LessThan, StrictGreaterThan, StrictLessThan)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -33,17 +33,15 @@ from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture, iterable
 from sympy.utilities.exceptions import ignore_warnings, SymPyDeprecationWarning
-from sympy.testing.pytest import (raises, XFAIL, slow, skip,
+from sympy.testing.pytest import (raises, XFAIL, slow, skip, skip_under_pyodide,
                                   warns_deprecated_sympy, warns)
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
-from sympy.external import import_module
 from sympy.algebras import Quaternion
 
 from sympy.abc import a, b, c, d, x, y, z, t
 
-pyodide_js = import_module('pyodide_js')
 
 # don't re-order this list
 classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
@@ -2985,9 +2983,8 @@ def test_func():
     assert A.analytic_func(exp(x*t), x) == expand(simplify((A*t).exp()))
 
 
+@skip_under_pyodide("Cannot create threads under pyodide.")
 def test_issue_19809():
-    if pyodide_js:
-        skip("can't run on pyodide")
 
     def f():
         assert _dotprodsimp_state.state == None

--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -19,7 +19,7 @@ def test_qs_1():
         {18640889198609, 20991129234731}
 
 
-def test_qs_2():
+def test_qs_2() -> None:
     n = 10009202107
     M = 50
     # a = 10, b = 15, modified_coeff = [a**2, 2*a*b, b**2 - N]

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1072,7 +1072,7 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
     code = stringify_expr(s, local_dict, global_dict, _transformations)
 
     if not evaluate:
-        code = compile(evaluateFalse(code), '<string>', 'eval')
+        code = compile(evaluateFalse(code), '<string>', 'eval') # type: ignore
 
     try:
         rv = eval_expr(code, local_dict, global_dict)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -224,7 +224,7 @@ class ReprPrinter(Printer):
         return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
     def _print_Symbol(self, expr):
-        d = expr._assumptions.generator
+        d = expr._assumptions_orig
         # print the dummy_index like it was an assumption
         if expr.is_Dummy:
             d['dummy_index'] = expr.dummy_index

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -17,7 +17,7 @@ from sympy.tensor.array import Array
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
     PermuteDims, ArrayDiagonal
 from sympy.printing.numpy import JaxPrinter, _jax_known_constants, _jax_known_functions
-from sympy.tensor.array.expressions.conv_matrix_to_array import convert_matrix_to_array
+from sympy.tensor.array.expressions.from_matrix_to_array import convert_matrix_to_array
 
 from sympy.testing.pytest import skip, raises
 from sympy.external import import_module

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -364,3 +364,25 @@ def warns_deprecated_sympy():
     '''
     with warns(SymPyDeprecationWarning):
         yield
+
+
+def _running_under_pyodide():
+    """Test if running under pyodide."""
+    try:
+        import pyodide_js  # type: ignore  # noqa
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+def skip_under_pyodide(message):
+    """Decorator to skip a test if running under pyodide."""
+    def decorator(test_func):
+        @functools.wraps(test_func)
+        def test_wrapper():
+            if _running_under_pyodide():
+                skip(message)
+            return test_func()
+        return test_wrapper
+    return decorator

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -4,7 +4,8 @@ from subprocess import Popen, PIPE
 import os
 
 from sympy.core.singleton import S
-from sympy.testing.pytest import raises, warns_deprecated_sympy, skip
+from sympy.testing.pytest import (raises, warns_deprecated_sympy,
+                                  skip_under_pyodide)
 from sympy.utilities.misc import (translate, replace, ordinal, rawlines,
                                   strlines, as_int, find_executable)
 from sympy.external import import_module
@@ -114,9 +115,8 @@ def test_translate_args():
         assert False
 
 
+@skip_under_pyodide("Cannot create subprocess under pyodide.")
 def test_debug_output():
-    if pyodide_js:
-        skip("can't run on pyodide")
     env = os.environ.copy()
     env['SYMPY_DEBUG'] = 'True'
     cmd = 'from sympy import *; x = Symbol("x"); print(integrate((1-cos(x))/x, x))'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of 
gh-24880
gh-24892
gh-24882

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * A rare bug from using Symbol in multithreaded code was fixed. Previously an exception might be raised when comparing two symbols while querying an assumption in a parallel thread.
   * Symbols with assumptions are now encoded more efficiently in pickles reducing the number of bytes needed for each symbol.
<!-- END RELEASE NOTES -->
