### PR TITLE
Add sphinxcontrib-jquery as a docs dependency (1.12 branch)

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath flake8 flake8-comprehensions ruff
+      - run: pip install mpmath flake8 ruff
 
       - name: Basic code quality tests
         run: bin/test quality

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,6 +14,7 @@ sphinxcontrib-applehelp
 sphinxcontrib-devhelp
 sphinxcontrib-htmlhelp
 sphinxcontrib-jsmath
+sphinxcontrib-jquery
 sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
 sphinx-reredirects

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -32,9 +32,9 @@ sys.path = ['ext'] + sys.path
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode',
               'sphinx_math_dollar', 'sphinx.ext.mathjax', 'numpydoc',
               'sphinx_reredirects', 'sphinx_copybutton',
-              'sphinx.ext.graphviz', 'matplotlib.sphinxext.plot_directive',
-              'myst_parser', 'convert-svg-to-pdf', 'sphinx.ext.intersphinx',
-              ]
+              'sphinx.ext.graphviz', 'sphinxcontrib.jquery',
+              'matplotlib.sphinxext.plot_directive', 'myst_parser',
+              'convert-svg-to-pdf', 'sphinx.ext.intersphinx', ]
 
 # Add redirects here. This should be done whenever a page that is in the
 # existing release docs is moved somewhere else so that the URLs don't break.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ select = [
 
 # Ignore rules that currently fail on the SymPy codebase
 ignore = [
+    "C416",  # Unnecessary `dict` comprehension (rewrite using `dict()`)
     "E401",  # Multiple imports on one line
     "E402",  # Module level import not at top of file
     "E501",  # Line too long (<LENGTH> > 88 characters)


### PR DESCRIPTION
Sphinx 6 stopped bundling jquery. We use it for the version selector in the sidebar.

Fixes #24987.

This is the same as https://github.com/sympy/sympy/pull/24989 but against the 1.12 branch. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
