### PR TITLE
Implemented `WrappingPathway` in `sympy.physics.mechanics`

### DIFF
--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -76,6 +76,25 @@ class GeometryBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def _geodesic_end_vectors(
+        self,
+        point_1: Point,
+        point_2: Point,
+    ) -> tuple[Vector, Vector]:
+        """The vectors parallel to the geodesic at the two end points.
+
+        Parameters
+        ==========
+
+        point_1 : Point
+            The point from which the geodesic originates.
+        point_2 : Point
+            The point at which the geodesic terminates.
+
+        """
+        pass
+
     def __repr__(self) -> str:
         """Default representation of a geometry object."""
         return f'{self.__class__.__name__}()'

--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -391,7 +391,7 @@ class Cylinder(GeometryBase):
 
     @axis.setter
     def axis(self, axis: Vector) -> None:
-        self._axis = axis
+        self._axis = axis.normalize()
 
     def _point_is_on_surface(self, point: Point) -> bool:
         """Determine if a point is on the cylinder's surface.

--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -48,6 +48,12 @@ class GeometryBase(ABC):
 
     """
 
+    @property
+    @abstractmethod
+    def point(cls) -> Point:
+        """The point with which the geometry is associated."""
+        pass
+
     @abstractmethod
     def _point_is_on_surface(self, point: Point) -> bool:
         """Determine if a point is on the geometry's surface.

--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -282,6 +282,40 @@ class Sphere(GeometryBase):
         geodesic_length = self.radius * central_angle
         return geodesic_length
 
+    def _geodesic_end_vectors(
+        self,
+        point_1: Point,
+        point_2: Point,
+    ) -> tuple[Vector, Vector]:
+        """The vectors parallel to the geodesic at the two end points.
+
+        Parameters
+        ==========
+
+        point_1 : Point
+            The point from which the geodesic originates.
+        point_2 : Point
+            The point at which the geodesic terminates.
+
+        """
+        pA, pB = point_1, point_2
+        pO = self.point
+        pA_vec = pA.pos_from(pO)
+        pB_vec = pB.pos_from(pO)
+
+        if pA_vec.cross(pB_vec) == 0:
+            msg = (
+                f'Can\'t compute geodesic end vectors for the pair of points '
+                f'{pA} and {pB} on a sphere {self} as they are diametrically '
+                f'opposed, thus the geodesic is not defined.'
+            )
+            raise ValueError(msg)
+
+        return (
+            pA_vec.cross(pB.pos_from(pA)).cross(pA_vec).normalize(),
+            pB_vec.cross(pA.pos_from(pB)).cross(pB_vec).normalize(),
+        )
+
     def __repr__(self) -> str:
         """Representation of a ``Sphere``."""
         return (

--- a/sympy/physics/mechanics/_geometry.py
+++ b/sympy/physics/mechanics/_geometry.py
@@ -554,6 +554,60 @@ class Cylinder(GeometryBase):
         geodesic_length = sqrt(parallel_length**2 + planar_arc_length**2)
         return geodesic_length
 
+    def _geodesic_end_vectors(
+        self,
+        point_1: Point,
+        point_2: Point,
+    ) -> tuple[Vector, Vector]:
+        """The vectors parallel to the geodesic at the two end points.
+
+        Parameters
+        ==========
+
+        point_1 : Point
+            The point from which the geodesic originates.
+        point_2 : Point
+            The point at which the geodesic terminates.
+
+        """
+        point_1_from_origin_point = point_1.pos_from(self.point)
+        point_2_from_origin_point = point_2.pos_from(self.point)
+
+        if point_1_from_origin_point == point_2_from_origin_point:
+            msg = (
+                f'Cannot compute geodesic end vectors for coincident points '
+                f'{point_1} and {point_2} as no geodesic exists.'
+            )
+            raise ValueError(msg)
+
+        point_1_parallel = point_1_from_origin_point.dot(self.axis) * self.axis
+        point_2_parallel = point_2_from_origin_point.dot(self.axis) * self.axis
+        point_1_normal = (point_1_from_origin_point - point_1_parallel)
+        point_2_normal = (point_2_from_origin_point - point_2_parallel)
+
+        if point_1_normal == point_2_normal:
+            point_1_perpendicular = Vector(0)
+            point_2_perpendicular = Vector(0)
+        else:
+            point_1_perpendicular = self.axis.cross(point_1_normal).normalize()
+            point_2_perpendicular = -self.axis.cross(point_2_normal).normalize()
+
+        geodesic_length = self.geodesic_length(point_1, point_2)
+        relative_position = point_2.pos_from(point_1)
+        parallel_length = relative_position.dot(self.axis)
+        planar_arc_length = sqrt(geodesic_length**2 - parallel_length**2)
+
+        point_1_vector = (
+            planar_arc_length * point_1_perpendicular
+            + parallel_length * self.axis
+        ).normalize()
+        point_2_vector = (
+            planar_arc_length * point_2_perpendicular
+            - parallel_length * self.axis
+        ).normalize()
+
+        return (point_1_vector, point_2_vector)
+
     def __repr__(self) -> str:
         """Representation of a ``Cylinder``."""
         return (

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -56,6 +56,12 @@ class PathwayBase(ABC):
 
     @attachments.setter
     def attachments(self, attachments: tuple[Point, ...]) -> None:
+        if hasattr(self, '_attachments'):
+            msg = (
+                f'Can\'t set attribute `attachments` to {repr(attachments)} '
+                f'as it is immutable.'
+            )
+            raise AttributeError(msg)
         if len(attachments) != 2:
             msg = (
                 f'Value {repr(attachments)} passed to `attachments` was an '

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from sympy.core.backend import S
 from sympy.physics.mechanics import Force, Point
+from sympy.physics.mechanics._geometry import GeometryBase
 from sympy.physics.vector import dynamicsymbols
 
 if TYPE_CHECKING:
@@ -336,3 +337,27 @@ class WrappingPathway(PathwayBase):
         The geometry about which the pathway wraps.
 
     """
