### PR TITLE
Simplified hierarchy of Plot class and *Backend classes

### DIFF
--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -88,9 +88,6 @@ Series Classes
 Backends
 --------
 
-.. autoclass:: sympy.plotting.plot::BaseBackend
-   :members:
-
 .. autoclass:: sympy.plotting.plot::MatplotlibBackend
    :members:
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1710,22 +1710,6 @@ class MatplotlibBackend(Plot):
         if isinstance(ax, Axes3D) and self.zlabel:
             zlbl = _str_or_latex(self.zlabel)
             ax.set_zlabel(zlbl, position=(0, 1))
-        if self.annotations:
-            for a in self.annotations:
-                ax.annotate(**a)
-        if self.markers:
-            for marker in self.markers:
-                # make a copy of the marker dictionary
-                # so that it doesn't get altered
-                m = marker.copy()
-                args = m.pop('args')
-                ax.plot(*args, **m)
-        if self.rectangles:
-            for r in self.rectangles:
-                rect = self.matplotlib.patches.Rectangle(**r)
-                ax.add_patch(rect)
-        if self.fill:
-            ax.fill_between(**self.fill)
 
         # xlim and ylim should always be set at last so that plot limits
         # doesn't get altered during the process.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1335,11 +1335,11 @@ class MatplotlibBackend(Plot):
         if self._plotgrid_fig is not None:
             self.fig = self._plotgrid_fig
             self.ax = self._plotgrid_ax
-            if not any([s.is_3D for s in self._series]):
+            if not any(s.is_3D for s in self._series):
                 set_spines(self.ax)
         else:
             self.fig = self.plt.figure(figsize=self.size)
-            if any([s.is_3D for s in self._series]):
+            if any(s.is_3D for s in self._series):
                 self.ax = self.fig.add_subplot(1, 1, 1, projection="3d")
             else:
                 self.ax = self.fig.add_subplot(1, 1, 1)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -223,7 +223,7 @@ class Plot:
     """
 
     def __new__(cls, *args, **kwargs):
-        backend = kwargs.pop("backend", "matplotlib")
+        backend = kwargs.pop("backend", "default")
         if isinstance(backend, str):
             if backend == "default":
                 matplotlib = import_module('matplotlib',
@@ -519,7 +519,7 @@ class PlotGrid:
         for arg in args:
             self._series.append(arg._series)
         self.size = size
-        if show:
+        if show and self.matplotlib:
             self.show()
 
     def _create_figure(self):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -68,10 +68,9 @@ def _str_or_latex(label):
 
 
 class Plot:
-    """The central class of the plotting module.
-
-    Explanation
-    ===========
+    """Base class for all backends. A backend represents the plotting library,
+    which implements the necessary functionalities in order to use SymPy
+    plotting functions.
 
     For interactive work the function :func:`plot()` is better suited.
 
@@ -173,7 +172,71 @@ class Plot:
     Aesthetics:
 
     - surface_color : function which returns a float.
+
+    Notes
+    =====
+
+    How the plotting module works:
+
+    1. Whenever a plotting function is called, the provided expressions are
+       processed and a list of instances of the :class:`BaseSeries` class is
+       created, containing the necessary information to plot the expressions
+       (e.g. the expression, ranges, series name, ...). Eventually, these
+       objects will generate the numerical data to be plotted.
+    2. A subclass of :class:`~.Plot` class is instantiaed (referred to as
+       backend, from now on), which stores the list of series and the main
+       attributes of the plot (e.g. axis labels, title, ...).
+       The backend implements the logic to generate the actual figure with
+       some plotting library.
+    3. When the ``show`` command is executed, series are processed one by one
+       to generate numerical data and add it to the figure. The backend is also
+       going to set the axis labels, title, ..., according to the values stored
+       in the Plot instance.
+
+    The backend should check if it supports the data series that it is given
+    (e.g. :class:`TextBackend` supports only :class:`LineOver1DRangeSeries`).
+
+    It is the backend responsibility to know how to use the class of data series
+    that it's given. Note that the current implementation of the ``*Series``
+    classes is "matplotlib-centric": the numerical data returned by the
+    ``get_points`` and ``get_meshes`` methods is meant to be used directly by
+    Matplotlib. Therefore, the new backend will have to pre-process the
+    numerical data to make it compatible with the chosen plotting library.
+    Keep in mind that future SymPy versions may improve the ``*Series`` classes
+    in order to return numerical data "non-matplotlib-centric", hence if you code
+    a new backend you have the responsibility to check if its working on each
+    SymPy release.
+
+    Please explore the :class:`MatplotlibBackend` source code to understand
+    how a backend should be coded.
+
+    In order to be used by SymPy plotting functions, a backend must implement
+    the following methods:
+
+    * show(self): used to loop over the data series, generate the numerical
+        data, plot it and set the axis labels, title, ...
+    * save(self, path): used to save the current plot to the specified file
+        path.
+    * close(self): used to close the current plot backend (note: some plotting
+        library does not support this functionality. In that case, just raise a
+        warning).
     """
