### PR TITLE
Fix intersection for symbolics

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1343,6 +1343,7 @@ Tasha Kim <jae_young_kim@brown.edu>
 Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
 Ted Horst <ted.horst@earthlink.net>
 Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Theo Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>
 Thilina Rathnayake <thilinarmtb@gmail.com>

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -394,7 +394,7 @@ class Plane(GeometryEntity):
                 return [o]
             # Check for symbolic case.
             elif any(isinstance(i, Symbol) for i in o) or any(i for i in symbolic_self):
-                return [Piecewise((o,Eq((o-self.p1).dot(Point3D(self.normal_vector)),0)),(set(),True))]
+                return [Piecewise((o, Eq((o-self.p1).dot(Point3D(self.normal_vector)), 0)),(set(), True))]
             else:
                 return []
         if isinstance(o, (LinearEntity, LinearEntity3D)):
@@ -433,10 +433,10 @@ class Plane(GeometryEntity):
                         conditions_eq = set()
                         conditions_ne = {Eq((o.p2 - o.p1).dot(n), 0), Ne((o.p1 - p1).dot(n), 0)}
                         if symbolic_o[0] or any(i for i in symbolic_self):
-                            conditions_eq.add(Eq((o.p1 - p1).dot(n),0))
+                            conditions_eq.add(Eq((o.p1 - p1).dot(n), 0))
                         if symbolic_o[1] or any(i for i in symbolic_self):
-                            conditions_eq.add(Eq((o.p2 - p1).dot(n),0))
-                        return [Piecewise((o, And(*conditions_eq)),(set(),And(*conditions_ne)),(p, True))]
+                            conditions_eq.add(Eq((o.p2 - p1).dot(n), 0))
+                        return [Piecewise((o, And(*conditions_eq)), (set(), And(*conditions_ne)), (p, True))]
                     return [p]
         if isinstance(o, Plane):
             symbolic_o = [any(isinstance(i, Symbol) for i in o.p1), any(isinstance(i, Symbol) for i in o.normal_vector)]
@@ -445,7 +445,7 @@ class Plane(GeometryEntity):
             if self.is_parallel(o):
                 if symbolic_o[0] or symbolic_self[0] == True:
                     conditions = {Eq(i[0],i[1]) for i in zip(o.p1,self.p1)}
-                    return [Piecewise((self,And(*conditions)),(set(),True))]
+                    return [Piecewise((self, And(*conditions)), (set(),True))]
                 return []
             else:
                 x, y, z = map(Dummy, 'xyz')
@@ -466,7 +466,7 @@ class Plane(GeometryEntity):
                             for i in zip(o.normal_vector, self.normal_vector):
                                 conditions_eq.add(Eq(i[0],i[1]))
                                 conditions_ne.add(Eq(i[0],i[1]))
-                        return [Piecewise((self,And(*conditions_eq)),(set(),And(*conditions_ne)),(Line3D(Point3D(result), direction_ratio=c), True))]
+                        return [Piecewise((self, And(*conditions_eq)), (set(), And(*conditions_ne)), (Line3D(Point3D(result), direction_ratio=c), True))]
                 return [Line3D(Point3D(result), direction_ratio=c)]
 
 

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -11,11 +11,11 @@ from sympy.testing.pytest import raises
 
 
 def test_plane():
-    x, y, z, u, v, w, c, d, e, f, g, h = symbols('x y z u v w c d e f g h', real=True)
+    x, y, z, u, v, w, c, d, e, f, g, h, X, Y, A = symbols('x y z u v w c d e f g h X Y A', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)
-    sp1 = Point3D(x,y,z)
+    sp1 = Point3D(X,Y,A)
     pl3 = Plane(p1, p2, p3)
     pl4 = Plane(p1, normal_vector=(1, 1, 1))
     pl4b = Plane(p1, p2)