+
+    def __init__(
+        self,
+        attachment_1: Point,
+        attachment_2: Point,
+        geometry: GeometryBase,
+    ) -> None:
+        """Initializer for ``WrappingPathway``.
+
+        Parameters
+        ==========
+
+        attachment_1 : Point
+            The first of the pair of ``Point`` objects between which the
+            wrapping pathway spans.
+        attachment_2 : Point
+            The second of the pair of ``Point`` objects between which the
+            wrapping pathway spans.
+        geometry : GeometryBase
+            The geometry about which the pathway wraps.
+
+        """
+        super().__init__(attachment_1, attachment_2)
+        self.geometry = geometry

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -388,6 +388,11 @@ class WrappingPathway(PathwayBase):
         """Exact analytical expression for the pathway's length."""
         return self.geometry.geodesic_length(*self.attachments)
 
+    @property
+    def extension_velocity(self) -> ExprType:
+        """Exact analytical expression for the pathway's extension velocity."""
+        return self.length.diff(dynamicsymbols._t)  # type: ignore
+
     def __repr__(self) -> str:
         """Representation of a ``WrappingPathway``."""
         attachments = ', '.join(str(a) for a in self.attachments)

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -382,3 +382,11 @@ class WrappingPathway(PathwayBase):
             )
             raise TypeError(msg)
         self._geometry = geometry
+
+    def __repr__(self) -> str:
+        """Representation of a ``WrappingPathway``."""
+        attachments = ', '.join(str(a) for a in self.attachments)
+        return (
+            f'{self.__class__.__name__}({attachments}, '
+            f'geometry={self.geometry})'
+        )

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         from sympy.core.expr import Expr as ExprType
 
 
-__all__ = ['LinearPathway']
+__all__ = ['LinearPathway', 'WrappingPathway']
 
 
 class PathwayBase(ABC):
@@ -274,3 +274,65 @@ class LinearPathway(PathwayBase):
             Force(self.attachments[-1], force * relative_position / self.length),
         ]
         return loads
+
+
+class WrappingPathway(PathwayBase):
+    """Pathway that wraps a geometry object.
+
+    Explanation
+    ===========
+
+    A wrapping pathway interacts with a geometry object and forms a path that
+    wraps smoothly along its surface. The wrapping pathway along the geometry
+    object will be the geodesic that the geometry object defines based on the
+    two points. It will not interact with any other objects in the system, i.e.
+    a ``WrappingPathway`` will intersect other objects to ensure that the path
+    between its two ends (its attachments) is the shortest possible.
+
+    Examples
+    ========
+
+    As the ``_pathway.py`` module is experimental, it is not yet part of the
+    ``sympy.physics.mechanics`` namespace. ``WrappingPathway`` must therefore
+    be imported directly from the ``sympy.physics.mechanics._pathway`` module.
+
+    >>> from sympy.physics.mechanics._pathway import WrappingPathway
+
+    To construct a wrapping pathway, a geometry object, which the pathway can
+    wrap, is required. Similar to above, the ``_geometry.py`` module is also
+    experimental so geometry classes needed to be imported directly from the
+    ``sympy.physics.mechanics._geometry.py`` module. Let's create a wrapping
+    pathway that wraps around a cylinder. To do this we need to import the
+    ``Cylinder`` class.
+
+    >>> from sympy.physics.mechanics._geometry import Cylinder
+
+    To construct a wrapping pathway, like other pathways, a pair of points must
+    be passed, followed by an instance of a geometry class as a keyword
+    argument. We'll use a cylinder with radius ``r`` and its axis parallel to
+    ``N.x`` passing through a point ``pO``.
+
+    >>> from sympy import Symbol
+    >>> from sympy.physics.mechanics import Point, ReferenceFrame
+    >>> r = Symbol('r')
+    >>> N = ReferenceFrame('N')
+    >>> pA, pB, pO = Point('pA'), Point('pB'), Point('pO')
+    >>> cylinder = Cylinder(r, pO, N.x)
+    >>> wrapping_pathway = WrappingPathway(pA, pB, cylinder)
+    >>> wrapping_pathway
+    WrappingPathway(pA, pB, geometry=Cylinder(radius=r, point=pO,
+        axis=N.x))
+
+    Parameters
+    ==========
+
+    attachment_1 : Point
+        The first of the pair of ``Point`` objects between which the wrapping
+        pathway spans.
+    attachment_2 : Point
+        The second of the pair of ``Point`` objects between which the wrapping
+        pathway spans.
+    geometry : GeometryBase
+        The geometry about which the pathway wraps.
+
+    """

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -361,3 +361,24 @@ class WrappingPathway(PathwayBase):
         """
         super().__init__(attachment_1, attachment_2)
         self.geometry = geometry
+
+    @property
+    def geometry(self) -> GeometryBase:
+        """The geometry around which the pathway wraps."""
+        return self._geometry
+
+    @geometry.setter
+    def geometry(self, geometry: GeometryBase) -> None:
+        if hasattr(self, '_geometry'):
+            msg = (
+                f'Can\'t set attribute `geometry` to {repr(geometry)} as it '
+                f'is immutable.'
+            )
+            raise AttributeError(msg)
+        if not isinstance(geometry, GeometryBase):
+            msg = (
+                f'Value {repr(geometry)} passed to `geometry` was of type '
+                f'{type(geometry)}, must be {GeometryBase}.'
+            )
+            raise TypeError(msg)
+        self._geometry = geometry

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -123,7 +123,7 @@ class LinearPathway(PathwayBase):
 
     A linear pathway forms a straight-line segment between two points and is
     the simplest pathway that can be formed. It will not interact with any
-    other objects in the system, i.e. a ``LinearPathway`` will interest other
+    other objects in the system, i.e. a ``LinearPathway`` will intersect other
     objects to ensure that the path between its two ends (its attachments) is
     the shortest possible.
 

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -383,6 +383,11 @@ class WrappingPathway(PathwayBase):
             raise TypeError(msg)
         self._geometry = geometry
 
+    @property
+    def length(self) -> ExprType:
+        """Exact analytical expression for the pathway's length."""
+        return self.geometry.geodesic_length(*self.attachments)
+
     def __repr__(self) -> str:
         """Representation of a ``WrappingPathway``."""
         attachments = ', '.join(str(a) for a in self.attachments)

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         from sympy.core.expr import Expr as ExprType
 
 
-r = Symbol('r')
+r = Symbol('r', positive=True)
 x = Symbol('x')
 q = dynamicsymbols('q')
 N = ReferenceFrame('N')
