### PR TITLE
Cramer solve

### DIFF
--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -571,7 +571,7 @@ def _det(M, method="bareiss", iszerofunc=None):
 
         If it is set to ``'berkowitz'``, Berkowitz' algorithm will be used.
 
-        If it is set to ``'bird'``, Bird's algorithm will be used.
+        If it is set to ``'bird'``, Bird's algorithm will be used [1]_.
 
         If it is set to ``'laplace'``, Laplace's algorithm will be used.
 
@@ -623,6 +623,13 @@ def _det(M, method="bareiss", iszerofunc=None):
     True
     >>> M.det(method="domain-ge")
     -2
+
+    References
+    ==========
+
+    .. [1] Bird, R. S. (2011). A simple division-free algorithm for computing
+           determinants. Inf. Process. Lett., 111(21), 1072-1074. doi:
+           10.1016/j.ipl.2011.08.006
     """
 
     # sanitize `method`

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -571,9 +571,9 @@ def _det(M, method="bareiss", iszerofunc=None):
 
         If it is set to ``'berkowitz'``, Berkowitz' algorithm will be used.
 
-        If it is set to ``'bird'``, Bird' algorithm will be used.
+        If it is set to ``'bird'``, Bird's algorithm will be used.
 
-        If it is set to ``'laplace'``, Laplace' algorithm will be used.
+        If it is set to ``'laplace'``, Laplace's algorithm will be used.
 
         Otherwise, if it is set to ``'lu'``, LU decomposition will be used.
 
@@ -869,10 +869,10 @@ def _det_laplace(M):
 
 
 def _det_bird(M):
-    r"""Compute the determinant of a matrix using Bird' algorithm.
+    r"""Compute the determinant of a matrix using Bird's algorithm.
 
     Bird's algorithm is a simple division-free algorithm for computing, which
-    is of lower order than the Laplace' algorithm. It is described in [1]_.
+    is of lower order than the Laplace's algorithm. It is described in [1]_.
 
     References
     ==========
@@ -926,7 +926,7 @@ def _minor(M, i, j, method="berkowitz"):
 
     method : string, optional
         Method to use to find the determinant of the submatrix, can be
-        "bareiss", "berkowitz", "laplace" or "lu".
+        "bareiss", "berkowitz", "bird", "laplace" or "lu".
 
     Examples
     ========

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -878,7 +878,7 @@ def _det_bird(M):
     ==========
 
     .. [1] Bird, R. S. (2011). A simple division-free algorithm for computing
-           determinants. Inf. Process. Lett., 111(21), 1072–1074. doi:
+           determinants. Inf. Process. Lett., 111(21), 1072-1074. doi:
            10.1016/j.ipl.2011.08.006
     """
     def mu(X):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -59,7 +59,7 @@ from .graph import (
 from .solvers import (
     _diagonal_solve, _lower_triangular_solve, _upper_triangular_solve,
     _cholesky_solve, _LDLsolve, _LUsolve, _QRsolve, _gauss_jordan_solve,
-    _pinv_solve, _solve, _solve_least_squares)
+    _pinv_solve, _cramer_solve, _solve, _solve_least_squares)
 
 from .inverse import (
     _pinv, _inv_mod, _inv_ADJ, _inv_GE, _inv_LU, _inv_CH, _inv_LDL, _inv_QR,
@@ -2279,6 +2279,9 @@ class MatrixBase(MatrixDeprecated,
     def pinv_solve(self, B, arbitrary_matrix=None):
         return _pinv_solve(self, B, arbitrary_matrix=arbitrary_matrix)
 
+    def cramer_solve(self, rhs):
+        return _cramer_solve(self, rhs)
+
     def solve(self, rhs, method='GJ'):
         return _solve(self, rhs, method=method)
 
@@ -2349,6 +2352,7 @@ class MatrixBase(MatrixDeprecated,
     QRsolve.__doc__                = _QRsolve.__doc__
     gauss_jordan_solve.__doc__     = _gauss_jordan_solve.__doc__
     pinv_solve.__doc__             = _pinv_solve.__doc__
+    cramer_solve.__doc__           = _cramer_solve.__doc__
     solve.__doc__                  = _solve.__doc__
     solve_least_squares.__doc__    = _solve_least_squares.__doc__
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -33,7 +33,8 @@ from .utilities import _iszero, _is_zero_after_expand_mul, _simplify
 from .determinant import (
     _find_reasonable_pivot, _find_reasonable_pivot_naive,
     _adjugate, _charpoly, _cofactor, _cofactor_matrix, _per,
-    _det, _det_bareiss, _det_berkowitz, _det_LU, _minor, _minor_submatrix)
+    _det, _det_bareiss, _det_berkowitz, _det_laplace, _det_LU, _minor,
+    _minor_submatrix)
 
 from .reductions import _is_echelon, _echelon_form, _rank, _rref
 from .subspaces import _columnspace, _nullspace, _rowspace, _orthogonalize
@@ -109,6 +110,9 @@ class MatrixDeterminant(MatrixCommon):
     def _eval_det_lu(self, iszerofunc=_iszero, simpfunc=None):
         return _det_LU(self, iszerofunc=iszerofunc, simpfunc=simpfunc)
 
+    def _eval_det_laplace(self):
+        return _det_laplace(self)
+
     def _eval_determinant(self): # for expressions.determinant.Determinant
         return _det(self)
 
@@ -140,6 +144,7 @@ class MatrixDeterminant(MatrixCommon):
     _find_reasonable_pivot_naive.__doc__ = _find_reasonable_pivot_naive.__doc__
     _eval_det_bareiss.__doc__            = _det_bareiss.__doc__
     _eval_det_berkowitz.__doc__          = _det_berkowitz.__doc__
+    _eval_det_laplace.__doc__            = _det_laplace.__doc__
     _eval_det_lu.__doc__                 = _det_LU.__doc__
     _eval_determinant.__doc__            = _det.__doc__
     adjugate.__doc__                     = _adjugate.__doc__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2283,7 +2283,7 @@ class MatrixBase(MatrixDeprecated,
     def pinv_solve(self, B, arbitrary_matrix=None):
         return _pinv_solve(self, B, arbitrary_matrix=arbitrary_matrix)
 
-    def cramer_solve(self, rhs, det_method="bird"):
+    def cramer_solve(self, rhs, det_method="laplace"):
         return _cramer_solve(self, rhs, det_method=det_method)
 
     def solve(self, rhs, method='GJ'):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2283,7 +2283,7 @@ class MatrixBase(MatrixDeprecated,
     def pinv_solve(self, B, arbitrary_matrix=None):
         return _pinv_solve(self, B, arbitrary_matrix=arbitrary_matrix)
 
-    def cramer_solve(self, rhs, det_method="laplace"):
+    def cramer_solve(self, rhs, det_method="bird"):
         return _cramer_solve(self, rhs, det_method=det_method)
 
     def solve(self, rhs, method='GJ'):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -33,8 +33,8 @@ from .utilities import _iszero, _is_zero_after_expand_mul, _simplify
 from .determinant import (
     _find_reasonable_pivot, _find_reasonable_pivot_naive,
     _adjugate, _charpoly, _cofactor, _cofactor_matrix, _per,
-    _det, _det_bareiss, _det_berkowitz, _det_laplace, _det_LU, _minor,
-    _minor_submatrix)
+    _det, _det_bareiss, _det_berkowitz, _det_bird, _det_laplace, _det_LU,
+    _minor, _minor_submatrix)
 
 from .reductions import _is_echelon, _echelon_form, _rank, _rref
 from .subspaces import _columnspace, _nullspace, _rowspace, _orthogonalize
@@ -110,6 +110,9 @@ class MatrixDeterminant(MatrixCommon):
     def _eval_det_lu(self, iszerofunc=_iszero, simpfunc=None):
         return _det_LU(self, iszerofunc=iszerofunc, simpfunc=simpfunc)
 
+    def _eval_det_bird(self):
+        return _det_bird(self)
+
     def _eval_det_laplace(self):
         return _det_laplace(self)
 
@@ -144,6 +147,7 @@ class MatrixDeterminant(MatrixCommon):
     _find_reasonable_pivot_naive.__doc__ = _find_reasonable_pivot_naive.__doc__
     _eval_det_bareiss.__doc__            = _det_bareiss.__doc__
     _eval_det_berkowitz.__doc__          = _det_berkowitz.__doc__
+    _eval_det_bird.__doc__            = _det_bird.__doc__
     _eval_det_laplace.__doc__            = _det_laplace.__doc__
     _eval_det_lu.__doc__                 = _det_LU.__doc__
     _eval_determinant.__doc__            = _det.__doc__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2279,8 +2279,8 @@ class MatrixBase(MatrixDeprecated,
     def pinv_solve(self, B, arbitrary_matrix=None):
         return _pinv_solve(self, B, arbitrary_matrix=arbitrary_matrix)
 
-    def cramer_solve(self, rhs):
-        return _cramer_solve(self, rhs)
+    def cramer_solve(self, rhs, det_method="laplace"):
+        return _cramer_solve(self, rhs, det_method=det_method)
 
     def solve(self, rhs, method='GJ'):
         return _solve(self, rhs, method=method)

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -746,6 +746,11 @@ def _cramer_solve(M, rhs, det_method="bird"):
     [ 4,  3],
     [-6,  9]])
 
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Cramer%27s_rule#Explicit_formulas_for_small_systems
+
     """
     from .dense import zeros
 

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -712,8 +712,9 @@ def _cramer_solve(M, rhs, det_method="bird"):
     """Solves system of linear equations using Cramer's rule.
 
     This method is relatively inefficient compared to other methods.
-    However it only uses a single division, assuming a division free
-    determinant method is provided.
+    However it only uses a single division, assuming a division-free determinant
+    method is provided. This is helpful to minimize the chance of divide-by-zero
+    cases in symbolic solutions to linear systems.
 
     Parameters
     ==========

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -708,7 +708,7 @@ def _pinv_solve(M, B, arbitrary_matrix=None):
             A_pinv.multiply(A)).multiply(arbitrary_matrix)
 
 
-def _cramer_solve(M, rhs, det_method="laplace"):
+def _cramer_solve(M, rhs, det_method="bird"):
     """Solves system of linear equations using Cramer's rule.
 
     This method is relatively inefficient compared to other methods.
@@ -723,9 +723,8 @@ def _cramer_solve(M, rhs, det_method="laplace"):
         The matrix representing the right hand side of the equation.
     det_method : str or callable
         The method to use to calculate the determinant of the matrix.
-        The default is ``'laplace'``.  If a callable is passed, it
-        should take a single argument, the matrix, and return the
-        determinant of the matrix.
+        The default is ``'bird'``.  If a callable is passed, it should take a
+        single argument, the matrix, and return the determinant of the matrix.
 
     Returns
     =======
@@ -752,7 +751,10 @@ def _cramer_solve(M, rhs, det_method="laplace"):
     def entry(i, j):
         return rhs[i, sol] if j == col else M[i, j]
 
-    if det_method == "laplace":
+    if det_method == "bird":
+        from .determinant import _det_bird
+        det = _det_bird
+    elif det_method == "laplace":
         from .determinant import _det_laplace
         det = _det_laplace
     elif isinstance(det_method, str):

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -747,20 +747,23 @@ def _cramer_solve(M, rhs, det_method="laplace"):
     [-6,  9]])
 
     """
-    from .dense import zeros, Matrix
+    from .dense import zeros
 
     def entry(i, j):
         return rhs[i, sol] if j == col else M[i, j]
 
-    if isinstance(det_method, str):
-        det = lambda matrix: Matrix.det(matrix, method=det_method)
+    if det_method == "laplace":
+        from .determinant import _det_laplace
+        det = _det_laplace
+    elif isinstance(det_method, str):
+        det = lambda matrix: matrix.det(method=det_method)
     else:
         det = det_method
     det_M = det(M)
     x = zeros(*rhs.shape)
     for sol in range(rhs.shape[1]):
         for col in range(rhs.shape[0]):
-            x[col, sol] = det(Matrix(*M.shape, entry)) / det_M
+            x[col, sol] = det(M.__class__(*M.shape, entry)) / det_M
     return M.__class__(x)
 
 

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -31,6 +31,7 @@ def _diagonal_solve(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     if not M.is_diagonal():
@@ -56,6 +57,7 @@ def _lower_triangular_solve(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     from .dense import MutableDenseMatrix
@@ -94,6 +96,7 @@ def _lower_triangular_solve_sparse(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     if not M.is_square:
@@ -136,6 +139,7 @@ def _upper_triangular_solve(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     from .dense import MutableDenseMatrix
@@ -174,6 +178,7 @@ def _upper_triangular_solve_sparse(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     if not M.is_square:
@@ -219,6 +224,7 @@ def _cholesky_solve(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     if M.rows < M.cols:
@@ -276,6 +282,7 @@ def _LDLsolve(M, rhs):
     LUsolve
     QRsolve
     pinv_solve
+    cramer_solve
     """
 
     if M.rows < M.cols:
@@ -324,6 +331,7 @@ def _LUsolve(M, rhs, iszerofunc=_iszero):
     QRsolve
     pinv_solve
     LUdecomposition
+    cramer_solve
     """
 
     if rhs.rows != M.rows:
@@ -400,6 +408,7 @@ def _QRsolve(M, b):
     LUsolve
     pinv_solve
     QRdecomposition
+    cramer_solve
     """
 
     dps  = _get_intermediate_simp(expand_mul, expand_mul)
@@ -699,6 +708,62 @@ def _pinv_solve(M, B, arbitrary_matrix=None):
             A_pinv.multiply(A)).multiply(arbitrary_matrix)
 
 
+def _cramer_solve(M, rhs, det_method="laplace"):
+    """Solves system of linear equations using Cramer's rule.
+
+    This method is relatively inefficient compared to other methods.
+    However it only uses a single division, assuming a division free
+    determinant method is provided.
+
+    Parameters
+    ==========
+    M : Matrix
+        The matrix representing the left hand side of the equation.
+    rhs : Matrix
+        The matrix representing the right hand side of the equation.
+    det_method : str or callable
+        The method to use to calculate the determinant of the matrix.
+        The default is ``'laplace'``.  If a callable is passed, it
+        should take a single argument, the matrix, and return the
+        determinant of the matrix.
+
+    Returns
+    =======
+    x : Matrix
+        The matrix that will satisfy ``Ax = B``.  Will have as many rows as
+        matrix A has columns, and as many columns as matrix B.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> A = Matrix([[0, -6, 1], [0, -6, -1], [-5, -2, 3]])
+    >>> B = Matrix([[-30, -9], [-18, -27], [-26, 46]])
+    >>> x = A.cramer_solve(B)
+    >>> x
+    Matrix([
+    [ 0, -5],
+    [ 4,  3],
+    [-6,  9]])
+
+    """
+    from .dense import zeros, Matrix
+
+    def entry(i, j):
+        return rhs[i, sol] if j == col else M[i, j]
+
+    if isinstance(det_method, str):
+        det = lambda matrix: Matrix.det(matrix, method=det_method)
+    else:
+        det = det_method
+    det_M = det(M)
+    x = zeros(*rhs.shape)
+    for sol in range(rhs.shape[1]):
+        for col in range(rhs.shape[0]):
+            x[col, sol] = det(Matrix(*M.shape, entry)) / det_M
+    return M.__class__(x)
+
+
 def _solve(M, rhs, method='GJ'):
     """Solves linear equation where the unique solution exists.
 
@@ -717,6 +782,8 @@ def _solve(M, rhs, method='GJ'):
         If set to ``'QR'``, ``QRsolve`` routine will be used.
 
         If set to ``'PINV'``, ``pinv_solve`` routine will be used.
+
+        If set to ``'CRAMER'``, ``cramer_solve`` routine will be used.
 
         It also supports the methods available for special linear systems
 
@@ -769,6 +836,8 @@ def _solve(M, rhs, method='GJ'):
         return M.LDLsolve(rhs)
     elif method == 'PINV':
         return M.pinv_solve(rhs)
+    elif method == 'CRAMER':
+        return M.cramer_solve(rhs)
     else:
         return M.inv(method=method).multiply(rhs)
 

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -708,7 +708,7 @@ def _pinv_solve(M, B, arbitrary_matrix=None):
             A_pinv.multiply(A)).multiply(arbitrary_matrix)
 
 
-def _cramer_solve(M, rhs, det_method="bird"):
+def _cramer_solve(M, rhs, det_method="laplace"):
     """Solves system of linear equations using Cramer's rule.
 
     This method is relatively inefficient compared to other methods.
@@ -724,7 +724,7 @@ def _cramer_solve(M, rhs, det_method="bird"):
         The matrix representing the right hand side of the equation.
     det_method : str or callable
         The method to use to calculate the determinant of the matrix.
-        The default is ``'bird'``.  If a callable is passed, it should take a
+        The default is ``'laplace'``.  If a callable is passed, it should take a
         single argument, the matrix, and return the determinant of the matrix.
 
     Returns

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -15,7 +15,7 @@ from sympy.functions.combinatorial.factorials import factorial, subfactorial
 @pytest.mark.parametrize("method", [
     # Evaluating these directly because they are never reached via M.det()
     Matrix._eval_det_bareiss, Matrix._eval_det_berkowitz,
-    Matrix._eval_det_laplace, Matrix._eval_det_lu
+    Matrix._eval_det_bird, Matrix._eval_det_laplace, Matrix._eval_det_lu
 ])
 @pytest.mark.parametrize("M, sol", [
     (Matrix(), 1),
@@ -27,7 +27,7 @@ def test_eval_determinant(method, M, sol):
 
 
 @pytest.mark.parametrize("method", [
-    "domain-ge", "bareiss", "berkowitz", "laplace", "lu"])
+    "domain-ge", "bareiss", "berkowitz", "bird", "laplace", "lu"])
 @pytest.mark.parametrize("M, sol", [
     (Matrix(( (-3,  2),
               ( 8, -5) )), -1),
@@ -191,6 +191,7 @@ def test_adjugate():
     assert e.adjugate() == adj
     assert e.adjugate(method='bareiss') == adj
     assert e.adjugate(method='berkowitz') == adj
+    assert e.adjugate(method='bird') == adj
     assert e.adjugate(method='laplace') == adj
 
     a = Matrix(2, 3, [1, 2, 3, 4, 5, 6])
@@ -241,6 +242,7 @@ def test_cofactor_and_minors():
     assert e.cofactor_matrix() == cm
     assert e.cofactor_matrix(method="bareiss") == cm
     assert e.cofactor_matrix(method="berkowitz") == cm
+    assert e.cofactor_matrix(method="bird") == cm
     assert e.cofactor_matrix(method="laplace") == cm
 
     raises(ValueError, lambda: e.cofactor(4, 5))

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -15,7 +15,7 @@ from sympy.functions.combinatorial.factorials import factorial, subfactorial
 @pytest.mark.parametrize("method", [
     # Evaluating these directly because they are never reached via M.det()
     Matrix._eval_det_bareiss, Matrix._eval_det_berkowitz,
-    Matrix._eval_det_lu
+    Matrix._eval_det_laplace, Matrix._eval_det_lu
 ])
 @pytest.mark.parametrize("M, sol", [
     (Matrix(), 1),
@@ -27,7 +27,7 @@ def test_eval_determinant(method, M, sol):
 
 
 @pytest.mark.parametrize("method", [
-    "domain-ge", "bareiss", "berkowitz", "lu"])
+    "domain-ge", "bareiss", "berkowitz", "laplace", "lu"])
 @pytest.mark.parametrize("M, sol", [
     (Matrix(( (-3,  2),
               ( 8, -5) )), -1),
@@ -191,6 +191,7 @@ def test_adjugate():
     assert e.adjugate() == adj
     assert e.adjugate(method='bareiss') == adj
     assert e.adjugate(method='berkowitz') == adj
+    assert e.adjugate(method='laplace') == adj
 
     a = Matrix(2, 3, [1, 2, 3, 4, 5, 6])
     raises(NonSquareMatrixError, lambda: a.adjugate())
@@ -240,6 +241,7 @@ def test_cofactor_and_minors():
     assert e.cofactor_matrix() == cm
     assert e.cofactor_matrix(method="bareiss") == cm
     assert e.cofactor_matrix(method="berkowitz") == cm
+    assert e.cofactor_matrix(method="laplace") == cm
 
     raises(ValueError, lambda: e.cofactor(4, 5))
     raises(ValueError, lambda: e.minor(4, 5))

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -1,4 +1,5 @@
 import random
+import pytest
 from sympy.core.numbers import I
 from sympy.core.numbers import Rational
 from sympy.core.symbol import (Symbol, symbols)
@@ -11,165 +12,87 @@ from sympy.matrices.common import NonSquareMatrixError
 from sympy.functions.combinatorial.factorials import factorial, subfactorial
 
 
-def test_determinant():
-    M = Matrix()
-
-    assert M.det() == 1
+@pytest.mark.parametrize("method", [
     # Evaluating these directly because they are never reached via M.det()
-    assert M._eval_det_bareiss() == 1
-    assert M._eval_det_berkowitz() == 1
-    assert M._eval_det_lu() == 1
+    Matrix._eval_det_bareiss, Matrix._eval_det_berkowitz,
+    Matrix._eval_det_lu
+])
+@pytest.mark.parametrize("M, sol", [
+    (Matrix(), 1),
+    (Matrix([[0]]), 0),
+    (Matrix([[5]]), 5),
+])
+def test_eval_determinant(method, M, sol):
+    assert method(M) == sol
 
-    M = Matrix([ [0] ])
 
-    assert M.det() == 0
-    assert M._eval_det_bareiss() == 0
-    assert M._eval_det_berkowitz() == 0
-    assert M._eval_det_lu() == 0
+@pytest.mark.parametrize("method", [
+    "domain-ge", "bareiss", "berkowitz", "lu"])
+@pytest.mark.parametrize("M, sol", [
+    (Matrix(( (-3,  2),
+              ( 8, -5) )), -1),
+    (Matrix(( (x,   1),
+              (y, 2*y) )), 2*x*y - y),
+    (Matrix(( (1, 1, 1),
+              (1, 2, 3),
+              (1, 3, 6) )), 1),
+    (Matrix(( ( 3, -2,  0, 5),
+              (-2,  1, -2, 2),
+              ( 0, -2,  5, 0),
+              ( 5,  0,  3, 4) )), -289),
+    (Matrix(( ( 1,  2,  3,  4),
+              ( 5,  6,  7,  8),
+              ( 9, 10, 11, 12),
+              (13, 14, 15, 16) )), 0),
+    (Matrix(( (3, 2, 0, 0, 0),
+              (0, 3, 2, 0, 0),
+              (0, 0, 3, 2, 0),
+              (0, 0, 0, 3, 2),
+              (2, 0, 0, 0, 3) )), 275),
+    (Matrix(( ( 3,  0,  0, 0),
+              (-2,  1,  0, 0),
+              ( 0, -2,  5, 0),
+              ( 5,  0,  3, 4) )), 60),
+    (Matrix(( ( 1,  0,  0,  0),
+              ( 5,  0,  0,  0),
+              ( 9, 10, 11, 0),
+              (13, 14, 15, 16) )), 0),
+    (Matrix(( (3, 2, 0, 0, 0),
+              (0, 3, 2, 0, 0),
+              (0, 0, 3, 2, 0),
+              (0, 0, 0, 3, 2),
+              (0, 0, 0, 0, 3) )), 243),
+    (Matrix(( (1, 0,  1,  2, 12),
+              (2, 0,  1,  1,  4),
+              (2, 1,  1, -1,  3),
+              (3, 2, -1,  1,  8),
+              (1, 1,  1,  0,  6) )), -55),
+    (Matrix(( (-5,  2,  3,  4,  5),
+              ( 1, -4,  3,  4,  5),
+              ( 1,  2, -3,  4,  5),
+              ( 1,  2,  3, -2,  5),
+              ( 1,  2,  3,  4, -1) )), 11664),
+    (Matrix(( ( 2,  7, -1, 3, 2),
+              ( 0,  0,  1, 0, 1),
+              (-2,  0,  7, 0, 2),
+              (-3, -2,  4, 5, 3),
+              ( 1,  0,  0, 0, 1) )), 123),
+    (Matrix(( (x, y, z),
+              (1, 0, 0),
+              (y, z, x) )), z**2 - x*y),
+])
+def test_determinant(method, M, sol):
+    assert M.det(method=method) == sol
 
-    M = Matrix([ [5] ])
 
-    assert M.det() == 5
-    assert M._eval_det_bareiss() == 5
-    assert M._eval_det_berkowitz() == 5
-    assert M._eval_det_lu() == 5
-
-    M = Matrix(( (-3,  2),
-                 ( 8, -5) ))
-
-    assert M.det(method="domain-ge") == -1
-    assert M.det(method="bareiss") == -1
-    assert M.det(method="berkowitz") == -1
-    assert M.det(method="lu") == -1
-
-    M = Matrix(( (x,   1),
-                 (y, 2*y) ))
-
-    assert M.det(method="domain-ge") == 2*x*y - y
-    assert M.det(method="bareiss") == 2*x*y - y
-    assert M.det(method="berkowitz") == 2*x*y - y
-    assert M.det(method="lu") == 2*x*y - y
-
-    M = Matrix(( (1, 1, 1),
-                 (1, 2, 3),
-                 (1, 3, 6) ))
-
-    assert M.det(method="domain-ge") == 1
-    assert M.det(method="bareiss") == 1
-    assert M.det(method="berkowitz") == 1
-    assert M.det(method="lu") == 1
-
-    M = Matrix(( ( 3, -2,  0, 5),
-                 (-2,  1, -2, 2),
-                 ( 0, -2,  5, 0),
-                 ( 5,  0,  3, 4) ))
-
-    assert M.det(method="domain-ge") == -289
-    assert M.det(method="bareiss") == -289
-    assert M.det(method="berkowitz") == -289
-    assert M.det(method="lu") == -289
-
-    M = Matrix(( ( 1,  2,  3,  4),
-                 ( 5,  6,  7,  8),
-                 ( 9, 10, 11, 12),
-                 (13, 14, 15, 16) ))
-
-    assert M.det(method="domain-ge") == 0
-    assert M.det(method="bareiss") == 0
-    assert M.det(method="berkowitz") == 0
-    assert M.det(method="lu") == 0
-
-    M = Matrix(( (3, 2, 0, 0, 0),
-                 (0, 3, 2, 0, 0),
-                 (0, 0, 3, 2, 0),
-                 (0, 0, 0, 3, 2),
-                 (2, 0, 0, 0, 3) ))
-
-    assert M.det(method="domain-ge") == 275
-    assert M.det(method="bareiss") == 275
-    assert M.det(method="berkowitz") == 275
-    assert M.det(method="lu") == 275
-
-    M = Matrix(( ( 3,  0,  0, 0),
-                 (-2,  1,  0, 0),
-                 ( 0, -2,  5, 0),
-                 ( 5,  0,  3, 4) ))
-
-    assert M.det(method="domain-ge") == 60
-    assert M.det(method="bareiss") == 60
-    assert M.det(method="berkowitz") == 60
-    assert M.det(method="lu") == 60
-
-    M = Matrix(( ( 1,  0,  0,  0),
-                 ( 5,  0,  0,  0),
-                 ( 9, 10, 11, 0),
-                 (13, 14, 15, 16) ))
-
-    assert M.det(method="domain-ge") == 0
-    assert M.det(method="bareiss") == 0
-    assert M.det(method="berkowitz") == 0
-    assert M.det(method="lu") == 0
-
-    M = Matrix(( (3, 2, 0, 0, 0),
-                 (0, 3, 2, 0, 0),
-                 (0, 0, 3, 2, 0),
-                 (0, 0, 0, 3, 2),
-                 (0, 0, 0, 0, 3) ))
-
-    assert M.det(method="domain-ge") == 243
-    assert M.det(method="bareiss") == 243
-    assert M.det(method="berkowitz") == 243
-    assert M.det(method="lu") == 243
-
-    M = Matrix(( (1, 0,  1,  2, 12),
-                 (2, 0,  1,  1,  4),
-                 (2, 1,  1, -1,  3),
-                 (3, 2, -1,  1,  8),
-                 (1, 1,  1,  0,  6) ))
-
-    assert M.det(method="domain-ge") == -55
-    assert M.det(method="bareiss") == -55
-    assert M.det(method="berkowitz") == -55
-    assert M.det(method="lu") == -55
-
-    M = Matrix(( (-5,  2,  3,  4,  5),
-                 ( 1, -4,  3,  4,  5),
-                 ( 1,  2, -3,  4,  5),
-                 ( 1,  2,  3, -2,  5),
-                 ( 1,  2,  3,  4, -1) ))
-
-    assert M.det(method="domain-ge") == 11664
-    assert M.det(method="bareiss") == 11664
-    assert M.det(method="berkowitz") == 11664
-    assert M.det(method="lu") == 11664
-
-    M = Matrix(( ( 2,  7, -1, 3, 2),
-                 ( 0,  0,  1, 0, 1),
-                 (-2,  0,  7, 0, 2),
-                 (-3, -2,  4, 5, 3),
-                 ( 1,  0,  0, 0, 1) ))
-
-    assert M.det(method="domain-ge") == 123
-    assert M.det(method="bareiss") == 123
-    assert M.det(method="berkowitz") == 123
-    assert M.det(method="lu") == 123
-
-    M = Matrix(( (x, y, z),
-                 (1, 0, 0),
-                 (y, z, x) ))
-
-    assert M.det(method="domain-ge") == z**2 - x*y
-    assert M.det(method="bareiss") == z**2 - x*y
-    assert M.det(method="berkowitz") == z**2 - x*y
-    assert M.det(method="lu") == z**2 - x*y
-
-    # issue 13835
+def test_issue_13835():
     a = symbols('a')
     M = lambda n: Matrix([[i + a*j for i in range(n)]
                           for j in range(n)])
     assert M(5).det() == 0
     assert M(6).det() == 0
     assert M(7).det() == 0
+
 
 def test_issue_14517():
     M = Matrix([
@@ -182,86 +105,25 @@ def test_issue_14517():
     test_ev = random.choice(list(ev.keys()))
     assert (M - test_ev*eye(4)).det() == 0
 
-def test_legacy_det():
+
+@pytest.mark.parametrize("method", [
+    "bareis", "det_lu", "det_LU", "Bareis", "BAREISS", "BERKOWITZ", "LU"])
+@pytest.mark.parametrize("M, sol", [
+    (Matrix(( ( 3, -2,  0, 5),
+              (-2,  1, -2, 2),
+              ( 0, -2,  5, 0),
+              ( 5,  0,  3, 4) )), -289),
+    (Matrix(( (-5,  2,  3,  4,  5),
+              ( 1, -4,  3,  4,  5),
+              ( 1,  2, -3,  4,  5),
+              ( 1,  2,  3, -2,  5),
+              ( 1,  2,  3,  4, -1) )), 11664),
+])
+def test_legacy_det(method, M, sol):
     # Minimal support for legacy keys for 'method' in det()
     # Partially copied from test_determinant()
+    assert M.det(method=method) == sol
 
-    M = Matrix(( ( 3, -2,  0, 5),
-                 (-2,  1, -2, 2),
-                 ( 0, -2,  5, 0),
-                 ( 5,  0,  3, 4) ))
-
-    assert M.det(method="bareis") == -289
-    assert M.det(method="det_lu") == -289
-    assert M.det(method="det_LU") == -289
-
-    M = Matrix(( (3, 2, 0, 0, 0),
-                 (0, 3, 2, 0, 0),
-                 (0, 0, 3, 2, 0),
-                 (0, 0, 0, 3, 2),
-                 (2, 0, 0, 0, 3) ))
-
-    assert M.det(method="bareis") == 275
-    assert M.det(method="det_lu") == 275
-    assert M.det(method="Bareis") == 275
-
-    M = Matrix(( (1, 0,  1,  2, 12),
-                 (2, 0,  1,  1,  4),
-                 (2, 1,  1, -1,  3),
-                 (3, 2, -1,  1,  8),
-                 (1, 1,  1,  0,  6) ))
-
-    assert M.det(method="bareis") == -55
-    assert M.det(method="det_lu") == -55
-    assert M.det(method="BAREISS") == -55
-
-    M = Matrix(( ( 3,  0,  0, 0),
-                 (-2,  1,  0, 0),
-                 ( 0, -2,  5, 0),
-                 ( 5,  0,  3, 4) ))
-
-    assert M.det(method="bareiss") == 60
-    assert M.det(method="berkowitz") == 60
-    assert M.det(method="lu") == 60
-
-    M = Matrix(( ( 1,  0,  0,  0),
-                 ( 5,  0,  0,  0),
-                 ( 9, 10, 11, 0),
-                 (13, 14, 15, 16) ))
-
-    assert M.det(method="bareiss") == 0
-    assert M.det(method="berkowitz") == 0
-    assert M.det(method="lu") == 0
-
-    M = Matrix(( (3, 2, 0, 0, 0),
-                 (0, 3, 2, 0, 0),
-                 (0, 0, 3, 2, 0),
-                 (0, 0, 0, 3, 2),
-                 (0, 0, 0, 0, 3) ))
-
-    assert M.det(method="bareiss") == 243
-    assert M.det(method="berkowitz") == 243
-    assert M.det(method="lu") == 243
-
-    M = Matrix(( (-5,  2,  3,  4,  5),
-                 ( 1, -4,  3,  4,  5),
-                 ( 1,  2, -3,  4,  5),
-                 ( 1,  2,  3, -2,  5),
-                 ( 1,  2,  3,  4, -1) ))
-
-    assert M.det(method="bareis") == 11664
-    assert M.det(method="det_lu") == 11664
-    assert M.det(method="BERKOWITZ") == 11664
-
-    M = Matrix(( ( 2,  7, -1, 3, 2),
-                 ( 0,  0,  1, 0, 1),
-                 (-2,  0,  7, 0, 2),
-                 (-3, -2,  4, 5, 3),
-                 ( 1,  0,  0, 0, 1) ))
-
-    assert M.det(method="bareis") == 123
-    assert M.det(method="det_lu") == 123
-    assert M.det(method="LU") == 123
 
 def eye_Determinant(n):
     return Matrix(n, n, lambda i, j: int(i == j))

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -10,6 +10,7 @@ from sympy.matrices import (
     ImmutableMatrix, Matrix, eye, ones, ImmutableDenseMatrix, dotprodsimp)
 from sympy.testing.pytest import raises
 from sympy.matrices.common import NonInvertibleMatrixError
+from sympy.polys.matrices.exceptions import DMShapeError
 from sympy.solvers.solveset import linsolve
 from sympy.abc import x, y
 
@@ -582,11 +583,13 @@ def test_cramer_solve(det_method, M, rhs):
                     ) == Matrix.zeros(M.rows, rhs.cols)
 
 
-def test_cramer_solve_errors():
+@pytest.mark.parametrize("det_method, error", [
+    ("bird", DMShapeError), ("laplace", NonSquareMatrixError)])
+def test_cramer_solve_errors(det_method, error):
     # Non-square matrix
     A = Matrix([[0, -1, 2], [5, 10, 7]])
     b = Matrix([-2, 15])
-    raises(NonSquareMatrixError, lambda: A.cramer_solve(b))
+    raises(error, lambda: A.cramer_solve(b, det_method=det_method))
 
 
 def test_solve():

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -570,14 +570,15 @@ def test_linsolve_underdetermined_AND_gauss_jordan_solve():
     assert sol_2 == Matrix([[0], [0], [0]])
 
 
+@pytest.mark.parametrize("det_method", ["bird", "laplace"])
 @pytest.mark.parametrize("M, rhs", [
     (Matrix([[2, 3, 5], [3, 6, 2], [8, 3, 6]]), Matrix(3, 1, [3, 7, 5])),
     (Matrix([[2, 3, 5], [3, 6, 2], [8, 3, 6]]),
      Matrix([[1, 2], [3, 4], [5, 6]])),
     (Matrix(2, 2, symbols("a:4")), Matrix(2, 1, symbols("b:2"))),
 ])
-def test_cramer_solve(M, rhs):
-    assert simplify(M.cramer_solve(rhs) - M.LUsolve(rhs)
+def test_cramer_solve(det_method, M, rhs):
+    assert simplify(M.cramer_solve(rhs, det_method=det_method) - M.LUsolve(rhs)
                     ) == Matrix.zeros(M.rows, rhs.cols)
 
 

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -8,6 +8,7 @@ from sympy.simplify.simplify import simplify
 from sympy.matrices.matrices import (ShapeError, NonSquareMatrixError)
 from sympy.matrices import (
     ImmutableMatrix, Matrix, eye, ones, ImmutableDenseMatrix, dotprodsimp)
+from sympy.matrices.determinant import _det_laplace
 from sympy.testing.pytest import raises
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.polys.matrices.exceptions import DMShapeError
@@ -584,7 +585,7 @@ def test_cramer_solve(det_method, M, rhs):
 
 
 @pytest.mark.parametrize("det_method, error", [
-    ("bird", DMShapeError), ("laplace", NonSquareMatrixError)])
+    ("bird", DMShapeError), (_det_laplace, NonSquareMatrixError)])
 def test_cramer_solve_errors(det_method, error):
     # Non-square matrix
     A = Matrix([[0, -1, 2], [5, 10, 7]])

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -1,3 +1,4 @@
+import pytest
 from sympy.core.function import expand_mul
 from sympy.core.numbers import (I, Rational)
 from sympy.core.singleton import S
@@ -567,6 +568,24 @@ def test_linsolve_underdetermined_AND_gauss_jordan_solve():
     # https://github.com/sympy/sympy/issues/19815
     sol_2 = A[:, : -1 ] * sol_1 - A[:, -1 ]
     assert sol_2 == Matrix([[0], [0], [0]])
+
+
+@pytest.mark.parametrize("M, rhs", [
+    (Matrix([[2, 3, 5], [3, 6, 2], [8, 3, 6]]), Matrix(3, 1, [3, 7, 5])),
+    (Matrix([[2, 3, 5], [3, 6, 2], [8, 3, 6]]),
+     Matrix([[1, 2], [3, 4], [5, 6]])),
+    (Matrix(2, 2, symbols("a:4")), Matrix(2, 1, symbols("b:2"))),
+])
+def test_cramer_solve(M, rhs):
+    assert simplify(M.cramer_solve(rhs) - M.LUsolve(rhs)
+                    ) == Matrix.zeros(M.rows, rhs.cols)
+
+
+def test_cramer_solve_errors():
+    # Non-square matrix
+    A = Matrix([[0, -1, 2], [5, 10, 7]])
+    b = Matrix([-2, 15])
+    raises(NonSquareMatrixError, lambda: A.cramer_solve(b))
 
 
 def test_solve():

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -90,6 +90,11 @@ class KanesMethod(_Methods):
     number of operations. The weakness of this method is that it can result in zero
     division errors.
 
+    If zero divisions are encountered, a possible solver which may solve the problem
+    is ``"CRAMER"``. This method uses Cramer's rule to solve the system. This method
+    is slower and results in more operations than the default solver. However it only
+    uses a single division by default per equation.
+
     While a valid list of solvers can be found at
     :meth:`sympy.matrices.matrices.MatrixBase.solve`, it is also possible to supply a
     `callable`. This way it is possible to use a different solver routine. If the

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -93,7 +93,7 @@ class KanesMethod(_Methods):
     If zero divisions are encountered, a possible solver which may solve the problem
     is ``"CRAMER"``. This method uses Cramer's rule to solve the system. This method
     is slower and results in more operations than the default solver. However it only
-    uses a single division by default per equation.
+    uses a single division by default per entry of the solution.
 
     While a valid list of solvers can be found at
     :meth:`sympy.matrices.matrices.MatrixBase.solve`, it is also possible to supply a

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,4 +1,3 @@
-from sympy import cacheit, zeros, ImmutableMatrix
 from sympy.core.numbers import pi
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -8,33 +7,6 @@ from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols,
                                      KanesMethod, inertia, Point, RigidBody,
                                      dot)
 from sympy.testing.pytest import slow
-
-
-# TODO : This is a temporary implementation and can be removed once we support
-# a new matrix solver A.CramerSolve(b).
-@cacheit
-def det_laplace(matrix):
-    n = matrix.shape[0]
-    if n == 1:
-        return matrix[0]
-    elif n == 2:
-        return matrix[0, 0] * matrix[1, 1] - matrix[0, 1] * matrix[1, 0]
-    else:
-        return sum((-1) ** i * matrix[0, i] *
-                   det_laplace(matrix.minor_submatrix(0, i)) for i in range(n))
-
-
-def cramer_solve(A, b, det_method=det_laplace):
-    def entry(i, j):
-        return b[i, sol] if j == col else A[i, j]
-
-    A_imu = ImmutableMatrix(A)  # Convert to immutable for cache purposes
-    det_A = det_method(A_imu)
-    x = zeros(*b.shape)
-    for sol in range(b.shape[1]):
-        for col in range(b.shape[0]):
-            x[col, sol] = det_method(ImmutableMatrix(*A.shape, entry)) / det_A
-    return x
 
 
 @slow
@@ -206,7 +178,7 @@ def test_bicycle():
             u_ind=[u2, u3, u5],
             u_dependent=[u1, u4, u6], velocity_constraints=conlist_speed,
             kd_eqs=kd,
-            constraint_solver=cramer_solve)
+            constraint_solver="CRAMER")
     (fr, frstar) = KM.kanes_equations(BL, FL)
 
     # This is the start of entering in the numerical values from the benchmark
@@ -311,7 +283,7 @@ def test_bicycle():
             q4: 0,
             q5: 0,
         },
-        linear_solver=cramer_solve,
+        linear_solver="CRAMER",
     )
     # As mentioned above, the size of the linearized forcing terms is expanded
     # to include both q's and u's, so the mass matrix must have this done as


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially fixes #24780

#### Brief description of what is fixed or changed
This PR implements a solver based on Cramer's rule in combination with a division-free determinants. The advantage of Cramer's rule is that it will less likely cause zero divisions. This is due to the fact that it only uses one division per entry of the solution, assuming a division free determinant is used.

#### Other comments
Currently the Laplace determinant has been chosen as division-free algorithm. While Laplace as division-free algorithm has a decent speed for dense symbolic matrices as shown [here](https://github.com/sympy/sympy/issues/24780#issuecomment-1464734921), even though it is $\mathcal{O}(n!)$, it is probably better to use Bird's algorithm as @oscarbenjamin proposes [here](https://github.com/sympy/sympy/issues/24780#issuecomment-1462349131). However I'm unsure how and where it would be best to implement this algorithm, due to its usage of domain matrices. If we choose to let it use domain matrices, then it is probably also better if `cramer_solve` is able to directly use domain matrices as well to avoid unnecessary converting of types.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added a new solver based on Cramer's rule.
  * Added a new determinant computation based on Bird's algorithm.
  * Added a new determinant computation, which uses Laplace expansion.
<!-- END RELEASE NOTES -->
