### PR TITLE
Changed the function called by sqrt from mpmath to math

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Callable
-from math import log as _log, sqrt as _sqrt
+from math import log as _log
 from itertools import product
 
 from .sympify import _sympify
@@ -14,7 +14,7 @@ from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .parameters import global_parameters
 from .relational import is_gt, is_lt
 from .kind import NumberKind, UndefinedKind
-from sympy.external.gmpy import HAS_GMPY, gmpy
+from sympy.external.gmpy import HAS_GMPY, gmpy, sqrt
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import as_int
@@ -23,24 +23,38 @@ from sympy.multipledispatch import Dispatcher
 from mpmath.libmp import sqrtrem as mpmath_sqrtrem
 
 
-
 def isqrt(n):
-    """Return the largest integer less than or equal to sqrt(n)."""
-    if n < 0:
-        raise ValueError("n must be nonnegative")
-    n = int(n)
+    r""" Return the largest integer less than or equal to `\sqrt{n}`.
 
-    # Fast path: with IEEE 754 binary64 floats and a correctly-rounded
-    # math.sqrt, int(math.sqrt(n)) works for any integer n satisfying 0 <= n <
-    # 4503599761588224 = 2**52 + 2**27. But Python doesn't guarantee either
-    # IEEE 754 format floats *or* correct rounding of math.sqrt, so check the
-    # answer and fall back to the slow method if necessary.
-    if n < 4503599761588224:
-        s = int(_sqrt(n))
-        if 0 <= n - s*s <= 2*s:
-            return s
+    Parameters
+    ==========
 
-    return integer_nthroot(n, 2)[0]
+    n : non-negative integer
+
+    Returns
+    =======
+
+    int : `\left\lfloor\sqrt{n}\right\rfloor`
+
+    Raises
+    ======
+
+    ValueError
+        If n is negative integer.
+
+    Examples
+    ========
+
+    >>> from sympy.core.power import isqrt
+    >>> isqrt(0)
+    0
+    >>> isqrt(9)
+    3
+    >>> isqrt(10)
+    3
+
+    """
+    return int(sqrt(int(n)))
 
 
 def integer_nthroot(y, n):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -40,7 +40,10 @@ def isqrt(n):
     ======
 
     ValueError
-        If n is negative integer.
+        If n is negative.
+    TypeError
+        If n is of a type that cannot be compared to ``int``.
+        Therefore, a TypeError is raised for ``str``, but not for ``float``.
 
     Examples
     ========
@@ -52,8 +55,19 @@ def isqrt(n):
     3
     >>> isqrt(10)
     3
+    >>> isqrt("30")
+    Traceback (most recent call last):
+        ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
+    >>> from sympy.core.numbers import Rational
+    >>> isqrt(Rational(-1, 2))
+    Traceback (most recent call last):
+        ...
+    ValueError: n must be nonnegative
 
     """
+    if n < 0:
+        raise ValueError("n must be nonnegative")
     return int(sqrt(int(n)))
 
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1093,16 +1093,6 @@ def test_isqrt():
     assert isqrt(4503599761588224-tiny) == 67108864
     assert isqrt(10**100 - tiny) == 10**50 - 1
 
-    # Check that using an inaccurate math.sqrt doesn't affect the results.
-    from sympy.core import power
-    old_sqrt = power._sqrt
-    power._sqrt = lambda x: 2.999999999
-    try:
-        assert isqrt(9) == 3
-        assert isqrt(10000) == 100
-    finally:
-        power._sqrt = old_sqrt
-
 
 def test_powers_Integer():
     """Test Integer._eval_power"""

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -32,7 +32,7 @@ __all__ = [
     # Either the gmpy or the mpmath function
     'factorial',
 
-    # isqrt from gmpy or math
+    # isqrt from gmpy or mpmath
     'sqrt',
 
     # gcd from gmpy or math
@@ -115,7 +115,7 @@ else:
     MPQ = PythonMPQ
 
     factorial = lambda x: int(mlib.ifac(x))
-    sqrt = math.isqrt
+    sqrt = lambda x: int(mlib.isqrt(x))
     if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd
         lcm = math.lcm

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -32,7 +32,7 @@ __all__ = [
     # Either the gmpy or the mpmath function
     'factorial',
 
-    # isqrt from gmpy or mpmath
+    # isqrt from gmpy or math
     'sqrt',
 
     # gcd from gmpy or math

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -115,7 +115,7 @@ else:
     MPQ = PythonMPQ
 
     factorial = lambda x: int(mlib.ifac(x))
-    sqrt = lambda x: int(mlib.isqrt(x))
+    sqrt = math.isqrt
     if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd
         lcm = math.lcm

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -1,6 +1,6 @@
 from sympy.ntheory import sieve, isprime
-from sympy.core.power import integer_log, isqrt
-from sympy.external.gmpy import gcd, invert
+from sympy.core.power import integer_log
+from sympy.external.gmpy import gcd, invert, sqrt
 from sympy.utilities.misc import as_int
 import random
 
@@ -201,7 +201,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200):
     if isprime(n):
         return n
 
-    D = isqrt(B2)
+    D = sqrt(B2)
     beta = [0]*(D + 1)
     S = [0]*(D + 1)
     k = 1

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from sympy.core.function import Function
-from sympy.core.power import isqrt
 from sympy.core.singleton import S
-from sympy.external.gmpy import gcd, invert
+from sympy.external.gmpy import gcd, invert, sqrt
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
@@ -1155,7 +1154,7 @@ def _discrete_log_shanks_steps(n, a, b, order=None):
     b %= n
     if order is None:
         order = n_order(b, n)
-    m = isqrt(order) + 1
+    m = sqrt(order) + 1
     T = {}
     x = 1
     for i in range(m):


### PR DESCRIPTION
`sympy.external.gmpy.sqrt` used to use mpmath when gmpy was not used, but `math.isqrt` has been implemented since Python 3.8, so this is now used. Also, `sympy.core.power.isqrt` now calls `sympy.external.gmpy.sqrt`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25067

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
