### PR TITLE
polytools.gcd to numbers.igcd

### DIFF
--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -1,6 +1,6 @@
 from sympy.ntheory import sieve, isprime
-from sympy.core.numbers import mod_inverse
-from sympy.core.power import integer_log
+from sympy.core.numbers import mod_inverse, igcd
+from sympy.core.power import integer_log, isqrt
 from sympy.utilities.misc import as_int
 import random
 
@@ -201,9 +201,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     if isprime(n):
         return n
 
-    from sympy.functions.elementary.miscellaneous import sqrt
-    from sympy.polys.polytools import gcd
-    D = int(sqrt(B2))
+    D = isqrt(B2)
     beta = [0]*(D + 1)
     S = [0]*(D + 1)
     k = 1
@@ -224,7 +222,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
             a24 = pow(v - u, 3, n)*(3*u + v)*mod_inverse(16*u_3*v, n) % n
         except ValueError:
             #If the mod_inverse(16*u_3*v, n) doesn't exist (i.e., g != 1)
-            g = gcd(16*u_3*v, n)
+            g = igcd(16*u_3*v, n)
             #If g = n, try another curve
             if g == n:
                 continue
@@ -232,7 +230,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
 
         Q = Point(u_3, pow(v, 3, n), a24, n)
         Q = Q.mont_ladder(k)
-        g = gcd(Q.z_cord, n)
+        g = igcd(Q.z_cord, n)
 
         #Stage 1 factor
         if g != 1 and g != n:
@@ -267,7 +265,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
                 g = (g*f) % n
             #Swap
             T, R = R, R.add(S[D], T)
-        g = gcd(n, g)
+        g = igcd(n, g)
 
         #Stage 2 Factor found
         if g != 1 and g != n:


### PR DESCRIPTION
It is sufficient to be able to compute gcd in integers, even if you do not use polytools.gcd, which can compute more general gcd. There is also a function to compute the integer part of the square root, so this function is used.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
