### PR TITLE
Improve type inference for user code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,15 @@ module = [
 ]
 ignore_missing_imports = true
 
+# pyright type checker settings:
+[tool.pyright]
+include = ["sympy"]
+
+# This complains when self or cls is not used as the parameter name for an
+# instance method or class method. Since this is used a lot in SymPy we disable
+# this check.
+reportSelfClsParameterName = false
+
 [tool.slotscheck]
 strict-imports = true
 exclude-modules = '''

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from itertools import chain, zip_longest
 from functools import cmp_to_key
+from typing import TYPE_CHECKING
 
 from .assumptions import _prepare_class_assumptions
 from .cache import cacheit
@@ -19,6 +20,11 @@ from sympy.utilities.iterables import iterable, numbered_symbols
 from sympy.utilities.misc import filldedent, func_name
 
 from inspect import getmro
+
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+    from .assumptions import StdFactKB
 
 
 def as_Basic(expr):
@@ -218,11 +224,40 @@ class Basic(Printable):
     is_Point = False
     is_MatAdd = False
     is_MatMul = False
-    is_real: bool | None
-    is_extended_real: bool | None
-    is_zero: bool | None
+
+    default_assumptions: ClassVar[StdFactKB]
+
+    is_composite: bool | None
+    is_noninteger: bool | None
+    is_extended_positive: bool | None
     is_negative: bool | None
+    is_complex: bool | None
+    is_extended_nonpositive: bool | None
+    is_integer: bool | None
+    is_positive: bool | None
+    is_rational: bool | None
+    is_extended_nonnegative: bool | None
+    is_infinite: bool | None
+    is_antihermitian: bool | None
+    is_extended_negative: bool | None
+    is_extended_real: bool | None
+    is_finite: bool | None
+    is_polar: bool | None
+    is_imaginary: bool | None
+    is_transcendental: bool | None
+    is_extended_nonzero: bool | None
+    is_nonzero: bool | None
+    is_odd: bool | None
+    is_algebraic: bool | None
+    is_prime: bool | None
     is_commutative: bool | None
+    is_nonnegative: bool | None
+    is_nonpositive: bool | None
+    is_hermitian: bool | None
+    is_irrational: bool | None
+    is_real: bool | None
+    is_zero: bool | None
+    is_even: bool | None
 
     kind: Kind = UndefinedKind
 

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -5,8 +5,19 @@ The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from functools import wraps
 from .sympify import SympifyError, sympify
+
+
+if TYPE_CHECKING:
+    from typing import Callable, TypeVar, Union
+    T1 = TypeVar('T1')
+    T2 = TypeVar('T2')
+    T3 = TypeVar('T3')
 
 
 def _sympifyit(arg, retval=None):
@@ -69,7 +80,8 @@ def __sympifyit(func, arg, retval=None):
     return __sympifyit_wrapper
 
 
-def call_highest_priority(method_name):
+def call_highest_priority(method_name: str
+    ) -> Callable[[Callable[[T1, T2], T3]], Callable[[T1, T2], T3]]:
     """A decorator for binary special methods to handle _op_priority.
 
     Explanation
@@ -95,12 +107,12 @@ def call_highest_priority(method_name):
         def __rmul__(self, other):
         ...
     """
-    def priority_decorator(func):
+    def priority_decorator(func: Callable[[T1, T2], T3]) -> Callable[[T1, T2], T3]:
         @wraps(func)
-        def binary_op_wrapper(self, other):
+        def binary_op_wrapper(self: T1, other: T2) -> T3:
             if hasattr(other, '_op_priority'):
-                if other._op_priority > self._op_priority:
-                    f = getattr(other, method_name, None)
+                if other._op_priority > self._op_priority:  # type: ignore
+                    f: Union[Callable[[T1], T3], None] = getattr(other, method_name, None)
                     if f is not None:
                         return f(self)
             return func(self, other)
@@ -187,8 +199,8 @@ def sympify_return(*args):
     See the docstring of sympify_method_args for explanation.
     '''
     # Store a wrapper object for the decorated method
-    def wrapper(func):
-        return _SympifyWrapper(func, args)
+    def wrapper(func: Callable[[T1, T2], T3]) -> Callable[[T1, T2], T3]:
+        return _SympifyWrapper(func, args)  # type: ignore
     return wrapper
 
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -179,10 +179,10 @@ class Expr(Basic, EvalfMixin):
     def _mul_handler(self):
         return Mul
 
-    def __pos__(self):
+    def __pos__(self) -> Expr:
         return self
 
-    def __neg__(self):
+    def __neg__(self) -> Expr:
         # Mul has its own __neg__ routine, so we just
         # create a 2-args Mul with the -1 in the canonical
         # slot 0.
