### PR TITLE
test(polys): Add CI tests for GROUND_TYPES=flint

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -225,7 +225,7 @@ jobs:
   # -------------------- FLINT tests -------------------------------- #
 
   python-flint:
-    # needs: code-quality
+    needs: code-quality
 
     # Currently wheels are available for python-flint only on Windows and OSX
     # so we use OSX rather than Ubuntu for this job.
@@ -239,9 +239,6 @@ jobs:
       - run: pip install -r requirements-test.txt
       - run: pip install python-flint
       # Test modules that most directly use python-flint
-      - run: pwd
-      - run: ls -l
-      - run: ls sympy
       - run: |
           pytest --doctest-plus --doctest-glob='*.rst'    \
                     sympy/polys                           \

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -23,7 +23,8 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
 
-      - run: pip install mpmath flake8 flake8-comprehensions ruff pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install flake8 flake8-comprehensions ruff
 
       - name: Basic code quality tests
         run: bin/test quality
@@ -134,7 +135,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --split ${{ matrix.group }}/4
 
   # -------------------- Test Pyodide on node ---------------------- #
@@ -192,15 +193,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - run: pip install -r requirements-test.txt
+
       # Install the non-Python dependencies
       - run: sudo apt-get update
       - run: sudo apt-get install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev clang
       - run: python -m pip install --upgrade pip wheel setuptools
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy  \
-                         aesara wurlitzer autowrap lxml pytest hypothesis lark \
-                         'antlr4-python3-runtime==4.11.*'
+      - run: pip install numpy numexpr matplotlib ipython cython scipy aesara \
+                         wurlitzer autowrap lxml lark                         \
+                         'antlr4-python3-runtime==4.11.*'                     \
+                         #
 
       # Not available in pypy or cpython 3.11 (yet).
       - if: ${{ ! contains(matrix.python-version, 'pypy') && ! contains(matrix.python-version, '3.11') }}
@@ -218,6 +222,36 @@ jobs:
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py
 
+  # -------------------- FLINT tests -------------------------------- #
+
+  python-flint:
+    # needs: code-quality
+
+    # Currently wheels are available for python-flint only on Windows and OSX
+    # so we use OSX rather than Ubuntu for this job.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-test.txt
+      - run: pip install python-flint
+      # Test modules that most directly use python-flint
+      - run: pwd
+      - run: ls -l
+      - run: ls sympy
+      - run: |
+          pytest --doctest-plus --doctest-glob='*.rst'    \
+                    sympy/polys                           \
+                    doc/src/modules/polys                 \
+                    sympy/ntheory                         \
+                    doc/src/modules/ntheory.rst           \
+        env:
+          SYMPY_GROUND_TYPES: flint
+
+
   # -------------------- Tensorflow tests -------------------------- #
 
   tensorflow:
@@ -231,7 +265,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy scipy tensorflow pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install numpy scipy tensorflow
       # Test modules that can use tensorflow
       - run: bin/test_tensorflow.py
 
@@ -247,7 +282,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy symengine pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install numpy symengine
       # Test modules that can use tensorflow
       - run: bin/test_symengine.py
         env:
@@ -269,7 +305,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split pytest-timeout hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --slow --timeout 595 --split ${{ matrix.group }}/4
 
   # -------------------- Test older (and newer) Python --------------- #
@@ -295,7 +331,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --split ${{ matrix.group }}/4
 
   # -------------------- Doctests older (and newer) Python --------------------- #

