### PR TITLE
Extend matrix refinement (diagonal/hermitian)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1539,6 +1539,7 @@ rushyam <rushyamsonu@gmail.com>
 sbt4104 <sthorat661@gmail.com>
 scimax <max.kellermeier@hotmail.de>
 seadavis <45022599+seadavis@users.noreply.github.com>
+senselessDev <senselessDev@users.noreply.github.com>
 sevaader <sevaader@gmail.com>
 sfoo <sfoohei@gmail.com>
 sharma-kunal <kunalsharma6914@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -373,7 +373,7 @@ def refine_sign(expr, assumptions):
 
 def refine_matrixelement(expr, assumptions):
     """
-    Handler for symmetric part.
+    Handler for matrix elements.
 
     Examples
     ========
@@ -385,13 +385,30 @@ def refine_matrixelement(expr, assumptions):
     X[0, 1]
     >>> refine_matrixelement(X[1, 0], Q.symmetric(X))
     X[0, 1]
+    >>> refine_matrixelement(X[1, 0], Q.hermitian(X))
+    conjugate(X[0, 1])
+    >>> refine_matrixelement(X[0, 0], Q.diagonal(X))
+    (X[0, 0])
+    >>> refine_matrixelement(X[0, 1], Q.diagonal(X))
+    0
     """
     from sympy.matrices.expressions.matexpr import MatrixElement
     matrix, i, j = expr.args
+    if ask(Q.diagonal(matrix), assumptions):
+        if i == j:
+            return expr
+        return S.Zero
     if ask(Q.symmetric(matrix), assumptions):
         if (i - j).could_extract_minus_sign():
             return expr
         return MatrixElement(matrix, j, i)
+    if ask(Q.hermitian(matrix), assumptions):
+        diff = i - j
+        # following zero diff checking is necessary to avoid infinite recursion
+        # (different to 'symmetric', where the diagonal elements are not changed)
+        if diff.is_zero or diff.could_extract_minus_sign():
+            return expr
+        return MatrixElement(matrix, j, i).conjugate()
 
 handlers_dict: dict[str, Callable[[Expr, Boolean], Expr]] = {
     'Abs': refine_abs,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -388,7 +388,7 @@ def refine_matrixelement(expr, assumptions):
     >>> refine_matrixelement(X[1, 0], Q.hermitian(X))
     conjugate(X[0, 1])
     >>> refine_matrixelement(X[0, 0], Q.diagonal(X))
-    (X[0, 0])
+    X[0, 0]
     >>> refine_matrixelement(X[0, 1], Q.diagonal(X))
     0
     """

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -221,7 +221,13 @@ def test_matrixelement():
     x = MatrixSymbol('x', 3, 3)
     i = Symbol('i', positive = True)
     j = Symbol('j', positive = True)
+    assert refine(x[i, i], Q.diagonal(x)) == x[i, i]
+    assert refine(x[i, i + 1], Q.diagonal(x)) == 0
     assert refine(x[0, 1], Q.symmetric(x)) == x[0, 1]
     assert refine(x[1, 0], Q.symmetric(x)) == x[0, 1]
     assert refine(x[i, j], Q.symmetric(x)) == x[j, i]
     assert refine(x[j, i], Q.symmetric(x)) == x[j, i]
+    assert refine(x[0, 1], Q.hermitian(x)) == x[0, 1]
+    assert refine(x[1, 0], Q.hermitian(x)) == x[0, 1].conjugate()
+    assert refine(x[i, j], Q.hermitian(x)) == x[j, i].conjugate()
+    assert refine(x[j, i], Q.hermitian(x)) == x[j, i]


### PR DESCRIPTION
#### References to other Issues or PRs
* similar to #18681 

#### Brief description of what is fixed or changed
Allow more assumption-based refinement for matrices: diagonal and hermitian.

Simple examples as also given in the docstring:
```python
>>> refine_matrixelement(X[1, 0], Q.hermitian(X))
conjugate(X[0, 1])

>>> refine_matrixelement(X[0, 0], Q.diagonal(X))
X[0, 0]

>>> refine_matrixelement(X[0, 1], Q.diagonal(X))
0
```

Examples for taking advantage of the matrix properties:
```python
>>> sympy.refine(x[1, 0] + x[0, 1], sympy.Q.hermitian(x)).expand(complex=True)
2*re(x[0, 1])

>>> sympy.refine(x.T, sympy.Q.diagonal(x))
x
```

#### Other comments
None

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Extend `refine` function for hermitian and diagonal matrices
<!-- END RELEASE NOTES -->
