### PR TITLE
Fix docs preview build

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -14,6 +14,7 @@ jobs:
           artifact-path: 0/doc/_build/html/index.html
           circleci-jobs: Build Docs Preview
           job-title: Click here to see a preview of the documentation.
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
       - name: Check the URL
         if: github.event.status != 'pending'
         run: |


### PR DESCRIPTION
See
https://github.com/larsoner/circleci-artifacts-redirector-action/issues/40#issuecomment-1505543564

I don't know if we will be able to see if this works without merging it. It should make the "click here to see the docs preview" build actually show up again.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
