### PR TITLE
Change call to subclass of KanesMethod instead of KanesMethod itself

### DIFF
--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -850,7 +850,7 @@ class System(_Methods):
                       "velocity_constraints": velocity_constraints,
                       "forcelist": loads, "bodies": self.bodies,
                       "explicit_kinematics": False, **kwargs}
-            self._eom_method = KanesMethod(**kwargs)
+            self._eom_method = eom_method(**kwargs)
         elif issubclass(eom_method, LagrangesMethod):
             disallowed_kwargs = {
                 "frame", "qs", "forcelist", "bodies", "hol_coneqs",

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -85,6 +85,15 @@ class TestSystemBase:
         assert ('joints' in exclude or
                 self.system.joints == tuple(self.joints))
 
+    @pytest.fixture()
+    def _moving_point_mass(self, _empty_system_setup):
+        self.system.q_ind = q[0]
+        self.system.u_ind = u[0]
+        self.system.kdes = u[0] - q[0].diff(t)
+        p = Particle('p', mass=symbols('m'))
+        self.system.add_bodies(p)
+        p.masscenter.set_pos(self.system.origin, q[0] * self.system.x)
+
 
 class TestSystem(TestSystemBase):
     def test_empty_system(self, _empty_system_setup):
@@ -440,19 +449,21 @@ class TestSystem(TestSystemBase):
         else:
             assert body == self.bodies[body_index]
 
+    @pytest.mark.parametrize('eom_method', [KanesMethod, LagrangesMethod])
+    def test_form_eoms_calls_subclass(self, _moving_point_mass, eom_method):
+        class MyMethod(eom_method):
+            pass
+
+        self.system.form_eoms(eom_method=MyMethod)
+        assert isinstance(self.system.eom_method, MyMethod)
+
     @pytest.mark.parametrize('kwargs, expected', [
         ({}, ImmutableMatrix([[-1, 0], [0, symbols('m')]])),
         ({'explicit_kinematics': True}, ImmutableMatrix([[1, 0],
                                                          [0, symbols('m')]])),
     ])
-    def test_system_kane_form_eoms_kwargs(self, _empty_system_setup, kwargs,
+    def test_system_kane_form_eoms_kwargs(self, _moving_point_mass, kwargs,
                                           expected):
-        self.system.q_ind = q[0]
-        self.system.u_ind = u[0]
-        self.system.kdes = u[0] - q[0].diff(t)
-        p = Particle('p', mass=symbols('m'))
-        self.system.add_bodies(p)
-        p.masscenter.set_pos(self.system.origin, q[0] * self.system.x)
         self.system.form_eoms(**kwargs)
         assert self.system.mass_matrix_full == expected
 
@@ -460,12 +471,8 @@ class TestSystem(TestSystemBase):
         ({}, ImmutableMatrix([[1, 0], [0, symbols('m')]]),
          ImmutableMatrix([q[0].diff(t), 0])),
     ])
-    def test_system_lagrange_form_eoms_kwargs(self, _empty_system_setup, kwargs,
+    def test_system_lagrange_form_eoms_kwargs(self, _moving_point_mass, kwargs,
                                               mm, gm):
-        self.system.q_ind = q[0]
-        p = Particle('p', mass=symbols('m'))
-        self.system.add_bodies(p)
-        p.masscenter.set_pos(self.system.origin, q[0] * self.system.x)
         self.system.form_eoms(eom_method=LagrangesMethod, **kwargs)
         assert self.system.mass_matrix_full == mm
         assert self.system.forcing_full == gm


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to the mechanics experimental development (#24234)

#### Brief description of what is fixed or changed
Fixes the bug, where `KanesMethod` is called instead of the passed class, which might actually be a subclass of `KanesMethod`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
