### PR TITLE
Updated the target frame and the reference frame for counter intuitive directions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -790,6 +790,8 @@ Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapal
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
+Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
+Kaustubh <kaustubh.am765@gmail.com>
 Kaustubh Chaudhari <ckaustubhm06@gmail.com> Kaustubh <ckaustubhm06@gmail.com>
 Kaustubh Chaudhari <ckaustubhm06@gmail.com> kc611 <ckaustubhm06@gmail.com>
 KaustubhDamania <kaustubh.damania@gmail.com>

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -701,6 +701,10 @@ class TorqueActuator(ActuatorBase):
         constructor class method ``at_pin_joint`` of the ``TorqueActuator``
         class.
 
+        Note: The positive torque will result in a positive displacement of the joint
+        coordinate or that the torque is applied on the child body with a reaction
+        torque on the parent.
+
         >>> actuator = TorqueActuator.at_pin_joint(torque, pin_joint)
         >>> actuator
         TorqueActuator(T, axis=N.z, target_frame=A, reaction_frame=N)

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -699,11 +699,9 @@ class TorqueActuator(ActuatorBase):
         To create the torque actuator from the ``torque`` and ``pin_joint``
         variables previously instantiated, these can be passed to the alternate
         constructor class method ``at_pin_joint`` of the ``TorqueActuator``
-        class.
-
-        Note: The positive torque will result in a positive displacement of the joint
-        coordinate or that the torque is applied on the child body with a reaction
-        torque on the parent.
+        class. It should be noted that a positive torque will cause a positive 
+        displacement of the joint coordinate or that the torque is applied on the 
+        child body with a reaction torque on the parent.
 
         >>> actuator = TorqueActuator.at_pin_joint(torque, pin_joint)
         >>> actuator

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -605,7 +605,7 @@ class TorqueActuator(ActuatorBase):
     >>> axis = N.z
     >>> parent = RigidBody('parent', frame=N)
     >>> child = RigidBody('child', frame=A)
-    >>> bodies = (parent, child)
+    >>> bodies = (child, parent)
     >>> actuator = TorqueActuator(torque, axis, *bodies)
     >>> actuator
     TorqueActuator(T, axis=N.z, target_frame=A, reaction_frame=N)
@@ -703,7 +703,7 @@ class TorqueActuator(ActuatorBase):
 
         >>> actuator = TorqueActuator.at_pin_joint(torque, pin_joint)
         >>> actuator
-        TorqueActuator(T, axis=N.z, target_frame=N, reaction_frame=A)
+        TorqueActuator(T, axis=N.z, target_frame=A, reaction_frame=N)
 
         Parameters
         ==========
@@ -860,7 +860,7 @@ class TorqueActuator(ActuatorBase):
         ``to_loads`` method.
 
         >>> actuator.to_loads()
-        [(N, T*N.z), (A, - T*N.z)]
+        [(A, T*N.z), (N, - T*N.z)]
 
         Alternatively, if a torque actuator is created without a reaction frame
         then the loads returned by the ``to_loads`` method will contain just

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -730,8 +730,7 @@ class TorqueActuator(ActuatorBase):
             torque,
             pin_joint.joint_axis,
             pin_joint.child_interframe,
-            pin_joint.parent_interframe,
-            
+            pin_joint.parent_interframe,    
         )
 
     @property

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -608,7 +608,7 @@ class TorqueActuator(ActuatorBase):
     >>> bodies = (parent, child)
     >>> actuator = TorqueActuator(torque, axis, *bodies)
     >>> actuator
-    TorqueActuator(T, axis=N.z, target_frame=N, reaction_frame=A)
+    TorqueActuator(T, axis=N.z, target_frame=A, reaction_frame=N)
 
     Note that because torques actually act on frames, not bodies,
     ``TorqueActuator`` will extract the frame associated with a ``RigidBody``
@@ -729,8 +729,9 @@ class TorqueActuator(ActuatorBase):
         return cls(
             torque,
             pin_joint.joint_axis,
-            pin_joint.parent_interframe,
             pin_joint.child_interframe,
+            pin_joint.parent_interframe,
+            
         )
 
     @property

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -699,8 +699,8 @@ class TorqueActuator(ActuatorBase):
         To create the torque actuator from the ``torque`` and ``pin_joint``
         variables previously instantiated, these can be passed to the alternate
         constructor class method ``at_pin_joint`` of the ``TorqueActuator``
-        class. It should be noted that a positive torque will cause a positive 
-        displacement of the joint coordinate or that the torque is applied on the 
+        class. It should be noted that a positive torque will cause a positive
+        displacement of the joint coordinate or that the torque is applied on the
         child body with a reaction torque on the parent.
 
         >>> actuator = TorqueActuator.at_pin_joint(torque, pin_joint)

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -730,7 +730,7 @@ class TorqueActuator(ActuatorBase):
             torque,
             pin_joint.joint_axis,
             pin_joint.child_interframe,
-            pin_joint.parent_interframe,    
+            pin_joint.parent_interframe,
         )
 
     @property

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -677,11 +677,11 @@ class TestTorqueActuator:
 
         assert hasattr(instance, 'target_frame')
         assert isinstance(instance.target_frame, ReferenceFrame)
-        assert instance.target_frame == self.N
+        assert instance.target_frame == self.A
 
         assert hasattr(instance, 'reaction_frame')
         assert isinstance(instance.reaction_frame, ReferenceFrame)
-        assert instance.reaction_frame == self.A
+        assert instance.reaction_frame == self.N
 
     def test_at_pin_joint_pin_joint_not_pin_joint_invalid(self) -> None:
         with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Updated the frame in TorqueActuator

#### References to other Issues or PRs
"Fixes #25319 "
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The frame of reference is updated, where the child frame is made the target frame and the parent frame is made the reference frame. This leads to positive value calculation of the torque.


 `TorqueActuator.at_pin_joint`  is updated.

and the test case is updates to

`assert instance.target_frame == self.A`
`assert instance.reaction_frame == self.N`


#### Other comments
Kindly review the changes.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
