### PR TITLE
CodePrinter func rewrite precedence bug fix

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -444,11 +444,8 @@ class CodePrinter(StrPrinter):
             # Simple rewrite to supported function possible
             target_f, required_fs = self._rewriteable_functions[expr.func.__name__]
             if self._can_print(target_f) and all(self._can_print(f) for f in required_fs):
-                target_expr = expr.rewrite(target_f)
-                if target_expr.func in (Add, Mul, Pow):
-                    return '(' + self._print(target_expr) + ')'
-                else:
-                    return self._print(target_expr)
+                return '(' + self._print(expr.rewrite(target_f)) + ')'
+
         if expr.is_Function and self._settings.get('allow_unknown_functions', False):
             return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -444,7 +444,11 @@ class CodePrinter(StrPrinter):
             # Simple rewrite to supported function possible
             target_f, required_fs = self._rewriteable_functions[expr.func.__name__]
             if self._can_print(target_f) and all(self._can_print(f) for f in required_fs):
-                return self._print(expr.rewrite(target_f))
+                target_expr = expr.rewrite(target_f)
+                if target_expr.func in (Add, Mul, Pow):
+                    return '(' + self._print(target_expr) + ')'
+                else:
+                    return self._print(target_expr)
         if expr.is_Function and self._settings.get('allow_unknown_functions', False):
             return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -164,8 +164,8 @@ def test_ccode_functions2():
     assert ccode(Mod(p1, p2)**s) == 'pow(p1 % p2, s)'
     n = symbols('n', integer=True, negative=True)
     assert ccode(Mod(-n, p2)) == '(-n) % p2'
-    assert ccode(fibonacci(n)) == '(1.0/5.0)*pow(2, -n)*sqrt(5)*(-pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n))'
-    assert ccode(lucas(n)) == 'pow(2, -n)*(pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n))'
+    assert ccode(fibonacci(n)) == '((1.0/5.0)*pow(2, -n)*sqrt(5)*(-pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n)))'
+    assert ccode(lucas(n)) == '(pow(2, -n)*(pow(1 - sqrt(5), n) + pow(1 + sqrt(5), n)))'
 
 
 def test_ccode_user_functions():

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -263,12 +263,12 @@ def test_ccode_sinc():
     from sympy.functions.elementary.trigonometric import sinc
     expr = sinc(x)
     assert ccode(expr) == (
-            "((x != 0) ? (\n"
+            "(((x != 0) ? (\n"
             "   sin(x)/x\n"
             ")\n"
             ": (\n"
             "   1\n"
-            "))")
+            ")))")
 
 
 def test_ccode_Piecewise_deep():

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -54,8 +54,8 @@ def test_CXX17CodePrinter():
     assert CXX17CodePrinter().doprint(zeta(x)) == 'std::riemann_zeta(x)'
 
     # Automatic rewrite
-    assert CXX17CodePrinter().doprint(frac(x)) == 'x - std::floor(x)'
-    assert CXX17CodePrinter().doprint(riemann_xi(x)) == '(1.0/2.0)*std::pow(M_PI, -1.0/2.0*x)*x*(x - 1)*std::tgamma((1.0/2.0)*x)*std::riemann_zeta(x)'
+    assert CXX17CodePrinter().doprint(frac(x)) == '(x - std::floor(x))'
+    assert CXX17CodePrinter().doprint(riemann_xi(x)) == '((1.0/2.0)*std::pow(M_PI, -1.0/2.0*x)*x*(x - 1)*std::tgamma((1.0/2.0)*x)*std::riemann_zeta(x))'
 
 
 def test_cxxcode():

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -376,7 +376,7 @@ def test_maple_derivatives():
 
 def test_automatic_rewrites():
     assert maple_code(lucas(x)) == '(2^(-x)*((1 - sqrt(5))^x + (1 + sqrt(5))^x))'
-    assert maple_code(sinc(x)) == 'piecewise(x <> 0, sin(x)/x, 1)'
+    assert maple_code(sinc(x)) == '(piecewise(x <> 0, sin(x)/x, 1))'
 
 
 def test_specfun():

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -375,7 +375,7 @@ def test_maple_derivatives():
 
 
 def test_automatic_rewrites():
