### PR TITLE
[GSOC 2.2] Add method to evaluate system response of Transfer Functions. 

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -818,6 +818,31 @@ class TransferFunction(SISOLinearTimeInvariant):
         """
         return _roots(Poly(self.num, self.var), self.var)
 
+    def evalfr(self,other):
+        """
+        Returns the system response at any point in the real or complex plane.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s, p, a
+        >>> from sympy.physics.control.lti import TransferFunction
+        >>> tf1 = TransferFunction(1, s**2 + 2*s + 1, s)
+        >>> omega = 0.1
+        >>> tf1.evalfr(I*omega)
+        TransferFunction(1, 0.99 + 0.2*I, s)
+        >>> tf2 = TransferFunction(s**2, a*s + p, s)
+        >>> tf2.evalfr(2)
+        TransferFunction(4, 2*a + p, s)
+        >>> tf2.evalfr(I*2)
+        TransferFunction(-4, 2*I*a + p, s)
+
+        """
+        arg_num = self.num.subs(self.var, other)
+        arg_den = self.den.subs(self.var, other)
+        argnew = TransferFunction(arg_num, arg_den, self.var)
+        return argnew.expand()
+
     def is_stable(self):
         """
         Returns True if the transfer function is asymptotically stable; else False.

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -827,6 +827,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 
         >>> from sympy.abc import s, p, a
         >>> from sympy.physics.control.lti import TransferFunction
+        >>> from sympy import I
         >>> tf1 = TransferFunction(1, s**2 + 2*s + 1, s)
         >>> omega = 0.1
         >>> tf1.evalfr(I*omega)
@@ -3222,6 +3223,30 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
 
         """
         return [[element.zeros() for element in row] for row in self.doit().args[0]]
+
+    def evalfr(self,other):
+        """
+        Evaluates each element of the ``TransferFunctionMatrix`` at a frequency.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s
+        >>> from sympy.physics.control.lti import TransferFunction, TransferFunctionMatrix
+        >>> from sympy import I
+        >>> tf_1 = TransferFunction(3, (s + 1), s)
+        >>> tf_2 = TransferFunction(s + 6, (s + 1)*(s + 2), s)
+        >>> tf_3 = TransferFunction(s + 3, s**2 + 3*s + 2, s)
+        >>> tf_4 = TransferFunction(s**2 - 9*s + 20, s**2 + 5*s - 10, s)
+        >>> tfm_1 = TransferFunctionMatrix([[tf_1, tf_2], [tf_3, tf_4]])
+        >>> tfm_1
+        TransferFunctionMatrix(((TransferFunction(3, s + 1, s), TransferFunction(s + 6, (s + 1)*(s + 2), s)), (TransferFunction(s + 3, s**2 + 3*s + 2, s), TransferFunction(s**2 - 9*s + 20, s**2 + 5*s - 10, s))))
+        >>> tfm_1.evalfr(2*I)
+        TransferFunctionMatrix(((TransferFunction(3 - 6*I, 5, s), TransferFunction((1 - 2*I)*(2 - 2*I)*(6 + 2*I), 40, s)), (TransferFunction((-2 - 6*I)*(3 + 2*I), 40, s), TransferFunction((-14 - 10*I)*(16 - 18*I), 296, s))))
+
+        """
+        mat = self._expr_mat.subs(self.var, other)
+        return _to_TFM(mat, self.var)
 
     def _flat(self):
         """Returns flattened list of args in TransferFunctionMatrix"""

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -198,6 +198,15 @@ def test_TransferFunction_functions():
     assert G3.expand() == TransferFunction(e, f, s)
     assert G4.expand() == TransferFunction(a0*s**s - b0*p**p, g, p)
 
+    # evaluate the transfer function at particular frequencies.
+    assert tf1.evalfr(wn) == TransferFunction(wn**2 + 2*wn - 3, wn**2 + 4*wn - 5, p)
+    assert G1.evalfr(1 + I) == TransferFunction(-1, -3 + 4*I, s)
+    assert G3.evalfr(I*3) == \
+        TransferFunction(3**(2*p)*I**(2*p)*a2 + 3**p*I**p*a0*p**p + 3**(3*I)*3**p*I**(3*I)*I**p*a1 + 3**p*I**p*a2*p**(3*I) + a0*p**(3*I)*p**p + 3**(3*I)*I**(3*I)*a1*p**(3*I),
+        3*3**(3*I)*I*I**(3*I)*b0*b2*p + 3**(3*I)*I**(3*I)*b0*p**p + 3*I*b1*b2*p*p**(3*I) + b1*p**(3*I)*p**p, s)
+    assert G4.evalfr(S(5)/3) == \
+        TransferFunction(a0*s**s - 5*3**(S(1)/3)*5**(S(2)/3)*b0/9, a1*a2*s**(S(8)/3) + S(5)*a1*s/3 + 5*a2*b1*s**(S(8)/3)/3 + S(25)*b1*s/9, p)
+
     # purely symbolic polynomials.
     p1 = a1*s + a0
     p2 = b2*s**2 + b1*s + b0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25315 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added evalfr method to TransferFunction and TransferFunctionMatrix class.
<!-- END RELEASE NOTES -->
