### PR TITLE
feat(matrices): use scc to speed up charpoly

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -491,7 +491,7 @@ def _is_diagonalizable(M, reals_only=False, **kwargs):
     See Also
     ========
 
-    is_diagonal
+    sympy.matrices.common.MatrixCommon.is_diagonal
     diagonalize
     """
     if not M.is_square:
@@ -677,7 +677,7 @@ def _diagonalize(M, reals_only=False, sort=False, normalize=False):
     See Also
     ========
 
-    is_diagonal
+    sympy.matrices.common.MatrixCommon.is_diagonal
     is_diagonalizable
     """
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -693,6 +693,20 @@ class DDM(list):
         zero = self.domain.zero
         return all(Mij == zero for i, Mi in enumerate(self) for Mij in Mi[i+1:])
 
+    def is_diagonal(self):
+        """
+        Says whether this matrix is diagonal. True can be returned even if
+        the matrix is not square.
+        """
+        return self.is_upper() and self.is_lower()
+
+    def diagonal(self):
+        """
+        Returns a list of the elements from the diagonal of the matrix.
+        """
+        m, n = self.shape
+        return [self[i][i] for i in range(min(m, n))]
+
     def lll(A, delta=QQ(3, 4)):
         return ddm_lll(A, delta=delta)
 

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -151,10 +151,10 @@ class SDM(dict):
 
         sdm1 = self
         sdm2 = {}
-        for i1 in rowset & set(sdm1):
+        for i1 in rowset & sdm1.keys():
             row1 = sdm1[i1]
             row2 = {}
-            for j1 in colset & set(row1):
+            for j1 in colset & row1.keys():
                 row1_j1 = row1[j1]
                 for j2 in colmap[j1]:
                     row2[j2] = row1_j1
