### PR TITLE
Refactored LaTeX parser tests

### DIFF
--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -22,6 +22,8 @@ from sympy.series.limits import Limit
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.abc import x, y, z, a, b, c, t, k, n
+
+from sympy.parsing.latex import parse_latex, LaTeXParsingError
 antlr4 = import_module("antlr4")
 
 # disable tests if antlr4-python3-runtime is not present
@@ -326,10 +328,73 @@ MISCELLANEOUS_EXPRESSION_PAIRS = [
     (r"[a + b]", _Add(a, b)),
 ]
 
+def test_symbol_expressions():
+    for latex_str, sympy_expr in SYMBOL_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
 
-def test_parseable():
+def test_simple_expressions():
+    for latex_str, sympy_expr in SIMPLE_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_fraction_expressions():
     from sympy.parsing.latex import parse_latex
-    for latex_str, sympy_expr in GOOD_PAIRS:
+    for latex_str, sympy_expr in FRACTION_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_relation_expressions():
+    for latex_str, sympy_expr in RELATION_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_integral_expressions():
+    for latex_str, sympy_expr in INTEGRAL_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_derivative_expressions():
+    for latex_str, sympy_expr in DERIVATIVE_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_trigonometric_expressions():
+    for latex_str, sympy_expr in TRIGONOMETRIC_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_limit_expressions():
+    for latex_str, sympy_expr in LIMIT_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_square_root_expressions():
+    for latex_str, sympy_expr in SQRT_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_factorial_expressions():
+    for latex_str, sympy_expr in FACTORIAL_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_sum_expressions():
+    for latex_str, sympy_expr in SUM_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_product_expressions():
+    for latex_str, sympy_expr in PRODUCT_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_applied_function_expressions():
+    for latex_str, sympy_expr in APPLIED_FUNCTION_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_common_function_expressions():
+    for latex_str, sympy_expr in COMMON_FUNCTION_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_spacing():
+    for latex_str, sympy_expr in SPACING_RELATED_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_binomial_expressions():
+    for latex_str, sympy_expr in BINOMIAL_EXPRESSION_PAIRS:
+        assert parse_latex(latex_str) == sympy_expr, latex_str
+
+def test_miscellaneous_expressions():
+    for latex_str, sympy_expr in MISCELLANEOUS_EXPRESSION_PAIRS:
         assert parse_latex(latex_str) == sympy_expr, latex_str
 
 # These bad LaTeX strings should raise a LaTeXParsingError when parsed
@@ -375,7 +440,6 @@ BAD_STRINGS = [
 ]
 
 def test_not_parseable():
-    from sympy.parsing.latex import parse_latex, LaTeXParsingError
     for latex_str in BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str)
@@ -396,14 +460,12 @@ FAILING_BAD_STRINGS = [
 
 @XFAIL
 def test_failing_not_parseable():
-    from sympy.parsing.latex import parse_latex, LaTeXParsingError
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str)
 
 # In strict mode, FAILING_BAD_STRINGS would fail
 def test_strict_mode():
