### PR TITLE
[GSoC] Modified methods of the Truss class to accept multiple inputs in a single call

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -668,6 +668,7 @@ Ian Swire <oversizedpenguin@gmail.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
+Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <ishan9096137017@gmail.com>
 Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>

--- a/sympy/physics/continuum_mechanics/tests/test_truss.py
+++ b/sympy/physics/continuum_mechanics/tests/test_truss.py
@@ -21,9 +21,7 @@ def test_truss():
     assert t.internal_forces == {}
 
     # testing the add_node method
-    t.add_node(A, 0, 0)
-    t.add_node(B, 2, 2)
-    t.add_node(C, 3, 0)
+    t.add_node((A, 0, 0), (B, 2, 2), (C, 3, 0))
     assert t.nodes == [(A, 0, 0), (B, 2, 2), (C, 3, 0)]
     assert t.node_labels == [A, B, C]
     assert t.node_positions == [(0, 0), (2, 2), (3, 0)]
@@ -39,12 +37,10 @@ def test_truss():
     assert t.loads == {}
     assert t.supports == {}
 
-    t.add_node(C, 3, 0)
+    t.add_node((C, 3, 0))
 
     # testing the add_member method
-    t.add_member(AB, A, B)
-    t.add_member(BC, B, C)
-    t.add_member(AC, A, C)
+    t.add_member((AB, A, B), (BC, B, C), (AC, A, C))
     assert t.members == {AB: [A, B], BC: [B, C], AC: [A, C]}
     assert t.internal_forces == {AB: 0, BC: 0, AC: 0}
 
@@ -53,39 +49,35 @@ def test_truss():
     assert t.members == {AB: [A, B], AC: [A, C]}
     assert t.internal_forces == {AB: 0, AC: 0}
 
-    t.add_member(BC, B, C)
+    t.add_member((BC, B, C))
 
     D, CD = symbols('D, CD')
 
     # testing the change_label methods
-    t.change_node_label(B, D)
+    t.change_node_label((B, D))
     assert t.nodes == [(A, 0, 0), (D, 2, 2), (C, 3, 0)]
     assert t.node_labels == [A, D, C]
     assert t.loads == {}
     assert t.supports == {}
     assert t.members == {AB: [A, D], BC: [D, C], AC: [A, C]}
 
-    t.change_member_label(BC, CD)
+    t.change_member_label((BC, CD))
     assert t.members == {AB: [A, D], CD: [D, C], AC: [A, C]}
     assert t.internal_forces == {AB: 0, CD: 0, AC: 0}
 
 
     # testing the apply_load method
-    t.apply_load(A, P, 90)
-    t.apply_load(A, P/4, 90)
-    t.apply_load(A, 2*P,45)
-    t.apply_load(D, P/2, 90)
+    t.apply_load((A, P, 90), (A, P/4, 90), (A, 2*P,45), (D, P/2, 90))
     assert t.loads == {A: [[P, 90], [P/4, 90], [2*P, 45]], D: [[P/2, 90]]}
     assert t.loads[A] == [[P, 90], [P/4, 90], [2*P, 45]]
 
     # testing the remove_load method
-    t.remove_load(A, P/4, 90)
+    t.remove_load((A, P/4, 90))
     assert t.loads == {A: [[P, 90], [2*P, 45]], D: [[P/2, 90]]}
     assert t.loads[A] == [[P, 90], [2*P, 45]]
 
     # testing the apply_support method
-    t.apply_support(A, "pinned")
-    t.apply_support(D, "roller")
+    t.apply_support((A, "pinned"), (D, "roller"))
     assert t.supports == {A: 'pinned', D: 'roller'}
     assert t.reaction_loads == {}
     assert t.loads == {A: [[P, 90], [2*P, 45], [Symbol('R_A_x'), 0], [Symbol('R_A_y'), 90]],  D: [[P/2, 90], [Symbol('R_D_y'), 90]]}
@@ -96,7 +88,7 @@ def test_truss():
     assert t.reaction_loads == {}
     assert t.loads == {A: [[P, 90], [2*P, 45]], D: [[P/2, 90], [Symbol('R_D_y'), 90]]}
 
-    t.apply_support(A, "pinned")
+    t.apply_support((A, "pinned"))
 
     # testing the solve method
     t.solve()

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -170,10 +170,10 @@ class Truss:
             x = sympify(x)
             y=i[2]
             y = sympify(y)
-            if label in self._node_labels:
+            if label in self._node_coordinates:
                 raise ValueError("Node needs to have a unique label")
 
-            elif x in self._node_position_x and y in self._node_position_y and self._node_position_x.index(x)==self._node_position_y.index(y):
+            elif [x, y] in self._node_coordinates.values():
                 raise ValueError("A node already exists at the given position")
 
             else :
@@ -216,7 +216,7 @@ class Truss:
                     x = self._node_position_x[i]
                     y = self._node_position_y[i]
 
-            if label not in self._node_labels:
+            if label not in self._node_coordinates:
                 raise ValueError("No such node exists in the truss")
 
             else:
@@ -269,10 +269,10 @@ class Truss:
             start = i[1]
             end = i[2]
 
-            if start not in self._node_labels or end not in self._node_labels or start==end:
+            if start not in self._node_coordinates or end not in self._node_coordinates or start==end:
                 raise ValueError("The start and end points of the member must be unique nodes")
 
-            elif label in list(self._members):
+            elif label in self._members:
                 raise ValueError("A member with the same label already exists for the truss")
 
             elif self._nodes_occupied.get((start, end)):
@@ -308,7 +308,7 @@ class Truss:
         {'AB': ['A', 'B']}
         """
         for label in args:
-            if label not in list(self._members):
+            if label not in self._members:
                 raise ValueError("No such member exists in the Truss")
 
             else:
@@ -348,9 +348,9 @@ class Truss:
         for i in args:
             label = i[0]
             new_label = i[1]
-            if label not in self._node_labels:
+            if label not in self._node_coordinates:
                 raise ValueError("No such node exists for the Truss")
-            elif new_label in self._node_labels:
+            elif new_label in self._node_coordinates:
                 raise ValueError("A node with the given label already exists")
             else:
                 for node in self._nodes:
@@ -449,7 +449,7 @@ class Truss:
         for i in args:
             label = i[0]
             new_label = i[1]
-            if label not in list(self._members):
+            if label not in self._members:
                 raise ValueError("No such member exists for the Truss")
             else:
                 members_duplicate = list(self._members).copy()
@@ -501,7 +501,7 @@ class Truss:
             magnitude = sympify(magnitude)
             direction = sympify(direction)
 
-            if location not in self.node_labels:
+            if location not in self._node_coordinates:
                 raise ValueError("Load must be applied at a known node")
 
             else:
@@ -552,7 +552,7 @@ class Truss:
             magnitude = sympify(magnitude)
             direction = sympify(direction)
 
-            if location not in self.node_labels:
+            if location not in self._node_coordinates:
                 raise ValueError("Load must be removed from a known node")
 
             else:
@@ -590,7 +590,7 @@ class Truss:
         for i in args:
             location = i[0]
             type = i[1]
-            if location not in self._node_labels:
+            if location not in self._node_coordinates:
                 raise ValueError("Support must be added on a known node")
 
             else:
@@ -633,10 +633,10 @@ class Truss:
         """
         for location in args:
 
