### PR TITLE
KanesMethod specify linear solver

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -9,6 +9,7 @@ from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
 from sympy.core.backend import (Matrix, sympify, Mul, Derivative, sin, cos,
                                 tan, AppliedUndef, S)
+from sympy.codegen.matrix_nodes import MatrixSolve
 
 __all__ = ['inertia',
            'inertia_of_point_mass',
@@ -777,3 +778,15 @@ def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
                     speed.free_symbols == t_set):
                 raise ValueError(f'Generalized speed "{speed}" is not a '
                                  f'dynamicsymbol.')
+
+def _parse_linear_solver(solver):
+    if callable(solver):
+        return solver
+    elif solver.casefold() == 'lu'.casefold():
+        solver = Matrix.LUsolve
+    elif solver.casefold() == 'numeric'.casefold():
+        solver = MatrixSolve
+    else:
+        raise NotImplementedError(f"Linear solver '{solver} has not been "
+                                  f"implemented.")
+    return solver

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -781,13 +781,15 @@ def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
 
 
 def _parse_linear_solver(solver):
+    """Helper function to retrieve a specified linear solver."""
     if callable(solver):
         return solver
-    elif solver.casefold() == 'lu'.casefold():
+    solver = solver.casefold()
+    if solver == 'lu'.casefold():
         solver = Matrix.LUsolve
-    elif solver.casefold() == 'numeric'.casefold():
+    elif solver == 'numeric'.casefold():
         solver = MatrixSolve
     else:
