### PR TITLE
Removing `trailing` from `is_primitive_root`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -212,10 +212,10 @@ def primitive_root(p, smallest=True):
     if p <= 4:
         return p - 1
     if not smallest:
-        p_even = p%2 == 0
+        p_even = p % 2 == 0
         if not p_even:
             q = p  # p is odd
-        elif p%4:
+        elif p % 4:
             q = p//2  # p had 1 factor of 2
         else:
             return None  # p had more than one factor of 2
@@ -309,13 +309,15 @@ def is_primitive_root(a, p):
     if p <= 4:
         # The primitive root is only p-1.
         return a == p - 1
-    t = trailing(p)
-    if t > 1:
-        return False
-    q = p >> t
+    if p % 2:
+        q = p  # p is odd
+    elif p % 4:
+        q = p//2  # p had 1 factor of 2
+    else:
+        return False  # p had more than one factor of 2
     if isprime(q):
         group_order = q - 1
-        factors = set(factorint(q - 1).keys())
+        factors = factorint(q - 1).keys()
     else:
         m = perfect_power(q)
         if not m:


### PR DESCRIPTION
Removed `trailing` as in `primitive_root`.
Also, when a prime factor of p-1 is obtained, there is no need to convert it to a set, so that process has also been removed.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#24883

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
