### PR TITLE
sympy.physics.vector : physics vector equations solvable (supporting examples to be added as solution)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1304,6 +1304,7 @@ Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>
 Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
 Sudhanshu Mishra <mrsud94@gmail.com>
+Sujant Kumar Kv <sujantkv@gmail.com>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1304,7 +1304,7 @@ Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>
 Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
 Sudhanshu Mishra <mrsud94@gmail.com>
-Sujant Kumar Kv <sujantkv@gmail.com>
+Sujant Kumar Kv <sujantkv@gmail.com> Sujant Kumar Kv <sujant@Sujants-MacBook-Air.local>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -164,6 +164,8 @@ that would be used if there were custom indices. ::
   >>> vlatex(N.z)
   'cat'
 
+
+
 dynamicsymbols
 --------------
 The ``dynamicsymbols`` function also has 'hidden' functionality; the variable
@@ -198,3 +200,65 @@ so dynamic symbols created before or after will print the same way.
 Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and
 methods. Don't mix and match symbols representing time.
+
+
+
+Solving Vectors
+---------------
+We would be looking at an example to understand it better.
+
+PROBLEM:
+
+A ball is thrown at an angle of 45 degrees to the horizontal with a velocity of
+10 m/s in a ground frame G. Another reference frame B is at an angle of 30 degrees
+with respect to G. The position of the ball in the B reference frame at time 
+t = 2 seconds is at point P with a position vector of 3B.x + 4B.y.
+What is the velocity vector of the ball at time t = 2 seconds w.r.t ground frame?
+
+SOLUTION:
+
+We can define two reference frames:
+The ground reference frame, which is fixed with respect to the Earth and has its
+x-axis pointing towards the east and its y-axis pointing towards the north.
+The ``B`` reference frame, which is at an angle of 30 degrees with respect to ``G``. 
+
+We can define two points in the problem:
+
+1) Point O, which is the origin of both reference frames.
+2) Point P, where the ball is located at time t = 2 seconds w.r.t ``B``.
+
+We can define the position vector of point P in ``B`` as:
+>>> r_b = 3*B.x + 4*B.y
+
+We can also define the velocity of the ball in the ``B`` reference frame at time t = 2 seconds as:
+>>> v_b = 10cos(pi/4)*B.x + 10sin(pi/4)*B.y - 9.82*B.z
+
+Therefore, the velocity vector of the ball in the ``G`` reference frame at time t = 2 seconds is:
+>>> v_a = v_b + omega.cross(r_b)
+where ``omega`` is the angular velocity of the ``B`` reference frame w.r.t ground frame, and 
+cross represents the vector cross product.
+
+>>> from sympy import *
+>>> from sympy.physics.vector import *
+>>> G = ReferenceFrame('G')
+>>> B = ReferenceFrame('B')
+>>> B.orient_axis(G, pi/6, G.z)
+>>> r_b = 3*B.x + 4*B.y
+>>> v_b = 10*cos(pi/4)*B.x + 10*sin(pi/4)*B.y - 9.8*2*B.z
+>>> omega = 2*B.z
+>>> v_g = v_b + omega.cross(r_b)
+>>> v_gx, v_gy, v_gz = symbols('v_gx, v_gy, v_gz')
+>>> eqn = Eq(v_g.to_matrix(G), Matrix([[v_gx], [v_gy], [v_gz]]))
+>>> eqn
+Eq(Matrix([
+[-5*sqrt(2)/2 - 3 + sqrt(3)*(-8 + 5*sqrt(2))/2],
+[ -4 + 5*sqrt(2)/2 + sqrt(3)*(6 + 5*sqrt(2))/2],
+[                                        -19.6]]), Matrix([
+[vx],
+[vy],
+[vz]]))
+>>> solve(eqn, [v_gx, v_gy, v_gz])
+{ v_gx: -7.34001277925030,
+  v_gy: 10.8554106855973,
+  v_gz: -19.6000000000000
+}

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -236,11 +236,6 @@ Putting it all together:
   >>> A = ReferenceFrame('A')
   >>> B = ReferenceFrame('B')
   >>> B.orient_axis(A, pi/6, A.z)
