### PR TITLE
feat(polys): Add Laurent polynomial ring domain

### DIFF
--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -1156,7 +1156,7 @@ complicated domains::
   >>> construct_domain([x/2, 3])[0]
   QQ[x]
   >>> construct_domain([2/x, 3])[0]
-  ZZ(x)
+  ZZ[x,1/x]
   >>> construct_domain([x, y])[0]
   ZZ[x,y]
 

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -12,7 +12,7 @@ from sympy.polys.polymatrix import PolyMatrix as Matrix
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
-from sympy.polys.domains.rationalfield import QQ
+from sympy.polys.domains import ZZ, QQ
 from sympy.polys.polytools import Poly
 from sympy.abc import x, t, n
 
@@ -102,9 +102,10 @@ def test_constant_system():
 def test_prde_spde():
     D = [Poly(x, t), Poly(-x*t, t)]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    R = ZZ.laurent_poly_ring(x)
     # TODO: when bound_degree() can handle this, test degree bound from that too
     assert prde_spde(Poly(t, t), Poly(-1/x, t), D, n, DE) == \
-        (Poly(t, t), Poly(0, t, domain='ZZ(x)'),
+        (Poly(t, t), Poly(0, t, domain=R),
         [Poly(2*x, t, domain='ZZ(x)'), Poly(-x, t, domain='ZZ(x)')],
         [Poly(-x**2, t, domain='ZZ(x)'), Poly(0, t, domain='ZZ(x)')], n - 1)
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,4 +1,5 @@
 """Most of these tests come from the examples in Bronstein's book."""
+from sympy import QQ
 from sympy.core.function import (Function, Lambda, diff, expand_log)
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import Ne
@@ -66,7 +67,7 @@ def test_derivation():
     assert derivation(Poly(1, t), DE) == Poly(0, t)
     assert derivation(Poly(t, t), DE) == DE.d
     assert derivation(Poly(t**2 + 1/x*t + (1 - 2*x)/(4*x**2), t), DE) == \
-        Poly(-2*t**3 - 4/x*t**2 - (5 - 2*x)/(2*x**2)*t - (1 - 2*x)/(2*x**3), t, domain='ZZ(x)')
+        Poly(-2*t**3 - 4/x*t**2 - (5 - 2*x)/(2*x**2)*t - (1 - 2*x)/(2*x**3), t, domain=QQ.laurent_poly_ring(x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1), Poly(t, t)]})
     assert derivation(Poly(x*t*t1, t), DE) == Poly(t*t1 + x*t*t1 + t, t)
     assert derivation(Poly(x*t*t1, t), DE, coefficientD=True) == \
@@ -85,8 +86,8 @@ def test_splitfactor():
         (2*x + 7*x**2 + 2*x**3)*t**2 + (1 - 4*x - 4*x**2)*t - 1 + 2*x, t, field=True)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t**2 - 3/(2*x)*t + 1/(2*x), t)]})
     assert splitfactor(p, DE) == (Poly(4*x**4*t**3 + (-8*x**3 - 4*x**4)*t**2 +
-        (4*x**2 + 8*x**3)*t - 4*x**2, t, domain='ZZ(x)'),
-        Poly(t**2 + 1/x*t + (1 - 2*x)/(4*x**2), t, domain='ZZ(x)'))
+        (4*x**2 + 8*x**3)*t - 4*x**2, t, domain='QQ(x)'),
+        Poly(t**2 + 1/x*t + (1 - 2*x)/(4*x**2), t, domain='QQ(x)'))
     assert splitfactor(Poly(x, t), DE) == (Poly(x, t), Poly(1, t))
     r = Poly(-4*x**4*z**2 + 4*x**6*z**2 - z*x**3 - 4*x**5*z**3 + 4*x**3*z**3 + x**4 + z*x**5 - x**6, t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
@@ -125,10 +126,10 @@ def test_hermite_reduce():
     assert hermite_reduce(
             Poly(x**2*t**5 + x*t**4 - nu**2*t**3 - x*(x**2 + 1)*t**2 - (x**2 - nu**2)*t - x**5/4, t),
             Poly(x**2*t**4 + x**2*(x**2 + 2)*t**2 + x**2 + x**4 + x**6/4, t), DE) == \
-        ((Poly(-x**2 - 4, t, domain='ZZ(x,nu)'), Poly(4*t**2 + 2*x**2 + 4, t, domain='ZZ(x,nu)')),
-         (Poly((-2*nu**2 - x**4)*t - (2*x**3 + 2*x), t, domain='ZZ(x,nu)'),
-          Poly(2*x**2*t**2 + x**4 + 2*x**2, t, domain='ZZ(x,nu)')),
-         (Poly(x*t + 1, t, domain='ZZ(x,nu)'), Poly(x, t, domain='ZZ(x,nu)')))
+        ((Poly(-x**2 - 4, t, domain='QQ(x,nu)'), Poly(4*t**2 + 2*x**2 + 4, t, domain='QQ(x,nu)')),
+         (Poly((-nu**2 - x**4/2)*t - (x**3 + x), t, domain='QQ(x,nu)'),
+          Poly(x**2*t**2 + x**4/2 + x**2, t, domain='QQ(x,nu)')),
+         (Poly(x*t + 1, t, domain='QQ(x,nu)'), Poly(x, t, domain='QQ(x,nu)')))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
 
@@ -136,10 +137,10 @@ def test_hermite_reduce():
     d = Poly(x*t**6 - 4*x**2*t**5 + 6*x**3*t**4 - 4*x**4*t**3 + x**5*t**2, t)
 
     assert hermite_reduce(a, d, DE) == \
-        ((Poly(3*t**2 + t + 3*x, t, domain='ZZ(x)'),
-          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='ZZ(x)')),
-         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
-         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')))
+        ((Poly(3*t**2 + t + 3*x, t, domain='QQ(x)'),
+          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='QQ(x)')),
+         (Poly(0, t, domain='QQ(x)'), Poly(1, t, domain='QQ(x)')),
+         (Poly(0, t, domain='QQ(x)'), Poly(1, t, domain='QQ(x)')))
 
     assert hermite_reduce(
             Poly(-t**2 + 2*t + 2, t, domain='ZZ(x)'),
@@ -159,10 +160,10 @@ def test_hermite_reduce():
     assert hermite_reduce(
             Poly((-2 + 3*x)*t**3 + (-1 + x)*t**2 + (-4*x + 2*x**2)*t + x**2, t),
             Poly(x*t**6 - 4*x**2*t**5 + 6*x**3*t**4 - 4*x**4*t**3 + x**5*t**2, t), DE) == \
-        ((Poly(3*t**2 + t + 3*x, t, domain='ZZ(x)'),
-          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='ZZ(x)')),
-         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
-         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')))
+        ((Poly(3*t**2 + t + 3*x, t, domain='QQ(x)'),
+          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='QQ(x)')),
+         (Poly(0, t, domain='QQ(x)'), Poly(1, t, domain='QQ(x)')),
+         (Poly(0, t, domain='QQ(x)'), Poly(1, t, domain='QQ(x)')))
 
 
 def test_polynomial_reduce():
@@ -226,9 +227,9 @@ def test_residue_reduce():
     assert residue_reduce(a, d, DE, z, invert=True) == \
         ([(Poly(z**2 - Rational(1, 4), z, domain='ZZ(x)'), Poly(t + 2*x*z, t))], False)
     assert residue_reduce(Poly(-2/x, t), Poly(t**2 - 1, t,), DE, z, invert=False) == \
-        ([(Poly(z**2 - 1, z, domain='QQ'), Poly(-2*z*t/x - 2/x, t, domain='ZZ(z,x)'))], True)
+        ([(Poly(z**2 - 1, z, domain='ZZ(x)'), Poly(-z*t/x - 1/x, t, domain='ZZ(z,x)'))], True)
     ans = residue_reduce(Poly(-2/x, t), Poly(t**2 - 1, t), DE, z, invert=True)
-    assert ans == ([(Poly(z**2 - 1, z, domain='QQ'), Poly(t + z, t))], True)
+    assert ans == ([(Poly(z**2 - 1, z, domain='ZZ(x)'), Poly(t + z, t))], True)
     assert residue_reduce_to_basic(ans[0], DE, z) == -log(-1 + log(x)) + log(1 + log(x))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t**2 - t/x - (1 - nu**2/x**2), t)]})
@@ -236,7 +237,7 @@ def test_residue_reduce():
     assert residue_reduce(Poly((-2*nu**2 - x**4)/(2*x**2)*t - (1 + x**2)/x, t),
     Poly(t**2 + 1 + x**2/2, t), DE, z) == \
         ([(Poly(z + S.Half, z, domain='QQ'), Poly(t**2 + 1 + x**2/2, t,
-            domain='ZZ(x,nu)'))], True)
+            domain='QQ(x,nu)'))], True)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1 + t**2, t)]})
     assert residue_reduce(Poly(-2*x*t + 1 - x**2, t),
     Poly(t**2 + 2*x*t + 1 + x**2, t), DE, z) == \

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -317,10 +317,7 @@ def dup_quo_ground(f, c, K):
     if not f:
         return f
 