@@ -235,9 +235,9 @@ def test_plane():
     assert pl4.intersection(Line((x,y,z),(u,v,w))) == [Piecewise((Line3D(Point3D(x, y, z), Point3D(u, v, w)), Eq(u + v + w, 0) & Eq(x + y + z, 0)), (set(), Ne(x + y + z, 0) & Eq(u + v + w - x - y - z, 0)), (Point3D(x + (u - x)*(x + y + z)/(-u - v - w + x + y + z), y + (v - y)*(x + y + z)/(-u - v - w + x + y + z), z + (w - z)*(x + y + z)/(-u - v - w + x + y + z)), True))]
     assert pl4.intersection(Plane((x,y,z),(1,1,1))) == [Piecewise((Plane(Point3D(0, 0, 0), (1, 1, 1)), Eq(x, 0) & Eq(y, 0) & Eq(z, 0)), (set(), True))]
     assert pl4.intersection(Plane((x,y,z),(u,v,w))) == [Piecewise((Plane(Point3D(0, 0, 0), (1, 1, 1)), Eq(u, 1) & Eq(v, 1) & Eq(w, 1) & Eq(x + y + z, 0)), (set(), Eq(u, 1) & Eq(v, 1) & Eq(w, 1) & Ne(x + y + z, 0)), (Line3D(Point3D((u*x + v*y + w*z)/(u - v), (-u*x - v*y - w*z)/(u - v), 0), Point3D(-v + w + (u*x + v*y + w*z)/(u - v), u - w + (-u*x - v*y - w*z)/(u - v), -u + v)), True))]
