### PR TITLE
physics: Unit dyads access from ReferenceFrames

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -802,6 +802,7 @@ Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>
 Konstantin Togoi <konstantin.togoi@gmail.com> <togoi.konstantin@outlook.com>
+Konstantinos Riganas <kostasriganas24@gmail.com> kostas-rigan <t8200145@aueb.gr>
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1400,47 +1400,47 @@ class ReferenceFrame:
     def z(self):
         """The basis Vector for the ReferenceFrame, in the z direction. """
         return self._z
-    
+
     @property
     def xx(self):
         """Unit dyad of basis Vectors x and x for the ReferenceFrame."""
         return Vector.outer(self.x, self.x)
-    
+
     @property
     def xy(self):
         """Unit dyad of basis Vectors x and y for the ReferenceFrame."""
         return Vector.outer(self.x, self.y)
-    
+
     @property
     def xz(self):
         """Unit dyad of basis Vectors x and z for the ReferenceFrame."""
         return Vector.outer(self.x, self.z)
-    
+
     @property
     def yx(self):
         """Unit dyad of basis Vectors y and x for the ReferenceFrame."""
         return Vector.outer(self.y, self.x)
-    
+
     @property
     def yy(self):
         """Unit dyad of basis Vectors y and y for the ReferenceFrame."""
         return Vector.outer(self.y, self.y)
-    
+
     @property
     def yz(self):
         """Unit dyad of basis Vectors y and z for the ReferenceFrame."""
         return Vector.outer(self.y, self.z)
-    
+
     @property
     def zx(self):
         """Unit dyad of basis Vectors z and x for the ReferenceFrame."""
         return Vector.outer(self.z, self.x)
-    
+
     @property
     def zy(self):
         """Unit dyad of basis Vectors z and y for the ReferenceFrame."""
         return Vector.outer(self.z, self.y)
-    
+
     @property
     def zz(self):
         """Unit dyad of basis Vectors z and z for the ReferenceFrame."""

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -145,6 +145,19 @@ class ReferenceFrame:
         >>> type(A) == type(D)
         True
 
+        Unit dyads for the ReferenceFrame can be accessed through the attributes xx, xy, etc. For example:
+
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> N = ReferenceFrame('N')
+        >>> N.yz
+        (N.y|N.z)
+        >>> N.zx
+        (N.z|N.x)
+        >>> F = ReferenceFrame('F', indices=['1', '2', '3'])
+        >>> F.xx
+        (F['1']|F['1'])
+        >>> F.zy
+        (F['3']|F['2'])
         """
 
         if not isinstance(name, str):
@@ -1387,6 +1400,51 @@ class ReferenceFrame:
     def z(self):
         """The basis Vector for the ReferenceFrame, in the z direction. """
         return self._z
+    
+    @property
+    def xx(self):
+        """Unit dyad of basis Vectors x and x for the ReferenceFrame."""
+        return Vector.outer(self.x, self.x)
+    
+    @property
+    def xy(self):
+        """Unit dyad of basis Vectors x and y for the ReferenceFrame."""
+        return Vector.outer(self.x, self.y)
+    
+    @property
+    def xz(self):
+        """Unit dyad of basis Vectors x and z for the ReferenceFrame."""
+        return Vector.outer(self.x, self.z)
+    
+    @property
+    def yx(self):
+        """Unit dyad of basis Vectors y and x for the ReferenceFrame."""
+        return Vector.outer(self.y, self.x)
+    
+    @property
+    def yy(self):
+        """Unit dyad of basis Vectors y and y for the ReferenceFrame."""
+        return Vector.outer(self.y, self.y)
+    
+    @property
+    def yz(self):
+        """Unit dyad of basis Vectors y and z for the ReferenceFrame."""
+        return Vector.outer(self.y, self.z)
+    
+    @property
+    def zx(self):
+        """Unit dyad of basis Vectors z and x for the ReferenceFrame."""
+        return Vector.outer(self.z, self.x)
+    
+    @property
+    def zy(self):
+        """Unit dyad of basis Vectors z and y for the ReferenceFrame."""
+        return Vector.outer(self.z, self.y)
+    
+    @property
+    def zz(self):
+        """Unit dyad of basis Vectors z and z for the ReferenceFrame."""
+        return Vector.outer(self.z, self.z)
 
     def partial_velocity(self, frame, *gen_speeds):
         """Returns the partial angular velocities of this frame in the given

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -163,7 +163,7 @@ class ReferenceFrame:
 
         >>> from sympy.physics.vector import ReferenceFrame
         >>> N = ReferenceFrame('N')
