### PR TITLE
C type declarations

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1507,6 +1507,7 @@ kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+kujuo <61703000+kujuo@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
 luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
@@ -1515,6 +1516,7 @@ mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>
 naelsondouglas <naelson17@gmail.com>
+nikkiakali <nakali@andrew.cmu.edu>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -162,6 +162,7 @@ class C89CodePrinter(CodePrinter):
         'dereference': set(),
         'error_on_reserved': False,
         'reserved_word_suffix': '_',
+        'declare':None
     }
 
     type_aliases = {

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -135,7 +135,7 @@ class CodePrinter(StrPrinter):
 
         def _handle_assign_to(expr, assign_to):
             if assign_to is None:
-                return Assignment(expr, expr)
+                return sympify(expr)
             if isinstance(assign_to, (list, tuple)):
                 if len(expr) != len(assign_to):
                     raise ValueError('Failed to assign an expression of length {} to {} variables'.format(len(expr), len(assign_to)))
@@ -182,6 +182,8 @@ class CodePrinter(StrPrinter):
             result = (num_syms, self._not_supported, "\n".join(lines))
         self._not_supported = set()
         self._number_symbols = set()
+        if 'declare' in self._settings and self._settings['declare']:
+            return self._settings['declare'] + " " + result
         return result
 
     def _doprint_loops(self, expr, assign_to=None):
@@ -391,8 +393,6 @@ class CodePrinter(StrPrinter):
             lhs_code = self._print(lhs) # b, left on output and right on input
             rhs_code = self._print(rhs) # pow(a, 2)
             codestring = "%s = %s"
-            if 'declare' in self._settings and self._settings['declare']:
-                codestring = self._settings['declare'] + " " + codestring
             return self._get_statement(codestring % (lhs_code, rhs_code))
 
     def _print_AugmentedAssignment(self, expr):

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -135,7 +135,7 @@ class CodePrinter(StrPrinter):
 
         def _handle_assign_to(expr, assign_to):
             if assign_to is None:
-                return sympify(expr)
+                return Assignment(expr, expr)
             if isinstance(assign_to, (list, tuple)):
                 if len(expr) != len(assign_to):
                     raise ValueError('Failed to assign an expression of length {} to {} variables'.format(len(expr), len(assign_to)))
@@ -388,8 +388,8 @@ class CodePrinter(StrPrinter):
             # print the required loops.
             return self._doprint_loops(rhs, lhs)
         else:
-            lhs_code = self._print(lhs)
-            rhs_code = self._print(rhs)
+            lhs_code = self._print(lhs) # b, left on output and right on input
+            rhs_code = self._print(rhs) # pow(a, 2)
             codestring = "%s = %s"
             if 'declare' in self._settings and self._settings['declare']:
                 codestring = self._settings['declare'] + " " + codestring
@@ -410,7 +410,6 @@ class CodePrinter(StrPrinter):
         return self._print(expr.symbol)
 
     def _print_Symbol(self, expr):
-
         name = super()._print_Symbol(expr)
 
         if name in self.reserved_words:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -64,6 +64,7 @@ class CodePrinter(StrPrinter):
         'human': True,
         'inline': False,
         'allow_unknown_functions': False,
+        'declare': None
     }
 
     # Functions which are "simple" to rewrite to other functions that
@@ -389,7 +390,10 @@ class CodePrinter(StrPrinter):
         else:
             lhs_code = self._print(lhs)
             rhs_code = self._print(rhs)
-            return self._get_statement("%s = %s" % (lhs_code, rhs_code))
+            codestring = "%s = %s"
+            if 'declare' in self._settings and self._settings['declare']:
+                codestring = self._settings['declare'] + " " + codestring
+            return self._get_statement(codestring % (lhs_code, rhs_code))
 
     def _print_AugmentedAssignment(self, expr):
         lhs_code = self._print(expr.lhs)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #10446

Fixes C type declarations so the following is returned:
```
>> ccode(a, declare='double')
'double a'

>> ccode(a**2, b, declare='double')
'double b = pow(a, 2);'
```
Previously, the following was returned:
```
>> ccode(a, declare='double')
Type error!

>> ccode(a**2, b, declare='double')
Type error!

```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->