### PR TITLE
fix(sets): Make Contains a Boolean subclass

### DIFF
--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -6,7 +6,8 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.sets.sets import (Interval, Union)
+from sympy.sets.sets import Interval, Union
+from sympy.sets.contains import Contains
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or,
@@ -1049,6 +1050,12 @@ def test_issue_14700():
     # Should not be more complicated with don't cares
     assert SOPform([w, x, y, z], minterms, dontcares) == \
         (x & ~w) | (y & z & ~x)
+
+
+def test_issue_25115():
+    cond = Contains(x, S.Integers)
+    # Previously this raised an exception:
+    assert simplify_logic(cond) == cond
 
 
 def test_relational_simplification():

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -212,7 +212,7 @@ with
         try:
             lambda_cond = lamda(other)
         except TypeError:
-            return Contains(other, self, evaluate=False)
+            return None
         else:
             return And(base_cond, lambda_cond)
 

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -1,11 +1,13 @@
 from sympy.core import S
+from sympy.core.sympify import sympify
 from sympy.core.relational import Eq, Ne
-from sympy.logic.boolalg import BooleanFunction
+from sympy.core.parameters import global_parameters
+from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
 from .sets import Set
 
 
-class Contains(BooleanFunction):
+class Contains(Boolean):
     """
     Asserts that x is an element of the set S.
 
@@ -26,16 +28,29 @@ class Contains(BooleanFunction):
 
     .. [1] https://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
-    @classmethod
-    def eval(cls, x, s):
+    def __new__(cls, x, s, evaluate=None):
+        x = sympify(x)
+        s = sympify(s)
+
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
 
         if not isinstance(s, Set):
             raise TypeError('expecting Set, not %s' % func_name(s))
 
-        ret = s.contains(x)
-        if not isinstance(ret, Contains) and (
-                ret in (S.true, S.false) or isinstance(ret, Set)):
-            return ret
+        if evaluate:
+            # _contains can return symbolic booleans that would be returned by
+            # s.contains(x) but here for Contains(x, s) we only evaluate to
+            # true, false or return the unevaluated Contains.
+            result = s._contains(x)
+
+            if isinstance(result, Boolean):
+                if result in (S.true, S.false):
+                    return result
+            elif result is not None:
+                raise TypeError("_contains() should return Boolean or None")
+
+        return super().__new__(cls, x, s)
 
     @property
     def binary_symbols(self):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -16,7 +16,7 @@ from sympy.core.sympify import _sympify, sympify, _sympy_converter
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.logic.boolalg import And, Or
-from .sets import Set, Interval, Union, FiniteSet, ProductSet, SetKind
+from .sets import tfn, Set, Interval, Union, FiniteSet, ProductSet, SetKind
 from sympy.utilities.misc import filldedent
 
 
@@ -44,8 +44,8 @@ class Rationals(Set, metaclass=Singleton):
 
     def _contains(self, other):
         if not isinstance(other, Expr):
-            return False
-        return other.is_rational
+            return S.false
+        return tfn[other.is_rational]
 
     def __iter__(self):
         yield S.Zero
@@ -106,11 +106,11 @@ class Naturals(Set, metaclass=Singleton):
 
     def _contains(self, other):
         if not isinstance(other, Expr):
-            return False
+            return S.false
         elif other.is_positive and other.is_integer:
-            return True
+            return S.true
         elif other.is_integer is False or other.is_positive is False:
-            return False
+            return S.false
 
     def _eval_is_subset(self, other):
         return Range(1, oo).is_subset(other)
@@ -200,7 +200,7 @@ class Integers(Set, metaclass=Singleton):
     def _contains(self, other):
         if not isinstance(other, Expr):
             return S.false
-        return other.is_integer
+        return tfn[other.is_integer]
 
     def __iter__(self):
         yield S.Zero
@@ -475,7 +475,7 @@ class ImageSet(Set):
         for eq in get_equations(expr, other):
             # Unsatisfiable equation?
             if eq is False:
-                return False
+                return S.false
             equations.append(eq)
 
         # Map the symbols in the signature to the corresponding domains
@@ -494,7 +494,7 @@ class ImageSet(Set):
         solnset = _solveset_multi(equations, variables, base_sets)
         if solnset is None:
             return None
-        return fuzzy_not(solnset.is_empty)
+        return tfn[fuzzy_not(solnset.is_empty)]
 
     @property
     def is_iterable(self):
@@ -711,7 +711,7 @@ class Range(Set):
         if other.is_infinite:
             return S.false
         if not other.is_integer:
-            return other.is_integer
+            return tfn[other.is_integer]
         if self.has(Symbol):
             n = (self.stop - self.start)/self.step
             if not n.is_extended_positive or not all(
@@ -1346,7 +1346,7 @@ class ComplexRegion(Set):
 
     def _contains(self, other):
         from sympy.functions import arg, Abs
-        other = sympify(other)
+
         isTuple = isinstance(other, Tuple)
         if isTuple and len(other) != 2:
             raise ValueError('expecting Tuple of length 2')
@@ -1354,20 +1354,21 @@ class ComplexRegion(Set):
         # If the other is not an Expression, and neither a Tuple
         if not isinstance(other, (Expr, Tuple)):
             return S.false
+
         # self in rectangular form
         if not self.polar:
             re, im = other if isTuple else other.as_real_imag()
-            return fuzzy_or(fuzzy_and([
+            return tfn[fuzzy_or(fuzzy_and([
                 pset.args[0]._contains(re),
                 pset.args[1]._contains(im)])
-                for pset in self.psets)
+                for pset in self.psets)]
 
         # self in polar form
         elif self.polar:
             if other.is_zero:
                 # ignore undefined complex argument
-                return fuzzy_or(pset.args[0]._contains(S.Zero)
-                    for pset in self.psets)
+                return tfn[fuzzy_or(pset.args[0]._contains(S.Zero)
+                    for pset in self.psets)]
             if isTuple:
                 r, theta = other
             else:
@@ -1375,10 +1376,10 @@ class ComplexRegion(Set):
             if theta.is_real and theta.is_number:
                 # angles in psets are normalized to [0, 2pi)
                 theta %= 2*S.Pi
-                return fuzzy_or(fuzzy_and([
+                return tfn[fuzzy_or(fuzzy_and([
                     pset.args[0]._contains(r),
                     pset.args[1]._contains(theta)])
-                    for pset in self.psets)
+                    for pset in self.psets)]
 
 
 class CartesianComplexRegion(ComplexRegion):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -352,14 +352,34 @@ class Set(Basic, EvalfMixin):
         return b
 
     def _contains(self, other):
-        raise NotImplementedError(filldedent('''
-            (%s)._contains(%s) is not defined. This method, when
-            defined, will receive a sympified object. The method
-            should return True, False, None or something that
-            expresses what must be true for the containment of that
-            object in self to be evaluated. If None is returned
-            then a generic Contains object will be returned
-            by the ``contains`` method.''' % (self, other)))
+        """Test if ``other`` is an element of the set ``self``.
+
+        This is an internal method that is expected to be overridden by
+        subclasses of ``Set`` and will be called by the public
+        :func:`Set.contains` method or the :class:`Contains` expression.
+
+        Parameters
+        ==========
+
+        other: Sympified :class:`Basic` instance
+            The object whose membership in ``self`` is to be tested.
+
+        Returns
+        =======
+
+        Symbolic :class:`Boolean` or ``None``.
+
+        A return value of ``None`` indicates that it is unknown whether
+        ``other`` is contained in ``self``. Returning ``None`` from here
+        ensures that ``self.contains(other)`` or ``Contains(self, other)`` will
+        return an unevaluated :class:`Contains` expression.
+
+        If not ``None`` then the returned value is a :class:`Boolean` that is
+        logically equivalent to the statement that ``other`` is an element of
+        ``self``. Usually this would be either ``S.true`` or ``S.false`` but
+        not always.
+        """
+        raise NotImplementedError(f"{type(self).__name__}._contains")
 
     def is_subset(self, other):
         """
