### PR TITLE
SMT-Lib printing: Handle predicate objects from new assumptions

### DIFF
--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -16,8 +16,10 @@ from sympy.logic.boolalg import BooleanTrue, BooleanFalse, BooleanFunction, Not,
 from sympy.printing.printer import Printer
 from sympy.sets import Interval
 from sympy.assumptions.assume import AppliedPredicate
-from sympy.assumptions.ask import Q
 from sympy.assumptions.relation.binrel import AppliedBinaryRelation
+from sympy.assumptions.ask import Q
+from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
+
 
 class SMTLibPrinter(Printer):
     printmethod = "_smtlib"
@@ -44,11 +46,11 @@ class SMTLibPrinter(Printer):
             StrictLessThan: '<',
             StrictGreaterThan: '>',
 
-            Q.eq: '=',
-            Q.le: '<=',
-            Q.ge: '>=',
-            Q.lt: '<',
-            Q.gt: '>',
+            EqualityPredicate(): '=',
+            LessThanPredicate(): '<=',
+            GreaterThanPredicate(): '>=',
+            StrictLessThanPredicate(): '<',
+            StrictGreaterThanPredicate(): '>',
 
             exp: 'exp',
             log: 'log',
@@ -341,7 +343,6 @@ def smtlib_code(
     ]
 
     if not symbol_table: symbol_table = {}
-
     symbol_table = _auto_infer_smtlib_types(
         *expr, symbol_table=symbol_table
     )

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -175,7 +175,7 @@ class SMTLibPrinter(Printer):
         elif e.function == Q.nonzero:
             rel = Q.ne(e.arguments[0], 0)
         else:
-            return str(e.function)[2:] + "_" + "_".join([str(arg) for arg in e.arguments])
+            raise ValueError(f"Predicate (`{e}`) can't be expressed as an inequality or equality")
 
         return self._print_AppliedBinaryRelation(rel)
 

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -18,7 +18,7 @@ from sympy.sets import Interval
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.relation.binrel import AppliedBinaryRelation
 from sympy.assumptions.ask import Q
-from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
+#from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
 
 
 class SMTLibPrinter(Printer):

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -18,7 +18,7 @@ from sympy.sets import Interval
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.relation.binrel import AppliedBinaryRelation
 from sympy.assumptions.ask import Q
-#from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
+from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
 
 
 class SMTLibPrinter(Printer):
@@ -46,11 +46,11 @@ class SMTLibPrinter(Printer):
             StrictLessThan: '<',
             StrictGreaterThan: '>',
 
-#            EqualityPredicate(): '=',
-#            LessThanPredicate(): '<=',
-#            GreaterThanPredicate(): '>=',
-#            StrictLessThanPredicate(): '<',
-#            StrictGreaterThanPredicate(): '>',
+            EqualityPredicate: '=',
+            LessThanPredicate: '<=',
+            GreaterThanPredicate: '>=',
+            StrictLessThanPredicate: '<',
+            StrictGreaterThanPredicate: '>',
 
             exp: 'exp',
             log: 'log',
@@ -114,8 +114,8 @@ class SMTLibPrinter(Printer):
             op = self._known_functions[type(e)]
         elif type(type(e)) == UndefinedFunction:
             op = e.name
-        elif isinstance(e,(AppliedBinaryRelation,AppliedPredicate)) and e.function in self._known_functions:
-            op = self._known_functions[e.function]
+        elif isinstance(e,(AppliedBinaryRelation)) and type(e.function) in self._known_functions:
+            op = self._known_functions[type(e.function)]
             return self._s_expr(op, e.arguments)
         else:
             op = self._known_functions[e]  # throw KeyError

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -46,11 +46,11 @@ class SMTLibPrinter(Printer):
             StrictLessThan: '<',
             StrictGreaterThan: '>',
 
-            EqualityPredicate(): '=',
-            LessThanPredicate(): '<=',
-            GreaterThanPredicate(): '>=',
-            StrictLessThanPredicate(): '<',
-            StrictGreaterThanPredicate(): '>',
+#            EqualityPredicate(): '=',
+#            LessThanPredicate(): '<=',
+#            GreaterThanPredicate(): '>=',
+#            StrictLessThanPredicate(): '<',
+#            StrictGreaterThanPredicate(): '>',
 
             exp: 'exp',
             log: 'log',

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -18,9 +18,6 @@ from sympy.sets import Interval
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.ask import Q
 from sympy.assumptions.relation.binrel import AppliedBinaryRelation
