### PR TITLE
Fix printing Lambda in MathMLContentPrinter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -474,6 +474,7 @@ Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
 Daniel Ingram <ingramds@appstate.edu>
 Daniel Mahler <dmahler@gmail.com>
 Daniel Sears <highpost@users.noreply.github.com>
+Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
 Daniel Wennberg <daniel.wennberg@gmail.com>
 Danny Hermes <daniel.j.hermes@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -574,6 +574,17 @@ class MathMLContentPrinter(MathMLPrinterBase):
             x.appendChild(self._print(arg))
         return x
 
+    def _print_Lambda(self, e):
+        # MathML reference for the lambda element:
+        # https://www.w3.org/TR/MathML2/chapter4.html#id.4.2.1.7
+        x = self.dom.createElement(self.mathml_tag(e))
+        for arg in e.signature:
+            x_1 = self.dom.createElement('bvar')
+            x_1.appendChild(self._print(arg))
+            x.appendChild(x_1)
+        x.appendChild(self._print(e.expr))
+        return x
+
     # XXX Symmetric difference is not supported for MathML content printers.
 
 
@@ -634,6 +645,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             'mathieuc': 'C',
             'mathieusprime': 'S&#x2032;',
             'mathieucprime': 'C&#x2032;',
+            'Lambda': 'lambda',
         }
 
         def mul_symbol_selection():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -130,6 +130,16 @@ def test_content_mathml_functions():
     assert mml_3.childNodes[1].childNodes[
         0].nodeName == 'ci'  # below bvar there's <ci>x/ci>
 
+    mml_4 = mp._print(Lambda((x, y), x * y))
+    assert mml_4.nodeName == 'lambda'
+    assert mml_4.childNodes[0].nodeName == 'bvar'
+    assert mml_4.childNodes[0].childNodes[
+        0].nodeName == 'ci'  # below bvar there's <ci>x/ci>
+    assert mml_4.childNodes[1].nodeName == 'bvar'
+    assert mml_4.childNodes[1].childNodes[
+        0].nodeName == 'ci'  # below bvar there's <ci>y/ci>
+    assert mml_4.childNodes[2].nodeName == 'apply'
+
 
 def test_content_mathml_limits():
     # XXX No unevaluated limits


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #25061

#### Brief description of what is fixed or changed

MathMLContentPrinter didn't print the signature of `sympy.Lambda` correctly. It does now.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug with printing Lambdas. Formerly, the signature was printed incorrectly as `<tuple>`.
<!-- END RELEASE NOTES -->