@@ -42,7 +42,7 @@ class TestSphere:
 
     @staticmethod
     def test_valid_constructor() -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         sphere = Sphere(r, pO)
         assert isinstance(sphere, Sphere)
@@ -54,7 +54,7 @@ class TestSphere:
     @staticmethod
     @pytest.mark.parametrize('position', [S.Zero, Integer(2) * r * N.x])
     def test_geodesic_length_point_not_on_surface_invalid(position: Vector) -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         sphere = Sphere(r, pO)
 
@@ -84,7 +84,7 @@ class TestSphere:
         ]
     )
     def test_geodesic_length(position_1: Vector, position_2: Vector, expected: ExprType) -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         sphere = Sphere(r, pO)
 
@@ -101,7 +101,7 @@ class TestCylinder:
     @staticmethod
     def test_valid_constructor() -> None:
         N = ReferenceFrame('N')
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         cylinder = Cylinder(r, pO, N.x)
         assert isinstance(cylinder, Cylinder)
@@ -128,7 +128,7 @@ class TestCylinder:
         ]
     )
     def test_point_is_on_surface(position: Vector, expected: bool) -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         cylinder = Cylinder(r, pO, N.x)
 
@@ -140,7 +140,7 @@ class TestCylinder:
     @staticmethod
     @pytest.mark.parametrize('position', [S.Zero, Integer(2) * r * N.y])
     def test_geodesic_length_point_not_on_surface_invalid(position: Vector) -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         cylinder = Cylinder(r, pO, N.x)
 
@@ -179,7 +179,7 @@ class TestCylinder:
         position_2: Vector,
         expected: ExprType,
     ) -> None:
