### PR TITLE
physics.continuum_mechanics: Fixed the ramp load

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -524,7 +524,7 @@ class Beam:
 
         Examples
         ========
-        There is a beam of length 6 meters. A ramp load of magnitude 4 N/m is 
+        There is a beam of length 6 meters. A ramp load of magnitude 4 N/m is
         applied in the downward direction starting from 3 meters away from the
         starting point of the beam till the end of the beam. Find the expression
         for the load.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25016 


#### Brief description of what is fixed or changed
Added a dividing factor for ramp loads which was needed to be divided to get the right answer.
The dividing factor is equal to `(end-start)` for order 1 (ramp loads).
It has been added to the functions `apply_load()`, `remove_load()`, `_handle_end()`.
The constant distributed load and parabolic ramp loads are satisfying the doctests, Hence,
dividing_factor is set to 1. Previously, no Doctest or Test was added to test the ramp load.
So, this error had been overlooked. Added a Doctest with ramp load to validate the changes.

Examples:
There is a beam of length 6 meters. A ramp load of magnitude 4 N/m is
applied in the downward direction starting from 3 meters away from the
starting point of the beam till the end of the beam. Find the expression
for the load.

```
>>> from sympy.physics.continuum_mechanics.beam import Beam
>>> from sympy import symbols
>>> E, I = symbols('E, I')
>>> b = Beam(6, E, I)
>>> b.apply_load(4, 3, 1, end=6)
>>> b.load
```

Result:
`4*SingularityFunction(x, 3, 1)/3 - 4*SingularityFunction(x, 6, 0) - 4*SingularityFunction(x, 6, 1)/3
`
Which is the correct answer.
We can verify this by seeing that the value of load at **x=3 is 0** and at **x=6 is 4**.


#### Other comments
Previously, the answer was:
`4*SingularityFunction(x, 3, 1) - 12*SingularityFunction(x, 6, 0) - 4*SingularityFunction(x, 6, 1)`
We can check this using the above example where it gives an answer of **12 for x = 6** which is wrong

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Fixed the bug with ramp load by creating a dividing factor
  * Added a Doctest to validate the change

<!-- END RELEASE NOTES -->
