### PR TITLE
Revert "Dimension Cancelling Fix"

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -275,7 +275,6 @@ class Mul(Expr, AssocOp):
 
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.matrices.expressions import MatrixExpr
-        from sympy.physics.units import Dimension
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -370,10 +369,6 @@ class Mul(Expr, AssocOp):
                 continue
 
             elif isinstance(o, AccumBounds):
-                coeff = o.__mul__(coeff)
-                continue
-
-            elif isinstance(o, Dimension):
                 coeff = o.__mul__(coeff)
                 continue
 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -127,14 +127,6 @@ def test_Dimension_mul_div_exp():
     c_dim = c.subs({a: length, b: length})
     assert dimsys_SI.equivalent_dims(c_dim, length)
 
-    mul_sub = 3*a
-    mul_sub_dim = mul_sub.subs({a: length})
-    assert mul_sub_dim == length
-
-    no_cancel = a - b
-    no_cancel_dim = no_cancel.subs({a: length, b: length})
-    assert  no_cancel_dim == length
-
 def test_Dimension_functions():
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(cos(length)))
     raises(TypeError, lambda: dimsys_SI.get_dimensional_dependencies(acos(angle)))


### PR DESCRIPTION
Reverts sympy/sympy#25382

The PR #25382 causes slowdowns in the benchmarks. It is not yet clear what the cause of the slowdowns is but the changes in the PR should be reverted in any case. Mul should not import units and should not special case units.

For now we should revert the change and then look at a better fix.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->