### PR TITLE
igcd/ilcm only calls gcd/lcm

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -426,10 +426,7 @@ def ilcm(*args):
     if len(args) < 2:
         raise TypeError(
             'ilcm() takes at least 2 arguments (%s given)' % len(args))
-    ret = int(number_lcm(*map(as_int, args)))
-    if issubclass(type(args[0]), Integer):
-        return Integer(ret)
-    return ret
+    return int(number_lcm(*map(as_int, args)))
 
 
 def igcdex(a, b):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -426,7 +426,10 @@ def ilcm(*args):
     if len(args) < 2:
         raise TypeError(
             'ilcm() takes at least 2 arguments (%s given)' % len(args))
-    return int(number_lcm(*map(as_int, args)))
+    ret = int(number_lcm(*map(as_int, args)))
+    if issubclass(type(args[0]), Integer):
+        return Integer(ret)
+    return ret
 
 
 def igcdex(a, b):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -19,7 +19,8 @@ from .cache import cacheit, clear_cache
 from .decorators import _sympifyit
 from .logic import fuzzy_not
 from .kind import NumberKind
-from sympy.external.gmpy import SYMPY_INTS, HAS_GMPY, gmpy
+from sympy.external.gmpy import (SYMPY_INTS, HAS_GMPY, gmpy,
+                                 gcd as number_gcd, lcm as number_lcm)
 from sympy.multipledispatch import dispatch
 import mpmath
 import mpmath.libmp as mlib
@@ -237,11 +238,6 @@ def igcd(*args):
     improve speed, ``igcd()`` has its own caching mechanism.
     If you do not need the cache mechanism, using ``sympy.external.gmpy.gcd``.
 
-    It is also possible to give symbolic arguments such as
-    ``sympy.core.numbers.Integer`` to compute gcd, but it is not recommended;
-    consider converting to ``int``, etc. and using
-    ``sympy.external.gmpy.gcd``.
-
     Examples
     ========
 
@@ -260,17 +256,7 @@ def igcd(*args):
     if len(args) < 2:
         raise TypeError(
             'igcd() takes at least 2 arguments (%s given)' % len(args))
-    args_temp = [abs(as_int(i)) for i in args]
-    if 1 in args_temp:
-        return 1
-    a = args_temp.pop()
-    if HAS_GMPY: # Using gmpy if present to speed up.
-        for b in args_temp:
-            a = gmpy.gcd(a, b) if b else a
-        return as_int(a)
-    for b in args_temp:
-        a = math.gcd(a, b)
-    return a
+    return int(number_gcd(*map(as_int, args)))
 
 
 igcd2 = math.gcd
@@ -425,10 +411,6 @@ def igcd_lehmer(a, b):
 def ilcm(*args):
     """Computes integer least common multiple.
 
-    It is retained for historical reasons,
-    but if there are no special needs,
-    please use ``sympy.external.gmpy.lcm``.
-
     Examples
     ========
 
@@ -444,12 +426,7 @@ def ilcm(*args):
     if len(args) < 2:
         raise TypeError(
             'ilcm() takes at least 2 arguments (%s given)' % len(args))
-    if 0 in args:
-        return 0
-    a = args[0]
-    for b in args[1:]:
-        a = a // igcd(a, b) * b # since gcd(a,b) | a
-    return a
+    return int(number_lcm(*map(as_int, args)))
 
 
 def igcdex(a, b):

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1187,7 +1187,7 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
             raise NotImplementedError("Cannot work with non-rational "
                 "coefficients in this case.")
         else:
-            n = reduce(ilcm, [i.as_numer_denom()[1] for i in u])
+            n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
             u *= n
             terms = ([DE.T[i] for i in DE.indices('exp')] +
                     [DE.extargs[i] for i in DE.indices('log')])
@@ -1305,7 +1305,7 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
             return None
         # Note: if residueterms = [], returns (1, 1)
         # f had better be 0 in that case.
-        n = reduce(ilcm, [i.as_numer_denom()[1] for _, i in residueterms], S.One)
+        n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for _, i in residueterms], 1)
         u = Mul(*[Pow(i, j*n) for i, j in residueterms])
         return (n, u)
 
@@ -1321,8 +1321,8 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
         raise ValueError("case must be one of {'primitive', 'exp', 'tan', "
         "'base', 'auto'}, not %s" % case)
 
-    common_denom = reduce(ilcm, [i.as_numer_denom()[1] for i in [j for _, j in
-        residueterms]] + [n], S.One)
+    common_denom = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in [j for _, j in
+        residueterms]] + [n], 1)
     residueterms = [(i, j*common_denom) for i, j in residueterms]
     m = common_denom//n
     if common_denom != n*m:  # Verify exact division


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25085

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `ilcm` now returns an int, not an Integer
<!-- END RELEASE NOTES -->
