### PR TITLE
fix(docs): fix broken sphinx references

### DIFF
--- a/doc/src/guides/solving/solve-equation-algebraically.md
+++ b/doc/src/guides/solving/solve-equation-algebraically.md
@@ -55,7 +55,7 @@ Here are recommendations on when to use:
 
 Refer to
 [](solving-guidance.md#include-the-variable-to-be-solved-for-in-the-function-call)
-and [](solving-guidance.md#ensure-consistent-formatting-from).
+and [](ensure-consistent-formatting-from-solve).
 
 ## Solve an Equation Algebraically
 
@@ -311,7 +311,7 @@ Intersection({-sqrt(y), sqrt(y)}, Reals)
 
 ## Options That Can Speed up {func}`~.solve`
 
-Refer to [solving guidance](solving-guidance.md#options-that-can-speed-up).
+Refer to [solving guidance](options-that-can-speed-up-solve).
 
 ## Not All Equations Can Be Solved
 

--- a/doc/src/guides/solving/solve-system-of-equations-algebraically.md
+++ b/doc/src/guides/solving/solve-system-of-equations-algebraically.md
@@ -36,7 +36,7 @@ Whether your equations are linear or nonlinear, you can use {func}`~.solve`:
 
 Refer to
 [](solving-guidance.md#include-the-variable-to-be-solved-for-in-the-function-call)
-and [](solving-guidance.md#ensure-consistent-formatting-from).
+and [](ensure-consistent-formatting-from-solve).
 
 There are two methods below for containing solution results:
 [dictionary](#solve-and-use-results-in-a-dictionary) or
@@ -89,7 +89,7 @@ solve([x**2 + y - 2*z, y + 4*z], [x, y], set=True)
 
 ## Options That Can Speed up {func}`~.solve`
 
-Refer to [](solving-guidance.md#options-that-can-speed-up).
+Refer to [](options-that-can-speed-up-solve).
 
 ## Not All Systems of Equations Can be Solved
 

--- a/doc/src/guides/solving/solving-guidance.md
+++ b/doc/src/guides/solving/solving-guidance.md
@@ -142,7 +142,7 @@ result. For example, this exact equation can be solved:
 ```
 
 but if you use the inexact equation `eq = x**1.4142135623730951 - 2`, SymPy will
-not return a result despite attempting for a long time. 
+not return a result despite attempting for a long time.
 
 ## Include the Variable to be Solved for in the Function Call
 
@@ -168,6 +168,7 @@ Specifying the variable to solve for ensures that SymPy solves for it:
 [{x: -sqrt(y)}, {x: sqrt(y)}]
 ```
 
+(ensure-consistent-formatting-from-solve)=
 ## Ensure Consistent Formatting From {func}`~.solve`
 
 {func}`~.solve` produces a variety of output as explained in
@@ -175,8 +176,8 @@ Specifying the variable to solve for ensures that SymPy solves for it:
 which is especially important when extracting information about the solution
 programmatically.
 
-To extract the solutions, you can iterate through the list of dictionaries:  
-    
+To extract the solutions, you can iterate through the list of dictionaries:
+
 ```py
 >>> from sympy import parse_expr, solve, solveset
 >>> from sympy.abc import x
@@ -191,6 +192,7 @@ Eq(x**2, y)
 {-sqrt(y), sqrt(y)}
 ```
 
+(options-that-can-speed-up-solve)=
 ## Options That Can Speed up {func}`~.solve`
 
 ### Include Solutions Making Any Denominator Zero


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-25247

#### Brief description of what is fixed or changed

Fix broken sphinx references. The references were using section titles but presumed that it was okay to miss off the final word of the title. Since the final word is itself a reference it is not clear how to reference the title without an explicit reference so I added an explicit label that can be referenced.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
