### PR TITLE
Make `physics.mechanics.pathway` public.

### DIFF
--- a/doc/src/modules/physics/mechanics/api/index.rst
+++ b/doc/src/modules/physics/mechanics/api/index.rst
@@ -13,3 +13,4 @@ Mechanics API Reference
    expr_manip.rst
    printing.rst
    wrapping_geometry.rst
+   pathway.rst

--- a/doc/src/modules/physics/mechanics/api/pathway.rst
+++ b/doc/src/modules/physics/mechanics/api/pathway.rst
@@ -1,0 +1,6 @@
+====================
+Pathway (Docstrings)
+====================
+
+.. automodule:: sympy.physics.mechanics.pathway
+   :members:

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -36,6 +36,8 @@ __all__ = [
     'JointsMethod',
 
     'WrappingCylinder', 'WrappingGeometryBase', 'WrappingSphere',
+
+    'PathwayBase', 'LinearPathway', 'WrappingPathway',
 ]
 
 from sympy.physics import vector
@@ -77,3 +79,5 @@ from .joint import (PinJoint, PrismaticJoint, CylindricalJoint, PlanarJoint,
 
 from .wrapping_geometry import (WrappingCylinder, WrappingGeometryBase,
                                 WrappingSphere)
+
+from .pathway import PathwayBase, LinearPathway, WrappingPathway

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -260,8 +260,7 @@ class ForceActuator(ActuatorBase):
         the ``to_loads`` method.
 
         >>> damper.to_loads()
-        [(pA, c*q(t)**2*Derivative(q(t), t)/q(t)**2*N.x),
-         (pB, - c*q(t)**2*Derivative(q(t), t)/q(t)**2*N.x)]
+        [(pA, c*Derivative(q(t), t)*N.x), (pB, - c*Derivative(q(t), t)*N.x)]
 
         """
         return self.pathway.compute_loads(self.force)
@@ -498,7 +497,7 @@ class LinearDamper(ForceActuator):
     direction of length change.
 
     >>> damper.force
-    -c*q(t)*Derivative(q(t), t)/sqrt(q(t)**2)
+    -c*sqrt(q(t)**2)*Derivative(q(t), t)/q(t)
 
     Parameters
     ==========

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -22,7 +22,7 @@ from sympy.physics.mechanics import (
     Torque,
     Vector,
 )
-from sympy.physics.mechanics._pathway import PathwayBase
+from sympy.physics.mechanics.pathway import PathwayBase
 
 if USE_SYMENGINE:
     from sympy.core.backend import Basic as ExprType
@@ -101,7 +101,7 @@ class ForceActuator(ActuatorBase):
     This is similarly the case for imports from the ``_pathway.py`` module like
     ``LinearPathway``.
 
-    >>> from sympy.physics.mechanics._pathway import LinearPathway
+    >>> from sympy.physics.mechanics.pathway import LinearPathway
 
     To construct an actuator, an expression (or symbol) must be supplied to
     represent the force it can produce, alongside a pathway specifying its line
@@ -220,7 +220,7 @@ class ForceActuator(ActuatorBase):
         coordinate ``q`` in the ``x`` direction of the global frame ``N``.
 
         >>> from sympy.physics.mechanics import Point, ReferenceFrame
-        >>> from sympy.physics.mechanics._pathway import LinearPathway
+        >>> from sympy.physics.mechanics.pathway import LinearPathway
         >>> from sympy.physics.vector import dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> N = ReferenceFrame('N')
@@ -301,7 +301,7 @@ class LinearSpring(ForceActuator):
     This is similarly the case for imports from the ``_pathway.py`` module like
     ``LinearPathway``.
 
-    >>> from sympy.physics.mechanics._pathway import LinearPathway
+    >>> from sympy.physics.mechanics.pathway import LinearPathway
 
     To construct a linear spring, an expression (or symbol) must be supplied to
     represent the stiffness (spring constant) of the spring, alongside a
@@ -473,7 +473,7 @@ class LinearDamper(ForceActuator):
     This is similarly the case for imports from the ``_pathway.py`` module like
     ``LinearPathway``.
 
-    >>> from sympy.physics.mechanics._pathway import LinearPathway
+    >>> from sympy.physics.mechanics.pathway import LinearPathway
 
     To construct a linear damper, an expression (or symbol) must be supplied to
     represent the damping coefficient of the damper (we'll use the symbol

--- a/sympy/physics/mechanics/_actuator.py
+++ b/sympy/physics/mechanics/_actuator.py
@@ -16,13 +16,13 @@ from typing import TYPE_CHECKING, Any
 
 from sympy.core.backend import S, USE_SYMENGINE, sympify
 from sympy.physics.mechanics import (
+    PathwayBase,
     PinJoint,
     ReferenceFrame,
     RigidBody,
     Torque,
     Vector,
 )
-from sympy.physics.mechanics.pathway import PathwayBase
 
 if USE_SYMENGINE:
     from sympy.core.backend import Basic as ExprType
@@ -98,11 +98,6 @@ class ForceActuator(ActuatorBase):
 
     >>> from sympy.physics.mechanics._actuator import ForceActuator
 
-    This is similarly the case for imports from the ``_pathway.py`` module like
-    ``LinearPathway``.
-
-    >>> from sympy.physics.mechanics.pathway import LinearPathway
-
     To construct an actuator, an expression (or symbol) must be supplied to
     represent the force it can produce, alongside a pathway specifying its line
     of action. Let's also create a global reference frame and spatially fix one
@@ -111,7 +106,8 @@ class ForceActuator(ActuatorBase):
     ``q``.
 
     >>> from sympy import Symbol
-    >>> from sympy.physics.mechanics import Point, ReferenceFrame
+    >>> from sympy.physics.mechanics import (LinearPathway, Point,
+    ...     ReferenceFrame)
     >>> from sympy.physics.vector import dynamicsymbols
     >>> N = ReferenceFrame('N')
     >>> q = dynamicsymbols('q')
@@ -219,8 +215,8 @@ class ForceActuator(ActuatorBase):
         First, create a linear pathway between two points separated by the
         coordinate ``q`` in the ``x`` direction of the global frame ``N``.
 
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame
-        >>> from sympy.physics.mechanics.pathway import LinearPathway
+        >>> from sympy.physics.mechanics import (LinearPathway, Point,
+        ...     ReferenceFrame)
         >>> from sympy.physics.vector import dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> N = ReferenceFrame('N')
@@ -298,11 +294,6 @@ class LinearSpring(ForceActuator):
 
     >>> from sympy.physics.mechanics._actuator import LinearSpring
 
-    This is similarly the case for imports from the ``_pathway.py`` module like
-    ``LinearPathway``.
-
-    >>> from sympy.physics.mechanics.pathway import LinearPathway
-
     To construct a linear spring, an expression (or symbol) must be supplied to
     represent the stiffness (spring constant) of the spring, alongside a
     pathway specifying its line of action. Let's also create a global reference
@@ -311,7 +302,8 @@ class LinearSpring(ForceActuator):
     specified by the coordinate ``q``.
 
     >>> from sympy import Symbol
-    >>> from sympy.physics.mechanics import Point, ReferenceFrame
+    >>> from sympy.physics.mechanics import (LinearPathway, Point,
+    ...     ReferenceFrame)
     >>> from sympy.physics.vector import dynamicsymbols
     >>> N = ReferenceFrame('N')
     >>> q = dynamicsymbols('q')
@@ -470,11 +462,6 @@ class LinearDamper(ForceActuator):
 
     >>> from sympy.physics.mechanics._actuator import LinearDamper
 
-    This is similarly the case for imports from the ``_pathway.py`` module like
-    ``LinearPathway``.
-
-    >>> from sympy.physics.mechanics.pathway import LinearPathway
-
     To construct a linear damper, an expression (or symbol) must be supplied to
     represent the damping coefficient of the damper (we'll use the symbol
     ``c``), alongside a pathway specifying its line of action. Let's also
@@ -486,7 +473,8 @@ class LinearDamper(ForceActuator):
     (i.e., ``u = Derivative(q(t), t)``).
 
     >>> from sympy import Symbol
-    >>> from sympy.physics.mechanics import Point, ReferenceFrame
+    >>> from sympy.physics.mechanics import (LinearPathway, Point,
+    ...     ReferenceFrame)
     >>> from sympy.physics.vector import dynamicsymbols
     >>> N = ReferenceFrame('N')
     >>> q = dynamicsymbols('q')

--- a/sympy/physics/mechanics/_pathway.py
+++ b/sympy/physics/mechanics/_pathway.py
@@ -1,13 +1,4 @@
-"""Implementations of pathways for use by actuators.
-
-Notes
-=====
-
-This module is experimental and so is named with a leading underscore to
-indicate that the API is not yet stabilized and could be subject to breaking
-changes.
-
-"""
+"""Implementations of pathways for use by actuators."""
 
 from __future__ import annotations
 
@@ -29,7 +20,7 @@ if TYPE_CHECKING:
         from sympy.core.expr import Expr as ExprType
 
 
-__all__ = ['LinearPathway', 'WrappingPathway']
+__all__ = ['PathwayBase', 'LinearPathway', 'WrappingPathway']
 
 
 class PathwayBase(ABC):
@@ -131,11 +122,7 @@ class LinearPathway(PathwayBase):
     Examples
     ========
 
-    As the ``_pathway.py`` module is experimental, it is not yet part of the
-    ``sympy.physics.mechanics`` namespace. ``LinearPathway`` must therefore be
-    imported directly from the ``sympy.physics.mechanics._pathway`` module.
-
-    >>> from sympy.physics.mechanics._pathway import LinearPathway
+    >>> from sympy.physics.mechanics.pathway import LinearPathway
 
     To construct a pathway, two points are required to be passed to the
     ``attachments`` parameter as a ``tuple``.
@@ -155,7 +142,7 @@ class LinearPathway(PathwayBase):
     >>> from sympy.physics.vector import dynamicsymbols
     >>> N = ReferenceFrame('N')
     >>> q = dynamicsymbols('q')
-    >>> pB.set_pos(pA, q * N.x)
+    >>> pB.set_pos(pA, q*N.x)
     >>> pB.pos_from(pA)
     q(t)*N.x
 
@@ -178,7 +165,7 @@ class LinearPathway(PathwayBase):
     ==========
 
     attachments : tuple[Point, Point]
-        The pair of ``Point`` objects between which the linear pathway spans.
+        Pair of ``Point`` objects between which the linear pathway spans.
 
     """
 
@@ -192,8 +179,7 @@ class LinearPathway(PathwayBase):
         ==========
 
         attachments : tuple[Point, Point]
-            The pair of ``Point`` objects between which the linear pathway
-            spans.
+            Pair of ``Point`` objects between which the linear pathway spans.
 
         """
         super().__init__(*attachments)
@@ -243,12 +229,12 @@ class LinearPathway(PathwayBase):
         ``x`` direction of the global frame ``N``.
 
         >>> from sympy.physics.mechanics import Point, ReferenceFrame
-        >>> from sympy.physics.mechanics._pathway import LinearPathway
+        >>> from sympy.physics.mechanics.pathway import LinearPathway
         >>> from sympy.physics.vector import dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> N = ReferenceFrame('N')
         >>> pA, pB = Point('pA'), Point('pB')
-        >>> pB.set_pos(pA, q * N.x)
+        >>> pB.set_pos(pA, q*N.x)
         >>> linear_pathway = LinearPathway(pA, pB)
 
         Now create a symbol ``F`` to describe the magnitude of the (expansile)
@@ -265,14 +251,14 @@ class LinearPathway(PathwayBase):
         ==========
 
         force : Expr
-            The force acting along the length of the pathway. It is assumed
-            that this ``Expr`` represents an expansile force.
+            Magnitude of the force acting along the length of the pathway. It
+            is assumed that this ``Expr`` represents an expansile force.
 
         """
         relative_position = self.attachments[-1].pos_from(self.attachments[0])
         loads: list[LoadBase] = [
-            Force(self.attachments[0], -force * relative_position / self.length),
-            Force(self.attachments[-1], force * relative_position / self.length),
+            Force(self.attachments[0], -force*relative_position/self.length),
+            Force(self.attachments[-1], force*relative_position/self.length),
         ]
         return loads
 
@@ -293,18 +279,11 @@ class WrappingPathway(PathwayBase):
     Examples
     ========
 
-    As the ``_pathway.py`` module is experimental, it is not yet part of the
-    ``sympy.physics.mechanics`` namespace. ``WrappingPathway`` must therefore
-    be imported directly from the ``sympy.physics.mechanics._pathway`` module.
-
-    >>> from sympy.physics.mechanics._pathway import WrappingPathway
+    >>> from sympy.physics.mechanics.pathway import WrappingPathway
 
     To construct a wrapping pathway, a geometry object, which the pathway can
-    wrap, is required. Similar to above, the ``wrapping_geometry.py`` module is
-    also experimental so geometry classes needed to be imported directly from
-    the ``sympy.physics.mechanics.wrapping_geometry.py`` module. Let's create a
-    wrapping pathway that wraps around a cylinder. To do this we need to import
-    the ``Cylinder`` class.
+    wrap, is required. Let's create a wrapping pathway that wraps around a
+    cylinder. To do this we need to import the ``Cylinder`` class.
 
     >>> from sympy.physics.mechanics.wrapping_geometry import Cylinder
 
@@ -313,9 +292,9 @@ class WrappingPathway(PathwayBase):
     argument. We'll use a cylinder with radius ``r`` and its axis parallel to
     ``N.x`` passing through a point ``pO``.
 
-    >>> from sympy import Symbol
+    >>> from sympy import symbols
     >>> from sympy.physics.mechanics import Point, ReferenceFrame
-    >>> r = Symbol('r')
+    >>> r = symbols('r')
     >>> N = ReferenceFrame('N')
     >>> pA, pB, pO = Point('pA'), Point('pB'), Point('pO')
     >>> cylinder = Cylinder(r, pO, N.x)
@@ -328,13 +307,13 @@ class WrappingPathway(PathwayBase):
     ==========
 
     attachment_1 : Point
-        The first of the pair of ``Point`` objects between which the wrapping
+        First of the pair of ``Point`` objects between which the wrapping
         pathway spans.
     attachment_2 : Point
-        The second of the pair of ``Point`` objects between which the wrapping
+        Second of the pair of ``Point`` objects between which the wrapping
         pathway spans.
     geometry : GeometryBase
-        The geometry about which the pathway wraps.
+        Geometry about which the pathway wraps.
 
     """
 
@@ -350,13 +329,13 @@ class WrappingPathway(PathwayBase):
         ==========
 
         attachment_1 : Point
-            The first of the pair of ``Point`` objects between which the
-            wrapping pathway spans.
+            First of the pair of ``Point`` objects between which the wrapping
+            pathway spans.
         attachment_2 : Point
-            The second of the pair of ``Point`` objects between which the
-            wrapping pathway spans.
+            Second of the pair of ``Point`` objects between which the wrapping
+            pathway spans.
         geometry : GeometryBase
-            The geometry about which the pathway wraps.
+            Geometry about which the pathway wraps.
 
         """
         super().__init__(attachment_1, attachment_2)
@@ -364,7 +343,7 @@ class WrappingPathway(PathwayBase):
 
     @property
     def geometry(self) -> GeometryBase:
-        """The geometry around which the pathway wraps."""
+        """Geometry around which the pathway wraps."""
         return self._geometry
 
     @geometry.setter
@@ -417,11 +396,11 @@ class WrappingPathway(PathwayBase):
         parallel to the ``N.z`` direction of the global frame ``N`` that also
         passes through a point ``pO``.
 
-        >>> from sympy import Symbol
+        >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Point, ReferenceFrame
         >>> from sympy.physics.mechanics.wrapping_geometry import Cylinder
         >>> N = ReferenceFrame('N')
-        >>> r = Symbol('r', positive=True)
+        >>> r = symbol('r', positive=True)
         >>> pO = Point('pO')
         >>> cylinder = Cylinder(r, pO, N.z)
 
@@ -432,12 +411,12 @@ class WrappingPathway(PathwayBase):
 
         >>> from sympy import cos, sin
         >>> from sympy.physics.mechanics import dynamicsymbols
-        >>> from sympy.physics.mechanics._pathway import WrappingPathway
+        >>> from sympy.physics.mechanics.pathway import WrappingPathway
         >>> q = dynamicsymbols('q')
         >>> pA = Point('pA')
         >>> pB = Point('pB')
-        >>> pA.set_pos(pO, r * N.x)
-        >>> pB.set_pos(pO, r * (cos(q) * N.x + sin(q) * N.y))
+        >>> pA.set_pos(pO, r*N.x)
+        >>> pB.set_pos(pO, r*(cos(q)*N.x + sin(q)*N.y))
         >>> pB.pos_from(pA)
         (r*cos(q(t)) - r)*N.x + r*sin(q(t))*N.y
         >>> pathway = WrappingPathway(pA, pB, cylinder)
@@ -457,8 +436,8 @@ class WrappingPathway(PathwayBase):
         ==========
 
         force : Expr
-            The force acting along the length of the pathway. It is assumed
-            that this ``Expr`` represents an expansile force.
+            Magnitude of the force acting along the length of the pathway. It
+            is assumed that this ``Expr`` represents an expansile force.
 
         """
         pA, pB = self.attachments

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -1,7 +1,5 @@
 """Implementations of pathways for use by actuators."""
 
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 
 from sympy.core.backend import S

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -242,8 +242,8 @@ class LinearPathway(PathwayBase):
         ``KanesMethod`` requires can be produced by calling the pathway's
         ``compute_loads`` method with ``F`` passed as the only argument.
 
-        >>> from sympy import Symbol
-        >>> F = Symbol('F')
+        >>> from sympy import symbols
+        >>> F = symbols('F')
         >>> linear_pathway.compute_loads(F)
         [(pA, - F*q(t)/sqrt(q(t)**2)*N.x), (pB, F*q(t)/sqrt(q(t)**2)*N.x)]
 
@@ -400,7 +400,7 @@ class WrappingPathway(PathwayBase):
         >>> from sympy.physics.mechanics import Point, ReferenceFrame
         >>> from sympy.physics.mechanics.wrapping_geometry import Cylinder
         >>> N = ReferenceFrame('N')
-        >>> r = symbol('r', positive=True)
+        >>> r = symbols('r', positive=True)
         >>> pO = Point('pO')
         >>> cylinder = Cylinder(r, pO, N.z)
 
@@ -426,7 +426,7 @@ class WrappingPathway(PathwayBase):
         ``KanesMethod`` requires can be produced by calling the pathway's
         ``compute_loads`` method with ``F`` passed as the only argument.
 
-        >>> F = Symbol('F')
+        >>> F = symbols('F')
         >>> loads = pathway.compute_loads(F)
         >>> [load.__class__(load.location, load.vector.simplify()) for load in loads]
         [(pA, F*N.y), (pB, F*sin(q(t))*N.x - F*cos(q(t))*N.y),

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -20,24 +20,6 @@ class PathwayBase(ABC):
     Instances of this class cannot be directly instantiated by users. However,
     it can be used to created custom pathway types through subclassing.
 
-    All pathways use the same sign conventions for the relative speed of and
-    forces acting on the attachment points. Take attachment points ``a1`` and
-    ``a2`` that move along the same line and have an equal and opposite force
-    of magnitude ``F``. If we define the positive sense of the velocity of each
-    point to the right (positive ``v1`` or ``v2`` describe rightward motion)
-    and the equal and opposite force ``F`` has a sign convention such that
-    positive force is in the same direction for ``a2`` and opposite direction
-    as ``a1``, respectively, then we have the following sign convention::
-
-       a1          a2
-       o<--- F --->o
-       |           |
-       --> v1      --> v2
-
-    We define the relative speed, or extension velocity,  as ``v2 - v1`` with a
-    positive ``F`` tending to move ``a2`` the right and ``a1`` to the left,
-    i.e. expanding if ``a2``'s position is to the right of ``a1``'s.
-
     """
 
     def __init__(
@@ -124,6 +106,23 @@ class LinearPathway(PathwayBase):
     other objects in the system, i.e. a ``LinearPathway`` will intersect other
     objects to ensure that the path between its two ends (its attachments) is
     the shortest possible.
+
+    A linear pathway is made up of two points that can move relative to each
+    other and a pair of equal and opposite forces acting on the points. If the
+    positive time varying Euclidean distance between the two points is defined,
+    then the "extension velocity" is the time derivative of this distance and
+    is positive when the two points are moving away from each other and
+    negative when moving closer to each other. The direction for the force
+    acting on either point is determined by constructing a unit vector directed
+    from the other point to this point. This establishes a sign convention such
+    that a positive force magnitude tends to push the points apart. The
+    following diagram shows the positive force sense and the distance between
+    the points::
+
+       P           Q
+       o<--- F --->o
+       |           |
+       |<--l(t)--->|
 
     Examples
     ========

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -125,7 +125,7 @@ class LinearPathway(PathwayBase):
     Examples
     ========
 
-    >>> from sympy.physics.mechanics.pathway import LinearPathway
+    >>> from sympy.physics.mechanics import LinearPathway
 
     To construct a pathway, two points are required to be passed to the
     ``attachments`` parameter as a ``tuple``.
@@ -228,8 +228,8 @@ class LinearPathway(PathwayBase):
         actuator between two points separated by the coordinate ``q`` in the
         ``x`` direction of the global frame ``N``.
 
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame
-        >>> from sympy.physics.mechanics.pathway import LinearPathway
+        >>> from sympy.physics.mechanics import (LinearPathway, Point,
+        ...     ReferenceFrame)
         >>> from sympy.physics.vector import dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> N = ReferenceFrame('N')
@@ -279,7 +279,7 @@ class WrappingPathway(PathwayBase):
     Examples
     ========
 
-    >>> from sympy.physics.mechanics.pathway import WrappingPathway
+    >>> from sympy.physics.mechanics import WrappingPathway
 
     To construct a wrapping pathway, like other pathways, a pair of points must
     be passed, followed by an instance of a wrapping geometry class as a
@@ -400,8 +400,7 @@ class WrappingPathway(PathwayBase):
         relative to ``pA`` by the dynamics symbol ``q``.
 
         >>> from sympy import cos, sin
-        >>> from sympy.physics.mechanics import dynamicsymbols
-        >>> from sympy.physics.mechanics.pathway import WrappingPathway
+        >>> from sympy.physics.mechanics import WrappingPathway, dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> pA = Point('pA')
         >>> pB = Point('pB')

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -20,10 +20,7 @@ class PathwayBase(ABC):
 
     """
 
-    def __init__(
-        self,
-        *attachments: Point,
-    ):
+    def __init__(self, *attachments):
         """Initializer for ``PathwayBase``."""
         self.attachments = attachments
 

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -103,16 +103,16 @@ class LinearPathway(PathwayBase):
     the shortest possible.
 
     A linear pathway is made up of two points that can move relative to each
-    other and a pair of equal and opposite forces acting on the points. If the
-    positive time varying Euclidean distance between the two points is defined,
-    then the "extension velocity" is the time derivative of this distance and
-    is positive when the two points are moving away from each other and
-    negative when moving closer to each other. The direction for the force
-    acting on either point is determined by constructing a unit vector directed
-    from the other point to this point. This establishes a sign convention such
-    that a positive force magnitude tends to push the points apart. The
-    following diagram shows the positive force sense and the distance between
-    the points::
+    other, and a pair of equal and opposite forces acting on the points. If the
+    positive time-varying Euclidean distance between the two points is defined,
+    then the "extension velocity" is the time derivative of this distance. The
+    extension velocity is positive when the two points are moving away from
+    each other and negative when moving closer to each other. The direction for
+    the force acting on either point is determined by constructing a unit
+    vector directed from the other point to this point. This establishes a sign
+    convention such that a positive force magnitude tends to push the points
+    apart. The following diagram shows the positive force sense and the
+    distance between the points::
 
        P           Q
        o<--- F --->o
@@ -248,8 +248,11 @@ class LinearPathway(PathwayBase):
         ==========
 
         force : Expr
-            Magnitude of the force acting along the length of the pathway. It
-            is assumed that this ``Expr`` represents an expansile force.
+            Magnitude of the force acting along the length of the pathway. As
+            per the sign conventions for the pathway length, pathway extension
+            velocity, and pair of point forces, if this ``Expr`` is positive
+            then the force will act to push the pair of points away from one
+            another (it is expansile).
 
         """
         relative_position = self.attachments[-1].pos_from(self.attachments[0])
@@ -272,6 +275,26 @@ class WrappingPathway(PathwayBase):
     two points. It will not interact with any other objects in the system, i.e.
     a ``WrappingPathway`` will intersect other objects to ensure that the path
     between its two ends (its attachments) is the shortest possible.
+
+    To explain the sign conventions used for pathway length, extension
+    velocity, and direction of applied forces, we can ignore the geometry with
+    which the wrapping pathway interacts. A wrapping pathway is made up of two
+    points that can move relative to each other, and a pair of equal and
+    opposite forces acting on the points. If the positive time-varying
+    Euclidean distance between the two points is defined, then the "extension
+    velocity" is the time derivative of this distance. The extension velocity
+    is positive when the two points are moving away from each other and
+    negative when moving closer to each other. The direction for the force
+    acting on either point is determined by constructing a unit vector directed
+    from the other point to this point. This establishes a sign convention such
+    that a positive force magnitude tends to push the points apart. The
+    following diagram shows the positive force sense and the distance between
+    the points::
+
+       P           Q
+       o<--- F --->o
+       |           |
+       |<--l(t)--->|
 
     Examples
     ========

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -184,23 +184,12 @@ class LinearPathway(PathwayBase):
     @property
     def length(self):
         """Exact analytical expression for the pathway's length."""
-        length = self.attachments[-1].pos_from(self.attachments[0]).magnitude()
-        return length
+        return self.attachments[-1].pos_from(self.attachments[0]).magnitude()
 
     @property
     def extension_velocity(self):
         """Exact analytical expression for the pathway's extension velocity."""
-        relative_position = self.attachments[-1].pos_from(self.attachments[0])
-        if not relative_position:
-            return S.Zero
-        t = dynamicsymbols._t
-        # A reference frame is needed to differentiate ``relative_position`` to
-        # ``relative_velocity`` so choose the first ``ReferenceFrame`` that
-        # ``relative_position`` is defined using.
-        frame = relative_position.args[0][1]
-        relative_velocity = relative_position.diff(t, frame)
-        extension_velocity = relative_velocity.dot(relative_position.normalize())
-        return extension_velocity
+        return self.length.diff(dynamicsymbols._t)
 
     def compute_loads(self, force):
         """Loads required by the equations of motion method classes.

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -326,7 +326,7 @@ class WrappingPathway(PathwayBase):
     attachment_2 : Point
         Second of the pair of ``Point`` objects between which the wrapping
         pathway spans.
-    geometry : GeometryBase
+    geometry : WrappingGeometryBase
         Geometry about which the pathway wraps.
 
     """

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -158,7 +158,7 @@ class LinearPathway(PathwayBase):
     ``extension_velocity`` attribute.
 
     >>> linear_pathway.extension_velocity
-    q(t)*Derivative(q(t), t)/sqrt(q(t)**2)
+    sqrt(q(t)**2)*Derivative(q(t), t)/q(t)
 
     Parameters
     ==========

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -2,7 +2,6 @@
 
 from abc import ABC, abstractmethod
 
-from sympy.core.backend import S
 from sympy.physics.mechanics import Force, Point, WrappingGeometryBase
 from sympy.physics.vector import dynamicsymbols
 

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -32,6 +32,24 @@ class PathwayBase(ABC):
     Instances of this class cannot be directly instantiated by users. However,
     it can be used to created custom pathway types through subclassing.
 
+    All pathways use the same sign conventions for the relative speed of and
+    forces acting on the attachment points. Take attachment points ``a1`` and
+    ``a2`` that move along the same line and have an equal and opposite force
+    of magnitude ``F``. If we define the positive sense of the velocity of each
+    point to the right (positive ``v1`` or ``v2`` describe rightward motion)
+    and the equal and opposite force ``F`` has a sign convention such that
+    positive force is in the same direction for ``a2`` and opposite direction
+    as ``a1``, respectively, then we have the following sign convention::
+
+       a1          a2
+       o<--- F --->o
+       |           |
+       --> v1      --> v2
+
+    We define the relative speed, or extension velocity,  as ``v2 - v1`` with a
+    positive ``F`` tending to move ``a2`` the right and ``a1`` to the left,
+    i.e. expanding if ``a2``'s position is to the right of ``a1``'s.
+
     """
 
     def __init__(

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -17,7 +17,9 @@ from sympy.core.backend import (
 from sympy.physics.mechanics import (
     Force,
     KanesMethod,
+    LinearPathway,
     Particle,
+    PathwayBase,
     PinJoint,
     Point,
     ReferenceFrame,
@@ -32,7 +34,6 @@ from sympy.physics.mechanics._actuator import (
     LinearSpring,
     TorqueActuator,
 )
-from sympy.physics.mechanics.pathway import LinearPathway, PathwayBase
 
 if USE_SYMENGINE:
     from sympy.core.backend import Basic as ExprType

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -362,7 +362,7 @@ class TestLinearDamper:
         assert isinstance(damper.pathway, LinearPathway)
         assert damper.pathway == self.pathway
 
-        expected_force = -self.damping * self.dq * self.q / sqrt(self.q**2)
+        expected_force = -self.damping*sqrt(self.q**2)*self.dq/self.q
         assert hasattr(damper, 'force')
         assert isinstance(damper.force, ExprType)
         assert damper.force == expected_force

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -32,7 +32,7 @@ from sympy.physics.mechanics._actuator import (
     LinearSpring,
     TorqueActuator,
 )
-from sympy.physics.mechanics._pathway import LinearPathway, PathwayBase
+from sympy.physics.mechanics.pathway import LinearPathway, PathwayBase
 
 if USE_SYMENGINE:
     from sympy.core.backend import Basic as ExprType

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -362,6 +362,18 @@ class TestLinearDamper:
         assert isinstance(damper.pathway, LinearPathway)
         assert damper.pathway == self.pathway
 
+    @pytest.mark.skipif(
+        USE_SYMENGINE,
+        reason=(
+            'SymEngine give equivalent expression that does not compare equal;'
+            'SymPy puts the sqrt(q(t)**2) term in the numerator, while '
+            'SymEngine puts it in the denominator'
+        )
+    )
+    def test_valid_constructor_force(self) -> None:
+        self.pB.set_pos(self.pA, self.q * self.N.x)
+        damper = LinearDamper(self.damping, self.pathway)
+
         expected_force = -self.damping*sqrt(self.q**2)*self.dq/self.q
         assert hasattr(damper, 'force')
         assert isinstance(damper.force, ExprType)

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -124,6 +124,14 @@ class TestLinearPathway:
         expected = 2*sqrt(self.q1**2)
         assert self.pathway.length == expected
 
+    @pytest.mark.skipif(
+        USE_SYMENGINE,
+        reason=(
+            'SymEngine give equivalent expression that does not compare equal;'
+            'SymPy puts the sqrt(q(t)**2) term in the numerator, while '
+            'SymEngine puts it in the denominator'
+        )
+    )
     def test_2D_pathway_extension_velocity(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = 2*sqrt(self.q1**2)*self.q1d/self.q1

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -1,4 +1,4 @@
-"""Tests for the ``sympy.physics.mechanics._pathway.py`` module."""
+"""Tests for the ``sympy.physics.mechanics.pathway.py`` module."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from sympy.physics.mechanics import (
 )
 from sympy.physics.mechanics.wrapping_geometry import (Cylinder, GeometryBase,
                                                        Sphere)
-from sympy.physics.mechanics._pathway import (
+from sympy.physics.mechanics.pathway import (
     LinearPathway,
     PathwayBase,
     WrappingPathway,

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
-
 import pytest
 
 from sympy.core.backend import (
@@ -30,15 +28,10 @@ from sympy.physics.mechanics.pathway import (
 )
 from sympy.simplify.simplify import simplify
 
-if TYPE_CHECKING:
-    from sympy.core.expr import Expr
-    from sympy.core.numbers import Number
-    from sympy.physics.mechanics.loads import LoadBase
-
 
 class TestLinearPathway:
 
-    def test_is_pathway_base_subclass(self) -> None:
+    def test_is_pathway_base_subclass(self):
         assert issubclass(LinearPathway, PathwayBase)
 
     @staticmethod
@@ -48,7 +41,7 @@ class TestLinearPathway:
             ((Point('pA'), Point('pB')), {}),
         ]
     )
-    def test_valid_constructor(args: tuple, kwargs: dict) -> None:
+    def test_valid_constructor(args, kwargs):
         pointA, pointB = args
         instance = LinearPathway(*args, **kwargs)
         assert isinstance(instance, LinearPathway)
@@ -70,10 +63,10 @@ class TestLinearPathway:
         ]
     )
     def test_invalid_attachments_incorrect_number(
-        attachments: tuple[Point, ...],
-    ) -> None:
+        attachments,
+    ):
         with pytest.raises(ValueError):