-    assert maple_code(lucas(x)) == '2^(-x)*((1 - sqrt(5))^x + (1 + sqrt(5))^x)'
+    assert maple_code(lucas(x)) == '(2^(-x)*((1 - sqrt(5))^x + (1 + sqrt(5))^x))'
     assert maple_code(sinc(x)) == 'piecewise(x <> 0, sin(x)/x, 1)'
 
 

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -497,7 +497,7 @@ def test_specfun():
     # Automatic rewrite
     assert octave_code(Ei(x)) == 'logint(exp(x))'
     assert octave_code(dirichlet_eta(x)) == '((x == 1).*(log(2)) + (~(x == 1)).*((1 - 2.^(1 - x)).*zeta(x)))'
-    assert octave_code(riemann_xi(x)) == 'pi.^(-x/2).*x.*(x - 1).*gamma(x/2).*zeta(x)/2'
+    assert octave_code(riemann_xi(x)) == '(pi.^(-x/2).*x.*(x - 1).*gamma(x/2).*zeta(x)/2)'
 
 
 def test_MatrixElement_printing():
@@ -519,5 +519,5 @@ def test_zeta_printing_issue_14820():
 
 
 def test_automatic_rewrite():
-    assert octave_code(Li(x)) == 'logint(x) - logint(2)'
-    assert octave_code(erf2(x, y)) == '-erf(x) + erf(y)'
+    assert octave_code(Li(x)) == '(logint(x) - logint(2))'
+    assert octave_code(erf2(x, y)) == '(-erf(x) + erf(y))'

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -495,8 +495,8 @@ def test_specfun():
     assert octave_code(LambertW(x, n)) == 'lambertw(n, x)'
 
     # Automatic rewrite
-    assert octave_code(Ei(x)) == 'logint(exp(x))'
-    assert octave_code(dirichlet_eta(x)) == '((x == 1).*(log(2)) + (~(x == 1)).*((1 - 2.^(1 - x)).*zeta(x)))'
+    assert octave_code(Ei(x)) == '(logint(exp(x)))'
+    assert octave_code(dirichlet_eta(x)) == '(((x == 1).*(log(2)) + (~(x == 1)).*((1 - 2.^(1 - x)).*zeta(x))))'
     assert octave_code(riemann_xi(x)) == '(pi.^(-x/2).*x.*(x - 1).*gamma(x/2).*zeta(x)/2)'
 
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -47,8 +47,8 @@ def test_PythonCodePrinter():
     assert prntr.module_imports == {'math': {'pi', 'sqrt'}}
 
     assert prntr.doprint(acos(x)) == 'math.acos(x)'
-    assert prntr.doprint(cot(x)) == '1/math.tan(x)'
-    assert prntr.doprint(coth(x)) == '(math.exp(x) + math.exp(-x))/(math.exp(x) - math.exp(-x))'
+    assert prntr.doprint(cot(x)) == '(1/math.tan(x))'
+    assert prntr.doprint(coth(x)) == '((math.exp(x) + math.exp(-x))/(math.exp(x) - math.exp(-x)))'
     assert prntr.doprint(asec(x)) == 'math.acos(1/x)'
     assert prntr.doprint(acsch(x)) == 'math.log(math.sqrt(1 + x**(-2)) + 1/x)'
 
@@ -346,13 +346,13 @@ def test_beta():
     assert prntr.doprint(expr) == 'scipy.special.beta(x, y)'
 
     prntr = NumPyPrinter()
-    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+    assert prntr.doprint(expr) == '(math.gamma(x)*math.gamma(y)/math.gamma(x + y))'
 
     prntr = PythonCodePrinter()
-    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+    assert prntr.doprint(expr) == '(math.gamma(x)*math.gamma(y)/math.gamma(x + y))'
 
     prntr = PythonCodePrinter({'allow_unknown_functions': True})
-    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+    assert prntr.doprint(expr) == '(math.gamma(x)*math.gamma(y)/math.gamma(x + y))'
 
     prntr = MpmathPrinter()
     assert prntr.doprint(expr) ==  'mpmath.beta(x, y)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -6,7 +6,7 @@ from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth
