### PR TITLE
Fermion anticommutation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -667,6 +667,7 @@ Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelint
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
 Ishan Pandhare <ishan9096137017@gmail.com>
+Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
 Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -35,7 +35,6 @@ def _expand_powers(factors):
 
     return new_factors
 
-
 def _normal_ordered_form_factor(product, independent=False, recursive_limit=10,
                                 _recursive_depth=0):
     """
@@ -51,86 +50,46 @@ def _normal_ordered_form_factor(product, independent=False, recursive_limit=10,
     new_factors = []
     n = 0
     while n < len(factors) - 1:
+        current, next = factors[n], factors[n + 1]
+        if any(not isinstance(f, (FermionOp, BosonOp)) for f in (current, next)):
+            new_factors.append(current)
+            n += 1
+            continue
 
-        if isinstance(factors[n], BosonOp):
-            # boson
-            if not isinstance(factors[n + 1], BosonOp):
-                new_factors.append(factors[n])
+        key_1 = (current.is_annihilation, str(current.name))
+        key_2 = (next.is_annihilation, str(next.name))
 
-            elif factors[n].is_annihilation == factors[n + 1].is_annihilation:
-                if (independent and
-                        str(factors[n].name) > str(factors[n + 1].name)):
-                    new_factors.append(factors[n + 1])
-                    new_factors.append(factors[n])
-                    n += 1
-                else:
-                    new_factors.append(factors[n])
+        if key_1 <= key_2:
+            new_factors.append(current)
+            print(new_factors, 'here')
+            n += 1
+            continue
 
-            elif not factors[n].is_annihilation:
-                new_factors.append(factors[n])
-
-            else:
-                if factors[n + 1].is_annihilation:
-                    new_factors.append(factors[n])
-                else:
-                    if factors[n].args[0] != factors[n + 1].args[0]:
-                        if independent:
-                            c = 0
-                        else:
-                            c = Commutator(factors[n], factors[n + 1])
-                        new_factors.append(factors[n + 1] * factors[n] + c)
+        n += 2
+        if current.is_annihilation and not next.is_annihilation:
+            if isinstance(current, BosonOp) and isinstance(next, BosonOp):
+                if current.args[0] != next.args[0]:
+                    if independent:
+                        c = 0
                     else:
-                        c = Commutator(factors[n], factors[n + 1])
-                        new_factors.append(
-                            factors[n + 1] * factors[n] + c.doit())
-                    n += 1
-
-        elif isinstance(factors[n], FermionOp):
-            # fermion
-            if not isinstance(factors[n + 1], FermionOp):
-                new_factors.append(factors[n])
-
-            elif factors[n].is_annihilation == factors[n + 1].is_annihilation:
-                if (independent and
-                        str(factors[n].name) > str(factors[n + 1].name)):
-                    new_factors.append(-factors[n + 1])
-                    new_factors.append(factors[n])
-                    n += 1
+                        c = Commutator(current, next)
+                    new_factors.append(next * current + c)
                 else:
-                    new_factors.append(factors[n])
-
-            elif not factors[n].is_annihilation:
-                new_factors.append(factors[n])
-
-            else:
-                if factors[n + 1].is_annihilation:
-                    new_factors.append(factors[n])
-                else:
-                    if factors[n].args[0] != factors[n + 1].args[0]:
-                        if independent:
-                            c = 0
-                        else:
-                            c = AntiCommutator(factors[n], factors[n + 1])
-                        new_factors.append(-factors[n + 1] * factors[n] + c)
+                    new_factors.append(next * current + 1)
+            elif isinstance(current, FermionOp) and isinstance(next, FermionOp):
+                if current.args[0] != next.args[0]:
+                    if independent:
+                        c = 0
                     else:
-                        c = AntiCommutator(factors[n], factors[n + 1])
-                        new_factors.append(
-                            -factors[n + 1] * factors[n] + c.doit())
-                    n += 1
-
-        elif isinstance(factors[n], Operator):
-
-            if isinstance(factors[n + 1], (BosonOp, FermionOp)):
-                new_factors.append(factors[n + 1])
-                new_factors.append(factors[n])
-                n += 1
-            else:
-                new_factors.append(factors[n])
-
+                        c = AntiCommutator(current, next)
+                    new_factors.append(-next * current + c)
+                else:
+                    new_factors.append(-next * current + 1)
+        elif (current.is_annihilation == next.is_annihilation and
+            isinstance(current, FermionOp) and isinstance(next, FermionOp)):
+            new_factors.append(-next * current)
         else:
-            new_factors.append(factors[n])
-
-        n += 1
+            new_factors.append(next * current)
 
     if n == len(factors) - 1:
         new_factors.append(factors[-1])

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -61,7 +61,6 @@ def _normal_ordered_form_factor(product, independent=False, recursive_limit=10,
 
         if key_1 <= key_2:
             new_factors.append(current)
-            print(new_factors, 'here')
             n += 1
             continue
 

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -177,7 +177,10 @@ def normal_ordered_form(expr, independent=False, recursive_limit=10,
 
     expr : expression
         The expression write on normal ordered form.
-
+    independent : bool (default False)
+        Whether to consider operator with different names as operating in
+        different Hilbert spaces. If False, the (anti-)commutation is left
+        explicit.
     recursive_limit : int (default 10)
         The number of allowed recursive applications of the function.
 

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -6,7 +6,7 @@ from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer
 from sympy.core.power import Pow
-from sympy.physics.quantum import Operator, Commutator, AntiCommutator
+from sympy.physics.quantum import Commutator, AntiCommutator
 from sympy.physics.quantum.boson import BosonOp
 from sympy.physics.quantum.fermion import FermionOp
 

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -93,7 +93,7 @@ def _normal_ordered_form_factor(product, independent=False, recursive_limit=10,
             elif factors[n].is_annihilation == factors[n + 1].is_annihilation:
                 if (independent and
                         str(factors[n].name) > str(factors[n + 1].name)):
-                    new_factors.append(factors[n + 1])
+                    new_factors.append(-factors[n + 1])
                     new_factors.append(factors[n])
                     n += 1
                 else:

--- a/sympy/physics/quantum/tests/test_operatorordering.py
+++ b/sympy/physics/quantum/tests/test_operatorordering.py
@@ -21,8 +21,10 @@ def test_normal_order():
 
 def test_normal_ordered_form():
     a = BosonOp('a')
+    b = BosonOp('b')
 
     c = FermionOp('c')
+    d = FermionOp('d')
 
     assert normal_ordered_form(Dagger(a) * a) == Dagger(a) * a
     assert normal_ordered_form(a * Dagger(a)) == 1 + Dagger(a) * a
@@ -36,3 +38,13 @@ def test_normal_ordered_form():
     assert normal_ordered_form(c ** 2 * Dagger(c)) == Dagger(c) * c ** 2
     assert normal_ordered_form(c ** 3 * Dagger(c)) == \
         c ** 2 - Dagger(c) * c ** 3
+
+    assert normal_ordered_form(a * Dagger(b), True) == Dagger(b) * a
+    assert normal_ordered_form(Dagger(a) * b, True) == Dagger(a) * b
+    assert normal_ordered_form(b * a, True) == a * b
+    assert normal_ordered_form(Dagger(b) * Dagger(a), True) == Dagger(a) * Dagger(b)
+
+    assert normal_ordered_form(c * Dagger(d), True) == -Dagger(d) * c
+    assert normal_ordered_form(Dagger(c) * d, True) == Dagger(c) * d
+    assert normal_ordered_form(d * c, True) == -c * d
+    assert normal_ordered_form(Dagger(d) * Dagger(c), True) == -Dagger(c) * Dagger(d)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25073
Fixes #25075

#### Brief description of what is fixed or changed

Fixes a forgotten minus sign in fermionic anticommutation rules.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.quantum
  * Fix normal_ordered_form of multiple fermions

<!-- END RELEASE NOTES -->