-    from sympy.parsing.latex import parse_latex, LaTeXParsingError
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str, strict=True)

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -97,7 +97,7 @@ SYMBOL_EXPRESSION_PAIRS = [
     (r"\mathit{x}", Symbol('x')),
     (r"\mathit{test}", Symbol('test')),
     (r"\mathit{TEST}", Symbol('TEST')),
-    (r"\mathit{HELLO world}", Symbol('HELLO world')),
+    (r"\mathit{HELLO world}", Symbol('HELLO world'))
 ]
 
 SIMPLE_EXPRESSION_PAIRS = [
@@ -121,7 +121,7 @@ SIMPLE_EXPRESSION_PAIRS = [
     (r"a + b", a + b),
     (r"a + b - a", _Add(a + b, -a)),
     (r"(x + y) z", _Mul(_Add(x, y), z)),
-    (r"a'b+ab'", _Add(_Mul(Symbol("a'"), b), _Mul(a, Symbol("b'")))),
+    (r"a'b+ab'", _Add(_Mul(Symbol("a'"), b), _Mul(a, Symbol("b'"))))
 ]
 
 FRACTION_EXPRESSION_PAIRS = [
@@ -132,9 +132,8 @@ FRACTION_EXPRESSION_PAIRS = [
     (r"\frac12y", _Mul(_Pow(2, -1), y)),
     (r"\frac1234", _Mul(_Pow(2, -1), 34)),
     (r"\frac2{3}", _Mul(2, _Pow(3, -1))),
-    (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1))), # TODO: Check later.
     (r"\frac{a + b}{c}", _Mul(a + b, _Pow(c, -1))),
-    (r"\frac{7}{3}", _Mul(7, _Pow(3, -1))),
+    (r"\frac{7}{3}", _Mul(7, _Pow(3, -1)))
 ]
 
 RELATION_EXPRESSION_PAIRS = [
@@ -151,7 +150,7 @@ RELATION_EXPRESSION_PAIRS = [
     (r"x > y", StrictGreaterThan(x, y)),
     (r"x \geq y", GreaterThan(x, y)),
     (r"x \neq y", Unequality(x, y)), # same as 2nd one in the list
-    (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2)),
+    (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2))
 ]
 
 POWER_EXPRESSION_PAIRS = [
@@ -159,7 +158,7 @@ POWER_EXPRESSION_PAIRS = [
     (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
     (r"x^{3 + 1}", x ** _Add(3, 1)),
     (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
-    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
 ]
 
 INTEGRAL_EXPRESSION_PAIRS = [
@@ -205,7 +204,8 @@ TRIGONOMETRIC_EXPRESSION_PAIRS = [
     (r"\sin a \cos b", _Mul(sin(a), cos(b))),
     (r"\sin \cos \theta", sin(cos(theta))),
     (r"\sin(\cos \theta)", sin(cos(theta))),
-    (r"(\csc x)(\sec y)", csc(x) * sec(y))
+    (r"(\csc x)(\sec y)", csc(x) * sec(y)),
+    (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1)))
 ]
 
 LIMIT_EXPRESSION_PAIRS = [
@@ -218,7 +218,7 @@ LIMIT_EXPRESSION_PAIRS = [
     (r"\lim_{x \to 3^{-}} a", Limit(a, x, 3, dir='-')),
     (r"\lim_{x \to 3^+} a", Limit(a, x, 3, dir='+')),
     (r"\lim_{x \to 3^-} a", Limit(a, x, 3, dir='-')),
-    (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Pow(x, -1), x, oo)),
+    (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Pow(x, -1), x, oo))
 ]
 
 SQRT_EXPRESSION_PAIRS = [
@@ -227,7 +227,7 @@ SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
     (r"\sqrt[y]{\sin x}", root(sin(x), y)),
     (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
-    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1)))),
+    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
 ]
 
 FACTORIAL_EXPRESSION_PAIRS = [
@@ -237,7 +237,7 @@ FACTORIAL_EXPRESSION_PAIRS = [
     (r"(x + 1)!", _factorial(_Add(x, 1))),
     (r"(x!)!", _factorial(_factorial(x))),
     (r"x!!!", _factorial(_factorial(_factorial(x)))),
-    (r"5!7!", _Mul(_factorial(5), _factorial(7))),
+    (r"5!7!", _Mul(_factorial(5), _factorial(7)))
 ]
 
 SUM_EXPRESSION_PAIRS = [
@@ -247,14 +247,14 @@ SUM_EXPRESSION_PAIRS = [
     (r"\sum^3_{k = 1} c", Sum(c, (k, 1, 3))),
     (r"\sum_{k = 1}^{10} k^2", Sum(k ** 2, (k, 1, 10))),
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}",
-     Sum(_Pow(_factorial(n), -1), (n, 0, oo))),
+     Sum(_Pow(_factorial(n), -1), (n, 0, oo)))
 ]
 
 PRODUCT_EXPRESSION_PAIRS = [
     (r"\prod_{a = b}^{c} x", Product(x, (a, b, c))),
     (r"\prod_{a = b}^c x", Product(x, (a, b, c))),
     (r"\prod^{c}_{a = b} x", Product(x, (a, b, c))),
-    (r"\prod^c_{a = b} x", Product(x, (a, b, c))),
+    (r"\prod^c_{a = b} x", Product(x, (a, b, c)))
 ]
 
 APPLIED_FUNCTION_EXPRESSION_PAIRS = [
@@ -268,7 +268,7 @@ APPLIED_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{z}", _Conjugate(z)),
     (r"\overline{\overline{z}}", _Conjugate(_Conjugate(z))),
     (r"\overline{x + y}", _Conjugate(_Add(x, y))),
-    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
+    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y))
 ]
 
 COMMON_FUNCTION_EXPRESSION_PAIRS = [
@@ -290,7 +290,7 @@ COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\log_{11} x", _log(x, 11)),
     (r"\log_{a^2} x", _log(x, _Pow(a, 2))),
     (r"\log_2 x", _log(x, 2)),
-    (r"\log_a x", _log(x, a)),
+    (r"\log_a x", _log(x, a))
 ]
 
 SPACING_RELATED_EXPRESSION_PAIRS = [
@@ -305,7 +305,7 @@ SPACING_RELATED_EXPRESSION_PAIRS = [
     (r"a \! b", _Mul(a, b)),
     (r"a \negthinspace b", _Mul(a, b)),
     (r"a \negmedspace b", _Mul(a, b)),
-    (r"a \negthickspace b", _Mul(a, b)),
+    (r"a \negthickspace b", _Mul(a, b))
 ]
 
 BINOMIAL_EXPRESSION_PAIRS = [
@@ -313,7 +313,7 @@ BINOMIAL_EXPRESSION_PAIRS = [
     (r"\tbinom{n}{k}", _binomial(n, k)),
     (r"\dbinom{n}{k}", _binomial(n, k)),
     (r"\binom{n}{0}", _binomial(n, 0)),
-    (r"x^\binom{n}{k}", _Pow(x, _binomial(n, k))),
+    (r"x^\binom{n}{k}", _Pow(x, _binomial(n, k)))
 ]
 
 MISCELLANEOUS_EXPRESSION_PAIRS = [
@@ -325,7 +325,7 @@ MISCELLANEOUS_EXPRESSION_PAIRS = [
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
     (r"[x]", x),
-    (r"[a + b]", _Add(a, b)),
+    (r"[a + b]", _Add(a, b))
 ]
 
 def test_symbol_expressions():
@@ -337,7 +337,6 @@ def test_simple_expressions():
         assert parse_latex(latex_str) == sympy_expr, latex_str
 
 def test_fraction_expressions():
-    from sympy.parsing.latex import parse_latex
     for latex_str, sympy_expr in FRACTION_EXPRESSION_PAIRS:
         assert parse_latex(latex_str) == sympy_expr, latex_str
 

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -25,8 +25,7 @@ from sympy.abc import x, y, z, a, b, c, t, k, n
 antlr4 = import_module("antlr4")
 
 # disable tests if antlr4-python3-runtime is not present
-if not antlr4:
-    disabled = True
+disabled = antlr4 is None
 
 theta = Symbol('theta')
 f = Function('f')
@@ -84,37 +83,59 @@ def test_import():
 
 
 # These LaTeX strings should parse to the corresponding SymPy expression
-GOOD_PAIRS = [
+SYMBOL_EXPRESSION_PAIRS = [
+    (r"x_0", Symbol('x_{0}')),
+    (r"x_{1}", Symbol('x_{1}')),
+    (r"x_a", Symbol('x_{a}')),
+    (r"x_{b}", Symbol('x_{b}')),
+    (r"h_\theta", Symbol('h_{theta}')),
+    (r"h_{\theta}", Symbol('h_{theta}')),
+    (r"y''_1", Symbol("y_{1}''")),
+    (r"y_1''", Symbol("y_{1}''")),
+    (r"\mathit{x}", Symbol('x')),
+    (r"\mathit{test}", Symbol('test')),
+    (r"\mathit{TEST}", Symbol('TEST')),
+    (r"\mathit{HELLO world}", Symbol('HELLO world')),
+]
+
+SIMPLE_EXPRESSION_PAIRS = [
     (r"0", 0),
     (r"1", 1),
     (r"-3.14", -3.14),
     (r"(-7.13)(1.5)", _Mul(-7.13, 1.5)),
-    (r"x", x),
-    (r"2x", 2*x),
-    (r"x^2", x**2),
-    (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
-    (r"x^{3 + 1}", x**_Add(3, 1)),
-    (r"-c", -c),
-    (r"a \cdot b", a * b),
-    (r"a / b", a / b),
-    (r"a \div b", a / b),
-    (r"a + b", a + b),
-    (r"a + b - a", _Add(a+b, -a)),
-    (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2)),
-    (r"(x + y) z", _Mul(_Add(x, y), z)),
-    (r"a'b+ab'", _Add(_Mul(Symbol("a'"), b), _Mul(a, Symbol("b'")))),
-    (r"y''_1", Symbol("y_{1}''")),
-    (r"y_1''", Symbol("y_{1}''")),
-    (r"\left(x + y\right) z", _Mul(_Add(x, y), z)),
-    (r"\left( x + y\right ) z", _Mul(_Add(x, y), z)),
-    (r"\left(  x + y\right ) z", _Mul(_Add(x, y), z)),
-    (r"\left[x + y\right] z", _Mul(_Add(x, y), z)),
-    (r"\left\{x + y\right\} z", _Mul(_Add(x, y), z)),
     (r"1+1", _Add(1, 1)),
     (r"0+1", _Add(0, 1)),
     (r"1*2", _Mul(1, 2)),
     (r"0*1", _Mul(0, 1)),
+    (r"x", x),
+    (r"2x", 2 * x),
+    (r"3x - 1", _Add(_Mul(3, x), -1)),
+    (r"-c", -c),
+    (r"\infty", oo),
+    (r"a \cdot b", a * b),
     (r"1 \times 2 ", _Mul(1, 2)),
+    (r"a / b", a / b),
+    (r"a \div b", a / b),
+    (r"a + b", a + b),
+    (r"a + b - a", _Add(a + b, -a)),
+    (r"(x + y) z", _Mul(_Add(x, y), z)),
+    (r"a'b+ab'", _Add(_Mul(Symbol("a'"), b), _Mul(a, Symbol("b'")))),
+]
+
+FRACTION_EXPRESSION_PAIRS = [
+    (r"\frac{a}{b}", a / b),
+    (r"\dfrac{a}{b}", a / b),
+    (r"\tfrac{a}{b}", a / b),
+    (r"\frac12", _Pow(2, -1)),
+    (r"\frac12y", _Mul(_Pow(2, -1), y)),
+    (r"\frac1234", _Mul(_Pow(2, -1), 34)),
+    (r"\frac2{3}", _Mul(2, _Pow(3, -1))),
+    (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1))), # TODO: Check later.
+    (r"\frac{a + b}{c}", _Mul(a + b, _Pow(c, -1))),
+    (r"\frac{7}{3}", _Mul(7, _Pow(3, -1))),
+]
+
+RELATION_EXPRESSION_PAIRS = [
     (r"x = y", Eq(x, y)),
     (r"x \neq y", Ne(x, y)),
     (r"x < y", Lt(x, y)),
@@ -123,56 +144,27 @@ GOOD_PAIRS = [
     (r"x \geq y", Ge(x, y)),
     (r"x \le y", Le(x, y)),
     (r"x \ge y", Ge(x, y)),
-    (r"\lfloor x \rfloor", floor(x)),
-    (r"\lceil x \rceil", ceiling(x)),
-    (r"\langle x |", Bra('x')),
-    (r"| x \rangle", Ket('x')),
-    (r"\sin \theta", sin(theta)),
-    (r"\sin(\theta)", sin(theta)),
-    (r"\sin^{-1} a", asin(a)),
-    (r"\sin a \cos b", _Mul(sin(a), cos(b))),
-    (r"\sin \cos \theta", sin(cos(theta))),
-    (r"\sin(\cos \theta)", sin(cos(theta))),
-    (r"\frac{a}{b}", a / b),
-    (r"\dfrac{a}{b}", a / b),
-    (r"\tfrac{a}{b}", a / b),
-    (r"\frac12", _Pow(2, -1)),
-    (r"\frac12y", _Mul(_Pow(2, -1), y)),
-    (r"\frac1234", _Mul(_Pow(2, -1), 34)),
-    (r"\frac2{3}", _Mul(2, _Pow(3, -1))),
-    (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1))),
-    (r"\frac{a + b}{c}", _Mul(a + b, _Pow(c, -1))),
-    (r"\frac{7}{3}", _Mul(7, _Pow(3, -1))),
-    (r"(\csc x)(\sec y)", csc(x)*sec(y)),
-    (r"\lim_{x \to 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \rightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \Rightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \Longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \to 3^{+}} a", Limit(a, x, 3, dir='+')),
-    (r"\lim_{x \to 3^{-}} a", Limit(a, x, 3, dir='-')),
-    (r"\lim_{x \to 3^+} a", Limit(a, x, 3, dir='+')),
-    (r"\lim_{x \to 3^-} a", Limit(a, x, 3, dir='-')),
-    (r"\infty", oo),
-    (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Pow(x, -1), x, oo)),
-    (r"\frac{d}{dx} x", Derivative(x, x)),
-    (r"\frac{d}{dt} x", Derivative(x, t)),
-    (r"f(x)", f(x)),
-    (r"f(x, y)", f(x, y)),
-    (r"f(x, y, z)", f(x, y, z)),
-    (r"f'_1(x)", Function("f_{1}'")(x)),
-    (r"f_{1}''(x+y)", Function("f_{1}''")(x+y)),
-    (r"\frac{d f(x)}{dx}", Derivative(f(x), x)),
-    (r"\frac{d\theta(x)}{dx}", Derivative(Function('theta')(x), x)),
-    (r"x \neq y", Unequality(x, y)),
-    (r"|x|", _Abs(x)),
-    (r"||x||", _Abs(Abs(x))),
-    (r"|x||y|", _Abs(x)*_Abs(y)),
-    (r"||x||y||", _Abs(_Abs(x)*_Abs(y))),
-    (r"\pi^{|xy|}", Symbol('pi')**_Abs(x*y)),
+    (r"x < y", StrictLessThan(x, y)),
+    (r"x \leq y", LessThan(x, y)),
+    (r"x > y", StrictGreaterThan(x, y)),
+    (r"x \geq y", GreaterThan(x, y)),
+    (r"x \neq y", Unequality(x, y)), # same as 2nd one in the list
+    (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2)),
+]
+
+POWER_EXPRESSION_PAIRS = [
+    (r"x^2", x ** 2),
+    (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
+    (r"x^{3 + 1}", x ** _Add(3, 1)),
+    (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
+]
+
+INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int x dx", Integral(x, x)),
+    (r"\int x \, dx", Integral(x, x)),
     (r"\int x d\theta", Integral(x, theta)),
-    (r"\int (x^2 - y)dx", Integral(x**2 - y, x)),
+    (r"\int (x^2 - y)dx", Integral(x ** 2 - y, x)),
     (r"\int x + a dx", Integral(_Add(x, a), x)),
     (r"\int da", Integral(1, a)),
     (r"\int_0^7 dx", Integral(1, (x, 0, 7))),
@@ -187,21 +179,56 @@ GOOD_PAIRS = [
     (r"\int (x+a)", Integral(_Add(x, a), x)),
     (r"\int a + b + c dx", Integral(_Add(_Add(a, b), c), x)),
     (r"\int \frac{dz}{z}", Integral(Pow(z, -1), z)),
-    (r"\int \frac{3 dz}{z}", Integral(3*Pow(z, -1), z)),
+    (r"\int \frac{3 dz}{z}", Integral(3 * Pow(z, -1), z)),
     (r"\int \frac{1}{x} dx", Integral(Pow(x, -1), x)),
     (r"\int \frac{1}{a} + \frac{1}{b} dx",
      Integral(_Add(_Pow(a, -1), Pow(b, -1)), x)),
     (r"\int \frac{3 \cdot d\theta}{\theta}",
-     Integral(3*_Pow(theta, -1), theta)),
-    (r"\int \frac{1}{x} + 1 dx", Integral(_Add(_Pow(x, -1), 1), x)),
-    (r"x_0", Symbol('x_{0}')),
-    (r"x_{1}", Symbol('x_{1}')),
-    (r"x_a", Symbol('x_{a}')),
-    (r"x_{b}", Symbol('x_{b}')),
-    (r"h_\theta", Symbol('h_{theta}')),
-    (r"h_{\theta}", Symbol('h_{theta}')),
-    (r"h_{\theta}(x_0, x_1)",
-     Function('h_{theta}')(Symbol('x_{0}'), Symbol('x_{1}'))),
+     Integral(3 * _Pow(theta, -1), theta)),
+    (r"\int \frac{1}{x} + 1 dx", Integral(_Add(_Pow(x, -1), 1), x))
+]
+
+DERIVATIVE_EXPRESSION_PAIRS = [
+    (r"\frac{d}{dx} x", Derivative(x, x)),
+    (r"\frac{d}{dt} x", Derivative(x, t)),
+    (r"\frac{d}{dx} [ \tan x ]", Derivative(tan(x), x)),
+    (r"\frac{d f(x)}{dx}", Derivative(f(x), x)),
+    (r"\frac{d\theta(x)}{dx}", Derivative(Function('theta')(x), x))
+]
+
+TRIGONOMETRIC_EXPRESSION_PAIRS = [
+    (r"\sin \theta", sin(theta)),
+    (r"\sin(\theta)", sin(theta)),
+    (r"\sin^{-1} a", asin(a)),
+    (r"\sin a \cos b", _Mul(sin(a), cos(b))),
+    (r"\sin \cos \theta", sin(cos(theta))),
+    (r"\sin(\cos \theta)", sin(cos(theta))),
+    (r"(\csc x)(\sec y)", csc(x) * sec(y))
+]
+
+LIMIT_EXPRESSION_PAIRS = [
+    (r"\lim_{x \to 3} a", Limit(a, x, 3, dir='+-')),
+    (r"\lim_{x \rightarrow 3} a", Limit(a, x, 3, dir='+-')),
+    (r"\lim_{x \Rightarrow 3} a", Limit(a, x, 3, dir='+-')),
+    (r"\lim_{x \longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
+    (r"\lim_{x \Longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
+    (r"\lim_{x \to 3^{+}} a", Limit(a, x, 3, dir='+')),
+    (r"\lim_{x \to 3^{-}} a", Limit(a, x, 3, dir='-')),
+    (r"\lim_{x \to 3^+} a", Limit(a, x, 3, dir='+')),
+    (r"\lim_{x \to 3^-} a", Limit(a, x, 3, dir='-')),
+    (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Pow(x, -1), x, oo)),
+]
+
+SQRT_EXPRESSION_PAIRS = [
+    (r"\sqrt{x}", sqrt(x)),
+    (r"\sqrt{x + b}", sqrt(_Add(x, b))),
+    (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
+    (r"\sqrt[y]{\sin x}", root(sin(x), y)),
+    (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
+    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1)))),
+]
+
+FACTORIAL_EXPRESSION_PAIRS = [
     (r"x!", _factorial(x)),
     (r"100!", _factorial(100)),
     (r"\theta!", _factorial(theta)),
@@ -209,54 +236,62 @@ GOOD_PAIRS = [
     (r"(x!)!", _factorial(_factorial(x))),
     (r"x!!!", _factorial(_factorial(_factorial(x)))),
     (r"5!7!", _Mul(_factorial(5), _factorial(7))),
-    (r"\sqrt{x}", sqrt(x)),
-    (r"\sqrt{x + b}", sqrt(_Add(x, b))),
-    (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
-    (r"\sqrt[y]{\sin x}", root(sin(x), y)),
-    (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
-    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1)))),
-    (r"\overline{z}", _Conjugate(z)),
-    (r"\overline{\overline{z}}", _Conjugate(_Conjugate(z))),
-    (r"\overline{x + y}", _Conjugate(_Add(x, y))),
-    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
-    (r"x < y", StrictLessThan(x, y)),
-    (r"x \leq y", LessThan(x, y)),
-    (r"x > y", StrictGreaterThan(x, y)),
-    (r"x \geq y", GreaterThan(x, y)),
-    (r"\mathit{x}", Symbol('x')),
-    (r"\mathit{test}", Symbol('test')),
-    (r"\mathit{TEST}", Symbol('TEST')),
-    (r"\mathit{HELLO world}", Symbol('HELLO world')),
+]
+
+SUM_EXPRESSION_PAIRS = [
     (r"\sum_{k = 1}^{3} c", Sum(c, (k, 1, 3))),
     (r"\sum_{k = 1}^3 c", Sum(c, (k, 1, 3))),
     (r"\sum^{3}_{k = 1} c", Sum(c, (k, 1, 3))),
     (r"\sum^3_{k = 1} c", Sum(c, (k, 1, 3))),
-    (r"\sum_{k = 1}^{10} k^2", Sum(k**2, (k, 1, 10))),
+    (r"\sum_{k = 1}^{10} k^2", Sum(k ** 2, (k, 1, 10))),
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}",
      Sum(_Pow(_factorial(n), -1), (n, 0, oo))),
