### PR TITLE
Pr assumptions backport

### DIFF
--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -5,8 +5,9 @@ from sympy.core.symbol import (Dummy, Symbol, Wild, symbols)
 from sympy.core.sympify import sympify  # can't import as S yet
 from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, skip_under_pyodide
 from sympy.core.symbol import disambiguate
+
 
 def test_Str():
     a1 = Str('a')
@@ -14,6 +15,7 @@ def test_Str():
     b = Str('b')
     assert a1 == a2 != b
     raises(TypeError, lambda: Str())
+
 
 def test_Symbol():
     a = Symbol("a")
@@ -391,3 +393,27 @@ def test_disambiguate():
     assert disambiguate(*t7) == (y*y_1, y_1)
     assert disambiguate(Dummy('x_1'), Dummy('x_1')
         ) == (x_1, Symbol('x_1_1'))
+
+
+@skip_under_pyodide("Cannot create threads under pyodide.")
+def test_issue_gh_16734():
+    # https://github.com/sympy/sympy/issues/16734
+
+    syms = list(symbols('x, y'))
+
+    def thread1():
+        for n in range(1000):
+            syms[0], syms[1] = symbols(f'x{n}, y{n}')
+            syms[0].is_positive # Check an assumption in this thread.
+        syms[0] = None
+
+    def thread2():
+        while syms[0] is not None:
+            # Compare the symbol in this thread.
+            result = (syms[0] == syms[1])  # noqa
+
+    # Previously this would be very likely to raise an exception:
+    thread = threading.Thread(target=thread1)
+    thread.start()
+    thread2()
+    thread.join()

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -33,17 +33,15 @@ from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture, iterable
 from sympy.utilities.exceptions import ignore_warnings, SymPyDeprecationWarning
-from sympy.testing.pytest import (raises, XFAIL, slow, skip,
+from sympy.testing.pytest import (raises, XFAIL, slow, skip, skip_under_pyodide,
                                   warns_deprecated_sympy, warns)
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
-from sympy.external import import_module
 from sympy.algebras import Quaternion
 
 from sympy.abc import a, b, c, d, x, y, z, t
 
-pyodide_js = import_module('pyodide_js')
 
 # don't re-order this list
 classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
@@ -2985,9 +2983,8 @@ def test_func():
     assert A.analytic_func(exp(x*t), x) == expand(simplify((A*t).exp()))
 
 
+@skip_under_pyodide("Cannot create threads under pyodide.")
 def test_issue_19809():
-    if pyodide_js:
-        skip("can't run on pyodide")
 
     def f():
         assert _dotprodsimp_state.state == None

--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -19,7 +19,7 @@ def test_qs_1():
         {18640889198609, 20991129234731}
 
 
-def test_qs_2():
+def test_qs_2() -> None:
     n = 10009202107
     M = 50
     # a = 10, b = 15, modified_coeff = [a**2, 2*a*b, b**2 - N]

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1072,7 +1072,7 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
     code = stringify_expr(s, local_dict, global_dict, _transformations)
 
     if not evaluate:
-        code = compile(evaluateFalse(code), '<string>', 'eval')
+        code = compile(evaluateFalse(code), '<string>', 'eval') # type: ignore
 
     try:
         rv = eval_expr(code, local_dict, global_dict)

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -364,3 +364,25 @@ def warns_deprecated_sympy():
     '''
     with warns(SymPyDeprecationWarning):
         yield
+
+
+def _running_under_pyodide():
+    """Test if running under pyodide."""
+    try:
+        import pyodide_js  # type: ignore  # noqa
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+def skip_under_pyodide(message):
+    """Decorator to skip a test if running under pyodide."""
+    def decorator(test_func):
+        @functools.wraps(test_func)
+        def test_wrapper():
+            if _running_under_pyodide():
+                skip(message)
+            return test_func()
+        return test_wrapper
+    return decorator

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -4,7 +4,8 @@ from subprocess import Popen, PIPE
 import os
 
 from sympy.core.singleton import S
-from sympy.testing.pytest import raises, warns_deprecated_sympy, skip
+from sympy.testing.pytest import (raises, warns_deprecated_sympy,
+                                  skip_under_pyodide)
 from sympy.utilities.misc import (translate, replace, ordinal, rawlines,
                                   strlines, as_int, find_executable)
 from sympy.external import import_module
@@ -114,9 +115,8 @@ def test_translate_args():
         assert False
 
 
+@skip_under_pyodide("Cannot create subprocess under pyodide.")
 def test_debug_output():
-    if pyodide_js:
-        skip("can't run on pyodide")
     env = os.environ.copy()
     env['SYMPY_DEBUG'] = 'True'
     cmd = 'from sympy import *; x = Symbol("x"); print(integrate((1-cos(x))/x, x))'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-23693


#### Brief description of what is fixed or changed

Use less evaluatio in assumptions

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * A bug preventing the use of the old assumptions under evaluate(False) was fixed.
<!-- END RELEASE NOTES -->
