### PR TITLE
Form eoms kwargs

### DIFF
--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -798,34 +798,34 @@ class System(_Methods):
         # KanesMethod does not accept empty iterables
         loads = self.loads if self.loads else None
         if issubclass(eom_method, KanesMethod):
-            not_allowed_kwargs = {
+            disallowed_kwargs = {
                 "frame", "q_ind", "u_ind", "kd_eqs", "q_dependent",
                 "u_dependent", "configuration_constraints",
                 "velocity_constraints", "forcelist", "bodies"}
-            wrong_kwargs = not_allowed_kwargs.intersection(kwargs)
+            wrong_kwargs = disallowed_kwargs.intersection(kwargs)
             if wrong_kwargs:
                 raise ValueError(
-                    f"The key word arguments {wrong_kwargs} are not allowed to "
-                    f"be overwritten in {eom_method.__name__}.")
+                    f"The following keyword arguments are not allowed to be "
+                    f"overwritten in {eom_method.__name__}: {wrong_kwargs}.")
             velocity_constraints = self.holonomic_constraints.diff(
                 dynamicsymbols._t).col_join(self.nonholonomic_constraints)
-            kwargs = {"frame": self.frame, "q_ind": self.q_ind, "u_ind": self.u_ind,
-                      "kd_eqs": self.kdes, "q_dependent": self.q_dep,
-                      "u_dependent": self.u_dep,
+            kwargs = {"frame": self.frame, "q_ind": self.q_ind,
+                      "u_ind": self.u_ind, "kd_eqs": self.kdes,
+                      "q_dependent": self.q_dep, "u_dependent": self.u_dep,
                       "configuration_constraints": self.holonomic_constraints,
                       "velocity_constraints": velocity_constraints,
                       "forcelist": loads, "bodies": self.bodies,
                       "explicit_kinematics": False, **kwargs}
             self._eom_method = KanesMethod(**kwargs)
         elif issubclass(eom_method, LagrangesMethod):
-            not_allowed_kwargs = {
+            disallowed_kwargs = {
                 "frame", "qs", "forcelist", "bodies", "hol_coneqs",
                 "nonhol_coneqs", "Lagrangian"}
-            wrong_kwargs = not_allowed_kwargs.intersection(kwargs)
+            wrong_kwargs = disallowed_kwargs.intersection(kwargs)
             if wrong_kwargs:
                 raise ValueError(
-                    f"The key word arguments {wrong_kwargs} are not allowed to "
-                    f"be overwritten in {eom_method.__name__}.")
+                    f"The following keyword arguments are not allowed to be "
+                    f"overwritten in {eom_method.__name__}: {wrong_kwargs}.")
             kwargs = {"frame": self.frame, "qs": self.q, "forcelist": loads,
                       "bodies": self.bodies,
                       "hol_coneqs": self.holonomic_constraints,

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -425,6 +425,21 @@ class TestSystem(TestSystemBase):
         else:
             assert body == self.bodies[body_index]
 
+    @pytest.mark.parametrize('kwargs, expected', [
+        ({}, ImmutableMatrix([[-1, 0], [0, symbols("m")]])),
+        ({'explicit_kinematics': True}, ImmutableMatrix([[1, 0], [0, symbols("m")]])),
+        ({"bodies": []}, ImmutableMatrix([[-1, 0], [0, 0]])),
+    ])
+    def test_system_kane_kwargs(self, _empty_system_setup, kwargs, expected):
+        self.system.q_ind = q[0]
+        self.system.u_ind = u[0]
+        self.system.kdes = u[0] - q[0].diff(t)
+        p = Particle("p", mass=symbols("m"))
+        self.system.add_bodies(p)
+        p.masscenter.set_pos(self.system.origin, q[0] * self.system.x)
+        self.system.form_eoms(**kwargs)
+        assert self.system.mass_matrix_full == expected
+
 
 class TestValidateSystem(TestSystemBase):
     @pytest.mark.parametrize('valid_method, invalid_method, with_speeds', [

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -430,7 +430,7 @@ class TestSystem(TestSystemBase):
         ({'explicit_kinematics': True}, ImmutableMatrix([[1, 0], [0, symbols("m")]])),
         ({"bodies": []}, ImmutableMatrix([[-1, 0], [0, 0]])),
     ])
-    def test_system_kane_kwargs(self, _empty_system_setup, kwargs, expected):
+    def test_system_kane_form_eoms_kwargs(self, _empty_system_setup, kwargs, expected):
         self.system.q_ind = q[0]
         self.system.u_ind = u[0]
         self.system.kdes = u[0] - q[0].diff(t)
@@ -449,7 +449,7 @@ class TestSystem(TestSystemBase):
          ImmutableMatrix([[1, 0], [0, symbols("m")]]),
          ImmutableMatrix([q[0].diff(t), -symbols("g")])),
     ])
-    def test_system_lagrange_kwargs(self, _empty_system_setup, kwargs, mm, gm):
+    def test_system_lagrange_form_eoms_kwargs(self, _empty_system_setup, kwargs, mm, gm):
         self.system.q_ind = q[0]
         p = Particle("p", mass=symbols("m"))
         self.system.add_bodies(p)
@@ -457,6 +457,15 @@ class TestSystem(TestSystemBase):
         self.system.form_eoms(eom_method=LagrangesMethod, **kwargs)
         assert self.system.mass_matrix_full == mm
         assert self.system.forcing_full == gm
+
+    @pytest.mark.parametrize('eom_method', [KanesMethod, LagrangesMethod])
+    def test_unspecified_form_eoms_kwargs(self, _empty_system_setup, eom_method):
+        self.system.q_ind = q[0]
+        p = Particle("p", mass=symbols("m"))
+        self.system.add_bodies(p)
+        p.masscenter.set_pos(self.system.origin, q[0] * self.system.x)
+        with pytest.raises(TypeError):
+            self.system.form_eoms(eom_method=eom_method, not_existing_kwarg=1)
 
 
 class TestValidateSystem(TestSystemBase):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Add the functionality to specify method specific key word arguments in the `System.form_eoms` method.

#### Other comments
Huge advantage of this options is that it will for example allow one to specify the constraint solver or auxilary speeds and forces when using `KanesMethod`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Added functionality to specify key word arguments of the backend used to form the equations of motion.
<!-- END RELEASE NOTES -->
