### PR TITLE
ruff: Apply simple bugprone autofixits

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -63,7 +63,7 @@ class Mod(Function):
                         return S.One
 
             if hasattr(p, '_eval_Mod'):
-                rv = getattr(p, '_eval_Mod')(q)
+                rv = p._eval_Mod(q)
                 if rv is not None:
                     return rv
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -887,14 +887,14 @@ def hessian(f, varlist, constraints=()):
             raise ShapeError("`len(varlist)` must not be zero.")
     else:
         raise ValueError("Improper variable list in hessian function")
-    if not getattr(f, 'diff'):
+    if not f.diff:
         # check differentiability
         raise ValueError("Function `f` (%s) is not differentiable" % f)
     m = len(constraints)
     N = m + n
     out = zeros(N)
     for k, g in enumerate(constraints):
-        if not getattr(g, 'diff'):
+        if not g.diff:
             # check differentiability
             raise ValueError("Function `f` (%s) is not differentiable" % f)
         for i in range(n):

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -303,7 +303,7 @@ def test_LUdecomposition_Simple_iszerofunc():
         assert magic_string == err.args[0]
         return
 
-    assert False
+    raise AssertionError()
 
 def test_LUdecomposition_iszerofunc():
     # Test if callable passed to matrices.LUdecomposition() as iszerofunc keyword argument is used inside
@@ -318,7 +318,7 @@ def test_LUdecomposition_iszerofunc():
         assert magic_string == err.args[0]
         return
 
-    assert False
+    raise AssertionError()
 
 def test_LDLdecomposition():
     raises(NonSquareMatrixError, lambda: Matrix((1, 2)).LDLdecomposition())

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2007,7 +2007,7 @@ def test_diff_by_matrix():
 def test_getattr():
     A = Matrix(((1, 4, x), (y, 2, 4), (10, 5, x**2 + 1)))
     raises(AttributeError, lambda: A.nonexistantattribute)
