### PR TITLE
Added `_csolve_prime_las_vegas`

### DIFF
--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -3,7 +3,7 @@
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
 from sympy.core.random import uniform, randint, seed as seed_func
-from sympy.external.gmpy import SYMPY_INTS, invert
+from sympy.external.gmpy import SYMPY_INTS, MPZ, invert
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import _sort_factors
@@ -2453,7 +2453,7 @@ def csolve_prime(f, p, e=1):
     from solution [1] (mod 3).
     """
     from sympy.polys.domains import ZZ
-    g = f.copy()
+    g = list(map(lambda x: MPZ(int(x)), f))
     # Convert to polynomial of degree at most p-1
     for i in range(len(g) - p):
         g[i + p - 1] += g[i]

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1,12 +1,16 @@
 """Dense univariate polynomials with coefficients in Galois fields. """
 
+import random
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
 from sympy.core.random import uniform
-from sympy.external.gmpy import SYMPY_INTS
+from sympy.external.gmpy import SYMPY_INTS, invert
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import _sort_factors
+
+
+rgen = random.Random()
 
 
 def gf_crt(U, M, K=None):
@@ -2328,15 +2332,121 @@ def _raise_mod_power(x, s, p, f):
     return linear_congruence(alpha, beta, p)
 
 
-def csolve_prime(f, p, e=1):
+def _csolve_prime_las_vegas(f, p):
+    r""" Solutions of `f(x) \equiv 0 \pmod{p}`, `f(0) \not\equiv 0 \pmod{p}`.
+
+    Explanation
+    ===========
+
+    This algorithm is classified as the Las Vegas method.
+    That is, it always returns the correct answer and solves the problem
+    fast in many cases, but if it is unlucky, it does not answer forever.
+
+    Suppose the polynomial f is not a zero polynomial. Assume further
+    that it is of degree at most p-1 and `f(0)\not\equiv 0 \pmod{p}`.
+    These assumptions are not an essential part of the algorithm,
+    only that it is more convenient for the function calling this
+    function to resolve them.
+
+    Note that `x^{p-1} - 1 \equiv \prod_{a=1}^{p-1}(x - a) \pmod{p}`.
+    Thus, the greatest common divisor with f is `\prod_{s \in S}(x - s)`,
+    with S being the set of solutions to f. Furthermore,
+    when a is randomly determined, `(x+a)^{(p-1)/2}-1` is
+    a polynomial with (p-1)/2 randomly chosen solutions.
+    The greatest common divisor of f may be a nontrivial factor of f.
+
+    When p is large and the degree of f is small,
+    it is faster than naive solution methods.
+
+    Parameters
+    ==========
+
+    f : polynomial
+    p : prime number
+
+    Returns
+    =======
+
+    list[int]
+        a list of solutions, sorted in ascending order
+        by integers in the range [1, p). The same value
+        does not exist in the list even if there is
+        a multiple solution. If no solution exists, returns [].
+
+    Examples
+    ========
+
+    >>> from sympy.polys.galoistools import _csolve_prime_las_vegas
+    >>> _csolve_prime_las_vegas([1, 4, 3], 7) # x^2 + 4x + 3 = 0 (mod 7)
+    [4, 6]
+    >>> _csolve_prime_las_vegas([5, 7, 1, 9], 11) # 5x^3 + 7x^2 + x + 9 = 0 (mod 11)
+    [1, 5, 8]
+
+    References
+    ==========
+
+    .. [1] R. Crandall and C. Pomerance "Prime Numbers", 2nd Ed., Algorithm 2.3.10
+
     """
-    Solutions of f(x) congruent 0 mod(p**e).
+    from sympy.polys.domains import ZZ
+    from sympy.ntheory import sqrt_mod
+    root = set()
+    g = gf_pow_mod([1, 0], p - 1, f, p, ZZ)
+    g = gf_sub_ground(g, 1, p, ZZ)
+    # We want to calculate gcd(x**(p-1) - 1, f(x))
+    factors = [gf_gcd(f, g, p, ZZ)]
+    while factors:
+        f = factors.pop()
+        # If the degree is small, solve directly
+        if len(f) <= 1:
+            continue
+        if len(f) == 2:
+            root.add(-invert(f[0], p) * f[1] % p)
+            continue
+        if len(f) == 3:
+            inv = invert(f[0], p)
+            b = f[1] * inv % p
+            b = (b + p * (b % 2)) // 2
+            root.update((r - b) % p for r in
+                        sqrt_mod(b**2 - f[2] * inv, p, all_roots=True))
+            continue
+        while True:
+            # Determine `a` randomly and
+            # compute gcd((x+a)**((p-1)//2)-1, f(x))
+            a = rgen.randint(0, p - 1)
+            g = gf_pow_mod([1, a], (p - 1) // 2, f, p, ZZ)
+            g = gf_sub_ground(g, 1, p, ZZ)
+            g = gf_gcd(f, g, p, ZZ)
+            if 1 < len(g) < len(f):
+                factors.append(g)
+                factors.append(gf_div(f, g, p, ZZ)[0])
+                break
+    return sorted(root)
+
+
+def csolve_prime(f, p, e=1):
+    r""" Solutions of `f(x) \equiv 0 \pmod{p^e}`.
+
+    Parameters
+    ==========
+
+    f : polynomial
+    p : prime number
+    e : positive integer
+
+    Returns
+    =======
+
+    list[int]
+        a list of solutions, sorted in ascending order
+        by integers in the range [1, p**e). The same value
+        does not exist in the list even if there is
+        a multiple solution. If no solution exists, returns [].
 
     Examples
     ========
 
     >>> from sympy.polys.galoistools import csolve_prime