-        >>> N.unit
+        >>> N.u
         (N.x|N.x) + (N.y|N.y) + (N.z|N.z)
         >>> P = ReferenceFrame('P', indices=['1', '2', '3'])
         >>> P.u

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -156,7 +156,7 @@ class ReferenceFrame:
         >>> P = ReferenceFrame('P', indices=['1', '2', '3'])
         >>> P.xx
         (P['1']|P['1'])
-        >>> F.zy
+        >>> P.zy
         (P['3']|P['2'])
 
         Unit dyadic is also accessible via the ``u`` attribute:

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -145,7 +145,7 @@ class ReferenceFrame:
         >>> type(A) == type(D)
         True
 
-        Unit dyads for the ReferenceFrame can be accessed through the attributes xx, xy, etc. For example:
+        Unit dyads for the ReferenceFrame can be accessed through the attributes ``xx``, ``xy``, etc. For example:
 
         >>> from sympy.physics.vector import ReferenceFrame
         >>> N = ReferenceFrame('N')
@@ -153,11 +153,22 @@ class ReferenceFrame:
         (N.y|N.z)
         >>> N.zx
         (N.z|N.x)
-        >>> F = ReferenceFrame('F', indices=['1', '2', '3'])
-        >>> F.xx
-        (F['1']|F['1'])
+        >>> P = ReferenceFrame('P', indices=['1', '2', '3'])
+        >>> P.xx
+        (P['1']|P['1'])
         >>> F.zy
-        (F['3']|F['2'])
+        (P['3']|P['2'])
+
+        Unit dyadic is also accessible via the ``u`` attribute:
+
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> N = ReferenceFrame('N')
+        >>> N.unit
+        (N.x|N.x) + (N.y|N.y) + (N.z|N.z)
+        >>> P = ReferenceFrame('P', indices=['1', '2', '3'])
+        >>> P.u
+        (P['1']|P['1']) + (P['2']|P['2']) + (P['3']|P['3'])
+
         """
 
         if not isinstance(name, str):
@@ -1445,6 +1456,11 @@ class ReferenceFrame:
     def zz(self):
         """Unit dyad of basis Vectors z and z for the ReferenceFrame."""
         return Vector.outer(self.z, self.z)
+
+    @property
+    def u(self):
+        """Unit dyadic for the ReferenceFrame."""
+        return self.xx + self.yy + self.zz
 
     def partial_velocity(self, frame, *gen_speeds):
         """Returns the partial angular velocities of this frame in the given

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -658,3 +658,63 @@ def test_dcm_cache_dict():
     assert A._dcm_dict == A._dcm_cache
     assert B._dcm_dict == {C: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]]), \
         A: Matrix([[1, 0, 0],[0, cos(b), -sin(b)],[0, sin(b),  cos(b)]])}
+
+def test_xx_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.xx == Vector.outer(N.x, N.x)
+    assert F.xx == Vector.outer(F.x, F.x)
+
+def test_xy_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.xy == Vector.outer(N.x, N.y)
+    assert F.xy == Vector.outer(F.x, F.y)
+
+def test_xz_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.xz == Vector.outer(N.x, N.z)
+    assert F.xz == Vector.outer(F.x, F.z)
+
+def test_yx_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.yx == Vector.outer(N.y, N.x)
+    assert F.yx == Vector.outer(F.y, F.x)
+
+def test_yy_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.yy == Vector.outer(N.y, N.y)
+    assert F.yy == Vector.outer(F.y, F.y)
+
+def test_yz_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.yz == Vector.outer(N.y, N.z)
+    assert F.yz == Vector.outer(F.y, F.z)
+
+def test_zx_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.zx == Vector.outer(N.z, N.x)
+    assert F.zx == Vector.outer(F.z, F.x)
+
+def test_zy_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.zy == Vector.outer(N.z, N.y)
+    assert F.zy == Vector.outer(F.z, F.y)
+
+def test_zz_dyad():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.zz == Vector.outer(N.z, N.z)
+    assert F.zz == Vector.outer(F.z, F.z)
+
+def test_unit_dyadic():
+    N = ReferenceFrame('N')
+    F = ReferenceFrame('F', indices=['1', '2', '3'])
+    assert N.u == N.xx + N.yy + N.zz
+    assert F.u == F.xx + F.yy + F.zz


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #24965



#### Brief description of what is fixed or changed
Unit dyads and unit dyadic can be accessed through attributes of a ReferenceFrame object. It is an addition related to issue #24965, allowing easy access to unit dyads without the need to use the outer() function. This commit adds 10 functions with the property decorator, along with a few examples in the constructor's documentation.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
    * Added access to unit dyads and unit dyadic directly from ReferenceFrame objects.

<!-- END RELEASE NOTES -->
