### PR TITLE
Remove use of Vector.simp in sympy.physics.vector and .mechanics

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
@@ -16,11 +16,8 @@ construction of the equations of motion in :mod:`sympy.physics.mechanics`. ::
 
 Note that this code has been crudely ported from Autolev, which is the reason
 for some of the unusual naming conventions. It was purposefully as similar as
-possible in order to aid initial porting & debugging. We set Vector.simp to
-False (in case it has been set True elsewhere), since it slows down the
-computations::
+possible in order to aid initial porting & debugging.::
 
-  >>> Vector.simp = False
   >>> mechanics_printing(pretty_print=False)
 
 Declaration of Coordinates & Speeds:

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -544,7 +544,7 @@ def test_pin_joint_arbitrary_axis():
                                                      u*A.z)/sqrt(3)
     assert A.ang_vel_in(N).magnitude() == sqrt(u**2)
     angle = A.ang_vel_in(N).angle_between(A.x + A.y-A.z)
-    assert angle.xreplace({u: 1}) == 0
+    assert angle.xreplace({u: 1}).simplify() == 0
     assert C.masscenter.vel(N).simplify() == (u*A.y + u*A.z)/sqrt(3)
     assert C.masscenter.pos_from(P.masscenter) == N.x - A.x
     assert (C.masscenter.pos_from(P.masscenter).express(N).simplify() ==
@@ -800,7 +800,7 @@ def test_prismatic_joint_arbitrary_axis():
     N, A, P, C = _generate_body()
     PrismaticJoint('S', P, C, parent_point=N.x, child_point=A.x,
                    child_interframe=A.x + A.y - A.z)
-    assert N.x.angle_between(A.x + A.y - A.z) == 0 #Axis are aligned
+    assert N.x.angle_between(A.x + A.y - A.z).simplify() == 0 #Axis are aligned
     assert (A.x + A.y - A.z).express(N) == sqrt(3)*N.x
     assert _simplify_matrix(A.dcm(N)) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
                                                  [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -13,7 +13,6 @@ from sympy.physics.vector import Vector, ReferenceFrame, Point
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
-Vector.simp = True
 t = dynamicsymbols._t # type: ignore
 
 
@@ -1057,7 +1056,7 @@ def test_spherical_joint_orient_body():
     assert S._rot_order == 123
     assert _simplify_matrix(N.dcm(A) - N_R_A) == zeros(3)
     assert A.ang_vel_in(N).to_matrix(A) == N_w_A
-    assert C.masscenter.vel(N).to_matrix(A) == N_v_Co
+    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
     # Test change of amounts
     N, A, P, C, Pint, Cint = _generate_body(True)
     S = SphericalJoint('S', P, C, coordinates=[q0, q1, q2], speeds=[u0, u1, u2],
@@ -1070,7 +1069,7 @@ def test_spherical_joint_orient_body():
     assert S._rot_order == 123
     assert _simplify_matrix(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
     assert A.ang_vel_in(N).to_matrix(A) == switch_order(N_w_A)
-    assert C.masscenter.vel(N).to_matrix(A) == switch_order(N_v_Co)
+    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
     # Test different rot_order
     N, A, P, C, Pint, Cint = _generate_body(True)
     S = SphericalJoint('S', P, C, coordinates=[q0, q1, q2], speeds=[u0, u1, u2],
@@ -1088,7 +1087,7 @@ def test_spherical_joint_orient_body():
     assert A.ang_vel_in(N).to_matrix(A) == Matrix([
         [u0 * sin(q1) - u2], [u0 * cos(q1) * cos(q2) - u1 * sin(q2)],
         [u0 * sin(q2) * cos(q1) + u1 * cos(q2)]])
-    assert C.masscenter.vel(N).to_matrix(A) == Matrix([
+    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == Matrix([
         [-sqrt(2) * (u0 * sin(q2 + pi / 4) * cos(q1) + u1 * cos(q2 + pi / 4))],
         [u0 * sin(q1) - u2], [u0 * sin(q1) - u2]])
 

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -572,12 +572,12 @@ def test_pin_joint_arbitrary_axis():
          2*sin(q + pi/6)/3 + S(1)/3],
         [-2*sin(q + pi/6)/3 - S(1)/3, 2*cos(q + pi/3)/3 + S(1)/3,
          2*cos(q)/3 - S(1)/3]])
-    assert A.ang_vel_in(N) == (u*N.x - u*N.y + u*N.z)/sqrt(3)
+    assert (A.ang_vel_in(N) - (u*N.x - u*N.y + u*N.z)/sqrt(3)).simplify()
     assert A.ang_vel_in(N).express(A).simplify() == (u*A.x + u*A.y -
                                                      u*A.z)/sqrt(3)
     assert A.ang_vel_in(N).magnitude() == sqrt(u**2)
     angle = A.ang_vel_in(N).angle_between(A.x+A.y-A.z)
-    assert angle.xreplace({u: 1}) == 0
+    assert angle.xreplace({u: 1}).simplify() == 0
     assert (C.masscenter.vel(N).simplify() ==
             sqrt(3)*n*u/3*A.y + sqrt(3)*n*u/3*A.z)
     assert C.masscenter.pos_from(P.masscenter) == m*N.x - n*A.x
@@ -801,15 +801,16 @@ def test_prismatic_joint_arbitrary_axis():
     PrismaticJoint('S', P, C, parent_point=N.x, child_point=A.x,
                    child_interframe=A.x + A.y - A.z)
     assert N.x.angle_between(A.x + A.y - A.z).simplify() == 0 #Axis are aligned
-    assert (A.x + A.y - A.z).express(N) == sqrt(3)*N.x
+    assert ((A.x + A.y - A.z).express(N) - sqrt(3)*N.x).simplify() == 0
     assert _simplify_matrix(A.dcm(N)) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
                                                  [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
                                                  [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
     assert C.masscenter.pos_from(P.masscenter) == (q + 1)*N.x - A.x
-    assert C.masscenter.pos_from(P.masscenter).express(N) == \
-        (q - sqrt(3)/3 + 1)*N.x + sqrt(3)/3*N.y - sqrt(3)/3*N.z
+    assert (C.masscenter.pos_from(P.masscenter).express(N) -
+        ((q - sqrt(3)/3 + 1)*N.x + sqrt(3)/3*N.y - sqrt(3)/3*N.z)).simplify() == 0
     assert C.masscenter.vel(N) == u*N.x
-    assert C.masscenter.vel(N).express(A) == sqrt(3)*u/3*A.x + sqrt(3)*u/3*A.y - sqrt(3)*u/3*A.z
+    assert (C.masscenter.vel(N).express(A) - (
+        sqrt(3)*u/3*A.x + sqrt(3)*u/3*A.y - sqrt(3)*u/3*A.z)).simplify()
     assert A.ang_vel_in(N) == 0
     assert N.ang_vel_in(A) == 0
 
@@ -820,16 +821,20 @@ def test_prismatic_joint_arbitrary_axis():
                    parent_interframe=N.x - N.y + N.z)
     # 0 angle means that the axis are aligned
     assert (N.x-N.y+N.z).angle_between(A.x+A.y-A.z).simplify() == 0
-    assert (A.x+A.y-A.z).express(N) == N.x - N.y + N.z
+    assert ((A.x+A.y-A.z).express(N) - (N.x - N.y + N.z)).simplify() == 0
     assert _simplify_matrix(A.dcm(N)) == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
                                                  [S(2)/3, S(1)/3, S(2)/3],
                                                  [-S(2)/3, S(2)/3, S(1)/3]])
-    assert C.masscenter.pos_from(P.masscenter) == \
-        (m + sqrt(3)*q/3)*N.x - sqrt(3)*q/3*N.y + sqrt(3)*q/3*N.z - n*A.x
-    assert C.masscenter.pos_from(P.masscenter).express(N) == \
-        (m + n/3 + sqrt(3)*q/3)*N.x + (2*n/3 - sqrt(3)*q/3)*N.y + (-2*n/3 + sqrt(3)*q/3)*N.z
-    assert C.masscenter.vel(N) == sqrt(3)*u/3*N.x - sqrt(3)*u/3*N.y + sqrt(3)*u/3*N.z
-    assert C.masscenter.vel(N).express(A) == sqrt(3)*u/3*A.x + sqrt(3)*u/3*A.y - sqrt(3)*u/3*A.z
+    assert (C.masscenter.pos_from(P.masscenter) - (
+        (m + sqrt(3)*q/3)*N.x - sqrt(3)*q/3*N.y + sqrt(3)*q/3*N.z - n*A.x)
+            ).express(N).simplify() == 0
+    assert (C.masscenter.pos_from(P.masscenter).express(N) - (
+        (m + n/3 + sqrt(3)*q/3)*N.x + (2*n/3 - sqrt(3)*q/3)*N.y +
+        (-2*n/3 + sqrt(3)*q/3)*N.z)).simplify() == 0
+    assert (C.masscenter.vel(N).express(N) - (
+        sqrt(3)*u/3*N.x - sqrt(3)*u/3*N.y + sqrt(3)*u/3*N.z)).simplify() == 0
+    assert (C.masscenter.vel(N).express(A) -
+            (sqrt(3)*u/3*A.x + sqrt(3)*u/3*A.y - sqrt(3)*u/3*A.z)).simplify() == 0
     assert A.ang_vel_in(N) == 0
     assert N.ang_vel_in(A) == 0
 
@@ -1055,7 +1060,7 @@ def test_spherical_joint_orient_body():
     assert S._rot_type.upper() == 'BODY'
     assert S._rot_order == 123
     assert _simplify_matrix(N.dcm(A) - N_R_A) == zeros(3)
-    assert A.ang_vel_in(N).to_matrix(A) == N_w_A
+    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - N_w_A) == zeros(3, 1)
     assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
     # Test change of amounts
     N, A, P, C, Pint, Cint = _generate_body(True)
@@ -1068,7 +1073,8 @@ def test_spherical_joint_orient_body():
     assert S._rot_type.upper() == 'BODY'
     assert S._rot_order == 123
     assert _simplify_matrix(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
-    assert A.ang_vel_in(N).to_matrix(A) == switch_order(N_w_A)
+    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - switch_order(N_w_A)
+                            ) == zeros(3, 1)
     assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
     # Test different rot_order
     N, A, P, C, Pint, Cint = _generate_body(True)
@@ -1084,9 +1090,9 @@ def test_spherical_joint_orient_body():
         [-sin(q1), -cos(q1) * cos(q2), -sin(q2) * cos(q1)],
         [cos(q0) * cos(q1), -sin(q0) * sin(q2) - sin(q1) * cos(q0) * cos(q2),
          sin(q0) * cos(q2) - sin(q1) * sin(q2) * cos(q0)]])) == zeros(3)