-  >>> B.dcm(A)
-  Matrix([
-  [sqrt(3)/2,       1/2, 0],
-  [     -1/2, sqrt(3)/2, 0],
-  [        0,         0, 1]])
   >>> p, q = symbols('p, q')
   >>> va = 10*A.x
   >>> vb = p*B.x + q*B.y

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -254,9 +254,9 @@ Eq(Matrix([
 [-5*sqrt(2)/2 - 3 + sqrt(3)*(-8 + 5*sqrt(2))/2],
 [ -4 + 5*sqrt(2)/2 + sqrt(3)*(6 + 5*sqrt(2))/2],
 [                                        -19.6]]), Matrix([
-[vx],
-[vy],
-[vz]]))
+[v_gx],
+[v_gy],
+[v_gz]]))
 >>> solve(eqn, [v_gx, v_gy, v_gz])
 { v_gx: -7.34001277925030,
   v_gy: 10.8554106855973,

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -204,40 +204,44 @@ methods. Don't mix and match symbols representing time.
 
 
 Solving Vector Equations
----------------
+========================
 Solving for unknown scalar variables in a set of vector equations is a common need, but 
 SymPy's solvers do not work directly with the physics vectors, so you must first transform
-the vector equations into a set of scalar equations. The `to_matrix()` method provides
-a simple way to do this. For example:
+the vector equations into a set of scalar equations.
+The :func:`sympy.physics.vector.vector.Vector.to_matrix` method provides a simple way to do this. For example:
 
-PROBLEM:
+**PROBLEM**:
 
 A ball is thrown from origin at a velocity of 10m/s along the x-axis w.r.t frame ``A``.
 An observer ``B``'s reference frame is rotated by 30 degrees w.r.t ``A``.
 What are the x and y component values of the velocity vector of the ball as 
 observed by the observer in its frame?
 
-SOLUTION:
+**SOLUTION**:
 
 We have two reference frames: ``A`` & ``B``.
 We can define the velocity vector of ball in ``A`` as:
-  >>> v_a = 10*A.x
 
-We have to align the ``B`` w.r.t ``A` by 30 degrees and this can be done using the ``orient_axis()`` method.
-  >>>B.orient_axis(A, pi/6, A.z)
+``v_a = 10 * A.x``
+
+We have to align the ``B`` w.r.t ``A`` by 30 degrees and this can be done using the ``orient_axis()``
+method from ``ReferenceFrame`` as:
+
+``B.orient_axis(A, pi/6, A.z)``
 
 We can also define the velocity of the ball in the ``B`` reference frame as:
-  >>>vb = p*B.x + q*B.y
 
-Putting it all together:
+``v_b = p * B.x + q * B.y``
 
-  >>> from sympy import *
-  >>> from sympy.physics.vector import *
+Putting it all together. ::
+
+  >>> from sympy import solve, pi, symbols
+  >>> from sympy.physics.vector import ReferenceFrame
   >>> A = ReferenceFrame('A')
   >>> B = ReferenceFrame('B')
   >>> B.orient_axis(A, pi/6, A.z)
   >>> p, q = symbols('p, q')
-  >>> va = 10*A.x
-  >>> vb = p*B.x + q*B.y
-  >>> solve((va - vb).to_matrix(B), [p, q])
+  >>> v_a = 10 * A.x
+  >>> v_b = p * B.x + q * B.y
+  >>> solve((v_a - v_b).to_matrix(B), [p, q])
   {p: 5*sqrt(3), q: -5}

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -203,62 +203,46 @@ methods. Don't mix and match symbols representing time.
 
 
 
-Solving Vectors
+Solving Vector Equations
 ---------------
-We would be looking at an example to understand it better.
+Solving for unknown scalar variables in a set of vector equations is a common need, but 
+SymPy's solvers do not work directly with the physics vectors, so you must first transform
+the vector equations into a set of scalar equations. The `to_matrix()` method provides
+a simple way to do this. For example:
 
 PROBLEM:
 
-A ball is thrown at an angle of 45 degrees to the horizontal with a velocity of
-10 m/s in a ground frame G. Another reference frame B is at an angle of 30 degrees
-with respect to G. The position of the ball in the B reference frame at time 
-t = 2 seconds is at point P with a position vector of 3B.x + 4B.y.
-What is the velocity vector of the ball at time t = 2 seconds w.r.t ground frame?
+A ball is thrown from origin at a velocity of 10m/s along the x-axis w.r.t frame ``A``.
+An observer ``B``'s reference frame is rotated by 30 degrees w.r.t ``A``.
+What are the x and y component values of the velocity vector of the ball as 
+observed by the observer in its frame?
 
 SOLUTION:
 
-We can define two reference frames:
-The ground reference frame, which is fixed with respect to the Earth and has its
-x-axis pointing towards the east and its y-axis pointing towards the north.
-The ``B`` reference frame, which is at an angle of 30 degrees with respect to ``G``. 
+We have two reference frames: ``A`` & ``B``.
+We can define the velocity vector of ball in ``A`` as:
+  >>> v_a = 10*A.x
 
-We can define two points in the problem:
+We have to align the ``B`` w.r.t ``A` by 30 degrees and this can be done using the ``orient_axis()`` method.
+  >>>B.orient_axis(A, pi/6, A.z)
 
-1) Point O, which is the origin of both reference frames.
-2) Point P, where the ball is located at time t = 2 seconds w.r.t ``B``.
+We can also define the velocity of the ball in the ``B`` reference frame as:
+  >>>vb = p*B.x + q*B.y
 
