### PR TITLE
parsing: Add noqa to silence flake8

### DIFF
--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -28,7 +28,7 @@ ErrorListener = import_module('antlr4.error.ErrorListener',
 
 
 if ErrorListener:
-    class MathErrorListener(ErrorListener.ErrorListener):  # type: ignore
+    class MathErrorListener(ErrorListener.ErrorListener):  # type:ignore # noqa:F811
         def __init__(self, src):
             super(ErrorListener.ErrorListener, self).__init__()
             self.src = src


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

I also opened a pyflakes ticket:
https://github.com/PyCQA/pyflakes/issues/780

#### Brief description of what is fixed or changed

Add noqa because the latest release of flake8 complains about the antlr code.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
