### PR TITLE
`numbers.igcd` to `gmpy.gcd`

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -235,6 +235,7 @@ def igcd(*args):
 
     The algorithm is based on the well known Euclid's algorithm [1]_. To
     improve speed, ``igcd()`` has its own caching mechanism.
+    If you do not need the cache mechanism, using `sympy.external.gmpy.gcd`.
 
     Examples
     ========

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -29,7 +29,7 @@ from sympy.ntheory import reduced_totient as _carmichael
 from sympy.ntheory.generate import nextprime
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import FF
-from sympy.polys.polytools import gcd, Poly
+from sympy.polys.polytools import Poly
 from sympy.utilities.misc import as_int, filldedent, translate
 from sympy.utilities.iterables import uniq, multiset
 

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -19,8 +19,9 @@ import warnings
 from itertools import cycle
 
 from sympy.core import Symbol
-from sympy.core.numbers import igcdex, mod_inverse, igcd, Rational
+from sympy.core.numbers import igcdex, mod_inverse, Rational
 from sympy.core.random import _randrange, _randint
+from sympy.external.gmpy import gcd
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, primitive_root, factorint
 from sympy.ntheory import totient as _euler
@@ -1561,7 +1562,7 @@ def _rsa_key(*args, public=True, private=True, totient='Euler', index=None, mult
                 ).warn(stacklevel=4)
         phi = _totient._from_factors(tally)
 
-    if igcd(e, phi) == 1:
+    if gcd(e, phi) == 1:
         if public and not private:
             if isinstance(index, int):
                 e = e % phi
@@ -1880,7 +1881,7 @@ def _encipher_decipher_rsa(i, key, factors=None):
         is_coprime_set = True
         for i in range(len(l)):
             for j in range(i+1, len(l)):
-                if igcd(l[i], l[j]) != 1:
+                if gcd(l[i], l[j]) != 1:
                     is_coprime_set = False
                     break
         return is_coprime_set

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -16,6 +16,7 @@ from sympy.crypto.crypto import (cycle_list,
       bg_private_key, bg_public_key, encipher_rot13, decipher_rot13,
       encipher_atbash, decipher_atbash, NonInvertibleCipherWarning,
       encipher_railfence, decipher_railfence)
+from sympy.external.gmpy import gcd
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, is_primitive_root
 from sympy.polys.domains import FF
@@ -348,7 +349,6 @@ def test_rsa_multiprime_exhanstive():
 
 
 def test_rsa_multipower_exhanstive():
-    from sympy.core.numbers import igcd
     primes = [5, 5, 7]
     e = 7
     args = primes + [e]
@@ -357,7 +357,7 @@ def test_rsa_multipower_exhanstive():
     n = puk[0]
 
     for msg in range(n):
-        if igcd(msg, n) != 1:
+        if gcd(msg, n) != 1:
             continue
 
         encrypted = encipher_rsa(msg, puk)

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -108,7 +108,7 @@ else:
 
     factorial = lambda x: int(mlib.ifac(x))
     sqrt = lambda x: int(mlib.isqrt(x))
-    if not sys.version_info[:2] >= (3, 9):
+    if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd
     else:
         # Until python 3.8 is no longer supported

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Tuple as tTuple, Type
 
 import mpmath.libmp as mlib
@@ -33,6 +34,9 @@ __all__ = [
 
     # isqrt from gmpy or mpmath
     'sqrt',
+
+    # gcd from gmpy or math
+    'gcd',
 ]
 
 
@@ -90,9 +94,11 @@ if gmpy is not None:
 
     factorial = gmpy.fac
     sqrt = gmpy.isqrt
+    gcd = gmpy.gcd
 
 else:
     from .pythonmpq import PythonMPQ
+    import math
 
     HAS_GMPY = 0
     GROUND_TYPES = 'python'
@@ -102,3 +108,9 @@ else:
 
     factorial = lambda x: int(mlib.ifac(x))
     sqrt = lambda x: int(mlib.isqrt(x))
+    if not sys.version_info[:2] >= (3, 9):
+        gcd = math.gcd
+    else:
+        # Until python 3.8 is no longer supported
+        from functools import reduce
+        gcd = lambda *args: reduce(math.gcd, args, 0)

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -1,6 +1,7 @@
 from sympy.ntheory import sieve, isprime
-from sympy.core.numbers import mod_inverse, igcd
+from sympy.core.numbers import mod_inverse
 from sympy.core.power import integer_log, isqrt
