### PR TITLE
SMT-Lib printing: Handle predicate objects from new assumptions

### DIFF
--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -15,6 +15,10 @@ from sympy.logic.boolalg import And, Or, Xor, Implies, Boolean
 from sympy.logic.boolalg import BooleanTrue, BooleanFalse, BooleanFunction, Not, ITE
 from sympy.printing.printer import Printer
 from sympy.sets import Interval
+from sympy.assumptions.assume import AppliedPredicate
+from sympy.assumptions.relation.binrel import AppliedBinaryRelation
+from sympy.assumptions.ask import Q
+from sympy.assumptions.relation.equality import StrictGreaterThanPredicate, StrictLessThanPredicate, GreaterThanPredicate, LessThanPredicate, EqualityPredicate
 
 
 class SMTLibPrinter(Printer):
@@ -41,6 +45,12 @@ class SMTLibPrinter(Printer):
             GreaterThan: '>=',
             StrictLessThan: '<',
             StrictGreaterThan: '>',
+
+            EqualityPredicate(): '=',
+            LessThanPredicate(): '<=',
+            GreaterThanPredicate(): '>=',
+            StrictLessThanPredicate(): '<',
+            StrictGreaterThanPredicate(): '>',
 
             exp: 'exp',
             log: 'log',
@@ -104,6 +114,9 @@ class SMTLibPrinter(Printer):
             op = self._known_functions[type(e)]
         elif type(type(e)) == UndefinedFunction:
             op = e.name
+        elif isinstance(e, AppliedBinaryRelation) and e.function in self._known_functions:
+            op = self._known_functions[e.function]
+            return self._s_expr(op, e.arguments)
         else:
             op = self._known_functions[e]  # throw KeyError
 
@@ -147,6 +160,30 @@ class SMTLibPrinter(Printer):
             raise ValueError(f'One-sided intervals (`{e}`) are not supported in SMT.')
         else:
             return f'[{e.start}, {e.end}]'
+
+    def _print_AppliedPredicate(self, e: AppliedPredicate):
+        if e.function == Q.positive:
+            rel = Q.gt(e.arguments[0],0)
+        elif e.function == Q.negative:
+            rel = Q.lt(e.arguments[0], 0)
+        elif e.function == Q.zero:
+            rel = Q.eq(e.arguments[0], 0)
+        elif e.function == Q.nonpositive:
+            rel = Q.le(e.arguments[0], 0)
+        elif e.function == Q.nonnegative:
+            rel = Q.ge(e.arguments[0], 0)
+        elif e.function == Q.nonzero:
+            rel = Q.ne(e.arguments[0], 0)
+        else:
+            raise ValueError(f"Predicate (`{e}`) is not handled.")
+
+        return self._print_AppliedBinaryRelation(rel)
+
+    def _print_AppliedBinaryRelation(self, e: AppliedPredicate):
+        if e.function == Q.ne:
+            return self._print_Unequality(Unequality(*e.arguments))
+        else:
+            return self._print_Function(e)
 
     # todo: Sympy does not support quantifiers yet as of 2022, but quantifiers can be handy in SMT.
     # For now, users can extend this class and build in their own quantifier support.

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -11,6 +11,7 @@ from sympy.core import Mul, Pow
 from sympy.core import (S, pi, symbols, Function, Rational, Integer,
                         Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, exp, sin, cos
+from sympy.assumptions.ask import Q
 from sympy.printing.smtlib import smtlib_code
 from sympy.testing.pytest import raises, Failed
 
@@ -72,6 +73,27 @@ def test_Relational():
         assert smtlib_code(Gt(x, y), auto_declare=False, log_warn=w) == "(assert (> x y))"
         assert smtlib_code(Ge(x, y), auto_declare=False, log_warn=w) == "(assert (>= x y))"
 
+
+def test_AppliedBinaryRelation():
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 12) as w:
+        assert smtlib_code(Q.eq(x, y), auto_declare=False, log_warn=w) == "(assert (= x y))"
+        assert smtlib_code(Q.ne(x, y), auto_declare=False, log_warn=w) == "(assert (not (= x y)))"
+        assert smtlib_code(Q.lt(x, y), auto_declare=False, log_warn=w) == "(assert (< x y))"
+        assert smtlib_code(Q.le(x, y), auto_declare=False, log_warn=w) == "(assert (<= x y))"
+        assert smtlib_code(Q.gt(x, y), auto_declare=False, log_warn=w) == "(assert (> x y))"
+        assert smtlib_code(Q.ge(x, y), auto_declare=False, log_warn=w) == "(assert (>= x y))"
+
+    raises(ValueError, lambda: smtlib_code(Q.complex(x), log_warn=w))
+
+
+def test_AppliedPredicate():
+    with _check_warns([_W.DEFAULTING_TO_FLOAT] * 6) as w:
+        assert smtlib_code(Q.positive(x), auto_declare=False, log_warn=w) == "(assert (> x 0))"
+        assert smtlib_code(Q.negative(x), auto_declare=False, log_warn=w) == "(assert (< x 0))"
+        assert smtlib_code(Q.zero(x), auto_declare=False, log_warn=w) == "(assert (= x 0))"
+        assert smtlib_code(Q.nonpositive(x), auto_declare=False, log_warn=w) == "(assert (<= x 0))"
+        assert smtlib_code(Q.nonnegative(x), auto_declare=False, log_warn=w) == "(assert (>= x 0))"
+        assert smtlib_code(Q.nonzero(x), auto_declare=False, log_warn=w) == "(assert (not (= x 0)))"
 
 def test_Function():
     with _check_warns([_W.DEFAULTING_TO_FLOAT, _W.WILL_NOT_ASSERT]) as w:


### PR DESCRIPTION
The smtlib_code function will no longer throw an error when it tries to print some predicate from the new assumptions. The printer throws an error if given a predicate that can’t be translated to SMT-Lib or could be but hasn’t been Implemented. While it’s possible to handle even, odd, and some other predicate, this isn’t really all that important so this functionality was dropped.

Example:

In [1]: from sympy.printing.smtlib import smtlib_code

In [2]: from sympy.assumptions.ask import Q

In [3]:smtlib_code(Q.positive(x))

Out[3]]: '(declare-const x Real)\n(assert (> x 0))'

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is a continuation of this pull request #25232. I worked on a lot of stuff that didn't seem to be a priority so this pull request contains the most essential bits of that one without any distracting commits or comments.

#### Other Comments

@kunalsheth if you want to review this it would be appreciated. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * make SMT-Lib printer handle some predicates from the new assumptions
<!-- END RELEASE NOTES -->