### PR TITLE
Fixes Ruff warning due to PIE802 being remapped to C419

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ markers = [
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
     "C40",
+    "C419",
     "E",
     "F",
-    "PIE802",
     "PIE810",
     "SIM101",
 ]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
N/A

#### Brief description of what is fixed or changed
Ruff has remapped the PIE802 rule to C419. We have PIE802 selected in our Ruff configuration, which currently raises a warning and will raise an error in future. This PR removes PIE802 from `pyproject.toml` and adds C419, thus removing the warning.

#### Other comments
Our flake8 config actually has all C4 rules selected. Another option would be to change this to select C4 (rather than C40 and C419) in the Ruff config so the two are equivalent.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
