### PR TITLE
Sets `JaxPrinter.printmethod` to `_jaxcode`

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -483,6 +483,7 @@ class JaxPrinter(NumPyPrinter):
 
     def __init__(self, settings=None):
         super().__init__(settings=settings)
+        self.printmethod = '_jaxcode'
 
     # These need specific override to allow for the lack of "jax.numpy.reduce"
     def _print_And(self, expr):

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -9,7 +9,7 @@ from sympy.matrices.expressions.special import Identity
 from sympy.utilities.lambdify import lambdify
 
 from sympy.abc import x, i, j, a, b, c, d
-from sympy.core import Pow
+from sympy.core import Function, Pow, Symbol
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Sqrt
@@ -355,3 +355,16 @@ def test_jax_printmethod():
     printer = JaxPrinter()
     assert hasattr(printer, 'printmethod')
     assert printer.printmethod == '_jaxcode'
+
+
+def test_jax_custom_print_method():
+
+    class expm1(Function):
+
+        def _jaxcode(self, printer):
+            x, = self.args
+            function = f'expm1({printer._print(x)})'
+            return printer._module_format(printer._module + '.' + function)
+
+    printer = JaxPrinter()
+    assert printer.doprint(expm1(Symbol('x'))) == 'jax.numpy.expm1(x)'

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -36,6 +36,7 @@ if jax:
     deafult_float_info = jax.numpy.finfo(jax.numpy.array([]).dtype)
     JAX_DEFAULT_EPSILON = deafult_float_info.eps
 
+
 def test_jax_piecewise_regression():
     """
     NumPyPrinter needs to print Piecewise()'s choicelist as a list to avoid
@@ -330,9 +331,11 @@ def test_issue_17006():
     N = MatrixSymbol("M", n, n)
     raises(NotImplementedError, lambda: lambdify(N, N + Identity(n), 'jax'))
 
+
 def test_jax_array():
     assert JaxPrinter().doprint(Array(((1, 2), (3, 5)))) == 'jax.numpy.array([[1, 2], [3, 5]])'
     assert JaxPrinter().doprint(Array((1, 2))) == 'jax.numpy.array((1, 2))'
+
 
 def test_jax_known_funcs_consts():
     assert _jax_known_constants['NaN'] == 'jax.numpy.nan'
@@ -340,6 +343,7 @@ def test_jax_known_funcs_consts():
 
     assert _jax_known_functions['acos'] == 'jax.numpy.arccos'
     assert _jax_known_functions['log'] == 'jax.numpy.log'
+
 
 def test_jax_print_methods():
     prntr = JaxPrinter()

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -349,3 +349,9 @@ def test_jax_print_methods():
     prntr = JaxPrinter()
     assert hasattr(prntr, '_print_acos')
     assert hasattr(prntr, '_print_log')
+
+
+def test_jax_printmethod():
+    printer = JaxPrinter()
+    assert hasattr(printer, 'printmethod')
+    assert printer.printmethod == '_jaxcode'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25438. 

#### Brief description of what is fixed or changed
`JaxPrinter.printmethod`, which was previously an invalid identifier meaning that custom JAX printing for custom classes couldn't be defined, is now `_jaxcode`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug that prohibited users from defining custom JAX printing for custom classes, which can now be done by defining a `_jaxcode` method.
<!-- END RELEASE NOTES -->
