### PR TITLE
Remove links to the wiki development workflow page

### DIFF
--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -352,8 +352,7 @@ beyond Python and mpmath.
 
 - **git**: The [SymPy source code](https://github.com/sympy/sympy) uses the
   [git](https://git-scm.com/) version control system. See the [installation
-  guide](installation-git) and [development
-  workflow](https://github.com/sympy/sympy/wiki/Development-workflow#set-up-git)
+  guide](installation-git) and the [contributor guide](devsetup)
   for instructions on how to get the development version of SymPy from git.
 
 ### Running the Tests

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -48,9 +48,6 @@ function does.
 ----------------------------------
 
 The contributing guide goes over the details necessary to contribute to SymPy.
-See also the full `Development Workflow
-<https://github.com/sympy/sympy/wiki/Development-workflow>`_ guide on the
-SymPy wiki.
 
 .. toctree::
    :hidden:

--- a/doc/src/tutorials/intro-tutorial/next.rst
+++ b/doc/src/tutorials/intro-tutorial/next.rst
@@ -14,6 +14,4 @@ The :ref:`SymPy API Reference <reference>` has a detailed description of the
 SymPy API.
 
 If you are interested in contributing to SymPy, visit the :ref:`contribution
-guides <contributing>` and the full `Development Workflow
-<https://github.com/sympy/sympy/wiki/Development-workflow>`_ guide on the
-SymPy wiki.
+guides <contributing>`.


### PR DESCRIPTION
This page is now in the main SymPy documentation.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
