### PR TITLE
[GSoC'23] Add pseudo-remainder, pseudo-division, pseudo-quotient and pseudo-exact quotient methods using sparse representation

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2535,7 +2535,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         Coefficient of ``self`` with respect to ``x**deg``.
 
-        Treating *self* as a univariate polynomial in ``x`` this finds the
+        Treating ``self`` as a univariate polynomial in ``x`` this finds the
         coefficient of ``x**deg`` as a polynomial in the other generators.
 
         Parameters
@@ -2586,32 +2586,21 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def prem(self, g, x=None):
         """
-        Computes the pseudo-remainder of the polynomial ``self`` with respect
-        to ``g``.
-
-        Euclidean division is a well-defined operation for univariate
-        polynomials ``f`` and ``g`` with coefficients in a field. It yields a
-        unique pair of polynomials ``q`` and ``r``, the quotient and remainder,
-        respectively, satisfying ``f = gq + r``, where ``deg(r) < deg(g)``.
-
-        In the context of the ``prem`` method, multivariate polynomials in a
-        ring like ``R[x,y,z]`` are treated as univariate polynomials with
-        coefficients that are polynomials, such as ``R[x,y][z]``.
+        Pseudo-remainder of the polynomial ``self`` with respect to ``g``.
 
         The pseudo-quotient ``q`` and pseudo-remainder ``r`` with respect to
-        ``z`` when dividing ``f`` by ``g`` satisfy ``mf = gq + r``,
+        ``z`` when dividing ``f`` by ``g`` satisfy ``m*f = g*q + r``,
         where ``deg(r,z) < deg(g,z)`` and
         ``m = LC(g,z)**(deg(f,z) - deg(g,z)+1)``.
 
-        The ``prem`` method returns the pseudo-remainder ``r``,
-        the ``pquo`` method returns the pseudo-quotient ``q``,
-        and ``pdiv`` returns the tuple ``(q, r)``.
+        See :meth:`pdiv` for explanation of pseudo-division.
+
 
         Parameters
         ==========
 
         g : :py:class:`~.PolyElement`
-            The polynomial to divide *self* by.
+            The polynomial to divide ``self`` by.
         x : generator or generator index, optional
             The main variable of the polynomials and default is first generator.
 
@@ -2636,6 +2625,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> g = 2*x + 2
         >>> f.prem(g) # first generator is chosen by default if it is not given
         -4*y + 4
+        >>> f.rem(g) # shows the differnce between prem and rem
+        x**2 + x*y
         >>> f.prem(g, y) # generator is given
         0
         >>> f.prem(g, 1) # generator index is given
@@ -2644,7 +2635,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        pdiv, pquo, pexquo
+        pdiv, pquo, pexquo, sympy.polys.domains.ring.Ring.rem
 
         """
         f = self
@@ -2686,10 +2677,10 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def pdiv(self, g, x=None):
         """
-        Computes the pseudo-division of the polynomial *self* with respect to ``g``.
+        Computes the pseudo-division of the polynomial ``self`` with respect to ``g``.
 
         The pseudo-division algorithm is used to find the pseudo-quotient ``q``
-        and pseudo-remainder ``r`` such that ``mf = gq + r``, where ``m``
+        and pseudo-remainder ``r`` such that ``m*f = g*q + r``, where ``m``
         represents the multiplier and ``f`` is the dividend polynomial.
 
         The pseudo-quotient ``q`` and pseudo-remainder ``r`` are polynomials in
@@ -2705,11 +2696,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         as univariate polynomials with coefficients that are polynomials,
         such as ``R[x,y][z]``. When dividing ``f`` by ``g`` with respect to the
         variable ``z``, the pseudo-quotient ``q`` and pseudo-remainder ``r``
-        satisfy ``mf = gq + r``, where ``deg(r, z) < deg(g, z)``
+        satisfy ``m*f = g*q + r``, where ``deg(r, z) < deg(g, z)``
         and ``m = LC(g, z)^(deg(f, z) - deg(g, z) + 1)``.
 
         In this function, the pseudo-remainder ``r`` can be obtained using the
-        `:py:class:`~.PolyElement.prem` method, the pseudo-quotient ``q`` can
+        ``prem`` method, the pseudo-quotient ``q`` can
         be obtained using the ``pquo`` method, and
         the function ``pdiv`` itself returns a tuple ``(q, r)``.
 
@@ -2718,7 +2709,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ==========
 
         g : :py:class:`~.PolyElement`
-            The polynomial to divide *self* by.
+            The polynomial to divide ``self`` by.
         x : generator or generator index, optional
             The main variable of the polynomials and default is first generator.
 
@@ -2743,6 +2734,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> g = 2*x + 2
         >>> f.pdiv(g) # first generator is chosen by default if it is not given
         (2*x + 2*y - 2, -4*y + 4)
+        >>> f.div(g) # shows the difference between pdiv and div
+        (0, x**2 + x*y)
         >>> f.pdiv(g, y) # generator is given
         (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
         >>> f.pdiv(g, 1) # generator index is given
@@ -2751,7 +2744,15 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        prem, pquo, pexquo
+        prem
+            Computes only the pseudo-remainder more efficiently than
+            `f.pdiv(g)[1]`.
+        pquo
+            Returns only the pseudo-quotient.
+        pexquo
+            Returns only an exact pseudo-quotient having no remainder.
+        div
+            Returns quotient and remainder of f and g polynomials.
 
         """
         f = self
@@ -2802,7 +2803,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def pquo(self, g, x=None):
         """
-        Polynomial exact pseudo-quotient in multivariate polynomial ring.
+        Polynomial pseudo-quotient in multivariate polynomial ring.
 
         Examples
         ========
@@ -2814,13 +2815,17 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> h = 2*x + 2
         >>> f.pquo(g)
         2*x
+        >>> f.quo(g) # shows the difference between pquo and quo
+        0
         >>> f.pquo(h)
         2*x + 2*y - 2
+        >>> f.quo(h) # shows the difference between pquo and quo
+        0
 
         See Also
         ========
 
-        prem, pdiv, pexquo
+        prem, pdiv, pexquo, sympy.polys.domains.ring.Ring.quo
 
         """
         f = self
@@ -2828,7 +2833,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def pexquo(self, g, x=None):
         """
-        Polynomial pseudo-quotient in multivariate polynomial ring.
+        Polynomial exact pseudo-quotient in multivariate polynomial ring.
 
         Examples
         ========
@@ -2840,6 +2845,10 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> h = 2*x + 2
         >>> f.pexquo(g)
         2*x
+        >>> f.exquo(g) # shows the differnce between pexquo and exquo
+        Traceback (most recent call last):
+        ...
+        ExactQuotientFailed: 2*x + 2*y does not divide x**2 + x*y
         >>> f.pexquo(h)
         Traceback (most recent call last):
         ...
@@ -2848,7 +2857,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        prem, pdiv, pquo
+        prem, pdiv, pquo, sympy.polys.domains.ring.Ring.exquo
 
         """
         f = self

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2586,13 +2586,20 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def prem(self, g, x=None):
         """
-        Computes the pseudo-remainder of the polynomial ``self`` with respect to ``g``.
+        Computes the pseudo-remainder of the polynomial ``self`` with respect
+        to ``g``.
 
-        Euclidean division is a well-defined operation for univariate polynomials ``f`` and ``g`` with coefficients in a field. It yields a unique pair of polynomials ``q`` and ``r``, the quotient and remainder, respectively, satisfying ``f = gq + r``, where ``deg(r) < deg(g)``.
+        Euclidean division is a well-defined operation for univariate
+        polynomials ``f`` and ``g`` with coefficients in a field. It yields a
+        unique pair of polynomials ``q`` and ``r``, the quotient and remainder,
+        respectively, satisfying ``f = gq + r``, where ``deg(r) < deg(g)``.
 
-        In the context of the ``prem`` method, multivariate polynomials in a ring like ``R[x,y,z]`` are treated as univariate polynomials with coefficients that are polynomials, such as ``R[x,y][z]``.
+        In the context of the ``prem`` method, multivariate polynomials in a
+        ring like ``R[x,y,z]`` are treated as univariate polynomials with
+        coefficients that are polynomials, such as ``R[x,y][z]``.
 
-        The pseudo-quotient ``q`` and pseudo-remainder ``r`` with respect to ``z`` when dividing ``f`` by ``g`` satisfy ``mf = gq + r``,
+        The pseudo-quotient ``q`` and pseudo-remainder ``r`` with respect to
+        ``z`` when dividing ``f`` by ``g`` satisfy ``mf = gq + r``,
         where ``deg(r,z) < deg(g,z)`` and
         ``m = LC(g,z)**(deg(f,z) - deg(g,z)+1)``.
 
@@ -2682,9 +2689,12 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         Computes the pseudo-division of the polynomial *self* with respect to ``g``.
 
         The pseudo-division algorithm is used to find the pseudo-quotient ``q``
-        and pseudo-remainder ``r`` such that ``mf = gq + r``, where ``m`` represents the multiplier and ``f`` is the dividend polynomial.
+        and pseudo-remainder ``r`` such that ``mf = gq + r``, where ``m``
+        represents the multiplier and ``f`` is the dividend polynomial.
 
-        The pseudo-quotient ``q`` and pseudo-remainder ``r`` are polynomials in the variable ``x``, with the degree of ``r`` with respect to ``x`` being strictly less than the degree of ``g`` with respect to ``x``.
+        The pseudo-quotient ``q`` and pseudo-remainder ``r`` are polynomials in
+        the variable ``x``, with the degree of ``r`` with respect to ``x``
+        being strictly less than the degree of ``g`` with respect to ``x``.
 
         The multiplier ``m`` is defined as
         ``LC(g, x) ^ (deg(f, x) - deg(g, x) + 1)``,
@@ -2693,10 +2703,14 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         It is important to note that in the context of the ``prem`` method,
         multivariate polynomials in a ring, such as ``R[x,y,z]``, are treated
         as univariate polynomials with coefficients that are polynomials,
-        such as ``R[x,y][z]``. When dividing ``f`` by ``g`` with respect to the variable ``z``, the pseudo-quotient ``q`` and pseudo-remainder ``r`` satisfy ``mf = gq + r``, where ``deg(r, z) < deg(g, z)``
+        such as ``R[x,y][z]``. When dividing ``f`` by ``g`` with respect to the
+        variable ``z``, the pseudo-quotient ``q`` and pseudo-remainder ``r``
+        satisfy ``mf = gq + r``, where ``deg(r, z) < deg(g, z)``
         and ``m = LC(g, z)^(deg(f, z) - deg(g, z) + 1)``.
 
-        In this function, the pseudo-remainder ``r`` can be obtained using the ``prem`` method, the pseudo-quotient ``q`` can be obtained using the ``pquo`` method, and
+        In this function, the pseudo-remainder ``r`` can be obtained using the
+        `:py:class:`~.PolyElement.prem` method, the pseudo-quotient ``q`` can
+        be obtained using the ``pquo`` method, and
         the function ``pdiv`` itself returns a tuple ``(q, r)``.
 
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2535,7 +2535,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         Coefficient of ``self`` with respect to ``x**deg``.
 
-        Treating ``self`` as a univariate polynomial in ``x`` this finds the
+        Treating *self* as a univariate polynomial in ``x`` this finds the
         coefficient of ``x**deg`` as a polynomial in the other generators.
 
         Parameters
@@ -2549,7 +2549,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         Returns
         =======
 
-        PolyElement
+        :py:class:`~.PolyElement`
             The coefficient of ``x**deg`` as a polynomial in the same ring.
 
         Examples
@@ -2557,6 +2557,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         >>> from sympy.polys import ring, ZZ
         >>> R, x, y, z = ring("x, y, z", ZZ)
+
         >>> p = 2*x**4 + 3*y**4 + 10*z**2 + 10*x*z**2
         >>> deg = 2
         >>> p.coeff_wrt(2, deg) # Using the generator index
@@ -2569,7 +2570,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        coeff, coeffs, LC
+        coeff, coeffs
 
         """
         p = self
@@ -2587,46 +2588,43 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         Computes the pseudo-remainder of the polynomial ``self`` with respect to ``g``.
 
-        Euclidean division is a well-defined operation for univariate polynomials
-        `f` and `g` with coefficients in a field. It yields a unique pair of polynomials
-        `q` and `r`, the quotient and remainder, respectively, satisfying `f = gq + r`,
-        where `deg(r) < deg(g)`.
+        Euclidean division is a well-defined operation for univariate polynomials ``f`` and ``g`` with coefficients in a field. It yields a unique pair of polynomials ``q`` and ``r``, the quotient and remainder, respectively, satisfying ``f = gq + r``, where ``deg(r) < deg(g)``.
 
-        In the context of the `prem` method, multivariate polynomials in a ring
-        like `R[x,y,z]` are treated as univariate polynomials with coefficients
-        that are polynomials, such as `R[x,y][z]`. The pseudo-quotient `q` and
-        pseudo-remainder `r` with respect to `z` when dividing `f` by `g`
-        satisfy `mf = gq + r`, where `deg(r,z) < deg(g,z)` and
-        `m = LC(g,z)**(deg(f,z) - deg(g,z)+1)`.
+        In the context of the ``prem`` method, multivariate polynomials in a ring like ``R[x,y,z]`` are treated as univariate polynomials with coefficients that are polynomials, such as ``R[x,y][z]``.
 
-        The `prem` method returns the pseudo-remainder `r`,
-        the `pquo` method returns the pseudo-quotient `q`,
-        and `pdiv` returns the tuple `(q, r)`.
+        The pseudo-quotient ``q`` and pseudo-remainder ``r`` with respect to ``z`` when dividing ``f`` by ``g`` satisfy ``mf = gq + r``,
+        where ``deg(r,z) < deg(g,z)`` and
+        ``m = LC(g,z)**(deg(f,z) - deg(g,z)+1)``.
+
+        The ``prem`` method returns the pseudo-remainder ``r``,
+        the ``pquo`` method returns the pseudo-quotient ``q``,
+        and ``pdiv`` returns the tuple ``(q, r)``.
 
         Parameters
         ==========
 
-        g : PolyElement
-            The polynomial to divide `self` by.
+        g : :py:class:`~.PolyElement`
+            The polynomial to divide *self* by.
         x : generator or generator index, optional
             The main variable of the polynomials and default is first generator.
 
         Returns
         =======
 
-        PolyElement
+        :py:class:`~.PolyElement`
             The pseudo-remainder polynomial.
 
         Raises
         ======
 
-        ZeroDivisionError : If `g` is the zero polynomial.
+        ZeroDivisionError : If ``g`` is the zero polynomial.
 
         Examples
         ========
 
         >>> from sympy.polys import ring, ZZ
         >>> R, x, y = ring("x, y", ZZ)
+
         >>> f = x**2 + x*y
         >>> g = 2*x + 2
         >>> f.prem(g) # first generator is chosen by default if it is not given
@@ -2681,58 +2679,56 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def pdiv(self, g, x=None):
         """
-        Computes the pseudo-division of the polynomial ``self`` with respect to ``g``.
+        Computes the pseudo-division of the polynomial *self* with respect to ``g``.
 
-        The pseudo-division algorithm is used to find the pseudo-quotient `q`
-        and pseudo-remainder `r` such that `mf = gq + r`, where `m` represents
-        the multiplier and `f` is the dividend polynomial. The pseudo-quotient `q`
-        and pseudo-remainder `r` are polynomials in the variable `x`, with the
-        degree of `r` with respect to `x` being strictly less than the degree of `g`
-        with respect to `x`.
-        The multiplier `m` is defined as `LC(g, x) ^ (deg(f, x) - deg(g, x) + 1)`,
-        where `LC(g, x)` represents the leading coefficient of `g`.
+        The pseudo-division algorithm is used to find the pseudo-quotient ``q``
+        and pseudo-remainder ``r`` such that ``mf = gq + r``, where ``m`` represents the multiplier and ``f`` is the dividend polynomial.
 
-        It is important to note that in the context of the `prem` method,
-        multivariate polynomials in a ring, such as `R[x,y,z]`, are treated
+        The pseudo-quotient ``q`` and pseudo-remainder ``r`` are polynomials in the variable ``x``, with the degree of ``r`` with respect to ``x`` being strictly less than the degree of ``g`` with respect to ``x``.
+
+        The multiplier ``m`` is defined as
+        ``LC(g, x) ^ (deg(f, x) - deg(g, x) + 1)``,
+        where ``LC(g, x)`` represents the leading coefficient of ``g``.
+
+        It is important to note that in the context of the ``prem`` method,
+        multivariate polynomials in a ring, such as ``R[x,y,z]``, are treated
         as univariate polynomials with coefficients that are polynomials,
-        such as `R[x,y][z]`. When dividing `f` by `g` with respect to the variable `z`,
-        the pseudo-quotient `q` and pseudo-remainder `r` satisfy `mf = gq + r`,
-        where `deg(r, z) < deg(g, z)` and `m = LC(g, z)^(deg(f, z) - deg(g, z) + 1)`.
+        such as ``R[x,y][z]``. When dividing ``f`` by ``g`` with respect to the variable ``z``, the pseudo-quotient ``q`` and pseudo-remainder ``r`` satisfy ``mf = gq + r``, where ``deg(r, z) < deg(g, z)``
+        and ``m = LC(g, z)^(deg(f, z) - deg(g, z) + 1)``.
 
-        In this function, the pseudo-remainder `r` can be obtained using the `prem` method,
-        the pseudo-quotient `q` can be obtained using the `pquo` method, and
-        the function `pdiv` itself returns a tuple `(q, r)`
+        In this function, the pseudo-remainder ``r`` can be obtained using the ``prem`` method, the pseudo-quotient ``q`` can be obtained using the ``pquo`` method, and
+        the function ``pdiv`` itself returns a tuple ``(q, r)``.
 
 
         Parameters
         ==========
 
-        g : PolyElement
-            The polynomial to divide `self` by.
+        g : :py:class:`~.PolyElement`
+            The polynomial to divide *self* by.
         x : generator or generator index, optional
             The main variable of the polynomials and default is first generator.
 
         Returns
         =======
 
-        PolyElement
-            The pseudo-division polynomial (tuple of `q` and `r`).
+        :py:class:`~.PolyElement`
+            The pseudo-division polynomial (tuple of ``q`` and ``r``).
 
         Raises
         ======
 
-        ZeroDivisionError : If `g` is the zero polynomial.
+        ZeroDivisionError : If ``g`` is the zero polynomial.
 
         Examples
         ========
 
         >>> from sympy.polys import ring, ZZ
         >>> R, x, y = ring("x, y", ZZ)
+
         >>> f = x**2 + x*y
         >>> g = 2*x + 2
         >>> f.pdiv(g) # first generator is chosen by default if it is not given
         (2*x + 2*y - 2, -4*y + 4)
-
         >>> f.pdiv(g, y) # generator is given
         (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
         >>> f.pdiv(g, 1) # generator index is given
@@ -2798,6 +2794,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ========
         >>> from sympy.polys import ring, ZZ
         >>> R, x,y = ring("x,y", ZZ)
+
         >>> f = x**2 + x*y
         >>> g = 2*x + 2*y
         >>> h = 2*x + 2
@@ -2813,7 +2810,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         """
         f = self
-        x = f.ring.index(x)
         return f.pdiv(g, x)[0]
 
     def pexquo(self, g, x=None):
@@ -2824,12 +2820,12 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ========
         >>> from sympy.polys import ring, ZZ
         >>> R, x,y = ring("x,y", ZZ)
+
         >>> f = x**2 + x*y
         >>> g = 2*x + 2*y
         >>> h = 2*x + 2
         >>> f.pexquo(g)
         2*x
-
         >>> f.pexquo(h)
         Traceback (most recent call last):
         ...
@@ -2842,7 +2838,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         """
         f = self
-        x = f.ring.index(x)
         q, r = f.pdiv(g, x)
 
         if r.is_zero:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2593,12 +2593,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         `q` and `r`, the quotient and remainder, respectively, satisfying `f = gq + r`,
         where `deg(r) < deg(g)`.
 
-        For polynomials `f` and `g` with coefficients in a domain, polynomial
-        pseudo-division can be used. It also yields a unique pair of polynomials
-        `q` and `r`, satisfying `mf = gq + r`, where deg(r) < deg(g), `m` is a power
-        of the leading coefficient of `g`, and `f` is pre-multiplied by `m` to ensure
-        exact coefficient divisions.
-
         In the context of the `prem` method, multivariate polynomials in a ring
         like `R[x,y,z]` are treated as univariate polynomials with coefficients
         that are polynomials, such as `R[x,y][z]`. The pseudo-quotient `q` and
@@ -2615,8 +2609,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         g : PolyElement
             The polynomial to divide `self` by.
-        x : generator or generator index(optional)
-            The main variable of the polynomials.
+        x : generator or generator index, optional
+            The main variable of the polynomials and default is first generator.
 
         Returns
         =======

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2650,7 +2650,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             G = g * lc_r * xp**j
             r = R - G
 
-            _dr, dr = dr, r.degree(x)
+            dr = r.degree(x)
 
             if dr < dg:
                 break

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2723,10 +2723,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> g = 2*x + 2
         >>> f.pdiv(g) # first generator is chosen by default if it is not given
         (2*x + 2*y - 2, -4*y + 4)
-        >>> f.div(g, y) # generator is given
-        0
-        >>> f.div(g, 1) # generator index is given
-        0
+
+        >>> f.pdiv(g, y) # generator is given
+        (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
+        >>> f.pdiv(g, 1) # generator index is given
+        (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
 
         See Also
         ========
@@ -2743,7 +2744,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         if dg < 0:
             raise ZeroDivisionError("polynomial division")
 
-        q, r, dr = 0, f, df
+        q, r, dr = x, f, df
 
         if df < dg:
             return q, r
@@ -2751,7 +2752,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         N = df - dg + 1
         lc_g = g.coeff_wrt(x, dg)
 
-        xp = f.ring.gens[0]
+        xp = f.ring.gens[x]
 
         while True:
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2686,14 +2686,26 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         Computes the pseudo-division of the polynomial ``self`` with respect to ``g``.
 
-        The pseudo-division algorithm finds the pseudo-remainder `r` such that the relationship
-        `ma = bq + r` is satisfied, where `m` is the multiplier and `q` is the pseudo-quotient.
-        `r` and `q` are polynomials in `x`, with `degree(r, x) < degree(b, x)`. The multiplier
-        `m` is defined as `lcoeff(b, x) ^ (degree(a, x) - degree(b, x) + 1)` and is free of `x`.
+        The pseudo-division algorithm is used to find the pseudo-quotient `q`
+        and pseudo-remainder `r` such that `mf = gq + r`, where `m` represents
+        the multiplier and `f` is the dividend polynomial. The pseudo-quotient `q`
+        and pseudo-remainder `r` are polynomials in the variable `x`, with the
+        degree of `r` with respect to `x` being strictly less than the degree of `g`
+        with respect to `x`.
+        The multiplier `m` is defined as `LC(g, x) ^ (deg(f, x) - deg(g, x) + 1)`,
+        where `LC(g, x)` represents the leading coefficient of `g`.
 
-        The `prem` method returns the pseudo-remainder `r`,
-        the `pquo` method returns the pseudo-quotient `q`,
-        and `pdiv` returns the tuple `(q, r)`.
+        It is important to note that in the context of the `prem` method,
+        multivariate polynomials in a ring, such as `R[x,y,z]`, are treated
+        as univariate polynomials with coefficients that are polynomials,
+        such as `R[x,y][z]`. When dividing `f` by `g` with respect to the variable `z`,
+        the pseudo-quotient `q` and pseudo-remainder `r` satisfy `mf = gq + r`,
+        where `deg(r, z) < deg(g, z)` and `m = LC(g, z)^(deg(f, z) - deg(g, z) + 1)`.
+
+        In this function, the pseudo-remainder `r` can be obtained using the `prem` method,
+        the pseudo-quotient `q` can be obtained using the `pquo` method, and
+        the function `pdiv` itself returns a tuple `(q, r)`
+
 
         Parameters
         ==========
@@ -2818,10 +2830,10 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> f = x**2 + x*y
         >>> g = 2*x + 2*y
         >>> h = 2*x + 2
-        >>> R.pexquo(f, g)
+        >>> f.pexquo(g)
         2*x
 
-        >>> R.pexquo(f, h)
+        >>> f.pexquo(h)
         Traceback (most recent call last):
         ...
         ExactQuotientFailed: 2*x + 2 does not divide x**2 + x*y

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -6,6 +6,8 @@ from typing import Any
 from operator import add, mul, lt, le, gt, ge
 from functools import reduce
 from types import GeneratorType
+from itertools import compress
+from collections import defaultdict
 
 from sympy.core.expr import Expr
 from sympy.core.numbers import igcd, oo
@@ -2530,6 +2532,185 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             poly += subpoly
 
         return poly
+
+
+    def coeff_wrt(self, sym, dg):
+        """
+        Coefficient of ``f`` with respect to ``x**deg``.
+
+        Treating ``f`` as a univariate polynomial in ``x`` this finds the
+        coefficient of ``x**deg`` as a polynomial in the other generators.
+
+        Parameters
+        ==========
+
+            p1 : sympy.Poly
+                The polynomial to compute the sparse coefficient for.
+            sym : int
+                The symbol to compute the coefficient for.
+            dg : int
+                The degree of the monomial to compute the coefficient for.
+
+        Returns
+        =======
+
+            sympy.Number
+                The sparse coefficient of the polynomial at the given symbol and degree.
+
+        Examples
+        ========
+
+        >>> from sympy.polys import ring, ZZ
+        >>> _, x, y, z = ring("x, y, z", ZZ)
+        >>> p1 = 2*x**4 + 3*y**4 + 10*z**2 + 3
+        >>> dg = 2
+        >>> sym = 2
+        >>> coeff_wrt(p1, sym, dg)
+        10
+
+        """
+        p1 = self
+        p2 = as_polynomial(p1, {sym})
+        monomial = [0] * len(p1.ring.gens)
+        monomial[sym] = dg
+        monomial = tuple(monomial)
+        return p1.ring(p2[monomial])
+
+
+    def as_polynomial(self, syms):
+        """
+        It converts a polynomial p1 into a sparse representation where the
+        monomials are split into parts with symbols and parts without symbols,
+        and the coefficients are stored accordingly.
+
+        Parameters
+        ==========
+
+            p1 : sympy.Poly
+                The polynomial to compute the sparse coefficients for.
+            syms : set
+                The set of symbols to keep in the sparse coefficients.
+
+        Returns
+        =======
+
+            dict
+                A dictionary of sparse coefficients. The keys are tuples of the symbols
+                that are kept, and the values are dictionaries of the coefficients of
+                the monomials where the symbols are not present.
+
+        Examples
+        ========
+
+        >>> from sympy.polys import ring, ZZ
+        >>> _, x, y, z = ring("x, y, z", ZZ)
+        >>> p1 = 2*x**4 + 3*y**4 + 10*z**2 + 3
+        >>> syms = {0}
+        >>> as_polynomial(p1, syms)
+        >>> {(4, 0, 0): {(0, 0, 0): 2}, (0, 0, 0): {(0, 4, 0): 3, (0, 0, 2): 10, (0, 0, 0): 3}}
+
+        """
+        p1 = self
+        num_variables = len(p1.ring.gens)
+        non_symbol_indices = set(range(num_variables)) - syms
+        p2 = defaultdict(dict)
+        variable_range = range(num_variables)
+
+        for monomial, coefficient in p1.items():
+            symbol_indices = set(compress(variable_range, monomial))
+            monomial_with_symbols = [0] * num_variables
+            monomial_without_symbols = [0] * num_variables
+
+            for i in symbol_indices & syms:
+                monomial_with_symbols[i] = monomial[i]
+
+            for i in symbol_indices & non_symbol_indices:
+                monomial_without_symbols[i] = monomial[i]
+
+            p2[tuple(monomial_with_symbols)][tuple(monomial_without_symbols)] = coefficient
+
+        return dict(p2)
+
+
+    def sparse_prem(self, g, x):
+        """
+        Computes the pseudo-remainder of the polynomial `f` with respect to `g` using the sparse representation.
+
+        Parameters
+        ==========
+
+            f (PolyElement): The polynomial to compute the pseudo-remainder for.
+            g (PolyElement): The polynomial to divide `f` by.
+            x (Symbol): The main variable of the polynomials.
+
+        Returns
+        =======
+
+            PolyElement: The pseudo-remainder polynomial.
+
+        Raises
+        ======
+
+            ZeroDivisionError: If the degree of `g` is negative.
+            ValueError: If the algorithm encounters an unexpected condition.
+
+        This function implements the pseudo-remainder algorithm for sparse polynomials, which is used to compute
+        the pseudo-remainder of `f` divided by `g`. It starts by checking the degree of `g` and ensures it is
+        non-negative. Then, it initializes the remainder `r` with `f` and sets the current degree `dr` to be the
+        degree of `f`. If the degree of `f` is lower than the degree of `g`, it returns `r` as the pseudo-remainder.
+        Otherwise, it proceeds with the main pseudo-remainder loop.
+
+        After the loop, it calculates the coefficient `c` by raising `lc_g` to the power of `N`. Finally, it returns
+        the polynomial `r` multiplied by `c` as the pseudo-remainder.
+
+        Examples
+        ========
+
+        >>> from sympy.polys import ring, ZZ
+        >>> _, x, y, z = ring("x, y, z", ZZ)
+
+        >>> f = x**2 + x*y
+        >>> g = 2*x + 2
+        >>> sparse_prem(f, g, 0)
+        -4*y + 4
+
+        """
+        f = self
+        df = f.degree(x)
+        dg = g.degree(x)
+
+        if dg < 0:
+            raise ZeroDivisionError
+
+        r, dr = f, df
+
+        if df < dg:
+            return r
+
+        N = df - dg + 1
+
+        lc_g = coeff_wrt(g, x, dg)
+
+        xp = f.ring.gens[x]
+
+        while True:
+            lc_r = coeff_wrt(r, x, dr)
+            j, N = dr - dg, N - 1
+
+            R = r * lc_g
+            G = g * lc_r * xp**j
+            r = R - G
+
+            _dr, dr = dr, r.degree(x)
+
+            if dr < dg:
+                break
+            elif not (dr < _dr):
+                raise ValueError
+
+        c = lc_g ** N
+
+        return r * c
 
     # TODO: following methods should point to polynomial
     # representation independent algorithm implementations.

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2578,7 +2578,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         terms = [(m, c) for m, c in p.iterterms() if m[i] == deg]
 
         if not terms:
-            return 0
+            return p.ring.zero
 
         monoms, coeffs = zip(*terms)
         monoms = [m[:i] + (0,) + m[i + 1:] for m in monoms]
@@ -2586,16 +2586,29 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     def prem(self, g, x=None):
         """
-        Computes the pseudo-remainder of the polynomial `f` with respect to `g`.
+        Computes the pseudo-remainder of the polynomial ``self`` with respect to ``g``.
 
-        The pseudo-remainder `r` of `self` with respect to `g` is a polynomial
-        such that there exist polynomials `q0`, `q1`, ..., `q(n-1)` satisfying
-        the equation:
+        Euclidean division is a well-defined operation for univariate polynomials
+        `f` and `g` with coefficients in a field. It yields a unique pair of polynomials
+        `q` and `r`, the quotient and remainder, respectively, satisfying `f = gq + r`,
+        where `deg(r) < deg(g)`.
 
-        self = q0 * g + r
+        For polynomials `f` and `g` with coefficients in a domain, polynomial
+        pseudo-division can be used. It also yields a unique pair of polynomials
+        `q` and `r`, satisfying `mf = gq + r`, where deg(r) < deg(g), `m` is a power
+        of the leading coefficient of `g`, and `f` is pre-multiplied by `m` to ensure
+        exact coefficient divisions.
 
-        where the degree of polynomial `r` (with respect to the variable `x`) is strictly
-        lower than the degree of polynomial `g` (with respect to the variable `x`).
+        In the context of the `prem` method, multivariate polynomials in a ring
+        like `R[x,y,z]` are treated as univariate polynomials with coefficients
+        that are polynomials, such as `R[x,y][z]`. The pseudo-quotient `q` and
+        pseudo-remainder `r` with respect to `z` when dividing `f` by `g`
+        satisfy `mf = gq + r`, where `deg(r,z) < deg(g,z)` and
+        `m = LC(g,z)**(deg(f,z) - deg(g,z)+1)`.
+
+        The `prem` method returns the pseudo-remainder `r`,
+        the `pquo` method returns the pseudo-quotient `q`,
+        and `pdiv` returns the tuple `(q, r)`.
 
         Parameters
         ==========

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2543,11 +2543,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ==========
 
         p : sympy.Poly
-            The polynomial to compute the sparse coefficient for.
-        x : int
-            The symbol to compute the coefficient for.
+            The polynomial to compute the expression for.
+        x : generator or generator index
+            The generator or generator index to compute the expression for.
         dg : int
-            The degree of the monomial to compute the coefficient for.
+            The degree of the monomial to compute the expression for.
 
         Returns
         =======
@@ -2559,11 +2559,12 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ========
 
         >>> from sympy.polys import ring, ZZ
-        >>> _, x, y, z = ring("x, y, z", ZZ)
+        >>> R, x, y, z = ring("x, y, z", ZZ)
         >>> p = 2*x**4 + 3*y**4 + 10*z**2 + 10*x*z**2
         >>> dg = 2
-        >>> x = 2
-        >>> p.coeff_wrt(x, dg)
+        >>> p.coeff_wrt(2, dg) # Using the generator index
+        10*x + 10
+        >>> p.coeff_wrt(z, 2) # Using the generator
         10*x + 10
 
         """
@@ -2579,15 +2580,12 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         Computes the pseudo-remainder of the polynomial `f` with respect to `g`.
 
-        The pseudo-remainder is a concept in polynomial division that provides a way to divide `f` by `g`
-        and obtain a remainder while still preserving some properties of division. It is defined as follows:
+        The function `prem` returns the pseudo-remainder `r` such that `f` and `g`, the
+        pseudo-remainder `r` of `f` with respect to `g` is a polynomial such that there
+        exist polynomials `q0`, `q1`, ..., `q(n-1)` such that:
+            `f = q0 * g + r`
 
-        Given two polynomials `f` and `g`, the pseudo-remainder `r` of `f` with respect to `g` is a polynomial
-        such that there exist polynomials `q0`, `q1`, ..., `q(n-1)` satisfying the following conditions:
-
-        1. `f = q0 * g + r`
-        2. The degree of `r` is less than the degree of `g`
-        3. For each `i` from 0 to n-1, the degree of `q(i) * g` is less than or equal to the degree of `f`
+        where the degree of `r` is less than the degree of `g`.
 
         Parameters
         ==========
@@ -2596,25 +2594,24 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             The polynomial to compute the pseudo-remainder for.
         g : PolyElement
             The polynomial to divide `f` by.
-        x : Symbol
+        x : Symbol(optional)
             The main variable of the polynomials.
 
         Returns
         =======
 
-        PolyElement: The pseudo-remainder polynomial.
+        PolyElement : The pseudo-remainder polynomial.
 
         Raises
         ======
 
-        ZeroDivisionError : If the degree of `g` is negative or g is the zero polynomial.
-        ValueError : It is raised when the degree of `r` with respect to `x` stops decreasing and remains the same or increases in consecutive iterations of the while loop.
+        ZeroDivisionError : If `g` is the zero polynomial.
 
         Examples
         ========
 
         >>> from sympy.polys import ring, ZZ
-        >>> _, x, y, z = ring("x, y, z", ZZ)
+        >>> R, x, y, z = ring("x, y, z", ZZ)
 
         >>> f = x**2 + x*y
         >>> g = 2*x + 2
@@ -2657,8 +2654,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
             if dr < dg:
                 break
-            elif not (dr < _dr):
-                raise ValueError
 
         c = lc_g ** N
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2563,7 +2563,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> p = 2*x**4 + 3*y**4 + 10*z**2 + 3
         >>> dg = 2
         >>> sym = 2
-        >>> coeff_wrt(p, sym, dg)
+        >>> p.coeff_wrt(sym, dg)
         10
 
         """
@@ -2574,7 +2574,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         return p.ring.from_dict(dict(zip(monoms, coeffs)))
 
 
-    def prem(self, g, x):
+    def prem2(self, g, x):
         """
         Computes the pseudo-remainder of the polynomial `f` with respect to `g`.
 
@@ -2607,7 +2607,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         >>> f = x**2 + x*y
         >>> g = 2*x + 2
-        >>> prem(f, g, 0)
+        >>> f.prem2(g, 0)
         -4*y + 4
 
         """
@@ -2616,7 +2616,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         dg = g.degree(x)
 
         if dg < 0:
-            raise ZeroDivisionError
+            raise ZeroDivisionError('polynomial division')
 
         r, dr = f, df
 
@@ -2624,15 +2624,14 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             return r
 
         N = df - dg + 1
-        self = g
 
-        lc_g = self.coeff_wrt(x, dg)
+        lc_g = g.coeff_wrt(x, dg)
 
         xp = f.ring.gens[x]
 
         while True:
-            self = r
-            lc_r = self.coeff_wrt(x, dr)
+
+            lc_r = r.coeff_wrt(x, dr)
             j, N = dr - dg, N - 1
 
             R = r * lc_g

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2768,7 +2768,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
             r = R - G
 
-            _dr, dr = dr, r.degree(x)
+            dr = r.degree(x)
 
             if dr < dg:
                 break

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2682,17 +2682,166 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         return r * c
 
+    def pdiv(self, g, x=None):
+        """
+        Computes the pseudo-division of the polynomial ``self`` with respect to ``g``.
+
+        The pseudo-division algorithm finds the pseudo-remainder `r` such that the relationship
+        `ma = bq + r` is satisfied, where `m` is the multiplier and `q` is the pseudo-quotient.
+        `r` and `q` are polynomials in `x`, with `degree(r, x) < degree(b, x)`. The multiplier
+        `m` is defined as `lcoeff(b, x) ^ (degree(a, x) - degree(b, x) + 1)` and is free of `x`.
+
+        The `prem` method returns the pseudo-remainder `r`,
+        the `pquo` method returns the pseudo-quotient `q`,
+        and `pdiv` returns the tuple `(q, r)`.
+
+        Parameters
+        ==========
+
+        g : PolyElement
+            The polynomial to divide `self` by.
+        x : generator or generator index, optional
+            The main variable of the polynomials and default is first generator.
+
+        Returns
+        =======
+
+        PolyElement
+            The pseudo-division polynomial (tuple of `q` and `r`).
+
+        Raises
+        ======
+
+        ZeroDivisionError : If `g` is the zero polynomial.
+
+        Examples
+        ========
+
+        >>> from sympy.polys import ring, ZZ
+        >>> R, x, y = ring("x, y", ZZ)
+        >>> f = x**2 + x*y
+        >>> g = 2*x + 2
+        >>> f.pdiv(g) # first generator is chosen by default if it is not given
+        (2*x + 2*y - 2, -4*y + 4)
+        >>> f.div(g, y) # generator is given
+        0
+        >>> f.div(g, 1) # generator index is given
+        0
+
+        See Also
+        ========
+
+        prem, pquo, pexquo
+
+        """
+        f = self
+        x = f.ring.index(x)
+
+        df = f.degree(x)
+        dg = g.degree(x)
+
+        if dg < 0:
+            raise ZeroDivisionError("polynomial division")
+
+        q, r, dr = 0, f, df
+
+        if df < dg:
+            return q, r
+
+        N = df - dg + 1
+        lc_g = g.coeff_wrt(x, dg)
+
+        xp = f.ring.gens[0]
+
+        while True:
+
+            lc_r = r.coeff_wrt(x, dr)
+            j, N = dr - dg, N - 1
+
+            Q = q * lc_g
+
+            q = Q + (lc_r)*xp**j
+
+            R = r * lc_g
+
+            G = g * lc_r * xp**j
+
+            r = R - G
+
+            _dr, dr = dr, r.degree(x)
+
+            if dr < dg:
+                break
+
+        c = lc_g**N
+
+        q = q * c
+        r = r * c
+
+        return q, r
+
+    def pquo(self, g, x=None):
+        """
+        Polynomial exact pseudo-quotient in multivariate polynomial ring.
+
+        Examples
+        ========
+        >>> from sympy.polys import ring, ZZ
+        >>> R, x,y = ring("x,y", ZZ)
+        >>> f = x**2 + x*y
+        >>> g = 2*x + 2*y
+        >>> h = 2*x + 2
+        >>> f.pquo(g)
+        2*x
+        >>> f.pquo(h)
+        2*x + 2*y - 2
+
+        See Also
+        ========
+
+        prem, pdiv, pexquo
+
+        """
+        f = self
+        x = f.ring.index(x)
+        return f.pdiv(g, x)[0]
+
+    def pexquo(self, g, x=None):
+        """
+        Polynomial pseudo-quotient in multivariate polynomial ring.
+
+        Examples
+        ========
+        >>> from sympy.polys import ring, ZZ
+        >>> R, x,y = ring("x,y", ZZ)
+        >>> f = x**2 + x*y
+        >>> g = 2*x + 2*y
+        >>> h = 2*x + 2
+        >>> R.pexquo(f, g)
+        2*x
+
+        >>> R.pexquo(f, h)
+        Traceback (most recent call last):
+        ...
+        ExactQuotientFailed: 2*x + 2 does not divide x**2 + x*y
+
+        See Also
+        ========
+
+        prem, pdiv, pquo
+
+        """
+        f = self
+        x = f.ring.index(x)
+        q, r = f.pdiv(g, x)
+
+        if r.is_zero:
+            return q
+        else:
+            raise ExactQuotientFailed(f, g)
+
     # TODO: following methods should point to polynomial
     # representation independent algorithm implementations.
-
-    def pdiv(f, g):
-        return f.ring.dmp_pdiv(f, g)
-
-    def pquo(f, g):
-        return f.ring.dmp_quo(f, g)
-
-    def pexquo(f, g):
-        return f.ring.dmp_exquo(f, g)
 
     def half_gcdex(f, g):
         return f.ring.dmp_half_gcdex(f, g)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2643,12 +2643,16 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> f.prem(g, 1) # generator index is given
         0
 
+        See Also
+        ========
+
+        pquo
+        pdiv
+        pexquo
+
         """
         f = self
         x = f.ring.index(x)
-        if x is None:
-            x = f.ring.index(x)
-
         df = f.degree(x)
         dg = g.degree(x)
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2569,8 +2569,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        coeff
-        coeffs
+        coeff, coeffs, LC
 
         """
         p = self
@@ -2640,9 +2639,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         See Also
         ========
 
-        pquo
-        pdiv
-        pexquo
+        pdiv, pquo, pexquo
 
         """
         f = self

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1359,17 +1359,31 @@ def test_PolyElement_pdiv():
     q, r = x + y, 0
 
     assert f.pdiv(g) == (q, r)
-    assert f.prem(g) == r
     assert f.pquo(g) == q
     assert f.pexquo(g) == q
 
 
-def test_PolyElement_sparse():
+def test_PolyElement_coeff_wrt():
 
-    _, x, y, z = ring("x, y, z", ZZ)
-    p1 = 4*x**3 + 5*y**2 + 6*z + 7
-    dg, sym = 2, 1
-    assert p1.coeff_wrt(sym, dg) == 5
+    R, x, y, z = ring("x, y, z", ZZ)
+    p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
+
+    assert p.coeff_wrt(1, 2) == 6*z + 5 # using generator index
+    assert p.coeff_wrt(x, 3) == 4 # using generator
+    
+    p1 = 2*x**4 + 3*x*y**2*z + 10*y**2 + 10*x*z**2 
+    
+    assert p1.coeff_wrt(x, 1) == 3*y**2*z + 10*z**2
+    assert p1.coeff_wrt(y, 2) == 3*x*z + 10
+
+    p2 = 4*x**2 + 2*x*y + 5
+    raises(ValueError, lambda: p2.coeff_wrt(z, 1))
+    raises(ValueError, lambda: p2.coeff_wrt(y, 2))
+
+
+
+def test_PolyElement_prem():
+    R, x, y, z = ring("x, y, z", ZZ)
 
     f, g = x**2 + x*y, 2*x + 2
     assert f.prem(g) == -4*y + 4
@@ -1383,6 +1397,8 @@ def test_PolyElement_sparse():
     g2 = x + y
     assert f2.prem(g2) == -y**2 - 2*y + 1
     assert f2.prem(g2, 1) == -x**2 + 2*x + 1
+    
+    raises(ZeroDivisionError, lambda: f2.prem(R(0)))
 
 
 def test_PolyElement_gcdex():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1363,6 +1363,32 @@ def test_PolyElement_pdiv():
     assert f.pquo(g) == q
     assert f.pexquo(g) == q
 
+
+def test_PolyElement_sparse():
+
+    _, x, y, z = ring("x, y, z", ZZ)
+    p1 = 4*x**3 + 5*y**2 + 6*z + 7
+    dg, sym = 2, 1
+    assert coeff_wrt(p1, sym, dg) == 5
+
+    syms = {0}
+    assert as_polynomial(p1, syms) == {(3, 0, 0): {(0, 0, 0): 4}, (0, 0, 0): {(0, 2, 0): 5, (0, 0, 1): 6, (0, 0, 0): 7}}
+
+
+    f, g = x**2 + x*y, 2*x + 2
+    assert sparse_prem(f, g, 0) == -4*y + 4
+
+    f1 = x**2 + 1
+    g = 2*x - 4
+    assert sparse_prem(f1, g1, 0) == 20
+    assert sparse_prem(f1, g1, 1) == 0
+
+    f2 = x*y + 2*x + 1
+    g2 = x + y
+    assert sparse_prem(f2, g2, 0) == -y**2 - 2*y + 1
+    assert sparse_prem(f2, g2, 1) == -x**2 + 2*x + 1
+
+
 def test_PolyElement_gcdex():
     _, x = ring("x", QQ)
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1366,20 +1366,18 @@ def test_PolyElement_pdiv():
 def test_PolyElement_coeff_wrt():
 
     R, x, y, z = ring("x, y, z", ZZ)
-    p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
 
+    p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
     assert p.coeff_wrt(1, 2) == 6*z + 5 # using generator index
     assert p.coeff_wrt(x, 3) == 4 # using generator
-    
-    p1 = 2*x**4 + 3*x*y**2*z + 10*y**2 + 10*x*z**2 
-    
+
+    p1 = 2*x**4 + 3*x*y**2*z + 10*y**2 + 10*x*z**2
     assert p1.coeff_wrt(x, 1) == 3*y**2*z + 10*z**2
     assert p1.coeff_wrt(y, 2) == 3*x*z + 10
 
     p2 = 4*x**2 + 2*x*y + 5
     raises(ValueError, lambda: p2.coeff_wrt(z, 1))
     raises(ValueError, lambda: p2.coeff_wrt(y, 2))
-
 
 
 def test_PolyElement_prem():
@@ -1397,7 +1395,7 @@ def test_PolyElement_prem():
     g2 = x + y
     assert f2.prem(g2) == -y**2 - 2*y + 1
     assert f2.prem(g2, 1) == -x**2 + 2*x + 1
-    
+
     raises(ZeroDivisionError, lambda: f2.prem(R(0)))
 
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1372,17 +1372,17 @@ def test_PolyElement_sparse():
     assert p1.coeff_wrt(sym, dg) == 5
 
     f, g = x**2 + x*y, 2*x + 2
-    assert f.prem2(g, 0) == -4*y + 4
+    assert f.prem(g) == -4*y + 4
 
     f1 = x**2 + 1
     g1 = 2*x - 4
-    assert f1.prem2(g1, 0) == 20
-    assert f1.prem2(g1, 1) == 0
+    assert f1.prem(g1) == 20
+    assert f1.prem(g1, 1) == 0
 
     f2 = x*y + 2*x + 1
     g2 = x + y
-    assert f2.prem2(g2, 0) == -y**2 - 2*y + 1
-    assert f2.prem2(g2, 1) == -x**2 + 2*x + 1
+    assert f2.prem(g2) == -y**2 - 2*y + 1
+    assert f2.prem(g2, 1) == -x**2 + 2*x + 1
 
 
 def test_PolyElement_gcdex():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1365,7 +1365,7 @@ def test_PolyElement_pdiv():
 
 def test_PolyElement_coeff_wrt():
 
-    R, x, y, z = ring("x, y, z", ZZ)
+    _, x, y, z = ring("x, y, z", ZZ)
 
     p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
     assert p.coeff_wrt(1, 2) == 6*z + 5 # using generator index
@@ -1376,25 +1376,25 @@ def test_PolyElement_coeff_wrt():
     assert p1.coeff_wrt(y, 2) == 3*x*z + 10
 
     p2 = 4*x**2 + 2*x*y + 5
-    raises(ValueError, lambda: p2.coeff_wrt(z, 1))
-    raises(ValueError, lambda: p2.coeff_wrt(y, 2))
+    assert p2.coeff_wrt(z, 1) == 0
+    assert p2.coeff_wrt(y, 2) == 0
 
 
 def test_PolyElement_prem():
-    R, x, y, z = ring("x, y, z", ZZ)
+    R, x, y = ring("x, y", ZZ)
 
     f, g = x**2 + x*y, 2*x + 2
     assert f.prem(g) == -4*y + 4
 
     f1 = x**2 + 1
     g1 = 2*x - 4
-    assert f1.prem(g1) == 20
+    assert f1.prem(g1) == f1.prem(g1, x) == 20 # first generator is chosen by default if it is not given
     assert f1.prem(g1, 1) == 0
 
     f2 = x*y + 2*x + 1
     g2 = x + y
     assert f2.prem(g2) == -y**2 - 2*y + 1
-    assert f2.prem(g2, 1) == -x**2 + 2*x + 1
+    assert f2.prem(g2, 1) == f2.prem(g2, y) == -x**2 + 2*x + 1
 
     raises(ZeroDivisionError, lambda: f2.prem(R(0)))
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1369,24 +1369,20 @@ def test_PolyElement_sparse():
     _, x, y, z = ring("x, y, z", ZZ)
     p1 = 4*x**3 + 5*y**2 + 6*z + 7
     dg, sym = 2, 1
-    assert coeff_wrt(p1, sym, dg) == 5
-
-    syms = {0}
-    assert as_polynomial(p1, syms) == {(3, 0, 0): {(0, 0, 0): 4}, (0, 0, 0): {(0, 2, 0): 5, (0, 0, 1): 6, (0, 0, 0): 7}}
-
+    assert PolyElement.coeff_wrt(p1, sym, dg) == 5
 
     f, g = x**2 + x*y, 2*x + 2
-    assert sparse_prem(f, g, 0) == -4*y + 4
+    assert PolyElement.prem(f, g, 0) == -4*y + 4
 
     f1 = x**2 + 1
-    g = 2*x - 4
-    assert sparse_prem(f1, g1, 0) == 20
-    assert sparse_prem(f1, g1, 1) == 0
+    g1 = 2*x - 4
+    assert PolyElement.prem(f1, g1, 0) == 20
+    assert PolyElement.prem(f1, g1, 1) == 0
 
     f2 = x*y + 2*x + 1
     g2 = x + y
-    assert sparse_prem(f2, g2, 0) == -y**2 - 2*y + 1
-    assert sparse_prem(f2, g2, 1) == -x**2 + 2*x + 1
+    assert PolyElement.prem(f2, g2, 0) == -y**2 - 2*y + 1
+    assert PolyElement.prem(f2, g2, 1) == -x**2 + 2*x + 1
 
 
 def test_PolyElement_gcdex():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1365,7 +1365,7 @@ def test_PolyElement_pdiv():
 
 def test_PolyElement_coeff_wrt():
 
-    _, x, y, z = ring("x, y, z", ZZ)
+    R, x, y, z = ring("x, y, z", ZZ)
 
     p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
     assert p.coeff_wrt(1, 2) == 6*z + 5 # using generator index
@@ -1376,20 +1376,20 @@ def test_PolyElement_coeff_wrt():
     assert p1.coeff_wrt(y, 2) == 3*x*z + 10
 
     p2 = 4*x**2 + 2*x*y + 5
-    assert p2.coeff_wrt(z, 1) == 0
-    assert p2.coeff_wrt(y, 2) == 0
+    assert p2.coeff_wrt(z, 1) == R(0)
+    assert p2.coeff_wrt(y, 2) == R(0)
 
 
 def test_PolyElement_prem():
     R, x, y = ring("x, y", ZZ)
 
     f, g = x**2 + x*y, 2*x + 2
-    assert f.prem(g) == -4*y + 4
+    assert f.prem(g) == -4*y + 4 # first generator is chosen by default if it is not given
 
     f1 = x**2 + 1
     g1 = 2*x - 4
-    assert f1.prem(g1) == f1.prem(g1, x) == 20 # first generator is chosen by default if it is not given
-    assert f1.prem(g1, 1) == 0
+    assert f1.prem(g1) == f1.prem(g1, x) == 20
+    assert f1.prem(g1, 1) == R(0)
 
     f2 = x*y + 2*x + 1
     g2 = x + y

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1369,20 +1369,20 @@ def test_PolyElement_sparse():
     _, x, y, z = ring("x, y, z", ZZ)
     p1 = 4*x**3 + 5*y**2 + 6*z + 7
     dg, sym = 2, 1
-    assert PolyElement.coeff_wrt(p1, sym, dg) == 5
+    assert p1.coeff_wrt(sym, dg) == 5
 
     f, g = x**2 + x*y, 2*x + 2
-    assert PolyElement.prem(f, g, 0) == -4*y + 4
+    assert f.prem2(g, 0) == -4*y + 4
 
     f1 = x**2 + 1
     g1 = 2*x - 4
-    assert PolyElement.prem(f1, g1, 0) == 20
-    assert PolyElement.prem(f1, g1, 1) == 0
+    assert f1.prem2(g1, 0) == 20
+    assert f1.prem2(g1, 1) == 0
 
     f2 = x*y + 2*x + 1
     g2 = x + y
-    assert PolyElement.prem(f2, g2, 0) == -y**2 - 2*y + 1
-    assert PolyElement.prem(f2, g2, 1) == -x**2 + 2*x + 1
+    assert f2.prem2(g2, 0) == -y**2 - 2*y + 1
+    assert f2.prem2(g2, 1) == -x**2 + 2*x + 1
 
 
 def test_PolyElement_gcdex():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1352,33 +1352,20 @@ def test_PolyElement_drop():
     raises(ValueError, lambda: z.drop(0).drop(0).drop(0))
     raises(ValueError, lambda: x.drop(0))
 
-def test_PolyElement_pdiv():
-    _, x, y = ring("x,y", ZZ)
-
-    f, g = x**2 - y**2, x - y
-    q, r = x + y, 0
-
-    assert f.pdiv(g) == (q, r)
-    assert f.pquo(g) == q
-    assert f.pexquo(g) == q
-
-
 def test_PolyElement_coeff_wrt():
-
     R, x, y, z = ring("x, y, z", ZZ)
 
     p = 4*x**3 + 5*y**2 + 6*y**2*z + 7
     assert p.coeff_wrt(1, 2) == 6*z + 5 # using generator index
     assert p.coeff_wrt(x, 3) == 4 # using generator
 
-    p1 = 2*x**4 + 3*x*y**2*z + 10*y**2 + 10*x*z**2
-    assert p1.coeff_wrt(x, 1) == 3*y**2*z + 10*z**2
-    assert p1.coeff_wrt(y, 2) == 3*x*z + 10
+    p = 2*x**4 + 3*x*y**2*z + 10*y**2 + 10*x*z**2
+    assert p.coeff_wrt(x, 1) == 3*y**2*z + 10*z**2
+    assert p.coeff_wrt(y, 2) == 3*x*z + 10
 
-    p2 = 4*x**2 + 2*x*y + 5
-    assert p2.coeff_wrt(z, 1) == R(0)
-    assert p2.coeff_wrt(y, 2) == R(0)
-
+    p = 4*x**2 + 2*x*y + 5
+    assert p.coeff_wrt(z, 1) == R(0)
+    assert p.coeff_wrt(y, 2) == R(0)
 
 def test_PolyElement_prem():
     R, x, y = ring("x, y", ZZ)
@@ -1386,18 +1373,51 @@ def test_PolyElement_prem():
     f, g = x**2 + x*y, 2*x + 2
     assert f.prem(g) == -4*y + 4 # first generator is chosen by default if it is not given
 
-    f1 = x**2 + 1
-    g1 = 2*x - 4
-    assert f1.prem(g1) == f1.prem(g1, x) == 20
-    assert f1.prem(g1, 1) == R(0)
+    f, g = x**2 + 1, 2*x - 4
+    assert f.prem(g) == f.prem(g, x) == 20
+    assert f.prem(g, 1) == R(0)
 
-    f2 = x*y + 2*x + 1
-    g2 = x + y
-    assert f2.prem(g2) == -y**2 - 2*y + 1
-    assert f2.prem(g2, 1) == f2.prem(g2, y) == -x**2 + 2*x + 1
+    f, g = x*y + 2*x + 1, x + y
+    assert f.prem(g) == -y**2 - 2*y + 1
+    assert f.prem(g, 1) == f.prem(g, y) == -x**2 + 2*x + 1
 
-    raises(ZeroDivisionError, lambda: f2.prem(R(0)))
+    raises(ZeroDivisionError, lambda: f.prem(R(0)))
 
+def test_PolyElement_pdiv():
+    R, x, y = ring("x,y", ZZ)
+
+    f, g = x**4 + 5*x**3 + 7*x**2, 2*x**2 + 3
+    assert f.pdiv(g) == f.pdiv(g, x) == (4*x**2 + 20*x + 22, -60*x - 66)
+
+    f, g = x**2 - y**2, x - y
+    assert f.pdiv(g) == f.pdiv(g, 0) == (x + y, 0)
+
+    f, g = x*y + 2*x + 1, x + y
+    assert f.pdiv(g) == (y + 2, -y**2 - 2*y + 1)
+    assert f.pdiv(g, y) == f.pdiv(g, 1) == (x + 1, -x**2 + 2*x + 1)
+
+    assert R(0).pdiv(g) == (0, 0)
+    raises(ZeroDivisionError, lambda: f.prem(R(0)))
+
+def test_PolyElement_pquo():
+    R, x, y = ring("x, y", ZZ)
+
+    f, g = x**4 - 4*x**2*y + 4*y**2, x**2 - 2*y
+    assert f.pquo(g) == f.pquo(g, x) == x**2 - 2*y
+    assert f.pquo(g, y) == 4*x**2 - 8*y + 4
+
+    f, g = x**4 - y**4, x**2 - y**2
+    assert f.pquo(g) == f.pquo(g, 0) == x**2 + y**2
+
+def test_PolyElement_pexquo():
+    R, x, y = ring("x, y", ZZ)
+
+    f, g = x**2 - y**2, x - y
+    assert f.pexquo(g) == f.pexquo(g, x) == x + y
+    assert f.pexquo(g, y) == f.pexquo(g, 1) == x + y + 1
+
+    f, g = x**2 + 3*x + 6, x + 2
+    raises(ExactQuotientFailed, lambda: f.pexquo(g))
 
 def test_PolyElement_gcdex():
     _, x = ring("x", QQ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Reference PR 
https://github.com/sympy/sympy/pull/25226

Related Issues:
#23131 
#20874 

Benchmarks for the `gcd` methods:
https://github.com/sympy/sympy_benchmarks/pull/89
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