-        r = Symbol('r')
+        r = Symbol('r', positive=True)
         pO = Point('pO')
         cylinder = Cylinder(r, pO, axis)
 

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -158,6 +158,34 @@ class TestSphere:
         with pytest.raises(ValueError):
             _ = sphere._geodesic_end_vectors(p1, p2)
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        'position_1, position_2',
+        [
+            (r * N.x, -r * N.x),
+            (-r * N.y, r * N.y),
+            (
+                r * cos(q) * N.x + r * sin(q) * N.y,
+                -r * cos(q) * N.x - r * sin(q) * N.y,
+            )
+        ]
+    )
+    def test_geodesic_end_vectors_invalid_diametrically_opposite(
+        position_1: Vector,
+        position_2: Vector,
+    ) -> None:
+        r = Symbol('r', positive=True)
+        pO = Point('pO')
+        sphere = Sphere(r, pO)
+
+        p1 = Point('p1')
+        p1.set_pos(pO, position_1)
+        p2 = Point('p2')
+        p2.set_pos(pO, position_2)
+
+        with pytest.raises(ValueError):
+            _ = sphere._geodesic_end_vectors(p1, p2)
+
 
 class TestCylinder:
 

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -280,3 +280,70 @@ class TestCylinder:
         p2.set_pos(pO, position_2)
 
         assert simplify(Eq(cylinder.geodesic_length(p1, p2), expected))
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'axis, position_1, position_2, vector_1, vector_2',
+        [
+            (N.z, r * N.x, r * N.y, N.y, N.x),
+            (N.z, r * N.x, -r * N.x, N.y, N.y),
+            (N.z, -r * N.x, r * N.x, -N.y, -N.y),
+            (-N.z, r * N.x, -r * N.x, -N.y, -N.y),
+            (-N.z, -r * N.x, r * N.x, N.y, N.y),
+            (N.z, r * N.x, -r * N.y, N.y, -N.x),
+            (
+                N.z,
+                r * N.y,
+                sqrt(2)/2 * r * N.x - sqrt(2)/2 * r * N.y,
+                - N.x,
+                - sqrt(2)/2 * N.x - sqrt(2)/2 * N.y,
+            ),
+            (
+                N.z,
+                r * N.x,
+                r / 2 * N.x + sqrt(3)/2 * r * N.y,
+                N.y,
+                sqrt(3)/2 * N.x - 1/2 * N.y,
+            ),
+            (
+                N.z,
+                r * N.x,
+                sqrt(2)/2 * r * N.x + sqrt(2)/2 * r * N.y,
+                N.y,
+                sqrt(2)/2 * N.x - sqrt(2)/2 * N.y,
+            ),
+            (
+                N.z,
+                r * N.x,
+                r * N.x + N.z,
+                N.z,
+                -N.z,
+            ),
+            (
+                N.z,
+                r * N.x,
+                r * N.y + pi/2 * r * N.z,
+                sqrt(2)/2 * N.y + sqrt(2)/2 * N.z,
+                sqrt(2)/2 * N.x - sqrt(2)/2 * N.z,
+            ),
+        ]
+    )
+    def test_geodesic_end_vectors(
+        axis: Vector,
+        position_1: Vector,
+        position_2: Vector,
+        vector_1: Vector,
+        vector_2: Vector,
+    ) -> None:
+        r = Symbol('r', positive=True)
+        pO = Point('pO')
+        cylinder = Cylinder(r, pO, axis)
+
+        p1 = Point('p1')
+        p1.set_pos(pO, position_1)
+        p2 = Point('p2')
+        p2.set_pos(pO, position_2)
+
+        expected = (vector_1, vector_2)
+
+        assert cylinder._geodesic_end_vectors(p1, p2) == expected

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -11,6 +11,7 @@ from sympy.core.backend import (
     Rational,
     S,
     Symbol,
+    USE_SYMENGINE,
     acos,
     cos,
     pi,
@@ -23,7 +24,6 @@ from sympy.physics.mechanics._geometry import Cylinder, Sphere
 from sympy.simplify.simplify import simplify
 
 if TYPE_CHECKING:
-    from sympy.core.backend import USE_SYMENGINE
     from sympy.physics.mechanics import Vector
 
     if USE_SYMENGINE:
@@ -96,6 +96,7 @@ class TestSphere:
         assert simplify(Eq(sphere.geodesic_length(p1, p2), expected))
 
     @staticmethod
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'position_1, position_2, vector_1, vector_2',
         [
@@ -282,6 +283,7 @@ class TestCylinder:
         assert simplify(Eq(cylinder.geodesic_length(p1, p2), expected))
 
     @staticmethod
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'axis, position_1, position_2, vector_1, vector_2',
         [

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -95,6 +95,51 @@ class TestSphere:
 
         assert simplify(Eq(sphere.geodesic_length(p1, p2), expected))
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        'position_1, position_2, vector_1, vector_2',
+        [
+            (r * N.x, r * N.y, N.y, N.x),
+            (r * N.x, -r * N.y, -N.y, N.x),
+            (
+                r * N.y,
+                sqrt(2)/2 * r * N.x - sqrt(2)/2 * r * N.y,
+                N.x,
+                sqrt(2)/2 * N.x + sqrt(2)/2 * N.y,
+            ),
+            (
+                r * N.x,
+                r / 2 * N.x + sqrt(3)/2 * r * N.y,
+                N.y,
+                sqrt(3)/2 * N.x - 1/2 * N.y,
+            ),
+            (
+                r * N.x,
+                sqrt(2)/2 * r * N.x + sqrt(2)/2 * r * N.y,
+                N.y,
+                sqrt(2)/2 * N.x - sqrt(2)/2 * N.y,
+            ),
+        ]
+    )
+    def test_geodesic_end_vectors(
+        position_1: Vector,
+        position_2: Vector,
+        vector_1: Vector,
+        vector_2: Vector,
+    ) -> None:
+        r = Symbol('r', positive=True)
+        pO = Point('pO')
+        sphere = Sphere(r, pO)
+
+        p1 = Point('p1')
+        p1.set_pos(pO, position_1)
+        p2 = Point('p2')
+        p2.set_pos(pO, position_2)
+
+        expected = (vector_1, vector_2)
+
+        assert sphere._geodesic_end_vectors(p1, p2) == expected
+
 
 class TestCylinder:
 

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -140,6 +140,24 @@ class TestSphere:
 
         assert sphere._geodesic_end_vectors(p1, p2) == expected
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        'position',
+        [r * N.x, r * cos(q) * N.x + r * sin(q) * N.y]
+    )
+    def test_geodesic_end_vectors_invalid_coincident(position: Vector) -> None:
+        r = Symbol('r', positive=True)
+        pO = Point('pO')
+        sphere = Sphere(r, pO)
+
+        p1 = Point('p1')
+        p1.set_pos(pO, position)
+        p2 = Point('p2')
+        p2.set_pos(pO, position)
+
+        with pytest.raises(ValueError):
+            _ = sphere._geodesic_end_vectors(p1, p2)
+
 
 class TestCylinder:
 

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -347,3 +347,27 @@ class TestCylinder:
         expected = (vector_1, vector_2)
 
         assert cylinder._geodesic_end_vectors(p1, p2) == expected
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'axis, position',
+        [
+            (N.z, r * N.x),
+            (N.z, r * cos(q) * N.x + r * sin(q) * N.y + N.z),
+        ]
+    )
+    def test_geodesic_end_vectors_invalid_coincident(
+        axis: Vector,
+        position: Vector,
+    ) -> None:
+        r = Symbol('r', positive=True)
+        pO = Point('pO')
+        cylinder = Cylinder(r, pO, axis)
+
+        p1 = Point('p1')
+        p1.set_pos(pO, position)
+        p2 = Point('p2')
+        p2.set_pos(pO, position)
+
+        with pytest.raises(ValueError):
+            _ = cylinder._geodesic_end_vectors(p1, p2)

--- a/sympy/physics/mechanics/tests/test_geometry.py
+++ b/sympy/physics/mechanics/tests/test_geometry.py
@@ -326,6 +326,13 @@ class TestCylinder:
                 sqrt(2)/2 * N.y + sqrt(2)/2 * N.z,
                 sqrt(2)/2 * N.x - sqrt(2)/2 * N.z,
             ),
