### PR TITLE
Apply ruff PIE810 rule: merge startswith call

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -569,7 +569,7 @@ def go(sympy_top, file, verbose=False, no_color=False, exact=True, sphinx=True):
             total_sphinx += _total_sphinx
             num_functions += _num_functions
         return doctests, total_sphinx, num_functions
-    if (not (file.endswith('.py') or file.endswith('.pyx')) or
+    if (not (file.endswith((".py", ".pyx"))) or
         file.endswith('__init__.py') or
         not exact and ('test_' in file or 'bench_' in file or
         any(name in file for name in skip_paths))):

--- a/bin/test_external_imports.py
+++ b/bin/test_external_imports.py
@@ -31,8 +31,7 @@ import sys
 import os
 
 def is_stdlib(p):
-    return ((p.startswith(sys.prefix)
-            or p.startswith(sys.base_prefix))
+    return ((p.startswith((sys.prefix, sys.base_prefix)))
             and 'site-packages' not in p)
 
 stdlib = {p for p in sys.path if is_stdlib(p)}

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -141,7 +141,7 @@ class NumpyDocString(Mapping):
             return True
 
         l2 = self._doc.peek(1).strip()  # ---------- or ==========
-        return l2.startswith('-'*len(l1)) or l2.startswith('='*len(l1))
+        return l2.startswith(('-' * len(l1), '=' * len(l1)))
 
     def _strip(self, doc):
         i = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,11 @@ markers = [
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
-    "C4",
+    "C40",
     "E",
     "F",
     "PIE802",
+    "PIE810",
     "SIM101",
 ]
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -767,12 +767,12 @@ def auto_number(tokens: List[TOKEN], local_dict: DICT, global_dict: DICT):
             number = tokval
             postfix = []
 
-            if number.endswith('j') or number.endswith('J'):
+            if number.endswith(('j', 'J')):
                 number = number[:-1]
                 postfix = [(OP, '*'), (NAME, 'I')]
 
             if '.' in number or (('e' in number or 'E' in number) and
-                    not (number.startswith('0x') or number.startswith('0X'))):
+                    not (number.startswith(('0x', '0X')))):
                 seq = [(NAME, 'Float'), (OP, '('),
                     (NUMBER, repr(str(number))), (OP, ')')]
             else:

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -174,9 +174,7 @@ if __name__ == "__main__":
             if fromlist != None:
                 symbol_list = fromlist
                 if '*' in symbol_list:
-                    if (importer_filename.endswith('__init__.py')
-                        or importer_filename.endswith('__init__.pyc')
-                        or importer_filename.endswith('__init__.pyo')):
+                    if (importer_filename.endswith(("__init__.py", "__init__.pyc", "__init__.pyo"))):
                         # We do not check starred imports inside __init__
                         # That's the normal "please copy over its imports to my namespace"
                         symbol_list = []

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -232,7 +232,7 @@ def test_files():
                     test_set.add(line[3:].split('(')[0].strip())
                     if len(test_set) != tests:
                         assert False, message_duplicate_test % (fname, idx + 1)
-            if line.endswith(" \n") or line.endswith("\t\n"):
+            if line.endswith((" \n", "\t\n")):
                 assert False, message_space % (fname, idx + 1)
             if line.endswith("\r\n"):
                 assert False, message_carriage % (fname, idx + 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

This enables the PIE810 ruff rule which merges together startswith, endswith calls on strings. Not only is this more readable, but it's more efficient as the string is only iterated through once.

I also remapped the C4 rule to C40 to remove an warning being output by the latest versions of ruff.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
