### PR TITLE
Fix increment => decrement typo

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1190,6 +1190,7 @@ Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94
 Saloni Jain <tosalonijain@gmail.com>
 Sam Brockie <sambrockie@icloud.com>
 Sam Magura <samtheman132@gmail.com>
+Sam Ritchie <sam@mentat.org> sritchie09 <sritchie09@gmail.com>
 Sam Sleight <samuel.sleight@gmail.com>
 Sam Tygier <sam.tygier@hep.manchester.ac.uk>
 Sambuddha Basu <sammygamer@live.com>

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -624,7 +624,7 @@ class MultisetPartitionTraverser():
         """
 
         if amt == 1:
-            # In this case we always need to increment, *before*
+            # In this case we always need to decrement, *before*
             # enforcing the "sufficient unallocated multiplicity"
             # constraint.  Easiest for this is just to call the
             # regular decrement method.


### PR DESCRIPTION
This PR fixes a small error in the description of the lower-bounding piece of the multiset partitions algorithm from TAOCP.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->