-from sympy.core.symbol import Dummy
-from sympy.assumptions.predicates.sets import IntegerPredicate
-from sympy.assumptions.handlers.ntheory import EvenPredicate, OddPredicate, PrimePredicate, CompositePredicate
 
 class SMTLibPrinter(Printer):
     printmethod = "_smtlib"
@@ -52,14 +49,6 @@ class SMTLibPrinter(Printer):
             Q.ge: '>=',
             Q.lt: '<',
             Q.gt: '>',
-
-            # These are non-standard functions
-            # See the custom_Z3_functions variable for their definitions
-            IntegerPredicate(): 'is-int',
-            EvenPredicate(): 'is-even',
-            OddPredicate(): 'is-odd',
-            PrimePredicate(): 'is-prime',
-            CompositePredicate(): 'is-composite',
 
             exp: 'exp',
             log: 'log',
@@ -171,9 +160,7 @@ class SMTLibPrinter(Printer):
             return f'[{e.start}, {e.end}]'
 
     def _print_AppliedPredicate(self, e: AppliedPredicate):
-        if e.function in [Q.integer, Q.even, Q.odd, Q.prime, Q.composite]:
-            return self._print_Function(e)
-        elif e.function == Q.positive:
+        if e.function == Q.positive:
             rel = Q.gt(e.arguments[0],0)
         elif e.function == Q.negative:
             rel = Q.lt(e.arguments[0], 0)
@@ -254,38 +241,6 @@ class SMTLibPrinter(Printer):
 
     def emptyPrinter(self, expr):
         raise NotImplementedError(f'Cannot convert `{repr(expr)}` of type `{type(expr)}` to SMT.')
-
-
-# Note that these functions were written with Z3 in mind.
-# They may not work in other SMT solvers
-custom_Z3_functions = """\
-; Define a function to check if a real number is an integer
-(define-fun is-int ((n Real)) Bool
-  (= n (to_int n)))
-
-; Define a function to check if a real number is even
-(define-fun is-even ((n Real)) Bool
-  (= (mod n 2) 0))
-
-; Define a function to check if a real number is odd
-(define-fun is-odd ((n Real)) Bool
-  (= (mod n 2) 1))
-
-; Define a function to check if an integer is prime
-(define-fun is-p ((n Int)) Bool
-  (and (> n 1)
-       (forall ((i Int))
-         (=> (and (> i 1) (< i n))
-             (not (= 0 (mod n i)))))))
-
-; Define function to check if a real number is prime
-(define-fun is-prime ((n Real)) Bool
-  (and (is-int n) (is-p n) ))
-
-; Define function to check if a real number is composite
-(define-fun is-composite ((n Real)) Bool
-  (and (> n 1) (is-int n) (not (is-p n))))
-"""
 
 
 def smtlib_code(
@@ -387,8 +342,6 @@ def smtlib_code(
 
     if not symbol_table: symbol_table = {}
 
-    expr = _dummify_unhandled_predicate(expr, symbol_table)
-
     symbol_table = _auto_infer_smtlib_types(
         *expr, symbol_table=symbol_table
     )
@@ -410,9 +363,6 @@ def smtlib_code(
 
     if not prefix_expressions: prefix_expressions = []
     if not suffix_expressions: suffix_expressions = []
-
-    if _contains_custom_predicate(expr):
-        prefix_expressions.append(custom_Z3_functions)
 
     p = SMTLibPrinter(settings, symbol_table)
     del symbol_table
@@ -479,41 +429,6 @@ def smtlib_code(
             for e in suffix_expressions
         ],
     ])
-
-
-def _contains_custom_predicate(expr):
-    custom_predicate = [Q.integer, Q.even, Q.odd, Q.prime, Q.composite]
-    if isinstance(expr, AppliedPredicate) and expr.function in custom_predicate:
-        return True
-    elif isinstance(expr, (And, Or, Not)):
-        return any([_contains_custom_predicate(arg) for arg in expr.args])
-    elif isinstance(expr, list):
-        return any([_contains_custom_predicate(e) for e in expr])
-    else:
-        return False
-
-
-def _dummify_unhandled_predicate(expr, symbol_table):
-    dummies_dict = {}
-    handled_pred = [Q.eq, Q.ne, Q.lt, Q.le, Q.gt, Q.ge, Q.positive, Q.negative, Q.zero, Q.nonpositive, Q.nonnegative,
-                    Q.nonzero, Q.integer, Q.even, Q.odd, Q.prime, Q.composite]
-    def _dummify(expr, symbol_table):
-        if isinstance(expr, AppliedPredicate) and expr.function not in handled_pred:
-            if expr in dummies_dict:
-                return dummies_dict[expr]
-            else:
-                d = Dummy()
-                dummies_dict[expr] = d
-                symbol_table[d] = bool
-                return d
-        elif isinstance(expr, (And, Or, Not)):
-            return expr.func(*[_dummify(arg,symbol_table) for arg in expr.args])
-        elif isinstance(expr, list):
-            return [_dummify(x, symbol_table) for x in expr]
-        else:
-            return expr
-
-    return _dummify(expr, symbol_table)
 
 
 def _auto_declare_smtlib(sym: typing.Union[Symbol, Function], p: SMTLibPrinter, log_warn: typing.Callable[[str], None]):

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -12,7 +12,7 @@ from sympy.core import (S, pi, symbols, Function, Rational, Integer,
                         Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, exp, sin, cos
 from sympy.assumptions.ask import Q
-from sympy.printing.smtlib import smtlib_code, custom_Z3_functions
+from sympy.printing.smtlib import smtlib_code
 from sympy.testing.pytest import raises, Failed
 
 x, y, z = symbols('x,y,z')
@@ -85,27 +85,13 @@ def test_AppliedBinaryRelation():
 
 
 def test_AppliedPredicate():
-    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 11) as w:
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 6) as w:
         assert smtlib_code(Q.positive(x), auto_declare=False, log_warn=w) == "(assert (> x 0))"
         assert smtlib_code(Q.negative(x), auto_declare=False, log_warn=w) == "(assert (< x 0))"
         assert smtlib_code(Q.zero(x), auto_declare=False, log_warn=w) == "(assert (= x 0))"
         assert smtlib_code(Q.nonpositive(x), auto_declare=False, log_warn=w) == "(assert (<= x 0))"
         assert smtlib_code(Q.nonnegative(x), auto_declare=False, log_warn=w) == "(assert (>= x 0))"
         assert smtlib_code(Q.nonzero(x), auto_declare=False, log_warn=w) == "(assert (not (= x 0)))"