@@ -195,32 +195,32 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__radd__')
-    def __add__(self, other):
+    def __add__(self, other) -> Expr:
         return Add(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__add__')
-    def __radd__(self, other):
+    def __radd__(self, other) -> Expr:
         return Add(other, self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rsub__')
-    def __sub__(self, other):
+    def __sub__(self, other) -> Expr:
         return Add(self, -other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__sub__')
-    def __rsub__(self, other):
+    def __rsub__(self, other) -> Expr:
         return Add(other, -self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmul__')
-    def __mul__(self, other):
+    def __mul__(self, other) -> Expr:
         return Mul(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__mul__')
-    def __rmul__(self, other):
+    def __rmul__(self, other) -> Expr:
         return Mul(other, self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
@@ -246,12 +246,12 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__pow__')
-    def __rpow__(self, other):
+    def __rpow__(self, other) -> Expr:
         return Pow(other, self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rtruediv__')
-    def __truediv__(self, other):
+    def __truediv__(self, other) -> Expr:
         denom = Pow(other, S.NegativeOne)
         if self is S.One:
             return denom
@@ -260,7 +260,7 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__truediv__')
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other) -> Expr:
         denom = Pow(self, S.NegativeOne)
         if other is S.One:
             return denom
@@ -269,40 +269,40 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmod__')
-    def __mod__(self, other):
+    def __mod__(self, other) -> Expr:
         return Mod(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__mod__')
-    def __rmod__(self, other):
+    def __rmod__(self, other) -> Expr:
         return Mod(other, self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rfloordiv__')
-    def __floordiv__(self, other):
+    def __floordiv__(self, other) -> Expr:
         from sympy.functions.elementary.integers import floor
         return floor(self / other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__floordiv__')
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other) -> Expr:
         from sympy.functions.elementary.integers import floor
         return floor(other / self)
 
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rdivmod__')
-    def __divmod__(self, other):
+    def __divmod__(self, other) -> tuple[Expr, Expr]:
         from sympy.functions.elementary.integers import floor
         return floor(self / other), Mod(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__divmod__')
-    def __rdivmod__(self, other):
+    def __rdivmod__(self, other) -> tuple[Expr, Expr]:
         from sympy.functions.elementary.integers import floor
         return floor(other / self), Mod(other, self)
 
-    def __int__(self):
+    def __int__(self) -> int:
         if not self.is_number:
             raise TypeError("Cannot convert symbols to int")
         r = self.round(2)
@@ -328,7 +328,7 @@ class Expr(Basic, EvalfMixin):
             return i - (1 if i > 0 else -1)
         return i
 
-    def __float__(self):
+    def __float__(self) -> float:
         # Don't bother testing if it's a number; if it's not this is going
         # to fail, and if it is we still need to check that it evalf'ed to
         # a number.
@@ -339,7 +339,7 @@ class Expr(Basic, EvalfMixin):
             raise TypeError("Cannot convert complex to float")
         raise TypeError("Cannot convert expression to float")
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         result = self.evalf()
         re, im = result.as_real_imag()
         return complex(float(re), float(im))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -440,10 +440,10 @@ class Function(Application, Expr):
         return False
 
     @cacheit
-    def __new__(cls, *args, **options):
+    def __new__(cls, *args, **options) -> Function:
         # Handle calls like Function('f')
         if cls is Function:
-            return UndefinedFunction(*args, **options)
+            return UndefinedFunction(*args, **options)  # type: ignore
 
         n = len(args)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -440,11 +440,15 @@ class Function(Application, Expr):
         return False
 
     @cacheit
-    def __new__(cls, *args, **options) -> Function:
+    def __new__(cls, *args, **options) -> type[AppliedUndef]:  # type: ignore
         # Handle calls like Function('f')
         if cls is Function:
             return UndefinedFunction(*args, **options)  # type: ignore
+        else:
+            return cls._new_(*args, **options)  # type: ignore
 
+    @classmethod
+    def _new_(cls, *args, **options) -> Expr:
         n = len(args)
 
         if not cls._valid_nargs(n):
@@ -809,6 +813,14 @@ class Function(Application, Expr):
             return self
 
 
+class DefinedFunction(Function):
+    """Base class for defined functions like ``sin``, ``cos``, ..."""
+
+    @cacheit
+    def __new__(cls, *args, **options) -> Expr:  # type: ignore
+        return cls._new_(*args, **options)
+
+
 class AppliedUndef(Function):
     """
     Base class for expressions resulting from the application of an undefined
@@ -817,13 +829,13 @@ class AppliedUndef(Function):
 
     is_number = False
 
-    def __new__(cls, *args, **options):
-        args = list(map(sympify, args))
+    def __new__(cls, *args, **options) -> Expr:  # type: ignore
+        args = tuple(map(sympify, args))
         u = [a.name for a in args if isinstance(a, UndefinedFunction)]
         if u:
             raise TypeError('Invalid argument: expecting an expression, not UndefinedFunction%s: %s' % (
                 's'*(len(u) > 1), ', '.join(u)))
-        obj = super().__new__(cls, *args, **options)
+        obj: Expr = super().__new__(cls, *args, **options)  # type: ignore
         return obj
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
@@ -862,11 +874,15 @@ class UndefSageHelper:
 
 _undef_sage_helper = UndefSageHelper()
 
+
 class UndefinedFunction(FunctionClass):
     """
     The (meta)class of undefined functions.
     """
-    def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs):
+    name: str
+    _sage_: UndefSageHelper
+
+    def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs) -> type[AppliedUndef]:
         from .symbol import _filter_assumptions
         # Allow Function('f', real=True)
         # and/or Function(Symbol('f', real=True))
@@ -894,10 +910,10 @@ class UndefinedFunction(FunctionClass):
         __dict__.update({'_kwargs': kwargs})
         # do this for pickling
         __dict__['__module__'] = None
-        obj = super().__new__(mcl, name, bases, __dict__)
+        obj = super().__new__(mcl, name, bases, __dict__)  # type: ignore
         obj.name = name
         obj._sage_ = _undef_sage_helper
-        return obj
+        return obj  # type: ignore
 
     def __instancecheck__(cls, instance):
         return cls in type(instance).__mro__

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,6 +1,6 @@
 from .add import Add
 from .exprtools import gcd_terms
-from .function import Function
+from .function import DefinedFunction
 from .kind import NumberKind
 from .logic import fuzzy_and, fuzzy_not
 from .mul import Mul
@@ -8,7 +8,7 @@ from .numbers import equal_valued
 from .singleton import S
 
 
-class Mod(Function):
+class Mod(DefinedFunction):
     """Represents a modulo operation on symbolic expressions.
 
     Parameters

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -655,6 +655,11 @@ def test_sympy__core__function__AppliedUndef():
     assert _test_args(AppliedUndef(1, 2, 3))
 
 
+def test_sympy__core__function__DefinedFunction():
+    from sympy.core.function import DefinedFunction
+    assert _test_args(DefinedFunction(1, 2, 3))
+
+
 def test_sympy__core__function__Derivative():
     from sympy.core.function import Derivative
     assert _test_args(Derivative(2, x, y, 3))

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -3,7 +3,7 @@ from functools import reduce
 
 from sympy.core import S, sympify, Dummy, Mod
 from sympy.core.cache import cacheit
-from sympy.core.function import Function, ArgumentIndexError, PoleError
+from sympy.core.function import DefinedFunction, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import Integer, pi, I
 from sympy.core.relational import Eq
@@ -14,7 +14,7 @@ from sympy.polys.polytools import Poly
 
 from math import factorial as _factorial, prod, sqrt as _sqrt
 
-class CombinatorialFunction(Function):
+class CombinatorialFunction(DefinedFunction):
     """Base class for combinatorial functions. """
 
     def _eval_simplify(self, **kwargs):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -14,7 +14,7 @@ from sympy.core import S, Symbol, Add, Dummy
 from sympy.core.cache import cacheit
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
-from sympy.core.function import ArgumentIndexError, Function, expand_mul
+from sympy.core.function import ArgumentIndexError, DefinedFunction, expand_mul
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import E, I, pi, oo, Rational, Integer
@@ -55,7 +55,7 @@ _sym = Symbol('x')
 #                                                                            #
 #----------------------------------------------------------------------------#
 
-class carmichael(Function):
+class carmichael(DefinedFunction):
     r"""
     Carmichael Numbers:
 
@@ -185,7 +185,7 @@ directly instead.
 #----------------------------------------------------------------------------#
 
 
-class fibonacci(Function):
+class fibonacci(DefinedFunction):
     r"""
     Fibonacci numbers / Fibonacci polynomials
 
@@ -273,7 +273,7 @@ class fibonacci(Function):
 #----------------------------------------------------------------------------#
 
 
-class lucas(Function):
+class lucas(DefinedFunction):
     """
     Lucas numbers
 
@@ -325,7 +325,7 @@ class lucas(Function):
 #----------------------------------------------------------------------------#
 
 
-class tribonacci(Function):
+class tribonacci(DefinedFunction):
     r"""
     Tribonacci numbers / Tribonacci polynomials
 
@@ -415,7 +415,7 @@ class tribonacci(Function):
 #----------------------------------------------------------------------------#
 
 
-class bernoulli(Function):
+class bernoulli(DefinedFunction):
     r"""
     Bernoulli numbers / Bernoulli polynomials / Bernoulli function
 
@@ -605,7 +605,7 @@ class bernoulli(Function):
 #----------------------------------------------------------------------------#
 
 
-class bell(Function):
+class bell(DefinedFunction):
     r"""
     Bell numbers / Bell polynomials
 
@@ -758,7 +758,7 @@ class bell(Function):
 #----------------------------------------------------------------------------#
 
 
-class harmonic(Function):
+class harmonic(DefinedFunction):
     r"""
     Harmonic numbers
 
@@ -1023,7 +1023,7 @@ class harmonic(Function):
 #----------------------------------------------------------------------------#
 
 
-class euler(Function):
+class euler(DefinedFunction):
     r"""
     Euler numbers / Euler polynomials / Euler function
 
@@ -1180,7 +1180,7 @@ class euler(Function):
 #----------------------------------------------------------------------------#
 
 
-class catalan(Function):
+class catalan(DefinedFunction):
     r"""
     Catalan numbers
 
@@ -1326,7 +1326,7 @@ class catalan(Function):
 #----------------------------------------------------------------------------#
 
 
-class genocchi(Function):
+class genocchi(DefinedFunction):
     r"""
     Genocchi numbers / Genocchi polynomials / Genocchi function
 
@@ -1466,7 +1466,7 @@ class genocchi(Function):
 #----------------------------------------------------------------------------#
 
 
-class andre(Function):
+class andre(DefinedFunction):
     r"""
     Andre numbers / Andre function
 
@@ -1580,8 +1580,7 @@ class andre(Function):
 #                                                                            #
 #----------------------------------------------------------------------------#
 
-
-class partition(Function):
+class partition(DefinedFunction):
     r"""
     Partition numbers
 
@@ -2925,7 +2924,7 @@ def nT(n, k=None):
 #-----------------------------------------------------------------------------#
 
 
-class motzkin(Function):
+class motzkin(DefinedFunction):
     """
     The nth Motzkin number is the number
     of ways of drawing non-intersecting chords

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1631,7 +1631,7 @@ class partition(DefinedFunction):
             return True
 
 
-class divisor_sigma(Function):
+class divisor_sigma(DefinedFunction):
     r"""
     Calculate the divisor function `\sigma_k(n)` for positive integer n
 
@@ -1698,7 +1698,7 @@ class divisor_sigma(Function):
                 return Mul(*[cancel((p**(k*(e + 1)) - 1) / (p**k - 1)) for p, e in factorint(n).items()])
 
 
-class udivisor_sigma(Function):
+class udivisor_sigma(DefinedFunction):
     r"""
     Calculate the unitary divisor function `\sigma_k^*(n)` for positive integer n
 
@@ -1770,7 +1770,7 @@ class udivisor_sigma(Function):
             return Mul(*[1+p**(k*e) for p, e in factorint(n).items()])
 
 
-class legendre_symbol(Function):
+class legendre_symbol(DefinedFunction):
     r"""
     Returns the Legendre symbol `(a / p)`.
 
@@ -1818,7 +1818,7 @@ class legendre_symbol(Function):
             return S(legendre(as_int(a), as_int(p)))
 
 
-class jacobi_symbol(Function):
+class jacobi_symbol(DefinedFunction):
     r"""
     Returns the Jacobi symbol `(m / n)`.
 
@@ -1889,7 +1889,7 @@ class jacobi_symbol(Function):
             return S(jacobi(as_int(m), as_int(n)))
 
 
-class kronecker_symbol(Function):
+class kronecker_symbol(DefinedFunction):
     r"""
     Returns the Kronecker symbol `(a / n)`.
 
@@ -1928,7 +1928,7 @@ class kronecker_symbol(Function):
             return S(kronecker(as_int(a), as_int(n)))
 
 
-class mobius(Function):
+class mobius(DefinedFunction):
     """
     Mobius function maps natural number to {-1, 0, 1}
 
@@ -2008,7 +2008,7 @@ class mobius(Function):
         return result
 
 
-class primenu(Function):
+class primenu(DefinedFunction):
     r"""
     Calculate the number of distinct prime factors for a positive integer n.
 
@@ -2060,7 +2060,7 @@ class primenu(Function):
             return S(len(factorint(n)))
 
 
-class primeomega(Function):
+class primeomega(DefinedFunction):
     r"""
     Calculate the number of prime factors counting multiplicities for a
     positive integer n.
@@ -2113,7 +2113,7 @@ class primeomega(Function):
             return S(sum(factorint(n).values()))
 
 
-class totient(Function):
+class totient(DefinedFunction):
     r"""
     Calculate the Euler totient function phi(n)
 
@@ -2163,7 +2163,7 @@ class totient(Function):
             return S(prod(p**(k-1)*(p-1) for p, k in factorint(n).items()))
 
 
-class reduced_totient(Function):
+class reduced_totient(DefinedFunction):
     r"""
     Calculate the Carmichael reduced totient function lambda(n)
 
@@ -2221,7 +2221,7 @@ class reduced_totient(Function):
             return S(lcm(t, *((p-1)*p**(k-1) for p, k in factorint(n).items())))
 
 
-class primepi(Function):
+class primepi(DefinedFunction):
     r""" Represents the prime counting function pi(n) = the number
     of prime numbers less than or equal to n.
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -3,7 +3,7 @@ from typing import Tuple as tTuple
 from sympy.core import S, Add, Mul, sympify, Symbol, Dummy, Basic
 from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
-from sympy.core.function import (Function, Derivative, ArgumentIndexError,
+from sympy.core.function import (DefinedFunction, Derivative, ArgumentIndexError,
     AppliedUndef, expand_mul, PoleError)
 from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.core.numbers import pi, I, oo
@@ -17,7 +17,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 ###############################################################################
 
 
-class re(Function):
+class re(DefinedFunction):
     """
     Returns real part of expression. This function performs only
     elementary analysis and so it will fail to decompose properly
@@ -139,7 +139,7 @@ class re(Function):
             return True
 
 
-class im(Function):
+class im(DefinedFunction):
     """
     Returns imaginary part of expression. This function performs only
     elementary analysis and so it will fail to decompose properly more
@@ -262,7 +262,7 @@ class im(Function):
 ############### SIGN, ABSOLUTE VALUE, ARGUMENT and CONJUGATION ################
 ###############################################################################
 
-class sign(Function):
+class sign(DefinedFunction):
     """
     Returns the complex sign of an expression:
 
@@ -443,7 +443,7 @@ class sign(Function):
         return self.func(factor_terms(self.args[0]))  # XXX include doit?
 
 
-class Abs(Function):
+class Abs(DefinedFunction):
     """
     Return the absolute value of the argument.
 
@@ -693,7 +693,7 @@ class Abs(Function):
         return sqrt(arg*conjugate(arg))
 
 
-class arg(Function):
+class arg(DefinedFunction):
     r"""
     Returns the argument (in radians) of a complex number. The argument is
     evaluated in consistent convention with ``atan2`` where the branch-cut is
@@ -817,7 +817,7 @@ class arg(Function):
         return self._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
 
-class conjugate(Function):
+class conjugate(DefinedFunction):
     """
     Returns the *complex conjugate* [1]_ of an argument.
     In mathematics, the complex conjugate of a complex number
@@ -894,7 +894,7 @@ class conjugate(Function):
         return self.args[0].is_algebraic
 
 
-class transpose(Function):
+class transpose(DefinedFunction):
     """
     Linear map transposition.
 
@@ -951,7 +951,7 @@ class transpose(Function):
         return self.args[0]
 
 
-class adjoint(Function):
+class adjoint(DefinedFunction):
     """
     Conjugate transpose or Hermite conjugation.
 
@@ -1017,7 +1017,7 @@ class adjoint(Function):
 ###############################################################################
 
 
-class polar_lift(Function):
+class polar_lift(DefinedFunction):
     """
     Lift argument to the Riemann surface of the logarithm, using the
     standard branch.
@@ -1102,7 +1102,7 @@ class polar_lift(Function):
         return Abs(self.args[0], evaluate=True)
 
 
-class periodic_argument(Function):
+class periodic_argument(DefinedFunction):
     r"""
     Represent the argument on a quotient of the Riemann surface of the
     logarithm. That is, given a period $P$, always return a value in
@@ -1230,7 +1230,7 @@ def unbranched_argument(arg):
     return periodic_argument(arg, oo)
 
 
-class principal_branch(Function):
+class principal_branch(DefinedFunction):
     """
     Represent a polar number reduced to its principal branch on a quotient
     of the Riemann surface of the logarithm.

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -4,7 +4,7 @@ from typing import Tuple as tTuple
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
-from sympy.core.function import (Function, ArgumentIndexError, expand_log,
+from sympy.core.function import (DefinedFunction, ArgumentIndexError, expand_log,
     expand_mul, FunctionClass, PoleError, expand_multinomial, expand_complex)
 from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.core.mul import Mul
@@ -32,7 +32,7 @@ from sympy.ntheory.factor_ import factorint
 # p.is_positive.]
 
 
-class ExpBase(Function):
+class ExpBase(DefinedFunction):
 
     unbranched = True
     _singularities = (S.ComplexInfinity,)
@@ -447,7 +447,7 @@ class exp(ExpBase, metaclass=ExpMeta):
 
         if old is exp and not new.is_Function:
             return new**self.exp._subs(old, new)
-        return Function._eval_subs(self, old, new)
+        return super()._eval_subs(old, new)
 
     def _eval_is_extended_real(self):
         if self.args[0].is_extended_real:
@@ -604,7 +604,7 @@ def match_real_imag(expr):
         return (None, None) # simpler to check for than None
 
 
-class log(Function):
+class log(DefinedFunction):
     r"""
     The natural logarithm function `\ln(x)` or `\log(x)`.
 
@@ -1105,7 +1105,7 @@ class log(Function):
         return res
 
 
-class LambertW(Function):
+class LambertW(DefinedFunction):
     r"""
     The Lambert W function $W(z)$ is defined as the inverse
     function of $w \exp(w)$ [1]_.

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1,6 +1,6 @@
 from sympy.core import S, sympify, cacheit
 from sympy.core.add import Add
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.logic import fuzzy_or, fuzzy_and, fuzzy_not, FuzzyBool
 from sympy.core.numbers import I, pi, Rational
 from sympy.core.symbol import Dummy
@@ -103,7 +103,7 @@ def _asech_table():
 ###############################################################################
 
 
-class HyperbolicFunction(Function):
+class HyperbolicFunction(DefinedFunction):
     """
     Base class for hyperbolic functions.
 
@@ -1197,7 +1197,7 @@ class sech(ReciprocalHyperbolicFunction):
 ############################# HYPERBOLIC INVERSES #############################
 ###############################################################################
 
-class InverseHyperbolicFunction(Function):
+class InverseHyperbolicFunction(DefinedFunction):
     """Base class for inverse hyperbolic functions."""
 
     pass
@@ -1330,7 +1330,7 @@ class asinh(InverseHyperbolicFunction):
         if arg0 in (I, -I):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 
@@ -1516,7 +1516,7 @@ class acosh(InverseHyperbolicFunction):
         if arg0 in (S.One, S.NegativeOne):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 
@@ -1687,7 +1687,7 @@ class atanh(InverseHyperbolicFunction):
         if arg0 in (S.One, S.NegativeOne):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 
@@ -1839,7 +1839,7 @@ class acoth(InverseHyperbolicFunction):
         if arg0 in (S.One, S.NegativeOne):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 
@@ -2030,7 +2030,7 @@ class asech(InverseHyperbolicFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 
@@ -2234,7 +2234,7 @@ class acsch(InverseHyperbolicFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -5,7 +5,7 @@ from sympy.core.expr import Expr
 
 from sympy.core import Add, S
 from sympy.core.evalf import get_integer_part, PrecisionExhausted
-from sympy.core.function import Function
+from sympy.core.function import DefinedFunction
 from sympy.core.logic import fuzzy_or
 from sympy.core.numbers import Integer, int_valued
 from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
@@ -18,7 +18,7 @@ from sympy.multipledispatch import dispatch
 ###############################################################################
 
 
-class RoundFunction(Function):
+class RoundFunction(DefinedFunction):
     """Abstract base class for rounding functions."""
 
     args: tTuple[Expr]
@@ -428,7 +428,7 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(floor), rhs) or is_eq(lhs.rewrite(frac),rhs)
 
 
-class frac(Function):
+class frac(DefinedFunction):
     r"""Represents the fractional part of x
 
     For real numbers it is defined [1]_ as

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,10 +1,10 @@
-from sympy.core import Function, S, sympify, NumberKind
+from sympy.core import S, sympify, NumberKind
 from sympy.utilities.iterables import sift
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
-    ArgumentIndexError)
+    ArgumentIndexError, DefinedFunction)
 from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.mod import Mod
@@ -636,7 +636,7 @@ class MinMaxBase(Expr, LatticeOp):
             try:
                 df = self.fdiff(i)
             except ArgumentIndexError:
-                df = Function.fdiff(self, i)
+                df = super().fdiff(i)
             l.append(df * da)
         return Add(*l)
 
@@ -861,7 +861,7 @@ class Min(MinMaxBase, Application):
         return fuzzy_or(a.is_negative for a in self.args)
 
 
-class Rem(Function):
+class Rem(DefinedFunction):
     """Returns the remainder when ``p`` is divided by ``q`` where ``p`` is finite
     and ``q`` is not equal to zero. The result, ``p - int(p/q)*q``, has the same sign
     as the divisor.

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,5 +1,6 @@
-from sympy.core import S, Function, diff, Tuple, Dummy, Mul
+from sympy.core import S, diff, Tuple, Dummy, Mul
 from sympy.core.basic import Basic, as_Basic
+from sympy.core.function import DefinedFunction
 from sympy.core.numbers import Rational, NumberSymbol, _illegal
 from sympy.core.parameters import global_parameters
 from sympy.core.relational import (Lt, Gt, Eq, Ne, Relational,
@@ -61,7 +62,7 @@ class ExprCondPair(Tuple):
         return self.func(*[a.simplify(**kwargs) for a in self.args])
 
 
-class Piecewise(Function):
+class Piecewise(DefinedFunction):
     """
     Represents a piecewise function.
 

--- a/sympy/functions/elementary/tests/test_interface.py
+++ b/sympy/functions/elementary/tests/test_interface.py
@@ -1,6 +1,10 @@
 # This test file tests the SymPy function interface, that people use to create
 # their own new functions. It should be as easy as possible.
-from sympy.core.function import Function
+#
+# We test that it works with both Function and DefinedFunction. New code should
+# use DefinedFunction because it has better type inference. Old code still
+# using Function should continue to work though.
+from sympy.core.function import Function, DefinedFunction
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.trigonometric import (cos, sin)
@@ -11,38 +15,42 @@ from sympy.abc import x
 def test_function_series1():
     """Create our new "sin" function."""
 
-    class my_function(Function):
+    for F in [Function, DefinedFunction]:
 
-        def fdiff(self, argindex=1):
-            return cos(self.args[0])
+        class my_function(F):
 
-        @classmethod
-        def eval(cls, arg):
-            arg = sympify(arg)
-            if arg == 0:
-                return sympify(0)
+            def fdiff(self, argindex=1):
+                return cos(self.args[0])
 
-    #Test that the taylor series is correct
-    assert my_function(x).series(x, 0, 10) == sin(x).series(x, 0, 10)
-    assert limit(my_function(x)/x, x, 0) == 1
+            @classmethod
+            def eval(cls, arg):
+                arg = sympify(arg)
+                if arg == 0:
+                    return sympify(0)
+
+        #Test that the taylor series is correct
+        assert my_function(x).series(x, 0, 10) == sin(x).series(x, 0, 10)
+        assert limit(my_function(x)/x, x, 0) == 1
 
 
 def test_function_series2():
     """Create our new "cos" function."""
 
-    class my_function2(Function):
+    for F in [Function, DefinedFunction]:
 
-        def fdiff(self, argindex=1):
-            return -sin(self.args[0])
+        class my_function2(F):
 
-        @classmethod
-        def eval(cls, arg):
-            arg = sympify(arg)
-            if arg == 0:
-                return sympify(1)
+            def fdiff(self, argindex=1):
+                return -sin(self.args[0])
 
-    #Test that the taylor series is correct
-    assert my_function2(x).series(x, 0, 10) == cos(x).series(x, 0, 10)
+            @classmethod
+            def eval(cls, arg):
+                arg = sympify(arg)
+                if arg == 0:
+                    return sympify(1)
+
+        #Test that the taylor series is correct
+        assert my_function2(x).series(x, 0, 10) == cos(x).series(x, 0, 10)
 
 
 def test_function_series3():
@@ -56,17 +64,19 @@ def test_function_series3():
         since tanh(x).diff(x) == 1-tanh(x)**2
     """
 
-    class mytanh(Function):
+    for F in [Function, DefinedFunction]:
 
-        def fdiff(self, argindex=1):
-            return 1 - mytanh(self.args[0])**2
+        class mytanh(F):
 
-        @classmethod
-        def eval(cls, arg):
-            arg = sympify(arg)
-            if arg == 0:
-                return sympify(0)
+            def fdiff(self, argindex=1):
+                return 1 - mytanh(self.args[0])**2
 
-    e = tanh(x)
-    f = mytanh(x)
-    assert e.series(x, 0, 6) == f.series(x, 0, 6)
+            @classmethod
+            def eval(cls, arg):
+                arg = sympify(arg)
+                if arg == 0:
+                    return sympify(0)
+
+        e = tanh(x)
+        f = mytanh(x)
+        assert e.series(x, 0, 6) == f.series(x, 0, 6)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2,7 +2,7 @@ from typing import Tuple as tTuple, Union as tUnion
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
-from sympy.core.function import Function, ArgumentIndexError, PoleError, expand_mul
+from sympy.core.function import DefinedFunction, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
 from sympy.core.mod import Mod
 from sympy.core.numbers import Rational, pi, Integer, Float, equal_valued
@@ -42,7 +42,7 @@ def _imaginary_unit_as_coefficient(arg):
 ###############################################################################
 
 
-class TrigonometricFunction(Function):
+class TrigonometricFunction(DefinedFunction):
     """Base class for trigonometric functions. """
 
     unbranched = True
@@ -434,7 +434,7 @@ class sin(TrigonometricFunction):
             arg = arg.subs(log(x), logx)
         if arg.subs(x, 0).has(S.NaN, S.ComplexInfinity):
             raise PoleError("Cannot expand %s around 0" % (self))
-        return Function._eval_nseries(self, x, n=n, logx=logx, cdir=cdir)
+        return super()._eval_nseries(x, n=n, logx=logx, cdir=cdir)
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -763,7 +763,7 @@ class cos(TrigonometricFunction):
             arg = arg.subs(log(x), logx)
         if arg.subs(x, 0).has(S.NaN, S.ComplexInfinity):
             raise PoleError("Cannot expand %s around 0" % (self))
-        return Function._eval_nseries(self, x, n=n, logx=logx, cdir=cdir)
+        return super()._eval_nseries(x, n=n, logx=logx, cdir=cdir)
 
     def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
@@ -1114,7 +1114,7 @@ class tan(TrigonometricFunction):
         i = self.args[0].limit(x, 0)*2/pi
         if i and i.is_Integer:
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
-        return Function._eval_nseries(self, x, n=n, logx=logx)
+        return super()._eval_nseries(x, n=n, logx=logx)
 
     def _eval_rewrite_as_Pow(self, arg, **kwargs):
         if isinstance(arg, log):
@@ -1902,7 +1902,7 @@ class csc(ReciprocalTrigonometricFunction):
         return self.func(x0) if x0.is_finite else self
 
 
-class sinc(Function):
+class sinc(DefinedFunction):
     r"""
     Represents an unnormalized sinc function:
 
@@ -2026,7 +2026,7 @@ class sinc(Function):
 ###############################################################################
 
 
-class InverseTrigonometricFunction(Function):
+class InverseTrigonometricFunction(DefinedFunction):
     """Base class for inverse trigonometric functions."""
     _singularities = (S.One, S.NegativeOne, S.Zero, S.ComplexInfinity)  # type: tTuple[Expr, ...]
 
@@ -2293,7 +2293,7 @@ class asin(InverseTrigonometricFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
@@ -2529,7 +2529,7 @@ class acos(InverseTrigonometricFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
@@ -2742,7 +2742,7 @@ class atan(InverseTrigonometricFunction):
         if arg0 in (S.ImaginaryUnit, S.NegativeOne*S.ImaginaryUnit):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         ndir = self.args[0].dir(x, cdir if cdir else 1)
         if arg0 is S.ComplexInfinity:
             if re(ndir) > 0:
@@ -2957,7 +2957,7 @@ class acot(InverseTrigonometricFunction):
         if arg0 in (S.ImaginaryUnit, S.NegativeOne*S.ImaginaryUnit):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
         ndir = self.args[0].dir(x, cdir if cdir else 1)
@@ -3198,7 +3198,7 @@ class asec(InverseTrigonometricFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
         # Handling points lying on branch cuts (-1, 1)
@@ -3408,7 +3408,7 @@ class acsc(InverseTrigonometricFunction):
             res = (res1.removeO()*sqrt(f)).expand()
             return ser.removeO().subs(t, res).expand().powsimp() + O(x**n, x)
 
-        res = Function._eval_nseries(self, x, n=n, logx=logx)
+        res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
         # Handling points lying on branch cuts (-1, 1)

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -4,7 +4,7 @@ from sympy.core import S
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
-from sympy.core.function import Function, ArgumentIndexError, _mexpand
+from sympy.core.function import DefinedFunction, ArgumentIndexError, _mexpand
 from sympy.core.logic import fuzzy_or, fuzzy_not
 from sympy.core.numbers import Rational, pi, I
 from sympy.core.power import Pow
@@ -33,7 +33,7 @@ from mpmath import mp, workprec
 # o Add solvers to ode.py (or rather add solvers for the hypergeometric equation).
 
 
-class BesselBase(Function):
+class BesselBase(DefinedFunction):
     """
     Abstract base class for Bessel-type functions.
 
@@ -1320,7 +1320,7 @@ def jn_zeros(n, k, method="sympy", dps=15):
     return roots
 
 
-class AiryBase(Function):
+class AiryBase(DefinedFunction):
     """
     Abstract base class for Airy functions.
 
@@ -2017,7 +2017,7 @@ class airybiprime(AiryBase):
                     return S.Half * (sqrt(3)*(pf - S.One)*airyaiprime(newarg) + (pf + S.One)*airybiprime(newarg))
 
 
-class marcumq(Function):
+class marcumq(DefinedFunction):
     r"""
     The Marcum Q-function.
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -2122,7 +2122,7 @@ class marcumq(DefinedFunction):
         if all(arg.is_zero for arg in self.args):
             return True
 
-class _besseli(Function):
+class _besseli(DefinedFunction):
     """
     Helper function to make the $\\mathrm{besseli}(nu, z)$
     function tractable for the Gruntz algorithm.
@@ -2153,7 +2153,7 @@ class _besseli(Function):
         return super()._eval_nseries(x, n, logx)
 
 
-class _besselk(Function):
+class _besselk(DefinedFunction):
     """
     Helper function to make the $\\mathrm{besselk}(nu, z)$
     function tractable for the Gruntz algorithm.

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -1,5 +1,5 @@
 from sympy.core import S
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.symbol import Dummy, uniquely_named_symbol
 from sympy.functions.special.gamma_functions import gamma, digamma
 from sympy.functions.combinatorial.numbers import catalan
@@ -17,7 +17,7 @@ def betainc_mpmath_fix(a, b, x1, x2, reg=0):
 ############################ COMPLETE BETA  FUNCTION ##########################
 ###############################################################################
 
-class beta(Function):
+class beta(DefinedFunction):
     r"""
     The beta integral is called the Eulerian integral of the first kind by
     Legendre:
@@ -170,7 +170,7 @@ class beta(Function):
 ########################## INCOMPLETE BETA FUNCTION ###########################
 ###############################################################################
 
-class betainc(Function):
+class betainc(DefinedFunction):
     r"""
     The Generalized Incomplete Beta function is defined as
 
@@ -279,7 +279,7 @@ class betainc(Function):
 #################### REGULARIZED INCOMPLETE BETA FUNCTION #####################
 ###############################################################################
 
-class betainc_regularized(Function):
+class betainc_regularized(DefinedFunction):
     r"""
     The Generalized Regularized Incomplete Beta function is given by
 
@@ -353,7 +353,7 @@ class betainc_regularized(Function):
     unbranched = True
 
     def __new__(cls, a, b, x1, x2):
-        return Function.__new__(cls, a, b, x1, x2)
+        return super().__new__(cls, a, b, x1, x2)
 
     def _eval_mpmath(self):
         return betainc_mpmath_fix, (*self.args, S(1))

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -1,5 +1,5 @@
 from sympy.core import S, diff
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.logic import fuzzy_not
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.complexes import im, sign
@@ -14,7 +14,7 @@ from sympy.utilities.misc import filldedent
 ###############################################################################
 
 
-class DiracDelta(Function):
+class DiracDelta(DefinedFunction):
     r"""
     The DiracDelta function and its derivatives.
 
@@ -390,7 +390,7 @@ class DiracDelta(Function):
 ###############################################################################
 
 
-class Heaviside(Function):
+class Heaviside(DefinedFunction):
     r"""
     Heaviside step function.
 

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -1,7 +1,7 @@
 """ Elliptic Integrals. """
 
 from sympy.core import S, pi, I, Rational
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.symbol import Dummy,uniquely_named_symbol
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.hyperbolic import atanh
@@ -10,7 +10,7 @@ from sympy.functions.elementary.trigonometric import sin, tan
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper, meijerg
 
-class elliptic_k(Function):
+class elliptic_k(DefinedFunction):
     r"""
     The complete elliptic integral of the first kind, defined by
 
@@ -100,7 +100,7 @@ class elliptic_k(Function):
         return Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2))
 
 
-class elliptic_f(Function):
+class elliptic_f(DefinedFunction):
     r"""
     The Legendre incomplete elliptic integral of the first
     kind, defined by
@@ -185,7 +185,7 @@ class elliptic_f(Function):
             return True
 
 
-class elliptic_e(Function):
+class elliptic_e(DefinedFunction):
     r"""
     Called with two arguments $z$ and $m$, evaluates the
     incomplete elliptic integral of the second kind, defined by
@@ -307,7 +307,7 @@ class elliptic_e(Function):
         return Integral(sqrt(1 - m*sin(t)**2), (t, 0, z))
 
 
-class elliptic_pi(Function):
+class elliptic_pi(DefinedFunction):
     r"""
     Called with three arguments $n$, $z$ and $m$, evaluates the
     Legendre incomplete elliptic integral of the third kind, defined by

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -4,7 +4,7 @@
 from sympy.core import EulerGamma # Must be imported from core, not core.numbers
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
-from sympy.core.function import Function, ArgumentIndexError, expand_mul
+from sympy.core.function import DefinedFunction, ArgumentIndexError, expand_mul
 from sympy.core.logic import fuzzy_or
 from sympy.core.numbers import I, pi, Rational, Integer
 from sympy.core.relational import is_eq
@@ -46,7 +46,7 @@ def real_to_real_as_real_imag(self, deep=True, **hints):
 ###############################################################################
 
 
-class erf(Function):
+class erf(DefinedFunction):
     r"""
     The Gauss error function.
 
@@ -285,7 +285,7 @@ class erf(Function):
     as_real_imag = real_to_real_as_real_imag
 
 
-class erfc(Function):
+class erfc(DefinedFunction):
     r"""
     Complementary Error Function.
 
@@ -479,7 +479,7 @@ class erfc(Function):
         return S.One - erf(*self.args)._eval_aseries(n, args0, x, logx)
 
 
-class erfi(Function):
+class erfi(DefinedFunction):
     r"""
     Imaginary error function.
 
@@ -671,7 +671,7 @@ class erfi(Function):
         return super(erfi, self)._eval_aseries(n, args0, x, logx)
 
 
-class erf2(Function):
+class erf2(DefinedFunction):
     r"""
     Two-argument error function.
 
@@ -816,7 +816,7 @@ class erf2(Function):
     def _eval_is_zero(self):
         return is_eq(*self.args)
 
-class erfinv(Function):
+class erfinv(DefinedFunction):
     r"""
     Inverse Error Function. The erfinv function is defined as:
 
@@ -909,7 +909,7 @@ class erfinv(Function):
         return self.args[0].is_zero
 
 
-class erfcinv (Function):
+class erfcinv (DefinedFunction):
     r"""
     Inverse Complementary Error Function. The erfcinv function is defined as:
 
@@ -992,7 +992,7 @@ class erfcinv (Function):
         return fuzzy_or([z.is_zero, is_eq(z, Integer(2))])
 
 
-class erf2inv(Function):
+class erf2inv(DefinedFunction):
     r"""
     Two-argument Inverse error function. The erf2inv function is defined as:
 
@@ -1089,7 +1089,7 @@ class erf2inv(Function):
 #################### EXPONENTIAL INTEGRALS ####################################
 ###############################################################################
 
-class Ei(Function):
+class Ei(DefinedFunction):
     r"""
     The classical exponential integral.
 
@@ -1202,8 +1202,8 @@ class Ei(Function):
 
     def _eval_evalf(self, prec):
         if (self.args[0]/polar_lift(-1)).is_positive:
-            return Function._eval_evalf(self, prec) + (I*pi)._eval_evalf(prec)
-        return Function._eval_evalf(self, prec)
+            return super()._eval_evalf(prec) + (I*pi)._eval_evalf(prec)
+        return super()._eval_evalf(prec)
 
     def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy.functions.special.gamma_functions import uppergamma
@@ -1272,7 +1272,7 @@ class Ei(Function):
         return super(Ei, self)._eval_aseries(n, args0, x, logx)
 
 
-class expint(Function):
+class expint(DefinedFunction):
     r"""
     Generalized exponential integral.
 
@@ -1499,7 +1499,7 @@ def E1(z):
     return expint(1, z)
 
 
-class li(Function):
+class li(DefinedFunction):
     r"""
     The classical logarithmic integral.
 
@@ -1666,7 +1666,7 @@ class li(Function):
         if z.is_zero:
             return True
 
-class Li(Function):
+class Li(DefinedFunction):
     r"""
     The offset logarithmic integral.
 
@@ -1762,7 +1762,7 @@ class Li(Function):
 #################### TRIGONOMETRIC INTEGRALS ##################################
 ###############################################################################
 
-class TrigonometricIntegral(Function):
+class TrigonometricIntegral(DefinedFunction):
     """ Base class for trigonometric integrals. """
 
 
@@ -2324,7 +2324,7 @@ class Chi(TrigonometricIntegral):
 #################### FRESNEL INTEGRALS ########################################
 ###############################################################################
 
-class FresnelIntegral(Function):
+class FresnelIntegral(DefinedFunction):
     """ Base class for the Fresnel integrals."""
 
     unbranched = True
@@ -2707,7 +2707,7 @@ class fresnelc(FresnelIntegral):
 ###############################################################################
 
 
-class _erfs(Function):
+class _erfs(DefinedFunction):
     """
     Helper function to make the $\\mathrm{erf}(z)$ function
     tractable for the Gruntz algorithm.
@@ -2756,7 +2756,7 @@ class _erfs(Function):
         return (S.One - erf(z))*exp(z**2)
 
 
-class _eis(Function):
+class _eis(DefinedFunction):
     """
     Helper function to make the $\\mathrm{Ei}(z)$ and $\\mathrm{li}(z)$
     functions tractable for the Gruntz algorithm.

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -2,7 +2,7 @@ from math import prod
 
 from sympy.core import Add, S, Dummy, expand_func
 from sympy.core.expr import Expr
-from sympy.core.function import Function, ArgumentIndexError, PoleError
+from sympy.core.function import DefinedFunction, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and, fuzzy_not
 from sympy.core.numbers import Rational, pi, oo, I
 from sympy.core.power import Pow
@@ -31,7 +31,7 @@ def intlike(n):
 ############################ COMPLETE GAMMA FUNCTION ##########################
 ###############################################################################
 
-class gamma(Function):
+class gamma(DefinedFunction):
     r"""
     The gamma function
 
@@ -219,7 +219,7 @@ class gamma(Function):
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
 ###############################################################################
 
-class lowergamma(Function):
+class lowergamma(DefinedFunction):
     r"""
     The lower incomplete gamma function.
 
@@ -395,7 +395,7 @@ class lowergamma(Function):
             return True
 
 
-class uppergamma(Function):
+class uppergamma(DefinedFunction):
     r"""
     The upper incomplete gamma function.
 
@@ -561,7 +561,7 @@ class uppergamma(Function):
 ###################### POLYGAMMA and LOGGAMMA FUNCTIONS #######################
 ###############################################################################
 
-class polygamma(Function):
+class polygamma(DefinedFunction):
     r"""
     The function ``polygamma(n, z)`` returns ``log(gamma(z)).diff(n + 1)``.
 
@@ -862,7 +862,7 @@ class polygamma(Function):
         return Expr._from_mpmath(res, prec)
 
 
-class loggamma(Function):
+class loggamma(DefinedFunction):
     r"""
     The ``loggamma`` function implements the logarithm of the
     gamma function (i.e., $\log\Gamma(x)$).
@@ -1057,7 +1057,7 @@ class loggamma(Function):
             raise ArgumentIndexError(self, argindex)
 
 
-class digamma(Function):
+class digamma(DefinedFunction):
     r"""
     The ``digamma`` function is the first derivative of the ``loggamma``
     function
@@ -1151,7 +1151,7 @@ class digamma(Function):
 
 
 
-class trigamma(Function):
+class trigamma(DefinedFunction):
     r"""
     The ``trigamma`` function is the second derivative of the ``loggamma``
     function
@@ -1252,7 +1252,7 @@ class trigamma(Function):
 ###############################################################################
 
 
-class multigamma(Function):
+class multigamma(DefinedFunction):
     r"""
     The multivariate gamma function is a generalization of the gamma function
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -4,7 +4,7 @@ from collections import Counter
 from sympy.core import S, Mod
 from sympy.core.add import Add
 from sympy.core.expr import Expr
-from sympy.core.function import Function, Derivative, ArgumentIndexError
+from sympy.core.function import DefinedFunction, Derivative, ArgumentIndexError
 
 from sympy.core.containers import Tuple
 from sympy.core.mul import Mul
@@ -68,7 +68,7 @@ def _prep_tuple(v):
     return TupleArg(*[unpolarify(x) for x in v])
 
 
-class TupleParametersBase(Function):
+class TupleParametersBase(DefinedFunction):
     """ Base class that takes care of differentiation, when some of
         the arguments are actually tuples. """
     # This is not deduced automatically since there are Tuples as arguments.
@@ -220,7 +220,7 @@ class hyper(TupleParametersBase):
         else:
             ap = list(ordered(ap))
             bq = list(ordered(bq))
-        return Function.__new__(cls, _prep_tuple(ap), _prep_tuple(bq), z, **kwargs)
+        return super().__new__(cls, _prep_tuple(ap), _prep_tuple(bq), z, **kwargs)
 
     @classmethod
     def eval(cls, ap, bq, z):
@@ -541,7 +541,7 @@ class meijerg(TupleParametersBase):
                          "any b1, ..., bm by a positive integer")
 
         # TODO should we check convergence conditions?
-        return Function.__new__(cls, arg0, arg1, args[2], **kwargs)
+        return super().__new__(cls, arg0, arg1, args[2], **kwargs)
 
     def fdiff(self, argindex=3):
         if argindex != 3:
@@ -793,7 +793,7 @@ class meijerg(TupleParametersBase):
         return not self.free_symbols
 
 
-class HyperRep(Function):
+class HyperRep(DefinedFunction):
     """
     A base class for "hyper representation functions".
 
@@ -1126,7 +1126,7 @@ class HyperRep_sinasin(HyperRep):
     def _expr_big_minus(cls, a, z, n):
         return -1/sqrt(1 + 1/z)*sinh(2*a*asinh(sqrt(z)) + 2*a*pi*I*n)
 
-class appellf1(Function):
+class appellf1(DefinedFunction):
     r"""
     This is the Appell hypergeometric function of two variables as:
 

--- a/sympy/functions/special/mathieu_functions.py
+++ b/sympy/functions/special/mathieu_functions.py
@@ -1,12 +1,12 @@
 """ This module contains the Mathieu functions.
 """
 
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin, cos
 
 
-class MathieuBase(Function):
+class MathieuBase(DefinedFunction):
     """
     Abstract base class for Mathieu functions.
 

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -7,7 +7,7 @@ combinatorial polynomials.
 """
 
 from sympy.core import Rational
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.factorials import binomial, factorial, RisingFactorial
@@ -25,7 +25,7 @@ from sympy.polys.orthopolys import (chebyshevt_poly, chebyshevu_poly,
 _x = Dummy('x')
 
 
-class OrthogonalPolynomial(Function):
+class OrthogonalPolynomial(DefinedFunction):
     """Base class for orthogonal polynomials.
     """
 
@@ -684,7 +684,7 @@ class chebyshevu(OrthogonalPolynomial):
         return self._eval_rewrite_as_Sum(n, x, **kwargs)
 
 
-class chebyshevt_root(Function):
+class chebyshevt_root(DefinedFunction):
     r"""
     ``chebyshev_root(n, k)`` returns the $k$th root (indexed from zero) of
     the $n$th Chebyshev polynomial of the first kind; that is, if
@@ -725,7 +725,7 @@ class chebyshevt_root(Function):
         return cos(S.Pi*(2*k + 1)/(2*n))
 
 
-class chebyshevu_root(Function):
+class chebyshevu_root(DefinedFunction):
     r"""
     ``chebyshevu_root(n, k)`` returns the $k$th root (indexed from zero) of the
     $n$th Chebyshev polynomial of the second kind; that is, if $0 \le k < n$,
@@ -886,7 +886,7 @@ class legendre(OrthogonalPolynomial):
         return self._eval_rewrite_as_Sum(n, x, **kwargs)
 
 
-class assoc_legendre(Function):
+class assoc_legendre(DefinedFunction):
     r"""
     ``assoc_legendre(n, m, x)`` gives $P_n^m(x)$, where $n$ and $m$ are
     the degree and order or an expression which is related to the nth

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -1,5 +1,5 @@
 from sympy.core import S, oo, diff
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.logic import fuzzy_not
 from sympy.core.relational import Eq
 from sympy.functions.elementary.complexes import im
@@ -11,7 +11,7 @@ from sympy.functions.special.delta_functions import Heaviside
 ###############################################################################
 
 
-class SingularityFunction(Function):
+class SingularityFunction(DefinedFunction):
     r"""
     Singularity functions are a class of discontinuous functions.
 

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -1,5 +1,5 @@
 from sympy.core.expr import Expr
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import DefinedFunction, ArgumentIndexError
 from sympy.core.numbers import I, pi
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
@@ -12,7 +12,7 @@ from sympy.functions.elementary.trigonometric import sin, cos, cot
 
 _x = Dummy("x")
 
-class Ynm(Function):
+class Ynm(DefinedFunction):
     r"""
     Spherical harmonics defined as
 
@@ -264,7 +264,7 @@ def Ynm_c(n, m, theta, phi):
     return conjugate(Ynm(n, m, theta, phi))
 
 
-class Znm(Function):
+class Znm(DefinedFunction):
     r"""
     Real spherical harmonics defined as
 

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,7 +1,7 @@
 from math import prod
 
 from sympy.core import S, Integer
-from sympy.core.function import Function
+from sympy.core.function import DefinedFunction
 from sympy.core.logic import fuzzy_not
 from sympy.core.relational import Ne
 from sympy.core.sorting import default_sort_key
@@ -39,7 +39,7 @@ def eval_levicivita(*args):
     # converting factorial(i) to int is slightly faster
 
 
-class LeviCivita(Function):
+class LeviCivita(DefinedFunction):
     """
     Represent the Levi-Civita symbol.
 
@@ -87,7 +87,7 @@ class LeviCivita(Function):
         return eval_levicivita(*self.args)
 
 
-class KroneckerDelta(Function):
+class KroneckerDelta(DefinedFunction):
     """
     The discrete, or Kronecker, delta function.
 

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -2,7 +2,7 @@
 
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
-from sympy.core.function import ArgumentIndexError, expand_mul, Function
+from sympy.core.function import ArgumentIndexError, expand_mul, DefinedFunction
 from sympy.core.numbers import pi, I, Integer
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -21,7 +21,7 @@ from sympy.polys.polytools import Poly
 ###############################################################################
 
 
-class lerchphi(Function):
+class lerchphi(DefinedFunction):
     r"""
     Lerch transcendent (Lerch phi function).
 
@@ -219,7 +219,7 @@ class lerchphi(Function):
 ###############################################################################
 
 
-class polylog(Function):
+class polylog(DefinedFunction):
     r"""
     Polylogarithm function.
 
@@ -391,7 +391,7 @@ class polylog(Function):
 ###############################################################################
 
 
-class zeta(Function):
+class zeta(DefinedFunction):
     r"""
     Hurwitz zeta function (or Riemann zeta function).
 
@@ -582,7 +582,7 @@ class zeta(Function):
         return super(zeta, self)._eval_as_leading_term(x, logx, cdir)
 
 
-class dirichlet_eta(Function):
+class dirichlet_eta(DefinedFunction):
     r"""
     Dirichlet eta function.
 
@@ -665,7 +665,7 @@ class dirichlet_eta(Function):
             return self.rewrite(zeta)._eval_evalf(prec)
 
 
-class riemann_xi(Function):
+class riemann_xi(DefinedFunction):
     r"""
     Riemann Xi function.
 
@@ -704,7 +704,7 @@ class riemann_xi(Function):
         return s*(s - 1)*gamma(s/2)*zeta(s)/(2*pi**(s/2))
 
 
-class stieltjes(Function):
+class stieltjes(DefinedFunction):
     r"""
     Represents Stieltjes constants, $\gamma_{k}$ that occur in
     Laurent Series expansion of the Riemann zeta function.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -15,7 +15,8 @@ from sympy.core.logic import fuzzy_bool
 from sympy.core.numbers import Rational, oo
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, uniquely_named_symbol, _symbol
-from sympy.simplify import simplify, trigsimp
+from sympy.simplify.simplify import simplify
+from sympy.simplify.trigsimp import trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt, Max
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.elliptic_integrals import elliptic_e

--- a/sympy/geometry/parabola.py
+++ b/sympy/geometry/parabola.py
@@ -13,7 +13,7 @@ from sympy.geometry.point import Point, Point2D
 from sympy.geometry.line import Line, Line2D, Ray2D, Segment2D, LinearEntity3D
 from sympy.geometry.ellipse import Ellipse
 from sympy.functions import sign
-from sympy.simplify import simplify
+from sympy.simplify.simplify import simplify
 from sympy.solvers.solvers import solve
 
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -24,7 +24,7 @@ from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.numbers import Float
 from sympy.core.parameters import global_parameters
-from sympy.simplify import nsimplify, simplify
+from sympy.simplify.simplify import nsimplify, simplify
 from sympy.geometry.exceptions import GeometryError
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.complexes import im


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See also long discussion in gh-17945

#### Brief description of what is fixed or changed

Adds type hints for various attributes and methods of Basic and Expr. Adds a new `DefinedFunction` class as a subclass of `Function` that should be the base class for defined functions like `sin`, `cos` etc.

These changes are enough for simple end user code involving sympy expressions to be statically analysable so that code completion and editor warnings can work with e.g. the pyright language server that is often used with vscode and other editors (I use pyright from within vim myself now).

It is also possible to use pyright as a type checker e.g.:
```
pip install pyright
pyright sympy
```
(You need to have node and npm installed for this to work.)

Running pyright like this over the codebase takes about 5 minutes on this computer and for master shows:
```
42405 errors, 926 warnings, 0 informations
```
With this PR it is:
```
26598 errors, 39 warnings, 0 informations
```
So this removes around half of all of the "errors" in the codebase and pretty much all the warnings. Most of the other errors are probably not that hard to improve with some type declarations but each case requires a bit of analysis and I thought I would stop here before making the diff any larger.

#### Other comments

It is increasingly common that users of sympy will use an editor like vscode that performs analysis of the code either through type inference or using type hints using a langauge server like pyright. Personally I don't use vscode but I do have the pyright language server running inside vim. The sympy codebase does too many strange things for type inference to work without some type hints. What that means is that if you have pyright running in your editor then just opening a file that uses sympy will cause pyright to consume huge amounts of RAM and CPU while it tries to analyse the sympy codebase. Even then it fails and so the result looks something like this:
![image](https://user-images.githubusercontent.com/1159732/236049488-483bc1c8-bc34-4ff0-a4bf-0ea2ee04b7aa.png)
In other words ordinary code using sympy shows up as being full of errors. The errors are because type inference fails even for basic things like `cos(1)`. It is even worse if you open up a sympy test suite file e.g. `test_manual.py`:
![image](https://user-images.githubusercontent.com/1159732/236054374-a21e7597-508e-4afb-9e86-e4df7796af8b.png)

The number one thing that confuses pyright is `Function.__new__` and I have looked at how to make accurate type hints for `Function.__new__` but it is impossible because it basically works like this:
```python
class Function(Expr):
    def __new__(cls, *args, **kwargs):
        if cls is Function:
            # f = Function('f'), returns an Expr subclass
            return dynamically_created_subclass_of_AppliedUndef
        else:
            # expr = cos(1), returns an Expr instance
            return super().__new__(cls, *args, **kwargs)

class sin(Function):
    # sin is a Function subclass

f = Function('f')  # f is an Expr subclass
```
What this `__new__` method does is that it returns two completely different types of object. More confusingly `Function.__new__` returns a completely different type of object from any `FunctionSubclass.__new__` method. There is just no way to type a method such that it returns a different tpye when called from a subclass.

The only way that I could make sense of this was to introduce a new class:
```python
class Function(Expr):
    def __new__(cls, *args, **kwargs) -> Type[AppliedUndef]:
        if cls is Function:
            # f = Function('f'), returns an Expr subclass
            return dynamically_created_subclass_of_AppliedUndef
        else:
            # Tell the type checker to ignore this. It will only be used by
            # a direct subclass of Function but not by any subclass of 
            # DefinedFunction. We only need to keep this for compatibility.
            return cls._new_(*args, **kwargs)  # type: ignore

    @classmethod
    def _new_(cls, *args, **kwargs) -> Expr:
        return super().__new__(cls, *args, **kwargs)

class DefinedFunction(Function):
    # Override Function.__new__
    def __new__(cls, *args, **kwargs) -> Expr:
        return cls._new_(*args, **kwargs)

class sin(DefinedFunction):
     ...

f = Function('f')  # f is an Expr subclass
```
Most of the lines changed in the diff are just changing many classes to subclass `DefinedFunction` instead of `Function`.

With these changes pyright understands the types of sympy expressions so that it does not report errors and can handle autocompletion etc:
![image](https://user-images.githubusercontent.com/1159732/236052375-f9b73b23-3a77-432f-97d8-82adb97436bd.png)
![image](https://user-images.githubusercontent.com/1159732/236052616-f2e1f155-cdc3-4a1e-92b7-f46efba76293.png)
![image](https://user-images.githubusercontent.com/1159732/236053033-98842f46-f4f9-46fb-9d86-bd736393a90f.png)
Obviously this kind of completion/help only works if the language server can infer something about the types of variables like `e2` in the code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Type hints have been added to improve type inference for code that uses sympy expressions. This should improve code completion and help tips for end users using an editor such as vscode that typically uses the pyright language server.
<!-- END RELEASE NOTES -->
