### PR TITLE
Use a tooslow marker for slow tests that are skipped in CI.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 # Don't run the tests marked as slow by default.
-addopts = "-m 'not slow'"
+addopts = "-m 'not slow and not tooslow'"
 
 # Only run tests under the sympy/ directory. Otherwise pytest will attempt to
 # collect tests from e.g. the bin/ directory as well.
@@ -23,6 +23,7 @@ norecursedirs = [
 
 markers = [
     "nocache_fail",
+    "tooslow",
 ]
 
 [tool.ruff]

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -12,37 +12,52 @@ from sympy.functions.elementary.trigonometric import (acos, atan, cos, sin, tan)
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy.functions.special.gamma_functions import gamma
 from sympy.integrals.integrals import (Integral, integrate)
+from sympy.simplify.fu import fu
 
 
-from sympy.testing.pytest import XFAIL, SKIP, slow, skip, ON_CI
+from sympy.testing.pytest import XFAIL, slow, tooslow
 
 from sympy.abc import x, k, c, y, b, h, a, m, z, n, t
 
 
-@SKIP("Too slow for @slow")
+@tooslow
 @XFAIL
 def test_issue_3880():
     # integrate_hyperexponential(Poly(t*2*(1 - t0**2)*t0*(x**3 + x**2), t), Poly((1 + t0**2)**2*2*(x**2 + x + 1), t), [Poly(1, x), Poly(1 + t0**2, t0), Poly(t, t)], [x, t0, t], [exp, tan])
     assert not integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3 + x**2)/(2*(x**2 + x + 1)), x).has(Integral)
 
 
+def test_issue_4212_real():
+    xr = symbols('xr', real=True)
+    negabsx = Piecewise((-xr, xr < 0), (xr, True))
+    assert integrate(sign(xr), xr) == negabsx
+
+
 @XFAIL
 def test_issue_4212():
+    # XXX: Maybe this should be expected to fail without real assumptions on x.
+    # As a complex function sign(x) is not analytic and so there is no complex
+    # function whose complex derivative is sign(x). With real assumptions this
+    # works (see test_issue_4212_real above).
     assert not integrate(sign(x), x).has(Integral)
 
 
-@XFAIL
 def test_issue_4511():
-    # This works, but gives a complicated answer.  The correct answer is x - cos(x).
-    # If current answer is simplified, 1 - cos(x) + x is obtained.
-    # The last one is what Maple gives.  It is also quite slow.
-    assert integrate(cos(x)**2 / (1 - sin(x))) in [x - cos(x), 1 - cos(x) + x,
-            -2/(tan((S.Half)*x)**2 + 1) + x]
+    # This works, but gives a slightly over-complicated answer.
+    f = integrate(cos(x)**2 / (1 - sin(x)), x)
+    assert fu(f) == x - cos(x) - 1
+    assert f == ((x*tan(x/2)**2 + x - 2)/(tan(x/2)**2 + 1)).expand()
+
+
+def test_integrate_DiracDelta_no_meijerg():
+    assert integrate(integrate(integrate(
+        DiracDelta(x - y - z), (z, 0, oo)), (y, 0, 1), meijerg=False), (x, 0, 1)) == S.Half
 
 
 @XFAIL
 def test_integrate_DiracDelta_fails():
     # issue 6427
+    # works without meijerg. See test_integrate_DiracDelta_no_meijerg above.
     assert integrate(integrate(integrate(
         DiracDelta(x - y - z), (z, 0, oo)), (y, 0, 1)), (x, 0, 1)) == S.Half
 
@@ -55,10 +70,8 @@ def test_issue_4525():
 
 
 @XFAIL
-@slow
+@tooslow
 def test_issue_4540():
