### PR TITLE
fix(polys): fix factor_list over EX domain

### DIFF
--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -61,6 +61,9 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
             except SympifyError:
                 return None
 
+        def __lt__(f, g):
+            return f.ex.sort_key() < g.ex.sort_key()
+
         def __add__(f, g):
             g = f._to_ex(g)
 

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1171,6 +1171,11 @@ def test_EX_EXRAW():
     assert EX.unify(EXRAW) == EXRAW
 
 
+def test_EX_ordering():
+    elements = [EX(1), EX(x), EX(3)]
+    assert sorted(elements) == [EX(1), EX(3), EX(x)]
+
+
 def test_canonical_unit():
 
     for K in [ZZ, QQ, RR]: # CC?

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3349,7 +3349,10 @@ class Poly(Basic):
             try:
                 coeff, factors = f.rep.factor_list()
             except DomainError:
-                return S.One, [(f, 1)]
+                if f.degree() == 0:
+                    return f.as_expr(), []
+                else:
+                    return S.One, [(f, 1)]
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'factor_list')
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2604,6 +2604,21 @@ def test_factor():
     assert factor_list(x**3 - x*y**2, t, w, x) == (
         1, [(x, 1), (x - y, 1), (x + y, 1)])
 
+    # https://github.com/sympy/sympy/issues/24952
+    s2, s2p, s2n = sqrt(2), 1 + sqrt(2), 1 - sqrt(2)
+    pip, pin = 1 + pi, 1 - pi
+    assert factor_list(s2p*s2n) == (-1, [(-s2n, 1), (s2p, 1)])
+    assert factor_list(pip*pin) == (-1, [(-pin, 1), (pip, 1)])
+    # Not sure about this one. Maybe coeff should be 1 or -1?
+    assert factor_list(s2*s2n) == (-s2, [(-s2n, 1)])
+    assert factor_list(pi*pin) == (-1, [(-pin, 1), (pi, 1)])
+    assert factor_list(s2p*s2n, x) == (s2p*s2n, [])
+    assert factor_list(pip*pin, x) == (pip*pin, [])
+    assert factor_list(s2*s2n, x) == (s2*s2n, [])
+    assert factor_list(pi*pin, x) == (pi*pin, [])
+    assert factor_list((x - sqrt(2)*pi)*(x + sqrt(2)*pi), x) == (
+        1, [(x - sqrt(2)*pi, 1), (x + sqrt(2)*pi, 1)])
+
 
 def test_factor_large():
     f = (x**2 + 4*x + 4)**10000000*(x**2 + 1)*(x**2 + 2*x + 1)**1234567


### PR DESCRIPTION
The `factor_list` function would fail over the EX domain when generators were provided e.g.:
```
   factor_list((1 + sqrt(2))*(1 - sqrt(2)), x)
```
The failure comes from attempting to sort the factors when elements of EX are not comparable. In this example actually both factors should be part of the coeff rather than the factor list so that is fixed by handling the case of zero degree polynomials in `Poly.factor_list`. It is still possible to see the problem with ordering factors over EX though with somethng like:
```
   factor_list((x + sqrt(2)*pi)*(x - sqrt(2)*pi), x)
```
The `__lt__` method has been added to EX so that its elements can be ordered as expected by `factor_list`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes a bug in `factor_list` identified at (https://github.com/sympy/sympy/issues/24952#issuecomment-1479425788).


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * A bug in factor_list was fixed. Previously factor_list might fail with an exception when factoring over EX e.g. an expression involving radicals like `sqrt(2)`. This was causing some integral computations to fail with the same exception.
<!-- END RELEASE NOTES -->
