### PR TITLE
Implemented `LinearDamper` in `sympy.physics.mechanics`

### DIFF
--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     'ForceActuator',
+    'LinearDamper',
     'LinearSpring',
     'TorqueActuator',
 ]
@@ -414,6 +415,127 @@ class LinearSpring(ForceActuator):
         else:
             string += f', equilibrium_length={self.equilibrium_length})'
         return string
+
+
+class LinearDamper(ForceActuator):
+    """A damper who's force as a linear function of its extension velocity.
+
+    Explanation
+    ===========
+
+    Note that the "linear" in the name ``LinearDamper`` refers to the fact that
+    the damping force is a linear function of the damper's length. I.e. for a
+    linear damper with damping ``c`` and extension velocity ``v``, the damping
+    force will be ``-c*v``, which is a linear function in ``v``. To create a
+    damper that follows a linear, or straight, pathway between its two ends, a
+    ``LinearPathway`` instance needs to be passed to the ``pathway`` parameter.
+
+    Examples
+    ========
+
+    As the ``_actuator.py`` module is experimental, it is not yet part of the
+    ``sympy.physics.mechanics`` namespace. ``LinearDamper`` must therefore be
+    imported directly from the ``sympy.physics.mechanics._actuator`` module.
+
+    >>> from sympy.physics.mechanics._actuator import LinearDamper
+
+    This is similarly the case for imports from the ``_pathway.py`` module like
+    ``LinearPathway``.
+
+    >>> from sympy.physics.mechanics._pathway import LinearPathway
+
+    To construct a linear damper, an expression (or symbol) must be supplied to
+    represent the damping coefficient of the damper (we'll use the symbol
+    ``c``), alongside a pathway specifying its line of action. Let's also
+    create a global reference frame and spatially fix one of the points in it
+    while setting the other to be positioned such that it can freely move in
+    the frame's x direction specified by the coordinate ``q``. The velocity
+    that the two points move away from one another can be specified by the
+    coordinate ``u`` where ``u`` is the first time derivative of ``q``
+    (i.e., ``u = Derivative(q(t), t)``).
+
+    >>> from sympy import Symbol
+    >>> from sympy.physics.mechanics import Point, ReferenceFrame
+    >>> from sympy.physics.vector import dynamicsymbols
+    >>> N = ReferenceFrame('N')
+    >>> q = dynamicsymbols('q')
+    >>> damping = Symbol('c')
+    >>> pA, pB = Point('pA'), Point('pB')
+    >>> pA.set_vel(N, 0)
+    >>> pB.set_pos(pA, q * N.x)
+    >>> pB.pos_from(pA)
+    q(t)*N.x
+    >>> pB.vel(N)
+    Derivative(q(t), t)*N.x
+    >>> linear_pathway = LinearPathway(pA, pB)
+    >>> damper = LinearDamper(damping, linear_pathway)
+    >>> damper
+    LinearDamper(c, LinearPathway(pA, pB))
+
+    This damper will produce a force that is proportional to both its damping
+    coefficient and the pathway's extension length. Note that this force is
+    negative as SymPy's sign convention for actuators is that negative forces
+    are contractile and the damping force of the damper will oppose the
+    direction of length change.
+
+    >>> damper.force
+    -c*q(t)*Derivative(q(t), t)/sqrt(q(t)**2)
+
+    Parameters
+    ==========
+
+    damping : Expr
+        The damping constant.
+    pathway : PathwayBase
+        The pathway that the actuator follows. This must be an instance of a
+        concrete subclass of ``PathwayBase``, e.g. ``LinearPathway``.
+
+    See Also
+    ========
+
+    ForceActuator: force-producing actuator (superclass of ``LinearDamper``).
+    LinearPathway: straight-line pathway between a pair of points.
+
+    """
+
+    def __init__(self, damping: ExprType, pathway: PathwayBase) -> None:
+        """Initializer for ``LinearDamper``.
+
+        Parameters
+        ==========
+
+        damping : Expr
+            The damping constant.
+        pathway : PathwayBase
+            The pathway that the actuator follows. This must be an instance of
+            a concrete subclass of ``PathwayBase``, e.g. ``LinearPathway``.
+
+        """
+        # ``damping`` attribute
+        self._damping = sympify(damping, strict=True)
+
+        # ``pathway`` attribute
+        if not isinstance(pathway, PathwayBase):
+            msg = (
+                f'Value {repr(pathway)} passed to `pathway` was of type '
+                f'{type(pathway)}, must be {PathwayBase}.'
+            )
+            raise TypeError(msg)
+        self._pathway = pathway
+
+    @property
+    def force(self) -> ExprType:
+        """The damping force produced by the linear damper."""
+        return -self.damping * self.pathway.extension_velocity
+
+    @property
+    def damping(self) -> ExprType:
+        """The damping constant for the linear damper."""
+        return self._damping
+
+    def __repr__(self) -> str:
+        """Representation of a ``LinearDamper``."""
+        return f'{self.__class__.__name__}({self.damping}, {self.pathway})'
 
 
 class TorqueActuator(ActuatorBase):

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -418,17 +418,18 @@ class LinearSpring(ForceActuator):
 
 
 class LinearDamper(ForceActuator):
