### PR TITLE
Fix factorial parsing for Python 3.12

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.12.0-alpha - 3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.12', 'pypy-3.8']
         experimental: [false]
         group: [1, 2, 3, 4]
         # Maybe use this to add 3.12 when the time comes:
@@ -308,7 +308,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.12.0-alpha - 3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.12', 'pypy-3.8']
         experimental: [false]
         # Maybe use this to add 3.12 when the time comes:
         #include:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.12-dev', 'pypy-3.8']
         experimental: [false]
         group: [1, 2, 3, 4]
         # Maybe use this to add 3.12 when the time comes:
@@ -308,7 +308,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.12-dev', 'pypy-3.8']
         experimental: [false]
         # Maybe use this to add 3.12 when the time comes:
         #include:

--- a/.mailmap
+++ b/.mailmap
@@ -1030,6 +1030,10 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
+Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo Salgado <Pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <Pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
 Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
 Pan Peng <pengpanster@gmail.com>
@@ -1523,7 +1527,6 @@ naelsondouglas <naelson17@gmail.com>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
-pablogsal <pablogsal@gmail.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 prshnt19 <prashant.rawat216@gmail.com>
 rahuldan <rahul02013@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1523,6 +1523,7 @@ naelsondouglas <naelson17@gmail.com>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
+pablogsal <pablogsal@gmail.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 prshnt19 <prashant.rawat216@gmail.com>
 rahuldan <rahul02013@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -627,7 +627,10 @@ def factorial_notation(tokens: List[TOKEN], local_dict: DICT, global_dict: DICT)
     result: List[TOKEN] = []
     nfactorial = 0
     for toknum, tokval in tokens:
-        if toknum == ERRORTOKEN:
+        if toknum == OP and tokval == "!":
+            # In Python 3.12 "!" are OP instead of ERRORTOKEN
+            nfactorial += 1
+        elif toknum == ERRORTOKEN:
             op = tokval
             if op == '!':
                 nfactorial += 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Relates to #25185

#### Brief description of what is fixed or changed

This PR fixes the parsing of the factorial syntax to account for the token value changes of 3.12 (ERRORTOKEN -> OP).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * Fix parsing of factorial syntax for Python 3.12
<!-- END RELEASE NOTES -->
