### PR TITLE
Solves the issue #25190 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,6 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
+ABHISHEK KUMAR <kumarabhishekuprama@gmail.com> Abhishek Kumar <abhishek.nitdelhi@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -213,7 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
-ABHISHEK KUMAR <kumarabhishekuprama@gmail.com> Abhishek Kumar <abhishek.nitdelhi@gmail.com>
+ABHISHEK KUMAR <abhishekkumaruprama1@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -908,10 +908,10 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         np = import_module('numpy')
         if self.only_integers is True:
             if self.xscale == 'log':
-                list_x = np.logspace(int(self.start), int(self.end),
+                list_x = np.logspace(np.log10(int(self.start)), np.log10(int(self.end)),
                         num=int(self.end) - int(self.start) + 1)
             else:
-                list_x = np.linspace(int(np.log10(self.start)), int(np.log10(self.end)),
+                list_x = np.linspace(int(self.start), int(self.end),
                     num=int(self.end) - int(self.start) + 1)
         else:
             if self.xscale == 'log':

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -911,11 +911,11 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 list_x = np.logspace(int(self.start), int(self.end),
                         num=int(self.end) - int(self.start) + 1)
             else:
-                list_x = np.linspace(int(self.start), int(self.end),
+                list_x = np.linspace(int(np.log10(self.start)), int(np.log10(self.end)),
                     num=int(self.end) - int(self.start) + 1)
         else:
             if self.xscale == 'log':
-                list_x = np.logspace(self.start, self.end, num=self.nb_of_points)
+                list_x = np.logspace(np.log10(self.start), np.log10(self.end), num=self.nb_of_points)
             else:
                 list_x = np.linspace(self.start, self.end, num=self.nb_of_points)
         f = vectorized_lambdify([self.var], self.expr)


### PR DESCRIPTION
### Changed the argument of logspace in plotting.py
Solves the issue Logscale plotting uses incorrect x range for adaptive=False 

Fixes #25190 
#### Brief description of what is fixed or changed
```list_x = np.logspace(np.log10(int(self.start)), np.log10(int(self.end)),```
```list_x = np.logspace(np.log10(self.start), np.log10(self.end), num=self.nb_of_points)```
Arguements of logspace is changed so that it matches when we try to plot in logscale arguments
#### Other comments
In mailmap my email address and name is added.
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* In sympy/plotting/plot.py logspace argument was changed to solve the issue #25190 
<!-- END RELEASE NOTES -->