### PR TITLE
TensorProduct fails for ImmutableMatrix: correct to MatrixBase instead of Matrix

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -5,7 +5,7 @@ from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.sympify import sympify
-from sympy.matrices.dense import MutableDenseMatrix as Matrix
+from sympy.matrices.matrices import MatrixBase
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import QuantumError

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -5,7 +5,8 @@ from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.sympify import sympify
-from sympy.matrices.matrices import MatrixBase
+from sympy.matrices.dense import DenseMatrix as Matrix
+from sympy.matrices.immutable import ImmutableDenseMatrix as ImmutableMatrix
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import QuantumError
@@ -120,7 +121,8 @@ class TensorProduct(Expr):
     is_commutative = False
 
     def __new__(cls, *args):
-        if isinstance(args[0], (MatrixBase, numpy_ndarray, scipy_sparse_matrix)):
+        if isinstance(args[0], (Matrix, ImmutableMatrix, numpy_ndarray,
+                                                    scipy_sparse_matrix)):
             return matrix_tensor_product(*args)
         c_part, new_args = cls.flatten(sympify(args))
         c_part = Mul(*c_part)

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -120,7 +120,7 @@ class TensorProduct(Expr):
     is_commutative = False
 
     def __new__(cls, *args):
-        if isinstance(args[0], (Matrix, numpy_ndarray, scipy_sparse_matrix)):
+        if isinstance(args[0], (MatrixBase, numpy_ndarray, scipy_sparse_matrix)):
             return matrix_tensor_product(*args)
         c_part, new_args = cls.flatten(sympify(args))
         c_part = Mul(*c_part)

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -1,7 +1,7 @@
 from sympy.core.numbers import I
 from sympy.core.symbol import symbols
 from sympy.core.expr import unchanged
-from sympy.matrices import Matrix, SparseMatrix
+from sympy.matrices import Matrix, SparseMatrix, ImmutableMatrix
 
 from sympy.physics.quantum.commutator import Commutator as Comm
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -125,3 +125,13 @@ def test_eval_trace():
                         1.0*A*Dagger(C)*Tr(B*Dagger(D)) +
                         1.0*C*Dagger(A)*Tr(D*Dagger(B)) +
                         1.0*C*Dagger(C)*Tr(D*Dagger(D)))
+
+
+def test_pr24993():
+    from sympy.matrices.expressions.kronecker import matrix_kronecker_product
+    from sympy.physics.quantum.matrixutils    import matrix_tensor_product
+    X = Matrix([[0, 1], [1, 0]])
+    Xi = ImmutableMatrix(X)
+    assert TensorProduct(Xi, Xi) == TensorProduct(X, X)
+    assert TensorProduct(Xi, Xi) == matrix_tensor_product(X, X)
+    assert TensorProduct(Xi, Xi) == matrix_kronecker_product(X, X)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`TensorProduct` doesn't identify `ImmutableMatrix` (or any other matrix class that is not derived from mutable `Matrix`) as a matrix:
```
from sympy import *
from sympy.physics.quantum.tensorproduct import TensorProduct
X = Matrix([[0, 1], [1, 0]])
TensorProduct(X, X)
# displays full 4 x 4 matrix with all 1's on anti-diagonal
Xi = ImmutableMatrix([[0, 1], [1, 0]])
TensorProduct(Xi, Xi)
# displays unevaluated Xi * Xi
```
The reason is that `TensorProduct.__new__()`  checks if the arguments are of type `Matrix` instead of `MatrixBase`. `Matrix` is mutable, so no immutable matrix type inherits from `Matrix`, and immutable matrices are not passed on to `matrix_tensor_product()`. This clearly is a typo, as in `sympy.physics.quantum.matrixutils.matrix_tensor_product()`, `sympy.matrices.kronecker.matrix_kronecker_product()` and any other function e.g. in `matrixutils.py` the code checks for `isinstance(m, MatrixBase)`, so they work for mutable and immutable matrices alike.
However, in the testfile test_tensorproduct.py:25 the original author explicitly tests that `SparseMatrix` should not evaluate - for unknown reason, since `scipy_sparse_matrix` type _is accepted_ for evaluation in TensorProduct. So in order to avoid further implications and also to exclude symbolic matrices like `Identity()` which `matrix_kronecker_product()` cannot handle anyway, I propose to accept `ImmutableMatrix` in addition to `Matrix` instead of all `MatrixBase`.

#### Other comments
It's important to use ImmutableMatrix (or MatrixExpr in general) in sympy instead of mutable matrices because the sympy cache cannot work with mutable expressions and this may lead to random errors. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * TensorProduct now processes immutable matrices and mutable matrices alike. Fixed a bug that TensorProduct didn't compute the result matrix if the argument matrices were immutable.
<!-- END RELEASE NOTES -->