-    assert getattr(A, 'diff')(x) == Matrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
+    assert A.diff(x) == Matrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
 
 
 def test_hessenberg():

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -35,7 +35,7 @@ def test_smith_normal_deprecated():
 
     with warns_deprecated_sympy():
         m = Matrix([[12, 6, 4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
-    setattr(m, 'ring', ZZ)
+    m.ring = ZZ
     with warns_deprecated_sympy():
         smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
     assert smith_normal_form(m) == smf
@@ -45,13 +45,13 @@ def test_smith_normal_deprecated():
         m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
                     [0, Poly(x), Poly(-1,x)],
                     [Poly(0,x),Poly(-1,x),Poly(x)]])
-    setattr(m, 'ring', QQ[x])
+    m.ring = QQ[x]
     invs = (Poly(1, x, domain='QQ'), Poly(x - 1, domain='QQ'), Poly(x**2 - 1, domain='QQ'))
     assert invariant_factors(m) == invs
 
     with warns_deprecated_sympy():
         m = Matrix([[2, 4]])
-    setattr(m, 'ring', ZZ)
+    m.ring = ZZ
     with warns_deprecated_sympy():
         smf = Matrix([[2, 0]])
     assert smith_normal_form(m) == smf

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -88,7 +88,7 @@ def test_factorial_fail():
     for text in inputs:
         try:
             parse_expr(text)
-            assert False
+            raise AssertionError()
         except TokenError:
             assert True
 

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -431,7 +431,7 @@ def test_remove_load():
     except ValueError:
         assert True
     else:
-        assert False
+        raise AssertionError()
 
     b.apply_load(-3, 0, -2)
     b.apply_load(4, 2, -1)
@@ -447,7 +447,7 @@ def test_remove_load():
     except ValueError:
         assert True
     else:
-        assert False
+        raise AssertionError()
 
     b.remove_load(-3, 0, -2)
     b.remove_load(4, 2, -1)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -546,7 +546,7 @@ def test_cse_unevaluated():
         assert red == (-1 + x0) / (1 + x0)
     else:
         msg = f'Expected common subexpression {xp1} or {-xp1}, instead got {ue}'
-        assert False, msg
+        raise AssertionError(msg)
 
 
 def test_cse__performance():

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -2245,7 +2245,7 @@ def homogeneous_order(eq, *symbols):
     # Replace all functions with dummy variables
     dum = numbered_symbols(prefix='d', cls=Dummy)
     newsyms = set()
-    for i in [j for j in symset if getattr(j, 'is_Function')]:
+    for i in (j for j in symset if j.is_Function):
         iargs = set(i.args)
         if iargs.difference(symset):
             return None

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -2245,7 +2245,7 @@ def homogeneous_order(eq, *symbols):
     # Replace all functions with dummy variables
     dum = numbered_symbols(prefix='d', cls=Dummy)
     newsyms = set()
-    for i in (j for j in symset if j.is_Function):
+    for i in [j for j in symset if j.is_Function]:
         iargs = set(i.args)
         if iargs.difference(symset):
             return None

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -60,7 +60,7 @@ def test_chain():
 
 def test_tryit():
     def rl(expr: Basic) -> Basic:
-        assert False
+        raise AssertionError()
 
     safe_rl = tryit(rl, AssertionError)
     assert safe_rl(S(1)) == S(1)

--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -87,11 +87,11 @@ def _test_this_file_encoding(
                 has_unicode = True
 
         if not has_unicode and not is_in_strict_whitelist:
-            assert False, message_unicode_D % fname
+            raise AssertionError(message_unicode_D % fname)
 
     else:
         for idx, line in enumerate(test_file):
             try:
                 line.encode(encoding='ascii')
             except (UnicodeEncodeError, UnicodeDecodeError):
-                assert False, message_unicode_B % (fname, idx + 1)
+                raise AssertionError(message_unicode_B % (fname, idx + 1))

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -218,7 +218,7 @@ def test_files():
         if py.startswith('test_'):
             idx = line_with_bare_expr(code)
         if idx is not None:
-            assert False, message_bare_expr % (fname, idx + 1)
+            raise AssertionError(message_bare_expr % (fname, idx + 1))
 
         line = None  # to flag the case where there were no lines in file
         tests = 0
@@ -226,40 +226,39 @@ def test_files():
         for idx, line in enumerate(test_file):
             if test_file_re.match(fname):
                 if test_suite_def_re.match(line):
-                    assert False, message_test_suite_def % (fname, idx + 1)
+                    raise AssertionError(message_test_suite_def % (fname, idx + 1))
                 if test_ok_def_re.match(line):
                     tests += 1
                     test_set.add(line[3:].split('(')[0].strip())
                     if len(test_set) != tests:
-                        assert False, message_duplicate_test % (fname, idx + 1)
+                        raise AssertionError(message_duplicate_test % (fname, idx + 1))
             if line.endswith((" \n", "\t\n")):
-                assert False, message_space % (fname, idx + 1)
+                raise AssertionError(message_space % (fname, idx + 1))
             if line.endswith("\r\n"):
-                assert False, message_carriage % (fname, idx + 1)
+                raise AssertionError(message_carriage % (fname, idx + 1))
             if tab_in_leading(line):
-                assert False, message_tabs % (fname, idx + 1)
+                raise AssertionError(message_tabs % (fname, idx + 1))
             if str_raise_re.search(line):
-                assert False, message_str_raise % (fname, idx + 1)
+                raise AssertionError(message_str_raise % (fname, idx + 1))
             if gen_raise_re.search(line):
-                assert False, message_gen_raise % (fname, idx + 1)
+                raise AssertionError(message_gen_raise % (fname, idx + 1))
             if (implicit_test_re.search(line) and
                     not list(filter(lambda ex: ex in fname, import_exclude))):
-                assert False, message_implicit % (fname, idx + 1)
+                raise AssertionError(message_implicit % (fname, idx + 1))
             if func_is_re.search(line) and not test_file_re.search(fname):
-                assert False, message_func_is % (fname, idx + 1)
+                raise AssertionError(message_func_is % (fname, idx + 1))
 
             result = old_raise_re.search(line)
 
             if result is not None:
-                assert False, message_old_raise % (
-                    fname, idx + 1, result.group(2))
+                raise AssertionError(message_old_raise % (fname, idx + 1, result.group(2)))
 
         if line is not None:
             if line == '\n' and idx > 0:
-                assert False, message_multi_eof % (fname, idx + 1)
+                raise AssertionError(message_multi_eof % (fname, idx + 1))
             elif not line.endswith('\n'):
                 # eof newline check
-                assert False, message_eof % (fname, idx + 1)
+                raise AssertionError(message_eof % (fname, idx + 1))
 
 
     # Files to test at top level

--- a/sympy/testing/tests/test_pytest.py
+++ b/sympy/testing/tests/test_pytest.py
@@ -19,7 +19,7 @@ def test_expected_exception_is_silent_callable():
 def test_lack_of_exception_triggers_AssertionError_callable():
     try:
         raises(Exception, lambda: 1 + 1)
-        assert False
+        raise AssertionError()
     except Failed as e:
         assert "DID NOT RAISE" in str(e)
 
@@ -29,7 +29,7 @@ def test_unexpected_exception_is_passed_through_callable():
         raise ValueError("some error message")
     try:
         raises(TypeError, f)
-        assert False
+        raise AssertionError()
     except ValueError as e:
         assert str(e) == "some error message"
 
@@ -44,7 +44,7 @@ def test_lack_of_exception_triggers_AssertionError_with():
     try:
         with raises(Exception):
             1 + 1
-        assert False
+        raise AssertionError()
     except Failed as e:
         assert "DID NOT RAISE" in str(e)
 
@@ -53,7 +53,7 @@ def test_unexpected_exception_is_passed_through_with():
     try:
         with raises(TypeError):
             raise ValueError("some error message")
-        assert False
+        raise AssertionError()
     except ValueError as e:
         assert str(e) == "some error message"
 

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -103,7 +103,7 @@ def test_translate_args():
     except ValueError:
         pass # Exception raised successfully
     else:
-        assert False
+        raise AssertionError()
 
     assert translate('s', None, None, None) == 's'
 
@@ -112,7 +112,7 @@ def test_translate_args():
     except ValueError:
         pass # Exception raised successfully
     else:
-        assert False
+        raise AssertionError()
 
 
 @skip_under_pyodide("Cannot create subprocess under pyodide.")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Adds all the simple autofixits from the ruff rules for bugprone (flake8-bugprone) except B007 (which will be enabled later since there are way more instances of it). The main issues that get fixed are `assert False -> raise AssertionError()`, replacing `getattr` and `setattr` calls that use constant strings with direct attribute access since they are both more efficient and are better flagged by linters / refactors. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
