### PR TITLE
Added Tests for Integrals for Sum of Piecewise with A Neg Sign

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -211,6 +211,7 @@ Abhinav Chanda <abhinavchanda01@gmail.com>
 Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> Abhinav R Cillanki <95158195+JebronLames32@users.noreply.github.com>
 Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
 Abhishek <uchiha@pop-os.localdomain>
+Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2073,3 +2073,27 @@ def test_mul_pow_derivative():
     assert integrate(x*sec(x)**2, x) == x*tan(x) + log(cos(x))
     assert integrate(x**3*Derivative(f(x), (x, 4))) == \
            x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) + 6*x*Derivative(f(x), x) - 6*f(x)
+
+def test_issue_20782():
+    x_d = symbols('x_d')
+
+    fun1 = lambda x : -Piecewise((0, x < 0.0), (1, True))
+    fun2 = lambda x : Piecewise((0, x < 1.0), (1, True))
+    fun_sum = lambda x : +Piecewise((0, x < 0.0), (1, True)) \
+                        -Piecewise((0, x < 1.0), (1, True))
+
+    fun_sum_neg = lambda x : -Piecewise((0, x < 0.0), (1, True)) \
+                            +Piecewise((0, x < 1.0), (1, True))
+
+    assert integrate(-fun1(x_d), (x_d, -float('Inf'), 1)) == 1
+    assert integrate(-fun2(x_d), (x_d, -float('Inf'), 1)) == 0
+    assert integrate(fun1(x_d), (x_d, -float('Inf'), 1)) == -1
+    assert integrate(fun2(x_d), (x_d, -float('Inf'), 1)) == 0
+    assert integrate(fun_sum(x_d), (x_d, -float('Inf'), 1)) == 1
+    assert integrate(-fun_sum(x_d), (x_d, -float('Inf'), 1)) == -1
+    assert integrate(fun_sum_neg(x_d), (x_d, -float('Inf'), 1)) == -1
+    assert integrate(-fun_sum_neg(x_d), (x_d, -float('Inf'), 1)) == 1
+
+    f = Piecewise((0, x < 0.0), (1, True)) - Piecewise((0, x < 1.0), (1, True))
+    assert integrate(f, (x, -oo, 1)) == 1
+    assert integrate(-f, (x, -oo, 1)) == -1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Adds test cases from #20782

#### Brief description of what is fixed or changed
Adds `test_issue_20782` to `integrals\tests\test_integrals.py`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