-    assert A.ang_vel_in(N).to_matrix(A) == Matrix([
+    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - Matrix([
         [u0 * sin(q1) - u2], [u0 * cos(q1) * cos(q2) - u1 * sin(q2)],
-        [u0 * sin(q2) * cos(q1) + u1 * cos(q2)]])
+        [u0 * sin(q2) * cos(q1) + u1 * cos(q2)]])) == zeros(3, 1)
     assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == Matrix([
         [-sqrt(2) * (u0 * sin(q2 + pi / 4) * cos(q1) + u1 * cos(q2 + pi / 4))],
         [u0 * sin(q1) - u2], [u0 * sin(q1) - u2]])

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -436,9 +436,8 @@ class Dyadic(Printable, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy import symbols
+        >>> from sympy import symbols, trigsimp
         >>> from sympy.physics.vector import ReferenceFrame, Vector
-        >>> Vector.simp = True
         >>> from sympy.physics.mechanics import inertia
         >>> Ixx, Iyy, Izz, Ixy, Iyz, Ixz = symbols('Ixx, Iyy, Izz, Ixy, Iyz, Ixz')
         >>> N = ReferenceFrame('N')
@@ -450,7 +449,7 @@ class Dyadic(Printable, EvalfMixin):
         [Ixz, Iyz, Izz]])
         >>> beta = symbols('beta')
         >>> A = N.orientnew('A', 'Axis', (beta, N.x))
