### PR TITLE
Add simple pickle compatibility to ReferenceFrame

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -60,6 +60,9 @@ class CoordinateSym(Symbol):
         obj._id = (frame, index)
         return obj
 
+    def __getnewargs_ex__(self):
+        return (self.name, *self._id), {}
+
     @property
     def frame(self):
         return self._id[0]

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -12,6 +12,7 @@ from sympy.physics.vector.frame import _check_frame
 from sympy.physics.vector.vector import VectorTypeError
 from sympy.testing.pytest import raises
 import warnings
+import pickle
 
 
 def test_dict_list():
@@ -720,3 +721,13 @@ def test_unit_dyadic():
     F = ReferenceFrame('F', indices=['1', '2', '3'])
     assert N.u == N.xx + N.yy + N.zz
     assert F.u == F.xx + F.yy + F.zz
+
+
+def test_pickle_frame():
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+    A.orient_axis(N, N.x, 1)
+    A_C_N = A.dcm(N)
+    N1 = pickle.loads(pickle.dumps(N))
+    A1 = tuple(N1._dcm_dict.keys())[0]
+    assert A1.dcm(N1) == A_C_N


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially fixes [#279 from dill](https://github.com/uqfoundation/dill/issues/279).

#### Brief description of what is fixed or changed
Implement a `__getnewargs_ex__` in `CoordinateSym` to enable some simple pickling of reference frames. One should however note that a `ReferenceFrame` is not exactly the same after de-serialization as before, due to the hash being based on the memory location. Another problem is that `dynamicsymbols` are not pickable, as described in #4297 (this last problem seems to be fixed in `cloudpickle`). An option I looked into for solving the hash problem, namely creating a `_hash` attribute did not work well, due to having a bi-directional graph that uses dictionaries (and so the hashes).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
