### PR TITLE
Added leading term and nseries methods for Mod Class

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -248,3 +248,11 @@ class Mod(Function):
     def _eval_rewrite_as_floor(self, a, b, **kwargs):
         from sympy.functions.elementary.integers import floor
         return a - b*floor(a/b)
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.functions.elementary.integers import floor
+        return self.rewrite(floor)._eval_as_leading_term(x, logx=logx, cdir=cdir)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.functions.elementary.integers import floor
+        return self.rewrite(floor)._eval_nseries(x, n, logx=logx, cdir=cdir)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -318,8 +318,13 @@ class ceiling(RoundFunction):
             r = ceiling(arg0)
         if arg0.is_finite:
             if arg0 == r:
-                ndir = arg.dir(x, cdir=cdir)
-                return r if ndir.is_negative else r + 1
+                ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+                if ndir.is_negative:
+                    return r
+                elif ndir.is_positive:
+                    return r + 1
+                else:
+                    raise NotImplementedError("Not sure of sign of %s" % ndir)
             else:
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
@@ -339,7 +344,12 @@ class ceiling(RoundFunction):
             return s + o
         if arg0 == r:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
-            return r if ndir.is_negative else r + 1
+            if ndir.is_negative:
+                return r
+            elif ndir.is_positive:
+                return r + 1
+            else:
+                raise NotImplementedError("Not sure of sign of %s" % ndir)
         else:
             return r
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -150,8 +150,13 @@ class floor(RoundFunction):
             r = floor(arg0)
         if arg0.is_finite:
             if arg0 == r:
-                ndir = arg.dir(x, cdir=cdir)
-                return r - 1 if ndir.is_negative else r
+                ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
+                if ndir.is_negative:
+                    return r - 1
+                elif ndir.is_positive:
+                    return r
+                else:
+                    raise NotImplementedError("Not sure of sign of %s" % ndir)
             else:
                 return r
         return arg.as_leading_term(x, logx=logx, cdir=cdir)
@@ -171,7 +176,12 @@ class floor(RoundFunction):
             return s + o
         if arg0 == r:
             ndir = arg.dir(x, cdir=cdir if cdir != 0 else 1)
-            return r - 1 if ndir.is_negative else r
+            if ndir.is_negative:
+                return r - 1
+            elif ndir.is_positive:
+                return r
+            else:
+                raise NotImplementedError("Not sure of sign of %s" % ndir)
         else:
             return r
 

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -630,3 +630,11 @@ def test_issue_18689():
 def test_issue_18421():
     assert floor(float(0)) is S.Zero
     assert ceiling(float(0)) is S.Zero
+
+def test_issue_25230():
+    y = Symbol('y', positive = True)
+    z = Symbol('z', negative = True)
+    assert floor(x/y).as_leading_term(x, cdir = 1) == 0
+    assert floor(x/y).as_leading_term(x, cdir = -1) == -1
+    assert floor(x/z).as_leading_term(x, cdir = 1) == -1
+    assert floor(x/z).as_leading_term(x, cdir = -1) == 0

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -636,7 +636,12 @@ def test_issue_25230():
     b = Symbol('b', positive = True)
     c = Symbol('c', negative = True)
     raises(NotImplementedError, lambda: floor(x/a).as_leading_term(x, cdir = 1))
+    raises(NotImplementedError, lambda: ceiling(x/a).as_leading_term(x, cdir = 1))
     assert floor(x/b).as_leading_term(x, cdir = 1) == 0
     assert floor(x/b).as_leading_term(x, cdir = -1) == -1
     assert floor(x/c).as_leading_term(x, cdir = 1) == -1
     assert floor(x/c).as_leading_term(x, cdir = -1) == 0
+    assert ceiling(x/b).as_leading_term(x, cdir = 1) == 1
+    assert ceiling(x/b).as_leading_term(x, cdir = -1) == 0
+    assert ceiling(x/c).as_leading_term(x, cdir = 1) == 0
+    assert ceiling(x/c).as_leading_term(x, cdir = -1) == 1

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -10,7 +10,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin, cos, tan
 
 from sympy.core.expr import unchanged