+from sympy.external.gmpy import gcd
 from sympy.utilities.misc import as_int
 import random
 
@@ -222,7 +223,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
             a24 = pow(v - u, 3, n)*(3*u + v)*mod_inverse(16*u_3*v, n) % n
         except ValueError:
             #If the mod_inverse(16*u_3*v, n) doesn't exist (i.e., g != 1)
-            g = igcd(16*u_3*v, n)
+            g = gcd(16*u_3*v, n)
             #If g = n, try another curve
             if g == n:
                 continue
@@ -230,7 +231,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
 
         Q = Point(u_3, pow(v, 3, n), a24, n)
         Q = Q.mont_ladder(k)
-        g = igcd(Q.z_cord, n)
+        g = gcd(Q.z_cord, n)
 
         #Stage 1 factor
         if g != 1 and g != n:
@@ -265,7 +266,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
                 g = (g*f) % n
             #Swap
             T, R = R, R.add(S[D], T)
-        g = igcd(n, g)
+        g = gcd(n, g)
 
         #Stage 2 Factor found
         if g != 1 and g != n:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -14,10 +14,10 @@ from sympy.core.expr import Expr
 from sympy.core.function import Function
 from sympy.core.logic import fuzzy_and
 from sympy.core.mul import Mul
-from sympy.core.numbers import igcd, ilcm, Rational, Integer
+from sympy.core.numbers import ilcm, Rational, Integer
 from sympy.core.power import integer_nthroot, Pow, integer_log
 from sympy.core.singleton import S
-from sympy.external.gmpy import SYMPY_INTS
+from sympy.external.gmpy import SYMPY_INTS, gcd
 from .primetest import isprime
 from .generate import sieve, primerange, nextprime
 from .digits import digits
@@ -675,7 +675,7 @@ def pollard_rho(n, s=2, a=1, retries=5, seed=1234, max_steps=None, F=None):
             j += 1
             U = F(U)
             V = F(F(V))  # V is 2x further along than U
-            g = igcd(U - V, n)
+            g = gcd(U - V, n)
             if g == 1:
                 continue
             if g == n:
@@ -829,7 +829,7 @@ def pollard_pm1(n, B=10, a=2, retries=0, seed=1234):
         for p in sieve.primerange(2, B + 1):
             e = int(math.log(B, p))
             aM = pow(aM, pow(p, e), n)
-        g = igcd(aM - 1, n)
+        g = gcd(aM - 1, n)
         if 1 < g < n:
             return int(g)
 

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,7 +1,8 @@
 from functools import reduce
 from math import prod
 
-from sympy.core.numbers import igcdex, igcd
+from sympy.core.numbers import igcdex
+from sympy.external.gmpy import gcd
 from sympy.ntheory.primetest import isprime
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt, gf_crt1, gf_crt2
@@ -234,7 +235,7 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         a1, m1 = c1
         a2, m2 = c2
         a, b, c = m1, a2 - a1, m2
-        g = reduce(igcd, [a, b, c])
+        g = gcd(a, b, c)
         a, b, c = [i//g for i in [a, b, c]]
         if a != 1:
             inv_a, _, g = igcdex(a, c)

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,4 +1,3 @@
-from functools import reduce
 from math import prod
 
 from sympy.core.numbers import igcdex

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -1,7 +1,7 @@
 from mpmath.libmp import (fzero, from_int, from_rational,
     fone, fhalf, bitcount, to_int, to_str, mpf_mul, mpf_div, mpf_sub,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, mpf_cos, mpf_sin)
-from sympy.core.numbers import igcd
+from sympy.external.gmpy import gcd
 from .residue_ntheory import (_sqrt_mod_prime_power,
     legendre_symbol, jacobi_symbol, is_quad_residue)
 
@@ -99,7 +99,7 @@ def _a(n, k, prec):
             mpf_cos(arg, prec), prec)
 
     if p != 2 or e >= 3:
