### PR TITLE
Exact square root for abstract domain and Z,Q,R,C,Fp

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -100,6 +100,8 @@ if gmpy is not None:
 
     factorial = gmpy.fac
     sqrt = gmpy.isqrt
+    is_square = gmpy.is_square
+    sqrtrem = gmpy.isqrt_rem
     gcd = gmpy.gcd
     lcm = gmpy.lcm
     invert = gmpy.invert
@@ -116,6 +118,8 @@ else:
 
     factorial = lambda x: int(mlib.ifac(x))
     sqrt = lambda x: int(mlib.isqrt(x))
+    is_square = lambda x: x >= 0 and mlib.sqrtrem(x)[1] == 0
+    sqrtrem = lambda x: tuple(int(r) for r in mlib.sqrtrem(x))
     if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd
         lcm = math.lcm

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -147,5 +147,13 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         """Check if ``a`` and ``b`` are almost equal. """
         return self._context.almosteq(a, b, tolerance)
 
+    def is_square(self, a):
+        """Returns ``True`` as every complex number has a square root."""
+        return True
+
+    def exsqrt(self, a):
+        r"""Returns the complex square root of ``a`` whose argument is within
+        $(-\frac{\pi}{2}, \frac{\pi}{2}]$"""
+        return a ** 0.5
 
 CC = ComplexField()

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -148,12 +148,18 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         return self._context.almosteq(a, b, tolerance)
 
     def is_square(self, a):
-        """Returns ``True`` as every complex number has a square root."""
+        """Returns ``True``. Every complex number has a complex square root."""
         return True
 
     def exsqrt(self, a):
-        r"""Returns the complex square root of ``a`` whose argument is within
-        $(-\frac{\pi}{2}, \frac{\pi}{2}]$"""
+        r"""Returns the principal complex square root of ``a``.
+
+        Explanation
+        ===========
+        The argument of the principal square root is always within
+        $(-\frac{\pi}{2}, \frac{\pi}{2}]$. The square root may be
+        slightly inaccurate due to floating point rounding error.
+        """
         return a ** 0.5
 
 CC = ComplexField()

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1277,7 +1277,49 @@ class Domain:
         raise NotImplementedError
 
     def sqrt(self, a):
-        """Returns square root of ``a``. """
+        """Returns a (possibly inexact) square root of ``a``.
+
+        Explanation
+        ===========
+        There is no universal definition of "inexact square root" for all
+        domains. It is not recommended to implement this method for domains
+        other then :ref:`ZZ`.
+
+        See also
+        ========
+        exsqrt
+        """
+        raise NotImplementedError
+
+    def is_square(self, a):
+        """Returns whether ``a`` is a square in the domain.
+
+        Explanation
+        ===========
+        Returns ``True`` if there is an element ``b`` in the domain such that
+        ``b * b == a``, otherwise returns ``False``.
+
+        See also
+        ========
+        exsqrt
+        """
+        raise NotImplementedError
+
+    def exsqrt(self, a):
+        """Returns an exact square root of ``a``, or ``None`` if it doesn't
+        exist.
+
+        Explanation
+        ===========
+        The implementation of this method should return an element ``b`` in the
+        domain such that ``b * b == a``, or ``None`` if there is no such ``b``.
+        The choice among multiple possible ``b``s should follow a consistent
+        rule whenever possible.
+
+        See also
+        ========
+        sqrt, is_square
+        """
         raise NotImplementedError
 
     def evalf(self, a, prec=None, **options):

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1297,7 +1297,9 @@ class Domain:
         Explanation
         ===========
         Returns ``True`` if there is an element ``b`` in the domain such that
-        ``b * b == a``, otherwise returns ``False``.
+        ``b * b == a``, otherwise returns ``False``. For inexact domains like
+        :ref:`RR` and :ref:`CC`, a tiny difference in this equality can be
+        tolerated.
 
         See also
         ========
@@ -1306,15 +1308,15 @@ class Domain:
         raise NotImplementedError
 
     def exsqrt(self, a):
-        """Returns an exact square root of ``a``, or ``None`` if it doesn't
-        exist.
+        """Principal square root of a within the domain if ``a`` is square.
 
         Explanation
         ===========
         The implementation of this method should return an element ``b`` in the
         domain such that ``b * b == a``, or ``None`` if there is no such ``b``.
-        The choice among multiple possible ``b``s should follow a consistent
-        rule whenever possible.
+        For inexact domains like :ref:`RR` and :ref:`CC`, a tiny difference in
+        this equality can be tolerated. The choice of a "principal" square root
+        should follow a consistent rule whenever possible.
 
         See also
         ========

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -5,7 +5,7 @@ from sympy.polys.domains.field import Field
 
 from sympy.polys.domains.modularinteger import ModularIntegerFactory
 from sympy.polys.domains.simpledomain import SimpleDomain
