### PR TITLE
[GSOC 1.3] Add Instantiation methods for Transfer Functions

### DIFF
--- a/doc/src/guides/physics/control_problems.rst
+++ b/doc/src/guides/physics/control_problems.rst
@@ -28,9 +28,10 @@ Solution
     Subpart 1
 
     >>> s, k = symbols('s k')
-    >>> a = k*(s+3)                     # Zero at -3 in S plane
-    >>> b = (s+1)*(s+2-I)*(s+2+I)       # Poles at -1, (-2, j) and (-2, -j) in S plane
-    >>> tf = TransferFunction(a, b, s)
+    >>> gain = k                        # Let unknwon gain be k
+    >>> a = [-3]                        # Zero at -3 in S plane
+    >>> b = [-1, -2-I, -2+I]            # Poles at -1, (-2, j) and (-2, -j) in S plane
+    >>> tf = TransferFunction.from_zpk(a, b, gain, s)
     >>> pprint(tf)
                k*(s + 3)
     -------------------------------

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -554,19 +554,16 @@ class TransferFunction(SISOLinearTimeInvariant):
         Parameters
         ==========
 
-        num_list : List
-            List comprising of numerator coefficients.
-        den_list : List
-            List comprising of denominator coefficients.
+        num_list : Iterable
+            Sequence comprising of numerator coefficients.
+        den_list : Iterable
+            Sequence comprising of denominator coefficients.
         var : Symbol
             Complex variable of the Laplace transform used by the
             polynomials of the transfer function.
 
         Raises
         ======
-
-        ValueError
-            When ``num_list`` or ``den_list`` are not of data type `list`.
 
         ZeroDivisionError
             When the constructed denominator is zero.
@@ -588,9 +585,6 @@ class TransferFunction(SISOLinearTimeInvariant):
         TransferFunction(p*s + 1, 2*p*s**2 + 4, s)
 
         """
-        if not isinstance(num_list, list) or not isinstance(den_list, list):
-            raise TypeError("Input arguments should be composed of list.")
-
         num_list = num_list[::-1]
         den_list = den_list[::-1]
         num_var_powers = [var**i for i in range(len(num_list))]
@@ -612,21 +606,15 @@ class TransferFunction(SISOLinearTimeInvariant):
         Parameters
         ==========
 
-        zeros : List
-            List comprising of zeros of transfer function.
-        poles : List
-            List comprising of poles of transfer function.
+        zeros : Iterable
+            Sequence comprising of zeros of transfer function.
+        poles : Iterable
+            Sequence comprising of poles of transfer function.
         gain : Number, Symbol, Expression
             A scalar value specifying gain of the model.
         var : Symbol
             Complex variable of the Laplace transform used by the
             polynomials of the transfer function.
-
-        Raises
-        ======
-
-        ValueError
-            When ``poles`` or ``den_list`` are not of data type `list`.
 
         Examples
         ========
@@ -651,9 +639,6 @@ class TransferFunction(SISOLinearTimeInvariant):
         TransferFunction(-2*s, (s - 2)*(s - 1.0 - 1.0*I)*(s - 1.0 + 1.0*I), s)
 
         """
-        if not isinstance(poles, list) or not isinstance(zeros, list):
-            raise TypeError("Input arguments zeros and poles should be composed of list.")
-
         num_poly = 1
         den_poly = 1
         for zero in zeros:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -554,9 +554,9 @@ class TransferFunction(SISOLinearTimeInvariant):
         Parameters
         ==========
 
-        num_list : Iterable
+        num_list : Sequence
             Sequence comprising of numerator coefficients.
-        den_list : Iterable
+        den_list : Sequence
             Sequence comprising of denominator coefficients.
         var : Symbol
             Complex variable of the Laplace transform used by the
@@ -606,9 +606,9 @@ class TransferFunction(SISOLinearTimeInvariant):
         Parameters
         ==========
 
-        zeros : Iterable
+        zeros : Sequence
             Sequence comprising of zeros of transfer function.
-        poles : Iterable
+        poles : Sequence
             Sequence comprising of poles of transfer function.
         gain : Number, Symbol, Expression
             A scalar value specifying gain of the model.

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -578,7 +578,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         >>> from sympy.physics.control.lti import TransferFunction
         >>> num = [1, 0, 2]
         >>> den = [3, 2, 2, 1]
