### PR TITLE
Refactored property attributes in `sympy.physics.mechanics._actuator` for immutability

### DIFF
--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -496,11 +496,42 @@ class TorqueActuator(ActuatorBase):
            this frame.
 
         """
-        self.torque = torque
-        self.axis = axis
-        self.target_frame = target_frame  # type: ignore
-        self.reaction_frame = reaction_frame  # type: ignore
-        super().__init__()
+        # ``torque`` attribute
+        self._torque = sympify(torque, strict=True)
+
+        # ``axis`` attribute
+        if not isinstance(axis, Vector):
+            msg = (
+                f'Value {repr(axis)} passed to `axis` was of type '
+                f'{type(axis)}, must be {Vector}.'
+            )
+            raise TypeError(msg)
+        self._axis = axis
+
+        # ``target_frame`` attribute
+        if isinstance(target_frame, RigidBody):
+            target_frame = target_frame.frame
+        elif not isinstance(target_frame, ReferenceFrame):
+            msg = (
+                f'Value {repr(target_frame)} passed to `target_frame` was of '
+                f'type 'f'{type(target_frame)}, must be {ReferenceFrame}.'
+            )
+            raise TypeError(msg)
+        self._target_frame: ReferenceFrame = target_frame  # type: ignore
+
+        # ``reaction_frame`` attribute
+        if isinstance(reaction_frame, RigidBody):
+            reaction_frame = reaction_frame.frame
+        elif (
+            not isinstance(reaction_frame, ReferenceFrame)
+            and reaction_frame is not None
+        ):
+            msg = (
+                f'Value {repr(reaction_frame)} passed to `reaction_frame` was of '
+                f'type 'f'{type(reaction_frame)}, must be {ReferenceFrame}.'
+            )
+            raise TypeError(msg)
+        self._reaction_frame: ReferenceFrame | None = reaction_frame  # type: ignore
 
     @classmethod
     def at_pin_joint(
@@ -581,67 +612,20 @@ class TorqueActuator(ActuatorBase):
         """The magnitude of the torque produced by the actuator."""
         return self._torque
 
-    @torque.setter
-    def torque(self, torque: ExprType) -> None:
-        if not isinstance(torque, ExprType):
-            msg = (
-                f'Value {repr(torque)} passed to `torque` was of type '
-                f'{type(torque)}, must be {ExprType}.'
-            )
-            raise TypeError(msg)
-        self._torque = torque
-
     @property
     def axis(self) -> Vector:
         """The axis about which the torque acts."""
         return self._axis
-
-    @axis.setter
-    def axis(self, axis: Vector) -> None:
-        if not isinstance(axis, Vector):
-            msg = (
-                f'Value {repr(axis)} passed to `axis` was of type '
-                f'{type(axis)}, must be {Vector}.'
-            )
-            raise TypeError(msg)
-        self._axis = axis
 
     @property
     def target_frame(self) -> ReferenceFrame:
         """The primary reference frames on which the torque will act."""
         return self._target_frame
 
-    @target_frame.setter
-    def target_frame(self, target_frame: ReferenceFrame | RigidBody) -> None:
-        if isinstance(target_frame, RigidBody):
-            target_frame = target_frame.frame
-        elif not isinstance(target_frame, ReferenceFrame):
-            msg = (
-                f'Value {repr(target_frame)} passed to `target_frame` was of '
-                f'type 'f'{type(target_frame)}, must be {ReferenceFrame}.'
-            )
-            raise TypeError(msg)
-        self._target_frame: ReferenceFrame = target_frame  # type: ignore
-
     @property
     def reaction_frame(self) -> ReferenceFrame | None:
         """The primary reference frames on which the torque will act."""
         return self._reaction_frame
-
-    @reaction_frame.setter
-    def reaction_frame(self, reaction_frame: ReferenceFrame | RigidBody | None) -> None:
-        if isinstance(reaction_frame, RigidBody):
-            reaction_frame = reaction_frame.frame
-        elif (
-            not isinstance(reaction_frame, ReferenceFrame)
-            and reaction_frame is not None
-        ):
-            msg = (
-                f'Value {repr(reaction_frame)} passed to `reaction_frame` was of '
-                f'type 'f'{type(reaction_frame)}, must be {ReferenceFrame}.'
-            )
-            raise TypeError(msg)
-        self._reaction_frame: ReferenceFrame | None = reaction_frame  # type: ignore
 
     def to_loads(self) -> list[LoadBase]:
         """Loads required by the equations of motion method classes.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -392,6 +392,7 @@ class TestTorqueActuator:
         self.torque = Symbol('T')
         self.N = ReferenceFrame('N')
         self.A = ReferenceFrame('A')
