### PR TITLE
Removed `evaluate=False` from the Lark-based LaTeX parser

### DIFF
--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -114,30 +114,30 @@ class TransformToSymPyExpr(Transformer):
             raise LaTeXParsingError() # TODO: Fill descriptive error message.
 
     def add(self, tokens):
-        return tokens[0] + tokens[2]
+        return sympy.Add(tokens[0], tokens[2])
 
     def sub(self, tokens):
         if len(tokens) == 2:
             return -tokens[1]
         elif len(tokens) == 3:
-            return tokens[0] - tokens[2]
+            return sympy.Add(tokens[0], -tokens[2])
 
     def mul(self, tokens):
         if len(tokens) == 2:
-            return tokens[0] * tokens[1]
+            return sympy.Mul(tokens[0], tokens[1])
         elif len(tokens) == 3:
-            return tokens[0] * tokens[2]
+            return sympy.Mul(tokens[0], tokens[2])
         else:
             raise LaTeXParsingError() # TODO: fill out descriptive error message
 
     def div(self, tokens):
-        return tokens[0] / tokens[2]
+        return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
 
     def superscript(self, tokens):
-        return tokens[0] ** tokens[2]
+        return sympy.Pow(tokens[0], tokens[2])
 
     def fraction(self, tokens):
-        return tokens[1] / tokens[2]
+        return sympy.Mul(tokens[1], sympy.Pow(tokens[2], -1))
 
     def binomial(self, tokens):
         return sympy.binomial(tokens[1], tokens[2])
@@ -314,42 +314,42 @@ class TransformToSymPyExpr(Transformer):
         if exponent == -1:
             return sympy.asin(tokens[-1])
         else:
-            return sympy.sin(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.sin(tokens[-1]), exponent)
 
     def cos_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acos(tokens[-1])
         else:
-            return sympy.cos(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.cos(tokens[-1]), exponent)
 
     def tan_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.atan(tokens[-1])
         else:
-            return sympy.tan(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.tan(tokens[-1]), exponent)
 
     def csc_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acsc(tokens[-1])
         else:
-            return sympy.csc(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.csc(tokens[-1]), exponent)
 
     def sec_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.asec(tokens[-1])
         else:
-            return sympy.sec(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.sec(tokens[-1]), exponent)
 
     def cot_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acot(tokens[-1])
         else:
-            return sympy.cot(tokens[-1]) ** exponent
+            return sympy.Pow(sympy.cot(tokens[-1]), exponent)
 
     def arcsin(self, tokens):
         return sympy.asin(tokens[1])

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -114,30 +114,30 @@ class TransformToSymPyExpr(Transformer):
             raise LaTeXParsingError() # TODO: Fill descriptive error message.
 
     def add(self, tokens):
-        return sympy.Add(tokens[0], tokens[2])
+        return tokens[0] + tokens[2]
 
     def sub(self, tokens):
         if len(tokens) == 2:
             return -tokens[1]
         elif len(tokens) == 3:
-            return sympy.Add(tokens[0], -tokens[2])
+            return tokens[0] - tokens[2]
 
     def mul(self, tokens):
         if len(tokens) == 2:
-            return sympy.Mul(tokens[0], tokens[1])
+            return tokens[0] * tokens[1]
         elif len(tokens) == 3:
-            return sympy.Mul(tokens[0], tokens[2])
+            return tokens[0] * tokens[2]
         else:
             raise LaTeXParsingError() # TODO: fill out descriptive error message
 
     def div(self, tokens):
-        return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
+        return tokens[0] / tokens[2]
 
     def superscript(self, tokens):
-        return sympy.Pow(tokens[0], tokens[2])
+        return tokens[0] ** tokens[2]
 
     def fraction(self, tokens):
-        return sympy.Mul(tokens[1], sympy.Pow(tokens[2], -1))
+        return tokens[1] / tokens[2]
 
     def binomial(self, tokens):
         return sympy.binomial(tokens[1], tokens[2])
@@ -314,42 +314,42 @@ class TransformToSymPyExpr(Transformer):
         if exponent == -1:
             return sympy.asin(tokens[-1])
         else:
-            return sympy.Pow(sympy.sin(tokens[-1]), exponent)
+            return sympy.sin(tokens[-1]) ** exponent
 
     def cos_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acos(tokens[-1])
         else:
-            return sympy.Pow(sympy.cos(tokens[-1]), exponent)
+            return sympy.cos(tokens[-1]) ** exponent
 
     def tan_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.atan(tokens[-1])
         else:
-            return sympy.Pow(sympy.tan(tokens[-1]), exponent)
+            return sympy.tan(tokens[-1]) ** exponent
 
     def csc_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acsc(tokens[-1])
         else:
-            return sympy.Pow(sympy.csc(tokens[-1]), exponent)
+            return sympy.csc(tokens[-1]) ** exponent
 
     def sec_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.asec(tokens[-1])
         else:
-            return sympy.Pow(sympy.sec(tokens[-1]), exponent)
+            return sympy.sec(tokens[-1]) ** exponent
 
     def cot_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
             return sympy.acot(tokens[-1])
         else:
-            return sympy.Pow(sympy.cot(tokens[-1]), exponent)
+            return sympy.cot(tokens[-1]) ** exponent
 
     def arcsin(self, tokens):
         return sympy.asin(tokens[1])

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -114,33 +114,33 @@ class TransformToSymPyExpr(Transformer):
             raise LaTeXParsingError() # TODO: Fill descriptive error message.
 
     def add(self, tokens):
-        return sympy.Add(tokens[0], tokens[2], evaluate=False)
+        return sympy.Add(tokens[0], tokens[2])
 
     def sub(self, tokens):
         if len(tokens) == 2:
             return -tokens[1]
         elif len(tokens) == 3:
