### PR TITLE
Add `kronecker_symbol`

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -177,6 +177,8 @@ Ntheory Functions Reference
 
 .. autofunction:: jacobi_symbol
 
+.. autofunction:: kronecker_symbol
+
 .. autofunction:: discrete_log
 
 .. autofunction:: quadratic_congruence

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -35,6 +35,12 @@ __all__ = [
     # isqrt from gmpy or mpmath
     'sqrt',
 
+    # is_square from gmpy or mpmath
+    'is_square',
+
+    # sqrtrem from gmpy or mpmath
+    'sqrtrem',
+
     # gcd from gmpy or math
     'gcd',
 
@@ -49,6 +55,9 @@ __all__ = [
 
     # jacobi from gmpy or sympy
     'jacobi',
+
+    # kronecker from gmpy or sympy
+    'kronecker',
 ]
 
 
@@ -113,6 +122,7 @@ if gmpy is not None:
     invert = gmpy.invert
     legendre = gmpy.legendre
     jacobi = gmpy.jacobi
+    kronecker = gmpy.kronecker
 
 else:
     from .pythonmpq import PythonMPQ
@@ -189,3 +199,20 @@ else:
                 j = -j
             x %= y
         return j
+
+    def kronecker(x, y):
+        """ Return Kronecker symbol (x / y)."""
+        if gcd(x, y) != 1:
+            return 0
+        if y == 0:
+            return 1
+        sign = -1 if y < 0 and x < 0 else 1
+        y = abs(y)
+        # We want to calculate s = trailing(y)
+        s = 0
+        while y % 2 == 0:
+            y >>= 1
+            s += 1
+        if s % 2 and x % 8 in [3, 5]:
+            sign = -sign
+        return sign * jacobi(x, y)

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -15,7 +15,7 @@ from .factor_ import divisors, proper_divisors, factorint, multiplicity, \
 
 from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
-    legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \
+    legendre_symbol, jacobi_symbol, kronecker_symbol, n_order, sqrt_mod, quadratic_residues, \
     primitive_root, nthroot_mod, is_nthpow_residue, sqrt_mod_iter, mobius, \
     discrete_log, quadratic_congruence, polynomial_congruence
 from .multinomial import binomial_coefficients, binomial_coefficients_list, \
@@ -44,7 +44,7 @@ __all__ = [
     'npartitions',
 
     'is_primitive_root', 'is_quad_residue', 'legendre_symbol',
-    'jacobi_symbol', 'n_order', 'sqrt_mod', 'quadratic_residues',
+    'jacobi_symbol', 'kronecker_symbol', 'n_order', 'sqrt_mod', 'quadratic_residues',
     'primitive_root', 'nthroot_mod', 'is_nthpow_residue', 'sqrt_mod_iter',
     'mobius', 'discrete_log', 'quadratic_congruence', 'polynomial_congruence',
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1116,7 +1116,7 @@ def kronecker_symbol(a, n):
     >>> from sympy.ntheory.residue_ntheory import kronecker_symbol
     >>> kronecker_symbol(45, 77)
     -1
-    >>> jacobi_symbol(13, -120)
+    >>> kronecker_symbol(13, -120)
     1
 
     See Also

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sympy.core.function import Function
 from sympy.core.singleton import S
-from sympy.external.gmpy import gcd, invert, sqrt, legendre, jacobi
+from sympy.external.gmpy import gcd, invert, sqrt, legendre, jacobi, kronecker
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
@@ -1098,6 +1098,39 @@ def jacobi_symbol(m, n):
     """
     m, n = as_int(m), as_int(n)
     return int(jacobi(m, n))
+
+
+def kronecker_symbol(a, n):
+    r"""
+    Returns the Kronecker symbol `(a / n)`.
+
+    Parameters
+    ==========
+
+    a : integer
+    n : integer
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.residue_ntheory import kronecker_symbol
+    >>> kronecker_symbol(45, 77)
+    -1
+    >>> jacobi_symbol(13, -120)
+    1
+
+    See Also
+    ========
+
+    jacobi_symbol, legendre_symbol
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Kronecker_symbol
+
+    """
+    return int(kronecker(as_int(a), as_int(n)))
 
 
 class mobius(Function):

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -4,7 +4,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol)
 
 from sympy.ntheory import n_order, is_primitive_root, is_quad_residue, \
-    legendre_symbol, jacobi_symbol, totient, primerange, sqrt_mod, \
+    legendre_symbol, jacobi_symbol, kronecker_symbol, totient, primerange, sqrt_mod, \
     primitive_root, quadratic_residues, is_nthpow_residue, nthroot_mod, \
     sqrt_mod_iter, mobius, discrete_log, quadratic_congruence, \
     polynomial_congruence, sieve
@@ -237,6 +237,25 @@ def test_residue():
     assert jacobi_symbol(2, 1) == 1
     assert jacobi_symbol(1, 3) == 1
     raises(ValueError, lambda: jacobi_symbol(3, 8))
+
+    for n in range(3, 10, 2):
+        for a in range(-n, n):
+            val = kronecker_symbol(a, n)
+            assert val == jacobi_symbol(a, n)
+            minus = kronecker_symbol(a, -n)
+            if a < 0:
+                assert -minus == val
+            else:
+                assert minus == val
+            even = kronecker_symbol(a, 2 * n)
+            if a % 2 == 0:
+                assert even == 0
+            elif a % 8 in [1, 7]:
+                assert even == val
+            else:
+                assert -even == val
+    assert kronecker_symbol(1, 0) == kronecker_symbol(-1, 0) == 1
+    assert kronecker_symbol(0, 0) == 0
 
     assert mobius(13*7) == 1
     assert mobius(1) == 1


### PR DESCRIPTION
Added `kronecker_symbol`, the function to calculate the Kronecker symbol, to `ntheory.residue_ntheory`. The Kronecker symbol was implemented in `external.gmpy` since the function also exists in gmpy2.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
Referenced by [Wikipedia](https://en.wikipedia.org/wiki/Kronecker_symbol)


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Add new function `kronecker_symbol`
<!-- END RELEASE NOTES -->
