### PR TITLE
Add to_DM and clear_denoms methods to Matrix

### DIFF
--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -393,69 +393,6 @@ class RepMatrix(MatrixBase):
                     rv = ans
         return rv
 
-    def clear_denoms(self, **opts):
-        """Clear denominators and extract their lcm.
-
-        Examples
-        ========
-
-        >>> from sympy import Matrix
-        >>> from sympy import Rational as Q
-        >>> M = Matrix([[Q(1,2), Q(2,3)], [Q(3,4), Q(4,5)]])
-        >>> M
-        Matrix([
-        [1/2, 2/3],
-        [3/4, 4/5]])
-        >>> den, Mnum = M.clear_denoms()
-        >>> den
-        60
-        >>> Mnum
-        Matrix([
-        [30, 40],
-        [45, 48]])
-        >>> Mnum / den == M
-        True
-
-        >>> from sympy.abc import a, b, c, d
-        >>> M = Matrix([
-        ... [1/b + 1/a, -1/b, 0],
-        ... [-1/b, 1/c + 1/b, -1/c],
-        ... [0, -1/c, 1/d + 1/c]])
-
-        >>> M
-        Matrix([
-        [1/b + 1/a,      -1/b,         0],
-        [     -1/b, 1/c + 1/b,      -1/c],
-        [        0,      -1/c, 1/d + 1/c]])
-        >>> den, M1 = M.clear_denoms()
-        >>> den
-        a*b*c*d
-        >>> M1
-        Matrix([
-        [a*c*d + b*c*d,        -a*c*d,             0],
-        [       -a*c*d, a*b*d + a*c*d,        -a*b*d],
-        [            0,        -a*b*d, a*b*c + a*b*d]])
-
-        The returned matrix is equal to the original matrix multiplied by the
-        extracted denominator:
-
-        >>> M1 == (den*M).expand()
-        True
-
-        Any keyword arguments are passed to :meth:`to_DM()` and are used to
-        choose the domain for the calculation.
-
-        See Also
-        ========
-
-        sympy.core.expr.Expr.as_numer_denom
-        DomainMatrix.clear_denoms
-        Poly.clear_denoms
-        """
-        dM = self.to_DM(**opts)
-        den, dM1 = dM.clear_denoms()
-        return den.to_sympy(), dM1.to_Matrix()
-
 
 class MutableRepMatrix(RepMatrix):
     """Mutable matrix based on DomainMatrix as the internal representation"""

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -9,6 +9,7 @@ from sympy.core.sympify import _sympify, SympifyError
 from sympy.core.singleton import S
 from sympy.polys.domains import ZZ, QQ, EXRAW
 from sympy.polys.matrices import DomainMatrix
+from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import filldedent
@@ -58,6 +59,84 @@ class RepMatrix(MatrixBase):
                 return NotImplemented
 
         return self._rep.unify_eq(other._rep)
+
+    def to_DM(self, domain=None, **kwargs):
+        """Convert to a :class:`~.DomainMatrix`.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> M = Matrix([[1, 2], [3, 4]])
+        >>> M.to_DM()
+        DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
+
+        The :meth:`DomainMatrix.to_Matrix` method can be used to convert back:
+
+        >>> M.to_DM().to_Matrix() == M
+        True
+
+        The domain can be given explicitly or otherwise it will be chosen by
+        :func:`construct_domain`. Any keyword arguments (besides ``domain``)
+        are passed to :func:`construct_domain`:
+
+        >>> from sympy import QQ, symbols
+        >>> x = symbols('x')
+        >>> M = Matrix([[x, 1], [1, x]])
+        >>> M
+        Matrix([
+        [x, 1],
+        [1, x]])
+        >>> M.to_DM().domain
+        ZZ[x]
+        >>> M.to_DM(field=True).domain
+        ZZ(x)
+        >>> M.to_DM(domain=QQ[x]).domain
+        QQ[x]
+
+        See Also
+        ========
+
+        DomainMatrix
+        DomainMatrix.to_Matrix
+        DomainMatrix.convert_to
+        DomainMatrix.choose_domain
+        construct_domain
+        """
+        if domain is not None:
+            if kwargs:
+                raise TypeError("Options cannot be used with domain parameter")
+            return self._rep.convert_to(domain)
+
+        rep = self._rep
+        dom = rep.domain
+
+        # If the internal DomainMatrix is already ZZ or QQ then we can maybe
+        # bypass calling construct_domain or performing any conversions. Some
+        # kwargs might affect this though e.g. field=True (not sure if there
+        # are others).
+        if not kwargs:
+            if dom.is_ZZ:
+                return rep.copy()
+            elif dom.is_QQ:
+                # All elements might be integers
+                try:
+                    return rep.convert_to(ZZ)
+                except CoercionFailed:
+                    pass
+                return rep.copy()
+
+        # Let construct_domain choose a domain
+        rep_dom = rep.choose_domain(**kwargs)
+
+        # XXX: There should be an option to construct_domain to choose EXRAW
+        # instead of EX. At least converting to EX does not initially trigger
+        # EX.simplify which is what we want here but should probably be
+        # considered a bug in EX.
+        if rep_dom.domain.is_EX:
+            rep_dom = rep_dom.convert_to(EXRAW)
+
+        return rep_dom
 
     @classmethod
     def _unify_element_sympy(cls, rep, element):

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -392,6 +392,69 @@ class RepMatrix(MatrixBase):
                     rv = ans
         return rv
 