-            if location not in self._node_labels:
+            if location not in self._node_coordinates:
                 raise ValueError("No such node exists in the Truss")
 
-            elif location not in list(self._supports):
+            elif location not in self._supports:
                 raise ValueError("No support has been added to the given node")
 
             else:

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -48,7 +48,7 @@ class Truss:
     >>> t.add_member(("member_1", "node_1", "node_4"), ("member_2", "node_2", "node_4"), ("member_3", "node_1", "node_3"))
     >>> t.add_member(("member_4", "node_2", "node_3"), ("member_5", "node_3", "node_4"))
     >>> t.apply_load(("node_4", 10, 270))
-    >>> t.apply_support(("node_1", "fixed"), ("node_2", "roller"))
+    >>> t.apply_support(("node_1", "pinned"), ("node_2", "roller"))
     """
 
     def __init__(self):
@@ -795,29 +795,16 @@ class Truss:
             >>> from sympy.physics.continuum_mechanics.truss import Truss
             >>> import math
             >>> t = Truss()
-            >>> t.add_node("A", -4, 0)
-            >>> t.add_node("B", 0, 0)
-            >>> t.add_node("C", 4, 0)
-            >>> t.add_node("D", 8, 0)
-            >>> t.add_node("E", 6, 2/math.sqrt(3))
-            >>> t.add_node("F", 2, 2*math.sqrt(3))
-            >>> t.add_node("G", -2, 2/math.sqrt(3))
-            >>> t.add_member("AB","A","B")
-            >>> t.add_member("BC","B","C")
-            >>> t.add_member("CD","C","D")
-            >>> t.add_member("AG","A","G")
-            >>> t.add_member("GB","G","B")
-            >>> t.add_member("GF","G","F")
-            >>> t.add_member("BF","B","F")
-            >>> t.add_member("FC","F","C")
-            >>> t.add_member("CE","C","E")
-            >>> t.add_member("FE","F","E")
-            >>> t.add_member("DE","D","E")
-            >>> t.apply_support("A","pinned")
-            >>> t.apply_support("D","roller")
-            >>> t.apply_load("G", 3, 90)
-            >>> t.apply_load("E", 3, 90)
-            >>> t.apply_load("F", 2, 90)
+            >>> t.add_node(("A", -4, 0), ("B", 0, 0), ("C", 4, 0), ("D", 8, 0))
+            >>> t.add_node(("E", 6, 2/math.sqrt(3)))
+            >>> t.add_node(("F", 2, 2*math.sqrt(3)))
+            >>> t.add_node(("G", -2, 2/math.sqrt(3)))
+            >>> t.add_member(("AB","A","B"), ("BC","B","C"), ("CD","C","D"))
+            >>> t.add_member(("AG","A","G"), ("GB","G","B"), ("GF","G","F"))
+            >>> t.add_member(("BF","B","F"), ("FC","F","C"), ("CE","C","E"))
+            >>> t.add_member(("FE","F","E"), ("DE","D","E"))
+            >>> t.apply_support(("A","pinned"), ("D","roller"))
+            >>> t.apply_load(("G", 3, 90), ("E", 3, 90), ("F", 2, 90))
             >>> p = t.draw()
             >>> p
             Plot object containing:

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -37,18 +37,11 @@ class Truss:
 
     >>> from sympy.physics.continuum_mechanics.truss import Truss
     >>> t = Truss()
-    >>> t.add_node("node_1", 0, 0)
-    >>> t.add_node("node_2", 6, 0)
-    >>> t.add_node("node_3", 2, 2)
-    >>> t.add_node("node_4", 2, 0)
-    >>> t.add_member("member_1", "node_1", "node_4")
-    >>> t.add_member("member_2", "node_2", "node_4")
-    >>> t.add_member("member_3", "node_1", "node_3")
-    >>> t.add_member("member_4", "node_2", "node_3")
-    >>> t.add_member("member_5", "node_3", "node_4")
-    >>> t.apply_load("node_4", magnitude=10, direction=270)
-    >>> t.apply_support("node_1", type="fixed")
-    >>> t.apply_support("node_2", type="roller")
+    >>> t.add_node(("node_1", 0, 0), ("node_2", 6, 0), ("node_3", 2, 2), ("node_4", 2, 0))
+    >>> t.add_member(("member_1", "node_1", "node_4"), ("member_2", "node_2", "node_4"), ("member_3", "node_1", "node_3"))
+    >>> t.add_member(("member_4", "node_2", "node_3"), ("member_5", "node_3", "node_4"))
+    >>> t.apply_load(("node_4", 10, 270))
+    >>> t.apply_support(("node_1", "fixed"), ("node_2", "roller"))
     """
 
     def __init__(self):
@@ -677,18 +670,11 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node("node_1", 0, 0)
-        >>> t.add_node("node_2", 6, 0)
-        >>> t.add_node("node_3", 2, 2)
-        >>> t.add_node("node_4", 2, 0)
-        >>> t.add_member("member_1", "node_1", "node_4")
-        >>> t.add_member("member_2", "node_2", "node_4")
-        >>> t.add_member("member_3", "node_1", "node_3")
-        >>> t.add_member("member_4", "node_2", "node_3")
-        >>> t.add_member("member_5", "node_3", "node_4")
-        >>> t.apply_load("node_4", magnitude=10, direction=270)
-        >>> t.apply_support("node_1", type="pinned")
-        >>> t.apply_support("node_2", type="roller")
+        >>> t.add_node(("node_1", 0, 0), ("node_2", 6, 0), ("node_3", 2, 2), ("node_4", 2, 0))
+        >>> t.add_member(("member_1", "node_1", "node_4"), ("member_2", "node_2", "node_4"), ("member_3", "node_1", "node_3"))
+        >>> t.add_member(("member_4", "node_2", "node_3"), ("member_5", "node_3", "node_4"))
+        >>> t.apply_load(("node_4", 10, 270))
+        >>> t.apply_support(("node_1", "pinned"), ("node_2", "roller"))
         >>> t.solve()
         >>> t.reaction_loads
         {'R_node_1_x': 0, 'R_node_1_y': 20/3, 'R_node_2_y': 10/3}

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -183,7 +183,7 @@ class Truss:
                 self._node_position_y.append(y)
                 self._node_coordinates[label] = [x, y]
 
