### PR TITLE
Fix broken link in `lambdify.py`

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -483,7 +483,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
       ``implemented_function`` and user defined subclasses of Function. If
       specified, numexpr may be the only option in modules. The official list
       of numexpr functions can be found at:
-      https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html#supported-functions
+      https://numexpr.readthedocs.io/en/latest/user_guide.html#supported-functions
 
     - In the above examples, the generated functions can accept scalar
       values or numpy arrays as arguments.  However, in some cases


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#24140 

#### Brief description of what is fixed or changed
Actual motivation behind this is to check if I am able to build docs locally.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->