### PR TITLE
Evaluate floor and ceil for half odd/even integer arguments

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -76,6 +76,12 @@ class RoundFunction(Function):
         elif isinstance(spart, (floor, ceiling)):
             return ipart + spart
         else:
+            numer, denom = spart.as_numer_denom()
+            if denom == 2:
+                if numer.is_even:
+                    return ipart + spart
+                if numer.is_odd:
+                    return ipart + spart + cls._dir/S(2)
             return ipart + cls(spart, evaluate=False)
 
     @classmethod
@@ -196,6 +202,16 @@ class floor(RoundFunction):
 
     def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg - frac(arg)
+
+    def _eval_simplify(self, **kwargs):
+        arg = self.args[0]
+        numer, denom = arg.as_numer_denom()
+        if denom == 2:
+            if numer.is_even:
+                return arg
+            if numer.is_odd:
+                return arg - S.Half
+        return self
 
     def __le__(self, other):
         other = S(other)
@@ -364,6 +380,15 @@ class ceiling(RoundFunction):
 
     def _eval_is_nonpositive(self):
         return self.args[0].is_nonpositive
+
+    def _eval_simplify(self, **kwargs):
+        num, den = self.args[0].as_numer_denom()
+        if den == 2:
+            if num.is_even:
+                return self.args[0]
+            if num.is_odd:
+                return self.args[0] + S.Half
+        return self
 
     def __lt__(self, other):
         other = S(other)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -203,6 +203,13 @@ def test_floor():
     assert (floor(y) < n) == (y < n)
     assert (floor(y) > n) == (y >= n + 1)
 
+    Neven = Symbol('N', even=True)
+    Nodd = Symbol('N', odd=True)
+    assert floor(Neven/2) == Neven/2
+    assert floor(Nodd/2) == Nodd/2 - S.Half
+    assert floor((Neven - 1)/2) == Neven/2 - 1
+    assert floor((Nodd - 1)/2) == Nodd/2 - S.Half
+
 
 def test_ceiling():
 
@@ -387,6 +394,13 @@ def test_ceiling():
     assert (ceiling(y) >= n) == (y > n - 1)
     assert (ceiling(y) < n) == (y <= n - 1)
     assert (ceiling(y) > n) == (y > n)
+
+    Neven = Symbol('N', even=True)
+    Nodd = Symbol('N', odd=True)
+    assert ceiling(Neven/2) == Neven/2
+    assert ceiling(Nodd/2) == Nodd/2 + S.Half
+    assert ceiling((Neven - 1)/2) == Neven/2
+    assert ceiling((Nodd - 1)/2) == Nodd/2 - S.Half
 
 
 def test_frac():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I required a way to simplify this and thought it was worth adding as the default behavior as the added tests already passes for the even case.

Also, there are quite limited things that can be done later on with `floor` and `ceiling`, so getting rid of it if possible should be beneficial most of the time.

#### Other comments

There is also a dedicated `_eval_simplify` added. However, this will typically not work since the resulting expression of e.g. `floor(Nodd/2)` is not considered smaller.  This was especially a problem when the floor is an exponent (which was the case I had). Not sure if there is any benefit to keep it.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `floor` and `ceiling` evaluates if the argument is half of an odd or even number. 
<!-- END RELEASE NOTES -->