-        
+
 
     def remove_node(self, *args):
         """
@@ -234,7 +234,7 @@ class Truss:
                     self._supports.pop(label)
                 self._node_coordinates.pop(label)
 
-        
+
 
     def add_member(self, *args):
         """
@@ -242,7 +242,7 @@ class Truss:
 
         Parameters
         ==========
-        The input(s) of the method are tuple(s) of the form (label, start, end). 
+        The input(s) of the method are tuple(s) of the form (label, start, end).
 
         label: String or Symbol
             The label for a member. It is the only way to identify a particular member.
@@ -282,7 +282,7 @@ class Truss:
                 self._nodes_occupied[start, end] = True
                 self._nodes_occupied[end, start] = True
                 self._internal_forces[label] = 0
-        
+
 
     def remove_member(self, *args):
         """
@@ -315,7 +315,7 @@ class Truss:
                 self._nodes_occupied.pop((self._members[label][1], self._members[label][0]))
                 self._members.pop(label)
                 self._internal_forces.pop(label)
-        
+
 
     def change_node_label(self, *args):
         """
@@ -459,7 +459,7 @@ class Truss:
                         self._members.pop(label)
                         self._internal_forces[new_label] = self._internal_forces[label]
                         self._internal_forces.pop(label)
-        
+
 
     def apply_load(self, *args):
         """

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -229,9 +229,9 @@ class Truss:
                 self._node_positions.remove((x, y))
                 self._node_position_x.remove(x)
                 self._node_position_y.remove(y)
-                if label in list(self._loads):
+                if label in self._loads:
                     self._loads.pop(label)
-                if label in list(self._supports):
+                if label in self._supports:
                     self._supports.pop(label)
                 self._node_coordinates.pop(label)
 
@@ -359,12 +359,12 @@ class Truss:
                         self._node_labels[self._node_labels.index(node[0])] = new_label
                         self._node_coordinates[new_label] = self._node_coordinates[label]
                         self._node_coordinates.pop(label)
-                        if node[0] in list(self._supports):
+                        if node[0] in self._supports:
                             self._supports[new_label] = self._supports[node[0]]
                             self._supports.pop(node[0])
-                        if new_label in list(self._supports):
+                        if new_label in self._supports:
                             if self._supports[new_label] == 'pinned':
-                                if 'R_'+str(label)+'_x' in list(self._reaction_loads) and 'R_'+str(label)+'_y' in list(self._reaction_loads):
+                                if 'R_'+str(label)+'_x' in self._reaction_loads and 'R_'+str(label)+'_y' in self._reaction_loads:
                                     self._reaction_loads['R_'+str(new_label)+'_x'] = self._reaction_loads['R_'+str(label)+'_x']
                                     self._reaction_loads['R_'+str(new_label)+'_y'] = self._reaction_loads['R_'+str(label)+'_y']
                                     self._reaction_loads.pop('R_'+str(label)+'_x')
@@ -396,10 +396,10 @@ class Truss:
                                 self.apply_load(new_label, Symbol('R_'+str(new_label)+'_y'), 90)
                                 self._loads.pop(label)
                         else:
-                            if label in list(self._loads):
+                            if label in self._loads:
                                 self._loads[new_label] = self._loads[label]
                                 self._loads.pop(label)
-                        for member in list(self._members):
+                        for member in self._members:
                             if self._members[member][0] == node[0]:
                                 self._members[member][0] = new_label
                                 self._nodes_occupied[(new_label, self._members[member][1])] = True
@@ -505,7 +505,7 @@ class Truss:
                 raise ValueError("Load must be applied at a known node")
 
             else:
-                if location in list(self._loads):
+                if location in self._loads:
                     self._loads[location].append([magnitude, direction])
                 else:
                     self._loads[location] = [[magnitude, direction]]
@@ -594,7 +594,7 @@ class Truss:
                 raise ValueError("Support must be added on a known node")
 
             else:
-                if location not in list(self._supports):
+                if location not in self._supports:
                     if type == 'pinned':
                         self.apply_load((location, Symbol('R_'+str(location)+'_x'), 0))
                         self.apply_load((location, Symbol('R_'+str(location)+'_y'), 90))
@@ -691,7 +691,7 @@ class Truss:
         """
         count_reaction_loads = 0
         for node in self._nodes:
-            if node[0] in list(self._supports):
+            if node[0] in self._supports:
                 if self._supports[node[0]]=='pinned':
                     count_reaction_loads += 2
                 elif self._supports[node[0]]=='roller':
@@ -702,7 +702,7 @@ class Truss:
         load_matrix = zeros(2*len(self.nodes), 1)
         load_matrix_row = 0
         for node in self._nodes:
-            if node[0] in list(self._loads):
+            if node[0] in self._loads:
                 for load in self._loads[node[0]]:
                     if load[0]!=Symbol('R_'+str(node[0])+'_x') and load[0]!=Symbol('R_'+str(node[0])+'_y'):
                         load_matrix[load_matrix_row] -= load[0]*cos(pi*load[1]/180)
@@ -720,7 +720,7 @@ class Truss:
                     coefficients_matrix[row+1][cols] += 1
                     cols += 1
             row += 2
-        for member in list(self._members):
+        for member in self._members:
             start = self._members[member][0]
             end = self._members[member][1]
             length = sqrt((self._node_coordinates[start][0]-self._node_coordinates[end][0])**2 + (self._node_coordinates[start][1]-self._node_coordinates[end][1])**2)
@@ -740,7 +740,7 @@ class Truss:
         i = 0
         min_load = inf
         for node in self._nodes:
-            if node[0] in list(self._loads):
+            if node[0] in self._loads:
                 for load in self._loads[node[0]]:
                     if type(load[0]) not in [Symbol, Mul, Add]:
                         min_load = min(min_load, load[0])