+]
+
+PRODUCT_EXPRESSION_PAIRS = [
     (r"\prod_{a = b}^{c} x", Product(x, (a, b, c))),
     (r"\prod_{a = b}^c x", Product(x, (a, b, c))),
     (r"\prod^{c}_{a = b} x", Product(x, (a, b, c))),
     (r"\prod^c_{a = b} x", Product(x, (a, b, c))),
+]
+
+APPLIED_FUNCTION_EXPRESSION_PAIRS = [
+    (r"f(x)", f(x)),
+    (r"f(x, y)", f(x, y)),
+    (r"f(x, y, z)", f(x, y, z)),
+    (r"f'_1(x)", Function("f_{1}'")(x)),
+    (r"f_{1}''(x+y)", Function("f_{1}''")(x + y)),
+    (r"h_{\theta}(x_0, x_1)",
+     Function('h_{theta}')(Symbol('x_{0}'), Symbol('x_{1}'))),
+    (r"\overline{z}", _Conjugate(z)),
+    (r"\overline{\overline{z}}", _Conjugate(_Conjugate(z))),
+    (r"\overline{x + y}", _Conjugate(_Add(x, y))),
+    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
+]
+
+COMMON_FUNCTION_EXPRESSION_PAIRS = [
+    (r"|x|", _Abs(x)),
+    (r"||x||", _Abs(Abs(x))),
+    (r"|x||y|", _Abs(x) * _Abs(y)),
+    (r"||x||y||", _Abs(_Abs(x) * _Abs(y))),
+    (r"\lfloor x \rfloor", floor(x)),
+    (r"\lceil x \rceil", ceiling(x)),
     (r"\exp x", _exp(x)),
     (r"\exp(x)", _exp(x)),
     (r"\lg x", _log(x, 10)),
     (r"\ln x", _log(x, E)),
-    (r"\ln xy", _log(x*y, E)),
+    (r"\ln xy", _log(x * y, E)),
     (r"\log x", _log(x, E)),
-    (r"\log xy", _log(x*y, E)),
+    (r"\log xy", _log(x * y, E)),
     (r"\log_{2} x", _log(x, 2)),
     (r"\log_{a} x", _log(x, a)),
     (r"\log_{11} x", _log(x, 11)),
     (r"\log_{a^2} x", _log(x, _Pow(a, 2))),
-    (r"[x]", x),
-    (r"[a + b]", _Add(a, b)),
-    (r"\frac{d}{dx} [ \tan x ]", Derivative(tan(x), x)),
-    (r"\binom{n}{k}", _binomial(n, k)),
-    (r"\tbinom{n}{k}", _binomial(n, k)),
-    (r"\dbinom{n}{k}", _binomial(n, k)),
-    (r"\binom{n}{0}", _binomial(n, 0)),
-    (r"x^\binom{n}{k}", _Pow(x, _binomial(n, k))),
+    (r"\log_2 x", _log(x, 2)),
+    (r"\log_a x", _log(x, a)),
+]
+
+SPACING_RELATED_EXPRESSION_PAIRS = [
     (r"a \, b", _Mul(a, b)),
     (r"a \thinspace b", _Mul(a, b)),
     (r"a \: b", _Mul(a, b)),
@@ -269,11 +304,26 @@ GOOD_PAIRS = [
     (r"a \negthinspace b", _Mul(a, b)),
     (r"a \negmedspace b", _Mul(a, b)),
     (r"a \negthickspace b", _Mul(a, b)),
-    (r"\int x \, dx", Integral(x, x)),
-    (r"\log_2 x", _log(x, 2)),
-    (r"\log_a x", _log(x, a)),
-    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
-    (r"3x - 1", _Add(_Mul(3, x), -1))
+]
+
+BINOMIAL_EXPRESSION_PAIRS = [
+    (r"\binom{n}{k}", _binomial(n, k)),
+    (r"\tbinom{n}{k}", _binomial(n, k)),
+    (r"\dbinom{n}{k}", _binomial(n, k)),
+    (r"\binom{n}{0}", _binomial(n, 0)),
+    (r"x^\binom{n}{k}", _Pow(x, _binomial(n, k))),
+]
+
+MISCELLANEOUS_EXPRESSION_PAIRS = [
+    (r"\left(x + y\right) z", _Mul(_Add(x, y), z)),
+    (r"\left( x + y\right ) z", _Mul(_Add(x, y), z)),
+    (r"\left(  x + y\right ) z", _Mul(_Add(x, y), z)),
+    (r"\left[x + y\right] z", _Mul(_Add(x, y), z)),
+    (r"\left\{x + y\right\} z", _Mul(_Add(x, y), z)),
+    (r"\langle x |", Bra('x')),
+    (r"| x \rangle", Ket('x')),
+    (r"[x]", x),
+    (r"[a + b]", _Add(a, b)),
 ]
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This PR addresses the first part of #25366 and completes the first task mentioned in the issue.

#### Brief description of what is fixed or changed

I broke down the monolithic list of `GOOD_PAIRS` into separate categories and wrote tests for each category, so that we get more helpful error messages if something goes wrong (for example, it'll now report, say, "`test_fraction` failed", instead of just the generic "`test_latex` failed").

Another side benefit of this is that we can more easily see similar tests. (I found a duplicated test, but the expected SymPy string for each test is different.)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