-        >>> inertia_dyadic.to_matrix(A)
+        >>> trigsimp(inertia_dyadic.to_matrix(A))
         Matrix([
         [                           Ixx,                                           Ixy*cos(beta) + Ixz*sin(beta),                                           -Ixy*sin(beta) + Ixz*cos(beta)],
         [ Ixy*cos(beta) + Ixz*sin(beta), Iyy*cos(2*beta)/2 + Iyy/2 + Iyz*sin(2*beta) - Izz*cos(2*beta)/2 + Izz/2,                 -Iyy*sin(2*beta)/2 + Iyz*cos(2*beta) + Izz*sin(2*beta)/2],

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -437,7 +437,7 @@ class Dyadic(Printable, EvalfMixin):
         ========
 
         >>> from sympy import symbols, trigsimp
-        >>> from sympy.physics.vector import ReferenceFrame, Vector
+        >>> from sympy.physics.vector import ReferenceFrame
         >>> from sympy.physics.mechanics import inertia
         >>> Ixx, Iyy, Izz, Ixy, Iyz, Ixz = symbols('Ixx, Iyy, Izz, Ixy, Iyz, Ixz')
         >>> N = ReferenceFrame('N')

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -2,11 +2,10 @@ from sympy.core.numbers import (Float, pi)
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.immutable import ImmutableDenseMatrix as Matrix
-from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols, outer
+from sympy.physics.vector import ReferenceFrame, dynamicsymbols, outer
 from sympy.physics.vector.dyadic import _check_dyadic
 from sympy.testing.pytest import raises
 
-Vector.simp = True
 A = ReferenceFrame('A')
 
 

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -1,5 +1,6 @@
 from sympy.core.numbers import pi
 from sympy.core.symbol import symbols
+from sympy.simplify import trigsimp
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import (eye, zeros)
 from sympy.matrices.immutable import ImmutableDenseMatrix as Matrix
@@ -11,8 +12,6 @@ from sympy.physics.vector.frame import _check_frame
 from sympy.physics.vector.vector import VectorTypeError
 from sympy.testing.pytest import raises
 import warnings
-
-Vector.simp = True
 
 
 def test_dict_list():
@@ -77,22 +76,25 @@ def test_coordinate_vars():
     assert express(B[0]*B.x + B[1]*B.y + B[2]*B.z, A) == \
            (B[0]*cos(q) - B[1]*sin(q))*A.x + (B[0]*sin(q) + \
            B[1]*cos(q))*A.y + B[2]*A.z
-    assert express(B[0]*B.x + B[1]*B.y + B[2]*B.z, A, variables=True) == \
-           A[0]*A.x + A[1]*A.y + A[2]*A.z
+    assert express(B[0]*B.x + B[1]*B.y + B[2]*B.z, A,
+                   variables=True).simplify() == A[0]*A.x + A[1]*A.y + A[2]*A.z
     assert express(A[0]*A.x + A[1]*A.y + A[2]*A.z, B) == \
            (A[0]*cos(q) + A[1]*sin(q))*B.x + \
            (-A[0]*sin(q) + A[1]*cos(q))*B.y + A[2]*B.z
-    assert express(A[0]*A.x + A[1]*A.y + A[2]*A.z, B, variables=True) == \
-           B[0]*B.x + B[1]*B.y + B[2]*B.z
+    assert express(A[0]*A.x + A[1]*A.y + A[2]*A.z, B,
+                   variables=True).simplify() == B[0]*B.x + B[1]*B.y + B[2]*B.z
     N = B.orientnew('N', 'Axis', [-q, B.z])
-    assert N.variable_map(A) == {N[0]: A[0], N[2]: A[2], N[1]: A[1]}
+    assert ({k: v.simplify() for k, v in N.variable_map(A).items()} ==
+            {N[0]: A[0], N[2]: A[2], N[1]: A[1]})
     C = A.orientnew('C', 'Axis', [q, A.x + A.y + A.z])
     mapping = A.variable_map(C)
-    assert mapping[A[0]] == 2*C[0]*cos(q)/3 + C[0]/3 - 2*C[1]*sin(q + pi/6)/3 +\
-           C[1]/3 - 2*C[2]*cos(q + pi/3)/3 + C[2]/3
-    assert mapping[A[1]] == -2*C[0]*cos(q + pi/3)/3 + \
+    assert trigsimp(mapping[A[0]]) == (2*C[0]*cos(q)/3 + C[0]/3 -
+                                       2*C[1]*sin(q + pi/6)/3 +
+                                       C[1]/3 - 2*C[2]*cos(q + pi/3)/3 +
+                                       C[2]/3)
+    assert trigsimp(mapping[A[1]]) == -2*C[0]*cos(q + pi/3)/3 + \
            C[0]/3 + 2*C[1]*cos(q)/3 + C[1]/3 - 2*C[2]*sin(q + pi/6)/3 + C[2]/3
-    assert mapping[A[2]] == -2*C[0]*sin(q + pi/6)/3 + C[0]/3 - \
+    assert trigsimp(mapping[A[2]]) == -2*C[0]*sin(q + pi/6)/3 + C[0]/3 - \
            2*C[1]*cos(q + pi/3)/3 + C[1]/3 + 2*C[2]*cos(q)/3 + C[2]/3
 
 

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -10,9 +10,9 @@ from sympy.physics.vector.functions import (cross, dot, express,
                                             kinematic_equations, outer,
                                             partial_velocity,
                                             get_motion_params, dynamicsymbols)
+from sympy.simplify import trigsimp
 from sympy.testing.pytest import raises
 
-Vector.simp = True
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
 N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])