+
+    def __new__(cls, *args, **kwargs):
+        backend = kwargs.pop("backend", "matplotlib")
+        if isinstance(backend, str):
+            if backend == "default":
+                matplotlib = import_module('matplotlib',
+                    min_module_version='1.1.0', catch=(RuntimeError,))
+                if matplotlib:
+                    return MatplotlibBackend(*args, **kwargs)
+                return TextBackend(*args, **kwargs)
+            return plot_backends[backend](*args, **kwargs)
+        elif (type(backend) == type) and issubclass(backend, cls):
+            return backend(*args, **kwargs)
+        else:
+            raise TypeError(
+                "backend must be either a string or a subclass of ``Plot``.")
 
     def __init__(self, *args,
         title=None, xlabel=None, ylabel=None, zlabel=None, aspect_ratio='auto',
@@ -181,7 +244,6 @@ class Plot:
         xscale='linear', yscale='linear', legend=False, autoscale=True,
         margin=0, annotations=None, markers=None, rectangles=None,
         fill=None, backend='default', size=None, **kwargs):
-        super().__init__()
 
         # Options for the graph as a whole.
         # The possible values for each option are described in the docstring of
@@ -208,17 +270,6 @@ class Plot:
         self._series = []
         self._series.extend(args)
 
-        # The backend type. On every show() a new backend instance is created
-        # in self._backend which is tightly coupled to the Plot instance
-        # (thanks to the parent attribute of the backend).
-        if isinstance(backend, str):
-            self.backend = plot_backends[backend]
-        elif (type(backend) == type) and issubclass(backend, BaseBackend):
-            self.backend = backend
-        else:
-            raise TypeError(
-                "backend must be either a string or a subclass of BaseBackend")
-
         is_real = \
             lambda lim: all(getattr(i, 'is_real', True) for i in lim)
         is_finite = \
@@ -242,19 +293,13 @@ class Plot:
         self.size = None
         check_and_set("size", size)
 
+    @property
+    def _backend(self):
+        return self
 
