### PR TITLE
Move `primetest.is_square` to `gmpy.is_square`

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -178,6 +178,8 @@ power
 .. autoclass:: Pow
    :members:
 
+.. autofunction:: isqrt
+
 .. autofunction:: integer_nthroot
 
 .. autofunction:: integer_log

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -136,7 +136,40 @@ else:
 
     factorial = lambda x: int(mlib.ifac(x))
     sqrt = lambda x: int(mlib.isqrt(x))
-    is_square = lambda x: x >= 0 and mlib.sqrtrem(x)[1] == 0
+
+    def is_square(x):
+        if x < 0:
+            return False
+        # Note that the possible values of y**2 % n for a given n are limited.
+        # For example, when n=4, y**2 % n can only take 0 or 1.
+        # In other words, if x % 4 is 2 or 3, then x is not a square number.
+        # Mathematically, it determines if it belongs to the set {y**2 % n},
+        # but implementationally, it can be realized as a logical conjunction
+        # with an n-bit integer.
+        # see https://mersenneforum.org/showpost.php?p=110896
+        # def magic(n):
+        #     s = {y**2 % n for y in range(n)}
+        #     s = set(range(n)) - s
+        #     return sum(1 << bit for bit in s)
+        # >>> print(hex(magic(128)))
+        # 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec
+        # >>> print(hex(magic(99)))
+        # 0x5f6f9ffb6fb7ddfcb75befdec
+        # >>> print(hex(magic(91)))
+        # 0x6fd1bfcfed5f3679d3ebdec
+        # >>> print(hex(magic(85)))
+        # 0xdef9ae771ffe3b9d67dec
+        if 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec & (1 << (x & 127)):
+            return False  # e.g. 2, 3
+        m = x % 765765 # 765765 = 99 * 91 * 85
+        if 0x5f6f9ffb6fb7ddfcb75befdec & (1 << (m % 99)):
+            return False  # e.g. 17, 68
+        if 0x6fd1bfcfed5f3679d3ebdec & (1 << (m % 91)):
+            return False  # e.g. 97, 388
+        if 0xdef9ae771ffe3b9d67dec & (1 << (m % 85)):
+            return False  # e.g. 793, 1408
+        return mlib.sqrtrem(x)[1] == 0
+
     sqrtrem = lambda x: tuple(int(r) for r in mlib.sqrtrem(x))
     if sys.version_info[:2] >= (3, 9):
         gcd = math.gcd

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -17,7 +17,7 @@ from sympy.core.numbers import Rational, Integer
 from sympy.core.power import integer_nthroot, Pow, integer_log
 from sympy.core.random import _randint
 from sympy.core.singleton import S
-from sympy.external.gmpy import SYMPY_INTS, gcd, lcm, sqrt, sqrtrem
+from sympy.external.gmpy import SYMPY_INTS, gcd, lcm, sqrt as isqrt, sqrtrem
 from .primetest import isprime
 from .generate import sieve, primerange, nextprime
 from .digits import digits
@@ -1309,7 +1309,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
             # square root anyway. Finding 2 factors is easy if they are
             # "close enough." This is the big root equivalent of dividing by
             # 2, 3, 5.
-            sqrt_n = sqrt(n)
+            sqrt_n = isqrt(n)
             a = sqrt_n + 1
             a2 = a**2
             b2 = a2 - n

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -17,7 +17,7 @@ from sympy.core.numbers import Rational, Integer
 from sympy.core.power import integer_nthroot, Pow, integer_log
 from sympy.core.random import _randint
 from sympy.core.singleton import S
-from sympy.external.gmpy import SYMPY_INTS, gcd, lcm
+from sympy.external.gmpy import SYMPY_INTS, gcd, lcm, sqrt, sqrtrem
 from .primetest import isprime
 from .generate import sieve, primerange, nextprime
 from .digits import digits
@@ -1309,17 +1309,17 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
             # square root anyway. Finding 2 factors is easy if they are
             # "close enough." This is the big root equivalent of dividing by
             # 2, 3, 5.
-            sqrt_n = integer_nthroot(n, 2)[0]
+            sqrt_n = sqrt(n)
             a = sqrt_n + 1
             a2 = a**2
             b2 = a2 - n
             for i in range(3):
-                b, fermat = integer_nthroot(b2, 2)
-                if fermat:
+                b, fermat = sqrtrem(b2)
+                if not fermat:
                     break
                 b2 += 2*a + 1  # equiv to (a + 1)**2 - n
                 a += 1
-            if fermat:
+            if not fermat:
                 if verbose:
                     print(fermat_msg)
                 if limit:
@@ -2430,8 +2430,8 @@ def is_perfect(n):
         last2 = n % 100
         if last2 != 28 and last2 % 10 != 6:
             return False
