### PR TITLE
feat(matrices): add cancel_denom, content and primitive

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -172,6 +172,7 @@ class DDM(list):
 
         to_list_flat
         """
+        assert type(flat) is list
         rows, cols = shape
         if not (len(flat) == rows*cols):
             raise DMBadInputError("Inconsistent flat-list shape")

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -39,6 +39,7 @@ from sympy.polys.domains import ZZ, EXRAW, QQ
 from sympy.polys.densetools import (
     dup_content,
     dup_clear_denoms,
+    dup_primitive,
     dup_quo_ground,
 )
 
@@ -1709,6 +1710,65 @@ class DomainMatrix:
         M_denoms = M.from_flat_nz(list(denoms), data, K)
 
         return (M_numers, M_denoms)
+
+    def content(self):
+        """
+        Return the gcd of the elements of the matrix.
+
+        Requires ``gcd`` in the ground domain.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import ZZ
+        >>> M = DM([[2, 4], [4, 12]], ZZ)
+        >>> M.content()
+        2
+
+        See Also
+        ========
+
+        primitive
+        cancel_denom
+        """
+        K = self.domain
+        elements, _ = self.to_flat_nz()
+        return dup_content(elements, K)
+
+    def primitive(self):
+        """
+        Factor out gcd of the elements of a matrix.
+
+        Requires ``gcd`` in the ground domain.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import ZZ
+        >>> M = DM([[2, 4], [4, 12]], ZZ)
+        >>> content, M_primitive = M.primitive()
+        >>> content
+        2
+        >>> M_primitive
+        DomainMatrix([[1, 2], [2, 6]], (2, 2), ZZ)
+        >>> content * M_primitive == M
+        True
+        >>> M_primitive.content() == ZZ(1)
+        True
+
+        See Also
+        ========
+
+        content
+        cancel_denom
+        """
+        K = self.domain
+        elements, data = self.to_flat_nz()
+        content, prims = dup_primitive(elements, K)
+        M_primitive = self.from_flat_nz(prims, data, K)
+        return content, M_primitive
 
     def rref(self):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -36,7 +36,11 @@ from .domainscalar import DomainScalar
 
 from sympy.polys.domains import ZZ, EXRAW, QQ
 
-from sympy.polys.densetools import dup_clear_denoms
+from sympy.polys.densetools import (
+    dup_content,
+    dup_clear_denoms,
+    dup_quo_ground,
+)
 
 
 def DM(rows, domain):
@@ -1546,6 +1550,165 @@ class DomainMatrix:
         num = self.from_flat_nz(elems1, data, Knum)
 
         return den, num
+
+    def cancel_denom(self, denom):
+        """
+        Cancel factors between a matrix and a denominator.
+
+        Returns a matrix and denominator on lowest terms.
+
+        Requires ``gcd`` in the ground domain.
+
+        Methods like :meth:`solve_den`, :meth:`inv_den` and :meth:`rref_den`
+        return a matrix and denominator but not necessarily on lowest terms.
+        Reduction to lowest terms without fractions can be performed with
+        :meth:`cancel_denom`.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import ZZ
+        >>> M = DM([[2, 2, 0],
+        ...         [0, 2, 2],
+        ...         [0, 0, 2]], ZZ)
+        >>> Minv, den = M.inv_den()
+        >>> Minv.to_Matrix()
+        Matrix([
+        [4, -4,  4],
+        [0,  4, -4],
+        [0,  0,  4]])
+        >>> den
+        8
+        >>> Minv_reduced, den_reduced = Minv.cancel_denom(den)
+        >>> Minv_reduced.to_Matrix()
+        Matrix([
+        [1, -1,  1],
+        [0,  1, -1],
+        [0,  0,  1]])
+        >>> den_reduced
+        2
+        >>> Minv_reduced.to_field() / den_reduced == Minv.to_field() / den
+        True
+
+        Any factor common to _all_ elements will be cancelled but there can
+        still be factors in common between _some_ elements of the matrix and
+        the denominator. To cancel factors between each element and the
+        denominator, use :meth:`cancel_denom_elementwise` or otherwise convert
+        to a field and use division:
+
+        >>> M = DM([[4, 6]], ZZ)
+        >>> den = ZZ(12)
+        >>> M.cancel_denom(den)
+        (DomainMatrix([[2, 3]], (1, 2), ZZ), 6)
+        >>> numers, denoms = M.cancel_denom_elementwise(den)
+        >>> numers
+        DomainMatrix([[1, 1]], (1, 2), ZZ)
+        >>> denoms
+        DomainMatrix([[3, 2]], (1, 2), ZZ)
+        >>> M.to_field() / den
+        DomainMatrix([[1/3, 1/2]], (1, 2), QQ)
+
+        See Also
+        ========
+
+        solve_den
+        inv_den
+        rref_den
+        cancel_denom_elementwise
+        """
+        M = self
+        K = self.domain
+
+        if K.is_zero(denom):
+            raise ZeroDivisionError('denominator is zero')
+        elif K.is_one(denom):
+            return (M.copy(), denom)
+
+        elements, data = M.to_flat_nz()
+
+        # Often after e.g. solve_den the denominator will be much more
+        # complicated than the elements of the numerator. Hopefully it will be
+        # quicker to find the gcd of the numerator and if there is no content
+        # then we do not need to look at the denominator at all.
+        content = dup_content(elements, K)
+
+        if K.is_one(content):
+            return (M.copy(), denom)
+
+        common = K.gcd(content, denom)
+
+        if K.is_one(common):
+            return (M.copy(), denom)
+
+        elements_cancelled = dup_quo_ground(elements, common, K)
+        denom_cancelled = K.quo(denom, common)
+
+        M_cancelled = M.from_flat_nz(elements_cancelled, data, K)
+
+        return M_cancelled, denom_cancelled
+
+    def cancel_denom_elementwise(self, denom):
+        """
+        Cancel factors between the elements of a matrix and a denominator.
+
+        Returns a matrix of numerators and matrix of denominators.
+
+        Requires ``gcd`` in the ground domain.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import ZZ
+        >>> M = DM([[2, 3], [4, 12]], ZZ)
+        >>> denom = ZZ(6)
+        >>> numers, denoms = M.cancel_denom_elementwise(denom)
+        >>> numers.to_Matrix()
+        Matrix([
+        [1, 1],
+        [2, 2]])
+        >>> denoms.to_Matrix()
+        Matrix([
+        [3, 2],
+        [3, 1]])
+        >>> M_frac = (M.to_field() / denom).to_Matrix()
+        >>> M_frac
+        Matrix([
+        [1/3, 1/2],
+        [2/3,   2]])
+        >>> denoms_inverted = denoms.to_Matrix().applyfunc(lambda e: 1/e)
+        >>> numers.to_Matrix().multiply_elementwise(denoms_inverted) == M_frac
+        True
+
+        Use :meth:`cancel_denom` to cancel factors between the matrix and the
+        denominator while preserving the form of a matrix with a scalar
+        denominator.
+
+        See Also
+        ========
+
+        cancel_denom
+        """
+        K = self.domain
+        M = self
+
+        if K.is_zero(denom):
+            raise ZeroDivisionError('denominator is zero')
+        elif K.is_one(denom):
+            M_numers = M.copy()
+            M_denoms = M.ones(M.shape, M.domain)
+            return (M_numers, M_denoms)
+
+        elements, data = M.to_flat_nz()
+
+        cofactors = [K.cofactors(numer, denom) for numer in elements]
+        gcds, numers, denoms = zip(*cofactors)
+
+        M_numers = M.from_flat_nz(list(numers), data, K)
+        M_denoms = M.from_flat_nz(list(denoms), data, K)
+
+        return (M_numers, M_denoms)
 
     def rref(self):
         r"""

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -544,6 +544,15 @@ def test_DomainMatrix_cancel_denom_elementwise():
 
     raises(ZeroDivisionError, lambda: A.cancel_denom_elementwise(ZZ(0)))
 