-    if K.is_Field:
-        return [ K.quo(cf, c) for cf in f ]
-    else:
-        return [ cf // c for cf in f ]
+    return [ K.quo(cf, c) for cf in f ]
 
 
 def dmp_quo_ground(f, c, u, K):

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -685,7 +685,7 @@ def dup_primitive(f, K):
     if K.is_one(cont):
         return cont, f
     else:
-        return cont, dup_quo_ground(f, cont, K)
+        return cont, dup_exquo_ground(f, cont, K)
 
 
 def dmp_ground_primitive(f, u, K):

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -322,6 +322,7 @@ class Domain:
     is_ComplexField = is_CC = False
     is_AlgebraicField = is_Algebraic = False
     is_PolynomialRing = is_Poly = False
+    is_LaurentPolynomialRing = is_Laurent = False
     is_FractionField = is_Frac = False
     is_SymbolicDomain = is_EX = False
     is_SymbolicRawDomain = is_EXRAW = False
@@ -646,6 +647,11 @@ class Domain:
         if a.is_ground:
             return K1.convert(a.LC, K0.dom)
 
+    def from_LaurentPolynomialRing(K1, a, K0):
+        """Convert a Laurent polynomial to ``dtype``. """
+        if a.is_ground:
+            return K1.convert(a.numer.LC, K0.dom)
+
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """
         return None
@@ -876,6 +882,11 @@ class Domain:
         """Returns a fraction field, i.e. `K(X)`. """
         from sympy.polys.domains.old_fractionfield import FractionField
         return FractionField(self, *symbols, **kwargs)
+
+    def laurent_poly_ring(self, *symbols, **kwargs):
+        """Returns a Laurent polynomial ring, i.e. `K[x,1/x]`. """
+        from sympy.polys.domains.laurentpolynomialring import LaurentPolynomialRing
+        return LaurentPolynomialRing(self, symbols, **kwargs)
 
     def algebraic_field(self, *extension, alias=None):
         r"""Returns an algebraic field, i.e. `K(\alpha, \ldots)`. """

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -211,6 +211,10 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         """Convert a ``DMF`` object to ``dtype``. """
         return K1(K0.to_sympy(a))
 
+    def from_LaurentPolynomialRing(K1, a, K0):
+        """Convert a Laurent polynomial to ``dtype``. """
+        return K1(K0.to_sympy(a))
+
     def from_ExpressionDomain(K1, a, K0):
         """Convert a ``EX`` object to ``dtype``. """
         return a

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -144,6 +144,17 @@ class FractionField(Field, CompositeDomain):
             except (CoercionFailed, GeneratorsError):
                 return None
 
+    def from_LaurentPolynomialRing(K1, a, K0):
+        """Convert a Laurent polynomial to ``dtype``. """
+        if a.is_ground:
+            return K1.convert_from(a.numer.coeff(1), K0.domain)
+        try:
+            numer = a.numer.set_ring(K1.field.ring)
+            denom = a.denom.set_ring(K1.field.ring)
+            return K1.new((numer, denom))
+        except (CoercionFailed, GeneratorsError):
+            return None
+
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """
         try:

--- a/sympy/polys/domains/laurentpolynomialring.py
+++ b/sympy/polys/domains/laurentpolynomialring.py
@@ -1,0 +1,172 @@
+from sympy.polys.domains.ring import Ring
+from sympy.polys.domains.compositedomain import CompositeDomain
+
+
+class LaurentPolynomialRing(Ring, CompositeDomain):
+    """Domain for Laurent polynomials.
+
+    Examples
+    ========
+
+    >>> from sympy import QQ
+    >>> from sympy.abc import x, y
+    >>> R = QQ.laurent_poly_ring([x, y])
+    >>> R
+    QQ[x,1/x,y,1/y]
+    >>> p = R.from_sympy(x + 1/y)
+    >>> p
+    x + 1/y
+    """
+
+    is_LaurentPolynomialRing = is_Laurent = True
+
+    has_assoc_Ring = True
+    has_assoc_Field = True
+
+    def __init__(self, domain_or_ring, symbols=None, order=None):
+        from sympy.polys.laurent import LaurentPolyRing, LaurentPolyElement
+
+        if isinstance(domain_or_ring, LaurentPolyRing) and symbols is None and order is None:
+            ring = domain_or_ring
+        else:
+            ring = LaurentPolyRing(symbols, domain_or_ring, order)
+
+        self.ring = ring
+        self.dtype = LaurentPolyElement
+
+        self.domain = ring.domain
+        self.symbols = ring.symbols
+        self.gens = ring.gens
+        self.one = ring.one
+        self.zero = ring.zero
+        self.order = ring.order
+
+        # Needed in some places:
+        self.dom = self.domain
+
+    def __str__(self):
+        syms = [str(s) for s in self.symbols]
+        gens = [f'{s},1/{s}' for s in syms]
+        return f'{self.domain}[{",".join(gens)}]'
+
+    def __eq__(self, other):
+        if not isinstance(other, LaurentPolynomialRing):
+            return NotImplemented
+        return self.ring == other.ring
+
+    def __hash__(self):
+        return hash(self.ring)
+
+    def new(self, element):
+        return self.ring.ring_new(element)
+
+    def get_ring(self):
+        return self.ring.numer_ring.to_domain()
+
+    def get_field(self):
+        return self.ring.to_field().to_domain()
+
+    def numer(self, a):
+        """Returns numerator of ``a`` as an element of the numerator ring. """
+        return a.numer
+
+    def denom(self, a):
+        """Returns denominator of ``a`` as an element of the numerator ring. """
+        return a.denom
+
+    def is_positive(self, a):
+        """Returns True if `LC(a)` is positive. """
+        return self.domain.is_positive(a.LC)
+
+    def is_negative(self, a):
+        """Returns True if `LC(a)` is negative. """
+        return self.domain.is_negative(a.LC)
+
+    def is_nonpositive(self, a):
+        """Returns True if `LC(a)` is non-positive. """
+        return self.domain.is_nonpositive(a.LC)
+
+    def is_nonnegative(self, a):
+        """Returns True if `LC(a)` is non-negative. """
+        return self.domain.is_nonnegative(a.LC)
+
+    def is_unit(self, a):
+        """Returns ``True`` if ``a`` is a unit of ``self``"""
+        if not a.is_term:
+            return False
+        K = self.domain
+        return K.is_unit(a.LC)
+
+    def exquo(self, a, b):
+        return a.exquo(b)
+
+    def gcd(self, a, b):
+        return a.gcd(b)
+
+    def from_sympy(self, expr):
+        return self.ring.from_expr(expr)
+
+    def to_sympy(self, poly):
+        return poly.as_expr()
+
+    def from_ZZ(K1, a, K0):
+        """Convert an integer to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_QQ(K1, a, K0):
+        """Convert a rational number to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_GaussianIntegerRing(K1, a, K0):
+        """Convert a Gaussian integer to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_GaussianRationalField(K1, a, K0):
+        """Convert a Gaussian rational number to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_AlgebraicField(K1, a, K0):
+        """Convert an algebraic number to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_RealField(K1, a, K0):
+        """Convert a mpmath `mpf` object to `dtype`. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_ComplexField(K1, a, K0):
+        """Convert a mpmath ``mpc`` object to ``dtype``. """
+        return K1(K1.domain.convert(a, K0))
+
+    def from_PolynomialRing(K1, a, K0):
+        """Convert a polynomial to ``dtype``. """
+        numer_ring = K1.ring.numer_ring
+        if K0.ring == numer_ring:
+            return K1.ring.from_polyelement(a)
+        else:
+            a = numer_ring.to_domain().convert(a, K0)
+            return K1.ring.from_polyelement(a)
+
+    def from_LaurentPolynomialRing(K1, a, K0):
+        """Convert a Laurent polynomial to ``dtype``. """
+        if K1 == K0:
+            return a
+        else:
+            R0 = K0.ring.numer_ring.to_domain()
+            R1 = K1.ring.numer_ring.to_domain()
+            numer = R1.convert(a.numer, R0)
+            denom = R1.convert(a.denom, R0)
+            return K1.ring.new(numer, denom)
+
+    def from_FractionField(K1, a, K0):
+        """Convert a rational function to ``dtype``. """
+        if not a.denom.is_term:
+            return None
+        numer_ring = K1.ring.numer_ring
+        if K0.field.ring == numer_ring:
+            return K1.ring.new(a.numer, a.denom)
+        else:
+            R1 = numer_ring.to_domain()
+            R0 = K0.field.ring.to_domain()
+            numer = R1.convert(a.numer, R0)
+            denom = R1.convert(a.denom, R0)
+            return K1.ring.new(numer, denom)

--- a/sympy/polys/domains/laurentpolynomialring.py
+++ b/sympy/polys/domains/laurentpolynomialring.py
@@ -10,7 +10,7 @@ class LaurentPolynomialRing(Ring, CompositeDomain):
 
     >>> from sympy import QQ
     >>> from sympy.abc import x, y
-    >>> R = QQ.laurent_poly_ring([x, y])
+    >>> R = QQ.laurent_poly_ring(x, y)
     >>> R
     QQ[x,1/x,y,1/y]
     >>> p = R.from_sympy(x + 1/y)

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -140,6 +140,15 @@ class PolynomialRing(Ring, CompositeDomain):
         except (CoercionFailed, GeneratorsError):
             return None
 
+    def from_LaurentPolynomialRing(K1, a, K0):
+        """Convert a Laurent polynomial to ``dtype``. """
+        if a.denom.is_zero:
+            return None
+        try:
+            return a.numer.set_ring(K1.ring)
+        except (CoercionFailed, GeneratorsError):
+            return None
+
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """
         if K1.domain == K0:

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -8,6 +8,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
 from sympy.polys.polytools import Poly
 from sympy.abc import x, y, z
+from sympy import lex
 
 from sympy.external.gmpy import HAS_GMPY
 
@@ -16,10 +17,13 @@ from sympy.polys.domains import (ZZ, QQ, RR, CC, FF, GF, EX, EXRAW, ZZ_gmpy,
 from sympy.polys.domains.algebraicfield import AlgebraicField
 from sympy.polys.domains.gaussiandomains import ZZ_I, QQ_I
 from sympy.polys.domains.polynomialring import PolynomialRing
+from sympy.polys.domains.laurentpolynomialring import LaurentPolynomialRing
 from sympy.polys.domains.realfield import RealField
 
 from sympy.polys.numberfields.subfield import field_isomorphism
-from sympy.polys.rings import ring
+from sympy.polys.rings import ring, PolyRing
+from sympy.polys.laurent import (laurent_ring, LaurentPolyRing,
+    LaurentPolyElement)
 from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.polys.fields import field
 
@@ -51,6 +55,7 @@ def test_Domain_unify():
     assert unify(F3, RR) == RR
     assert unify(F3, CC) == CC
     assert unify(F3, ZZ[x]) == ZZ[x]
+    assert unify(F3, ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
     assert unify(F3, ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(F3, EX) == EX
 
@@ -61,6 +66,7 @@ def test_Domain_unify():
     assert unify(ZZ, RR) == RR
     assert unify(ZZ, CC) == CC
     assert unify(ZZ, ZZ[x]) == ZZ[x]
+    assert unify(ZZ, ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
     assert unify(ZZ, ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ, EX) == EX
 
@@ -71,6 +77,7 @@ def test_Domain_unify():
     assert unify(QQ, RR) == RR
     assert unify(QQ, CC) == CC
     assert unify(QQ, ZZ[x]) == QQ[x]
+    assert unify(QQ, ZZ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
     assert unify(QQ, ZZ.frac_field(x)) == QQ.frac_field(x)
     assert unify(QQ, EX) == EX
 
@@ -83,6 +90,8 @@ def test_Domain_unify():
     assert unify(ZZ_I, CC) == CC
     assert unify(ZZ_I, ZZ[x]) == ZZ_I[x]
     assert unify(ZZ_I, ZZ_I[x]) == ZZ_I[x]
+    assert unify(ZZ_I, ZZ.laurent_poly_ring(x)) == ZZ_I.laurent_poly_ring(x)
+    assert unify(ZZ_I, ZZ_I.laurent_poly_ring(x)) == ZZ_I.laurent_poly_ring(x)
     assert unify(ZZ_I, ZZ.frac_field(x)) == ZZ_I.frac_field(x)
     assert unify(ZZ_I, ZZ_I.frac_field(x)) == ZZ_I.frac_field(x)
     assert unify(ZZ_I, EX) == EX
@@ -98,6 +107,10 @@ def test_Domain_unify():
     assert unify(QQ_I, ZZ_I[x]) == QQ_I[x]
     assert unify(QQ_I, QQ[x]) == QQ_I[x]
     assert unify(QQ_I, QQ_I[x]) == QQ_I[x]
+    assert unify(QQ_I, ZZ.laurent_poly_ring(x)) == QQ_I.laurent_poly_ring(x)
+    assert unify(QQ_I, ZZ_I.laurent_poly_ring(x)) == QQ_I.laurent_poly_ring(x)
+    assert unify(QQ_I, QQ.laurent_poly_ring(x)) == QQ_I.laurent_poly_ring(x)
+    assert unify(QQ_I, QQ_I.laurent_poly_ring(x)) == QQ_I.laurent_poly_ring(x)
     assert unify(QQ_I, ZZ.frac_field(x)) == QQ_I.frac_field(x)
     assert unify(QQ_I, ZZ_I.frac_field(x)) == QQ_I.frac_field(x)
     assert unify(QQ_I, QQ.frac_field(x)) == QQ_I.frac_field(x)
@@ -111,6 +124,7 @@ def test_Domain_unify():
     assert unify(RR, RR) == RR
     assert unify(RR, CC) == CC
     assert unify(RR, ZZ[x]) == RR[x]
+    assert unify(RR, ZZ.laurent_poly_ring(x)) == RR.laurent_poly_ring(x)
     assert unify(RR, ZZ.frac_field(x)) == RR.frac_field(x)
     assert unify(RR, EX) == EX
     assert RR[x].unify(ZZ.frac_field(y)) == RR.frac_field(x, y)
@@ -122,6 +136,7 @@ def test_Domain_unify():
     assert unify(CC, RR) == CC
     assert unify(CC, CC) == CC
     assert unify(CC, ZZ[x]) == CC[x]
+    assert unify(CC, ZZ.laurent_poly_ring(x)) == CC.laurent_poly_ring(x)
     assert unify(CC, ZZ.frac_field(x)) == CC.frac_field(x)
     assert unify(CC, EX) == EX
 
@@ -132,8 +147,20 @@ def test_Domain_unify():
     assert unify(ZZ[x], RR) == RR[x]
     assert unify(ZZ[x], CC) == CC[x]
     assert unify(ZZ[x], ZZ[x]) == ZZ[x]
+    assert unify(ZZ[x], ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
     assert unify(ZZ[x], ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ[x], EX) == EX
+
+    assert unify(ZZ.laurent_poly_ring(x), F3) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), ZZ) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), QQ) == QQ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), ALG) == ALG.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), RR) == RR.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), CC) == CC.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), ZZ[x]) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.frac_field(x)) == ZZ.frac_field(x)
+    assert unify(ZZ.laurent_poly_ring(x), EX) == EX
 
     assert unify(ZZ.frac_field(x), F3) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), ZZ) == ZZ.frac_field(x)
@@ -142,6 +169,7 @@ def test_Domain_unify():
     assert unify(ZZ.frac_field(x), RR) == RR.frac_field(x)
     assert unify(ZZ.frac_field(x), CC) == CC.frac_field(x)
     assert unify(ZZ.frac_field(x), ZZ[x]) == ZZ.frac_field(x)
+    assert unify(ZZ.frac_field(x), ZZ.laurent_poly_ring(x)) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), EX) == EX
 
@@ -152,6 +180,7 @@ def test_Domain_unify():
     assert unify(EX, RR) == EX
     assert unify(EX, CC) == EX
     assert unify(EX, ZZ[x]) == EX
+    assert unify(EX, ZZ.laurent_poly_ring(x)) == EX
     assert unify(EX, ZZ.frac_field(x)) == EX
     assert unify(EX, EX) == EX
 
@@ -175,6 +204,26 @@ def test_Domain_unify_composite():
     assert unify(QQ, ZZ.poly_ring(x, y)) == QQ.poly_ring(x, y)
     assert unify(ZZ, QQ.poly_ring(x, y)) == QQ.poly_ring(x, y)
     assert unify(QQ, QQ.poly_ring(x, y)) == QQ.poly_ring(x, y)
+
+    assert unify(ZZ.laurent_poly_ring(x), ZZ) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), QQ) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), ZZ) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), QQ) == QQ.laurent_poly_ring(x)
+
+    assert unify(ZZ, ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
+    assert unify(QQ, ZZ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(ZZ, QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(QQ, QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+
+    assert unify(ZZ.laurent_poly_ring(x, y), ZZ) == ZZ.laurent_poly_ring(x, y)
+    assert unify(ZZ.laurent_poly_ring(x, y), QQ) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), ZZ) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), QQ) == QQ.laurent_poly_ring(x, y)
+
+    assert unify(ZZ, ZZ.laurent_poly_ring(x, y)) == ZZ.laurent_poly_ring(x, y)
+    assert unify(QQ, ZZ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(ZZ, QQ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ, QQ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
 
     assert unify(ZZ.frac_field(x), ZZ) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), QQ) == QQ.frac_field(x)
@@ -216,6 +265,26 @@ def test_Domain_unify_composite():
     assert unify(QQ.poly_ring(x, y), ZZ.poly_ring(x, z)) == QQ.poly_ring(x, y, z)
     assert unify(QQ.poly_ring(x, y), QQ.poly_ring(x, z)) == QQ.poly_ring(x, y, z)
 
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), ZZ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x)
+
+    assert unify(ZZ.laurent_poly_ring(x, y), ZZ.laurent_poly_ring(x)) == ZZ.laurent_poly_ring(x, y)
+    assert unify(ZZ.laurent_poly_ring(x, y), QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), ZZ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), QQ.laurent_poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.laurent_poly_ring(x, y)) == ZZ.laurent_poly_ring(x, y)
+    assert unify(ZZ.laurent_poly_ring(x), QQ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x), ZZ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x), QQ.laurent_poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+
+    assert unify(ZZ.laurent_poly_ring(x, y), ZZ.laurent_poly_ring(x, z)) == ZZ.laurent_poly_ring(x, y, z)
+    assert unify(ZZ.laurent_poly_ring(x, y), QQ.laurent_poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
+    assert unify(QQ.laurent_poly_ring(x, y), ZZ.laurent_poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
+    assert unify(QQ.laurent_poly_ring(x, y), QQ.laurent_poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
+
     assert unify(ZZ.frac_field(x), ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), QQ.frac_field(x)) == QQ.frac_field(x)
     assert unify(QQ.frac_field(x), ZZ.frac_field(x)) == QQ.frac_field(x)
@@ -255,6 +324,26 @@ def test_Domain_unify_composite():
     assert unify(ZZ.poly_ring(x, y), QQ.frac_field(x, z)) == ZZ.frac_field(x, y, z)
     assert unify(QQ.poly_ring(x, y), ZZ.frac_field(x, z)) == ZZ.frac_field(x, y, z)
     assert unify(QQ.poly_ring(x, y), QQ.frac_field(x, z)) == QQ.frac_field(x, y, z)
+
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.poly_ring(x)) == ZZ.laurent_poly_ring(x)
+    assert unify(ZZ.laurent_poly_ring(x), QQ.poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), ZZ.poly_ring(x)) == QQ.laurent_poly_ring(x)
+    assert unify(QQ.laurent_poly_ring(x), QQ.poly_ring(x)) == QQ.laurent_poly_ring(x)
+
+    assert unify(ZZ.laurent_poly_ring(x, y), ZZ.poly_ring(x)) == ZZ.laurent_poly_ring(x, y)
+    assert unify(ZZ.laurent_poly_ring(x, y), QQ.poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), ZZ.poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x, y), QQ.poly_ring(x)) == QQ.laurent_poly_ring(x, y)
+
+    assert unify(ZZ.laurent_poly_ring(x), ZZ.poly_ring(x, y)) == ZZ.laurent_poly_ring(x, y)
+    assert unify(ZZ.laurent_poly_ring(x), QQ.poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x), ZZ.poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+    assert unify(QQ.laurent_poly_ring(x), QQ.poly_ring(x, y)) == QQ.laurent_poly_ring(x, y)
+
+    assert unify(ZZ.laurent_poly_ring(x, y), ZZ.poly_ring(x, z)) == ZZ.laurent_poly_ring(x, y, z)
+    assert unify(ZZ.laurent_poly_ring(x, y), QQ.poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
+    assert unify(QQ.laurent_poly_ring(x, y), ZZ.poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
+    assert unify(QQ.laurent_poly_ring(x, y), QQ.poly_ring(x, z)) == QQ.laurent_poly_ring(x, y, z)
 
     assert unify(ZZ.frac_field(x), ZZ.poly_ring(x)) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), QQ.poly_ring(x)) == ZZ.frac_field(x)
@@ -360,6 +449,8 @@ def test_Domain__contains__():
     assert (0 in ZZ[x, y]) is True
     assert (0 in QQ[x, y]) is True
     assert (0 in RR[x, y]) is True
+    assert (0 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (0 in ZZ.frac_field(x, y)) is True
 
     assert (-7 in EX) is True
     assert (-7 in ZZ) is True
@@ -370,6 +461,8 @@ def test_Domain__contains__():
     assert (-7 in ZZ[x, y]) is True
     assert (-7 in QQ[x, y]) is True
     assert (-7 in RR[x, y]) is True
+    assert (-7 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (-7 in ZZ.frac_field(x, y)) is True
 
     assert (17 in EX) is True
     assert (17 in ZZ) is True
@@ -380,6 +473,8 @@ def test_Domain__contains__():
     assert (17 in ZZ[x, y]) is True
     assert (17 in QQ[x, y]) is True
     assert (17 in RR[x, y]) is True
+    assert (17 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (17 in ZZ.frac_field(x, y)) is True
 
     assert (Rational(-1, 7) in EX) is True
     assert (Rational(-1, 7) in ZZ) is False
@@ -390,6 +485,10 @@ def test_Domain__contains__():
     assert (Rational(-1, 7) in ZZ[x, y]) is False
     assert (Rational(-1, 7) in QQ[x, y]) is True
     assert (Rational(-1, 7) in RR[x, y]) is True
+    assert (Rational(-1, 7) in ZZ.laurent_poly_ring(x, y)) is False
+    assert (Rational(-1, 7) in QQ.laurent_poly_ring(x, y)) is True
+    assert (Rational(-1, 7) in ZZ.frac_field(x, y)) is True
+    assert (Rational(-1, 7) in QQ.frac_field(x, y)) is True
 
     assert (Rational(3, 5) in EX) is True
     assert (Rational(3, 5) in ZZ) is False
@@ -400,6 +499,10 @@ def test_Domain__contains__():
     assert (Rational(3, 5) in ZZ[x, y]) is False
     assert (Rational(3, 5) in QQ[x, y]) is True
     assert (Rational(3, 5) in RR[x, y]) is True
+    assert (Rational(3, 5) in ZZ.laurent_poly_ring(x, y)) is False
+    assert (Rational(3, 5) in QQ.laurent_poly_ring(x, y)) is True
+    assert (Rational(3, 5) in ZZ.frac_field(x, y)) is True
+    assert (Rational(3, 5) in QQ.frac_field(x, y)) is True
 
     assert (3.0 in EX) is True
     assert (3.0 in ZZ) is True
@@ -410,6 +513,10 @@ def test_Domain__contains__():
     assert (3.0 in ZZ[x, y]) is True
     assert (3.0 in QQ[x, y]) is True
     assert (3.0 in RR[x, y]) is True
+    assert (3.0 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (3.0 in QQ.laurent_poly_ring(x, y)) is True
+    assert (3.0 in ZZ.frac_field(x, y)) is True
+    assert (3.0 in QQ.frac_field(x, y)) is True
 
     assert (3.14 in EX) is True
     assert (3.14 in ZZ) is False
@@ -420,16 +527,24 @@ def test_Domain__contains__():
     assert (3.14 in ZZ[x, y]) is False
     assert (3.14 in QQ[x, y]) is True
     assert (3.14 in RR[x, y]) is True
+    assert (3.14 in ZZ.laurent_poly_ring(x, y)) is False
+    assert (3.14 in QQ.laurent_poly_ring(x, y)) is True
+    assert (3.14 in ZZ.frac_field(x, y)) is False # ???
+    assert (3.14 in QQ.frac_field(x, y)) is True
 
     assert (oo in ALG) is False
     assert (oo in ZZ[x, y]) is False
     assert (oo in QQ[x, y]) is False
+    assert (oo in ZZ.laurent_poly_ring(x, y)) is False
+    assert (oo in ZZ.frac_field(x, y)) is False
 
     assert (-oo in ZZ) is False
     assert (-oo in QQ) is False
     assert (-oo in ALG) is False
     assert (-oo in ZZ[x, y]) is False
     assert (-oo in QQ[x, y]) is False
+    assert (-oo in ZZ.laurent_poly_ring(x, y)) is False
+    assert (-oo in ZZ.frac_field(x, y)) is False
 
     assert (sqrt(7) in EX) is True
     assert (sqrt(7) in ZZ) is False
@@ -440,6 +555,12 @@ def test_Domain__contains__():
     assert (sqrt(7) in ZZ[x, y]) is False
     assert (sqrt(7) in QQ[x, y]) is False
     assert (sqrt(7) in RR[x, y]) is True
+    assert (sqrt(7) in ZZ.laurent_poly_ring(x, y)) is False
+    assert (sqrt(7) in ALG.laurent_poly_ring(x, y)) is False
+    assert (sqrt(7) in RR.laurent_poly_ring(x, y)) is True
+    assert (sqrt(7) in ZZ.frac_field(x, y)) is False
+    assert (sqrt(7) in ALG.frac_field(x, y)) is False
+    assert (sqrt(7) in RR.frac_field(x, y)) is True
 
     assert (2*sqrt(3) + 1 in EX) is True
     assert (2*sqrt(3) + 1 in ZZ) is False
@@ -450,6 +571,12 @@ def test_Domain__contains__():
     assert (2*sqrt(3) + 1 in ZZ[x, y]) is False
     assert (2*sqrt(3) + 1 in QQ[x, y]) is False
     assert (2*sqrt(3) + 1 in RR[x, y]) is True
+    assert (2*sqrt(3) + 1 in ZZ.laurent_poly_ring(x, y)) is False
+    assert (2*sqrt(3) + 1 in ALG.laurent_poly_ring(x, y)) is True
+    assert (2*sqrt(3) + 1 in RR.laurent_poly_ring(x, y)) is True
+    assert (2*sqrt(3) + 1 in ZZ.frac_field(x, y)) is False
+    assert (2*sqrt(3) + 1 in ALG.frac_field(x, y)) is True
+    assert (2*sqrt(3) + 1 in RR.frac_field(x, y)) is True
 
     assert (sin(1) in EX) is True
     assert (sin(1) in ZZ) is False
@@ -460,6 +587,14 @@ def test_Domain__contains__():
     assert (sin(1) in ZZ[x, y]) is False
     assert (sin(1) in QQ[x, y]) is False
     assert (sin(1) in RR[x, y]) is True
+    assert (2*sqrt(3) + 1 in ZZ.laurent_poly_ring(x, y)) is False
+    assert (2*sqrt(3) + 1 in QQ.laurent_poly_ring(x, y)) is False
+    assert (2*sqrt(3) + 1 in ALG.laurent_poly_ring(x, y)) is True
+    assert (2*sqrt(3) + 1 in RR.laurent_poly_ring(x, y)) is True
+    assert (2*sqrt(3) + 1 in ZZ.frac_field(x, y)) is False
+    assert (2*sqrt(3) + 1 in QQ.frac_field(x, y)) is False
+    assert (2*sqrt(3) + 1 in ALG.frac_field(x, y)) is True
+    assert (2*sqrt(3) + 1 in RR.frac_field(x, y)) is True
 
     assert (x**2 + 1 in EX) is True
     assert (x**2 + 1 in ZZ) is False
@@ -473,6 +608,12 @@ def test_Domain__contains__():
     assert (x**2 + 1 in ZZ[x, y]) is True
     assert (x**2 + 1 in QQ[x, y]) is True
     assert (x**2 + 1 in RR[x, y]) is True
+    assert (x**2 + 1 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (x**2 + 1 in ALG.laurent_poly_ring(x, y)) is True
+    assert (x**2 + 1 in RR.laurent_poly_ring(x, y)) is True
+    assert (x**2 + 1 in ZZ.frac_field(x, y)) is True
+    assert (x**2 + 1 in ALG.frac_field(x, y)) is True
+    assert (x**2 + 1 in RR.frac_field(x, y)) is True
 
     assert (x**2 + y**2 in EX) is True
     assert (x**2 + y**2 in ZZ) is False
@@ -486,6 +627,12 @@ def test_Domain__contains__():
     assert (x**2 + y**2 in ZZ[x, y]) is True
     assert (x**2 + y**2 in QQ[x, y]) is True
     assert (x**2 + y**2 in RR[x, y]) is True
+    assert (x**2 + y**2 in ZZ.laurent_poly_ring(x, y)) is True
+    assert (x**2 + y**2 in ALG.laurent_poly_ring(x, y)) is True
+    assert (x**2 + y**2 in RR.laurent_poly_ring(x, y)) is True
+    assert (x**2 + y**2 in ZZ.frac_field(x, y)) is True
+    assert (x**2 + y**2 in ALG.frac_field(x, y)) is True
+    assert (x**2 + y**2 in RR.frac_field(x, y)) is True
 
     assert (Rational(3, 2)*x/(y + 1) - z in QQ[x, y, z]) is False
 
@@ -505,6 +652,10 @@ def test_Domain_get_ring():
     assert QQ[x].has_assoc_Ring is True
     assert ZZ[x, y].has_assoc_Ring is True
     assert QQ[x, y].has_assoc_Ring is True
+    assert ZZ.laurent_poly_ring(x).has_assoc_Ring is True
+    assert QQ.laurent_poly_ring(x).has_assoc_Ring is True
+    assert ZZ.laurent_poly_ring(x, y).has_assoc_Ring is True
+    assert QQ.laurent_poly_ring(x, y).has_assoc_Ring is True
     assert ZZ.frac_field(x).has_assoc_Ring is True
     assert QQ.frac_field(x).has_assoc_Ring is True
     assert ZZ.frac_field(x, y).has_assoc_Ring is True
@@ -516,10 +667,17 @@ def test_Domain_get_ring():
 
     assert ZZ.get_ring() == ZZ
     assert QQ.get_ring() == ZZ
+
     assert ZZ[x].get_ring() == ZZ[x]
     assert QQ[x].get_ring() == QQ[x]
     assert ZZ[x, y].get_ring() == ZZ[x, y]
     assert QQ[x, y].get_ring() == QQ[x, y]
+
+    assert ZZ.laurent_poly_ring(x).get_ring() == ZZ[x]
+    assert QQ.laurent_poly_ring(x).get_ring() == QQ[x]
+    assert ZZ.laurent_poly_ring(x, y).get_ring() == ZZ[x, y]
+    assert QQ.laurent_poly_ring(x, y).get_ring() == QQ[x, y]
+
     assert ZZ.frac_field(x).get_ring() == ZZ[x]
     assert QQ.frac_field(x).get_ring() == QQ[x]
     assert ZZ.frac_field(x, y).get_ring() == ZZ[x, y]
@@ -542,6 +700,14 @@ def test_Domain_get_field():
     assert QQ[x].has_assoc_Field is True
     assert ZZ[x, y].has_assoc_Field is True
     assert QQ[x, y].has_assoc_Field is True
+    assert ZZ.laurent_poly_ring(x).has_assoc_Field is True
+    assert QQ.laurent_poly_ring(x).has_assoc_Field is True
+    assert ZZ.laurent_poly_ring(x, y).has_assoc_Field is True
+    assert QQ.laurent_poly_ring(x, y).has_assoc_Field is True
+    assert ZZ.frac_field(x).has_assoc_Field is True
+    assert QQ.frac_field(x).has_assoc_Field is True
+    assert ZZ.frac_field(x, y).has_assoc_Field is True
+    assert QQ.frac_field(x, y).has_assoc_Field is True
 
     assert EX.get_field() == EX
     assert ZZ.get_field() == QQ
@@ -552,6 +718,14 @@ def test_Domain_get_field():
     assert QQ[x].get_field() == QQ.frac_field(x)
     assert ZZ[x, y].get_field() == ZZ.frac_field(x, y)
     assert QQ[x, y].get_field() == QQ.frac_field(x, y)
+    assert ZZ.laurent_poly_ring(x).get_field() == ZZ.frac_field(x)
+    assert QQ.laurent_poly_ring(x).get_field() == QQ.frac_field(x)
+    assert ZZ.laurent_poly_ring(x, y).get_field() == ZZ.frac_field(x, y)
+    assert QQ.laurent_poly_ring(x, y).get_field() == QQ.frac_field(x, y)
+    assert ZZ.frac_field(x).get_field() == ZZ.frac_field(x)
+    assert QQ.frac_field(x).get_field() == QQ.frac_field(x)
+    assert ZZ.frac_field(x, y).get_field() == ZZ.frac_field(x, y)
+    assert QQ.frac_field(x, y).get_field() == QQ.frac_field(x, y)
 
 
 def test_Domain_get_exact():
@@ -564,6 +738,10 @@ def test_Domain_get_exact():
     assert QQ[x].get_exact() == QQ[x]
     assert ZZ[x, y].get_exact() == ZZ[x, y]
     assert QQ[x, y].get_exact() == QQ[x, y]
+    assert ZZ.laurent_poly_ring(x).get_exact() == ZZ.laurent_poly_ring(x)
+    assert QQ.laurent_poly_ring(x).get_exact() == QQ.laurent_poly_ring(x)
+    assert ZZ.laurent_poly_ring(x, y).get_exact() == ZZ.laurent_poly_ring(x, y)
+    assert QQ.laurent_poly_ring(x, y).get_exact() == QQ.laurent_poly_ring(x, y)
     assert ZZ.frac_field(x).get_exact() == ZZ.frac_field(x)
     assert QQ.frac_field(x).get_exact() == QQ.frac_field(x)
     assert ZZ.frac_field(x, y).get_exact() == ZZ.frac_field(x, y)
@@ -574,15 +752,26 @@ def test_Domain_is_unit():
     nums = [-2, -1, 0, 1, 2]
     invring = [False, True, False, True, False]
     invfield = [True, True, False, True, True]
-    ZZx, QQx, QQxf = ZZ[x], QQ[x], QQ.frac_field(x)
+    ZZx = ZZ[x]
+    QQx = QQ[x]
+    ZZxl = ZZ.laurent_poly_ring(x)
+    QQxl = QQ.laurent_poly_ring(x)
+    ZZxf = ZZ.frac_field(x)
+    QQxf = QQ.frac_field(x)
     assert [ZZ.is_unit(ZZ(n)) for n in nums] == invring
     assert [QQ.is_unit(QQ(n)) for n in nums] == invfield
     assert [ZZx.is_unit(ZZx(n)) for n in nums] == invring
     assert [QQx.is_unit(QQx(n)) for n in nums] == invfield
+    assert [ZZxl.is_unit(ZZxl(n)) for n in nums] == invring
+    assert [QQxl.is_unit(QQxl(n)) for n in nums] == invfield
+    assert [ZZxf.is_unit(ZZxf(n)) for n in nums] == invfield
     assert [QQxf.is_unit(QQxf(n)) for n in nums] == invfield
     assert ZZx.is_unit(ZZx(x)) is False
     assert QQx.is_unit(QQx(x)) is False
+    assert ZZxl.is_unit(ZZxl(x)) is True
+    assert ZZxl.is_unit(ZZxl(1 + x)) is False
     assert QQxf.is_unit(QQxf(x)) is True
+    assert QQxf.is_unit(QQxf(1 + x)) is True
 
 
 def test_Domain_convert():
@@ -601,10 +790,18 @@ def test_Domain_convert():
     def composite_domains(K):
         domains = [
             K,
-            K[y], K[z], K[y, z],
-            K.frac_field(y), K.frac_field(z), K.frac_field(y, z),
+            K[y],
+            K[z],
+            K[y, z],
+            K.laurent_poly_ring(y),
+            K.laurent_poly_ring(z),
+            K.laurent_poly_ring(y, z),
+            K.frac_field(y),
+            K.frac_field(z),
+            K.frac_field(y, z),
             # XXX: These should be tested and made to work...
-            # K.old_poly_ring(y), K.old_frac_field(y),
+            # K.old_poly_ring(y),
+            # K.old_frac_field(y),
         ]
         return domains
 
@@ -631,7 +828,9 @@ def test_Domain_convert():
     K2 = ZZ.frac_field(x)
     K3 = QQ[x]
     K4 = ZZ[x]
-    Ks = [K1, K2, K3, K4]
+    K5 = QQ.laurent_poly_ring(x)
+    K6 = ZZ.laurent_poly_ring(x)
+    Ks = [K1, K2, K3, K4, K5, K6]
     for Ka, Kb in product(Ks, Ks):
         assert Ka.convert_from(Kb.from_sympy(x), Kb) == Ka.from_sympy(x)
 
@@ -660,6 +859,11 @@ def test_PolynomialRing__init():
     assert ZZ.poly_ring() == R.to_domain()
 
 
+def test_LaurentPolynomialRing__init():
+    R, = laurent_ring("", ZZ)
+    assert ZZ.laurent_poly_ring() == R.to_domain()
+
+
 def test_FractionField__init():
     F, = field("", ZZ)
     assert ZZ.frac_field() == F.to_domain()
@@ -675,6 +879,7 @@ def test_FractionField_convert():
 def test_inject():
     assert ZZ.inject(x, y, z) == ZZ[x, y, z]
     assert ZZ[x].inject(y, z) == ZZ[x, y, z]
+    assert ZZ.laurent_poly_ring(x).inject(y, z) == ZZ.laurent_poly_ring(x, y, z)
     assert ZZ.frac_field(x).inject(y, z) == ZZ.frac_field(x, y, z)
     raises(GeneratorsError, lambda: ZZ[x].inject(x))
 
@@ -683,10 +888,14 @@ def test_drop():
     assert ZZ.drop(x) == ZZ
     assert ZZ[x].drop(x) == ZZ
     assert ZZ[x, y].drop(x) == ZZ[y]
+    assert ZZ.laurent_poly_ring(x).drop(x) == ZZ
+    assert ZZ.laurent_poly_ring(x, y).drop(x) == ZZ.laurent_poly_ring(y)
     assert ZZ.frac_field(x).drop(x) == ZZ
     assert ZZ.frac_field(x, y).drop(x) == ZZ.frac_field(y)
     assert ZZ[x][y].drop(y) == ZZ[x]
     assert ZZ[x][y].drop(x) == ZZ[y]
+    assert ZZ.laurent_poly_ring(x)[y].drop(x) == ZZ[y]
+    assert ZZ.laurent_poly_ring(x)[y].drop(y) == ZZ.laurent_poly_ring(x)
     assert ZZ.frac_field(x)[y].drop(x) == ZZ[y]
     assert ZZ.frac_field(x)[y].drop(y) == ZZ.frac_field(x)
     Ky = FiniteExtension(Poly(x**2-1, x, domain=ZZ[y]))
@@ -711,6 +920,12 @@ def test_Domain___eq__():
 
     assert (ZZ[x, y] == QQ[x, y]) is False
     assert (QQ[x, y] == ZZ[x, y]) is False
+
+    assert (ZZ.laurent_poly_ring(x, y) == ZZ.laurent_poly_ring(x, y)) is True
+    assert (QQ.laurent_poly_ring(x, y) == QQ.laurent_poly_ring(x, y)) is True
+
+    assert (ZZ.laurent_poly_ring(x, y) == QQ.laurent_poly_ring(x, y)) is False
+    assert (QQ.laurent_poly_ring(x, y) == ZZ.laurent_poly_ring(x, y)) is False
 
     assert (ZZ.frac_field(x, y) == ZZ.frac_field(x, y)) is True
     assert (QQ.frac_field(x, y) == QQ.frac_field(x, y)) is True
@@ -790,6 +1005,7 @@ def test_PolynomialRing_from_FractionField():
     assert R.to_domain().from_FractionField(g, F.to_domain()) == X**2/4 + Y**2/4
     assert R.to_domain().from_FractionField(h, F.to_domain()) == X**2 + Y**2
 
+
 def test_FractionField_from_PolynomialRing():
     R, x,y = ring("x,y", QQ)
     F, X,Y = field("x,y", ZZ)
@@ -799,6 +1015,7 @@ def test_FractionField_from_PolynomialRing():
 
     assert F.to_domain().from_PolynomialRing(f, R.to_domain()) == 3*X**2 + 5*Y**2
     assert F.to_domain().from_PolynomialRing(g, R.to_domain()) == (5*X**2 + 3*Y**2)/15
+
 
 def test_FF_of_type():
     assert FF(3).of_type(FF(3)(1)) is True
@@ -1146,6 +1363,64 @@ def test_gaussian_domains():
             assert G.denom(q2) == ZZ_I(6)
 
 
+def test_LaurentPolynomialRing():
+    R = LaurentPolyRing([x, y], ZZ)
+    D1 = LaurentPolynomialRing(ZZ, "x, y")
+    D2 = ZZ.laurent_poly_ring(x, y)
+    D3 = LaurentPolynomialRing(R)
+    D4 = R.to_domain()
+    assert D1 == D2 == D3 == D4
+
+    for D in [D1, D2, D3, D4]:
+        assert D.ring == R
+        assert D.dtype == LaurentPolyElement
+        assert D.domain == ZZ
+        assert D.symbols == (x, y)
+        assert D.gens == (R.x, R.y)
+        assert D.order == lex
+        assert D(1) == D.one == R.one
+        assert D(0) == D.zero == R.zero
+        assert D.one.parent() == D
+        assert D.zero.parent() == D
+
+    Rp = PolyRing([x, y], ZZ)
+    D = ZZ.laurent_poly_ring(x, y)
+    assert D.numer(D.one) == Rp.one
+    assert D.denom(D(1/x)) == Rp(x)
+
+    # These predicates just apply to the leading coefficient.
+    nums = [-1, 0, 1]
+    expected = [
+        (D.is_positive, [False, False, True]),
+        (D.is_negative, [True, False, False]),
+        (D.is_nonpositive, [True, True, False]),
+        (D.is_nonnegative, [False, True, True]),
+    ]
+    for pred, answers in expected:
+        for num, ans in zip(nums, answers):
+            assert pred(D(num)) is ans
+            assert pred(D(num*x)) is ans
+            assert pred(D(num/x)) is ans
+            if num != 0:
+                assert pred(D(num*x**2 + x)) is ans
+                assert pred(D(num*x**2 - x)) is ans
+
+    expr = (2*x + 3*y)/y
+    assert D(expr) == D.from_sympy(expr)
+    assert D.to_sympy(D(expr)) == expr
+
+    F = ZZ.frac_field(x, y)
+    assert D.convert_from(F(expr), F) == D(expr)
+    expr2 = F((x + y)/(x - y))
+    raises(CoercionFailed, D.convert_from, expr2, F)
+
+    p1 = D((x + y)/x)
+    p2 = D((x - y)/y)
+    g = D((x**2 + 3*y)/(x*y))
+    assert D.gcd(p1*g, p2*g) == g
+    assert D.exquo(p1*g, g) == p1
+
+
 def test_EX_EXRAW():
     assert EXRAW.zero is S.Zero
     assert EXRAW.one is S.One
@@ -1195,6 +1470,11 @@ def test_canonical_unit():
 
     K = ZZ_I[x]
     assert K.canonical_unit(K.from_sympy(I*x)) == ZZ_I(0, -1)
+
+    K = ZZ_I.laurent_poly_ring(x, y)
+    i = K.from_sympy(I)
+    assert i / i == K.one
+    assert (K.one + i)/(i - K.one) == -i
 
     K = ZZ_I.frac_field(x, y)
     i = K.from_sympy(I)

--- a/sympy/polys/laurent.py
+++ b/sympy/polys/laurent.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+from functools import reduce
+from operator import add, mul
+
+from sympy.core.expr import Expr
+from sympy.core.add import Add
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify, CantSympify
+from sympy.polys.domains.domainelement import DomainElement
+from sympy.polys.domains.laurentpolynomialring import LaurentPolynomialRing
+from sympy.polys.fields import FracField
+from sympy.polys.orderings import LexOrder
+from sympy.polys.polyerrors import CoercionFailed
+from sympy.polys.rings import PolyElement, PolyRing
+from sympy.printing.defaults import DefaultPrinting
+
+from typing import Any, Optional
+
+
+def laurent_ring(symbols, domain, order='lex'):
+    """Construct a Laurent polynomial ring.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.laurent import laurent_ring
+    >>> from sympy import ZZ
+    >>> R, x, y = laurent_ring('x,y', ZZ, order='lex')
+    >>> R
+    Laurent polynomial ring in x, y over ZZ with lex order
+    >>> p = x**2 + 1/y
+    >>> p
+    x**2 + 1/y
+    >>> p ** 2
+    x**4 + 2*x**2/y + 1/y**2
+    """
+    ring = LaurentPolyRing(symbols, domain, order=order)
+    return (ring,) + ring.gens
+
+
+class LaurentPolyRing:
+    """Ring of Laurent polynomials.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.laurent import LaurentPolyRing
+    >>> from sympy import ZZ
+    >>> from sympy.abc import x, y
+    >>> R = LaurentPolyRing([x, y], ZZ, order='lex')
+    >>> R
+    Laurent polynomial ring in x, y over ZZ with lex order
+    >>> p = R.from_expr(1/x + x*y)
+    >>> x, y = R.gens
+    >>> p = 1/x + x*y
+    >>> p
+    x*y + 1/x
+    >>> p ** 2
+    x**2*y**2 + 2*y + 1/x**2
+    """
+    def __init__(self, symbols, domain, order=LexOrder()):
+        numer_ring = PolyRing(symbols, domain, order=order)
+
+        self.numer_ring = numer_ring
+        self.domain = numer_ring.domain
+        self.symbols = numer_ring.symbols
+        self.order = numer_ring.order
+
+        self.zero = self.from_polyelement(numer_ring.zero)
+        self.one = self.from_polyelement(numer_ring.one)
+        self.gens = tuple(self.from_polyelement(g) for g in numer_ring.gens)
+
+        # Make the symbols accessible as R.x, R.y etc.
+        for symbol, generator in zip(self.symbols, self.gens):
+            if isinstance(symbol, Symbol):
+                name = symbol.name
+                if not hasattr(self, name):
+                    setattr(self, name, generator)
+
+    def __eq__(self, other):
+        if not isinstance(other, LaurentPolyRing):
+            return NotImplemented
+        return self.numer_ring == other.numer_ring
+
+    def __hash__(self):
+        return hash(self.numer_ring)
+
+    def __repr__(self):
+        syms = ', '.join(map(str, self.symbols))
+        return f"Laurent polynomial ring in {syms} over {self.domain} with {self.order} order"
+
+    def __call__(self, element):
+        return self.ring_new(element)
+
+    def new(self, numer, denom=None):
+        """Construct a new Laurent polynomial from a numerator and denominator."""
+        if denom is None:
+            denom = self.numer_ring.one
+        return LaurentPolyElement(self, numer, denom)
+
+    def ring_new(self, element):
+        if isinstance(element, tuple) and len(element) == 2:
+            numer, denom = element
+            numer = self.numer_ring.ring_new(numer)
+            denom = self.numer_ring.ring_new(denom)
+            return self.new(numer, denom)
+        elif isinstance(element, Expr):
+            return self.from_expr(element)
+        else:
+            numer = self.numer_ring.ring_new(element)
+            return self.new(numer)
+
+    def ground_new(self, coeff):
+        """Construct a new Laurent polynomial from an element of the ground domain."""
+        return self.from_polyelement(self.numer_ring.ground_new(coeff))
+
+    def from_polyelement(self, numer: PolyElement):
+        """Construct a new Laurent polynomial from a polynomial."""
+        assert self.numer_ring == numer.ring
+        return LaurentPolyElement(self, numer, self.numer_ring.one)
+
+    def from_expr(self, expr):
+        """Construct a new Laurent polynomial from a SymPy expression."""
+        mapping = dict(list(zip(self.symbols, self.gens)))
+
+        try:
+            poly = self._rebuild_expr(expr, mapping)
+        except CoercionFailed:
+            raise ValueError("expected an expression convertible to a polynomial in %s, got %s" % (self, expr))
+        else:
+            return poly
+
+    def _rebuild_expr(self, expr, mapping):
+        # XXX: This is mostly just a copy from PolyElement. Maybe it could be
+        #      refactored into something reusable...
+        domain = self.domain
+
+        def _rebuild(expr):
+            generator = mapping.get(expr)
+
+            if generator is not None:
+                return generator
+            elif expr.is_Add:
+                return reduce(add, list(map(_rebuild, expr.args)))
+            elif expr.is_Mul:
+                return reduce(mul, list(map(_rebuild, expr.args)))
+            else:
+                # XXX: Use as_base_exp() to handle Pow(x, n) and also exp(n)
+                # XXX: E can be a generator e.g. sring([exp(2)]) -> ZZ[E]
+                base, exp = expr.as_base_exp()
+                if exp.is_Integer and exp != 1:
+                    return _rebuild(base)**int(exp)
+                else:
+                    return self.ground_new(domain.convert(expr))
+
+        return _rebuild(sympify(expr))
+
+    def from_dict(self, element, orig_domain=None):
+        """Construct a new Laurent polynomial from a dictionary."""
+        min_degrees = tuple(map(min, zip(*element.keys())))
+
+        if all(d >= 0 for d in min_degrees):
+            numer = self.numer_ring.from_dict(element, orig_domain)
+            return self.new(numer)
+
+        # Factor out the denominator monomial
+        denom_monom = tuple(max(0, -d) for d in min_degrees)
+        monomial_mul = self.numer_ring.monomial_mul
+        element = {monomial_mul(m, denom_monom): c for m, c in element.items()}
+        numer = self.numer_ring.from_dict(element, orig_domain)
+        denom = self.numer_ring.term_new(denom_monom, self.numer_ring.domain.one)
+
+        return self.new(numer, denom)
+
+    def to_field(self) -> FracField:
+        """Return a ``FracField`` with the same generators."""
+        return FracField(self.symbols, self.domain, self.order)
+
+    def to_domain(self) -> LaurentPolynomialRing:
+        return LaurentPolynomialRing(self)
+
+
+class LaurentPolyElement(DomainElement, DefaultPrinting, CantSympify):
+    """A class for representing Laurent polynomials.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.laurent import laurent_ring
+    >>> from sympy import QQ
+    >>> R, x, y = laurent_ring('x,y', QQ)
+    >>> p = 1/x + x*y
+    >>> p
+    x*y + 1/x
+    >>> type(p)
+    <class 'sympy.polys.laurent.LaurentPolyElement'>
+    """
+    def __init__(self,
+                 ring: LaurentPolyRing,
+                 numer: PolyElement,
+                 denom: PolyElement
+                 ):
+        self._check(ring, numer, denom)
+        self.ring = ring
+        self.numer = numer
+        self.denom = denom
+
+    def parent(self) -> LaurentPolynomialRing:
+        return self.ring.to_domain()
+
+    def __eq__(self, other):
+        if not isinstance(other, LaurentPolyElement):
+            return NotImplemented
+        return (self.ring == other.ring
+                and self.numer == other.numer
+                and self.denom == other.denom)
+
+    def __hash__(self):
+        return hash((self.ring, self.numer, self.denom))
+
+    @classmethod
+    def _check(self,
+               ring: LaurentPolyRing,
+               numer: PolyElement,
+               denom: PolyElement,
+               check_cancelled: Optional[bool] = True
+               ) -> None:
+        """Validate the internal invariants."""
+        assert type(ring) is LaurentPolyRing
+        assert isinstance(numer, PolyElement)
+        assert isinstance(denom, PolyElement)
+        assert numer.ring == ring.numer_ring
+        assert denom.ring == ring.numer_ring
+        assert denom.is_term
+
+        [(denom_monom, denom_coeff)] = denom.iterterms()
+        assert ring.domain.is_one(denom_coeff)
+
+        min_degrees: tuple[int, ...] = tuple(map(min, zip(*numer.itermonoms())))
+        for d, m in zip(denom_monom, min_degrees):
+            assert d >= 0 and m >= 0, "Negative exponents in numer or denom"
+            if check_cancelled:
+                assert d == 0 or m == 0, "Uncancelled exponents between numer and denom"
+
+    def new(self,
+            numer: PolyElement,
+            denom: Optional[PolyElement] = None
+            ) -> 'LaurentPolyElement':
+        """Construct a new Laurent polynomial in the same ring as ``self``."""
+        ring = self.ring
+        if denom is None:
+            denom = ring.numer_ring.one
+        numer, denom = self._normalize_poly(ring, numer, denom)
+        return self.__class__(ring, numer, denom)
+
+    @classmethod
+    def _normalize_poly(cls,
+                        ring: LaurentPolyRing,
+                        numer: PolyElement,
+                        denom: PolyElement
+                        ) -> tuple[PolyElement, PolyElement]:
+        """Normalize a poly/denom representation of a Laurent polynomial.
+
+        The monomials are required to have non-negative exponents.
+        """
+        cls._check(ring, numer, denom, check_cancelled=False)
+
+        [denom_monom] = denom.itermonoms()
+
+        numer_ring = ring.numer_ring
+        if denom_monom == numer_ring.zero_monom:
+            return numer, denom
+
+        monomial_gcd = numer_ring.monomial_gcd
+        monomial_ldiv = numer_ring.monomial_ldiv
+        domain = numer_ring.domain
+
+        monom_gcd = denom_monom
+
+        for monom in numer.itermonoms():
+            monom_gcd = monomial_gcd(monom_gcd, monom)
+            if monom_gcd == numer_ring.zero_monom:
+                return numer, denom
+
+        denom_monom_new = monomial_ldiv(denom_monom, monom_gcd)
+        numer_new = {monomial_ldiv(m, monom_gcd): c for m, c in numer.items()}
+
+        denom_poly = numer_ring.term_new(denom_monom_new, domain.one)
+        numer_poly = numer_ring.from_dict(numer_new)
+
+        return numer_poly, denom_poly
+
+    def convert_to_ring(self, element: Any) -> Optional['LaurentPolyElement']:
+        """Convert ``element`` to the ring of ``self``.
+
+        Returns ``None`` if the conversion is not possible.
+        """
+        if isinstance(element, LaurentPolyElement) and self.ring == element.ring:
+            return element
+        elif isinstance(element, PolyElement) and self.ring.numer_ring == element.ring:
+            return self.new(element)
+        else:
+            try:
+                return self.ring.ground_new(element)
+            except CoercionFailed:
+                return None
+
+    def _terms_num_den(self) -> list[tuple[PolyElement, PolyElement]]:
+        denom = self.denom
+        term_new = self.ring.numer_ring.term_new
+        terms = [term_new(m, c) for m, c in self.numer.terms()]
+        terms_num_den = []
+        for term in terms:
+            _, num, den = term._gcd_monom(denom)
+            terms_num_den.append((num, den))
+        return terms_num_den
+
+    def as_expr(self, fraction=True) -> Expr:
+        """Convert a Laurent polynomial to a SymPy expression."""
+        if fraction:
+            return self.as_expr_fraction()
+        else:
+            return self.as_expr_add()
+
+    def as_expr_add(self) -> Expr:
+        """Convert a Laurent polynomial to a SymPy expression."""
+        terms = []
+        for num, den in self._terms_num_den():
+            if den == self.ring.numer_ring.one:
+                terms.append(num.as_expr())
+            else:
+                terms.append(num.as_expr() / den.as_expr())
+        return Add(*terms)
+
+    def as_expr_fraction(self) -> Expr:
+        """Convert a Laurent polynomial to a SymPy expression."""
+        return self.numer.as_expr() / self.denom.as_expr()
+
+    def __str__(self):
+        terms_str = []
+        for num, den in self._terms_num_den():
+            if den == self.ring.numer_ring.one:
+                terms_str.append(str(num))
+            else:
+                terms_str.append(f'{num}/{den}')
+
+        if not terms_str:
+            return '0'
+
+        return ' + '.join(terms_str)
+
+    @property
+    def is_term(self):
+        return self.numer.is_term
+
+    @property
+    def is_zero(self):
+        return not self
+
+    @property
+    def is_one(self):
+        return self.numer.is_one and self.denom.is_one
+
+    @property
+    def is_ground(self):
+        return self.numer.is_ground and self.denom.is_ground
+
+    @property
+    def LC(self):
+        return self.numer.LC
+
+    def __bool__(self):
+        return bool(self.numer)
+
+    def __pos__(self):
+        return self
+
+    def __neg__(self):
+        return self.new(-self.numer, self.denom)
+
+    def __add__(self, other: PolyElement) -> 'LaurentPolyElement':
+        other_ring = self.convert_to_ring(other)
+        if other_ring is None:
+            return NotImplemented
+        return self._add(other_ring)
+
+    def __radd__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other._add(self)
+
+    def _add(self, other):
+        numer = self.numer * other.denom + self.denom * other.numer
+        denom = self.denom * other.denom
+        return self.new(numer, denom)
+
+    def __sub__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self._sub(other)
+
+    def __rsub__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other._sub(self)
+
+    def _sub(self, other):
+        numer = self.numer * other.denom - self.denom * other.numer
+        denom = self.denom * other.denom
+        return self.new(numer, denom)
+
+    def __mul__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self._mul(other)
+
+    def __rmul__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other._mul(self)
+
+    def _mul(self, other):
+        numer = self.numer * other.numer
+        denom = self.denom * other.denom
+        return self.new(numer, denom)
+
+    def __pow__(self, n: int):
+        if not isinstance(n, int):
+            return NotImplemented
+
+        if n == 0:
+            return self.ring.one
+
+        numer, denom = self.numer, self.denom
+
+        if n < 0:
+            if not self:
+                raise ZeroDivisionError("Inversion of zero")
+            elif not numer.is_term:
+                raise NotImplementedError("Inversion of non-term")
+            numer, denom = denom, numer
+            n = -n
+
+        return self.new(numer ** n, denom ** n)
+
+    def __rtruediv__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other._div_term(self)
+
+    def __truediv__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self._div_term(other)
+
+    def _div_term(self, other):
+        if other.is_zero:
+            raise ZeroDivisionError("Division by zero")
+        if not other.is_term:
+            raise NotImplementedError("Division by non-term")
+
+        [(monom, coeff)] = other.numer.items()
+        numer_ring = self.ring.numer_ring
+        monom = numer_ring.term_new(monom, numer_ring.domain.one)
+
+        # XXX: Use exquo_ground when available
+        numer = (self.numer * other.denom).quo_ground(coeff)
+        denom = self.denom * monom
+
+        return self.new(numer, denom)
+
+    def __mod__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self.rem(other)
+
+    def __rmod__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other.rem(self)
+
+    def __floordiv__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self.quo(other)
+
+    def __rfloordiv__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other.quo(self)
+
+    def __divmod__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return self.div(other)
+
+    def __rdivmod__(self, other):
+        other = self.convert_to_ring(other)
+        if other is None:
+            return NotImplemented
+        return other.div(self)
+
+    def div(self, other):
+        """Quotient and remainder division of Laurent polynomials."""
+        # self = other * quo + rem
+        # p1/m1 = p2/m2 * q + r
+        # p1 = p2*(q*m1/m2) + r*m1
+        # q*m1/m2 = p1 // p2
+        # r*m1 = p1 % p2
+        # q = (p1 // p2) * (m2/m1)
+        # r = (p1 % p2) / m1
+        # deg(r*m1) < deg(p2)
+        quo, rem = self.numer.div(other.numer)
+        quo_laurent = self.new(quo * other.denom, self.denom)
+        rem_laurent = self.new(rem, self.denom)
+        return quo_laurent, rem_laurent
+
+    def quo(self, other):
+        return self.div(other)[0]
+
+    def rem(self, other):
+        return self.div(other)[1]
+
+    def exquo(self, other):
+        quo_numer = self.numer.exquo(other.numer)
+        numer = quo_numer * other.denom
+        denom = self.denom
+        return self.new(numer, denom)
+
+    def gcd(self, other):
+        gcd_numer = self.numer.gcd(other.numer)
+        gcd_denom = self.denom.gcd(other.denom)
+        return self.new(gcd_numer, gcd_denom)
+
+    def _factor_list(self):
+        """Compute a factorization of ``self``."""
+        # XXX: Should negative multiplicity should be used for the denominator
+        # rather than positive powers of a reciprocal?
+        #
+        # We will leave this as a private method for now...
+        coeff, numer_factors = self.numer.factor_list()
+        _, denom_factors = self.denom.factor_list()
+
+        one = self.ring.numer_ring.one
+        factors = []
+        for factor, exp in numer_factors:
+            factor_laurent = self.new(factor, one)
+            factors.append((factor_laurent, exp))
+        for factor, exp in denom_factors:
+            factor_laurent = self.new(one, factor)
+            factors.append((factor_laurent, exp))
+
+        return coeff, factors

--- a/sympy/polys/laurent.py
+++ b/sympy/polys/laurent.py
@@ -51,7 +51,6 @@ class LaurentPolyRing:
     >>> R = LaurentPolyRing([x, y], ZZ, order='lex')
     >>> R
     Laurent polynomial ring in x, y over ZZ with lex order
-    >>> p = R.from_expr(1/x + x*y)
     >>> x, y = R.gens
     >>> p = 1/x + x*y
     >>> p

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2269,8 +2269,7 @@ class Poly(Basic):
 
         """
         f = self
-
-        if not f.rep.dom.is_Field:
+        if not (f.rep.dom.is_Field or f.rep.dom.is_Laurent):
             return S.One, f
 
         dom = f.get_domain()
@@ -2317,7 +2316,7 @@ class Poly(Basic):
         f = per(f)
         g = per(g)
 
-        if not (dom.is_Field and dom.has_assoc_Ring):
+        if not ((dom.is_Field or dom.is_Laurent) and dom.has_assoc_Ring):
             return f, g
 
         a, f = f.clear_denoms(convert=True)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -350,7 +350,7 @@ class PolyRing(DefaultPrinting, IPolys):
 
     __call__ = ring_new
 
-    def from_dict(self, element, orig_domain=None):
+    def from_dict(self, element, orig_domain=None) -> PolyElement:
         domain_new = self.domain_new
         poly = self.zero
 
@@ -571,6 +571,8 @@ class PolyRing(DefaultPrinting, IPolys):
 
 class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     """Element of multivariate distributed polynomial ring. """
+
+    ring: PolyRing
 
     def new(self, init):
         return self.__class__(init)
@@ -2011,6 +2013,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         if domain.is_Field:
             quo = domain.quo
             terms = [ (monom, quo(coeff, x)) for monom, coeff in f.iterterms() ]
+        elif domain.is_LaurentPolynomialRing and x.is_term:
+            terms = [ (monom, coeff / x) for monom, coeff in f.iterterms() ]
         else:
             terms = [ (monom, coeff // x) for monom, coeff in f.iterterms() if not (coeff % x) ]
 

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -125,25 +125,45 @@ def test_construct_domain():
     assert construct_domain([x/2, I*3.5*y]) == \
         (dom, [dom.convert(x/2), dom.convert(I*3.5*y)])
 
-    dom = ZZ.frac_field(x)
+    dom = ZZ.laurent_poly_ring(x)
 
     assert construct_domain([2/x, 3]) == \
         (dom, [dom.convert(2/x), dom.convert(3)])
 
-    dom = ZZ.frac_field(x, y)
+    dom = ZZ.laurent_poly_ring(x, y)
 
     assert construct_domain([2/x, 3*y]) == \
         (dom, [dom.convert(2/x), dom.convert(3*y)])
 
-    dom = RR.frac_field(x)
+    dom = RR.laurent_poly_ring(x)
 
     assert construct_domain([2/x, 3.5]) == \
         (dom, [dom.convert(2/x), dom.convert(3.5)])
 
-    dom = RR.frac_field(x, y)
+    dom = RR.laurent_poly_ring(x, y)
 
     assert construct_domain([2/x, 3.5*y]) == \
         (dom, [dom.convert(2/x), dom.convert(3.5*y)])
+
+    dom = ZZ.frac_field(x)
+
+    assert construct_domain([2/(1-x), 3]) == \
+        (dom, [dom.convert(2/(1-x)), dom.convert(3)])
+
+    dom = ZZ.frac_field(x, y)
+
+    assert construct_domain([2/(1-x), 3*y]) == \
+        (dom, [dom.convert(2/(1-x)), dom.convert(3*y)])
+
+    dom = RR.frac_field(x)
+
+    assert construct_domain([2/(1-x), 3.5]) == \
+        (dom, [dom.convert(2/(1-x)), dom.convert(3.5)])
+
+    dom = RR.frac_field(x, y)
+
+    assert construct_domain([2/(1-x), 3.5*y]) == \
+        (dom, [dom.convert(2/(1-x)), dom.convert(3.5*y)])
 
     dom = RealField(prec=336)[x]
 

--- a/sympy/polys/tests/test_laurent.py
+++ b/sympy/polys/tests/test_laurent.py
@@ -1,0 +1,347 @@
+from sympy import symbols, ring, ZZ, QQ, lex, ExactQuotientFailed
+from sympy.polys.fields import FracField
+from sympy.polys.laurent import laurent_ring, LaurentPolyRing, LaurentPolyElement
+
+from sympy.testing.pytest import raises
+
+
+def test_LaurentRing_init():
+    x, y = symbols("x y")
+    Rp, _, _ = ring("x y", ZZ)
+    R1, xr, yr = laurent_ring("x y", ZZ)
+    R2 = LaurentPolyRing([x, y], ZZ, "lex")
+    R3, _, _ = laurent_ring([x, y], ZZ)
+
+    assert R1 == R2 == R3
+
+    for R in [R1, R2, R3]:
+        assert R.numer_ring == Rp
+        assert R.domain == ZZ
+        assert R.gens == (xr, yr)
+        assert R.symbols == (x, y)
+        assert R.order == lex
+        assert R.zero == LaurentPolyElement(R, Rp.zero, Rp.one)
+        assert R.one == LaurentPolyElement(R, Rp.one, Rp.one)
+        assert R.x == xr
+        assert R.y == yr
+
+
+def test_LaurentRing_eq_hash():
+    x, y = symbols("x y")
+    R1, _, _ = laurent_ring("x y", ZZ)
+    R2, _, _ = laurent_ring("x y", ZZ)
+    R3, _, _ = laurent_ring("y x", ZZ)
+    R4, _, _ = laurent_ring("x y", QQ)
+    R5, _, _ = laurent_ring("x y", ZZ, order='grevlex')
+    Rs = [R1, R2, R3, R4, R5, ZZ, QQ, ZZ[x,y]]
+
+    for i, Ri in enumerate(Rs):
+        for j, Rj in enumerate(Rs):
+            if i == j or {i, j} == {0, 1}:
+                assert hash(Ri) == hash(Rj)
+                assert (Ri == Rj) is True
+                assert (Ri != Rj) is False
+            else:
+                assert (Ri == Rj) is False
+                assert (Ri != Rj) is True
+
+    assert (R1 == QQ) is False
+    assert (R1 != QQ) is True
+
+
+def test_LaurentRing_str():
+    R, x, y = laurent_ring("x y", ZZ)
+    assert str(R) == "Laurent polynomial ring in x, y over ZZ with lex order"
+
+
+def test_LaurentRing_new():
+    x, y = symbols("x y")
+    Rp, _, _ = ring("x y", ZZ)
+    Rl, _, _ = laurent_ring("x y", ZZ)
+
+    assert Rl(1) == Rl.one
+    assert Rl(0) == Rl.zero
+    assert Rl(Rp(1)) == Rl.one
+    assert Rl(Rp(0)) == Rl.zero
+    assert Rl(Rl.one) == Rl.one
+    assert Rl(Rl.zero) == Rl.zero
+    assert Rl(x) == Rl.x
+    assert Rl(y) == Rl.y
+    assert Rl((x + y)/y) == (Rl.x + Rl.y)/Rl.y
+
+    assert Rl.new(Rp.one) == Rl.one
+    assert Rl.new(Rp.x, Rp.y) == Rl.new(Rp.x) / Rl.new(Rp.y) == Rl(x/y)
+
+    assert Rl.ground_new(1) == Rl.one
+    assert Rl.ground_new(0) == Rl.zero
+    assert Rl.ground_new(ZZ(1)) == Rl.one
+    assert Rl.ground_new(ZZ(0)) == Rl.zero
+
+    assert Rl.ring_new(1) == Rl.one
+    assert Rl.ring_new(0) == Rl.zero
+    assert Rl.ring_new(Rp(1)) == Rl.one
+    assert Rl.ring_new(Rp(0)) == Rl.zero
+
+    numer = 2*Rp.x + Rp.y
+    p = Rl.ring_new(numer)
+    assert p.numer == numer
+    assert p.denom == Rp.one
+
+    numer = ZZ(2)
+    denom = Rp.x
+    p = Rl.ring_new((numer, denom))
+    p2 = Rl.new(Rp(numer), Rp(denom))
+    assert p.numer == numer
+    assert p.denom == denom
+    assert p == p2
+
+    p = Rl.from_expr((2*x + y)/x)
+    assert p.numer == 2*Rp.x + Rp.y
+    assert p.denom == Rp.x
+    assert p == (2*Rl.x + Rl.y)/Rl.x
+
+    p = {(-1, 1): 2, (0, 0): 1}
+    assert Rl.from_dict(p) == 1 + 2*Rl.y/Rl.x
+    p = {(0, 0): 1, (1, 1): 2}
+    assert Rl.from_dict(p) == 1 + 2*Rl.x*Rl.y
+
+    raises(ValueError, Rl.from_expr, x**y)
+
+
+def test_ring_field():
+    x, y = symbols("x y")
+    R, _, _ = laurent_ring("x y", ZZ)
+    assert R.to_domain() == ZZ.laurent_poly_ring(x, y)
+    assert R.to_field() == FracField([x, y], ZZ)
+
+
+def test_LaurentPolyElement_init():
+    Rp, _, _ = ring("x y", ZZ)
+    Rl, _, _ = laurent_ring("x y", ZZ)
+
+    numer = 2*Rp.x + Rp.y
+    denom = Rp.x
+    p = LaurentPolyElement(Rl, numer, denom)
+    assert p.ring == Rl
+    assert p.numer == numer
+    assert p.denom == denom
+
+    Rp2, _, _ = ring("x y", QQ)
+
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, numer, 1))
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, Rp2.one, Rl.one))
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, Rl.one, Rp2.one))
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, Rp.one, 2*Rp.one))
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, Rp.one, 2*Rp.x + Rp.y))
+    raises(AssertionError, lambda: LaurentPolyElement(Rl, Rp.x, Rp.x))
+
+
+def test_LaurentPolyElement_eq_hash():
+    Rp, _, _ = ring("x y", ZZ)
+    Rl, _, _ = laurent_ring("x y", ZZ)
+    p1 = (2*Rl.x + Rl.y) / Rl.x
+    p2 = (2*Rl.x + Rl.y) / Rl.y
+    p3 = (3*Rl.x + Rl.y) / Rl.x
+    p4 = (2*Rl.x + Rl.y) / Rl.x**2
+    ps = [p1, p2, p3, p4]
+    for i, pi in enumerate(ps):
+        for j, pj in enumerate(ps):
+            if i == j:
+                assert hash(pi) == hash(pj)
+                assert (pi == pj) is True
+                assert (pi != pj) is False
+            else:
+                assert (pi == pj) is False
+                assert (pi != pj) is True
+
+    p = Rl.x + Rl.y
+    assert (p == p.numer) is False
+    assert (p != p.numer) is True
+
+
+def test_LaurentPolyElement_attributes():
+    Rp, _, _ = ring("x y", ZZ)
+    Rl, _, _ = laurent_ring("x y", ZZ)
+    p = (2*Rl.x + Rl.y) / Rl.x
+    assert p.ring == Rl
+    assert p.numer == 2*Rp.x + Rp.y
+    assert p.denom == Rp.x
+
+
+def test_LaurentPolyElement_str():
+    R, x, y = laurent_ring("x y", ZZ)
+    p = (2*x + y)/x
+    assert str(p) == "2 + y/x"
+    assert str(R.zero) == "0"
+    assert str(R.one) == "1"
+
+
+def test_LaurentPolyElement_as_expr():
+    x, y = symbols("x y")
+    R, _, _ = laurent_ring("x y", ZZ)
+    p = (2*R.x + R.y)/R.x
+    assert p.as_expr() == p.as_expr_fraction() == (2*x + y)/x
+    assert p.as_expr(fraction=False) == p.as_expr_add() == 2 + y/x
+
+
+def test_LaurentPolyElement_properties():
+    R, x, y = laurent_ring("x y", ZZ)
+
+    assert bool(R.zero) is False
+    assert bool(R.one) is True
+    assert bool(x) is True
+
+    assert R.zero.is_zero is True
+    assert x.is_zero is False
+    assert R.one.is_one is True
+    assert x.is_one is False
+
+    assert R.one.is_term is True
+    assert R(2).is_term is True
+    assert x.is_term is True
+    assert (2*x).is_term is True
+    assert (1/x).is_term is True
+    assert (x + y).is_term is False
+
+    assert R.zero.is_ground is True
+    assert x.is_ground is False
+    assert R.one.is_ground is True
+    assert (2*R.one).is_ground is True
+
+    assert R.zero.LC == ZZ.zero
+    assert R.one.LC == ZZ.one
+    assert x.LC == ZZ.one
+    assert (2*x).LC == ZZ(2)
+
+
+def test_LaurentPolyElement_arith():
+    Rp, _, _ = ring("x y", ZZ)
+    R, x, y = laurent_ring("x y", ZZ)
+    p = (2*x + y)/x
+    q = (3*x + 2*y)/y
+    assert +p == p
+    assert -p == (-2*x - y)/x
+    assert p + q == (3*x**2 + 4*y*x + y**2) / (x*y)
+    assert p - q == (-3*x**2 + y**2) / (x*y)
+    assert p*q == (6*x**2 + 7*y*x + 2*y**2) / (x*y)
+    assert p**2 == (4*x**2 + 4*y*x + y**2) / (x**2)
+    assert p/x == (2*x + y) / x**2
+    assert p/y == (2*x + y) / (x*y)
+    assert (x**2 + x**2*y) / x == x + x*y
+    assert (x**2 + x**2*y) / x**2 == 1 + y
+    assert (x**2 + x**2*y) / x**3 == (1 + y) / x
+
+    assert p + Rp.x == p + R.x
+    assert p - Rp.x == p - R.x
+    assert p * Rp.x == p * R.x
+    assert p / Rp.x == p / R.x
+    assert Rp.x + x == Rp.x + x
+    assert Rp.x - x == Rp.x - x
+    assert Rp.x * x == Rp.x * x
+    assert Rp.x / x == Rp.x / x
+
+    R2, x2, y2 = laurent_ring("x y", QQ)
+    p = x
+    p2 = x2
+    assert p + 1 == x + R.one
+    assert 1 + p == x + R.one
+    assert p - 1 == x - R.one
+    assert 1 - p == R.one - x
+    assert p * 2 == 2*x
+    assert 2 * p == 2*x
+    assert p * p == x**2
+
+    raises(TypeError, lambda: p + ())
+    raises(TypeError, lambda: () + p)
+    raises(TypeError, lambda: p + p2)
+    raises(TypeError, lambda: p2 + p)
+
+    raises(TypeError, lambda: p - ())
+    raises(TypeError, lambda: () - p)
+    raises(TypeError, lambda: p - p2)
+    raises(TypeError, lambda: p2 - p)
+
+    raises(TypeError, lambda: p * ())
+    raises(TypeError, lambda: () * p)
+    raises(TypeError, lambda: p * p2)
+    raises(TypeError, lambda: p2 * p)
+
+    assert x**0 == R.one
+    assert x**1 == x
+    assert x**2 == x*x
+    assert x**-1 == 1/x
+    assert x**-2 == 1/x**2
+    raises(ZeroDivisionError, lambda: R.zero ** -1)
+    raises(NotImplementedError, lambda: (x + y)**-1)
+    raises(TypeError, lambda: p ** p)
+
+    assert (x + 1) / x == 1 + 1/x
+    assert x / x == R.one
+    assert (x + y) / (x*y) == 1/x + 1/y
+    raises(ZeroDivisionError, lambda: x / 0)
+    raises(ZeroDivisionError, lambda: x / R.zero)
+    raises(NotImplementedError, lambda: 1 / (x + y))
+    raises(TypeError, lambda: x / ())
+    raises(TypeError, lambda: () / x)
+    raises(TypeError, lambda: p / p2)
+
+
+def test_LaurentPolyElement_division():
+    R, x, y = laurent_ring("x y", ZZ)
+    a = (2*x + y)/x
+    q = (1 + x)/y
+    b = a*q
+    assert b.exquo(a) == q
+
+    raises(ExactQuotientFailed, lambda: a.exquo(b))
+    raises(ZeroDivisionError, lambda: a.exquo(R.zero))
+
+    assert ((x**2 - y**2)/x) % (x - y) == R.zero
+    assert ((x**2 - y**2)/x + 1) % (x - y) == y/x
+    assert R.x % 1 == R.zero
+    assert 1 % R.x == R.one
+
+    assert ((x**2 - y**2)/x) // (x - y) == (x + y)/x
+    assert x // 1 == x
+    assert 1 // x == R.zero
+
+    p1 = (x**2 - y**2)/x
+    p2 = (x**2 - y**2)/x + 1
+    assert (p1 // p2) * p2 + (p1 % p2) == p1
+    assert divmod(p1, p2) == (p1 // p2, p1 % p2)
+    assert divmod(1, R.x) == divmod(R.one, R.x) == (R.zero, R.one)
+
+    raises(ZeroDivisionError, lambda: R.one % R.zero)
+    raises(ZeroDivisionError, lambda: R.one // R.zero)
+    raises(ZeroDivisionError, lambda: divmod(R.one, R.zero))
+
+    raises(TypeError, lambda: R.x % ())
+    raises(TypeError, lambda: () % R.x)
+    raises(TypeError, lambda: R.x // ())
+    raises(TypeError, lambda: () // R.x)
+    raises(TypeError, lambda: divmod(R.x, ()))
+    raises(TypeError, lambda: divmod((), R.x))
+
+    assert divmod((x**2 - y**2)/x, x - y) == ((x + y)/x, R.zero)
+
+
+
+def test_LaurentPolyElement_gcd():
+    R, x, y = laurent_ring("x y", ZZ)
+    p = (2*x + y)/x
+    q = (3*x + 2*y)/y
+    g = (x + y)/x
+    assert (p*g).gcd(q*g) == g
+
+
+def test_LaurentPolyElement_factor_list():
+    R, x, y = laurent_ring("x y", ZZ)
+    p = (2*x + y)/x**2
+    q = (3*x + 2*y)/y
+    factors = [
+        (2*x + y, 1),
+        (3*x + 2*y, 1),
+        (1/y, 1),
+        (1/x, 2),
+    ]
+    assert (p*q)._factor_list() == (ZZ(1), factors)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -5,6 +5,7 @@ from operator import add, mul
 
 from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement
 from sympy.polys.fields import field, FracField
+from sympy.polys.laurent import LaurentPolyRing
 from sympy.polys.domains import ZZ, QQ, RR, FF, EX
 from sympy.polys.orderings import lex, grlex
 from sympy.polys.polyerrors import GeneratorsError, \
@@ -180,9 +181,13 @@ def test_sring():
     R = PolyRing("x,y,z", Rt, lex)
     assert sring(x + t*y/2 + t**2*z/3, x, y, z) == (R, R.x + Rt.t*R.y/2 + Rt.t**2*R.z/3)
 
-    Rt = FracField("t", ZZ, lex)
+    Rt = LaurentPolyRing("t", QQ, lex)
     R = PolyRing("x,y,z", Rt, lex)
     assert sring(x + 2*y/t + t**2*z/3, x, y, z) == (R, R.x + 2*R.y/Rt.t + Rt.t**2*R.z/3)
+
+    Rt = FracField("t", ZZ, lex)
+    R = PolyRing("x,y,z", Rt, lex)
+    assert sring(x + 2*y/(1-t) + t**2*z/3, x, y, z) == (R, R.x + 2*R.y/(1 - Rt.t) + Rt.t**2*R.z/3)
 
     r = sqrt(2) - sqrt(3)
     R, a = sring(r, extension=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1746,7 +1746,7 @@ def test_latex_Poly():
     assert latex(Poly(x**2 + 2 * x, x)) == \
         r"\operatorname{Poly}{\left( x^{2} + 2 x, x, domain=\mathbb{Z} \right)}"
     assert latex(Poly(x/y, x)) == \
-        r"\operatorname{Poly}{\left( \frac{1}{y} x, x, domain=\mathbb{Z}\left(y\right) \right)}"
+        r"\operatorname{Poly}{\left( \frac{1}{y} x, x, domain=\mathtt{\text{ZZ[y,1/y]}} \right)}"
     assert latex(Poly(2.0*x + y)) == \
         r"\operatorname{Poly}{\left( 2.0 x + 1.0 y, x, y, domain=\mathbb{R} \right)}"
 

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -723,7 +723,7 @@ def test_GammaProcess_symbolic():
     # Equivalent to E(2*X(1)) + E(X(1)**2) + E(X(1)**3), where E(X(1)) == g/l
     assert E(X(t)**2 + X(d)*2 + X(y)**3, Contains(t, Interval.Lopen(0, 1))
         & Contains(d, Interval.Lopen(1, 2)) & Contains(y, Interval.Ropen(3, 4))) == \
-            2*g/l + (g**2 + g)/l**2 + (g**3 + 3*g**2 + 2*g)/l**3
+            2*g/l + 2*((g**2/2 + g/2)/l**2) + 6*((g**3/6 + g**2/2 + g/3)/l**3)
 
     assert P(X(t) > 3, Contains(t, Interval.Lopen(3, 4))).simplify() == \
                                 1 - lowergamma(g, 3*l)/gamma(g) # equivalent to P(X(1)>3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes gh-5131

Adds rings for working with multivariate Laurent polynomials. These are polynomials where there can be negative powers of the generators like `x + 2/x + 3*y/x**2` etc. The representation here is just a sparse polynomial divided by a sparse polynomial that has only one term and a coefficient of 1. These rings allows polynomial-like ring operations to be used in situations where there are some symbols in the denominator (which is common in applied maths/physics).

The PR also adds a Laurent polynomial ring domain to the domain system as well as support in `construct_domain` to generate such a domain automatically when possible. This potentially provides a lighter weight alternative to rational function fields but I am still unsure about it (see below).

#### Other comments

I am still unsure if Laurent polynomial rings should be used by default in the domain system (i.e. whether `construct_domain` should choose them) rather than just using division free methods with rational function fields. For now I am just parking this to see what others think and so that the PR can be used for testing different scenarios.

The main benefit of Laurent polynomial rings is that they allow some symbols to have negative powers without going all the way to rational function fields. That means that they sit in between polynomial rings and rational function fields. Rational function fields can be slow because of slow multivariate polynomial gcd and Laurent polynomials don't have this problem but can also accommodate some symbols raised to negative powers.

On the other hand if the expressions involved can be represented as Laurent polynomials and we only use the operations that are available for Laurent polynomials (i.e. only divide by ground or monomials) then maybe rational function fields would have similar performance. That might mean that incorporating Laurent polynomials into the domain system is a lot of extra complexity without much benefit...

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * A new domain for representing Laurent polynomial rings like `R[x,1/x,y,1/y]` was added.
<!-- END RELEASE NOTES -->
