### PR TITLE
Fix the evaluate context manager to be reentrant when it is reused

### DIFF
--- a/sympy/core/parameters.py
+++ b/sympy/core/parameters.py
@@ -93,14 +93,14 @@ class evaluate:
     """
     def __init__(self, x):
         self.x = x
-        self.old = None
+        self.old = []
 
     def __enter__(self):
-        self.old = global_parameters.evaluate
+        self.old.append(global_parameters.evaluate)
         global_parameters.evaluate = self.x
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        global_parameters.evaluate = self.old
+        global_parameters.evaluate = self.old.pop()
 
 @contextmanager
 def distribute(x):

--- a/sympy/core/tests/test_parameters.py
+++ b/sympy/core/tests/test_parameters.py
@@ -112,3 +112,15 @@ def test_reusability():
     with f:
         expr = x + x
         assert expr.args == (x, x)
+
+    # Assure reentrancy with reusability
+    ctx = evaluate(False)
+    with ctx:
+        expr = x + x
+        assert expr.args == (x, x)
+        with ctx:
+            expr = x + x
+            assert expr.args == (x, x)
+
+    expr = x + x
+    assert expr.args == (2, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fix from the code introduced in https://github.com/sympy/sympy/pull/25000

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
