### PR TITLE
Refactoring of `nthroot_mod`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1024,8 +1024,8 @@ def nthroot_mod(a, n, p, all_roots=False):
         prime_power.append(q**e)
         base.append(sorted(tot_roots))
     P, E, S = gf_crt1(prime_power, ZZ)
-    ret = sorted(map(int, set(gf_crt2(c, prime_power, P, E, S, ZZ)
-                              for c in product(*base))))
+    ret = sorted(map(int, {gf_crt2(c, prime_power, P, E, S, ZZ)
+                           for c in product(*base)}))
     if all_roots:
         return ret
     if ret:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -819,6 +819,29 @@ def _nthroot_mod1(s, q, p, all_roots):
     Root of ``x**q = s mod p``, ``p`` prime and ``q`` divides ``p - 1``.
     Assume that the root exists.
 
+    Parameters
+    ==========
+
+    a : integer
+    q : integer, n > 2. ``q`` divides ``p - 1``.
+    p : prime number
+    all_roots : if False returns the smallest root, else the list of roots
+
+    Returns
+    =======
+
+    list[int] | int :
+        Root of ``x**q = s mod p``. If ``all_roots == True``,
+        returned ascending list. otherwise, returned an int.
+
+    Examples
+    ========
+
+    >>> _nthroot_mod1(5, 3, 13, False)
+    7
+    >>> _nthroot_mod1(13, 4, 17, True)
+    [3, 5, 12, 14]
+
     References
     ==========
 
@@ -851,71 +874,82 @@ def _nthroot_mod1(s, q, p, all_roots):
     return min(res)
 
 
-def _help(m, prime_modulo_method, diff_method, expr_val):
-    """
-    Helper function for _nthroot_mod_composite.
+def _nthroot_mod_prime_power(a, n, p, k):
+    """ Root of ``x**n = a mod p**k``.
 
     Parameters
     ==========
 
-    m : positive integer
-    prime_modulo_method : function to calculate the root of the congruence
-    equation for the prime divisors of m
-    diff_method : function to calculate derivative of expression at any
-    given point
-    expr_val : function to calculate value of the expression at any
-    given point
+    a : integer
+    n : integer, n > 2
+    p : prime number
+    k : positive integer
+
+    Returns
+    =======
+
+    list[int] :
+        Ascending list of roots of ``x**n = a mod p**k``.
+        If no solution exists, return ``[]``.
+
     """
-    from sympy.ntheory.modular import crt
-    f = factorint(m)
-    dd = {}
-    for p, e in f.items():
-        tot_roots = set()
-        if e == 1:
-            tot_roots.update(prime_modulo_method(p))
+    if not _is_nthpow_residue_bign_prime_power(a, n, p, k):
+        return []
+    a_mod_p = a % p
+    if a_mod_p == 0:
+        base_roots = [0]
+    elif (p - 1) % n == 0:
+        base_roots = _nthroot_mod1(a_mod_p, n, p, all_roots=True)
+    else:
+        # The roots of ``x**n - a = 0 (mod p)`` are roots of
+        # ``gcd(x**n - a, x**(p - 1) - 1) = 0 (mod p)``
+        pa = n
+        pb = p - 1
+        b = 1
+        if pa < pb:
+            a_mod_p, pa, b, pb = b, pb, a_mod_p, pa
+        # gcd(x**pa - a, x**pb - b) = gcd(x**pb - b, x**pc - c)
+        # where pc = pa % pb; c = b**-q * a mod p
+        while pb:
+            q, pc = divmod(pa, pb)
+            c = pow(b, -q, p) * a_mod_p % p
+            pa, pb = pb, pc
+            a_mod_p, b = b, c
+        if pa == 1:
+            base_roots = [a_mod_p]
+        elif pa == 2:
+            base_roots = sqrt_mod(a_mod_p, p, all_roots=True)
         else:
-            for root in prime_modulo_method(p):
-                diff = diff_method(root, p)
-                if diff != 0:
-                    ppow = p
-                    m_inv = invert(diff, p)
-                    for j in range(1, e):
-                        ppow *= p
-                        root = (root - expr_val(root, ppow) * m_inv) % ppow
-                    tot_roots.add(root)
-                else:
-                    new_base = p
-                    roots_in_base = {root}
-                    while new_base < pow(p, e):
-                        new_base *= p
-                        new_roots = set()
-                        for k in roots_in_base:
-                            if expr_val(k, new_base)!= 0:
-                                continue
-                            while k not in new_roots:
-                                new_roots.add(k)
-                                k = (k + (new_base // p)) % new_base
-                        roots_in_base = new_roots
-                    tot_roots = tot_roots | roots_in_base
-        if tot_roots == set():
-            return []
-        dd[pow(p, e)] = tot_roots
-    a = []
-    m = []
-    for x, y in dd.items():
-        m.append(x)
-        a.append(list(y))
-    return sorted({crt(m, list(i))[0] for i in product(*a)})
-
-
-def _nthroot_mod_composite(a, n, m):
-    """
-    Find the solutions to ``x**n = a mod m`` when m is not prime.
-    """
-    return _help(m,
-        lambda p: nthroot_mod(a, n, p, True),
-        lambda root, p: (pow(root, n - 1, p) * (n % p)) % p,
-        lambda root, p: (pow(root, n, p) - a) % p)
+            base_roots = _nthroot_mod1(a_mod_p, pa, p, all_roots=True)
+    if k == 1:
+        return base_roots
+    a %= p**k
+    tot_roots = set()
+    for root in base_roots:
+        diff = pow(root, n - 1, p)*n % p
+        new_base = p
+        if diff != 0:
+            m_inv = invert(diff, p)
+            for _ in range(k - 1):
+                new_base *= p
+                tmp = pow(root, n, new_base) - a
+                tmp *= m_inv
+                root = (root - tmp) % new_base
+            tot_roots.add(root)
+        else:
+            roots_in_base = {root}
+            for _ in range(k - 1):
+                new_base *= p
+                new_roots = set()
+                for k_ in roots_in_base:
+                    if pow(k_, n, new_base) != a % new_base:
+                        continue
+                    while k_ not in new_roots:
+                        new_roots.add(k_)
+                        k_ = (k_ + (new_base // p)) % new_base
+                roots_in_base = new_roots
+            tot_roots = tot_roots | roots_in_base
+    return sorted(tot_roots)
 
 
 def nthroot_mod(a, n, p, all_roots=False):
@@ -930,6 +964,29 @@ def nthroot_mod(a, n, p, all_roots=False):
     p : positive integer
     all_roots : if False returns the smallest root, else the list of roots
 
+    Returns
+    =======
+
+        list[int] | int | None :
+            solutions to ``x**n = a mod p``.
+            The table of the output type is:
+
+            ========== ========== ==========
+            all_roots  has roots  Returns
+            ========== ========== ==========
+            True       Yes        list[int]
+            True       No         []
+            False      Yes        int
+            False      No         None
+            ========== ========== ==========
+
+    Raises
+    ======
+
+        ValueError
+            If ``a``, ``n`` or ``p`` is not integer.
+            If ``n`` or ``p`` is not positive.
+
     Examples
     ========
 
@@ -940,46 +997,39 @@ def nthroot_mod(a, n, p, all_roots=False):
     [8, 11]
     >>> nthroot_mod(68, 3, 109)
     23
+
+    References
+    ==========
+
+    .. [1] P. Hackman "Elementary Number Theory" (2009), page 76
+
     """
     a = a % p
     a, n, p = as_int(a), as_int(n), as_int(p)
 