@@ -749,7 +749,7 @@ class Truss:
                 if abs(forces_matrix[j]/min_load) <1E-10:
                     forces_matrix[j] = 0
         for node in self._nodes:
-            if node[0] in list(self._supports):
+            if node[0] in self._supports:
                 if self._supports[node[0]]=='pinned':
                     self._reaction_loads['R_'+str(node[0])+'_x'] = forces_matrix[i]
                     self._reaction_loads['R_'+str(node[0])+'_y'] = forces_matrix[i+1]
@@ -757,7 +757,7 @@ class Truss:
                 elif self._supports[node[0]]=='roller':
                     self._reaction_loads['R_'+str(node[0])+'_y'] = forces_matrix[i]
                     i += 1
-        for member in list(self._members):
+        for member in self._members:
             self._internal_forces[member] = forces_matrix[i]
             i += 1
         return
@@ -837,7 +837,7 @@ class Truss:
         ymax = -INF
         ymin = INF
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
             xmin = min(xmin, self._node_coordinates[node][0])
             ymax = max(ymax, self._node_coordinates[node][1])
@@ -857,7 +857,7 @@ class Truss:
     def _draw_nodes(self, subs_dict):
         node_markers = []
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             if (type(self._node_coordinates[node][0]) in (Symbol, Quantity)):
                 if self._node_coordinates[node][0] in list(subs_dict):
                     self._node_coordinates[node][0] = subs_dict[self._node_coordinates[node][0]]
@@ -888,7 +888,7 @@ class Truss:
                             self._node_coordinates[node][1] /= object
                             self._node_coordinates[node][1] *= subs_dict[object]
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             node_markers.append(
                 {
                     'args':[[self._node_coordinates[node][0]], [self._node_coordinates[node][1]]],
@@ -908,7 +908,7 @@ class Truss:
         ymax = -INF
         ymin = INF
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
             xmin = min(xmin, self._node_coordinates[node][0])
             ymax = max(ymax, self._node_coordinates[node][1])
@@ -998,7 +998,7 @@ class Truss:
         ymax = -INF
         ymin = INF
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
             xmin = min(xmin, self._node_coordinates[node][0])
             ymax = max(ymax, self._node_coordinates[node][1])
@@ -1068,7 +1068,7 @@ class Truss:
         ymax = -INF
         ymin = INF
 
-        for node in list(self._node_coordinates):
+        for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
             xmin = min(xmin, self._node_coordinates[node][0])
             ymax = max(ymax, self._node_coordinates[node][1])

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -132,12 +132,15 @@ class Truss:
         """
         return self._internal_forces
 
-    def add_node(self, label, x, y):
+    def add_node(self, *args):
         """
         This method adds a node to the truss along with its name/label and its location.
+        Multiple nodes can be added at the same time.
 
         Parameters
         ==========
+        The input(s) for this method are tuples of the form (label, x, y).
+
         label:  String or a Symbol
             The label for a node. It is the only way to identify a particular node.
 
@@ -152,36 +155,45 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
+        >>> t.add_node(('A', 0, 0))
         >>> t.nodes
         [('A', 0, 0)]
-        >>> t.add_node('B', 3, 0)
+        >>> t.add_node(('B', 3, 0), ('C', 4, 1))
         >>> t.nodes
-        [('A', 0, 0), ('B', 3, 0)]
+        [('A', 0, 0), ('B', 3, 0), ('C', 4, 1)]
         """
-        x = sympify(x)
-        y = sympify(y)
 
-        if label in self._node_labels:
-            raise ValueError("Node needs to have a unique label")
+        for i in args:
+            label = i[0]
+            x = i[1]
+            x = sympify(x)
+            y=i[2]
+            y = sympify(y)
+            if label in self._node_labels:
+                raise ValueError("Node needs to have a unique label")
 
-        elif x in self._node_position_x and y in self._node_position_y and self._node_position_x.index(x)==self._node_position_y.index(y):
-            raise ValueError("A node already exists at the given position")
+            elif x in self._node_position_x and y in self._node_position_y and self._node_position_x.index(x)==self._node_position_y.index(y):
+                raise ValueError("A node already exists at the given position")
 
-        else :
-            self._nodes.append((label, x, y))
-            self._node_labels.append(label)
-            self._node_positions.append((x, y))
-            self._node_position_x.append(x)
-            self._node_position_y.append(y)
-            self._node_coordinates[label] = [x, y]
+            else :
+                self._nodes.append((label, x, y))
+                self._node_labels.append(label)
+                self._node_positions.append((x, y))
+                self._node_position_x.append(x)
+                self._node_position_y.append(y)
+                self._node_coordinates[label] = [x, y]
 
-    def remove_node(self, label):
+        
+
+    def remove_node(self, *args):
         """
         This method removes a node from the truss.
+        Multiple nodes can be removed at the same time.
 
         Parameters
         ==========
+        The input(s) for this method are the labels of the nodes to be removed.
+
         label:  String or Symbol
             The label of the node to be removed.
 
@@ -190,46 +202,48 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0), ('C', 5, 0))
         >>> t.nodes
-        [('A', 0, 0)]
-        >>> t.add_node('B', 3, 0)
-        >>> t.nodes
-        [('A', 0, 0), ('B', 3, 0)]
-        >>> t.remove_node('A')
+        [('A', 0, 0), ('B', 3, 0), ('C', 5, 0)]
+        >>> t.remove_node('A', 'C')
         >>> t.nodes
         [('B', 3, 0)]
         """
-        for i in range(len(self.nodes)):
-            if self._node_labels[i] == label:
-                x = self._node_position_x[i]
-                y = self._node_position_y[i]
+        for label in args:
+            for i in range(len(self.nodes)):
+                if self._node_labels[i] == label:
+                    x = self._node_position_x[i]
+                    y = self._node_position_y[i]
 
-        if label not in self._node_labels:
-            raise ValueError("No such node exists in the truss")
+            if label not in self._node_labels:
+                raise ValueError("No such node exists in the truss")
 
-        else:
-            members_duplicate = self._members.copy()
-            for member in members_duplicate:
-                if label == self._members[member][0] or label == self._members[member][1]:
-                    raise ValueError("The node given has members already attached to it")
-            self._nodes.remove((label, x, y))
-            self._node_labels.remove(label)
-            self._node_positions.remove((x, y))
-            self._node_position_x.remove(x)
-            self._node_position_y.remove(y)
-            if label in list(self._loads):
-                self._loads.pop(label)
-            if label in list(self._supports):
-                self._supports.pop(label)
-            self._node_coordinates.pop(label)
+            else:
+                members_duplicate = self._members.copy()
+                for member in members_duplicate:
+                    if label == self._members[member][0] or label == self._members[member][1]:
+                        raise ValueError("The node given has members already attached to it")
+                self._nodes.remove((label, x, y))
+                self._node_labels.remove(label)
+                self._node_positions.remove((x, y))
+                self._node_position_x.remove(x)
+                self._node_position_y.remove(y)
+                if label in list(self._loads):
+                    self._loads.pop(label)
+                if label in list(self._supports):
+                    self._supports.pop(label)
+                self._node_coordinates.pop(label)
 
-    def add_member(self, label, start, end):
+        
+
+    def add_member(self, *args):
         """
         This method adds a member between any two nodes in the given truss.
 
         Parameters
         ==========