+            (
+                N.z,
+                r * N.x,
+                r * cos(q) * N.x + r * sin(q) * N.y,
+                N.y,
+                sin(q) * N.x - cos(q) * N.y,
+            ),
         ]
     )
     def test_geodesic_end_vectors(
@@ -345,8 +352,12 @@ class TestCylinder:
         p2.set_pos(pO, position_2)
 
         expected = (vector_1, vector_2)
+        end_vectors = tuple(
+            end_vector.simplify()
+            for end_vector in cylinder._geodesic_end_vectors(p1, p2)
+        )
 
-        assert cylinder._geodesic_end_vectors(p1, p2) == expected
+        assert end_vectors == expected
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -210,3 +210,17 @@ class TestWrappingPathway:
     ) -> None:
         with pytest.raises(TypeError):
             _ = WrappingPathway(*attachments, self.cylinder)  # type: ignore
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'attachments',
+        [
+            (None, Point('pB')),
+            (Point('pA'), None),
+        ]
+    )
+    def test_invalid_constructor_attachments_not_point(
+        attachments: Sequence[Any],
+    ) -> None:
+        with pytest.raises(TypeError):
+            _ = WrappingPathway(*attachments)  # type: ignore

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -2,14 +2,29 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pytest
 
-from sympy.core.backend import Symbol, sqrt
-from sympy.physics.mechanics import Point, ReferenceFrame, dynamicsymbols
-from sympy.physics.mechanics._pathway import LinearPathway
+from sympy.core.backend import Rational, Symbol, cos, pi, sin, sqrt
+from sympy.physics.mechanics import (
+    Force,
+    Point,
+    ReferenceFrame,
+    dynamicsymbols,
+)
+from sympy.physics.mechanics._geometry import Cylinder, GeometryBase, Sphere
+from sympy.physics.mechanics._pathway import (
+    LinearPathway,
+    PathwayBase,
+    WrappingPathway,
+)
 from sympy.simplify.simplify import simplify
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.core.numbers import Number
+    from sympy.physics.mechanics.loads import LoadBase
 
 
 class TestLinearPathway:

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -224,3 +224,7 @@ class TestWrappingPathway:
     ) -> None:
         with pytest.raises(TypeError):
             _ = WrappingPathway(*attachments)  # type: ignore
+
+    def test_invalid_constructor_geometry_is_not_supplied(self) -> None:
+        with pytest.raises(TypeError):
+            _ = WrappingPathway(self.pA, self.pB)  # type: ignore

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -250,3 +250,7 @@ class TestWrappingPathway:
             self.pathway.attachments[0] = self.pB  # type: ignore
         with pytest.raises(TypeError):
             self.pathway.attachments[1] = self.pA  # type: ignore
+
+    def test_geometry_property_is_immutable(self) -> None:
+        with pytest.raises(AttributeError):
+            self.pathway.geometry = None  # type: ignore

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -77,7 +77,11 @@ class TestLinearPathway:
     def test_properties_are_immutable(self) -> None:
         instance = LinearPathway(self.pA, self.pB)
         with pytest.raises(AttributeError):
