### PR TITLE
feat(polys): Add GROUND_TYPES='flint'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ ignore_errors = true
 module = [
     "antlr4.*",
     "Cython.*",
+    "flint.*",
     "gmpy.*",
     "gmpy2.*",
     "IPython.*",

--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -42,8 +42,10 @@ def pytest_report_header(config):
         import gmpy2
         version = gmpy2.version()
     elif GROUND_TYPES == 'flint':
-        import flint
-        version = flint.version()
+        # XXX: flint does not have a version() function
+        #import flint
+        #version = flint.version()
+        version = 'unknown'
     s += "ground types: %s %s\n" % (GROUND_TYPES, version)
     return s
 

--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -4,15 +4,18 @@ from sympy.external.importtools import version_tuple
 
 import pytest
 from sympy.core.cache import clear_cache, USE_CACHE
-from sympy.external.gmpy import GROUND_TYPES, HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 from sympy.utilities.misc import ARCH
 import re
 from hypothesis import settings
 
+
 sp = re.compile(r'([0-9]+)/([1-9][0-9]*)')
+
 
 settings.register_profile("sympy_hypothesis_profile", deadline=None)
 settings.load_profile("sympy_hypothesis_profile")
+
 
 def process_split(config, items):
     split = config.getoption("--split")
@@ -36,11 +39,11 @@ def pytest_report_header(config):
     s += "cache:        %s\n" % USE_CACHE
     version = ''
     if GROUND_TYPES =='gmpy':
-        if HAS_GMPY == 1:
-            import gmpy
-        elif HAS_GMPY == 2:
-            import gmpy2 as gmpy
-        version = gmpy.version()
+        import gmpy2
+        version = gmpy2.version()
+    elif GROUND_TYPES == 'flint':
+        import flint
+        version = flint.version()
     s += "ground types: %s %s\n" % (GROUND_TYPES, version)
     return s
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -19,7 +19,7 @@ from .cache import cacheit, clear_cache
 from .decorators import _sympifyit
 from .logic import fuzzy_not
 from .kind import NumberKind
-from sympy.external.gmpy import (SYMPY_INTS, HAS_GMPY, gmpy,
+from sympy.external.gmpy import (SYMPY_INTS, gmpy, flint,
                                  gcd as number_gcd, lcm as number_lcm)
 from sympy.multipledispatch import dispatch
 import mpmath
@@ -4528,23 +4528,35 @@ def equal_valued(x, y):
 def _eval_is_eq(self, other): # noqa: F811
     return False
 
+
 def sympify_fractions(f):
     return Rational(f.numerator, f.denominator, 1)
 
 _sympy_converter[fractions.Fraction] = sympify_fractions
 
-if HAS_GMPY:
+
+if gmpy is not None:
+
     def sympify_mpz(x):
         return Integer(int(x))
 
-    # XXX: The sympify_mpq function here was never used because it is
-    # overridden by the other sympify_mpq function below. Maybe it should just
-    # be removed or maybe it should be used for something...
     def sympify_mpq(x):
         return Rational(int(x.numerator), int(x.denominator))
 
     _sympy_converter[type(gmpy.mpz(1))] = sympify_mpz
     _sympy_converter[type(gmpy.mpq(1, 2))] = sympify_mpq
+
+
+if flint is not None:
+
+    def sympify_fmpz(x):
+        return Integer(int(x))
+
+    def sympify_fmpq(x):
+        return Rational(int(x.numerator), int(x.denominator))
+
+    _sympy_converter[type(flint.fmpz(1))] = sympify_fmpz
+    _sympy_converter[type(flint.fmpq(1, 2))] = sympify_fmpq
 
 
 def sympify_mpmath_mpq(x):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -14,7 +14,7 @@ from .logic import fuzzy_bool, fuzzy_not, fuzzy_and, fuzzy_or
 from .parameters import global_parameters
 from .relational import is_gt, is_lt
 from .kind import NumberKind, UndefinedKind
-from sympy.external.gmpy import HAS_GMPY, gmpy, sqrt
+from sympy.external.gmpy import gmpy, sqrt
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import as_int
@@ -103,16 +103,14 @@ def integer_nthroot(y, n):
         raise ValueError("y must be nonnegative")
     if n < 1:
         raise ValueError("n must be positive")
-    if HAS_GMPY and n < 2**63:
-        # Currently it works only for n < 2**63, else it produces TypeError
+    if gmpy is not None and n < 2**63:
+        # gmpy.iroot works only for n < 2**63, else it produces TypeError
         # sympy issue: https://github.com/sympy/sympy/issues/18374
         # gmpy2 issue: https://github.com/aleaxit/gmpy/issues/257
-        if HAS_GMPY >= 2:
-            x, t = gmpy.iroot(y, n)
-        else:
-            x, t = gmpy.root(y, n)
+        x, t = gmpy.iroot(y, n)
         return as_int(x), bool(t)
-    return _integer_nthroot_python(y, n)
+    else:
+        return _integer_nthroot_python(y, n)
 
 def _integer_nthroot_python(y, n):
     if y in (0, 1):

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -27,7 +27,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import gmpy as _gmpy, flint as _flint
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 
@@ -101,16 +101,24 @@ def test_sympify_Fraction():
 
 
 def test_sympify_gmpy():
-    if HAS_GMPY:
-        if HAS_GMPY == 2:
-            import gmpy2 as gmpy
-        elif HAS_GMPY == 1:
-            import gmpy
+    if _gmpy is not None:
+        import gmpy2
 
-        value = sympify(gmpy.mpz(1000001))
+        value = sympify(gmpy2.mpz(1000001))
         assert value == Integer(1000001) and type(value) is Integer
 
-        value = sympify(gmpy.mpq(101, 127))
+        value = sympify(gmpy2.mpq(101, 127))
+        assert value == Rational(101, 127) and type(value) is Rational
+
+
+def test_sympify_flint():
+    if _flint is not None:
+        import flint
+
+        value = sympify(flint.fmpz(1000001))
+        assert value == Integer(1000001) and type(value) is Integer
+
+        value = sympify(flint.fmpq(101, 127))
         assert value == Rational(101, 127) and type(value) is Rational
 
 

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -113,12 +113,15 @@ elif GROUND_TYPES == 'flint':
         from warnings import warn
         warn("python_flint is not installed, switching to 'python' ground types")
         GROUND_TYPES = 'python'
+    else:
+        GROUND_TYPES = 'flint'
 
 elif GROUND_TYPES == 'python':
 
     # The user asked for Python so ignore gmpy2/flint
     gmpy = None
     flint = None
+    GROUND_TYPES = 'python'
 
 else:
 
@@ -126,9 +129,9 @@ else:
     from warnings import warn
     warn("SYMPY_GROUND_TYPES environment variable unrecognised. "
          "Should be 'python', 'auto', 'gmpy', or 'gmpy2'")
-    GROUND_TYPES = 'python'
     gmpy = None
     flint = None
+    GROUND_TYPES = 'python'
 
 
 #
@@ -162,9 +165,9 @@ elif GROUND_TYPES == 'flint':
 
     HAS_GMPY = 0
     GROUND_TYPES = 'flint'
-    SYMPY_INTS = (int, flint.fmpz)
-    MPZ = flint.fmpz
-    MPQ = flint.fmpq
+    SYMPY_INTS = (int, flint.fmpz) # type: ignore
+    MPZ = flint.fmpz # type: ignore
+    MPQ = flint.fmpq # type: ignore
 
     factorial = python_factorial
     sqrt = python_sqrt

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -92,10 +92,13 @@ if GROUND_TYPES in ('auto', 'gmpy', 'gmpy2'):
                 module_version_attr='version', module_version_attr_call_args=())
     flint = None
 
-    # Warn if user explicitly asked for gmpy but it isn't available.
-    if gmpy is None and GROUND_TYPES in ('gmpy', 'gmpy2'):
-        from warnings import warn
-        warn("gmpy library is not installed, switching to 'python' ground types")
+    if gmpy is None:
+        # Warn if user explicitly asked for gmpy but it isn't available.
+        if GROUND_TYPES != 'auto':
+            from warnings import warn
+            warn("gmpy library is not installed, switching to 'python' ground types")
+
+        # Fall back to Python if gmpy2 is not available
         GROUND_TYPES = 'python'
     else:
         GROUND_TYPES = 'gmpy'

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -1,10 +1,23 @@
 import os
-import sys
 from typing import Tuple as tTuple, Type
 
-import mpmath.libmp as mlib
-
 from sympy.external import import_module
+
+from .pythonmpq import PythonMPQ
+
+from .ntheory import (
+    factorial as python_factorial,
+    sqrt as python_sqrt,
+    sqrtrem as python_sqrtrem,
+    gcd as python_gcd,
+    lcm as python_lcm,
+    is_square as python_is_square,
+    invert as python_invert,
+    legendre as python_legendre,
+    jacobi as python_jacobi,
+    kronecker as python_kronecker,
+)
+
 
 __all__ = [
     # GROUND_TYPES is either 'gmpy' or 'python' depending on which is used. If
@@ -77,24 +90,42 @@ if GROUND_TYPES in ('auto', 'gmpy', 'gmpy2'):
     # Actually import gmpy2
     gmpy = import_module('gmpy2', min_module_version='2.0.0',
                 module_version_attr='version', module_version_attr_call_args=())
+    flint = None
 
     # Warn if user explicitly asked for gmpy but it isn't available.
     if gmpy is None and GROUND_TYPES in ('gmpy', 'gmpy2'):
         from warnings import warn
         warn("gmpy library is not installed, switching to 'python' ground types")
+        GROUND_TYPES = 'python'
+    else:
+        GROUND_TYPES = 'gmpy'
+
+elif GROUND_TYPES == 'flint':
+
+    # Try to use python_flint
+    flint = import_module('flint')
+    gmpy = None
+
+    if flint is None:
+        from warnings import warn
+        warn("python_flint is not installed, switching to 'python' ground types")
+        GROUND_TYPES = 'python'
 
 elif GROUND_TYPES == 'python':
 
-    # The user asked for Python so ignore gmpy2 module.
+    # The user asked for Python so ignore gmpy2/flint
     gmpy = None
+    flint = None
 
 else:
 
-    # Invalid value for SYMPY_GROUND_TYPES. Ignore the gmpy2 module.
+    # Invalid value for SYMPY_GROUND_TYPES. Warn and default to Python.
     from warnings import warn
     warn("SYMPY_GROUND_TYPES environment variable unrecognised. "
          "Should be 'python', 'auto', 'gmpy', or 'gmpy2'")
+    GROUND_TYPES = 'python'
     gmpy = None
+    flint = None
 
 
 #
@@ -105,7 +136,7 @@ else:
 #
 SYMPY_INTS: tTuple[Type, ...]
 
-if gmpy is not None:
+if GROUND_TYPES == 'gmpy':
 
     HAS_GMPY = 2
     GROUND_TYPES = 'gmpy'
@@ -124,9 +155,26 @@ if gmpy is not None:
     jacobi = gmpy.jacobi
     kronecker = gmpy.kronecker
 
-else:
-    from .pythonmpq import PythonMPQ
-    import math
+elif GROUND_TYPES == 'flint':
+
+    HAS_GMPY = 0
+    GROUND_TYPES = 'flint'
+    SYMPY_INTS = (int, flint.fmpz)
+    MPZ = flint.fmpz
+    MPQ = flint.fmpq
+
+    factorial = python_factorial
+    sqrt = python_sqrt
+    is_square = python_is_square
+    sqrtrem = python_sqrtrem
+    gcd = python_gcd
+    lcm = python_lcm
+    invert = python_invert
+    legendre = python_legendre
+    jacobi = python_jacobi
+    kronecker = python_kronecker
+
+elif GROUND_TYPES == 'python':
 
     HAS_GMPY = 0
     GROUND_TYPES = 'python'
@@ -134,118 +182,16 @@ else:
     MPZ = int
     MPQ = PythonMPQ
 
-    factorial = lambda x: int(mlib.ifac(x))
-    sqrt = lambda x: int(mlib.isqrt(x))
+    factorial = python_factorial
+    sqrt = python_sqrt
+    is_square = python_is_square
+    sqrtrem = python_sqrtrem
+    gcd = python_gcd
+    lcm = python_lcm
+    invert = python_invert
+    legendre = python_legendre
+    jacobi = python_jacobi
+    kronecker = python_kronecker
 
-    def is_square(x):
-        if x < 0:
-            return False
-        # Note that the possible values of y**2 % n for a given n are limited.
-        # For example, when n=4, y**2 % n can only take 0 or 1.
-        # In other words, if x % 4 is 2 or 3, then x is not a square number.
-        # Mathematically, it determines if it belongs to the set {y**2 % n},
-        # but implementationally, it can be realized as a logical conjunction
-        # with an n-bit integer.
-        # see https://mersenneforum.org/showpost.php?p=110896
-        # def magic(n):
-        #     s = {y**2 % n for y in range(n)}
-        #     s = set(range(n)) - s
-        #     return sum(1 << bit for bit in s)
-        # >>> print(hex(magic(128)))
-        # 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec
-        # >>> print(hex(magic(99)))
-        # 0x5f6f9ffb6fb7ddfcb75befdec
-        # >>> print(hex(magic(91)))
-        # 0x6fd1bfcfed5f3679d3ebdec
-        # >>> print(hex(magic(85)))
-        # 0xdef9ae771ffe3b9d67dec
-        if 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec & (1 << (x & 127)):
-            return False  # e.g. 2, 3
-        m = x % 765765 # 765765 = 99 * 91 * 85
-        if 0x5f6f9ffb6fb7ddfcb75befdec & (1 << (m % 99)):
-            return False  # e.g. 17, 68
-        if 0x6fd1bfcfed5f3679d3ebdec & (1 << (m % 91)):
-            return False  # e.g. 97, 388
-        if 0xdef9ae771ffe3b9d67dec & (1 << (m % 85)):
-            return False  # e.g. 793, 1408
-        return mlib.sqrtrem(x)[1] == 0
-
-    sqrtrem = lambda x: tuple(int(r) for r in mlib.sqrtrem(x))
-    if sys.version_info[:2] >= (3, 9):
-        gcd = math.gcd
-        lcm = math.lcm
-    else:
-        # Until python 3.8 is no longer supported
-        from functools import reduce
-        gcd = lambda *args: reduce(math.gcd, args, 0)
-
-        def lcm(*args):
-            if 0 in args:
-                return 0
-            return reduce(lambda x, y: x*y//math.gcd(x, y), args, 1)
-
-    def invert(x, m):
-        """ Return y such that x*y == 1 modulo m.
-
-        Uses ``math.pow`` but reproduces the behaviour of ``gmpy2.invert``
-        which raises ZeroDivisionError if no inverse exists.
-        """
-        try:
-            return pow(x, -1, m)
-        except ValueError:
-            raise ZeroDivisionError("invert() no inverse exists")
-
-    def legendre(x, y):
-        """ Return Legendre symbol (x / y).
-
-        Following the implementation of gmpy2,
-        the error is raised only when y is an even number.
-        """
-        if y <= 0 or not y % 2:
-            raise ValueError("y should be an odd prime")
-        x %= y
-        if not x:
-            return 0
-        if pow(x, (y - 1) // 2, y) == 1:
-            return 1
-        return -1
-
-    def jacobi(x, y):
-        """ Return Jacobi symbol (x / y)."""
-        if y <= 0 or not y % 2:
-            raise ValueError("y should be an odd positive integer")
-        x %= y
-        if not x:
-            return int(y == 1)
-        if y == 1 or x == 1:
-            return 1
-        if gcd(x, y) != 1:
-            return 0
-        j = 1
-        while x != 0:
-            while x % 2 == 0 and x > 0:
-                x >>= 1
-                if y % 8 in [3, 5]:
-                    j = -j
-            x, y = y, x
-            if x % 4 == y % 4 == 3:
-                j = -j
-            x %= y
-        return j
-
-    def kronecker(x, y):
-        """ Return Kronecker symbol (x / y)."""
-        if gcd(x, y) != 1:
-            return 0
-        if y == 0:
-            return 1
-        sign = -1 if y < 0 and x < 0 else 1
-        y = abs(y)
-        # We want to calculate s = trailing(y)
-        s = 0
-        while y % 2 == 0:
-            y >>= 1
-            s += 1
-        if s % 2 and x % 8 in [3, 5]:
-            sign = -sign
-        return sign * jacobi(x, y)
+else:
+    assert False

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -1,0 +1,155 @@
+# sympy.external.ntheory
+#
+# This module provides pure Python implementations of some number theory
+# functions that are alternately used from gmpy2 if it is installed.
+
+import sys
+import math
+
+import mpmath.libmp as mlib
+
+
+def factorial(x):
+    """Return x!."""
+    return int(mlib.ifac(x))
+
+
+def sqrt(x):
+    """Integer square root of x."""
+    return int(mlib.sqrt(x))
+
+
+def sqrtrem(x):
+    """Integer square root of x and remainder."""
+    s, r = mlib.sqrtrem(x)
+    return (int(s), int(r))
+
+
+if sys.version_info[:2] >= (3, 9):
+    # As of Python 3.9 these can take multiple arguments
+    gcd = math.gcd
+    lcm = math.lcm
+
+else:
+    # Until python 3.8 is no longer supported
+    from functools import reduce
+
+
+    def gcd(*args):
+        """gcd of multiple integers."""
+        return reduce(math.gcd, args, 0)
+
+
+    def lcm(*args):
+        """lcm of multiple integers."""
+        if 0 in args:
+            return 0
+        return reduce(lambda x, y: x*y//math.gcd(x, y), args, 1)
+
+
+def is_square(x):
+    """Return True if x is a square number."""
+    if x < 0:
+        return False
+
+    # Note that the possible values of y**2 % n for a given n are limited.
+    # For example, when n=4, y**2 % n can only take 0 or 1.
+    # In other words, if x % 4 is 2 or 3, then x is not a square number.
+    # Mathematically, it determines if it belongs to the set {y**2 % n},
+    # but implementationally, it can be realized as a logical conjunction
+    # with an n-bit integer.
+    # see https://mersenneforum.org/showpost.php?p=110896
+    # def magic(n):
+    #     s = {y**2 % n for y in range(n)}
+    #     s = set(range(n)) - s
+    #     return sum(1 << bit for bit in s)
+    # >>> print(hex(magic(128)))
+    # 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec
+    # >>> print(hex(magic(99)))
+    # 0x5f6f9ffb6fb7ddfcb75befdec
+    # >>> print(hex(magic(91)))
+    # 0x6fd1bfcfed5f3679d3ebdec
+    # >>> print(hex(magic(85)))
+    # 0xdef9ae771ffe3b9d67dec
+    if 0xfdfdfdedfdfdfdecfdfdfdedfdfcfdec & (1 << (x & 127)):
+        return False  # e.g. 2, 3
+    m = x % 765765 # 765765 = 99 * 91 * 85
+    if 0x5f6f9ffb6fb7ddfcb75befdec & (1 << (m % 99)):
+        return False  # e.g. 17, 68
+    if 0x6fd1bfcfed5f3679d3ebdec & (1 << (m % 91)):
+        return False  # e.g. 97, 388
+    if 0xdef9ae771ffe3b9d67dec & (1 << (m % 85)):
+        return False  # e.g. 793, 1408
+    return mlib.sqrtrem(x)[1] == 0
+
+
+def invert(x, m):
+    """Modular inverse of x modulo m.
+
+    Returns y such that x*y == 1 mod m.
+
+    Uses ``math.pow`` but reproduces the behaviour of ``gmpy2.invert``
+    which raises ZeroDivisionError if no inverse exists.
+    """
+    try:
+        return pow(x, -1, m)
+    except ValueError:
+        raise ZeroDivisionError("invert() no inverse exists")
+
+
+def legendre(x, y):
+    """Legendre symbol (x / y).
+
+    Following the implementation of gmpy2,
+    the error is raised only when y is an even number.
+    """
+    if y <= 0 or not y % 2:
+        raise ValueError("y should be an odd prime")
+    x %= y
+    if not x:
+        return 0
+    if pow(x, (y - 1) // 2, y) == 1:
+        return 1
+    return -1
+
+
+def jacobi(x, y):
+    """Jacobi symbol (x / y)."""
+    if y <= 0 or not y % 2:
+        raise ValueError("y should be an odd positive integer")
+    x %= y
+    if not x:
+        return int(y == 1)
+    if y == 1 or x == 1:
+        return 1
+    if gcd(x, y) != 1:
+        return 0
+    j = 1
+    while x != 0:
+        while x % 2 == 0 and x > 0:
+            x >>= 1
+            if y % 8 in [3, 5]:
+                j = -j
+        x, y = y, x
+        if x % 4 == y % 4 == 3:
+            j = -j
+        x %= y
+    return j
+
+
+def kronecker(x, y):
+    """Kronecker symbol (x / y)."""
+    if gcd(x, y) != 1:
+        return 0
+    if y == 0:
+        return 1
+    sign = -1 if y < 0 and x < 0 else 1
+    y = abs(y)
+    # We want to calculate s = trailing(y)
+    s = 0
+    while y % 2 == 0:
+        y >>= 1
+        s += 1
+    if s % 2 and x % 8 in [3, 5]:
+        sign = -sign
+    return sign * jacobi(x, y)

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -11,17 +11,17 @@ import mpmath.libmp as mlib
 
 def factorial(x):
     """Return x!."""
-    return int(mlib.ifac(x))
+    return int(mlib.ifac(int(x)))
 
 
 def sqrt(x):
     """Integer square root of x."""
-    return int(mlib.sqrt(x))
+    return int(mlib.isqrt(int(x)))
 
 
 def sqrtrem(x):
     """Integer square root of x and remainder."""
-    s, r = mlib.sqrtrem(x)
+    s, r = mlib.sqrtrem(int(x))
     return (int(s), int(r))
 
 
@@ -80,7 +80,7 @@ def is_square(x):
         return False  # e.g. 97, 388
     if 0xdef9ae771ffe3b9d67dec & (1 << (m % 85)):
         return False  # e.g. 793, 1408
-    return mlib.sqrtrem(x)[1] == 0
+    return mlib.sqrtrem(int(x))[1] == 0
 
 
 def invert(x, m):

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -6,7 +6,7 @@ Primality testing
 from itertools import count
 
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import HAS_GMPY, jacobi, is_square as gmpy_is_square
+from sympy.external.gmpy import gmpy as _gmpy, jacobi, is_square as gmpy_is_square
 from sympy.utilities.misc import as_int
 
 from mpmath.libmp import bitcount as _bitlength
@@ -621,9 +621,8 @@ def isprime(n):
     # If we have GMPY2, skip straight to step 3 and do a strong BPSW test.
     # This should be a bit faster than our step 2, and for large values will
     # be a lot faster than our step 3 (C+GMP vs. Python).
-    if HAS_GMPY == 2:
-        from gmpy2 import is_strong_prp, is_strong_selfridge_prp
-        return is_strong_prp(n, 2) and is_strong_selfridge_prp(n)
+    if _gmpy is not None:
+        return _gmpy.is_strong_prp(n, 2) and _gmpy.is_strong_selfridge_prp(n)
 
 
     # Step 2: deterministic Miller-Rabin testing for numbers < 2^64.  See:

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -334,8 +334,10 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
 
     def __eq__(self, other):
         """Returns ``True`` if two domains are equivalent. """
-        return isinstance(other, AlgebraicField) and \
-            self.dtype == other.dtype and self.ext == other.ext
+        if isinstance(other, AlgebraicField):
+            return self.dtype == other.dtype and self.ext == other.ext
+        else:
+            return NotImplemented
 
     def algebraic_field(self, *extension, alias=None):
         r"""Returns an algebraic field, i.e. `\mathbb{Q}(\alpha, \ldots)`. """

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -1,6 +1,7 @@
 """Implementation of :class:`ComplexField` class. """
 
 
+from sympy.external.gmpy import SYMPY_INTS
 from sympy.core.numbers import Float, I
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
@@ -46,9 +47,27 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         context._parent = self
         self._context = context
 
-        self.dtype = context.mpc
+        self._dtype = context.mpc
         self.zero = self.dtype(0)
         self.one = self.dtype(1)
+
+    @property
+    def tp(self):
+        # XXX: Domain treats tp as an alis of dtype. Here we need to two
+        # separate things: dtype is a callable to make/convert instances.
+        # We use tp with isinstance to check if an object is an instance
+        # of the domain already.
+        return self._dtype
+
+    def dtype(self, x, y=0):
+        # XXX: This is needed because mpmath does not recognise fmpz.
+        # It might be better to add conversion routines to mpmath and if that
+        # happens then this can be removed.
+        if isinstance(x, SYMPY_INTS):
+            x = int(x)
+        if isinstance(y, SYMPY_INTS):
+            y = int(y)
+        return self._dtype(x, y)
 
     def __eq__(self, other):
         return (isinstance(other, ComplexField)
@@ -75,17 +94,17 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
     def from_ZZ(self, element, base):
         return self.dtype(element)
 
-    def from_QQ(self, element, base):
-        return self.dtype(int(element.numerator)) / int(element.denominator)
+    def from_ZZ_gmpy(self, element, base):
+        return self.dtype(int(element))
 
     def from_ZZ_python(self, element, base):
         return self.dtype(element)
 
+    def from_QQ(self, element, base):
+        return self.dtype(int(element.numerator)) / int(element.denominator)
+
     def from_QQ_python(self, element, base):
         return self.dtype(element.numerator) / element.denominator
-
-    def from_ZZ_gmpy(self, element, base):
-        return self.dtype(int(element))
 
     def from_QQ_gmpy(self, element, base):
         return self.dtype(int(element.numerator)) / int(element.denominator)

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -75,7 +75,7 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
            and self.tolerance == other.tolerance)
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self.dtype, self.precision, self.tolerance))
+        return hash((self.__class__.__name__, self._dtype, self.precision, self.tolerance))
 
     def to_sympy(self, element):
         """Convert ``element`` to SymPy number. """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -6,7 +6,7 @@ from typing import Any
 from sympy.core.numbers import AlgebraicNumber
 from sympy.core import Basic, sympify
 from sympy.core.sorting import default_sort_key, ordered
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.orderings import lex
 from sympy.polys.polyerrors import UnificationFailed, CoercionFailed, DomainError
@@ -422,14 +422,11 @@ class Domain:
         if isinstance(element, int):
             return self.convert_from(ZZ(element), ZZ)
 
-        if HAS_GMPY:
-            integers = ZZ
-            if isinstance(element, integers.tp):
-                return self.convert_from(element, integers)
-
-            rationals = QQ
-            if isinstance(element, rationals.tp):
-                return self.convert_from(element, rationals)
+        if GROUND_TYPES != 'python':
+            if isinstance(element, ZZ.tp):
+                return self.convert_from(element, ZZ)
+            if isinstance(element, QQ.tp):
+                return self.convert_from(element, QQ)
 
         if isinstance(element, float):
             parent = RealField(tol=False)

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -817,6 +817,7 @@ class Domain:
 
     def __eq__(self, other):
         """Returns ``True`` if two domains are equivalent. """
+        # XXX: Remove this.
         return isinstance(other, Domain) and self.dtype == other.dtype
 
     def __ne__(self, other):

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -165,6 +165,9 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         else:
             return NotImplemented
 
+    def __hash__(self):
+        return hash("EX")
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return a.as_expr()

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -159,6 +159,12 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
     def __init__(self):
         pass
 
+    def __eq__(self, other):
+        if isinstance(other, ExpressionDomain):
+            return True
+        else:
+            return NotImplemented
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return a.as_expr()

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -438,6 +438,17 @@ class GaussianIntegerRing(GaussianDomain, Ring):
     def __init__(self):  # override Domain.__init__
         """For constructing ZZ_I."""
 
+    def __eq__(self, other):
+        """Returns ``True`` if two domains are equivalent. """
+        if isinstance(other, GaussianIntegerRing):
+            return True
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        """Compute hash code of ``self``. """
+        return hash('ZZ_I')
+
     def get_ring(self):
         """Returns a ring associated with ``self``. """
         return self
@@ -608,6 +619,17 @@ class GaussianRationalField(GaussianDomain, Field):
 
     def __init__(self):  # override Domain.__init__
         """For constructing QQ_I."""
+
+    def __eq__(self, other):
+        """Returns ``True`` if two domains are equivalent. """
+        if isinstance(other, GaussianRationalField):
+            return True
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        """Compute hash code of ``self``. """
+        return hash('QQ_I')
 
     def get_ring(self):
         """Returns a ring associated with ``self``. """

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -1,7 +1,7 @@
 """Ground types for various mathematical domains in SymPy. """
 
 import builtins
-from sympy.external.gmpy import HAS_GMPY, factorial, sqrt, is_square, sqrtrem
+from sympy.external.gmpy import GROUND_TYPES, factorial, sqrt, is_square, sqrtrem
 
 PythonInteger = builtins.int
 PythonReal = builtins.float
@@ -18,7 +18,17 @@ from sympy.core.numbers import (
 from sympy.core.numbers import (Float as SymPyReal, Integer as SymPyInteger, Rational as SymPyRational)
 
 
-if HAS_GMPY == 2:
+class _GMPYInteger:
+    def __init__(self, obj):
+        pass
+
+class _GMPYRational:
+    def __init__(self, obj):
+        pass
+
+
+if GROUND_TYPES == 'gmpy':
+
     from gmpy2 import (
         mpz as GMPYInteger,
         mpq as GMPYRational,
@@ -32,15 +42,31 @@ if HAS_GMPY == 2:
     gcdex = gmpy_gcdex
     gcd = gmpy_gcd
     lcm = gmpy_lcm
+
+elif GROUND_TYPES == 'flint':
+
+    from flint import fmpz as _fmpz
+
+    GMPYInteger = _GMPYInteger
+    GMPYRational = _GMPYRational
+    gmpy_numer = None
+    gmpy_denom = None
+    gmpy_gcdex = None
+    gmpy_gcd = None
+    gmpy_lcm = None
+    gmpy_qdiv = None
+
+    def gcd(a, b):
+        return a.gcd(b)
+
+    def gcdex(a, b):
+        x, y, g = a.gcdex(b)
+        return _fmpz(x), _fmpz(y), _fmpz(g)
+
+    def lcm(a, b):
+        return a.lcm(b)
+
 else:
-    class _GMPYInteger:
-        def __init__(self, obj):
-            pass
-
-    class _GMPYRational:
-        def __init__(self, obj):
-            pass
-
     GMPYInteger = _GMPYInteger
     GMPYRational = _GMPYRational
     gmpy_numer = None

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -60,7 +60,7 @@ elif GROUND_TYPES == 'flint':
         return a.gcd(b)
 
     def gcdex(a, b):
-        x, y, g = a.gcdex(b)
+        x, y, g = python_gcdex(a, b)
         return _fmpz(x), _fmpz(y), _fmpz(g)
 
     def lcm(a, b):

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -1,6 +1,6 @@
 """Implementation of :class:`IntegerRing` class. """
 
-from sympy.external.gmpy import MPZ, HAS_GMPY
+from sympy.external.gmpy import MPZ, GROUND_TYPES
 
 from sympy.polys.domains.groundtypes import (
     SymPyInteger,
@@ -206,7 +206,8 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
     def gcdex(self, a, b):
         """Compute extended GCD of ``a`` and ``b``. """
         h, s, t = gcdex(a, b)
-        if HAS_GMPY:
+        # XXX: This conditional logic should be handled somewhere else.
+        if GROUND_TYPES == 'gmpy':
             return s, t, h
         else:
             return h, s, t

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -50,6 +50,17 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
     def __init__(self):
         """Allow instantiation of this domain. """
 
+    def __eq__(self, other):
+        """Returns ``True`` if two domains are equivalent. """
+        if isinstance(other, IntegerRing):
+            return True
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        """Compute a hash value for this domain. """
+        return hash('ZZ')
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return SymPyInteger(int(a))

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -151,7 +151,7 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
         This function uses ``math.log`` which is based on ``float`` so it will
         fail for large integer arguments.
         """
-        return self.dtype(math.log(int(a), b))
+        return self.dtype(int(math.log(int(a), b)))
 
     def from_FF(K1, a, K0):
         """Convert ``ModularInteger(int)`` to GMPY's ``mpz``. """
@@ -197,7 +197,10 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
         p, q = K0.to_rational(a)
 
         if q == 1:
-            return MPZ(p)
+            # XXX: If MPZ is flint.fmpz and p is a gmpy2.mpz, then we need
+            # to convert via int because fmpz and mpz do not know about each
+            # other.
+            return MPZ(int(p))
 
     def from_GaussianIntegerRing(K1, a, K0):
         if a.y == 0:

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -45,6 +45,17 @@ class RationalField(Field, CharacteristicZero, SimpleDomain):
     def __init__(self):
         pass
 
+    def __eq__(self, other):
+        """Returns ``True`` if two domains are equivalent. """
+        if isinstance(other, RationalField):
+            return True
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        """Returns hash code of ``self``. """
+        return hash('QQ')
+
     def get_ring(self):
         """Returns ring associated with ``self``. """
         from sympy.polys.domains import ZZ

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -74,7 +74,7 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
            and self.tolerance == other.tolerance)
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self.dtype, self.precision, self.tolerance))
+        return hash((self.__class__.__name__, self._dtype, self.precision, self.tolerance))
 
     def to_sympy(self, element):
         """Convert ``element`` to SymPy number. """

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -1,6 +1,7 @@
 """Implementation of :class:`RealField` class. """
 
 
+from sympy.external.gmpy import SYMPY_INTS
 from sympy.core.numbers import Float
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -47,9 +48,25 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         context._parent = self
         self._context = context
 
-        self.dtype = context.mpf
+        self._dtype = context.mpf
         self.zero = self.dtype(0)
         self.one = self.dtype(1)
+
+    @property
+    def tp(self):
+        # XXX: Domain treats tp as an alis of dtype. Here we need to two
+        # separate things: dtype is a callable to make/convert instances.
+        # We use tp with isinstance to check if an object is an instance
+        # of the domain already.
+        return self._dtype
+
+    def dtype(self, arg):
+        # XXX: This is needed because mpmath does not recognise fmpz.
+        # It might be better to add conversion routines to mpmath and if that
+        # happens then this can be removed.
+        if isinstance(arg, SYMPY_INTS):
+            arg = int(arg)
+        return self._dtype(arg)
 
     def __eq__(self, other):
         return (isinstance(other, RealField)
@@ -78,14 +95,18 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
     def from_ZZ_python(self, element, base):
         return self.dtype(element)
 
-    def from_QQ(self, element, base):
-        return self.dtype(element.numerator) / element.denominator
-
-    def from_QQ_python(self, element, base):
-        return self.dtype(element.numerator) / element.denominator
-
     def from_ZZ_gmpy(self, element, base):
         return self.dtype(int(element))
+
+    # XXX: We need to convert the denominators to int here because mpmath does
+    # not recognise mpz. Ideally mpmath would handle this and if it changed to
+    # do so then the calls to int here could be removed.
+
+    def from_QQ(self, element, base):
+        return self.dtype(element.numerator) / int(element.denominator)
+
+    def from_QQ_python(self, element, base):
+        return self.dtype(element.numerator) / int(element.denominator)
 
     def from_QQ_gmpy(self, element, base):
         return self.dtype(int(element.numerator)) / int(element.denominator)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.trigonometric import sin
 from sympy.polys.polytools import Poly
 from sympy.abc import x, y, z
 
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 
 from sympy.polys.domains import (ZZ, QQ, RR, CC, FF, GF, EX, EXRAW, ZZ_gmpy,
     ZZ_python, QQ_gmpy, QQ_python)
@@ -1109,8 +1109,14 @@ def test_gaussian_domains():
             assert G.is_nonnegative(qi) is False
             assert G.is_nonpositive(qi) is False
 
-        domains = [ZZ_python(), QQ_python(), AlgebraicField(QQ, I)]
-        if HAS_GMPY:
+        domains = [ZZ, QQ, AlgebraicField(QQ, I)]
+
+        # XXX: These domains are all obsolete because ZZ/QQ with MPZ/MPQ
+        # already use either gmpy, flint or python depending on the
+        # availability of these libraries. We can keep these tests for now but
+        # ideally we should remove these alternate domains entirely.
+        domains += [ZZ_python(), QQ_python()]
+        if GROUND_TYPES == 'gmpy':
             domains += [ZZ_gmpy(), QQ_gmpy()]
 
         for K in domains:

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1404,7 +1404,8 @@ def gf_random(n, p, K):
     [1, 2, 3, 2, 1, 1, 1, 2, 0, 4, 2]
 
     """
-    return [K.one] + [ K(int(uniform(0, p))) for i in range(0, n) ]
+    pi = int(p)
+    return [K.one] + [ K(int(uniform(0, pi))) for i in range(0, n) ]
 
 
 def gf_irreducible(n, p, K):

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -1,5 +1,5 @@
 from sympy.testing.pytest import raises
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 
 from sympy.polys import ZZ, QQ
 
@@ -39,7 +39,7 @@ def test_DDM_getsetitem():
 
 def test_DDM_str():
     ddm = DDM([[ZZ(0), ZZ(1)], [ZZ(2), ZZ(3)]], (2, 2), ZZ)
-    if HAS_GMPY: # pragma: no cover
+    if GROUND_TYPES == 'gmpy': # pragma: no cover
         assert str(ddm) == '[[0, 1], [2, 3]]'
         assert repr(ddm) == 'DDM([[mpz(0), mpz(1)], [mpz(2), mpz(3)]], (2, 2), ZZ)'
     else:        # pragma: no cover

--- a/sympy/polys/matrices/tests/test_sdm.py
+++ b/sympy/polys/matrices/tests/test_sdm.py
@@ -5,7 +5,7 @@ Tests for the basic functionality of the SDM class.
 from itertools import product
 
 from sympy.core.singleton import S
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 from sympy.testing.pytest import raises
 
 from sympy.polys.domains import QQ, ZZ, EXRAW
@@ -28,7 +28,7 @@ def test_SDM():
 def test_DDM_str():
     sdm = SDM({0:{0:ZZ(1)}, 1:{1:ZZ(1)}}, (2, 2), ZZ)
     assert str(sdm) == '{0: {0: 1}, 1: {1: 1}}'
-    if HAS_GMPY: # pragma: no cover
+    if GROUND_TYPES == 'gmpy': # pragma: no cover
         assert repr(sdm) == 'SDM({0: {0: mpz(1)}, 1: {1: mpz(1)}}, (2, 2), ZZ)'
     else:        # pragma: no cover
         assert repr(sdm) == 'SDM({0: {0: 1}, 1: {1: 1}}, (2, 2), ZZ)'

--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -2031,7 +2031,7 @@ def _to_ZZ_poly(f, ring):
 
         for i in range(n):
             if coeff[i]:
-                c = domain(coeff[i] * den) * m
+                c = domain.convert(coeff[i] * den) * m
 
                 if (monom[0], n-i-1) not in f_:
                     f_[(monom[0], n-i-1)] = c

--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -1746,12 +1746,12 @@ def _integer_rational_reconstruction(c, m, domain):
 
     bound = sqrt(m / 2) # still correct if replaced by ZZ.sqrt(m // 2) ?
 
-    while r1 >= bound:
+    while int(r1) >= bound:
         quo = r0 // r1
         r0, r1 = r1, r0 - quo*r1
         s0, s1 = s1, s0 - quo*s1
 
-    if abs(s1) >= bound:
+    if abs(int(s1)) >= bound:
         return None
 
     if s1 < 0:

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -330,7 +330,10 @@ class Resolvent:
             return a
         # If we use python's built-in `round()`, we lose precision.
         # If we use `ZZ` directly, we may add or subtract 1.
-        return ZZ(a.context.nint(a))
+        #
+        # XXX: We have to convert to int before converting to ZZ because
+        # flint.fmpz cannot convert a mpmath mpf.
+        return ZZ(int(a.context.nint(a)))
 
     def round_roots_to_integers_for_poly(self, T):
         """

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -1,5 +1,7 @@
 """Tests for dense recursive polynomials' arithmetics. """
 
+from sympy.external.gmpy import GROUND_TYPES
+
 from sympy.polys.densebasic import (
     dup_normal, dmp_normal,
 )
@@ -864,9 +866,7 @@ def test_dup_ff_div():
     assert dup_ff_div(f, g, QQ) == (q, r)
 
 def test_dup_ff_div_gmpy2():
-    try:
-        from gmpy2 import mpq
-    except ImportError:
+    if GROUND_TYPES != 'gmpy2':
         return
 
     from sympy.polys.domains import GMPYRationalField

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -869,6 +869,7 @@ def test_dup_ff_div_gmpy2():
     if GROUND_TYPES != 'gmpy2':
         return
 
+    from gmpy2 import mpq
     from sympy.polys.domains import GMPYRationalField
     K = GMPYRationalField()
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2878,6 +2878,12 @@ class LatexPrinter(Printer):
     def _print_mpq(self, expr):
         return str(expr)
 
+    def _print_fmpz(self, expr):
+        return str(expr)
+
+    def _print_fmpq(self, expr):
+        return str(expr)
+
     def _print_Predicate(self, expr):
         return r"\operatorname{{Q}}_{{\text{{{}}}}}".format(latex_escape(str(expr.name)))
 

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -37,7 +37,7 @@ from inspect import unwrap
 
 from sympy.core.cache import clear_cache
 from sympy.external import import_module
-from sympy.external.gmpy import GROUND_TYPES, HAS_GMPY
+from sympy.external.gmpy import GROUND_TYPES
 
 IS_WINDOWS = (os.name == 'nt')
 ON_CI = os.getenv('CI', None)
@@ -2205,10 +2205,7 @@ class PyTestReporter(Reporter):
         self.write("cache:              %s\n" % USE_CACHE)
         version = ''
         if GROUND_TYPES =='gmpy':
-            if HAS_GMPY == 1:
-                import gmpy
-            elif HAS_GMPY == 2:
-                import gmpy2 as gmpy
+            import gmpy2 as gmpy
             version = gmpy.version()
         self.write("ground types:       %s %s\n" % (GROUND_TYPES, version))
         numpy = import_module('numpy')

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -21,7 +21,7 @@ from sympy.core.function import Derivative, Function, FunctionClass, Lambda, \
 from sympy.sets.sets import Interval
 from sympy.core.multidimensional import vectorize
 
-from sympy.external.gmpy import HAS_GMPY
+from sympy.external.gmpy import gmpy as _gmpy
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy.core.singleton import S
@@ -450,7 +450,7 @@ def test_pickling_polys_domains():
     for c in (PythonRationalField, PythonRationalField()):
         check(c, check_attr=False)
 
-    if HAS_GMPY:
+    if _gmpy is not None:
         # from sympy.polys.domains.gmpyfinitefield import GMPYFiniteField
         from sympy.polys.domains.gmpyintegerring import GMPYIntegerRing
         from sympy.polys.domains.gmpyrationalfield import GMPYRationalField


### PR DESCRIPTION
CC @fredrik-johansson 

Adds the option to use python-flint for the ground types instead of gmpy2. Set the environment variable SYMPY_GROUND_TYPES='flint' to activate this (and install python-flint).

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See the python-flint package:
https://github.com/fredrik-johansson/python-flint

The underlying Flint C library:
https://flintlib.org/

Possibly the latest master version of python-flint is needed. An older version of python-flint can be installed with conda (although not on Windows). Otherwise it needs to be built from source which is not completely trivial. The next release of python-flint will have binaries on PyPI for Windows, OSX and Linux.

#### Brief description of what is fixed or changed

Adds a new `GROUND_TYPES=flint` option in addition to `GROUND_TYPES=python` and `GROUND_TYPES=gmpy`. If `python-flint` is installed and the environment variable `SYMPY_GROUND_TYPES` is set to `flint` then python-flint's `fmpz` and `fmpq` types will be used as the implementation of the `ZZ` and `QQ` poly domains.

To see the effect of the changes in this PR you can do:
```python
$ SYMPY_GROUND_TYPES=python python -c 'import sympy; print(type(sympy.ZZ(1)))'
<class 'int'>
$ SYMPY_GROUND_TYPES=gmpy python -c 'import sympy; print(type(sympy.ZZ(1)))'
<class 'mpz'>
$ SYMPY_GROUND_TYPES=flint python -c 'import sympy; print(type(sympy.ZZ(1)))'
<class 'flint._flint.fmpz'>
```
The `HAS_GMPY` variable no longer really makes sense if there are more than two ground type options so most usage is replaced by checking `GROUND_TYPES` instead. Now `HAS_GMPY` is not used anywhere outside of the `sympy.external.gmpy` module although the variable is still there in case any downstream code uses it. If `flint` is used then `HAS_GMPY` is set to `0` so `HAS_GMPY==0` does not imply `GROUND_TYPES=='python'` any more but `HAS_GMPY==2` still implies `GROUND_TYPES=='gmpy'`.

The `sympy.external.gmpy` module should probably be renamed but for now I left it there although I did move the various pure Python number theory functions into a separate `sympy.external.ntheory` module.

I have not added any CI testing for this although I have run the core and polys tests locally and I will test the full test suite. Changes are needed both in python-flint and in sympy to make this work. I will add CI testing when there is a release of python-flint that has the latest changes in master and also binaries on PyPI that can be installed easily in SymPy's CI. I can see some things that don't work but so far I think that those are things to be fixed in python-flint rather than in SymPy so it should not hold up merging this so that `GROUND_TYPES='flint'` can be tested more widely.

#### Other comments

As it stands with this PR I don't expect that using `GROUND_TYPES=flint` will bring any substantial improvements over using `gmpy2` but this is just the first step. This might make some things faster and might make other things slower. Using flint is not enabled by default though so it should not introduce any regression unless someone opts in with `SYMPY_GROUND_TYPES=flint`.

The big improvements for SymPy will come later from using `python-flint` for things that gmpy2 does not provide like polynomials, matrices, Arb, calcium etc.

The reason to use flint for the ground types is that:

1. If someone is using python-flint then they no longer need to have gmpy2 installed as well.
2. Using `fmpz` and `fmpq` as the ground types makes it more efficient to convert say a list of `ZZ` into a `fmpz_poly` so when it is possible to use flint's other types it will make sense to use them also for ZZ and QQ. 

As an example of this conversion we can do e.g.:
```python
In [7]: M = randMatrix(50)

In [8]: %time ok = M.det()
CPU times: user 2.47 s, sys: 9.13 ms, total: 2.48 s
Wall time: 2.48 s

In [9]: %time ok = M.to_DM().det()  # DomainMatrix
CPU times: user 75.5 ms, sys: 12 µs, total: 75.5 ms
Wall time: 74.3 ms

In [10]: %time ok = flint.fmpz_mat(M.to_DM().to_list()).det()
CPU times: user 6.86 ms, sys: 3.91 ms, total: 10.8 ms
Wall time: 10.9 ms
```
Actually flint is a lot faster than that so the overhead here is mostly conversion:
```python
In [11]: fM =  flint.fmpz_mat(M.to_DM().to_list())

In [12]: %time fM.det()
CPU times: user 4.55 ms, sys: 39 µs, total: 4.59 ms
Wall time: 4.54 ms
Out[12]: -15247324201397047106854518724916370205843752908424986648046567389005648338935854480845854186655584056237196

In [13]: %timeit fM.det()
1.38 ms ± 3.69 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
I intend to make it so that flint matrices can be used as the dense version of DomainMatrix for any supported domains i.e. ZZ and QQ. This example with a matrix of integers is not the most interesting comparison because SymPy already has `DomainMatrix` that is now relatively fast for a pure Python implementation and in simple cases probably uses similar algorithms.

Bigger improvements will come from using flint's univariate dense polynomials:
```python
In [11]: p1 = random_poly(x, 50, -100, 100)

In [12]: p2 = random_poly(x, 50, -100, 100)

In [13]: p = (p1*p2).expand()

In [14]: fp = flint.fmpz_poly(p.as_poly().rep.rep)

In [15]: %time ok = fp.factor()
CPU times: user 20.1 ms, sys: 0 ns, total: 20.1 ms
Wall time: 20 ms
```
That is a lot faster than e.g.
```
In [16]: %time ok = p.factor()
CPU times: user 796 ms, sys: 236 µs, total: 796 ms
Wall time: 796 ms
```
The differences will be more significant for larger polynomials and probably other algorithms than just factorisation (the polys module has relatively good algorithms for some things but not so much for others).

Currently python-flint does not expose flint's sparse polynomials but that is something that should be exposed and that will make a *huge* speed difference for SymPy in things like `solve`, matrix operations etc.

It is also possible to use flint for `GF(p)` although a bit more work would be needed on that. Currently with python-flint `GF(p)` only works for `p` up to the word-size:
```python
In [2]: n = flint.nmod(5, nextprime(2**64))
---------------------------------------------------------------------------
OverflowError 
```
Within flint itself there is an implementation of `GF(p)` (`fmpz_mod`)  for large `p` but probably the `python-flint` wrapper should smooth over this difference on behalf of its Python-based users. SymPy could still use flint for `GF(p)` with small `p` but would need to deprecate and remove the `to_int` method first.

Other python-flint feature such as Arb could be used in `evalf`. There is too much there fore me to list it all here.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * A new ground type option is added to use python-flint for the ground types rather than Python or gmpy2. For now this is experimental and is not used by default but can be enabled by installing `python-flint` and setting the environment variable `SYMPY_GROUND_TYPES=flint` before importing SymPy. With `GROUND_TYPES=flint` the `ZZ` and `QQ` poly domains will use `flint.fmpz` and `flint.fmpq` rather than `gmpy2.mpz` and `gmpy2.mpq`. This should not lead to any noticeable difference in behaviour for ordinary usage of SymPy but might have an effect on performance in some cases. Both `gmpy2` and `python-flint` use GMP internally so for pure integer/rational arithmetic they should mostly have comparable performance. Adding `GROUND_TYPES=flint` lays the ground work for adding other flint types that gmpy2 does not have such as polynomials and matrices in future which will bring significant future speedups for SymPy.
<!-- END RELEASE NOTES -->
