### PR TITLE
[GSOC 2.3] Add System Margins for Transfer Functions

### DIFF
--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,5 +1,5 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
-    Feedback, MIMOFeedback, TransferFunctionMatrix, gbt, bilinear, forward_diff, backward_diff)
+    Feedback, MIMOFeedback, TransferFunctionMatrix, gbt, bilinear, forward_diff, backward_diff, phase_margin)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
@@ -7,9 +7,9 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','gbt',
-    'bilinear', 'forward_diff', 'backward_diff', 'pole_zero_numerical_data',
-    'pole_zero_plot', 'step_response_numerical_data', 'step_response_plot',
-    'impulse_response_numerical_data', 'impulse_response_plot',
+    'bilinear', 'forward_diff', 'backward_diff', 'phase_margin',
+    'pole_zero_numerical_data', 'pole_zero_plot', 'step_response_numerical_data',
+    'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',
     'bode_magnitude_numerical_data', 'bode_phase_numerical_data',
     'bode_magnitude_plot', 'bode_phase_plot', 'bode_plot']

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,5 +1,6 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
-    Feedback, MIMOFeedback, TransferFunctionMatrix, gbt, bilinear, forward_diff, backward_diff, phase_margin)
+    Feedback, MIMOFeedback, TransferFunctionMatrix, gbt, bilinear, forward_diff, backward_diff, phase_margin,
+    gain_margin)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
@@ -7,7 +8,7 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix','gbt',
-    'bilinear', 'forward_diff', 'backward_diff', 'phase_margin',
+    'bilinear', 'forward_diff', 'backward_diff', 'phase_margin', 'gain_margin',
     'pole_zero_numerical_data', 'pole_zero_plot', 'step_response_numerical_data',
     'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,5 +1,5 @@
 from typing import Type
-from sympy import Interval, numer, Rational, solveset, S
+from sympy import Interval, numer, Rational, solveset
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -14,7 +14,6 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions import arg, Abs
 from sympy.matrices import ImmutableMatrix, eye
 from sympy.matrices.expressions import MatMul, MatAdd
 from sympy.polys import Poly, rootof
@@ -253,6 +252,8 @@ def phase_margin(system):
     .. [1] https://en.wikipedia.org/wiki/Phase_margin
 
     """
+    from sympy.functions import arg, Abs
+
     if not isinstance(system, SISOLinearTimeInvariant):
         raise ValueError("Margins are only applicable for SISO LTI systems.")
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -12,6 +12,7 @@ from sympy.core.numbers import I, pi, oo
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol
+from sympy.functions import Abs
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.matrices import ImmutableMatrix, eye
@@ -252,7 +253,7 @@ def phase_margin(system):
     .. [1] https://en.wikipedia.org/wiki/Phase_margin
 
     """
-    from sympy.functions import arg, Abs
+    from sympy.functions import arg
 
     if not isinstance(system, SISOLinearTimeInvariant):
         raise ValueError("Margins are only applicable for SISO LTI systems.")

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -262,12 +262,12 @@ def phase_margin(system):
     repl = I*_w
     expr = system.to_expr()
     len_free_symbols = len(expr.free_symbols)
-    if len_free_symbols > 1:
+    if expr.has(exp):
+        raise NotImplementedError("Margins for systems with Time delay terms are not supported.")
+    elif len_free_symbols > 1:
         raise ValueError("Extra degree of freedom found. Make sure"
             " that there are no free symbols in the dynamical system other"
             " than the variable of Laplace transform.")
-    if expr.has(exp):
-        raise NotImplementedError("Margins for systems with Time delay terms are not supported.")
 
     w_expr = expr.subs({system.var: repl})
 
@@ -337,12 +337,12 @@ def gain_margin(system):
     repl = I*_w
     expr = system.to_expr()
     len_free_symbols = len(expr.free_symbols)
-    if len_free_symbols > 1:
+    if expr.has(exp):
+        raise NotImplementedError("Margins for systems with Time delay terms are not supported.")
+    elif len_free_symbols > 1:
         raise ValueError("Extra degree of freedom found. Make sure"
             " that there are no free symbols in the dynamical system other"
             " than the variable of Laplace transform.")