-
     >>> csolve_prime([1, 1, 7], 3, 1)
     [1]
     >>> csolve_prime([1, 1, 7], 3, 2)
@@ -2346,7 +2456,29 @@ def csolve_prime(f, p, e=1):
     from solution [1] (mod 3).
     """
     from sympy.polys.domains import ZZ
-    X1 = [i for i in range(p) if gf_eval(f, i, p, ZZ) == 0]
+    g = f.copy()
+    # Convert to polynomial of degree at most p-1
+    for i in range(len(g) - p):
+        g[i + p - 1] += g[i]
+        g[i] = 0
+    g = gf_trunc(g, p)
+    # Checks whether g(x) is divisible by x
+    k = 0
+    while k < len(g) and g[len(g) - k - 1] == 0:
+        k += 1
+    if k:
+        g = g[:-k]
+        root_zero = [0]
+    else:
+        root_zero = []
+    if g == []:
+        X1 = list(range(p))
+    elif len(g)**2 < p:
+        # The conditions under which `_csolve_prime_las_vegas` is faster than
+        # a naive solution are worth considering.
+        X1 = root_zero + _csolve_prime_las_vegas(g, p)
+    else:
+        X1 = root_zero + [i for i in range(p) if gf_eval(g, i, p, ZZ) == 0]
     if e == 1:
         return X1
     X = []

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -2,7 +2,7 @@
 
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
-from sympy.core.random import uniform, randint
+from sympy.core.random import uniform, randint, seed as seed_func
 from sympy.external.gmpy import SYMPY_INTS, invert
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
@@ -2328,7 +2328,7 @@ def _raise_mod_power(x, s, p, f):
     return linear_congruence(alpha, beta, p)
 
 
-def _csolve_prime_las_vegas(f, p):
+def _csolve_prime_las_vegas(f, p, seed=1234):
     r""" Solutions of `f(x) \equiv 0 \pmod{p}`, `f(0) \not\equiv 0 \pmod{p}`.
 
     Explanation
@@ -2386,6 +2386,7 @@ def _csolve_prime_las_vegas(f, p):
     """
     from sympy.polys.domains import ZZ
     from sympy.ntheory import sqrt_mod
+    seed_func(seed)
     root = set()
     g = gf_pow_mod([1, 0], p - 1, f, p, ZZ)
     g = gf_sub_ground(g, 1, p, ZZ)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -2453,7 +2453,7 @@ def csolve_prime(f, p, e=1):
     from solution [1] (mod 3).
     """
     from sympy.polys.domains import ZZ
