### PR TITLE
Doc: Fix dangling hyphens.

### DIFF
--- a/doc/src/contributing/docstring.rst
+++ b/doc/src/contributing/docstring.rst
@@ -47,8 +47,8 @@ module docstring is the docstring at the very top of the file, for example, the
 docstring for `solvers.ode
 <https://github.com/sympy/sympy/blob/85e684f782c71d247b13af71f2f134a9d894507e/sympy/solvers/ode.py>`_.
 
-A public function is one that is intended to be used by the end-
-user, or the public. Documentation is important for public functions because
+A public function is one that is intended to be used by the end-user,
+or the public. Documentation is important for public functions because
 they will be seen and used by many people.
 
 A private function, on the other hand, is one that is only intended to be used
@@ -740,8 +740,8 @@ Here are some troubleshooting tips to fix the errors:
   functions like ``int`` or ``NotImplementedError``, functions from other
   modules outside of SymPy like ``matplotlib.plot``, and variable or parameter
   names that are specific to the text at hand. In general, if the object cannot
-  be accessed as ``sympy.something.something.object``, it cannot be cross-
-  referenced and you should not use the ``:obj:`` syntax.
+  be accessed as ``sympy.something.something.object``, it cannot be
+  cross-referenced and you should not use the ``:obj:`` syntax.
 * If you are using are using one of the `type specific
   <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects>`_
   identifiers like ``:func:``, be sure that the type for it is correct.

--- a/doc/src/modules/combinatorics/fp_groups.rst
+++ b/doc/src/modules/combinatorics/fp_groups.rst
@@ -4,10 +4,10 @@ Finitely Presented Groups
 Introduction
 ------------
 
-This module presents the functionality designed for computing with finitely-
-presented groups (fp-groups for short). The name of the corresponding SymPy
-object is ``FpGroup``. The functions or classes described here are studied
-under **computational group theory**. All code examples assume:
+This module presents the functionality designed for computing with
+finitely-presented groups (fp-groups for short). The name of the corresponding
+SymPy object is ``FpGroup``. The functions or classes described here are
+studied under **computational group theory**. All code examples assume:
 
 >>> from sympy.combinatorics.free_groups import free_group, vfree_group, xfree_group
 >>> from sympy.combinatorics.fp_groups import FpGroup, CosetTable, coset_enumeration_r

--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -116,7 +116,7 @@ appear in the iterable.
   >>> C = A.orient_new('C', (axis_orienter, body_orienter))
 
 The :mod:`sympy.vector` API provides the following four ``Orienter``
-classes for orientation purposes-
+classes for orientation purposes:
 
 1. ``AxisOrienter``
 
@@ -214,7 +214,7 @@ expressions and dyadic tensors.
 :mod:`sympy.vector` supports the expression of vector/scalar quantities
 in different coordinate systems using the ``express`` function.
 
-For purposes of this section, assume the following initializations-
+For purposes of this section, assume the following initializations:
 
   >>> from sympy.vector import CoordSys3D, express
   >>> from sympy.abc import a, b, c


### PR DESCRIPTION
Dangling hyphens in sphinx are rendered with a space, see screenshot from https://docs.sympy.org/latest/contributing/docstring.html:

![Screenshot 2023-03-11 at 10-40-02 SymPy Docstrings Style Guide - SymPy 1 11 documentation](https://user-images.githubusercontent.com/239510/224477009-96896b2b-9c45-4d17-b46d-085fceda1b42.png)

It'll be catched by the next release of sphinx-lint: https://github.com/sphinx-contrib/sphinx-lint/pull/56

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->