### PR TITLE
Swap System.__init__ argument order

### DIFF
--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -242,30 +242,30 @@ class System(_Methods):
 
     """
 
-    def __init__(self, origin=None, frame=None):
+    def __init__(self, frame=None, origin=None):
         """Initialize the system.
 
         Parameters
         ==========
 
-        origin : Point, optional
-            The origin of the system. If none is supplied, a new origin will be
-            created.
         frame : ReferenceFrame, optional
             The inertial frame of the system. If none is supplied, a new frame
             will be created.
+        origin : Point, optional
+            The origin of the system. If none is supplied, a new origin will be
+            created.
 
         """
-        if origin is None:
-            origin = Point('inertial_origin')
-        elif not isinstance(origin, Point):
-            raise TypeError('Origin must be an instance of Point.')
-        self._origin = origin
         if frame is None:
             frame = ReferenceFrame('inertial_frame')
         elif not isinstance(frame, ReferenceFrame):
             raise TypeError('Frame must be an instance of ReferenceFrame.')
         self._frame = frame
+        if origin is None:
+            origin = Point('inertial_origin')
+        elif not isinstance(origin, Point):
+            raise TypeError('Origin must be an instance of Point.')
+        self._origin = origin
         self._origin.set_vel(self._frame, 0)
         self._q_ind = Matrix(1, 0, []).T
         self._q_dep = Matrix(1, 0, []).T
@@ -286,7 +286,7 @@ class System(_Methods):
         if isinstance(newtonian, Particle):
             raise TypeError('A Particle has no frame so cannot act as '
                             'the Newtonian.')
-        system = cls(origin=newtonian.masscenter, frame=newtonian.frame)
+        system = cls(frame=newtonian.frame, origin=newtonian.masscenter)
         system.add_bodies(newtonian)
         return system
 

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -19,7 +19,7 @@ u = dynamicsymbols('u:6')  # type: ignore
 class TestSystemBase:
     @pytest.fixture()
     def _empty_system_setup(self):
-        self.system = System(Point('origin'), ReferenceFrame('frame'))
+        self.system = System(ReferenceFrame('frame'), Point('origin'))
 
     def _empty_system_check(self, exclude=()):
         matrices = ('q_ind', 'q_dep', 'q', 'u_ind', 'u_dep', 'u', 'kdes',
@@ -35,7 +35,7 @@ class TestSystemBase:
             assert self.system.eom_method is None
 
     def _create_filled_system(self, with_speeds=True):
-        self.system = System(Point('origin'), ReferenceFrame('frame'))
+        self.system = System(ReferenceFrame('frame'), Point('origin'))
         u = dynamicsymbols('u:6') if with_speeds else qd
         self.bodies = symbols('rb1:5', cls=RigidBody)
         self.joints = (
@@ -110,7 +110,7 @@ class TestSystem(TestSystemBase):
         if origin is None and frame is None:
             self.system = System()
         else:
-            self.system = System(origin, frame)
+            self.system = System(frame, origin)
         if origin is None:
             assert self.system.origin.name == 'inertial_origin'
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to the mechanics experimental development (#24234)


#### Brief description of what is fixed or changed
This PR changes swaps the arguments of `System.__init__` from `origin=None, frame=None` to `frame=None, origin=None`. Overall, it is more sensible to have the frame as first argument:
- The frame is more important (the origin is currently not even really being used internally).
- `KanesMethod` also requires the `frame` as first argument.
- The swap puts the arguments in alphabetic order.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
