### PR TITLE
Add Contributor Metrics Widget to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ See <https://docs.sympy.org/dev/install.html> for more information.
 
 ## Contributing
 
+<a href="https://github.com/monoclehq">
+    <img src="https://open-source-assets.middlewarehq.com/svgs/sympy-sympy-contributor-metrics-dark-widget.svg"></img>
+</a>
+
 We welcome contributions from anyone, even if you are new to open
 source. Please read our [Introduction to Contributing](https://github.com/sympy/sympy/wiki/Introduction-to-contributing)
 page and the [SymPy Documentation Style Guide](https://docs.sympy.org/dev/documentation-style-guide.html). If you


### PR DESCRIPTION
#### Brief description of what is fixed or changed

- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics regularly and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 2 months.

![image](https://github.com/sympy/sympy/assets/70485812/c3c3357e-dbe1-44bd-a360-e8299b03cd9d)

#### Other comments

Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
- A widget showcasing recent contributions can be motivating for new contributors.
- This widget is already present in some selected opensource repositories- [RocketChat/Apps.GitHub22](https://github.com/RocketChat/Apps.Github22), [RocketChat/EmbeddedChat](https://github.com/RocketChat/EmbeddedChat), [RocketChat/RC4Community](https://github.com/RocketChat/RC4Community) etc. and has helped in community building around those projects. 
- A number of  students had mentioned their rank on this widget in their GSoC 2023 proposal for RocketChat. Hence, this can be great motivator for student contributors. 