### PR TITLE
polylog: pretty fall back for non-integer order

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1664,10 +1664,8 @@ class PrettyPrinter(Printer):
         return self.emptyPrinter(expr)
 
     def _print_polylog(self, e):
-        if self._use_unicode:
-            func_name = f"Li_{e.args[0].__str__()}"
-            new_e = Function(func_name)(e.args[1])
-            return self._print_Function(new_e)
+        if e.args[0].is_Integer and self._use_unicode:
+            return self._print_Function(Function('Li_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)
 
     def _print_lerchphi(self, e):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7509,13 +7509,18 @@ def test_print_polylog():
 
 
 @XFAIL  # Issue #25312
-def test_print_polylog_symbolic_order():
+def test_print_expint_polylog_symbolic_order():
     s, z = symbols("s, z")
     uresult = 'Liₛ(z)'
     aresult = 'polylog(s, z)'
     assert pretty(polylog(s, z)) == aresult
     assert upretty(polylog(s, z)) == uresult
     # TODO: TBD polylog(s - 1, z)
+    uresult = 'Eₛ(z)'
+    aresult = 'expint(s, z)'
+    assert pretty(expint(s, z)) == aresult
+    assert upretty(expint(s, z)) == uresult
+
 
 
 def test_print_polylog_long_order_issue_25309():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -80,6 +80,7 @@ from sympy.testing.pytest import raises, _both_exp_pow, warns_deprecated_sympy
 
 from sympy.vector import CoordSys3D, Gradient, Curl, Divergence, Dot, Cross, Laplacian
 
+from sympy.testing.pytest import XFAIL
 
 
 import sympy as sym
@@ -7501,22 +7502,26 @@ def test_issue_15560():
 
 def test_print_polylog():
     # Part of issue 6013
-    s,z = symbols("s, z")
     uresult = 'Li₂(3)'
     aresult = 'polylog(2, 3)'
-    assert pretty(polylog(2,3)) == aresult
-    assert upretty(polylog(2,3)) == uresult
+    assert pretty(polylog(2, 3)) == aresult
+    assert upretty(polylog(2, 3)) == uresult
 
+
+@XFAIL
+def test_print_polylog_symbolic_order():
+    s, z = symbols("s, z")
     uresult = 'Liₛ(z)'
     aresult = 'polylog(s, z)'
-    assert pretty(polylog(s,z)) == aresult
-    assert upretty(polylog(s,z)) == uresult
+    assert pretty(polylog(s, z)) == aresult
+    assert upretty(polylog(s, z)) == uresult
 
 
 def test_print_polylog_long_order_issue_25309():
+    s, z = symbols("s, z")
     result = 'polylog(s - 1, z)'
-    assert pretty(polylog(s - 1,z)) == result
-    assert upretty(polylog(s - 1,z)) == result
+    assert pretty(polylog(s - 1, z)) == result
+    assert upretty(polylog(s - 1, z)) == result
 
 
 def test_print_lerchphi():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7508,7 +7508,7 @@ def test_print_polylog():
     assert upretty(polylog(2, 3)) == uresult
 
 
-@XFAIL
+@XFAIL  # Issue #25312
 def test_print_polylog_symbolic_order():
     s, z = symbols("s, z")
     uresult = 'Liₛ(z)'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7515,13 +7515,17 @@ def test_print_polylog_symbolic_order():
     aresult = 'polylog(s, z)'
     assert pretty(polylog(s, z)) == aresult
     assert upretty(polylog(s, z)) == uresult
+    # TODO: TBD polylog(s - 1, z)
 
 
 def test_print_polylog_long_order_issue_25309():
     s, z = symbols("s, z")
-    result = 'polylog(s - 1, z)'
-    assert pretty(polylog(s - 1, z)) == result
-    assert upretty(polylog(s - 1, z)) == result
+    ucode_str = \
+"""\
+       ⎛ 2   ⎞\n\
+polylog⎝s , z⎠\
+"""
+    assert pretty(polylog(s**2, z)) == ucode_str
 
 
 def test_print_lerchphi():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7525,7 +7525,7 @@ def test_print_polylog_long_order_issue_25309():
        ⎛ 2   ⎞\n\
 polylog⎝s , z⎠\
 """
-    assert pretty(polylog(s**2, z)) == ucode_str
+    assert upretty(polylog(s**2, z)) == ucode_str
 
 
 def test_print_lerchphi():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7513,6 +7513,12 @@ def test_print_polylog():
     assert upretty(polylog(s,z)) == uresult
 
 
+def test_print_polylog_long_order_issue_25309():
+    result = 'polylog(s - 1, z)'
+    assert pretty(polylog(s - 1,z)) == result
+    assert upretty(polylog(s - 1,z)) == result
+
+
 def test_print_lerchphi():
     # Part of issue 6013
     a = Symbol('a')


### PR DESCRIPTION
Fixes Issue #25309.

@PSXBRosa there is some loss compared to your original: for example your original would've pretty printed `polylog(s, z)`  as `Liₛ(z)` which is quite nice.  Likely there is still room for improvement!


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
