### PR TITLE
Change joint argument order to avoid deprecation warning

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -843,6 +843,7 @@ Lucas Wiman <lucas.wiman@gmail.com>
 Lucy Mountain <lucymountain1@icloud.com> LucyMountain <lucymountain1@icloud.com>
 Luis Garcia <ppn.online@me.com>
 Luis Talavera <luisfertalavera15@gmail.com> Luis F. Talavera R <47088091+LuisFerTR@users.noreply.github.com>
+Lukas Molleman <Lukas.Molleman@gmail.com>
 Lukas Zorich <lukas.zorich@gmail.com>
 Luke Peterson <hazelnusse@gmail.com>
 Luv Agarwal <agarwal.iiit@gmail.com>

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -132,8 +132,8 @@ class Joint(ABC):
     """
 
     def __init__(self, name, parent, child, coordinates=None, speeds=None,
-                 parent_point=None, child_point=None, parent_axis=None,
-                 child_axis=None, parent_interframe=None, child_interframe=None,
+                 parent_point=None, child_point=None, parent_interframe=None,
+                 child_interframe=None, parent_axis=None, child_axis=None,
                  parent_joint_pos=None, child_joint_pos=None):
 
         if not isinstance(name, str):
@@ -775,14 +775,14 @@ class PinJoint(Joint):
     """
 
     def __init__(self, name, parent, child, coordinates=None, speeds=None,
-                 parent_point=None, child_point=None, parent_axis=None,
-                 child_axis=None, parent_interframe=None, child_interframe=None,
+                 parent_point=None, child_point=None, parent_interframe=None,
+                 child_interframe=None, parent_axis=None, child_axis=None,
                  joint_axis=None, parent_joint_pos=None, child_joint_pos=None):
 
         self._joint_axis = joint_axis
         super().__init__(name, parent, child, coordinates, speeds, parent_point,
-                         child_point, parent_axis, child_axis,
-                         parent_interframe, child_interframe, parent_joint_pos,
+                         child_point, parent_interframe, child_interframe,
+                         parent_axis, child_axis, parent_joint_pos,
                          child_joint_pos)
 
     def __str__(self):
@@ -1038,14 +1038,14 @@ class PrismaticJoint(Joint):
     """
 
     def __init__(self, name, parent, child, coordinates=None, speeds=None,
-                 parent_point=None, child_point=None, parent_axis=None,
-                 child_axis=None, parent_interframe=None, child_interframe=None,
+                 parent_point=None, child_point=None, parent_interframe=None,
+                 child_interframe=None, parent_axis=None, child_axis=None,
                  joint_axis=None, parent_joint_pos=None, child_joint_pos=None):
 
         self._joint_axis = joint_axis
         super().__init__(name, parent, child, coordinates, speeds, parent_point,
-                         child_point, parent_axis, child_axis,
-                         parent_interframe, child_interframe, parent_joint_pos,
+                         child_point, parent_interframe, child_interframe,
+                         parent_axis, child_axis, parent_joint_pos,
                          child_joint_pos)
 
     def __str__(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #24968


#### Brief description of what is fixed or changed
Swaps parent_axis and parent_interframe, child_axis and child_interframe in init args to avoid deprecation warning.


#### Other comments


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