+    def clear_denoms(self, **opts):
+        """Clear denominators and extract their lcm.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> from sympy import Rational as Q
+        >>> M = Matrix([[Q(1,2), Q(2,3)], [Q(3,4), Q(4,5)]])
+        >>> M
+        Matrix([
+        [1/2, 2/3],
+        [3/4, 4/5]])
+        >>> den, Mnum = M.clear_denoms()
+        >>> den
+        60
+        >>> Mnum
+        Matrix([
+        [30, 40],
+        [45, 48]])
+        >>> Mnum / den == M
+        True
+
+        >>> from sympy.abc import a, b, c, d
+        >>> M = Matrix([
+        ... [1/b + 1/a, -1/b, 0],
+        ... [-1/b, 1/c + 1/b, -1/c],
+        ... [0, -1/c, 1/d + 1/c]])
+
+        >>> M
+        Matrix([
+        [1/b + 1/a,      -1/b,         0],
+        [     -1/b, 1/c + 1/b,      -1/c],
+        [        0,      -1/c, 1/d + 1/c]])
+        >>> den, M1 = M.clear_denoms()
+        >>> den
+        a*b*c*d
+        >>> M1
+        Matrix([
+        [a*c*d + b*c*d,        -a*c*d,             0],
+        [       -a*c*d, a*b*d + a*c*d,        -a*b*d],
+        [            0,        -a*b*d, a*b*c + a*b*d]])
+
+        The returned matrix is equal to the original matrix multiplied by the
+        extracted denominator:
+
+        >>> M1 == (den*M).expand()
+        True
+
+        Any keyword arguments are passed to :meth:`to_DM()` and are used to
+        choose the domain for the calculation.
+
+        See Also
+        ========
+
+        sympy.core.expr.Expr.as_numer_denom
+        DomainMatrix.clear_denoms
+        Poly.clear_denoms
+        """
+        dM = self.to_DM(**opts)
+        den, dM1 = dM.clear_denoms()
+        return den.to_sympy(), dM1.to_Matrix()
+
 
 class MutableRepMatrix(RepMatrix):
     """Mutable matrix based on DomainMatrix as the internal representation"""

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -132,7 +132,8 @@ class RepMatrix(MatrixBase):
         # XXX: There should be an option to construct_domain to choose EXRAW
         # instead of EX. At least converting to EX does not initially trigger
         # EX.simplify which is what we want here but should probably be
-        # considered a bug in EX.
+        # considered a bug in EX. Perhaps also this could be handled in
+        # DomainMatrix.choose_domain rather than here...
         if rep_dom.domain.is_EX:
             rep_dom = rep_dom.convert_to(EXRAW)
 

