### PR TITLE
Fix the grammar in function examples of Beam3D

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -208,6 +208,7 @@ Abhigyan Khaund <mail@abhigyan.xyz>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -208,8 +208,8 @@ Abhigyan Khaund <mail@abhigyan.xyz>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
-Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
 Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> Abhinav R Cillanki <95158195+JebronLames32@users.noreply.github.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -209,6 +209,7 @@ Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
 Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> Abhinav R Cillanki <95158195+JebronLames32@users.noreply.github.com>
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -3641,3 +3641,4 @@ class Beam3D(Beam):
         max_def.append(self._max_deflection('y'))
         max_def.append(self._max_deflection('z'))
         return max_def
+        

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2880,7 +2880,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -2982,7 +2982,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3085,7 +3085,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3188,7 +3188,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3263,7 +3263,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3360,7 +3360,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters and area of cross section 2 square
-        meters. It it supported by rollers at of its end. A linear load having
+        meters. It it supported by rollers at both of its ends. A linear load having
         slope equal to 12 is applied along y-axis. A constant distributed load
         of magnitude 15 N is applied from start till its end along z-axis.
 
@@ -3456,7 +3456,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3531,7 +3531,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 
@@ -3609,7 +3609,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters. It it supported by rollers
-        at of its end. A linear load having slope equal to 12 is applied
+        at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -3641,4 +3641,3 @@ class Beam3D(Beam):
         max_def.append(self._max_deflection('y'))
         max_def.append(self._max_deflection('z'))
         return max_def
-        

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2879,7 +2879,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -2981,7 +2981,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3084,7 +3084,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3187,7 +3187,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3262,7 +3262,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3360,7 +3360,7 @@ class Beam3D(Beam):
         Examples
         ========
         There is a beam of length 20 meters and area of cross section 2 square
-        meters. It it supported by rollers at both of its ends. A linear load having
+        meters. It is supported by rollers at both of its ends. A linear load having
         slope equal to 12 is applied along y-axis. A constant distributed load
         of magnitude 15 N is applied from start till its end along z-axis.
 
@@ -3455,7 +3455,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3530,7 +3530,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.
@@ -3608,7 +3608,7 @@ class Beam3D(Beam):
 
         Examples
         ========
-        There is a beam of length 20 meters. It it supported by rollers
+        There is a beam of length 20 meters. It is supported by rollers
         at both of its ends. A linear load having slope equal to 12 is applied
         along y-axis. A constant distributed load of magnitude 15 N is
         applied from start till its end along z-axis.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The example problems in most functions had a common grammatical error.
That has been changed in the respective functions. 
The list of functions where change is made are:
plot_shear_force, plot_bending_moment, plot_slope,plot_deflection, 
plot_loading_results, plot_shear_stress, max_shear_force, max_bending_moment,
max_deflection.


#### Other comments
NO ENTRY


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