-from sympy.polys.galoistools import gf_zassenhaus
+from sympy.polys.galoistools import gf_zassenhaus, gf_irred_p_rabin
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 from sympy.polys.domains.groundtypes import SymPyInteger
@@ -204,15 +204,22 @@ class FiniteField(Field, SimpleDomain):
             return K1.dtype(K1.dom.dtype(p))
 
     def is_square(self, a):
-        """Returns True if ``a`` is a square modulo p. """
-        # TODO: Faster algorithm without computing sqrt, for example using
-        # Legendre symbol
-        return self.exsqrt(a) is not None
+        """Returns True if ``a`` is a quadratic residue modulo p. """
+        # a is not a square <=> x**2-a is irreducible
+        poly = [x.val for x in [self.one, self.zero, -a]]
+        return not gf_irred_p_rabin(poly, self.mod, self.dom)
 
     def exsqrt(self, a):
-        """Returns the square root of ``a`` modulo p that is no larger than
-        ``p // 2``, or ``None`` if it does not exist. """
-        # Factorize x**2 - a
+        """Square root modulo p of ``a`` if it is a quadratic residue.
+
+        Explanation
+        ===========
+        Always returns the square root that is no larger than ``p // 2``.
+        """
+        # x**2-a is not square-free if a=0 or the field is characteristic 2
+        if self.mod == 2 or a == 0:
+            return a
+        # Otherwise, use square-free factorization routine to factorize x**2-a
         poly = [x.val for x in [self.one, self.zero, -a]]
         for factor in gf_zassenhaus(poly, self.mod, self.dom):
             if len(factor) == 2 and factor[1] <= self.mod // 2:

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -5,6 +5,7 @@ from sympy.polys.domains.field import Field
 
 from sympy.polys.domains.modularinteger import ModularIntegerFactory
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.galoistools import gf_zassenhaus
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 from sympy.polys.domains.groundtypes import SymPyInteger
@@ -201,6 +202,22 @@ class FiniteField(Field, SimpleDomain):
 
         if q == 1:
             return K1.dtype(K1.dom.dtype(p))
+
+    def is_square(self, a):
+        """Returns True if ``a`` is a square modulo p. """
+        # TODO: Faster algorithm without computing sqrt, for example using
+        # Legendre symbol
+        return self.exsqrt(a) is not None
+
+    def exsqrt(self, a):
+        """Returns the square root of ``a`` modulo p that is no larger than
+        ``p // 2``, or ``None`` if it does not exist. """
+        # Factorize x**2 - a
+        poly = [x.val for x in [self.one, self.zero, -a]]
+        for factor in gf_zassenhaus(poly, self.mod, self.dom):
+            if len(factor) == 2 and factor[1] <= self.mod // 2:
+                return self.dtype(factor[1])
+        return None
 
 
 FF = GF = FiniteField

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -1,7 +1,7 @@
 """Ground types for various mathematical domains in SymPy. """
 
 import builtins
-from sympy.external.gmpy import HAS_GMPY, factorial, sqrt
+from sympy.external.gmpy import HAS_GMPY, factorial, sqrt, is_square, sqrtrem
 
 PythonInteger = builtins.int
 PythonReal = builtins.float
@@ -67,7 +67,7 @@ __all__ = [
     'gmpy_denom', 'gmpy_gcdex', 'gmpy_gcd', 'gmpy_lcm',
     'gmpy_qdiv',
 
-    'factorial', 'sqrt',
+    'factorial', 'sqrt', 'is_square', 'sqrtrem',
 
     'GMPYInteger', 'GMPYRational',
 ]

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -224,12 +224,22 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
         return sqrt(a)
 
     def is_square(self, a):
-        """Return ``True`` if ``a`` is a perfect square. """
+        """Return ``True`` if ``a`` is a square.
+
+        Explanation
+        ===========
+        An integer is a square if and only if there exists an integer
+        ``b`` such that ``b * b == a``.
+        """
         return is_square(a)
 
     def exsqrt(self, a):