-            return sympy.Add(tokens[0], -tokens[2], evaluate=False)
+            return sympy.Add(tokens[0], -tokens[2])
 
     def mul(self, tokens):
         if len(tokens) == 2:
-            return sympy.Mul(tokens[0], tokens[1], evaluate=False)
+            return sympy.Mul(tokens[0], tokens[1])
         elif len(tokens) == 3:
-            return sympy.Mul(tokens[0], tokens[2], evaluate=False)
+            return sympy.Mul(tokens[0], tokens[2])
         else:
             raise LaTeXParsingError() # TODO: fill out descriptive error message
 
     def div(self, tokens):
-        return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1, evaluate=False), evaluate=False)
+        return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
 
     def superscript(self, tokens):
-        return sympy.Pow(tokens[0], tokens[2], evaluate=False)
+        return sympy.Pow(tokens[0], tokens[2])
 
     def fraction(self, tokens):
-        return sympy.Mul(tokens[1], sympy.Pow(tokens[2], -1, evaluate=False), evaluate=False)
+        return sympy.Mul(tokens[1], sympy.Pow(tokens[2], -1))
 
     def binomial(self, tokens):
-        return sympy.binomial(tokens[1], tokens[2], evaluate=False)
+        return sympy.binomial(tokens[1], tokens[2])
 
     def integral(self, tokens):
         underscore_index = None
@@ -292,143 +292,143 @@ class TransformToSymPyExpr(Transformer):
         return sympy.Function(tokens[0])(*tokens[2])
 
     def sin(self, tokens):
-        return sympy.sin(tokens[1], evaluate=False)
+        return sympy.sin(tokens[1])
 
     def cos(self, tokens):
-        return sympy.cos(tokens[1], evaluate=False)
+        return sympy.cos(tokens[1])
 
     def tan(self, tokens):
-        return sympy.tan(tokens[1], evaluate=False)
+        return sympy.tan(tokens[1])
 
     def csc(self, tokens):
-        return sympy.csc(tokens[1], evaluate=False)
+        return sympy.csc(tokens[1])
 
     def sec(self, tokens):
-        return sympy.sec(tokens[1], evaluate=False)
+        return sympy.sec(tokens[1])
 
     def cot(self, tokens):
-        return sympy.cot(tokens[1], evaluate=False)
+        return sympy.cot(tokens[1])
 
     def sin_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.asin(tokens[-1], evaluate=False)
+            return sympy.asin(tokens[-1])
         else:
-            return sympy.Pow(sympy.sin(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.sin(tokens[-1]), exponent)
 
     def cos_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acos(tokens[-1], evaluate=False)
+            return sympy.acos(tokens[-1])
         else:
-            return sympy.Pow(sympy.cos(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.cos(tokens[-1]), exponent)
 
     def tan_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.atan(tokens[-1], evaluate=False)
+            return sympy.atan(tokens[-1])
         else:
-            return sympy.Pow(sympy.tan(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.tan(tokens[-1]), exponent)
 
     def csc_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acsc(tokens[-1], evaluate=False)
+            return sympy.acsc(tokens[-1])
         else:
-            return sympy.Pow(sympy.csc(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.csc(tokens[-1]), exponent)
 
     def sec_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.asec(tokens[-1], evaluate=False)
+            return sympy.asec(tokens[-1])
         else:
-            return sympy.Pow(sympy.sec(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.sec(tokens[-1]), exponent)
 
     def cot_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acot(tokens[-1], evaluate=False)
+            return sympy.acot(tokens[-1])
         else:
-            return sympy.Pow(sympy.cot(tokens[-1], evaluate=False), exponent, evaluate=False)
+            return sympy.Pow(sympy.cot(tokens[-1]), exponent)
 
     def arcsin(self, tokens):
-        return sympy.asin(tokens[1], evaluate=False)
+        return sympy.asin(tokens[1])
 
     def arccos(self, tokens):
-        return sympy.acos(tokens[1], evaluate=False)
+        return sympy.acos(tokens[1])
 
     def arctan(self, tokens):
-        return sympy.atan(tokens[1], evaluate=False)
+        return sympy.atan(tokens[1])
 
     def arccsc(self, tokens):
-        return sympy.acsc(tokens[1], evaluate=False)
+        return sympy.acsc(tokens[1])
 
     def arcsec(self, tokens):
-        return sympy.asec(tokens[1], evaluate=False)
+        return sympy.asec(tokens[1])
 
     def arccot(self, tokens):
-        return sympy.acot(tokens[1], evaluate=False)
+        return sympy.acot(tokens[1])
 
     def sinh(self, tokens):
-        return sympy.sinh(tokens[1], evaluate=False)
+        return sympy.sinh(tokens[1])
 
     def cosh(self, tokens):
-        return sympy.cosh(tokens[1], evaluate=False)
+        return sympy.cosh(tokens[1])
 
     def tanh(self, tokens):
-        return sympy.tanh(tokens[1], evaluate=False)
+        return sympy.tanh(tokens[1])
 
     def asinh(self, tokens):
-        return sympy.asinh(tokens[1], evaluate=False)
+        return sympy.asinh(tokens[1])
 
     def acosh(self, tokens):
-        return sympy.acosh(tokens[1], evaluate=False)
+        return sympy.acosh(tokens[1])
 
     def atanh(self, tokens):
-        return sympy.atanh(tokens[1], evaluate=False)
+        return sympy.atanh(tokens[1])
 
     def abs(self, tokens):
-        return sympy.Abs(tokens[1], evaluate=False)
+        return sympy.Abs(tokens[1])
 
     def floor(self, tokens):
-        return sympy.floor(tokens[1], evaluate=False)
+        return sympy.floor(tokens[1])
 
     def ceil(self, tokens):
-        return sympy.ceiling(tokens[1], evaluate=False)
+        return sympy.ceiling(tokens[1])
 
     def factorial(self, tokens):
-        return sympy.factorial(tokens[0], evaluate=False)
+        return sympy.factorial(tokens[0])
 
     def conjugate(self, tokens):
-        return sympy.conjugate(tokens[1], evaluate=False)
+        return sympy.conjugate(tokens[1])
 
     def square_root(self, tokens):
         if len(tokens) == 2:
             # then there was no square bracket argument
-            return sympy.sqrt(tokens[1], evaluate=False)
+            return sympy.sqrt(tokens[1])
         elif len(tokens) == 3:
             # then there _was_ a square bracket argument
-            return sympy.root(tokens[2], tokens[1], evaluate=False)
+            return sympy.root(tokens[2], tokens[1])
 
     def exponential(self, tokens):
-        return sympy.exp(tokens[1], evaluate=False)
+        return sympy.exp(tokens[1])
 
     def log(self, tokens):
         if tokens[0].type == "FUNC_LG":
             # we don't need to check if there's an underscore or not because having one
             # in this case would be meaningless
             # TODO: ANTLR refers to ISO 80000-2:2019. should we keep base 10 or base 2?
-            return sympy.log(tokens[1], 10, evaluate=False)
+            return sympy.log(tokens[1], 10)
         elif tokens[0].type == "FUNC_LN":
-            return sympy.log(tokens[1], evaluate=False)
+            return sympy.log(tokens[1])
         elif tokens[0].type == "FUNC_LOG":
             # we check if a base was specified or not
             if "_" in tokens:
                 # then a base was specified
-                return sympy.log(tokens[3], tokens[2], evaluate=False) # fix the arguments
+                return sympy.log(tokens[3], tokens[2]) # fix the arguments
             else:
                 # a base was not specified
-                return sympy.log(tokens[1], evaluate=False)
+                return sympy.log(tokens[1])
 
 
 class LarkLatexParser:

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -5,19 +5,19 @@ from sympy.external import import_module
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.add import Add
-from sympy.core.function import (Derivative, Function)
+from sympy.core.function import Derivative, Function
 from sympy.core.mul import Mul
-from sympy.core.numbers import (E, oo)
+from sympy.core.numbers import E, oo, Rational
 from sympy.core.parameters import evaluate
 from sympy.core.power import Pow
-from sympy.core.relational import (GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality)
+from sympy.core.relational import GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality
 from sympy.core.symbol import Symbol
-from sympy.functions.combinatorial.factorials import (binomial, factorial)
-from sympy.functions.elementary.complexes import (Abs, conjugate)
-from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.integers import (ceiling, floor)
-from sympy.functions.elementary.miscellaneous import (root, sqrt)
-from sympy.functions.elementary.trigonometric import (asin, cos, csc, sec, sin, tan)
+from sympy.functions.combinatorial.factorials import binomial, factorial
+from sympy.functions.elementary.complexes import Abs, conjugate
+from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.integers import ceiling, floor
+from sympy.functions.elementary.miscellaneous import root, sqrt
+from sympy.functions.elementary.trigonometric import asin, cos, csc, sec, sin, tan
 from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
@@ -95,7 +95,7 @@ SYMBOL_EXPRESSION_PAIRS = [
     (r"\mathit{HELLO world}", Symbol('HELLO world'))
 ]
 
-SIMPLE_EXPRESSION_PAIRS = [
+UNEVALUATED_SIMPLE_EXPRESSION_PAIRS = [
     (r"0", 0),
     (r"1", 1),
     (r"-3.14", -3.14),
@@ -119,7 +119,25 @@ SIMPLE_EXPRESSION_PAIRS = [
     (r"a'b+ab'", _Add(_Mul(Symbol("a'"), b), _Mul(a, Symbol("b'"))))
 ]
 
-FRACTION_EXPRESSION_PAIRS = [
+EVALUATED_SIMPLE_EXPRESSION_PAIRS = [
+    (r"(-7.13)(1.5)", -10.695),
+    (r"1+1", 2),
+    (r"0+1", 1),
+    (r"1*2", 2),
+    (r"0*1", 0),
+    (r"2x", 2 * x),
+    (r"3x - 1", 3 * x - 1),
+    (r"-c", -c),
+    (r"a \cdot b", a * b),
+    (r"1 \times 2 ", 2),
+    (r"a / b", a / b),
+    (r"a \div b", a / b),
+    (r"a + b", a + b),
+    (r"a + b - a", b),
+    (r"(x + y) z", (x + y) * z),
+]
+
+UNEVALUATED_FRACTION_EXPRESSION_PAIRS = [
     (r"\frac{a}{b}", a / b),
     (r"\dfrac{a}{b}", a / b),
     (r"\tfrac{a}{b}", a / b),
@@ -129,6 +147,18 @@ FRACTION_EXPRESSION_PAIRS = [
     (r"\frac2{3}", _Mul(2, _Pow(3, -1))),
     (r"\frac{a + b}{c}", _Mul(a + b, _Pow(c, -1))),
     (r"\frac{7}{3}", _Mul(7, _Pow(3, -1)))
+]
+
+EVALUATED_FRACTION_EXPRESSION_PAIRS = [
+    (r"\frac{a}{b}", a / b),
+    (r"\dfrac{a}{b}", a / b),
+    (r"\tfrac{a}{b}", a / b),
+    (r"\frac12", 1 / 2),
+    (r"\frac12y", y / 2),
+    (r"\frac1234", 17),
+    (r"\frac2{3}", Rational(2, 3)),
+    (r"\frac{a + b}{c}", (a + b) / c),
+    (r"\frac{7}{3}", Rational(7, 3))
 ]
 
 RELATION_EXPRESSION_PAIRS = [
@@ -148,7 +178,7 @@ RELATION_EXPRESSION_PAIRS = [
     (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2))
 ]
 
-POWER_EXPRESSION_PAIRS = [
+UNEVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"x^2", x ** 2),
     (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
     (r"x^{3 + 1}", x ** _Add(3, 1)),
@@ -156,7 +186,15 @@ POWER_EXPRESSION_PAIRS = [
     (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
 ]
 
-INTEGRAL_EXPRESSION_PAIRS = [
+EVALUATED_POWER_EXPRESSION_PAIRS = [
+    (r"x^2", x ** 2),
+    (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
+    (r"x^{3 + 1}", x ** _Add(3, 1)),
+    (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
+]
+
+UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int x dx", Integral(_Mul(1, x), x)),
     (r"\int x \, dx", Integral(_Mul(1, x), x)),
     (r"\int x d\theta", Integral(_Mul(1, x), theta)),
@@ -202,7 +240,7 @@ TRIGONOMETRIC_EXPRESSION_PAIRS = [
     (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1)))
 ]
 
-LIMIT_EXPRESSION_PAIRS = [
+UNEVALUATED_LIMIT_EXPRESSION_PAIRS = [
     (r"\lim_{x \to 3} a", Limit(a, x, 3, dir='+-')),
     (r"\lim_{x \rightarrow 3} a", Limit(a, x, 3, dir='+-')),
     (r"\lim_{x \Rightarrow 3} a", Limit(a, x, 3, dir='+-')),
@@ -215,7 +253,7 @@ LIMIT_EXPRESSION_PAIRS = [
     (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Mul(1, _Pow(x, -1)), x, oo))
 ]
 
-SQRT_EXPRESSION_PAIRS = [
+UNEVALUATED_SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{x}", sqrt(x)),
     (r"\sqrt{x + b}", sqrt(_Add(x, b))),
     (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
@@ -224,7 +262,7 @@ SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
 ]
 
-FACTORIAL_EXPRESSION_PAIRS = [
+UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
     (r"x!", _factorial(x)),
     (r"100!", _factorial(100)),
     (r"\theta!", _factorial(theta)),
@@ -234,7 +272,7 @@ FACTORIAL_EXPRESSION_PAIRS = [
     (r"5!7!", _Mul(_factorial(5), _factorial(7)))
 ]
 
-SUM_EXPRESSION_PAIRS = [
+UNEVALUATED_SUM_EXPRESSION_PAIRS = [
     (r"\sum_{k = 1}^{3} c", Sum(_Mul(1, c), (k, 1, 3))),
     (r"\sum_{k = 1}^3 c", Sum(_Mul(1, c), (k, 1, 3))),
     (r"\sum^{3}_{k = 1} c", Sum(_Mul(1, c), (k, 1, 3))),
@@ -244,7 +282,7 @@ SUM_EXPRESSION_PAIRS = [
      Sum(_Mul(1, _Mul(1, _Pow(_factorial(n), -1))), (n, 0, oo)))
 ]
 
-PRODUCT_EXPRESSION_PAIRS = [
+UNEVALUATED_PRODUCT_EXPRESSION_PAIRS = [
     (r"\prod_{a = b}^{c} x", Product(x, (a, b, c))),
     (r"\prod_{a = b}^c x", Product(x, (a, b, c))),
     (r"\prod^{c}_{a = b} x", Product(x, (a, b, c))),
@@ -314,12 +352,8 @@ MISCELLANEOUS_EXPRESSION_PAIRS = [
     (r"\left(x + y\right) z", _Mul(_Add(x, y), z)),
     (r"\left( x + y\right ) z", _Mul(_Add(x, y), z)),
     (r"\left(  x + y\right ) z", _Mul(_Add(x, y), z)),
-    (r"\left[x + y\right] z", _Mul(_Add(x, y), z)),
-    (r"\left\{x + y\right\} z", _Mul(_Add(x, y), z)),
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
-    (r"[x]", x),
-    (r"[a + b]", _Add(a, b))
 ]
 
 
@@ -334,17 +368,25 @@ def test_symbol_expressions():
 
 def test_simple_expressions():
     expected_failures = {20}
-    for i, (latex_str, sympy_expr) in enumerate(SIMPLE_EXPRESSION_PAIRS):
+    for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_SIMPLE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
+    for i, (latex_str, sympy_expr) in enumerate(EVALUATED_SIMPLE_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
 
 def test_fraction_expressions():
-    for latex_str, sympy_expr in FRACTION_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_FRACTION_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for latex_str, sympy_expr in EVALUATED_FRACTION_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_relation_expressions():
@@ -355,7 +397,7 @@ def test_relation_expressions():
 
 def test_integral_expressions():
     expected_failures = {14, 16, 17, 20}
-    for i, (latex_str, sympy_expr) in enumerate(INTEGRAL_EXPRESSION_PAIRS):
+    for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
         with evaluate(False):
@@ -379,37 +421,37 @@ def test_trigonometric_expressions():
 
 
 def test_limit_expressions():
-    for latex_str, sympy_expr in LIMIT_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_LIMIT_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_square_root_expressions():
-    for latex_str, sympy_expr in SQRT_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_SQRT_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_factorial_expressions():
-    for latex_str, sympy_expr in FACTORIAL_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_sum_expressions():
-    for latex_str, sympy_expr in SUM_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_SUM_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_product_expressions():
-    for latex_str, sympy_expr in PRODUCT_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_PRODUCT_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 @XFAIL
 def test_applied_function_expressions():
-    expected_failures = {0, 3, 4} # 0 is ambiguous, and the others require not-yet-added features
+    expected_failures = {0, 3, 4}  # 0 is ambiguous, and the others require not-yet-added features
     # not sure why 1, and 2 are failing
     for i, (latex_str, sympy_expr) in enumerate(APPLIED_FUNCTION_EXPRESSION_PAIRS):
         if i in expected_failures:

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -221,6 +221,32 @@ UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int \frac{1}{x} + 1 dx", Integral(_Mul(1, _Add(_Mul(1, _Pow(x, -1)), 1)), x))
 ]
 
+EVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
+    (r"\int x dx", Integral(x, x)),
+    (r"\int x \, dx", Integral(x, x)),
+    (r"\int x d\theta", Integral(x, theta)),
+    (r"\int (x^2 - y)dx", Integral(x ** 2 - y, x)),
+    (r"\int x + a dx", Integral(x + a, x)),
+    (r"\int da", Integral(1, a)),
+    (r"\int_0^7 dx", Integral(1, (x, 0, 7))),
+    (r"\int\limits_{0}^{1} x dx", Integral(x, (x, 0, 1))),
+    (r"\int_a^b x dx", Integral(x, (x, a, b))),
+    (r"\int^b_a x dx", Integral(x, (x, a, b))),
+    (r"\int_{a}^b x dx", Integral(x, (x, a, b))),
+    (r"\int^{b}_a x dx", Integral(x, (x, a, b))),
+    (r"\int_{a}^{b} x dx", Integral(x, (x, a, b))),
+    (r"\int^{b}_{a} x dx", Integral(x, (x, a, b))),
+    (r"\int_{f(a)}^{f(b)} f(z) dz", Integral(f(z), (z, f(a), f(b)))),
+    (r"\int a + b + c dx", Integral(a + b + c, x)),
+    (r"\int \frac{dz}{z}", Integral(Pow(z, -1), z)),
+    (r"\int \frac{3 dz}{z}", Integral(3 * Pow(z, -1), z)),
+    (r"\int \frac{1}{x} dx", Integral(1 / x, x)),
+    (r"\int \frac{1}{a} + \frac{1}{b} dx", Integral(1 / a + 1 / b, x)),
+    (r"\int \frac{3 \cdot d\theta}{\theta}",
+     Integral(3 * _Pow(theta, -1), theta)),
+    (r"\int \frac{1}{x} + 1 dx", Integral(1 / x + 1, x))
+]
+
 DERIVATIVE_EXPRESSION_PAIRS = [
     (r"\frac{d}{dx} x", Derivative(x, x)),
     (r"\frac{d}{dt} x", Derivative(x, t)),
@@ -241,22 +267,28 @@ TRIGONOMETRIC_EXPRESSION_PAIRS = [
 ]
 
 UNEVALUATED_LIMIT_EXPRESSION_PAIRS = [
-    (r"\lim_{x \to 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \rightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \Rightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \Longrightarrow 3} a", Limit(a, x, 3, dir='+-')),
-    (r"\lim_{x \to 3^{+}} a", Limit(a, x, 3, dir='+')),
-    (r"\lim_{x \to 3^{-}} a", Limit(a, x, 3, dir='-')),
-    (r"\lim_{x \to 3^+} a", Limit(a, x, 3, dir='+')),
-    (r"\lim_{x \to 3^-} a", Limit(a, x, 3, dir='-')),
+    (r"\lim_{x \to 3} a", Limit(a, x, 3, dir="+-")),
+    (r"\lim_{x \rightarrow 3} a", Limit(a, x, 3, dir="+-")),
+    (r"\lim_{x \Rightarrow 3} a", Limit(a, x, 3, dir="+-")),
+    (r"\lim_{x \longrightarrow 3} a", Limit(a, x, 3, dir="+-")),
+    (r"\lim_{x \Longrightarrow 3} a", Limit(a, x, 3, dir="+-")),
+    (r"\lim_{x \to 3^{+}} a", Limit(a, x, 3, dir="+")),
+    (r"\lim_{x \to 3^{-}} a", Limit(a, x, 3, dir="-")),
+    (r"\lim_{x \to 3^+} a", Limit(a, x, 3, dir="+")),
+    (r"\lim_{x \to 3^-} a", Limit(a, x, 3, dir="-")),
     (r"\lim_{x \to \infty} \frac{1}{x}", Limit(_Mul(1, _Pow(x, -1)), x, oo))
+]
+
+EVALUATED_LIMIT_EXPRESSION_PAIRS = [
+    (r"\lim_{x \to \infty} \frac{1}{x}", Limit(1 / x, x, oo))
 ]
 
 UNEVALUATED_SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{x}", sqrt(x)),
     (r"\sqrt{x + b}", sqrt(_Add(x, b))),
-    (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
+    (r"\sqrt[3]{\sin x}", _Pow(sin(x), _Pow(3, -1))),
+    # the above test needed to be handled differently than the ones below because root
+    # acts differently if its second argument is a number
     (r"\sqrt[y]{\sin x}", root(sin(x), y)),
     (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
     (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
@@ -264,11 +296,11 @@ UNEVALUATED_SQRT_EXPRESSION_PAIRS = [
 
 EVALUATED_SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{x}", sqrt(x)),
-    (r"\sqrt{x + b}", sqrt(_Add(x, b))),
+    (r"\sqrt{x + b}", sqrt(x + b)),
     (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
     (r"\sqrt[y]{\sin x}", root(sin(x), y)),
     (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
-    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
+    (r"\sqrt{\frac{12}{6}}", sqrt(2))
 ]
 
 UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
@@ -281,6 +313,16 @@ UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
     (r"5!7!", _Mul(_factorial(5), _factorial(7)))
 ]
 
+EVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
+    (r"x!", factorial(x)),
+    (r"100!", factorial(100)),
+    (r"\theta!", factorial(theta)),
+    (r"(x + 1)!", factorial(x + 1)),
+    (r"(x!)!", factorial(factorial(x))),
+    (r"x!!!", factorial(factorial(factorial(x)))),
+    (r"5!7!", factorial(5) * factorial(7))
+]
+
 UNEVALUATED_SUM_EXPRESSION_PAIRS = [
     (r"\sum_{k = 1}^{3} c", Sum(_Mul(1, c), (k, 1, 3))),
     (r"\sum_{k = 1}^3 c", Sum(_Mul(1, c), (k, 1, 3))),
@@ -289,6 +331,15 @@ UNEVALUATED_SUM_EXPRESSION_PAIRS = [
     (r"\sum_{k = 1}^{10} k^2", Sum(_Mul(1, k ** 2), (k, 1, 10))),
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}",
      Sum(_Mul(1, _Mul(1, _Pow(_factorial(n), -1))), (n, 0, oo)))
+]
+
+EVALUATED_SUM_EXPRESSION_PAIRS = [
+    (r"\sum_{k = 1}^{3} c", Sum(c, (k, 1, 3))),
+    (r"\sum_{k = 1}^3 c", Sum(c, (k, 1, 3))),
+    (r"\sum^{3}_{k = 1} c", Sum(c, (k, 1, 3))),
+    (r"\sum^3_{k = 1} c", Sum(c, (k, 1, 3))),
+    (r"\sum_{k = 1}^{10} k^2", Sum(k ** 2, (k, 1, 10))),
+    (r"\sum_{n = 0}^{\infty} \frac{1}{n!}", Sum(1 / factorial(n), (n, 0, oo)))
 ]
 
 UNEVALUATED_PRODUCT_EXPRESSION_PAIRS = [
@@ -308,7 +359,7 @@ APPLIED_FUNCTION_EXPRESSION_PAIRS = [
      Function('h_{theta}')(Symbol('x_{0}'), Symbol('x_{1}')))
 ]
 
-COMMON_FUNCTION_EXPRESSION_PAIRS = [
+UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"|x|", _Abs(x)),
     (r"||x||", _Abs(Abs(x))),
     (r"|x||y|", _Abs(x) * _Abs(y)),
@@ -334,6 +385,32 @@ COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y))
 ]
 
+EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
+    (r"|x|", Abs(x)),
+    (r"||x||", Abs(Abs(x))),
+    (r"|x||y|", Abs(x) * Abs(y)),
+    (r"||x||y||", Abs(Abs(x) * Abs(y))),
+    (r"\lfloor x \rfloor", floor(x)),
+    (r"\lceil x \rceil", ceiling(x)),
+    (r"\exp x", exp(x)),
+    (r"\exp(x)", exp(x)),
+    (r"\lg x", log(x, 10)),
+    (r"\ln x", log(x)),
+    (r"\ln xy", log(x * y)),
+    (r"\log x", log(x)),
+    (r"\log xy", log(x * y)),
+    (r"\log_{2} x", log(x, 2)),
+    (r"\log_{a} x", log(x, a)),
+    (r"\log_{11} x", log(x, 11)),
+    (r"\log_{a^2} x", log(x, _Pow(a, 2))),
+    (r"\log_2 x", log(x, 2)),
+    (r"\log_a x", log(x, a)),
+    (r"\overline{z}", conjugate(z)),
+    (r"\overline{\overline{z}}", conjugate(conjugate(z))),
+    (r"\overline{x + y}", conjugate(x + y)),
+    (r"\overline{x} + \overline{y}", conjugate(x) + conjugate(y))
+]
+
 SPACING_RELATED_EXPRESSION_PAIRS = [
     (r"a \, b", _Mul(a, b)),
     (r"a \thinspace b", _Mul(a, b)),
@@ -349,12 +426,20 @@ SPACING_RELATED_EXPRESSION_PAIRS = [
     (r"a \negthickspace b", _Mul(a, b))
 ]
 
-BINOMIAL_EXPRESSION_PAIRS = [
+UNEVALUATED_BINOMIAL_EXPRESSION_PAIRS = [
     (r"\binom{n}{k}", _binomial(n, k)),
     (r"\tbinom{n}{k}", _binomial(n, k)),
     (r"\dbinom{n}{k}", _binomial(n, k)),
     (r"\binom{n}{0}", _binomial(n, 0)),
     (r"x^\binom{n}{k}", _Pow(x, _binomial(n, k)))
+]
+
+EVALUATED_BINOMIAL_EXPRESSION_PAIRS = [
+    (r"\binom{n}{k}", binomial(n, k)),
+    (r"\tbinom{n}{k}", binomial(n, k)),
+    (r"\dbinom{n}{k}", binomial(n, k)),
+    (r"\binom{n}{0}", binomial(n, 0)),
+    (r"x^\binom{n}{k}", x ** binomial(n, k))
 ]
 
 MISCELLANEOUS_EXPRESSION_PAIRS = [
@@ -425,6 +510,11 @@ def test_integral_expressions():
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
+    for i, (latex_str, sympy_expr) in enumerate(EVALUATED_INTEGRAL_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
 # feature yet to be added
 @XFAIL
 def test_derivative_expressions():
@@ -453,17 +543,26 @@ def test_square_root_expressions():
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
+    for latex_str, sympy_expr in EVALUATED_SQRT_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
 
 def test_factorial_expressions():
     for latex_str, sympy_expr in UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
+    for latex_str, sympy_expr in EVALUATED_FACTORIAL_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
 
 def test_sum_expressions():
     for latex_str, sympy_expr in UNEVALUATED_SUM_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for latex_str, sympy_expr in EVALUATED_SUM_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_product_expressions():
@@ -483,9 +582,12 @@ def test_applied_function_expressions():
 
 
 def test_common_function_expressions():
-    for latex_str, sympy_expr in COMMON_FUNCTION_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for latex_str, sympy_expr in EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 # unhandled bug causing these to fail
 @XFAIL
@@ -496,9 +598,12 @@ def test_spacing():
 
 
 def test_binomial_expressions():
-    for latex_str, sympy_expr in BINOMIAL_EXPRESSION_PAIRS:
+    for latex_str, sympy_expr in UNEVALUATED_BINOMIAL_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for latex_str, sympy_expr in EVALUATED_BINOMIAL_EXPRESSION_PAIRS:
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 # sus expressions
 @XFAIL

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -8,6 +8,7 @@ from sympy.core.add import Add
 from sympy.core.function import (Derivative, Function)
 from sympy.core.mul import Mul
 from sympy.core.numbers import (E, oo)
+from sympy.core.parameters import evaluate
 from sympy.core.power import Pow
 from sympy.core.relational import (GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality)
 from sympy.core.symbol import Symbol
@@ -156,30 +157,30 @@ POWER_EXPRESSION_PAIRS = [
 ]
 
 INTEGRAL_EXPRESSION_PAIRS = [
-    (r"\int x dx", Integral(x, x)),
-    (r"\int x \, dx", Integral(x, x)),
-    (r"\int x d\theta", Integral(x, theta)),
-    (r"\int (x^2 - y)dx", Integral(x ** 2 - y, x)),
-    (r"\int x + a dx", Integral(_Add(x, a), x)),
-    (r"\int da", Integral(1, a)),
-    (r"\int_0^7 dx", Integral(1, (x, 0, 7))),
-    (r"\int\limits_{0}^{1} x dx", Integral(x, (x, 0, 1))),
-    (r"\int_a^b x dx", Integral(x, (x, a, b))),
-    (r"\int^b_a x dx", Integral(x, (x, a, b))),
-    (r"\int_{a}^b x dx", Integral(x, (x, a, b))),
-    (r"\int^{b}_a x dx", Integral(x, (x, a, b))),
-    (r"\int_{a}^{b} x dx", Integral(x, (x, a, b))),
-    (r"\int^{b}_{a} x dx", Integral(x, (x, a, b))),
+    (r"\int x dx", Integral(_Mul(1, x), x)),
+    (r"\int x \, dx", Integral(_Mul(1, x), x)),
+    (r"\int x d\theta", Integral(_Mul(1, x), theta)),
+    (r"\int (x^2 - y)dx", Integral(_Mul(1, x ** 2 - y), x)),
+    (r"\int x + a dx", Integral(_Mul(1, _Add(x, a)), x)),
+    (r"\int da", Integral(_Mul(1, 1), a)),
+    (r"\int_0^7 dx", Integral(_Mul(1, 1), (x, 0, 7))),
+    (r"\int\limits_{0}^{1} x dx", Integral(_Mul(1, x), (x, 0, 1))),
+    (r"\int_a^b x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int^b_a x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int_{a}^b x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int^{b}_a x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int_{a}^{b} x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int^{b}_{a} x dx", Integral(_Mul(1, x), (x, a, b))),
     (r"\int_{f(a)}^{f(b)} f(z) dz", Integral(f(z), (z, f(a), f(b)))),
-    (r"\int a + b + c dx", Integral(_Add(_Add(a, b), c), x)),
+    (r"\int a + b + c dx", Integral(_Mul(1, _Add(_Add(a, b), c)), x)),
     (r"\int \frac{dz}{z}", Integral(Pow(z, -1), z)),
     (r"\int \frac{3 dz}{z}", Integral(3 * Pow(z, -1), z)),
-    (r"\int \frac{1}{x} dx", Integral(_Mul(1, Pow(x, -1)), x)),
+    (r"\int \frac{1}{x} dx", Integral(_Mul(1, _Mul(1, Pow(x, -1))), x)),
     (r"\int \frac{1}{a} + \frac{1}{b} dx",
-     Integral(_Add(_Mul(1, _Pow(a, -1)), _Mul(1, Pow(b, -1))), x)),
+     Integral(_Mul(1, _Add(_Mul(1, _Pow(a, -1)), _Mul(1, Pow(b, -1)))), x)),
     (r"\int \frac{3 \cdot d\theta}{\theta}",
      Integral(3 * _Pow(theta, -1), theta)),
-    (r"\int \frac{1}{x} + 1 dx", Integral(_Add(_Mul(1, _Pow(x, -1)), 1), x))
+    (r"\int \frac{1}{x} + 1 dx", Integral(_Mul(1, _Add(_Mul(1, _Pow(x, -1)), 1)), x))
 ]
 
 DERIVATIVE_EXPRESSION_PAIRS = [
@@ -327,7 +328,8 @@ def test_symbol_expressions():
     for i, (latex_str, sympy_expr) in enumerate(SYMBOL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_simple_expressions():
@@ -335,17 +337,20 @@ def test_simple_expressions():
     for i, (latex_str, sympy_expr) in enumerate(SIMPLE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_fraction_expressions():
     for latex_str, sympy_expr in FRACTION_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_relation_expressions():
     for latex_str, sympy_expr in RELATION_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_integral_expressions():
@@ -353,13 +358,15 @@ def test_integral_expressions():
     for i, (latex_str, sympy_expr) in enumerate(INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 # feature yet to be added
 @XFAIL
 def test_derivative_expressions():
     for latex_str, sympy_expr in DERIVATIVE_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_trigonometric_expressions():
@@ -367,32 +374,38 @@ def test_trigonometric_expressions():
     for i, (latex_str, sympy_expr) in enumerate(TRIGONOMETRIC_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_limit_expressions():
     for latex_str, sympy_expr in LIMIT_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_square_root_expressions():
     for latex_str, sympy_expr in SQRT_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_factorial_expressions():
     for latex_str, sympy_expr in FACTORIAL_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_sum_expressions():
     for latex_str, sympy_expr in SUM_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_product_expressions():
     for latex_str, sympy_expr in PRODUCT_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 @XFAIL
 def test_applied_function_expressions():
@@ -401,26 +414,31 @@ def test_applied_function_expressions():
     for i, (latex_str, sympy_expr) in enumerate(APPLIED_FUNCTION_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_common_function_expressions():
     for latex_str, sympy_expr in COMMON_FUNCTION_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 # unhandled bug causing these to fail
 @XFAIL
 def test_spacing():
     for latex_str, sympy_expr in SPACING_RELATED_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_binomial_expressions():
     for latex_str, sympy_expr in BINOMIAL_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 # sus expressions
 @XFAIL
 def test_miscellaneous_expressions():
     for latex_str, sympy_expr in MISCELLANEOUS_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -235,13 +235,13 @@ FACTORIAL_EXPRESSION_PAIRS = [
 ]
 
 SUM_EXPRESSION_PAIRS = [
-    (r"\sum_{k = 1}^{3} c", Sum(c, (k, 1, 3))),
-    (r"\sum_{k = 1}^3 c", Sum(c, (k, 1, 3))),
-    (r"\sum^{3}_{k = 1} c", Sum(c, (k, 1, 3))),
-    (r"\sum^3_{k = 1} c", Sum(c, (k, 1, 3))),
-    (r"\sum_{k = 1}^{10} k^2", Sum(k ** 2, (k, 1, 10))),
+    (r"\sum_{k = 1}^{3} c", Sum(_Mul(1, c), (k, 1, 3))),
+    (r"\sum_{k = 1}^3 c", Sum(_Mul(1, c), (k, 1, 3))),
+    (r"\sum^{3}_{k = 1} c", Sum(_Mul(1, c), (k, 1, 3))),
+    (r"\sum^3_{k = 1} c", Sum(_Mul(1, c), (k, 1, 3))),
+    (r"\sum_{k = 1}^{10} k^2", Sum(_Mul(1, k ** 2), (k, 1, 10))),
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}",
-     Sum(_Mul(1, _Pow(_factorial(n), -1)), (n, 0, oo)))
+     Sum(_Mul(1, _Mul(1, _Pow(_factorial(n), -1))), (n, 0, oo)))
 ]
 
 PRODUCT_EXPRESSION_PAIRS = [

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -180,7 +180,7 @@ RELATION_EXPRESSION_PAIRS = [
 
 UNEVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"x^2", x ** 2),
-    (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
+    (r"x^\frac{1}{2}", _Pow(x, _Mul(1, _Pow(2, -1)))),
     (r"x^{3 + 1}", x ** _Add(3, 1)),
     (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
     (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
@@ -188,10 +188,10 @@ UNEVALUATED_POWER_EXPRESSION_PAIRS = [
 
 EVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"x^2", x ** 2),
-    (r"x^\frac{1}{2}", _Pow(x, _Pow(2, -1))),
-    (r"x^{3 + 1}", x ** _Add(3, 1)),
+    (r"x^\frac{1}{2}", sqrt(x)),
+    (r"x^{3 + 1}", x ** 4),
     (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
-    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
+    (r"5^0 - 4^0", 0)
 ]
 
 UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
@@ -254,6 +254,15 @@ UNEVALUATED_LIMIT_EXPRESSION_PAIRS = [
 ]
 
 UNEVALUATED_SQRT_EXPRESSION_PAIRS = [
+    (r"\sqrt{x}", sqrt(x)),
+    (r"\sqrt{x + b}", sqrt(_Add(x, b))),
+    (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
+    (r"\sqrt[y]{\sin x}", root(sin(x), y)),
+    (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
+    (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
+]
+
+EVALUATED_SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{x}", sqrt(x)),
     (r"\sqrt{x + b}", sqrt(_Add(x, b))),
     (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
@@ -393,6 +402,19 @@ def test_relation_expressions():
     for latex_str, sympy_expr in RELATION_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+def test_power_expressions():
+    expected_failures = {3}
+    for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_POWER_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for i, (latex_str, sympy_expr) in enumerate(EVALUATED_POWER_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_integral_expressions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses #24116 for the Lark-based LaTeX parser.

#### Brief description of what is fixed or changed

Originally, the ANTLR LaTeX parser returned unevaluated expressions. There were concerns that unevaluated expressions can [create all sorts of issues ](https://github.com/sympy/sympy/issues/24116#issue-1398475575), so we wanted to change this behavior.

I made it so that both `evaluate=False` and `evaluate=True` work with the Lark-based LaTeX parser, with `evaluate=True` being the default.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
    * The Lark-based LaTeX parser now evaluates the input string and returns the result. For example, `"\sqrt{\frac{12}{6}}"` will re turn `\sqrt(2)` now. The previous behavior can achieved by using the `evaluate(False)` context manager.
<!-- END RELEASE NOTES -->