@@ -45,7 +45,8 @@ def test_dot_different_frames():
     assert dot(N.z, A.y) == 0
     assert dot(N.z, A.z) == 1
 
-    assert dot(N.x, A.x + A.y) == sqrt(2)*cos(q1 + pi/4) == dot(A.x + A.y, N.x)
+    assert trigsimp(dot(N.x, A.x + A.y)) == sqrt(2)*cos(q1 + pi/4)
+    assert trigsimp(dot(N.x, A.x + A.y)) == trigsimp(dot(A.x + A.y, N.x))
 
     assert dot(A.x, C.x) == cos(q3)
     assert dot(A.x, C.y) == 0
@@ -92,7 +93,7 @@ def test_cross_different_frames():
     assert cross(A.x, C.y) == -sin(q3)*C.x + cos(q3)*C.z
     assert cross(A.x, C.z) == -cos(q3)*C.y
     assert cross(C.x, A.x) == -sin(q3)*C.y
-    assert cross(C.y, A.x) == sin(q3)*C.x - cos(q3)*C.z
+    assert cross(C.y, A.x).express(C).simplify() == sin(q3)*C.x - cos(q3)*C.z
     assert cross(C.z, A.x) == cos(q3)*C.y
 
 def test_operator_match():
@@ -266,13 +267,13 @@ def test_express():
     assert express(C.z, C) == C.z == (C.z)
 
     #  Check to make sure Vectors get converted back to UnitVectors
