### PR TITLE
Refactoring of `pi_hex_digits`

### DIFF
--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -71,7 +71,6 @@ array (perhaps just a matter of preference).
 
 '''
 
-import math
 from sympy.utilities.misc import as_int
 
 
@@ -81,8 +80,7 @@ def _series(j, n, prec=14):
     s = 0
     D = _dn(n, prec)
     D4 = 4 * D
-    k = 0
-    d = 8 * k + j
+    d = j
     for k in range(n + 1):
         s += (pow(16, n - k, d) << D4) // d
         d += 8
@@ -93,7 +91,7 @@ def _series(j, n, prec=14):
 
     t = 0
     k = n + 1
-    e = 4*(D + n - k)
+    e = D4 - 4 # 4*(D + n - k)
     d = 8 * k + j
     while True:
         dt = (1 << e) // d
@@ -115,6 +113,26 @@ def pi_hex_digits(n, prec=14):
     returned value starts with 3; n = 1 corresponds to the first
     digit past the decimal point (which in hex is 2).
 
+    Parameters
+    ==========
+
+    n : non-negative integer
+    prec : non-negative integer. default = 14
+
+    Returns
+    =======
+
+    str : Returns a string containing ``prec`` digits
+          starting at the nth digit of pi in hex.
+          If ``prec`` = 0, returns empty string.
+
+    Raises
+    ======
+
+    ValueError
+        If ``n`` < 0 or ``prec`` < 0.
+        Or ``n`` or ``prec`` is not an integer.
+
     Examples
     ========
 
@@ -124,6 +142,14 @@ def pi_hex_digits(n, prec=14):
     >>> pi_hex_digits(0, 3)
     '324'
 
+    These are consistent with the following results
+
+    >>> import math
+    >>> hex(int(math.pi * 2**((14-1)*4)))
+    '0x3243f6a8885a30'
+    >>> hex(int(math.pi * 2**((3-1)*4)))
+    '0x324'
+
     References
     ==========
 
@@ -132,6 +158,8 @@ def pi_hex_digits(n, prec=14):
     n, prec = as_int(n), as_int(prec)
     if n < 0:
         raise ValueError('n cannot be negative')
+    if prec < 0:
+        raise ValueError('prec cannot be negative')
     if prec == 0:
         return ''
 
@@ -156,4 +184,7 @@ def _dn(n, prec):
     # n = starting digit index
     # prec = the number of total digits to compute
     n += 1  # because we subtract 1 for _series
-    return int(math.log(n + prec)/math.log(16) + prec + 3)
+
+    # assert int(math.log(n + prec)/math.log(16)) ==\
+    #  ((n + prec).bit_length() - 1) // 4
+    return ((n + prec).bit_length() - 1) // 4 + prec + 3

--- a/sympy/ntheory/tests/test_bbp_pi.py
+++ b/sympy/ntheory/tests/test_bbp_pi.py
@@ -123,6 +123,7 @@ def test_hex_pi_nth_digits():
     assert pi_hex_digits(0, 3) == '324'
     assert pi_hex_digits(0, 0) == ''
     raises(ValueError, lambda: pi_hex_digits(-1))
+    raises(ValueError, lambda: pi_hex_digits(0, -1))
     raises(ValueError, lambda: pi_hex_digits(3.14))
 
     # this will pick a random segment to compute every time


### PR DESCRIPTION
* Removed unused variables
* Added docstring
* An error is now raised when `prec` is negative
* We have avoided doing logarithmic calculations. Although this is not a realistic assumption, when n is large, incorrect results could be returned due to calculation errors in floating numbers.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