+        The input(s) of the method are tuple(s) of the form (label, start, end). 
+
         label: String or Symbol
             The label for a member. It is the only way to identify a particular member.
 
@@ -244,36 +258,39 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
-        >>> t.add_node('C', 2, 2)
-        >>> t.add_member('AB', 'A', 'B')
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0), ('C', 2, 2))
+        >>> t.add_member(('AB', 'A', 'B'), ('BC', 'B', 'C'))
         >>> t.members
-        {'AB': ['A', 'B']}
+        {'AB': ['A', 'B'], 'BC': ['B', 'C']}
         """
+        for i in args:
+            label = i[0]
+            start = i[1]
+            end = i[2]
 
-        if start not in self._node_labels or end not in self._node_labels or start==end:
-            raise ValueError("The start and end points of the member must be unique nodes")
+            if start not in self._node_labels or end not in self._node_labels or start==end:
+                raise ValueError("The start and end points of the member must be unique nodes")
 
-        elif label in list(self._members):
-            raise ValueError("A member with the same label already exists for the truss")
+            elif label in list(self._members):
+                raise ValueError("A member with the same label already exists for the truss")
 
-        elif self._nodes_occupied.get((start, end)):
-            raise ValueError("A member already exists between the two nodes")
+            elif self._nodes_occupied.get((start, end)):
+                raise ValueError("A member already exists between the two nodes")
 
-        else:
-            self._members[label] = [start, end]
-            self._nodes_occupied[start, end] = True
-            self._nodes_occupied[end, start] = True
-            self._internal_forces[label] = 0
+            else:
+                self._members[label] = [start, end]
+                self._nodes_occupied[start, end] = True
+                self._nodes_occupied[end, start] = True
+                self._internal_forces[label] = 0
+        
 
-    def remove_member(self, label):
+    def remove_member(self, *args):
         """
-        This method removes a member from the given truss.
+        This method removes members from the given truss.
 
         Parameters
         ==========
-        label: String or Symbol
+        labels: String or Symbol
             The label for the member to be removed.
 
         Examples
@@ -281,33 +298,33 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
-        >>> t.add_node('C', 2, 2)
-        >>> t.add_member('AB', 'A', 'B')
-        >>> t.add_member('AC', 'A', 'C')
-        >>> t.add_member('BC', 'B', 'C')
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0), ('C', 2, 2))
+        >>> t.add_member(('AB', 'A', 'B'), ('AC', 'A', 'C'), ('BC', 'B', 'C'))
         >>> t.members
         {'AB': ['A', 'B'], 'AC': ['A', 'C'], 'BC': ['B', 'C']}
-        >>> t.remove_member('AC')
+        >>> t.remove_member('AC', 'BC')
         >>> t.members
-        {'AB': ['A', 'B'], 'BC': ['B', 'C']}
+        {'AB': ['A', 'B']}
         """
-        if label not in list(self._members):
-            raise ValueError("No such member exists in the Truss")
+        for label in args:
+            if label not in list(self._members):
+                raise ValueError("No such member exists in the Truss")
 
-        else:
-            self._nodes_occupied.pop((self._members[label][0], self._members[label][1]))
-            self._nodes_occupied.pop((self._members[label][1], self._members[label][0]))
-            self._members.pop(label)
-            self._internal_forces.pop(label)
+            else:
+                self._nodes_occupied.pop((self._members[label][0], self._members[label][1]))
+                self._nodes_occupied.pop((self._members[label][1], self._members[label][0]))
+                self._members.pop(label)
+                self._internal_forces.pop(label)
+        
 
-    def change_node_label(self, label, new_label):
+    def change_node_label(self, *args):
         """
-        This method changes the label of a node.
+        This method changes the label(s) of the specified node(s).
 
         Parameters
         ==========
+        The input(s) of this method are tuple(s) of the form (label, new_label).
+
         label: String or Symbol
             The label of the node for which the label has
             to be changed.
@@ -320,85 +337,89 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0))
         >>> t.nodes
         [('A', 0, 0), ('B', 3, 0)]
-        >>> t.change_node_label('A', 'C')
+        >>> t.change_node_label(('A', 'C'), ('B', 'D'))
         >>> t.nodes
