### PR TITLE
Dimension Cancelling Fix

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -275,6 +275,7 @@ class Mul(Expr, AssocOp):
 
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.matrices.expressions import MatrixExpr
+        from sympy.physics.units import Dimension
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -369,6 +370,10 @@ class Mul(Expr, AssocOp):
                 continue
 
             elif isinstance(o, AccumBounds):
+                coeff = o.__mul__(coeff)
+                continue
+
+            elif isinstance(o, Dimension):
                 coeff = o.__mul__(coeff)
                 continue
 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -127,6 +127,14 @@ def test_Dimension_mul_div_exp():
     c_dim = c.subs({a: length, b: length})
     assert dimsys_SI.equivalent_dims(c_dim, length)
 
+    mul_sub = 3*a
+    mul_sub_dim = mul_sub.subs({a: length})
+    assert mul_sub_dim == length
+
+    no_cancel = a - b
+    no_cancel_dim = no_cancel.subs({a: length, b: length})
+    assert  no_cancel_dim == length
+
 def test_Dimension_functions():
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(cos(length)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(acos(angle)))


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Dimension expressions with substitutions could result in unintentional cancelling when negative multiplication was present. In the following example, dimensions of `length - length` should be `length`. It works without substitution but the units cancel when there is substitution since the multiplication remains unevaluated. This proposed change allows the multiplication to be evaluated using the Dimension `__mul__` operator in the same way other entities are handled during substitution.

Old behavior:
``` python
>>> import sympy as sp
>>> from sympy.physics.units.definitions.dimension_definitions import length
>>> length-length
Dimension(length, L)
>>> a,b = sp.symbols('a,b')
>>> (a - b).subs({a: length, b: length})
0
```

New behavior:
``` python
>>> import sympy as sp
>>> from sympy.physics.units.definitions.dimension_definitions import length
>>> length-length
Dimension(length, L)
>>> a,b = sp.symbols('a,b')
>>> (a - b).subs({a: length, b: length})
Dimension(length, L)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.units
  * Fix incorrect cancellation of dimensions when performing substitutions with negative coefficients

<!-- END RELEASE NOTES -->
