### PR TITLE
Deprecating markers, annotations, fill, rectangles properties of the Plot class

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -493,7 +493,7 @@ David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
 David P. Sanders <dpsanders@gmail.com>
 David Roberts <dvdr18@gmail.com> David Roberts (dvdr18 [at] gmail [dot] com) <devnull@localhost>
 David T <derDavidT@users.noreply.github.com>
-Davide Sandonà <sandona.davide@gmail.com> Davide_sd <sandona.davide@gmail.com>
+Davide Sandonà <sandona.davide@gmail.com>
 Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
 Demian Wassermann <demian@bwh.harvard.edu>
 Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -84,6 +84,29 @@ The new implementation saves user-provided numerical data into appropriate
 data series, which can easily be processed by ``MatplotlibBackend``.
 Instead of setting those properties directly, users should pass the homonym
 keyword arguments to the plotting functions.
+
+The supported behavior is to pass keyword arguments to the plotting functions,
+which works fine both for previous and current implementation:
+
+```py
+p = plot(x,
+  markers=[{"args":[[0, 1], [0, 1]], "marker": "*", "linestyle": "none"}],
+  annotations=[{"text": "test", "xy": (0, 0)}],
+  fill={"x": [0, 1, 2, 3], "y1": [0, 1, 2, 3]},
+  rectangles=[{"xy": (0, 0), "width": 5, "height": 1}])
+```
+
+Setting attributes on the plot object is deprecated and will raise warnings:
+
+```py
+p = plot(x, show=False)
+p.markers = [{"args":[[0, 1], [0, 1]], "marker": "*", "linestyle": "none"}]
+p.annotations = [{"text": "test", "xy": (0, 0)}]
+p.fill = {"x": [0, 1, 2, 3], "y1": [0, 1, 2, 3]}
+p.rectangles = [{"xy": (0, 0), "width": 5, "height": 1}]
+p.show()
+```
+
 Motivation for this deprecation: the implementation of the ``Plot`` class
 suggests that it is ok to add attributes and hard-coded if-statements in the
 ``MatplotlibBackend`` class to provide more and more functionalities for

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,38 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
+(deprecated-markers-annotations-fill-rectangles)=
+### Deprecate markers, annotations, fill, rectangles of the Plot class
+The properties ``markers, annotations, fill, rectangles`` (containing
+user-provided numerical data to be added on a plot) are deprecated.
+The new implementation saves user-provided numerical data into appropriate
+data series, which can easily be processed by ``MatplotlibBackend``.
+Instead of setting those properties directly, users should pass the homonym
+keyword arguments to the plotting functions.
+Motivation for this deprecation: the implementation of the ``Plot`` class
+suggests that it is ok to add attributes and hard-coded if-statements in the
+``MatplotlibBackend`` class to provide more and more functionalities for
+user-provided numerical data (e.g. adding horizontal lines, or vertical
+lines, or bar plots, etc). However, in doing so one would reinvent the wheel:
+plotting libraries already implements the necessary API. There is no need to
+hard code these things. The plotting module should facilitate the visualization
+of symbolic expressions. The best way to add custom numerical data is to
+retrieve the figure created by the plotting module and use the API of a
+particular plotting library. For example:
+
+```py
+# plot symbolic expression
+p = plot(cos(x))
+# retrieve Matplotlib's figure and axes object
+fig, ax = p._backend.fig, p._backend.ax[0]
+# add the desired numerical data using Matplotlib's API
+ax.plot([0, 1, 2], [0, 1, -1], "*")
+ax.axhline(0.5)
+# visualize the figure
+fig
+```
+
+
 (moved-mechanics-functions)=
 ### Moved mechanics functions
 With the introduction of some new objects like the ``Inertia`` and load objects

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -86,7 +86,7 @@ Instead of setting those properties directly, users should pass the homonym
 keyword arguments to the plotting functions.
 
 The supported behavior is to pass keyword arguments to the plotting functions,