-        [('C', 0, 0), ('B', 3, 0)]
+        [('C', 0, 0), ('D', 3, 0)]
         """
-        if label not in self._node_labels:
-            raise ValueError("No such node exists for the Truss")
-        elif new_label in self._node_labels:
-            raise ValueError("A node with the given label already exists")
-        else:
-            for node in self._nodes:
-                if node[0] == label:
-                    self._nodes[self._nodes.index((label, node[1], node[2]))] = (new_label, node[1], node[2])
-                    self._node_labels[self._node_labels.index(node[0])] = new_label
-                    self._node_coordinates[new_label] = self._node_coordinates[label]
-                    self._node_coordinates.pop(label)
-                    if node[0] in list(self._supports):
-                        self._supports[new_label] = self._supports[node[0]]
-                        self._supports.pop(node[0])
-                    if new_label in list(self._supports):
-                        if self._supports[new_label] == 'pinned':
-                            if 'R_'+str(label)+'_x' in list(self._reaction_loads) and 'R_'+str(label)+'_y' in list(self._reaction_loads):
-                                self._reaction_loads['R_'+str(new_label)+'_x'] = self._reaction_loads['R_'+str(label)+'_x']
-                                self._reaction_loads['R_'+str(new_label)+'_y'] = self._reaction_loads['R_'+str(label)+'_y']
-                                self._reaction_loads.pop('R_'+str(label)+'_x')
-                                self._reaction_loads.pop('R_'+str(label)+'_y')
-                            self._loads[new_label] = self._loads[label]
-                            for load in self._loads[new_label]:
-                                if load[1] == 90:
-                                    load[0] -= Symbol('R_'+str(label)+'_y')
-                                    if load[0] == 0:
-                                        self._loads[label].remove(load)
-                                    break
-                            for load in self._loads[new_label]:
-                                if load[1] == 0:
-                                    load[0] -= Symbol('R_'+str(label)+'_x')
-                                    if load[0] == 0:
-                                        self._loads[label].remove(load)
-                                    break
-                            self.apply_load(new_label, Symbol('R_'+str(new_label)+'_x'), 0)
-                            self.apply_load(new_label, Symbol('R_'+str(new_label)+'_y'), 90)
-                            self._loads.pop(label)
-                        elif self._supports[new_label] == 'roller':
-                            self._loads[new_label] = self._loads[label]
-                            for load in self._loads[label]:
-                                if load[1] == 90:
-                                    load[0] -= Symbol('R_'+str(label)+'_y')
-                                    if load[0] == 0:
-                                        self._loads[label].remove(load)
-                                    break
-                            self.apply_load(new_label, Symbol('R_'+str(new_label)+'_y'), 90)
-                            self._loads.pop(label)
-                    else:
-                        if label in list(self._loads):
-                            self._loads[new_label] = self._loads[label]
-                            self._loads.pop(label)
-                    for member in list(self._members):
-                        if self._members[member][0] == node[0]:
-                            self._members[member][0] = new_label
-                            self._nodes_occupied[(new_label, self._members[member][1])] = True
-                            self._nodes_occupied[(self._members[member][1], new_label)] = True
-                            self._nodes_occupied.pop((label, self._members[member][1]))
-                            self._nodes_occupied.pop((self._members[member][1], label))
-                        elif self._members[member][1] == node[0]:
-                            self._members[member][1] = new_label
-                            self._nodes_occupied[(self._members[member][0], new_label)] = True
-                            self._nodes_occupied[(new_label, self._members[member][0])] = True
-                            self._nodes_occupied.pop((self._members[member][0], label))
-                            self._nodes_occupied.pop((label, self._members[member][0]))
+        for i in args:
+            label = i[0]
+            new_label = i[1]
+            if label not in self._node_labels:
+                raise ValueError("No such node exists for the Truss")
+            elif new_label in self._node_labels:
+                raise ValueError("A node with the given label already exists")
+            else:
+                for node in self._nodes:
+                    if node[0] == label:
+                        self._nodes[self._nodes.index((label, node[1], node[2]))] = (new_label, node[1], node[2])
+                        self._node_labels[self._node_labels.index(node[0])] = new_label
+                        self._node_coordinates[new_label] = self._node_coordinates[label]
+                        self._node_coordinates.pop(label)
+                        if node[0] in list(self._supports):
+                            self._supports[new_label] = self._supports[node[0]]
+                            self._supports.pop(node[0])
+                        if new_label in list(self._supports):
+                            if self._supports[new_label] == 'pinned':
+                                if 'R_'+str(label)+'_x' in list(self._reaction_loads) and 'R_'+str(label)+'_y' in list(self._reaction_loads):
+                                    self._reaction_loads['R_'+str(new_label)+'_x'] = self._reaction_loads['R_'+str(label)+'_x']
+                                    self._reaction_loads['R_'+str(new_label)+'_y'] = self._reaction_loads['R_'+str(label)+'_y']
+                                    self._reaction_loads.pop('R_'+str(label)+'_x')
+                                    self._reaction_loads.pop('R_'+str(label)+'_y')
+                                self._loads[new_label] = self._loads[label]
+                                for load in self._loads[new_label]:
+                                    if load[1] == 90:
+                                        load[0] -= Symbol('R_'+str(label)+'_y')
+                                        if load[0] == 0:
+                                            self._loads[label].remove(load)
+                                        break
+                                for load in self._loads[new_label]:
+                                    if load[1] == 0:
+                                        load[0] -= Symbol('R_'+str(label)+'_x')
+                                        if load[0] == 0:
+                                            self._loads[label].remove(load)
+                                        break
+                                self.apply_load(new_label, Symbol('R_'+str(new_label)+'_x'), 0)
+                                self.apply_load(new_label, Symbol('R_'+str(new_label)+'_y'), 90)
+                                self._loads.pop(label)
+                            elif self._supports[new_label] == 'roller':
+                                self._loads[new_label] = self._loads[label]
+                                for load in self._loads[label]:
+                                    if load[1] == 90:
+                                        load[0] -= Symbol('R_'+str(label)+'_y')
+                                        if load[0] == 0:
+                                            self._loads[label].remove(load)
+                                        break
+                                self.apply_load(new_label, Symbol('R_'+str(new_label)+'_y'), 90)
+                                self._loads.pop(label)
+                        else:
+                            if label in list(self._loads):
+                                self._loads[new_label] = self._loads[label]
+                                self._loads.pop(label)
+                        for member in list(self._members):
+                            if self._members[member][0] == node[0]:
+                                self._members[member][0] = new_label
+                                self._nodes_occupied[(new_label, self._members[member][1])] = True
+                                self._nodes_occupied[(self._members[member][1], new_label)] = True
+                                self._nodes_occupied.pop((label, self._members[member][1]))
+                                self._nodes_occupied.pop((self._members[member][1], label))
+                            elif self._members[member][1] == node[0]:
+                                self._members[member][1] = new_label
+                                self._nodes_occupied[(self._members[member][0], new_label)] = True
+                                self._nodes_occupied[(new_label, self._members[member][0])] = True
+                                self._nodes_occupied.pop((self._members[member][0], label))
+                                self._nodes_occupied.pop((label, self._members[member][0]))
 
-    def change_member_label(self, label, new_label):
+    def change_member_label(self, *args):
         """
-        This method changes the label of a member.
+        This method changes the label(s) of the specified member(s).
 
         Parameters
         ==========
+        The input(s) of this method are tuple(s) of the form (label, new_label)
+
         label: String or Symbol
             The label of the member for which the label has
             to be changed.
@@ -411,38 +432,43 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0), ('D', 5, 0))
         >>> t.nodes
