### PR TITLE
fix(core): fix unpickling of symbols pickled with sympy 1.8

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -300,6 +300,9 @@ class Symbol(AtomicExpr, Boolean):
         if not isinstance(name, str):
             raise TypeError("name should be a string, not %s" % repr(type(name)))
 
+        # XXX: If making any changes here make sure that __setstate__ below is
+        # updated for unpickling symbols pickled with SymPy 1.8 or older.
+
         # This is retained purely so that srepr can include commutative=True if
         # that was explicitly specified but not if it was not. Ideally srepr
         # should not distinguish these cases because the symbols otherwise
@@ -352,11 +355,16 @@ class Symbol(AtomicExpr, Boolean):
     # NOTE: __setstate__ is not needed for pickles created by __getnewargs_ex__
     # but was used before Symbol was changed to use __getnewargs_ex__ in v1.9.
     # Pickles created in previous SymPy versions will still need __setstate__
-    # so that they can be unpickled in SymPy > v1.9.
+    # so that they can be unpickled in SymPy >= v1.9.
 
     def __setstate__(self, state):
-        for name, value in state.items():
-            setattr(self, name, value)
+        for name, assumptions in state.items():
+            if name != '_assumptions':
+                raise TypeError(f"No attribute: {name!r}")
+            assumptions0 = {k: v for k, v in assumptions.items() if v is not None}
+            self._assumptions = assumptions
+            self._assumptions0 = assumptions0
+            self._assumptions_orig = assumptions0
 
     def _hashable_content(self):
         # Note: user-specified assumptions not hashed, just derived ones


### PR DESCRIPTION
<!-- Your title above should be a short des cription of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fix for gh-25134 on the master branch.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * A bug that caused incorrect unpickling  of Symbols from pickles created by SymPy 1.8 (or older) was fixed.
<!-- END RELEASE NOTES -->