### PR TITLE
New distance method added to Line3D that supports Point3D, Line3D and Plane

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -892,6 +892,7 @@ Mark Shoulson <mark@kli.org>
 Markus Mohrhard <markus.mohrhard@googlemail.com>
 Markus Müller <markus.mueller.1.g@googlemail.com>
 Martha Giannoudovardi <maapxa@gmail.com>
+Martin Manns <mmanns@gmx.net>
 Martin Povišer <martin.povik@gmail.com>
 Martin Roelfs <u0114255@kuleuven.be>
 Martin Thoma <info@martin-thoma.de>

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2638,7 +2638,7 @@ class Line3D(LinearEntity3D, Line):
 
         from .plane import Plane  # Avoid circular import
 
-        if isinstance(other, tuple) or isinstance(other, list):
+        if isinstance(other, (tuple, list)):
             try:
                 other = Point3D(other)
             except ValueError:

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2594,7 +2594,7 @@ class Line3D(LinearEntity3D, Line):
 
     def distance(self, other):
         """
-        Finds the shortest distance between a line segment and a point.
+        Finds the shortest distance between a line segment and another object.
 
         Parameters
         ==========

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2592,6 +2592,79 @@ class Line3D(LinearEntity3D, Line):
                 break
         return Tuple(*[i.subs(k, kk).as_numer_denom()[0] for i in eqs])
 
+    def distance(self, other):
+        """
+        Finds the shortest distance between a line segment and a point.
+
+        Parameters
+        ==========
+
+        Point3D, Line3D, Plane, tuple, list
+
+        Returns
+        =======
+
+        distance
+
+        Notes
+        =====
+
+        This method accepts only 3D entities as it's parameter
+
+        Tuples and lists are converted to Point3D and therefore must be of
+        length 3, 2 or 1.
+
+        NotImplementedError is raised if `other` is not an instance of one
+        of the specified classes
+
+        Examples
+        ========
+
+        >>> from sympy.geometry import Line3D
+        >>> l1 = Line3D((0, 0, 0), (0, 0, 1))
+        >>> l2 = Line3D((0, 1, 0), (1, 1, 1))
+        >>> l1.distance(l2)
+        1
+
+        The computed distance may be symbolic, too:
+
+        >>> from sympy.abc import x, y
+        >>> l1 = Line3D((0, 0, 0), (0, 0, 1))
+        >>> l2 = Line3D((0, x, 0), (y, x, 1))
+        >>> l1.distance(l2)
+        Abs(x*y)/Abs(sqrt(y**2))
+
+        """
+
+        from .plane import Plane  # Avoid circular import
+
+        if isinstance(other, tuple) or isinstance(other, list):
+            try:
+                other = Point3D(other)
+            except ValueError:
+                pass
+
+        if isinstance(other, Point3D):
+            return super().distance(other)
+
+        if isinstance(other, Line3D):
+            if self == other:
+                return S.Zero
+            elif self.is_parallel(other):
+                return super().distance(other.p1)
+            else:
+                self_direction = Matrix(self.direction_ratio)
+                other_direction = Matrix(other.direction_ratio)
+                normal = self_direction.cross(other_direction)
+                plane_through_self = Plane(p1=self.p1, normal_vector=normal)
+                return other.p1.distance(plane_through_self)
+
+        if isinstance(other, Plane):
+            return other.distance(self)
+
+        msg = f"{other} has type {type(other)}, which is unsupported"
+        raise NotImplementedError(msg)
+
 
 class Ray3D(LinearEntity3D, Ray):
     """

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2594,7 +2594,7 @@ class Line3D(LinearEntity3D, Line):
 
     def distance(self, other):
         """
-        Finds the shortest distance between a line segment and another object.
+        Finds the shortest distance between a line and another object.
 
         Parameters
         ==========
@@ -2615,7 +2615,7 @@ class Line3D(LinearEntity3D, Line):
         length 3, 2 or 1.
 
         NotImplementedError is raised if `other` is not an instance of one
-        of the specified classes: Point, Line, or Plane.
+        of the specified classes: Point3D, Line3D, or Plane.
 
         Examples
         ========

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2652,12 +2652,13 @@ class Line3D(LinearEntity3D, Line):
                 return S.Zero
             if self.is_parallel(other):
                 return super().distance(other.p1)
-            else:
-                self_direction = Matrix(self.direction_ratio)
-                other_direction = Matrix(other.direction_ratio)
-                normal = self_direction.cross(other_direction)
-                plane_through_self = Plane(p1=self.p1, normal_vector=normal)
-                return other.p1.distance(plane_through_self)
+
+            # Skew lines
+            self_direction = Matrix(self.direction_ratio)
+            other_direction = Matrix(other.direction_ratio)
+            normal = self_direction.cross(other_direction)
+            plane_through_self = Plane(p1=self.p1, normal_vector=normal)
+            return other.p1.distance(plane_through_self)
 
         if isinstance(other, Plane):
             return other.distance(self)

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2650,7 +2650,7 @@ class Line3D(LinearEntity3D, Line):
         if isinstance(other, Line3D):
             if self == other:
                 return S.Zero
-            elif self.is_parallel(other):
+            if self.is_parallel(other):
                 return super().distance(other.p1)
             else:
                 self_direction = Matrix(self.direction_ratio)

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2615,7 +2615,7 @@ class Line3D(LinearEntity3D, Line):
         length 3, 2 or 1.
 
         NotImplementedError is raised if `other` is not an instance of one
-        of the specified classes
+        of the specified classes: Point, Line, or Plane.
 
         Examples
         ========

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -9,7 +9,7 @@ from sympy.simplify.simplify import simplify
 from sympy.functions.elementary.trigonometric import tan
 from sympy.geometry import (Circle, GeometryError, Line, Point, Ray,
     Segment, Triangle, intersection, Point3D, Line3D, Ray3D, Segment3D,
-    Point2D, Line2D)
+    Point2D, Line2D, Plane)
 from sympy.geometry.line import Undecidable
 from sympy.geometry.polygon import _asa as asa
 from sympy.utilities.iterables import cartes
@@ -406,6 +406,15 @@ def test_distance_3d():
     assert Line3D((0, 0, 0), (0, 1, 0)).distance(p2) == sqrt(2)
     assert Line3D((0, 0, 0), (1, 0, 0)).distance(p1) == 0
     assert Line3D((0, 0, 0), (1, 0, 0)).distance(p2) == sqrt(2)
+    # Line to line
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Line3D((0, 0, 0), (0, 1, 2))) == 0
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Line3D((0, 0, 0), (1, 0, 0))) == 0
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Line3D((10, 0, 0), (10, 1, 2))) == 0
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Line3D((0, 1, 0), (0, 1, 1))) == 1
+    # Line to plane
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Plane((2, 0, 0), (0, 0, 1))) == 0
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Plane((0, 1, 0), (0, 1, 0))) == 1
+    assert Line3D((0, 0, 0), (1, 0, 0)).distance(Plane((1, 1, 3), (1, 0, 0))) == 0
     # Ray to point
     assert r.distance(Point3D(-1, -1, -1)) == sqrt(3)
     assert r.distance(Point3D(1, 1, 1)) == 0


### PR DESCRIPTION
#### References to other Issues or PRs

#22790 `Added a class method 'nearest_points()' to calculate distance between two lines in 3D.`
#22776 `New method to calculate nearest distance between two lines`
#22774 `have a method to calculate the distance between two lines`

While this pull request addresses the same deficiency of `Line3D`, i.e. that it does not provide a distance method to other objects of its type, its approach differs from both PRs. Existing methods have not been changed. Instead, the PR overloads the distance method for `Line3D` and therefore only addresses its 3D distance measurement.

#### Brief description of what is fixed or changed

A new distance method has been added to `Line3D`. It supports `Line3D`, `Point3D`, `Plane` as `other`. If instances of `tuple` and `list` are provided they are converted to `Point3D`. A `NotImplementedError` is thrown if `other` is not an instance of these types.

This commit addresses the issue that `Line3D` does not support distance measurement to other `Line3D` or `Plane` objects. This functionality may be added later to the method.

#### Other comments

Unit tests have been added to `test_line.py` for full code coverage.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Added a distance method to Line3D that supports Plane, Line3D and Point3D.
<!-- END RELEASE NOTES -->