-        [('A', 0, 0), ('B', 3, 0)]
-        >>> t.change_node_label('A', 'C')
+        [('A', 0, 0), ('B', 3, 0), ('D', 5, 0)]
+        >>> t.change_node_label(('A', 'C'))
         >>> t.nodes
-        [('C', 0, 0), ('B', 3, 0)]
-        >>> t.add_member('BC', 'B', 'C')
+        [('C', 0, 0), ('B', 3, 0), ('D', 5, 0)]
+        >>> t.add_member(('BC', 'B', 'C'), ('BD', 'B', 'D'))
         >>> t.members
-        {'BC': ['B', 'C']}
-        >>> t.change_member_label('BC', 'BC_new')
+        {'BC': ['B', 'C'], 'BD': ['B', 'D']}
+        >>> t.change_member_label(('BC', 'BC_new'), ('BD', 'BD_new'))
         >>> t.members
-        {'BC_new': ['B', 'C']}
+        {'BC_new': ['B', 'C'], 'BD_new': ['B', 'D']}
         """
-        if label not in list(self._members):
-            raise ValueError("No such member exists for the Truss")
+        for i in args:
+            label = i[0]
+            new_label = i[1]
+            if label not in list(self._members):
+                raise ValueError("No such member exists for the Truss")
 
-        else:
-            members_duplicate = list(self._members).copy()
-            for member in members_duplicate:
-                if member == label:
-                    self._members[new_label] = [self._members[member][0], self._members[member][1]]
-                    self._members.pop(label)
-                    self._internal_forces[new_label] = self._internal_forces[label]
-                    self._internal_forces.pop(label)
+            else:
+                members_duplicate = list(self._members).copy()
+                for member in members_duplicate:
+                    if member == label:
+                        self._members[new_label] = [self._members[member][0], self._members[member][1]]
+                        self._members.pop(label)
+                        self._internal_forces[new_label] = self._internal_forces[label]
+                        self._internal_forces.pop(label)
+        
 
-    def apply_load(self, location, magnitude, direction):
+    def apply_load(self, *args):
         """
-        This method applies an external load at a particular node
+        This method applies external load(s) at the specified node(s).
 
         Parameters
         ==========
+        The input(s) of the method are tuple(s) of the form (location, magnitude, direction).
+
         location: String or Symbol
             Label of the Node at which load is applied.
 
@@ -461,34 +487,37 @@ class Truss:
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> from sympy import symbols
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0))
         >>> P = symbols('P')
-        >>> t.apply_load('A', P, 90)
-        >>> t.apply_load('A', P/2, 45)
-        >>> t.apply_load('A', P/4, 90)
+        >>> t.apply_load(('A', P, 90), ('A', P/2, 45), ('A', P/4, 90))
         >>> t.loads
         {'A': [[P, 90], [P/2, 45], [P/4, 90]]}
         """
-        magnitude = sympify(magnitude)
-        direction = sympify(direction)
+        for i in args:
+            location = i[0]
+            magnitude = i[1]
+            direction = i[2]
+            magnitude = sympify(magnitude)
+            direction = sympify(direction)
 
-        if location not in self.node_labels:
-            raise ValueError("Load must be applied at a known node")
+            if location not in self.node_labels:
+                raise ValueError("Load must be applied at a known node")
 
-        else:
-            if location in list(self._loads):
-                self._loads[location].append([magnitude, direction])
             else:
-                self._loads[location] = [[magnitude, direction]]
+                if location in list(self._loads):
+                    self._loads[location].append([magnitude, direction])
+                else:
+                    self._loads[location] = [[magnitude, direction]]
 
-    def remove_load(self, location, magnitude, direction):
+    def remove_load(self, *args):
         """
-        This method removes an already
-        present external load at a particular node
+        This method removes already
+        present external load(s) at specified node(s).
 
         Parameters
         ==========
+        The input(s) of this method are tuple(s) of the form (location, magnitude, direction).
+
         location: String or Symbol
             Label of the Node at which load is applied and is to be removed.
 
@@ -506,38 +535,40 @@ class Truss:
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> from sympy import symbols
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0))
         >>> P = symbols('P')
-        >>> t.apply_load('A', P, 90)
-        >>> t.apply_load('A', P/2, 45)
-        >>> t.apply_load('A', P/4, 90)
+        >>> t.apply_load(('A', P, 90), ('A', P/2, 45), ('A', P/4, 90))
         >>> t.loads
         {'A': [[P, 90], [P/2, 45], [P/4, 90]]}
-        >>> t.remove_load('A', P/4, 90)
+        >>> t.remove_load(('A', P/4, 90), ('A', P/2, 45))
         >>> t.loads
-        {'A': [[P, 90], [P/2, 45]]}
+        {'A': [[P, 90]]}
         """
-        magnitude = sympify(magnitude)
-        direction = sympify(direction)
+        for i in args:
+            location = i[0]
+            magnitude = i[1]
+            direction = i[2]
+            magnitude = sympify(magnitude)
+            direction = sympify(direction)
 
-        if location not in self.node_labels:
-            raise ValueError("Load must be removed from a known node")
+            if location not in self.node_labels:
+                raise ValueError("Load must be removed from a known node")
 
-        else:
-            if [magnitude, direction] not in self._loads[location]:
-                raise ValueError("No load of this magnitude and direction has been applied at this node")
             else:
-                self._loads[location].remove([magnitude, direction])
-        if self._loads[location] == []:
-            self._loads.pop(location)
+                if [magnitude, direction] not in self._loads[location]:
+                    raise ValueError("No load of this magnitude and direction has been applied at this node")
+                else:
+                    self._loads[location].remove([magnitude, direction])
+            if self._loads[location] == []:
+                self._loads.pop(location)
 
-    def apply_support(self, location, type):
+    def apply_support(self, *args):
         """
-        This method adds a pinned or roller support at a particular node
+        This method adds a pinned or roller support at specified node(s).
 
         Parameters
         ==========
+        The input(s) of this method are of the form (location, type).
 
         location: String or Symbol
             Label of the Node at which support is added.
@@ -550,67 +581,70 @@ class Truss:
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
-        >>> t.apply_support('A', 'pinned')
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0))
+        >>> t.apply_support(('A', 'pinned'), ('B', 'roller'))
         >>> t.supports