-            _ = LinearPathway(*attachments)  # type: ignore
+            _ = LinearPathway(*attachments)
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -83,12 +76,12 @@ class TestLinearPathway:
             (Point('pA'), None),
         ]
     )
-    def test_invalid_attachments_not_point(attachments: Sequence[Any]) -> None:
+    def test_invalid_attachments_not_point(attachments):
         with pytest.raises(TypeError):
-            _ = LinearPathway(*attachments)  # type: ignore
+            _ = LinearPathway(*attachments)
 
     @pytest.fixture(autouse=True)
-    def _linear_pathway_fixture(self) -> None:
+    def _linear_pathway_fixture(self):
         self.N = ReferenceFrame('N')
         self.pA = Point('pA')
         self.pB = Point('pB')
@@ -101,29 +94,29 @@ class TestLinearPathway:
         self.q3d = dynamicsymbols('q3', 1)
         self.F = Symbol('F')
 
-    def test_properties_are_immutable(self) -> None:
+    def test_properties_are_immutable(self):
         instance = LinearPathway(self.pA, self.pB)
         with pytest.raises(AttributeError):
-            instance.attachments = None  # type: ignore
+            instance.attachments = None
         with pytest.raises(TypeError):
-            instance.attachments[0] = None  # type: ignore
+            instance.attachments[0] = None
         with pytest.raises(TypeError):