-    def show(self):
-        # TODO move this to the backend (also for save)
-        if hasattr(self, '_backend'):
-            self._backend.close()
-        self._backend = self.backend(self)
-        self._backend.show()
-
-    def save(self, path):
-        if hasattr(self, '_backend'):
-            self._backend.close()
-        self._backend = self.backend(self)
-        self._backend.save(path)
+    @property
+    def backend(self):
+        return type(self)
 
     def __str__(self):
         series_strs = [('[%d]: ' % i) + str(s)
@@ -341,6 +386,15 @@ class Plot:
             self._series.extend(arg)
         else:
             raise TypeError('Expecting Plot or sequence of BaseSeries')
+
+    def show(self):
+        raise NotImplementedError
+
+    def save(self, path):
+        raise NotImplementedError
+
+    def close(self):
+        raise NotImplementedError
 
 
 class PlotGrid:
@@ -454,28 +508,62 @@ class PlotGrid:
             the overall figure. The default value is set to ``None``, meaning
             the size will be set by the default backend.
         """
+        self.matplotlib = import_module('matplotlib',
+            import_kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
+            min_module_version='1.1.0', catch=(RuntimeError,))
         self.nrows = nrows
         self.ncolumns = ncolumns
         self._series = []
+        self._fig = None
         self.args = args
         for arg in args:
             self._series.append(arg._series)
-        self.backend = DefaultBackend
         self.size = size
         if show:
             self.show()
 
+    def _create_figure(self):
+        gs = self.matplotlib.gridspec.GridSpec(self.nrows, self.ncolumns)
+        mapping = {}
+        c = 0
+        for i in range(self.nrows):
+            for j in range(self.ncolumns):
+                if c < len(self.args):
+                    mapping[gs[i, j]] = self.args[c]
+                c += 1
+
+        kw = {} if not self.size else {"figsize": self.size}
+        self._fig = self.matplotlib.pyplot.figure(**kw)
+        for spec, p in mapping.items():
+            kw = ({"projection": "3d"} if (len(p._series) > 0 and
+                p._series[0].is_3D) else {})
+            cur_ax = self._fig.add_subplot(spec, **kw)
+            p._plotgrid_fig = self._fig
+            p._plotgrid_ax = cur_ax
+            p.process_series()
+
+    @property
+    def fig(self):
+        if not self._fig:
+            self._create_figure()
+        return self._fig
+
+    @property
+    def _backend(self):
+        return self
+
+    def close(self):
+        self.matplotlib.pyplot.close(self.fig)
+
     def show(self):
-        if hasattr(self, '_backend'):
-            self._backend.close()
-        self._backend = self.backend(self)
-        self._backend.show()
+        if _show:
+            self.fig.tight_layout()
+            self.matplotlib.pyplot.show()
+        else:
+            self.close()
 
     def save(self, path):
-        if hasattr(self, '_backend'):
-            self._backend.close()
-        self._backend = self.backend(self)
-        self._backend.save(path)
+        self.fig.savefig(path)
 
     def __str__(self):
         plot_strs = [('Plot[%d]:' % i) + str(plot)
@@ -1208,123 +1296,54 @@ class ContourSeries(BaseSeries):
 # Backends
 ##############################################################################
 
-class BaseBackend:
-    """Base class for all backends. A backend represents the plotting library,
-    which implements the necessary functionalities in order to use SymPy
-    plotting functions.
-
-    How the plotting module works:
-
-    1. Whenever a plotting function is called, the provided expressions are
-        processed and a list of instances of the :class:`BaseSeries` class is
-        created, containing the necessary information to plot the expressions
-        (e.g. the expression, ranges, series name, ...). Eventually, these
-        objects will generate the numerical data to be plotted.
-    2. A :class:`~.Plot` object is instantiated, which stores the list of
-        series and the main attributes of the plot (e.g. axis labels, title, ...).
-    3. When the ``show`` command is executed, a new backend is instantiated,
-        which loops through each series object to generate and plot the
-        numerical data. The backend is also going to set the axis labels, title,
-        ..., according to the values stored in the Plot instance.
-
-    The backend should check if it supports the data series that it is given
-    (e.g. :class:`TextBackend` supports only :class:`LineOver1DRangeSeries`).
-
-    It is the backend responsibility to know how to use the class of data series
-    that it's given. Note that the current implementation of the ``*Series``
-    classes is "matplotlib-centric": the numerical data returned by the
-    ``get_points`` and ``get_meshes`` methods is meant to be used directly by
-    Matplotlib. Therefore, the new backend will have to pre-process the
-    numerical data to make it compatible with the chosen plotting library.
-    Keep in mind that future SymPy versions may improve the ``*Series`` classes
-    in order to return numerical data "non-matplotlib-centric", hence if you code
-    a new backend you have the responsibility to check if its working on each
-    SymPy release.
-
-    Please explore the :class:`MatplotlibBackend` source code to understand how a
-    backend should be coded.
-
-    Methods
-    =======
-
-    In order to be used by SymPy plotting functions, a backend must implement
-    the following methods:
-
-    * show(self): used to loop over the data series, generate the numerical
-        data, plot it and set the axis labels, title, ...
-    * save(self, path): used to save the current plot to the specified file
-        path.
-    * close(self): used to close the current plot backend (note: some plotting
-        library does not support this functionality. In that case, just raise a
-        warning).
-
-    See also
-    ========
-
-    MatplotlibBackend
-    """
-    def __init__(self, parent):
-        super().__init__()
-        self.parent = parent
-
-    def show(self):
-        raise NotImplementedError
-
-    def save(self, path):
-        raise NotImplementedError
-
-    def close(self):
-        raise NotImplementedError
-
 
 # Don't have to check for the success of importing matplotlib in each case;
 # we will only be using this backend if we can successfully import matploblib
-class MatplotlibBackend(BaseBackend):
+class MatplotlibBackend(Plot):
     """ This class implements the functionalities to use Matplotlib with SymPy
     plotting functions.
     """
-    def __init__(self, parent):
-        super().__init__(parent)
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, *series, **kwargs):
+        super().__init__(*series, **kwargs)
         self.matplotlib = import_module('matplotlib',
             import_kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
             min_module_version='1.1.0', catch=(RuntimeError,))
         self.plt = self.matplotlib.pyplot
         self.cm = self.matplotlib.cm
         self.LineCollection = self.matplotlib.collections.LineCollection
-        aspect = getattr(self.parent, 'aspect_ratio', 'auto')
-        if aspect != 'auto':
-            aspect = float(aspect[1]) / aspect[0]
+        self.aspect = kwargs.get('aspect_ratio', 'auto')
+        if self.aspect != 'auto':
+            self.aspect = float(self.aspect[1]) / self.aspect[0]
+        # PlotGrid can provide its figure and axes to be populated with
+        # the data from the series.
+        self._plotgrid_fig = kwargs.pop("fig", None)
+        self._plotgrid_ax = kwargs.pop("ax", None)
 
-        if isinstance(self.parent, Plot):
-            nrows, ncolumns = 1, 1
-            series_list = [self.parent._series]
-        elif isinstance(self.parent, PlotGrid):
-            nrows, ncolumns = self.parent.nrows, self.parent.ncolumns
-            series_list = self.parent._series
+    def _create_figure(self):
+        def set_spines(ax):
+            ax.spines['left'].set_position('zero')
+            ax.spines['right'].set_color('none')
+            ax.spines['bottom'].set_position('zero')
+            ax.spines['top'].set_color('none')
+            ax.xaxis.set_ticks_position('bottom')
+            ax.yaxis.set_ticks_position('left')
 
-        self.ax = []
-        self.fig = self.plt.figure(figsize=parent.size)
-
-        for i, series in enumerate(series_list):
-            are_3D = [s.is_3D for s in series]
-
-            if any(are_3D) and not all(are_3D):
-                raise ValueError('The matplotlib backend cannot mix 2D and 3D.')
-            elif all(are_3D):
-                # mpl_toolkits.mplot3d is necessary for
-                # projection='3d'
-                mpl_toolkits = import_module('mpl_toolkits', # noqa
-                                     import_kwargs={'fromlist': ['mplot3d']})
-                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1, projection='3d', aspect=aspect))
-
-            elif not any(are_3D):
-                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1, aspect=aspect))
-                self.ax[i].spines['left'].set_position('zero')
-                self.ax[i].spines['right'].set_color('none')
-                self.ax[i].spines['bottom'].set_position('zero')
-                self.ax[i].spines['top'].set_color('none')
-                self.ax[i].xaxis.set_ticks_position('bottom')
-                self.ax[i].yaxis.set_ticks_position('left')
+        if self._plotgrid_fig is not None:
+            self.fig = self._plotgrid_fig
+            self.ax = self._plotgrid_ax
+            if not any([s.is_3D for s in self._series]):
+                set_spines(self.ax)
+        else:
+            self.fig = self.plt.figure(figsize=self.size)
+            if any([s.is_3D for s in self._series]):
+                self.ax = self.fig.add_subplot(1, 1, 1, projection="3d")
+            else:
+                self.ax = self.fig.add_subplot(1, 1, 1)
+                set_spines(self.ax)
 
     @staticmethod
     def get_segments(x, y, z=None):
@@ -1352,7 +1371,7 @@ class MatplotlibBackend(BaseBackend):
         points = np.ma.array(points).T.reshape(-1, 1, dim)
         return np.ma.concatenate([points[:-1], points[1:]], axis=1)
 
-    def _process_series(self, series, ax, parent):
+    def _process_series(self, series, ax):
         np = import_module('numpy')
         mpl_toolkits = import_module(
             'mpl_toolkits', import_kwargs={'fromlist': ['mplot3d']})
@@ -1462,14 +1481,14 @@ class MatplotlibBackend(BaseBackend):
         # Set global options.
         # TODO The 3D stuff
         # XXX The order of those is important.
-        if parent.xscale and not isinstance(ax, Axes3D):
-            ax.set_xscale(parent.xscale)
-        if parent.yscale and not isinstance(ax, Axes3D):
-            ax.set_yscale(parent.yscale)
+        if self.xscale and not isinstance(ax, Axes3D):
+            ax.set_xscale(self.xscale)
+        if self.yscale and not isinstance(ax, Axes3D):
+            ax.set_yscale(self.yscale)
         if not isinstance(ax, Axes3D) or self.matplotlib.__version__ >= '1.2.0':  # XXX in the distant future remove this check
-            ax.set_autoscale_on(parent.autoscale)
-        if parent.axis_center:
-            val = parent.axis_center
+            ax.set_autoscale_on(self.autoscale)
+        if self.axis_center:
+            val = self.axis_center
             if isinstance(ax, Axes3D):
                 pass
             elif val == 'center':
@@ -1485,48 +1504,49 @@ class MatplotlibBackend(BaseBackend):
             else:
                 ax.spines['left'].set_position(('data', val[0]))
                 ax.spines['bottom'].set_position(('data', val[1]))
-        if not parent.axis:
+        if not self.axis:
             ax.set_axis_off()
-        if parent.legend:
+        if self.legend:
             if ax.legend():
-                ax.legend_.set_visible(parent.legend)
-        if parent.margin:
-            ax.set_xmargin(parent.margin)
-            ax.set_ymargin(parent.margin)
-        if parent.title:
-            ax.set_title(parent.title)
-        if parent.xlabel:
-            xlbl = _str_or_latex(parent.xlabel)
+                ax.legend_.set_visible(self.legend)
+        if self.margin:
+            ax.set_xmargin(self.margin)
+            ax.set_ymargin(self.margin)
+        if self.title:
+            ax.set_title(self.title)
+        if self.xlabel:
+            xlbl = _str_or_latex(self.xlabel)
             ax.set_xlabel(xlbl, position=(1, 0))
-        if parent.ylabel:
-            ylbl = _str_or_latex(parent.ylabel)
+        if self.ylabel:
+            ylbl = _str_or_latex(self.ylabel)
             ax.set_ylabel(ylbl, position=(0, 1))
-        if isinstance(ax, Axes3D) and parent.zlabel:
-            zlbl = _str_or_latex(parent.zlabel)
+        if isinstance(ax, Axes3D) and self.zlabel:
+            zlbl = _str_or_latex(self.zlabel)
             ax.set_zlabel(zlbl, position=(0, 1))
-        if parent.annotations:
-            for a in parent.annotations:
+        if self.annotations:
+            for a in self.annotations:
                 ax.annotate(**a)
-        if parent.markers:
-            for marker in parent.markers:
+        if self.markers:
+            for marker in self.markers:
                 # make a copy of the marker dictionary
                 # so that it doesn't get altered
                 m = marker.copy()
                 args = m.pop('args')
                 ax.plot(*args, **m)
-        if parent.rectangles:
-            for r in parent.rectangles:
+        if self.rectangles:
+            for r in self.rectangles:
                 rect = self.matplotlib.patches.Rectangle(**r)
                 ax.add_patch(rect)
-        if parent.fill:
-            ax.fill_between(**parent.fill)
+        if self.fill:
+            ax.fill_between(**self.fill)
 
         # xlim and ylim should always be set at last so that plot limits
         # doesn't get altered during the process.
-        if parent.xlim:
-            ax.set_xlim(parent.xlim)
-        if parent.ylim:
-            ax.set_ylim(parent.ylim)
+        if self.xlim:
+            ax.set_xlim(self.xlim)
+        if self.ylim:
+            ax.set_ylim(self.ylim)
+        self.ax.set_aspect(self.aspect)
 
 
     def process_series(self):
@@ -1534,16 +1554,8 @@ class MatplotlibBackend(BaseBackend):
         Iterates over every ``Plot`` object and further calls
         _process_series()
         """
-        parent = self.parent
-        if isinstance(parent, Plot):
-            series_list = [parent._series]
-        else:
-            series_list = parent._series
-
-        for i, (series, ax) in enumerate(zip(series_list, self.ax)):
-            if isinstance(self.parent, PlotGrid):
-                parent = self.parent.args[i]
-            self._process_series(series, ax, parent)
+        self._create_figure()
+        self._process_series(self._series, self.ax)
 
     def show(self):
         self.process_series()
@@ -1564,40 +1576,33 @@ class MatplotlibBackend(BaseBackend):
         self.plt.close(self.fig)
 
 
-class TextBackend(BaseBackend):
-    def __init__(self, parent):
-        super().__init__(parent)
+class TextBackend(Plot):
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def show(self):
         if not _show:
             return
-        if len(self.parent._series) != 1:
+        if len(self._series) != 1:
             raise ValueError(
                 'The TextBackend supports only one graph per Plot.')
-        elif not isinstance(self.parent._series[0], LineOver1DRangeSeries):
+        elif not isinstance(self._series[0], LineOver1DRangeSeries):
             raise ValueError(
                 'The TextBackend supports only expressions over a 1D range')
         else:
-            ser = self.parent._series[0]
+            ser = self._series[0]
             textplot(ser.expr, ser.start, ser.end)
 
     def close(self):
         pass
 
 
-class DefaultBackend(BaseBackend):
-    def __new__(cls, parent):
-        matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
-        if matplotlib:
-            return MatplotlibBackend(parent)
-        else:
-            return TextBackend(parent)
-
-
 plot_backends = {
     'matplotlib': MatplotlibBackend,
     'text': TextBackend,
-    'default': DefaultBackend
 }
 
 

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -29,7 +29,7 @@ Arithmetic. Master's thesis. University of Toronto, 1996
 """
 
 
-from .plot import BaseSeries, Plot
+from .plot import BaseSeries, plot_factory
 from .experimental_lambdify import experimental_lambdify, vectorized_lambdify
 from .intervalmath import interval
 from sympy.core.relational import (Equality, GreaterThan, LessThan,
@@ -426,7 +426,7 @@ def plot_implicit(expr, x_var=None, y_var=None, adaptive=True, depth=0,
     # set the x and y labels
     kwargs.setdefault('xlabel', var_start_end_x[0])
     kwargs.setdefault('ylabel', var_start_end_y[0])
-    p = Plot(series_argument, **kwargs)
+    p = plot_factory(series_argument, **kwargs)
     if show:
         p.show()
     return p

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -29,7 +29,7 @@ Arithmetic. Master's thesis. University of Toronto, 1996
 """
 
 
-from .plot import BaseSeries, plot_factory
+from .plot import BaseSeries, plot_factory, _set_discretization_points
 from .experimental_lambdify import experimental_lambdify, vectorized_lambdify
 from .intervalmath import interval
 from sympy.core.relational import (Equality, GreaterThan, LessThan,

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -19,8 +19,7 @@ from sympy.plotting.plot import (
     Plot, plot, plot_parametric, plot3d_parametric_line, plot3d,
     plot3d_parametric_surface)
 from sympy.plotting.plot import (
-    unset_show, plot_contour, PlotGrid, DefaultBackend, MatplotlibBackend,
-    TextBackend, BaseBackend)
+    unset_show, plot_contour, PlotGrid, MatplotlibBackend, TextBackend)
 from sympy.testing.pytest import skip, raises, warns, warns_deprecated_sympy
 from sympy.utilities import lambdify as lambdify_
 from sympy.utilities.exceptions import ignore_warnings
@@ -33,18 +32,22 @@ matplotlib = import_module(
     'matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
 
 
-class DummyBackendNotOk(BaseBackend):
+class DummyBackendNotOk(Plot):
     """ Used to verify if users can create their own backends.
     This backend is meant to raise NotImplementedError for methods `show`,
     `save`, `close`.
     """
-    pass
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
 
 
-class DummyBackendOk(BaseBackend):
+class DummyBackendOk(Plot):
     """ Used to verify if users can create their own backends.
     This backend is meant to pass all tests.
     """
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
     def show(self):
         pass
 
@@ -623,11 +626,11 @@ def test_issue_13516():
     assert len(pt[0].get_data()[0]) >= 30
 
     pd = plot(sin(x), backend="default", show=False)
-    assert pd.backend == DefaultBackend
+    assert pd.backend == MatplotlibBackend
     assert len(pd[0].get_data()[0]) >= 30
 
     p = plot(sin(x), show=False)
-    assert p.backend == DefaultBackend
+    assert p.backend == MatplotlibBackend
     assert len(p[0].get_data()[0]) >= 30
 
 
@@ -639,10 +642,10 @@ def test_plot_limits():
     p = plot(x, x**2, (x, -10, 10))
     backend = p._backend
 
-    xmin, xmax = backend.ax[0].get_xlim()
+    xmin, xmax = backend.ax.get_xlim()
     assert abs(xmin + 10) < 2
     assert abs(xmax - 10) < 2
-    ymin, ymax = backend.ax[0].get_ylim()
+    ymin, ymax = backend.ax.get_ylim()
     assert abs(ymin + 10) < 10
     assert abs(ymax - 100) < 10
 
@@ -658,26 +661,26 @@ def test_plot3d_parametric_line_limits():
     p = plot3d_parametric_line(v1, v2)
     backend = p._backend
 
-    xmin, xmax = backend.ax[0].get_xlim()
+    xmin, xmax = backend.ax.get_xlim()
     assert abs(xmin + 2) < 1e-2
     assert abs(xmax - 2) < 1e-2
-    ymin, ymax = backend.ax[0].get_ylim()
+    ymin, ymax = backend.ax.get_ylim()
     assert abs(ymin + 2) < 1e-2
     assert abs(ymax - 2) < 1e-2
-    zmin, zmax = backend.ax[0].get_zlim()
+    zmin, zmax = backend.ax.get_zlim()
     assert abs(zmin + 10) < 1e-2
     assert abs(zmax - 10) < 1e-2
 
     p = plot3d_parametric_line(v2, v1)
     backend = p._backend
 
-    xmin, xmax = backend.ax[0].get_xlim()
+    xmin, xmax = backend.ax.get_xlim()
     assert abs(xmin + 2) < 1e-2
     assert abs(xmax - 2) < 1e-2
-    ymin, ymax = backend.ax[0].get_ylim()
+    ymin, ymax = backend.ax.get_ylim()
     assert abs(ymin + 2) < 1e-2
     assert abs(ymax - 2) < 1e-2
-    zmin, zmax = backend.ax[0].get_zlim()
+    zmin, zmax = backend.ax.get_zlim()
     assert abs(zmin + 10) < 1e-2
     assert abs(zmax - 10) < 1e-2
 
@@ -707,8 +710,7 @@ def test_issue_20113():
     x = Symbol('x')
 
     # verify the capability to use custom backends
-    with raises(TypeError):
-        plot(sin(x), backend=Plot, show=False)
+    plot(sin(x), backend=Plot, show=False)
     p2 = plot(sin(x), backend=MatplotlibBackend, show=False)
     assert p2.backend == MatplotlibBackend
     assert len(p2[0].get_data()[0]) >= 30

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -531,8 +531,10 @@ def test_empty_Plot():
 
     # No exception showing an empty plot
     plot()
+    # Plot is only a base class: doesn't implement any logic for showing
+    # images
     p = Plot()
-    p.show()
+    raises(NotImplementedError, lambda: p.show())
 
 
 def test_issue_17405():

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -778,10 +778,10 @@ def test_generic_data_series():
         annotations=[{"text": "test", "xy": (0, 0)}],
         fill={"x": [0, 1, 2, 3], "y1": [0, 1, 2, 3]},
         rectangles=[{"xy": (0, 0), "width": 5, "height": 1}])
-    assert len(p._backend.ax[0].collections) == 1
-    assert len(p._backend.ax[0].patches) == 1
-    assert len(p._backend.ax[0].lines) == 2
-    assert len(p._backend.ax[0].texts) == 1
+    assert len(p._backend.ax.collections) == 1
+    assert len(p._backend.ax.patches) == 1
+    assert len(p._backend.ax.lines) == 2
+    assert len(p._backend.ax.texts) == 1
 
 
 def test_deprecated_markers_annotations_rectangles_fill():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Another PR related to #23036 .

#### Brief description of what is fixed or changed

The `Plot` class used OOP composition with respect to a `*Backend` class. In other words, an instance of `*Backend` was saved into the `_backend` attribute of the `Plot` instance.

This PR changes it to inheritance: the `Plot` class becomes the base class for `*Backend` classes, holding the most common attributes expected to be used by most plotting libraries, like title, axis labels, etc. In doing so, the `BaseBackend` and `DefaultBackend` classes are no longer needed: their logic have been incorporated into the `Plot` class.

Previously, `MatplotlibBackend` had to keep track of all the axes required by the `PlotGrid` class. For example, a PlotGrid containing 4 plots created one instance of `MatplotlibBackend`, which created a figure with 4 subplots (hence, the `ax` attribute was a list containing 4 matplotlib's axes). This PR changes it: `MatplotlibBackend` is only going to deal with one axes (one subplot). As a consequence, `PlotGrid` was modified to create the overall figure and subplot-axes, which are then going to be fed to the backend.

This simplifies the overall structure, while allowing new behaviors to be implemented on future PRs, specifically:

1. interactive widget plots.
2. more complex grid layouts with PlotGrid.

**EDIT: information for users that created custom backends.**

To update a custom backend class:

1. make it subclass the `Plot` class.
2. Add a `__new__` method.
3. Modify the `__init__` method to call the base class `__init__`.
4. Replace occurrences of `self.parent` with `self`.

```py
class MyBackend(Plot):
    def __new__(cls, *args, **kwargs):
        return object.__new__(cls)

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        # your old code here
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* plotting
  * BREAKING CHANGE: Changed relationship between `Plot` and `*Backend` classes. Moving from composition to inheritance.
<!-- END RELEASE NOTES -->