-        r, b = integer_nthroot(1 + 8*n, 2)
-        if not b:
+        r, b = sqrtrem(1 + 8*n)
+        if b:
             return False
         m, x = divmod(1 + r, 4)
         if x:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -3,9 +3,8 @@ Primality testing
 
 """
 
-from sympy.core.power import integer_nthroot
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import HAS_GMPY, gcd, jacobi
+from sympy.external.gmpy import HAS_GMPY, gcd, jacobi, is_square as gmpy_is_square
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -80,7 +79,7 @@ def is_square(n, prep=True):
 
     See Also
     ========
-    sympy.core.power.integer_nthroot
+    sympy.core.power.isqrt
     """
     if prep:
         n = as_int(n)
@@ -88,38 +87,7 @@ def is_square(n, prep=True):
             return False
         if n in (0, 1):
             return True
-    # def magic(n):
-    #     s = {x**2 % n for x in range(n)}
-    #     return sum(1 << bit for bit in s)
-    # >>> print(hex(magic(128)))
-    # 0x2020212020202130202021202030213
-    # >>> print(hex(magic(99)))
-    # 0x209060049048220348a410213
-    # >>> print(hex(magic(91)))
-    # 0x102e403012a0c9862c14213
-    # >>> print(hex(magic(85)))
-    # 0x121065188e001c46298213
-    if not 0x2020212020202130202021202030213 & (1 << (n & 127)):
-        return False  # e.g. 2, 3
-    m = n % (99 * 91 * 85)
-    if not 0x209060049048220348a410213 & (1 << (m % 99)):
-        return False  # e.g. 17, 68
-    if not 0x102e403012a0c9862c14213 & (1 << (m % 91)):
-        return False  # e.g. 97, 388
-    if not 0x121065188e001c46298213 & (1 << (m % 85)):
-        return False  # e.g. 793, 1408
-    # n is either:
-    #   a) odd = 4*even + 1 (and square if even = k*(k + 1))
-    #   b) even with
-    #     odd multiplicity of 2 --> not square, e.g. 39040
-    #     even multiplicity of 2, e.g. 4, 16, 36, ..., 16324
-    #         removal of factors of 2 to give an odd, and rejection if
-    #         any(i%2 for i in divmod(odd - 1, 4))
-    #         will give an odd number in form 4*even + 1.
-    # Use of `trailing` to check the power of 2 is not done since it
-    # does not apply to a large percentage of arbitrary numbers
-    # and the integer_nthroot is able to quickly resolve these cases.
-    return integer_nthroot(n, 2)[1]
+    return gmpy_is_square(n)
 
 
 def _test(n, base, s, t):
@@ -351,7 +319,7 @@ def is_lucas_prp(n):
         return True
     if n < 2 or (n % 2) == 0:
         return False
-    if is_square(n, False):
+    if gmpy_is_square(n):
         return False
 
     D, P, Q = _lucas_selfridge_params(n)
@@ -397,7 +365,7 @@ def is_strong_lucas_prp(n):
         return True
     if n < 2 or (n % 2) == 0:
         return False
-    if is_square(n, False):
+    if gmpy_is_square(n):
         return False
 
     D, P, Q = _lucas_selfridge_params(n)
@@ -470,7 +438,7 @@ def is_extra_strong_lucas_prp(n):
         return True
     if n < 2 or (n % 2) == 0:
         return False
-    if is_square(n, False):
+    if gmpy_is_square(n):
         return False
 
     D, P, Q = _lucas_extrastrong_params(n)

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -1,6 +1,5 @@
-from sympy.core.power import integer_nthroot
 from sympy.core.random import _randint
-from sympy.external.gmpy import gcd, invert
+from sympy.external.gmpy import gcd, invert, sqrt as isqrt
 from sympy.ntheory.residue_ntheory import _sqrt_mod_prime_power
 from sympy.ntheory import isprime
 from math import log, sqrt
@@ -295,7 +294,7 @@ def _trial_division_stage(N, M, factor_base, sieve_array, sieve_poly, partial_re
     partial_relations : stores partial relations with one large prime
     ERROR_TERM : error term for accumulated_val
     """
-    sqrt_n = sqrt(float(N))
+    sqrt_n = isqrt(N)
     accumulated_val = log(M * sqrt_n)*2**10 - ERROR_TERM
     smooth_relations = []
     proper_factor = set()
@@ -431,7 +430,7 @@ def _find_factor(dependent_rows, mark, gauss_matrix, index, smooth_relations, N)
     for i in independent_v:
         v *= i
     #assert u**2 % N == v % N
-    v = integer_nthroot(v, 2)[0]
+    v = isqrt(v)
     return gcd(u - v, N)
 
 


### PR DESCRIPTION
Other minor changes to use `gmpy.sqrt` and `gmpy.sqrtrem`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25067

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