+        self.axis = self.N.z
         self.target = RigidBody('target', frame=self.N)
         self.reaction = RigidBody('reaction', frame=self.A)
 
@@ -423,7 +424,7 @@ class TestTorqueActuator:
     ) -> None:
         instance = TorqueActuator(
             torque,
-            self.N.z,
+            self.axis,
             target_frame,
             reaction_frame,
         )
@@ -435,7 +436,7 @@ class TestTorqueActuator:
 
         assert hasattr(instance, 'axis')
         assert isinstance(instance.axis, Vector)
-        assert instance.axis == self.N.z
+        assert instance.axis == self.axis
 
         assert hasattr(instance, 'target_frame')
         assert isinstance(instance.target_frame, ReferenceFrame)
@@ -459,7 +460,7 @@ class TestTorqueActuator:
         torque: ExprType,
         target_frame: ReferenceFrame | RigidBody,
     ) -> None:
-        instance = TorqueActuator(torque, self.N.z, target_frame)
+        instance = TorqueActuator(torque, self.axis, target_frame)
         assert isinstance(instance, TorqueActuator)
 
         assert hasattr(instance, 'torque')
@@ -468,7 +469,7 @@ class TestTorqueActuator:
 
         assert hasattr(instance, 'axis')
         assert isinstance(instance.axis, Vector)
-        assert instance.axis == self.N.z
+        assert instance.axis == self.axis
 
         assert hasattr(instance, 'target_frame')
         assert isinstance(instance.target_frame, ReferenceFrame)
@@ -504,7 +505,7 @@ class TestTorqueActuator:
         frames: tuple[Any, Any],
     ) -> None:
         with pytest.raises(TypeError):
-            _ = TorqueActuator(self.torque, self.N.z, *frames)  # type: ignore
+            _ = TorqueActuator(self.torque, self.axis, *frames)  # type: ignore
 
     @pytest.mark.parametrize(
         'property_name, fixture_attr_name',
@@ -522,7 +523,7 @@ class TestTorqueActuator:
     ) -> None:
         actuator = TorqueActuator(
             self.torque,
-            self.N.z,
+            self.axis,
             self.target,
             self.reaction,
         )
@@ -531,14 +532,14 @@ class TestTorqueActuator:
             setattr(actuator, property_name, value)
 
     def test_repr_without_reaction(self) -> None:
-        actuator = TorqueActuator(self.torque, self.N.z, self.target)
+        actuator = TorqueActuator(self.torque, self.axis, self.target)
         expected = 'TorqueActuator(T, axis=N.z, target_frame=N)'
         assert repr(actuator) == expected
 
     def test_repr_with_reaction(self) -> None:
         actuator = TorqueActuator(
             self.torque,
-            self.N.z,
+            self.axis,
             self.target,
             self.reaction,
         )
@@ -553,7 +554,7 @@ class TestTorqueActuator:
             coordinates=dynamicsymbols('q'),
             speeds=dynamicsymbols('u'),
             parent_interframe=self.N,
-            joint_axis=self.N.z,
+            joint_axis=self.axis,
         )
         instance = TorqueActuator.at_pin_joint(self.torque, pin_joint)
         assert isinstance(instance, TorqueActuator)
@@ -564,7 +565,7 @@ class TestTorqueActuator:
 
         assert hasattr(instance, 'axis')
         assert isinstance(instance.axis, Vector)
-        assert instance.axis == self.N.z
+        assert instance.axis == self.axis
 
         assert hasattr(instance, 'target_frame')
         assert isinstance(instance.target_frame, ReferenceFrame)
@@ -579,21 +580,21 @@ class TestTorqueActuator:
             _ = TorqueActuator.at_pin_joint(self.torque, Symbol('pin'))  # type: ignore
 
     def test_to_loads_without_reaction(self) -> None:
-        actuator = TorqueActuator(self.torque, self.N.z, self.target)
+        actuator = TorqueActuator(self.torque, self.axis, self.target)
         expected = [
-            (self.N, self.torque * self.N.z),
+            (self.N, self.torque * self.axis),
         ]
         assert actuator.to_loads() == expected
 
     def test_to_loads_with_reaction(self) -> None:
         actuator = TorqueActuator(
             self.torque,
-            self.N.z,
+            self.axis,
             self.target,
             self.reaction,
         )
         expected = [
-            (self.N, self.torque * self.N.z),
-            (self.A, - self.torque * self.N.z),
+            (self.N, self.torque * self.axis),
+            (self.A, - self.torque * self.axis),
         ]
         assert actuator.to_loads() == expected

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -79,9 +79,13 @@ class TestForceActuator:
         assert isinstance(instance.force, ExprType)
         assert instance.force == expected_force
 