-    if expr.has(exp):
-        raise NotImplementedError("Margins for systems with Time delay terms are not supported.")
 
     w_expr = expr.subs({system.var: repl})
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1319,19 +1319,27 @@ def test_TransferFunction_phase_margin():
     tf1 = TransferFunction(10, p**3 + 1, p)
     tf2 = TransferFunction(s**2, 10, s)
     tf3 = TransferFunction(1, a*s+b, s)
+    tf4 = TransferFunction((s + 1)*exp(s/tau), s**2 + 2, s)
+    tf_m = TransferFunctionMatrix([[tf2],[tf3]])
 
     assert phase_margin(tf1) == -180 + 180*atan(3*sqrt(11))/pi
     assert phase_margin(tf2) == 0
 
     raises(ValueError, lambda: phase_margin(tf3))
+    raises(NotImplementedError, lambda: phase_margin(tf4))
+    raises(ValueError, lambda: phase_margin(MIMOSeries(tf_m)))
 
 def test_TransferFunction_gain_margin():
     # Test for gain margin
     tf1 = TransferFunction(s**2, 5*(s+1)*(s-5)*(s-10), s)
     tf2 = TransferFunction(s**2 + 2*s + 1, 1, s)
     tf3 = TransferFunction(1, a*s+b, s)
+    tf4 = TransferFunction((s + 1)*exp(s/tau), s**2 + 2, s)
+    tf_m = TransferFunctionMatrix([[tf2],[tf3]])
 
     assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)
     assert gain_margin(tf2) == oo
 
     raises(ValueError, lambda: gain_margin(tf3))
+    raises(NotImplementedError, lambda: gain_margin(tf4))
+    raises(ValueError, lambda: gain_margin(MIMOSeries(tf_m)))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1325,8 +1325,8 @@ def test_TransferFunction_phase_margin():
     assert phase_margin(tf1) == -180 + 180*atan(3*sqrt(11))/pi
     assert phase_margin(tf2) == 0
 
-    raises(ValueError, lambda: phase_margin(tf3))
     raises(NotImplementedError, lambda: phase_margin(tf4))
+    raises(ValueError, lambda: phase_margin(tf3))
     raises(ValueError, lambda: phase_margin(MIMOSeries(tf_m)))
 
 def test_TransferFunction_gain_margin():
@@ -1340,6 +1340,6 @@ def test_TransferFunction_gain_margin():
     assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)
     assert gain_margin(tf2) == oo
 
-    raises(ValueError, lambda: gain_margin(tf3))
     raises(NotImplementedError, lambda: gain_margin(tf4))
+    raises(ValueError, lambda: gain_margin(tf3))
     raises(ValueError, lambda: gain_margin(MIMOSeries(tf_m)))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1326,7 +1326,7 @@ def test_TransferFunction_phase_margin():
 
 def test_TransferFunction_gain_margin():
     tf1 = TransferFunction(s**2, 5*(s+1)*(s-5)*(s-10), s)
