### PR TITLE
Improve distance for symbolic case

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -298,7 +298,7 @@ class Plane(GeometryEntity):
                 return S.Zero
             else:
                 # Store values to return `Piecewise` answer.
-                conditions = set(Eq(var, expr) for dictionary in singularity_points for var, exprs in dictionary.items() for expr in exprs)
+                conditions = {Eq(var, expr) for dictionary in singularity_points for var, exprs in dictionary.items() for expr in exprs}
                 piecewise_answer = True
 
         if isinstance(o, (Segment3D, Ray3D)):

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -1,15 +1,20 @@
+from sympy.core import Eq
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (asin, cos, sin)
 from sympy.geometry import Line, Point, Ray, Segment, Point3D, Line3D, Ray3D, Segment3D, Plane, Circle
 from sympy.geometry.util import are_coplanar
+from sympy.logic import And
 from sympy.testing.pytest import raises
 
 
+
 def test_plane():
-    x, y, z, u, v = symbols('x y z u v', real=True)
+    x, y, z, u, v, w = symbols('x y z u v w', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)
@@ -115,7 +120,8 @@ def test_plane():
     assert pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
     assert pl6.distance(Ray3D(Point3D(1, 3, 4), direction_ratio=[1, 0, -3])) == 4*sqrt(3)/3
     assert pl6.distance(Ray3D(Point3D(2, 3, 1), direction_ratio=[-1, 0, 3])) == 0
-
+    assert pl4.distance(Line((x,y,z),(1,1,1))) == Piecewise((Abs(sqrt(3)*x/3 + sqrt(3)*y/3 + sqrt(3)*z/3), Eq(x, -y - z + 3) & Eq(y, -x - z + 3) & Eq(z, -x - y + 3)), (0, True))
+    assert pl4.distance(Line((x,y,z),(u,v,w))) == Piecewise((Abs(sqrt(3)*x/3 + sqrt(3)*y/3 + sqrt(3)*z/3), Eq(u, -v - w + x + y + z) & Eq(v, -u - w + x + y + z) & Eq(w, -u - v + x + y + z) & Eq(x, u + v + w - y - z) & Eq(y, u + v + w - x - z) & Eq(z, u + v + w - x - y)), (0, True))
 
     assert pl6.angle_between(pl3) == pi/2
     assert pl6.angle_between(pl6) == 0

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -8,7 +8,6 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (asin, cos, sin)
 from sympy.geometry import Line, Point, Ray, Segment, Point3D, Line3D, Ray3D, Segment3D, Plane, Circle
 from sympy.geometry.util import are_coplanar
-from sympy.logic import And
 from sympy.testing.pytest import raises
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25157 

#### Brief description of what is fixed or changed
Implemented Piecewise solution described in the issue. 

#### Other comments
Note some of the conditions are duplicated for Piecewise answer (see tests). However, this should be handled in another function which is outside the scope of the issue. (eg currently `And(Eq(x,y),Eq(y,x)) = Eq(x,y)`. This could be expanded to do the same for more complicated equations.)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed a bug with Plane.distance() for symbolic case. Formerly, Plane.distance() did not account for singularities when
  dealing with symbols.
<!-- END RELEASE NOTES -->
