### PR TITLE
Refactoring of `is_nthpow_residue`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -8,7 +8,7 @@ from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence
 from .primetest import isprime
-from .factor_ import factorint, trailing, totient, multiplicity, perfect_power
+from .factor_ import factorint, trailing, multiplicity, perfect_power
 from .modular import crt
 from sympy.utilities.misc import as_int
 from sympy.core.random import _randint, randint


### PR DESCRIPTION
Prevent `_is_nthpow_residue_bign_prime_power` from calling `_is_nthpow_residue_bign` recursively. Then `_is_nthpow_residue_bign` was removed because it would only be a function to factorize prime and call `_is_nthpow_residue_bign_prime_power`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * removed `_is_nthpow_residue_bign`
<!-- END RELEASE NOTES -->
