### PR TITLE
adding ELLIPSIS to doctests

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2146,12 +2146,13 @@ class Beam:
             >>> b.apply_support(0, "fixed")
             >>> b.apply_support(20, "roller")
             >>> p = b.draw()
-            >>> p
+            >>> p  # doctest: +ELLIPSIS
             Plot object containing:
             [0]: cartesian line: 25*SingularityFunction(x, 5, 0) - 25*SingularityFunction(x, 23, 0)
             + SingularityFunction(x, 30, 1) - 20*SingularityFunction(x, 50, 0)
             - SingularityFunction(x, 50, 1) + 5 for x over (0.0, 50.0)
             [1]: cartesian line: 5 for x over (0.0, 50.0)
+            ...
             >>> p.show()
 
         """

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -806,9 +806,10 @@ class Truss:
             >>> t.apply_support(("A","pinned"), ("D","roller"))
             >>> t.apply_load(("G", 3, 90), ("E", 3, 90), ("F", 2, 90))
             >>> p = t.draw()
-            >>> p
+            >>> p  # doctest: +ELLIPSIS
             Plot object containing:
             [0]: cartesian line: 1 for x over (1.0, 1.0)
+            ...
             >>> p.show()
         """
         if not numpy:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Issue #25477

#### Brief description of what is fixed or changed

After #25117 was implemented and merged, some doctests were not updated. Fixing them to make doctest pass.

#### Other comments

Reason to add ELLIPSIS: prior to #25117, numerical data was added directly to Matplotlib's axis, with no easy way to test if the data was actually there. After that PR, the numerical data has been added to a `GenericDataSeries`. Doctests failed because they detected more data series than when they were written. The continuum mechanics module clearly add many GenericDataSeries (probably to add scatters), which makes the output of doctests very long and tedius, and IMHO, unnecessary to the scope of a documentation, which is informing users about useful stuff and not about testing. Hence, the ellipsis.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.continuum_mechanics
  * fixed doctests in `beam.py` and `truss.py`

<!-- END RELEASE NOTES -->
