### PR TITLE
Add Flint matrices for ZZ and QQ

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -238,14 +238,16 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-test.txt
       - run: pip install python-flint
-      # Test modules that most directly use python-flint
-      - run: |
-          pytest --doctest-plus --doctest-glob='*.rst'    \
+      # Test the modules that most directly use python-flint
+      - run: pytest sympy/polys sympy/ntheory sympy/matrices
+        env:
+          SYMPY_GROUND_TYPES: flint
+      - run: bin/doctest                                  \
                     sympy/polys                           \
-                    doc/src/modules/polys                 \
                     sympy/ntheory                         \
-                    doc/src/modules/ntheory.rst           \
                     sympy/matrices                        \
+                    doc/src/modules/polys                 \
+                    doc/src/modules/ntheory.rst           \
                     doc/src/modules/matrices              \
                     doc/src/tutorials/intro-tutorial/     \
         env:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -225,7 +225,7 @@ jobs:
   # -------------------- FLINT tests -------------------------------- #
 
   python-flint:
-    # needs: code-quality
+    needs: code-quality
 
     # Currently wheels are available for python-flint only on Windows and OSX
     # so we use OSX rather than Ubuntu for this job.
@@ -239,9 +239,6 @@ jobs:
       - run: pip install -r requirements-test.txt
       - run: pip install python-flint
       # Test modules that most directly use python-flint
-      - run: pwd
-      - run: ls -l
-      - run: ls sympy
       - run: |
           pytest --doctest-plus --doctest-glob='*.rst'    \
                     sympy/polys                           \

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -245,6 +245,9 @@ jobs:
                     doc/src/modules/polys                 \
                     sympy/ntheory                         \
                     doc/src/modules/ntheory.rst           \
+                    sympy/matrices                        \
+                    doc/src/modules/matrices              \
+                    doc/src/tutorials/intro-tutorial/     \
         env:
           SYMPY_GROUND_TYPES: flint
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -23,7 +23,8 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
 
-      - run: pip install mpmath flake8 flake8-comprehensions ruff pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install flake8 flake8-comprehensions ruff
 
       - name: Basic code quality tests
         run: bin/test quality
@@ -134,7 +135,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --split ${{ matrix.group }}/4
 
   # -------------------- Test Pyodide on node ---------------------- #
@@ -192,15 +193,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - run: pip install -r requirements-test.txt
+
       # Install the non-Python dependencies
       - run: sudo apt-get update
       - run: sudo apt-get install antlr4 libgfortran5 gfortran libmpfr-dev libmpc-dev libopenblas-dev clang
       - run: python -m pip install --upgrade pip wheel setuptools
 
       # dependencies to install in all Python versions:
-      - run: pip install mpmath numpy numexpr matplotlib ipython cython scipy \
-                         aesara wurlitzer autowrap lxml pytest hypothesis     \
-                         'antlr4-python3-runtime==4.11.*'
+      - run: pip install numpy numexpr matplotlib ipython cython scipy aesara \
+                         wurlitzer autowrap lxml                              \
+                         'antlr4-python3-runtime==4.11.*'                     \
+                         #
 
       # Not available in pypy or cpython 3.11 (yet).
       - if: ${{ ! contains(matrix.python-version, 'pypy') && ! contains(matrix.python-version, '3.11') }}
@@ -218,6 +222,36 @@ jobs:
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py
 
+  # -------------------- FLINT tests -------------------------------- #
+
+  python-flint:
+    # needs: code-quality
+
+    # Currently wheels are available for python-flint only on Windows and OSX
+    # so we use OSX rather than Ubuntu for this job.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-test.txt
+      - run: pip install python-flint
+      # Test modules that most directly use python-flint
+      - run: pwd
+      - run: ls -l
+      - run: ls sympy
+      - run: |
+          pytest --doctest-plus --doctest-glob='*.rst'    \
+                    sympy/polys                           \
+                    doc/src/modules/polys                 \
+                    sympy/ntheory                         \
+                    doc/src/modules/ntheory.rst           \
+        env:
+          SYMPY_GROUND_TYPES: flint
+
+
   # -------------------- Tensorflow tests -------------------------- #
 
   tensorflow:
@@ -231,7 +265,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy scipy tensorflow pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install numpy scipy tensorflow
       # Test modules that can use tensorflow
       - run: bin/test_tensorflow.py
 
@@ -247,7 +282,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath numpy symengine pytest hypothesis
+      - run: pip install -r requirements-test.txt
+      - run: pip install numpy symengine
       # Test modules that can use tensorflow
       - run: bin/test_symengine.py
         env:
@@ -269,7 +305,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split pytest-timeout hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --slow --timeout 595 --split ${{ matrix.group }}/4
 
   # -------------------- Test older (and newer) Python --------------- #
@@ -295,7 +331,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath pytest pytest-split hypothesis
+      - run: pip install -r requirements-test.txt
       - run: bin/test --split ${{ matrix.group }}/4
 
   # -------------------- Doctests older (and newer) Python --------------------- #