+
+def test_DomainMatrix_content_primitive():
+    A = DM([[2, 4], [6, 8]], ZZ)
+    A_primitive = DM([[1, 2], [3, 4]], ZZ)
+    A_content = ZZ(2)
+    assert A.content() == A_content
+    assert A.primitive() == (A_content, A_primitive)
+
+
 def test_DomainMatrix_scc():
     Ad = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)],
                        [ZZ(0), ZZ(1), ZZ(0)],

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -521,6 +521,29 @@ def test_DomainMatrix_clear_denoms():
     assert A.clear_denoms(convert=True) == (den_Z, Anum_Z)
 
 
+def test_DomainMatrix_cancel_denom():
+    A = DM([[2, 4], [6, 8]], ZZ)
+    assert A.cancel_denom(ZZ(1)) == (DM([[2, 4], [6, 8]], ZZ), ZZ(1))
+    assert A.cancel_denom(ZZ(3)) == (DM([[2, 4], [6, 8]], ZZ), ZZ(3))
+    assert A.cancel_denom(ZZ(4)) == (DM([[1, 2], [3, 4]], ZZ), ZZ(2))
+
+    A = DM([[1, 2], [3, 4]], ZZ)
+    assert A.cancel_denom(ZZ(2)) == (A, ZZ(2))
+
+    raises(ZeroDivisionError, lambda: A.cancel_denom(ZZ(0)))
+
+
+def test_DomainMatrix_cancel_denom_elementwise():
+    A = DM([[2, 4], [6, 8]], ZZ)
+    numers, denoms = A.cancel_denom_elementwise(ZZ(1))
+    assert numers == DM([[2, 4], [6, 8]], ZZ)
+    assert denoms == DM([[1, 1], [1, 1]], ZZ)
+    numers, denoms = A.cancel_denom_elementwise(ZZ(4))
+    assert numers == DM([[1, 1], [3, 2]], ZZ)
+    assert denoms == DM([[2, 1], [2, 1]], ZZ)
+
+    raises(ZeroDivisionError, lambda: A.cancel_denom_elementwise(ZZ(0)))
+
 def test_DomainMatrix_scc():
     Ad = DomainMatrix([[ZZ(1), ZZ(2), ZZ(3)],
                        [ZZ(0), ZZ(1), ZZ(0)],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows gh-25346

#### Brief description of what is fixed or changed

Add two methods to DomainMatrix `cancel_denom` and `cancel_denom_elementwise`. These are useful for post-processing the results of `solve_den` and other fraction-free DomainMatrix functions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * DomainMatrix methods are added for extracting gcd and cancelling factors between a matrix and a denominator. These are useful for simplifying the output of fraction free solvers like `solve_den` as a step towards converting the output back to ordinary sympy expressions. A method `cancel_denom` is added to cancel common factors between a matrix and a scalar denominator. A method `cancel_denom_elementwise` is added for fully reducing all elements of a matrix over a denominator. Methods `content` and `primitive` are added to compute and factor out the gcd of a matrix.
<!-- END RELEASE NOTES -->