### PR TITLE
stop putting noncommutative exponent in denominator

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -63,6 +63,8 @@ class ExpBase(Function):
         """
         # this should be the same as Pow.as_numer_denom wrt
         # exponent handling
+        if not self.is_commutative:
+            return self, S.One
         exp = self.exp
         neg_exp = exp.is_negative
         if not neg_exp and not (-exp).is_negative:

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -686,6 +686,9 @@ def test_as_numer_denom():
     assert exp(-I*x).as_numer_denom() == (1, exp(I*x))
     assert exp(-I*n).as_numer_denom() == (1, exp(I*n))
     assert exp(-n).as_numer_denom() == (exp(-n), 1)
+    # Check noncommutativity
+    a = symbols('a', commutative=False)
+    assert exp(-a).as_numer_denom() == (exp(-a), 1)
 
 
 @_both_exp_pow


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #25086

#### Brief description of what is fixed or changed
Avoid putting a noncommutative exponent into a denominator of `as_num_denom`, which messes up order of multiplications in noncommutative expressions.

Essentially applies the patch suggested in #25086

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed noncommutative exponents being incorrectly put in denominators of expressions.
<!-- END RELEASE NOTES -->
