### PR TITLE
[GSOC_2.4] Support phase unwrapping in frequency response

### DIFF
--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -778,7 +778,7 @@ def bode_magnitude_plot(system, initial_exp=-5, final_exp=5,
     return plt
 
 
-def bode_phase_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit='rad/sec', phase_unit='rad', **kwargs):
+def bode_phase_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit='rad/sec', phase_unit='rad', phase_unwrap = True, **kwargs):
     """
     Returns the numerical data of the Bode phase plot of the system.
     It is internally used by ``bode_phase_plot`` to get the data
@@ -799,6 +799,8 @@ def bode_phase_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit='ra
         User can choose between ``'rad/sec'`` (radians/second) and '``'Hz'`` (Hertz) as frequency units.
     phase_unit : string, optional
         User can choose between ``'rad'`` (radians) and ``'deg'`` (degree) as phase units.
+    phase_unwrap : bool, optional
+        Set to ``True`` by default.
 
     Returns
     =======
@@ -863,18 +865,35 @@ def bode_phase_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit='ra
     x, y = LineOver1DRangeSeries(phase,
         (_w, 10**initial_exp, 10**final_exp), xscale='log', **kwargs).get_points()
 
+    if phase_unwrap:
+        if(phase_unit == 'rad'):
+            for i in range(1, len(y)):
+                diff = y[i] - y[i - 1]
+                if diff > pi:      # Jump from -pi to pi
+                    y[i] = (y[i] - 2*pi)
+                elif diff < -pi:   # Jump from pi to -pi
+                    y[i] = (y[i] + 2*pi)
+
+        elif(phase_unit == 'deg'):
+            for i in range(1, len(y)):
+                diff = y[i] - y[i - 1]
+                if diff > 180:      # Jump from -180 to 180
+                    y[i] = (y[i] - 360)
+                elif diff < -180:   # Jump from 180 to -180
+                    y[i] = (y[i] + 360)
+
     return x, y
 
 
 def bode_phase_plot(system, initial_exp=-5, final_exp=5,
-    color='b', show_axes=False, grid=True, show=True, freq_unit='rad/sec', phase_unit='rad', **kwargs):
+    color='b', show_axes=False, grid=True, show=True, freq_unit='rad/sec', phase_unit='rad', phase_unwrap=True, **kwargs):
     r"""
     Returns the Bode phase plot of a continuous-time system.
 
     See ``bode_plot`` for all the parameters.
     """
     x, y = bode_phase_numerical_data(system, initial_exp=initial_exp,
-        final_exp=final_exp, freq_unit=freq_unit, phase_unit=phase_unit)
+        final_exp=final_exp, freq_unit=freq_unit, phase_unit=phase_unit, phase_unwrap=phase_unwrap)
     plt.plot(x, y, color=color, **kwargs)
     plt.xscale('log')
 
@@ -895,7 +914,7 @@ def bode_phase_plot(system, initial_exp=-5, final_exp=5,
 
 
 def bode_plot(system, initial_exp=-5, final_exp=5,
-    grid=True, show_axes=False, show=True, freq_unit='rad/sec', phase_unit='rad', **kwargs):
+    grid=True, show_axes=False, show=True, freq_unit='rad/sec', phase_unit='rad', phase_unwrap=True, **kwargs):
     r"""
     Returns the Bode phase and magnitude plots of a continuous-time system.
 
@@ -952,7 +971,7 @@ def bode_plot(system, initial_exp=-5, final_exp=5,
     mag.xlabel(None)
     plt.subplot(212)
     bode_phase_plot(system, initial_exp=initial_exp, final_exp=final_exp,
-        show=False, grid=grid, show_axes=show_axes, freq_unit=freq_unit, phase_unit=phase_unit, **kwargs).title(None)
+        show=False, grid=grid, show_axes=show_axes, freq_unit=freq_unit, phase_unit=phase_unit, phase_unwrap=phase_unwrap, **kwargs).title(None)
 
     if show:
         plt.show()

--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -865,22 +865,20 @@ def bode_phase_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit='ra
     x, y = LineOver1DRangeSeries(phase,
         (_w, 10**initial_exp, 10**final_exp), xscale='log', **kwargs).get_points()
 
+    half = None
     if phase_unwrap:
         if(phase_unit == 'rad'):
-            for i in range(1, len(y)):
-                diff = y[i] - y[i - 1]
-                if diff > pi:      # Jump from -pi to pi
-                    y[i] = (y[i] - 2*pi)
-                elif diff < -pi:   # Jump from pi to -pi
-                    y[i] = (y[i] + 2*pi)
-
+            half = pi
         elif(phase_unit == 'deg'):
-            for i in range(1, len(y)):
-                diff = y[i] - y[i - 1]
-                if diff > 180:      # Jump from -180 to 180
-                    y[i] = (y[i] - 360)
-                elif diff < -180:   # Jump from 180 to -180
-                    y[i] = (y[i] + 360)
+            half = 180
+    if half:
+        unit = 2*half
+        for i in range(1, len(y)):
+            diff = y[i] - y[i - 1]
+            if diff > half:      # Jump from -half to half
+                y[i] = (y[i] - unit)
+            elif diff < -half:   # Jump from half to -half
+                y[i] = (y[i] + unit)
 
     return x, y
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25444 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added support for phase unwrap in bode plot
<!-- END RELEASE NOTES -->
