### PR TITLE
Updated mul.py

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -161,7 +161,7 @@ class Mul(Expr, AssocOp):
     """
     __slots__ = ()
 
-    args: tTuple[Expr]
+    args: tuple[Expr, ...]
 
     is_Mul = True
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -161,7 +161,7 @@ class Mul(Expr, AssocOp):
     """
     __slots__ = ()
 
-    args: tuple[Expr, ...]
+    args: tTuple[Expr, ...]
 
     is_Mul = True
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Change type annotation at line no 164 in [sympy/sympy/core/mul.py](https://github.com/sympy/sympy/blob/5c03f65eeab34368bec9a7f76feffaf2f0b7a110/sympy/core/mul.py#L164)

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24871


#### Brief description of what is fixed or changed

"args: tTuple[Expr]" changed to  "args: tuple[Expr, ...] "


#### Other comments

The issue with the syntax tTuple[Expr] is that it does not allow for a tuple of variable length. The tTuple type annotation, if it is a user-defined type annotation, may have been defined to only allow tuples of a fixed length.

On the other hand, tuple[Expr, ...] is a built-in type annotation that allows for a tuple of any length, as indicated by the ellipsis .... This syntax is recommended for defining a tuple of variable length.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
