### PR TITLE
Some fixes to some code using evaluate=False

### DIFF
--- a/doc/src/guides/custom-functions.md
+++ b/doc/src/guides/custom-functions.md
@@ -895,7 +895,8 @@ To implement rewriting, define a method `_eval_rewrite(self, rule, args,
 
 - `**hints` are additional keyword arguments which may be used to specify the
   behavior of the rewrite. Unknown hints should be ignored as they may be
-  passed to other `_eval_rewrite()` methods.
+  passed to other `_eval_rewrite()` methods. If you recursively call rewrite,
+  you should pass the `**hints` through.
 
 
 The method should return a rewritten expression, using `args` as the

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4341,7 +4341,7 @@ class Catalan(NumberSymbol, metaclass=Singleton):
         elif issubclass(number_cls, Rational):
             return (Rational(9, 10, 1), S.One)
 
-    def _eval_rewrite_as_Sum(self, k_sym=None, symbols=None):
+    def _eval_rewrite_as_Sum(self, k_sym=None, symbols=None, **hints):
         if (k_sym is not None) or (symbols is not None):
             return self
         from .symbol import Dummy

--- a/sympy/core/parameters.py
+++ b/sympy/core/parameters.py
@@ -67,8 +67,7 @@ class _global_parameters(local):
 
 global_parameters = _global_parameters(evaluate=True, distribute=True, exp_is_pow=False)
 
-@contextmanager
-def evaluate(x):
+class evaluate:
     """ Control automatic evaluation
 
     Explanation
@@ -92,15 +91,16 @@ def evaluate(x):
     ...     print(x + x)
     x + x
     """
+    def __init__(self, x):
+        self.x = x
+        self.old = None
 
-    old = global_parameters.evaluate
+    def __enter__(self):
+        self.old = global_parameters.evaluate
+        global_parameters.evaluate = self.x
 
-    try:
-        global_parameters.evaluate = x
-        yield
-    finally:
-        global_parameters.evaluate = old
-
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        global_parameters.evaluate = self.old
 
 @contextmanager
 def distribute(x):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1536,13 +1536,15 @@ class Pow(Expr):
         if base.is_zero or base.has(exp) or expo.has(exp):
             return base**expo
 
+        evaluate = expo.has(Symbol)
+
         if base.has(Symbol):
             # delay evaluation if expo is non symbolic
             # (as exp(x*log(5)) automatically reduces to x**5)
             if global_parameters.exp_is_pow:
-                return Pow(S.Exp1, log(base)*expo, evaluate=expo.has(Symbol))
+                return Pow(S.Exp1, log(base)*expo, evaluate=evaluate)
             else:
-                return exp(log(base)*expo, evaluate=expo.has(Symbol))
+                return exp(log(base)*expo, evaluate=evaluate)
 
         else:
             from sympy.functions.elementary.complexes import arg, Abs

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1861,17 +1861,17 @@ class Pow(Expr):
         from sympy.functions.combinatorial.factorials import factorial
         return x**n/factorial(n)
 
-    def _eval_rewrite_as_sin(self, base, exp):
+    def _eval_rewrite_as_sin(self, base, exp, **hints):
         if self.base is S.Exp1:
             from sympy.functions.elementary.trigonometric import sin
             return sin(S.ImaginaryUnit*self.exp + S.Pi/2) - S.ImaginaryUnit*sin(S.ImaginaryUnit*self.exp)
 
-    def _eval_rewrite_as_cos(self, base, exp):
+    def _eval_rewrite_as_cos(self, base, exp, **hints):
         if self.base is S.Exp1:
             from sympy.functions.elementary.trigonometric import cos
             return cos(S.ImaginaryUnit*self.exp) + S.ImaginaryUnit*cos(S.ImaginaryUnit*self.exp + S.Pi/2)
 
-    def _eval_rewrite_as_tanh(self, base, exp):
+    def _eval_rewrite_as_tanh(self, base, exp, **hints):
         if self.base is S.Exp1:
             from sympy.functions.elementary.hyperbolic import tanh
             return (1 + tanh(self.exp/2))/(1 - tanh(self.exp/2))

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -626,7 +626,7 @@ class Equality(Relational):
     def _eval_relation(cls, lhs, rhs):
         return _sympify(lhs == rhs)
 
-    def _eval_rewrite_as_Add(self, *args, **kwargs):
+    def _eval_rewrite_as_Add(self, L, R, evaluate=True, **kwargs):
         """
         return Eq(L, R) as L - R. To control the evaluation of
         the result set pass `evaluate=True` to give L - R;
@@ -649,12 +649,10 @@ class Equality(Relational):
         (b, x, b, -x)
         """
         from .add import _unevaluated_Add, Add
-        L, R = args
         if L == 0:
             return R
         if R == 0:
             return L
-        evaluate = kwargs.get('evaluate', True)
         if evaluate:
             # allow cancellation of args
             return L - R

--- a/sympy/core/tests/test_parameters.py
+++ b/sympy/core/tests/test_parameters.py
@@ -88,3 +88,27 @@ def test_nested():
         expr = (x + x) + (y + y)
         assert expr.args == ((x + x), (y + y))
         assert expr.args[0].args == (x, x)
+
+def test_reentrantcy():
+    with evaluate(False):
+        expr = x + x
+        assert expr.args == (x, x)
+        with evaluate(True):
+            expr = x + x
+            assert expr.args == (2, x)
+        expr = x + x
+        assert expr.args == (x, x)
+
+def test_reusability():
+    f = evaluate(False)
+
+    with f:
+        expr = x + x
+        assert expr.args == (x, x)
+
+    expr = x + x
+    assert expr.args == (2, x)
+
+    with f:
+        expr = x + x
+        assert expr.args == (x, x)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -495,13 +495,13 @@ class cosh(HyperbolicFunction):
         return (exp(arg) + exp(-arg)) / 2
 
     def _eval_rewrite_as_cos(self, arg, **kwargs):
-        return cos(I * arg)
+        return cos(I * arg, evaluate=False)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
-        return 1 / sec(I * arg)
+        return 1 / sec(I * arg, evaluate=False)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
-        return -I*sinh(arg + pi*I/2)
+        return -I*sinh(arg + pi*I/2, evaluate=False)
 
     def _eval_rewrite_as_tanh(self, arg, **kwargs):
         tanh_half = tanh(S.Half*arg)**2
@@ -753,16 +753,16 @@ class tanh(HyperbolicFunction):
         return (pos_exp - neg_exp)/(pos_exp + neg_exp)
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
-        return -I * tan(I * arg)
+        return -I * tan(I * arg, evaluate=False)
 
     def _eval_rewrite_as_cot(self, arg, **kwargs):
-        return -I / cot(I * arg)
+        return -I / cot(I * arg, evaluate=False)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
-        return I*sinh(arg)/sinh(pi*I/2 - arg)
+        return I*sinh(arg)/sinh(pi*I/2 - arg, evaluate=False)
 
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
-        return I*cosh(pi*I/2 - arg)/cosh(arg)
+        return I*cosh(pi*I/2 - arg, evaluate=False)/cosh(arg)
 
     def _eval_rewrite_as_coth(self, arg, **kwargs):
         return 1/coth(arg)
@@ -948,10 +948,10 @@ class coth(HyperbolicFunction):
         return (pos_exp + neg_exp)/(pos_exp - neg_exp)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
-        return -I*sinh(pi*I/2 - arg)/sinh(arg)
+        return -I*sinh(pi*I/2 - arg, evaluate=False)/sinh(arg)
 
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
-        return -I*cosh(arg)/cosh(pi*I/2 - arg)
+        return -I*cosh(arg)/cosh(pi*I/2 - arg, evaluate=False)
 
     def _eval_rewrite_as_tanh(self, arg, **kwargs):
         return 1/tanh(arg)
@@ -1118,13 +1118,13 @@ class csch(ReciprocalHyperbolicFunction):
             return 2 * (1 - 2**n) * B/F * x**n
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
-        return I / sin(I * arg)
+        return I / sin(I * arg, evaluate=False)
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
-        return I * csc(I * arg)
+        return I * csc(I * arg, evaluate=False)
 
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
-        return I / cosh(arg + I * pi / 2)
+        return I / cosh(arg + I * pi / 2, evaluate=False)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return 1 / sinh(arg)
@@ -1177,13 +1177,13 @@ class sech(ReciprocalHyperbolicFunction):
             return euler(n) / factorial(n) * x**(n)
 
     def _eval_rewrite_as_cos(self, arg, **kwargs):
-        return 1 / cos(I * arg)
+        return 1 / cos(I * arg, evaluate=False)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
-        return sec(I * arg)
+        return sec(I * arg, evaluate=False)
 
     def _eval_rewrite_as_sinh(self, arg, **kwargs):
-        return I / sinh(arg + I * pi /2)
+        return I / sinh(arg + I * pi /2, evaluate=False)
 
     def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return 1 / cosh(arg)
@@ -1352,10 +1352,10 @@ class asinh(InverseHyperbolicFunction):
         return I*(sqrt(1 - ix)/sqrt(ix - 1) * acosh(ix) - pi/2)
 
     def _eval_rewrite_as_asin(self, x, **kwargs):
-        return -I * asin(I * x)
+        return -I * asin(I * x, evaluate=False)
 
     def _eval_rewrite_as_acos(self, x, **kwargs):
-        return I * acos(I * x) - I*pi/2
+        return I * acos(I * x, evaluate=False) - I*pi/2
 
     def inverse(self, argindex=1):
         """
@@ -1521,7 +1521,7 @@ class acosh(InverseHyperbolicFunction):
         return sqrt(x - 1)/sqrt(1 - x) * (pi/2 - asin(x))
 
     def _eval_rewrite_as_asinh(self, x, **kwargs):
-        return sqrt(x - 1)/sqrt(1 - x) * (pi/2 + I*asinh(I*x))
+        return sqrt(x - 1)/sqrt(1 - x) * (pi/2 + I*asinh(I*x, evaluate=False))
 
     def _eval_rewrite_as_atanh(self, x, **kwargs):
         sxm1 = sqrt(x - 1)
@@ -1998,7 +1998,7 @@ class asech(InverseHyperbolicFunction):
         return acosh(1/arg)
 
     def _eval_rewrite_as_asinh(self, arg, **kwargs):
-        return sqrt(1/arg - 1)/sqrt(1 - 1/arg)*(I*asinh(I/arg)
+        return sqrt(1/arg - 1)/sqrt(1 - 1/arg)*(I*asinh(I/arg, evaluate=False)
                                                 + pi*S.Half)
 
     def _eval_rewrite_as_atanh(self, x, **kwargs):
@@ -2006,7 +2006,7 @@ class asech(InverseHyperbolicFunction):
                 + sqrt(1/(x + 1))*sqrt(x + 1)*atanh(sqrt(1 - x**2)))
 
     def _eval_rewrite_as_acsch(self, x, **kwargs):
-        return sqrt(1/x - 1)/sqrt(1 - 1/x)*(pi/2 - I*acsch(I*x))
+        return sqrt(1/x - 1)/sqrt(1 - 1/x)*(pi/2 - I*acsch(I*x, evaluate=False))
 
 
 class acsch(InverseHyperbolicFunction):
@@ -2191,7 +2191,7 @@ class acsch(InverseHyperbolicFunction):
 
     def _eval_rewrite_as_acosh(self, arg, **kwargs):
         return I*(sqrt(1 - I/arg)/sqrt(I/arg - 1)*
-                                acosh(I/arg) - pi*S.Half)
+                                acosh(I/arg, evaluate=False) - pi*S.Half)
 
     def _eval_rewrite_as_atanh(self, arg, **kwargs):
         arg2 = arg**2

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -930,7 +930,7 @@ class Piecewise(Function):
             last = ITE(c, a, last)
         return _canonical(last)
 
-    def _eval_rewrite_as_KroneckerDelta(self, *args):
+    def _eval_rewrite_as_KroneckerDelta(self, *args, **kwargs):
         from sympy.functions.special.tensor_functions import KroneckerDelta
 
         rules = {

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -559,9 +559,9 @@ def test_asinh_rewrite():
     x = Symbol('x')
     assert asinh(x).rewrite(log) == log(x + sqrt(x**2 + 1))
     assert asinh(x).rewrite(atanh) == atanh(x/sqrt(1 + x**2))
-    assert asinh(x).rewrite(asin) == asinh(x)
+    assert asinh(x).rewrite(asin) == -I*asin(I*x, evaluate=False)
     assert asinh(x*(1 + I)).rewrite(asin) == -I*asin(I*x*(1+I))
-    assert asinh(x).rewrite(acos) == I*(-I*asinh(x) + pi/2) - I*pi/2
+    assert asinh(x).rewrite(acos) == I*acos(I*x, evaluate=False) - I*pi/2
 
 
 def test_asinh_leading_term():
@@ -683,7 +683,7 @@ def test_acosh_rewrite():
     x = Symbol('x')
     assert acosh(x).rewrite(log) == log(x + sqrt(x - 1)*sqrt(x + 1))
     assert acosh(x).rewrite(asin) == sqrt(x - 1)*(-asin(x) + pi/2)/sqrt(1 - x)
-    assert acosh(x).rewrite(asinh) == sqrt(x - 1)*(-asin(x) + pi/2)/sqrt(1 - x)
+    assert acosh(x).rewrite(asinh) == sqrt(x - 1)*(I*asinh(I*x, evaluate=False) + pi/2)/sqrt(1 - x)
     assert acosh(x).rewrite(atanh) == \
         (sqrt(x - 1)*sqrt(x + 1)*atanh(sqrt(x**2 - 1)/x)/sqrt(x**2 - 1) +
          pi*sqrt(x - 1)*(-x*sqrt(x**(-2)) + 1)/(2*sqrt(1 - x)))
@@ -862,7 +862,7 @@ def test_asech_rewrite():
     x = Symbol('x')
     assert asech(x).rewrite(log) == log(1/x + sqrt(1/x - 1) * sqrt(1/x + 1))
     assert asech(x).rewrite(acosh) == acosh(1/x)
-    assert asech(x).rewrite(asinh) == sqrt(-1 + 1/x)*(-asin(1/x) + pi/2)/sqrt(1 - 1/x)
+    assert asech(x).rewrite(asinh) == sqrt(-1 + 1/x)*(I*asinh(I/x, evaluate=False) + pi/2)/sqrt(1 - 1/x)
     assert asech(x).rewrite(atanh) == \
         sqrt(x + 1)*sqrt(1/(x + 1))*atanh(sqrt(1 - x**2)) + I*pi*(-sqrt(x)*sqrt(1/x) + 1 - I*sqrt(x**2)/(2*sqrt(-x**2)) - I*sqrt(-x)/(2*sqrt(x)))
 
@@ -1334,7 +1334,7 @@ def test_cosh_rewrite():
     x = Symbol('x')
     assert cosh(x).rewrite(exp) == (exp(x) + exp(-x))/2 \
         == cosh(x).rewrite('tractable')
-    assert cosh(x).rewrite(sinh) == -I*sinh(x + I*pi/2)
+    assert cosh(x).rewrite(sinh) == -I*sinh(x + I*pi/2, evaluate=False)
     tanh_half = tanh(S.Half*x)**2
     assert cosh(x).rewrite(tanh) == (1 + tanh_half)/(1 - tanh_half)
     coth_half = coth(S.Half*x)**2
@@ -1345,8 +1345,8 @@ def test_tanh_rewrite():
     x = Symbol('x')
     assert tanh(x).rewrite(exp) == (exp(x) - exp(-x))/(exp(x) + exp(-x)) \
         == tanh(x).rewrite('tractable')
-    assert tanh(x).rewrite(sinh) == I*sinh(x)/sinh(I*pi/2 - x)
-    assert tanh(x).rewrite(cosh) == I*cosh(I*pi/2 - x)/cosh(x)
+    assert tanh(x).rewrite(sinh) == I*sinh(x)/sinh(I*pi/2 - x, evaluate=False)
+    assert tanh(x).rewrite(cosh) == I*cosh(I*pi/2 - x, evaluate=False)/cosh(x)
     assert tanh(x).rewrite(coth) == 1/coth(x)
 
 
@@ -1354,8 +1354,8 @@ def test_coth_rewrite():
     x = Symbol('x')
     assert coth(x).rewrite(exp) == (exp(x) + exp(-x))/(exp(x) - exp(-x)) \
         == coth(x).rewrite('tractable')
-    assert coth(x).rewrite(sinh) == -I*sinh(I*pi/2 - x)/sinh(x)
-    assert coth(x).rewrite(cosh) == -I*cosh(x)/cosh(I*pi/2 - x)
+    assert coth(x).rewrite(sinh) == -I*sinh(I*pi/2 - x, evaluate=False)/sinh(x)
+    assert coth(x).rewrite(cosh) == -I*cosh(x)/cosh(I*pi/2 - x, evaluate=False)
     assert coth(x).rewrite(tanh) == 1/tanh(x)
 
 
@@ -1363,7 +1363,7 @@ def test_csch_rewrite():
     x = Symbol('x')
     assert csch(x).rewrite(exp) == 1 / (exp(x)/2 - exp(-x)/2) \
         == csch(x).rewrite('tractable')
-    assert csch(x).rewrite(cosh) == I/cosh(x + I*pi/2)
+    assert csch(x).rewrite(cosh) == I/cosh(x + I*pi/2, evaluate=False)
     tanh_half = tanh(S.Half*x)
     assert csch(x).rewrite(tanh) == (1 - tanh_half**2)/(2*tanh_half)
     coth_half = coth(S.Half*x)
@@ -1374,7 +1374,7 @@ def test_sech_rewrite():
     x = Symbol('x')
     assert sech(x).rewrite(exp) == 1 / (exp(x)/2 + exp(-x)/2) \
         == sech(x).rewrite('tractable')
-    assert sech(x).rewrite(sinh) == I/sinh(x + I*pi/2)
+    assert sech(x).rewrite(sinh) == I/sinh(x + I*pi/2, evaluate=False)
     tanh_half = tanh(S.Half*x)**2
     assert sech(x).rewrite(tanh) == (1 - tanh_half)/(1 + tanh_half)
     coth_half = coth(S.Half*x)**2

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -465,10 +465,10 @@ class sin(TrigonometricFunction):
                          (2*cot_half/(1 + cot_half**2), True))
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
-        return self.rewrite(cos).rewrite(pow)
+        return self.rewrite(cos, **kwargs).rewrite(pow, **kwargs)
 
     def _eval_rewrite_as_sqrt(self, arg, **kwargs):
-        return self.rewrite(cos).rewrite(sqrt)
+        return self.rewrite(cos, **kwargs).rewrite(sqrt, **kwargs)
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
         return 1/csc(arg)
@@ -769,7 +769,7 @@ class cos(TrigonometricFunction):
         I = S.ImaginaryUnit
         from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
-            arg = arg.func(arg.args[0]).rewrite(exp)
+            arg = arg.func(arg.args[0]).rewrite(exp, **kwargs)
         return (exp(arg*I) + exp(-arg*I))/2
 
     def _eval_rewrite_as_Pow(self, arg, **kwargs):
@@ -794,7 +794,7 @@ class cos(TrigonometricFunction):
                          ((cot_half - 1)/(cot_half + 1), True))
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
-        return self._eval_rewrite_as_sqrt(arg)
+        return self._eval_rewrite_as_sqrt(arg, **kwargs)
 
     def _eval_rewrite_as_sqrt(self, arg: Expr, **kwargs):
         from sympy.functions.special.polynomials import chebyshevt
@@ -819,7 +819,7 @@ class cos(TrigonometricFunction):
 
         if not pi_coeff.q % 2:  # recursively remove factors of 2
             pico2 = pi_coeff * 2
-            nval = cos(pico2 * pi).rewrite(sqrt)
+            nval = cos(pico2 * pi).rewrite(sqrt, **kwargs)
             x = (pico2 + 1) / 2
             sign_cos = -1 if int(x) % 2 else 1
             return sign_cos * sqrt((1 + nval) / 2)
@@ -837,13 +837,13 @@ class cos(TrigonometricFunction):
 
         if not FC or len(FC) == 1:
             return pcls
-        return pcls.rewrite(sqrt)
+        return pcls.rewrite(sqrt, **kwargs)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
         return 1/sec(arg)
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
-        return 1/sec(arg).rewrite(csc)
+        return 1/sec(arg).rewrite(csc, **kwargs)
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -1179,23 +1179,23 @@ class tan(TrigonometricFunction):
         return 1/cot(arg)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
-        sin_in_sec_form = sin(arg).rewrite(sec)
-        cos_in_sec_form = cos(arg).rewrite(sec)
+        sin_in_sec_form = sin(arg).rewrite(sec, **kwargs)
+        cos_in_sec_form = cos(arg).rewrite(sec, **kwargs)
         return sin_in_sec_form/cos_in_sec_form
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
-        sin_in_csc_form = sin(arg).rewrite(csc)
-        cos_in_csc_form = cos(arg).rewrite(csc)
+        sin_in_csc_form = sin(arg).rewrite(csc, **kwargs)
+        cos_in_csc_form = cos(arg).rewrite(csc, **kwargs)
         return sin_in_csc_form/cos_in_csc_form
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
-        y = self.rewrite(cos).rewrite(pow)
+        y = self.rewrite(cos, **kwargs).rewrite(pow, **kwargs)
         if y.has(cos):
             return None
         return y
 
     def _eval_rewrite_as_sqrt(self, arg, **kwargs):
-        y = self.rewrite(cos).rewrite(sqrt)
+        y = self.rewrite(cos, **kwargs).rewrite(sqrt, **kwargs)
         if y.has(cos):
             return None
         return y
@@ -1440,7 +1440,7 @@ class cot(TrigonometricFunction):
         from sympy.functions.elementary.hyperbolic import HyperbolicFunction
         I = S.ImaginaryUnit
         if isinstance(arg, (TrigonometricFunction, HyperbolicFunction)):
-            arg = arg.func(arg.args[0]).rewrite(exp)
+            arg = arg.func(arg.args[0]).rewrite(exp, **kwargs)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
         return I*(pos_exp + neg_exp)/(pos_exp - neg_exp)
 
@@ -1463,23 +1463,23 @@ class cot(TrigonometricFunction):
         return 1/tan(arg)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
-        cos_in_sec_form = cos(arg).rewrite(sec)
-        sin_in_sec_form = sin(arg).rewrite(sec)
+        cos_in_sec_form = cos(arg).rewrite(sec, **kwargs)
+        sin_in_sec_form = sin(arg).rewrite(sec, **kwargs)
         return cos_in_sec_form/sin_in_sec_form
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
-        cos_in_csc_form = cos(arg).rewrite(csc)
-        sin_in_csc_form = sin(arg).rewrite(csc)
+        cos_in_csc_form = cos(arg).rewrite(csc, **kwargs)
+        sin_in_csc_form = sin(arg).rewrite(csc, **kwargs)
         return cos_in_csc_form/sin_in_csc_form
 
     def _eval_rewrite_as_pow(self, arg, **kwargs):
-        y = self.rewrite(cos).rewrite(pow)
+        y = self.rewrite(cos, **kwargs).rewrite(pow, **kwargs)
         if y.has(cos):
             return None
         return y
 
     def _eval_rewrite_as_sqrt(self, arg, **kwargs):
-        y = self.rewrite(cos).rewrite(sqrt)
+        y = self.rewrite(cos, **kwargs).rewrite(sqrt, **kwargs)
         if y.has(cos):
             return None
         return y
@@ -1731,10 +1731,10 @@ class sec(ReciprocalTrigonometricFunction):
         return sin(arg)/(cos(arg)*sin(arg))
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
-        return (1/cos(arg).rewrite(sin))
+        return (1/cos(arg).rewrite(sin, **kwargs))
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
-        return (1/cos(arg).rewrite(tan))
+        return (1/cos(arg).rewrite(tan, **kwargs))
 
     def _eval_rewrite_as_csc(self, arg, **kwargs):
         return csc(pi/2 - arg, evaluate=False)
@@ -1832,13 +1832,13 @@ class csc(ReciprocalTrigonometricFunction):
         return (1 + cot_half**2)/(2*cot_half)
 
     def _eval_rewrite_as_cos(self, arg, **kwargs):
-        return 1/sin(arg).rewrite(cos)
+        return 1/sin(arg).rewrite(cos, **kwargs)
 
     def _eval_rewrite_as_sec(self, arg, **kwargs):
         return sec(pi/2 - arg, evaluate=False)
 
     def _eval_rewrite_as_tan(self, arg, **kwargs):
-        return (1/sin(arg).rewrite(tan))
+        return (1/sin(arg).rewrite(tan, **kwargs))
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -93,7 +93,7 @@ class elliptic_k(Function):
         if m.is_infinite:
             return True
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
         t = Dummy('t')
         m = self.args[0]
@@ -171,7 +171,7 @@ class elliptic_f(Function):
         if (m.is_real and (m - 1).is_positive) is False:
             return self.func(z.conjugate(), m.conjugate())
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
         t = Dummy('t')
         z, m = self.args[0], self.args[1]
@@ -300,7 +300,7 @@ class elliptic_e(Function):
             return -meijerg(((S.Half, Rational(3, 2)), []), \
                             ((S.Zero,), (S.Zero,)), -m)/4
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
         z, m = (pi/2, self.args[0]) if len(self.args) == 1 else self.args
         t = Dummy('t')
@@ -435,7 +435,7 @@ class elliptic_pi(Function):
                 return (elliptic_e(m)/(m - 1) + elliptic_pi(n, m))/(2*(n - m))
         raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
         if len(self.args) == 2:
             n, m, z = self.args[0], self.args[1], pi/2

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1982,7 +1982,9 @@ def test_issue_11254b():
 
 
 def test_issue_11254d():
-    assert integrate((sech(x)**2).rewrite(sinh), x) == 2*tanh(x/2)/(tanh(x/2)**2 + 1)
+    # (sech(x)**2).rewrite(sinh)
+    assert integrate(-1/sinh(x + I*pi/2, evaluate=False)**2, x) == -2/(exp(2*x) + 1)
+    assert integrate(cosh(x)**(-2), x) == 2*tanh(x/2)/(tanh(x/2)**2 + 1)
 
 
 def test_issue_22863():

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2264,7 +2264,7 @@ class DisjointUnion(Set):
                 iter_flag = iter_flag and set_i.is_iterable
         return iter_flag
 
-    def _eval_rewrite_as_Union(self, *sets):
+    def _eval_rewrite_as_Union(self, *sets, **kwargs):
         """
         Rewrites the disjoint union as the union of (``set`` x {``i``})
         where ``set`` is the element in ``sets`` at index = ``i``

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -73,15 +73,15 @@ class Probability(Expr):
         condition = self.args[0]
         given_condition = self._condition
         numsamples = hints.get('numsamples', False)
-        for_rewrite = not hints.get('for_rewrite', False)
+        evaluate = hints.get('evaluate', True)
 
         if isinstance(condition, Not):
             return S.One - self.func(condition.args[0], given_condition,
-                                    evaluate=for_rewrite).doit(**hints)
+                                    evaluate=evaluate).doit(**hints)
 
         if condition.has(RandomIndexedSymbol):
             return pspace(condition).probability(condition, given_condition,
-                                             evaluate=for_rewrite)
+                                             evaluate=evaluate)
 
         if isinstance(given_condition, RandomSymbol):
             condrv = random_symbols(condition)
@@ -117,13 +117,13 @@ class Probability(Expr):
             return Probability(condition, given_condition)
 
         result = pspace(condition).probability(condition)
-        if hasattr(result, 'doit') and for_rewrite:
+        if hasattr(result, 'doit') and evaluate:
             return result.doit()
         else:
             return result
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
-        return self.func(arg, condition=condition).doit(for_rewrite=True)
+        return self.func(arg, condition=condition).doit(evaluate=False)
 
     _eval_rewrite_as_Sum = _eval_rewrite_as_Integral
 
@@ -249,7 +249,7 @@ class Expectation(Expr):
         condition = self._condition
         expr = self.args[0]
         numsamples = hints.get('numsamples', False)
-        for_rewrite = not hints.get('for_rewrite', False)
+        evaluate = hints.get('evaluate', True)
 
         if deep:
             expr = expr.doit(**hints)
@@ -280,8 +280,8 @@ class Expectation(Expr):
         if pspace(expr) == PSpace():
             return self.func(expr)
         # Otherwise case is simple, pass work off to the ProbabilitySpace
-        result = pspace(expr).compute_expectation(expr, evaluate=for_rewrite)
-        if hasattr(result, 'doit') and for_rewrite:
+        result = pspace(expr).compute_expectation(expr, evaluate=evaluate)
+        if hasattr(result, 'doit') and evaluate:
             return result.doit(**hints)
         else:
             return result
@@ -312,8 +312,8 @@ class Expectation(Expr):
             else:
                 return Sum(arg.replace(rv, symbol)*Probability(Eq(rv, symbol), condition), (symbol, rv.pspace.domain.set.inf, rv.pspace.set.sup))
 
-    def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
-        return self.func(arg, condition=condition).doit(deep=False, for_rewrite=True)
+    def _eval_rewrite_as_Integral(self, arg, condition=None, evaluate=False, **kwargs):
+        return self.func(arg, condition=condition).doit(deep=False, evaluate=evaluate)
 
     _eval_rewrite_as_Sum = _eval_rewrite_as_Integral # For discrete this will be Sum
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2706,7 +2706,7 @@ class TensAdd(TensExpr, AssocOp):
             raise ValueError("No iteration on abstract tensors")
         return self.data.flatten().__iter__()
 
-    def _eval_rewrite_as_Indexed(self, *args):
+    def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         return Add.fromiter(args)
 
     def _eval_partial_derivative(self, s):
@@ -3138,7 +3138,7 @@ class Tensor(TensExpr):
     def contract_delta(self, metric):
         return self.contract_metric(metric)
 
-    def _eval_rewrite_as_Indexed(self, tens, indices):
+    def _eval_rewrite_as_Indexed(self, tens, indices, **kwargs):
         from sympy.tensor.indexed import Indexed
         # TODO: replace .args[0] with .name:
         index_symbols = [i.args[0] for i in self.get_indices()]
@@ -4070,7 +4070,7 @@ class TensMul(TensExpr, AssocOp):
                 exclude.update(get_indices(new_renamed))
         return newrule
 
-    def _eval_rewrite_as_Indexed(self, *args):
+    def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         from sympy.concrete.summations import Sum
         index_symbols = [i.args[0] for i in self.get_indices()]
         args = [arg.args[0] if isinstance(arg, Sum) else arg for arg in args]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This is the non-controversial parts of #24549

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - Hyperbolic function rewrites now correctly disable evaluation in cases where they would just rewrite back to another expression.
- core
  - The `evaluate` context manager is now reentrant and reusable.
- stats
  - The (internal) `for_rewrite` flag has been renamed to `evaluate`.
<!-- END RELEASE NOTES -->
