### PR TITLE
printing: prefer print methods over hardcoded literals

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -18,7 +18,7 @@ from functools import wraps
 from itertools import chain
 
 from sympy.core import S
-from sympy.core.numbers import equal_valued
+from sympy.core.numbers import equal_valued, Float
 from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
@@ -283,8 +283,7 @@ class C89CodePrinter(CodePrinter):
         PREC = precedence(expr)
         suffix = self._get_func_suffix(real)
         if equal_valued(expr.exp, -1):
-            literal_suffix = self._get_literal_suffix(real)
-            return '1.0%s/%s' % (literal_suffix, self.parenthesize(expr.base, PREC))
+            return '%s/%s' % (self._print_Float(Float(1.0)), self.parenthesize(expr.base, PREC))
         elif equal_valued(expr.exp, 0.5):
             return '%ssqrt%s(%s)' % (self._ns, suffix, self._print(expr.base))
         elif expr.exp == S.One/3 and self.standard != 'C89':

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
+from sympy.core.numbers import Integer
 from sympy.core.relational import Relational
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
@@ -908,7 +909,7 @@ class StrPrinter(Printer):
     def _print_Zero(self, expr):
         if self._settings.get("sympy_integers", False):
             return "S(0)"
-        return "0"
+        return self._print_Integer(Integer(0))
 
     def _print_DMP(self, p):
         try:

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -1,3 +1,4 @@
+from sympy.core.numbers import Float, Integer, Rational
 from sympy.core.symbol import symbols
 from sympy.functions import beta, Ei, zeta, Max, Min, sqrt, riemann_xi, frac
 from sympy.printing.cxx import CXX98CodePrinter, CXX11CodePrinter, CXX17CodePrinter, cxxcode
@@ -65,3 +66,21 @@ def test_cxxcode_nested_minmax():
         == 'std::max(std::min(u, v), std::min(x, y))'
     assert cxxcode(Min(Max(x, y), Max(u, v))) \
         == 'std::min(std::max(u, v), std::max(x, y))'
+
+def test_subclass_Integer_Float():
+    class MyPrinter(CXX17CodePrinter):
+        def _print_Integer(self, arg):
+            return 'bigInt("%s")' % super()._print_Integer(arg)
+
+        def _print_Float(self, arg):
+            rat = Rational(arg)
+            return 'bigFloat(%s, %s)' % (
+                self._print(Integer(rat.p)),
+                self._print(Integer(rat.q))
+            )
+
+    p = MyPrinter()
+    for i in range(13):
+        assert p.doprint(i) == 'bigInt("%d")' % i
+    assert p.doprint(Float(0.5)) == 'bigFloat(bigInt("1"), bigInt("2"))'
+    assert p.doprint(x**-1.0) == 'bigFloat(bigInt("1"), bigInt("1"))/x'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- `_print_Pow` in `printing/c.py` was using a hardcoded string literal, which is limiting in e.g. C++ where we can have user defined floating point types.
- A user should not need to override both `_print_Integer` and `_print_Zero` to e.g. wrap integers in some arbitrary precision integer class.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