-    tf2 = TransferFunction(s**2 + 2*s + 1,1, s)
+    tf2 = TransferFunction(s**2 + 2*s + 1, 1, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
     assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1314,22 +1314,28 @@ def test_TransferFunction_backward_diff():
 
     assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num
 
-def test_TransferFunction_phase_margin():
+def test_TransferFunction_pm():
+    # Test for phase margin
     tf1 = TransferFunction(10, p**3 + 1, p)
     tf2 = TransferFunction(s**2, 10, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
-    assert phase_margin(tf1) == -180 + 180*atan(3*sqrt(11))/pi
-    assert phase_margin(tf2) == 0
+    pm1 = phase_margin(tf1)
+    pm2 = phase_margin(tf2)
+    assert pm1 == -180 + 180*atan(3*sqrt(11))/pi
+    assert pm2 == 0
 
     raises(ValueError, lambda: phase_margin(tf3))
 
-def test_TransferFunction_gain_margin():
+def test_TransferFunction_gm():
+    # Test for gain margin
     tf1 = TransferFunction(s**2, 5*(s+1)*(s-5)*(s-10), s)
     tf2 = TransferFunction(s**2 + 2*s + 1, 1, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
-    assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)
-    assert gain_margin(tf2) == oo
+    gm1 = gain_margin(tf1)
+    gm2 = gain_margin(tf2)
+    assert gm1 == -20*log(S(7)/540)/log(10)
+    assert gm2 == oo
 
     raises(ValueError, lambda: gain_margin(tf3))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1314,28 +1314,24 @@ def test_TransferFunction_backward_diff():
 
     assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num
 
-def test_TransferFunction_pm():
+def test_TransferFunction_phase_margin():
     # Test for phase margin
     tf1 = TransferFunction(10, p**3 + 1, p)
     tf2 = TransferFunction(s**2, 10, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
-    pm1 = phase_margin(tf1)
-    pm2 = phase_margin(tf2)
-    assert pm1 == -180 + 180*atan(3*sqrt(11))/pi
-    assert pm2 == 0
+    assert phase_margin == -180 + 180*atan(3*sqrt(11))/pi
+    assert phase_margin == 0
 
     raises(ValueError, lambda: phase_margin(tf3))
 
-def test_TransferFunction_gm():
+def test_TransferFunction_gain_margin():
     # Test for gain margin
     tf1 = TransferFunction(s**2, 5*(s+1)*(s-5)*(s-10), s)
     tf2 = TransferFunction(s**2 + 2*s + 1, 1, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
-    gm1 = gain_margin(tf1)
-    gm2 = gain_margin(tf2)
-    assert gm1 == -20*log(S(7)/540)/log(10)
-    assert gm2 == oo
+    assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)
+    assert gain_margin(tf2) == oo
 
     raises(ValueError, lambda: gain_margin(tf3))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1,12 +1,13 @@
 from sympy.core.add import Add
 from sympy.core.function import Function
 from sympy.core.mul import Mul
-from sympy.core.numbers import (I, Rational, oo)
+from sympy.core.numbers import (I, pi, Rational, oo)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
-from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.trigonometric import atan
 from sympy.matrices.dense import eye
 from sympy.polys.polytools import factor
 from sympy.polys.rootoftools import CRootOf
@@ -15,7 +16,7 @@ from sympy.core.containers import Tuple
 from sympy.matrices import ImmutableMatrix, Matrix
 from sympy.physics.control import (TransferFunction, Series, Parallel,
     Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
-    gbt, bilinear, forward_diff, backward_diff)
+    gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises
 
 a, x, b, s, g, d, p, k, a0, a1, a2, b0, b1, b2, tau, zeta, wn, T = symbols('a, x, b, s, g, d, p, k,\
@@ -1312,3 +1313,23 @@ def test_TransferFunction_backward_diff():
     tf_test_manual = TransferFunction(s * T/(a + b*T), s - a/(a + b*T), s)
 
     assert S.Zero == (tf_test_backward.simplify()-tf_test_manual.simplify()).simplify().num
+
+def test_TransferFunction_phase_margin():
+    tf1 = TransferFunction(10, p**3 + 1, p)
+    tf2 = TransferFunction(s**2, 10, s)
+    tf3 = TransferFunction(1, a*s+b, s)
+
+    assert phase_margin(tf1) == -180 + 180*atan(3*sqrt(11))/pi
+    assert phase_margin(tf2) == 0
+
+    raises(ValueError, lambda: phase_margin(tf3))
+
+def test_TransferFunction_gain_margin():
+    tf1 = TransferFunction(s**2, 5*(s+1)*(s-5)*(s-10), s)
+    tf2 = TransferFunction(s**2 + 2*s + 1,1, s)
+    tf3 = TransferFunction(1, a*s+b, s)
+
+    assert gain_margin(tf1) == -20*log(S(7)/540)/log(10)
+    assert gain_margin(tf2) == oo
+
+    raises(ValueError, lambda: gain_margin(tf3))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1320,8 +1320,8 @@ def test_TransferFunction_phase_margin():
     tf2 = TransferFunction(s**2, 10, s)
     tf3 = TransferFunction(1, a*s+b, s)
 
-    assert phase_margin == -180 + 180*atan(3*sqrt(11))/pi
-    assert phase_margin == 0
+    assert phase_margin(tf1) == -180 + 180*atan(3*sqrt(11))/pi
+    assert phase_margin(tf2) == 0
 
     raises(ValueError, lambda: phase_margin(tf3))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added phase and gain margins for transfer functions.
<!-- END RELEASE NOTES -->
