### PR TITLE
feat: Add 'strict' parameter to parse_latex in sympy

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1564,10 +1564,10 @@ wuyudi <wuyudi119@163.com>
 ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>
 znxftw <vishnu2101@gmail.com>
 zsc347 <zsc347@gmail.com>
+zzc <1378113190@qq.com>
+zzc <58017008+zzc0430@users.noreply.github.com>
 zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
-zzc <1378113190@qq.com>
-zzc <58017008+zzc0430@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1569,3 +1569,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
+zzc <1378113190@qq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1570,3 +1570,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 zzc <1378113190@qq.com>
+zzc <58017008+zzc0430@users.noreply.github.com>

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -4,7 +4,7 @@ from sympy.utilities.decorator import doctest_depends_on
 from .errors import LaTeXParsingError  # noqa
 
 @doctest_depends_on(modules=('antlr4',))
-def parse_latex(s):
+def parse_latex(s, strict=False):
     r"""Converts the string ``s`` to a SymPy ``Expr``
 
     Parameters
@@ -15,6 +15,10 @@ def parse_latex(s):
         *raw strings* (denoted with ``r"``, like this one) are preferred,
         as LaTeX makes liberal use of the ``\`` character, which would
         trigger escaping in normal Python strings.
+    strict : bool, optional
+        If True, raise an exception if the string cannot be parsed as
+        valid LaTeX. If False, try to recover gracefully from common
+        mistakes.
 
     Examples
     ========
@@ -32,4 +36,4 @@ def parse_latex(s):
         import_kwargs={'fromlist': ['X']})
 
     if _latex is not None:
-        return _latex.parse_latex(s)
+        return _latex.parse_latex(s, strict)

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -58,7 +58,7 @@ if ErrorListener:
             raise LaTeXParsingError(err)
 
 
-def parse_latex(sympy):
+def parse_latex(sympy, strict=False):
     antlr4 = import_module('antlr4')
 
     if None in [antlr4, MathErrorListener] or \
@@ -67,6 +67,7 @@ def parse_latex(sympy):
                           " provided by pip (antlr4-python3-runtime) or"
                           " conda (antlr-python-runtime), version 4.11")
 
+    sympy = sympy.strip()
     matherror = MathErrorListener(sympy)
 
     stream = antlr4.InputStream(sympy)
@@ -82,6 +83,8 @@ def parse_latex(sympy):
     parser.addErrorListener(matherror)
 
     relation = parser.math().relation()
+    if strict and (relation.start.start != 0 or relation.stop.stop != len(sympy) - 1):
+        raise LaTeXParsingError("Invalid LaTeX")
     expr = convert_relation(relation)
 
     return expr

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -350,3 +350,11 @@ def test_failing_not_parseable():
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str)
+
+# In strict mode, FAILING_BAD_STRINGS would fail
+def test_strict_mode():
+    from sympy.parsing.latex import parse_latex, LaTeXParsingError
+    for latex_str in FAILING_BAD_STRINGS:
+        with raises(LaTeXParsingError):
+            parse_latex(latex_str, strict=True)
+    

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -357,4 +357,3 @@ def test_strict_mode():
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str, strict=True)
-    


### PR DESCRIPTION
The 'strict' parameter is introduced as an additional option in the parse_latex. When set to true, it throws exceptions for invalid formulas.

#### References to other Issues or PRs


#### Brief description of what is fixed or changed

The 'strict' parameter is introduced as an additional option in the parse_latex. When set to true, it throws exceptions for invalid formulas.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
  * The 'strict' parameter is introduced as an additional option in the parse_latex. When set to true, it throws exceptions for invalid formulas.
<!-- END RELEASE NOTES -->