--- a/sympy/matrices/tests/test_domains.py
+++ b/sympy/matrices/tests/test_domains.py
@@ -1,0 +1,113 @@
+# Test Matrix/DomainMatrix interaction.
+
+
+from sympy import GF, ZZ, QQ, EXRAW
+from sympy.polys.matrices import DomainMatrix, DM
+
+from sympy import (
+    Matrix,
+    MutableMatrix,
+    ImmutableMatrix,
+    SparseMatrix,
+    MutableDenseMatrix,
+    ImmutableDenseMatrix,
+    MutableSparseMatrix,
+    ImmutableSparseMatrix,
+)
+from sympy import symbols, S, sqrt
+
+from sympy.testing.pytest import raises
+
+
+x, y = symbols('x y')
+
+
+MATRIX_TYPES = (
+    Matrix,
+    MutableMatrix,
+    ImmutableMatrix,
+    SparseMatrix,
+    MutableDenseMatrix,
+    ImmutableDenseMatrix,
+    MutableSparseMatrix,
+    ImmutableSparseMatrix,
+)
+IMMUTABLE = (
+    ImmutableMatrix,
+    ImmutableDenseMatrix,
+    ImmutableSparseMatrix,
+)
+
+
+def DMs(items, domain):
+    return DM(items, domain).to_sparse()
+
+
+def test_Matrix_rep_domain():
+
+    for Mat in MATRIX_TYPES:
+
+        M = Mat([[1, 2], [3, 4]])
+        assert M._rep == DMs([[1, 2], [3, 4]], ZZ)
+        assert (M / 2)._rep == DMs([[(1,2), 1], [(3,2), 2]], QQ)
+        if not isinstance(M, IMMUTABLE):
+            M[0, 0] = x
+            assert M._rep == DMs([[x, 2], [3, 4]], EXRAW)
+
+        M = Mat([[S(1)/2, 2], [3, 4]])
+        assert M._rep == DMs([[(1,2), 2], [3, 4]], QQ)
+        if not isinstance(M, IMMUTABLE):
+            M[0, 0] = x
+            assert M._rep == DMs([[x, 2], [3, 4]], EXRAW)
+
+        dM = DMs([[1, 2], [3, 4]], ZZ)
+        assert Mat._fromrep(dM)._rep == dM
+
+    # XXX: This is not intended. Perhaps it should be coerced to EXRAW?
+    # The private _fromrep method is never called like this but perhaps it
+    # should be guarded.
+    #
+    # It is not clear how to integrate domains other than ZZ, QQ and EXRAW with
+    # the rest of Matrix or if the public type for this needs to be something
+    # different from Matrix somehow.
+    K = QQ.algebraic_field(sqrt(2))
+    dM = DM([[1, 2], [3, 4]], K)
+    assert Mat._fromrep(dM)._rep.domain == K
+
+
+def test_Matrix_to_DM():
+
+    M = Matrix([[1, 2], [3, 4]])
+    assert M.to_DM() == DMs([[1, 2], [3, 4]], ZZ)
+    assert M.to_DM() is not M._rep
+    assert M.to_DM(field=True) == DMs([[1, 2], [3, 4]], QQ)
+    assert M.to_DM(domain=QQ) == DMs([[1, 2], [3, 4]], QQ)
+    assert M.to_DM(domain=QQ[x]) == DMs([[1, 2], [3, 4]], QQ[x])
+    assert M.to_DM(domain=GF(3)) == DMs([[1, 2], [0, 1]], GF(3))
+
+    M = Matrix([[1, 2], [3, 4]])
+    M[0, 0] = x
+    assert M._rep.domain == EXRAW
+    M[0, 0] = 1
+    assert M.to_DM() == DMs([[1, 2], [3, 4]], ZZ)
+
+    M = Matrix([[S(1)/2, 2], [3, 4]])
+    assert M.to_DM() == DMs([[QQ(1,2), 2], [3, 4]], QQ)
+
+    M = Matrix([[x, 2], [3, 4]])
+    assert M.to_DM() == DMs([[x, 2], [3, 4]], ZZ[x])
+    assert M.to_DM(field=True) == DMs([[x, 2], [3, 4]], ZZ.frac_field(x))
+
+    M = Matrix([[1/x, 2], [3, 4]])
+    assert M.to_DM() == DMs([[1/x, 2], [3, 4]], ZZ.frac_field(x))
+
+    M = Matrix([[1, sqrt(2)], [3, 4]])
+    K = QQ.algebraic_field(sqrt(2))
+    sqrt2 = K.from_sympy(sqrt(2)) # XXX: Maybe K(sqrt(2)) should work
+    M_K = DomainMatrix([[K(1), sqrt2], [K(3), K(4)]], (2, 2), K)
+    assert M.to_DM() == DMs([[1, sqrt(2)], [3, 4]], EXRAW)
+    assert M.to_DM(extension=True) == M_K.to_sparse()
+
+    # Options cannot be used with the domain parameter
+    M = Matrix([[1, 2], [3, 4]])
+    raises(TypeError, lambda: M.to_DM(domain=QQ, field=True))

--- a/sympy/matrices/tests/test_domains.py
+++ b/sympy/matrices/tests/test_domains.py
@@ -111,11 +111,3 @@ def test_Matrix_to_DM():
     # Options cannot be used with the domain parameter
     M = Matrix([[1, 2], [3, 4]])
     raises(TypeError, lambda: M.to_DM(domain=QQ, field=True))
-
-
-def test_Matrix_clear_denoms():
-    M = Matrix([[1/x, x/2], [3, 4]])
-    den, Mnum = M.clear_denoms()
-    assert den == 2*x
-    assert Mnum == Matrix([[2, x**2], [6*x, 8*x]])
-    assert M * den == Mnum

--- a/sympy/matrices/tests/test_domains.py
+++ b/sympy/matrices/tests/test_domains.py
@@ -111,3 +111,11 @@ def test_Matrix_to_DM():
     # Options cannot be used with the domain parameter
     M = Matrix([[1, 2], [3, 4]])
     raises(TypeError, lambda: M.to_DM(domain=QQ, field=True))
+
+
+def test_Matrix_clear_denoms():
+    M = Matrix([[1/x, x/2], [3, 4]])
+    den, Mnum = M.clear_denoms()
+    assert den == 2*x
+    assert Mnum == Matrix([[2, x**2], [6*x, 8*x]])
+    assert M * den == Mnum

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -65,6 +65,8 @@ from itertools import chain
 
 from .exceptions import DMBadInputError, DMShapeError, DMDomainError
 
