### PR TITLE
Fixes calculating density of sum of normal and normal to the 5:th power

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -531,11 +531,13 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
 
         gs = solveset(expr - y, self.value, S.Reals)
 
-        if isinstance(gs, Intersection) and S.Reals in gs.args:
-            gs = list(gs.args[1])
+        if isinstance(gs, Intersection):
+            if len(gs.args) == 2 and gs.args[0] is S.Reals:
+                gs = gs.args[1]
 
-        if not gs:
-            raise ValueError("Can not solve %s for %s"%(expr, self.value))
+        if not gs.is_FiniteSet:
+            raise ValueError("Can not solve %s for %s" % (expr, self.value))
+
         fx = self.compute_density(self.value)
         fy = sum(fx(g) * abs(g.diff(y)) for g in gs)
         return Lambda(y, fy)

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -2,7 +2,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.numbers import (oo, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.core.symbol import symbols, Symbol
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -136,6 +136,12 @@ def test_Compound_Distribution():
     assert C.set == S.Naturals0
     assert C.pdf(z, evaluate=True).simplify() == t**z*(t + 1)**(-k - z)*gamma(k \
                     + z)/(gamma(k)*gamma(z + 1))
+
+
+def test_issue_24940():
+    sigma = Symbol("sigma")
+    X = Normal('X', 0, sigma**2)
+    raises(ValueError, lambda: density(X**5 + X))
 
 
 def test_compound_pspace():

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -138,7 +138,7 @@ def test_Compound_Distribution():
                     + z)/(gamma(k)*gamma(z + 1))
 
 
-def test_issue_24940():
+def test_issue_24915():
     sigma = Symbol("sigma")
     X = Normal('X', 0, sigma**2)
     raises(ValueError, lambda: density(X**5 + X))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24915 
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
