### PR TITLE
Remove unnecessary code in MathML printer

### DIFF
--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1215,24 +1215,6 @@ def test_presentation_settings():
                                      method="garbage"))
 
 
-def test_toprettyxml_hooking():
-    # test that the patch doesn't influence the behavior of the standard
-    # library
-    import xml.dom.minidom
-    doc1 = xml.dom.minidom.parseString(
-        "<apply><plus/><ci>x</ci><cn>1</cn></apply>")
-    doc2 = xml.dom.minidom.parseString(
-        "<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>")
-    prettyxml_old1 = doc1.toprettyxml()
-    prettyxml_old2 = doc2.toprettyxml()
-
-    mp.apply_patch()
-    mp.restore_patch()
-
-    assert prettyxml_old1 == doc1.toprettyxml()
-    assert prettyxml_old2 == doc2.toprettyxml()
-
-
 def test_print_domains():
     from sympy.sets import Integers, Naturals, Naturals0, Reals, Complexes
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I removed the `apply_patch` and `restore_patch` functions. They were originally created to workaround [this issue in the Python `xml` module](https://bugs.python.org/issue4147).

However, the Python versions affected by this bug are listed to be Python 3.2 and 3.3. The bug is marked as resolved on the [issue page](https://bugs.python.org/issue4147), and the [SymPy documentation](https://docs.sympy.org/dev/install.html#installation) states that we support Python 3.8 and above, so this code is entirely unnecessary.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