-    def test_invalid_constructor_force_not_expr(self) -> None:
+    @pytest.mark.parametrize('force', [None, 'F'])
+    def test_invalid_constructor_force_not_sympifyable(
+        self,
+        force: Any,
+    ) -> None:
         with pytest.raises(SympifyError):
-            _ = ForceActuator(None, self.pathway)  # type: ignore
+            _ = ForceActuator(force, self.pathway)  # type: ignore
 
     @pytest.mark.parametrize(
         'pathway',
@@ -226,6 +230,26 @@ class TestLinearSpring:
         assert hasattr(spring, 'force')
         assert isinstance(spring.force, ExprType)
         assert spring.force == force
+
+    @pytest.mark.parametrize('stiffness', [None, 'k'])
+    def test_invalid_constructor_stiffness_not_sympifyable(
+        self,
+        stiffness: Any,
+    ) -> None:
+        with pytest.raises(SympifyError):
+            _ = LinearSpring(stiffness, self.pathway, self.l)
+
+    def test_invalid_constructor_pathway_not_pathway_base(self) -> None:
+        with pytest.raises(TypeError):
+            _ = LinearSpring(self.stiffness, None, self.l)  # type: ignore
+
+    @pytest.mark.parametrize('equilibrium_length', [None, 'l'])
+    def test_invalid_constructor_equilibrium_length_not_sympifyable(
+        self,
+        equilibrium_length: Any,
+    ) -> None:
+        with pytest.raises(SympifyError):
+            _ = LinearSpring(self.stiffness, self.pathway, equilibrium_length)
 
     @pytest.mark.parametrize(
         'stiffness, equilibrium_length',
@@ -417,13 +441,15 @@ class TestTorqueActuator:
         assert hasattr(instance, 'reaction_frame')
         assert instance.reaction_frame is None
 
-    @pytest.mark.parametrize(
-        'axis',
-        [
-            Symbol('a'),
-            dynamicsymbols('a'),
-        ]
-    )
+    @pytest.mark.parametrize('torque', [None, 'T'])
+    def test_invalid_constructor_torque_not_sympifyable(
+        self,
+        torque: Any,
+    ) -> None:
+        with pytest.raises(SympifyError):
+            _ = TorqueActuator(torque, self.axis, self.target)  # type: ignore
+
+    @pytest.mark.parametrize('axis', [Symbol('a'), dynamicsymbols('a')])
     def test_invalid_constructor_axis_not_vector(self, axis: Any) -> None:
         with pytest.raises(TypeError):
             _ = TorqueActuator(self.torque, axis, self.target, self.reaction)  # type: ignore

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -104,6 +104,23 @@ class TestForceActuator:
         with pytest.raises(TypeError):
             _ = ForceActuator(self.force, None)  # type: ignore
 
+    @pytest.mark.parametrize(
+        'property_name, fixture_attr_name',
+        [
+            ('force', 'force'),
+            ('pathway', 'pathway'),
+        ]
+    )
+    def test_properties_are_immutable(
+        self,
+        property_name: str,
+        fixture_attr_name: str,
+    ) -> None:
+        instance = ForceActuator(self.force, self.pathway)
+        value = getattr(self, fixture_attr_name)
+        with pytest.raises(AttributeError):
+            setattr(instance, property_name, value)
+
     def test_repr(self) -> None:
         actuator = ForceActuator(self.force, self.pathway)
         expected = "ForceActuator(F, LinearPathway(pA, pB))"
@@ -252,21 +269,22 @@ class TestLinearSpring:
             _ = LinearSpring(self.stiffness, self.pathway, equilibrium_length)
 
     @pytest.mark.parametrize(
-        'stiffness, equilibrium_length',
+        'property_name, fixture_attr_name',
         [
-            (None, 0),
-            ('k', 0),
-            (Symbol('k'), None),
-            (Symbol('k'), 'l'),
+            ('stiffness', 'stiffness'),
+            ('pathway', 'pathway'),
+            ('equilibrium_length', 'l'),
         ]
     )
-    def test_invalid_constructor(
+    def test_properties_are_immutable(
         self,
-        stiffness: Any,
-        equilibrium_length: Any,
+        property_name: str,
+        fixture_attr_name: str,
     ) -> None:
-        with pytest.raises(SympifyError):
-            _ = LinearSpring(stiffness, self.pathway, equilibrium_length)
+        spring = LinearSpring(self.stiffness, self.pathway, self.l)
+        value = getattr(self, fixture_attr_name)
+        with pytest.raises(AttributeError):
+            setattr(spring, property_name, value)
 
     @pytest.mark.parametrize(
         'equilibrium_length, expected',

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
 import pytest
 

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -72,7 +72,11 @@ class TestForceActuator:
             (Symbol('F')**2 + Symbol('F'), Symbol('F')**2 + Symbol('F')),
         ]
     )
-    def test_valid_constructor_force(self, force: Any, expected_force: ExprType) -> None:
+    def test_valid_constructor_force(
+        self,
+        force: Any,
+        expected_force: ExprType,
+    ) -> None:
         instance = ForceActuator(force, self.pathway)
         assert isinstance(instance, ForceActuator)
         assert hasattr(instance, 'force')
@@ -187,7 +191,13 @@ class TestLinearSpring:
         assert issubclass(LinearSpring, ActuatorBase)
 
     @pytest.mark.parametrize(
-        'stiffness, expected_stiffness, equilibrium_length, expected_equilibrium_length, force',
+        (
+            'stiffness, '
+            'expected_stiffness, '
+            'equilibrium_length, '
+            'expected_equilibrium_length, '
+            'force'
+        ),
         [
             (
                 1,
@@ -290,7 +300,10 @@ class TestLinearSpring:
         'equilibrium_length, expected',
         [
             (S.Zero, 'LinearSpring(k, LinearPathway(pA, pB))'),
-            (Symbol('l'), 'LinearSpring(k, LinearPathway(pA, pB), equilibrium_length=l)'),
+            (
+                Symbol('l'),
+                'LinearSpring(k, LinearPathway(pA, pB), equilibrium_length=l)',
+            ),
         ]
     )
     def test_repr(self, equilibrium_length: Any, expected: str) -> None:
@@ -408,7 +421,12 @@ class TestTorqueActuator:
         target_frame: ReferenceFrame | RigidBody,
         reaction_frame: ReferenceFrame | RigidBody,
     ) -> None:
-        instance = TorqueActuator(torque, self.N.z, target_frame, reaction_frame)
+        instance = TorqueActuator(
+            torque,
+            self.N.z,
+            target_frame,
+            reaction_frame,
+        )
         assert isinstance(instance, TorqueActuator)
 
         assert hasattr(instance, 'torque')
@@ -481,9 +499,36 @@ class TestTorqueActuator:
             (RigidBody('parent'), True),
         ]
     )
-    def test_invalid_frames_not_frame(self, frames: Sequence[Any]) -> None:
+    def test_invalid_constructor_frames_not_frame(
+        self,
+        frames: tuple[Any, Any],
+    ) -> None:
         with pytest.raises(TypeError):
             _ = TorqueActuator(self.torque, self.N.z, *frames)  # type: ignore
+
+    @pytest.mark.parametrize(
+        'property_name, fixture_attr_name',
+        [
+            ('torque', 'torque'),
+            ('axis', 'axis'),
+            ('target_frame', 'target'),
+            ('reaction_frame', 'reaction'),
+        ]
+    )
+    def test_properties_are_immutable(
+        self,
+        property_name: str,
+        fixture_attr_name: str,
+    ) -> None:
+        actuator = TorqueActuator(
+            self.torque,
+            self.N.z,
+            self.target,
+            self.reaction,
+        )
+        value = getattr(self, fixture_attr_name)
+        with pytest.raises(AttributeError):
+            setattr(actuator, property_name, value)
 
     def test_repr_without_reaction(self) -> None:
         actuator = TorqueActuator(self.torque, self.N.z, self.target)
@@ -491,7 +536,12 @@ class TestTorqueActuator:
         assert repr(actuator) == expected
 
     def test_repr_with_reaction(self) -> None:
-        actuator = TorqueActuator(self.torque, self.N.z, self.target, self.reaction)
+        actuator = TorqueActuator(
+            self.torque,
+            self.N.z,
+            self.target,
+            self.reaction,
+        )
         expected = 'TorqueActuator(T, axis=N.z, target_frame=N, reaction_frame=A)'
         assert repr(actuator) == expected
 
@@ -536,7 +586,12 @@ class TestTorqueActuator:
         assert actuator.to_loads() == expected
 
     def test_to_loads_with_reaction(self) -> None:
-        actuator = TorqueActuator(self.torque, self.N.z, self.target, self.reaction)
+        actuator = TorqueActuator(
+            self.torque,
+            self.N.z,
+            self.target,
+            self.reaction,
+        )
         expected = [
             (self.N, self.torque * self.N.z),
             (self.A, - self.torque * self.N.z),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

Related to #24966, #25105, and #25116.

#### Brief description of what is fixed or changed
This PR refactors the property attributes of the actuator classes in `sympy.physics.mechanics._actuator` to make them immutable. Additional tests are also added to help ensure that the behaviour is as intended.

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the module is moved to `sympy/physics/mechanics/actuator.py`.

#### Other comments
I have specifically left the release notes entry empty. These will be added in the PR that moves the module to `sympy/physics/mechanics/actuator.py`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