-        d1, d2 = igcd(k1, 24), igcd(k2, 24)
+        d1, d2 = gcd(k1, 24), gcd(k2, 24)
         e = 24//(d1*d2)
         n1 = ((d2*e*n + (k2**2 - 1)//d1)*
             pow(e*k2*k2*d2, _totient[k1] - 1, k1)) % k1

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -3,10 +3,9 @@ Primality testing
 
 """
 
-from sympy.core.numbers import igcd
 from sympy.core.power import integer_nthroot
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import HAS_GMPY, gcd
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -283,7 +282,7 @@ def _lucas_selfridge_params(n):
     from sympy.ntheory.residue_ntheory import jacobi_symbol
     D = 5
     while True:
-        g = igcd(abs(D), n)
+        g = gcd(D, n)
         if g > 1 and g != n:
             return (0, 0, 0)
         if jacobi_symbol(D, n) == -1:
@@ -307,7 +306,7 @@ def _lucas_extrastrong_params(n):
     from sympy.ntheory.residue_ntheory import jacobi_symbol
     P, Q, D = 3, 1, 5
     while True:
-        g = igcd(D, n)
+        g = gcd(D, n)
         if g > 1 and g != n:
             return (0, 0, 0)
         if jacobi_symbol(D, n) == -1:

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -1,5 +1,6 @@
-from sympy.core.numbers import igcd, mod_inverse
+from sympy.core.numbers import mod_inverse
 from sympy.core.power import integer_nthroot
+from sympy.external.gmpy import gcd
 from sympy.ntheory.residue_ntheory import _sqrt_mod_prime_power
 from sympy.ntheory import isprime
 from math import log, sqrt
@@ -434,7 +435,7 @@ def _find_factor(dependent_rows, mark, gauss_matrix, index, smooth_relations, N)
         v *= i
     #assert u**2 % N == v % N
     v = integer_nthroot(v, 2)[0]
-    return igcd(u - v, N)
+    return gcd(u - v, N)
 
 
 def qs(N, prime_bound, M, ERROR_TERM=25, seed=1234):

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from sympy.core.function import Function
-from sympy.core.numbers import igcd, igcdex, mod_inverse
+from sympy.core.numbers import igcdex, mod_inverse
 from sympy.core.power import isqrt
 from sympy.core.singleton import S
+from sympy.external.gmpy import gcd
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
@@ -45,7 +46,7 @@ def n_order(a, n):
     # Trivial
     if a == 1:
         return 1
-    if igcd(a, n) != 1:
+    if gcd(a, n) != 1:
         raise ValueError("The two numbers should be relatively prime")
     # We want to calculate
     # order = totient(n), factors = factorint(order)
@@ -116,7 +117,7 @@ def _primitive_root_prime_iter(p):
     yield g
     # g**k is the primitive root of p iff gcd(p - 1, k) = 1
     for k in range(3, p, 2):
-        if igcd(p - 1, k) == 1:
+        if gcd(p - 1, k) == 1:
             yield pow(g, k, p)
 
 
@@ -263,7 +264,7 @@ def primitive_root(p, smallest=True):
                 return g
             else:
                 for i in range(2, g + p1 + 1):
-                    if igcd(i, p) == 1 and is_primitive_root(i, p):
+                    if gcd(i, p) == 1 and is_primitive_root(i, p):
                         return i
 
     return next(_primitive_root_prime_iter(p))
@@ -302,7 +303,7 @@ def is_primitive_root(a, p):
     if p <= 1:
         raise ValueError("p should be an integer greater than 1")
     a = a % p
-    if igcd(a, p) != 1:
+    if gcd(a, p) != 1:
         raise ValueError("The two numbers should be relatively prime")
     # Primitive root of p exist only for
     # p = 2, 4, q**e, 2*q**e (q is odd prime)
@@ -475,7 +476,8 @@ def sqrt_mod_iter(a, p, domain=int):
             res = _sqrt_mod_prime_power(a, p, 1)
         if res:
             if domain is ZZ:
-                yield from res
+                for x in res:
+                    yield ZZ(x)
             else:
                 for x in res:
                     yield domain(x)
@@ -708,7 +710,7 @@ def _is_nthpow_residue_bign_prime_power(a, n, p, k):
         k -= mu
     if p != 2:
         f = p**(k - 1)*(p - 1) # f = totient(p**k)
-        return pow(a, f // igcd(f, n), pow(p, k)) == 1
+        return pow(a, f // gcd(f, n), pow(p, k)) == 1
     if n & 1:
         return True
     c = trailing(n)
@@ -1013,7 +1015,7 @@ def jacobi_symbol(m, n):
         return int(n == 1)
     if n == 1 or m == 1:
         return 1
-    if igcd(m, n) != 1:
+    if gcd(m, n) != 1:
         return 0
 
     j = 1

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -23,7 +23,7 @@ from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
-from sympy.external.gmpy import gcd
+from sympy.external.gmpy import gcd as number_gcd
 from sympy.polys.matrices.linsolve import _linear_eq_to_dict
 from sympy.polys.polyroots import UnsolvableFactorError
 from sympy.simplify.simplify import simplify, fraction, trigsimp, nsimplify
@@ -760,7 +760,7 @@ def _solve_trig2(f, symbol, domain):
 
     # ilcm() require more than one argument
     if len(numerators) > 1:
-        mu = Rational(2)*ilcm(*denominators)/gcd(*numerators)
+        mu = Rational(2)*ilcm(*denominators)/number_gcd(*numerators)
     else:
         assert len(numerators) == 1
         mu = Rational(2)*denominators[0]/numerators[0]
@@ -1333,9 +1333,9 @@ def _invert_modular(modterm, rhs, n, symbol):
         base, expo = a.args
         if expo.has(symbol) and not base.has(symbol):
             # remainder -> solution independent of n of equation.
-            # m, rhs are made coprime by dividing gcd(m, rhs)
+            # m, rhs are made coprime by dividing number_gcd(m, rhs)
             try:
-                remainder = discrete_log(m / gcd(m, rhs), rhs, a.base)
+                remainder = discrete_log(m / number_gcd(m, rhs), rhs, a.base)
             except ValueError:  # log does not exist
                 return modterm, rhs
             # period -> coefficient of n in the solution and also referred as
@@ -1345,7 +1345,7 @@ def _invert_modular(modterm, rhs, n, symbol):
             period = totient(m)
             for p in divisors(period):
                 # there might a lesser period exist than totient(m).
-                if pow(a.base, p, m / gcd(m, a.base)) == 1:
+                if pow(a.base, p, m / number_gcd(m, a.base)) == 1:
                     period = p
                     break
             # recursion is not applied here since _invert_modular is currently

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -17,12 +17,13 @@ from sympy.core.containers import Tuple
 from sympy.core.function import (Lambda, expand_complex, AppliedUndef,
                                 expand_log, _mexpand, expand_trig, nfloat)
 from sympy.core.mod import Mod
-from sympy.core.numbers import igcd, I, Number, Rational, oo, ilcm
+from sympy.core.numbers import I, Number, Rational, oo, ilcm
 from sympy.core.power import integer_log
 from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
+from sympy.external.gmpy import gcd
 from sympy.polys.matrices.linsolve import _linear_eq_to_dict
 from sympy.polys.polyroots import UnsolvableFactorError
 from sympy.simplify.simplify import simplify, fraction, trigsimp, nsimplify
@@ -757,9 +758,9 @@ def _solve_trig2(f, symbol, domain):
 
     x = Dummy('x')
 
-    # ilcm() and igcd() require more than one argument
+    # ilcm() require more than one argument
     if len(numerators) > 1:
-        mu = Rational(2)*ilcm(*denominators)/igcd(*numerators)
+        mu = Rational(2)*ilcm(*denominators)/gcd(*numerators)
     else:
         assert len(numerators) == 1
         mu = Rational(2)*denominators[0]/numerators[0]
@@ -1332,9 +1333,9 @@ def _invert_modular(modterm, rhs, n, symbol):
         base, expo = a.args
         if expo.has(symbol) and not base.has(symbol):
             # remainder -> solution independent of n of equation.
-            # m, rhs are made coprime by dividing igcd(m, rhs)
+            # m, rhs are made coprime by dividing gcd(m, rhs)
             try:
-                remainder = discrete_log(m / igcd(m, rhs), rhs, a.base)
+                remainder = discrete_log(m / gcd(m, rhs), rhs, a.base)
             except ValueError:  # log does not exist
                 return modterm, rhs
             # period -> coefficient of n in the solution and also referred as
@@ -1344,7 +1345,7 @@ def _invert_modular(modterm, rhs, n, symbol):
             period = totient(m)
             for p in divisors(period):
                 # there might a lesser period exist than totient(m).
-                if pow(a.base, p, m / igcd(m, a.base)) == 1:
+                if pow(a.base, p, m / gcd(m, a.base)) == 1:
                     period = p
                     break
             # recursion is not applied here since _invert_modular is currently


### PR DESCRIPTION
We have moved to `sympy.external.gmpy.gcd` as much as possible where we currently use `sympy.core.numbers.igcd`.

I wish I could have changed all of them, but due to my inability to do so, some are still intact.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25067

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
