### PR TITLE
Refactor `isinstance` checks with, and type hinting of, `Expr` in `sympy/physics/mechanics`

### DIFF
--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -22,9 +22,13 @@ from sympy.physics.vector import Vector, dot
 from sympy.simplify.simplify import trigsimp
 
 if TYPE_CHECKING:
-    from sympy.core.backend import Symbol
-    from sympy.core.expr import Expr
+    from sympy.core.backend import USE_SYMENGINE, Symbol
     from sympy.physics.mechanics import Point
+
+    if USE_SYMENGINE:
+        from sympy.core.backend import Basic as ExprType
+    else:
+        from sympy.core.expr import Expr as ExprType
 
 
 __all__ = [
@@ -58,7 +62,7 @@ class GeometryBase(ABC):
         pass
 
     @abstractmethod
-    def geodesic_length(self, point_1: Point, point_2: Point) -> Expr:
+    def geodesic_length(self, point_1: Point, point_2: Point) -> ExprType:
         """The shortest distance between two points on a geometry's surface.
 
         Parameters
@@ -176,7 +180,7 @@ class Sphere(GeometryBase):
             point_radius = point_vector**2
         return Eq(point_radius, self.radius**2) == True
 
-    def geodesic_length(self, point_1: Point, point_2: Point) -> Expr:
+    def geodesic_length(self, point_1: Point, point_2: Point) -> ExprType:
         r"""The shortest distance between two points on a geometry's surface.
 
         Explanation
@@ -390,7 +394,7 @@ class Cylinder(GeometryBase):
             point_radius = point_vector**2
         return Eq(trigsimp(point_radius), self.radius**2) == True
 
-    def geodesic_length(self, point_1: Point, point_2: Point) -> Expr:
+    def geodesic_length(self, point_1: Point, point_2: Point) -> ExprType:
         r"""The shortest distance between two points on a geometry's surface.
 
         Explanation
@@ -505,7 +509,7 @@ class Cylinder(GeometryBase):
         )
 
 
-def _directional_atan(numerator: Expr, denominator: Expr) -> Expr:
+def _directional_atan(numerator: ExprType, denominator: ExprType) -> ExprType:
     """Compute atan in a directional sense as required for geodesics.
 
     Explanation

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -15,12 +15,17 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from sympy.core.backend import S
-from sympy.core.expr import Expr
 from sympy.physics.mechanics import Force, Point
 from sympy.physics.vector import dynamicsymbols
 
 if TYPE_CHECKING:
+    from sympy.core.backend import USE_SYMENGINE
     from sympy.physics.mechanics.loads import LoadBase
+
+    if USE_SYMENGINE:
+        from sympy.core.backend import Basic as ExprType
+    else:
+        from sympy.core.expr import Expr as ExprType
 
 
 __all__ = ['LinearPathway']
@@ -69,18 +74,18 @@ class PathwayBase(ABC):
 
     @property
     @abstractmethod
-    def length(self) -> Expr:
+    def length(self) -> ExprType:
         """An expression representing the pathway's length."""
         pass
 
     @property
     @abstractmethod
-    def extension_velocity(self) -> Expr:
+    def extension_velocity(self) -> ExprType:
         """An expression representing the pathway's extension velocity."""
         pass
 
     @abstractmethod
-    def compute_loads(self, force: Expr) -> list[LoadBase]:
+    def compute_loads(self, force: ExprType) -> list[LoadBase]:
         """Loads required by the equations of motion method classes.
 
         Explanation
@@ -187,13 +192,13 @@ class LinearPathway(PathwayBase):
         super().__init__(*attachments)
 
     @property
-    def length(self) -> Expr:
+    def length(self) -> ExprType:
         """Exact analytical expression for the pathway's length."""
         length = self.attachments[-1].pos_from(self.attachments[0]).magnitude()
         return length
 
     @property
-    def extension_velocity(self) -> Expr:
+    def extension_velocity(self) -> ExprType:
         """Exact analytical expression for the pathway's extension velocity."""
         relative_position = self.attachments[-1].pos_from(self.attachments[0])
         if not relative_position:
@@ -207,7 +212,7 @@ class LinearPathway(PathwayBase):
         extension_velocity = relative_velocity.dot(relative_position.normalize())
         return extension_velocity
 
-    def compute_loads(self, force: Expr) -> list[LoadBase]:
+    def compute_loads(self, force: ExprType) -> list[LoadBase]:
         """Loads required by the equations of motion method classes.
 
         Explanation

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -23,8 +23,13 @@ from sympy.physics.mechanics._geometry import Cylinder, Sphere
 from sympy.simplify.simplify import simplify
 
 if TYPE_CHECKING:
-    from sympy.core.expr import Expr
+    from sympy.core.backend import USE_SYMENGINE
     from sympy.physics.mechanics import Vector
+
+    if USE_SYMENGINE:
+        from sympy.core.backend import Basic as ExprType
+    else:
+        from sympy.core.expr import Expr as ExprType
 
 
 r = Symbol('r')
@@ -78,7 +83,7 @@ class TestSphere:
             ),
         ]
     )
-    def test_geodesic_length(position_1: Vector, position_2: Vector, expected: Expr) -> None:
+    def test_geodesic_length(position_1: Vector, position_2: Vector, expected: ExprType) -> None:
         r = Symbol('r')
         pO = Point('pO')
         sphere = Sphere(r, pO)
@@ -172,7 +177,7 @@ class TestCylinder:
         axis: Vector,
         position_1: Vector,
         position_2: Vector,
-        expected: Expr,
+        expected: ExprType,
     ) -> None:
         r = Symbol('r')
         pO = Point('pO')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR refactors the private modules in `sympy.physics.mechanics` to use a consistent idiom for SymEngine-compatible `isinstance` checks with, and type hinting of, `Expr` (as SymEngine doesn't have the `Expr` type).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
