### PR TITLE
Geometric Distribution: Density function returning non-zero values

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -207,7 +207,8 @@ class GeometricDistribution(SingleDiscreteDistribution):
         _value_check((0 < p, p <= 1), "p must be between 0 and 1")
 
     def pdf(self, k):
-        return (1 - self.p)**(k - 1) * self.p
+        expr = (1 - self.p)**(k - 1) * self.p
+        return Piecewise((expr, self.set.as_relational(k)), (0, True))
 
     def _characteristic_function(self, t):
         p = self.p

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -76,6 +76,14 @@ def test_GeometricDistribution():
     Y = Geometric('Y', Rational(3, 10))
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
 
+    g = Geometric("G",p=S(1)/4)
+    assert density(g)(0) == 0
+    assert density(g)(-1) == 0
+    assert density(g)(0.5) == 0
+    assert density(g)(S(1)/2) == 0
+    assert density(g)(S(3)/2) == 0
+
+
 
 def test_Hermite():
     a1 = Symbol("a1", positive=True)

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -76,7 +76,7 @@ def test_GeometricDistribution():
     Y = Geometric('Y', Rational(3, 10))
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
 
-    g = Geometric("G",p=S(1)/4)
+    g = Geometric("G", p=S(1)/4)
     assert density(g)(0) == 0
     assert density(g)(-1) == 0
     assert density(g)(0.5) == 0


### PR DESCRIPTION
Original request: Issues with Geometric random variables #20031

Fixes non-zero outputs from geometric density function
Changed Geometric Distribution pdf function so that for certain inputs, the value of the "density function" (more properly, mass function) should be 0, since the geometric value should be limited to integers 1 or greater if it's intended to be discrete and have the mass function given in the documentation. Added tests to check non-zeron fractional and negative input possibilities.

Example:
	g = Geometric("G",p=S(1)/4)
	assert density(g)(-1) == 0
        assert density(g)(0.5) == 0