@@ -1049,6 +1049,21 @@ class SDM(dict):
         even if the matrix is not square.
         """
         return all(i >= j for i, row in self.items() for j in row)
+
+    def is_diagonal(self):
+        """
+        Says whether this matrix is diagonal. True can be returned
+        even if the matrix is not square.
+        """
+        return all(i == j for i, row in self.items() for j in row)
+
+    def diagonal(self):
+        """
+        Returns the diagonal of the matrix as a list.
+        """
+        m, n = self.shape
+        zero = self.domain.zero
+        return [row.get(i, zero) for i, row in self.items() if i < n]
 
     def lll(A, delta=QQ(3, 4)):
         return A.from_ddm(ddm_lll(A.to_ddm(), delta=delta))

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -354,11 +354,27 @@ def test_DomainMatrix_is_lower():
     assert B.is_lower is False
 
 
+def test_DomainMatrix_is_diagonal():
+    A = DM([[1, 0], [0, 4]], ZZ)
+    B = DM([[1, 2], [3, 4]], ZZ)
+    assert A.is_diagonal is A.to_sparse().is_diagonal is True
+    assert B.is_diagonal is B.to_sparse().is_diagonal is False
+
+
 def test_DomainMatrix_is_square():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     B = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)], [ZZ(5), ZZ(6)]], (3, 2), ZZ)
     assert A.is_square is True
     assert B.is_square is False
+
+
+def test_DomainMatrix_diagonal():
+    A = DM([[1, 2], [3, 4]], ZZ)
+    assert A.diagonal() == A.to_sparse().diagonal() == [ZZ(1), ZZ(4)]
+    A = DM([[1, 2], [3, 4], [5, 6]], ZZ)
+    assert A.diagonal() == A.to_sparse().diagonal() == [ZZ(1), ZZ(4)]
+    A = DM([[1, 2, 3], [4, 5, 6]], ZZ)
+    assert A.diagonal() == A.to_sparse().diagonal() == [ZZ(1), ZZ(5)]
 
 
 def test_DomainMatrix_rank():
@@ -562,6 +578,9 @@ def test_DomainMatrix_scc():
     Asdm = As.rep
     for A in [Ad, As, Addm, Asdm]:
         assert Ad.scc() == [[1], [0, 2]]
+
+    A = DM([[ZZ(1), ZZ(2), ZZ(3)]], ZZ)
+    raises(DMNonSquareMatrixError, lambda: A.scc())
 
 
 def test_DomainMatrix_rref():
@@ -966,6 +985,27 @@ def test_DomainMatrix_charpoly():
 
     Ans = DomainMatrix([[QQ(1), QQ(2)]], (1, 2), QQ)
     raises(DMNonSquareMatrixError, lambda: Ans.charpoly())
+
+
+def test_DomainMatrix_charpoly_factor_list():
+    A = DomainMatrix([], (0, 0), ZZ)
+    assert A.charpoly_factor_list() == []
+
+    A = DM([[1]], ZZ)
+    assert A.charpoly_factor_list() == [
+        ([ZZ(1), ZZ(-1)], 1)
+    ]
+
+    A = DM([[1, 2], [3, 4]], ZZ)
+    assert A.charpoly_factor_list() == [
+        ([ZZ(1), ZZ(-5), ZZ(-2)], 1)
+    ]
+
+    A = DM([[1, 2, 0], [3, 4, 0], [0, 0, 1]], ZZ)
+    assert A.charpoly_factor_list() == [
+        ([ZZ(1), ZZ(-1)], 1),
+        ([ZZ(1), ZZ(-5), ZZ(-2)], 1)
+    ]
 
 
 def test_DomainMatrix_eye():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Use `scc` (strongly connected components) to decompose a matrix for faster calculation of `charpoly`. This decomposition naturally results in computing a factorisation of the characteristic polynomial but it s not a full factorisation. Two methods are added to `DomainMatrix`: `charpoly_factor_blocks` computes this efficient factorisation of the characteristic polynomial and `charpoly_factor_list` uses this to compute a full factorisation more efficiently than it could if using `charpoly`. Now `DomainMatrix.charpoly` calls `charpoly_factor_blocks` and multiplies the factors together to produce the expanded `charpoly`. The other methods are added because often a factorisation of the `charpoly` is wanted and so it is inefficient to expand the factors and then try to factorise them again afterwards. Here is an example where the factorisation is wanted:
https://github.com/sympy/sympy/blob/0ec134d277f14961e8b6629182895fc986658c2e/sympy/polys/matrices/eigen.py#L17-L21

The PR also adds `diagonal` and `is_diagonal` to `DomainMatrix` (At first I thought these would be useful for charpoly but actually with `scc` there is no need for `is_upper`, `diagonal` etc.) These methods can be useful for other things though so I kept them in.

Here is an example timing with a large sparse almost diagonal matrix:
```python
In [14]: M = eye(10000)

In [15]: M[1,2] = M[2,1] = 3

In [16]: M[:10,:10]
Out[16]: 
⎡1  0  0  0  0  0  0  0  0  0⎤
⎢                            ⎥
⎢0  1  3  0  0  0  0  0  0  0⎥
⎢                            ⎥
⎢0  3  1  0  0  0  0  0  0  0⎥
⎢                            ⎥
⎢0  0  0  1  0  0  0  0  0  0⎥
⎢                            ⎥
⎢0  0  0  0  1  0  0  0  0  0⎥
⎢                            ⎥
⎢0  0  0  0  0  1  0  0  0  0⎥
⎢                            ⎥
⎢0  0  0  0  0  0  1  0  0  0⎥
⎢                            ⎥
⎢0  0  0  0  0  0  0  1  0  0⎥
⎢                            ⎥
⎢0  0  0  0  0  0  0  0  1  0⎥
⎢                            ⎥
⎣0  0  0  0  0  0  0  0  0  1⎦

In [17]: M.shape
Out[17]: (10000, 10000)

In [18]: %time M.to_DM().charpoly_factor_list()
CPU times: user 501 ms, sys: 11.9 ms, total: 513 ms
Wall time: 514 ms
Out[18]: [([mpz(1), mpz(-4)], 1), ([mpz(1), mpz(2)], 1), ([mpz(1), mpz(-1)], 9998)]

In [19]: %time M.to_DM().charpoly_factor_blocks()
CPU times: user 369 ms, sys: 30 µs, total: 369 ms
Wall time: 368 ms
Out[19]: [([mpz(1), mpz(-1)], 9998), ([mpz(1), mpz(-2), mpz(-8)], 1)]
```
Here we obtain a full factorisation of the charpoly of a large matrix quickly. More realistic examples where this would typically help would usually be smaller but with more complicated expressions e.g. a 10x10 matrix that decomposes into several 2x2 and 3x3 matrices.

#### Other comments

The Berkowitz algorithm used to compute characteristic polynomials is inherently dense with its use of Toeplitz matrices. There might be an efficient way to implement it in a sparse setting but a better starting point is to use sparse methods (`scc`) to reduce the problem as much as possible.

The use of `scc` here could equally apply to other things such as `det`, `eigenvals`, `eigenvects`. Other cases can either use a weakly connected components decomposition or otherwise a more complicated strongly connected components implementation to implement things like `inv`, `solve` etc. What `scc` can do is reduce a large but structured sparse matrix problem to a number of much smaller problems. Not all problems can be reduced but when the method applies it brings a big gain.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * DomainMatrix methods `charpoly_factor_list` and `charpoly_factor_blocks` are add in addition to the existing `charpoly` method. These are used to compute factorisation of the characteristic polynomial more efficiently if the matrix can be permuted into block triangular form. Also the DomainMatrix `charpoly` method was made faster in the case of such matrices.
<!-- END RELEASE NOTES -->
