### PR TITLE
Moved implementation in `external.gmpy` to `external.ntheory`

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -2,8 +2,6 @@ import os
 import sys
 from typing import Tuple as tTuple, Type
 
-import mpmath.libmp as mlib
-
 from sympy.external import import_module
 
 __all__ = [
@@ -29,25 +27,14 @@ __all__ = [
     # MPZ is either gmpy.mpz or int.
     'MPZ',
 
-    # Either the gmpy or the mpmath function
     'factorial',
-
-    # isqrt from gmpy or mpmath
     'sqrt',
-
-    # gcd from gmpy or math
+    'is_square',
+    'sqrtrem',
     'gcd',
-
-    # lcm from gmpy or math
     'lcm',
-
-    # invert from gmpy or pow
     'invert',
-
-    # legendre from gmpy or sympy
     'legendre',
-
-    # jacobi from gmpy or sympy
     'jacobi',
 ]
 
@@ -117,6 +104,9 @@ if gmpy is not None:
 else:
     from .pythonmpq import PythonMPQ
     import math
+    from .ntheory import (factorial_python, sqrt_python, is_square_python,
+                          sqrtrem_python, invert_python, legendre_python,
+                          jacobi_python)
 
     HAS_GMPY = 0
     GROUND_TYPES = 'python'
@@ -124,10 +114,10 @@ else:
     MPZ = int
     MPQ = PythonMPQ
 
-    factorial = lambda x: int(mlib.ifac(x))
-    sqrt = lambda x: int(mlib.isqrt(x))
-    is_square = lambda x: x >= 0 and mlib.sqrtrem(x)[1] == 0
-    sqrtrem = lambda x: tuple(int(r) for r in mlib.sqrtrem(x))
+    factorial = factorial_python
+    sqrt = sqrt_python
+    is_square = is_square_python
+    sqrtrem = sqrtrem_python
     if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd
         lcm = math.lcm
@@ -140,52 +130,6 @@ else:
             if 0 in args:
                 return 0
             return reduce(lambda x, y: x*y//math.gcd(x, y), args, 1)
-
-    def invert(x, m):
-        """ Return y such that x*y == 1 modulo m.
-
-        Uses ``math.pow`` but reproduces the behaviour of ``gmpy2.invert``
-        which raises ZeroDivisionError if no inverse exists.
-        """
-        try:
-            return pow(x, -1, m)
-        except ValueError:
-            raise ZeroDivisionError("invert() no inverse exists")
-
-    def legendre(x, y):
-        """ Return Legendre symbol (x / y).
-
-        Following the implementation of gmpy2,
-        the error is raised only when y is an even number.
-        """
-        if y <= 0 or not y % 2:
-            raise ValueError("y should be an odd prime")
-        x %= y
-        if not x:
-            return 0
-        if pow(x, (y - 1) // 2, y) == 1:
-            return 1
-        return -1
-
-    def jacobi(x, y):
-        """ Return Jacobi symbol (x / y)."""
-        if y <= 0 or not y % 2:
-            raise ValueError("y should be an odd positive integer")
-        x %= y
-        if not x:
-            return int(y == 1)
-        if y == 1 or x == 1:
-            return 1
-        if gcd(x, y) != 1:
-            return 0
-        j = 1
-        while x != 0:
-            while x % 2 == 0 and x > 0:
-                x >>= 1
-                if y % 8 in [3, 5]:
-                    j = -j
-            x, y = y, x
-            if x % 4 == y % 4 == 3:
-                j = -j
-            x %= y
-        return j
+    invert = invert_python
+    legendre = legendre_python
+    jacobi = jacobi_python

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -1,0 +1,115 @@
+""" This module is an alternative implementation of the gmpy2 function.
+
+In sympy, gmpy2 is optional. This means that we need to provide
+some alternative function for environments where gmpy2 is not installed.
+On the other hand, for developers, we want to provide functions without making
+them aware of the differences. `sympy.external.gmpy` is provided
+with such an intention. That is, when gmpy2 is installed,
+the functions of gmpy2 are used, and when gmpy2 is not installed,
+the functions defined in this module are used. The choice of which
+function to use is handled by `sympy.external.gmpy`,
+which implements the alternative functions that may be selected.
+Therefore, it is not expected that functions in this module
+will be called directly by the user.
+"""
+
+import math
+import mpmath.libmp as mlib
+
+
+def factorial_python(x):
+    return int(mlib.ifac(x))
+
+
+def sqrt_python(x):
+    return int(mlib.isqrt(x))
+
+
+def is_square_python(x):
+    if x < 0:
+        return False
+    # Note that the possible values of y**2 % n for a given n are limited.
+    # For example, when n=4, y**2 % n can only take 0 or 1.
+    # In other words, if x % 4 is 2 or 3, then x is not a square number.
+    # Mathematically, it determines if it belongs to the set {y**2 % n},
+    # but implementationally, it can be realized as a logical conjunction
+    # with an n-bit integer.
+    # see https://mersenneforum.org/showpost.php?p=110896
+    # def magic(n):
+    #     s = {y**2 % n for y in range(n)}
+    #     s = set(range(n)) - s
+    #     return sum(1 << bit for bit in s)
+    # >>> print(hex(magic(128)))
+    # 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec
+    # >>> print(hex(magic(99)))
+    # 0x5f6f9ffb6fb7ddfcb75befdec
+    # >>> print(hex(magic(91)))
+    # 0x6fd1bfcfed5f3679d3ebdec
+    # >>> print(hex(magic(85)))
+    # 0xdef9ae771ffe3b9d67dec
+    if 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec & (1 << (x & 127)):
+        return False  # e.g. 2, 3
+    m = x % 765765 # 765765 = 99 * 91 * 85
+    if 0x5f6f9ffb6fb7ddfcb75befdec & (1 << (m % 99)):
+        return False  # e.g. 17, 68
+    if 0x6fd1bfcfed5f3679d3ebdec & (1 << (m % 91)):
+        return False  # e.g. 97, 388
+    if 0xdef9ae771ffe3b9d67dec & (1 << (m % 85)):
+        return False  # e.g. 793, 1408
+    return mlib.sqrtrem(x)[1] == 0
+
+
+def sqrtrem_python(x):
+    return tuple(int(r) for r in mlib.sqrtrem(x))
+
+
+def invert_python(x, m):
+    """ Return y such that x*y == 1 modulo m.
+
+    Uses ``math.pow`` but reproduces the behaviour of ``gmpy2.invert``
+    which raises ZeroDivisionError if no inverse exists.
+    """
+    try:
+        return pow(x, -1, m)
+    except ValueError:
+        raise ZeroDivisionError("invert() no inverse exists")
+
+
+def legendre_python(x, y):
+    """ Return Legendre symbol (x / y).
+
+    Following the implementation of gmpy2,
+    the error is raised only when y is an even number.
+    """
+    if y <= 0 or not y % 2:
+        raise ValueError("y should be an odd prime")
+    x %= y
+    if not x:
+        return 0
+    if pow(x, (y - 1) // 2, y) == 1:
+        return 1
+    return -1
+
+
+def jacobi_python(x, y):
+    """ Return Jacobi symbol (x / y)."""
+    if y <= 0 or not y % 2:
+        raise ValueError("y should be an odd positive integer")
+    x %= y
+    if not x:
+        return int(y == 1)
+    if y == 1 or x == 1:
+        return 1
+    if math.gcd(x, y) != 1:
+        return 0
+    j = 1
+    while x != 0:
+        while x % 2 == 0 and x > 0:
+            x >>= 1
+            if y % 8 in [3, 5]:
+                j = -j
+        x, y = y, x
+        if x % 4 == y % 4 == 3:
+            j = -j
+        x %= y
+    return j

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -3,9 +3,8 @@ Primality testing
 
 """
 
-from sympy.core.power import integer_nthroot
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import HAS_GMPY, gcd, jacobi
+from sympy.external.gmpy import HAS_GMPY, gcd, jacobi, is_square as is_square_gmpy
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -88,38 +87,7 @@ def is_square(n, prep=True):
             return False
         if n in (0, 1):
             return True
-    # def magic(n):
-    #     s = {x**2 % n for x in range(n)}
-    #     return sum(1 << bit for bit in s)
-    # >>> print(hex(magic(128)))
-    # 0x2020212020202130202021202030213
-    # >>> print(hex(magic(99)))
-    # 0x209060049048220348a410213
-    # >>> print(hex(magic(91)))
-    # 0x102e403012a0c9862c14213
-    # >>> print(hex(magic(85)))
-    # 0x121065188e001c46298213
-    if not 0x2020212020202130202021202030213 & (1 << (n & 127)):
-        return False  # e.g. 2, 3
-    m = n % (99 * 91 * 85)
-    if not 0x209060049048220348a410213 & (1 << (m % 99)):
-        return False  # e.g. 17, 68
-    if not 0x102e403012a0c9862c14213 & (1 << (m % 91)):
-        return False  # e.g. 97, 388
-    if not 0x121065188e001c46298213 & (1 << (m % 85)):
-        return False  # e.g. 793, 1408
-    # n is either:
-    #   a) odd = 4*even + 1 (and square if even = k*(k + 1))
-    #   b) even with
-    #     odd multiplicity of 2 --> not square, e.g. 39040
-    #     even multiplicity of 2, e.g. 4, 16, 36, ..., 16324
-    #         removal of factors of 2 to give an odd, and rejection if
-    #         any(i%2 for i in divmod(odd - 1, 4))
-    #         will give an odd number in form 4*even + 1.
-    # Use of `trailing` to check the power of 2 is not done since it
-    # does not apply to a large percentage of arbitrary numbers
-    # and the integer_nthroot is able to quickly resolve these cases.
-    return integer_nthroot(n, 2)[1]
+    return is_square_gmpy(n)
 
 
 def _test(n, base, s, t):


### PR DESCRIPTION
Miscellaneous,
* Added `is_square` and `sqrtrem` to `external.gmpy.__all__`.
* moved `ntheory.primetest.is_square` code to `external.ntheory.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25140

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
