### PR TITLE
New ticks for special points

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1503,6 +1503,7 @@ kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+kujuo <61703000+kujuo@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
 luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -134,6 +134,10 @@ class Plot:
     - margin : float in [0, 1]
     - backend : {'default', 'matplotlib', 'text'} or a subclass of BaseBackend
     - size : optional tuple of two floats, (width, height); default: None
+    - special_points : list of tuples of either two or three floats
+        Special points are only considered for ``MatplotlibBackend`` at the 
+        moment. Special points must also describe points in all axes available, 
+        depending on whether the plot is 3D or 2D.
 
     The per data series options and aesthetics are:
     There are none in the base series. See below for options for subclasses.
@@ -1529,12 +1533,17 @@ class MatplotlibBackend(BaseBackend):
         if parent.special_points:
             xticks = ax.get_xticks()
             yticks = ax.get_yticks()
+            if isinstance(ax, Axes3D): zticks = ax.get_zticks()
             for point in parent.special_points: 
                 xticks = np.append(xticks, point[0])
                 yticks = np.append(yticks, point[1])
+                if isinstance(ax, Axes3D):
+                    zticks = np.append(yticks, point[2])
+                    self.plt.plot(point[0], point[1], point[2], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue")
                 self.plt.plot(point[0], point[1], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue")
             ax.set_xticks(xticks)
             ax.set_yticks(yticks)
+            if isinstance(ax, Axes3D): ax.set_yticks(zticks)
 
     def process_series(self):
         """

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -180,7 +180,7 @@ class Plot:
         xlim=None, ylim=None, axis_center='auto', axis=True,
         xscale='linear', yscale='linear', legend=False, autoscale=True,
         margin=0, annotations=None, markers=None, rectangles=None,
-        fill=None, backend='default', size=None, **kwargs):
+        fill=None, backend='default', size=None, special_points=None, **kwargs):
         super().__init__()
 
         # Options for the graph as a whole.
@@ -202,6 +202,7 @@ class Plot:
         self.markers = markers
         self.rectangles = rectangles
         self.fill = fill
+        self.special_points = special_points
 
         # Contains the data objects to be plotted. The backend should be smart
         # enough to iterate over this list.
@@ -241,7 +242,6 @@ class Plot:
         check_and_set("ylim", ylim)
         self.size = None
         check_and_set("size", size)
-
 
     def show(self):
         # TODO move this to the backend (also for save)
@@ -1304,7 +1304,6 @@ class MatplotlibBackend(BaseBackend):
 
         self.ax = []
         self.fig = self.plt.figure(figsize=parent.size)
-
         for i, series in enumerate(series_list):
             are_3D = [s.is_3D for s in series]
 
@@ -1325,7 +1324,6 @@ class MatplotlibBackend(BaseBackend):
                 self.ax[i].spines['top'].set_color('none')
                 self.ax[i].xaxis.set_ticks_position('bottom')
                 self.ax[i].yaxis.set_ticks_position('left')
-
     @staticmethod
     def get_segments(x, y, z=None):
         """ Convert two list of coordinates to a list of segments to be used
@@ -1528,6 +1526,15 @@ class MatplotlibBackend(BaseBackend):
         if parent.ylim:
             ax.set_ylim(parent.ylim)
 
+        if parent.special_points:
+            xticks = ax.get_xticks()
+            yticks = ax.get_yticks()
+            for point in parent.special_points: 
+                xticks = np.append(xticks, point[0])
+                yticks = np.append(yticks, point[1])
+                self.plt.plot(point[0], point[1], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue")
+            ax.set_xticks(xticks)
+            ax.set_yticks(yticks)
 
     def process_series(self):
         """

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -135,8 +135,8 @@ class Plot:
     - backend : {'default', 'matplotlib', 'text'} or a subclass of BaseBackend
     - size : optional tuple of two floats, (width, height); default: None
     - special_points : list of tuples of either two or three floats
-        Special points are only considered for ``MatplotlibBackend`` at the 
-        moment. Special points must also describe points in all axes available, 
+        Special points are only considered for ``MatplotlibBackend`` at the
+        moment. Special points must also describe points in all axes available,
         depending on whether the plot is 3D or 2D.
 
     The per data series options and aesthetics are:
@@ -1522,6 +1522,20 @@ class MatplotlibBackend(BaseBackend):
                 ax.add_patch(rect)
         if parent.fill:
             ax.fill_between(**parent.fill)
+        if parent.special_points:
+            xticks = ax.get_xticks()
+            yticks = ax.get_yticks()
+            if isinstance(ax, Axes3D): zticks = ax.get_zticks()
+            for point in parent.special_points:
+                xticks = np.append(xticks, point[0])
+                yticks = np.append(yticks, point[1])
+                if isinstance(ax, Axes3D):
+                    zticks = np.append(yticks, point[2])
+                    self.plt.plot(point[0], point[1], point[2], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue", zorder=10)
+                else: self.plt.plot(point[0], point[1], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue", zorder=10)
+            ax.set_xticks(xticks)
+            ax.set_yticks(yticks)
+            if isinstance(ax, Axes3D): ax.set_yticks(zticks)
 
         # xlim and ylim should always be set at last so that plot limits
         # doesn't get altered during the process.
@@ -1529,21 +1543,6 @@ class MatplotlibBackend(BaseBackend):
             ax.set_xlim(parent.xlim)
         if parent.ylim:
             ax.set_ylim(parent.ylim)
-
-        if parent.special_points:
-            xticks = ax.get_xticks()
-            yticks = ax.get_yticks()
-            if isinstance(ax, Axes3D): zticks = ax.get_zticks()
-            for point in parent.special_points: 
-                xticks = np.append(xticks, point[0])
-                yticks = np.append(yticks, point[1])
-                if isinstance(ax, Axes3D):
-                    zticks = np.append(yticks, point[2])
-                    self.plt.plot(point[0], point[1], point[2], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue")
-                self.plt.plot(point[0], point[1], marker="o", markersize=5, markeredgecolor="blue", markerfacecolor="blue")
-            ax.set_xticks(xticks)
-            ax.set_yticks(yticks)
-            if isinstance(ax, Axes3D): ax.set_yticks(zticks)
 
     def process_series(self):
         """

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -762,3 +762,14 @@ def test_deprecated_get_segments():
     p = plot(f, (x, -10, 10), show=False)
     with warns_deprecated_sympy():
         p[0].get_segments()
+
+def test_special_points():
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+
+    x = Symbol('x')
+    y = Symbol('y')
+    f = sin(x)
+    plot(f, special_points=[(0, 0), (float(pi)/2, 1, )])
+    f3d = x + y
+    plot3d(f3d, special_points=[(0, 0, 0), (1, 2, 3)])


### PR DESCRIPTION
#### References to other Issues or PRs
Resolves #25027 

#### Brief description of what is fixed or changed
Adds `special_points` as an option in the Plot class, where `special_points` are a list of points provided by the user that can represent important points on the plot (i.e., `special_points=[(0, 0), (4.5, 5.5), (10, 20)]` or `special_points=[(0, 0, 0), (4.5, 5.5, 4.5), (10, 20, 30)]`). Special points then display on plot (currently just with ``MatplotlibBackend`` out of the default backends) 

`plot(3-abs(x))` produces: 
![without_points](https://user-images.githubusercontent.com/61703000/236367336-5d329b87-0ba6-411a-881a-ce6607d418e2.png)

`plot(3-abs(x), special_points=[(0, 3)])` produces: 
![with_special](https://user-images.githubusercontent.com/61703000/236367387-4c13ca43-67dd-403a-9eb2-2dc176bd426e.png)

#### Other comments
Text plot left unchanged due to its presence as a generally more bare bones plotting feature. 

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