-        """Compute the non-negative exact square root of ``a`` if it is a
-        perfect square, or return ``None`` if it isn't. """
+        """Non-negative square root of ``a`` if ``a`` is a square.
+
+        See also
+        ========
+        is_square
+        """
         if a < 0:
             return None
         root, rem = sqrtrem(a)

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -5,7 +5,7 @@ from sympy.external.gmpy import MPZ, HAS_GMPY
 from sympy.polys.domains.groundtypes import (
     SymPyInteger,
     factorial,
-    gcdex, gcd, lcm, sqrt,
+    gcdex, gcd, lcm, sqrt, is_square, sqrtrem,
 )
 
 from sympy.polys.domains.characteristiczero import CharacteristicZero
@@ -222,6 +222,20 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
     def sqrt(self, a):
         """Compute square root of ``a``. """
         return sqrt(a)
+
+    def is_square(self, a):
+        """Return ``True`` if ``a`` is a perfect square. """
+        return is_square(a)
+
+    def exsqrt(self, a):
+        """Compute the non-negative exact square root of ``a`` if it is a
+        perfect square, or return ``None`` if it isn't. """
+        if a < 0:
+            return None
+        root, rem = sqrtrem(a)
+        if rem != 0:
+            return None
+        return root
 
     def factorial(self, a):
         """Compute factorial of ``a``. """

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -160,12 +160,22 @@ class RationalField(Field, CharacteristicZero, SimpleDomain):
         return a.denominator
 
     def is_square(self, a):
-        """Return ``True`` if ``a`` is a perfect square. """
+        """Return ``True`` if ``a`` is a square.
+
+        Explanation
+        ===========
+        A rational number is a square if and only if there exists
+        a rational number ``b`` such that ``b * b == a``.
+        """
         return is_square(a.numerator) and is_square(a.denominator)
 
     def exsqrt(self, a):
-        """Compute the non-negative exact square root of ``a`` if it is a
-        perfect square, or return ``None`` if it isn't. """
+        """Non-negative square root of ``a`` if ``a`` is a square.
+
+        See also
+        ========
+        is_square
+        """
         if a.numerator < 0:  # denominator is always positive
             return None
         p_sqrt, p_rem = sqrtrem(a.numerator)

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -3,7 +3,7 @@
 
 from sympy.external.gmpy import MPQ
 
-from sympy.polys.domains.groundtypes import SymPyRational
+from sympy.polys.domains.groundtypes import SymPyRational, is_square, sqrtrem
 
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
@@ -159,5 +159,21 @@ class RationalField(Field, CharacteristicZero, SimpleDomain):
         """Returns denominator of ``a``. """
         return a.denominator
 
+    def is_square(self, a):
+        """Return ``True`` if ``a`` is a perfect square. """
+        return is_square(a.numerator) and is_square(a.denominator)
+
+    def exsqrt(self, a):
+        """Compute the non-negative exact square root of ``a`` if it is a
+        perfect square, or return ``None`` if it isn't. """
+        if a.numerator < 0:  # denominator is always positive
+            return None
+        p_sqrt, p_rem = sqrtrem(a.numerator)
+        if p_rem != 0:
+            return None
+        q_sqrt, q_rem = sqrtrem(a.denominator)
+        if q_rem != 0:
+            return None
+        return MPQ(p_sqrt, q_sqrt)
 
 QQ = RationalField()

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -129,13 +129,17 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         return self._context.almosteq(a, b, tolerance)
 
     def is_square(self, a):
-        """Returns ``True`` if and only if ``a`` is non-negative so that it
-        has a real square root"""
+        """Returns ``True`` if ``a >= 0`` and ``False`` otherwise. """
         return a >= 0
 
     def exsqrt(self, a):
-        """Returns the non-negative real square root of ``a`` if ``a`` is
-        non-negative, and ``None`` otherwise."""
+        """Non-negative square root for ``a >= 0`` and ``None`` otherwise.
+
+        Explanation
+        ===========
+        The square root may be slightly inaccurate due to floating point
+        rounding error.
+        """
         return a ** 0.5 if a >= 0 else None
 
 

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -128,5 +128,15 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         """Check if ``a`` and ``b`` are almost equal. """
         return self._context.almosteq(a, b, tolerance)
 
+    def is_square(self, a):
+        """Returns ``True`` if and only if ``a`` is non-negative so that it
+        has a real square root"""
+        return a >= 0
+
+    def exsqrt(self, a):
+        """Returns the non-negative real square root of ``a`` if ``a`` is
+        non-negative, and ``None`` otherwise."""
+        return a ** 0.5 if a >= 0 else None
+
 
 RR = RealField()

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1276,62 +1276,62 @@ def test_AlgebraicField_alias():
 
 
 def test_exsqrt():
-    assert ZZ.is_square(ZZ(4))
+    assert ZZ.is_square(ZZ(4)) is True
     assert ZZ.exsqrt(ZZ(4)) == ZZ(2)