-            instance.attachments[1] = None  # type: ignore
+            instance.attachments[1] = None
 
-    def test_repr(self) -> None:
+    def test_repr(self):
         pathway = LinearPathway(self.pA, self.pB)
         expected = 'LinearPathway(pA, pB)'
         assert repr(pathway) == expected
 
-    def test_static_pathway_length(self) -> None:
+    def test_static_pathway_length(self):
         self.pB.set_pos(self.pA, 2*self.N.x)
         assert self.pathway.length == 2
 
-    def test_static_pathway_extension_velocity(self) -> None:
+    def test_static_pathway_extension_velocity(self):
         self.pB.set_pos(self.pA, 2*self.N.x)
         assert self.pathway.extension_velocity == 0
 
-    def test_static_pathway_compute_loads(self) -> None:
+    def test_static_pathway_compute_loads(self):
         self.pB.set_pos(self.pA, 2*self.N.x)
         expected = [
             (self.pA, - self.F*self.N.x),
@@ -131,17 +124,17 @@ class TestLinearPathway:
         ]
         assert self.pathway.compute_loads(self.F) == expected
 
-    def test_2D_pathway_length(self) -> None:
+    def test_2D_pathway_length(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = 2*sqrt(self.q1**2)
         assert self.pathway.length == expected
 
-    def test_2D_pathway_extension_velocity(self) -> None:
+    def test_2D_pathway_extension_velocity(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = 2*self.q1*self.q1d/sqrt(self.q1**2)
         assert self.pathway.extension_velocity == expected
 
-    def test_2D_pathway_compute_loads(self) -> None:
+    def test_2D_pathway_compute_loads(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = [
             (self.pA, - self.F*(self.q1 / sqrt(self.q1**2))*self.N.x),
@@ -149,7 +142,7 @@ class TestLinearPathway:
         ]
         assert self.pathway.compute_loads(self.F) == expected
 
-    def test_3D_pathway_length(self) -> None:
+    def test_3D_pathway_length(self):
         self.pB.set_pos(
             self.pA,
             self.q1*self.N.x - self.q2*self.N.y + 2*self.q3*self.N.z,
@@ -157,7 +150,7 @@ class TestLinearPathway:
         expected = sqrt(self.q1**2 + self.q2**2 + 4*self.q3**2)
         assert simplify(self.pathway.length - expected) == 0
 
-    def test_3D_pathway_extension_velocity(self) -> None:
+    def test_3D_pathway_extension_velocity(self):
         self.pB.set_pos(
             self.pA,
             self.q1*self.N.x - self.q2*self.N.y + 2*self.q3*self.N.z,
@@ -170,7 +163,7 @@ class TestLinearPathway:
         )
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
-    def test_3D_pathway_compute_loads(self) -> None:
+    def test_3D_pathway_compute_loads(self):
         self.pB.set_pos(
             self.pA,
             self.q1*self.N.x - self.q2*self.N.y + 2*self.q3*self.N.z,
@@ -195,11 +188,11 @@ class TestLinearPathway:
 
 class TestWrappingPathway:
 
-    def test_is_pathway_base_subclass(self) -> None:
+    def test_is_pathway_base_subclass(self):
         assert issubclass(WrappingPathway, PathwayBase)
 
     @pytest.fixture(autouse=True)
-    def _wrapping_pathway_fixture(self) -> None:
+    def _wrapping_pathway_fixture(self):
         self.pA = Point('pA')
         self.pB = Point('pB')
         self.r = Symbol('r', positive=True)
@@ -211,7 +204,7 @@ class TestWrappingPathway:
         self.pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
         self.F = Symbol('F')
 
-    def test_valid_constructor(self) -> None:
+    def test_valid_constructor(self):
         instance = WrappingPathway(self.pA, self.pB, self.cylinder)
         assert isinstance(instance, WrappingPathway)
         assert hasattr(instance, 'attachments')
@@ -233,10 +226,10 @@ class TestWrappingPathway:
     )
     def test_invalid_constructor_attachments_incorrect_number(
         self,
-        attachments: Sequence[Point],
-    ) -> None:
+        attachments,
+    ):
         with pytest.raises(TypeError):
-            _ = WrappingPathway(*attachments, self.cylinder)  # type: ignore
+            _ = WrappingPathway(*attachments, self.cylinder)
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -247,14 +240,14 @@ class TestWrappingPathway:
         ]
     )
     def test_invalid_constructor_attachments_not_point(
-        attachments: Sequence[Any],
-    ) -> None:
+        attachments,
+    ):
         with pytest.raises(TypeError):
