### PR TITLE
Fixed bug with sqrt(a) factors in Erf/Fresnel rules

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1229,6 +1229,7 @@ Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>
 Sean Ge <seange727@gmail.com>
 Sean P. Cornelius <spcornelius@gmail.com>
 Sean Vig <sean.v.775@gmail.com>
+Seb Tiburzio <sebtiburzio@gmail.com>
 Sebastian East <sebastianeast@ymail.com> sebastian-east <sebastianeast@ymail.com>
 Sebastian Koslowski <koslowski@kit.edu>
 Sebastian Krause <sebastian.krause@gmx.de>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -659,11 +659,11 @@ class ErfRule(AtomicRule):
         a, b, c, x = self.a, self.b, self.c, self.variable
         if a.is_extended_real:
             return Piecewise(
-                (sqrt(S.Pi/(-a))/2 * exp(c - b**2/(4*a)) *
+                (sqrt(S.Pi)/sqrt(-a)/2 * exp(c - b**2/(4*a)) *
                     erf((-2*a*x - b)/(2*sqrt(-a))), a < 0),
-                (sqrt(S.Pi/a)/2 * exp(c - b**2/(4*a)) *
+                (sqrt(S.Pi)/sqrt(a)/2 * exp(c - b**2/(4*a)) *
                     erfi((2*a*x + b)/(2*sqrt(a))), True))
-        return sqrt(S.Pi/a)/2 * exp(c - b**2/(4*a)) * \
+        return sqrt(S.Pi)/sqrt(a)/2 * exp(c - b**2/(4*a)) * \
                 erfi((2*a*x + b)/(2*sqrt(a)))
 
 
@@ -675,7 +675,7 @@ class FresnelCRule(AtomicRule):
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
-        return sqrt(S.Pi/(2*a)) * (
+        return sqrt(S.Pi)/sqrt(2*a) * (
             cos(b**2/(4*a) - c)*fresnelc((2*a*x + b)/sqrt(2*a*S.Pi)) +
             sin(b**2/(4*a) - c)*fresnels((2*a*x + b)/sqrt(2*a*S.Pi)))
 
@@ -688,7 +688,7 @@ class FresnelSRule(AtomicRule):
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
-        return sqrt(S.Pi/(2*a)) * (
+        return sqrt(S.Pi)/sqrt(2*a) * (
             cos(b**2/(4*a) - c)*fresnels((2*a*x + b)/sqrt(2*a*S.Pi)) -
             sin(b**2/(4*a) - c)*fresnelc((2*a*x + b)/sqrt(2*a*S.Pi)))
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1662,8 +1662,8 @@ def test_integrate_with_complex_constants():
     x = Symbol('x', real=True)
     m = Symbol('m', real=True)
     t = Symbol('t', real=True)
-    assert integrate(exp(-I*K*x**2+m*x), x) == sqrt(I)*sqrt(pi)*exp(-I*m**2
-                    /(4*K))*erfi((-2*I*K*x + m)/(2*sqrt(K)*sqrt(-I)))/(2*sqrt(K))
+    assert integrate(exp(-I*K*x**2+m*x), x) == sqrt(pi)*exp(-I*m**2
+                    /(4*K))*erfi((-2*I*K*x + m)/(2*sqrt(K)*sqrt(-I)))/(2*sqrt(K)*sqrt(-I))
     assert integrate(1/(1 + I*x**2), x) == (-I*(sqrt(-I)*log(x - I*sqrt(-I))/2
             - sqrt(-I)*log(x + I*sqrt(-I))/2))
     assert integrate(exp(-I*x**2), x) == sqrt(pi)*erf(sqrt(I)*x)/(2*sqrt(I))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -600,6 +600,20 @@ def test_issue_23566():
     assert i == -log(4 - 2*sqrt(3)) + log(2)
     assert str(i.n()) == '1.31695789692482'
 
+def test_issue_25090():
+    a, b, x = symbols('a b x')
+    assert manualintegrate(exp(a*x**2 + b), x) == sqrt(pi)*exp(b)*erfi(sqrt(a)*x)/(2*sqrt(a))
+    assert manualintegrate(sin(a*x**2 + b), x) == \
+        sqrt(2)*sqrt(pi)*(sin(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
+    assert manualintegrate(cos(a*x**2 + b), x) == \
+        sqrt(2)*sqrt(pi)*(-sin(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
+    a = Symbol('a', negative=True)
+    assert manualintegrate(exp(a*x**2 + b), x) == -sqrt(pi)*exp(b)*erf(a*x/sqrt(-a))/(2*sqrt(-a))
+    assert manualintegrate(sin(a*x**2 + b), x) == \
+        sqrt(2)*sqrt(pi)*(sin(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
+    assert manualintegrate(cos(a*x**2 + b), x) == \
+        sqrt(2)*sqrt(pi)*(-sin(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
+
 
 def test_nested_pow():
     assert_is_integral_of(sqrt(x**2), x*sqrt(x**2)/2)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -600,7 +600,7 @@ def test_issue_23566():
     assert i == -log(4 - 2*sqrt(3)) + log(2)
     assert str(i.n()) == '1.31695789692482'
 
-def test_issue_25090():
+def test_issue_25093():
     a, b, x = symbols('a b x')
     assert manualintegrate(exp(a*x**2 + b), x) == sqrt(pi)*exp(b)*erfi(sqrt(a)*x)/(2*sqrt(a))
     assert manualintegrate(sin(a*x**2 + b), x) == \

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -600,19 +600,19 @@ def test_issue_23566():
     assert i == -log(4 - 2*sqrt(3)) + log(2)
     assert str(i.n()) == '1.31695789692482'
 
+
 def test_issue_25093():
-    a, b, x = symbols('a b x')
+    ap = Symbol('ap', positive=True)
+    an = Symbol('an', negative=True)
     assert manualintegrate(exp(a*x**2 + b), x) == sqrt(pi)*exp(b)*erfi(sqrt(a)*x)/(2*sqrt(a))
-    assert manualintegrate(sin(a*x**2 + b), x) == \
-        sqrt(2)*sqrt(pi)*(sin(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
-    assert manualintegrate(cos(a*x**2 + b), x) == \
-        sqrt(2)*sqrt(pi)*(-sin(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
-    a = Symbol('a', negative=True)
-    assert manualintegrate(exp(a*x**2 + b), x) == -sqrt(pi)*exp(b)*erf(a*x/sqrt(-a))/(2*sqrt(-a))
-    assert manualintegrate(sin(a*x**2 + b), x) == \
-        sqrt(2)*sqrt(pi)*(sin(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
-    assert manualintegrate(cos(a*x**2 + b), x) == \
-        sqrt(2)*sqrt(pi)*(-sin(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)) + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a))
+    assert manualintegrate(exp(ap*x**2 + b), x) == sqrt(pi)*exp(b)*erfi(sqrt(ap)*x)/(2*sqrt(ap))
+    assert manualintegrate(exp(an*x**2 + b), x) == -sqrt(pi)*exp(b)*erf(an*x/sqrt(-an))/(2*sqrt(-an))
+    assert manualintegrate(sin(a*x**2 + b), x) == (
+        sqrt(2)*sqrt(pi)*(sin(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi))
+        + cos(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a)))
+    assert manualintegrate(cos(a*x**2 + b), x) == (
+        sqrt(2)*sqrt(pi)*(-sin(b)*fresnels(sqrt(2)*sqrt(a)*x/sqrt(pi))
+        + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a)))
 
 
 def test_nested_pow():


### PR DESCRIPTION
#### References to other Issues or PRs
"Fixes #25093"

#### Brief description of what is fixed or changed
`ErfRule()`, `FresnelSRule()` and `FresenelCRule()` modified to use factors of `sqrt(pi)/sqrt(a)` instead of `sqrt(pi/a)`. This gives a correct result when `a` is negative.

Tests added to `test_manual.py` that check correctness of the result for negative `a`.

One test in `test_integrals.py` updated to pass with the new formulation.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed bug with `sqrt(a)` factors in Erf/Fresnel rules to give correct result for negative `a`
<!-- END RELEASE NOTES -->