@@ -905,9 +925,9 @@ ProductSet(iterable) is deprecated. Use ProductSet(*iterable) instead.
             return None
 
         if not isinstance(element, Tuple) or len(element) != len(self.sets):
-            return False
+            return S.false
 
-        return fuzzy_and(s._contains(e) for s, e in zip(self.sets, element))
+        return And(*[s.contains(e) for s, e in zip(self.sets, element)])
 
     def as_relational(self, *symbols):
         symbols = [_sympify(s) for s in symbols]
@@ -1201,7 +1221,7 @@ class Interval(Set):
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
             if other.is_real is not None:
-                return other.is_real
+                return tfn[other.is_real]
 
         d = Dummy()
         return self.as_relational(d).subs(d, other)
@@ -2026,12 +2046,11 @@ class FiniteSet(Set):
 
         """
         if other in self._args_set:
-            return True
+            return S.true
         else:
             # evaluate=True is needed to override evaluate=False context;
             # we need Eq to do the evaluation
-            return fuzzy_or(fuzzy_bool(Eq(e, other, evaluate=True))
-                for e in self.args)
+            return Or(*[Eq(e, other, evaluate=True) for e in self.args])
 
     def _eval_is_subset(self, other):
         return fuzzy_and(other._contains(e) for e in self.args)
@@ -2300,15 +2319,15 @@ class DisjointUnion(Set):
         Passes operation on to constituent sets
         """
         if not isinstance(element, Tuple) or len(element) != 2:
