### PR TITLE
 `Determinant.doit()` performs recursive call to its arguments `doit()` methods

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1566,7 +1566,7 @@ ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>
 znxftw <vishnu2101@gmail.com>
 zsc347 <zsc347@gmail.com>
 zzc <1378113190@qq.com>
-zzc <58017008+zzc0430@users.noreply.github.com>c
+zzc <58017008+zzc0430@users.noreply.github.com>
 zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -919,6 +919,7 @@ Matthew Wardrop <matthew.wardrop@airbnb.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com>
 Matthias Geier <Matthias.Geier@gmail.com>
 Matthias Köppe <mkoeppe@math.ucdavis.edu> Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
 Matthias Toews <mat.toews@googlemail.com>
 Mauro Garavello <mauro.garavello@unimib.it>
 Max Hutchinson <maxhutch@gmail.com>
@@ -1565,7 +1566,7 @@ ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>
 znxftw <vishnu2101@gmail.com>
 zsc347 <zsc347@gmail.com>
 zzc <1378113190@qq.com>
-zzc <58017008+zzc0430@users.noreply.github.com>
+zzc <58017008+zzc0430@users.noreply.github.com>c
 zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -49,7 +49,7 @@ class Determinant(Expr):
         if result is not None:
             return result
 
-        return Determinant(arg)
+        return self
 
 
 def det(matexpr):

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -3,7 +3,6 @@ from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.matrices.common import NonSquareMatrixError
-from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
 class Determinant(Expr):

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -3,6 +3,7 @@ from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.matrices.common import NonSquareMatrixError
+from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
 class Determinant(Expr):
@@ -45,11 +46,9 @@ class Determinant(Expr):
         if hints.get('deep', True):
             arg = arg.doit(**hints)
 
-        _eval_determinant = getattr(arg, '_eval_determinant', None)
-        if _eval_determinant is not None:
-            result = _eval_determinant()
-            if result is not None:
-                return result
+        result = arg._eval_determinant()
+        if result is not None:
+            return result
 
         return Determinant(arg)
 

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -40,11 +40,19 @@ class Determinant(Expr):
     def kind(self):
         return self.arg.kind.element_kind
 
-    def doit(self, expand=False, **hints):
-        try:
-            return self.arg._eval_determinant()
-        except (AttributeError, NotImplementedError):
-            return self
+    def doit(self, **hints):
+        arg = self.arg
+        if hints.get('deep', True):
+            arg = arg.doit(**hints)
+
+        _eval_determinant = getattr(arg, '_eval_determinant', None)
+        if _eval_determinant is not None:
+            result = _eval_determinant()
+            if result is not None:
+                return result
+
+        return Determinant(arg)
+
 
 def det(matexpr):
     """ Matrix Determinant

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -3,7 +3,7 @@ from sympy.matrices import eye, ones, Matrix, ShapeError
 from sympy.matrices.expressions import (
     Identity, MatrixExpr, MatrixSymbol, Determinant,
     det, per, ZeroMatrix, Transpose,
-    Permanent
+    Permanent, MatMul
 )
 from sympy.matrices.expressions.special import OneMatrix
 from sympy.testing.pytest import raises
@@ -28,6 +28,7 @@ def test_det():
 
     assert Determinant(A).arg is A
 
+
 def test_eval_determinant():
     assert det(Identity(n)) == 1
     assert det(ZeroMatrix(n, n)) == 0
@@ -35,6 +36,7 @@ def test_eval_determinant():
     assert det(OneMatrix(1, 1)) == 1
     assert det(OneMatrix(2, 2)) == 0
     assert det(Transpose(A)) == det(A)
+    assert Determinant(MatMul(eye(2), eye(2))).doit(deep=True) == 1
 
 
 def test_refine():
@@ -50,6 +52,7 @@ def test_commutative():
     assert det_a.is_commutative
     assert det_b.is_commutative
     assert det_a * det_b == det_b * det_a
+
 
 def test_permanent():
     assert isinstance(Permanent(A), Permanent)


### PR DESCRIPTION
Fixes #25053 

<!--  Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
Contrary, to the `doit()` methods of other matrix expressions, `Determinant.doit()` did not perform a `deep` doit.
This means, it did not call the `doit()` methods of its argument. This might result in unexpected results as shown in the example.

```python
>>> Determinant(MatMul(eye(2), eye(2)).doit()
Determinant(Matrix([
[1, 0],
[0, 1]]))**2
```

Now, the method `Determinant.doit()` performs a recursive call by default.
This returns now 1.

```python
>>> Determinant(MatMul(eye(2), eye(2)).doit()
1
```

The recurisve call can still be turned off  by setting the `deep` argument to `False` (`Determinant.doit(deep=False)`).  

A new test line has been added to test this behaviour.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed Determinant.doit()
<!-- END RELEASE NOTES -->