-        assert re.match(r"^\(declare-const Dummy_\d+ Bool\)\n" \
-                        r"\(assert Dummy_\d+\)$",
-                        smtlib_code(Q.imaginary(x))) is not None
-
-        assert smtlib_code(Q.integer(x), auto_declare=False,
-                           log_warn=w) == custom_Z3_functions + "\n(assert (is-int x))"
-        assert smtlib_code(Q.even(x), auto_declare=False,
-                           log_warn=w) == custom_Z3_functions + "\n(assert (is-even x))"
-        assert smtlib_code(Q.odd(x), auto_declare=False,
-                           log_warn=w) == custom_Z3_functions + "\n(assert (is-odd x))"
-        assert smtlib_code(Q.prime(x), auto_declare=False,
-                           log_warn=w) == custom_Z3_functions + "\n(assert (is-prime x))"
-        assert smtlib_code(Q.composite(x), auto_declare=False,
-                           log_warn=w) == custom_Z3_functions + "\n(assert (is-composite x))"
 
 
 def test_Function():

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -11,8 +11,9 @@ from sympy.core import Mul, Pow
 from sympy.core import (S, pi, symbols, Function, Rational, Integer,
                         Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, exp, sin, cos
+from sympy.assumptions.ask import Q
 from sympy.printing.smtlib import smtlib_code
-from sympy.testing.pytest import raises, Failed
+from sympy.testing.pytest import raises, Failed, XFAIL
 
 x, y, z = symbols('x,y,z')
 
@@ -72,6 +73,29 @@ def test_Relational():
         assert smtlib_code(Gt(x, y), auto_declare=False, log_warn=w) == "(assert (> x y))"
         assert smtlib_code(Ge(x, y), auto_declare=False, log_warn=w) == "(assert (>= x y))"
 
+
+def test_AppliedBinaryRelation():
+    assert smtlib_code(Q.eq(x, y), auto_declare=False) == "(assert (= x y))"
+    assert smtlib_code(Q.ne(x, y), auto_declare=False) == "(assert (not (= x y)))"
+    assert smtlib_code(Q.lt(x, y), auto_declare=False) == "(assert (< x y))"
+    assert smtlib_code(Q.le(x, y), auto_declare=False) == "(assert (<= x y))"
+    assert smtlib_code(Q.gt(x, y), auto_declare=False) == "(assert (> x y))"
+    assert smtlib_code(Q.ge(x, y), auto_declare=False) == "(assert (>= x y))"
+
+
+def test_AppliedPredicate():
+    assert smtlib_code(Q.positive(x), auto_declare=False) == "(assert (> x 0))"
+    assert smtlib_code(Q.negative(x), auto_declare=False) == "(assert (< x 0))"
+    assert smtlib_code(Q.zero(x), auto_declare=False) == "(assert (= x 0))"
+    assert smtlib_code(Q.nonpositive(x), auto_declare=False) == "(assert (<= x 0))"
+    assert smtlib_code(Q.nonnegative(x), auto_declare=False) == "(assert (>= x 0))"
+    assert smtlib_code(Q.nonzero(x), auto_declare=False) == "(assert (not (= x 0)))"
+
+
+@XFAIL
+def test_AppliedPredicate_FAIL():
+    assert smtlib_code(Q.imaginary(x)) == "(declare-const imaginary_x Bool)\n" \
+                                          "(assert imaginary_x)"
 
 def test_Function():
     with _check_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]) as w:

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -12,7 +12,7 @@ from sympy.core import (S, pi, symbols, Function, Rational, Integer,
                         Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, exp, sin, cos
 from sympy.assumptions.ask import Q
-from sympy.printing.smtlib import smtlib_code
+from sympy.printing.smtlib import smtlib_code, custom_Z3_functions
 from sympy.testing.pytest import raises, Failed
 
 x, y, z = symbols('x,y,z')
@@ -85,7 +85,7 @@ def test_AppliedBinaryRelation():
 
 
 def test_AppliedPredicate():
-    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 6) as w:
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 11) as w:
         assert smtlib_code(Q.positive(x), auto_declare=False, log_warn=w) == "(assert (> x 0))"
         assert smtlib_code(Q.negative(x), auto_declare=False, log_warn=w) == "(assert (< x 0))"
         assert smtlib_code(Q.zero(x), auto_declare=False, log_warn=w) == "(assert (= x 0))"
