### PR TITLE
Add timeout facilities

### DIFF
--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -12,7 +12,7 @@ from .lambdify import lambdify
 
 from .decorator import threaded, xthreaded, public, memoize_property
 
-from .timeutils import timed
+from .timeutils import timed, timeout
 
 __all__ = [
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
@@ -26,5 +26,5 @@ __all__ = [
 
     'threaded', 'xthreaded', 'public', 'memoize_property',
 
-    'timed',
+    'timed', 'timeout',
 ]

--- a/sympy/utilities/tests/test_timeutils.py
+++ b/sympy/utilities/tests/test_timeutils.py
@@ -1,6 +1,9 @@
 """Tests for simple tools for timing functions' execution. """
 
-from sympy.utilities.timeutils import timed
+import signal
+import time
+from sympy.testing.pytest import raises, skip
+from sympy.utilities.timeutils import timed, timeout, TimeoutError, TimeoutSignal, TimeoutThreading
 
 def test_timed():
     result = timed(lambda: 1 + 1, limit=100000)
@@ -8,3 +11,54 @@ def test_timed():
 
     result = timed("1 + 1", limit=100000)
     assert result[0] == 100000 and result[3] == "ns"
+
+
+
+def test_timeout():
+    def will_timeout():
+        with timeout(1):
+            time.sleep(2)
+
+    def will_not_timeout():
+        with timeout(duration_seconds=2):
+            time.sleep(1)
+
+    raises(TimeoutError, will_timeout)
+    will_not_timeout()
+
+
+def _test_Timeout(Cls):
+    def func_fast(a, b):
+        return 42*a+b
+
+    def func_slow(a, b):
+        time.sleep(2)
+        return 17*a+b
+
+    # gen is intentionally created already here.
+    gen = Cls.map(lambda f, *args: f(*args), [func_fast, func_slow], [2, 3], [4, 5], seconds_per_item=1)
+
+    def will_timeout():
+        with Cls(duration_seconds=1):
+            time.sleep(2)
+
+    def will_not_timeout():
+        with Cls(2):
+            time.sleep(1)
+
+    raises(TimeoutError, will_timeout)
+    will_not_timeout()
+
+    # we deliberately test gen several seconds after its creation.
+    result = list(gen)
+    assert result[0] == 42*2 + 4
+    assert isinstance(result[1], TimeoutError)
+    assert len(result) == 2
+
+def test_TimeoutThreading():
+    _test_Timeout(TimeoutThreading)
+
+def test_TimeoutSignal():
+    if not hasattr(signal, 'SIGALRM'):
+        skip("ALARM signal not present.")
+    _test_Timeout(TimeoutSignal)

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -1,6 +1,14 @@
 """Simple tools for timing functions' execution, when IPython is not available. """
 
-
+import contextlib
+import os
+import threading
+import _thread
+from typing import Callable
+import queue
+import time
+import warnings
+import signal
 import timeit
 import math
 
@@ -74,3 +82,143 @@ def timethis(name):
             return r
         return wrapper
     return decorator
+
+
+class TimeoutError(Exception):
+    pass
+
+
+class _TimeoutContextManager(contextlib.AbstractContextManager):
+    """Context manager to limit execution time.
+
+    Examples
+    --------
+    >>> with TimeoutThreading(2) as t:
+    ...     res = solve(expr, x)
+    ...
+    TimeoutError: Execution time exceeded 2 s.
+
+    >>>
+    >>> solutions = TimeoutThreading.map(solve, exprs, dep_vars, seconds_per_item=2)
+    """
+
+    def __init__(self, duration_seconds: int):
+        self.duration_seconds = duration_seconds
+
+    @classmethod
+    def exception_type(cls) -> type[Exception]:
+        return TimeoutError
+
+    @classmethod
+    def map(cls, func: Callable[..., ...], *args, seconds_per_item: int):
+        for tup in zip(*args):
+            try:
+                with cls(duration_seconds=seconds_per_item):
+                    yield func(*tup)
+            except cls.exception_type() as e:
+                yield e
+
+    @property
+    def elapsed(self) -> float:
+        """Elapsed time in seconds."""
+        return time.time() - self._t0
+
+    @property
+    def remaining(self) -> float:
+        """Remaining time in seconds."""
+        return self.duration_seconds - self.elapsed
+
+
+    def exception_message(self) -> str:
+        return f"Execution time exceeded {self.duration_seconds} s."
+
+    def _construct_exception(self) -> Exception:
+        return self.exception_type()(self.exception_message)
+
+    def __enter__(self):
+        self._t0 = time.time()
+
+
+class TimeoutThreading(_TimeoutContextManager):
+    def __enter__(self):
+        super().__enter__()
+        self._queue = queue.Queue()
+        self.timer_thread = threading.Timer(self.duration_seconds, self._terminate)
+        self.timer_thread.start()
+        return self
+
+    def _terminate(self):
+        self._queue.put(self._construct_exception())
+        _thread.interrupt_main()  # raises KeyboardInterrupt on the main thread.
+
+    def __exit__(self, *exc):
+        try:
+            exc = self._queue.get(block=False)
+        except queue.Empty:
+            self.timer_thread.cancel()
+            return False
+        else:
+            # there will be spurious KeyboardInterrupt exception in the traceback
+            # if one really wanted to, it could be edited away, e.g.:
+            # https://github.com/pallets/jinja/blob/9dad679695ccf84f06f8df897a6c5908e1963363/src/jinja2/debug.py#L14
+            raise exc
+
+
+class TimeoutSignal(_TimeoutContextManager):
+    """Uses an ALARM signal (for POSIX compliant systems) to limit execution time."""
+    def __enter__(self):
+        super().__enter__()
+        if os.name == 'nt':
+            warnings.warn("Windows might not support ALARM signal, prefer TimeoutThreading instead.")
+        signal.signal(signal.SIGALRM, self._terminate)
+        signal.alarm(self.duration_seconds)
+        return self
+
+    def _terminate(self, signum, frame):
+        assert signum == signal.SIGALRM
+        raise self._construct_exception()
+
+    def __exit__(self, *exc):
+        signal.alarm(0)
+        return False
+
+
+default_timeout_context_manager_class = TimeoutThreading if os.name == 'nt' else TimeoutSignal
+
+
+def timeout(duration_seconds: int):
+    """Creates a context manager to limit the execution time of a code block.
+
+    Parameters
+    ----------
+    duration_seconds: int
+        Maximum execution time, after which a TimeoutError will be raised.
+
+    Examples
+    --------
+    >>> with timeout(3) as t:
+    ...     print("you will see this")
+    ...     i = 0
+    ...     for _ in range(10**20):
+    ...         i += 1
+    ...         if i % 10**7 == 0:
+    ...             print(t.remaining)
+    ...     print("but never this")  # DOCTEST: +ignore
+    you will see this
+    3.0
+    2.21881103515625
+    1.4843239784240723
+    0.8278305530548096
+    0.12401294708251953
+    ---------------------------------------------------------------------------
+    KeyboardInterrupt                         Traceback (most recent call last)
+    ...
+    During handling of the above exception, another exception occurred:
+
+    TimeoutError                              Traceback (most recent call last)
+    ...
+    TimeoutError: Execution time exceeded 3 s.
+
+
+    """
+    return default_timeout_context_manager_class(duration_seconds)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes gh-9691
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This introduces the function `timeout` which creates a context manager. It should work on both posix and windows based systems.

#### Other comments
I've tested the threading implementation on a win11 VM under python 3.11, seems to work alright. The `KeyboardInterrupt` from `_thread.interrupt_main` is perhaps not pretty but it was the easiest I could come up with. 

There's also this project:
 https://github.com/kata198/func_timeout
but it's using ctypes directly, which I think looks scary.

Docstrings need some work (help is most welcomed), and probably the type annotations too.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `timeout` can be used in `with`-blocks to limit execution time.
<!-- END RELEASE NOTES -->