-            _ = WrappingPathway(*attachments)  # type: ignore
+            _ = WrappingPathway(*attachments)
 
-    def test_invalid_constructor_geometry_is_not_supplied(self) -> None:
+    def test_invalid_constructor_geometry_is_not_supplied(self):
         with pytest.raises(TypeError):
-            _ = WrappingPathway(self.pA, self.pB)  # type: ignore
+            _ = WrappingPathway(self.pA, self.pB)
 
     @pytest.mark.parametrize(
         'geometry',
@@ -267,22 +260,22 @@ class TestWrappingPathway:
     )
     def test_invalid_geometry_not_geometry(
         self,
-        geometry: Any,
-    ) -> None:
+        geometry,
+    ):
         with pytest.raises(TypeError):
             _ = WrappingPathway(self.pA, self.pB, geometry)
 
-    def test_attachments_property_is_immutable(self) -> None:
+    def test_attachments_property_is_immutable(self):
         with pytest.raises(TypeError):
-            self.pathway.attachments[0] = self.pB  # type: ignore
+            self.pathway.attachments[0] = self.pB
         with pytest.raises(TypeError):
-            self.pathway.attachments[1] = self.pA  # type: ignore
+            self.pathway.attachments[1] = self.pA
 
-    def test_geometry_property_is_immutable(self) -> None:
+    def test_geometry_property_is_immutable(self):
         with pytest.raises(AttributeError):