-    assert not ZZ.is_square(ZZ(42))
+    assert ZZ.is_square(ZZ(42)) is False
     assert ZZ.exsqrt(ZZ(42)) is None
-    assert ZZ.is_square(ZZ(0))
+    assert ZZ.is_square(ZZ(0)) is True
     assert ZZ.exsqrt(ZZ(0)) == ZZ(0)
-    assert not ZZ.is_square(ZZ(-1))
+    assert ZZ.is_square(ZZ(-1)) is False
     assert ZZ.exsqrt(ZZ(-1)) is None
 
-    assert QQ.is_square(QQ(9, 4))
+    assert QQ.is_square(QQ(9, 4)) is True
     assert QQ.exsqrt(QQ(9, 4)) == QQ(3, 2)
-    assert QQ.is_square(QQ(18, 8))
+    assert QQ.is_square(QQ(18, 8)) is True
     assert QQ.exsqrt(QQ(18, 8)) == QQ(3, 2)
-    assert QQ.is_square(QQ(-9, -4))
+    assert QQ.is_square(QQ(-9, -4)) is True
     assert QQ.exsqrt(QQ(-9, -4)) == QQ(3, 2)
-    assert not QQ.is_square(QQ(11, 4))
+    assert QQ.is_square(QQ(11, 4)) is False
     assert QQ.exsqrt(QQ(11, 4)) is None
-    assert not QQ.is_square(QQ(9, 5))
+    assert QQ.is_square(QQ(9, 5)) is False
     assert QQ.exsqrt(QQ(9, 5)) is None
-    assert QQ.is_square(QQ(4))
+    assert QQ.is_square(QQ(4)) is True
     assert QQ.exsqrt(QQ(4)) == QQ(2)
-    assert QQ.is_square(QQ(0))
+    assert QQ.is_square(QQ(0)) is True
     assert QQ.exsqrt(QQ(0)) == QQ(0)
-    assert not QQ.is_square(QQ(-16, 9))
+    assert QQ.is_square(QQ(-16, 9)) is False
     assert QQ.exsqrt(QQ(-16, 9)) is None
 
-    assert RR.is_square(RR(6.25))
+    assert RR.is_square(RR(6.25)) is True
     assert RR.exsqrt(RR(6.25)) == RR(2.5)
-    assert RR.is_square(RR(2))
+    assert RR.is_square(RR(2)) is True
     assert RR.almosteq(RR.exsqrt(RR(2)), RR(1.4142135623730951), tolerance=1e-15)
-    assert RR.is_square(RR(0))
+    assert RR.is_square(RR(0)) is True
     assert RR.exsqrt(RR(0)) == RR(0)
-    assert not RR.is_square(RR(-1))
+    assert RR.is_square(RR(-1)) is False
     assert RR.exsqrt(RR(-1)) is None
 
-    assert CC.is_square(CC(2))
+    assert CC.is_square(CC(2)) is True
     assert CC.almosteq(CC.exsqrt(CC(2)), CC(1.4142135623730951), tolerance=1e-15)
-    assert CC.is_square(CC(0))
+    assert CC.is_square(CC(0)) is True
     assert CC.exsqrt(CC(0)) == CC(0)
-    assert CC.is_square(CC(-1))
+    assert CC.is_square(CC(-1)) is True
     assert CC.exsqrt(CC(-1)) == CC(0, 1)
-    assert CC.is_square(CC(0, 2))
+    assert CC.is_square(CC(0, 2)) is True
     assert CC.exsqrt(CC(0, 2)) == CC(1, 1)
-    assert CC.is_square(CC(-3, -4))
+    assert CC.is_square(CC(-3, -4)) is True
     assert CC.exsqrt(CC(-3, -4)) == CC(1, -2)
 
     F2 = FF(2)
-    assert F2.is_square(F2(1))
+    assert F2.is_square(F2(1)) is True
     assert F2.exsqrt(F2(1)) == F2(1)
-    assert F2.is_square(F2(0))
+    assert F2.is_square(F2(0)) is True
     assert F2.exsqrt(F2(0)) == F2(0)
 
     F7 = FF(7)
-    assert F7.is_square(F7(2))
+    assert F7.is_square(F7(2)) is True
     assert F7.exsqrt(F7(2)) == F7(3)
-    assert not F7.is_square(F7(3))
+    assert F7.is_square(F7(3)) is False
     assert F7.exsqrt(F7(3)) is None
