### PR TITLE
Added gbt()  and converted exist sampling methods in Control API

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -366,6 +366,7 @@ Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
 B McG <bmcg0890@gmail.com>
 Baiyuan Qiu <1061688677@qq.com> <qby1061688677@gmail.com>
+Baiyuan Qiu <51898470+bugmaker2@users.noreply.github.com>
 Bao Chau <chauquocbao0907@gmail.com>
 Barry Wardell <barry.wardell@gmail.com>
 Barun Parruck <barun.parruck@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -365,6 +365,7 @@ Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
 B McG <bmcg0890@gmail.com>
+Baiyuan Qiu <1061688677@qq.com> <qby1061688677@gmail.com>
 Bao Chau <chauquocbao0907@gmail.com>
 Barry Wardell <barry.wardell@gmail.com>
 Barun Parruck <barun.parruck@gmail.com>

--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -31,6 +31,10 @@ lti
 .. autoclass:: MIMOFeedback
    :members:
 
+.. autofunction:: gbt
+
 .. autofunction:: bilinear
+
+.. autofunction:: forward_diff
 
 .. autofunction:: backward_diff

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,13 +1,13 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
-    Feedback, MIMOFeedback, TransferFunctionMatrix, sample)
+    Feedback, MIMOFeedback, TransferFunctionMatrix, gbt, bilinear, forward_diff, backward_diff)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
     bode_phase_plot, bode_plot)
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
-    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','sample',
-    'backward_diff', 'pole_zero_numerical_data',
+    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','gbt',
+    'bilinear', 'forward_diff', 'backward_diff', 'pole_zero_numerical_data',
     'pole_zero_plot', 'step_response_numerical_data', 'step_response_plot',
     'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,12 +1,12 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
-    Feedback, MIMOFeedback, TransferFunctionMatrix, bilinear, backward_diff)
+    Feedback, MIMOFeedback, TransferFunctionMatrix, sample)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
     bode_phase_plot, bode_plot)
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
-    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','bilinear',
+    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','sample',
     'backward_diff', 'pole_zero_numerical_data',
     'pole_zero_plot', 'step_response_numerical_data', 'step_response_plot',
     'impulse_response_numerical_data', 'impulse_response_plot',

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -50,9 +50,9 @@ def gbt(tf, sample_per, alpha):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = gbt(tf, T, 0.5)
     >>> numZ
-    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
+    [0.5*T/(1.0*L + 0.5*R*T), 0.5*T/(1.0*L + 0.5*R*T)]
     >>> denZ
