### PR TITLE
Add error msg if there is clash in variables in plane equation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1343,6 +1343,7 @@ Tasha Kim <jae_young_kim@brown.edu>
 Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
 Ted Horst <ted.horst@earthlink.net>
 Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>
 Thilina Rathnayake <thilinarmtb@gmail.com>

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -350,8 +350,8 @@ class Plane(GeometryEntity):
         x, y, z = [i if i else Symbol(j, real=True) for i, j in zip((x, y, z), 'xyz')]
         # https://github.com/sympy/sympy/issues/25228
         if any(i in self.p1.free_symbols for i in [x,y,z]) or any(i in self.normal_vector.free_symbols for i in [x,y,z]):
-            X, Y, Z = symbols('X Y Z', real=True)
-            return self.equation(X, Y, Z)
+            raise NotImplementedError(
+                f"Use different variables than x, y, z for {self} to avoid clash when calcualting plane equation.")
         a = Point3D(x, y, z)
         b = self.p1.direction_ratio(a)
         c = self.normal_vector

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -6,7 +6,7 @@ Plane
 
 """
 
-from sympy.core import Dummy, Rational, S, Symbol, symbols
+from sympy.core import Dummy, Rational, S, Symbol
 from sympy.core.symbol import _symbol
 from sympy.functions.elementary.trigonometric import cos, sin, acos, asin, sqrt
 from .entity import GeometryEntity

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -6,7 +6,7 @@ Plane
 
 """
 
-from sympy.core import Dummy, Rational, S, Symbol
+from sympy.core import Dummy, Rational, S, Symbol, symbols
 from sympy.core.symbol import _symbol
 from sympy.functions.elementary.trigonometric import cos, sin, acos, asin, sqrt
 from .entity import GeometryEntity
@@ -348,6 +348,10 @@ class Plane(GeometryEntity):
 
         """
         x, y, z = [i if i else Symbol(j, real=True) for i, j in zip((x, y, z), 'xyz')]
+        # https://github.com/sympy/sympy/issues/25228
+        if any(i in self.p1.free_symbols for i in [x,y,z]) or any(i in self.normal_vector.free_symbols for i in [x,y,z]):
+            X, Y, Z = symbols('X Y Z', real=True)
+            return self.equation(X, Y, Z)
         a = Point3D(x, y, z)
         b = self.p1.direction_ratio(a)
         c = self.normal_vector

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -9,7 +9,7 @@ from sympy.testing.pytest import raises
 
 
 def test_plane():
-    x, y, z, u, v, X, Y, Z = symbols('x y z u v X Y Z', real=True)
+    x, y, z, u, v= symbols('x y z u v', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -9,7 +9,7 @@ from sympy.testing.pytest import raises
 
 
 def test_plane():
-    x, y, z, u, v= symbols('x y z u v', real=True)
+    x, y, z, u, v = symbols('x y z u v', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -9,7 +9,7 @@ from sympy.testing.pytest import raises
 
 
 def test_plane():
-    x, y, z, u, v = symbols('x y z u v', real=True)
+    x, y, z, u, v, X, Y, Z = symbols('x y z u v X Y Z', real=True)
     p1 = Point3D(0, 0, 0)
     p2 = Point3D(1, 1, 1)
     p3 = Point3D(1, 2, 3)
@@ -26,6 +26,7 @@ def test_plane():
     l1 = Line3D(Point3D(5, 0, 0), Point3D(1, -1, 1))
     l2 = Line3D(Point3D(0, -2, 0), Point3D(3, 1, 1))
     l3 = Line3D(Point3D(0, -1, 0), Point3D(5, -1, 9))
+    spl1 = Plane((x,y,z),(1,1,1))
 
     raises(ValueError, lambda: Plane(p1, p1, p1))
 
@@ -42,6 +43,7 @@ def test_plane():
 
     assert pl5.equation(x, y, z) == x + 2*y + 3*z - 14
     assert pl3.equation(x, y, z) == x - 2*y + z
+    assert spl1.equation() == X + Y + Z - x - y - z
 
     assert pl3.p1 == p1
     assert pl4.p1 == p1

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -43,8 +43,7 @@ def test_plane():
 
     assert pl5.equation(x, y, z) == x + 2*y + 3*z - 14
     assert pl3.equation(x, y, z) == x - 2*y + z
-    assert spl1.equation() == X + Y + Z - x - y - z
-
+    assert raises(NotImplementedError, lambda: spl1.equation())
     assert pl3.p1 == p1
     assert pl4.p1 == p1
     assert pl5.p1 == p3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/25228

#### Brief description of what is fixed or changed
Updated Plane((x,y,z),(u,v,w)).equation() to raise an error when `x, y, z` are overloaded.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Updated `Plane.equation()` to raise an error if assignment of `x, y, z` clashes with equation.
<!-- END RELEASE NOTES -->
