### PR TITLE
SYMPY_USE_CACHE not defined error. 

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -137,6 +137,7 @@ else:
     try:
         SYMPY_CACHE_SIZE = int(scs)
     except ValueError:
+        SYMPY_CACHE_SIZE = scs
         raise RuntimeError(
             'SYMPY_CACHE_SIZE must be a valid integer or None. ' + \
             'Got: %s' % SYMPY_CACHE_SIZE)


### PR DESCRIPTION
SYMPY_USE_CACHE not defined error.  when you did not enter this line function unable to find the SYMPY_USE_CACHE so not defined error occurred.



<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

****example :  in place of value we gave like " king " we will get error like :  NameError: name 'SYMPY_CACHE_SIZE' is not defined

if you replace int( scs ) again you will get another like : ValueError: invalid literal for int() with base 10: 'king'

so, if we add this line we will raise exception like  : RuntimeError: SYMPY_CACHE_SIZE must be a valid integer or None. Got: king   [  this is our error ]  and it is fixed**** 

#### Other comments


#### Release Notes

solvers : solved the NameError: name 'SYMPY_CACHE_SIZE' is not defined

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
solved the NameError: name 'SYMPY_CACHE_SIZE' is not defined
<!-- END RELEASE NOTES -->
