### PR TITLE
Added a test for the unused array function parameter in the C code generator

### DIFF
--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -651,7 +651,6 @@ def test_ccode_unused_array_arg_func():
         '}\n'
     )
     assert source == expected
-    
 
 def test_empty_f_code():
     code_gen = FCodeGen()

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -633,6 +633,26 @@ def test_ccode_unused_array_arg():
     )
     assert source == expected
 
+def test_ccode_unused_array_arg_func():
+    # issue 16689
+    X = MatrixSymbol('X',3,1)
+    Y = MatrixSymbol('Y',3,1)
+    z = symbols('z',integer = True)
+    name_expr = ('testBug', X[0] + X[1])
+    result = codegen(name_expr, language='C', header=False, empty=False, argument_sequence=(X, Y, z))
+    source = result[0][1]
+    expected = (
+        '#include "testBug.h"\n'
+        '#include <math.h>\n'
+        'double testBug(double *X, double *Y, int z) {\n'
+        '   double testBug_result;\n'
+        '   testBug_result = X[0] + X[1];\n'
+        '   return testBug_result;\n'
+        '}\n'
+    )
+    assert source == expected
+    
+
 def test_empty_f_code():
     code_gen = FCodeGen()
     source = get_string(code_gen.dump_f95, [])
@@ -1554,7 +1574,7 @@ def test_custom_codegen():
     assert source == expected
 
 def test_c_with_printer():
-    #issue 13586
+    # issue 13586
     from sympy.printing.c import C99CodePrinter
     class CustomPrinter(C99CodePrinter):
         def _print_Pow(self, expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
As discussed in #16689, I added a regression test for the unused function parameter bug.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
