### PR TITLE
Have `IdentityOperator` inherit from `UnitaryOperator` and `HermitianOperator` instead of `Operator`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1388,6 +1388,7 @@ Versus Void <versusvoid@gmail.com>
 ViacheslavP <public.viacheslav@gmail.com>
 Victor Brebenar <v.brebenar@gmail.com>
 Victor Immanuel <chrollolucilfer1402@gmail.com> victor immanuel <89346667+victorchrollo14@users.noreply.github.com>
+Victory Omole <vtomole2@gmail.com>
 Vighnesh Shenoy <vighneshq@gmail.com>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijair <vijair@umich.edu>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijairam20 <vijairamg@gmail.com>

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -625,6 +625,7 @@ class IdentityGate(OneQubitGate):
     ========
 
     """
+    is_hermitian = True
     gate_name = '1'
     gate_name_latex = '1'
 
@@ -806,6 +807,7 @@ class PhaseGate(OneQubitGate):
     ========
 
     """
+    is_hermitian =  False
     gate_name = 'S'
     gate_name_latex = 'S'
 
@@ -834,6 +836,7 @@ class TGate(OneQubitGate):
     ========
 
     """
+    is_hermitian = False
     gate_name = 'T'
     gate_name_latex = 'T'
 
@@ -989,6 +992,7 @@ class SwapGate(TwoQubitGate):
     ========
 
     """
+    is_hermitian = True
     gate_name = 'SWAP'
     gate_name_latex = r'\text{SWAP}'
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -8,6 +8,7 @@ TODO:
 * Doctests and documentation of special methods for InnerProduct, Commutator,
   AntiCommutator, represent, apply_operators.
 """
+from typing import Optional
 
 from sympy.core.add import Add
 from sympy.core.expr import Expr
@@ -100,8 +101,8 @@ class Operator(QExpr):
     .. [1] https://en.wikipedia.org/wiki/Operator_%28physics%29
     .. [2] https://en.wikipedia.org/wiki/Observable
     """
-    is_hermitian = None
-    is_unitary = None
+    is_hermitian: Optional[bool] = None
+    is_unitary: Optional[bool] = None
     @classmethod
     def default_args(self):
         return ("O",)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -249,7 +249,7 @@ class UnitaryOperator(Operator):
         return self._eval_inverse()
 
 
-class IdentityOperator(Operator):
+class IdentityOperator(UnitaryOperator):
     """An identity operator I that satisfies op * I == I * op == op for any
     operator op.
 
@@ -288,9 +288,6 @@ class IdentityOperator(Operator):
         return 2 * other
 
     def _eval_inverse(self):
-        return self
-
-    def _eval_adjoint(self):
         return self
 
     def _apply_operator(self, ket, **options):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -100,7 +100,8 @@ class Operator(QExpr):
     .. [1] https://en.wikipedia.org/wiki/Operator_%28physics%29
     .. [2] https://en.wikipedia.org/wiki/Observable
     """
-
+    is_hermitian = None
+    is_unitary = None
     @classmethod
     def default_args(self):
         return ("O",)
@@ -244,12 +245,12 @@ class UnitaryOperator(Operator):
     >>> U*Dagger(U)
     1
     """
-
+    is_unitary = True
     def _eval_adjoint(self):
         return self._eval_inverse()
 
 
-class IdentityOperator(HermitianOperator, UnitaryOperator):
+class IdentityOperator(Operator):
     """An identity operator I that satisfies op * I == I * op == op for any
     operator op.
 
@@ -267,6 +268,8 @@ class IdentityOperator(HermitianOperator, UnitaryOperator):
     >>> IdentityOperator()
     I
     """
+    is_hermitian = True
+    is_unitary = True
     @property
     def dimension(self):
         return self.N
@@ -287,11 +290,20 @@ class IdentityOperator(HermitianOperator, UnitaryOperator):
     def _eval_anticommutator(self, other, **hints):
         return 2 * other
 
+    def _eval_inverse(self):
+        return self
+
+    def _eval_adjoint(self):
+        return self
+
     def _apply_operator(self, ket, **options):
         return ket
 
     def _apply_from_right_to(self, bra, **options):
         return bra
+
+    def _eval_power(self, exp):
+        return self
 
     def _print_contents(self, printer, *args):
         return 'I'

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -249,7 +249,7 @@ class UnitaryOperator(Operator):
         return self._eval_inverse()
 
 
-class IdentityOperator(UnitaryOperator):
+class IdentityOperator(HermitianOperator, UnitaryOperator):
     """An identity operator I that satisfies op * I == I * op == op for any
     operator op.
 
@@ -287,17 +287,11 @@ class IdentityOperator(UnitaryOperator):
     def _eval_anticommutator(self, other, **hints):
         return 2 * other
 
-    def _eval_inverse(self):
-        return self
-
     def _apply_operator(self, ket, **options):
         return ket
 
     def _apply_from_right_to(self, bra, **options):
         return bra
-
-    def _eval_power(self, exp):
-        return self
 
     def _print_contents(self, printer, *args):
         return 'I'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed
The [Identity operator is unitary](https://en.wikipedia.org/wiki/Identity_matrix). This change is to reflect that.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:




See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Change the baseclass of `IdentityOperator` from `Operator` to `HermitianOperator` and `UnitaryOperator`
<!-- END RELEASE NOTES -->