-    assert N.x == express((cos(q1)*A.x - sin(q1)*A.y), N)
-    assert N.y == express((sin(q1)*A.x + cos(q1)*A.y), N)
+    assert N.x == express((cos(q1)*A.x - sin(q1)*A.y), N).simplify()
+    assert N.y == express((sin(q1)*A.x + cos(q1)*A.y), N).simplify()
     assert N.x == express((cos(q1)*B.x - sin(q1)*cos(q2)*B.y +
-            sin(q1)*sin(q2)*B.z), N)
+            sin(q1)*sin(q2)*B.z), N).simplify()
     assert N.y == express((sin(q1)*B.x + cos(q1)*cos(q2)*B.y -
-        sin(q2)*cos(q1)*B.z), N)
-    assert N.z == express((sin(q2)*B.y + cos(q2)*B.z), N)
+        sin(q2)*cos(q1)*B.z), N).simplify()
+    assert N.z == express((sin(q2)*B.y + cos(q2)*B.z), N).simplify()
 
     """
     These don't really test our code, they instead test the auto simplification
@@ -289,33 +290,33 @@ def test_express():
             cos(q2)*cos(q3)*C.z), N)
     """
 
-    assert A.x == express((cos(q1)*N.x + sin(q1)*N.y), A)
-    assert A.y == express((-sin(q1)*N.x + cos(q1)*N.y), A)
+    assert A.x == express((cos(q1)*N.x + sin(q1)*N.y), A).simplify()
+    assert A.y == express((-sin(q1)*N.x + cos(q1)*N.y), A).simplify()
 
