### PR TITLE
Changed writing style to not use `StopIteration`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -441,8 +441,9 @@ def _sqrt_mod_tonelli_shanks(a, p):
     Parameters
     ==========
 
-    a : integer
-    p : odd prime number
+    a : int
+    p : int
+        Odd prime number
 
     Returns
     =======

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -524,7 +524,7 @@ def sqrt_mod(a, p, all_roots=False):
     for r in sqrt_mod_iter(a, p):
         if r < halfp:
             return r
-        elif r > p // 2:
+        elif r > halfp:
             return p - r
         else:
             x = r

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -433,10 +433,34 @@ def _sqrt_mod_tonelli_shanks(a, p):
     """
     Returns the square root in the case of ``p`` prime with ``p == 1 (mod 8)``
 
+    Assume that the root exists (if it does not, we are in an infinite loop).
+    Although ``p`` correctly returns the answer for any odd prime,
+    ``p != 1 (mod 8)``, there is no advantage to using this algorithm since
+    a more efficient algorithm exists.
+
+    Parameters
+    ==========
+
+    a : integer
+    p : odd prime number
+
+    Returns
+    =======
+
+    int : Generally, there are two roots, but only one is returned.
+          Which one is returned is random.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.residue_ntheory import _sqrt_mod_tonelli_shanks
+    >>> _sqrt_mod_tonelli_shanks(2, 17) in [6, 11]
+    True
+
     References
     ==========
 
-    .. [1] R. Crandall and C. Pomerance "Prime Numbers", 2nt Ed., page 101
+    .. [1] R. Crandall and C. Pomerance "Prime Numbers", 2nd Ed., page 101
 
     """
     s = trailing(p - 1)
@@ -493,24 +517,16 @@ def sqrt_mod(a, p, all_roots=False):
     """
     if all_roots:
         return sorted(sqrt_mod_iter(a, p))
-    try:
-        p = abs(as_int(p))
-        it = sqrt_mod_iter(a, p)
-        r = next(it)
-        if r > p // 2:
+    p = abs(as_int(p))
+    x = None
+    for r in sqrt_mod_iter(a, p):
+        if r < p // 2:
+            return r
+        elif r > p // 2:
             return p - r
-        elif r < p // 2:
-            return r
         else:
-            try:
-                r = next(it)
-                if r > p // 2:
-                    return p - r
-            except StopIteration:
-                pass
-            return r
-    except StopIteration:
-        return None
+            x = r
+    return x
 
 
 def _product(*iters):

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -522,7 +522,7 @@ def sqrt_mod(a, p, all_roots=False):
     halfp = p // 2
     x = None
     for r in sqrt_mod_iter(a, p):
-        if r < p // 2:
+        if r < halfp:
             return r
         elif r > p // 2:
             return p - r

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -519,6 +519,7 @@ def sqrt_mod(a, p, all_roots=False):
     if all_roots:
         return sorted(sqrt_mod_iter(a, p))
     p = abs(as_int(p))
+    halfp = p // 2
     x = None
     for r in sqrt_mod_iter(a, p):
         if r < p // 2:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -433,7 +433,7 @@ def _sqrt_mod_tonelli_shanks(a, p):
     """
     Returns the square root in the case of ``p`` prime with ``p == 1 (mod 8)``
 
-    Assume that the root exists (if it does not, we are in an infinite loop).
+    Assume that the root exists.
     Although ``p`` correctly returns the answer for any odd prime,
     ``p != 1 (mod 8)``, there is no advantage to using this algorithm since
     a more efficient algorithm exists.


### PR DESCRIPTION
I think it would be easier to understand using `for` statements instead of using `StopIteration` in `sqrt_mod`.

Also, I added a docstring for `_sqrt_mod_tonelli_shanks`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