+from sympy.polys.domains import QQ
+
 from .dense import (
         ddm_transpose,
         ddm_iadd,
@@ -81,7 +83,6 @@ from .dense import (
         ddm_berk,
         )
 
-from sympy.polys.domains import QQ
 from .lll import ddm_lll, ddm_lll_transform
 
 
@@ -125,10 +126,56 @@ class DDM(list):
         return list(self)
 
     def to_list_flat(self):
+        """
+        Convert to a flat list of elements.
+
+        Examples
+        ========
+
+        >>> from sympy import QQ
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> A.to_list_flat()
+        [1, 2, 3, 4]
+        >>> A == DDM.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        from_list_flat
+        """
         flat = []
         for row in self:
             flat.extend(row)
         return flat
+
+    @classmethod
+    def from_list_flat(cls, flat, shape, domain):
+        """
+        Create a :class:`DDM` from a flat list of elements.
+
+        Examples
+        ========
+
+        >>> from sympy import QQ
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> A = DDM.from_list_flat([1, 2, 3, 4], (2, 2), QQ)
+        >>> A
+        [[1, 2], [3, 4]]
+        >>> A == DDM.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        to_list_flat
+        """
+        rows, cols = shape
+        if not (len(flat) == rows*cols):
+            raise DMBadInputError("Inconsistent flat-list shape")
+        lol = [flat[i*cols:(i+1)*cols] for i in range(rows)]
+        return cls(lol, shape, domain)
 
     def flatiter(self):
         return chain.from_iterable(self)
@@ -139,8 +186,122 @@ class DDM(list):
             items.extend(row)
         return items
 
+    def to_flat_nz(self):
+        """
+        Convert to a flat list of possibly nonzero elements and data.
+
+        Explanation
+        ===========
+
+        This is used to operate on a list of the elements of a matrix and then
+        reconstruct a matrix using :meth:`from_flat_nz`. Zero elements are
+        included in the list but that may change in the future.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> elements, data = A.to_flat_nz()
+        >>> elements
+        [1, 2, 3, 4]
+        >>> A == DDM.from_flat_nz(elements, data, A.domain)
+        True
+
+        See Also
+        ========
+
+        from_flat_nz
+        SDM.to_flat_nz
+        DomainMatrix.to_flat_nz
+        """
+        elements = self.to_list_flat()
+        data = self.shape
+        return elements, data
+
+    @classmethod
+    def from_flat_nz(cls, elements, data, domain):
+        """
+        Reconstruct a :class:`DDM` after calling :meth:`to_flat_nz`.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> elements, data = A.to_flat_nz()
+        >>> elements
+        [1, 2, 3, 4]
+        >>> A == DDM.from_flat_nz(elements, data, A.domain)
+        True
+
+        See Also
+        ========
+
+        to_flat_nz
+        SDM.from_flat_nz
+        DomainMatrix.from_flat_nz
+        """
+        shape = data
+        return cls.from_list_flat(elements, shape, domain)
+
     def to_dok(self):
-        return {(i, j): e for i, row in enumerate(self) for j, e in enumerate(row)}
+        """
+        Convert :class:`DDM` to dictionary of keys (dok) format.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> A.to_dok()
+        {(0, 0): 1, (0, 1): 2, (1, 0): 3, (1, 1): 4}
+
+        See Also
+        ========
+
+        from_dok
+        SDM.to_dok
+        DomainMatrix.to_dok
+        MutableDenseMatrix.todok
+        """
+        dok = {}
+        for i, row in enumerate(self):
+            for j, element in enumerate(row):
+                if element:
+                    dok[i, j] = element
+        return dok
+
+    @classmethod
+    def from_dok(cls, dok, shape, domain):
+        """
+        Create a :class:`DDM` from a dictionary of keys (dok) format.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> dok = {(0, 0): 1, (0, 1): 2, (1, 0): 3, (1, 1): 4}
+        >>> A = DDM.from_dok(dok, (2, 2), QQ)
+        >>> A
+        [[1, 2], [3, 4]]
+
+        See Also
+        ========
+
+        to_dok
+        SDM.from_dok
+        DomainMatrix.from_dok
+        """
+        rows, cols = shape
+        lol = [[domain.zero] * cols for _ in range(rows)]
+        for (i, j), element in dok.items():
+            lol[i][j] = element
+        return DDM(lol, shape, domain)
 
     def to_ddm(self):
         return self

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -213,8 +213,8 @@ class DDM(list):
         ========
 
         from_flat_nz
-        SDM.to_flat_nz
-        DomainMatrix.to_flat_nz
+        sympy.polys.matrices.sdm.SDM.to_flat_nz
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_flat_nz
         """
         elements = self.to_list_flat()
         data = self.shape
@@ -241,8 +241,8 @@ class DDM(list):
         ========
 
         to_flat_nz
-        SDM.from_flat_nz
-        DomainMatrix.from_flat_nz
+        sympy.polys.matrices.sdm.SDM.from_flat_nz
+        sympy.polys.matrices.domainmatrix.DomainMatrix.from_flat_nz
         """
         shape = data
         return cls.from_list_flat(elements, shape, domain)
@@ -264,9 +264,8 @@ class DDM(list):
         ========
 
         from_dok
-        SDM.to_dok
-        DomainMatrix.to_dok
-        MutableDenseMatrix.todok
+        sympy.polys.matrices.sdm.SDM.to_dok
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_dok
         """
         dok = {}
         for i, row in enumerate(self):
@@ -294,8 +293,8 @@ class DDM(list):
         ========
 
         to_dok
-        SDM.from_dok
-        DomainMatrix.from_dok
+        sympy.polys.matrices.sdm.SDM.from_dok
+        sympy.polys.matrices.domainmatrix.DomainMatrix.from_dok
         """
         rows, cols = shape
         lol = [[domain.zero] * cols for _ in range(rows)]

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -450,7 +450,7 @@ class DomainMatrix:
 
         >>> from sympy.abc import x
         >>> M = DM([[1, x], [x**2, x**3]], ZZ[x])
-        >>> M.choose_domain(field=True)
+        >>> M.choose_domain(field=True).domain
         ZZ(x)
 
         Keyword arguments are passed to :func:`~.construct_domain`.
@@ -461,7 +461,7 @@ class DomainMatrix:
         construct_domain
         convert_to
         """
-        elements, data = self.to_flat_nz()
+        elements, data = self.to_sympy().to_flat_nz()
         dom, elements_dom = construct_domain(elements, **opts)
         return self.from_flat_nz(elements_dom, data, dom)
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -435,7 +435,7 @@ class DomainMatrix:
         return K, items_K
 
     def choose_domain(self, **opts):
-        """Convert to a domain found by :func:`construct_domain`.
+        """Convert to a domain found by :func:`~.construct_domain`.
 
         Examples
         ========
@@ -448,7 +448,12 @@ class DomainMatrix:
         >>> M.choose_domain(field=True)
         DomainMatrix([[1, 2], [3, 4]], (2, 2), QQ)
 
-        Keyword arguments are passed to :func:`construct_domain`.
+        >>> from sympy.abc import x
+        >>> M = DM([[1, x], [x**2, x**3]], ZZ[x])
+        >>> M.choose_domain(field=True)
+        ZZ(x)
+
+        Keyword arguments are passed to :func:`~.construct_domain`.
 
         See Also
         ========
@@ -700,13 +705,64 @@ class DomainMatrix:
         return MutableDenseMatrix._fromrep(rep)
 
     def to_list(self):
+        """
+        Convert :class:`DomainMatrix` to list of lists.
+
+        See Also
+        ========
+
+        from_list
+        to_list_flat
+        to_flat_nz
+        to_dok
+        """
         return self.rep.to_list()
 
     def to_list_flat(self):
+        """
+        Convert :class:`DomainMatrix` to flat list.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> A.to_list_flat()
+        [1, 2, 3, 4]
+
+        See Also
+        ========
+
+        from_list_flat
+        to_list
+        to_flat_nz
+        to_dok
+        """
         return self.rep.to_list_flat()
 
     @classmethod
     def from_list_flat(cls, elements, shape, domain):
+        """
+        Create :class:`DomainMatrix` from flat list.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> element_list = [ZZ(1), ZZ(2), ZZ(3), ZZ(4)]
+        >>> A = DomainMatrix.from_list_flat(element_list, (2, 2), ZZ)
+        >>> A
+        DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
+        >>> A == A.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        to_list_flat
+        """
         return cls.from_rep(DDM.from_list_flat(elements, shape, domain))
 
     def to_flat_nz(self):
@@ -1413,8 +1469,7 @@ class DomainMatrix:
         See Also
         ========
 
-        Matrix.clear_denoms
-        Poly.clear_denoms
+        sympy.polys.polytools.Poly.clear_denoms
         """
         elems0, data = self.to_flat_nz()
 

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -11,9 +11,10 @@ from sympy.utilities.iterables import _strongly_connected_components
 
 from .exceptions import DMBadInputError, DMDomainError, DMShapeError
 
+from sympy.polys.domains import QQ
+
 from .ddm import DDM
 from .lll import ddm_lll, ddm_lll_transform
-from sympy.polys.domains import QQ
 
 
 class SDM(dict):
@@ -226,6 +227,7 @@ class SDM(dict):
     @classmethod
     def from_list(cls, ddm, shape, domain):
         """
+        Create :py:class:`~.SDM` object from a list of lists.
 
         Parameters
         ==========
@@ -252,6 +254,13 @@ class SDM(dict):
         >>> A
         {0: {0: 1/2}, 1: {1: 3/4}}
 
+        See Also
+        ========
+
+        to_list
+        from_list_flat
+        from_dok
+        from_ddm
         """
 
         m, n = shape
@@ -265,8 +274,7 @@ class SDM(dict):
     @classmethod
     def from_ddm(cls, ddm):
         """
-        converts object of :py:class:`~.DDM` to
-        :py:class:`~.SDM`
+        Create :py:class:`~.SDM` from a :py:class:`~.DDM`.
 
         Examples
         ========
@@ -278,14 +286,22 @@ class SDM(dict):
         >>> A = SDM.from_ddm(ddm)
         >>> A
         {0: {0: 1/2}, 1: {1: 3/4}}
+        >>> SDM.from_ddm(ddm).to_ddm() == ddm
+        True
 
+        See Also
+        ========
+
+        to_ddm
+        from_list
+        from_list_flat
+        from_dok
         """
         return cls.from_list(ddm, ddm.shape, ddm.domain)
 
     def to_list(M):
         """
-
-        Converts a :py:class:`~.SDM` object to a list
+        Convert a :py:class:`~.SDM` object to a list of lists.
 
         Examples
         ========
@@ -297,6 +313,7 @@ class SDM(dict):
         >>> A.to_list()
         [[0, 2], [0, 0]]
 
+
         """
         m, n = M.shape
         zero = M.domain.zero
@@ -307,6 +324,28 @@ class SDM(dict):
         return ddm
 
     def to_list_flat(M):
+        """
+        Convert :py:class:`~.SDM` to a flat list.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0:{1:QQ(2)}, 1:{0: QQ(3)}}, (2, 2), QQ)
+        >>> A.to_list_flat()
+        [0, 2, 3, 0]
+        >>> A == A.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        from_list_flat
+        to_list
+        to_dok
+        to_ddm
+        """
         m, n = M.shape
         zero = M.domain.zero
         flat = [zero] * (m * n)
@@ -315,8 +354,149 @@ class SDM(dict):
                 flat[i*n + j] = e
         return flat
 
+    @classmethod
+    def from_list_flat(cls, elements, shape, domain):
+        """
+        Create :py:class:`~.SDM` from a flat list of elements.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM.from_list_flat([QQ(0), QQ(2), QQ(0), QQ(0)], (2, 2), QQ)
+        >>> A
+        {0: {1: 2}}
+        >>> A == A.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        to_list_flat
+        from_list
+        from_dok
+        from_ddm
+        """
+        m, n = shape
+        if len(elements) != m * n:
+            raise DMBadInputError("Inconsistent flat-list shape")
+        sdm = defaultdict(dict)
+        for inj, element in enumerate(elements):
+            if element:
+                i, j = divmod(inj, n)
+                sdm[i][j] = element
+        return cls(sdm, shape, domain)
+
+    def to_flat_nz(M):
+        """
+        Convert :class:`SDM` to a flat list of nonzero elements and data.
+
+        Explanation
+        ===========
+
+        This is used to operate on a list of the elements of a matrix and then
+        reconstruct a modified matrix with elements in the same positions using
+        :meth:`from_flat_nz`. Zero elements are omitted from the list.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0:{1:QQ(2)}, 1:{0: QQ(3)}}, (2, 2), QQ)
+        >>> elements, data = A.to_flat_nz()
+        >>> elements
+        [2, 3]
+        >>> A == A.from_flat_nz(elements, data, A.domain)
+        True
+
+        See Also
+        ========
+
+        from_flat_nz
+        DDM.to_flat_nz
+        DomainMatrix.to_flat_nz
+        to_flat_list
+        """
+        dok = M.to_dok()
+        indices = tuple(dok)
+        elements = list(dok.values())
+        data = (indices, M.shape)
+        return elements, data
+
+    @classmethod
+    def from_flat_nz(cls, elements, data, domain):
+        """
+        Reconstruct a :class:`~.SDM` after calling :meth:`to_flat_nz`.
+
+        See :meth:`to_flat_nz` for explanation.
+
+        See Also
+        ========
+
+        to_flat_nz
+        DDM.from_flat_nz
+        DomainMatrix.from_flat_nz
+        from_flat_list
+        """
+        indices, shape = data
+        dok = dict(zip(indices, elements))
+        return cls.from_dok(dok, shape, domain)
+
     def to_dok(M):
+        """
+        Convert to dictionary of keys (dok) format.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0: {1: QQ(2)}, 1: {0: QQ(3)}}, (2, 2), QQ)
+        >>> A.to_dok()
+        {(0, 1): 2, (1, 0): 3}
+
+        See Also
+        ========
+
+        from_dok
+        to_list
+        to_list_flat
+        to_ddm
+        """
         return {(i, j): e for i, row in M.items() for j, e in row.items()}
+
+    @classmethod
+    def from_dok(cls, dok, shape, domain):
+        """
+        Create :py:class:`~.SDM` from dictionary of keys (dok) format.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> dok = {(0, 1): QQ(2), (1, 0): QQ(3)}
+        >>> A = SDM.from_dok(dok, (2, 2), QQ)
+        >>> A
+        {0: {1: 2}, 1: {0: 3}}
+        >>> A == SDM.from_dok(A.to_dok(), A.shape, A.domain)
+        True
+
+        See Also
+        ========
+
+        to_dok
+        from_list
+        from_list_flat
+        from_ddm
+        """
+        sdm = defaultdict(dict)
+        for (i, j), e in dok.items():
+            if e:
+                sdm[i][j] = e
+        return cls(sdm, shape, domain)
 
     def to_ddm(M):
         """
@@ -573,7 +753,6 @@ class SDM(dict):
 
     def convert_to(A, K):
         """
-
         Converts the :py:class:`~.Domain` of a :py:class:`~.SDM` matrix to K
 
         Examples

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -415,9 +415,9 @@ class SDM(dict):
         ========
 
         from_flat_nz
-        DDM.to_flat_nz
-        DomainMatrix.to_flat_nz
-        to_flat_list
+        to_list_flat
+        sympy.polys.matrices.ddm.DDM.to_flat_nz
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_flat_nz
         """
         dok = M.to_dok()
         indices = tuple(dok)
@@ -436,9 +436,9 @@ class SDM(dict):
         ========
 
         to_flat_nz
-        DDM.from_flat_nz
-        DomainMatrix.from_flat_nz
-        from_flat_list
+        from_list_flat
+        sympy.polys.matrices.ddm.DDM.from_flat_nz
+        sympy.polys.matrices.domainmatrix.DomainMatrix.from_flat_nz
         """
         indices, shape = data
         dok = dict(zip(indices, elements))

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -509,6 +509,17 @@ def test_DomainMatrix_pow():
     raises(DMNonSquareMatrixError, lambda: A ** 1)
 
 
+def test_DomainMatrix_clear_denoms():
+    A = DM([[(1,2),(1,3)],[(1,4),(1,5)]], QQ)
+
+    den_Z = DomainScalar(ZZ(60), ZZ)
+    Anum_Z = DM([[30, 20], [15, 12]], ZZ)
+    Anum_Q = DM([[30, 20], [15, 12]], QQ)
+
+    assert A.clear_denoms() == (den_Z, Anum_Q)
+    assert A.clear_denoms(convert=True) == (den_Z, Anum_Z)
+
+
 def test_DomainMatrix_scc():
     Ad = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)],
                        [ZZ(0), ZZ(1), ZZ(0)],

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -194,6 +194,26 @@ def test_DomainMatrix_convert_to():
     assert Acopy == A and Acopy is not A
 
 