-from sympy.testing.pytest import XFAIL
+from sympy.testing.pytest import XFAIL, raises
 
 x = Symbol('x')
 i = Symbol('i', imaginary=True)
@@ -632,9 +632,11 @@ def test_issue_18421():
     assert ceiling(float(0)) is S.Zero
 
 def test_issue_25230():
-    y = Symbol('y', positive = True)
-    z = Symbol('z', negative = True)
-    assert floor(x/y).as_leading_term(x, cdir = 1) == 0
-    assert floor(x/y).as_leading_term(x, cdir = -1) == -1
-    assert floor(x/z).as_leading_term(x, cdir = 1) == -1
-    assert floor(x/z).as_leading_term(x, cdir = -1) == 0
+    a = Symbol('a', real = True)
+    b = Symbol('b', positive = True)
+    c = Symbol('c', negative = True)
+    raises(NotImplementedError, lambda: floor(x/a).as_leading_term(x, cdir = 1))
+    assert floor(x/b).as_leading_term(x, cdir = 1) == 0
+    assert floor(x/b).as_leading_term(x, cdir = -1) == -1
+    assert floor(x/c).as_leading_term(x, cdir = 1) == -1
+    assert floor(x/c).as_leading_term(x, cdir = -1) == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -3,6 +3,7 @@ from itertools import product
 from sympy.concrete.summations import Sum
 from sympy.core.function import (Function, diff)
 from sympy.core import EulerGamma
+from sympy.core.mod import Mod
 from sympy.core.numbers import (E, I, Rational, oo, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -1309,3 +1310,13 @@ def test_issue_24276():
     assert fx.simplify().limit(x, oo) == 2
     assert fx.rewrite(sin).limit(x, oo) == 2
     assert fx.rewrite(sin).simplify().limit(x, oo) == 2
+
+def test_issue_25230():
+    a = Symbol('a', real = True)
+    b = Symbol('b', positive = True)
+    c = Symbol('c', negative = True)
+    raises(NotImplementedError, lambda: limit(Mod(x, a), x, a))
+    assert limit(Mod(x, b), x, b, '+') == 0
+    assert limit(Mod(x, b), x, b, '-') == b
+    assert limit(Mod(x, c), x, c, '+') == c
+    assert limit(Mod(x, c), x, c, '-') == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1315,8 +1315,9 @@ def test_issue_25230():
     a = Symbol('a', real = True)
     b = Symbol('b', positive = True)
     c = Symbol('c', negative = True)
+    n = Symbol('n', integer = True)
     raises(NotImplementedError, lambda: limit(Mod(x, a), x, a))
-    assert limit(Mod(x, b), x, b, '+') == 0
-    assert limit(Mod(x, b), x, b, '-') == b
-    assert limit(Mod(x, c), x, c, '+') == c
-    assert limit(Mod(x, c), x, c, '-') == 0
+    assert limit(Mod(x, b), x, n*b, '+') == 0
+    assert limit(Mod(x, b), x, n*b, '-') == b
+    assert limit(Mod(x, c), x, n*c, '+') == c
+    assert limit(Mod(x, c), x, n*c, '-') == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25230 

#### Brief description of what is fixed or changed
The `Mod` class lacked the leading term and nseries methods and hence was returning wrong results . This has been fixed in this Pr.
```
>>> x = Symbol('x')
>>> y = Symbol('y', positive=True)
>>> z = Symbol('z', negative=True)
>>> n = Symbol('n', integer=True)
>>> limit(Mod(x, y), x, n*y, '+')
0
>>> limit(Mod(x, y), x, n*y, '-')
y
>>> limit(Mod(x, z), x, n*z, '+')
z
>>> limit(Mod(x, z), x, n*z, '-')
0
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Added leading term and nseries methods for Mod Class.
<!-- END RELEASE NOTES -->
