### PR TITLE
Fix caching of TensorHead

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1805,7 +1805,7 @@ class TensorHead(Basic):
         else:
             assert symmetry.rank == len(index_types)
 
-        obj = Basic.__new__(cls, name_symbol, Tuple(*index_types), symmetry)
+        obj = Basic.__new__(cls, name_symbol, Tuple(*index_types), symmetry, sympify(comm))
         obj.comm = TensorManager.comm_symbols2i(comm)
         return obj
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1815,7 +1815,6 @@ class TensorHead(Basic):
             assert symmetry.rank == len(index_types)
 
         obj = Basic.__new__(cls, name_symbol, Tuple(*index_types), symmetry, sympify(comm))
-        obj.comm = TensorManager.comm_symbols2i(comm)
         return obj
 
     @property
@@ -1829,6 +1828,10 @@ class TensorHead(Basic):
     @property
     def symmetry(self):
         return self.args[2]
+
+    @property
+    def comm(self):
+        return TensorManager.comm_symbols2i(self.args[3])
 
     @property
     def rank(self):
@@ -4271,10 +4274,12 @@ class WildTensorHead(TensorHead):
             raise NotImplementedError("Wild matching based on symmetry is not implemented.")
 
         obj = Basic.__new__(cls, name_symbol, Tuple(*index_types), sympify(symmetry), sympify(comm), sympify(unordered_indices))
-        obj.comm = TensorManager.comm_symbols2i(comm)
-        obj.unordered_indices = unordered_indices
 
         return obj
+
+    @property
+    def unordered_indices(self):
+        return self.args[4]
 
     def __call__(self, *indices, **kwargs):
         tensor = WildTensor(self, indices, **kwargs)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -43,6 +43,7 @@ from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
+from sympy.core.cache import clear_cache
 from sympy.core.containers import Tuple, Dict
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Symbol, symbols
@@ -920,6 +921,14 @@ class _TensorManager:
         nj = self._comm_symbols2i[j]
         self._comm[ni][nj] = c
         self._comm[nj][ni] = c
+
+        """
+        Cached sympy functions (e.g. expand) may have cached the results of
+        expressions involving tensors, but those results may not be valid after
+        changing the commutation properties. To stay on the safe side, we clear
+        the cache of all functions.
+        """
+        clear_cache()
 
     def set_comms(self, *args):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -903,6 +903,9 @@ class _TensorManager:
         if c not in (0, 1, None):
             raise ValueError('`c` can assume only the values 0, 1 or None')
 
+        i = sympify(i)
+        j = sympify(j)
+
         if i not in self._comm_symbols2i:
             n = len(self._comm)
             self._comm.append({})


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier, the commutation group of a tensor was set as a property of the Python object (not as one of the args of the corresponding `Basic` instance). Due to this, functions that use sympy's cache (e.g. `simplify`) would not distinguish between tensors with the same name but different commutation properties.

Now, the commutation group (the argument `comm`) is one of the args of the generated Basic object.

Since the user can change commutation properties of tensors (I believe it would be rare to do this more than once per session), we now clear Sympy's cache each time the user does this.

#### Other comments
This is needed in order to make TensExpr reuse sympy's core expand function (future PR).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
