### PR TITLE
Fixed link by %-encoding parentheses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -748,6 +748,7 @@ Johan Guzman <jguzm022@ucr.edu>
 Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
 Johannes Hartung <joha2@gmx.net>
 John Connor <john.theman.connor@gmail.com>
+John Möller <john.moller@outlook.com>
 John V. Siratt <jvsiratt@gmail.com>
 Jonathan A. Gross <jarthurgross@gmail.com>
 Jonathan Allan <jjallan@users.noreply.github.com>

--- a/sympy/combinatorics/galois.py
+++ b/sympy/combinatorics/galois.py
@@ -458,7 +458,7 @@ def find_transitive_subgroups_of_S6(*targets, print_report=False):
     ==========
 
     .. [2] https://en.wikipedia.org/wiki/Projective_linear_group#Exceptional_isomorphisms
-    .. [3] https://en.wikipedia.org/wiki/Automorphisms_of_the_symmetric_and_alternating_groups#PGL(2,5)
+    .. [3] https://en.wikipedia.org/wiki/Automorphisms_of_the_symmetric_and_alternating_groups#PGL%282,5%29
 
     """
     def elts_by_order(G):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#24140

#### Brief description of what is fixed or changed
The link was previously https://en.wikipedia.org/wiki/Automorphisms_of_the_symmetric_and_alternating_groups#PGL(2,5) but the last parenthesis was not included in the link in the compiled documentation webpage, so I changed the left and right parentheses to %28 respectively %29 as per URL encoding. (See https://www.wikipedia.org/wiki/URL_encoding.)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