-We can define the position vector of point P in ``B`` as:
->>> r_b = 3*B.x + 4*B.y
+Putting it all together:
 
-We can also define the velocity of the ball in the ``B`` reference frame at time t = 2 seconds as:
->>> v_b = 10*cos(pi/4)*B.x + 10*sin(pi/4)*B.y - 9.82*B.z
-
-Therefore, the velocity vector of the ball in the ``G`` reference frame at time t = 2 seconds is:
->>> v_a = v_b + omega.cross(r_b)
-where ``omega`` is the angular velocity of the ``B`` reference frame w.r.t ground frame, and 
-cross represents the vector cross product.
-
->>> from sympy import *
->>> from sympy.physics.vector import *
->>> G = ReferenceFrame('G')
->>> B = ReferenceFrame('B')
->>> B.orient_axis(G, pi/6, G.z)
->>> r_b = 3*B.x + 4*B.y
->>> v_b = 10*cos(pi/4)*B.x + 10*sin(pi/4)*B.y - 9.8*2*B.z
->>> omega = 2*B.z
->>> v_g = v_b + omega.cross(r_b)
->>> v_gx, v_gy, v_gz = symbols('v_gx, v_gy, v_gz')
->>> eqn = Eq(v_g.to_matrix(G), Matrix([[v_gx], [v_gy], [v_gz]]))
->>> eqn
-Eq(Matrix([
-[-5*sqrt(2)/2 - 3 + sqrt(3)*(-8 + 5*sqrt(2))/2],
-[ -4 + 5*sqrt(2)/2 + sqrt(3)*(6 + 5*sqrt(2))/2],
-[                                        -19.6]]), Matrix([
-[v_gx],
-[v_gy],
-[v_gz]]))
->>> solve(eqn, [v_gx, v_gy, v_gz])
-{ v_gx: -7.34001277925030,
-  v_gy: 10.8554106855973,
-  v_gz: -19.6000000000000
-}
+  >>> from sympy import *
+  >>> from sympy.physics.vector import *
+  >>> A = ReferenceFrame('A')
+  >>> B = ReferenceFrame('B')
+  >>> B.orient_axis(A, pi/6, A.z)
+  >>> B.dcm(A)
+  Matrix([
+  [sqrt(3)/2,       1/2, 0],
+  [     -1/2, sqrt(3)/2, 0],
+  [        0,         0, 1]])
+  >>> p, q = symbols('p, q')
+  >>> va = 10*A.x
+  >>> vb = p*B.x + q*B.y
+  >>> solve((va - vb).to_matrix(B), [p, q])
+  {p: 5*sqrt(3), q: -5}

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -231,7 +231,7 @@ We can define the position vector of point P in ``B`` as:
 >>> r_b = 3*B.x + 4*B.y
 
 We can also define the velocity of the ball in the ``B`` reference frame at time t = 2 seconds as:
->>> v_b = 10cos(pi/4)*B.x + 10sin(pi/4)*B.y - 9.82*B.z
+>>> v_b = 10*cos(pi/4)*B.x + 10*sin(pi/4)*B.y - 9.82*B.z
 
 Therefore, the velocity vector of the ball in the ``G`` reference frame at time t = 2 seconds is:
 >>> v_a = v_b + omega.cross(r_b)

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -98,6 +98,57 @@ class Vector(Printable, EvalfMixin):
         >>> dot(N.y, A.y)
         cos(q1)
 