-        raise NotImplementedError(f"Linear solver '{solver} has not been "
+        raise NotImplementedError(f"Linear solver '{solver}' has not been "
                                   f"implemented.")
     return solver

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -779,6 +779,7 @@ def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
                 raise ValueError(f'Generalized speed "{speed}" is not a '
                                  f'dynamicsymbol.')
 
+
 def _parse_linear_solver(solver):
     if callable(solver):
         return solver

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -9,7 +9,6 @@ from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
 from sympy.core.backend import (Matrix, sympify, Mul, Derivative, sin, cos,
                                 tan, AppliedUndef, S)
-from sympy.codegen.matrix_nodes import MatrixSolve
 
 __all__ = ['inertia',
            'inertia_of_point_mass',
@@ -784,12 +783,4 @@ def _parse_linear_solver(solver):
     """Helper function to retrieve a specified linear solver."""
     if callable(solver):
         return solver
-    solver = solver.casefold()
-    if solver == 'lu'.casefold():
-        solver = Matrix.LUsolve
-    elif solver == 'numeric'.casefold():
-        solver = MatrixSolve
-    else:
-        raise NotImplementedError(f"Linear solver '{solver}' has not been "
-                                  f"implemented.")
-    return solver
+    return lambda A, b: Matrix.solve(A, b, method=solver)

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -779,8 +779,8 @@ def _validate_coordinates(coordinates=None, speeds=None, check_duplicates=True,
                                  f'dynamicsymbol.')
 
 
-def _parse_linear_solver(solver):
+def _parse_linear_solver(linear_solver):
     """Helper function to retrieve a specified linear solver."""
-    if callable(solver):
-        return solver
-    return lambda A, b: Matrix.solve(A, b, method=solver)
+    if callable(linear_solver):
+        return linear_solver
+    return lambda A, b: Matrix.solve(A, b, method=linear_solver)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -60,14 +60,14 @@ class KanesMethod(_Methods):
         Method used to solve the kinematic differential equations. If a string is
         supplied, it should be a valid method that can be used with the
         :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should take two arguments - the `A` matrix and the `rhs`, and solve the
+        should take two arguments - the ``A`` matrix and the ``rhs``, and solve the
         equations and return the solution. The default uses LU solve. See the notes for
         more information.
     constraint_solver : str, callable
         Method used to solve the velocity constraints. If a string is
         supplied, it should be a valid method that can be used with the
         :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should take two arguments - the `A` matrix and the `rhs`, and solve the
+        should take two arguments - the ``A`` matrix and the ``rhs``, and solve the
         equations and return the solution. The default uses LU solve. See the notes for
         more information.
 
@@ -226,10 +226,9 @@ class KanesMethod(_Methods):
         self._udot = self.u.diff(dynamicsymbols._t)
         self._uaux = none_handler(u_aux)
 
-    def _initialize_constraint_matrices(self, config, vel, acc,
-                                        constraint_solver='lu'):
+    def _initialize_constraint_matrices(self, config, vel, acc, linear_solver='LU'):
         """Initializes constraint matrices."""
-        constraint_solver = _parse_linear_solver(constraint_solver)
+        linear_solver = _parse_linear_solver(linear_solver)
         # Define vector dimensions
         o = len(self.u)
         m = len(self._udep)
@@ -286,7 +285,7 @@ class KanesMethod(_Methods):
             # to independent speeds as: udep = Ars*uind, neglecting the C term.
             B_ind = self._k_nh[:, :p]
             B_dep = self._k_nh[:, p:o]
-            self._Ars = -constraint_solver(B_dep, B_ind)
+            self._Ars = -linear_solver(B_dep, B_ind)
         else:
             self._f_nh = Matrix()
             self._k_nh = Matrix()
@@ -294,7 +293,7 @@ class KanesMethod(_Methods):
             self._k_dnh = Matrix()
             self._Ars = Matrix()
 
-    def _initialize_kindiffeq_matrices(self, kdeqs, kd_eqs_solver='lu'):
+    def _initialize_kindiffeq_matrices(self, kdeqs, linear_solver='LU'):
         """Initialize the kinematic differential equation matrices.
 
         Parameters
@@ -305,7 +304,7 @@ class KanesMethod(_Methods):
             coordinates and generalized speeds.
 
         """
-        kd_eqs_solver = _parse_linear_solver(kd_eqs_solver)
+        linear_solver = _parse_linear_solver(linear_solver)
         if kdeqs:
             if len(self.q) != len(kdeqs):
                 raise ValueError('There must be an equal number of kinematic '
@@ -352,8 +351,8 @@ class KanesMethod(_Methods):
             # NOTE : Solving the kinematic differential equations here is not
             # necessary and prevents the equations from being provided in fully
             # implicit form.
-            f_k_explicit = kd_eqs_solver(k_kqdot, f_k)
-            k_ku_explicit = kd_eqs_solver(k_kqdot, k_ku)
+            f_k_explicit = linear_solver(k_kqdot, f_k)
+            k_ku_explicit = linear_solver(k_kqdot, k_ku)
             self._qdot_u_map = dict(zip(qdot, -(k_ku_explicit*u + f_k_explicit)))
 
             self._f_k = f_k_explicit.xreplace(uaux_zero)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -96,7 +96,7 @@ class KanesMethod(_Methods):
     can result in zero division errors.
 
     By specifying a ``callable`` you can also specify the use of a different
-    solver like ``Matrix.solve``.
+    solver like ``Matrix.solve`` and ``lambda A, b: A.inv() * b``.
 
     Examples
     ========

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -57,18 +57,19 @@ class KanesMethod(_Methods):
         explicit form (default) or implicit form for kinematics.
         See the notes for more details.
     kd_eqs_solver : str, callable
-        Solver to be used for the kinematic differential equations. Supported
-        solvers are:
-        - ``'lu'``: LU solver which utilizes ``Matrix.LUsolve`` (default)
-        - ``callable``: custom solver supplied by the user, which takes the
-          ``A`` matrix as the first argument and ``b`` matrix as the second.
-        See the notes for more information.
+        Method used to solve the kinematic differential equations. If a string is
+        supplied, it should be a valid method that can be used with the
+        :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
+        should take two arguments - the `A` matrix and the `rhs`, and solve the
+        equations and return the solution. The default uses LU solve. See the notes for
+        more information.
     constraint_solver : str, callable
-        Solver to be used for the velocity constraints. Supported solvers are:
-        - ``'lu'``: LU solver which utilizes ``Matrix.LUsolve`` (default)
-        - ``callable``: custom solver supplied by the user, which takes the
-          ``A`` matrix as the first argument and ``b`` matrix as the second.
-        See the notes for more information.
+        Method used to solve the velocity constraints. If a string is
+        supplied, it should be a valid method that can be used with the
+        :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
+        should take two arguments - the `A` matrix and the `rhs`, and solve the
+        equations and return the solution. The default uses LU solve. See the notes for
+        more information.
 
     Notes
     =====
@@ -83,20 +84,21 @@ class KanesMethod(_Methods):
 
     Two linear solvers can be supplied to ``KanesMethod``: one for solving the
     kinematic differential equations and one to solve the velocity constraints.
-    Both of these sets of equations form a linear system ``Ax = b``, which has
-    to be solved in order to obtain the equations of motion.
+    Both of these sets of equations can be expressed as a linear system ``Ax = rhs``,
+    which have to be solved in order to obtain the equations of motion.
 
-    The implemented solvers are:
-        - ``'lu'``: LU solver which utilizes ``Matrix.LUsolve`` (default)
-        - ``callable``: custom solver supplied by the user, which takes the
-          ``A`` matrix as the first argument and ``b`` matrix as the second.
+    The default solver, LU solve, results in the fastest execution time after
+    lambdifying the solution. The weakness of this method is that it can result in zero
+    division errors.
 
-    The default solver, ``Matrix.LUsolve``, results in the fastest execution
-    time after lambdifying the solution. The weakness of this method is that it
-    can result in zero division errors.
-
-    By specifying a ``callable`` you can also specify the use of a different
-    solver like ``Matrix.solve`` and ``lambda A, b: A.inv() * b``.
+    While a valid list of solvers can be found at
+    :meth:`sympy.matrices.matrices.MatrixBase.solve`, it is also possible to supply a
+    `callable`. This way it is possible to use a different solver routine. If the
+    kinematic differential equations are not too complex it can be worth it to simplify
+    the solution by using ``lambda A, b: simplify(Matrix.LUsolve(A, b))``. Another
+    option solver one may use is :func:`sympy.solvers.solveset.linsolve`. This can be
+    done using `lambda A, b: tuple(linsolve((A, b)))[0]`, where we select the first
+    solution as our system should have only one unique solution.
 
     Examples
     ========
@@ -168,8 +170,8 @@ class KanesMethod(_Methods):
                  configuration_constraints=None, u_dependent=None,
                  velocity_constraints=None, acceleration_constraints=None,
                  u_auxiliary=None, bodies=None, forcelist=None,
-                 explicit_kinematics=True, kd_eqs_solver='lu',
-                 constraint_solver='lu'):
+                 explicit_kinematics=True, kd_eqs_solver='LU',
+                 constraint_solver='LU'):
 
         """Please read the online documentation. """
         if not q_ind:

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -59,17 +59,15 @@ class KanesMethod(_Methods):
     kd_eqs_solver : str, callable
         Method used to solve the kinematic differential equations. If a string is
         supplied, it should be a valid method that can be used with the
-        :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should take two arguments - the ``A`` matrix and the ``rhs``, and solve the
-        equations and return the solution. The default uses LU solve. See the notes for
-        more information.
+        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
+        should have the format ``f(A, rhs)``, where it solves the equations and returns
+        the solution. The default utilizes LU solve. See the notes for more information.
     constraint_solver : str, callable
         Method used to solve the velocity constraints. If a string is
         supplied, it should be a valid method that can be used with the
-        :meth:`~sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should take two arguments - the ``A`` matrix and the ``rhs``, and solve the
-        equations and return the solution. The default uses LU solve. See the notes for
-        more information.
+        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
+        should have the format ``f(A, rhs)``, where it solves the equations and returns
+        the solution. The default utilizes LU solve. See the notes for more information.
 
     Notes
     =====
@@ -87,8 +85,8 @@ class KanesMethod(_Methods):
     Both of these sets of equations can be expressed as a linear system ``Ax = rhs``,
     which have to be solved in order to obtain the equations of motion.
 
-    The default solver, LU solve, results in the fastest execution time after
-    lambdifying the solution. The weakness of this method is that it can result in zero
+    The default solver ``'LU'``, which stands for LU solve, results relatively low
+    number of operations. The weakness of this method is that it can result in zero
     division errors.
 
     While a valid list of solvers can be found at

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -293,5 +293,6 @@ def test_validate_coordinates():
 
 
 def test_parse_linear_solver():
-    assert _parse_linear_solver('Lu') == Matrix.LUsolve
-    assert _parse_linear_solver(Matrix.solve) == Matrix.solve
+    A, b = Matrix(3, 3, symbols('a:9')), Matrix(3, 2, symbols('b:6'))
+    assert _parse_linear_solver(Matrix.LDLsolve) == Matrix.LDLsolve  # Test callable
+    assert _parse_linear_solver('LU')(A, b) == Matrix.LUsolve(A, b)

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -294,5 +294,5 @@ def test_validate_coordinates():
 
 def test_parse_linear_solver():
     A, b = Matrix(3, 3, symbols('a:9')), Matrix(3, 2, symbols('b:6'))
-    assert _parse_linear_solver(Matrix.LDLsolve) == Matrix.LDLsolve  # Test callable
+    assert _parse_linear_solver(Matrix.LUsolve) == Matrix.LUsolve  # Test callable
     assert _parse_linear_solver('LU')(A, b) == Matrix.LUsolve(A, b)

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -295,4 +295,3 @@ def test_validate_coordinates():
 def test_parse_linear_solver():
     assert _parse_linear_solver('Lu') == Matrix.LUsolve
     assert _parse_linear_solver(Matrix.solve) == Matrix.solve
-

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -7,8 +7,8 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
                                      outer, potential_energy, msubs,
                                      find_dynamicsymbols, Lagrangian)
 
-from sympy.physics.mechanics.functions import (gravity, center_of_mass,
-                                               _validate_coordinates)
+from sympy.physics.mechanics.functions import (
+    gravity, center_of_mass, _validate_coordinates, _parse_linear_solver)
 from sympy.testing.pytest import raises
 
 
@@ -290,3 +290,9 @@ def test_validate_coordinates():
     _validate_coordinates([f1(a), f2(a)])
     raises(ValueError, lambda: _validate_coordinates([f1(t), f2(t)]))
     dynamicsymbols._t = t
+
+
+def test_parse_linear_solver():
+    assert _parse_linear_solver('Lu') == Matrix.LUsolve
+    assert _parse_linear_solver(Matrix.solve) == Matrix.solve
+

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -98,7 +98,7 @@ def test_kane_rolling_disc_lu():
                        props['kdes'], u_dependent=props['u_dep'],
                        velocity_constraints=props['fnh'],
                        bodies=props['bodies'], forcelist=props['loads'],
-                       explicit_kinematics=False, constraint_solver='lu')
+                       explicit_kinematics=False, constraint_solver='LU')
     kane.kanes_equations()
     _verify_rolling_disc_numerically(kane)
 
@@ -117,7 +117,7 @@ def test_kane_rolling_disc_kdes_callable():
     qd = dynamicsymbols('q1:6', 1)
     eval_kdes = lambdify((q, qd, u, p), tuple(kane.kindiffdict().items()))
     eps = 1e-10
-    # Test with only zeros. If 'lu' would be used this would result in nan.
+    # Test with only zeros. If 'LU' would be used this would result in nan.
     p_vals = (9.81, 0.25, 3.5)
     zero_vals = (0, 0, 0, 0, 0)
     assert all(abs(qdi - fui) < eps for qdi, fui in

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -1,9 +1,14 @@
-from sympy.core.backend import zeros, Matrix, symbols, lambdify, _simplify_matrix
+from sympy.core.backend import (zeros, Matrix, symbols, lambdify,
+                                _simplify_matrix)
 from sympy.matrices.expressions import MatrixExpr
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.physics.mechanics.models import n_link_pendulum_on_cart
 from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
+from sympy.testing.pytest import skip
+from sympy.external import import_module
+
+np = import_module('numpy')
 
 
 def _create_rolling_disc():
@@ -127,6 +132,8 @@ def test_kane_rolling_disc_lu():
 
 
 def test_kane_rolling_disc_numeric():
+    if not np:
+        skip('numpy not installed.')
     props = _create_rolling_disc()
     kane = KanesMethod(
         props['frame'], props['q_ind'], props['u_ind'], props['kdes'],

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -3,6 +3,7 @@ from sympy.core.backend import (zeros, Matrix, symbols, lambdify,
 from sympy.matrices.expressions import MatrixExpr
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.physics.mechanics.models import n_link_pendulum_on_cart
+from sympy.physics.mechanics.functions import _parse_linear_solver
 from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
 from sympy.testing.pytest import skip
@@ -115,9 +116,9 @@ def test_kane_block_matrix_no_constraints():
 
 
 def test_parse_linear_solver():
-    assert KanesMethod._parse_linear_solver('Lu') == Matrix.LUsolve
-    assert KanesMethod._parse_linear_solver('NumEriC') == MatrixSolve
-    assert KanesMethod._parse_linear_solver(lambdify) == lambdify
+    assert _parse_linear_solver('Lu') == Matrix.LUsolve
+    assert _parse_linear_solver('NumEriC') == MatrixSolve
+    assert _parse_linear_solver(lambdify) == lambdify
 
 
 def test_kane_rolling_disc_lu():

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -1,0 +1,138 @@
+from sympy.core.backend import zeros, Matrix, symbols, lambdify, _simplify_matrix
+from sympy.matrices.expressions import MatrixExpr
+from sympy.codegen.matrix_nodes import MatrixSolve
+from sympy.physics.mechanics.models import n_link_pendulum_on_cart
+from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
+                                     ReferenceFrame, KanesMethod)
+
+
+def create_rolling_disc():
+    # Define symbols and coordinates
+    t = dynamicsymbols._t
+    q1, q2, q3, q4, q5, u1, u2, u3, u4, u5 = dynamicsymbols('q1:6 u1:6')
+    g, r, m = symbols('g r m')
+    # Define bodies and frames
+    ground = RigidBody('ground')
+    disc = RigidBody('disk', mass=m)
+    disc.inertia = (m * r ** 2 / 4 * inertia(disc.frame, 1, 2, 1),
+                    disc.masscenter)
+    ground.masscenter.set_vel(ground.frame, 0)
+    disc.masscenter.set_vel(disc.frame, 0)
+    int_frame = ReferenceFrame('int_frame')
+    # Orient frames
+    int_frame.orient_body_fixed(ground.frame, (q1, q2, 0), 'zxy')
+    disc.frame.orient_axis(int_frame, int_frame.y, q3)
+    g_w_d = disc.frame.ang_vel_in(ground.frame)
+    disc.frame.set_ang_vel(ground.frame,
+                           u1 * disc.x + u2 * disc.y + u3 * disc.z)
+    # Define points
+    cp = ground.masscenter.locatenew('contact_point',
+                                     q4 * ground.x + q5 * ground.y)
+    cp.set_vel(ground.frame, u4 * ground.x + u5 * ground.y)
+    disc.masscenter.set_pos(cp, r * int_frame.z)
+    disc.masscenter.set_vel(ground.frame, cross(
+        disc.frame.ang_vel_in(ground.frame), disc.masscenter.pos_from(cp)))
+    # Define kinematic differential equations
+    kdes = [g_w_d.dot(disc.x) - u1, g_w_d.dot(disc.y) - u2,
+            g_w_d.dot(disc.z) - u3, q4.diff(t) - u4, q5.diff(t) - u5]
+    # Define nonholonomic constraints
+    v0 = cp.vel(ground.frame) + cross(
+        disc.frame.ang_vel_in(int_frame), cp.pos_from(disc.masscenter))
+    fnh = [v0.dot(ground.x), v0.dot(ground.y)]
+    # Define loads
+    loads = [(disc.masscenter, -disc.mass * g * ground.z)]
+    bodies = [disc]
+    return {
+        'frame': ground.frame,
+        'q_ind': [q1, q2, q3, q4, q5],
+        'u_ind': [u1, u2, u3],
+        'u_dep': [u4, u5],
+        'kdes': kdes,
+        'fnh': fnh,
+        'bodies': bodies,
+        'loads': loads
+    }
+
+
+def verify_rolling_disc_numerically(kane, all_zero=False):
+    q, u, p = dynamicsymbols('q1:6'), dynamicsymbols('u1:6'), symbols('g r m')
+    eval_sys = lambdify((q, u, p), (kane.mass_matrix_full, kane.forcing_full),
+                        cse=True)
+    solve_sys = lambda q, u, p: Matrix.LUsolve(
+        *(Matrix(mat) for mat in eval_sys(q, u, p)))
+    solve_u_dep = lambdify((q, u[:3], p), kane._Ars * Matrix(u[:3]), cse=True)
+    eps = 1e-10
+    p_vals = (9.81, 0.26, 3.43)
+    # First numeric test
+    q_vals = (0.3, 0.1, 1.97, -0.35, 2.27)
+    u_vals = [-0.2, 1.3, 0.15]
+    u_vals.extend(solve_u_dep(q_vals, u_vals, p_vals)[:2, 0])
+    expected = Matrix([
+        0.126603940595934, 0.215942571601660, 1.28736069604936,
+        0.319764288376543, 0.0989146857254898, -0.925848952664489,
+        -0.0181350656532944, 2.91695398184589, -0.00992793421754526,
+        0.0412861634829171])
+    assert all(abs(x) < eps for x in
+               (solve_sys(q_vals, u_vals, p_vals) - expected))
+    # Second numeric test
+    q_vals = (3.97, -0.28, 8.2, -0.35, 2.27)
+    u_vals = [-0.25, -2.2, 0.62]
+    u_vals.extend(solve_u_dep(q_vals, u_vals, p_vals)[:2, 0])
+    expected = Matrix([
+        0.0259159090798597, 0.668041660387416, -2.19283799213811,
+        0.385441810852219, 0.420109283790573, 1.45030568179066,
+        -0.0110924422400793, -8.35617840186040, -0.154098542632173,
+        -0.146102664410010])
+    assert all(abs(x) < eps for x in
+               (solve_sys(q_vals, u_vals, p_vals) - expected))
+    if all_zero:
+        q_vals = (0, 0, 0, 0, 0)
+        u_vals = (0, 0, 0, 0, 0)
+        assert solve_sys(q_vals, u_vals, p_vals) == zeros(10, 1)
+
+
+def test_kane_block_matrix_no_constraints():
+    # Uses the n_link_pendulum_on_cart to verify whether block matrices are also
+    # returned correctly when not using velocity constraints
+    kane = n_link_pendulum_on_cart()
+    assert kane.use_block_matrices == False
+    md, fd = kane.mass_matrix, kane.forcing
+    mf, ff = kane.mass_matrix_full, kane.forcing_full
+    assert not any(isinstance(mat, MatrixExpr) for mat in (md, fd, mf, ff))
+    kane.use_block_matrices = True
+    assert all(isinstance(mat, MatrixExpr) for mat in (
+        kane.mass_matrix, kane.forcing, kane.mass_matrix_full,
+        kane.forcing_full))
+    assert Matrix(kane.mass_matrix - md) == zeros(2, 2)
+    assert Matrix(kane.forcing - fd) == zeros(2, 1)
+    assert Matrix(kane.mass_matrix_full - mf) == zeros(4, 4)
+    assert Matrix(kane.forcing_full - ff) == zeros(4, 1)
+
+
+def test_parse_linear_solver():
+    assert KanesMethod._parse_linear_solver('Lu') == Matrix.LUsolve
+    assert KanesMethod._parse_linear_solver('NumEriC') == MatrixSolve
+    assert KanesMethod._parse_linear_solver(lambdify) == lambdify
+
+
+def test_kane_rolling_disc_lu():
+    props = create_rolling_disc()
+    kane = KanesMethod(props['frame'], props['q_ind'], props['u_ind'],
+                       props['kdes'], u_dependent=props['u_dep'],
+                       velocity_constraints=props['fnh'],
+                       bodies=props['bodies'], forcelist=props['loads'],
+                       explicit_kinematics=False, constraint_solver='lu')
+    kane.kanes_equations()
+    verify_rolling_disc_numerically(kane)
+
+
+def test_kane_rolling_disc_numeric():
+    props = create_rolling_disc()
+    kane = KanesMethod(
+        props['frame'], props['q_ind'], props['u_ind'], props['kdes'],
+        u_dependent=props['u_dep'], velocity_constraints=props['fnh'],
+        bodies=props['bodies'], forcelist=props['loads'],
+        explicit_kinematics=False, constraint_solver='numeric',
+        kd_eqs_solver=lambda A, b: _simplify_matrix(A.LUsolve(b)))
+    kane.kanes_equations()
+    verify_rolling_disc_numerically(kane, all_zero=True)

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -6,7 +6,7 @@ from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
 
 
-def create_rolling_disc():
+def _create_rolling_disc():
     # Define symbols and coordinates
     t = dynamicsymbols._t
     q1, q2, q3, q4, q5, u1, u2, u3, u4, u5 = dynamicsymbols('q1:6 u1:6')
@@ -54,7 +54,7 @@ def create_rolling_disc():
     }
 
 
-def verify_rolling_disc_numerically(kane, all_zero=False):
+def _verify_rolling_disc_numerically(kane, all_zero=False):
     q, u, p = dynamicsymbols('q1:6'), dynamicsymbols('u1:6'), symbols('g r m')
     eval_sys = lambdify((q, u, p), (kane.mass_matrix_full, kane.forcing_full),
                         cse=True)
@@ -116,18 +116,18 @@ def test_parse_linear_solver():
 
 
 def test_kane_rolling_disc_lu():
-    props = create_rolling_disc()
+    props = _create_rolling_disc()
     kane = KanesMethod(props['frame'], props['q_ind'], props['u_ind'],
                        props['kdes'], u_dependent=props['u_dep'],
                        velocity_constraints=props['fnh'],
                        bodies=props['bodies'], forcelist=props['loads'],
                        explicit_kinematics=False, constraint_solver='lu')
     kane.kanes_equations()
-    verify_rolling_disc_numerically(kane)
+    _verify_rolling_disc_numerically(kane)
 
 
 def test_kane_rolling_disc_numeric():
-    props = create_rolling_disc()
+    props = _create_rolling_disc()
     kane = KanesMethod(
         props['frame'], props['q_ind'], props['u_ind'], props['kdes'],
         u_dependent=props['u_dep'], velocity_constraints=props['fnh'],
@@ -135,4 +135,4 @@ def test_kane_rolling_disc_numeric():
         explicit_kinematics=False, constraint_solver='numeric',
         kd_eqs_solver=lambda A, b: _simplify_matrix(A.LUsolve(b)))
     kane.kanes_equations()
-    verify_rolling_disc_numerically(kane, all_zero=True)
+    _verify_rolling_disc_numerically(kane, all_zero=True)

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -1,12 +1,8 @@
 from sympy.core.backend import (zeros, Matrix, symbols, lambdify, sqrt, pi,
-                                _simplify_matrix)
-from sympy.matrices.expressions import MatrixExpr
-from sympy.physics.mechanics.models import n_link_pendulum_on_cart
+                                _simplify_matrix, USE_SYMENGINE)
 from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
-from sympy.external import import_module
-
-np = import_module('numpy')
+from sympy.testing.pytest import skip
 
 
 def _create_rolling_disc():
@@ -94,25 +90,9 @@ def _verify_rolling_disc_numerically(kane, all_zero=False):
         assert solve_sys(q_vals, u_vals, p_vals) == zeros(10, 1)
 
 
-def test_kane_block_matrix_no_constraints():
-    # Uses the n_link_pendulum_on_cart to verify whether block matrices are also
-    # returned correctly when not using velocity constraints
-    kane = n_link_pendulum_on_cart()
-    assert kane.use_block_matrices == False
-    md, fd = kane.mass_matrix, kane.forcing
-    mf, ff = kane.mass_matrix_full, kane.forcing_full
-    assert not any(isinstance(mat, MatrixExpr) for mat in (md, fd, mf, ff))
-    kane.use_block_matrices = True
-    assert all(isinstance(mat, MatrixExpr) for mat in (
-        kane.mass_matrix, kane.forcing, kane.mass_matrix_full,
-        kane.forcing_full))
-    assert Matrix(kane.mass_matrix - md) == zeros(2, 2)
-    assert Matrix(kane.forcing - fd) == zeros(2, 1)
-    assert Matrix(kane.mass_matrix_full - mf) == zeros(4, 4)
-    assert Matrix(kane.forcing_full - ff) == zeros(4, 1)
-
-
 def test_kane_rolling_disc_lu():
+    if USE_SYMENGINE:
+        skip('symengine does not support lambdify with dynamicsymbols.')
     props = _create_rolling_disc()
     kane = KanesMethod(props['frame'], props['q_ind'], props['u_ind'],
                        props['kdes'], u_dependent=props['u_dep'],
@@ -124,6 +104,8 @@ def test_kane_rolling_disc_lu():
 
 
 def test_kane_rolling_disc_kdes_callable():
+    if USE_SYMENGINE:
+        skip('symengine does not support lambdify with dynamicsymbols.')
     props = _create_rolling_disc()
     kane = KanesMethod(
         props['frame'], props['q_ind'], props['u_ind'], props['kdes'],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #24780

#### Brief description of what is fixed or changed
This PR implements two new key word argument for `KanesMethod` to be able to specify the to be used linear solver.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Added the option to specify the linear solvers used in `KanesMethod`
<!-- END RELEASE NOTES -->