-    assert A.y == express((cos(q2)*B.y - sin(q2)*B.z), A)
-    assert A.z == express((sin(q2)*B.y + cos(q2)*B.z), A)
+    assert A.y == express((cos(q2)*B.y - sin(q2)*B.z), A).simplify()
+    assert A.z == express((sin(q2)*B.y + cos(q2)*B.z), A).simplify()
 
-    assert A.x == express((cos(q3)*C.x + sin(q3)*C.z), A)
+    assert A.x == express((cos(q3)*C.x + sin(q3)*C.z), A).simplify()
 
     # Tripsimp messes up here too.
     #print express((sin(q2)*sin(q3)*C.x + cos(q2)*C.y -
     #        sin(q2)*cos(q3)*C.z), A)
     assert A.y == express((sin(q2)*sin(q3)*C.x + cos(q2)*C.y -
-            sin(q2)*cos(q3)*C.z), A)
+            sin(q2)*cos(q3)*C.z), A).simplify()
 
     assert A.z == express((-sin(q3)*cos(q2)*C.x + sin(q2)*C.y +
-            cos(q2)*cos(q3)*C.z), A)
-    assert B.x == express((cos(q1)*N.x + sin(q1)*N.y), B)
+            cos(q2)*cos(q3)*C.z), A).simplify()
+    assert B.x == express((cos(q1)*N.x + sin(q1)*N.y), B).simplify()
     assert B.y == express((-sin(q1)*cos(q2)*N.x +
-            cos(q1)*cos(q2)*N.y + sin(q2)*N.z), B)
+            cos(q1)*cos(q2)*N.y + sin(q2)*N.z), B).simplify()
 
     assert B.z == express((sin(q1)*sin(q2)*N.x -
-            sin(q2)*cos(q1)*N.y + cos(q2)*N.z), B)
+            sin(q2)*cos(q1)*N.y + cos(q2)*N.z), B).simplify()
 