+    if n < 1:
+        raise ValueError("n should be positive")
+    if p < 1:
+        raise ValueError("p should be positive")
+    if n == 1:
+        return [a] if all_roots else a
     if n == 2:
         return sqrt_mod(a, p, all_roots)
-    # see Hackman "Elementary Number Theory" (2009), page 76
-    if not isprime(p):
-        return _nthroot_mod_composite(a, n, p)
-    if a % p == 0:
-        return [0]
-    if not is_nthpow_residue(a, n, p):
-        return [] if all_roots else None
-    if (p - 1) % n == 0:
-        return _nthroot_mod1(a, n, p, all_roots)
-    # The roots of ``x**n - a = 0 (mod p)`` are roots of
-    # ``gcd(x**n - a, x**(p - 1) - 1) = 0 (mod p)``
-    pa = n
-    pb = p - 1
-    b = 1
-    if pa < pb:
-        a, pa, b, pb = b, pb, a, pa
-    while pb:
-        # x**pa - a = 0; x**pb - b = 0
-        # x**pa - a = x**(q*pb + r) - a = (x**pb)**q * x**r - a =
-        #             b**q * x**r - a; x**r - c = 0; c = b**-q * a mod p
-        q, r = divmod(pa, pb)
-        c = pow(b, -q, p) * a % p
-        pa, pb = pb, r
-        a, b = b, c
-    if pa == 1:
-        if all_roots:
-            res = [a]
-        else:
-            res = a
-    elif pa == 2:
-        return sqrt_mod(a, p, all_roots)
-    else:
-        res = _nthroot_mod1(a, pa, p, all_roots)
-    return res
+    base = []
+    prime_power = []
+    for q, e in factorint(p).items():
+        tot_roots = _nthroot_mod_prime_power(a, n, q, e)
+        if not tot_roots:
+            return [] if all_roots else None
+        prime_power.append(q**e)
+        base.append(sorted(tot_roots))
+    P, E, S = gf_crt1(prime_power, ZZ)
+    ret = sorted(map(int, set(gf_crt2(c, prime_power, P, E, S, ZZ)
+                              for c in product(*base))))
+    if all_roots:
+        return ret
+    if ret:
+        return ret[0]
 
 
 def quadratic_residues(p) -> list[int]:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -837,6 +837,7 @@ def _nthroot_mod1(s, q, p, all_roots):
     Examples
     ========
 
