### PR TITLE
Add Determinant Hint for doit method

### DIFF
--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -41,9 +41,12 @@ class Determinant(Expr):
         return self.arg.kind.element_kind
 
     def doit(self, expand=False, **hints):
-        try:
-            return self.arg._eval_determinant()
-        except (AttributeError, NotImplementedError):
+        if hints.get('determinant', True):
+            try:
+                return self.arg._eval_determinant()
+            except (AttributeError, NotImplementedError):
+                return self
+        else:
             return self
 
 def det(matexpr):

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -41,13 +41,14 @@ class Determinant(Expr):
         return self.arg.kind.element_kind
 
     def doit(self, expand=False, **hints):
-        if hints.get('determinant', True):
-            try:
-                return self.arg._eval_determinant()
-            except (AttributeError, NotImplementedError):
-                return self
-        else:
+        if hints.get('determinant', True) is False:
             return self
+
+        try:
+            return self.arg._eval_determinant()
+        except (AttributeError, NotImplementedError):
+            return self
+
 
 def det(matexpr):
     """ Matrix Determinant

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -28,6 +28,8 @@ def test_det():
 
     assert Determinant(A).arg is A
 
+    assert isinstance(Determinant(eye(2)).doit(determinant=False), Determinant)
+
 def test_eval_determinant():
     assert det(Identity(n)) == 1
     assert det(ZeroMatrix(n, n)) == 0


### PR DESCRIPTION
#### Brief description of what is fixed or changed
The evaluation of determinants can be expensive when performed on symbolic matrices of even modest size. Because of this, it is desirable to be able to delay the evaluation of determinants in some cases by passing a hint to the `doit` method similar to the `inv_expand` hint for matrix inverse. This change adds the `determinant` hint to achieve this goal.

Old Behavior:
```python
>>> import sympy as sp
>>> a,b,c,d = sp.symbols('a,b,c,d')
>>> sp.Determinant(sp.Matrix([[a,b],[c,d]])).doit(determinant=False)
a*d - b*c
```

New Behavior:
```python
>>> import sympy as sp
>>> a,b,c,d = sp.symbols('a,b,c,d')
>>> sp.Determinant(sp.Matrix([[a,b],[c,d]])).doit(determinant=False)
Determinant(Matrix([
[a, b],
[c, d]]))
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Add determinant hint for doit method to allow the evaluation of matrix determinants to be skipped when set to False .
<!-- END RELEASE NOTES -->