-    """A damper who's force as a linear function of its extension velocity.
+    """A damper whose force is a linear function of its extension velocity.
 
     Explanation
     ===========
 
     Note that the "linear" in the name ``LinearDamper`` refers to the fact that
-    the damping force is a linear function of the damper's length. I.e. for a
-    linear damper with damping ``c`` and extension velocity ``v``, the damping
-    force will be ``-c*v``, which is a linear function in ``v``. To create a
-    damper that follows a linear, or straight, pathway between its two ends, a
-    ``LinearPathway`` instance needs to be passed to the ``pathway`` parameter.
+    the damping force is a linear function of the damper's rate of change in
+    its length. I.e. for a linear damper with damping ``c`` and extension
+    velocity ``v``, the damping force will be ``-c*v``, which is a linear
+    function in ``v``. To create a damper that follows a linear, or straight,
+    pathway between its two ends, a ``LinearPathway`` instance needs to be
+    passed to the ``pathway`` parameter.
 
     Examples
     ========

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -292,6 +292,25 @@ class TestLinearDamper:
     def test_is_actuator_base_subclass(self) -> None:
         assert issubclass(LinearDamper, ActuatorBase)
 
+    def test_valid_constructor(self) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        damper = LinearDamper(self.damping, self.pathway)
+
+        assert isinstance(damper, LinearDamper)
+
+        assert hasattr(damper, 'damping')
+        assert isinstance(damper.damping, ExprType)
+        assert damper.damping == self.damping
+
+        assert hasattr(damper, 'pathway')
+        assert isinstance(damper.pathway, LinearPathway)
+        assert damper.pathway == self.pathway
+
+        expected_force = -self.damping * self.dq * self.q / sqrt(self.q**2)
+        assert hasattr(damper, 'force')
+        assert isinstance(damper.force, ExprType)
+        assert damper.force == expected_force
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -346,6 +346,15 @@ class TestLinearDamper:
         expected = 'LinearDamper(c, LinearPathway(pA, pB))'
         assert repr(damper) == expected
 
+    def test_to_loads(self) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        damper = LinearDamper(self.damping, self.pathway)
+        direction = self.q**2 / self.q**2 * self.N.x
+        pA_force = self.damping * self.dq * direction
+        pB_force = -self.damping * self.dq * direction
+        expected = [Force(self.pA, pA_force), Force(self.pB, pB_force)]
+        assert damper.to_loads() == expected
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -286,6 +286,12 @@ class TestLinearDamper:
         self.u = dynamicsymbols('u')
         self.N = ReferenceFrame('N')
 
