### PR TITLE
Fixes and adds test for error with adjoint of matrix with operator elements

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1195,6 +1195,7 @@ Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
 Saicharan <saicharanhahaha@gmail.com>
+Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>
 Sakirul Alam <binarysakir@gmail.com>

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -1,14 +1,19 @@
 from sympy.core.expr import Expr
+from sympy.core.function import Derivative, Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer)
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.complexes import conjugate
 from sympy.matrices.dense import Matrix
 
-from sympy.physics.quantum.dagger import adjoint, Dagger
 from sympy.external import import_module
 from sympy.testing.pytest import skip
-from sympy.physics.quantum.operator import Operator, IdentityOperator
+from sympy.physics.quantum.dagger import adjoint, Dagger
+from sympy.physics.quantum.operator import (
+    Operator, IdentityOperator, HermitianOperator,
+    OuterProduct, UnitaryOperator, DifferentialOperator
+)
+from sympy.physics.quantum.state import Ket, Bra
 
 
 def test_scalars():
@@ -34,9 +39,29 @@ def test_matrix():
     m = Matrix([[I, x*I], [2, 4]])
     assert Dagger(m) == m.H
 
+
+def test_dagger_matrix_operator():
     A = Operator('A')
-    assert Dagger(Matrix([[A]])) != Matrix([[A.conjugate()]])
     assert Dagger(Matrix([[A]])) == Matrix([[A.adjoint()]])
+
+    I = IdentityOperator()
+    assert Dagger(Matrix([[I]])) == Matrix([[I.adjoint()]])
+
+    H = HermitianOperator('H')
+    assert Dagger(Matrix([[H]])) == Matrix([[H.adjoint()]])
+
+    U = UnitaryOperator('U')
+    assert Dagger(Matrix([[U]])) == Matrix([[U.adjoint()]])
+
+    k = Ket('k')
+    b = Bra('b')
+    O = OuterProduct(k, b)
+    assert Dagger(Matrix([[O]])) == Matrix([[O.adjoint()]])
+
+    y = symbols('y')
+    f = Function('f')
+    D = DifferentialOperator(Derivative(f(y), y), f(y))
+    assert Dagger(Matrix([[D]])) == Matrix([[D.adjoint()]])
 
 
 def test_dagger_mul():

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -34,6 +34,10 @@ def test_matrix():
     m = Matrix([[I, x*I], [2, 4]])
     assert Dagger(m) == m.H
 
+    A = Operator('A')
+    assert Dagger(Matrix([[A]])) != Matrix([[A.conjugate()]])
+    assert Dagger(Matrix([[A]])) == Matrix([[A.adjoint()]])
+
 
 def test_dagger_mul():
     O = Operator('O')

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -4,8 +4,6 @@ Module for the SDM class.
 
 """
 
-import sympy
-
 from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
@@ -926,7 +924,17 @@ def sdm_transpose(M):
     MT = {}
     for i, Mi in M.items():
         for j, Mij in Mi.items():
-            is_operator = lambda x: issubclass(x.__class__, sympy.physics.quantum.operator.Operator)
+            # Operator class names are hardcoded instead of using 
+            # issubclass() to avoid circular imports.
+            operator_class_names = [
+                "<class 'sympy.physics.quantum.operator.Operator'>",
+                "<class 'sympy.physics.quantum.operator.IdentityOperator'>",
+                "<class 'sympy.physics.quantum.operator.HermitianOperator'>",
+                "<class 'sympy.physics.quantum.operator.UnitaryOperator'>",
+                "<class 'sympy.physics.quantum.operator.OuterProduct'>",
+                "<class 'sympy.physics.quantum.operator.DifferentialOperator'>"
+            ]
+            is_operator = lambda x: str(x.__class__) in operator_class_names
             try:
                 MT[j][i] = Mij.transpose() if is_operator(Mij) else Mij
             except KeyError:

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -924,7 +924,7 @@ def sdm_transpose(M):
     MT = {}
     for i, Mi in M.items():
         for j, Mij in Mi.items():
-            # Operator class names are hardcoded instead of using 
+            # Operator class names are hardcoded instead of using
             # issubclass() to avoid circular imports.
             operator_class_names = [
                 "<class 'sympy.physics.quantum.operator.Operator'>",

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -4,6 +4,8 @@ Module for the SDM class.
 
 """
 
+import sympy
+
 from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
@@ -924,10 +926,11 @@ def sdm_transpose(M):
     MT = {}
     for i, Mi in M.items():
         for j, Mij in Mi.items():
+            is_operator = lambda x: issubclass(x.__class__, sympy.physics.quantum.operator.Operator)
             try:
-                MT[j][i] = Mij
+                MT[j][i] = Mij.transpose() if is_operator(Mij) else Mij
             except KeyError:
-                MT[j] = {i: Mij}
+                MT[j] = {i: Mij.transpose() if is_operator(Mij) else Mij}
     return MT
 
 


### PR DESCRIPTION
Fixes #25130.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The solution implemented is only limited to the classes of `Operator, IdentityOperator, HermitianOperator, UnitaryOperator, OuterProduct, DifferentialOperator` in the file `sympy.physics.quantum.operator`. It simply transposes the matrix element if that element is of the Operator class or a subclass of the Operator class (within the list above).


#### Other comments

- The solution is hardcoded to check the output of `str(x.__class__)` where `x` is the instance of the operator in the matrix. This string comparison replaces the `issubclass(x, sympy.physics.quantum.operator.Operator)` (a much preferred solution) due to failure in tests and circular imports.
  - Using `from sympy.physics.quantum.operator import Operator` in `sympy/polys/matrices/sdm.py` leads to circular imports due to modules imported for `sympy.physics`.
  - Using `import sympy` in `sympy/polys/matrices/sdm.py` and then `issubclass(x,sympy.physics.quantum.operator.Operator)` in the transpose function leads to failed tests after committing with error messages like
    - `AttributeError: module 'sympy' has no attribute 'physics'`
    - `AttributeError: module 'sympy.physics' has no attribute 'quantum'`
  - The problem with the `AttributeError` is that it does not show up when running tests on my local machine.
- Another possible solution is to take each matrix as a block matrix and transpose each element if that element has a transpose operation. However, this solution leads to errors in tests in multiple modules and needs further discussion and planning.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