--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -289,14 +289,24 @@ multiplication will work for the elements of any domain and will produce new
 domain elements. Division with ``/`` (Python's "true division" operator) is not
 possible for all domains and should not be used with domain elements unless
 the domain is known to be a field. For example dividing two elements of :ref:`ZZ`
-gives a ``float`` which is not an element of :ref:`ZZ`::
+might give a ``float`` which is not an element of :ref:`ZZ`::
 
-  >>> z1 / z1
+  >>> z1 / z1  # doctest: +SKIP
   1.0
   >>> type(z1 / z1)  # doctest: +SKIP
   <class 'float'>
   >>> ZZ.is_Field
   False
+
+The behaviour of ``/`` for non-fields can also differ for different
+implementations of the ground types of the domain. For example with
+`SYMPY_GROUND_TYPES=flint` dividing two elements of :ref:`ZZ` will raise an
+error rather than return a float::
+
+   >>> z1 / z1  # doctest: +SKIP
+   Traceback (most recent call last):
+   ...
+   TypeError: unsupported operand type(s) for /: 'flint._flint.fmpz' and 'flint._flint.fmpz'
 
 Most domains representing non-field rings allow floor and modulo division
 (remainder) with Python's floor division ``//`` and modulo division ``%``

--- a/release/compare_tar_against_git.py
+++ b/release/compare_tar_against_git.py
@@ -53,7 +53,7 @@ git_whitelist = {
     'CODEOWNERS',
     'asv.conf.actions.json',
     'codecov.yml',
-    'requirements-tests.txt',
+    'requirements-test.txt',
     'MANIFEST.in',
     'banner.svg',
     # Code of conduct

--- a/release/compare_tar_against_git.py
+++ b/release/compare_tar_against_git.py
@@ -53,6 +53,7 @@ git_whitelist = {
     'CODEOWNERS',
     'asv.conf.actions.json',
     'codecov.yml',
+    'requirements-tests.txt',
     'MANIFEST.in',
     'banner.svg',
     # Code of conduct

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+mpmath
+pytest
+pytest-xdist
+pytest-timeout
+pytest-split
+pytest-doctestplus
+hypothesis

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -484,7 +484,7 @@ def dup_normal(f, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dup_normal
 
-    >>> dup_normal([0, 1.5, 2, 3], ZZ)
+    >>> dup_normal([0, 1, 2, 3], ZZ)
     [1, 2, 3]
 
     """
@@ -501,7 +501,7 @@ def dmp_normal(f, u, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dmp_normal
 
-    >>> dmp_normal([[], [0, 1.5, 2]], 1, ZZ)
+    >>> dmp_normal([[], [0, 1, 2]], 1, ZZ)
     [[1, 2]]
 
     """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1101,12 +1101,20 @@ class Domain:
 
         Since the default :py:attr:`~.Domain.dtype` for :ref:`ZZ` is ``int``
         (or ``mpz``) division as ``a / b`` should not be used as it would give
-        a ``float``.
+        a ``float`` which is not a domain element.
 
-        >>> ZZ(4) / ZZ(2)
+        >>> ZZ(4) / ZZ(2) # doctest: +SKIP
         2.0
-        >>> ZZ(5) / ZZ(2)
+        >>> ZZ(5) / ZZ(2) # doctest: +SKIP
         2.5
+
+        On the other hand with `SYMPY_GROUND_TYPES=flint` elements of :ref:`ZZ`
+        are ``flint.fmpz`` and division would raise an exception:
+
+        >>> ZZ(4) / ZZ(2) # doctest: +SKIP
+        Traceback (most recent call last):
+        ...
+        TypeError: unsupported operand type(s) for /: 'fmpz' and 'fmpz'
 
         Using ``/`` with :ref:`ZZ` will lead to incorrect results so
         :py:meth:`~.Domain.exquo` should be used instead.

--- a/sympy/polys/numberfields/exceptions.py
+++ b/sympy/polys/numberfields/exceptions.py
@@ -11,8 +11,7 @@ class ClosureFailure(Exception):
 
     >>> from sympy.polys import Poly, cyclotomic_poly, ZZ
     >>> from sympy.polys.matrices import DomainMatrix
-    >>> from sympy.polys.numberfields.modules import PowerBasis, to_col, ClosureFailure
-    >>> from sympy.testing.pytest import raises
+    >>> from sympy.polys.numberfields.modules import PowerBasis, to_col
     >>> T = Poly(cyclotomic_poly(5))
     >>> A = PowerBasis(T)
     >>> B = A.submodule_from_matrix(2 * DomainMatrix.eye(4, ZZ))

--- a/sympy/polys/numberfields/exceptions.py
+++ b/sympy/polys/numberfields/exceptions.py
@@ -28,8 +28,10 @@ class ClosureFailure(Exception):
     but ``B`` cannot represent an element with an odd coefficient:
 
     >>> a2 = A(to_col([1, 2, 2, 2]))
-    >>> print(raises(ClosureFailure, lambda: B.represent(a2)))
-    <ExceptionInfo ClosureFailure('Element in QQ-span but not ZZ-span of this basis.')>
+    >>> B.represent(a2)
+    Traceback (most recent call last):
+    ...
+    ClosureFailure: Element in QQ-span but not ZZ-span of this basis.
 
     """
     pass


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follow up from gh-25474

#### Brief description of what is fixed or changed

Now that python-flint 0.4.1 is released with wheels for OSX and Windows we can add CI tests for `GROUND_TYPES='flint'`. This adds a CI job for that testing the same modules as are tested for gmpy2.

Also I created a `requirements-test.txt` file because the number of test requirements is growing and it is useful to be able to install them all in one (I'm not sure what would happen if e.g. a CI job forgot to install hypothesis).

#### Other comments

I plan to follow up shortly with PRs that make use of python-flint to speed up matrices and polynomials over ZZ and QQ.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
