### PR TITLE
added `as_int`

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -235,7 +235,12 @@ def igcd(*args):
 
     The algorithm is based on the well known Euclid's algorithm [1]_. To
     improve speed, ``igcd()`` has its own caching mechanism.
-    If you do not need the cache mechanism, using `sympy.external.gmpy.gcd`.
+    If you do not need the cache mechanism, using ``sympy.external.gmpy.gcd``.
+
+    It is also possible to give symbolic arguments such as
+    ``sympy.core.numbers.Integer`` to compute gcd, but it is not recommended;
+    consider converting to ``int``, etc. and using
+    ``sympy.external.gmpy.gcd``.
 
     Examples
     ========

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1329,14 +1329,17 @@ def _invert_modular(modterm, rhs, n, symbol):
             return _invert_modular(Mod(h, m), Mod(x_indep_term, m), n, symbol)
 
     if a.is_Pow:
-        from sympy.utilities.misc import as_int
         # base**expo = a
         base, expo = a.args
         if expo.has(symbol) and not base.has(symbol):
             # remainder -> solution independent of n of equation.
             # m, rhs are made coprime by dividing number_gcd(m, rhs)
+            if not m.is_Integer and rhs.is_Integer and a.base.is_Integer:
+                return modterm, rhs
+
+            mdiv = m.p // number_gcd(m.p, rhs.p)
             try:
-                remainder = discrete_log(m / number_gcd(as_int(m), as_int(rhs)), rhs, a.base)
+                remainder = discrete_log(mdiv, rhs.p, a.base.p)
             except ValueError:  # log does not exist
                 return modterm, rhs
             # period -> coefficient of n in the solution and also referred as
@@ -1346,7 +1349,7 @@ def _invert_modular(modterm, rhs, n, symbol):
             period = totient(m)
             for p in divisors(period):
                 # there might a lesser period exist than totient(m).
-                if pow(a.base, p, m / number_gcd(as_int(m), as_int(a.base))) == 1:
+                if pow(a.base, p, m / number_gcd(m.p, a.base.p)) == 1:
                     period = p
                     break
             # recursion is not applied here since _invert_modular is currently

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1329,13 +1329,14 @@ def _invert_modular(modterm, rhs, n, symbol):
             return _invert_modular(Mod(h, m), Mod(x_indep_term, m), n, symbol)
 
     if a.is_Pow:
+        from sympy.utilities.misc import as_int
         # base**expo = a
         base, expo = a.args
         if expo.has(symbol) and not base.has(symbol):
             # remainder -> solution independent of n of equation.
             # m, rhs are made coprime by dividing number_gcd(m, rhs)
             try:
-                remainder = discrete_log(m / number_gcd(m, rhs), rhs, a.base)
+                remainder = discrete_log(m / number_gcd(as_int(m), as_int(rhs)), rhs, a.base)
             except ValueError:  # log does not exist
                 return modterm, rhs
             # period -> coefficient of n in the solution and also referred as
@@ -1345,7 +1346,7 @@ def _invert_modular(modterm, rhs, n, symbol):
             period = totient(m)
             for p in divisors(period):
                 # there might a lesser period exist than totient(m).
-                if pow(a.base, p, m / number_gcd(m, a.base)) == 1:
+                if pow(a.base, p, m / number_gcd(as_int(m), as_int(a.base))) == 1:
                     period = p
                     break
             # recursion is not applied here since _invert_modular is currently


### PR DESCRIPTION
The argument of `external.gmpy.gcd` is now converted to an `int`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#25067

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
