### PR TITLE
Fix bug where ask fails to raise inconsistent assumptions exception  

### DIFF
--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -132,7 +132,6 @@ def extract_predargs(proposition, assumptions=None, context=None):
     {x, y, Abs(x*y)}
 
     """
-    req_keys = find_symbols(proposition)
     keys = proposition.all_predicates()
     # XXX: We need this since True/False are not Basic
     lkeys = set()
@@ -142,16 +141,7 @@ def extract_predargs(proposition, assumptions=None, context=None):
         lkeys |= context.all_predicates()
 
     lkeys = lkeys - {S.true, S.false}
-    tmp_keys = None
-    while tmp_keys != set():
-        tmp = set()
-        for l in lkeys:
-            syms = find_symbols(l)
-            if (syms & req_keys) != set():
-                tmp |= syms
-        tmp_keys = tmp - req_keys
-        req_keys |= tmp_keys
-    keys |= {l for l in lkeys if find_symbols(l) & req_keys != set()}
+    keys |= lkeys
 
     exprs = set()
     for key in keys:

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -39,7 +39,10 @@ def test_satask():
     assert satask(Q.positive(x), Q.zero(x)) is False
     assert satask(Q.real(x), Q.zero(x)) is True
     assert satask(Q.zero(x), Q.zero(x*y)) is None
-    assert satask(Q.zero(x*y), Q.zero(x))
+    assert satask(Q.zero(x*y), Q.zero(x)) is True
+
+    # https://github.com/sympy/sympy/issues/25349
+    assert raises(ValueError, satask(Q.positive(x), Q.positive(x) & Q.positive(y) & Q.zero(y)))
 
 
 def test_zero():


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partially fixes #25349

#### Brief description of what is fixed or changed

Before this fix, extract_predargs was not extracting arguements that were only present in the assumptions in some cases. As a result, satask would fail to raise an inconsistent assumptions exception in some cases. This is now fixed.

An unfortunate consequence of this fix is that it makes satask slower. Previously running the tests for the new assumptions took 21.7 +/- .2 seconds for me. Now they take 26.5 +/- .2 seconds.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  *  Fixed bug where ask incorrectly gave True when assumptions contained arguments not present in proposition

<!-- END RELEASE NOTES -->
