### PR TITLE
Rationalizing floats in the intersection function in util.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1493,6 +1493,7 @@ bluebrook <perl4logic@gmail.com>
 carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>
 cocolato <haiizhu@outlook.com> Hai Zhu <35182391+cocolato@users.noreply.github.com>
+codecruisader <nnisarg55@gmail.com>
 cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -254,7 +254,7 @@ def test_ellipse_geom():
     assert intersection(Ellipse(Point(0, 0), 2, 1), Ellipse(Point(3, 0), 1, 2)) == [Point(2, 0)]
     assert intersection(Circle(Point(0, 0), 2), Circle(Point(3, 0), 1)) == [Point(2, 0)]
     assert intersection(Circle(Point(0, 0), 2), Circle(Point(7, 0), 1)) == []
-    assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 1, 0.2)) == [Point(5, 0)]
+    assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 1, 0.2)) == [Point(5.0, 0)]
     assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 0.999, 0.2)) == []
     assert Circle((0, 0), S.Half).intersection(
         Triangle((-1, 0), (1, 0), (0, 1))) == [

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -254,7 +254,8 @@ def test_ellipse_geom():
     assert intersection(Ellipse(Point(0, 0), 2, 1), Ellipse(Point(3, 0), 1, 2)) == [Point(2, 0)]
     assert intersection(Circle(Point(0, 0), 2), Circle(Point(3, 0), 1)) == [Point(2, 0)]
     assert intersection(Circle(Point(0, 0), 2), Circle(Point(7, 0), 1)) == []
-    assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 1, 0.2)) == [Point(5.0, 0)]
+    assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 1, 0.2)
+        ) == [Point(5.0, 0, evaluate=False)]
     assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 0.999, 0.2)) == []
     assert Circle((0, 0), S.Half).intersection(
         Triangle((-1, 0), (1, 0), (0, 1))) == [

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -4,8 +4,8 @@ from sympy.core.symbol import Symbol
 from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
-    intersection, centroid, Point3D, Line3D
-from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar
+    intersection, centroid, Point3D, Line3D, Ellipse
+from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar, rational_entity
 from sympy.solvers.solvers import solve
 from sympy.testing.pytest import raises
 
@@ -55,6 +55,12 @@ def test_intersection():
             Segment((-1, 0), (1, 0)),
             Line((0, 0), slope=1), pairwise=True) == [
         Point(0, 0), Segment((0, 0), (1, 0))]
+
+
+def test_rational_entity():
+    raises(TypeError, lambda: rational_entity(2.32))
+    e1 = Ellipse(center=Point2D(0, 0), hradius=4.5, vradius=2.5)
+    assert rational_entity(e1) == Ellipse(Point2D(0, 0), 9/2, 5/2)
 
 
 def test_convex_hull():

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -5,7 +5,7 @@ from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
     intersection, centroid, Point3D, Line3D, Ellipse
-from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar, rational_entity
+from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar
 from sympy.solvers.solvers import solve
 from sympy.testing.pytest import raises
 
@@ -57,10 +57,6 @@ def test_intersection():
         Point(0, 0), Segment((0, 0), (1, 0))]
 
 
-def test_rational_entity():
-    raises(TypeError, lambda: rational_entity(2.32))
-    e1 = Ellipse(center=Point2D(0, 0), hradius=4.5, vradius=2.5)
-    assert rational_entity(e1) == Ellipse(Point2D(0, 0), 9/2, 5/2)
 
 
 def test_convex_hull():

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,10 +1,12 @@
+import pytest
+from sympy.core.numbers import Float
 from sympy.core.function import (Derivative, Function)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
-    intersection, centroid, Point3D, Line3D
+    intersection, centroid, Point3D, Line3D, Ray, Ellipse
 from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar
 from sympy.solvers.solvers import solve
 from sympy.testing.pytest import raises
@@ -55,8 +57,16 @@ def test_intersection():
             Segment((-1, 0), (1, 0)),
             Line((0, 0), slope=1), pairwise=True) == [
         Point(0, 0), Segment((0, 0), (1, 0))]
-
-
+    assert intersection(
+            Ray(Point2D(0.001, -1),
+            Point2D(0.0008, -1.7)),
+            Ellipse(center=Point2D(0, 0), hradius=4.0, vradius=2.0), pairwise=True)[0].coordinates == pytest.approx(
+            Point2D(0.000714285723396502, -1.99999996811224, evaluate=False).coordinates)
+    assert intersection(
+            Ray(Point2D(0.001, -1),
+            Point2D(0.0008, -1.7)),
+            Ellipse(center=Point2D(0, 0), hradius=Float(4,10), vradius=2.0), pairwise=True)[0].coordinates == pytest.approx(
+            Point2D(0.000714285723396502, -1.99999996811224, evaluate=False).coordinates)
 
 
 def test_convex_hull():

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -4,7 +4,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
-    intersection, centroid, Point3D, Line3D, Ellipse
+    intersection, centroid, Point3D, Line3D
 from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar
 from sympy.solvers.solvers import solve
 from sympy.testing.pytest import raises

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -57,16 +57,23 @@ def test_intersection():
             Segment((-1, 0), (1, 0)),
             Line((0, 0), slope=1), pairwise=True) == [
         Point(0, 0), Segment((0, 0), (1, 0))]
