### PR TITLE
Implemented `LinearSpring` in `sympy.physics.mechanics`

### DIFF
--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -3,7 +3,7 @@ USE_SYMENGINE = os.getenv('USE_SYMENGINE', '0')
 USE_SYMENGINE = USE_SYMENGINE.lower() in ('1', 't', 'true')  # type: ignore
 
 if USE_SYMENGINE:
-    from symengine import (Symbol, Integer, sympify, S,
+    from symengine import (Symbol, Integer, sympify as sympify_symengine, S,
         SympifyError, exp, log, gamma, sqrt, I, E, pi, Matrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
         sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth,
@@ -12,6 +12,28 @@ if USE_SYMENGINE:
         ImmutableMatrix, MatrixBase, Rational, Basic)
     from symengine.lib.symengine_wrapper import gcd as igcd
     from symengine import AppliedUndef
+
+    def sympify(obj, *, strict=False):
+        """SymEngine-compatible strict ``sympify``.
+
+        Explanation
+        ===========
+
+        SymEngine's ``sympify`` does not accept keyword arguments and is
+        therefore not compatible with SymPy's ``sympify`` with ``strict=True``
+        (which ensures that only the types for which an explicit conversion has
+        been defined are converted).
+
+        See Also
+        ========
+
+        sympify: Converts an arbitrary expression to a type that can be used
+            inside SymPy.
+
+        """
+        if strict and isinstance(obj, str):
+            raise SympifyError(obj)
+        return sympify_symengine(obj)
 else:
     from sympy.core.add import Add
     from sympy.core.basic import Basic

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -33,10 +33,15 @@ if USE_SYMENGINE:
             inside SymPy.
 
         """
+        # The parameter ``a`` is used for this function to keep compatibility
+        # with the SymEngine docstring.
         if strict and isinstance(a, str):
             raise SympifyError(a)
         return sympify_symengine(a)
 
+    # Keep the SymEngine docstring and append the additional "Notes" and "See
+    # Also" sections. Replacement of spaces is required to correctly format the
+    # indentation of the combined docstring.
     sympify.__doc__ = (
         sympify_symengine.__doc__
         + sympify.__doc__.replace('        ', '    ')

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -13,7 +13,7 @@ if USE_SYMENGINE:
     from symengine.lib.symengine_wrapper import gcd as igcd
     from symengine import AppliedUndef
 
-    def sympify(obj, *, strict=False):
+    def sympify(a, *, strict=False):
         """
         Notes
         =====
@@ -33,9 +33,9 @@ if USE_SYMENGINE:
             inside SymPy.
 
         """
-        if strict and isinstance(obj, str):
-            raise SympifyError(obj)
-        return sympify_symengine(obj)
+        if strict and isinstance(a, str):
+            raise SympifyError(a)
+        return sympify_symengine(a)
 
     sympify.__doc__ = (
         sympify_symengine.__doc__

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -14,15 +14,17 @@ if USE_SYMENGINE:
     from symengine import AppliedUndef
 
     def sympify(obj, *, strict=False):
-        """SymEngine-compatible strict ``sympify``.
-
-        Explanation
-        ===========
+        """
+        Notes
+        =====
 
         SymEngine's ``sympify`` does not accept keyword arguments and is
         therefore not compatible with SymPy's ``sympify`` with ``strict=True``
         (which ensures that only the types for which an explicit conversion has
-        been defined are converted).
+        been defined are converted). This wrapper adds an addiotional parameter
+        ``strict`` (with default ``False``) that will raise a ``SympifyError``
+        if ``strict=True`` and the argument passed to the parameter ``a`` is a
+        string.
 
         See Also
         ========
@@ -34,6 +36,11 @@ if USE_SYMENGINE:
         if strict and isinstance(obj, str):
             raise SympifyError(obj)
         return sympify_symengine(obj)
+
+    sympify.__doc__ = (
+        sympify_symengine.__doc__
+        + sympify.__doc__.replace('        ', '    ')
+    )
 else:
     from sympy.core.add import Add
     from sympy.core.basic import Basic

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -44,7 +44,7 @@ if USE_SYMENGINE:
     # indentation of the combined docstring.
     sympify.__doc__ = (
         sympify_symengine.__doc__
-        + sympify.__doc__.replace('        ', '    ')
+        + sympify.__doc__.replace('        ', '    ')  # type: ignore
     )
 else:
     from sympy.core.add import Add

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -155,6 +155,7 @@ class ForceActuator(ActuatorBase):
             a concrete subclass of ``PathwayBase``, e.g. ``LinearPathway``.
 
         """
+        # ``force`` attribute
         if not isinstance(force, ExprType):
             msg = (
                 f'Value {repr(force)} passed to `force` was of type '
@@ -163,8 +164,14 @@ class ForceActuator(ActuatorBase):
             raise TypeError(msg)
         self._force = force
 
-        self.pathway = pathway
-        super().__init__()
+        # ``pathway`` attribute
+        if not isinstance(pathway, PathwayBase):
+            msg = (
+                f'Value {repr(pathway)} passed to `pathway` was of type '
+                f'{type(pathway)}, must be {PathwayBase}.'
+            )
+            raise TypeError(msg)
+        self._pathway = pathway
 
     @property
     def force(self) -> ExprType:
@@ -175,16 +182,6 @@ class ForceActuator(ActuatorBase):
     def pathway(self) -> PathwayBase:
         """The ``Pathway`` defining the actuator's line of action."""
         return self._pathway
-
-    @pathway.setter
-    def pathway(self, pathway: PathwayBase) -> None:
-        if not isinstance(pathway, PathwayBase):
-            msg = (
-                f'Value {repr(pathway)} passed to `pathway` was of type '
-                f'{type(pathway)}, must be {PathwayBase}.'
-            )
-            raise TypeError(msg)
-        self._pathway = pathway
 
     def to_loads(self) -> list[LoadBase]:
         """Loads required by the equations of motion method classes.
@@ -386,9 +383,33 @@ class LinearSpring(ForceActuator):
             function of the pathway's length with no constant offset.
 
         """
-        self.stiffness = stiffness
-        self.pathway = pathway
-        self.equilibrium_length = equilibrium_length
+        # ``stiffness`` attribute
+        if not isinstance(stiffness, ExprType):
+            msg = (
+                f'Value {repr(stiffness)} passed to `stiffness` was of type '
+                f'{type(stiffness)}, must be {ExprType}.'
+            )
+            raise TypeError(msg)
+        self._stiffness = stiffness
+
+        # ``pathway`` attribute
+        if not isinstance(pathway, PathwayBase):
+            msg = (
+                f'Value {repr(pathway)} passed to `pathway` was of type '
+                f'{type(pathway)}, must be {PathwayBase}.'
+            )
+            raise TypeError(msg)
+        self._pathway = pathway
+
+        # ``equilibrium_length`` attribute
+        if not isinstance(equilibrium_length, ExprType):
+            msg = (
+                f'Value {repr(equilibrium_length)} passed to '
+                f'`equilibrium_length` was of type '
+                f'{type(equilibrium_length)}, must be {ExprType}.'
+            )
+            raise TypeError(msg)
+        self._equilibrium_length = equilibrium_length
 
     @property
     def force(self) -> ExprType:
@@ -400,31 +421,10 @@ class LinearSpring(ForceActuator):
         """The spring constant for the linear spring."""
         return self._stiffness
 
-    @stiffness.setter
-    def stiffness(self, stiffness: ExprType) -> None:
-        if not isinstance(stiffness, ExprType):
-            msg = (
-                f'Value {repr(stiffness)} passed to `stiffness` was of type '
-                f'{type(stiffness)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._stiffness = stiffness
-
     @property
     def equilibrium_length(self) -> ExprType:
         """The length of the spring at which it produces no force."""
         return self._equilibrium_length
-
-    @equilibrium_length.setter
-    def equilibrium_length(self, equilibrium_length: ExprType) -> None:
-        if not isinstance(equilibrium_length, ExprType):
-            msg = (
-                f'Value {repr(equilibrium_length)} passed to '
-                f'`equilibrium_length` was of type '
-                f'{type(equilibrium_length)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._equilibrium_length = equilibrium_length
 
     def __repr__(self) -> str:
         """Representation of a ``LinearSpring``."""

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from sympy.core.backend import S, USE_SYMENGINE
+from sympy.core.backend import S, USE_SYMENGINE, sympify
 from sympy.physics.mechanics import (
     PinJoint,
     ReferenceFrame,
@@ -25,18 +25,8 @@ from sympy.physics.mechanics import (
 from sympy.physics.mechanics._pathway import PathwayBase
 
 if USE_SYMENGINE:
-    from sympy.core.backend import (
-        Basic as ExprType,
-        sympify as sympify_symengine,
-    )
-    from sympy.core.sympify import sympify as sympify_sympy
-
-    def sympify(*args, **kwargs):
-        if kwargs.get('strict') is True:
-            return sympify_symengine(sympify_sympy(*args, **kwargs))
-        return sympify_symengine(*args, **kwargs)
+    from sympy.core.backend import Basic as ExprType
 else:
-    from sympy.core.backend import sympify
     from sympy.core.expr import Expr as ExprType
 
 if TYPE_CHECKING:

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -25,8 +25,18 @@ from sympy.physics.mechanics import (
 from sympy.physics.mechanics._pathway import PathwayBase
 
 if USE_SYMENGINE:
-    from sympy.core.backend import Basic as ExprType
+    from sympy.core.backend import (
+        Basic as ExprType,
+        sympify as sympify_symengine,
+    )
+    from sympy.core.sympify import sympify as sympify_sympy
+
+    def sympify(*args, **kwargs):
+        if kwargs.get('strict') is True:
+            return sympify_symengine(sympify_sympy(*args, **kwargs))
+        return sympify_symengine(*args, **kwargs)
 else:
+    from sympy.core.backend import sympify
     from sympy.core.expr import Expr as ExprType
 
 if TYPE_CHECKING:
@@ -156,13 +166,7 @@ class ForceActuator(ActuatorBase):
 
         """
         # ``force`` attribute
-        if not isinstance(force, ExprType):
-            msg = (
-                f'Value {repr(force)} passed to `force` was of type '
-                f'{type(force)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._force = force
+        self._force = sympify(force, strict=True)
 
         # ``pathway`` attribute
         if not isinstance(pathway, PathwayBase):
@@ -383,13 +387,7 @@ class LinearSpring(ForceActuator):
 
         """
         # ``stiffness`` attribute
-        if not isinstance(stiffness, ExprType):
-            msg = (
-                f'Value {repr(stiffness)} passed to `stiffness` was of type '
-                f'{type(stiffness)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._stiffness = stiffness
+        self._stiffness = sympify(stiffness, strict=True)
 
         # ``pathway`` attribute
         if not isinstance(pathway, PathwayBase):
@@ -401,14 +399,7 @@ class LinearSpring(ForceActuator):
         self._pathway = pathway
 
         # ``equilibrium_length`` attribute
-        if not isinstance(equilibrium_length, ExprType):
-            msg = (
-                f'Value {repr(equilibrium_length)} passed to '
-                f'`equilibrium_length` was of type '
-                f'{type(equilibrium_length)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._equilibrium_length = equilibrium_length
+        self._equilibrium_length = sympify(equilibrium_length, strict=True)
 
     @property
     def force(self) -> ExprType:

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -33,7 +33,11 @@ if TYPE_CHECKING:
     from sympy.physics.mechanics.loads import LoadBase
 
 
-__all__ = ['ForceActuator']
+__all__ = [
+    'ForceActuator',
+    'LinearSpring',
+    'TorqueActuator',
+]
 
 
 class ActuatorBase(ABC):

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -364,7 +364,6 @@ class LinearSpring(ForceActuator):
         self,
         stiffness: ExprType,
         pathway: PathwayBase,
-        *,
         equilibrium_length: ExprType = S.Zero,
     ) -> None:
         """Initializer for ``LinearSpring``.

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -155,17 +155,6 @@ class ForceActuator(ActuatorBase):
             a concrete subclass of ``PathwayBase``, e.g. ``LinearPathway``.
 
         """
-        self.force = force
-        self.pathway = pathway
-        super().__init__()
-
-    @property
-    def force(self) -> ExprType:
-        """The magnitude of the force produced by the actuator."""
-        return self._force
-
-    @force.setter
-    def force(self, force: ExprType) -> None:
         if not isinstance(force, ExprType):
             msg = (
                 f'Value {repr(force)} passed to `force` was of type '
@@ -173,6 +162,14 @@ class ForceActuator(ActuatorBase):
             )
             raise TypeError(msg)
         self._force = force
+
+        self.pathway = pathway
+        super().__init__()
+
+    @property
+    def force(self) -> ExprType:
+        """The magnitude of the force produced by the actuator."""
+        return self._force
 
     @property
     def pathway(self) -> PathwayBase:

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -357,7 +357,8 @@ class LinearSpring(ForceActuator):
     See Also
     ========
 
-    LinearPathway
+    ForceActuator: force-producing actuator (superclass of ``LinearSpring``).
+    LinearPathway: straight-line pathway between a pair of points.
 
     """
 

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -155,6 +155,44 @@ class TestLinearSpring:
     def test_is_actuator_base_subclass(self) -> None:
         assert issubclass(LinearSpring, ActuatorBase)
 
+    @pytest.mark.parametrize(
+        'stiffness, equilibrium_length, force',
+        [
+            (Symbol('k'), S.Zero, -Symbol('k')*sqrt(dynamicsymbols('q')**2)),
+            (Symbol('k'), Symbol('l'), -Symbol('k')*(sqrt(dynamicsymbols('q')**2) - Symbol('l'))),
+        ]
+    )
+    def test_valid_constructor(
+        self,
+        stiffness: ExprType,
+        equilibrium_length: ExprType,
+        force: ExprType,
+    ) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        spring = LinearSpring(
+            stiffness,
+            self.pathway,
+            equilibrium_length=equilibrium_length,
+        )
+
+        assert isinstance(spring, LinearSpring)
+
+        assert hasattr(spring, 'stiffness')
+        assert isinstance(spring.stiffness, ExprType)
+        assert spring.stiffness == stiffness
+
+        assert hasattr(spring, 'pathway')
+        assert isinstance(spring.pathway, LinearPathway)
+        assert spring.pathway == self.pathway
+
+        assert hasattr(spring, 'equilibrium_length')
+        assert isinstance(spring.equilibrium_length, ExprType)
+        assert spring.equilibrium_length == equilibrium_length
+
+        assert hasattr(spring, 'force')
+        assert isinstance(spring.force, ExprType)
+        assert spring.force == force
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -201,7 +201,7 @@ class TestLinearSpring:
             (Symbol('l'), 'LinearSpring(k, LinearPathway(pA, pB), equilibrium_length=l)'),
         ]
     )
-    def test_repr(self, equilibrium_length, expected) -> None:
+    def test_repr(self, equilibrium_length: Any, expected: str) -> None:
         self.pB.set_pos(self.pA, self.q * self.N.x)
         spring = LinearSpring(
             self.stiffness,

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -139,6 +139,16 @@ class TestForceActuator:
 
 class TestLinearSpring:
 
+    @pytest.fixture(autouse=True)
+    def _linear_pathway_fixture(self) -> None:
+        self.stiffness = Symbol('k')
+        self.l = Symbol('l')
+        self.pA = Point('pA')
+        self.pB = Point('pB')
+        self.pathway = LinearPathway(self.pA, self.pB)
+        self.q = dynamicsymbols('q')
+        self.N = ReferenceFrame('N')
+
     def test_is_force_actuator_subclass(self) -> None:
         assert issubclass(LinearSpring, ForceActuator)
 

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -170,11 +170,7 @@ class TestLinearSpring:
         force: ExprType,
     ) -> None:
         self.pB.set_pos(self.pA, self.q * self.N.x)
-        spring = LinearSpring(
-            stiffness,
-            self.pathway,
-            equilibrium_length=equilibrium_length,
-        )
+        spring = LinearSpring(stiffness, self.pathway, equilibrium_length)
 
         assert isinstance(spring, LinearSpring)
 
@@ -203,20 +199,12 @@ class TestLinearSpring:
     )
     def test_repr(self, equilibrium_length: Any, expected: str) -> None:
         self.pB.set_pos(self.pA, self.q * self.N.x)
-        spring = LinearSpring(
-            self.stiffness,
-            self.pathway,
-            equilibrium_length=equilibrium_length,
-        )
+        spring = LinearSpring(self.stiffness, self.pathway, equilibrium_length)
         assert repr(spring) == expected
 
     def test_to_loads(self) -> None:
         self.pB.set_pos(self.pA, self.q * self.N.x)
-        spring = LinearSpring(
-            self.stiffness,
-            self.pathway,
-            equilibrium_length=self.l,
-        )
+        spring = LinearSpring(self.stiffness, self.pathway, self.l)
         normal = self.q / sqrt(self.q**2) * self.N.x
         pA_force = self.stiffness * (sqrt(self.q**2) - self.l) * normal
         pB_force = -self.stiffness * (sqrt(self.q**2) - self.l) * normal

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -20,6 +20,7 @@ from sympy.physics.mechanics import (
 from sympy.physics.mechanics._actuator import (
     ActuatorBase,
     ForceActuator,
+    LinearSpring,
     TorqueActuator,
 )
 from sympy.physics.mechanics._pathway import LinearPathway, PathwayBase
@@ -134,6 +135,15 @@ class TestForceActuator:
             (self.pB, pI_force),
         ]
         assert actuator.to_loads() == expected
+
+
+class TestLinearSpring:
+
+    def test_is_force_actuator_subclass(self) -> None:
+        assert issubclass(LinearSpring, ForceActuator)
+
+    def test_is_actuator_base_subclass(self) -> None:
+        assert issubclass(LinearSpring, ActuatorBase)
 
 
 def test_forced_mass_spring_damper_model():

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -141,7 +141,7 @@ class TestForceActuator:
 class TestLinearSpring:
 
     @pytest.fixture(autouse=True)
-    def _linear_pathway_fixture(self) -> None:
+    def _linear_spring_fixture(self) -> None:
         self.stiffness = Symbol('k')
         self.l = Symbol('l')
         self.pA = Point('pA')

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -220,10 +220,7 @@ class TestLinearSpring:
         normal = self.q / sqrt(self.q**2) * self.N.x
         pA_force = self.stiffness * (sqrt(self.q**2) - self.l) * normal
         pB_force = -self.stiffness * (sqrt(self.q**2) - self.l) * normal
-        expected = [
-            Force(self.pA, pA_force),
-            Force(self.pB, pB_force),
-        ]
+        expected = [Force(self.pA, pA_force), Force(self.pB, pB_force)]
         loads = spring.to_loads()
 
         for load, (point, vector) in zip(loads, expected):

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -193,6 +193,22 @@ class TestLinearSpring:
         assert isinstance(spring.force, ExprType)
         assert spring.force == force
 
+    @pytest.mark.parametrize(
+        'equilibrium_length, expected',
+        [
+            (S.Zero, 'LinearSpring(k, LinearPathway(pA, pB))'),
+            (Symbol('l'), 'LinearSpring(k, LinearPathway(pA, pB), equilibrium_length=l)'),
+        ]
+    )
+    def test_repr(self, equilibrium_length, expected) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        spring = LinearSpring(
+            self.stiffness,
+            self.pathway,
+            equilibrium_length=equilibrium_length,
+        )
+        assert repr(spring) == expected
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -6,8 +6,14 @@ from typing import Any, Sequence
 
 import pytest
 
-from sympy.core.backend import S, USE_SYMENGINE, Matrix, Symbol, sqrt
-from sympy.core.sympify import SympifyError
+from sympy.core.backend import (
+    S,
+    USE_SYMENGINE,
+    Matrix,
+    Symbol,
+    SympifyError,
+    sqrt,
+)
 from sympy.physics.mechanics import (
     Force,
     KanesMethod,
@@ -222,21 +228,20 @@ class TestLinearSpring:
         assert spring.force == force
 
     @pytest.mark.parametrize(
-        'stiffness, equilibrium_length, expected_error',
+        'stiffness, equilibrium_length',
         [
-            (None, 0, SympifyError),
-            ('k', 0, ValueError),
-            (Symbol('k'), None, SympifyError),
-            (Symbol('k'), 'l', ValueError),
+            (None, 0),
+            ('k', 0),
+            (Symbol('k'), None),
+            (Symbol('k'), 'l'),
         ]
     )
     def test_invalid_constructor(
         self,
         stiffness: Any,
         equilibrium_length: Any,
-        expected_error: Exception,
     ) -> None:
-        with pytest.raises(expected_error):  # type: ignore
+        with pytest.raises(SympifyError):
             _ = LinearSpring(stiffness, self.pathway, equilibrium_length)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

Extends specifically #24966 (but is also related to #24914, #25068, and #25105).

#### Brief description of what is fixed or changed
This PR implements a new actuator class, `LinearSpring`, which extends `ForceActuator`, a concrete class of `ActuatorBase`. It represents a spring who's force-production capabilities are a linear function of its length. 

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the module is moved to `sympy/physics/mechanics/actuator.py`.

#### Other comments
I have specifically left the release notes entry empty. These will be added in the PR that moves the module to `sympy/physics/mechanics/actuator.py`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