-    g = list(map(lambda x: MPZ(int(x)), f))
+    g = [MPZ(int(c)) for c in f]
     # Convert to polynomial of degree at most p-1
     for i in range(len(g) - p):
         g[i + p - 1] += g[i]

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1,16 +1,12 @@
 """Dense univariate polynomials with coefficients in Galois fields. """
 
-import random
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
-from sympy.core.random import uniform
+from sympy.core.random import uniform, randint
 from sympy.external.gmpy import SYMPY_INTS, invert
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import _sort_factors
-
-
-rgen = random.Random()
 
 
 def gf_crt(U, M, K=None):
@@ -2413,7 +2409,7 @@ def _csolve_prime_las_vegas(f, p):
         while True:
             # Determine `a` randomly and
             # compute gcd((x+a)**((p-1)//2)-1, f(x))
-            a = rgen.randint(0, p - 1)
+            a = randint(0, p - 1)
             g = gf_pow_mod([1, a], (p - 1) // 2, f, p, ZZ)
             g = gf_sub_ground(g, 1, p, ZZ)
             g = gf_gcd(f, g, p, ZZ)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -2,7 +2,7 @@
 
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
-from sympy.core.random import uniform, randint, seed as seed_func
+from sympy.core.random import uniform, _randint
 from sympy.external.gmpy import SYMPY_INTS, MPZ, invert
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
@@ -2328,7 +2328,7 @@ def _raise_mod_power(x, s, p, f):
     return linear_congruence(alpha, beta, p)
 
 
-def _csolve_prime_las_vegas(f, p, seed=1234):
+def _csolve_prime_las_vegas(f, p, seed=None):
     r""" Solutions of `f(x) \equiv 0 \pmod{p}`, `f(0) \not\equiv 0 \pmod{p}`.
 
     Explanation
@@ -2386,7 +2386,7 @@ def _csolve_prime_las_vegas(f, p, seed=1234):
     """
     from sympy.polys.domains import ZZ
     from sympy.ntheory import sqrt_mod
-    seed_func(seed)
+    randint = _randint(seed)
     root = set()
     g = gf_pow_mod([1, 0], p - 1, f, p, ZZ)
     g = gf_sub_ground(g, 1, p, ZZ)

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -22,8 +22,8 @@ from sympy.polys.galoistools import (
     gf_edf_zassenhaus, gf_edf_shoup,
     gf_berlekamp,
     gf_factor_sqf, gf_factor,
-    gf_value, linear_congruence, csolve_prime, gf_csolve,
-    gf_frobenius_map, gf_frobenius_monomial_base
+    gf_value, linear_congruence, _csolve_prime_las_vegas,
+    csolve_prime, gf_csolve, gf_frobenius_map, gf_frobenius_monomial_base
 )
 
 from sympy.polys.polyerrors import (
@@ -852,6 +852,14 @@ def test_gf_csolve():
     assert linear_congruence(0, 5, 5) == [0, 1, 2, 3, 4]
     assert linear_congruence(3, 12, 15) == [4, 9, 14]
     assert linear_congruence(6, 0, 18) == [0, 3, 6, 9, 12, 15]
+    # _csolve_prime_las_vegas
+    assert _csolve_prime_las_vegas([2, 3, 1], 5) == [2, 4]
+    assert _csolve_prime_las_vegas([2, 0, 1], 5) == []
+    from sympy.ntheory import primerange
+    for p in primerange(2, 100):
+        # f = x**(p-1) - 1
+        f = gf_sub_ground(gf_pow([1, 0], p - 1, p, ZZ), 1, p, ZZ)
+        assert _csolve_prime_las_vegas(f, p) == list(range(1, p))
     # with power = 1
     assert csolve_prime([1, 3, 2, 17], 7) == [3]
     assert csolve_prime([1, 3, 1, 5], 5) == [0, 1]


### PR DESCRIPTION
Added `_csolve_prime_las_vegas` to `sympy.polys.galoistools`. This function is asymptotically faster than the existing `csolve_prime`. However, it is not always faster in practice due to overhead; when p is large and the degree of f is small,
it is faster than the naive method implemented by `csolve_prime`, so we use this one.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
