### PR TITLE
Adds latex and pretty printing methods for physics point and physics vector

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -4,6 +4,7 @@ from sympy.core.symbol import Symbol
 from sympy.simplify.trigsimp import trigsimp
 from sympy.physics.vector.vector import Vector, _check_vector
 from sympy.utilities.misc import translate
+from sympy.printing.defaults import Printable
 
 from warnings import warn
 
@@ -79,7 +80,7 @@ class CoordinateSym(Symbol):
         return (self._id[0].__hash__(), self._id[1]).__hash__()
 
 
-class ReferenceFrame:
+class ReferenceFrame(Printable):
     """A reference frame in classical mechanics.
 
     ReferenceFrame is a class used to represent a reference frame in classical
@@ -1501,6 +1502,16 @@ class ReferenceFrame:
             return partials[0]
         else:
             return tuple(partials)
+
+    def _latex(self, printer):
+        return r"{%s}" % self.name
+
+    def _pretty(self, printer):
+        e = self
+        class Fake:
+            def render(self, *args, **kwargs):
+                return r"{%s}" % e.name
+        return Fake()
 
 
 def _check_frame(other):

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -1,11 +1,12 @@
 from .vector import Vector, _check_vector
 from .frame import _check_frame
 from warnings import warn
+from sympy.printing.defaults import Printable
 
 __all__ = ['Point']
 
 
-class Point:
+class Point(Printable):
     """This object represents a point in a dynamic system.
 
     It stores the: position, velocity, and acceleration of a point.
@@ -627,3 +628,13 @@ class Point:
             return partials[0]
         else:
             return tuple(partials)
+
+    def _latex(self, printer):
+        return r"{%s}" % self.name
+
+    def _pretty(self, printer):
+        e = self
+        class Fake:
+            def render(self, *args, **kwargs):
+                return r"{%s}" % e.name
+        return Fake()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24967

#### Brief description of what is fixed or changed

methods for printing were implemented for the physics point and physics vector. Both classes now inherit Printable


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
