### PR TITLE
LUsolve now propagates iszerofunc properly.

### DIFF
--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -338,7 +338,7 @@ def _LUsolve(M, rhs, iszerofunc=_iszero):
 
     try:
         A, perm = M.LUdecomposition_Simple(
-            iszerofunc=_iszero, rankcheck=True)
+            iszerofunc=iszerofunc, rankcheck=True)
     except ValueError:
         raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
 

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -52,6 +52,19 @@ def test_issue_17247_expression_blowup_30():
 #             [(x + 1)/(4*x)],
 #             [    1/(x + 1)]])
 
+
+def test_LUsolve_iszerofunc():
+    # taken from https://github.com/sympy/sympy/issues/24679
+
+    M = Matrix([[(x + 1)**2 - (x**2 + 2*x + 1), x], [x, 0]])
+    b = Matrix([1, 1])
+    is_zero_func = lambda e: False if e._random() else True
+
+    x_exp = Matrix([1/x, (1-(-x**2 - 2*x + (x+1)**2 - 1)/x)/x])
+
+    assert (x_exp - M.LUsolve(b, iszerofunc=is_zero_func)) == Matrix([0, 0])
+
+
 def test_issue_17247_expression_blowup_32():
     M = Matrix([
         [x + 1, 1 - x,     0,     0],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes an issue mentioned here https://github.com/sympy/sympy/issues/24679#issuecomment-1468017766. Implements @oscarbenjamin's suggestion.


#### Brief description of what is fixed or changed

LUsolve ignored the iszerofunc and now it does not.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Fixed bug where LUsolve() ignored the iszerofunc kwarg. 

<!-- END RELEASE NOTES -->
