### PR TITLE
Do not generate png output by default in init_printing()

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -267,7 +267,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             Printable._repr_svg_ = Printable._repr_disabled
 
         png_formatter = ip.display_formatter.formatters['image/png']
-        if use_latex in (True, 'png'):
+        if use_latex == 'png':
             debug("init_printing: using png formatter")
             for cls in printable_types:
                 png_formatter.for_type(cls, _print_latex_png)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -366,6 +366,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             cmd.extend(commandend[cmd_variant])
 
             try:
+                debug("preview(): executing command %r" % cmd)
                 _check_output_no_window(cmd, cwd=workdir, stderr=STDOUT)
             except CalledProcessError as e:
                 raise RuntimeError(


### PR DESCRIPTION
PNG output gets saved in notebooks, which makes their size much bigger, but it
isn't ever actually used because the MathJax LaTeX output is preferred.

I thought this might affect the qtconsole, which uses png output, but it
doesn't seem to. init_printing() wiht no arguments still enables png output
there. So the impact of this change should be minimal.

Fixes #24983<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- interactive
  - `init_printing()` no longer generates png output by default (this would be saved in notebook files but never shown). png output can still be enabled using `init_printing(use_latex='png')`.
<!-- END RELEASE NOTES -->