+def test_DomainMatrix_choose_domain():
+    A = [[1, 2], [3, 0]]
+    assert DM(A, QQ).choose_domain() == DM(A, ZZ)
+    assert DM(A, QQ).choose_domain(field=True) == DM(A, QQ)
+    assert DM(A, ZZ).choose_domain(field=True) == DM(A, QQ)
+
+
+def test_DomainMatrix_to_flat_nz():
+    Adm = DM([[1, 2], [3, 0]], ZZ)
+    Addm = Adm.rep.to_ddm()
+    Asdm = Adm.rep.to_sdm()
+    for A in [Adm, Addm, Asdm]:
+        elems, data = A.to_flat_nz()
+        assert A.from_flat_nz(elems, data, A.domain) == A
+        elemsq = [QQ(e) for e in elems]
+        assert A.from_flat_nz(elemsq, data, QQ) == A.convert_to(QQ)
+        elems2 = [2*e for e in elems]
+        assert A.from_flat_nz(elems2, data, A.domain) == 2*A
+
+
 def test_DomainMatrix_to_sympy():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     assert A.to_sympy() == A.convert_to(EXRAW)
@@ -244,7 +264,11 @@ def test_DomainMatrix_unify():
 
 def test_DomainMatrix_to_Matrix():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert A.to_Matrix() == Matrix([[1, 2], [3, 4]])
