### PR TITLE
Added use of real_roots in _solve_as_poly

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -45,7 +45,7 @@ from sympy.ntheory.residue_ntheory import discrete_log, nthroot_mod
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf, factor, lcm, gcd)
 from sympy.polys.polyerrors import CoercionFailed
-from sympy.polys.polytools import invert, groebner, poly
+from sympy.polys.polytools import invert, groebner, poly, real_roots
 from sympy.polys.solvers import (sympy_eqs_to_ring, solve_lin_sys,
     PolyNonlinearError)
 from sympy.polys.matrices.linsolve import _linsolve
@@ -798,7 +798,11 @@ def _solve_as_poly(f, symbol, domain=S.Complexes):
     """
     result = None
     if f.is_polynomial(symbol):
-        solns = roots(f, symbol, cubics=True, quartics=True,
+        if (domain.is_subset(S.Reals) or domain==S.Reals) and (f.atoms(Symbol)==f.free_symbols) and (FiniteSet(*Poly(f,symbol).coeffs()).is_subset(S.Rationals)):
+            solns=FiniteSet(*real_roots(Poly(f,symbol))).evalf()
+            return solns
+        else:
+            solns = roots(f, symbol, cubics=True, quartics=True,
                       quintics=True, domain='EX')
         num_roots = sum(solns.values())
         if degree(f, symbol) <= num_roots:


### PR DESCRIPTION
Added use of real_roots in _solve_as_poly when coefficients are rational numbers and the domain is a subset of Reals.

Fixes #22793 

Previously roots were being calculated by roots() in all cases, however a much simpler approach of using real_roots can be used if the domain is R and the coefficients are rational numbers. 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->