### PR TITLE
Added center_of_mass and find_dynamicsymbols functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1266,6 +1266,7 @@ Shivani Kohli <shivanikohli.09@gmail.com>
 Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
+Shuai Zhou <shuaivzhou@berkeley.edu>
 Shubham Abhang <shubhamabhang77@gmail.com>
 Shubham Agrawal <shubham.ag6845@gmail.com>
 Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>

--- a/doc/src/modules/physics/mechanics/api/part_bod.rst
+++ b/doc/src/modules/physics/mechanics/api/part_bod.rst
@@ -37,6 +37,8 @@ Loads
 Other Functions
 ===============
 
+.. autofunction:: sympy.physics.mechanics.functions.center_of_mass
+
 .. autofunction:: sympy.physics.mechanics.functions.linear_momentum
 
 .. autofunction:: sympy.physics.mechanics.functions.angular_momentum
@@ -46,3 +48,5 @@ Other Functions
 .. autofunction:: sympy.physics.mechanics.functions.potential_energy
 
 .. autofunction:: sympy.physics.mechanics.functions.Lagrangian
+
+.. autofunction:: sympy.physics.mechanics.functions.find_dynamicsymbols


### PR DESCRIPTION
Added the center_of_mass and find_dynamicsymbols functions docstrings to the physics mechanics functions documentation.

#### References to other Issues or PRs

Fixes #25081

#### Brief description of what is fixed or changed

Physics mechanics `part_bod.rst` updated to include the `center_of_mass` and `find_dynamicsymbols` functions.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Added `center_of_mass` and `find_dynamicsymbols` to Sphinx API docs.
<!-- END RELEASE NOTES -->