-            return False
+            return S.false
 
         if not element[1].is_Integer:
-            return False
+            return S.false
 
         if element[1] >= len(self.sets) or element[1] < 0:
-            return False
+            return S.false
 
-        return element[0] in self.sets[element[1]]
+        return self.sets[element[1]]._contains(element[0])
 
     def _kind(self):
         if not self.args:

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -262,7 +262,7 @@ def test_contains():
 
 def test_as_relational():
     assert ConditionSet((x, y), x > 1, S.Integers**2).as_relational((x, y)
-        ) == (x > 1) & Contains((x, y), S.Integers**2)
+        ) == (x > 1) & Contains(x, S.Integers) & Contains(y, S.Integers)
     assert ConditionSet(x, x > 1, S.Integers).as_relational(x
         ) == Contains(x, S.Integers) & (x > 1)
 

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -7,6 +7,7 @@ from sympy.sets.contains import Contains
 from sympy.sets.sets import (FiniteSet, Interval)
 from sympy.testing.pytest import raises
 
+
 def test_contains_basic():
     raises(TypeError, lambda: Contains(S.Integers, 1))
     assert Contains(2, S.Integers) is S.true
@@ -44,6 +45,7 @@ def test_as_set():
     assert Contains(x, FiniteSet(y)).as_set() == FiniteSet(y)
     assert Contains(x, S.Integers).as_set() == S.Integers
     assert Contains(x, S.Reals).as_set() == S.Reals
+
 
 def test_type_error():
     # Pass in a parameter not of type "set"

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -632,7 +632,7 @@ def test_ProductSet():
     assert Z2.contains(x) == Contains(x, Z2, evaluate=False)
     assert Z2.contains(x).subs(x, 1) is S.false
     assert Z2.contains((x, 1)).subs(x, 2) is S.true
-    assert Z2.contains((x, y)) == Contains((x, y), Z2, evaluate=False)
+    assert Z2.contains((x, y)) == Contains(x, S.Integers) & Contains(y, S.Integers)
     assert unchanged(Contains, (x, y), Z2)
     assert Contains((1, 2), Z2) is S.true
 
@@ -803,17 +803,17 @@ def test_contains():
     assert FiniteSet(1, 2, 3).contains(2) is S.true
     assert FiniteSet(1, 2, Symbol('x')).contains(Symbol('x')) is S.true
 
-    assert FiniteSet(y)._contains(x) is None
+    assert FiniteSet(y)._contains(x) == Eq(y, x, evaluate=False)
     raises(TypeError, lambda: x in FiniteSet(y))
-    assert FiniteSet({x, y})._contains({x}) is None
-    assert FiniteSet({x, y}).subs(y, x)._contains({x}) is True
-    assert FiniteSet({x, y}).subs(y, x+1)._contains({x}) is False
+    assert FiniteSet({x, y})._contains({x}) == Eq({x, y}, {x}, evaluate=False)
+    assert FiniteSet({x, y}).subs(y, x)._contains({x}) is S.true
+    assert FiniteSet({x, y}).subs(y, x+1)._contains({x}) is S.false
 
     # issue 8197
     from sympy.abc import a, b
-    assert isinstance(FiniteSet(b).contains(-a), Contains)
-    assert isinstance(FiniteSet(b).contains(a), Contains)
-    assert isinstance(FiniteSet(a).contains(1), Contains)
+    assert FiniteSet(b).contains(-a) == Eq(b, -a)
+    assert FiniteSet(b).contains(a) == Eq(b, a)
+    assert FiniteSet(a).contains(1) == Eq(a, 1)
     raises(TypeError, lambda: 1 in FiniteSet(a))
 
     # issue 8209


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-25115

#### Brief description of what is fixed or changed

Make Contains subclass Boolean rather than BooleanFunction.

Also made the return types for the internal _contains method more consistent. It should now always return Boolean or None but not an ordinary bool. The `Set.contains` method now evaluates in a few more cases.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * The Contains type is no longer a subclass of BooleanFunction. Previously this caused simplify_logic to throw an exception when given an expression involving Contains.
<!-- END RELEASE NOTES -->