+    A_Matrix = Matrix([[1, 2], [3, 4]])
+    assert A.to_Matrix() == A_Matrix
+    assert A.to_sparse().to_Matrix() == A_Matrix
+    assert A.convert_to(QQ).to_Matrix() == A_Matrix
+    assert A.convert_to(QQ.algebraic_field(sqrt(2))).to_Matrix() == A_Matrix
 
 
 def test_DomainMatrix_to_list():
@@ -257,9 +281,44 @@ def test_DomainMatrix_to_list_flat():
     assert A.to_list_flat() == [ZZ(1), ZZ(2), ZZ(3), ZZ(4)]
 
 
+def test_DomainMatrix_flat():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    assert A.flat() == [ZZ(1), ZZ(2), ZZ(3), ZZ(4)]
+
+
+def test_DomainMatrix_from_list_flat():
+    nums = [ZZ(1), ZZ(2), ZZ(3), ZZ(4)]
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+
+    assert DomainMatrix.from_list_flat(nums, (2, 2), ZZ) == A
+    assert DDM.from_list_flat(nums, (2, 2), ZZ) == A.rep.to_ddm()
+    assert SDM.from_list_flat(nums, (2, 2), ZZ) == A.rep.to_sdm()
+
+    assert A == A.from_list_flat(A.to_list_flat(), A.shape, A.domain)
+
+    raises(DMBadInputError, DomainMatrix.from_list_flat, nums, (2, 3), ZZ)
+    raises(DMBadInputError, DDM.from_list_flat, nums, (2, 3), ZZ)
+    raises(DMBadInputError, SDM.from_list_flat, nums, (2, 3), ZZ)
+
+
 def test_DomainMatrix_to_dok():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     assert A.to_dok() == {(0, 0):ZZ(1), (0, 1):ZZ(2), (1, 0):ZZ(3), (1, 1):ZZ(4)}