-            self.pathway.geometry = None  # type: ignore
+            self.pathway.geometry = None
 
-    def test_repr(self) -> None:
+    def test_repr(self):
         expected = (
             f'WrappingPathway(pA, pB, '
             f'geometry={self.cylinder!r})'
@@ -303,10 +296,10 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_sphere_length(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-        expected_factor: Expr,
-    ) -> None:
+        pA_vec,
+        pB_vec,
+        expected_factor,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -337,10 +330,10 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_cylinder_length(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-        expected_factor: Expr,
-    ) -> None:
+        pA_vec,
+        pB_vec,
+        expected_factor,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -359,9 +352,9 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_sphere_extension_velocity(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-    ) -> None:
+        pA_vec,
+        pB_vec,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -383,9 +376,9 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_cylinder_extension_velocity(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-    ) -> None:
+        pA_vec,
+        pB_vec,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -415,12 +408,12 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_sphere_compute_loads(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-        pA_vec_expected: tuple[int | Number, int | Number, int | Number],
-        pB_vec_expected: tuple[int | Number, int | Number, int | Number],
-        pO_vec_expected: tuple[int | Number, int | Number, int | Number],
-    ) -> None:
+        pA_vec,
+        pB_vec,
+        pA_vec_expected,
+        pB_vec_expected,
+        pO_vec_expected,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -491,21 +484,24 @@ class TestWrappingPathway:
     )
     def test_static_pathway_on_cylinder_compute_loads(
         self,
-        pA_vec: tuple[int | Number, int | Number, int | Number],
-        pB_vec: tuple[int | Number, int | Number, int | Number],
-        pA_vec_expected: tuple[int | Number, int | Number, int | Number],
-        pB_vec_expected: tuple[int | Number, int | Number, int | Number],
-        pO_vec_expected: tuple[int | Number, int | Number, int | Number],
-    ) -> None:
+        pA_vec,
+        pB_vec,
+        pA_vec_expected,
+        pB_vec_expected,
+        pO_vec_expected,
+    ):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
         self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
 