-    assert B.y == express((cos(q2)*A.y + sin(q2)*A.z), B)
-    assert B.z == express((-sin(q2)*A.y + cos(q2)*A.z), B)
-    assert B.x == express((cos(q3)*C.x + sin(q3)*C.z), B)
-    assert B.z == express((-sin(q3)*C.x + cos(q3)*C.z), B)
+    assert B.y == express((cos(q2)*A.y + sin(q2)*A.z), B).simplify()
+    assert B.z == express((-sin(q2)*A.y + cos(q2)*A.z), B).simplify()
+    assert B.x == express((cos(q3)*C.x + sin(q3)*C.z), B).simplify()
+    assert B.z == express((-sin(q3)*C.x + cos(q3)*C.z), B).simplify()
 
     """
     assert C.x == express((
@@ -330,12 +331,12 @@ def test_express():
             cos(q2)*cos(q3)*N.z), C)
     """
     assert C.x == express((cos(q3)*A.x + sin(q2)*sin(q3)*A.y -
-            sin(q3)*cos(q2)*A.z), C)
-    assert C.y == express((cos(q2)*A.y + sin(q2)*A.z), C)
+            sin(q3)*cos(q2)*A.z), C).simplify()
+    assert C.y == express((cos(q2)*A.y + sin(q2)*A.z), C).simplify()
     assert C.z == express((sin(q3)*A.x - sin(q2)*cos(q3)*A.y +
-            cos(q2)*cos(q3)*A.z), C)
-    assert C.x == express((cos(q3)*B.x - sin(q3)*B.z), C)
-    assert C.z == express((sin(q3)*B.x + cos(q3)*B.z), C)
+            cos(q2)*cos(q3)*A.z), C).simplify()
+    assert C.x == express((cos(q3)*B.x - sin(q3)*B.z), C).simplify()
+    assert C.z == express((sin(q3)*B.x + cos(q3)*B.z), C).simplify()
 
 
 def test_time_derivative():

--- a/sympy/physics/vector/tests/test_output.py
+++ b/sympy/physics/vector/tests/test_output.py
@@ -2,7 +2,6 @@ from sympy.core.singleton import S
 from sympy.physics.vector import Vector, ReferenceFrame, Dyadic
 from sympy.testing.pytest import raises
 
-Vector.simp = True
 A = ReferenceFrame('A')
 
 

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -8,8 +8,6 @@ from sympy.physics.vector.vector import VectorTypeError
 from sympy.abc import x, y, z
 from sympy.testing.pytest import raises
 
-
-Vector.simp = True
 A = ReferenceFrame('A')
 
 
@@ -111,10 +109,9 @@ def test_Vector_diffs():
     assert v3.dt(A) == (q2dd * A.x + (2 * q3d**2 + q3 * q3dd) * N.x + (q3dd -
                         q3 * q3d**2) * N.y + (q3 * sin(q3) * q2d * q3d -
                         cos(q3) * q2d * q3d - q3 * cos(q3) * q2dd) * N.z)
