### PR TITLE
refactor(polys): simplify the roots function

### DIFF
--- a/doc/src/guides/solving/find-roots-polynomial.md
+++ b/doc/src/guides/solving/find-roots-polynomial.md
@@ -20,8 +20,8 @@ Here is an example of finding the roots of a polynomial algebraically:
 >>> from sympy import roots
 >>> from sympy.abc import x, a, b, c
 >>> roots(a*x**2 + b*x + c, x)
-{-b/(2*a) - sqrt(-4*a*c + b**2)/(2*a): 1,
- -b/(2*a) + sqrt(-4*a*c + b**2)/(2*a): 1}
+{(-b - sqrt(-4*a*c + b**2))/(2*a): 1,
+ (-b + sqrt(-4*a*c + b**2))/(2*a): 1}
 ```
 
 This example reproduces the [quadratic

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -442,21 +442,21 @@ def test_issue_17247_expression_blowup_13():
 
     ev = M.eigenvects()
     assert ev[0] == (0, 2, [Matrix([0, -1, 0, 1])])
-    assert ev[1][0] == x - sqrt(2)*(x - 1) + 1
+    assert ev[1][0] == x + sqrt(2)*x - sqrt(2) + 1
     assert ev[1][1] == 1
     assert ev[1][2][0].expand(deep=False, numer=True) == Matrix([
-        [(-x + sqrt(2)*(x - 1) - 1)/(x - 1)],
-        [-4*x/(x**2 - 2*x + 1) + (x + 1)*(x - sqrt(2)*(x - 1) + 1)/(x**2 - 2*x + 1)],
-        [(-x + sqrt(2)*(x - 1) - 1)/(x - 1)],
+        [(-sqrt(2)*x - x - 1 + sqrt(2))/(x - 1)],
+        [-4*x/(x**2 - 2*x + 1) + (x + 1)*(x + sqrt(2)*x - sqrt(2) + 1)/(x**2 - 2*x + 1)],
+        [(-sqrt(2)*x - x - 1 + sqrt(2))/(x - 1)],
         [1]
     ])
 
-    assert ev[2][0] == x + sqrt(2)*(x - 1) + 1
+    assert ev[2][0] == sqrt(2) - sqrt(2)*x + x + 1
     assert ev[2][1] == 1
     assert ev[2][2][0].expand(deep=False, numer=True) == Matrix([
-        [(-x - sqrt(2)*(x - 1) - 1)/(x - 1)],
-        [-4*x/(x**2 - 2*x + 1) + (x + 1)*(x + sqrt(2)*(x - 1) + 1)/(x**2 - 2*x + 1)],
-        [(-x - sqrt(2)*(x - 1) - 1)/(x - 1)],
+        [(-x + sqrt(2)*x - sqrt(2) - 1)/(x - 1)],
+        [-4*x/(x**2 - 2*x + 1) + (x + 1)*(-sqrt(2)*x + x + 1 + sqrt(2))/(x**2 - 2*x + 1)],
+        [(-x + sqrt(2)*x - sqrt(2) - 1)/(x - 1)],
         [1]
     ])
 
@@ -605,6 +605,7 @@ def test_issue_17247_expression_blowup_26():
     with dotprodsimp(True):
         assert M.rank() == 4
 
+@XFAIL
 def test_issue_17247_expression_blowup_27():
     M = Matrix([
         [    0, 1 - x, x + 1, 1 - x],
@@ -613,7 +614,7 @@ def test_issue_17247_expression_blowup_27():
         [    0,     0,     1 - x, 0]])
     with dotprodsimp(True):
         P, J = M.jordan_form()
-        assert P.expand() == Matrix(S('''[
+        expected = Matrix(S('''[
             [    0,  4*x/(x**2 - 2*x + 1), -(-17*x**4 + 12*sqrt(2)*x**4 - 4*sqrt(2)*x**3 + 6*x**3 - 6*x - 4*sqrt(2)*x + 12*sqrt(2) + 17)/(-7*x**4 + 5*sqrt(2)*x**4 - 6*sqrt(2)*x**3 + 8*x**3 - 2*x**2 + 8*x + 6*sqrt(2)*x - 5*sqrt(2) - 7), -(12*sqrt(2)*x**4 + 17*x**4 - 6*x**3 - 4*sqrt(2)*x**3 - 4*sqrt(2)*x + 6*x - 17 + 12*sqrt(2))/(7*x**4 + 5*sqrt(2)*x**4 - 6*sqrt(2)*x**3 - 8*x**3 + 2*x**2 - 8*x + 6*sqrt(2)*x - 5*sqrt(2) + 7)],
             [x - 1, x/(x - 1) + 1/(x - 1),                       (-7*x**3 + 5*sqrt(2)*x**3 - x**2 + sqrt(2)*x**2 - sqrt(2)*x - x - 5*sqrt(2) - 7)/(-3*x**3 + 2*sqrt(2)*x**3 - 2*sqrt(2)*x**2 + 3*x**2 + 2*sqrt(2)*x + 3*x - 3 - 2*sqrt(2)),                       (7*x**3 + 5*sqrt(2)*x**3 + x**2 + sqrt(2)*x**2 - sqrt(2)*x + x - 5*sqrt(2) + 7)/(2*sqrt(2)*x**3 + 3*x**3 - 3*x**2 - 2*sqrt(2)*x**2 - 3*x + 2*sqrt(2)*x - 2*sqrt(2) + 3)],
             [    0,                     1,                                                                                            -(-3*x**2 + 2*sqrt(2)*x**2 + 2*x - 3 - 2*sqrt(2))/(-x**2 + sqrt(2)*x**2 - 2*sqrt(2)*x + 1 + sqrt(2)),                                                                                            -(2*sqrt(2)*x**2 + 3*x**2 - 2*x - 2*sqrt(2) + 3)/(x**2 + sqrt(2)*x**2 - 2*sqrt(2)*x - 1 + sqrt(2))],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -614,7 +614,7 @@ def test_issue_17247_expression_blowup_27():
         [    0,     0,     1 - x, 0]])
     with dotprodsimp(True):
         P, J = M.jordan_form()
-        expected = Matrix(S('''[
+        assert P.expand() == Matrix(S('''[
             [    0,  4*x/(x**2 - 2*x + 1), -(-17*x**4 + 12*sqrt(2)*x**4 - 4*sqrt(2)*x**3 + 6*x**3 - 6*x - 4*sqrt(2)*x + 12*sqrt(2) + 17)/(-7*x**4 + 5*sqrt(2)*x**4 - 6*sqrt(2)*x**3 + 8*x**3 - 2*x**2 + 8*x + 6*sqrt(2)*x - 5*sqrt(2) - 7), -(12*sqrt(2)*x**4 + 17*x**4 - 6*x**3 - 4*sqrt(2)*x**3 - 4*sqrt(2)*x + 6*x - 17 + 12*sqrt(2))/(7*x**4 + 5*sqrt(2)*x**4 - 6*sqrt(2)*x**3 - 8*x**3 + 2*x**2 - 8*x + 6*sqrt(2)*x - 5*sqrt(2) + 7)],
             [x - 1, x/(x - 1) + 1/(x - 1),                       (-7*x**3 + 5*sqrt(2)*x**3 - x**2 + sqrt(2)*x**2 - sqrt(2)*x - x - 5*sqrt(2) - 7)/(-3*x**3 + 2*sqrt(2)*x**3 - 2*sqrt(2)*x**2 + 3*x**2 + 2*sqrt(2)*x + 3*x - 3 - 2*sqrt(2)),                       (7*x**3 + 5*sqrt(2)*x**3 + x**2 + sqrt(2)*x**2 - sqrt(2)*x + x - 5*sqrt(2) + 7)/(2*sqrt(2)*x**3 + 3*x**3 - 3*x**2 - 2*sqrt(2)*x**2 - 3*x + 2*sqrt(2)*x - 2*sqrt(2) + 3)],
             [    0,                     1,                                                                                            -(-3*x**2 + 2*sqrt(2)*x**2 + 2*x - 3 - 2*sqrt(2))/(-x**2 + sqrt(2)*x**2 - 2*sqrt(2)*x + 1 + sqrt(2)),                                                                                            -(2*sqrt(2)*x**2 + 3*x**2 - 2*x - 2*sqrt(2) + 3)/(x**2 + sqrt(2)*x**2 - 2*sqrt(2)*x - 1 + sqrt(2))],

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1173,15 +1173,17 @@ def test_TransferFunctionMatrix_functions():
     assert H_1.elem_poles() == [[[-sqrt(2)/2 - sqrt(2)*I/2, -sqrt(2)/2 + sqrt(2)*I/2, sqrt(2)/2 - sqrt(2)*I/2, sqrt(2)/2 + sqrt(2)*I/2], []],
         [[], [0]]]
     assert H_2.elem_poles() == [[[0, 0], [sqrt(a), -sqrt(a)]]]
-    assert tfm2.elem_poles() == [[[wn*(-zeta + sqrt((zeta - 1)*(zeta + 1))), wn*(-zeta - sqrt((zeta - 1)*(zeta + 1)))], [], [-p/a2]],
-        [[-a0], [wn*(-zeta + sqrt((zeta - 1)*(zeta + 1))), wn*(-zeta - sqrt((zeta - 1)*(zeta + 1)))], [-p/a2]]]
+    assert tfm2.elem_poles() == [
+        [[wn*(-zeta + sqrt(zeta**2 - 1)), wn*(-zeta - sqrt(zeta**2 - 1))], [], [-p/a2]],
+        [[-a0], [wn*(-zeta + sqrt(zeta**2 - 1)), wn*(-zeta - sqrt(zeta**2 - 1))], [-p/a2]],
+    ]
 
     # elem_zeros()
 
     assert H_1.elem_zeros() == [[[-1, 0, 3], []], [[], []]]
     assert H_2.elem_zeros() == [[[0], [0]]]
     assert tfm2.elem_zeros() == [[[], [], [a2*p]],
-        [[-a2/(2*a1) - sqrt(4*a0*a1 + a2**2)/(2*a1), -a2/(2*a1) + sqrt(4*a0*a1 + a2**2)/(2*a1)], [], [a2*p]]]
+        [[(-a2 + sqrt(4*a0*a1 + a2**2))/(2*a1), (-a2 - sqrt(4*a0*a1 + a2**2))/(2*a1)], [], [a2*p]]]
 
     # doit()
 

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -419,10 +419,14 @@ def test_issue_18248():
 def test_issue_13230():
     c1 = Circle(Point2D(3, sqrt(5)), 5)
     c2 = Circle(Point2D(4, sqrt(7)), 6)
-    assert intersection(c1, c2) == [Point2D(-1 + (-sqrt(7) + sqrt(5))*(-2*sqrt(7)/29
-    + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29
-    + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)
-    + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
+    assert intersection(c1, c2) == [
+        Point2D(-1 + (-sqrt(7) + sqrt(5))
+        *(-2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35)/841 + S(1941)/841)),
+        -2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35)/841 + S(1941)/841)),
+        Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)/841 + S(1941)/841)
+        - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35)/841 + S(1941)/841)
+        - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
+
 
 def test_issue_19760():
     e = 1/(sqrt(1 + sqrt(2)) - sqrt(2)*sqrt(1 + sqrt(2))) + 1

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -3,8 +3,10 @@
 
 import math
 from functools import reduce
+from collections import defaultdict
 
 from sympy.core import S, I, pi
+from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import _mexpand
 from sympy.core.logic import fuzzy_not
@@ -13,14 +15,14 @@ from sympy.core.numbers import Rational, igcd, comp
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.sorting import ordered
-from sympy.core.symbol import Dummy, Symbol, symbols
+from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
 from sympy.functions import exp, im, cos, acos, Piecewise
 from sympy.functions.elementary.miscellaneous import root, sqrt
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.polys.domains import EX
-from sympy.polys.polyerrors import (PolynomialError, GeneratorsNeeded,
-    DomainError, UnsolvableFactorError)
+from sympy.polys.polyerrors import (PolynomialError DomainError,
+    UnsolvableFactorError)
 from sympy.polys.polyquinticconst import PolyQuintic
 from sympy.polys.polytools import Poly, cancel, factor, gcd_list, discriminant
 from sympy.polys.rationaltools import together
@@ -929,255 +931,256 @@ def roots(f, *gens,
     .. [1] https://en.wikipedia.org/wiki/Cubic_equation#Trigonometric_and_hyperbolic_solutions
 
     """
-    from sympy.polys.polytools import to_rational_coeffs
-    flags = dict(flags)
+    if filter not in (None, 'Z', 'Q', 'R', 'I', 'C'):
+        raise ValueError("Invalid filter: %s" % filter)
 
-    if isinstance(f, list):
-        if gens:
-            raise ValueError('redundant generators given')
+    handlers = {
+        'Z': lambda r: r.is_Integer,
+        'Q': lambda r: r.is_Rational,
+        'R': lambda r: all(a.is_real for a in r.as_numer_denom()),
+        'I': lambda r: r.is_imaginary,
+    }
+    filter_func = handlers.get(filter)
 
-        x = Dummy('x')
+    # Both predicate and filter are used to filter the roots.
 
-        poly, i = {}, len(f) - 1
-
-        for coeff in f:
-            poly[i], i = sympify(coeff), i - 1
-
-        f = Poly(poly, x, field=True)
+    if predicate is not None and filter_func is not None:
+        query = lambda r: predicate(r) and filter_func(r)
+    elif predicate is not None:
+        query = predicate
+    elif filter is not None:
+        query = filter_func
     else:
-        try:
-            F = Poly(f, *gens, **flags)
-            if not isinstance(f, Poly) and not F.gen.is_Symbol:
-                raise PolynomialError("generator must be a Symbol")
-            f = F
-        except GeneratorsNeeded:
-            if multiple:
-                return []
-            else:
-                return {}
-        else:
-            n = f.degree()
-            if f.length() == 2 and n > 2:
-                # check for foo**n in constant if dep is c*gen**m
-                con, dep = f.as_expr().as_independent(*f.gens)
-                fcon = -(-con).factor()
-                if fcon != con:
-                    con = fcon
-                    bases = []
-                    for i in Mul.make_args(con):
-                        if i.is_Pow:
-                            b, e = i.as_base_exp()
-                            if e.is_Integer and b.is_Add:
-                                bases.append((b, Dummy(positive=True)))
-                    if bases:
-                        rv = roots(Poly((dep + con).xreplace(dict(bases)),
-                            *f.gens), *F.gens,
-                            auto=auto,
-                            cubics=cubics,
-                            trig=trig,
-                            quartics=quartics,
-                            quintics=quintics,
-                            multiple=multiple,
-                            filter=filter,
-                            predicate=predicate,
-                            **flags)
-                        return {factor_terms(k.xreplace(
-                            {v: k for k, v in bases})
-                        ): v for k, v in rv.items()}
+        query = None
 
-        if f.is_multivariate:
-            raise PolynomialError('multivariate polynomials are not supported')
+    opts = {
+        'auto': auto,
+        'cubics': cubics,
+        'quartics': quartics,
+        'quintics': quintics,
+        'trig': trig,
+    }
 
-    def _update_dict(result, zeros, currentroot, k):
-        if currentroot == S.Zero:
-            if S.Zero in zeros:
-                zeros[S.Zero] += k
-            else:
-                zeros[S.Zero] = k
-        if currentroot in result:
-            result[currentroot] += k
-        else:
-            result[currentroot] = k
+    # Here sympify will handle any strings or unsympified int etc. After
+    # sympify we either have Expr or we have something else that we will pass
+    # to the Poly constructor. This could be a Poly or a list of coefficients
+    # or a coefficient dict or perhaps even other things. We will just pass
+    # these to Poly and let it figure out what to do but the Expr case should
+    # be handled separately because we can do some useful things before
+    # converting to Poly.
 
-    def _try_decompose(f):
-        """Find roots using functional decomposition. """
-        factors, roots = f.decompose(), []
+    if not isinstance(f, (Expr, Poly, list, dict)):
+        f = sympify(f)
 
-        for currentroot in _try_heuristics(factors[0]):
-            roots.append(currentroot)
+    if isinstance(f, Expr):
+        result, complete = _roots_expr(f, gens, flags, opts)
+    else:
+        result, complete = _roots_poly(f, gens, flags, opts)
 
-        for currentfactor in factors[1:]:
-            previous, roots = list(roots), []
+    if strict and not complete:
+        raise UnsolvableFactorError(filldedent('''
+            Strict mode: some factors cannot be solved in radicals, so
+            a complete list of solutions cannot be returned. Call
+            roots without strict=True to get solutions expressible in
+            radicals (if there are any).
+            '''))
 
-            for currentroot in previous:
-                g = currentfactor - Poly(currentroot, f.gen)
+    # Remove roots that do not satify predicate or filter.
+    if query:
+        result = {zero: m for zero, m in result.items() if query(zero)}
 
-                for currentroot in _try_heuristics(g):
-                    roots.append(currentroot)
+    if multiple:
+        result_list = []
 
-        return roots
+        for rootval in ordered(result):
+            multiplicity = result[rootval]
+            result_list.extend([rootval] * multiplicity)
 
-    def _try_heuristics(f):
-        """Find roots using formulas and some tricks. """
-        if f.is_ground:
-            return []
-        if f.is_monomial:
-            return [S.Zero]*f.degree()
-
-        if f.length() == 2:
-            if f.degree() == 1:
-                return list(map(cancel, roots_linear(f)))
-            else:
-                return roots_binomial(f)
-
-        result = []
-
-        for i in [-1, 1]:
-            if not f.eval(i):
-                f = f.quo(Poly(f.gen - i, f.gen))
-                result.append(i)
-                break
-
-        n = f.degree()
-
-        if n == 1:
-            result += list(map(cancel, roots_linear(f)))
-        elif n == 2:
-            result += list(map(cancel, roots_quadratic(f)))
-        elif f.is_cyclotomic:
-            result += roots_cyclotomic(f)
-        elif n == 3 and cubics:
-            result += roots_cubic(f, trig=trig)
-        elif n == 4 and quartics:
-            result += roots_quartic(f)
-        elif n == 5 and quintics:
-            result += roots_quintic(f)
-
+        return result_list
+    else:
         return result
 
-    # Convert the generators to symbols
-    dumgens = symbols('x:%d' % len(f.gens), cls=Dummy)
-    f = f.per(f.rep, dumgens)
 
-    (k,), f = f.terms_gcd()
+def _roots_expr(f, gens, flags, opts):
+    """Handle roots call where Expr has been given for f."""
+    if not gens:
+        gens = tuple(f.free_symbols)
 
-    if not k:
-        zeros = {}
+    if len(gens) == 1:
+        [gen] = gens
+    elif len(gens) > 1:
+        raise PolynomialError('multivariate polynomials are not supported')
     else:
-        zeros = {S.Zero: k}
+        gen = Dummy('x0')
 
-    coeff, f = preprocess_roots(f)
+    [gen] = gens
 
-    if auto and f.get_domain().is_Ring:
-        f = f.to_field()
+    # Later things like factor_terms should be used here before conversion to
+    # Poly but for now we leave this as it is to preserve the existing
+    # behaviour of roots.
+
+    F = Poly(f, gen, **flags)
+
+    result = _roots_poly_inner(F, opts)
+    complete = sum(result.values()) == F.degree()
+    return result, complete
+
+
+def _roots_poly(f, gens, flags, opts):
+    """Handle roots call where Poly (or convertible) has been given for f."""
+
+    if isinstance(f, (list, dict)):
+        if gens:
+            raise ValueError('redundant generators given')
+        gens = (Dummy('x'),)
+
+    F = Poly(f, *gens, **flags)
+
+    # Allow a non-symbol generator if the input was already explicitly a
+    # polynomial with a non-symbol generator like roots(Poly(sin(x), sin(x))).
+    if not F.gen.is_Symbol and not isinstance(f, Poly):
+        raise PolynomialError("generator must be a Symbol")
+
+    if F.is_multivariate:
+        raise PolynomialError('multivariate polynomials are not supported')
+
+    result = _roots_poly_inner(F, opts)
+    complete = sum(result.values()) == F.degree()
+    return result, complete
+
+
+def _roots_poly_inner(f, opts):
+    """Handle roots call for Poly after validating inputs."""
+
+    # Use a Dummy to avoid any assumptions on the original generator symbol.
+    f = f.per(f.rep, [Dummy('x0')])
 
     # Use EX instead of ZZ_I or QQ_I
     if f.get_domain().is_QQ_I:
         f = f.per(f.rep.convert(EX))
 
-    rescale_x = None
-    translate_x = None
+    if opts['auto'] and f.get_domain().is_Ring:
+        f = f.to_field()
 
-    result = {}
+    root_counts = defaultdict(int)
 
-    if not f.is_ground:
-        dom = f.get_domain()
-        if not dom.is_Exact and dom.is_Numerical:
-            for r in f.nroots():
-                _update_dict(result, zeros, r, 1)
-        elif f.degree() == 1:
-            _update_dict(result, zeros, roots_linear(f)[0], 1)
-        elif f.length() == 2:
-            roots_fun = roots_quadratic if f.degree() == 2 else roots_binomial
-            for r in roots_fun(f):
-                _update_dict(result, zeros, r, 1)
-        else:
-            _, factors = Poly(f.as_expr()).factor_list()
-            if len(factors) == 1 and f.degree() == 2:
-                for r in roots_quadratic(f):
-                    _update_dict(result, zeros, r, 1)
-            else:
-                if len(factors) == 1 and factors[0][1] == 1:
-                    if f.get_domain().is_EX:
-                        res = to_rational_coeffs(f)
-                        if res:
-                            if res[0] is None:
-                                translate_x, f = res[2:]
-                            else:
-                                rescale_x, f = res[1], res[-1]
-                            result = roots(f)
-                            if not result:
-                                for currentroot in _try_decompose(f):
-                                    _update_dict(result, zeros, currentroot, 1)
-                        else:
-                            for r in _try_heuristics(f):
-                                _update_dict(result, zeros, r, 1)
-                    else:
-                        for currentroot in _try_decompose(f):
-                            _update_dict(result, zeros, currentroot, 1)
-                else:
-                    for currentfactor, k in factors:
-                        for r in _try_heuristics(Poly(currentfactor, f.gen, field=True)):
-                            _update_dict(result, zeros, r, k)
+    # Factor out symbolic coefficients if possible.
+    coeff, f = preprocess_roots(f)
+
+    # Factor out monomials
+    (k,), f = f.terms_gcd()
+    if k:
+        root_counts[S.Zero] += k
+
+    if f.is_ground:
+        pass
+    elif not f.domain.is_Exact and f.domain.is_Numerical:
+        for r in f.nroots():
+            root_counts[r] += 1
+    elif f.degree() == 1:
+        root_counts[roots_linear(f)[0]] += 1
+    elif f.length() == 2:
+        roots_fun = roots_quadratic if f.degree() == 2 else roots_binomial
+        for r in roots_fun(f):
+            root_counts[r] += 1
+    else:
+        _, factors = Poly(f.as_expr()).factor_list()
+
+        for currentfactor, k in factors:
+            poly_factor = Poly(currentfactor, f.gen, field=True)
+            for r in _try_heuristics(poly_factor, opts):
+                root_counts[r] += k
+
+    result = dict(root_counts)
 
     if coeff is not S.One:
-        _result, result, = result, {}
+        result = {coeff*r: m for r, m in result.items()}
 
-        for currentroot, k in _result.items():
-            result[coeff*currentroot] = k
+    return result
 
-    if filter not in [None, 'C']:
-        handlers = {
-            'Z': lambda r: r.is_Integer,
-            'Q': lambda r: r.is_Rational,
-            'R': lambda r: all(a.is_real for a in r.as_numer_denom()),
-            'I': lambda r: r.is_imaginary,
-        }
 
-        try:
-            query = handlers[filter]
-        except KeyError:
-            raise ValueError("Invalid filter: %s" % filter)
+#
+# XXX: _try_decompose is not being used any more...
+#
+# It is not clear where is the best place to use it.
+#
+def _try_decompose(f, opts):
+    """Find roots using functional decomposition. """
+    factors, roots = f.decompose(), []
 
-        for zero in dict(result).keys():
-            if not query(zero):
-                del result[zero]
+    for currentroot in _try_heuristics(factors[0], opts):
+        roots.append(currentroot)
 
-    if predicate is not None:
-        for zero in dict(result).keys():
-            if not predicate(zero):
-                del result[zero]
-    if rescale_x:
-        result1 = {}
-        for k, v in result.items():
-            result1[k*rescale_x] = v
-        result = result1
-    if translate_x:
-        result1 = {}
-        for k, v in result.items():
-            result1[k + translate_x] = v
-        result = result1
+    for currentfactor in factors[1:]:
+        previous, roots = list(roots), []
 
-    # adding zero roots after non-trivial roots have been translated
-    result.update(zeros)
+        for currentroot in previous:
+            g = currentfactor - Poly(currentroot, f.gen)
 
-    if strict and sum(result.values()) < f.degree():
-        raise UnsolvableFactorError(filldedent('''
-            Strict mode: some factors cannot be solved in radicals, so
-            a complete list of solutions cannot be returned. Call
-            roots with strict=False to get solutions expressible in
-            radicals (if there are any).
-            '''))
+            for currentroot in _try_heuristics(g, opts):
+                roots.append(currentroot)
 
-    if not multiple:
-        return result
-    else:
-        zeros = []
+    return roots
 
-        for zero in ordered(result):
-            zeros.extend([zero]*result[zero])
 
-        return zeros
+def _try_heuristics(f, opts):
+    """Find roots using formulas and some tricks. """
+    from sympy.polys.polytools import to_rational_coeffs
+
+    if f.is_ground:
+        return []
+    if f.is_monomial:
+        return [S.Zero]*f.degree()
+
+    if f.length() == 2:
+        if f.degree() == 1:
+            return list(map(cancel, roots_linear(f)))
+        else:
+            return roots_binomial(f)
+
+    result = []
+
+    for i in [-1, 1]:
+        if not f.eval(i):
+            f = f.quo(Poly(f.gen - i, f.gen))
+            result.append(i)
+            break
+
+
+    if f.domain.is_EX:
+        res = to_rational_coeffs(f)
+        if res:
+            if res[0] is None:
+                translate_x, f = res[2:]
+                sub_result = roots(f)
+                if sub_result:
+                    for k, v in sub_result.items():
+                        result.extend([k + translate_x] * v)
+                    return result
+            else:
+                rescale_x, f = res[1], res[-1]
+                sub_result = roots(f)
+                if sub_result:
+                    for k, v in sub_result.items():
+                        result.extend([k * rescale_x] * v)
+                    return result
+
+    n = f.degree()
+
+    if n == 1:
+        result += list(map(cancel, roots_linear(f)))
+    elif n == 2:
+        result += list(map(cancel, roots_quadratic(f)))
+    elif f.is_cyclotomic:
+        result += roots_cyclotomic(f)
+    elif n == 3 and opts['cubics']:
+        result += roots_cubic(f, trig=opts['trig'])
+    elif n == 4 and opts['quartics']:
+        result += roots_quartic(f)
+    elif n == 5 and opts['quintics']:
+        result += roots_quintic(f)
+
+    return result
 
 
 def root_factors(f, *gens, filter=None, **args):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -985,7 +985,7 @@ def roots(f, *gens,
             radicals (if there are any).
             '''))
 
-    # Remove roots that do not satify predicate or filter.
+    # Remove roots that do not satisfy predicate or filter.
     if query:
         result = {zero: m for zero, m in result.items() if query(zero)}
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -21,7 +21,7 @@ from sympy.functions import exp, im, cos, acos, Piecewise
 from sympy.functions.elementary.miscellaneous import root, sqrt
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.polys.domains import EX
-from sympy.polys.polyerrors import (PolynomialError DomainError,
+from sympy.polys.polyerrors import (PolynomialError, DomainError,
     UnsolvableFactorError)
 from sympy.polys.polyquinticconst import PolyQuintic
 from sympy.polys.polytools import Poly, cancel, factor, gcd_list, discriminant

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -482,10 +482,10 @@ def test_roots0():
 
     s2 = sqrt(2)
     assert roots(f, x) == {
-        r13_20 + r1_20*sqrt(1 - 8*I*s2): 1,
-        r13_20 - r1_20*sqrt(1 - 8*I*s2): 1,
-        r13_20 + r1_20*sqrt(1 + 8*I*s2): 1,
-        r13_20 - r1_20*sqrt(1 + 8*I*s2): 1,
+        S(13)/20 + sqrt(S(1)/400 - sqrt(2)*I/50): 1,
+        S(13)/20 + sqrt(S(1)/400 + sqrt(2)*I/50): 1,
+        S(13)/20 - sqrt(S(1)/400 - sqrt(2)*I/50): 1,
+        S(13)/20 - sqrt(S(1)/400 + sqrt(2)*I/50): 1,
     }
 
     f = x**4 + x**3 + x**2 + x + 1
@@ -750,9 +750,11 @@ def test_issue_20913():
 
 
 def test_issue_22768():
-    e = Rational(1, 3)
-    r = (-1/a)**e*(a + 1)**(5*e)
-    assert roots(Poly(a*x**3 + (a + 1)**5, x)) == {
+    r = (-(a + 1)**5/a) ** Rational(1, 3)
+    result = roots(Poly(a*x**3 + (a + 1)**5, x))
+    result_factored = {r.factor(deep=True): m for r, m in result.items()}
+    assert result_factored == {
         r: 1,
-        -r*(1 + sqrt(3)*I)/2: 1,
-        r*(-1 + sqrt(3)*I)/2: 1}
+        -I*r*(sqrt(3) - I)/2: 1,
+        +I*r*(sqrt(3) + I)/2: 1,
+    }

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -480,7 +480,6 @@ def test_roots0():
     r13_20, r1_20 = [ Rational(*r)
         for r in ((13, 20), (1, 20)) ]
 
-    s2 = sqrt(2)
     assert roots(f, x) == {
         S(13)/20 + sqrt(S(1)/400 - sqrt(2)*I/50): 1,
         S(13)/20 + sqrt(S(1)/400 + sqrt(2)*I/50): 1,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

I was thinking about adding a rootof parameter to roots (https://github.com/sympy/sympy/pull/24898#discussion_r1133073420) but then I realised that the roots function is a bit of a mess and it is not clear where exactly something like that should be added or checked for.

#### Brief description of what is fixed or changed

This PR simplifies the code for the roots function out into a few separate functions and reorganises the logic of the main loop. This will mean that in some cases the roots function can handle more things for example it will apply some techniques to all factors of a polynomial rather than only applying them if the polynomial cannot be factorised. Also in some cases the return types and parameter handling will be more consistent because this separates that logic out into separate functions.

#### Other comments

Still a work in progress. After some rewrite the `_try_decompose` function is not used any more. I haven't worked out where exactly is the best place to use it. The way it is used in master is not right because it is not applied to all factors.

Two tests are changed but the results are still correct and all tests in `test_polyroots` pass but I'm sure some other parts of the test suite will break.

The diff looks large but it is mostly just moving things around. I have broadly tried not to change the behaviour of the roots function but it just isn't possible to simplify the code without changing the behaviour in at least some cases because the code has many quirks that arise from being strangely organised.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The `roots` function was refactored to simplify the code and make behaviour more consistent for different kinds of inputs.
<!-- END RELEASE NOTES -->