-which works fine both for previous and current implementation:
+which works fine for all versions of SymPy (before and after 1.13):
 
 ```py
 p = plot(x,

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1311,20 +1311,16 @@ class GenericDataSeries(BaseSeries):
     in adding custom numerical data to a plot should retrieve the figure
     created by this plotting module. For example, this code:
 
-    .. code-block:: python
-
-       from sympy import *
-       var("x")
-       p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
+    >>> from sympy import Symbol, plot
+    >>> x = Symbol("x")
+    >>> p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
 
     Becomes:
 
-    .. code-block:: python
-
-       p = plot(cos(x))
-       fig, ax = p._backend.fig, p._backend.ax[0]
-       ax.plot([0, 1, 2], [0, 1, -1], "*")
-       fig
+    >>> p = plot(cos(x))
+    >>> fig, ax = p._backend.fig, p._backend.ax[0]
+    >>> ax.plot([0, 1, 2], [0, 1, -1], "*")
+    >>> fig
 
     Which is far better in terms of readibility. Also, it gives access to the
     full plotting library capabilities, without the need to reinvent the wheel.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1311,7 +1311,7 @@ class GenericDataSeries(BaseSeries):
     in adding custom numerical data to a plot should retrieve the figure
     created by this plotting module. For example, this code:
 
-    >>> from sympy import Symbol, plot
+    >>> from sympy import Symbol, plot, cos
     >>> x = Symbol("x")
     >>> p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -62,10 +62,33 @@ def _str_or_latex(label):
         return latex(label, mode='inline')
     return str(label)
 
+def _create_generic_data_series(**kwargs):
+    keywords = ["annotations", "markers", "fill", "rectangles"]
+    series = []
+    for kw in keywords:
+        dictionaries = kwargs.pop(kw, [])
+        if dictionaries is None:
+            dictionaries = []
+        if isinstance(dictionaries, dict):
+            dictionaries = [dictionaries]
+        for d in dictionaries:
+            args = d.pop("args", [])
+            series.append(GenericDataSeries(kw, *args, **d))
+    return series
+
 ##############################################################################
 # The public interface
 ##############################################################################
 
+def _deprecation_msg_m_a_r_f(attr):
+    sympy_deprecation_warning(
+        f"The `{attr}` property is deprecated. The `{attr}` keyword "
+        "argument should be passed to a plotting function, which generates "
+        "the appropriate data series. If needed, index the plot object to "
+        "retrieve a specific data series.",
+        deprecated_since_version="1.13",
+        active_deprecations_target="deprecated-markers-annotations-fill-rectangles",
+        stacklevel=4)
 
 class Plot:
     """The central class of the plotting module.
@@ -198,15 +221,18 @@ class Plot:
         self.legend = legend
         self.autoscale = autoscale
         self.margin = margin
-        self.annotations = annotations
-        self.markers = markers
-        self.rectangles = rectangles
-        self.fill = fill
+        self._annotations = annotations
+        self._markers = markers
+        self._rectangles = rectangles
+        self._fill = fill
 
         # Contains the data objects to be plotted. The backend should be smart
         # enough to iterate over this list.
         self._series = []
         self._series.extend(args)
+        self._series.extend(_create_generic_data_series(
+            annotations=annotations, markers=markers, rectangles=rectangles,
+            fill=fill))
 
         # The backend type. On every show() a new backend instance is created
         # in self._backend which is tightly coupled to the Plot instance
@@ -241,7 +267,6 @@ class Plot:
         check_and_set("ylim", ylim)
         self.size = None
         check_and_set("size", size)
-
 
     def show(self):
         # TODO move this to the backend (also for save)
@@ -341,6 +366,60 @@ class Plot:
             self._series.extend(arg)
         else:
             raise TypeError('Expecting Plot or sequence of BaseSeries')
+
+    # deprecations
+
+    @property
+    def markers(self):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("markers")
+        return self._markers
+
+    @markers.setter
+    def markers(self, v):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("markers")
+        self._series.extend(_create_generic_data_series(markers=v))
+        self._markers = v
+
+    @property
+    def annotations(self):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("annotations")
+        return self._annotations
+
+    @annotations.setter
+    def annotations(self, v):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("annotations")
+        self._series.extend(_create_generic_data_series(annotations=v))
+        self._annotations = v
+
+    @property
+    def rectangles(self):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("rectangles")
+        return self._rectangles
+
+    @rectangles.setter
+    def rectangles(self, v):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("rectangles")
+        self._series.extend(_create_generic_data_series(rectangles=v))
+        self._rectangles = v
+
+    @property
+    def fill(self):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("fill")
+        return self._fill
+
+    @fill.setter
+    def fill(self, v):
+        """.. deprecated:: 1.13"""
+        _deprecation_msg_m_a_r_f("fill")
+        self._series.extend(_create_generic_data_series(fill=v))
+        self._fill = v
 
 
 class PlotGrid:
@@ -546,6 +625,9 @@ class BaseSeries:
     # The calculation of aesthetics expects:
     #   - get_parameter_points returning one or two np.arrays (1D or 2D)
     # used for calculation aesthetics
+
+    is_generic = False
+    # Represent generic user-provided numerical data
 
     def __init__(self):
         super().__init__()
@@ -1204,6 +1286,59 @@ class ContourSeries(BaseSeries):
         return (mesh_x, mesh_y, f(mesh_x, mesh_y))
 
 
+class GenericDataSeries(BaseSeries):
+    """Represents generic numerical data.
+
+    Notes
+    =====
+    This class serves the purpose of back-compatibility with the "markers,
+    annotations, fill, rectangles" keyword arguments that represent
+    user-provided numerical data. In particular, it solves the problem of
+    combining together two or more plot-objects with the ``extend`` or
+    ``append`` methods: user-provided numerical data is also taken into
+    consideration because it is stored in this series class.
+
+    Also note that the current implementation is far from optimal, as each
+    keyword argument is stored into an attribute in the ``Plot`` class, which
+    requires a hard-coded if-statement in the ``MatplotlibBackend`` class.
+    The implementation suggests that it is ok to add attributes and
+    if-statements to provide more and more functionalities for user-provided
+    numerical data (e.g. adding horizontal lines, or vertical lines, or bar
+    plots, etc). However, in doing so one would reinvent the wheel: plotting
+    libraries (like Matplotlib) already implements the necessary API.
+
+    Instead of adding more keyword arguments and attributes, users interested
+    in adding custom numerical data to a plot should retrieve the figure
+    created by this plotting module. For example, this code:
+
+    .. code-block:: python
+
+       from sympy import *
+       var("x")
+       p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
+
+    Becomes:
+
+    .. code-block:: python
+
+       p = plot(cos(x))
+       fig, ax = p._backend.fig, p._backend.ax[0]
+       ax.plot([0, 1, 2], [0, 1, -1], "*")
+       fig
+
+    Which is far better in terms of readibility. Also, it gives access to the
+    full plotting library capabilities, without the need to reinvent the wheel.
+    """
+    is_generic = True
+
+    def __init__(self, tp, *args, **kwargs):
+        self.type = tp
+        self.args = args
+        self.rendering_kw = kwargs
+
+    def get_data(self):
+        return self.args
+
 ##############################################################################
 # Backends
 ##############################################################################
@@ -1424,6 +1559,20 @@ class MatplotlibBackend(BaseBackend):
                         ax.contour(xarray, yarray, zarray, cmap=colormap)
                     else:
                         ax.contourf(xarray, yarray, zarray, cmap=colormap)
+            elif s.is_generic:
+                if s.type == "markers":
+                    # s.rendering_kw["color"] = s.line_color
+                    ax.plot(*s.args, **s.rendering_kw)
+                elif s.type == "annotations":
+                    ax.annotate(*s.args, **s.rendering_kw)
+                elif s.type == "fill":
+                    # s.rendering_kw["color"] = s.line_color
+                    ax.fill_between(*s.args, **s.rendering_kw)
+                elif s.type == "rectangles":
+                    # s.rendering_kw["color"] = s.line_color
+                    ax.add_patch(
+                        self.matplotlib.patches.Rectangle(
+                            *s.args, **s.rendering_kw))
             else:
                 raise NotImplementedError(
                     '{} is not supported in the SymPy plotting module '
@@ -1504,22 +1653,6 @@ class MatplotlibBackend(BaseBackend):
         if isinstance(ax, Axes3D) and parent.zlabel:
             zlbl = _str_or_latex(parent.zlabel)
             ax.set_zlabel(zlbl, position=(0, 1))
-        if parent.annotations:
-            for a in parent.annotations:
-                ax.annotate(**a)
-        if parent.markers:
-            for marker in parent.markers:
-                # make a copy of the marker dictionary
-                # so that it doesn't get altered
-                m = marker.copy()
-                args = m.pop('args')
-                ax.plot(*args, **m)
-        if parent.rectangles:
-            for r in parent.rectangles:
-                rect = self.matplotlib.patches.Rectangle(**r)
-                ax.add_patch(rect)
-        if parent.fill:
-            ax.fill_between(**parent.fill)
 
         # xlim and ylim should always be set at last so that plot limits
         # doesn't get altered during the process.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1319,8 +1319,8 @@ class GenericDataSeries(BaseSeries):
 
     >>> p = plot(cos(x))
     >>> fig, ax = p._backend.fig, p._backend.ax[0]
-    >>> ax.plot([0, 1, 2], [0, 1, -1], "*")
-    >>> fig
+    >>> ax.plot([0, 1, 2], [0, 1, -1], "*") # doctest: +SKIP
+    >>> fig # doctest: +SKIP
 
     Which is far better in terms of readibility. Also, it gives access to the
     full plotting library capabilities, without the need to reinvent the wheel.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1311,16 +1311,24 @@ class GenericDataSeries(BaseSeries):
     in adding custom numerical data to a plot should retrieve the figure
     created by this plotting module. For example, this code:
 
-    >>> from sympy import Symbol, plot, cos
-    >>> x = Symbol("x")
-    >>> p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
+    .. plot::
+       :context: close-figs
+       :include-source: True
+
+       from sympy import Symbol, plot, cos
+       x = Symbol("x")
+       p = plot(cos(x), markers=[{"args": [[0, 1, 2], [0, 1, -1], "*"]}])
 
     Becomes:
 
-    >>> p = plot(cos(x))
-    >>> fig, ax = p._backend.fig, p._backend.ax[0]
-    >>> ax.plot([0, 1, 2], [0, 1, -1], "*") # doctest: +SKIP
-    >>> fig # doctest: +SKIP
+    .. plot::
+       :context: close-figs
+       :include-source: True
+
+       p = plot(cos(x), backend="matplotlib")
+       fig, ax = p._backend.fig, p._backend.ax[0]
+       ax.plot([0, 1, 2], [0, 1, -1], "*")
+       fig
 
     Which is far better in terms of readibility. Also, it gives access to the
     full plotting library capabilities, without the need to reinvent the wheel.

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -762,3 +762,39 @@ def test_deprecated_get_segments():
     p = plot(f, (x, -10, 10), show=False)
     with warns_deprecated_sympy():
         p[0].get_segments()
+
+def test_generic_data_series():
+    # verify that no errors are raised when generic data series are used
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+
+    x = Symbol("x")
+    p = plot(x,
+        markers=[{"args":[[0, 1], [0, 1]], "marker": "*", "linestyle": "none"}],
+        annotations=[{"text": "test", "xy": (0, 0)}],
+        fill={"x": [0, 1, 2, 3], "y1": [0, 1, 2, 3]},
+        rectangles=[{"xy": (0, 0), "width": 5, "height": 1}])
+    assert len(p._backend.ax[0].collections) == 1
+    assert len(p._backend.ax[0].patches) == 1
+    assert len(p._backend.ax[0].lines) == 2
+    assert len(p._backend.ax[0].texts) == 1
+
+
+def test_deprecated_markers_annotations_rectangles_fill():
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+
+    x = Symbol('x')
+    p = plot(sin(x), (x, -10, 10), show=False)
+    with warns_deprecated_sympy():
+        p.markers = [{"args":[[0, 1], [0, 1]], "marker": "*", "linestyle": "none"}]
+    assert len(p._series) == 2
+    with warns_deprecated_sympy():
+        p.annotations = [{"text": "test", "xy": (0, 0)}]
+    assert len(p._series) == 3
+    with warns_deprecated_sympy():
+        p.fill = {"x": [0, 1, 2, 3], "y1": [0, 1, 2, 3]}
+    assert len(p._series) == 4
+    with warns_deprecated_sympy():
+        p.rectangles = [{"xy": (0, 0), "width": 5, "height": 1}]
+    assert len(p._series) == 5


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

**NOTEs**:

1. this is the first PR related to Issue #23036 .
2. The first PRs (this one included) will address the necessary backwards incompatible changes.
3. The aforementioned issue will be used as a log with all PRs of the merging process.

#### Brief description of what is fixed or changed

The properties ``markers, annotations, fill, rectangles`` of the ``Plot`` class  (containing user-provided numerical data to be added on a plot) are deprecated. The new implementation saves user-provided numerical data into a new data series, `GenericDataSeries`, which can easily be processed by ``MatplotlibBackend``. This makes the properties unnecessary. It also means that user-provided numerical data is taken into consideration when combining multiple plots with the ``extend`` and ``append`` methods (previously, they were disregarded).

Instead of setting those properties directly, users should pass the homonym keyword arguments to the plotting functions.

**Motivation for this deprecation:** the implementation of the ``Plot`` class suggests that it is ok to add attributes and hard-coded if-statements in the ``MatplotlibBackend`` class to provide more and more functionalities for user-provided numerical data (e.g. adding horizontal lines, or vertical lines, or bar plots, etc). However, in doing so one would reinvent the wheel: plotting libraries already implement the necessary API. There is no need to hard code these things in this plotting module.

The plotting module should facilitate the visualization of symbolic expressions. Then, the best way to add custom numerical data is to retrieve the figure created by the plotting module and use the API of a particular plotting library. For example, with Matplotlib we would write:

```py
from sympy import *
var("x")
# visualize a symbolic expression
p = plot(cos(x))
# retrieve Matplotlib's figure and axes
fig, ax = p._backend.fig, p._backend.ax[0]
# add custom numerical data
ax.plot([0, 1, 2], [0, 1, -1], "*")
ax.axhline(0.5)
# visualize the figure
fig
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* plotting
  * DEPRECATION: Deprecating `markers`, `annotations`, `fill`, `rectangles` properties of the `Plot` class. These can still be provided as keyword arguments to the `plot` function but setting the attributes on the returned `Plot` object is now deprecated.

<!-- END RELEASE NOTES -->
