### PR TITLE
FpSubgroup.to_FpGroup() depends on a possibly missing #24811

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -556,13 +556,22 @@ class FpSubgroup(DefaultPrinting):
     group belongs to the subgroup
 
     '''
+    def define_subgroup(cls):
+        G = FreeGroup("a b")  # Define your free group with generators 'a' and 'b'
+        gens = [G.generators[0], G.generators[0]**-1]  # Define the generators for the subgroup
+        return G, gens
+
     def __init__(self, G, gens, normal=False):
-        super().__init__()
+        G, gens = FpSubgroup.define_subgroup()
+        #super().__init__()
         self.parent = G
         self.generators = list({g for g in gens if g != G.identity})
         self._min_words = None #for use in __contains__
         self.C = None
         self.normal = normal
+
+        if not isinstance(G, FreeGroup):
+            self.C = G.coset_enumeration(self.generators)
 
     def __contains__(self, g):
 

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -137,6 +137,7 @@ else:
     try:
         SYMPY_CACHE_SIZE = int(scs)
     except ValueError:
+        SYMPY_CACHE_SIZE = scs
         raise RuntimeError(
             'SYMPY_CACHE_SIZE must be a valid integer or None. ' + \
             'Got: %s' % SYMPY_CACHE_SIZE)

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -127,8 +127,8 @@ def copy(src, dst, only_update=False, copystat=True, cwd=None,
     if only_update:
         # This function is not defined:
         # XXX: This branch is clearly not tested!
-        if not missing_or_other_newer(dst, src): # noqa
-            return
+        if os.path.exists(src) and os.path.getatime(src) <= os.path.getatime(dst):
+            return None
 
     if os.path.islink(dst):
         dst = os.path.abspath(os.path.realpath(dst), cwd=cwd)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
@oscarbenjamin 
please check
# FpSubgroup.to_FpGroup() depends on a possibly missing is solved the self.C
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #24811 " (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
self.C value is not shows in the class functions. so added some code for to show. it will check before go to next step isinstance() method. we will first the generator (gens) and FreeGroup(G) will define in function and passed to __init__function and to access that data. before leaving __init__ we will check.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solver. FpSubgroup.to_FpGroup() depends on a possibly missing #24811
* details provide in description section
* solved if data not showing when we pass parameters. 

<!-- END RELEASE NOTES -->
