### PR TITLE
Added check for when 2 is not the primitive root

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -137,19 +137,15 @@ def _primitive_root_prime_iter(p):
     if p == 3:
         yield 2
         return
+    # Let p = +-1 (mod 4a). Legendre symbol (a/p) = 1, so `a` is not the primitive root.
+    # Corollary : If p = +-1 (mod 8), then 2 is not the primitive root of p.
+    g_min = 3 if p % 8 in [1, 7] else 2
     if p < 41:
         # small case
-        if p == 23:
-            g = 5
-        elif p == 7 or p % 7 == 3:
-            # 3 is the smallest primitive root of p = 7,17,31
-            g = 3
-        else:
-            # 2 is the smallest primitive root of p = 5,11,13,19,29,37
-            g = 2
+        g = 5 if p == 23 else g_min
     else:
         v = [(p - 1) // i for i in factorint(p - 1).keys()]
-        for g in range(2, p):
+        for g in range(g_min, p):
             if all(pow(g, pw, p) != 1 for pw in v):
                 break
     yield g
@@ -840,7 +836,7 @@ def _nthroot_mod1(s, q, p, all_roots):
     Parameters
     ==========
 
-    a : integer
+    s : integer
     q : integer, n > 2. ``q`` divides ``p - 1``.
     p : prime number
     all_roots : if False returns the smallest root, else the list of roots
@@ -864,10 +860,11 @@ def _nthroot_mod1(s, q, p, all_roots):
     References
     ==========
 
-    .. [1] A. M. Johnston "A Generalized qth Root Algorithm"
+    .. [1] A. M. Johnston, A Generalized qth Root Algorithm,
+           ACM-SIAM Symposium on Discrete Algorithms (1999), pp. 929-930
 
     """
-    g = primitive_root(p)
+    g = next(_primitive_root_prime_iter(p))
     r = s
     for qx, ex in factorint(q).items():
         f = (p - 1) // qx**ex


### PR DESCRIPTION
If p = +-1 (mod 8), then 2 is not the primitive root. Therefore, the primitive root check can be omitted.

Also, if the input is known to be prime, `_primitive_root_prime_iter` is called instead of `primitive_root`.

Other docstring fixes.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