+from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
 from sympy.printing.pycode import (
@@ -49,8 +49,8 @@ def test_PythonCodePrinter():
     assert prntr.doprint(acos(x)) == 'math.acos(x)'
     assert prntr.doprint(cot(x)) == '(1/math.tan(x))'
     assert prntr.doprint(coth(x)) == '((math.exp(x) + math.exp(-x))/(math.exp(x) - math.exp(-x)))'
-    assert prntr.doprint(asec(x)) == 'math.acos(1/x)'
-    assert prntr.doprint(acsch(x)) == 'math.log(math.sqrt(1 + x**(-2)) + 1/x)'
+    assert prntr.doprint(asec(x)) == '(math.acos(1/x))'
+    assert prntr.doprint(acsch(x)) == '(math.log(math.sqrt(1 + x**(-2)) + 1/x))'
 
     assert prntr.doprint(Assignment(x, 2)) == 'x = 2'
     assert prntr.doprint(Piecewise((1, Eq(x, 0)),
@@ -140,6 +140,9 @@ def test_NumPyPrinter():
     assert p.doprint(S.NaN) == 'numpy.nan'
     assert p.doprint(S.Infinity) == 'numpy.PINF'
     assert p.doprint(S.NegativeInfinity) == 'numpy.NINF'
+
+    # Function rewriting operator precedence fix
+    assert p.doprint(sec(x)**2) == '(numpy.cos(x)**(-1.0))**2'
 
 
 def test_issue_18770():

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -169,7 +169,7 @@ def test_rcode_sinc():
     from sympy.functions.elementary.trigonometric import sinc
     expr = sinc(x)
     res = rcode(expr)
-    ref = "ifelse(x != 0,sin(x)/x,1)"
+    ref = "(ifelse(x != 0,sin(x)/x,1))"
     assert res == ref
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
I searched but didn't find any related issues.

#### Brief description of what is fixed or changed
The `NumPyPrinter` relies on the `_print_Function` method of the  `CodePrinter` class to rewrite functions that don't exist in NumPy (such as the `cot` and `sec` functions). For some functions, the rewriting process results in expressions that are more complex than a single function call in the target code (for example, `sec` gets rewritten as `cos**-1`). This can cause issues when the function occurs in a larger expression since it may change the precedence of the final expression.   

Example where the current behavior generates code that is incorrect because of precedence rules :
```python
In [1]: import sympy as sp

In [2]: from sympy.printing.numpy import NumPyPrinter

In [3]: x,y,z = sp.symbols('x,y,z')

In [4]: NumPyPrinter().doprint(sp.sec(x)**2)
Out[4]: 'numpy.cos(x)**(-1.0)**2'
```

Note that the generated code is equivalent to `cos(x)**1.0` instead of the intended `cos(x)**-2` because of the right associativity of the `**` operator.

The [precedence rules of Python](https://docs.python.org/3/reference/expressions.html#operator-precedence) place function calls and parenthesized expressions at about the same precedence level with parenthesized expressions being slightly higher than function calls. Because of this,  the safest approach to fix this problem would be to place all rewritten functions in parenthesis. However, in many cases, where the result of the rewrite is itself a function, the parenthesis are unnecessary.  To avoid unnecessary parenthesis in the generated code, I modified the `_print_Function` method to only add the parenthesis if the call to `rewrite` results in a top level function that is `Add`, `Mul`, or `Pow`. As far as I can tell, these are the only cases that would result in the generated code using Python operators directly, which leads to the possibility of the unintended change in precedence.  However, there could be corner cases I'm missing. If it's preferable to take the safer option of always wrapping the expression resulting from the rewrite in parenthesis, let me know and I'll make the change.

New Behavior:
```python
In [1]: import sympy as sp

In [2]: from sympy.printing.numpy import NumPyPrinter

In [3]: x,y,z = sp.symbols('x,y,z')

In [4]: NumPyPrinter().doprint(sp.sec(x)**2)
Out[4]: '(numpy.cos(x)**(-1.0))**2'
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* printing
  * Fix cases where NumPyPrinter CodePrinter generates code with incorrect precedence when rewriting functions.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fix cases where NumPyPrinter CodePrinter generates code with incorrect precedence when rewriting functions.
<!-- END RELEASE NOTES -->
