### PR TITLE
Refactoring of `nextprime`

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -544,7 +544,23 @@ class primepi(Function):
 def nextprime(n, ith=1):
     """ Return the ith prime greater than n.
 
-        i must be an integer.
+        Parameters
+        ==========
+
+        n : integer
+        ith : positive integer
+
+        Returns
+        =======
+
+        int : Return the ith prime greater than n
+
+        Raises
+        ======
+
+        ValueError
+            If ``ith <= 0``.
+            If ``n`` or ``ith`` is not an integer.
 
         Notes
         =====
@@ -567,26 +583,20 @@ def nextprime(n, ith=1):
     """
     n = int(n)
     i = as_int(ith)
-    if i > 1:
-        pr = n
-        j = 1
-        while 1:
-            pr = nextprime(pr)
-            j += 1
-            if j > i:
-                break
-        return pr
-
+    if i <= 0:
+        raise ValueError("ith should be positive")
     if n < 2:
-        return 2
-    if n < 7:
-        return {2: 3, 3: 5, 4: 5, 5: 7, 6: 7}[n]
+        n = 2
+        i -= 1
     if n <= sieve._list[-2]:
-        l, u = sieve.search(n)
-        if l == u:
-            return sieve[u + 1]
-        else:
-            return sieve[u]
+        l, _ = sieve.search(n)
+        if l + i - 1 < len(sieve._list):
+            return sieve._list[l + i - 1]
+        return nextprime(sieve._list[-1], l + i - len(sieve._list))
+    if 1 < i:
+        for _ in range(i):
+            n = nextprime(n)
+        return n
     nn = 6*(n//6)
     if nn == n:
         n += 1

--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -129,6 +129,16 @@ def test_generate():
 
     assert nextprime(90) == 97
     assert nextprime(10**40) == (10**40 + 121)
+    primelist = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31,
+                 37, 41, 43, 47, 53, 59, 61, 67, 71, 73,
+                 79, 83, 89, 97]
+    for i in range(len(primelist) - 2):
+        for j in range(2, len(primelist) - i):
+            assert nextprime(primelist[i], j) == primelist[i + j]
+            if 3 < i:
+                assert nextprime(primelist[i] - 1, j) == primelist[i + j - 1]
+    raises(ValueError, lambda: nextprime(2, 0))
+    raises(ValueError, lambda: nextprime(2, -1))
     assert prevprime(97) == 89
     assert prevprime(10**40) == (10**40 - 17)
 


### PR DESCRIPTION
* Added docstring
* Raise error when ith is not a positive integer
* The number of calls to `nextprime`, which used to occur `ith` times, has been reduced by referencing `sieve`.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