@@ -95,6 +95,17 @@ def test_AppliedPredicate():
         assert re.match(r"^\(declare-const Dummy_\d+ Bool\)\n" \
                         r"\(assert Dummy_\d+\)$",
                         smtlib_code(Q.imaginary(x))) is not None
+
+        assert smtlib_code(Q.integer(x), auto_declare=False,
+                           log_warn=w) == custom_Z3_functions + "\n(assert (is-int x))"
+        assert smtlib_code(Q.even(x), auto_declare=False,
+                           log_warn=w) == custom_Z3_functions + "\n(assert (is-even x))"
+        assert smtlib_code(Q.odd(x), auto_declare=False,
+                           log_warn=w) == custom_Z3_functions + "\n(assert (is-odd x))"
+        assert smtlib_code(Q.prime(x), auto_declare=False,
+                           log_warn=w) == custom_Z3_functions + "\n(assert (is-prime x))"
+        assert smtlib_code(Q.composite(x), auto_declare=False,
+                           log_warn=w) == custom_Z3_functions + "\n(assert (is-composite x))"
 
 
 def test_Function():

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -13,7 +13,7 @@ from sympy.core import (S, pi, symbols, Function, Rational, Integer,
 from sympy.functions import Piecewise, exp, sin, cos
 from sympy.assumptions.ask import Q
 from sympy.printing.smtlib import smtlib_code
-from sympy.testing.pytest import raises, Failed, XFAIL
+from sympy.testing.pytest import raises, Failed
 
 x, y, z = symbols('x,y,z')
 
@@ -92,12 +92,10 @@ def test_AppliedPredicate():
         assert smtlib_code(Q.nonpositive(x), auto_declare=False, log_warn=w) == "(assert (<= x 0))"
         assert smtlib_code(Q.nonnegative(x), auto_declare=False, log_warn=w) == "(assert (>= x 0))"
         assert smtlib_code(Q.nonzero(x), auto_declare=False, log_warn=w) == "(assert (not (= x 0)))"
+        assert re.match(r"^\(declare-const Dummy_\d+ Bool\)\n" \
+                        r"\(assert Dummy_\d+\)$",
+                        smtlib_code(Q.imaginary(x))) is not None
 
-
-@XFAIL
-def test_AppliedPredicate_FAIL():
-    assert smtlib_code(Q.imaginary(x)) == "(declare-const imaginary_x Bool)\n" \
-                                          "(assert imaginary_x)"
 
 def test_Function():
     with _check_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]) as w:

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -75,21 +75,23 @@ def test_Relational():
 
 
 def test_AppliedBinaryRelation():