-        pA_force_expected = self.F*self._expand_pos_to_vec(pA_vec_expected, self.N)
-        pB_force_expected = self.F*self._expand_pos_to_vec(pB_vec_expected, self.N)
-        pO_force_expected = self.F*self._expand_pos_to_vec(pO_vec_expected, self.N)
+        pA_force_expected = self.F*self._expand_pos_to_vec(pA_vec_expected,
+                                                           self.N)
+        pB_force_expected = self.F*self._expand_pos_to_vec(pB_vec_expected,
+                                                           self.N)
+        pO_force_expected = self.F*self._expand_pos_to_vec(pO_vec_expected,
+                                                           self.N)
         expected = [
             Force(self.pA, pA_force_expected),
             Force(self.pB, pB_force_expected),
@@ -514,7 +510,7 @@ class TestWrappingPathway:
         assert self._simplify_loads(pathway.compute_loads(self.F)) == expected
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
-    def test_2D_pathway_on_cylinder_length(self) -> None:
+    def test_2D_pathway_on_cylinder_length(self):
         q = dynamicsymbols('q')
         pA_pos = self.r*self.N.x
         pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
@@ -524,7 +520,7 @@ class TestWrappingPathway:
         assert simplify(self.pathway.length - expected) == 0
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
-    def test_2D_pathway_on_cylinder_extension_velocity(self) -> None:
+    def test_2D_pathway_on_cylinder_extension_velocity(self):
         q = dynamicsymbols('q')
         qd = dynamicsymbols('q', 1)
         pA_pos = self.r*self.N.x
@@ -535,7 +531,7 @@ class TestWrappingPathway:
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
-    def test_2D_pathway_on_cylinder_compute_loads(self) -> None:
+    def test_2D_pathway_on_cylinder_compute_loads(self):
         q = dynamicsymbols('q')
         pA_pos = self.r*self.N.x
         pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
@@ -555,7 +551,7 @@ class TestWrappingPathway:
         assert loads == expected
 
     @staticmethod
-    def _simplify_loads(loads: list[LoadBase]) -> list[LoadBase]:
+    def _simplify_loads(loads):
         return [
             load.__class__(load.location, load.vector.simplify())
             for load in loads

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -1,7 +1,5 @@
 """Tests for the ``sympy.physics.mechanics.pathway.py`` module."""
 
-from __future__ import annotations
-
 import pytest
 
 from sympy.core.backend import (
@@ -64,9 +62,7 @@ class TestLinearPathway:
             (Point('pA'), Point('pB'), Point('pZ')),
         ]
     )
-    def test_invalid_attachments_incorrect_number(
-        attachments,
-    ):
+    def test_invalid_attachments_incorrect_number(attachments):
         with pytest.raises(ValueError):
             _ = LinearPathway(*attachments)
 
@@ -226,10 +222,7 @@ class TestWrappingPathway:
             (Point('pA'), Point('pB'), Point('pZ')),
         ]
     )
-    def test_invalid_constructor_attachments_incorrect_number(
-        self,
-        attachments,
-    ):
+    def test_invalid_constructor_attachments_incorrect_number(self, attachments):
         with pytest.raises(TypeError):
             _ = WrappingPathway(*attachments, self.cylinder)
 
@@ -241,9 +234,7 @@ class TestWrappingPathway:
             (Point('pA'), None),
         ]
     )
-    def test_invalid_constructor_attachments_not_point(
-        attachments,
-    ):
+    def test_invalid_constructor_attachments_not_point(attachments):
         with pytest.raises(TypeError):
             _ = WrappingPathway(*attachments)
 
@@ -260,10 +251,7 @@ class TestWrappingPathway:
             ReferenceFrame('N').x,
         ]
     )
-    def test_invalid_geometry_not_geometry(
-        self,
-        geometry,
-    ):
+    def test_invalid_geometry_not_geometry(self, geometry):
         with pytest.raises(TypeError):
             _ = WrappingPathway(self.pA, self.pB, geometry)
 
@@ -289,29 +277,24 @@ class TestWrappingPathway:
         return sum(mag*unit for (mag, unit) in zip(pos, frame))
 
     @pytest.mark.parametrize(
-        'pA_vec, pB_vec, expected_factor',
+        'pA_vec, pB_vec, factor',
         [
             ((1, 0, 0), (0, 1, 0), pi/2),
             ((0, 1, 0), (sqrt(2)/2, -sqrt(2)/2, 0), 3*pi/4),
             ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 0), pi/3),
         ]
     )
-    def test_static_pathway_on_sphere_length(
-        self,
-        pA_vec,
-        pB_vec,
-        expected_factor,
-    ):
+    def test_static_pathway_on_sphere_length(self, pA_vec, pB_vec, factor):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
         self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
-        expected = expected_factor*self.r
+        expected = factor*self.r
         assert simplify(pathway.length - expected) == 0
 
     @pytest.mark.parametrize(
-        'pA_vec, pB_vec, expected_factor',
+        'pA_vec, pB_vec, factor',
         [
             ((1, 0, 0), (0, 1, 0), Rational(1, 2)*pi),
             ((1, 0, 0), (-1, 0, 0), pi),
@@ -330,18 +313,13 @@ class TestWrappingPathway:
             ),
         ]
     )
-    def test_static_pathway_on_cylinder_length(
-        self,
-        pA_vec,
-        pB_vec,
-        expected_factor,
-    ):
+    def test_static_pathway_on_cylinder_length(self, pA_vec, pB_vec, factor):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
         self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
-        expected = expected_factor*sqrt(self.r**2)
+        expected = factor*sqrt(self.r**2)
         assert simplify(pathway.length - expected) == 0
 
     @pytest.mark.parametrize(
@@ -352,11 +330,7 @@ class TestWrappingPathway:
             ((1, 0, 0), (Rational(1, 2), sqrt(3)*Rational(1, 2), 0)),
         ]
     )
-    def test_static_pathway_on_sphere_extension_velocity(
-        self,
-        pA_vec,
-        pB_vec,
-    ):
+    def test_static_pathway_on_sphere_extension_velocity(self, pA_vec, pB_vec):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)
@@ -376,11 +350,7 @@ class TestWrappingPathway:
             ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 1)),
         ]
     )
-    def test_static_pathway_on_cylinder_extension_velocity(
-        self,
-        pA_vec,
-        pB_vec,
-    ):
+    def test_static_pathway_on_cylinder_extension_velocity(self, pA_vec, pB_vec):
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
         self.pA.set_pos(self.pO, self.r*pA_vec)

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -126,7 +126,7 @@ class TestLinearPathway:
 
     def test_2D_pathway_extension_velocity(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
-        expected = 2*self.q1*self.q1d/sqrt(self.q1**2)
+        expected = 2*sqrt(self.q1**2)*self.q1d/self.q1
         assert self.pathway.extension_velocity == expected
 
     def test_2D_pathway_compute_loads(self):

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -49,10 +49,13 @@ class TestLinearPathway:
         ]
     )
     def test_valid_constructor(args: tuple, kwargs: dict) -> None:
+        pointA, pointB = args
         instance = LinearPathway(*args, **kwargs)
         assert isinstance(instance, LinearPathway)
         assert hasattr(instance, 'attachments')
         assert len(instance.attachments) == 2
+        assert instance.attachments[0] is pointA
+        assert instance.attachments[1] is pointB
         assert isinstance(instance.attachments[0], Point)
         assert instance.attachments[0].name == 'pA'
         assert isinstance(instance.attachments[1], Point)
@@ -113,36 +116,36 @@ class TestLinearPathway:
         assert repr(pathway) == expected
 
     def test_static_pathway_length(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.N.x)
+        self.pB.set_pos(self.pA, 2*self.N.x)
         assert self.pathway.length == 2
 
     def test_static_pathway_extension_velocity(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.N.x)
+        self.pB.set_pos(self.pA, 2*self.N.x)
         assert self.pathway.extension_velocity == 0
 
     def test_static_pathway_compute_loads(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.N.x)
