### PR TITLE
Fix bug when multiplying Prefix and Quantity.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -821,6 +821,7 @@ Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Laura Domine <temigo@gmx.com>
 Lauren Glattly <laurenglattly@gmail.com>
+Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
 Lee Johnston <lee.johnston.100@gmail.com>
 Lejla Metohajrova <l.metohajrova@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -6,7 +6,7 @@ BIN_PREFIXES.
 """
 from sympy.core.expr import Expr
 from sympy.core.sympify import sympify
-
+from sympy.core.singleton import S
 
 class Prefix(Expr):
     """
@@ -87,7 +87,7 @@ class Prefix(Expr):
 
         if isinstance(other, Prefix):
             if fact == 1:
-                return 1
+                return S.One
             # simplify prefix
             for p in PREFIXES:
                 if PREFIXES[p].scale_factor == fact:
@@ -103,7 +103,7 @@ class Prefix(Expr):
         fact = self.scale_factor / other.scale_factor
 
         if fact == 1:
-            return 1
+            return S.One
         elif isinstance(other, Prefix):
             for p in PREFIXES:
                 if PREFIXES[p].scale_factor == fact:

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -85,9 +85,9 @@ class Prefix(Expr):
 
         fact = self.scale_factor * other.scale_factor
 
-        if fact == 1:
-            return 1
-        elif isinstance(other, Prefix):
+        if isinstance(other, Prefix):
+            if fact == 1:
+                return 1
             # simplify prefix
             for p in PREFIXES:
                 if PREFIXES[p].scale_factor == fact:

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -16,9 +16,9 @@ def test_prefix_operations():
     M = PREFIXES['M']
 
     dodeca = Prefix('dodeca', 'dd', 1, base=12)
-    
+
     assert m * k == S.One
-    assert m * W == W/1000
+    assert m * W == W / 1000
     assert k * k == M
     assert 1 / m == k
     assert k / m == M
@@ -26,7 +26,7 @@ def test_prefix_operations():
     assert dodeca * dodeca == 144
     assert 1 / dodeca == S.One / 12
     assert k / dodeca == S(1000) / 12
-    assert dodeca / dodeca == S.One
+    assert dodeca / dodeca == 1
 
     m = Quantity("fake_meter")
     SI.set_quantity_dimension(m, S.One)

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -2,7 +2,7 @@ from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
-from sympy.physics.units import Quantity, length, meter
+from sympy.physics.units import Quantity, length, meter, W
 from sympy.physics.units.prefixes import PREFIXES, Prefix, prefix_unit, kilo, \
     kibi
 from sympy.physics.units.systems import SI
@@ -16,8 +16,9 @@ def test_prefix_operations():
     M = PREFIXES['M']
 
     dodeca = Prefix('dodeca', 'dd', 1, base=12)
-
-    assert m * k == 1
+    
+    assert m * k == S.One
+    assert m * W == W/1000
     assert k * k == M
     assert 1 / m == k
     assert k / m == M
@@ -25,7 +26,7 @@ def test_prefix_operations():
     assert dodeca * dodeca == 144
     assert 1 / dodeca == S.One / 12
     assert k / dodeca == S(1000) / 12
-    assert dodeca / dodeca == 1
+    assert dodeca / dodeca == S.One
 
     m = Quantity("fake_meter")
     SI.set_quantity_dimension(m, S.One)

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -17,7 +17,7 @@ def test_prefix_operations():
 
     dodeca = Prefix('dodeca', 'dd', 1, base=12)
 
-    assert m * k == S.One
+    assert m * k is S.One
     assert m * W == W / 1000
     assert k * k == M
     assert 1 / m == k
@@ -26,7 +26,7 @@ def test_prefix_operations():
     assert dodeca * dodeca == 144
     assert 1 / dodeca == S.One / 12
     assert k / dodeca == S(1000) / 12
-    assert dodeca / dodeca == S.One
+    assert dodeca / dodeca is S.One
 
     m = Quantity("fake_meter")
     SI.set_quantity_dimension(m, S.One)

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -26,7 +26,7 @@ def test_prefix_operations():
     assert dodeca * dodeca == 144
     assert 1 / dodeca == S.One / 12
     assert k / dodeca == S(1000) / 12
-    assert dodeca / dodeca == 1
+    assert dodeca / dodeca == S.One
 
     m = Quantity("fake_meter")
     SI.set_quantity_dimension(m, S.One)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24832 

#### Brief description of what is fixed or changed
Previously, when multiplying a prefix and a quantity, the code would return 1 if the product of their scale factors was equal to 1. This resulted in incorrect output in some cases, such as when multiplying "milli" and "W", which would evaluate to 1 instead of W/1000. 
To fix this issue, the code has been updated to only return 1 when a prefix is multiplied by another prefix. When a prefix is multiplied by a quantity, the product of their scale factors is no longer checked for equality to 1.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.units
  * Corrected the bug in multiplication between prefix and quantity, e.g. milli * W = 1 which should be W/1000.
<!-- END RELEASE NOTES -->