-            instance.attachments = None
+            instance.attachments = None  # type: ignore
+        with pytest.raises(TypeError):
+            instance.attachments[0] = None  # type: ignore
+        with pytest.raises(TypeError):
+            instance.attachments[1] = None  # type: ignore
 
     def test_repr(self) -> None:
         pathway = LinearPathway(self.pA, self.pB)

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -365,3 +365,53 @@ class TestWrappingPathway:
         self.pB.set_pos(self.pO, self.r * pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
         assert pathway.extension_velocity == 0
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec, pA_vec_expected, pB_vec_expected, pO_vec_expected',
+        (
+            ((1, 0, 0), (0, 1, 0), (0, 1, 0), (1, 0, 0), (-1, -1, 0)),
+            (
+                (0, 1, 0),
+                (sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (1, 0, 0),
+                (sqrt(2) / 2, sqrt(2) / 2, 0),
+                (-1 - sqrt(2) / 2, -sqrt(2) / 2, 0)
+            ),
+            (
+                (1, 0, 0),
+                (Rational(1, 2), sqrt(3) / 2, 0),
+                (0, 1, 0),
+                (sqrt(3) / 2, -Rational(1, 2), 0),
+                (-sqrt(3) / 2, Rational(1, 2) - 1, 0),
+            ),
+        )
+    )
+    def test_static_pathway_on_sphere_compute_loads(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+        pA_vec_expected: tuple[int | Number, int | Number, int | Number],
+        pB_vec_expected: tuple[int | Number, int | Number, int | Number],
+        pO_vec_expected: tuple[int | Number, int | Number, int | Number],
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.sphere)
+
+        pA_vec_expected = sum(
+            mag * unit for (mag, unit) in zip(pA_vec_expected, self.N)
+        )
+        pB_vec_expected = sum(
+            mag * unit for (mag, unit) in zip(pB_vec_expected, self.N)
+        )
+        pO_vec_expected = sum(
+            mag * unit for (mag, unit) in zip(pO_vec_expected, self.N)
+        )
+        expected = [
+            Force(self.pA, self.F * (self.r**3 / sqrt(self.r**6)) * pA_vec_expected),
+            Force(self.pB, self.F * (self.r**3 / sqrt(self.r**6)) * pB_vec_expected),
+            Force(self.pO, self.F * (self.r**3 / sqrt(self.r**6)) * pO_vec_expected),
+        ]
+        assert pathway.compute_loads(self.F) == expected

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -6,7 +6,15 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import pytest
 
-from sympy.core.backend import Rational, Symbol, cos, pi, sin, sqrt
+from sympy.core.backend import (
+    Rational,
+    Symbol,
+    USE_SYMENGINE,
+    cos,
+    pi,
+    sin,
+    sqrt,
+)
 from sympy.physics.mechanics import (
     Force,
     Point,
@@ -431,6 +439,7 @@ class TestWrappingPathway:
         ]
         assert pathway.compute_loads(self.F) == expected
 
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'pA_vec, pB_vec, pA_vec_expected, pB_vec_expected, pO_vec_expected',
         (
@@ -500,6 +509,7 @@ class TestWrappingPathway:
         ]
         assert self._simplify_loads(pathway.compute_loads(self.F)) == expected
 
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_length(self) -> None:
         q = dynamicsymbols('q')
         pA_pos = self.r * self.N.x
@@ -509,6 +519,7 @@ class TestWrappingPathway:
         expected = self.r * sqrt(q**2)
         assert simplify(self.pathway.length - expected) == 0
 
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_extension_velocity(self) -> None:
         q = dynamicsymbols('q')
         qd = dynamicsymbols('q', 1)
@@ -519,6 +530,7 @@ class TestWrappingPathway:
         expected = self.r * (sqrt(q**2) / q) * qd
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
+    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_compute_loads(self) -> None:
         q = dynamicsymbols('q')
         pA_pos = self.r * self.N.x

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -341,3 +341,27 @@ class TestWrappingPathway:
         self.pB.set_pos(self.pO, self.r * pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
         assert pathway.extension_velocity == 0
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec',
+        [
+            ((1, 0, 0), (0, 1, 0)),
+            ((1, 0, 0), (-1, 0, 0)),
+            ((-1, 0, 0), (1, 0, 0)),
+            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0)),
+            ((0, 1, 0), (sqrt(2) * Rational(1, 2), -sqrt(2) / 2, 1)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 1)),
+        ]
+    )
+    def test_static_pathway_on_cylinder_extension_velocity(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
+        assert pathway.extension_velocity == 0

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -196,3 +196,17 @@ class TestWrappingPathway:
         assert hasattr(instance, 'geometry')
         assert isinstance(instance.geometry, GeometryBase)
         assert instance.geometry == self.cylinder
+
+    @pytest.mark.parametrize(
+        'attachments',
+        [
+            (Point('pA'), ),
+            (Point('pA'), Point('pB'), Point('pZ')),
+        ]
+    )
+    def test_invalid_constructor_attachments_incorrect_number(
+        self,
+        attachments: Sequence[Point],
+    ) -> None:
+        with pytest.raises(TypeError):
+            _ = WrappingPathway(*attachments, self.cylinder)  # type: ignore

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -484,3 +484,12 @@ class TestWrappingPathway:
             Force(self.pO, pO_force_expected),
         ]
         assert self._simplify_loads(pathway.compute_loads(self.F)) == expected
+
+    def test_2D_pathway_on_cylinder_length(self) -> None:
+        q = dynamicsymbols('q')
+        pA_pos = self.r * self.N.x
+        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        self.pA.set_pos(self.pO, pA_pos)
+        self.pB.set_pos(self.pO, pB_pos)
+        expected = self.r * sqrt(q**2)
+        assert simplify(self.pathway.length - expected) == 0

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -167,4 +167,6 @@ class TestLinearPathway:
 
 
 class TestWrappingPathway:
-    pass
+
+    def test_is_pathway_base_subclass(self) -> None:
+        assert issubclass(WrappingPathway, PathwayBase)

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -244,3 +244,9 @@ class TestWrappingPathway:
     ) -> None:
         with pytest.raises(TypeError):
             _ = WrappingPathway(self.pA, self.pB, geometry)
+
+    def test_attachments_property_is_immutable(self) -> None:
+        with pytest.raises(TypeError):
+            self.pathway.attachments[0] = self.pB  # type: ignore
+        with pytest.raises(TypeError):
+            self.pathway.attachments[1] = self.pA  # type: ignore

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -287,3 +287,37 @@ class TestWrappingPathway:
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
         expected = expected_factor * self.r
         assert simplify(pathway.length - expected) == 0
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec, expected_factor',
+        [
+            ((1, 0, 0), (0, 1, 0), Rational(1, 2) * pi),
+            ((1, 0, 0), (-1, 0, 0), pi),
+            ((-1, 0, 0), (1, 0, 0), pi),
+            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0), 5 * pi / 4),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0), pi / 3),
+            (
+                (0, 1, 0),
+                (sqrt(2) * Rational(1, 2), -sqrt(2)* Rational(1, 2), 1),
+                sqrt(1 + (Rational(5, 4) * pi)**2),
+            ),
+            (
+                (1, 0, 0),
+                (Rational(1, 2), sqrt(3) * Rational(1, 2), 1),
+                sqrt(1 + (Rational(1, 3) * pi)**2),
+            ),
+        ]
+    )
+    def test_static_pathway_on_cylinder_length(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+        expected_factor: Expr,
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
+        expected = expected_factor * sqrt(self.r**2)
+        assert simplify(pathway.length - expected) == 0

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -228,3 +228,19 @@ class TestWrappingPathway:
     def test_invalid_constructor_geometry_is_not_supplied(self) -> None:
         with pytest.raises(TypeError):
             _ = WrappingPathway(self.pA, self.pB)  # type: ignore
+
+    @pytest.mark.parametrize(
+        'geometry',
+        [
+            Symbol('r'),
+            dynamicsymbols('q'),
+            ReferenceFrame('N'),
+            ReferenceFrame('N').x,
+        ]
+    )
+    def test_invalid_geometry_not_geometry(
+        self,
+        geometry: Any,
+    ) -> None:
+        with pytest.raises(TypeError):
+            _ = WrappingPathway(self.pA, self.pB, geometry)

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -261,3 +261,29 @@ class TestWrappingPathway:
             f'geometry={self.cylinder!r})'
         )
         assert repr(self.pathway) == expected