+        self.pB.set_pos(self.pA, 2*self.N.x)
         expected = [
-            (self.pA, - self.F * self.N.x),
-            (self.pB, self.F * self.N.x),
+            (self.pA, - self.F*self.N.x),
+            (self.pB, self.F*self.N.x),
         ]
         assert self.pathway.compute_loads(self.F) == expected
 
     def test_2D_pathway_length(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.q1 * self.N.x)
-        expected = 2 * sqrt(self.q1**2)
+        self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
+        expected = 2*sqrt(self.q1**2)
         assert self.pathway.length == expected
 
     def test_2D_pathway_extension_velocity(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.q1 * self.N.x)
-        expected = 2 * self.q1 * self.q1d / sqrt(self.q1**2)
+        self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
+        expected = 2*self.q1*self.q1d/sqrt(self.q1**2)
         assert self.pathway.extension_velocity == expected
 
     def test_2D_pathway_compute_loads(self) -> None:
-        self.pB.set_pos(self.pA, 2 * self.q1 * self.N.x)
+        self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = [
-            (self.pA, - self.F * (self.q1 / sqrt(self.q1**2)) * self.N.x),
-            (self.pB, self.F * (self.q1 / sqrt(self.q1**2)) * self.N.x),
+            (self.pA, - self.F*(self.q1 / sqrt(self.q1**2))*self.N.x),
+            (self.pB, self.F*(self.q1 / sqrt(self.q1**2))*self.N.x),
         ]
         assert self.pathway.compute_loads(self.F) == expected
 
@@ -161,9 +164,9 @@ class TestLinearPathway:
         )
         length = sqrt(self.q1**2 + self.q2**2 + 4*self.q3**2)
         expected = (
-            self.q1 * self.q1d / length
-            + self.q2 * self.q2d / length
-            + 4 * self.q3 * self.q3d / length
+            self.q1*self.q1d/length
+            + self.q2*self.q2d/length
+            + 4*self.q3*self.q3d/length
         )
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
@@ -174,14 +177,14 @@ class TestLinearPathway:
         )
         length = sqrt(self.q1**2 + self.q2**2 + 4*self.q3**2)
         pO_force = (
-            - self.F * self.q1 * self.N.x / length
-            + self.F * self.q2 * self.N.y / length
-            - 2 * self.F * self.q3 * self.N.z / length
+            - self.F*self.q1*self.N.x/length
+            + self.F*self.q2*self.N.y/length
+            - 2*self.F*self.q3*self.N.z/length
         )
         pI_force = (
-            self.F * self.q1 * self.N.x / length
-            - self.F * self.q2 * self.N.y / length
-            + 2 * self.F * self.q3 * self.N.z / length
+            self.F*self.q1*self.N.x/length
+            - self.F*self.q2*self.N.y/length
+            + 2*self.F*self.q3*self.N.z/length
         )
         expected = [
             (self.pA, pO_force),
@@ -288,14 +291,14 @@ class TestWrappingPathway:
 
     @staticmethod
     def _expand_pos_to_vec(pos, frame):
-        return sum(mag * unit for (mag, unit) in zip(pos, frame))
+        return sum(mag*unit for (mag, unit) in zip(pos, frame))
 
     @pytest.mark.parametrize(
         'pA_vec, pB_vec, expected_factor',
         [
-            ((1, 0, 0), (0, 1, 0), pi / 2),
-            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0), 3 * pi / 4),
-            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0), pi / 3),
+            ((1, 0, 0), (0, 1, 0), pi/2),
+            ((0, 1, 0), (sqrt(2)/2, -sqrt(2)/2, 0), 3*pi/4),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 0), pi/3),
         ]
     )
     def test_static_pathway_on_sphere_length(
@@ -306,29 +309,29 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
-        expected = expected_factor * self.r
+        expected = expected_factor*self.r
         assert simplify(pathway.length - expected) == 0
 
     @pytest.mark.parametrize(
         'pA_vec, pB_vec, expected_factor',
         [
-            ((1, 0, 0), (0, 1, 0), Rational(1, 2) * pi),
+            ((1, 0, 0), (0, 1, 0), Rational(1, 2)*pi),
             ((1, 0, 0), (-1, 0, 0), pi),
             ((-1, 0, 0), (1, 0, 0), pi),
-            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0), 5 * pi / 4),
-            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0), pi / 3),
+            ((0, 1, 0), (sqrt(2)/2, -sqrt(2)/2, 0), 5*pi/4),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 0), pi/3),
             (
                 (0, 1, 0),
-                (sqrt(2) * Rational(1, 2), -sqrt(2)* Rational(1, 2), 1),
-                sqrt(1 + (Rational(5, 4) * pi)**2),
+                (sqrt(2)*Rational(1, 2), -sqrt(2)*Rational(1, 2), 1),
+                sqrt(1 + (Rational(5, 4)*pi)**2),
             ),
             (
                 (1, 0, 0),
-                (Rational(1, 2), sqrt(3) * Rational(1, 2), 1),
-                sqrt(1 + (Rational(1, 3) * pi)**2),
+                (Rational(1, 2), sqrt(3)*Rational(1, 2), 1),
+                sqrt(1 + (Rational(1, 3)*pi)**2),
             ),
         ]
     )
@@ -340,18 +343,18 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
-        expected = expected_factor * sqrt(self.r**2)
+        expected = expected_factor*sqrt(self.r**2)
         assert simplify(pathway.length - expected) == 0
 
     @pytest.mark.parametrize(
         'pA_vec, pB_vec',
         [
             ((1, 0, 0), (0, 1, 0)),
-            ((0, 1, 0), (sqrt(2) * Rational(1, 2), -sqrt(2)* Rational(1, 2), 0)),
-            ((1, 0, 0), (Rational(1, 2), sqrt(3) * Rational(1, 2), 0)),
+            ((0, 1, 0), (sqrt(2)*Rational(1, 2), -sqrt(2)*Rational(1, 2), 0)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3)*Rational(1, 2), 0)),
         ]
     )
     def test_static_pathway_on_sphere_extension_velocity(
@@ -361,8 +364,8 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
         assert pathway.extension_velocity == 0
 
@@ -372,10 +375,10 @@ class TestWrappingPathway:
             ((1, 0, 0), (0, 1, 0)),
             ((1, 0, 0), (-1, 0, 0)),
             ((-1, 0, 0), (1, 0, 0)),
-            ((0, 1, 0), (sqrt(2) / 2, -sqrt(2) / 2, 0)),
-            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 0)),
-            ((0, 1, 0), (sqrt(2) * Rational(1, 2), -sqrt(2) / 2, 1)),
-            ((1, 0, 0), (Rational(1, 2), sqrt(3) / 2, 1)),
+            ((0, 1, 0), (sqrt(2)/2, -sqrt(2)/2, 0)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 0)),
+            ((0, 1, 0), (sqrt(2)*Rational(1, 2), -sqrt(2)/2, 1)),
+            ((1, 0, 0), (Rational(1, 2), sqrt(3)/2, 1)),
         ]
     )
     def test_static_pathway_on_cylinder_extension_velocity(
@@ -385,8 +388,8 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
         assert pathway.extension_velocity == 0
 
@@ -396,17 +399,17 @@ class TestWrappingPathway:
             ((1, 0, 0), (0, 1, 0), (0, 1, 0), (1, 0, 0), (-1, -1, 0)),
             (
                 (0, 1, 0),
-                (sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (sqrt(2)/2, -sqrt(2)/2, 0),
                 (1, 0, 0),
-                (sqrt(2) / 2, sqrt(2) / 2, 0),
-                (-1 - sqrt(2) / 2, -sqrt(2) / 2, 0)
+                (sqrt(2)/2, sqrt(2)/2, 0),
+                (-1 - sqrt(2)/2, -sqrt(2)/2, 0)
             ),
             (
                 (1, 0, 0),
-                (Rational(1, 2), sqrt(3) / 2, 0),
+                (Rational(1, 2), sqrt(3)/2, 0),
                 (0, 1, 0),
-                (sqrt(3) / 2, -Rational(1, 2), 0),
-                (-sqrt(3) / 2, Rational(1, 2) - 1, 0),
+                (sqrt(3)/2, -Rational(1, 2), 0),
+                (-sqrt(3)/2, Rational(1, 2) - 1, 0),
             ),
         )
     )