-        >>> tf = TransferFunction.from_coeff_lists(num, den,s)
+        >>> tf = TransferFunction.from_coeff_lists(num, den, s)
         >>> tf
         TransferFunction(s**2 + 2, 3*s**3 + 2*s**2 + 2*s + 1, s)
 
@@ -616,7 +616,7 @@ class TransferFunction(SISOLinearTimeInvariant):
             List comprising of zeros of transfer function.
         poles : List
             List comprising of poles of transfer function.
-        gain : Number
+        gain : Number, Symbol, Expression
             A scalar value specifying gain of the model.
         var : Symbol
             Complex variable of the Laplace transform used by the

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -152,6 +152,30 @@ def test_TransferFunction_functions():
     assert TransferFunction.from_rational_expression(expr_8, s) == \
         TransferFunction(2*s**2 + 3*s + 2, s**2 + 1, s)
 
+    # classmethod from_coeff_lists
+    tf1 = TransferFunction.from_coeff_lists([1, 2], [3, 4, 5], s)
+    num2 = [p**2, 2*p]
+    den2 = [p**3, p + 1, 4]
+    tf2 = TransferFunction.from_coeff_lists(num2, den2, s)
+    num3 = [1, 2]
+    den3 = 100
+    num4 = [1, 2, 3]
+    den4 = [0, 0]
+
+    assert tf1 == TransferFunction(s + 2, 3*s**2 + 4*s + 5, s)
+    assert tf2 == TransferFunction(p**2*s + 2*p, p**3*s**2 + s*(p + 1) + 4, s)
+    raises(TypeError, lambda: TransferFunction.from_coeff_lists(num3, den3, s))
+    raises(ZeroDivisionError, lambda: TransferFunction.from_coeff_lists(num4, den4, s))
+
+    # classmethod from_zpk
+    zeros = [4]
+    poles = [-1+2j, -1-2j]
+    gain = 3
+    tf1 = TransferFunction.from_zpk(zeros, poles, gain, s)
+
+    assert tf1 == TransferFunction(3*s - 12, (s + 1.0 - 2.0*I)*(s + 1.0 + 2.0*I), s)
+    raises(TypeError, lambda: TransferFunction.from_coeff_lists(0, [1-1j, 1+1j, 2], s))
+
     # explicitly cancel poles and zeros.
     tf0 = TransferFunction(s**5 + s**3 + s, s - s**2, s)
     a = TransferFunction(-(s**4 + s**2 + 1), s - 1, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -157,15 +157,12 @@ def test_TransferFunction_functions():
     num2 = [p**2, 2*p]
     den2 = [p**3, p + 1, 4]
     tf2 = TransferFunction.from_coeff_lists(num2, den2, s)
-    num3 = [1, 2]
-    den3 = 100
-    num4 = [1, 2, 3]
-    den4 = [0, 0]
+    num3 = [1, 2, 3]
+    den3 = [0, 0]
 
     assert tf1 == TransferFunction(s + 2, 3*s**2 + 4*s + 5, s)
     assert tf2 == TransferFunction(p**2*s + 2*p, p**3*s**2 + s*(p + 1) + 4, s)
-    raises(TypeError, lambda: TransferFunction.from_coeff_lists(num3, den3, s))
-    raises(ZeroDivisionError, lambda: TransferFunction.from_coeff_lists(num4, den4, s))
+    raises(ZeroDivisionError, lambda: TransferFunction.from_coeff_lists(num3, den3, s))
 
     # classmethod from_zpk
     zeros = [4]
@@ -174,7 +171,6 @@ def test_TransferFunction_functions():
     tf1 = TransferFunction.from_zpk(zeros, poles, gain, s)
 
     assert tf1 == TransferFunction(3*s - 12, (s + 1.0 - 2.0*I)*(s + 1.0 + 2.0*I), s)
-    raises(TypeError, lambda: TransferFunction.from_coeff_lists(0, [1-1j, 1+1j, 2], s))
 
     # explicitly cancel poles and zeros.
     tf0 = TransferFunction(s**5 + s**3 + s, s - s**2, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This pull request adds methods to instantiate Transfer Functions as suggested in this [comment](https://github.com/sympy/sympy/pull/19390#issuecomment-635370437).
1. `from_coeff_lists`
2. `from_zpk`

#### Other comments
Relevant tests have been added.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.control
  * Added Instantiation methods for Transfer Functions

<!-- END RELEASE NOTES -->