+    A = DomainMatrix([[ZZ(1), ZZ(0)], [ZZ(0), ZZ(4)]], (2, 2), ZZ)
+    dok = {(0, 0):ZZ(1), (1, 1):ZZ(4)}
+    assert A.to_dok() == dok
+    assert A.to_dense().to_dok() == dok
+    assert A.to_sparse().to_dok() == dok
+    assert A.rep.to_ddm().to_dok() == dok
+    assert A.rep.to_sdm().to_dok() == dok
+
+
+def test_DomainMatrix_from_dok():
+    items = {(0, 0): ZZ(1), (1, 1): ZZ(2)}
+    A = DM([[1, 0], [0, 2]], ZZ)
+    assert DomainMatrix.from_dok(items, (2, 2), ZZ) == A.to_sparse()
+    assert DDM.from_dok(items, (2, 2), ZZ) == A.rep.to_ddm()
+    assert SDM.from_dok(items, (2, 2), ZZ) == A.rep.to_sdm()
 
 
 def test_DomainMatrix_repr():
@@ -271,11 +330,6 @@ def test_DomainMatrix_transpose():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     AT = DomainMatrix([[ZZ(1), ZZ(3)], [ZZ(2), ZZ(4)]], (2, 2), ZZ)
     assert A.transpose() == AT
