### PR TITLE
Added explanation to CRT

### DIFF
--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -106,9 +106,36 @@ def crt1(m):
     Examples
     ========
 
-    >>> from sympy.ntheory.modular import crt1
-    >>> crt1([18, 42, 6])
-    (4536, [252, 108, 756], [0, 2, 0])
+    >>> from sympy.ntheory.modular import crt, crt1, crt2
+    >>> m = [99, 97, 95]
+    >>> v = [49, 76, 65]
+
+    The following two codes have the same result.
+
+    >>> crt(m, v)
+    (639985, 912285)
+
+    >>> mm, e, s = crt1(m)
+    >>> crt2(m, v, mm, e, s)
+    (639985, 912285)
+
+    However, it is faster when we want to fix ``m`` and
+    compute for multiple ``v``, i.e. the following cases:
+
+    >>> mm, e, s = crt1(m)
+    >>> vs = [[52, 21, 37], [19, 46, 76]]
+    >>> for v in vs:
+    ...     print(crt2(m, v, mm, e, s))
+    (397042, 912285)
+    (803206, 912285)
+
+    See Also
+    ========
+
+    sympy.polys.galoistools.gf_crt1 : low level crt routine used by this routine
+    sympy.ntheory.modular.crt
+    sympy.ntheory.modular.crt2
+
     """
 
     return gf_crt1(m, ZZ)
@@ -117,6 +144,8 @@ def crt1(m):
 def crt2(m, v, mm, e, s, symmetric=False):
     """Second part of Chinese Remainder Theorem, for multiple application.
 
+    See ``crt1`` for usage.
+
     Examples
     ========
 
@@ -124,6 +153,14 @@ def crt2(m, v, mm, e, s, symmetric=False):
     >>> mm, e, s = crt1([18, 42, 6])
     >>> crt2([18, 42, 6], [0, 0, 0], mm, e, s)
     (0, 4536)
+
+    See Also
+    ========
+
+    sympy.polys.galoistools.gf_crt2 : low level crt routine used by this routine
+    sympy.ntheory.modular.crt
+    sympy.ntheory.modular.crt1
+
     """
 
     result = gf_crt2(v, m, mm, e, s, ZZ)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -62,10 +62,35 @@ def gf_crt1(M, K):
     ========
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.galoistools import gf_crt1
+    >>> from sympy.polys.galoistools import gf_crt, gf_crt1, gf_crt2
+    >>> U = [49, 76, 65]
+    >>> M = [99, 97, 95]
 
-    >>> gf_crt1([99, 97, 95], ZZ)
-    (912285, [9215, 9405, 9603], [62, 24, 12])
+    The following two codes have the same result.
+
+    >>> gf_crt(U, M, ZZ)
+    639985
+
+    >>> p, E, S = gf_crt1(M, ZZ)
+    >>> gf_crt2(U, M, p, E, S, ZZ)
+    639985
+
+    However, it is faster when we want to fix ``M`` and
+    compute for multiple U, i.e. the following cases:
+
+    >>> p, E, S = gf_crt1(M, ZZ)
+    >>> Us = [[49, 76, 65], [23, 42, 67]]
+    >>> for U in Us:
+    ...     print(gf_crt2(U, M, p, E, S, ZZ))
+    639985
+    236237
+
+    See Also
+    ========
+
+    sympy.ntheory.modular.crt1 : a higher level crt routine
+    sympy.polys.galoistools.gf_crt
+    sympy.polys.galoistools.gf_crt2
 
     """
     E, S = [], []
@@ -82,6 +107,8 @@ def gf_crt2(U, M, p, E, S, K):
     """
     Second part of the Chinese Remainder Theorem.
 
+    See ``gf_crt1`` for usage.
+
     Examples
     ========
 
@@ -96,6 +123,13 @@ def gf_crt2(U, M, p, E, S, K):
 
     >>> gf_crt2(U, M, p, E, S, ZZ)
     639985
+
+    See Also
+    ========
+
+    sympy.ntheory.modular.crt2 : a higher level crt routine
+    sympy.polys.galoistools.gf_crt
+    sympy.polys.galoistools.gf_crt1
 
     """
     v = K.zero


### PR DESCRIPTION
Example usage of `crt1`, `crt2`, `gf_crt1`, and `gf_crt2`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