-    assert intersection(
+    R = 4.0
+    intersection(
             Ray(Point2D(0.001, -1),
             Point2D(0.0008, -1.7)),
-            Ellipse(center=Point2D(0, 0), hradius=4.0, vradius=2.0), pairwise=True)[0].coordinates == pytest.approx(
+            Ellipse(center=Point2D(0, 0), hradius=R, vradius=2.0), pairwise=True)[0].coordinates
+    assert c == pytest.approx(
             Point2D(0.000714285723396502, -1.99999996811224, evaluate=False).coordinates)
-    assert intersection(
+    # check this is responds to a lower precision parameter
+    R = Float(4, 5)
+    c2 = intersection(
             Ray(Point2D(0.001, -1),
             Point2D(0.0008, -1.7)),
-            Ellipse(center=Point2D(0, 0), hradius=Float(4,10), vradius=2.0), pairwise=True)[0].coordinates == pytest.approx(
+            Ellipse(center=Point2D(0, 0), hradius=R, vradius=2.0), pairwise=True)[0].coordinates
+    assert c2 == pytest.approx(
             Point2D(0.000714285723396502, -1.99999996811224, evaluate=False).coordinates)
+    assert c[0]._prec == 53
+    assert c2[0]._prec == 20
 
 
 def test_convex_hull():

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -58,7 +58,7 @@ def test_intersection():
             Line((0, 0), slope=1), pairwise=True) == [
         Point(0, 0), Segment((0, 0), (1, 0))]
     R = 4.0
-    intersection(
+    c = intersection(
             Ray(Point2D(0.001, -1),
             Point2D(0.0008, -1.7)),
             Ellipse(center=Point2D(0, 0), hradius=R, vradius=2.0), pairwise=True)[0].coordinates

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -15,6 +15,10 @@ from collections import deque
 from math import sqrt as _sqrt
 
 
+from sympy import nsimplify
+from sympy.core.numbers import Rational
+from sympy.core.numbers import Float
+from sympy.core.symbol import Dummy
 from .entity import GeometryEntity
 from .exceptions import GeometryError
 from .point import Point, Point2D, Point3D
@@ -699,6 +703,7 @@ def intersection(*entities, pairwise=False, **kwargs):
     for i, e in enumerate(entities):
         if not isinstance(e, GeometryEntity):
             entities[i] = Point(e)
+        entities[i] = rational_entity(entities[i])
 
     if not pairwise:
         # find the intersection common to all objects
@@ -716,3 +721,35 @@ def intersection(*entities, pairwise=False, **kwargs):
         for k in range(j + 1, len(entities)):
             ans.extend(intersection(entities[j], entities[k]))
     return list(ordered(set(ans)))
+
+
+def rational_entity(entity):
+    """Returns the rationalized version of a geometric entity
+
+    Parameters
+    ==========
+    entity : A single geometric entity
+
+    Returns
+    ==========
+    entity : Rationalized geometric entity
+
+    Raises
+    ==========
+    TypeError : When passed an object which is not a geomtry entity
+
+    Examples
+    ==========
+    >>> from sympy import Dummy, Float, nsimplify
+    >>> from sympy.geometry import Ellipse, Point2D
+    >>> e1 = Ellipse(center=Point2D(0.23, 0), hradius=4.412, vradius=2.0)
+    >>> print(rational_entity(e1))
+    Ellipse(Point2D(23/100, 0), 1103/250, 2)
+
+    """
+    if not isinstance(entity,GeometryEntity):
+        raise TypeError("Expecting a geometry entity, but got type:  ",type(entity))
+    if not entity.has(Float):
+        return entity
+    y = Dummy()
+    return entity.replace(lambda x: x.is_Float, lambda x: nsimplify(x, rational=True)+y).xreplace({y: 0})

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -15,7 +15,6 @@ from collections import deque
 from math import sqrt as _sqrt
 
 from sympy import nsimplify
-from sympy.core.symbol import Dummy
 from .entity import GeometryEntity
 from .exceptions import GeometryError
 from .point import Point, Point2D, Point3D
@@ -28,6 +27,8 @@ from sympy.core.singleton import S
 from sympy.polys.polytools import cancel
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import is_sequence
+
+from mpmath.libmp.libmpf import prec_to_dps
 
 
 def find(x, equation):
@@ -695,13 +696,18 @@ def intersection(*entities, pairwise=False, **kwargs):
     if len(entities) <= 1:
         return []
 
-    # entities may be an immutable tuple
     entities = list(entities)
-    y = Dummy()
+    prec = None
     for i, e in enumerate(entities):
         if not isinstance(e, GeometryEntity):
-            entities[i] = Point(e)
-        entities[i] = entities[i].replace(lambda x: x.is_Float, lambda x: nsimplify(x, rational=True) + y).xreplace({y: 0})
+            # entities may be an immutable tuple
+            e = Point(e)
+        # convert to exact Rationals
+        d = {}
+        for f in e.atoms(Float):
+            prec = f._prec if prec is None else min(f._prec, prec)
+            d.setdefault(f, nsimplify(f, rational=True))
+        entities[i] = e.xreplace(d)
 
     if not pairwise:
         # find the intersection common to all objects
@@ -711,11 +717,16 @@ def intersection(*entities, pairwise=False, **kwargs):
             for x in res:
                 newres.extend(x.intersection(entity))
             res = newres
-        return res
+    else:
+        # find all pairwise intersections
+        ans = []
+        for j in range(len(entities)):
+            for k in range(j + 1, len(entities)):
+                ans.extend(intersection(entities[j], entities[k]))
+        res = list(ordered(set(ans)))
 
-    # find all pairwise intersections
-    ans = []
-    for j in range(len(entities)):
-        for k in range(j + 1, len(entities)):
-            ans.extend(intersection(entities[j], entities[k]))
-    return list(ordered(set(ans)))
+    # convert back to Floats
+    if prec is not None:
+        p = prec_to_dps(prec)
+        res = [i.n(p) for i in res]
+    return res

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -14,10 +14,7 @@ are_similar
 from collections import deque
 from math import sqrt as _sqrt
 
-
 from sympy import nsimplify
-from sympy.core.numbers import Rational
-from sympy.core.numbers import Float
 from sympy.core.symbol import Dummy
 from .entity import GeometryEntity
 from .exceptions import GeometryError
@@ -700,10 +697,11 @@ def intersection(*entities, pairwise=False, **kwargs):
 
     # entities may be an immutable tuple
     entities = list(entities)
+    y = Dummy()
     for i, e in enumerate(entities):
         if not isinstance(e, GeometryEntity):
             entities[i] = Point(e)
-        entities[i] = rational_entity(entities[i])
+        entities[i] = entities[i].replace(lambda x: x.is_Float, lambda x: nsimplify(x, rational=True) + y).xreplace({y: 0})
 
     if not pairwise:
         # find the intersection common to all objects
@@ -721,35 +719,3 @@ def intersection(*entities, pairwise=False, **kwargs):
         for k in range(j + 1, len(entities)):
             ans.extend(intersection(entities[j], entities[k]))
     return list(ordered(set(ans)))
-
-
-def rational_entity(entity):
-    """Returns the rationalized version of a geometric entity
-
-    Parameters
-    ==========
-    entity : A single geometric entity
-
-    Returns
-    ==========
-    entity : Rationalized geometric entity
-
-    Raises
-    ==========
-    TypeError : When passed an object which is not a geomtry entity
-
-    Examples
-    ==========
-    >>> from sympy import Dummy, Float, nsimplify
-    >>> from sympy.geometry import Ellipse, Point2D
-    >>> e1 = Ellipse(center=Point2D(0.23, 0), hradius=4.412, vradius=2.0)
-    >>> print(rational_entity(e1))
-    Ellipse(Point2D(23/100, 0), 1103/250, 2)
-
-    """
-    if not isinstance(entity,GeometryEntity):
-        raise TypeError("Expecting a geometry entity, but got type:  ",type(entity))
-    if not entity.has(Float):
-        return entity
-    y = Dummy()
-    return entity.replace(lambda x: x.is_Float, lambda x: nsimplify(x, rational=True)+y).xreplace({y: 0})

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -21,6 +21,7 @@ from .point import Point, Point2D, Point3D
 from sympy.core.containers import OrderedSet
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import Function, expand_mul
+from sympy.core.numbers import Float
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Symbol
 from sympy.core.singleton import S


### PR DESCRIPTION
Added functionality to rationalize floats in the intersection function in util.py

**References to other Issues or PRs**
Fixes [#25368](https://github.com/sympy/sympy/issues/25368)

**Brief description of what is fixed or changed**
Geometric Entities that have float values in them are rationalized in the intersection finding method in `util.py`. This intends to solve the problem of not finding intersections when having entities with float values.

**Release Notes**
<!-- BEGIN RELEASE NOTES -->
* geometry
  * Computes the correct intersection result when using floats.
<!-- END RELEASE NOTES -->

P.S. This is my first pull request in this project, please feel free to point out any mistake or optimization that you would like me to fix.