-
-
-def test_DomainMatrix_flat():
-    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-    assert A.flat() == [ZZ(1), ZZ(2), ZZ(3), ZZ(4)]
 
 
 def test_DomainMatrix_is_zero_matrix():

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1,10 +1,5 @@
-from sympy.testing.pytest import raises
+from sympy import Integer, Rational, S, sqrt, Matrix, symbols
 
-from sympy.core.numbers import Integer, Rational
-from sympy.core.singleton import S
-from sympy.functions import sqrt
-
-from sympy.matrices.dense import Matrix
 from sympy.polys.domains import FF, ZZ, QQ, EXRAW
 
 from sympy.polys.matrices.domainmatrix import DomainMatrix, DomainScalar, DM
@@ -14,6 +9,8 @@ from sympy.polys.matrices.exceptions import (
 )
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.sdm import SDM
+
+from sympy.testing.pytest import raises
 
 
 def test_DM():
@@ -199,6 +196,10 @@ def test_DomainMatrix_choose_domain():
     assert DM(A, QQ).choose_domain() == DM(A, ZZ)
     assert DM(A, QQ).choose_domain(field=True) == DM(A, QQ)
     assert DM(A, ZZ).choose_domain(field=True) == DM(A, QQ)
+
+    x = symbols('x')
+    B = [[1, x], [x**2, x**3]]
+    assert DM(B, QQ[x]).choose_domain(field=True) == DM(B, ZZ.frac_field(x))
 
 
 def test_DomainMatrix_to_flat_nz():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Two new methods are added to Matrix:

The `to_DM` method is a convenience for converting a Matrix to a DomainMatrix:
```python
In [1]: M = Matrix([[1, 2], [3, 4]])

In [2]: M
Out[2]: 
⎡1  2⎤
⎢    ⎥
⎣3  4⎦

In [3]: M.to_DM()
Out[3]: DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
```
This makes it easier to test out DomainMatrix methods which can be a lot faster for some operations e.g.:
```python
In [6]: M = randMatrix(10, 10)

In [7]: %time ok = M.inv()
CPU times: user 92.3 ms, sys: 3.53 ms, total: 95.8 ms
Wall time: 94.8 ms

In [8]: %time ok = M.to_DM(QQ).inv()
CPU times: user 4.06 ms, sys: 0 ns, total: 4.06 ms
Wall time: 4.04 ms
```

A `clear_denoms` method is added to ~~both `Matrix` and~~ `DomainMatrix` which is analogous to the `Poly.clear_denoms` method:
```python
In [9]: M = Matrix([[1, 2/x], [x/3, y/z]])

In [10]: M
Out[10]: 
⎡   2⎤
⎢1  ─⎥
⎢   x⎥
⎢    ⎥
⎢x  y⎥
⎢─  ─⎥
⎣3  z⎦

In [11]: M.clear_denoms()
Out[11]: 
⎛       ⎡3⋅x⋅z   6⋅z ⎤⎞
⎜       ⎢            ⎥⎟
⎜3⋅x⋅z, ⎢ 2          ⎥⎟
⎝       ⎣x ⋅z   3⋅x⋅y⎦⎠

In [12]: den, num = M.clear_denoms()

In [13]: M == num / den
Out[13]: True
```
This is a precursor step for working with division-free or fraction-free algorithms (gh-21834).

Also a number of conversion methods and docstrings were added in DomainMatrix and the related SDM and DDM classes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * Matrix now has a `to_DM()` method for converting a `Matrix` into the lower-level `DomainMatrix` type which can be faster for many operations and can also do things like working over finite fields.
    * A method `clear_denoms` is added to `DomainMatrix` which can factor out a common denominator from a matrix like the `Poly.clear_denoms` method.
    * Various conversion methods `from_dok`, `from_flat_list` etc have been added to `DomainMatrix` and related classes for a more complete set of conversions.
    * A `DomainMatrix.choose_domain` method was added to choose a domain based in the expressions in a matrix. This is analogous to the `Poly.retract` method.
<!-- END RELEASE NOTES -->
