### PR TITLE
Fix substituting TensExpr in Mul

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4861,3 +4861,23 @@ def _expand(expr, **kwargs):
         return expr._expand(**kwargs)
     else:
         return expr.expand(**kwargs)
+
+
+def get_postprocessor(cls):
+    def _postprocessor(expr):
+        tens_class = {Mul: TensMul, Add: TensAdd}[cls]
+        if any([isinstance(a, TensExpr) for a in expr.args]):
+            return tens_class(*expr.args)
+        else:
+            return expr
+
+    return _postprocessor
+
+"""
+The following makes sure that if a user tries to put a tensor in a Mul, it
+automatically gets converted to a TensMul (see github issue #25051). The
+conversion already seems to work for TensAdd, so we don't do anything for that.
+"""
+Basic._constructor_postprocessor_mapping[TensExpr] = {
+    "Mul": [get_postprocessor(Mul)],
+}

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4873,11 +4873,6 @@ def get_postprocessor(cls):
 
     return _postprocessor
 
-"""
-The following makes sure that if a user tries to put a tensor in a Mul, it
-automatically gets converted to a TensMul (see github issue #25051). The
-conversion already seems to work for TensAdd, so we don't do anything for that.
-"""
 Basic._constructor_postprocessor_mapping[TensExpr] = {
     "Mul": [get_postprocessor(Mul)],
 }

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4866,7 +4866,7 @@ def _expand(expr, **kwargs):
 def get_postprocessor(cls):
     def _postprocessor(expr):
         tens_class = {Mul: TensMul, Add: TensAdd}[cls]
-        if any([isinstance(a, TensExpr) for a in expr.args]):
+        if any(isinstance(a, TensExpr) for a in expr.args):
             return tens_class(*expr.args)
         else:
             return expr

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2040,3 +2040,22 @@ def test_TensorType():
 def test_dummy_fmt():
     with warns_deprecated_sympy():
         TensorIndexType('Lorentz', dummy_fmt='L')
+
+def test_postprocessor():
+    """
+    Test if substituting a Tensor into a Mul or Add automatically converts it
+    to TensMul or TensAdd respectively. See github issue #25051
+    """
+    R3 = TensorIndexType('R3', dim=3)
+    i = tensor_indices("i", R3)
+    K = TensorHead("K", [R3])
+    x,y,z = symbols("x y z")
+
+    assert isinstance((x*2).xreplace({x: K(i)}), TensMul)
+    assert isinstance((x+2).xreplace({x: K(i)*K(-i)}), TensAdd)
+
+    assert isinstance((x*2).subs({x: K(i)}), TensMul)
+    assert isinstance((x+2).subs({x: K(i)*K(-i)}), TensAdd)
+
+    assert isinstance((x*2).replace(x, K(i)), TensMul)
+    assert isinstance((x+2).replace(x, K(i)*K(-i)), TensAdd)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25051

#### Brief description of what is fixed or changed
Earlier, substituting a TensExpr into a Mul would output a Mul. Now, the Mul is converted to a TensMul.
I've also added some tests for Mul->TensMul and Add->TensAdd.

#### Other comments
The conversion already seemed to work for Add->TensAdd, so I've just added tests for it.

I have put the tests in tensor/tests/test_tensor.py, but is there a better place for them?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Substituting a Tensor into a Mul now produces a TensMul as expected.
<!-- END RELEASE NOTES -->