+
+    @staticmethod
+    def _expand_pos_to_vec(pos, frame):
+        return sum(mag * unit for (mag, unit) in zip(pos, frame))
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec, expected_factor',
+        [
+            ((1, 0, 0), (0, 1, 0), pi / 2),
+            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0), 3 * pi / 4),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0), pi / 3),
+        ]
+    )
+    def test_static_pathway_on_sphere_length(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+        expected_factor: Expr,
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.sphere)
+        expected = expected_factor * self.r
+        assert simplify(pathway.length - expected) == 0

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -415,3 +415,72 @@ class TestWrappingPathway:
             Force(self.pO, self.F * (self.r**3 / sqrt(self.r**6)) * pO_vec_expected),
         ]
         assert pathway.compute_loads(self.F) == expected
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec, pA_vec_expected, pB_vec_expected, pO_vec_expected',
+        (
+            ((1, 0, 0), (0, 1, 0), (0, 1, 0), (1, 0, 0), (-1, -1, 0)),
+            ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, 1, 0), (0, -2, 0)),
+            ((-1, 0, 0), (1, 0, 0), (0, -1, 0), (0, -1, 0), (0, 2, 0)),
+            (
+                (0, 1, 0),
+                (sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (-1, 0, 0),
+                (-sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (1 + sqrt(2) / 2, sqrt(2) / 2, 0)
+            ),
+            (
+                (1, 0, 0),
+                (Rational(1, 2), sqrt(3) / 2, 0),
+                (0, 1, 0),
+                (sqrt(3) / 2, -Rational(1, 2), 0),
+                (-sqrt(3) / 2, Rational(1, 2) - 1, 0),
+            ),
+            (
+                (1, 0, 0),
+                (sqrt(2) / 2, sqrt(2) / 2, 0),
+                (0, 1, 0),
+                (sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (-sqrt(2) / 2, sqrt(2) / 2 - 1, 0),
+            ),
+            ((0, 1, 0), (0, 1, 1), (0, 0, 1), (0, 0, -1), (0, 0, 0)),
+            (
+                (0, 1, 0),
+                (sqrt(2) / 2, -sqrt(2) / 2, 1),
+                (-5 * pi / sqrt(16 + 25*pi**2), 0, 4 / sqrt(16 + 25*pi**2)),
+                (
+                    -5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
+                    -5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
+                    -4 / sqrt(16 + 25*pi**2),
+                ),
+                (
+                    5 * (sqrt(2) + 2) * pi / (2 * sqrt(16 + 25*pi**2)),
+                    5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
+                    0,
+                ),
+            ),
+        )
+    )
+    def test_static_pathway_on_cylinder_compute_loads(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+        pA_vec_expected: tuple[int | Number, int | Number, int | Number],
+        pB_vec_expected: tuple[int | Number, int | Number, int | Number],
+        pO_vec_expected: tuple[int | Number, int | Number, int | Number],
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
+
+        pA_force_expected = self.F * self._expand_pos_to_vec(pA_vec_expected, self.N)
+        pB_force_expected = self.F * self._expand_pos_to_vec(pB_vec_expected, self.N)
+        pO_force_expected = self.F * self._expand_pos_to_vec(pO_vec_expected, self.N)
+        expected = [
+            Force(self.pA, pA_force_expected),
+            Force(self.pB, pB_force_expected),
+            Force(self.pO, pO_force_expected),
+        ]
+        assert self._simplify_loads(pathway.compute_loads(self.F)) == expected

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -504,6 +504,25 @@ class TestWrappingPathway:
         expected = self.r * (sqrt(q**2) / q) * qd
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
+    def test_2D_pathway_on_cylinder_compute_loads(self) -> None:
+        q = dynamicsymbols('q')
+        pA_pos = self.r * self.N.x
+        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        self.pA.set_pos(self.pO, pA_pos)
+        self.pB.set_pos(self.pO, pB_pos)
+
+        pA_force = self.F * self.N.y
+        pB_force = self.F * (sin(q) * self.N.x - cos(q) * self.N.y)
+        pO_force = self.F * (-sin(q) * self.N.x + (cos(q) - 1) * self.N.y)
+        expected = [
+            Force(self.pA, pA_force),
+            Force(self.pB, pB_force),
+            Force(self.pO, pO_force),
+        ]
+
+        loads = self._simplify_loads(self.pathway.compute_loads(self.F))
+        assert loads == expected
+
     @staticmethod
     def _simplify_loads(loads: list[LoadBase]) -> list[LoadBase]:
         return [

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -254,3 +254,10 @@ class TestWrappingPathway:
     def test_geometry_property_is_immutable(self) -> None:
         with pytest.raises(AttributeError):
             self.pathway.geometry = None  # type: ignore
+
+    def test_repr(self) -> None:
+        expected = (
+            f'WrappingPathway(pA, pB, '
+            f'geometry={self.cylinder!r})'
+        )
+        assert repr(self.pathway) == expected

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -494,6 +494,16 @@ class TestWrappingPathway:
         expected = self.r * sqrt(q**2)
         assert simplify(self.pathway.length - expected) == 0
 
+    def test_2D_pathway_on_cylinder_extension_velocity(self) -> None:
+        q = dynamicsymbols('q')
+        qd = dynamicsymbols('q', 1)
+        pA_pos = self.r * self.N.x
+        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        self.pA.set_pos(self.pO, pA_pos)
+        self.pB.set_pos(self.pO, pB_pos)
+        expected = self.r * (sqrt(q**2) / q) * qd
+        assert simplify(self.pathway.extension_velocity - expected) == 0
+
     @staticmethod
     def _simplify_loads(loads: list[LoadBase]) -> list[LoadBase]:
         return [

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -321,3 +321,23 @@ class TestWrappingPathway:
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
         expected = expected_factor * sqrt(self.r**2)
         assert simplify(pathway.length - expected) == 0
+
+    @pytest.mark.parametrize(
+        'pA_vec, pB_vec',
+        [
+            ((1, 0, 0), (0, 1, 0)),
+            ((0, 1, 0), (sqrt(2) * Rational(1, 2), -sqrt(2)* Rational(1, 2), 0)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3) * Rational(1, 2), 0)),
+        ]
+    )
+    def test_static_pathway_on_sphere_extension_velocity(
+        self,
+        pA_vec: tuple[int | Number, int | Number, int | Number],
+        pB_vec: tuple[int | Number, int | Number, int | Number],
+    ) -> None:
+        pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
+        pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
+        self.pA.set_pos(self.pO, self.r * pA_vec)
+        self.pB.set_pos(self.pO, self.r * pB_vec)
+        pathway = WrappingPathway(self.pA, self.pB, self.sphere)
+        assert pathway.extension_velocity == 0

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -164,3 +164,7 @@ class TestLinearPathway:
             (self.pB, pI_force),
         ]
         assert self.pathway.compute_loads(self.F) == expected
+
+
+class TestWrappingPathway:
+    pass

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -183,3 +183,16 @@ class TestWrappingPathway:
         self.cylinder = Cylinder(self.r, self.pO, self.ax)
         self.pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
         self.F = Symbol('F')
+
+    def test_valid_constructor(self) -> None:
+        instance = WrappingPathway(self.pA, self.pB, self.cylinder)
+        assert isinstance(instance, WrappingPathway)
+        assert hasattr(instance, 'attachments')
+        assert len(instance.attachments) == 2
+        assert isinstance(instance.attachments[0], Point)
+        assert instance.attachments[0] == self.pA
+        assert isinstance(instance.attachments[1], Point)
+        assert instance.attachments[1] == self.pB
+        assert hasattr(instance, 'geometry')
+        assert isinstance(instance.geometry, GeometryBase)
+        assert instance.geometry == self.cylinder

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -493,3 +493,10 @@ class TestWrappingPathway:
         self.pB.set_pos(self.pO, pB_pos)
         expected = self.r * sqrt(q**2)
         assert simplify(self.pathway.length - expected) == 0
+
+    @staticmethod
+    def _simplify_loads(loads: list[LoadBase]) -> list[LoadBase]:
+        return [
+            load.__class__(load.location, load.vector.simplify())
+            for load in loads
+        ]

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -79,6 +79,11 @@ class TestLinearPathway:
         with pytest.raises(AttributeError):
             instance.attachments = None
 
+    def test_repr(self) -> None:
+        pathway = LinearPathway(self.pA, self.pB)
+        expected = 'LinearPathway(pA, pB)'
+        assert repr(pathway) == expected
+
     def test_static_pathway_length(self) -> None:
         self.pB.set_pos(self.pA, 2 * self.N.x)
         assert self.pathway.length == 2

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -74,6 +74,11 @@ class TestLinearPathway:
         self.q3d = dynamicsymbols('q3', 1)
         self.F = Symbol('F')
 
+    def test_properties_are_immutable(self) -> None:
+        instance = LinearPathway(self.pA, self.pB)
+        with pytest.raises(AttributeError):
+            instance.attachments = None
+
     def test_static_pathway_length(self) -> None:
         self.pB.set_pos(self.pA, 2 * self.N.x)
         assert self.pathway.length == 2

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -170,3 +170,16 @@ class TestWrappingPathway:
 
     def test_is_pathway_base_subclass(self) -> None:
         assert issubclass(WrappingPathway, PathwayBase)
+
+    @pytest.fixture(autouse=True)
+    def _wrapping_pathway_fixture(self) -> None:
+        self.pA = Point('pA')
+        self.pB = Point('pB')
+        self.r = Symbol('r', positive=True)
+        self.pO = Point('pO')
+        self.N = ReferenceFrame('N')
+        self.ax = self.N.z
+        self.sphere = Sphere(self.r, self.pO)
+        self.cylinder = Cylinder(self.r, self.pO, self.ax)
+        self.pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
+        self.F = Symbol('F')

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -14,6 +14,9 @@ from sympy.simplify.simplify import simplify
 
 class TestLinearPathway:
 
+    def test_is_pathway_base_subclass(self) -> None:
+        assert issubclass(LinearPathway, PathwayBase)
+
     @staticmethod
     @pytest.mark.parametrize(
         'args, kwargs',


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240. Extends #24914 and #25068.

#### Brief description of what is fixed or changed

This PR introduces a new pathway class: `WrappingPathway`. This is a further concrete class of `PathwayBase` that interacts with concrete classes to `GeometryBase` to create a pathway that wraps around a geometry. An example application for biomechanical modelling is creating a pathway for a musculotendon that produces a geodetic wrapping around a solid cylinder.

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the module is moved to `sympy/physics/mechanics/pathway.py`.

#### Other comments

I have specifically left the release notes entry empty. These will be added in the PR that moves the module to `sympy/physics/mechanics/pathway.py`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
