### PR TITLE
added gmpy.legendre and gmpy.jacobi

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -43,6 +43,12 @@ __all__ = [
 
     # invert from gmpy or pow
     'invert',
+
+    # legendre from gmpy or sympy
+    'legendre',
+
+    # jacobi from gmpy or sympy
+    'jacobi',
 ]
 
 
@@ -105,6 +111,8 @@ if gmpy is not None:
     gcd = gmpy.gcd
     lcm = gmpy.lcm
     invert = gmpy.invert
+    legendre = gmpy.legendre
+    jacobi = gmpy.jacobi
 
 else:
     from .pythonmpq import PythonMPQ
@@ -143,3 +151,41 @@ else:
             return pow(x, -1, m)
         except ValueError:
             raise ZeroDivisionError("invert() no inverse exists")
+
+    def legendre(x, y):
+        """ Return Legendre symbol (x / y).
+
+        Following the implementation of gmpy2,
+        the error is raised only when y is an even number.
+        """
+        if y <= 0 or not y % 2:
+            raise ValueError("y should be an odd prime")
+        x %= y
+        if not x:
+            return 0
+        if pow(x, (y - 1) // 2, y) == 1:
+            return 1
+        return -1
+
+    def jacobi(x, y):
+        """ Return Jacobi symbol (x / y)."""
+        if y <= 0 or not y % 2:
+            raise ValueError("y should be an odd positive integer")
+        x %= y
+        if not x:
+            return int(y == 1)
+        if y == 1 or x == 1:
+            return 1
+        if gcd(x, y) != 1:
+            return 0
+        j = 1
+        while x != 0:
+            while x % 2 == 0 and x > 0:
+                x >>= 1
+                if y % 8 in [3, 5]:
+                    j = -j
+            x, y = y, x
+            if x % 4 == y % 4 == 3:
+                j = -j
+            x %= y
+        return j

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -1,9 +1,8 @@
 from mpmath.libmp import (fzero, from_int, from_rational,
     fone, fhalf, bitcount, to_int, to_str, mpf_mul, mpf_div, mpf_sub,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, mpf_cos, mpf_sin)
-from sympy.external.gmpy import gcd
-from .residue_ntheory import (_sqrt_mod_prime_power,
-    legendre_symbol, jacobi_symbol, is_quad_residue)
+from sympy.external.gmpy import gcd, legendre, jacobi
+from .residue_ntheory import _sqrt_mod_prime_power, is_quad_residue
 
 import math
 
@@ -63,7 +62,7 @@ def _a(n, k, prec):
             arg = mpf_div(mpf_mul(
                 from_int(4*m), pi, prec), from_int(mod), prec)
             return mpf_mul(mpf_mul(
-                from_int((-1)**e*jacobi_symbol(m - 1, m)),
+                from_int((-1)**e*jacobi(m - 1, m)),
                 mpf_sqrt(from_int(k), prec), prec),
                 mpf_sin(arg, prec), prec)
         if p == 3:
@@ -75,14 +74,14 @@ def _a(n, k, prec):
             arg = mpf_div(mpf_mul(from_int(4*m), pi, prec),
                 from_int(mod), prec)
             return mpf_mul(mpf_mul(
-                from_int(2*(-1)**(e + 1)*legendre_symbol(m, 3)),
+                from_int(2*(-1)**(e + 1)*legendre(m, 3)),
                 mpf_sqrt(from_int(k//3), prec), prec),
                 mpf_sin(arg, prec), prec)
         v = k + v % k
         if v % p == 0:
             if e == 1:
                 return mpf_mul(
-                    from_int(jacobi_symbol(3, k)),
+                    from_int(jacobi(3, k)),
                     mpf_sqrt(from_int(k), prec), prec)
             return fzero
         if not is_quad_residue(v, p):
@@ -94,7 +93,7 @@ def _a(n, k, prec):
             mpf_mul(from_int(4*m), pi, prec),
             from_int(k), prec)
         return mpf_mul(mpf_mul(
-            from_int(2*jacobi_symbol(3, k)),
+            from_int(2*jacobi(3, k)),
             mpf_sqrt(from_int(k), prec), prec),
             mpf_cos(arg, prec), prec)
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -5,7 +5,7 @@ Primality testing
 
 from sympy.core.power import integer_nthroot
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import HAS_GMPY, gcd
+from sympy.external.gmpy import HAS_GMPY, gcd, jacobi
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -279,13 +279,12 @@ def _lucas_selfridge_params(n):
     .. [1] "Lucas Pseudoprimes", Baillie and Wagstaff, 1980.
            http://mpqs.free.fr/LucasPseudoprimes.pdf
     """
-    from sympy.ntheory.residue_ntheory import jacobi_symbol
     D = 5
     while True:
         g = gcd(D, n)
         if g > 1 and g != n:
             return (0, 0, 0)
-        if jacobi_symbol(D, n) == -1:
+        if jacobi(D, n) == -1:
             break
         if D > 0:
           D = -D - 2
@@ -303,13 +302,12 @@ def _lucas_extrastrong_params(n):
            https://oeis.org/A217719
     .. [1] https://en.wikipedia.org/wiki/Lucas_pseudoprime
     """
-    from sympy.ntheory.residue_ntheory import jacobi_symbol
     P, Q, D = 3, 1, 5
     while True:
         g = gcd(D, n)
         if g > 1 and g != n:
             return (0, 0, 0)
-        if jacobi_symbol(D, n) == -1:
+        if jacobi(D, n) == -1:
             break
         P += 1
         D = P*P - 4

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sympy.core.function import Function
 from sympy.core.singleton import S
-from sympy.external.gmpy import gcd, invert, sqrt
+from sympy.external.gmpy import gcd, invert, sqrt, legendre, jacobi
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
@@ -345,7 +345,7 @@ def _sqrt_mod_tonelli_shanks(a, p):
     # find a non-quadratic residue
     while 1:
         d = randint(2, p - 1)
-        r = legendre_symbol(d, p)
+        r = jacobi(d, p)
         if r == -1:
             break
     #assert legendre_symbol(d, p) == -1
@@ -556,7 +556,7 @@ def _sqrt_mod_prime_power(a, p, k):
         return sorted([r, pk - r, (r + h) % pk, -(r + h) % pk])
 
     # If the Legendre symbol (a/p) is not 1, no solution exists.
-    if jacobi_symbol(a, p) != 1:
+    if jacobi(a, p) != 1:
         return None
     if p % 4 == 3:
         res = pow(a, (p + 1) // 4, p)
@@ -643,7 +643,7 @@ def is_quad_residue(a, p):
     if a < 2 or p < 3:
         return True
     if not isprime(p):
-        if p % 2 and jacobi_symbol(a, p) == -1:
+        if p % 2 and jacobi(a, p) == -1:
             return False
         r = sqrt_mod(a, p)
         if r is None:
@@ -935,14 +935,9 @@ def legendre_symbol(a, p):
 
     """
     a, p = as_int(a), as_int(p)
-    if not isprime(p) or p == 2:
+    if p == 2 or not isprime(p):
         raise ValueError("p should be an odd prime")
-    a = a % p
-    if not a:
-        return 0
-    if pow(a, (p - 1) // 2, p) == 1:
-        return 1
-    return -1
+    return int(legendre(a, p))
 
 
 def jacobi_symbol(m, n):
@@ -1003,28 +998,7 @@ def jacobi_symbol(m, n):
     is_quad_residue, legendre_symbol
     """
     m, n = as_int(m), as_int(n)
-    if n < 0 or not n % 2:
-        raise ValueError("n should be an odd positive integer")
-    if m < 0 or m > n:
-        m %= n
-    if not m:
-        return int(n == 1)
-    if n == 1 or m == 1:
-        return 1
-    if gcd(m, n) != 1:
-        return 0
-
-    j = 1
-    while m != 0:
-        while m % 2 == 0 and m > 0:
-            m >>= 1
-            if n % 8 in [3, 5]:
-                j = -j
-        m, n = n, m
-        if m % 4 == n % 4 == 3:
-            j = -j
-        m %= n
-    return j
+    return int(jacobi(m, n))
 
 
 class mobius(Function):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25067


#### Brief description of what is fixed or changed
Added `legendre` and `jacobi` to `sympy.external.gmpy`.

Changed `legendre_symbol` and `jacobi_symbol` in `sympy.ntheory.residue_ntheory` to call `legendre` and `jacobi`.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