-    assert spl1.intersection(Point(c,d,e)) == [Piecewise((Point3D(c, d, e), Eq(u*(c - x) + v*(d - y) + w*(e - z), 0)), (set(), True))]
-    assert spl1.intersection(Line((c,d,e),(f,g,h))) == [Piecewise((Line3D(Point3D(c, d, e), Point3D(f, g, h)), Eq(u*(c - x) + v*(d - y) + w*(e - z), 0) & Eq(u*(f - x) + v*(g - y) + w*(h - z), 0)), (set(), Eq(u*(-c + f) + v*(-d + g) + w*(-e + h), 0) & Ne(u*(c - x) + v*(d - y) + w*(e - z), 0)), (Point3D(c - (c - f)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w), d - (d - g)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w), e - (e - h)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w)), True))]
-    assert spl1.intersection(Plane((c,d,e),(f,g,h))) == [Piecewise((Plane(Point3D(x, y, z), (u, v, w)), Eq(f, u) & Eq(g, v) & Eq(h, w) & Eq(u*(c - x) + v*(d - y) + w*(e - z), 0)), (set(), Eq(f, u) & Eq(g, v) & Eq(h, w) & Ne(u*(c - x) + v*(d - y) + w*(e - z), 0)), (Line3D(Point3D((-c*f*v - d*g*v - e*h*v + g*u*x + g*v*y + g*w*z)/(-f*v + g*u), (c*f*u + d*g*u + e*h*u - f*u*x - f*v*y - f*w*z)/(-f*v + g*u), 0), Point3D(-g*w + h*v + (-c*f*v - d*g*v - e*h*v + g*u*x + g*v*y + g*w*z)/(-f*v + g*u), f*w - h*u + (c*f*u + d*g*u + e*h*u - f*u*x - f*v*y - f*w*z)/(-f*v + g*u), -f*v + g*u)), True))]
+    assert spl1.intersection(Point(c,d,e)) == [Piecewise((Point3D(c, d, e), Eq(u*(c - X) + v*(d - Y) + w*(e - A), 0)), (set(), True))]
+    assert spl1.intersection(Line((c,d,e),(f,g,h))) == [Piecewise((Line3D(Point3D(c, d, e), Point3D(f, g, h)), Eq(u*(c - X) + v*(d - Y) + w*(e - A), 0) & Eq(u*(f - X) + v*(g - Y) + w*(h - A), 0)), (set(), Eq(u*(-c + f) + v*(-d + g) + w*(-e + h), 0) & Ne(u*(c - X) + v*(d - Y) + w*(e - A), 0)), (Point3D(c - (c - f)*(c*u + d*v + e*w - u*X - v*Y - w*A)/(c*u + d*v + e*w - f*u - g*v - h*w), d - (d - g)*(c*u + d*v + e*w - u*X - v*Y - w*A)/(c*u + d*v + e*w - f*u - g*v - h*w), e - (e - h)*(c*u + d*v + e*w - u*X - v*Y - w*A)/(c*u + d*v + e*w - f*u - g*v - h*w)), True))]
+    assert spl1.intersection(Plane((c,d,e),(f,g,h))) == [Piecewise((Plane(Point3D(X, Y, A), (u, v, w)), Eq(f, u) & Eq(g, v) & Eq(h, w) & Eq(u*(c - X) + v*(d - Y) + w*(e - A), 0)), (set(), Eq(f, u) & Eq(g, v) & Eq(h, w) & Ne(u*(c - X) + v*(d - Y) + w*(e - A), 0)), (Line3D(Point3D((-c*f*v - d*g*v - e*h*v + g*u*X + g*v*Y + g*w*A)/(-f*v + g*u), (c*f*u + d*g*u + e*h*u - f*u*X - f*v*Y - f*w*A)/(-f*v + g*u), 0), Point3D(-g*w + h*v + (-c*f*v - d*g*v - e*h*v + g*u*X + g*v*Y + g*w*A)/(-f*v + g*u), f*w - h*u + (c*f*u + d*g*u + e*h*u - f*u*X - f*v*Y - f*w*A)/(-f*v + g*u), -f*v + g*u)), True))]
 
     # issue 8570
     l2 = Line3D(Point3D(Rational(50000004459633, 5000000000000),

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -1,6 +1,8 @@
+from sympy.core import Eq, Ne
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (asin, cos, sin)
 from sympy.geometry import Line, Point, Ray, Segment, Point3D, Line3D, Ray3D, Segment3D, Plane, Circle
@@ -9,10 +11,11 @@ from sympy.testing.pytest import raises
 
 
 def test_plane():
-    x, y, z, u, v = symbols('x y z u v', real=True)
+    x, y, z, u, v, w, c, d, e, f, g, h = symbols('x y z u v w c d e f g h', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)
+    sp1 = Point3D(x,y,z)
     pl3 = Plane(p1, p2, p3)
     pl4 = Plane(p1, normal_vector=(1, 1, 1))
     pl4b = Plane(p1, p2)
@@ -26,6 +29,7 @@ def test_plane():
     l1 = Line3D(Point3D(5, 0, 0), Point3D(1, -1, 1))
     l2 = Line3D(Point3D(0, -2, 0), Point3D(3, 1, 1))
     l3 = Line3D(Point3D(0, -1, 0), Point3D(5, -1, 9))
+    spl1 = Plane(sp1,normal_vector=(u,v,w))
 
     raises(ValueError, lambda: Plane(p1, p1, p1))
 
@@ -224,6 +228,16 @@ def test_plane():
     assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12)))
     assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12*sqrt(3))))
     assert pl8.equals(p1) is False