@@ -420,23 +423,23 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.sphere)
 
         pA_vec_expected = sum(
-            mag * unit for (mag, unit) in zip(pA_vec_expected, self.N)
+            mag*unit for (mag, unit) in zip(pA_vec_expected, self.N)
         )
         pB_vec_expected = sum(
-            mag * unit for (mag, unit) in zip(pB_vec_expected, self.N)
+            mag*unit for (mag, unit) in zip(pB_vec_expected, self.N)
         )
         pO_vec_expected = sum(
-            mag * unit for (mag, unit) in zip(pO_vec_expected, self.N)
+            mag*unit for (mag, unit) in zip(pO_vec_expected, self.N)
         )
         expected = [
-            Force(self.pA, self.F * (self.r**3 / sqrt(self.r**6)) * pA_vec_expected),
-            Force(self.pB, self.F * (self.r**3 / sqrt(self.r**6)) * pB_vec_expected),
-            Force(self.pO, self.F * (self.r**3 / sqrt(self.r**6)) * pO_vec_expected),
+            Force(self.pA, self.F*(self.r**3/sqrt(self.r**6))*pA_vec_expected),
+            Force(self.pB, self.F*(self.r**3/sqrt(self.r**6))*pB_vec_expected),
+            Force(self.pO, self.F*(self.r**3/sqrt(self.r**6))*pO_vec_expected),
         ]
         assert pathway.compute_loads(self.F) == expected
 
@@ -449,38 +452,38 @@ class TestWrappingPathway:
             ((-1, 0, 0), (1, 0, 0), (0, -1, 0), (0, -1, 0), (0, 2, 0)),
             (
                 (0, 1, 0),
-                (sqrt(2) / 2, -sqrt(2) / 2, 0),
+                (sqrt(2)/2, -sqrt(2)/2, 0),
                 (-1, 0, 0),
-                (-sqrt(2) / 2, -sqrt(2) / 2, 0),
-                (1 + sqrt(2) / 2, sqrt(2) / 2, 0)
+                (-sqrt(2)/2, -sqrt(2)/2, 0),
+                (1 + sqrt(2)/2, sqrt(2)/2, 0)
             ),
             (
                 (1, 0, 0),
-                (Rational(1, 2), sqrt(3) / 2, 0),
+                (Rational(1, 2), sqrt(3)/2, 0),
                 (0, 1, 0),
-                (sqrt(3) / 2, -Rational(1, 2), 0),
-                (-sqrt(3) / 2, Rational(1, 2) - 1, 0),
+                (sqrt(3)/2, -Rational(1, 2), 0),
+                (-sqrt(3)/2, Rational(1, 2) - 1, 0),
             ),
             (
                 (1, 0, 0),
-                (sqrt(2) / 2, sqrt(2) / 2, 0),
+                (sqrt(2)/2, sqrt(2)/2, 0),
                 (0, 1, 0),
-                (sqrt(2) / 2, -sqrt(2) / 2, 0),
-                (-sqrt(2) / 2, sqrt(2) / 2 - 1, 0),
+                (sqrt(2)/2, -sqrt(2)/2, 0),
+                (-sqrt(2)/2, sqrt(2)/2 - 1, 0),
             ),
             ((0, 1, 0), (0, 1, 1), (0, 0, 1), (0, 0, -1), (0, 0, 0)),
             (
                 (0, 1, 0),
-                (sqrt(2) / 2, -sqrt(2) / 2, 1),
-                (-5 * pi / sqrt(16 + 25*pi**2), 0, 4 / sqrt(16 + 25*pi**2)),
+                (sqrt(2)/2, -sqrt(2)/2, 1),
+                (-5*pi/sqrt(16 + 25*pi**2), 0, 4/sqrt(16 + 25*pi**2)),
                 (
-                    -5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
-                    -5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
-                    -4 / sqrt(16 + 25*pi**2),
+                    -5*sqrt(2)*pi/(2*sqrt(16 + 25*pi**2)),
+                    -5*sqrt(2)*pi/(2*sqrt(16 + 25*pi**2)),
+                    -4/sqrt(16 + 25*pi**2),
                 ),
                 (
-                    5 * (sqrt(2) + 2) * pi / (2 * sqrt(16 + 25*pi**2)),
-                    5 * sqrt(2) * pi / (2 * sqrt(16 + 25*pi**2)),
+                    5*(sqrt(2) + 2)*pi/(2*sqrt(16 + 25*pi**2)),
+                    5*sqrt(2)*pi/(2*sqrt(16 + 25*pi**2)),
                     0,
                 ),
             ),
@@ -496,13 +499,13 @@ class TestWrappingPathway:
     ) -> None:
         pA_vec = self._expand_pos_to_vec(pA_vec, self.N)
         pB_vec = self._expand_pos_to_vec(pB_vec, self.N)
-        self.pA.set_pos(self.pO, self.r * pA_vec)
-        self.pB.set_pos(self.pO, self.r * pB_vec)
+        self.pA.set_pos(self.pO, self.r*pA_vec)
+        self.pB.set_pos(self.pO, self.r*pB_vec)
         pathway = WrappingPathway(self.pA, self.pB, self.cylinder)
 
-        pA_force_expected = self.F * self._expand_pos_to_vec(pA_vec_expected, self.N)
-        pB_force_expected = self.F * self._expand_pos_to_vec(pB_vec_expected, self.N)
-        pO_force_expected = self.F * self._expand_pos_to_vec(pO_vec_expected, self.N)
+        pA_force_expected = self.F*self._expand_pos_to_vec(pA_vec_expected, self.N)
+        pB_force_expected = self.F*self._expand_pos_to_vec(pB_vec_expected, self.N)
+        pO_force_expected = self.F*self._expand_pos_to_vec(pO_vec_expected, self.N)
         expected = [
             Force(self.pA, pA_force_expected),
             Force(self.pB, pB_force_expected),
@@ -513,35 +516,35 @@ class TestWrappingPathway:
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_length(self) -> None:
         q = dynamicsymbols('q')
-        pA_pos = self.r * self.N.x
-        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        pA_pos = self.r*self.N.x
+        pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
         self.pA.set_pos(self.pO, pA_pos)
         self.pB.set_pos(self.pO, pB_pos)
-        expected = self.r * sqrt(q**2)
+        expected = self.r*sqrt(q**2)
         assert simplify(self.pathway.length - expected) == 0
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_extension_velocity(self) -> None:
         q = dynamicsymbols('q')
         qd = dynamicsymbols('q', 1)
-        pA_pos = self.r * self.N.x
-        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        pA_pos = self.r*self.N.x
+        pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
         self.pA.set_pos(self.pO, pA_pos)
         self.pB.set_pos(self.pO, pB_pos)
-        expected = self.r * (sqrt(q**2) / q) * qd
+        expected = self.r*(sqrt(q**2)/q)*qd
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_compute_loads(self) -> None:
         q = dynamicsymbols('q')
-        pA_pos = self.r * self.N.x
-        pB_pos = self.r * (cos(q) * self.N.x + sin(q) * self.N.y)
+        pA_pos = self.r*self.N.x
+        pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
         self.pA.set_pos(self.pO, pA_pos)
         self.pB.set_pos(self.pO, pB_pos)
 
-        pA_force = self.F * self.N.y
-        pB_force = self.F * (sin(q) * self.N.x - cos(q) * self.N.y)
-        pO_force = self.F * (-sin(q) * self.N.x + (cos(q) - 1) * self.N.y)
+        pA_force = self.F*self.N.y
+        pB_force = self.F*(sin(q)*self.N.x - cos(q)*self.N.y)
+        pO_force = self.F*(-sin(q)*self.N.x + (cos(q) - 1)*self.N.y)
         expected = [
             Force(self.pA, pA_force),
             Force(self.pB, pB_force),

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -13,18 +13,15 @@ from sympy.core.backend import (
 )
 from sympy.physics.mechanics import (
     Force,
+    LinearPathway,
+    PathwayBase,
     Point,
     ReferenceFrame,
     WrappingCylinder,
     WrappingGeometryBase,
+    WrappingPathway,
     WrappingSphere,
     dynamicsymbols,
-)
-
-from sympy.physics.mechanics.pathway import (
-    LinearPathway,
-    PathwayBase,
-    WrappingPathway,
 )
 from sympy.simplify.simplify import simplify
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Original PRs:

- https://github.com/sympy/sympy/pull/24914
- https://github.com/sympy/sympy/pull/25400

#### Brief description of what is fixed or changed

Make mechanic's `pathway.py` public and complete documentation.


#### Other comments

Merge https://github.com/sympy/sympy/pull/25510 first.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.mechanics
  * Adds module for constructing force pathways to physics.mechanics. Includes a linear pathway and wrapping pathway.

<!-- END RELEASE NOTES -->