-    assert F7.is_square(F7(0))
+    assert F7.is_square(F7(0)) is True
     assert F7.exsqrt(F7(0)) == F7(0)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1273,3 +1273,65 @@ def test_AlgebraicField_alias():
     k = QQ.algebraic_field(alpha)
     beta = k.to_alg_num(k([1, 2, 3]))
     assert beta.alias is alpha.alias
+
+
+def test_exsqrt():
+    assert ZZ.is_square(ZZ(4))
+    assert ZZ.exsqrt(ZZ(4)) == ZZ(2)
+    assert not ZZ.is_square(ZZ(42))
+    assert ZZ.exsqrt(ZZ(42)) is None
+    assert ZZ.is_square(ZZ(0))
+    assert ZZ.exsqrt(ZZ(0)) == ZZ(0)
+    assert not ZZ.is_square(ZZ(-1))
+    assert ZZ.exsqrt(ZZ(-1)) is None
+
+    assert QQ.is_square(QQ(9, 4))
+    assert QQ.exsqrt(QQ(9, 4)) == QQ(3, 2)
+    assert QQ.is_square(QQ(18, 8))
+    assert QQ.exsqrt(QQ(18, 8)) == QQ(3, 2)
+    assert QQ.is_square(QQ(-9, -4))
+    assert QQ.exsqrt(QQ(-9, -4)) == QQ(3, 2)
+    assert not QQ.is_square(QQ(11, 4))
+    assert QQ.exsqrt(QQ(11, 4)) is None
+    assert not QQ.is_square(QQ(9, 5))
+    assert QQ.exsqrt(QQ(9, 5)) is None
+    assert QQ.is_square(QQ(4))
+    assert QQ.exsqrt(QQ(4)) == QQ(2)
+    assert QQ.is_square(QQ(0))
+    assert QQ.exsqrt(QQ(0)) == QQ(0)
+    assert not QQ.is_square(QQ(-16, 9))
+    assert QQ.exsqrt(QQ(-16, 9)) is None
+
+    assert RR.is_square(RR(6.25))
+    assert RR.exsqrt(RR(6.25)) == RR(2.5)
+    assert RR.is_square(RR(2))
+    assert RR.almosteq(RR.exsqrt(RR(2)), RR(1.4142135623730951), tolerance=1e-15)
+    assert RR.is_square(RR(0))
+    assert RR.exsqrt(RR(0)) == RR(0)
+    assert not RR.is_square(RR(-1))
+    assert RR.exsqrt(RR(-1)) is None
+
+    assert CC.is_square(CC(2))
+    assert CC.almosteq(CC.exsqrt(CC(2)), CC(1.4142135623730951), tolerance=1e-15)
+    assert CC.is_square(CC(0))
+    assert CC.exsqrt(CC(0)) == CC(0)
+    assert CC.is_square(CC(-1))
+    assert CC.exsqrt(CC(-1)) == CC(0, 1)
+    assert CC.is_square(CC(0, 2))
+    assert CC.exsqrt(CC(0, 2)) == CC(1, 1)
+    assert CC.is_square(CC(-3, -4))
+    assert CC.exsqrt(CC(-3, -4)) == CC(1, -2)
+
+    F2 = FF(2)
+    assert F2.is_square(F2(1))
+    assert F2.exsqrt(F2(1)) == F2(1)
+    assert F2.is_square(F2(0))
+    assert F2.exsqrt(F2(0)) == F2(0)
+
+    F7 = FF(7)
+    assert F7.is_square(F7(2))
+    assert F7.exsqrt(F7(2)) == F7(3)
+    assert not F7.is_square(F7(3))
+    assert F7.exsqrt(F7(3)) is None
+    assert F7.is_square(F7(0))
+    assert F7.exsqrt(F7(0)) == F7(0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25094 

#### Brief description of what is fixed or changed
Added `is_square` to check if a ring element is a square, and `exsqrt` to compute an exact square root if it exists within the ring, for the abstract `Domain` base class, and each of `ZZ`, `QQ`, `RR`, `CC,` `FF`.

#### Other comments
For `FF`, trying to import `sympy.ntheory.residue_ntheory.sqrt_mod` will cause cyclic import error. So I have to resort to factorizing $x^2-a$. The time complexity of factorizing an $O(1)$ degree polynomial over $\mathbb{F}_p$ is $O(\log p)$ (see https://en.wikipedia.org/wiki/Factorization_of_polynomials_over_finite_fields), the same as most specialized modular square root algorithms, so there will be at most a constant factor slowdown.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added `is_square` and `exsqrt` methods for abstract `Domain` and `ZZ`, `QQ`, `RR`, `CC,` `FF`.
<!-- END RELEASE NOTES -->
