### PR TITLE
fixed Debian bug report #1040058 : now sagemath package's test suite …

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4511,7 +4511,10 @@ def equal_valued(x, y):
         # y even integer
         if q != 1:
             return False
-        if p.bit_length() != man.bit_length() + exp:
+        # 'sage.rings.integer.Integer' object has no attribute 'bit_length'
+        # so man.bit_length raises an AttributeError when testing sage
+        bl = man.bit_length() if hasattr(man, "bit_length") else man.nbits()
+        if p.bit_length() != bl + exp:
             return False
         return man << exp == p
     else:


### PR DESCRIPTION
…has fewer failures due to sympy
<!-- BEGIN RELEASE NOTES -->
* core
    * Debian bug report #1040058 is visible at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1040058

    * The main issue is that 'sage.rings.integer.Integer' objects are missing the attribute 'bit_length'.
       Replacing usages of the method 'bit_length' by 'nbits' seems to fix it.
<!-- END RELEASE NOTES -->