-    assert smtlib_code(Q.eq(x, y), auto_declare=False) == "(assert (= x y))"
-    assert smtlib_code(Q.ne(x, y), auto_declare=False) == "(assert (not (= x y)))"
-    assert smtlib_code(Q.lt(x, y), auto_declare=False) == "(assert (< x y))"
-    assert smtlib_code(Q.le(x, y), auto_declare=False) == "(assert (<= x y))"
-    assert smtlib_code(Q.gt(x, y), auto_declare=False) == "(assert (> x y))"
-    assert smtlib_code(Q.ge(x, y), auto_declare=False) == "(assert (>= x y))"
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 12) as w:
+        assert smtlib_code(Q.eq(x, y), auto_declare=False, log_warn=w) == "(assert (= x y))"
+        assert smtlib_code(Q.ne(x, y), auto_declare=False, log_warn=w) == "(assert (not (= x y)))"
+        assert smtlib_code(Q.lt(x, y), auto_declare=False, log_warn=w) == "(assert (< x y))"
+        assert smtlib_code(Q.le(x, y), auto_declare=False, log_warn=w) == "(assert (<= x y))"
+        assert smtlib_code(Q.gt(x, y), auto_declare=False, log_warn=w) == "(assert (> x y))"
+        assert smtlib_code(Q.ge(x, y), auto_declare=False, log_warn=w) == "(assert (>= x y))"
 
 
 def test_AppliedPredicate():
-    assert smtlib_code(Q.positive(x), auto_declare=False) == "(assert (> x 0))"
-    assert smtlib_code(Q.negative(x), auto_declare=False) == "(assert (< x 0))"
-    assert smtlib_code(Q.zero(x), auto_declare=False) == "(assert (= x 0))"
-    assert smtlib_code(Q.nonpositive(x), auto_declare=False) == "(assert (<= x 0))"
-    assert smtlib_code(Q.nonnegative(x), auto_declare=False) == "(assert (>= x 0))"
-    assert smtlib_code(Q.nonzero(x), auto_declare=False) == "(assert (not (= x 0)))"
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 6) as w:
+        assert smtlib_code(Q.positive(x), auto_declare=False, log_warn=w) == "(assert (> x 0))"
+        assert smtlib_code(Q.negative(x), auto_declare=False, log_warn=w) == "(assert (< x 0))"
+        assert smtlib_code(Q.zero(x), auto_declare=False, log_warn=w) == "(assert (= x 0))"
+        assert smtlib_code(Q.nonpositive(x), auto_declare=False, log_warn=w) == "(assert (<= x 0))"
+        assert smtlib_code(Q.nonnegative(x), auto_declare=False, log_warn=w) == "(assert (>= x 0))"
+        assert smtlib_code(Q.nonzero(x), auto_declare=False, log_warn=w) == "(assert (not (= x 0)))"
 
 
 @XFAIL


### PR DESCRIPTION
The smtlib_code function will no longer throw an error when it tries to print a predicate from the new assumptions. Predicates that can not be expressed as an equality or inequality should be represented as boolean variables; however, this doesn’t completely work yet.

Example:

In [1]: from sympy.printing.smtlib import smtlib_code

In [2]: from sympy.assumptions.ask import Q

In [3]:smtlib_code(Q.positive(x))

Out[3]]: '(declare-const x Real)\n(assert (> x 0))'

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Other comments

Behavior that I don't like:

In [3]:smtlib_code(Q.imaginary(x))

Out[3]]: '(declare-const x Real)\n(assert complex_x)'

It should do this:

In [3]:smtlib_code(Q.imaginary(x))

Out[3]]: '(declare-const imaginary_x Bool)\n(assert imaginary_x)'

I don't understand the code that infers types very well and this seems tricky to implement; `imaginary_x` is a variable that's being created that wasn't really part of the original expression and although x was part of the original expression it shouldn't be declared. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * make SMT-Lib printer handle predicates from the new assumptions

<!-- END RELEASE NOTES -->
