### PR TITLE
Compare symbol names when filtering duplicates in cse

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -747,6 +747,7 @@ Johan Blåbäck <johan_bluecreek@riseup.net> <johan.blaback@cea.fr>
 Johan Guzman <jguzm022@ucr.edu>
 Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
 Johannes Hartung <joha2@gmx.net>
+Johannes Kasimir <johannes.kasimir@math.lu.se>
 John Connor <john.theman.connor@gmail.com>
 John Möller <john.moller@outlook.com>
 John V. Siratt <jvsiratt@gmail.com>

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -621,7 +621,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
                 expr.is_Order or
                 isinstance(expr, (MatrixSymbol, MatrixElement))):
             if expr.is_Symbol:
-                excluded_symbols.add(expr)
+                excluded_symbols.add(expr.name)
             return
 
         if iterable(expr):
@@ -652,7 +652,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
     ## Rebuild tree
 
     # Remove symbols from the generator that conflict with names in the expressions.
-    symbols = (symbol for symbol in symbols if symbol not in excluded_symbols)
+    symbols = (_ for _ in symbols if _.name not in excluded_symbols)
 
     replacements = []
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -246,6 +246,14 @@ def test_issue_6263():
     assert cse(e, optimizations='basic') == ([], [True])
 
 
+def test_issue_25043():
+    c = symbols("c")
+    x = symbols("x0", real=True)
+    cse_expr = cse(c*x**2 + c*(x**4 - x**2))[-1][-1]
+    free = cse_expr.free_symbols
+    assert len(free) == len({i.name for i in free})
+
+
 def test_dont_cse_tuples():
     from sympy.core.function import Subs
     f = Function("f")


### PR DESCRIPTION
The cse method aims to avoid name collisions between symbols already in the expression and the symbols representing common subexpressions.
This is done by adding all symbols found in the expression to an `excluded_symbols` set and filtering the symbols iterator to exclude them.
However, symbols are equal only if their names and assumptions match, so this approach does not avoid symbol name collisions.

#### References to other Issues or PRs
Fixes #25043 


#### Brief description of what is fixed or changed
`excluded_symbols` stores names of symbols instead of symbols.
The symbols iterator is filtered to exlude all symbols sharing a name with a symbols already in the expression.


#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
    * Fixed a bug where cse adds temporary variables sharing names with symbols already in the expression.
<!-- END RELEASE NOTES -->
