### PR TITLE
Restrict transfer function to only polynomials and allow for time delay inputs

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -18,6 +18,7 @@ from sympy.polys import Poly, rootof
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import (cancel, degree)
 from sympy.series import limit
+from sympy.functions.elementary.exponential import exp
 
 from mpmath.libmp.libmpf import prec_to_dps
 
@@ -448,7 +449,7 @@ class TransferFunction(SISOLinearTimeInvariant):
     .. [2] https://en.wikipedia.org/wiki/Laplace_transform
 
     """
-    def __new__(cls, num, den, var, inputdelay=None):
+    def __new__(cls, num, den, var, inputdelay=0):
         num, den = _sympify(num), _sympify(den)
 
         if not isinstance(var, Symbol):
@@ -457,7 +458,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         if den == 0:
             raise ValueError("TransferFunction cannot have a zero denominator.")
 
-        if (num.is_polynomial(var) is not True or den.is_polynomial(var) is not True) and inputdelay is not None:
+        if (num.is_polynomial(var) is not True or den.is_polynomial(var) is not True):
             raise TypeError("Numerator and Denominator of TransferFunction must be a polynomial")
         
         if (((isinstance(num, Expr) and num.has(Symbol)) or num.is_number) and
@@ -466,13 +467,14 @@ class TransferFunction(SISOLinearTimeInvariant):
             obj._num = num
             obj._den = den
             obj._var = var
+            obj._delay = exp(-1 * var * inputdelay)
             return obj
 
         else:
             raise TypeError("Unsupported type for numerator or denominator of TransferFunction.")
 
     @classmethod
-    def from_rational_expression(cls, expr, var=None, inputdelay=None):
+    def from_rational_expression(cls, expr, var=None, inputdelay=0):
         r"""
         Creates a new ``TransferFunction`` efficiently from a rational expression.
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -448,7 +448,7 @@ class TransferFunction(SISOLinearTimeInvariant):
     .. [2] https://en.wikipedia.org/wiki/Laplace_transform
 
     """
-    def __new__(cls, num, den, var, inputdelay=0):
+    def __new__(cls, num, den, var, inputdelay=None):
         num, den = _sympify(num), _sympify(den)
 
         if not isinstance(var, Symbol):
@@ -457,7 +457,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         if den == 0:
             raise ValueError("TransferFunction cannot have a zero denominator.")
 
-        if (num.is_polynomial(var) is not True or den.is_polynomial(var) is not True) and inputdelay == 0:
+        if (num.is_polynomial(var) is not True or den.is_polynomial(var) is not True) and inputdelay is not None:
             raise TypeError("Numerator and Denominator of TransferFunction must be a polynomial")
         
         if (((isinstance(num, Expr) and num.has(Symbol)) or num.is_number) and
@@ -472,7 +472,7 @@ class TransferFunction(SISOLinearTimeInvariant):
             raise TypeError("Unsupported type for numerator or denominator of TransferFunction.")
 
     @classmethod
-    def from_rational_expression(cls, expr, var=None):
+    def from_rational_expression(cls, expr, var=None, inputdelay=None):
         r"""
         Creates a new ``TransferFunction`` efficiently from a rational expression.
 
@@ -547,7 +547,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         _num, _den = expr.as_numer_denom()
         if _den == 0 or _num.has(S.ComplexInfinity):
             raise ZeroDivisionError("TransferFunction cannot have a zero denominator.")
-        return cls(_num, _den, var)
+        return cls(_num, _den, var, inputdelay=inputdelay)
 
     @classmethod
     def from_coeff_lists(cls, num_list, den_list, var):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -448,7 +448,7 @@ class TransferFunction(SISOLinearTimeInvariant):
     .. [2] https://en.wikipedia.org/wiki/Laplace_transform
 
     """
-    def __new__(cls, num, den, var):
+    def __new__(cls, num, den, var, inputdelay=0):
         num, den = _sympify(num), _sympify(den)
 
         if not isinstance(var, Symbol):
@@ -457,6 +457,9 @@ class TransferFunction(SISOLinearTimeInvariant):
         if den == 0:
             raise ValueError("TransferFunction cannot have a zero denominator.")
 
+        if (num.is_polynomial(var) is not True or den.is_polynomial(var) is not True) and inputdelay == 0:
+            raise TypeError("Numerator and Denominator of TransferFunction must be a polynomial")
+        
         if (((isinstance(num, Expr) and num.has(Symbol)) or num.is_number) and
             ((isinstance(den, Expr) and den.has(Symbol)) or den.is_number)):
             obj = super(TransferFunction, cls).__new__(cls, num, den, var)


### PR DESCRIPTION
#### References to other Issues or PRs
Progress on #25326 


#### Brief description of what is fixed or changed
added an error for creating transfer functions from non polynomials and added a parameter for input delay.
also updated some of the transfer function methods and marked the ones not updated with #todo.  

#### What's needed
To proceed I need to know if we are going to then add the delay feature to the Parallel class and if we are going to use 'input delay' and 'output delay' like Matlab or just use delay



