### PR TITLE
Improve smtlib_code api

### DIFF
--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -17,6 +17,69 @@ from sympy.printing.printer import Printer
 from sympy.sets import Interval
 
 
+known_functions_dreal = {
+    Add: '+',
+    Mul: '*',
+
+    Equality: '=',
+    LessThan: '<=',
+    GreaterThan: '>=',
+    StrictLessThan: '<',
+    StrictGreaterThan: '>',
+
+    exp: 'exp',
+    log: 'log',
+    Abs: 'abs',
+    sin: 'sin',
+    cos: 'cos',
+    tan: 'tan',
+    asin: 'arcsin',
+    acos: 'arccos',
+    atan: 'arctan',
+    atan2: 'arctan2',
+    sinh: 'sinh',
+    cosh: 'cosh',
+    tanh: 'tanh',
+    Min: 'min',
+    Max: 'max',
+    Pow: 'pow',
+
+    And: 'and',
+    Or: 'or',
+    Xor: 'xor',
+    Not: 'not',
+    ITE: 'ite',
+    Implies: '=>',
+}
+
+known_functions_z3 = {
+    Add: '+',
+    Mul: '*',
+
+    Equality: '=',
+    LessThan: '<=',
+    GreaterThan: '>=',
+    StrictLessThan: '<',
+    StrictGreaterThan: '>',
+
+    Abs: 'abs',
+    sin: 'sin',
+    cos: 'cos',
+    tan: 'tan',
+    sinh: 'sinh',
+    cosh: 'cosh',
+    tanh: 'tanh',
+    Pow: '^',
+
+    And: 'and',
+    Or: 'or',
+    Xor: 'xor',
+    Not: 'not',
+    ITE: 'ite',
+    Implies: '=>',
+}
+
+
 class SMTLibPrinter(Printer):
     printmethod = "_smtlib"
 
@@ -209,6 +272,7 @@ class SMTLibPrinter(Printer):
 
 def smtlib_code(
     expr,
+    smt_solver = "Z3",
     auto_assert=True, auto_declare=True,
     precision=None,
     symbol_table=None,
@@ -318,7 +382,12 @@ def smtlib_code(
     if known_types: settings['known_types'] = known_types
     del known_types
 
-    if known_functions: settings['known_functions'] = known_functions
+    if smt_solver == "Z3":
+        settings['known_functions'] = known_functions_z3
+    elif smt_solver == "dreal":
+        settings['known_functions'] = known_functions_dreal
+    else:
+        if known_functions: settings['known_functions'] = known_functions
     del known_functions
 
     if known_constants: settings['known_constants'] = known_constants


### PR DESCRIPTION
It should be easy to use smtlib_code for smt solvers other than dreal. This pull request aims to add a setting to the printer for which smt solver is being used and perhaps cut down on unnecessary and confusing parameters.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