+        #Note
+        The function orientnew(...) has the following function definition ->
+
+        orientnew(self, newname, rot_type, amounts, rot_order='',
+                  variables=None, indices=None, latexs=None)
+
+        where
+        -----
+
+        newname : str
+            Name for the new reference frame.
+        rot_type : str
+            The method used to generate the direction cosine matrix. Supported
+            methods are:
+
+            - ``'Axis'``: simple rotations about a single common axis
+            - ``'DCM'``: for setting the direction cosine matrix directly
+            - ``'Body'``: three successive rotations about new intermediate
+              axes, also called "Euler and Tait-Bryan angles"
+            - ``'Space'``: three successive rotations about the parent
+              frames' unit vectors
+            - ``'Quaternion'``: rotations defined by four parameters which
+              result in a singularity free direction cosine matrix
+
+        amounts :
+            Expressions defining the rotation angles or direction cosine
+            matrix. These must match the ``rot_type``. See examples below for
+            details. The input types are:
+
+            - ``'Axis'``: 2-tuple (expr/sym/func, Vector)
+            - ``'DCM'``: Matrix, shape(3,3)
+            - ``'Body'``: 3-tuple of expressions, symbols, or functions
+            - ``'Space'``: 3-tuple of expressions, symbols, or functions
+            - ``'Quaternion'``: 4-tuple of expressions, symbols, or
+              functions
+
+        rot_order : str or int, optional
+            If applicable, the order of the successive of rotations. The string
+            ``'123'`` and integer ``123`` are equivalent, for example. Required
+            for ``'Body'`` and ``'Space'``.
+        indices : tuple of str
+            Enables the reference frame's basis unit vectors to be accessed by
+            Python's square bracket indexing notation using the provided three
+            indice strings and alters the printing of the unit vectors to
+            reflect this choice.
+        latexs : tuple of str
+            Alters the LaTeX printing of the reference frame's basis unit
+            vectors to the provided three valid LaTeX strings.
+
+        For reference examples, head over to function orientnew(...) in sympy.physics.vector.frame
+
         """
 
         from sympy.physics.vector.dyadic import Dyadic

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -91,63 +91,12 @@ class Vector(Printable, EvalfMixin):
         >>> q1 = symbols('q1')
         >>> N = ReferenceFrame('N')
         >>> dot(N.x, N.x)
-        1
+        1s
         >>> dot(N.x, N.y)
         0
         >>> A = N.orientnew('A', 'Axis', [q1, N.x])
         >>> dot(N.y, A.y)
         cos(q1)
-
-        #Note
-        The function orientnew(...) has the following function definition ->
-
-        orientnew(self, newname, rot_type, amounts, rot_order='',
-                  variables=None, indices=None, latexs=None)
-
-        where
-        -----
-
-        newname : str
-            Name for the new reference frame.
-        rot_type : str
-            The method used to generate the direction cosine matrix. Supported
-            methods are:
-
-            - ``'Axis'``: simple rotations about a single common axis
-            - ``'DCM'``: for setting the direction cosine matrix directly
-            - ``'Body'``: three successive rotations about new intermediate
-              axes, also called "Euler and Tait-Bryan angles"
-            - ``'Space'``: three successive rotations about the parent
-              frames' unit vectors
-            - ``'Quaternion'``: rotations defined by four parameters which
-              result in a singularity free direction cosine matrix
-
-        amounts :
-            Expressions defining the rotation angles or direction cosine
-            matrix. These must match the ``rot_type``. See examples below for
-            details. The input types are:
-
-            - ``'Axis'``: 2-tuple (expr/sym/func, Vector)
-            - ``'DCM'``: Matrix, shape(3,3)
-            - ``'Body'``: 3-tuple of expressions, symbols, or functions
-            - ``'Space'``: 3-tuple of expressions, symbols, or functions
-            - ``'Quaternion'``: 4-tuple of expressions, symbols, or
-              functions
-
-        rot_order : str or int, optional
-            If applicable, the order of the successive of rotations. The string
-            ``'123'`` and integer ``123`` are equivalent, for example. Required
-            for ``'Body'`` and ``'Space'``.
-        indices : tuple of str
-            Enables the reference frame's basis unit vectors to be accessed by
-            Python's square bracket indexing notation using the provided three
-            indice strings and alters the printing of the unit vectors to
-            reflect this choice.
-        latexs : tuple of str
-            Alters the LaTeX printing of the reference frame's basis unit
-            vectors to the provided three valid LaTeX strings.
-
-        For reference examples, head over to function orientnew(...) in sympy.physics.vector.frame
 
         """
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18692 with reference to closed PR #23068

#### Brief description of what is fixed or changed
A potential way existed to solve the physics vector equations via `.to_matrix()` function so the PR #23068 was closed and examples will be added to merge this PR.


#### Other comments
This initial commit just contains a docstring addition of extra notes describing `.orientnew(...)` in `sympy/physics/vector/vector.py` for the diff in order to open the PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 
<!-- END RELEASE NOTES -->