### PR TITLE
Fix deprecated bitwise not on boolean and fix pytest return warning

### DIFF
--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -147,7 +147,7 @@ def test_Permutation():
 
     assert rmul(~p, p).is_Identity
     assert (~p)**13 == Permutation([5, 2, 0, 4, 6, 1, 3])
-    assert ~(r**2).is_Identity
+    assert not (r**2).is_Identity
     assert p.max() == 6
     assert p.min() == 0
 

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -147,7 +147,6 @@ def test_Permutation():
 
     assert rmul(~p, p).is_Identity
     assert (~p)**13 == Permutation([5, 2, 0, 4, 6, 1, 3])
-    assert not (r**2).is_Identity
     assert p.max() == 6
     assert p.min() == 0
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1012,7 +1012,7 @@ class Xor(BooleanFunction):
             for j in range(i + 1, len(rel)):
                 rj, cj = rel[j][:2]
                 if cj == nc:
-                    odd = ~odd
+                    odd = not odd
                     break
                 elif cj == c:
                     break

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -19,6 +19,7 @@ from sympy.physics.quantum.matrixutils import (numpy_ndarray,
 from sympy.physics.quantum.cartesian import XKet, XOp, XBra
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.operatorset import operators_to_state
+from sympy.testing.pytest import raises
 
 Amat = Matrix([[1, I], [-I, 1]])
 Bmat = Matrix([[1, 2], [3, 4]])
@@ -169,11 +170,7 @@ x_op = XOp('X')
 def test_innerprod_represent():
     assert rep_innerproduct(x_ket) == InnerProduct(XBra("x_1"), x_ket).doit()
     assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet("x_1")).doit()
-
-    try:
-        rep_innerproduct(x_op)
-    except TypeError:
-        return True
+    raises(TypeError, lambda: rep_innerproduct(x_op))
 
 
 def test_operator_represent():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This attempts to fix some future warnings for python 3.14 and pytest.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
