### PR TITLE
Reference mpmath function lu_solve using Intersphinx

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -403,7 +403,7 @@ graphviz_output_format = 'svg'
 # Enable links to other packages
 intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org/stable/', None),
-    'mpmath': ('https://mpmath.org/doc/current/', None),
+    'mpmath': ('https://mpmath.readthedocs.io/en/latest/', None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }

--- a/doc/src/guides/solving/solve-matrix-equation.md
+++ b/doc/src/guides/solving/solve-matrix-equation.md
@@ -14,8 +14,7 @@ $ \left[\begin{array}{cc} x\\y\end{array}\right] = \left[\begin{array}{cc}
   packages instead of SymPy:
     - NumPy's {external:func}`numpy.linalg.solve`
     - SciPy's {external:func}`scipy.linalg.solve`
-    - mpmath's
-      [lu_solve()](https://mpmath.org/doc/current/matrices.html#linear-equations)
+    - mpmath's {external:func}`mpmath.lu_solve` 
 - Solving a matrix equation is equivalent to solving a system of linear
   equations, so if you prefer you can
   [](solve-system-of-equations-algebraically.md)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Reference [mpmath](https://github.com/mpmath/mpmath) function lu_solve using Intersphinx instead of hard-coding link to a mpmath documentation page, which is brittle: the link would break if mpmath reorganizes their documentation.

NOTE: This Intersphinx reference will not work until mpmath puts out a new release (after [1.3.0](https://github.com/mpmath/mpmath/releases/tag/1.3.0)), thus updating its canonical documentation site https://mpmath.org/doc/current/; I am creating this as a draft pull request so it can be tested and merged then.

#### Other comments
The reference will go to https://mpmath.org/doc/current/matrices.html per https://github.com/mpmath/mpmath/issues/644.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
