### PR TITLE
Removed unused import statements

### DIFF
--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -14,7 +14,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import sys
-import os
 if sys.version_info < (3, 8):
     sys.exit("This script requires Python 3.8 or newer")
 

--- a/bin/sympy_time_cache.py
+++ b/bin/sympy_time_cache.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import time
 import timeit
 
 

--- a/bin/test_executable.py
+++ b/bin/test_executable.py
@@ -5,7 +5,6 @@ Test that only executable files have an executable bit set
 from __future__ import print_function
 
 import os
-import sys
 
 from get_sympy import path_hack
 base_dir = path_hack()


### PR DESCRIPTION
In particular, `sympy_time_cache.py` causes errors in ruff check.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/25409#issuecomment-1646553394

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
