### PR TITLE
Fix ruff config bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ markers = [
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
 lint.select = [
-    "C40",
-    "C41",
+    "C4",
     "E",
     "F",
     "LOG",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,7 @@ markers = [
 # Enable Pyflakes `E` and `F` codes by default.
 lint.select = [
     "C40",
-    "C416",
-    "C419",
+    "C41",
     "E",
     "F",
     "LOG",


### PR DESCRIPTION
Accidentally excluded some ruff checks that were being applied by flake8-comprehensions

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Fixed ruff config bug where the 'C41' rules were being ignored by ruff, but not by flake8.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