-        {'A': 'pinned'}
+        {'A': 'pinned', 'B': 'roller'}
         """
-        if location not in self._node_labels:
-            raise ValueError("Support must be added on a known node")
+        for i in args:
+            location = i[0]
+            type = i[1]
+            if location not in self._node_labels:
+                raise ValueError("Support must be added on a known node")
 
-        else:
-            if location not in list(self._supports):
-                if type == 'pinned':
-                    self.apply_load(location, Symbol('R_'+str(location)+'_x'), 0)
-                    self.apply_load(location, Symbol('R_'+str(location)+'_y'), 90)
-                elif type == 'roller':
-                    self.apply_load(location, Symbol('R_'+str(location)+'_y'), 90)
-            elif self._supports[location] == 'pinned':
-                if type == 'roller':
-                    self.remove_load(location, Symbol('R_'+str(location)+'_x'), 0)
-            elif self._supports[location] == 'roller':
-                if type == 'pinned':
-                    self.apply_load(location, Symbol('R_'+str(location)+'_x'), 0)
-            self._supports[location] = type
+            else:
+                if location not in list(self._supports):
+                    if type == 'pinned':
+                        self.apply_load((location, Symbol('R_'+str(location)+'_x'), 0))
+                        self.apply_load((location, Symbol('R_'+str(location)+'_y'), 90))
+                    elif type == 'roller':
+                        self.apply_load((location, Symbol('R_'+str(location)+'_y'), 90))
+                elif self._supports[location] == 'pinned':
+                    if type == 'roller':
+                        self.remove_load((location, Symbol('R_'+str(location)+'_x'), 0))
+                elif self._supports[location] == 'roller':
+                    if type == 'pinned':
+                        self.apply_load((location, Symbol('R_'+str(location)+'_x'), 0))
+                self._supports[location] = type
 
-    def remove_support(self, location):
+    def remove_support(self, *args):
         """
-        This method removes support from a particular node
+        This method removes support from specified node(s.)
 
         Parameters
         ==========
 
-        location: String or Symbol
-            Label of the Node at which support is to be removed.
+        locations: String or Symbol
+            Label of the Node(s) at which support is to be removed.
 
         Examples
         ========
 
         >>> from sympy.physics.continuum_mechanics.truss import Truss
         >>> t = Truss()
-        >>> t.add_node('A', 0, 0)
-        >>> t.add_node('B', 3, 0)
-        >>> t.apply_support('A', 'pinned')
+        >>> t.add_node(('A', 0, 0), ('B', 3, 0))
+        >>> t.apply_support(('A', 'pinned'), ('B', 'roller'))
         >>> t.supports
-        {'A': 'pinned'}
-        >>> t.remove_support('A')
+        {'A': 'pinned', 'B': 'roller'}
+        >>> t.remove_support('A','B')
         >>> t.supports
         {}
         """
-        if location not in self._node_labels:
-            raise ValueError("No such node exists in the Truss")
+        for location in args:
 
-        elif location not in list(self._supports):
-            raise ValueError("No support has been added to the given node")
+            if location not in self._node_labels:
+                raise ValueError("No such node exists in the Truss")
 
-        else:
-            if self._supports[location] == 'pinned':
-                self.remove_load(location, Symbol('R_'+str(location)+'_x'), 0)
-                self.remove_load(location, Symbol('R_'+str(location)+'_y'), 90)
-            elif self._supports[location] == 'roller':
-                self.remove_load(location, Symbol('R_'+str(location)+'_y'), 90)
-            self._supports.pop(location)
+            elif location not in list(self._supports):
+                raise ValueError("No support has been added to the given node")
+
+            else:
+                if self._supports[location] == 'pinned':
+                    self.remove_load((location, Symbol('R_'+str(location)+'_x'), 0))
+                    self.remove_load((location, Symbol('R_'+str(location)+'_y'), 90))
+                elif self._supports[location] == 'roller':
+                    self.remove_load((location, Symbol('R_'+str(location)+'_y'), 90))
+                self._supports.pop(location)
 
     def solve(self):
         """

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -711,7 +711,7 @@ class Truss:
         cols = 0
         row = 0
         for node in self._nodes:
-            if node[0] in list(self._supports):
+            if node[0] in self._supports:
                 if self._supports[node[0]]=='pinned':
                     coefficients_matrix[row][cols] += 1
                     coefficients_matrix[row+1][cols+1] += 1
@@ -859,7 +859,7 @@ class Truss:
 
         for node in self._node_coordinates:
             if (type(self._node_coordinates[node][0]) in (Symbol, Quantity)):
-                if self._node_coordinates[node][0] in list(subs_dict):
+                if self._node_coordinates[node][0] in subs_dict:
                     self._node_coordinates[node][0] = subs_dict[self._node_coordinates[node][0]]
                 else:
                     raise ValueError("provided substituted dictionary is not adequate")
@@ -867,14 +867,14 @@ class Truss:
                 objects = self._node_coordinates[node][0].as_coeff_Mul()
                 for object in objects:
                     if type(object) in (Symbol, Quantity):
-                        if subs_dict==None or object not in list(subs_dict):
+                        if subs_dict==None or object not in subs_dict:
                             raise ValueError("provided substituted dictionary is not adequate")
                         else:
                             self._node_coordinates[node][0] /= object
                             self._node_coordinates[node][0] *= subs_dict[object]
 
             if (type(self._node_coordinates[node][1]) in (Symbol, Quantity)):
-                if self._node_coordinates[node][1] in list(subs_dict):
+                if self._node_coordinates[node][1] in subs_dict:
                     self._node_coordinates[node][1] = subs_dict[self._node_coordinates[node][1]]
                 else:
                     raise ValueError("provided substituted dictionary is not adequate")
@@ -882,7 +882,7 @@ class Truss:
                 objects = self._node_coordinates[node][1].as_coeff_Mul()
                 for object in objects:
                     if type(object) in (Symbol, Quantity):
-                        if subs_dict==None or object not in list(subs_dict):
+                        if subs_dict==None or object not in subs_dict:
                             raise ValueError("provided substituted dictionary is not adequate")
                         else:
                             self._node_coordinates[node][1] /= object

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -223,7 +223,7 @@ class Truss:
                 members_duplicate = self._members.copy()
                 for member in members_duplicate:
                     if label == self._members[member][0] or label == self._members[member][1]:
-                        raise ValueError("The node given has members already attached to it")
+                        raise ValueError("The given node already has member attached to it")
                 self._nodes.remove((label, x, y))
                 self._node_labels.remove(label)
                 self._node_positions.remove((x, y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The methods in Truss class were modified to accept multiple inputs in a single call.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Methods of Truss class now accept multiple inputs
<!-- END RELEASE NOTES -->