--- a/doc/src/modules/polys/domainmatrix.rst
+++ b/doc/src/modules/polys/domainmatrix.rst
@@ -47,6 +47,9 @@ In general, we represent a matrix without concerning about the :py:class:`~.Doma
 .. automodule:: sympy.polys.matrices.sdm
    :members:
 
+.. automodule:: sympy.polys.matrices._dfm
+   :members:
+
 .. currentmodule:: sympy.polys.matrices.normalforms
 
 .. autofunction:: smith_normal_form

--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -289,14 +289,24 @@ multiplication will work for the elements of any domain and will produce new
 domain elements. Division with ``/`` (Python's "true division" operator) is not
 possible for all domains and should not be used with domain elements unless
 the domain is known to be a field. For example dividing two elements of :ref:`ZZ`
-gives a ``float`` which is not an element of :ref:`ZZ`::
+might give a ``float`` which is not an element of :ref:`ZZ`::
 
-  >>> z1 / z1
+  >>> z1 / z1  # doctest: +SKIP
   1.0
   >>> type(z1 / z1)  # doctest: +SKIP
   <class 'float'>
   >>> ZZ.is_Field
   False
+
+The behaviour of ``/`` for non-fields can also differ for different
+implementations of the ground types of the domain. For example with
+`SYMPY_GROUND_TYPES=flint` dividing two elements of :ref:`ZZ` will raise an
+error rather than return a float::
+
+   >>> z1 / z1  # doctest: +SKIP
+   Traceback (most recent call last):
+   ...
+   TypeError: unsupported operand type(s) for /: 'flint._flint.fmpz' and 'flint._flint.fmpz'
 
 Most domains representing non-field rings allow floor and modulo division
 (remainder) with Python's floor division ``//`` and modulo division ``%``

--- a/release/compare_tar_against_git.py
+++ b/release/compare_tar_against_git.py
@@ -53,7 +53,7 @@ git_whitelist = {
     'CODEOWNERS',
     'asv.conf.actions.json',
     'codecov.yml',
-    'requirements-tests.txt',
+    'requirements-test.txt',
     'MANIFEST.in',
     'banner.svg',
     # Code of conduct

--- a/release/compare_tar_against_git.py
+++ b/release/compare_tar_against_git.py
@@ -53,6 +53,7 @@ git_whitelist = {
     'CODEOWNERS',
     'asv.conf.actions.json',
     'codecov.yml',
+    'requirements-tests.txt',
     'MANIFEST.in',
     'banner.svg',
     # Code of conduct

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+mpmath
+pytest
+pytest-xdist
+pytest-timeout
+pytest-split
+pytest-doctestplus
+hypothesis

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -903,7 +903,7 @@ def _det_bird(M):
                  enumerate(X)]
         return DDM(elems, X.shape, X.domain)
 
-    Mddm = M._rep.to_dense().rep
+    Mddm = M._rep.to_ddm()
     n = M.shape[0]
     if n == 0:
         return M.one

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -484,7 +484,7 @@ def dup_normal(f, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dup_normal
 
-    >>> dup_normal([0, 1.5, 2, 3], ZZ)
+    >>> dup_normal([0, 1, 2, 3], ZZ)
     [1, 2, 3]
 
     """
@@ -501,7 +501,7 @@ def dmp_normal(f, u, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dmp_normal
 
-    >>> dmp_normal([[], [0, 1.5, 2]], 1, ZZ)
+    >>> dmp_normal([[], [0, 1, 2]], 1, ZZ)
     [[1, 2]]
 
     """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1101,12 +1101,20 @@ class Domain:
 
         Since the default :py:attr:`~.Domain.dtype` for :ref:`ZZ` is ``int``
         (or ``mpz``) division as ``a / b`` should not be used as it would give
-        a ``float``.
+        a ``float`` which is not a domain element.
 
-        >>> ZZ(4) / ZZ(2)
+        >>> ZZ(4) / ZZ(2) # doctest: +SKIP
         2.0
-        >>> ZZ(5) / ZZ(2)
+        >>> ZZ(5) / ZZ(2) # doctest: +SKIP
         2.5
+
+        On the other hand with `SYMPY_GROUND_TYPES=flint` elements of :ref:`ZZ`
+        are ``flint.fmpz`` and division would raise an exception:
+
+        >>> ZZ(4) / ZZ(2) # doctest: +SKIP
+        Traceback (most recent call last):
+        ...
+        TypeError: unsupported operand type(s) for /: 'fmpz' and 'fmpz'
 
         Using ``/`` with :ref:`ZZ` will lead to incorrect results so
         :py:meth:`~.Domain.exquo` should be used instead.

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -1,0 +1,345 @@
+#
+# sympy.polys.matrices.dfm
+#
+# This modules defines the DFM class which is a wrapper for dense flint
+# matrices as found in python-flint.
+#
+# As of python-flint 0.4.1 matrices over the following domains can be supported
+# by python-flint:
+#
+#   ZZ: flint.fmpz_mat
+#   QQ: flint.fmpq_mat
+#   GF(p): flint.nmod_mat (p prime and p < ~2**62)
+#
+# The underlying flint library has many more domains, but these are not yet
+# supported by python-flint.
+#
+# The DFM class is a wrapper for the flint matrices and provides a common
+# interface for all supported domains that is interchangeable with the DDM
+# and SDM classes so that DomainMatrix can be used with any as its internal
+# matrix representation.
+#
+
+from sympy.polys.domains import ZZ, QQ
+from .exceptions import DMBadInputError
+
+import flint
+
+
+__all__ = ['DFM']
+
+
+class DFM:
+    """
+    Dense FLINT matrix. This class is a wrapper for matrices from python-flint.
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.matrices.dfm import DFM
+    >>> dfm = DFM([[1, 2], [3, 4]], (2, 2), ZZ)
+    >>> dfm
+    [[1, 2], [3, 4]]
+    >>> dfm.rep
+    [1, 2]
+    [3, 4]
+    >>> type(dfm.rep)
+    <class 'flint._flint.fmpz_mat'>
+
+    Usually, the DFM class is not instantiated directly, but is created as the
+    internal representation of :class:`DomainMatrix`. When `SYMPY_GROUND_TYPES`
+    is set to `flint` and `python-flint` is installed, the DFM class is used
+    automatically as the internal representation of :class:`DomainMatrix`in
+    dense format if the domain is supported by python-flint.
+
+    >>> from sympy.polys.matrices.domainmatrix import DomainMatrix
+    >>> dM = DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
+    >>> dM.rep
+    [[1, 2], [3, 4]]
+
+    A :class:`DomainMatrix` can be converted to a DFM by calling the
+    :meth:`to_dfm` method::
+
+    >>> dM.to_dfm()
+    [[1, 2], [3, 4]]
+
+    """
+
+    fmt = 'dense'
+    is_DFM = True
+    is_DDM = False
+
+    def __new__(cls, rowslist, shape, domain):
+        flint_mat = cls._get_flint_func(domain)
+
+        if 0 not in shape:
+            rep = flint_mat(rowslist)
+        else:
+            rep = flint_mat(*shape)
+
+        return cls._new(rep, shape, domain)
+
+    @classmethod
+    def _new(cls, rep, shape, domain):
+        cls._check(rep, shape, domain)
+        obj = object.__new__(cls)
+        obj.rep = rep
+        obj.shape = obj.rows, obj.cols = shape
+        obj.domain = domain
+        return obj
+
+    @classmethod
+    def _check(cls, rep, shape, domain):
+        repshape = (rep.nrows(), rep.ncols())
+        if repshape != shape:
+            raise DMBadInputError("Shape of rep does not match shape of DFM")
+        if domain == ZZ and not isinstance(rep, flint.fmpz_mat):
+            raise RuntimeError("Rep is not a flint.fmpz_mat")
+        elif domain == QQ and not isinstance(rep, flint.fmpq_mat):
+            raise RuntimeError("Rep is not a flint.fmpq_mat")
+        elif domain not in (ZZ, QQ):
+            raise NotImplementedError("Only ZZ and QQ are supported by DFM")
+
+    @classmethod
+    def _supports_domain(cls, domain):
+        return domain in (ZZ, QQ)
+
+    @classmethod
+    def _get_flint_func(cls, domain):
+        if domain == ZZ:
+            return flint.fmpz_mat
+        elif domain == QQ:
+            return flint.fmpq_mat
+        else:
+            raise NotImplementedError("Only ZZ and QQ are supported by DFM")
+
+    def __str__(self):
+        """Return ``str(self)``."""
+        return str(self.to_ddm())
+
+    def __repr__(self):
+        """Return ``repr(self)``."""
+        return f'DFM{repr(self.to_ddm())[3:]}'
+
+    def __eq__(self, other):
+        """Return ``self == other``."""
+        if not isinstance(other, DFM):
+            return NotImplemented
+        # Compare domains first because we do *not* want matrices with
+        # different domains to be equal but e.g. a flint fmpz_mat and fmpq_mat
+        # with the same entries will compare equal.
+        return self.domain == other.domain and self.rep == other.rep
+
+    def copy(self):
+        """Return a copy of self."""
+        # XXX: fmpz_mat and fmpq_mat do not have a copy method
+        return self.to_ddm().to_dfm()
+
+    def to_ddm(self):
+        """Convert to a DDM."""
+        return DDM(self.rep.tolist(), self.shape, self.domain)
+
+    def to_sdm(self):
+        """Convert to a SDM."""
+        return self.to_ddm().to_sdm()
+
+    def to_dfm(self):
+        """Return self."""
+        return self
+
+    def to_dfm_or_ddm(self):
+        """Return self."""
+        return self
+
+    def to_list(self):
+        """Convert to a nested list."""
+        return self.rep.tolist()
+
+    def to_list_flat(self):
+        """Convert to a flat list."""
+        return self.to_ddm().to_list_flat()
+
+    def to_flat_nz(self):
+        """Convert to a flat list of non-zeros."""
+        return self.to_ddm().to_flat_nz()
+
+    @classmethod
+    def from_flat_nz(cls, elements, data, domain):
+        """Inverse of :meth:`to_flat_nz`."""
+        return DDM.from_flat_nz(elements, data, domain).to_dfm()
+
+    def to_dok(self):
+        """Convert to a DOK."""
+        return self.to_ddm().to_dok()
+
+    def convert_to(self, domain):
+        """Convert to a new domain."""
+        # XXX: fmpz_mat and fmpq_mat do not have conversion methods. You can do
+        # fmpq_mat(fmpz_mat) but not fmpz_mat(fmpq_mat). The domain will be
+        # checked in __new__.
+        #
+        # It is the responsibility of the caller to ensure that the conversion
+        # is possible (i.e. DomainMatrix should have checked already).
+        return self.to_ddm().convert_to(domain).to_dfm()
+
+    def getitem(self, i, j):
+        """Get the ``(i, j)``-th entry."""
+        # XXX: flint matrices do not support negative indices
+        # XXX: They also raise ValueError instead of IndexError
+        m, n = self.shape
+        if i < 0:
+            i += m
+        if j < 0:
+            j += n
+        try:
+            return self.rep[i, j]
+        except ValueError:
+            raise IndexError(f"Invalid indices ({i}, {j}) for Matrix of shape {self.shape}")
+
+    def extract(self, rowslist, colslist):
+        """Extract a submatrix."""
+        # XXX: flint matrices do not support fancy indexing
+        return self.to_ddm().extract(rowslist, colslist).to_dfm()
+
+    def extract_slice(self, rowslice, colslice):
+        """Extract a submatrix."""
+        # XXX: flint matrices do not support slicing
+        return self.to_ddm().extract_slice(rowslice, colslice).to_dfm()
+
+    def neg(self):
+        """Negate a DFM matrix."""
+        return self._new(-self.rep, self.shape, self.domain)
+
+    def add(self, other):
+        """Add two DFM matrices."""
+        return self._new(self.rep + other.rep, self.shape, self.domain)
+
+    def sub(self, other):
+        """Subtract two DFM matrices."""
+        return self._new(self.rep - other.rep, self.shape, self.domain)
+
+    def mul(self, other):
+        """Multiply a DFM matrix from the right by a scalar."""
+        return self._new(self.rep * other, self.shape, self.domain)
+
+    def rmul(self, other):
+        """Multiply a DFM matrix from the left by a scalar."""
+        return self._new(other * self.rep, self.shape, self.domain)
+
+    def mul_elementwise(self, other):
+        """Elementwise multiplication of two DFM matrices."""
+        return self.to_ddm().mul_elementwise(other.to_ddm()).to_dfm()
+
+    def matmul(self, other):
+        """Multiply two DFM matrices."""
+        shape = (self.rows, other.cols)
+        return self._new(self.rep * other.rep, shape, self.domain)
+
+    def __neg__(self):
+        """Negate a DFM matrix."""
+        return self.neg()
+
+    @classmethod
+    def zeros(cls, shape, domain):
+        """Return a zero DFM matrix."""
+        func = cls._get_flint_func(domain)
+        return cls(func(*shape), shape, domain)
+
+    @classmethod
+    def eye(cls, n, domain):
+        """Return the identity matrix of size n."""
+        # XXX: DDM and SDM have inconsistent signatures for eye because SDM
+        # assumes a shape argument while DDM expects an integer size.
+        return DDM.eye(n, domain).to_dfm()
+
+    def applyfunc(self, func, domain):
+        """Apply a function to each entry of a DFM matrix."""
+        return self.to_ddm().applyfunc(func, domain).to_dfm()
+
+    def transpose(self):
+        """Transpose a DFM matrix."""
+        m, n = self.shape
+        return self._new(self.rep.transpose(), (n, m), self.domain)
+
+    def hstack(self, *others):
+        """Horizontally stack matrices."""
+        return self.to_ddm().hstack(*[o.to_ddm() for o in others]).to_dfm()
+
+    def vstack(self, *others):
+        """Vertically stack matrices."""
+        return self.to_ddm().vstack(*[o.to_ddm() for o in others]).to_dfm()
+
+    def diagonal(self):
+        """Return the diagonal of a DFM matrix."""
+        return self.to_ddm().diagonal()
+
+    def is_upper(self):
+        """Return ``True`` if the matrix is upper triangular."""
+        return self.to_ddm().is_upper()
+
+    def is_lower(self):
+        """Return ``True`` if the matrix is lower triangular."""
+        return self.to_ddm().is_lower()
+
+    def is_diagonal(self):
+        """Return ``True`` if the matrix is diagonal."""
+        return self.to_ddm().is_diagonal()
+
+    def is_zero_matrix(self):
+        """Return ``True`` if the matrix is the zero matrix."""
+        return self.to_ddm().is_zero_matrix()
+
+    def scc(self):
+        """Return the strongly connected components of the matrix."""
+        return self.to_ddm().scc()
+
+    def det(self):
+        """Return the determinant of the matrix."""
+        # XXX: Use the flint det method!!!
+        return self.to_ddm().det()
+
+    def inv(self):
+        """Return the inverse of the matrix."""
+        # XXX: Use the flint inv method!!!
+        return self.to_ddm().inv().to_dfm()
+
+    def charpoly(self):
+        """Return the characteristic polynomial of the matrix."""
+        # XXX: Use the flint charpoly method!!!
+        return self.to_ddm().charpoly()
+
+    def lu(self):
+        """Return the LU decomposition of the matrix."""
+        L, U, swaps = self.to_ddm().lu()
+        return L.to_dfm(), U.to_dfm(), swaps
+
+    def lu_solve(self, rhs):
+        """Solve a linear system using LU decomposition."""
+        return self.to_ddm().lu_solve(rhs.to_ddm()).to_dfm()
+
+    def nullspace(self):
+        """Return a basis for the nullspace of the matrix."""
+        ddm, nonpivots = self.to_ddm().nullspace()
+        return ddm.to_dfm(), nonpivots
+
+    def nullspace_from_rref(self, pivots=None):
+        """Return a basis for the nullspace of the matrix."""
+        sdm, nonpivots = self.to_sdm().nullspace_from_rref(pivots=pivots)
+        return sdm.to_dfm(), nonpivots
+
+    def particular(self):
+        """Return a particular solution to the system."""
+        return self.to_ddm().particular().to_dfm()
+
+    def lll(self, delta=QQ(3, 4)):
+        """Return an LLL-reduced basis for the matrix."""
+        # XXX: Use the flint lll method!!!
+        return self.to_ddm().lll().to_dfm()
+
+    def lll_transform(self, delta=QQ(3, 4)):
+        """Return the LLL-reduced basis and transform matrix."""
+        # XXX: Use the flint lll_transform method!!!
+        y, T = self.to_ddm().lll_transform()
+        return y.to_dfm(), T.to_dfm()
+
+
+# Avoid circular imports
+from sympy.polys.matrices.ddm import DDM

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -783,6 +783,7 @@ class DFM:
         # Actually call the flint method.
         return self.rep.lll(transform=transform, delta=delta, eta=eta, rep=rep, gram=gram)
 
+    @doctest_depends_on(ground_types='flint')
     def lll(self, delta=0.75):
         """Compute LLL-reduced basis using FLINT.
 
@@ -812,6 +813,7 @@ class DFM:
         rep = self._lll(delta=delta)
         return self._new_rep(rep)
 
+    @doctest_depends_on(ground_types='flint')
     def lll_transform(self, delta=0.75):
         """Compute LLL-reduced basis and transform using FLINT.
 

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -20,6 +20,25 @@
 # matrix representation.
 #
 
+# TODO:
+#
+# Implement the following methods that are provided by python-flint:
+#
+# - hnf (Hermite normal form)
+# - snf (Smith normal form)
+# - minpoly
+# - is_hnf
+# - is_snf
+# - rank
+#
+# The other types DDM and SDM do not have these methods and the algorithms
+# for hnf, snf and rank are already implemented. Algorithms for minpoly,
+# is_hnf and is_snf would need to be added.
+#
+# Add more methods to python-flint to expose more of Flint's functionality
+# and also to make some of the above methods simpler or more efficient e.g.
+# slicing, fancy indexing etc.
+
 from sympy.external.importtools import import_module
 from sympy.utilities.decorator import doctest_depends_on
 

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -175,7 +175,19 @@ class DFM:
         return self
 
     def to_dfm_or_ddm(self):
-        """Return self."""
+        """
+        Convert to a :class:`DFM`.
+
+        This :class:`DFM` method exists to parallel the :class:`~.DDM` and
+        :class:`~.SDM` methods. For :class:`DFM` it will always return self.
+
+        See Also
+        ========
+
+        to_ddm
+        to_sdm
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_dfm_or_ddm
+        """
         return self
 
     @classmethod
@@ -416,9 +428,33 @@ class DFM:
         return self.to_ddm().scc()
 
     def det(self):
-        """Return the determinant of the matrix."""
-        # XXX: Use the flint det method!!!
-        return self.to_ddm().det()
+        """Return the determinant of the matrix.
+
+        Calls the ``.det()`` method of the underlying FLINT matrix.
+
+        For :ref:`ZZ` or :ref:`QQ` this calls ``fmpz_mat_det`` or
+        ``fmpq_mat_det`` respectively.
+
+        At the time of writing the implementation of ``fmpz_mat_det`` uses one
+        of several algorithms depending on the size of the matrix and bit size
+        of the entries. The algorithms used are:
+
+        - Cofactor for very small (up to 4x4) matrices.
+        - Bareiss for small (up to 25x25) matrices.
+        - Modular algorithms for larger matrices (up to 60x60) or for larger
+          matrices with large bit sizes.
+        - Modular "accelerated" for larger matrices (60x60 upwards) if the bit
+          size is smaller than the dimensions of the matrix.
+
+        The implementation of ``fmpq_mat_det`` clears denominators from each
+        row (not the whole matrix) and then calls ``fmpz_mat_det`` and divides
+        by the product of the denominators.
+        """
+        # XXX: At least the first three algorithms described above should also
+        # be implemented in the pure Python DDM and SDM classes which at the
+        # time of writng just use Bareiss for all matrices and domains.
+        # Probably in Python the thresholds would be different though.
+        return self.rep.det()
 
     def inv(self):
         """Return the inverse of the matrix."""

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -772,7 +772,7 @@ class DFM:
         Examples
         ========
 
-        >>> from sympy import Matrix, QQ
+        >>> from sympy import Matrix
         >>> M = Matrix([[1, 2, 3], [4, 5, 6]])
         >>> M.to_DM().to_dfm().lll()
         [[2, 1, 0], [-1, 1, 3]]
@@ -799,7 +799,7 @@ class DFM:
         Examples
         ========
 
-        >>> from sympy import Matrix, QQ
+        >>> from sympy import Matrix
         >>> M = Matrix([[1, 2, 3], [4, 5, 6]]).to_DM().to_dfm()
         >>> M_lll, T = M.lll_transform()
         >>> M_lll

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -557,10 +557,49 @@ class DFM:
             # what happens here.
             raise NotImplementedError("DFM.inv() is not implemented for %s" % K)
 
+    @doctest_depends_on(ground_types='flint')
     def charpoly(self):
-        """Return the characteristic polynomial of the matrix."""
-        # XXX: Use the flint charpoly method!!!
-        return self.to_ddm().charpoly()
+        """
+        Compute the characteristic polynomial of the matrix using FLINT.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> M = Matrix([[1, 2], [3, 4]])
+        >>> dfm = M.to_DM().to_dfm()  # need ground types = 'flint'
+        >>> dfm
+        [[1, 2], [3, 4]]
+        >>> dfm.charpoly()
+        [1, -5, -2]
+
+        Notes
+        =====
+
+        Calls the ``.charpoly()`` method of the underlying FLINT matrix.
+
+        For :ref:`ZZ` or :ref:`QQ` this calls ``fmpz_mat_charpoly`` or
+        ``fmpq_mat_charpoly`` respectively.
+
+        At the time of writing the implementation of ``fmpq_mat_charpoly``
+        clears a denominator from the whole matrix and then calls
+        ``fmpz_mat_charpoly``. The coefficients of the characteristic
+        polynomial are then multiplied by powers of the denominator.
+
+        The ``fmpz_mat_charpoly`` method uses a modular algorithm with CRT
+        reconstruction. The modular algorithm uses ``nmod_mat_charpoly`` which
+        uses Berkowitz for small matrices and non-prime moduli or otherwise
+        the Danilevsky method.
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.charpoly
+            Higher level interface to compute the characteristic polynomial of
+            a matrix.
+        """
+        # FLINT polynomial coefficients are in reverse order compared to SymPy.
+        return self.rep.charpoly().coeffs()[::-1]
 
     def lu(self):
         """Return the LU decomposition of the matrix."""

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -204,11 +204,18 @@ class DFM:
     @classmethod
     def from_list_flat(cls, elements, shape, domain):
         """Inverse of :meth:`to_list_flat`."""
-        return DDM.from_list_flat(elements, shape, domain).to_dfm()
+        func = cls._get_flint_func(domain)
+        try:
+            rep = func(*shape, elements)
+        except ValueError:
+            raise DMBadInputError(f"Incorrect number of elements for shape {shape}")
+        except TypeError:
+            raise DMBadInputError(f"Input should be a list of {domain}")
+        return cls(func(*shape, elements), shape, domain)
 
     def to_list_flat(self):
         """Convert to a flat list."""
-        return self.to_ddm().to_list_flat()
+        return self.rep.entries()
 
     def to_flat_nz(self):
         """Convert to a flat list of non-zeros."""

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -49,18 +49,19 @@ class DFM:
     <class 'flint._flint.fmpz_mat'>
 
     Usually, the DFM class is not instantiated directly, but is created as the
-    internal representation of :class:`DomainMatrix`. When `SYMPY_GROUND_TYPES`
-    is set to `flint` and `python-flint` is installed, the DFM class is used
-    automatically as the internal representation of :class:`DomainMatrix`in
-    dense format if the domain is supported by python-flint.
+    internal representation of :class:`~.DomainMatrix`. When
+    `SYMPY_GROUND_TYPES` is set to `flint` and `python-flint` is installed, the
+    :class:`DFM` class is used automatically as the internal representation of
+    :class:`~.DomainMatrix` in dense format if the domain is supported by
+    python-flint.
 
     >>> from sympy.polys.matrices.domainmatrix import DM
     >>> dM = DM([[1, 2], [3, 4]], ZZ)
     >>> dM.rep
     [[1, 2], [3, 4]]
 
-    A :class:`DomainMatrix` can be converted to a DFM by calling the
-    :meth:`to_dfm` method::
+    A :class:`~.DomainMatrix` can be converted to :class:`DFM` by calling the
+    :meth:`to_dfm` method:
 
     >>> dM.to_dfm()
     [[1, 2], [3, 4]]

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -63,6 +63,8 @@ representation is friendlier.
 """
 from itertools import chain
 
+from sympy.utilities.decorator import doctest_depends_on
+
 from .exceptions import DMBadInputError, DMShapeError, DMDomainError
 
 from sympy.polys.domains import QQ
@@ -332,6 +334,7 @@ class DDM(list):
         """
         return SDM.from_list(self, self.shape, self.domain)
 
+    @doctest_depends_on(ground_types=['flint'])
     def to_dfm(self):
         """
         Convert to a :class:`~.DFM`.
@@ -355,6 +358,7 @@ class DDM(list):
         """
         return DFM(list(self), self.shape, self.domain)
 
+    @doctest_depends_on(ground_types=['flint'])
     def to_dfm_or_ddm(self):
         """
         Convert to :class:`~.DFM` if possible or otherwise return self.

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -337,7 +337,7 @@ class DDM(list):
     @doctest_depends_on(ground_types=['flint'])
     def to_dfm(self):
         """
-        Convert to a :class:`~.DFM`.
+        Convert to :class:`~.DDM` to :class:`~.DFM`.
 
         Examples
         ========
@@ -354,7 +354,7 @@ class DDM(list):
         ========
 
         DFM
-        sympy.polys.matrices.dfm.DFM.to_ddm
+        sympy.polys.matrices._dfm.DFM.to_ddm
         """
         return DFM(list(self), self.shape, self.domain)
 
@@ -379,7 +379,7 @@ class DDM(list):
 
         DFM
         DDM
-        sympy.polys.matrices.dfm.DFM.to_ddm
+        sympy.polys.matrices._dfm.DFM.to_ddm
         """
         if DFM._supports_domain(self.domain):
             return self.to_dfm()

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -95,6 +95,8 @@ class DDM(list):
     """
 
     fmt = 'dense'
+    is_DFM = False
+    is_DDM = True
 
     def __init__(self, rowslist, shape, domain):
         super().__init__(rowslist)
@@ -329,6 +331,55 @@ class DDM(list):
         sympy.polys.matrices.sdm.SDM.to_ddm
         """
         return SDM.from_list(self, self.shape, self.domain)
+
+    def to_dfm(self):
+        """
+        Convert to a :class:`~.DFM`.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> A.to_dfm()
+        [[1, 2], [3, 4]]
+        >>> type(A.to_dfm())
+        <class 'sympy.polys.matrices._dfm.DFM'>
+
+        See Also
+        ========
+
+        DFM
+        sympy.polys.matrices.dfm.DFM.to_ddm
+        """
+        return DFM(list(self), self.shape, self.domain)
+
+    def to_dfm_or_ddm(self):
+        """
+        Convert to :class:`~.DFM` if possible or otherwise return self.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[1, 2], [3, 4]], (2, 2), QQ)
+        >>> A.to_dfm_or_ddm()
+        [[1, 2], [3, 4]]
+        >>> type(A.to_dfm_or_ddm())
+        <class 'sympy.polys.matrices._dfm.DFM'>
+
+        See Also
+        ========
+
+        DFM
+        DDM
+        sympy.polys.matrices.dfm.DFM.to_ddm
+        """
+        if DFM._supports_domain(self.domain):
+            return self.to_dfm()
+        return self
 
     def convert_to(self, K):
         Kold = self.domain
@@ -759,3 +810,4 @@ class DDM(list):
 
 
 from .sdm import SDM
+from .dfm import DFM

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -355,6 +355,21 @@ class DDM(list):
         return DDM(lol, shape, domain)
 
     def to_ddm(self):
+        """
+        Convert to a :class:`DDM`.
+
+        This just returns ``self`` but exists to parallel the corresponding
+        method in other matrix types like :class:`~.SDM`.
+
+        See Also
+        ========
+
+        to_sdm
+        to_dfm
+        to_dfm_or_ddm
+        sympy.polys.matrices.sdm.SDM.to_ddm
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_ddm
+        """
         return self
 
     def to_sdm(self):
@@ -423,9 +438,9 @@ class DDM(list):
         See Also
         ========
 
-        DFM
-        DDM
-        sympy.polys.matrices._dfm.DFM.to_ddm
+        to_dfm
+        to_ddm
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_dfm_or_ddm
         """
         if DFM._supports_domain(self.domain):
             return self.to_dfm()

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -842,6 +842,8 @@ class DDM(list):
         m, n = a.shape
         m2, o = b.shape
         a._check(a, 'lu_solve', b, m, m2)
+        if not a.domain.is_Field:
+            raise DMDomainError("lu_solve requires a field")
 
         L, U, swaps = a.lu()
         x = a.zeros((n, o), a.domain)

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -65,7 +65,12 @@ from itertools import chain
 
 from sympy.utilities.decorator import doctest_depends_on
 
-from .exceptions import DMBadInputError, DMShapeError, DMDomainError
+from .exceptions import (
+    DMBadInputError,
+    DMDomainError,
+    DMNonSquareMatrixError,
+    DMShapeError,
+)
 
 from sympy.polys.domains import QQ
 
@@ -805,7 +810,7 @@ class DDM(list):
         """Determinant of a"""
         m, n = a.shape
         if m != n:
-            raise DMShapeError("Determinant of non-square matrix")
+            raise DMNonSquareMatrixError("Determinant of non-square matrix")
         b = a.copy()
         K = b.domain
         deta = ddm_idet(b, K)
@@ -815,7 +820,7 @@ class DDM(list):
         """Inverse of a"""
         m, n = a.shape
         if m != n:
-            raise DMShapeError("Determinant of non-square matrix")
+            raise DMNonSquareMatrixError("Determinant of non-square matrix")
         ainv = a.copy()
         K = a.domain
         ddm_iinv(ainv, a, K)
@@ -848,7 +853,7 @@ class DDM(list):
         K = a.domain
         m, n = a.shape
         if m != n:
-            raise DMShapeError("Charpoly of non-square matrix")
+            raise DMNonSquareMatrixError("Charpoly of non-square matrix")
         vec = ddm_berk(a, K)
         coeffs = [vec[i][0] for i in range(n+1)]
         return coeffs

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from operator import mul
 from .exceptions import (
     DMShapeError,
+    DMDomainError,
     DMNonInvertibleMatrixError,
     DMNonSquareMatrixError,
 )
@@ -525,7 +526,7 @@ def ddm_iinv(ainv, a, K):
     ddm_irref: the underlying routine.
     """
     if not K.is_Field:
-        raise ValueError('Not a field')
+        raise DMDomainError('Not a field')
 
     # a is (m x n)
     m = len(a)

--- a/sympy/polys/matrices/dfm.py
+++ b/sympy/polys/matrices/dfm.py
@@ -10,8 +10,7 @@ from sympy.external.gmpy import GROUND_TYPES
 if GROUND_TYPES == "flint":
     # When python-flint is installed we will try to use it for dense matrices
     # if the domain is supported by python-flint.
-    from ._dfm import DFM as DFM_flint
-    DFM = DFM_flint
+    from ._dfm import DFM
 
 else:
     # Other code should be able to import this and it should just present as a
@@ -27,4 +26,6 @@ else:
         def _supports_domain(cls, domain):
             return False
 
-    DFM = DFM_dummy
+    # mypy really struggles with this kind of conditional type assignment.
+    # Maybe there is a better way to annotate this rather than type: ignore.
+    DFM = DFM_dummy # type: ignore

--- a/sympy/polys/matrices/dfm.py
+++ b/sympy/polys/matrices/dfm.py
@@ -1,0 +1,30 @@
+"""
+sympy.polys.matrices.dfm
+
+Provides the :class:`DFM` class if ``GROUND_TYPES=flint'``. Otherwise, ``DFM``
+is a placeholder class that raises NotImplementedError when instantiated.
+"""
+
+from sympy.external.gmpy import GROUND_TYPES
+
+if GROUND_TYPES == "flint":
+    # When python-flint is installed we will try to use it for dense matrices
+    # if the domain is supported by python-flint.
+    from ._dfm import DFM as DFM_flint
+    DFM = DFM_flint
+
+else:
+    # Other code should be able to import this and it should just present as a
+    # version of DFM that does not support any domains.
+    class DFM_dummy:
+        """
+        Placeholder class for DFM when python-flint is not installed.
+        """
+        def __init__(*args, **kwargs):
+            raise NotImplementedError("DFM requires GROUND_TYPES=flint.")
+
+        @classmethod
+        def _supports_domain(cls, domain):
+            return False
+
+    DFM = DFM_dummy

--- a/sympy/polys/matrices/dfm.py
+++ b/sympy/polys/matrices/dfm.py
@@ -7,12 +7,12 @@ is a placeholder class that raises NotImplementedError when instantiated.
 
 from sympy.external.gmpy import GROUND_TYPES
 
-if GROUND_TYPES == "flint":
+if GROUND_TYPES == "flint":  # pragma: no cover
     # When python-flint is installed we will try to use it for dense matrices
     # if the domain is supported by python-flint.
     from ._dfm import DFM
 
-else:
+else: # pragma: no cover
     # Other code should be able to import this and it should just present as a
     # version of DFM that does not support any domains.
     class DFM_dummy:
@@ -25,6 +25,10 @@ else:
         @classmethod
         def _supports_domain(cls, domain):
             return False
+
+        @classmethod
+        def _get_flint_func(cls, domain):
+            raise NotImplementedError("DFM requires GROUND_TYPES=flint.")
 
     # mypy really struggles with this kind of conditional type assignment.
     # Maybe there is a better way to annotate this rather than type: ignore.

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -29,13 +29,7 @@ from .exceptions import (
     DMNonInvertibleMatrixError
 )
 
-from .ddm import DDM
-
-from .sdm import SDM
-
 from .domainscalar import DomainScalar
-
-from .rref import _dm_rref, _dm_rref_den
 
 from sympy.polys.domains import ZZ, EXRAW, QQ
 
@@ -49,6 +43,14 @@ from sympy.polys.densetools import (
 )
 from sympy.polys.factortools import dup_factor_list
 from sympy.polys.polyutils import _sort_factors
+
+from .ddm import DDM
+
+from .sdm import SDM
+
+from .dfm import DFM
+
+from .rref import _dm_rref, _dm_rref_den
 
 
 def DM(rows, domain):
@@ -118,7 +120,7 @@ class DomainMatrix:
     Poly
 
     """
-    rep: tUnion[SDM, DDM]
+    rep: tUnion[SDM, DDM, DFM]
     shape: tTuple[int, int]
     domain: Domain
 
@@ -140,7 +142,7 @@ class DomainMatrix:
             If any of rows, shape and domain are not provided
 
         """
-        if isinstance(rows, (DDM, SDM)):
+        if isinstance(rows, (DDM, SDM, DFM)):
             raise TypeError("Use from_rep to initialise from SDM/DDM")
         elif isinstance(rows, list):
             rep = DDM(rows, shape, domain)
@@ -158,17 +160,22 @@ class DomainMatrix:
             else:
                 raise ValueError("fmt should be 'sparse' or 'dense'")
 
+        # Use python-flint for dense matrices if possible
+        if rep.fmt == 'dense' and DFM._supports_domain(domain):
+            rep = rep.to_dfm()
+
         return cls.from_rep(rep)
 
-    def __getnewargs__(self):
+    def __reduce__(self):
         rep = self.rep
-        if isinstance(rep, DDM):
-            arg = list(rep)
-        elif isinstance(rep, SDM):
+        if rep.fmt == 'dense':
+            arg = self.to_list()
+        elif rep.fmt == 'sparse':
             arg = dict(rep)
         else:
             raise RuntimeError # pragma: no cover
-        return arg, self.shape, self.domain
+        args = (arg, rep.shape, rep.domain)
+        return (self.__class__, args)
 
     def __getitem__(self, key):
         i, j = key
@@ -254,7 +261,7 @@ class DomainMatrix:
         as this is supposed to be an efficient internal routine.
 
         """
-        if not isinstance(rep, (DDM, SDM)):
+        if not (isinstance(rep, (DDM, SDM)) or (DFM is not None and isinstance(rep, DFM))):
             raise TypeError("rep should be of type DDM or SDM")
         self = super().__new__(cls)
         self.rep = rep
@@ -516,9 +523,21 @@ class DomainMatrix:
         DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ_I)
 
         """
-        if K is None:
+        if K == self.domain:
             return self.copy()
-        return self.from_rep(self.rep.convert_to(K))
+
+        rep = self.rep
+
+        # The DFM, DDM and SDM types do not do any implicit conversions so we
+        # manage switching between DDM and DFM here.
+        if rep.is_DFM and not DFM._supports_domain(K):
+            rep_K = rep.to_ddm().convert_to(K)
+        elif rep.is_DDM and DFM._supports_domain(K):
+            rep_K = rep.convert_to(K).to_dfm()
+        else:
+            rep_K = rep.convert_to(K)
+
+        return self.from_rep(rep_K)
 
     def to_sympy(self):
         return self.convert_to(EXRAW)
@@ -568,7 +587,7 @@ class DomainMatrix:
         if self.rep.fmt == 'sparse':
             return self
 
-        return self.from_rep(SDM.from_ddm(self.rep))
+        return self.from_rep(self.rep.to_sdm())
 
     def to_dense(self):
         """
@@ -587,10 +606,18 @@ class DomainMatrix:
         [[1, 0], [0, 2]]
 
         """
-        if self.rep.fmt == 'dense':
+        rep = self.rep
+
+        if rep.fmt == 'dense':
             return self
 
-        return self.from_rep(SDM.to_ddm(self.rep))
+        rep_dense = rep.to_ddm()
+        K = rep_dense.domain
+
+        if DFM._supports_domain(K):
+            rep_dense = rep_dense.to_dfm()
+
+        return self.from_rep(rep_dense)
 
     def to_ddm(self):
         """
@@ -641,6 +668,31 @@ class DomainMatrix:
         sympy.polys.matrices.sdm.SDM.to_ddm
         """
         return self.rep.to_sdm()
+
+    def to_dfm(self):
+        """
+        Return a :class:`~.DFM` representation of *self*.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy import QQ
+        >>> A = DomainMatrix([[1, 0],[0, 2]], (2, 2), QQ)
+        >>> dfm = A.to_dfm()
+        >>> dfm
+        [[1, 0], [0, 2]]
+        >>> type(dfm)
+        <class 'sympy.polys.matrices._dfm.DFM'>
+
+        See Also
+        ========
+
+        to_ddm
+        to_dense
+        sympy.polys.matrices.dfm.DFM.to_ddm
+        """
+        return self.rep.to_dfm()
 
     @classmethod
     def _unify_domain(cls, *matrices):
@@ -831,7 +883,8 @@ class DomainMatrix:
 
         to_list_flat
         """
-        return cls.from_rep(DDM.from_list_flat(elements, shape, domain))
+        ddm = DDM.from_list_flat(elements, shape, domain)
+        return cls.from_rep(ddm.to_dfm_or_ddm())
 
     def to_flat_nz(self):
         """
@@ -1165,6 +1218,9 @@ class DomainMatrix:
         if a.rep.fmt != b.rep.fmt:
             msg = "Format mismatch: %s %s %s" % (a.rep.fmt, op, b.rep.fmt)
             raise DMFormatError(msg)
+        if type(a.rep) != type(b.rep):
+            msg = "Type mismatch: %s %s %s" % (type(a.rep), op, type(b.rep))
+            raise DMFormatError(msg)
 
     def add(A, B):
         r"""
@@ -1321,15 +1377,10 @@ class DomainMatrix:
         >>> A = DomainMatrix([
         ...    [ZZ(1), ZZ(2)],
         ...    [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-        >>> B = DomainMatrix([
-        ...    [ZZ(1), ZZ(1)],
-        ...    [ZZ(0), ZZ(1)]], (2, 2), ZZ)
+        >>> b = ZZ(2)
 
-        >>> A.mul(B)
-        DomainMatrix([[DomainMatrix([[1, 1], [0, 1]], (2, 2), ZZ),
-        DomainMatrix([[2, 2], [0, 2]], (2, 2), ZZ)],
-        [DomainMatrix([[3, 3], [0, 3]], (2, 2), ZZ),
-        DomainMatrix([[4, 4], [0, 4]], (2, 2), ZZ)]], (2, 2), ZZ)
+        >>> A.mul(b)
+        DomainMatrix([[2, 4], [6, 8]], (2, 2), ZZ)
 
         See Also
         ========
@@ -3306,7 +3357,7 @@ class DomainMatrix:
         DomainMatrix([[1, 1, 1], [1, 1, 1]], (2, 3), QQ)
 
         """
-        return cls.from_rep(DDM.ones(shape, domain))
+        return cls.from_rep(DDM.ones(shape, domain).to_dfm_or_ddm())
 
     def __eq__(A, B):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -613,13 +613,7 @@ class DomainMatrix:
         if rep.fmt == 'dense':
             return self
 
-        rep_dense = rep.to_ddm()
-        K = rep_dense.domain
-
-        if DFM._supports_domain(K):
-            rep_dense = rep_dense.to_dfm()
-
-        return self.from_rep(rep_dense)
+        return self.from_rep(rep.to_dfm_or_ddm())
 
     def to_ddm(self):
         """
@@ -696,6 +690,42 @@ class DomainMatrix:
         DFM
         """
         return self.rep.to_dfm()
+
+    @doctest_depends_on(ground_types=['flint'])
+    def to_dfm_or_ddm(self):
+        """
+        Return a :class:`~.DFM` or :class:`~.DDM` representation of *self*.
+
+        Explanation
+        ===========
+
+        The :class:`~.DFM` representation can only be used if the ground types
+        are ``flint`` and the ground domain is supported by ``python-flint``.
+        This method will return a :class:`~.DFM` representation if possible,
+        but will return a :class:`~.DDM` representation otherwise.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> from sympy import QQ
+        >>> A = DomainMatrix([[1, 0],[0, 2]], (2, 2), QQ)
+        >>> dfm = A.to_dfm_or_ddm()
+        >>> dfm
+        [[1, 0], [0, 2]]
+        >>> type(dfm)  # Depends on the ground domain and ground types
+        <class 'sympy.polys.matrices._dfm.DFM'>
+
+        See Also
+        ========
+
+        to_ddm: Always return a :class:`~.DDM` representation.
+        to_dfm: Returns a :class:`~.DFM` representation or raise an error.
+        to_dense: Convert internally to a :class:`~.DFM` or :class:`~.DDM`
+        DFM: The :class:`~.DFM` dense FLINT matrix representation.
+        DDM: The Python :class:`~.DDM` dense domain matrix representation.
+        """
+        return self.rep.to_dfm_or_ddm()
 
     @classmethod
     def _unify_domain(cls, *matrices):

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -693,7 +693,7 @@ class DomainMatrix:
 
         to_ddm
         to_dense
-        sympy.polys.matrices.dfm.DFM.to_ddm
+        DFM
         """
         return self.rep.to_dfm()
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -13,6 +13,8 @@ from collections import Counter
 from functools import reduce
 from typing import Union as tUnion, Tuple as tTuple
 
+from sympy.utilities.decorator import doctest_depends_on
+
 from sympy.core.sympify import _sympify
 
 from ..domains import Domain
@@ -669,6 +671,7 @@ class DomainMatrix:
         """
         return self.rep.to_sdm()
 
+    @doctest_depends_on(ground_types=['flint'])
     def to_dfm(self):
         """
         Return a :class:`~.DFM` representation of *self*.

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -67,7 +67,7 @@ def invariant_factors(m):
         return ()
 
     rows, cols = shape = m.shape
-    m = list(m.to_dense().rep)
+    m = list(m.to_dense().rep.to_ddm())
 
     def add_rows(m, i, j, a, b, c, d):
         # replace m[i, :] by a*m[i, :] + b*m[j, :]
@@ -207,7 +207,7 @@ def _hermite_normal_form(A):
     # We work one row at a time, starting from the bottom row, and working our
     # way up.
     m, n = A.shape
-    A = A.to_dense().rep.copy()
+    A = A.to_dense().rep.to_ddm().copy()
     # Our goal is to put pivot entries in the rightmost columns.
     # Invariant: Before processing each row, k should be the index of the
     # leftmost column in which we have so far put a pivot.
@@ -248,7 +248,7 @@ def _hermite_normal_form(A):
                 add_columns(A, j, k, 1, -q, 0, 1)
     # Finally, the HNF consists of those columns of A in which we succeeded in making
     # a nonzero pivot.
-    return DomainMatrix.from_rep(A)[:, k:]
+    return DomainMatrix.from_rep(A.to_dfm_or_ddm())[:, k:]
 
 
 def _hermite_normal_form_modulo_D(A, D):
@@ -314,7 +314,7 @@ def _hermite_normal_form_modulo_D(A, D):
     m, n = A.shape
     if n < m:
         raise DMShapeError('Matrix must have at least as many columns as rows.')
-    A = A.to_dense().rep.copy()
+    A = A.to_dense().rep.to_ddm().copy()
     k = n
     R = D
     for i in range(m - 1, -1, -1):

--- a/sympy/polys/matrices/rref.py
+++ b/sympy/polys/matrices/rref.py
@@ -207,11 +207,11 @@ def _dm_rref_GJ_sparse(M):
 
 def _dm_rref_GJ_dense(M):
     """Compute RREF using dense Gauss-Jordan elimination with division."""
-    ddm = M.rep.copy()
+    ddm = M.rep.to_ddm().copy()
     pivots = ddm_irref(ddm)
     M_rref_ddm = DDM(ddm, M.shape, M.domain)
     pivots = tuple(pivots)
-    return M.from_rep(M_rref_ddm), pivots
+    return M.from_rep(M_rref_ddm.to_dfm_or_ddm()), pivots
 
 
 def _dm_rref_den_FF_sparse(M):
@@ -224,11 +224,11 @@ def _dm_rref_den_FF_sparse(M):
 
 def _dm_rref_den_FF_dense(M):
     """Compute RREF using sparse fraction-free Gauss-Jordan elimination."""
-    ddm = M.rep.copy()
+    ddm = M.rep.to_ddm().copy()
     den, pivots = ddm_irref_den(ddm, M.domain)
     M_rref_ddm = DDM(ddm, M.shape, M.domain)
     pivots = tuple(pivots)
-    return M.from_rep(M_rref_ddm), den, pivots
+    return M.from_rep(M_rref_ddm.to_dfm_or_ddm()), den, pivots
 
 
 def _dm_rref_choose_method(M, method, *, denominator=False):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -7,6 +7,7 @@ Module for the SDM class.
 from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
+from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import _strongly_connected_components
 
 from .exceptions import DMBadInputError, DMDomainError, DMShapeError
@@ -519,6 +520,7 @@ class SDM(dict):
     def to_sdm(M):
         return M
 
+    @doctest_depends_on(ground_types=['flint'])
     def to_dfm(M):
         """
         Convert a :py:class:`~.SDM` object to a :py:class:`~.DFM` object

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1235,9 +1235,15 @@ class SDM(dict):
         return [row.get(i, zero) for i, row in self.items() if i < n]
 
     def lll(A, delta=QQ(3, 4)):
-        return A.from_ddm(ddm_lll(A.to_ddm(), delta=delta))
+        """
+        Returns the LLL-reduced basis for the :py:class:`~.SDM` matrix.
+        """
+        return A.to_dfm_or_ddm().lll(delta=delta).to_sdm()
 
     def lll_transform(A, delta=QQ(3, 4)):
+        """
+        Returns the LLL-reduced basis and transformation matrix.
+        """
         reduced, transform = ddm_lll_transform(A.to_ddm(), delta=delta)
         return A.from_ddm(reduced), A.from_ddm(transform)
 

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -15,7 +15,6 @@ from .exceptions import DMBadInputError, DMDomainError, DMShapeError
 from sympy.polys.domains import QQ
 
 from .ddm import DDM
-from .lll import ddm_lll, ddm_lll_transform
 
 
 class SDM(dict):
@@ -1244,8 +1243,8 @@ class SDM(dict):
         """
         Returns the LLL-reduced basis and transformation matrix.
         """
-        reduced, transform = ddm_lll_transform(A.to_ddm(), delta=delta)
-        return A.from_ddm(reduced), A.from_ddm(transform)
+        reduced, transform = A.to_dfm_or_ddm().lll_transform(delta=delta)
+        return reduced.to_sdm(), transform.to_sdm()
 
 
 def binop_dict(A, B, fab, fa, fb):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -518,6 +518,9 @@ class SDM(dict):
         return DDM(M.to_list(), M.shape, M.domain)
 
     def to_sdm(M):
+        """
+        Convert to :py:class:`~.SDM` format (returns self).
+        """
         return M
 
     @doctest_depends_on(ground_types=['flint'])
@@ -534,8 +537,39 @@ class SDM(dict):
         >>> A.to_dfm()
         [[0, 2], [0, 0]]
 
+        See Also
+        ========
+
+        to_ddm
+        to_dfm_or_ddm
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_dfm
         """
         return M.to_ddm().to_dfm()
+
+    @doctest_depends_on(ground_types=['flint'])
+    def to_dfm_or_ddm(M):
+        """
+        Convert to :py:class:`~.DFM` if possible, else :py:class:`~.DDM`.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0:{1:QQ(2)}, 1:{}}, (2, 2), QQ)
+        >>> A.to_dfm_or_ddm()
+        [[0, 2], [0, 0]]
+        >>> type(A.to_dfm_or_ddm())  # depends on the ground types
+        <class 'sympy.polys.matrices.dfm.DFM'>
+
+        See Also
+        ========
+
+        to_ddm
+        to_dfm
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_dfm_or_ddm
+        """
+        return M.to_ddm().to_dfm_or_ddm()
 
     @classmethod
     def zeros(cls, shape, domain):
@@ -891,7 +925,14 @@ class SDM(dict):
         -2
 
         """
-        return A.to_ddm().det()
+        # It would be better to have a sparse implementation of det for use
+        # with very sparse matrices. Extremely sparse matrices probably just
+        # have determinant zero and we could probably detect that very quickly.
+        # In the meantime, we convert to a dense matrix and use ddm_idet.
+        #
+        # If GROUND_TYPES=flint though then we will use Flint's implementation
+        # if possible (dfm).
+        return A.to_dfm_or_ddm().det()
 
     def lu(A):
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1197,7 +1197,7 @@ class SDM(dict):
         Poly(x**2 - 5*x - 2, x, domain='QQ')
 
         """
-        return A.to_ddm().charpoly()
+        return A.to_dfm_or_ddm().charpoly()
 
     def is_zero_matrix(self):
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -67,6 +67,8 @@ class SDM(dict):
     """
 
     fmt = 'sparse'
+    is_DFM = False
+    is_DDM = False
 
     def __init__(self, elemsdict, shape, domain):
         super().__init__(elemsdict)
@@ -516,6 +518,22 @@ class SDM(dict):
 
     def to_sdm(M):
         return M
+
+    def to_dfm(M):
+        """
+        Convert a :py:class:`~.SDM` object to a :py:class:`~.DFM` object
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0:{1:QQ(2)}, 1:{}}, (2, 2), QQ)
+        >>> A.to_dfm()
+        [[0, 2], [0, 0]]
+
+        """
+        return M.to_ddm().to_dfm()
 
     @classmethod
     def zeros(cls, shape, domain):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -585,13 +585,18 @@ class SDM(dict):
         {0: {0: 1}, 1: {1: 1}}
 
         """
-        rows, cols = shape
+        if isinstance(shape, int):
+            rows, cols = shape, shape
+        else:
+            rows, cols = shape
         one = domain.one
         sdm = {i: {i: one} for i in range(min(rows, cols))}
-        return cls(sdm, shape, domain)
+        return cls(sdm, (rows, cols), domain)
 
     @classmethod
-    def diag(cls, diagonal, domain, shape):
+    def diag(cls, diagonal, domain, shape=None):
+        if shape is None:
+            shape = (len(diagonal), len(diagonal))
         sdm = {i: {i: v} for i, v in enumerate(diagonal) if v}
         return cls(sdm, shape, domain)
 
@@ -616,11 +621,15 @@ class SDM(dict):
     def __add__(A, B):
         if not isinstance(B, SDM):
             return NotImplemented
+        elif A.shape != B.shape:
+            raise DMShapeError("Matrix size mismatch: %s + %s" % (A.shape, B.shape))
         return A.add(B)
 
     def __sub__(A, B):
         if not isinstance(B, SDM):
             return NotImplemented
+        elif A.shape != B.shape:
+            raise DMShapeError("Matrix size mismatch: %s - %s" % (A.shape, B.shape))
         return A.sub(B)
 
     def __neg__(A):
@@ -730,7 +739,6 @@ class SDM(dict):
         {0: {0: 3, 1: 2}, 1: {0: 1, 1: 4}}
 
         """
-
         Csdm = binop_dict(A, B, add, pos, pos)
         return A.new(Csdm, A.shape, A.domain)
 

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -560,7 +560,7 @@ class SDM(dict):
         >>> A.to_dfm_or_ddm()
         [[0, 2], [0, 0]]
         >>> type(A.to_dfm_or_ddm())  # depends on the ground types
-        <class 'sympy.polys.matrices.dfm.DFM'>
+        <class 'sympy.polys.matrices._dfm.DFM'>
 
         See Also
         ========
@@ -909,7 +909,7 @@ class SDM(dict):
         {0: {0: -2, 1: 1}, 1: {0: 3/2, 1: -1/2}}
 
         """
-        return A.from_ddm(A.to_ddm().inv())
+        return A.to_dfm_or_ddm().inv().to_sdm()
 
     def det(A):
         """

--- a/sympy/polys/matrices/tests/test_ddm.py
+++ b/sympy/polys/matrices/tests/test_ddm.py
@@ -335,7 +335,7 @@ def test_DDM_inv():
     raises(DMShapeError, lambda: A.inv())
 
     A = DDM([[ZZ(2)]], (1, 1), ZZ)
-    raises(ValueError, lambda: A.inv())
+    raises(DMDomainError, lambda: A.inv())
 
     A = DDM([], (0, 0), QQ)
     assert A.inv() == A

--- a/sympy/polys/matrices/tests/test_dense.py
+++ b/sympy/polys/matrices/tests/test_dense.py
@@ -7,8 +7,13 @@ from sympy.polys.matrices.dense import (
         ddm_transpose,
         ddm_iadd, ddm_isub, ddm_ineg, ddm_imatmul, ddm_imul, ddm_irref,
         ddm_idet, ddm_iinv, ddm_ilu, ddm_ilu_split, ddm_ilu_solve, ddm_berk)
+
 from sympy.polys.matrices.exceptions import (
-    DMShapeError, DMNonInvertibleMatrixError, DMNonSquareMatrixError)
+    DMDomainError,
+    DMNonInvertibleMatrixError,
+    DMNonSquareMatrixError,
+    DMShapeError,
+)
 
 
 def test_ddm_transpose():
@@ -143,7 +148,7 @@ def test_ddm_inv():
 
     A = []
     Ainv = []
-    raises(ValueError, lambda: ddm_iinv(Ainv, A, ZZ))
+    raises(DMDomainError, lambda: ddm_iinv(Ainv, A, ZZ))
 
     A = [[QQ(1), QQ(2)]]
     Ainv = [[QQ(0), QQ(0)]]

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1,3 +1,5 @@
+from sympy.external.gmpy import GROUND_TYPES
+
 from sympy import Integer, Rational, S, sqrt, Matrix, symbols
 from sympy import FF, ZZ, QQ, QQ_I, EXRAW
 
@@ -15,7 +17,10 @@ from sympy.testing.pytest import raises
 def test_DM():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     A = DM([[1, 2], [3, 4]], ZZ)
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -27,7 +32,10 @@ def test_DomainMatrix_init():
     sdm = SDM(dod, (2, 2), ZZ)
 
     A = DomainMatrix(lol, (2, 2), ZZ)
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -41,6 +49,8 @@ def test_DomainMatrix_init():
     raises(TypeError, lambda: DomainMatrix(Matrix([[1]]), (1, 1), ZZ))
 
     for fmt, rep in [('sparse', sdm), ('dense', ddm)]:
+        if fmt == 'dense' and GROUND_TYPES == 'flint':
+            rep = rep.to_dfm()
         A = DomainMatrix(lol, (2, 2), ZZ, fmt=fmt)
         assert A.rep == rep
         A = DomainMatrix(dod, (2, 2), ZZ, fmt=fmt)
@@ -54,6 +64,7 @@ def test_DomainMatrix_init():
 def test_DomainMatrix_from_rep():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     A = DomainMatrix.from_rep(ddm)
+    # XXX: Should from_rep convert to DFM?
     assert A.rep == ddm
     assert A.shape == (2, 2)
     assert A.domain == ZZ
@@ -71,20 +82,27 @@ def test_DomainMatrix_from_rep():
 def test_DomainMatrix_from_list():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     A = DomainMatrix.from_list([[1, 2], [3, 4]], ZZ)
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
     dom = FF(7)
     ddm = DDM([[dom(1), dom(2)], [dom(3), dom(4)]], (2, 2), dom)
     A = DomainMatrix.from_list([[1, 2], [3, 4]], dom)
+    # Not a DFM because FF(7) is not supported by DFM
     assert A.rep == ddm
     assert A.shape == (2, 2)
     assert A.domain == dom
 
     ddm = DDM([[QQ(1, 2), QQ(3, 1)], [QQ(1, 4), QQ(5, 1)]], (2, 2), QQ)
     A = DomainMatrix.from_list([[(1, 2), (3, 1)], [(1, 4), (5, 1)]], QQ)
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == QQ
 
@@ -92,7 +110,10 @@ def test_DomainMatrix_from_list():
 def test_DomainMatrix_from_list_sympy():
     ddm = DDM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     A = DomainMatrix.from_list_sympy(2, 2, [[1, 2], [3, 4]])
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == ZZ
 
@@ -148,7 +169,10 @@ def test_DomainMatrix_from_Matrix():
     A = DomainMatrix.from_Matrix(Matrix([[QQ(1, 2), QQ(3, 4)], [QQ(0, 1), QQ(0, 1)]]), fmt='dense')
     ddm = DDM([[QQ(1, 2), QQ(3, 4)], [QQ(0, 1), QQ(0, 1)]], (2, 2), QQ)
 
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == QQ
 
@@ -186,8 +210,6 @@ def test_DomainMatrix_convert_to():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     Aq = A.convert_to(QQ)
     assert Aq == DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(4)]], (2, 2), QQ)
-    Acopy = A.convert_to(None)
-    assert Acopy == A and Acopy is not A
 
 
 def test_DomainMatrix_choose_domain():
@@ -234,7 +256,11 @@ def test_DomainMatrix_to_sparse():
 def test_DomainMatrix_to_dense():
     A = DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3, 1: 4}}, (2, 2), ZZ)
     A_dense = A.to_dense()
-    assert A_dense.rep == DDM([[1, 2], [3, 4]], (2, 2), ZZ)
+    ddm = DDM([[1, 2], [3, 4]], (2, 2), ZZ)
+    if GROUND_TYPES != 'flint':
+        assert A_dense.rep == ddm
+    else:
+        assert A_dense.rep == ddm.to_dfm()
 
 
 def test_DomainMatrix_unify():
@@ -252,8 +278,8 @@ def test_DomainMatrix_unify():
     assert Ad.unify(Ad) == (Ad, Ad)
 
     Bs, Bd = As.unify(Ad, fmt='dense')
-    assert Bs.rep == DDM([[0, 1], [2, 0]], (2, 2), ZZ)
-    assert Bd.rep == DDM([[1, 2],[3, 4]], (2, 2), ZZ)
+    assert Bs.rep == DDM([[0, 1], [2, 0]], (2, 2), ZZ).to_dfm_or_ddm()
+    assert Bd.rep == DDM([[1, 2],[3, 4]], (2, 2), ZZ).to_dfm_or_ddm()
 
     Bs, Bd = As.unify(Ad, fmt='sparse')
     assert Bs.rep == SDM({0: {1: 1}, 1: {0: 2}}, (2, 2), ZZ)
@@ -412,9 +438,9 @@ def test_DomainMatrix_add():
     Asd = As + Ad
     Ads = Ad + As
     assert Asd == DomainMatrix([[1, 3], [5, 4]], (2, 2), ZZ)
-    assert Asd.rep == DDM([[1, 3], [5, 4]], (2, 2), ZZ)
+    assert Asd.rep == DDM([[1, 3], [5, 4]], (2, 2), ZZ).to_dfm_or_ddm()
     assert Ads == DomainMatrix([[1, 3], [5, 4]], (2, 2), ZZ)
-    assert Ads.rep == DDM([[1, 3], [5, 4]], (2, 2), ZZ)
+    assert Ads.rep == DDM([[1, 3], [5, 4]], (2, 2), ZZ).to_dfm_or_ddm()
     raises(DMFormatError, lambda: As.add(Ad))
 
 
@@ -449,7 +475,7 @@ def test_DomainMatrix_sub():
     Asd = As - Ad
     Ads = Ad - As
     assert Asd == DomainMatrix([[-1, -1], [-1, -4]], (2, 2), ZZ)
-    assert Asd.rep == DDM([[-1, -1], [-1, -4]], (2, 2), ZZ)
+    assert Asd.rep == DDM([[-1, -1], [-1, -4]], (2, 2), ZZ).to_dfm_or_ddm()
     assert Asd == -Ads
     assert Asd.rep == -Ads.rep
 
@@ -494,9 +520,9 @@ def test_DomainMatrix_mul():
     Asd = As * Ad
     Ads = Ad * As
     assert Asd == DomainMatrix([[3, 4], [2, 4]], (2, 2), ZZ)
-    assert Asd.rep == DDM([[3, 4], [2, 4]], (2, 2), ZZ)
+    assert Asd.rep == DDM([[3, 4], [2, 4]], (2, 2), ZZ).to_dfm_or_ddm()
     assert Ads == DomainMatrix([[4, 1], [8, 3]], (2, 2), ZZ)
-    assert Ads.rep == DDM([[4, 1], [8, 3]], (2, 2), ZZ)
+    assert Ads.rep == DDM([[4, 1], [8, 3]], (2, 2), ZZ).to_dfm_or_ddm()
 
 
 def test_DomainMatrix_mul_elementwise():
@@ -1054,7 +1080,10 @@ def test_DomainMatrix_zeros():
 
 def test_DomainMatrix_ones():
     A = DomainMatrix.ones((2, 3), QQ)
-    assert A.rep == DDM.ones((2, 3), QQ)
+    if GROUND_TYPES != 'flint':
+        assert A.rep == DDM.ones((2, 3), QQ)
+    else:
+        assert A.rep == SDM.ones((2, 3), QQ).to_dfm()
     assert A.shape == (2, 3)
     assert A.domain == QQ
 

--- a/sympy/polys/matrices/tests/test_lll.py
+++ b/sympy/polys/matrices/tests/test_lll.py
@@ -107,14 +107,14 @@ def test_lll_wrong_delta():
     for wrong_delta in [QQ(-1, 4), QQ(0, 1), QQ(1, 4), QQ(1, 1), QQ(100, 1)]:
         raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta))
         raises(DMValueError, lambda: ddm_lll(dummy_matrix.rep, delta=wrong_delta))
-        raises(DMRankError, lambda: dummy_matrix.rep.lll(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.rep.lll(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll(delta=wrong_delta))
-        raises(DMRankError, lambda: dummy_matrix.lll(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.lll(delta=wrong_delta))
         raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta, return_transform=True))
         raises(DMValueError, lambda: ddm_lll_transform(dummy_matrix.rep, delta=wrong_delta))
-        raises(DMRankError, lambda: dummy_matrix.rep.lll_transform(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.rep.lll_transform(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll_transform(delta=wrong_delta))
-        raises(DMRankError, lambda: dummy_matrix.lll_transform(delta=wrong_delta))
+        raises(DMValueError, lambda: dummy_matrix.lll_transform(delta=wrong_delta))
 
 
 def test_lll_wrong_shape():

--- a/sympy/polys/matrices/tests/test_lll.py
+++ b/sympy/polys/matrices/tests/test_lll.py
@@ -39,19 +39,19 @@ def test_lll():
     ]
     delta = QQ(5, 6)
     for basis_dm, reduced_dm in normal_test_data:
-        reduced = _ddm_lll(basis_dm.rep, delta=delta)[0]
-        assert reduced == reduced_dm.rep
+        reduced = _ddm_lll(basis_dm.rep.to_ddm(), delta=delta)[0]
+        assert reduced == reduced_dm.rep.to_ddm()
 
-        reduced = ddm_lll(basis_dm.rep, delta=delta)
-        assert reduced == reduced_dm.rep
+        reduced = ddm_lll(basis_dm.rep.to_ddm(), delta=delta)
+        assert reduced == reduced_dm.rep.to_ddm()
 
-        reduced, transform = _ddm_lll(basis_dm.rep, delta=delta, return_transform=True)
-        assert reduced == reduced_dm.rep
-        assert transform.matmul(basis_dm.rep) == reduced_dm.rep
+        reduced, transform = _ddm_lll(basis_dm.rep.to_ddm(), delta=delta, return_transform=True)
+        assert reduced == reduced_dm.rep.to_ddm()
+        assert transform.matmul(basis_dm.rep.to_ddm()) == reduced_dm.rep.to_ddm()
 
-        reduced, transform = ddm_lll_transform(basis_dm.rep, delta=delta)
-        assert reduced == reduced_dm.rep
-        assert transform.matmul(basis_dm.rep) == reduced_dm.rep
+        reduced, transform = ddm_lll_transform(basis_dm.rep.to_ddm(), delta=delta)
+        assert reduced == reduced_dm.rep.to_ddm()
+        assert transform.matmul(basis_dm.rep.to_ddm()) == reduced_dm.rep.to_ddm()
 
         reduced = basis_dm.rep.lll(delta=delta)
         assert reduced == reduced_dm.rep
@@ -90,13 +90,13 @@ def test_lll_linear_dependent():
             [10, -4, 2]], ZZ)
     ]
     for not_basis in linear_dependent_test_data:
-        raises(DMRankError, lambda: _ddm_lll(not_basis.rep))
-        raises(DMRankError, lambda: ddm_lll(not_basis.rep))
+        raises(DMRankError, lambda: _ddm_lll(not_basis.rep.to_ddm()))
+        raises(DMRankError, lambda: ddm_lll(not_basis.rep.to_ddm()))
         raises(DMRankError, lambda: not_basis.rep.lll())
         raises(DMRankError, lambda: not_basis.rep.to_sdm().lll())
         raises(DMRankError, lambda: not_basis.lll())
-        raises(DMRankError, lambda: _ddm_lll(not_basis.rep, return_transform=True))
-        raises(DMRankError, lambda: ddm_lll_transform(not_basis.rep))
+        raises(DMRankError, lambda: _ddm_lll(not_basis.rep.to_ddm(), return_transform=True))
+        raises(DMRankError, lambda: ddm_lll_transform(not_basis.rep.to_ddm()))
         raises(DMRankError, lambda: not_basis.rep.lll_transform())
         raises(DMRankError, lambda: not_basis.rep.to_sdm().lll_transform())
         raises(DMRankError, lambda: not_basis.lll_transform())
@@ -107,14 +107,14 @@ def test_lll_wrong_delta():
     for wrong_delta in [QQ(-1, 4), QQ(0, 1), QQ(1, 4), QQ(1, 1), QQ(100, 1)]:
         raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta))
         raises(DMValueError, lambda: ddm_lll(dummy_matrix.rep, delta=wrong_delta))
-        raises(DMValueError, lambda: dummy_matrix.rep.lll(delta=wrong_delta))
+        raises(DMRankError, lambda: dummy_matrix.rep.lll(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll(delta=wrong_delta))
-        raises(DMValueError, lambda: dummy_matrix.lll(delta=wrong_delta))
+        raises(DMRankError, lambda: dummy_matrix.lll(delta=wrong_delta))
         raises(DMValueError, lambda: _ddm_lll(dummy_matrix.rep, delta=wrong_delta, return_transform=True))
         raises(DMValueError, lambda: ddm_lll_transform(dummy_matrix.rep, delta=wrong_delta))
-        raises(DMValueError, lambda: dummy_matrix.rep.lll_transform(delta=wrong_delta))
+        raises(DMRankError, lambda: dummy_matrix.rep.lll_transform(delta=wrong_delta))
         raises(DMValueError, lambda: dummy_matrix.rep.to_sdm().lll_transform(delta=wrong_delta))
-        raises(DMValueError, lambda: dummy_matrix.lll_transform(delta=wrong_delta))
+        raises(DMRankError, lambda: dummy_matrix.lll_transform(delta=wrong_delta))
 
 
 def test_lll_wrong_shape():

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -802,3 +802,22 @@ def test_XXM_lu_solve_QQ(DM):
     dM4 = DM([[1, 2, 3], [4, 5, 6]])
     dM5 = DM([[1, 0], [0, 1], [0, 0]])
     raises(DMShapeError, lambda: dM4.lu_solve(dM5))
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_nullspace_QQ(DM):
+    dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    # XXX: Change the signature to just return the nullspace. Possibly
+    # returning the rank or nullity makes sense but the list of nonpivots is
+    # not useful.
+    assert dM1.nullspace() == (DM([[1, -2, 1]]), [2])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_lll(DM):
+    M = DM([[1, 2, 3], [4, 5, 20]])
+    M_lll = DM([[1, 2, 3], [-1, -5, 5]])
+    T = DM([[1, 0], [-5, 1]])
+    assert M.lll() == M_lll
+    assert M.lll_transform() == (M_lll, T)
+    assert T.matmul(M) == M_lll

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -770,3 +770,15 @@ def test_XXM_inv_ZZ(DM):
     # XXX: Maybe this should return a DM over QQ instead?
     # XXX: Handle unimodular matrices?
     raises(DMDomainError, lambda: dM1.inv())
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_charpoly_ZZ(DM):
+    dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+    assert dM1.charpoly() == [1, -16, -12, 3]
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_charpoly_QQ(DM):
+    dM1 = DM([[(1,2), (2,3)], [(3,4), (4,5)]])
+    assert dM1.charpoly() == [QQ(1,1), QQ(-13,10), QQ(-1,10)]

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -192,6 +192,8 @@ def test_to_XXM():
         assert A.to_sdm() == A_sdm
         if GROUND_TYPES != 'flint':
             raises(NotImplementedError, lambda: A.to_dfm())
+            assert A.to_dfm_or_ddm() == A_ddm
+
         # Add e.g. DDM.to_DM()?
         # assert A.to_DM() == A_dm
 
@@ -204,9 +206,12 @@ def test_to_XXM():
                 else:
                     A_K = A.convert_to(K)
                     if DFM._supports_domain(K):
-                        assert A_K.to_dfm() == A_dfm.convert_to(K)
+                        A_dfm_K = A_dfm.convert_to(K)
+                        assert A_K.to_dfm() == A_dfm_K
+                        assert A_K.to_dfm_or_ddm() == A_dfm_K
                     else:
                         raises(NotImplementedError, lambda: A_K.to_dfm())
+                        assert A_K.to_dfm_or_ddm() == A_ddm.convert_to(K)
 
 
 def test_DFM_domains():
@@ -307,8 +312,24 @@ def DMZ_dfm(lol):
     return _DMZ(lol, 'DFM')
 
 
+def DMQ_ddm(lol):
+    """Make a DDM from lol."""
+    return _DMQ(lol, 'DDM')
+
+
+def DMQ_sdm(lol):
+    """Make a SDM from lol."""
+    return _DMQ(lol, 'SDM')
+
+
+def DMQ_dfm(lol):
+    """Make a DFM from lol."""
+    return _DMQ(lol, 'DFM')
+
+
 DM_all = [DM_ddm, DM_sdm, DM_dfm]
 DMZ_all = [DMZ_ddm, DMZ_sdm, DMZ_dfm]
+DMQ_all = [DMQ_ddm, DMQ_sdm, DMQ_dfm]
 
 
 @pytest.mark.parametrize('DM', DMZ_all)
@@ -709,3 +730,15 @@ def test_XXM_diagonal(DM):
 def test_XXM_is_zero_matrix(DM):
     assert DM([[0, 0, 0], [0, 0, 0]]).is_zero_matrix() is True
     assert DM([[1, 0, 0], [0, 0, 0]]).is_zero_matrix() is False
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_det_ZZ(DM):
+    assert DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).det() == 0
+    assert DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]]).det() == -3
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_det_QQ(DM):
+    dM1 = DM([[(1,2), (2,3)], [(3,4), (4,5)]])
+    assert dM1.det() == QQ(-1,10)

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -1,0 +1,711 @@
+#
+# Test basic features of DDM, SDM and DFM.
+#
+# These three types are supposed to be interchangeable, so we should use the
+# same tests for all of them for the most part.
+#
+# The tests here cover the basic part of the inerface that the three types
+# should expose and that DomainMatrix should mostly rely on.
+#
+# More in-depth tests of the heavier algorithms like rref etc should go in
+# their own test files.
+#
+# Any new methods added to the DDM, SDM or DFM classes should be tested here
+# and added to all classes.
+#
+
+from sympy.external.gmpy import GROUND_TYPES
+
+from sympy import ZZ, QQ, GF, ZZ_I, symbols
+
+from sympy.polys.matrices.exceptions import DMBadInputError
+from sympy.polys.matrices.domainmatrix import DM, DomainMatrix, DDM, SDM, DFM
+
+from sympy.testing.pytest import raises, skip
+import pytest
+
+
+def test_XXM_constructors():
+    """Test the DDM, etc constructors."""
+
+    lol = [
+        [ZZ(1), ZZ(2)],
+        [ZZ(3), ZZ(4)],
+        [ZZ(5), ZZ(6)],
+    ]
+    dod = {
+        0: {0: ZZ(1), 1: ZZ(2)},
+        1: {0: ZZ(3), 1: ZZ(4)},
+        2: {0: ZZ(5), 1: ZZ(6)},
+    }
+
+    lol_0x0 = []
+    lol_0x2 = []
+    lol_2x0 = [[], []]
+    dod_0x0 = {}
+    dod_0x2 = {}
+    dod_2x0 = {}
+
+    lol_bad = [
+        [ZZ(1), ZZ(2)],
+        [ZZ(3), ZZ(4)],
+        [ZZ(5), ZZ(6), ZZ(7)],
+    ]
+    dod_bad = {
+        0: {0: ZZ(1), 1: ZZ(2)},
+        1: {0: ZZ(3), 1: ZZ(4)},
+        2: {0: ZZ(5), 1: ZZ(6), 2: ZZ(7)},
+    }
+
+    XDM_dense = [DDM]
+    XDM_sparse = [SDM]
+
+    if GROUND_TYPES == 'flint':
+        XDM_dense.append(DFM)
+
+    for XDM in XDM_dense:
+
+        A = XDM(lol, (3, 2), ZZ)
+        assert A.rows == 3
+        assert A.cols == 2
+        assert A.domain == ZZ
+        assert A.shape == (3, 2)
+        if XDM is not DFM:
+            assert ZZ.of_type(A[0][0]) is True
+        else:
+            assert ZZ.of_type(A.rep[0, 0]) is True
+
+        Adm = DomainMatrix(lol, (3, 2), ZZ)
+        if XDM is DFM:
+            assert Adm.rep == A
+            assert Adm.rep.to_ddm() != A
+        elif GROUND_TYPES == 'flint':
+            assert Adm.rep.to_ddm() == A
+            assert Adm.rep != A
+        else:
+            assert Adm.rep == A
+            assert Adm.rep.to_ddm() == A
+
+        assert XDM(lol_0x0, (0, 0), ZZ).shape == (0, 0)
+        assert XDM(lol_0x2, (0, 2), ZZ).shape == (0, 2)
+        assert XDM(lol_2x0, (2, 0), ZZ).shape == (2, 0)
+        raises(DMBadInputError, lambda: XDM(lol, (2, 3), ZZ))
+        raises(DMBadInputError, lambda: XDM(lol_bad, (3, 2), ZZ))
+        raises(DMBadInputError, lambda: XDM(dod, (3, 2), ZZ))
+
+    for XDM in XDM_sparse:
+
+        A = XDM(dod, (3, 2), ZZ)
+        assert A.rows == 3
+        assert A.cols == 2
+        assert A.domain == ZZ
+        assert A.shape == (3, 2)
+        assert ZZ.of_type(A[0][0]) is True
+
+        assert DomainMatrix(dod, (3, 2), ZZ).rep == A
+
+        assert XDM(dod_0x0, (0, 0), ZZ).shape == (0, 0)
+        assert XDM(dod_0x2, (0, 2), ZZ).shape == (0, 2)
+        assert XDM(dod_2x0, (2, 0), ZZ).shape == (2, 0)
+        raises(DMBadInputError, lambda: XDM(dod, (2, 3), ZZ))
+        raises(DMBadInputError, lambda: XDM(lol, (3, 2), ZZ))
+        raises(DMBadInputError, lambda: XDM(dod_bad, (3, 2), ZZ))
+
+    raises(DMBadInputError, lambda: DomainMatrix(lol, (2, 3), ZZ))
+    raises(DMBadInputError, lambda: DomainMatrix(lol_bad, (3, 2), ZZ))
+    raises(DMBadInputError, lambda: DomainMatrix(dod_bad, (3, 2), ZZ))
+
+
+def test_XXM_eq():
+    """Test equality for DDM, SDM, DFM and DomainMatrix."""
+
+    lol1 = [[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]]
+    dod1 = {0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(4)}}
+
+    lol2 = [[ZZ(1), ZZ(2)], [ZZ(3), ZZ(5)]]
+    dod2 = {0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(5)}}
+
+    A1_ddm = DDM(lol1, (2, 2), ZZ)
+    A1_sdm = SDM(dod1, (2, 2), ZZ)
+    A1_dm_d = DomainMatrix(lol1, (2, 2), ZZ)
+    A1_dm_s = DomainMatrix(dod1, (2, 2), ZZ)
+
+    A2_ddm = DDM(lol2, (2, 2), ZZ)
+    A2_sdm = SDM(dod2, (2, 2), ZZ)
+    A2_dm_d = DomainMatrix(lol2, (2, 2), ZZ)
+    A2_dm_s = DomainMatrix(dod2, (2, 2), ZZ)
+
+    A1_all = [A1_ddm, A1_sdm, A1_dm_d, A1_dm_s]
+    A2_all = [A2_ddm, A2_sdm, A2_dm_d, A2_dm_s]
+
+    if GROUND_TYPES == 'flint':
+
+        A1_dfm = DFM([[1, 2], [3, 4]], (2, 2), ZZ)
+        A2_dfm = DFM([[1, 2], [3, 5]], (2, 2), ZZ)
+
+        A1_all.append(A1_dfm)
+        A2_all.append(A2_dfm)
+
+    for n, An in enumerate(A1_all):
+        for m, Am in enumerate(A1_all):
+            if n == m:
+                assert (An == Am) is True
+                assert (An != Am) is False
+            else:
+                assert (An == Am) is False
+                assert (An != Am) is True
+
+    for n, An in enumerate(A2_all):
+        for m, Am in enumerate(A2_all):
+            if n == m:
+                assert (An == Am) is True
+                assert (An != Am) is False
+            else:
+                assert (An == Am) is False
+                assert (An != Am) is True
+
+    for n, A1 in enumerate(A1_all):
+        for m, A2 in enumerate(A2_all):
+            assert (A1 == A2) is False
+            assert (A1 != A2) is True
+
+
+def test_to_XXM():
+    """Test to_ddm etc. for DDM, SDM, DFM and DomainMatrix."""
+
+    lol = [[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]]
+    dod = {0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3), 1: ZZ(4)}}
+
+    A_ddm = DDM(lol, (2, 2), ZZ)
+    A_sdm = SDM(dod, (2, 2), ZZ)
+    A_dm_d = DomainMatrix(lol, (2, 2), ZZ)
+    A_dm_s = DomainMatrix(dod, (2, 2), ZZ)
+
+    A_all = [A_ddm, A_sdm, A_dm_d, A_dm_s]
+
+    if GROUND_TYPES == 'flint':
+        A_dfm = DFM(lol, (2, 2), ZZ)
+        A_all.append(A_dfm)
+
+    for A in A_all:
+        assert A.to_ddm() == A_ddm
+        assert A.to_sdm() == A_sdm
+        if GROUND_TYPES != 'flint':
+            raises(NotImplementedError, lambda: A.to_dfm())
+        # Add e.g. DDM.to_DM()?
+        # assert A.to_DM() == A_dm
+
+    if GROUND_TYPES == 'flint':
+        for A in A_all:
+            assert A.to_dfm() == A_dfm
+            for K in [ZZ, QQ, GF(5), ZZ_I]:
+                if isinstance(A, DFM) and not DFM._supports_domain(K):
+                    raises(NotImplementedError, lambda: A.convert_to(K))
+                else:
+                    A_K = A.convert_to(K)
+                    if DFM._supports_domain(K):
+                        assert A_K.to_dfm() == A_dfm.convert_to(K)
+                    else:
+                        raises(NotImplementedError, lambda: A_K.to_dfm())
+
+
+def test_DFM_domains():
+    """Test which domains are supported by DFM."""
+
+    x, y = symbols('x, y')
+
+    if GROUND_TYPES in ('python', 'gmpy'):
+
+        supported = []
+        flint_funcs = {}
+        not_supported = [ZZ, QQ, GF(5), QQ[x], QQ[x,y]]
+
+    elif GROUND_TYPES == 'flint':
+
+        import flint
+        supported = [ZZ, QQ]
+        flint_funcs = {
+            ZZ: flint.fmpz_mat,
+            QQ: flint.fmpq_mat,
+        }
+        not_supported = [
+            # This could be supported but not yet implemented in SymPy:
+            GF(5),
+            # Other domains could be supported but not implemented as matrices
+            # in python-flint:
+            QQ[x],
+            QQ[x,y],
+            QQ.frac_field(x,y),
+            # Others would potentially never be supported by python-flint:
+            ZZ_I,
+        ]
+
+    else:
+        assert False, "Unknown GROUND_TYPES: %s" % GROUND_TYPES
+
+    for domain in supported:
+        assert DFM._supports_domain(domain) is True
+        assert DFM._get_flint_func(domain) == flint_funcs[domain]
+    for domain in not_supported:
+        assert DFM._supports_domain(domain) is False
+        raises(NotImplementedError, lambda: DFM._get_flint_func(domain))
+
+
+def _DM(lol, typ, K):
+    """Make a DM of type typ over K from lol."""
+    A = DM(lol, K)
+
+    if typ == 'DDM':
+        return A.to_ddm()
+    elif typ == 'SDM':
+        return A.to_sdm()
+    elif typ == 'DFM':
+        if GROUND_TYPES != 'flint':
+            skip("DFM not supported in this ground type")
+        return A.to_dfm()
+    else:
+        assert False, "Unknown type %s" % typ
+
+
+def _DMZ(lol, typ):
+    """Make a DM of type typ over ZZ from lol."""
+    return _DM(lol, typ, ZZ)
+
+
+def _DMQ(lol, typ):
+    """Make a DM of type typ over QQ from lol."""
+    return _DM(lol, typ, QQ)
+
+
+def DM_ddm(lol, K):
+    """Make a DDM over K from lol."""
+    return _DM(lol, 'DDM', K)
+
+
+def DM_sdm(lol, K):
+    """Make a SDM over K from lol."""
+    return _DM(lol, 'SDM', K)
+
+
+def DM_dfm(lol, K):
+    """Make a DFM over K from lol."""
+    return _DM(lol, 'DFM', K)
+
+
+def DMZ_ddm(lol):
+    """Make a DDM from lol."""
+    return _DMZ(lol, 'DDM')
+
+
+def DMZ_sdm(lol):
+    """Make a SDM from lol."""
+    return _DMZ(lol, 'SDM')
+
+
+def DMZ_dfm(lol):
+    """Make a DFM from lol."""
+    return _DMZ(lol, 'DFM')
+
+
+DM_all = [DM_ddm, DM_sdm, DM_dfm]
+DMZ_all = [DMZ_ddm, DMZ_sdm, DMZ_dfm]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XDM_getitem(DM):
+    """Test getitem for DDM, etc."""
+
+    lol = [[0, 1], [2, 0]]
+    A = DM(lol)
+    m, n = A.shape
+
+    indices = [-3, -2, -1, 0, 1, 2]
+
+    for i in indices:
+        for j in indices:
+            if -2 <= i < m and -2 <= j < n:
+                assert A.getitem(i, j) == ZZ(lol[i][j])
+            else:
+                raises(IndexError, lambda: A.getitem(i, j))
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XDM_setitem(DM):
+    """Test setitem for DDM, etc."""
+
+    A = DM([[0, 1, 2], [3, 4, 5]])
+
+    A.setitem(0, 0, ZZ(6))
+    assert A == DM([[6, 1, 2], [3, 4, 5]])
+
+    A.setitem(0, 1, ZZ(7))
+    assert A == DM([[6, 7, 2], [3, 4, 5]])
+
+    A.setitem(0, 2, ZZ(8))
+    assert A == DM([[6, 7, 8], [3, 4, 5]])
+
+    A.setitem(0, -1, ZZ(9))
+    assert A == DM([[6, 7, 9], [3, 4, 5]])
+
+    A.setitem(0, -2, ZZ(10))
+    assert A == DM([[6, 10, 9], [3, 4, 5]])
+
+    A.setitem(0, -3, ZZ(11))
+    assert A == DM([[11, 10, 9], [3, 4, 5]])
+
+    raises(IndexError, lambda: A.setitem(0, 3, ZZ(12)))
+    raises(IndexError, lambda: A.setitem(0, -4, ZZ(13)))
+
+    A.setitem(1, 0, ZZ(14))
+    assert A == DM([[11, 10, 9], [14, 4, 5]])
+
+    A.setitem(1, 1, ZZ(15))
+    assert A == DM([[11, 10, 9], [14, 15, 5]])
+
+    A.setitem(-1, 1, ZZ(16))
+    assert A == DM([[11, 10, 9], [14, 16, 5]])
+
+    A.setitem(-2, 1, ZZ(17))
+    assert A == DM([[11, 17, 9], [14, 16, 5]])
+
+    raises(IndexError, lambda: A.setitem(2, 0, ZZ(18)))
+    raises(IndexError, lambda: A.setitem(-3, 0, ZZ(19)))
+
+    A.setitem(1, 2, ZZ(0))
+    assert A == DM([[11, 17, 9], [14, 16, 0]])
+
+    A.setitem(1, -2, ZZ(0))
+    assert A == DM([[11, 17, 9], [14, 0, 0]])
+
+    A.setitem(1, -3, ZZ(0))
+    assert A == DM([[11, 17, 9], [0, 0, 0]])
+
+    A.setitem(0, 0, ZZ(0))
+    assert A == DM([[0, 17, 9], [0, 0, 0]])
+
+    A.setitem(0, -1, ZZ(0))
+    assert A == DM([[0, 17, 0], [0, 0, 0]])
+
+    A.setitem(0, 0, ZZ(0))
+    assert A == DM([[0, 17, 0], [0, 0, 0]])
+
+    A.setitem(0, -2, ZZ(0))
+    assert A == DM([[0, 0, 0], [0, 0, 0]])
+
+    A.setitem(0, -3, ZZ(1))
+    assert A == DM([[1, 0, 0], [0, 0, 0]])
+
+
+class _Sliced:
+    def __getitem__(self, item):
+        return item
+
+
+_slice = _Sliced()
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_extract_slice(DM):
+    A = DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert A.extract_slice(*_slice[:,:]) == A
+    assert A.extract_slice(*_slice[1:,:]) == DM([[4, 5, 6], [7, 8, 9]])
+    assert A.extract_slice(*_slice[1:,1:]) == DM([[5, 6], [8, 9]])
+    assert A.extract_slice(*_slice[1:,:-1]) == DM([[4, 5], [7, 8]])
+    assert A.extract_slice(*_slice[1:,:-1:2]) == DM([[4], [7]])
+    assert A.extract_slice(*_slice[:,::2]) == DM([[1, 3], [4, 6], [7, 9]])
+    assert A.extract_slice(*_slice[::2,:]) == DM([[1, 2, 3], [7, 8, 9]])
+    assert A.extract_slice(*_slice[::2,::2]) == DM([[1, 3], [7, 9]])
+    assert A.extract_slice(*_slice[::2,::-2]) == DM([[3, 1], [9, 7]])
+    assert A.extract_slice(*_slice[::-2,::2]) == DM([[7, 9], [1, 3]])
+    assert A.extract_slice(*_slice[::-2,::-2]) == DM([[9, 7], [3, 1]])
+    assert A.extract_slice(*_slice[:,::-1]) == DM([[3, 2, 1], [6, 5, 4], [9, 8, 7]])
+    assert A.extract_slice(*_slice[::-1,:]) == DM([[7, 8, 9], [4, 5, 6], [1, 2, 3]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_extract(DM):
+
+    A = DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    assert A.extract([0, 1, 2], [0, 1, 2]) == A
+    assert A.extract([1, 2], [1, 2]) == DM([[5, 6], [8, 9]])
+    assert A.extract([1, 2], [0, 1]) == DM([[4, 5], [7, 8]])
+    assert A.extract([1, 2], [0, 2]) == DM([[4, 6], [7, 9]])
+    assert A.extract([1, 2], [0]) == DM([[4], [7]])
+    assert A.extract([1, 2], []) == DM([[1]]).zeros((2, 0), ZZ)
+    assert A.extract([], [0, 1, 2]) == DM([[1]]).zeros((0, 3), ZZ)
+
+    raises(IndexError, lambda: A.extract([1, 2], [0, 3]))
+    raises(IndexError, lambda: A.extract([1, 2], [0, -4]))
+    raises(IndexError, lambda: A.extract([3, 1], [0, 1]))
+    raises(IndexError, lambda: A.extract([-4, 2], [3, 1]))
+
+    B = DM([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+    assert B.extract([1, 2], [1, 2]) == DM([[0, 0], [0, 0]])
+
+
+def test_XXM_str():
+
+    A = DomainMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], (3, 3), ZZ)
+
+    assert str(A) == \
+        'DomainMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], (3, 3), ZZ)'
+    assert str(A.to_ddm()) == \
+        '[[1, 2, 3], [4, 5, 6], [7, 8, 9]]'
+    assert str(A.to_sdm()) == \
+        '{0: {0: 1, 1: 2, 2: 3}, 1: {0: 4, 1: 5, 2: 6}, 2: {0: 7, 1: 8, 2: 9}}'
+
+    assert repr(A) == \
+        'DomainMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], (3, 3), ZZ)'
+    assert repr(A.to_ddm()) == \
+        'DDM([[1, 2, 3], [4, 5, 6], [7, 8, 9]], (3, 3), ZZ)'
+    assert repr(A.to_sdm()) == \
+        'SDM({0: {0: 1, 1: 2, 2: 3}, 1: {0: 4, 1: 5, 2: 6}, 2: {0: 7, 1: 8, 2: 9}}, (3, 3), ZZ)'
+
+    B = DomainMatrix({0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(3)}}, (2, 2), ZZ)
+
+    assert str(B) == \
+        'DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3}}, (2, 2), ZZ)'
+    assert str(B.to_ddm()) == \
+        '[[1, 2], [3, 0]]'
+    assert str(B.to_sdm()) == \
+        '{0: {0: 1, 1: 2}, 1: {0: 3}}'
+
+    assert repr(B) == \
+        'DomainMatrix({0: {0: 1, 1: 2}, 1: {0: 3}}, (2, 2), ZZ)'
+
+    if GROUND_TYPES != 'gmpy':
+        assert repr(B.to_ddm()) == \
+            'DDM([[1, 2], [3, 0]], (2, 2), ZZ)'
+        assert repr(B.to_sdm()) == \
+            'SDM({0: {0: 1, 1: 2}, 1: {0: 3}}, (2, 2), ZZ)'
+    else:
+        assert repr(B.to_ddm()) == \
+            'DDM([[mpz(1), mpz(2)], [mpz(3), mpz(0)]], (2, 2), ZZ)'
+        assert repr(B.to_sdm()) == \
+            'SDM({0: {0: mpz(1), 1: mpz(2)}, 1: {0: mpz(3)}}, (2, 2), ZZ)'
+
+    if GROUND_TYPES == 'flint':
+
+        assert str(A.to_dfm()) == \
+            '[[1, 2, 3], [4, 5, 6], [7, 8, 9]]'
+        assert str(B.to_dfm()) == \
+            '[[1, 2], [3, 0]]'
+
+        assert repr(A.to_dfm()) == \
+            'DFM([[1, 2, 3], [4, 5, 6], [7, 8, 9]], (3, 3), ZZ)'
+        assert repr(B.to_dfm()) == \
+            'DFM([[1, 2], [3, 0]], (2, 2), ZZ)'
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_from_list(DM):
+    T = type(DM([[0]]))
+
+    lol = [[1, 2, 4], [4, 5, 6]]
+    lol_ZZ = [[ZZ(1), ZZ(2), ZZ(4)], [ZZ(4), ZZ(5), ZZ(6)]]
+    lol_ZZ_bad = [[ZZ(1), ZZ(2), ZZ(4)], [ZZ(4), ZZ(5), ZZ(6), ZZ(7)]]
+
+    assert T.from_list(lol_ZZ, (2, 3), ZZ) == DM(lol)
+    raises(DMBadInputError, lambda: T.from_list(lol_ZZ_bad, (3, 2), ZZ))
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_to_list(DM):
+    lol = [[1, 2, 4], [4, 5, 6]]
+    assert DM(lol).to_list() == [[ZZ(1), ZZ(2), ZZ(4)], [ZZ(4), ZZ(5), ZZ(6)]]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_to_list_flat(DM):
+    lol = [[1, 2, 4], [4, 5, 6]]
+    assert DM(lol).to_list_flat() == [ZZ(1), ZZ(2), ZZ(4), ZZ(4), ZZ(5), ZZ(6)]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_from_list_flat(DM):
+    T = type(DM([[0]]))
+    flat = [ZZ(1), ZZ(2), ZZ(4), ZZ(4), ZZ(5), ZZ(6)]
+    assert T.from_list_flat(flat, (2, 3), ZZ) == DM([[1, 2, 4], [4, 5, 6]])
+    raises(DMBadInputError, lambda: T.from_list_flat(flat, (3, 3), ZZ))
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_to_flat_nz(DM):
+    M = DM([[1, 2, 0], [0, 0, 0], [0, 0, 3]])
+    elements = [ZZ(1), ZZ(2), ZZ(3)]
+    indices = ((0, 0), (0, 1), (2, 2))
+    assert M.to_flat_nz() == (elements, (indices, M.shape))
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_from_flat_nz(DM):
+    T = type(DM([[0]]))
+    elements = [ZZ(1), ZZ(2), ZZ(3)]
+    indices = ((0, 0), (0, 1), (2, 2))
+    data = (indices, (3, 3))
+    result = DM([[1, 2, 0], [0, 0, 0], [0, 0, 3]])
+    assert T.from_flat_nz(elements, data, ZZ) == result
+    raises(DMBadInputError, lambda: T.from_flat_nz(elements, (indices, (2, 3)), ZZ))
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_from_ddm(DM):
+    T = type(DM([[0]]))
+    ddm = DDM([[1, 2, 4], [4, 5, 6]], (2, 3), ZZ)
+    assert T.from_ddm(ddm) == DM([[1, 2, 4], [4, 5, 6]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_zeros(DM):
+    T = type(DM([[0]]))
+    assert T.zeros((2, 3), ZZ) == DM([[0, 0, 0], [0, 0, 0]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_ones(DM):
+    T = type(DM([[0]]))
+    assert T.ones((2, 3), ZZ) == DM([[1, 1, 1], [1, 1, 1]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_eye(DM):
+    T = type(DM([[0]]))
+    assert T.eye(3, ZZ) == DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    assert T.eye((3, 2), ZZ) == DM([[1, 0], [0, 1], [0, 0]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_diag(DM):
+    T = type(DM([[0]]))
+    assert T.diag([1, 2, 3], ZZ) == DM([[1, 0, 0], [0, 2, 0], [0, 0, 3]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_transpose(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    assert A.transpose() == DM([[1, 4], [2, 5], [3, 6]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_add(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[1, 2, 3], [4, 5, 6]])
+    C = DM([[2, 4, 6], [8, 10, 12]])
+    assert A.add(B) == C
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_sub(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[1, 2, 3], [4, 5, 6]])
+    C = DM([[0, 0, 0], [0, 0, 0]])
+    assert A.sub(B) == C
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_mul(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    b = ZZ(2)
+    assert A.mul(b) == DM([[2, 4, 6], [8, 10, 12]])
+    assert A.rmul(b) == DM([[2, 4, 6], [8, 10, 12]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_matmul(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[1, 2], [3, 4], [5, 6]])
+    C = DM([[22, 28], [49, 64]])
+    assert A.matmul(B) == C
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_mul_elementwise(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[1, 2, 3], [4, 5, 6]])
+    C = DM([[1, 4, 9], [16, 25, 36]])
+    assert A.mul_elementwise(B) == C
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_neg(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    C = DM([[-1, -2, -3], [-4, -5, -6]])
+    assert A.neg() == C
+
+
+@pytest.mark.parametrize('DM', DM_all)
+def test_XXM_convert_to(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]], ZZ)
+    B = DM([[1, 2, 3], [4, 5, 6]], QQ)
+    assert A.convert_to(QQ) == B
+    assert B.convert_to(ZZ) == A
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_scc(DM):
+    A = DM([
+        [0, 1, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 0, 1],
+        [0, 0, 0, 0, 1, 0],
+        [0, 0, 0, 1, 0, 1]])
+    assert A.scc() == [[0, 1], [2], [3, 5], [4]]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_hstack(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[7, 8], [9, 10]])
+    C = DM([[1, 2, 3, 7, 8], [4, 5, 6, 9, 10]])
+    ABC = DM([[1, 2, 3, 7, 8, 1, 2, 3, 7, 8],
+              [4, 5, 6, 9, 10, 4, 5, 6, 9, 10]])
+    assert A.hstack(B) == C
+    assert A.hstack(B, C) == ABC
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_vstack(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[7, 8, 9]])
+    C = DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    ABC = DM([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert A.vstack(B) == C
+    assert A.vstack(B, C) == ABC
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_applyfunc(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    B = DM([[2, 4, 6], [8, 10, 12]])
+    assert A.applyfunc(lambda x: 2*x, ZZ) == B
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_is_upper(DM):
+    assert DM([[1, 2, 3], [0, 5, 6]]).is_upper() is True
+    assert DM([[1, 2, 3], [4, 5, 6]]).is_upper() is False
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_is_lower(DM):
+    assert DM([[1, 0, 0], [4, 5, 0]]).is_lower() is True
+    assert DM([[1, 2, 3], [4, 5, 6]]).is_lower() is False
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_is_diagonal(DM):
+    assert DM([[1, 0, 0], [0, 5, 0]]).is_diagonal() is True
+    assert DM([[1, 2, 3], [4, 5, 6]]).is_diagonal() is False
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_diagonal(DM):
+    assert DM([[1, 0, 0], [0, 5, 0]]).diagonal() == [1, 5]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_is_zero_matrix(DM):
+    assert DM([[0, 0, 0], [0, 0, 0]]).is_zero_matrix() is True
+    assert DM([[1, 0, 0], [0, 0, 0]]).is_zero_matrix() is False

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -18,7 +18,13 @@ from sympy.external.gmpy import GROUND_TYPES
 
 from sympy import ZZ, QQ, GF, ZZ_I, symbols
 
-from sympy.polys.matrices.exceptions import DMBadInputError
+from sympy.polys.matrices.exceptions import (
+    DMBadInputError,
+    DMDomainError,
+    DMNonSquareMatrixError,
+    DMNonInvertibleMatrixError,
+)
+
 from sympy.polys.matrices.domainmatrix import DM, DomainMatrix, DDM, SDM, DFM
 
 from sympy.testing.pytest import raises, skip
@@ -742,3 +748,25 @@ def test_XXM_det_ZZ(DM):
 def test_XXM_det_QQ(DM):
     dM1 = DM([[(1,2), (2,3)], [(3,4), (4,5)]])
     assert dM1.det() == QQ(-1,10)
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_inv_QQ(DM):
+    dM1 = DM([[(1,2), (2,3)], [(3,4), (4,5)]])
+    dM2 = DM([[(-8,1), (20,3)], [(15,2), (-5,1)]])
+    assert dM1.inv() == dM2
+    assert dM1.matmul(dM2) == DM([[1, 0], [0, 1]])
+
+    dM3 = DM([[(1,2), (2,3)], [(1,4), (1,3)]])
+    raises(DMNonInvertibleMatrixError, lambda: dM3.inv())
+
+    dM4 = DM([[(1,2), (2,3), (3,4)], [(1,4), (1,3), (1,2)]])
+    raises(DMNonSquareMatrixError, lambda: dM4.inv())
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_inv_ZZ(DM):
+    dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+    # XXX: Maybe this should return a DM over QQ instead?
+    # XXX: Handle unimodular matrices?
+    raises(DMDomainError, lambda: dM1.inv())

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -23,6 +23,7 @@ from sympy.polys.matrices.exceptions import (
     DMDomainError,
     DMNonSquareMatrixError,
     DMNonInvertibleMatrixError,
+    DMShapeError,
 )
 
 from sympy.polys.matrices.domainmatrix import DM, DomainMatrix, DDM, SDM, DFM
@@ -782,3 +783,22 @@ def test_XXM_charpoly_ZZ(DM):
 def test_XXM_charpoly_QQ(DM):
     dM1 = DM([[(1,2), (2,3)], [(3,4), (4,5)]])
     assert dM1.charpoly() == [QQ(1,1), QQ(-13,10), QQ(-1,10)]
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_lu_solve_ZZ(DM):
+    dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+    dM2 = DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    raises(DMDomainError, lambda: dM1.lu_solve(dM2))
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_lu_solve_QQ(DM):
+    dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+    dM2 = DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    dM3 = DM([[(-2,3),(-4,3),(1,1)],[(-2,3),(11,3),(-2,1)],[(1,1),(-2,1),(1,1)]])
+    assert dM1.lu_solve(dM2) == dM3 == dM1.inv()
+
+    dM4 = DM([[1, 2, 3], [4, 5, 6]])
+    dM5 = DM([[1, 0], [0, 1], [0, 0]])
+    raises(DMShapeError, lambda: dM4.lu_solve(dM5))

--- a/sympy/polys/numberfields/exceptions.py
+++ b/sympy/polys/numberfields/exceptions.py
@@ -11,8 +11,7 @@ class ClosureFailure(Exception):
 
     >>> from sympy.polys import Poly, cyclotomic_poly, ZZ
     >>> from sympy.polys.matrices import DomainMatrix
-    >>> from sympy.polys.numberfields.modules import PowerBasis, to_col, ClosureFailure
-    >>> from sympy.testing.pytest import raises
+    >>> from sympy.polys.numberfields.modules import PowerBasis, to_col
     >>> T = Poly(cyclotomic_poly(5))
     >>> A = PowerBasis(T)
     >>> B = A.submodule_from_matrix(2 * DomainMatrix.eye(4, ZZ))

--- a/sympy/polys/numberfields/exceptions.py
+++ b/sympy/polys/numberfields/exceptions.py
@@ -28,8 +28,10 @@ class ClosureFailure(Exception):
     but ``B`` cannot represent an element with an odd coefficient:
 
     >>> a2 = A(to_col([1, 2, 2, 2]))
-    >>> print(raises(ClosureFailure, lambda: B.represent(a2)))
-    <ExceptionInfo ClosureFailure('Element in QQ-span but not ZZ-span of this basis.')>
+    >>> B.represent(a2)
+    Traceback (most recent call last):
+    ...
+    ClosureFailure: Element in QQ-span but not ZZ-span of this basis.
 
     """
     pass

--- a/sympy/polys/numberfields/modules.py
+++ b/sympy/polys/numberfields/modules.py
@@ -1355,7 +1355,10 @@ class ModuleElement(IntegerPowerable):
         """
         Get a copy of this element's column, optionally converting to a domain.
         """
-        return self.col.convert_to(domain)
+        if domain is None:
+            return self.col.copy()
+        else:
+            return self.col.convert_to(domain)
 
     @property
     def coeffs(self):

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1528,7 +1528,8 @@ class SymPyDocTests:
                             executables=(),
                             modules=(),
                             disable_viewers=(),
-                            python_version=(3, 5)):
+                            python_version=(3, 5),
+                            ground_types=None):
         """
         Checks if the dependencies for the test are installed.
 
@@ -1572,6 +1573,10 @@ class SymPyDocTests:
         if python_version:
             if sys.version_info < python_version:
                 raise DependencyError("Requires Python >= " + '.'.join(map(str, python_version)))
+
+        if ground_types is not None:
+            if GROUND_TYPES not in ground_types:
+                raise DependencyError("Requires ground_types in " + str(ground_types))
 
         if 'pyglet' in modules:
             # monkey-patch pyglet s.t. it does not open a window during

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -123,7 +123,8 @@ class no_attrs_in_subclass:
         raise AttributeError
 
 
-def doctest_depends_on(exe=None, modules=None, disable_viewers=None, python_version=None):
+def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
+                       python_version=None, ground_types=None):
     """
     Adds metadata about the dependencies which need to be met for doctesting
     the docstrings of the decorated objects.
@@ -146,6 +147,8 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None, python_vers
         dependencies['disable_viewers'] = disable_viewers
     if python_version is not None:
         dependencies['python_version'] = python_version
+    if ground_types is not None:
+        dependencies['ground_types'] = ground_types
 
     def skiptests():
         from sympy.testing.runtests import DependencyError, SymPyDocTests, PyTestReporter # lazy import


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Followup from gh-25474

Built on top of gh-25492 (which could be merged first or otherwise this could be merged instead).

See also gh-25410.

#### Brief description of what is fixed or changed

Uses python-flint's fmpz and fmpq if `SYMPY_GROUND_TYPES=flint` for dense matrices over ZZ and QQ.

#### Other comments

Plenty more work can be done to make this faster but first step is to get it working.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * The dense implementation of DomainMatrix will now use python-flint matrices for matrices over ZZ and QQ if `SYMPY_GROUND_TYPES=flint` and python-flint is installed. A new low-level matrix type `DFM` is added to be a wrapper for dense flint matrices. `DomainMatrix` will use this internally by default for dense matrices when the ground types are `flint`. This makes many operations with dense DomainMatrix much faster although for now to test this you need to explicitly choose to use the dense implementation by doing e.g. `M = Matrix([[1, 2], [3, 4]]).to_DM().to_dense()` to get a matrix that has a flint matrix as its internal representation.
<!-- END RELEASE NOTES -->
