### PR TITLE
Fix mypy issues with `RawMatrix._sympify`

### DIFF
--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -31,7 +31,7 @@ class RawMatrix(MutableDenseMatrix):
        Matrix should be of type ``Expr``.
 
     """
-    _sympify = staticmethod(lambda x: x)
+    _sympify = staticmethod(lambda x, *args, **kwargs: x)
 
     def __init__(self, *args, **kwargs):
         sympy_deprecation_warning(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I attempt to fix the issue with failing mypy check in the master.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