-    assert v3.dt(B) == (q2dd * A.x - q3 * cos(q3) * q2d**2 * A.y + (2 *
-                        q3d**2 + q3 * q3dd) * N.x + (q3dd - q3 * q3d**2) *
-                        N.y + (2 * q3 * sin(q3) * q2d * q3d - 2 * cos(q3) *
-                        q2d * q3d - q3 * cos(q3) * q2dd) * N.z)
+    assert (v3.dt(B) - (q2dd*A.x - q3*cos(q3)*q2d**2*A.y + (2*q3d**2 +
+        q3*q3dd)*N.x + (q3dd - q3*q3d**2)*N.y + (2*q3*sin(q3)*q2d*q3d -
+        2*cos(q3)*q2d*q3d - q3*cos(q3)*q2dd)*N.z)).express(B).simplify() == 0
     assert v4.dt(N) == (q2dd * A.x + q3d * (q2d + q3d) * A.y + q3dd * B.x +
                         (q3d**2 + q3 * q3dd) * N.x + q3dd * N.y + (q3 *
                         sin(q3) * q2d * q3d - cos(q3) * q2d * q3d - q3 *
@@ -123,10 +120,10 @@ def test_Vector_diffs():
                         N.x + (q3dd - q3 * q3d**2) * N.y + (q3 * sin(q3) *
                         q2d * q3d - cos(q3) * q2d * q3d - q3 * cos(q3) *
                         q2dd) * N.z)
-    assert v4.dt(B) == (q2dd * A.x - q3 * cos(q3) * q2d**2 * A.y + q3dd * B.x +
-                        (2 * q3d**2 + q3 * q3dd) * N.x + (q3dd - q3 * q3d**2) *
-                        N.y + (2 * q3 * sin(q3) * q2d * q3d - 2 * cos(q3) *
-                        q2d * q3d - q3 * cos(q3) * q2dd) * N.z)
+    assert (v4.dt(B) - (q2dd*A.x - q3*cos(q3)*q2d**2*A.y + q3dd*B.x +
+                        (2*q3d**2 + q3*q3dd)*N.x + (q3dd - q3*q3d**2)*N.y +
+                        (2*q3*sin(q3)*q2d*q3d - 2*cos(q3)*q2d*q3d -
+                         q3*cos(q3)*q2dd)*N.z)).express(B).simplify() == 0
     assert v5.dt(B) == q1d*A.x + (q3*q2d + q2d)*A.y + (-q2*q2d + q3d)*A.z
     assert v5.dt(A) == q1d*A.x + q2d*A.y + q3d*A.z
     assert v5.dt(N) == (-q2*q3d + q1d)*A.x + (q1*q3d + q2d)*A.y + q3d*A.z

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -516,14 +516,13 @@ class Vector(Printable, EvalfMixin):
         >>> from sympy.physics.vector import Vector
         >>> from sympy.physics.vector import init_vprinting
         >>> init_vprinting(pretty_print=False)
-        >>> Vector.simp = True
         >>> t = Symbol('t')
         >>> q1 = dynamicsymbols('q1')
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.diff(t, N)
         - sin(q1)*q1'*N.x - cos(q1)*q1'*N.z
-        >>> A.x.diff(t, N).express(A)
+        >>> A.x.diff(t, N).express(A).simplify()
         - q1'*A.z
         >>> B = ReferenceFrame('B')
         >>> u1, u2 = dynamicsymbols('u1, u2')

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -513,7 +513,6 @@ class Vector(Printable, EvalfMixin):
 
         >>> from sympy import Symbol
         >>> from sympy.physics.vector import dynamicsymbols, ReferenceFrame
-        >>> from sympy.physics.vector import Vector
         >>> from sympy.physics.vector import init_vprinting
         >>> init_vprinting(pretty_print=False)
         >>> t = Symbol('t')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`Vector.simp` is a user convenience so that you don't have to explicitly simplify physics vectors when working with them. I think this should be deprecated, but to start I'd like to remove all uses of it in the code base and documentation. The tests can call simplify commands explicitly. We can leave it in as an undocumented feature for uers, but I think it is best that users also explicitly simplify things. Using `Vector.simp = True` will inevitably cause undesired slow downs when working interactively.

Setting this in the unit tests seems to possibly leak into other tests. See https://github.com/sympy/sympy/pull/24896#issuecomment-1484119679. But I'm not quite sure about that.

Here are the uses:

```
grep -r "Vector\.simp" --include "*.py"
sympy/physics/mechanics/tests/test_kane3.py:Vector.simp = False
sympy/physics/mechanics/tests/test_joint.py:Vector.simp = True
sympy/physics/vector/vector.py:        if Vector.simp:
sympy/physics/vector/vector.py:        >>> Vector.simp = True
sympy/physics/vector/functions.py:                if Vector.simp:
sympy/physics/vector/tests/test_vector.py:Vector.simp = True
sympy/physics/vector/tests/test_output.py:Vector.simp = True
sympy/physics/vector/tests/test_frame.py:Vector.simp = True
sympy/physics/vector/tests/test_functions.py:Vector.simp = True
sympy/physics/vector/tests/test_dyadic.py:Vector.simp = True
sympy/physics/vector/frame.py:        If Vector.simp is True, returns a simplified version of the mapped
sympy/physics/vector/frame.py:        if (otherframe, Vector.simp) in self._var_dict:
sympy/physics/vector/frame.py:            return self._var_dict[(otherframe, Vector.simp)]
sympy/physics/vector/frame.py:                if Vector.simp:
sympy/physics/vector/frame.py:            self._var_dict[(otherframe, Vector.simp)] = mapping
sympy/physics/vector/dyadic.py:        >>> Vector.simp = True
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * Removed use of Vector.simp in the documentation and unit tests.

<!-- END RELEASE NOTES -->