+    >>> from sympy.ntheory.residue_ntheory import _nthroot_mod1
     >>> _nthroot_mod1(5, 3, 13, False)
     7
     >>> _nthroot_mod1(13, 4, 17, True)

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -10,7 +10,7 @@ from sympy.ntheory import n_order, is_primitive_root, is_quad_residue, \
     polynomial_congruence, sieve
 from sympy.ntheory.residue_ntheory import _primitive_root_prime_iter, \
     _primitive_root_prime_power_iter, _primitive_root_prime_power2_iter, \
-    _discrete_log_trial_mul, _discrete_log_shanks_steps, \
+    _nthroot_mod_prime_power, _discrete_log_trial_mul, _discrete_log_shanks_steps, \
     _discrete_log_pollard_rho, _discrete_log_pohlig_hellman, \
     _binomial_mod_prime_power, binomial_mod
 from sympy.polys.domains import ZZ
@@ -186,9 +186,30 @@ def test_residue():
     assert not is_nthpow_residue(2, 2, 5)
     assert is_nthpow_residue(8547, 12, 10007)
     assert is_nthpow_residue(Dummy(even=True) + 3, 3, 2) == True
-    assert nthroot_mod(Dummy(odd=True), 3, 2) == 1
+    # _nthroot_mod_prime_power
+    for p in primerange(2, 10):
+        for a in range(3):
+            for n in range(3, 5):
+                ans = _nthroot_mod_prime_power(a, n, p, 1)
+                assert isinstance(ans, list)
+                if len(ans) == 0:
+                    for b in range(p):
+                        assert pow(b, n, p) != a % p
+                    for k in range(2, 10):
+                        assert _nthroot_mod_prime_power(a, n, p, k) == []
+                else:
+                    for b in range(p):
+                        pred = pow(b, n, p) == a % p
+                        assert not(pred ^ (b in ans))
+                    for k in range(2, 10):
+                        ans = _nthroot_mod_prime_power(a, n, p, k)
+                        if not ans:
+                            break
+                        for b in ans:
+                            assert pow(b, n , p**k) == a
 
-    assert nthroot_mod(29, 31, 74) == [45]
+    assert nthroot_mod(Dummy(odd=True), 3, 2) == 1
+    assert nthroot_mod(29, 31, 74) == 45
     assert nthroot_mod(1801, 11, 2663) == 44
     for a, q, p in [(51922, 2, 203017), (43, 3, 109), (1801, 11, 2663),
           (26118163, 1303, 33333347), (1499, 7, 2663), (595, 6, 2663),
@@ -198,26 +219,26 @@ def test_residue():
     assert nthroot_mod(11, 3, 109) is None
     assert nthroot_mod(16, 5, 36, True) == [4, 22]
     assert nthroot_mod(9, 16, 36, True) == [3, 9, 15, 21, 27, 33]
-    assert nthroot_mod(4, 3, 3249000) == []
+    assert nthroot_mod(4, 3, 3249000) is None
     assert nthroot_mod(36010, 8, 87382, True) == [40208, 47174]
     assert nthroot_mod(0, 12, 37, True) == [0]
     assert nthroot_mod(0, 7, 100, True) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     assert nthroot_mod(4, 4, 27, True) == [5, 22]
     assert nthroot_mod(4, 4, 121, True) == [19, 102]
     assert nthroot_mod(2, 3, 7, True) == []
-
-    for p in range(5, 100):
-        qv = range(3, p, 4)
-        for q in qv:
-            d = defaultdict(list)
-            for i in range(p):
-                d[pow(i, q, p)].append(i)
-            for a in range(1, p - 1):
-                res = nthroot_mod(a, q, p, True)
-                if d[a]:
-                    assert d[a] == res
+    for p in range(1, 20):
+        for a in range(p):
+            for n in range(1, p):
+                ans = nthroot_mod(a, n, p, True)
+                assert isinstance(ans, list)
+                for b in range(p):
+                    pred = pow(b, n, p) == a
+                    assert not(pred ^ (b in ans))
+                ans2 = nthroot_mod(a, n, p, False)
+                if ans2 is None:
+                    assert ans == []
                 else:
-                    assert res == []
+                    assert ans2 in ans
 
     assert legendre_symbol(5, 11) == 1
     assert legendre_symbol(25, 41) == 1


### PR DESCRIPTION
* Reorganized functions.
  * Removed `_help`.
  * added `_nthroot_mod_prime_power`
* added docstring
  * especially the return value of `_nthroot_mod`, since it was ambiguous.
* The behavior of `all_roots=False` is now unified.
  * currently, `nthroot_mod(3, 9, 5)` returns `3`, but `nthroot_mod(3, 9, 15)` returns `[3]` -- both should return `3`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In the current code, the return type depends on whether `p` is prime.
```python
>>> nthroot_mod(2, 3, 7, all_roots=False) is None
True
>>> nthroot_mod(2, 3, 4, all_roots=False)
[]
>>> nthroot_mod(29, 31, 71, all_roots=False)
8
>>> nthroot_mod(29, 31, 74, all_roots=False)
[45]
```

Or, multiple solutions are output despite `all_roots=False`.

```python
>>> nthroot_mod(21, 10, 74, False)
[15, 59]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `nthroot_mod` output when `all_roots=False` is not an int or None
<!-- END RELEASE NOTES -->