+    def test_is_force_actuator_subclass(self) -> None:
+        assert issubclass(LinearDamper, ForceActuator)
+
+    def test_is_actuator_base_subclass(self) -> None:
+        assert issubclass(LinearDamper, ActuatorBase)
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -28,6 +28,7 @@ from sympy.physics.mechanics import (
 from sympy.physics.mechanics._actuator import (
     ActuatorBase,
     ForceActuator,
+    LinearDamper,
     LinearSpring,
     TorqueActuator,
 )
@@ -269,6 +270,10 @@ class TestLinearSpring:
             assert isinstance(load, Force)
             assert load.point == point
             assert (load.vector - vector).simplify() == 0
+
+
+class TestLinearDamper:
+    pass
 
 
 def test_forced_mass_spring_damper_model():

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -311,6 +311,18 @@ class TestLinearDamper:
         assert isinstance(damper.force, ExprType)
         assert damper.force == expected_force
 
+    @pytest.mark.parametrize('damping', [None, 'c'])
+    def test_invalid_constructor_damping_not_sympifyable(
+        self,
+        damping: Any,
+    ) -> None:
+        with pytest.raises(SympifyError):
+            _ = LinearDamper(damping, self.pathway)
+
+    def test_invalid_constructor_pathway_not_pathway_base(self) -> None:
+        with pytest.raises(TypeError):
+            _ = LinearDamper(self.damping, None)  # type: ignore
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -273,7 +273,18 @@ class TestLinearSpring:
 
 
 class TestLinearDamper:
-    pass
+
+    @pytest.fixture(autouse=True)
+    def _linear_damper_fixture(self) -> None:
+        self.damping = Symbol('c')
+        self.l = Symbol('l')
+        self.pA = Point('pA')
+        self.pB = Point('pB')
+        self.pathway = LinearPathway(self.pA, self.pB)
+        self.q = dynamicsymbols('q')
+        self.dq = dynamicsymbols('q', 1)
+        self.u = dynamicsymbols('u')
+        self.N = ReferenceFrame('N')
 
 
 def test_forced_mass_spring_damper_model():

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -323,6 +323,23 @@ class TestLinearDamper:
         with pytest.raises(TypeError):
             _ = LinearDamper(self.damping, None)  # type: ignore
 
+    @pytest.mark.parametrize(
+        'property_name, fixture_attr_name',
+        [
+            ('damping', 'damping'),
+            ('pathway', 'pathway'),
+        ]
+    )
+    def test_properties_are_immutable(
+        self,
+        property_name: str,
+        fixture_attr_name: str,
+    ) -> None:
+        damper = LinearDamper(self.damping, self.pathway)
+        value = getattr(self, fixture_attr_name)
+        with pytest.raises(AttributeError):
+            setattr(damper, property_name, value)
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -423,6 +423,20 @@ class TestForcedMassSpringDamperModel():
         assert self.kanes_method.mass_matrix == self.mass_matrix
         assert self.kanes_method.forcing == self.forcing
 
+    def test_linear_spring_linear_damper(self):
+        spring = LinearSpring(self.k, self.pathway)
+        damper = LinearDamper(self.c, self.pathway)
+
+        loads = [
+            (self.attachment, self.F * self.frame.x),
+            *spring.to_loads(),
+            *damper.to_loads(),
+        ]
+        self.kanes_method.kanes_equations(self.bodies, loads)
+
+        assert self.kanes_method.mass_matrix == self.mass_matrix
+        assert self.kanes_method.forcing == self.forcing
+
 
 class TestTorqueActuator:
 

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -340,6 +340,12 @@ class TestLinearDamper:
         with pytest.raises(AttributeError):
             setattr(damper, property_name, value)
 
+    def test_repr(self) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        damper = LinearDamper(self.damping, self.pathway)
+        expected = 'LinearDamper(c, LinearPathway(pA, pB))'
+        assert repr(damper) == expected
+
 
 def test_forced_mass_spring_damper_model():
     r"""A single degree of freedom translational forced mass-spring-damper.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

Extends specifically #24966, analogous to #25116 (but is also related to #24914, #25068, and #25105).

#### Brief description of what is fixed or changed
This PR implements a new actuator class, `LinearDamper`, which extends `ForceActuator`, a concrete class of `ActuatorBase`. It represents a damper who's force-production capabilities are a linear function of its rate of change in length. 

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the module is moved to `sympy/physics/mechanics/actuator.py`.

#### Other comments
I have specifically left the release notes entry empty. These will be added in the PR that moves the module to `sympy/physics/mechanics/actuator.py`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
