### PR TITLE
Add documentation of the initialization parameters of Kane's method

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -33,7 +33,7 @@ class KanesMethod(_Methods):
     q, u : Matrix
         Matrices of the generalized coordinates and speeds
     bodies : iterable
-        Iterable of Point and RigidBody objects in the system.
+        Iterable of Particle and RigidBody objects in the system.
     loads : iterable
         Iterable of (Point, vector) or (ReferenceFrame, vector) tuples
         describing the forces on the system.
@@ -53,22 +53,56 @@ class KanesMethod(_Methods):
         The "mass matrix" for the u's and q's with dynamics and kinematics
     forcing_full : Matrix
         The "forcing vector" for the u's and q's with dynamics and kinematics
+
+    Parameters
+    ==========
+
+    frame : ReferenceFrame
+        The inertial reference frame for the system.
+    q_ind : iterable
+        Independent generalized coordinates.
+    u_ind : iterable
+        Independent generalized speeds.
+    kd_eqs : iterable, optional
+        Kinematic differential equations, which linearly relate the generalized
+        speeds to the time-derivatives of the generalized coordinates.
+    q_dependent : iterable, optional
+        Dependent generalized coordinates.
+    configuration_constraints : iterable, optional
+        Constraints on the system's configuration, i.e. holonomic constraints.
+    u_dependent : iterable, optional
+        Dependent generalized speeds.
+    velocity_constraints : iterable, optional
+        Constraints on the system's velocity, i.e. the combination of the
+        nonholonomic constraints and the time-derivative of the holonomic
+        constraints.
+    acceleration_constraints : iterable, optional
+        Constraints on the system's acceleration, by default these are the
+        time-derivative of the velocity constraints.
+    u_auxiliary : iterable, optional
+        Auxiliary generalized speeds.
+    bodies : iterable, optional
+        The particles and rigid bodies in the system.
+    forcelist : iterable, optional
+        Forces and torques applied on the system.
     explicit_kinematics : bool
         Boolean whether the mass matrices and forcing vectors should use the
         explicit form (default) or implicit form for kinematics.
         See the notes for more details.
     kd_eqs_solver : str, callable
-        Method used to solve the kinematic differential equations. If a string is
-        supplied, it should be a valid method that can be used with the
-        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should have the format ``f(A, rhs)``, where it solves the equations and returns
-        the solution. The default utilizes LU solve. See the notes for more information.
+        Method used to solve the kinematic differential equations. If a string
+        is supplied, it should be a valid method that can be used with the
+        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is
+        supplied, it should have the format ``f(A, rhs)``, where it solves the
+        equations and returns the solution. The default utilizes LU solve. See
+        the notes for more information.
     constraint_solver : str, callable
         Method used to solve the velocity constraints. If a string is
         supplied, it should be a valid method that can be used with the
-        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is supplied, it
-        should have the format ``f(A, rhs)``, where it solves the equations and returns
-        the solution. The default utilizes LU solve. See the notes for more information.
+        :meth:`sympy.matrices.matrices.MatrixBase.solve`. If a callable is
+        supplied, it should have the format ``f(A, rhs)``, where it solves the
+        equations and returns the solution. The default utilizes LU solve. See
+        the notes for more information.
 
     Notes
     =====

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -59,31 +59,31 @@ class KanesMethod(_Methods):
 
     frame : ReferenceFrame
         The inertial reference frame for the system.
-    q_ind : iterable
+    q_ind : iterable of dynamicsymbols
         Independent generalized coordinates.
-    u_ind : iterable
+    u_ind : iterable of dynamicsymbols
         Independent generalized speeds.
-    kd_eqs : iterable, optional
+    kd_eqs : iterable of Expr, optional
         Kinematic differential equations, which linearly relate the generalized
         speeds to the time-derivatives of the generalized coordinates.
-    q_dependent : iterable, optional
+    q_dependent : iterable of dynamicsymbols, optional
         Dependent generalized coordinates.
-    configuration_constraints : iterable, optional
+    configuration_constraints : iterable of Expr, optional
         Constraints on the system's configuration, i.e. holonomic constraints.
-    u_dependent : iterable, optional
+    u_dependent : iterable of dynamicsymbols, optional
         Dependent generalized speeds.
-    velocity_constraints : iterable, optional
+    velocity_constraints : iterable of Expr, optional
         Constraints on the system's velocity, i.e. the combination of the
         nonholonomic constraints and the time-derivative of the holonomic
         constraints.
-    acceleration_constraints : iterable, optional
+    acceleration_constraints : iterable of Expr, optional
         Constraints on the system's acceleration, by default these are the
         time-derivative of the velocity constraints.
-    u_auxiliary : iterable, optional
+    u_auxiliary : iterable of dynamicsymbols, optional
         Auxiliary generalized speeds.
-    bodies : iterable, optional
+    bodies : iterable of Particle and/or RigidBody, optional
         The particles and rigid bodies in the system.
-    forcelist : iterable, optional
+    forcelist : iterable of tuple[Point | ReferenceFrame, Vector], optional
         Forces and torques applied on the system.
     explicit_kinematics : bool
         Boolean whether the mass matrices and forcing vectors should use the


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added documentation of the initialization parameters of Kane's method.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