+
+    # test intersection in symbolic case
+    assert pl4.intersection(Point(x,y,z)) == [Piecewise((Point3D(x, y, z), Eq(x + y + z, 0)), (set(), True))]
+    assert pl4.intersection(Line((x,y,z),(0,0,0))) == [Piecewise((Line3D(Point3D(x, y, z), Point3D(0, 0, 0)), Eq(x + y + z, 0)), (Point3D(0, 0, 0), True))]
+    assert pl4.intersection(Line((x,y,z),(u,v,w))) == [Piecewise((Line3D(Point3D(x, y, z), Point3D(u, v, w)), Eq(u + v + w, 0) & Eq(x + y + z, 0)), (set(), Ne(x + y + z, 0) & Eq(u + v + w - x - y - z, 0)), (Point3D(x + (u - x)*(x + y + z)/(-u - v - w + x + y + z), y + (v - y)*(x + y + z)/(-u - v - w + x + y + z), z + (w - z)*(x + y + z)/(-u - v - w + x + y + z)), True))]
+    assert pl4.intersection(Plane((x,y,z),(1,1,1))) == [Piecewise((Plane(Point3D(0, 0, 0), (1, 1, 1)), Eq(x, 0) & Eq(y, 0) & Eq(z, 0)), (set(), True))]
+    assert pl4.intersection(Plane((x,y,z),(u,v,w))) == [Piecewise((Plane(Point3D(0, 0, 0), (1, 1, 1)), Eq(u, 1) & Eq(v, 1) & Eq(w, 1) & Eq(x + y + z, 0)), (set(), Eq(u, 1) & Eq(v, 1) & Eq(w, 1) & Ne(x + y + z, 0)), (Line3D(Point3D((u*x + v*y + w*z)/(u - v), (-u*x - v*y - w*z)/(u - v), 0), Point3D(-v + w + (u*x + v*y + w*z)/(u - v), u - w + (-u*x - v*y - w*z)/(u - v), -u + v)), True))]
+    assert spl1.intersection(Point(c,d,e)) == [Piecewise((Point3D(c, d, e), Eq(u*(c - x) + v*(d - y) + w*(e - z), 0)), (set(), True))]
+    assert spl1.intersection(Line((c,d,e),(f,g,h))) == [Piecewise((Line3D(Point3D(c, d, e), Point3D(f, g, h)), Eq(u*(c - x) + v*(d - y) + w*(e - z), 0) & Eq(u*(f - x) + v*(g - y) + w*(h - z), 0)), (set(), Eq(u*(-c + f) + v*(-d + g) + w*(-e + h), 0) & Ne(u*(c - x) + v*(d - y) + w*(e - z), 0)), (Point3D(c - (c - f)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w), d - (d - g)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w), e - (e - h)*(c*u + d*v + e*w - u*x - v*y - w*z)/(c*u + d*v + e*w - f*u - g*v - h*w)), True))]
+    assert spl1.intersection(Plane((c,d,e),(f,g,h))) == [Piecewise((Plane(Point3D(x, y, z), (u, v, w)), Eq(f, u) & Eq(g, v) & Eq(h, w) & Eq(u*(c - x) + v*(d - y) + w*(e - z), 0)), (set(), Eq(f, u) & Eq(g, v) & Eq(h, w) & Ne(u*(c - x) + v*(d - y) + w*(e - z), 0)), (Line3D(Point3D((-c*f*v - d*g*v - e*h*v + g*u*x + g*v*y + g*w*z)/(-f*v + g*u), (c*f*u + d*g*u + e*h*u - f*u*x - f*v*y - f*w*z)/(-f*v + g*u), 0), Point3D(-g*w + h*v + (-c*f*v - d*g*v - e*h*v + g*u*x + g*v*y + g*w*z)/(-f*v + g*u), f*w - h*u + (c*f*u + d*g*u + e*h*u - f*u*x - f*v*y - f*w*z)/(-f*v + g*u), -f*v + g*u)), True))]
 
     # issue 8570
     l2 = Line3D(Point3D(Rational(50000004459633, 5000000000000),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25222


#### Brief description of what is fixed or changed
`Plane.intersection` now supports symbolic case by returning `Piecewise` object. It effectively replicates the old logic but turns the conditions into equations to satisfy. 

#### Other comments
Currently, the plane intersecting another plane case won't work. This is due to https://github.com/sympy/sympy/issues/25228. This function is called when assessing `if self.equals(o)`. 

I will make a quick fix for the above and then we should re run the tests on this PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Added symbolic case to `Plane.intersection`. Previously, the results returned were wrong in the symbolic case.
<!-- END RELEASE NOTES -->