-    [1, (-L + R*T/2)/(L + R*T/2)]
+    [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
     >>> numZ, denZ = gbt(tf, T, 0)
     >>> numZ
     [T/L]
@@ -65,9 +65,9 @@ def gbt(tf, sample_per, alpha):
     [1, -L/(L + R*T)]
     >>> numZ, denZ = gbt(tf, T, 0.3)
     >>> numZ
-    [3*T/(10*(L + 3*R*T/10)), 7*T/(10*(L + 3*R*T/10))]
+    [0.3*T/(1.0*L + 0.3*R*T), 0.7*T/(1.0*L + 0.3*R*T)]
     >>> denZ
-    [1, (-L + 7*R*T/10)/(L + 3*R*T/10)]
+    [1, (-1.0*L + 0.7*R*T)/(1.0*L + 0.3*R*T)]
     """
     if not tf.is_SISO:
         raise NotImplementedError("Not implemented for MIMO systems.")
@@ -78,7 +78,7 @@ def gbt(tf, sample_per, alpha):
 
     np = tf.num.as_poly(s).all_coeffs()
     dp = tf.den.as_poly(s).all_coeffs()
-    alpha = Rational(alpha).limit_denominator(1000)
+    # alpha = Rational(alpha).limit_denominator(1000)
 
     # The next line results from multiplying H(z) with z^N/z^N
     N = max(len(np), len(dp)) - 1

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -136,7 +136,7 @@ def bilinear(tf, sample_per):
     >>> denZ
     [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
     """
-    return gbt(tf, sample_per, 0.5)
+    return gbt(tf, sample_per, S.Half)
 
 def forward_diff(tf, sample_per):
     r"""
@@ -166,7 +166,7 @@ def forward_diff(tf, sample_per):
     >>> denZ
     [1, (-L + R*T)/L]
     """
-    return gbt(tf, sample_per, 0)
+    return gbt(tf, sample_per, S.Zero)
 
 def backward_diff(tf, sample_per):
     r"""
@@ -196,7 +196,7 @@ def backward_diff(tf, sample_per):
     >>> denZ
     [1, -L/(L + R*T)]
     """
-    return gbt(tf, sample_per, 1)
+    return gbt(tf, sample_per, S.One)
 
 
 class LinearTimeInvariant(Basic, EvalfMixin):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -45,7 +45,7 @@ def gbt(tf, sample_per, alpha):
     as [a, b], [c, d].
     Examples
     ========
-    >>> from sympy.physics.control.lti import TransferFunction, bilinear
+    >>> from sympy.physics.control.lti import TransferFunction, gbt
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = gbt(tf, T, 0.5)
@@ -120,7 +120,7 @@ def forward_diff(tf, sample_per):
     as [a, b], [c, d].
     Examples
     ========
-    >>> from sympy.physics.control.lti import TransferFunction, bilinear
+    >>> from sympy.physics.control.lti import TransferFunction, forward_diff
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = forward_diff(tf, T)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,5 +1,4 @@
 from typing import Type
-from sympy import Rational
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -43,6 +42,7 @@ def gbt(tf, sample_per, alpha):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
+    
     Examples
     ========
     >>> from sympy.physics.control.lti import TransferFunction, gbt
@@ -104,6 +104,7 @@ def bilinear(tf, sample_per):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
+
     Examples
     ========
     >>> from sympy.physics.control.lti import TransferFunction, bilinear
@@ -127,6 +128,7 @@ def forward_diff(tf, sample_per):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
+
     Examples
     ========
     >>> from sympy.physics.control.lti import TransferFunction, forward_diff
@@ -150,6 +152,7 @@ def backward_diff(tf, sample_per):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
+
     Examples
     ========
     >>> from sympy.physics.control.lti import TransferFunction, backward_diff

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -35,12 +35,16 @@ def _roots(poly, var):
 def gbt(tf, sample_per, alpha):
     r"""
     Returns falling coefficients of H(z) from numerator and denominator.
+
+    Explanation
+    ===========
+
     Where H(z) is the corresponding discretized transfer function,
     discretized with the generalised bilinear transformation method.
     H(z) is obtained from the continuous transfer function H(s)
-    by substituting s(z) = (z-1) / (T * (alpha*z + (1-alpha))) into H(s), where T is the
+    by substituting $s(z) = \frac{z-1} {T(\alpha z + (1-\alpha))}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -48,27 +52,36 @@ def gbt(tf, sample_per, alpha):
 
     >>> from sympy.physics.control.lti import TransferFunction, gbt
     >>> from sympy.abc import s, L, R, T
+
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = gbt(tf, T, 0.5)
     >>> numZ
     [0.5*T/(1.0*L + 0.5*R*T), 0.5*T/(1.0*L + 0.5*R*T)]
     >>> denZ
     [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
+
     >>> numZ, denZ = gbt(tf, T, 0)
     >>> numZ
     [T/L]
     >>> denZ
     [1, (-L + R*T)/L]
+
     >>> numZ, denZ = gbt(tf, T, 1)
     >>> numZ
     [T/(L + R*T), 0]
     >>> denZ
     [1, -L/(L + R*T)]
+
     >>> numZ, denZ = gbt(tf, T, 0.3)
     >>> numZ
     [0.3*T/(1.0*L + 0.3*R*T), 0.7*T/(1.0*L + 0.3*R*T)]
     >>> denZ
     [1, (-1.0*L + 0.7*R*T)/(1.0*L + 0.3*R*T)]
+
+    References
+    ==========
+
+    .. [1] https://www.polyu.edu.hk/ama/profile/gfzhang/Research/ZCC09_IJC.pdf
     """
     if not tf.is_SISO:
         raise NotImplementedError("Not implemented for MIMO systems.")
@@ -101,9 +114,9 @@ def bilinear(tf, sample_per):
     Where H(z) is the corresponding discretized transfer function,
     discretized with the bilinear transform method.
     H(z) is obtained from the continuous transfer function H(s)
-    by substituting s(z) = 2/T * (z-1)/(z+1) into H(s), where T is the
+    by substituting $s(z) = \frac{2}{T}\frac{z-1}{z+1}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -126,9 +139,9 @@ def forward_diff(tf, sample_per):
     Where H(z) is the corresponding discretized transfer function,
     discretized with the forward difference transform method.
     H(z) is obtained from the continuous transfer function H(s)
-    by substituting s(z) = (z-1)/T into H(s), where T is the
+    by substituting $s(z) = \frac{z-1}{T}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -151,15 +164,17 @@ def backward_diff(tf, sample_per):
     Where H(z) is the corresponding discretized transfer function,
     discretized with the backward difference transform method.
     H(z) is obtained from the continuous transfer function H(s)
-    by substituting s(z) =  (z-1)/(T*z) into H(s), where T is the
+    by substituting $s(z) =  \frac{z-1}{Tz}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
     as [a, b], [c, d].
+
     Examples
     ========
 
     >>> from sympy.physics.control.lti import TransferFunction, backward_diff
     >>> from sympy.abc import s, L, R, T
+
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = backward_diff(tf, T)
     >>> numZ
@@ -184,7 +199,7 @@ class LinearTimeInvariant(Basic, EvalfMixin):
     @classmethod
     def _check_args(cls, args):
         if not args:
-            raise ValueError("Atleast 1 argument must be passed.")
+            raise ValueError("At least 1 argument must be passed.")
         if not all(isinstance(arg, cls._clstype) for arg in args):
             raise TypeError(f"All arguments must be of type {cls._clstype}.")
         var_set = {arg.var for arg in args}

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,5 +1,5 @@
 from typing import Type
-
+from sympy import nsimplify
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -83,7 +83,26 @@ def gbt(tf, sample_per, alpha):
     num_coefs = num.as_poly(z).all_coeffs()
     den_coefs = den.as_poly(z).all_coeffs()
 
-    return num_coefs, den_coefs
+    # Create a new fraction using the coefficients
+    d = Dummy()
+    new_num = 0
+    for i in range(len(num_coefs)):
+        new_num += num_coefs[i]*d**(len(num_coefs) - i - 1)
+    new_den = 0
+    for i in range(len(den_coefs)):
+        new_den += den_coefs[i]*d**(len(den_coefs) - i - 1)
+
+    # Simplify the fraction
+    new_tf = nsimplify(new_num / new_den).simplify()
+
+    # Extract the numerator and denominator
+    numerator, denominator = new_tf.as_numer_denom()
+
+    # Get the numerator polynomial and its coefficients
+    numerator_coefs = numerator.as_poly(d).all_coeffs()
+    demonator_coefs = denominator.as_poly(d).all_coeffs()
+
+    return numerator_coefs, demonator_coefs
 
 def bilinear(tf, sample_per):
     r"""

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -55,9 +55,9 @@ def gbt(tf, sample_per, alpha):
     [2*L + R*T, -2*L + R*T]
     >>> numZ, denZ = gbt(tf, T, 0)
     >>> numZ
-    [T, T]
+    [T]
     >>> denZ
-    [2*L + R*T, -2*L + R*T]
+    [L, -L + R*T]
     >>> numZ, denZ = gbt(tf, T, 1)
     >>> numZ
     [T, 0]
@@ -125,9 +125,9 @@ def forward_diff(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = forward_diff(tf, T)
     >>> numZ
-    [T, T]
+    [T]
     >>> denZ
-    [2*L + R*T, -2*L + R*T]
+    [L, -L + R*T]
     """
     return gbt(tf, sample_per, 0)
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -77,10 +77,9 @@ def gbt(tf, sample_per, alpha):
     # The next line results from multiplying H(z) with z^N/z^N
 
     N = max(len(np), len(dp)) - 1
-    num = Add(*[ 1 / alpha * T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
-    den = Add(*[ 1 / alpha * T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
-    print(type(num))
-    print(num)
+    num = Add(*[ T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
+    den = Add(*[ T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
+
     num_coefs = num.as_poly(z).all_coeffs()
     den_coefs = den.as_poly(z).all_coeffs()
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -114,9 +114,9 @@ def bilinear(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = bilinear(tf, T)
     >>> numZ
-    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
+    [0.5*T/(1.0*L + 0.5*R*T), 0.5*T/(1.0*L + 0.5*R*T)]
     >>> denZ
-    [1, (-L + R*T/2)/(L + R*T/2)]
+    [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
     """
     return gbt(tf, sample_per, 0.5)
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,5 +1,5 @@
 from typing import Type
-from sympy import nsimplify
+from sympy import Rational
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -50,19 +50,24 @@ def gbt(tf, sample_per, alpha):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = gbt(tf, T, 0.5)
     >>> numZ
-    [T, T]
+    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
     >>> denZ
-    [2*L + R*T, -2*L + R*T]
+    [1, (-L + R*T/2)/(L + R*T/2)]
     >>> numZ, denZ = gbt(tf, T, 0)
     >>> numZ
-    [T]
+    [T/L]
     >>> denZ
-    [L, -L + R*T]
+    [1, (-L + R*T)/L]
     >>> numZ, denZ = gbt(tf, T, 1)
     >>> numZ
-    [T, 0]
+    [T/(L + R*T), 0]
     >>> denZ
-    [L + R*T, -L]
+    [1, -L/(L + R*T)]
+    >>> numZ, denZ = gbt(tf, T, 0.3)
+    >>> numZ
+    [3*T/(10*(L + 3*R*T/10)), 7*T/(10*(L + 3*R*T/10))]
+    >>> denZ
+    [1, (-L + 7*R*T/10)/(L + 3*R*T/10)]
     """
     if not tf.is_SISO:
         raise NotImplementedError("Not implemented for MIMO systems.")
@@ -73,9 +78,9 @@ def gbt(tf, sample_per, alpha):
 
     np = tf.num.as_poly(s).all_coeffs()
     dp = tf.den.as_poly(s).all_coeffs()
+    alpha = Rational(alpha).limit_denominator(1000)
 
     # The next line results from multiplying H(z) with z^N/z^N
-
     N = max(len(np), len(dp)) - 1
     num = Add(*[ T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
     den = Add(*[ T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
@@ -83,26 +88,11 @@ def gbt(tf, sample_per, alpha):
     num_coefs = num.as_poly(z).all_coeffs()
     den_coefs = den.as_poly(z).all_coeffs()
 
-    # Create a new fraction using the coefficients
-    d = Dummy()
-    new_num = 0
-    for i in range(len(num_coefs)):
-        new_num += num_coefs[i]*d**(len(num_coefs) - i - 1)
-    new_den = 0
-    for i in range(len(den_coefs)):
-        new_den += den_coefs[i]*d**(len(den_coefs) - i - 1)
+    para = den_coefs[0]
+    num_coefs = [coef/para for coef in num_coefs]
+    den_coefs = [coef/para for coef in den_coefs]
 
-    # Simplify the fraction
-    new_tf = nsimplify(new_num / new_den).simplify()
-
-    # Extract the numerator and denominator
-    numerator, denominator = new_tf.as_numer_denom()
-
-    # Get the numerator polynomial and its coefficients
-    numerator_coefs = numerator.as_poly(d).all_coeffs()
-    demonator_coefs = denominator.as_poly(d).all_coeffs()
-
-    return numerator_coefs, demonator_coefs
+    return num_coefs, den_coefs
 
 def bilinear(tf, sample_per):
     r"""
@@ -121,9 +111,9 @@ def bilinear(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = bilinear(tf, T)
     >>> numZ
-    [T, T]
+    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
     >>> denZ
-    [2*L + R*T, -2*L + R*T]
+    [1, (-L + R*T/2)/(L + R*T/2)]
     """
     return gbt(tf, sample_per, 0.5)
 
@@ -144,9 +134,9 @@ def forward_diff(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = forward_diff(tf, T)
     >>> numZ
-    [T]
+    [T/L]
     >>> denZ
-    [L, -L + R*T]
+    [1, (-L + R*T)/L]
     """
     return gbt(tf, sample_per, 0)
 
@@ -167,9 +157,9 @@ def backward_diff(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = backward_diff(tf, T)
     >>> numZ
-    [T, 0]
+    [T/(L + R*T), 0]
     >>> denZ
-    [L + R*T, -L]
+    [1, -L/(L + R*T)]
     """
     return gbt(tf, sample_per, 1)
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -42,9 +42,9 @@ def gbt(tf, sample_per, alpha):
     Where H(z) is the corresponding discretized transfer function,
     discretized with the generalised bilinear transformation method.
     H(z) is obtained from the continuous transfer function H(s)
-    by substituting $s(z) = \frac{z-1} {T(\alpha z + (1-\alpha))}$ into H(s), where T is the
+    by substituting $s(z) = \frac{z-1}{T(\alpha z + (1-\alpha))}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -111,12 +111,16 @@ def gbt(tf, sample_per, alpha):
 def bilinear(tf, sample_per):
     r"""
     Returns falling coefficients of H(z) from numerator and denominator.
+
+    Explanation
+    ===========
+
     Where H(z) is the corresponding discretized transfer function,
     discretized with the bilinear transform method.
     H(z) is obtained from the continuous transfer function H(s)
     by substituting $s(z) = \frac{2}{T}\frac{z-1}{z+1}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -124,6 +128,7 @@ def bilinear(tf, sample_per):
 
     >>> from sympy.physics.control.lti import TransferFunction, bilinear
     >>> from sympy.abc import s, L, R, T
+
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = bilinear(tf, T)
     >>> numZ
@@ -136,12 +141,16 @@ def bilinear(tf, sample_per):
 def forward_diff(tf, sample_per):
     r"""
     Returns falling coefficients of H(z) from numerator and denominator.
+
+    Explanation
+    ===========
+
     Where H(z) is the corresponding discretized transfer function,
     discretized with the forward difference transform method.
     H(z) is obtained from the continuous transfer function H(s)
     by substituting $s(z) = \frac{z-1}{T}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples
@@ -149,6 +158,7 @@ def forward_diff(tf, sample_per):
 
     >>> from sympy.physics.control.lti import TransferFunction, forward_diff
     >>> from sympy.abc import s, L, R, T
+
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = forward_diff(tf, T)
     >>> numZ
@@ -161,12 +171,16 @@ def forward_diff(tf, sample_per):
 def backward_diff(tf, sample_per):
     r"""
     Returns falling coefficients of H(z) from numerator and denominator.
+
+    Explanation
+    ===========
+
     Where H(z) is the corresponding discretized transfer function,
     discretized with the backward difference transform method.
     H(z) is obtained from the continuous transfer function H(s)
     by substituting $s(z) =  \frac{z-1}{Tz}$ into H(s), where T is the
     sample period.
-    Coefficients are falling, i.e. $H(z) = \frac{az+b}/{cz+d}$ is returned
+    Coefficients are falling, i.e. $H(z) = \frac{az+b}{cz+d}$ is returned
     as [a, b], [c, d].
 
     Examples

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,4 +1,5 @@
 from typing import Type
+from sympy import Rational
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -56,9 +57,9 @@ def gbt(tf, sample_per, alpha):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = gbt(tf, T, 0.5)
     >>> numZ
-    [0.5*T/(1.0*L + 0.5*R*T), 0.5*T/(1.0*L + 0.5*R*T)]
+    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
     >>> denZ
-    [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
+    [1, (-L + R*T/2)/(L + R*T/2)]
 
     >>> numZ, denZ = gbt(tf, T, 0)
     >>> numZ
@@ -74,9 +75,9 @@ def gbt(tf, sample_per, alpha):
 
     >>> numZ, denZ = gbt(tf, T, 0.3)
     >>> numZ
-    [0.3*T/(1.0*L + 0.3*R*T), 0.7*T/(1.0*L + 0.3*R*T)]
+    [3*T/(10*(L + 3*R*T/10)), 7*T/(10*(L + 3*R*T/10))]
     >>> denZ
-    [1, (-1.0*L + 0.7*R*T)/(1.0*L + 0.3*R*T)]
+    [1, (-L + 7*R*T/10)/(L + 3*R*T/10)]
 
     References
     ==========
@@ -92,7 +93,7 @@ def gbt(tf, sample_per, alpha):
 
     np = tf.num.as_poly(s).all_coeffs()
     dp = tf.den.as_poly(s).all_coeffs()
-    # alpha = Rational(alpha).limit_denominator(1000)
+    alpha = Rational(alpha).limit_denominator(1000)
 
     # The next line results from multiplying H(z) with z^N/z^N
     N = max(len(np), len(dp)) - 1
@@ -132,9 +133,9 @@ def bilinear(tf, sample_per):
     >>> tf = TransferFunction(1, s*L + R, s)
     >>> numZ, denZ = bilinear(tf, T)
     >>> numZ
-    [0.5*T/(1.0*L + 0.5*R*T), 0.5*T/(1.0*L + 0.5*R*T)]
+    [T/(2*(L + R*T/2)), T/(2*(L + R*T/2))]
     >>> denZ
-    [1, (-1.0*L + 0.5*R*T)/(1.0*L + 0.5*R*T)]
+    [1, (-L + R*T/2)/(L + R*T/2)]
     """
     return gbt(tf, sample_per, S.Half)
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -42,9 +42,10 @@ def gbt(tf, sample_per, alpha):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
-    
+
     Examples
     ========
+
     >>> from sympy.physics.control.lti import TransferFunction, gbt
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)
@@ -107,6 +108,7 @@ def bilinear(tf, sample_per):
 
     Examples
     ========
+
     >>> from sympy.physics.control.lti import TransferFunction, bilinear
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)
@@ -131,6 +133,7 @@ def forward_diff(tf, sample_per):
 
     Examples
     ========
+
     >>> from sympy.physics.control.lti import TransferFunction, forward_diff
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)
@@ -152,9 +155,9 @@ def backward_diff(tf, sample_per):
     sample period.
     Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
     as [a, b], [c, d].
-
     Examples
     ========
+
     >>> from sympy.physics.control.lti import TransferFunction, backward_diff
     >>> from sympy.abc import s, L, R, T
     >>> tf = TransferFunction(1, s*L + R, s)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,7 +22,7 @@ from sympy.series import limit
 from mpmath.libmp.libmpf import prec_to_dps
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel',
-    'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'sample']
+    'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'gbt', 'bilinear', 'forward_diff', 'backward_diff']
 
 
 def _roots(poly, var):
@@ -33,67 +33,127 @@ def _roots(poly, var):
         r = [rootof(poly, var, k) for k in range(n)]
     return r
 
-def sample(tf, sample_per, method = 'bilinear'):
-        """
-        Returns falling coefficients of H(z) from numerator and denominator.
-        Where H(z) is the corresponding discretized transfer function,
-        discretized with the different transform method.
-        H(z) is obtained from the continuous transfer function H(s)
-        by substituting s(z) into H(s) according to different methods, where T is the
-        sample period.
-        Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
-        as [a, b], [c, d].
+def gbt(tf, sample_per, alpha):
+    r"""
+    Returns falling coefficients of H(z) from numerator and denominator.
+    Where H(z) is the corresponding discretized transfer function,
+    discretized with the generalised bilinear transformation method.
+    H(z) is obtained from the continuous transfer function H(s)
+    by substituting s(z) = (z-1) / (T * (alpha*z + (1-alpha))) into H(s), where T is the
+    sample period.
+    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    as [a, b], [c, d].
+    Examples
+    ========
+    >>> from sympy.physics.control.lti import TransferFunction, bilinear
+    >>> from sympy.abc import s, L, R, T
+    >>> tf = TransferFunction(1, s*L + R, s)
+    >>> numZ, denZ = gbt(tf, T, 0.5)
+    >>> numZ
+    [T, T]
+    >>> denZ
+    [2*L + R*T, -2*L + R*T]
+    >>> numZ, denZ = gbt(tf, T, 0)
+    >>> numZ
+    [T, T]
+    >>> denZ
+    [2*L + R*T, -2*L + R*T]
+    >>> numZ, denZ = gbt(tf, T, 1)
+    >>> numZ
+    [T, 0]
+    >>> denZ
+    [L + R*T, -L]
+    """
+    if not tf.is_SISO:
+        raise NotImplementedError("Not implemented for MIMO systems.")
 
-        Examples
-        ========
+    T = sample_per  # and sample period T
+    s = tf.var
+    z =  s         # dummy discrete variable z
 
-        >>> from sympy.physics.control.lti import TransferFunction, sample
-        >>> from sympy.abc import s, L, R, T
-        >>> tf = TransferFunction(1, s*L + R, s)
-        >>> numZ, denZ = sample(tf, T, 'bilinear')
-        >>> numZ
-        [T, T]
-        >>> denZ
-        [2*L + R*T, -2*L + R*T]
-        >>> numZ, denZ = sample(tf, T, 'backward_diff')
-        >>> numZ
-        [T, 0]
-        >>> denZ
-        [L + R*T, -L]
-        >>> numZ, denZ = sample(tf, T, 'forward_diff')
-        >>> numZ
-        [T]
-        >>> denZ
-        [L, -L + R*T]
-        """
+    np = tf.num.as_poly(s).all_coeffs()
+    dp = tf.den.as_poly(s).all_coeffs()
 
-        if not tf.is_SISO:
-            raise NotImplementedError('Not implemented for MIMO systems.')
+    # The next line results from multiplying H(z) with z^N/z^N
 
-        T = sample_per  # and sample period T
-        s = tf.var
-        z =  s # dummy discrete variable z
+    N = max(len(np), len(dp)) - 1
+    num = Add(*[ 1 / alpha * T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
+    den = Add(*[ 1 / alpha * T**(N-i) * c * (z-1)**i * (alpha * z + 1 - alpha)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
+    print(type(num))
+    print(num)
+    num_coefs = num.as_poly(z).all_coeffs()
+    den_coefs = den.as_poly(z).all_coeffs()
 
-        np = tf.num.as_poly(s).all_coeffs()
-        dp = tf.den.as_poly(s).all_coeffs()
+    return num_coefs, den_coefs
 
-        # The next line results from multiplying H(z) with (z-1)^N/(z+1)^N
-        N = max(len(np), len(dp)) - 1
+def bilinear(tf, sample_per):
+    r"""
+    Returns falling coefficients of H(z) from numerator and denominator.
+    Where H(z) is the corresponding discretized transfer function,
+    discretized with the bilinear transform method.
+    H(z) is obtained from the continuous transfer function H(s)
+    by substituting s(z) = 2/T * (z-1)/(z+1) into H(s), where T is the
+    sample period.
+    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    as [a, b], [c, d].
+    Examples
+    ========
+    >>> from sympy.physics.control.lti import TransferFunction, bilinear
+    >>> from sympy.abc import s, L, R, T
+    >>> tf = TransferFunction(1, s*L + R, s)
+    >>> numZ, denZ = bilinear(tf, T)
+    >>> numZ
+    [T, T]
+    >>> denZ
+    [2*L + R*T, -2*L + R*T]
+    """
+    return gbt(tf, sample_per, 0.5)
 
-        if method == 'bilinear':
-            num = Add(*[ T**(N-i) * 2**i * c * (z-1)**i * (z+1)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
-            den = Add(*[ T**(N-i) * 2**i * c * (z-1)**i * (z+1)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
-        if method == 'backward_diff':
-            num = Add(*[ T**(N-i) * c * (z-1)**i * (z)**(N-i) for c, i in zip(np[::-1], range(len(np))) ])
-            den = Add(*[ T**(N-i) * c * (z-1)**i * (z)**(N-i) for c, i in zip(dp[::-1], range(len(dp))) ])
-        if method == 'forward_diff':
-            num = Add(*[ T**(N-i) * c * (z-1)**i for c, i in zip(np[::-1], range(len(np))) ])
-            den = Add(*[ T**(N-i) * c * (z-1)**i for c, i in zip(dp[::-1], range(len(dp))) ])
+def forward_diff(tf, sample_per):
+    r"""
+    Returns falling coefficients of H(z) from numerator and denominator.
+    Where H(z) is the corresponding discretized transfer function,
+    discretized with the forward difference transform method.
+    H(z) is obtained from the continuous transfer function H(s)
+    by substituting s(z) = (z-1)/T into H(s), where T is the
+    sample period.
+    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    as [a, b], [c, d].
+    Examples
+    ========
+    >>> from sympy.physics.control.lti import TransferFunction, bilinear
+    >>> from sympy.abc import s, L, R, T
+    >>> tf = TransferFunction(1, s*L + R, s)
+    >>> numZ, denZ = forward_diff(tf, T)
+    >>> numZ
+    [T, T]
+    >>> denZ
+    [2*L + R*T, -2*L + R*T]
+    """
+    return gbt(tf, sample_per, 0)
 
-        num_coefs = num.as_poly(z).all_coeffs()
-        den_coefs = den.as_poly(z).all_coeffs()
-
-        return num_coefs, den_coefs
+def backward_diff(tf, sample_per):
+    r"""
+    Returns falling coefficients of H(z) from numerator and denominator.
+    Where H(z) is the corresponding discretized transfer function,
+    discretized with the backward difference transform method.
+    H(z) is obtained from the continuous transfer function H(s)
+    by substituting s(z) =  (z-1)/(T*z) into H(s), where T is the
+    sample period.
+    Coefficients are falling, i.e. H(z) = (az+b)/(cz+d) is returned
+    as [a, b], [c, d].
+    Examples
+    ========
+    >>> from sympy.physics.control.lti import TransferFunction, backward_diff
+    >>> from sympy.abc import s, L, R, T
+    >>> tf = TransferFunction(1, s*L + R, s)
+    >>> numZ, denZ = backward_diff(tf, T)
+    >>> numZ
+    [T, 0]
+    >>> denZ
+    [L + R*T, -L]
+    """
+    return gbt(tf, sample_per, 1)
 
 
 class LinearTimeInvariant(Basic, EvalfMixin):

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1226,39 +1226,39 @@ def test_TransferFunction_gbt():
     # simple transfer function, e.g. ohms law
     tf = TransferFunction(1, a*s+b, s)
     numZ, denZ = gbt(tf, T, 0.5)
-    # discretized transfer function with coefs from tf.bilinear()
-    tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
+    # discretized transfer function with coefs from tf.gbt()
+    tf_test_bilinear = TransferFunction(s * numZ[0] + numZ[1], s * denZ[0] + denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T+T, s*(T*b+2*a)+T*b-2*a, s)
+    tf_test_manual = TransferFunction(s * T/(2*(T*b/2 + a)) + T/(2*(T*b/2 + a)), s + (T*b/2 - a)/(T*b/2 + a), s)
 
-    assert S.Zero == (tf_test_bilinear-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 
     tf = TransferFunction(1, a*s+b, s)
     numZ, denZ = gbt(tf, T, 0)
-    # discretized transfer function with coefs from tf.bilinear()
-    tf_test_forward = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
+    # discretized transfer function with coefs from tf.gbt()
+    tf_test_forward = TransferFunction(numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T, s*a-a+b*T, s)
+    tf_test_manual = TransferFunction(T/a, s + (T*b - a)/a, s)
 
-    assert S.Zero == (tf_test_forward-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_forward.simplify()-tf_test_manual.simplify()).simplify().num
 
     tf = TransferFunction(1, a*s+b, s)
     numZ, denZ = gbt(tf, T, 1)
-    # discretized transfer function with coefs from tf.bilinear()
+    # discretized transfer function with coefs from tf.gbt()
     tf_test_backward = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T, s*(T*b+a)-a, s)
+    tf_test_manual = TransferFunction(s * T/(T*b + a), s - a/(T*b + a), s)
 
-    assert S.Zero == (tf_test_backward-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num
 
     tf = TransferFunction(1, a*s+b, s)
-    numZ, denZ = gbt(tf, T, 0.2)
-    # discretized transfer function with coefs from tf.bilinear()
+    numZ, denZ = gbt(tf, T, 0.3)
+    # discretized transfer function with coefs from tf.gbt()
     tf_test_gbt = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T+4*T, s*(T*b+5*a)+(4*T*b-5*a), s)
+    tf_test_manual = TransferFunction(s*3*T/(10*(3*T*b/10 + a)) + 7*T/(10*(3*T*b/10 + a)), s + (7*T*b/10 - a)/(3*T*b/10 + a), s)
 
-    assert S.Zero == (tf_test_gbt-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_gbt.simplify()-tf_test_manual.simplify()).simplify().num
 
 def test_TransferFunction_bilinear():
     # simple transfer function, e.g. ohms law
@@ -1267,20 +1267,20 @@ def test_TransferFunction_bilinear():
     # discretized transfer function with coefs from tf.bilinear()
     tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T+T, s*(T*b+2*a)+T*b-2*a, s)
+    tf_test_manual = TransferFunction(s * T / (2*(T*b/2 + a)) + T / (2*(T*b/2 + a)), s + (T*b/2 - a)/(T*b/2 + a), s)
 
-    assert S.Zero == (tf_test_bilinear-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 
 def test_TransferFunction_forward_diff():
     # simple transfer function, e.g. ohms law
     tf = TransferFunction(1, a*s+b, s)
     numZ, denZ = forward_diff(tf, T)
     # discretized transfer function with coefs from tf.forward_diff()
-    tf_test_forward = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
+    tf_test_forward = TransferFunction(numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T, s*a-a+b*T, s)
+    tf_test_manual = TransferFunction(T / a, s + (T*b - a)/a, s)
 
-    assert S.Zero == (tf_test_forward-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_forward.simplify()-tf_test_manual.simplify()).simplify().num
 
 def test_TransferFunction_backward_diff():
     # simple transfer function, e.g. ohms law
@@ -1289,6 +1289,6 @@ def test_TransferFunction_backward_diff():
     # discretized transfer function with coefs from tf.backward_diff()
     tf_test_backward = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T, s*(T*b+a)-a, s)
+    tf_test_manual = TransferFunction(s * T / (T*b + a), s - a/(T*b + a), s)
 
-    assert S.Zero == (tf_test_backward-tf_test_manual).simplify().num
+    assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1229,7 +1229,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_bilinear = TransferFunction(s * numZ[0] + numZ[1], s * denZ[0] + denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * 0.5*T/(1.0*a + 0.5*b*T) + 0.5*T/(1.0*a + 0.5*b*T), s + (-1.0*a + 0.5*b*T)/(1.0*a + 0.5*b*T), s)
+    tf_test_manual = TransferFunction(s * T/(2*(a + b*T/2)) + T/(2*(a + b*T/2)), s + (-a + b*T/2)/(a + b*T/2), s)
 
     assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1256,7 +1256,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_gbt = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*0.3*T/(1.0*a + 0.3*b*T) + 0.7*T/(1.0*a + 0.3*b*T), s + (-1.0*a + 0.7*b*T)/(1.0*a + 0.3*b*T), s)
+    tf_test_manual = TransferFunction(s*3*T/(10*(a + 3*b*T/10)) + 7*T/(10*(a + 3*b*T/10)), s + (-a + 7*b*T/10)/(a + 3*b*T/10), s)
 
     assert S.Zero == (tf_test_gbt.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1267,7 +1267,7 @@ def test_TransferFunction_bilinear():
     # discretized transfer function with coefs from tf.bilinear()
     tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * 0.5*T/(1.0*a + 0.5*b*T) + 0.5*T/(1.0*a + 0.5*b*T), s + (-1.0*a + 0.5*b*T)/(1.0*a + 0.5*b*T), s)
+    tf_test_manual = TransferFunction(s * T/(2*(a + b*T/2)) + T/(2*(a + b*T/2)), s + (-a + b*T/2)/(a + b*T/2), s)
 
     assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1274,7 +1274,7 @@ def test_TransferFunction_bilinear():
 def test_TransferFunction_forward_diff():
     # simple transfer function, e.g. ohms law
     tf = TransferFunction(1, a*s+b, s)
-    numZ, denZ = backward_diff(tf, T)
+    numZ, denZ = forward_diff(tf, T)
     # discretized transfer function with coefs from tf.forward_diff()
     tf_test_forward = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1229,7 +1229,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_bilinear = TransferFunction(s * numZ[0] + numZ[1], s * denZ[0] + denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * T/(2*(T*b/2 + a)) + T/(2*(T*b/2 + a)), s + (T*b/2 - a)/(T*b/2 + a), s)
+    tf_test_manual = TransferFunction(s * 0.5*T/(1.0*a + 0.5*b*T) + 0.5*T/(1.0*a + 0.5*b*T), s + (-1.0*a + 0.5*b*T)/(1.0*a + 0.5*b*T), s)
 
     assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1238,7 +1238,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_forward = TransferFunction(numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(T/a, s + (T*b - a)/a, s)
+    tf_test_manual = TransferFunction(T/a, s + (-a + b*T)/a, s)
 
     assert S.Zero == (tf_test_forward.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1247,7 +1247,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_backward = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * T/(T*b + a), s - a/(T*b + a), s)
+    tf_test_manual = TransferFunction(s * T/(a + b*T), s - a/(a + b*T), s)
 
     assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1256,7 +1256,7 @@ def test_TransferFunction_gbt():
     # discretized transfer function with coefs from tf.gbt()
     tf_test_gbt = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*3*T/(10*(3*T*b/10 + a)) + 7*T/(10*(3*T*b/10 + a)), s + (7*T*b/10 - a)/(3*T*b/10 + a), s)
+    tf_test_manual = TransferFunction(s*0.3*T/(1.0*a + 0.3*b*T) + 0.7*T/(1.0*a + 0.3*b*T), s + (-1.0*a + 0.7*b*T)/(1.0*a + 0.3*b*T), s)
 
     assert S.Zero == (tf_test_gbt.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1267,7 +1267,7 @@ def test_TransferFunction_bilinear():
     # discretized transfer function with coefs from tf.bilinear()
     tf_test_bilinear = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * T / (2*(T*b/2 + a)) + T / (2*(T*b/2 + a)), s + (T*b/2 - a)/(T*b/2 + a), s)
+    tf_test_manual = TransferFunction(s * 0.5*T/(1.0*a + 0.5*b*T) + 0.5*T/(1.0*a + 0.5*b*T), s + (-1.0*a + 0.5*b*T)/(1.0*a + 0.5*b*T), s)
 
     assert S.Zero == (tf_test_bilinear.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1278,7 +1278,7 @@ def test_TransferFunction_forward_diff():
     # discretized transfer function with coefs from tf.forward_diff()
     tf_test_forward = TransferFunction(numZ[0], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(T / a, s + (T*b - a)/a, s)
+    tf_test_manual = TransferFunction(T/a, s + (-a + b*T)/a, s)
 
     assert S.Zero == (tf_test_forward.simplify()-tf_test_manual.simplify()).simplify().num
 
@@ -1289,6 +1289,6 @@ def test_TransferFunction_backward_diff():
     # discretized transfer function with coefs from tf.backward_diff()
     tf_test_backward = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s * T / (T*b + a), s - a/(T*b + a), s)
+    tf_test_manual = TransferFunction(s * T/(a + b*T), s - a/(a + b*T), s)
 
     assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1254,9 +1254,9 @@ def test_TransferFunction_gbt():
     tf = TransferFunction(1, a*s+b, s)
     numZ, denZ = gbt(tf, T, 0.2)
     # discretized transfer function with coefs from tf.bilinear()
-    tf_test_gbt = TransferFunction(s*numZ[0], s*denZ[0]+denZ[1], s)
+    tf_test_gbt = TransferFunction(s*numZ[0]+numZ[1], s*denZ[0]+denZ[1], s)
     # corresponding tf with manually calculated coefs
-    tf_test_manual = TransferFunction(s*T*0.2+0.8*T, s*(0.2*T*b+1.0*a)+(0.8*T*b-1.0*a), s)
+    tf_test_manual = TransferFunction(s*T+4*T, s*(T*b+5*a)+(4*T*b-5*a), s)
 
     assert S.Zero == (tf_test_gbt-tf_test_manual).simplify().num
 


### PR DESCRIPTION
#### References to other Issues or PRs
An extension of @zolabar 's work on #24698 

#### Brief description of what is fixed or changed
1. Added a function named `gbt()` to discretize the transfer function. The functionality of pre-existed `bilinear()` and `backward_diff()` are integrated into the `gbt()`. 
2. Another method called `forward_diff()` was added. 

I believe merging them into a single function can improve the readability of the code. Also, more discretization methods can be added to this module.

**For users:**
`gbt()` and `forward_diff()` were added

**For developers:**
`bilinear()`, `forward_diff()` and `backward_diff()` are defined internally via `gbt()`.

Calling `bilinear(tf, Ts)` is the same as calling `gbt(tf, Ts, 0.5)`
`backward_diff(tf, Ts)` the same as `gbt(tf, Ts, 1)`
`forward_diff(tf, Ts)` the same as`gbt(tf, Ts, 0)`

Further, now, all methods return coefficients in normalized form (leading coefficient of denominator is 1).
$$H(z)=\sum_{i=0}^{n}a_i z^i  / \sum_{j=0}^{m} b_j z^j $$

$$H(z)=\sum_{i=0}^{n}\frac{a^i}{b_m}z^i / (1+\sum_{j=1}^{m} \frac{b_j}{b_m} z^j)$$

#### Other comments
More work needs to be done on the expansion of gbt(). We also expect there to be a `sample()` function developed within `TransferFuntion` which returns a discrete transfer function.

The reference for the implementation of `gbt()`
https://www.polyu.edu.hk/ama/profile/gfzhang/Research/ZCC09_IJC.pdf



We can take this doc as a reference as well
https://python-control.readthedocs.io/en/0.9.3.post2/generated/control.TransferFunction.html#control.TransferFunction.sample
The method includes `gbt()`, `bilinear()`, `euler()`, `backward_diff()` methods in sample().

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Add gbt and forware_diff in Control API
<!-- END RELEASE NOTES -->