-    if ON_CI:
-        skip("Too slow for CI.")
     # Note, this integral is probably nonelementary
     assert not integrate(
         (sin(1/x) - x*exp(x)) /
@@ -96,8 +109,6 @@ def test_issue_4895d():
 @XFAIL
 @slow
 def test_issue_4941():
-    if ON_CI:
-        skip("Too slow for CI.")
     assert not integrate(sqrt(1 + sinh(x/20)**2), (x, -25, 25)).has(Integral)
 
 
@@ -129,13 +140,9 @@ def test_issue_15925a():
     assert not integrate(sqrt((1+sin(x))**2+(cos(x))**2), (x, -pi/2, pi/2)).has(Integral)
 
 
-@XFAIL
-@slow
 def test_issue_15925b():
-    if ON_CI:
-        skip("Too slow for CI.")
-    assert not integrate(sqrt((-12*cos(x)**2*sin(x))**2+(12*cos(x)*sin(x)**2)**2),
-                         (x, 0, pi/6)).has(Integral)
+    f = sqrt((-12*cos(x)**2*sin(x))**2+(12*cos(x)*sin(x)**2)**2)
+    assert integrate(f, (x, 0, pi/6)) == Rational(3, 2)
 
 
 @XFAIL
@@ -145,10 +152,8 @@ def test_issue_15925b_manual():
 
 
 @XFAIL
-@slow
+@tooslow
 def test_issue_15227():
-    if ON_CI:
-        skip("Too slow for CI.")
     i = integrate(log(1-x)*log((1+x)**2)/x, (x, 0, 1))
     assert not i.has(Integral)
     # assert i == -5*zeta(3)/4

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -17,7 +17,7 @@ from sympy.matrices import Matrix
 from sympy.simplify.ratsimp import ratsimp
 from sympy.simplify.simplify import simplify
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
-from sympy.testing.pytest import XFAIL, skip, slow, ON_CI
+from sympy.testing.pytest import XFAIL, slow
 from sympy.integrals.integrals import integrate
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
@@ -270,12 +270,8 @@ def test_pmint_trig():
 
     assert heurisch(f, x) == g
 
-@slow # 8 seconds on 3.4 GHz
-def test_pmint_logexp():
-    if ON_CI:
-        # See https://github.com/sympy/sympy/pull/12795
-        skip("Too slow for CI.")
 
+def test_pmint_logexp():
     f = (1 + x + x*exp(x))*(x + log(x) + exp(x) - 1)/(x + log(x) + exp(x))**2/x
     g = log(x + exp(x) + log(x)) + 1/(x + exp(x) + log(x))
 
@@ -312,13 +308,9 @@ def test_pmint_besselj():
 
     assert heurisch(f, x) == g
 
+
 @slow
 def test_pmint_bessel_products():
-    # Note: Derivatives of Bessel functions have many forms.
-    # Recurrence relations are needed for comparisons.
-    if ON_CI:
-        skip("Too slow for CI.")
-
     f = x*besselj(nu, x)*bessely(nu, 2*x)
     g = -2*x*besselj(nu, x)*bessely(nu - 1, 2*x)/3 + x*besselj(nu - 1, x)*bessely(nu, 2*x)/3
 
@@ -329,10 +321,8 @@ def test_pmint_bessel_products():
 
     assert heurisch(f, x) == g
 
-@slow # 110 seconds on 3.4 GHz
+
 def test_pmint_WrightOmega():
-    if ON_CI:
-        skip("Too slow for CI.")
     def omega(x):
         return LambertW(exp(x))
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -38,8 +38,7 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import (raises, slow, skip, ON_CI,
-    warns_deprecated_sympy, warns)
+from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
@@ -1435,8 +1434,6 @@ def test_issue_8945():
 
 @slow
 def test_issue_7130():
-    if ON_CI:
-        skip("Too slow for CI.")
     i, L, a, b = symbols('i L a b')
     integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
     assert x not in integrate(integrand, (x, 0, L)).free_symbols

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -19,7 +19,7 @@ from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.hyper import (hyper, meijerg)
 from sympy.abc import z, a, b, c
-from sympy.testing.pytest import XFAIL, raises, slow, ON_CI, skip
+from sympy.testing.pytest import XFAIL, raises, slow, tooslow
 from sympy.core.random import verify_numerically as tn
 
 from sympy.core.numbers import (Rational, pi)
@@ -743,12 +743,7 @@ def test_prudnikov_2():
                 assert can_do([p, n], [m])
 
 
-@slow
 def test_prudnikov_3():
-    if ON_CI:
-        # See https://github.com/sympy/sympy/pull/12795
-        skip("Too slow for CI.")
-
     h = S.Half
     assert can_do([Rational(1, 4), Rational(3, 4)], [h])
     assert can_do([Rational(1, 4), Rational(3, 4)], [3*h])
@@ -756,6 +751,14 @@ def test_prudnikov_3():
     assert can_do([Rational(3, 4), Rational(5, 4)], [h])
     assert can_do([Rational(3, 4), Rational(5, 4)], [3*h])
 
+
+@tooslow
+def test_prudnikov_3_slow():
+    # XXX: This is marked as tooslow and hence skipped in CI. None of the
+    # individual cases below fails or hangs. Some cases are slow and the loops
+    # below generate 280 different cases. Is it really necessary to test all
+    # 280 cases here?
+    h = S.Half
     for p in [1, 2, 3, 4]:
         for n in [-h, h, 1, 3*h, 2, 5*h, 3, 7*h, 4, 9*h]:
             for m in [1, 3*h, 2, 5*h, 3, 7*h, 4]:

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -59,7 +59,7 @@ from sympy.solvers.ode.single import (FirstLinear, ODEMatchError,
 
 from sympy.solvers.ode.subscheck import checkodesol
 
-from sympy.testing.pytest import raises, slow, ON_CI
+from sympy.testing.pytest import raises, slow
 import traceback
 
 
@@ -275,7 +275,7 @@ def _test_particular_example(our_hint, ode_example, solver_flag=False):
             if len(expected_sol) == 1:
                 expected_checkodesol = (True, 0)
 
-            if not (checkodesol_too_slow and ON_CI):
+            if not checkodesol_too_slow:
                 if not checkodesol_XFAIL:
                     if checkodesol(eq, dsolve_sol, func, solve_for_func=False) != expected_checkodesol:
                         result['unsolve_list'] = example

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -21,7 +21,7 @@ from sympy.solvers.ode.systems import (_classify_linear_system, linear_ode_to_ma
 from sympy.functions import airyai, airybi
 from sympy.integrals.integrals import Integral
 from sympy.simplify.ratsimp import ratsimp
-from sympy.testing.pytest import ON_CI, raises, slow, skip, XFAIL
+from sympy.testing.pytest import raises, slow, tooslow, XFAIL
 
 
 C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C0:11')
@@ -2101,11 +2101,8 @@ def test_linear_neq_order1_type2_slow1():
 
 # Regression test case for issue #9204
 # https://github.com/sympy/sympy/issues/9204
-@slow
+@tooslow
 def test_linear_new_order1_type2_de_lorentz_slow_check():
-    if ON_CI:
-        skip("Too slow for CI.")
-
     m = Symbol("m", real=True)
     q = Symbol("q", real=True)
     t = Symbol("t", real=True)
@@ -2245,12 +2242,9 @@ def test_neq_order1_type4_slow_check3():
     assert checksysodesol(eqs, sol) == (True, [0, 0])
 
 
+@tooslow
 @XFAIL
-@slow
 def test_linear_3eq_order1_type4_long_dsolve_slow_xfail():
-    if ON_CI:
-        skip("Too slow for CI.")
-
     eq, sol = _linear_3eq_order1_type4_long()
 
     dsolve_sol = dsolve(eq)
@@ -2259,11 +2253,8 @@ def test_linear_3eq_order1_type4_long_dsolve_slow_xfail():
     assert dsolve_sol1 == sol
 
 
-@slow
+@tooslow
 def test_linear_3eq_order1_type4_long_dsolve_dotprodsimp():
-    if ON_CI:
-        skip("Too slow for CI.")
-
     eq, sol = _linear_3eq_order1_type4_long()
 
     # XXX: Only works with dotprodsimp see
@@ -2275,11 +2266,8 @@ def test_linear_3eq_order1_type4_long_dsolve_dotprodsimp():
     assert dsolve_sol1 == sol
 
 
-@slow
+@tooslow
 def test_linear_3eq_order1_type4_long_check():
-    if ON_CI:
-        skip("Too slow for CI.")
-
     eq, sol = _linear_3eq_order1_type4_long()
     assert checksysodesol(eq, sol) == (True, [0, 0, 0])
 
@@ -2358,11 +2346,9 @@ def test_second_order_type2_slow1():
     assert checksysodesol(eqs1, sol1) == (True, [0, 0])
 
 
-@slow
+@tooslow
 @XFAIL
 def test_nonlinear_3eq_order1_type1():
-    if ON_CI:
-        skip("Too slow for CI.")
     a, b, c = symbols('a b c')
 
     eqs = [
@@ -2387,11 +2373,9 @@ def test_nonlinear_3eq_order1_type4():
     # assert checksysodesol(eqs, dsolve_sol) == (True, [0, 0, 0])
 
 
-@slow
+@tooslow
 @XFAIL
 def test_nonlinear_3eq_order1_type3():
-    if ON_CI:
-        skip("Too slow for CI.")
     eqs = [
         Eq(f(x).diff(x), (2*f(x)**2 - 3        )),
         Eq(g(x).diff(x), (4         - 2*h(x)   )),

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -30,6 +30,7 @@ XFAIL: Callable[[Any], Any]
 skip: Callable[[Any], Any]
 SKIP: Callable[[Any], Any]
 slow: Callable[[Any], Any]
+tooslow: Callable[[Any], Any]
 nocache_fail: Callable[[Any], Any]
 
 
@@ -39,6 +40,7 @@ if USE_PYTEST:
     XFAIL = pytest.mark.xfail
     SKIP = pytest.mark.skip
     slow = pytest.mark.slow
+    tooslow = pytest.mark.tooslow
     nocache_fail = pytest.mark.nocache_fail
     from _pytest.outcomes import Failed
 
@@ -186,6 +188,17 @@ else:
 
         def func_wrapper():
             func()
+
+        func_wrapper = functools.update_wrapper(func_wrapper, func)
+        func_wrapper.__wrapped__ = func
+        return func_wrapper
+
+    def tooslow(func):
+        func._slow = True
+        func._tooslow = True
+
+        def func_wrapper():
+            skip("Too slow")
 
         func_wrapper = functools.update_wrapper(func_wrapper, func)
         func_wrapper.__wrapped__ = func

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -76,8 +76,7 @@ from sympy.functions.combinatorial.numbers import stirling
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.special.error_functions import Ci, Si, erf
 from sympy.functions.special.zeta_functions import zeta
-from sympy.testing.pytest import (XFAIL, slow, SKIP, skip, ON_CI,
-    raises)
+from sympy.testing.pytest import (XFAIL, slow, SKIP, tooslow, raises)
 from sympy.utilities.iterables import partitions
 from mpmath import mpi, mpc
 from sympy.matrices import Matrix, GramSchmidt, eye
@@ -2608,10 +2607,8 @@ def test_W23b():
 
 
 @XFAIL
-@slow
+@tooslow
 def test_W24():
-    if ON_CI:
-        skip("Too slow for CI.")
     # Not that slow, but does not fully evaluate so simplify is slow.
     # Maybe also require doit()
     x, y = symbols('x y', real=True)
@@ -2620,10 +2617,8 @@ def test_W24():
 
 
 @XFAIL
-@slow
+@tooslow
 def test_W25():
-    if ON_CI:
-        skip("Too slow for CI.")
     a, x, y = symbols('a x y', real=True)
     i1 = integrate(
         sin(a)*sin(y)/sqrt(1 - sin(a)**2*sin(x)**2*sin(y)**2),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently there are tests that are considered to be "too slow" and that are skipped in CI by checking the `ON_CI` variable. This is problematic because it means that these tests will not be skipped when running the slow tests locally.

This PR adds a `tooslow` marker for tests that are too slow and applies it to those tests around the codebase that were previously using `if ON_CI: skip()`. Now running `bin/test --slow` locally will run the same tests as the slow job in CI.

This means that there are now 3 levels of tests:
```
pytest
pytest -m slow
pytest -m tooslow
```
Most too slow tests are too slow to ever really be run and there is no benefit running them locally if they don't run in CI. Having these extremely slow tests just makes it less likely that anyone would ever run the slow tests locally.

Some tests were found to be not that slow or to have been fixed somehow so the tooslow decorator was not used 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
