### PR TITLE
Implement fermion exponentiation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -667,6 +667,7 @@ Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelint
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
 Ishan Pandhare <ishan9096137017@gmail.com>
+Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
 Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -111,21 +111,16 @@ class FermionOp(Operator):
 
     def _eval_power(self, exp):
         from sympy.core.singleton import S
-        try:
-            if exp == 0:
-                return S.One
-            elif exp == 1:
-                return self
-            elif exp > 1 and exp.is_integer:
-                return S.Zero
-            else:
-                raise ValueError("Fermionic operators can only be raised to a"
-                    " positive integer power")
-        except TypeError as e:  # fallback to default implementation
-            if e.args != ('cannot determine truth value of Relational',):
-                raise
-            return Operator._eval_power(self, exp)
-
+        if exp == 0:
+            return S.One
+        elif exp == 1:
+            return self
+        elif (exp > 1) == True and exp.is_integer == True:
+            return S.Zero
+        elif (exp < 0) == True or exp.is_integer == False:
+            raise ValueError("Fermionic operators can only be raised to a"
+                " positive integer power")
+        return Operator._eval_power(self, exp)
 
 class FermionFockKet(Ket):
     """Fock state ket for a fermionic mode.

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -109,6 +109,23 @@ class FermionOp(Operator):
         else:
             return pform**prettyForm('\N{DAGGER}')
 
+    def _eval_power(self, exp):
+        from sympy.core.singleton import S
+        try:
+            if exp == 0:
+                return S.One
+            elif exp == 1:
+                return self
+            elif exp > 1 and exp.is_integer:
+                return S.Zero
+            else:
+                raise ValueError("Fermionic operators can only be raised to a"
+                    " positive integer power")
+        except TypeError as e:  # fallback to default implementation
+            if e.args != ('cannot determine truth value of Relational',):
+                raise
+            return Operator._eval_power(self, exp)
+
 
 class FermionFockKet(Ket):
     """Fock state ket for a fermionic mode.

--- a/sympy/physics/quantum/tests/test_fermion.py
+++ b/sympy/physics/quantum/tests/test_fermion.py
@@ -1,6 +1,10 @@
+from pytest import raises
+
+import sympy
 from sympy.physics.quantum import Dagger, AntiCommutator, qapply
 from sympy.physics.quantum.fermion import FermionOp
 from sympy.physics.quantum.fermion import FermionFockKet, FermionFockBra
+from sympy import Symbol
 
 
 def test_fermionoperator():
@@ -34,3 +38,25 @@ def test_fermion_states():
 
     assert qapply(Dagger(c) * FermionFockKet(0)) == FermionFockKet(1)
     assert qapply(Dagger(c) * FermionFockKet(1)) == 0
+
+
+def test_power():
+    c = FermionOp("c")
+    assert c**0 == 1
+    assert c**1 == c
+    assert c**2 == 0
+    assert c**3 == 0
+    assert Dagger(c)**1 == Dagger(c)
+    assert Dagger(c)**2 == 0
+
+    assert (c**Symbol('a')).func == sympy.core.power.Pow
+    assert (c**Symbol('a')).args == (c, Symbol('a'))
+
+    with raises(ValueError):
+        c**-1
+
+    with raises(ValueError):
+        c**3.2
+
+    with raises(TypeError):
+        c**1j


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Fermions operators are nilpotent. This PR implements this.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Implemented fermion exponentiation.
<!-- END RELEASE NOTES -->
