### PR TITLE
Implemented muscle fibre passive force-length inverse characteristic curve in `sympy.physics._biomechanics`

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3384,6 +3384,12 @@ def test_sympy__physics___biomechanics__characteristic__FiberForceLengthPassiveD
     assert _test_args(FiberForceLengthPassiveDeGroote2016(l_M_tilde, c0, c1))
 
 
+def test_sympy__physics___biomechanics__characteristic__FiberForceLengthPassiveInverseDeGroote2016():
+    from sympy.physics._biomechanics import FiberForceLengthPassiveInverseDeGroote2016
+    fl_M_pas, c0, c1 = symbols('fl_M_pas, c0, c1')
+    assert _test_args(FiberForceLengthPassiveInverseDeGroote2016(fl_M_pas, c0, c1))
+
+
 def test_sympy__physics__paulialgebra__Pauli():
     from sympy.physics.paulialgebra import Pauli
     assert _test_args(Pauli(1))

--- a/sympy/physics/_biomechanics/__init__.py
+++ b/sympy/physics/_biomechanics/__init__.py
@@ -8,6 +8,7 @@ musculoskeletal models involding musculotendons and activation dynamics.
 
 from .characteristic import (
    FiberForceLengthPassiveDeGroote2016,
+   FiberForceLengthPassiveInverseDeGroote2016,
    TendonForceLengthDeGroote2016,
    TendonForceLengthInverseDeGroote2016,
 )
@@ -16,6 +17,7 @@ from .characteristic import (
 __all__ = [
    # Musculotendon characteristic curve functions
    'FiberForceLengthPassiveDeGroote2016',
+   'FiberForceLengthPassiveInverseDeGroote2016',
    'TendonForceLengthDeGroote2016',
    'TendonForceLengthInverseDeGroote2016',
 ]

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -663,3 +663,31 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
            engineering, 44(10), (2016) pp. 2922-2936
 
     """
+
+    @classmethod
+    def with_default_constants(cls, fl_M_pas):
+        r"""Recommended constructor that will use the published constants.
+
+        Explanation
+        ===========
+
+        Returns a new instance of the inverse muscle fiber passive force-length
+        function using the four constant values specified in the original
+        publication.
+
+        These have the values:
+
+        $c_0 = 0.6$
+        $c_1 = 4.0$
+
+        Parameters
+        ==========
+
+        fl_M_pas : Any (sympifiable)
+            Normalized passive muscle fiber force as a function of muscle fiber
+            length.
+
+        """
+        c0 = Rational(3, 5)
+        c1 = Integer(4)
+        return cls(fl_M_pas, c0, c1)

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -783,3 +783,17 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
 
         """
         return FiberForceLengthPassiveDeGroote2016
+
+    def _latex(self, printer):
+        """Print a LaTeX representation of the function defining the curve.
+
+        Parameters
+        ==========
+
+        printer : Printer
+            The printer to be used to print the LaTeX string representation.
+
+        """
+        fl_M_pas = self.args[0]
+        _fl_M_pas = printer._print(fl_M_pas)
+        return r'\left( \operatorname{fl}^M_{pas} \right)^{-1} \left( %s \right)' % _fl_M_pas

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -771,3 +771,15 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
             )
 
         raise ArgumentIndexError(self, argindex)
+
+    def inverse(self, argindex=1):
+        """Inverse function.
+
+        Parameters
+        ==========
+
+        argindex : int
+            Value to start indexing the arguments at. Default is ``1``.
+
+        """
+        return FiberForceLengthPassiveDeGroote2016

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -746,3 +746,28 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
             return c0*log(fl_M_pas*(exp(c1) - 1) + 1)/c1 + 1
 
         return c0*log(UnevaluatedExpr(fl_M_pas*(exp(c1) - 1)) + 1)/c1 + 1
+
+    def fdiff(self, argindex=1):
+        """Derivative of the function with respect to a single argument.
+
+        Parameters
+        ==========
+
+        argindex : int
+            The index of the function's arguments with respect to which the
+            derivative should be taken. Argument indexes start at ``1``.
+            Default is ``1``.
+
+        """
+        fl_M_pas, c0, c1 = self.args
+        if argindex == 1:
+            return c0*(exp(c1) - 1)/(c1*(fl_M_pas*(exp(c1) - 1) + 1))
+        elif argindex == 2:
+            return log(fl_M_pas*(exp(c1) - 1) + 1)/c1
+        elif argindex == 3:
+            return (
+                c0*fl_M_pas*exp(c1)/(c1*(fl_M_pas*(exp(c1) - 1) + 1))
+                - c0*log(fl_M_pas*(exp(c1) - 1) + 1)/c1**2
+            )
+
+        raise ArgumentIndexError(self, argindex)

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -714,3 +714,35 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
     def _eval_evalf(self, prec):
         """Evaluate the expression numerically using ``evalf``."""
         return self.doit(deep=False, evaluate=False)._eval_evalf(prec)
+
+    def doit(self, deep=True, evaluate=True, **hints):
+        """Evaluate the expression defining the function.
+
+        Parameters
+        ==========
+
+        deep : bool
+            Whether ``doit`` should be recursively called. Default is ``True``.
+        evaluate : bool.
+            Whether the SymPy expression should be evaluated as it is
+            constructed. If ``False``, then no constant folding will be
+            conducted which will leave the expression in a more numerically-
+            stable for values of ``l_T_tilde`` that correspond to a sensible
+            operating range for a musculotendon. Default is ``True``.
+        **kwargs : dict[str, Any]
+            Additional keyword argument pairs to be recursively passed to
+            ``doit``.
+
+        """
+        fl_M_pas, *constants = self.args
+        if deep:
+            hints['evaluate'] = evaluate
+            fl_M_pas = fl_M_pas.doit(deep=deep, **hints)
+            c0, c1 = [c.doit(deep=deep, **hints) for c in constants]
+        else:
+            c0, c1 = constants
+
+        if evaluate:
+            return c0*log(fl_M_pas*(exp(c1) - 1) + 1)/c1 + 1
+
+        return c0*log(UnevaluatedExpr(fl_M_pas*(exp(c1) - 1)) + 1)/c1 + 1

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -606,6 +606,18 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
 
         raise ArgumentIndexError(self, argindex)
 
+    def inverse(self, argindex=1):
+        """Inverse function.
+
+        Parameters
+        ==========
+
+        argindex : int
+            Value to start indexing the arguments at. Default is ``1``.
+
+        """
+        return FiberForceLengthPassiveInverseDeGroote2016
+
     def _latex(self, printer):
         """Print a LaTeX representation of the function defining the curve.
 

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -634,4 +634,32 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
 
 
 class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
-    pass
+    r"""Inverse passive muscle fiber force-length curve based on De Groote et
+    al., 2016 [1].
+
+    Explanation
+    ===========
+
+    The function is defined by the equation:
+
+    ${fl^M_{pas}}^{-1} = \frac{c_0 \log{\left(\exp{c_1} - 1\right)fl^M_pas + 1}}{c_1} + 1$
+
+    with constant values of $c_0 = 0.6$ and $c_1 = 4.0$. This function is the
+    exact analytical inverse of the related tendon force-length curve
+    ``fl_M_pas_de_groote_2016``.
+
+    While it is possible to change the constant values, these were carefully
+    selected in the original publication to give the characteristic curve
+    specific and required properties. For example, the function produces a
+    passive fiber force very close to 0 for all normalized fiber lengths
+    between 0 and 1.
+
+    References
+    ==========
+
+    .. [1] De Groote, F., Kinney, A. L., Rao, A. V., & Fregly, B. J., Evaluation
+           of direct collocation optimal control problem formulations for
+           solving the muscle redundancy problem, Annals of biomedical
+           engineering, 44(10), (2016) pp. 2922-2936
+
+    """

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -691,3 +691,26 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
         c0 = Rational(3, 5)
         c1 = Integer(4)
         return cls(fl_M_pas, c0, c1)
+
+    @classmethod
+    def eval(cls, fl_M_pas, c0, c1):
+        """Evaluation of basic inputs.
+
+        Parameters
+        ==========
+
+        fl_M_pas : Any (sympifiable)
+            Normalized passive muscle fiber force.
+        c0 : Any (sympifiable)
+            The first constant in the characteristic equation. The published
+            value is ``0.6``.
+        c1 : Any (sympifiable)
+            The second constant in the characteristic equation. The published
+            value is ``4.0``.
+
+        """
+        pass
+
+    def _eval_evalf(self, prec):
+        """Evaluate the expression numerically using ``evalf``."""
+        return self.doit(deep=False, evaluate=False)._eval_evalf(prec)

--- a/sympy/physics/_biomechanics/characteristic.py
+++ b/sympy/physics/_biomechanics/characteristic.py
@@ -8,6 +8,7 @@ from sympy.functions.elementary.exponential import exp, log
 
 __all__ = [
     'FiberForceLengthPassiveDeGroote2016',
+    'FiberForceLengthPassiveInverseDeGroote2016',
     'TendonForceLengthDeGroote2016',
     'TendonForceLengthInverseDeGroote2016',
 ]
@@ -618,3 +619,7 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
         l_M_tilde = self.args[0]
         _l_M_tilde = printer._print(l_M_tilde)
         return r'\operatorname{fl}^M_{pas} \left( %s \right)' % _l_M_tilde
+
+
+class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
+    pass

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -667,3 +667,13 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
     def test_inverse(self):
         fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
         assert fl_M_pas_inv.inverse() is FiberForceLengthPassiveDeGroote2016
+
+    def test_function_print_latex(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        expected = r'\left( \operatorname{fl}^M_{pas} \right)^{-1} \left( fl_{M pas} \right)'
+        assert LatexPrinter().doprint(fl_M_pas_inv) == expected
+
+    def test_expression_print_latex(self):
+        fl_T = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        expected = r'\frac{c_{0} \log{\left(fl_{M pas} \left(e^{c_{1}} - 1\right) + 1 \right)}}{c_{1}} + 1'
+        assert LatexPrinter().doprint(fl_T.doit()) == expected

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -663,3 +663,7 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
             - self.c0*log(self.fl_M_pas*(exp(self.c1) - 1) + 1)/self.c1**2
         )
         assert fl_M_pas_inv.diff(self.c1) == expected
+
+    def test_inverse(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        assert fl_M_pas_inv.inverse() is FiberForceLengthPassiveDeGroote2016

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -11,6 +11,7 @@ from sympy.functions.elementary.exponential import exp, log
 from sympy.physics._biomechanics.characteristic import (
     CharacteristicCurveFunction,
     FiberForceLengthPassiveDeGroote2016,
+    FiberForceLengthPassiveInverseDeGroote2016,
     TendonForceLengthDeGroote2016,
     TendonForceLengthInverseDeGroote2016,
 )
@@ -479,6 +480,10 @@ class TestFiberForceLengthPassiveDeGroote2016:
             + exp(self.c1*UnevaluatedExpr(self.l_M_tilde - 1)/self.c0)*(self.l_M_tilde - 1)/(self.c0*(exp(self.c1) - 1))
         )
         assert fl_M_pas.diff(self.c1) == expected
+
+    def test_inverse(self):
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016(self.l_M_tilde, *self.constants)
+        assert fl_M_pas.inverse() is FiberForceLengthPassiveInverseDeGroote2016
 
     def test_function_print_latex(self):
         fl_M_pas = FiberForceLengthPassiveDeGroote2016(self.l_M_tilde, *self.constants)

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -645,3 +645,21 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         fl_M_pas_inv_manual = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *constants)
         fl_M_pas_inv_constants = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
         assert fl_M_pas_inv_manual == fl_M_pas_inv_constants
+
+    def test_differentiate_wrt_fl_T(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        expected = self.c0*(exp(self.c1) - 1)/(self.c1*(self.fl_M_pas*(exp(self.c1) - 1) + 1))
+        assert fl_M_pas_inv.diff(self.fl_M_pas) == expected
+
+    def test_differentiate_wrt_c0(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        expected = log(self.fl_M_pas*(exp(self.c1) - 1) + 1)/self.c1
+        assert fl_M_pas_inv.diff(self.c0) == expected
+
+    def test_differentiate_wrt_c1(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        expected = (
+            self.c0*self.fl_M_pas*exp(self.c1)/(self.c1*(self.fl_M_pas*(exp(self.c1) - 1) + 1))
+            - self.c0*log(self.fl_M_pas*(exp(self.c1) - 1) + 1)/self.c1**2
+        )
+        assert fl_M_pas_inv.diff(self.c1) == expected

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -628,3 +628,11 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
         assert isinstance(fl_M_pas_inv, FiberForceLengthPassiveInverseDeGroote2016)
         assert str(fl_M_pas_inv) == 'FiberForceLengthPassiveInverseDeGroote2016(fl_M_pas, c_0, c_1)'
+
+    def test_doit(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants).doit()
+        assert fl_M_pas_inv == self.c0*log(self.fl_M_pas*(exp(self.c1) - 1) + 1)/self.c1 + 1
+
+    def test_doit_evaluate_false(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants).doit(evaluate=False)
+        assert fl_M_pas_inv == self.c0*log(UnevaluatedExpr(self.fl_M_pas*(exp(self.c1) - 1)) + 1)/self.c1 + 1

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -623,3 +623,8 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         assert issubclass(FiberForceLengthPassiveInverseDeGroote2016, Function)
         assert issubclass(FiberForceLengthPassiveInverseDeGroote2016, CharacteristicCurveFunction)
         assert FiberForceLengthPassiveInverseDeGroote2016.__name__ == 'FiberForceLengthPassiveInverseDeGroote2016'
+
+    def test_instance(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
+        assert isinstance(fl_M_pas_inv, FiberForceLengthPassiveInverseDeGroote2016)
+        assert str(fl_M_pas_inv) == 'FiberForceLengthPassiveInverseDeGroote2016(fl_M_pas, c_0, c_1)'

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -677,3 +677,79 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         fl_T = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants)
         expected = r'\frac{c_{0} \log{\left(fl_{M pas} \left(e^{c_{1}} - 1\right) + 1 \right)}}{c_{1}} + 1'
         assert LatexPrinter().doprint(fl_T.doit()) == expected
+
+    @pytest.mark.parametrize(
+        'code_printer, expected',
+        [
+            (
+                C89CodePrinter,
+                '1 + (3.0/20.0)*log(1 + fl_M_pas*(-1 + exp(4)))',
+            ),
+            (
+                C99CodePrinter,
+                '1 + (3.0/20.0)*log(1 + fl_M_pas*(-1 + exp(4)))',
+            ),
+            (
+                C11CodePrinter,
+                '1 + (3.0/20.0)*log(1 + fl_M_pas*(-1 + exp(4)))',
+            ),
+            (
+                CXX98CodePrinter,
+                '1 + (3.0/20.0)*log(1 + fl_M_pas*(-1 + exp(4)))',
+            ),
+            (
+                CXX11CodePrinter,
+                '1 + (3.0/20.0)*std::log(1 + fl_M_pas*(-1 + std::exp(4)))',
+            ),
+            (
+                CXX17CodePrinter,
+                '1 + (3.0/20.0)*std::log(1 + fl_M_pas*(-1 + std::exp(4)))',
+            ),
+            (
+                FCodePrinter,
+                '      1 + (3.0d0/20.0d0)*log(1.0d0 + fl_M_pas*(-1 + 54.598150033144239d0\n'
+                '      @ ))',
+            ),
+            (
+                OctaveCodePrinter,
+                '1 + 3*log(1 + fl_M_pas.*(-1 + exp(4)))/20',
+            ),
+            (
+                PythonCodePrinter,
+                '1 + (3/20)*math.log(1 + fl_M_pas*(-1 + math.exp(4)))',
+            ),
+            (
+                NumPyPrinter,
+                '1 + (3/20)*numpy.log(1 + fl_M_pas*(-1 + numpy.exp(4)))',
+            ),
+            (
+                SciPyPrinter,
+                '1 + (3/20)*numpy.log(1 + fl_M_pas*(-1 + numpy.exp(4)))',
+            ),
+            (
+                CuPyPrinter,
+                '1 + (3/20)*cupy.log(1 + fl_M_pas*(-1 + cupy.exp(4)))',
+            ),
+            (
+                JaxPrinter,
+                '1 + (3/20)*jax.numpy.log(1 + fl_M_pas*(-1 + jax.numpy.exp(4)))',
+            ),
+            (
+                MpmathPrinter,
+                '1 + (mpmath.mpf(3)/mpmath.mpf(20))*mpmath.log(1 + fl_M_pas*(-1 + mpmath.exp(4)))',
+            ),
+            (
+                LambdaPrinter,
+                '1 + (3/20)*math.log(1 + fl_M_pas*(-1 + math.exp(4)))',
+            ),
+        ]
+    )
+    def test_print_code(self, code_printer, expected):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        assert code_printer().doprint(fl_M_pas_inv) == expected
+
+    def test_derivative_print_code(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        dfl_M_pas_inv_dfl_T = fl_M_pas_inv.diff(self.fl_M_pas)
+        expected = '(-3/5 + (3/5)*math.exp(4))/(4*fl_M_pas*(-1 + math.exp(4)) + 4)'
+        assert PythonCodePrinter().doprint(dfl_M_pas_inv_dfl_T) == expected

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -613,7 +613,13 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
 
     @pytest.fixture(autouse=True)
     def _fiber_force_length_passive_arguments_fixture(self):
-        self.l_M_tilde = Symbol('l_M_tilde')
+        self.fl_M_pas = Symbol('fl_M_pas')
         self.c0 = Symbol('c_0')
         self.c1 = Symbol('c_1')
         self.constants = (self.c0, self.c1)
+
+    @staticmethod
+    def test_class():
+        assert issubclass(FiberForceLengthPassiveInverseDeGroote2016, Function)
+        assert issubclass(FiberForceLengthPassiveInverseDeGroote2016, CharacteristicCurveFunction)
+        assert FiberForceLengthPassiveInverseDeGroote2016.__name__ == 'FiberForceLengthPassiveInverseDeGroote2016'

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -753,3 +753,38 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         dfl_M_pas_inv_dfl_T = fl_M_pas_inv.diff(self.fl_M_pas)
         expected = '(-3/5 + (3/5)*math.exp(4))/(4*fl_M_pas*(-1 + math.exp(4)) + 4)'
         assert PythonCodePrinter().doprint(dfl_M_pas_inv_dfl_T) == expected
+
+    def test_lambdify(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv_callable = lambdify(self.fl_M_pas, fl_M_pas_inv)
+        assert fl_M_pas_inv_callable(0.0) == pytest.approx(1.0)
+
+    @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
+    def test_lambdify_numpy(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv_callable = lambdify(self.fl_M_pas, fl_M_pas_inv, 'numpy')
+        fl_M_pas = numpy.array([-0.01, 0.0, 0.01, 0.02, 0.05, 0.1])
+        expected = numpy.array([
+            0.8848253714,
+            1.0,
+            1.0643754386,
+            1.1092744701,
+            1.1954331425,
+            1.2774998934,
+        ])
+        numpy.testing.assert_allclose(fl_M_pas_inv_callable(fl_M_pas), expected)
+
+    @pytest.mark.skipif(jax is None, reason='JAX not installed')
+    def test_lambdify_jax(self):
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv_callable = jax.jit(lambdify(self.fl_M_pas, fl_M_pas_inv, 'jax'))
+        fl_M_pas = jax.numpy.array([-0.01, 0.0, 0.01, 0.02, 0.05, 0.1])
+        expected = jax.numpy.array([
+            0.8848253714,
+            1.0,
+            1.0643754386,
+            1.1092744701,
+            1.1954331425,
+            1.2774998934,
+        ])
+        numpy.testing.assert_allclose(fl_M_pas_inv_callable(fl_M_pas), expected)

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -607,3 +607,13 @@ class TestFiberForceLengthPassiveDeGroote2016:
             0.5043387669,
         ])
         numpy.testing.assert_allclose(fl_M_pas_callable(l_M_tilde), expected)
+
+
+class TestFiberForceLengthPassiveInverseDeGroote2016:
+
+    @pytest.fixture(autouse=True)
+    def _fiber_force_length_passive_arguments_fixture(self):
+        self.l_M_tilde = Symbol('l_M_tilde')
+        self.c0 = Symbol('c_0')
+        self.c1 = Symbol('c_1')
+        self.constants = (self.c0, self.c1)

--- a/sympy/physics/_biomechanics/tests/test_characteristic.py
+++ b/sympy/physics/_biomechanics/tests/test_characteristic.py
@@ -636,3 +636,12 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
     def test_doit_evaluate_false(self):
         fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants).doit(evaluate=False)
         assert fl_M_pas_inv == self.c0*log(UnevaluatedExpr(self.fl_M_pas*(exp(self.c1) - 1)) + 1)/self.c1 + 1
+
+    def test_with_default_constants(self):
+        constants = (
+            Rational(3, 5),
+            Integer(4),
+        )
+        fl_M_pas_inv_manual = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *constants)
+        fl_M_pas_inv_constants = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        assert fl_M_pas_inv_manual == fl_M_pas_inv_constants


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240. Follows directly on from #25441, #25509, and #25516.
 
#### Brief description of what is fixed or changed

This PR adds the muscle fibre inverse passive force-length characteristic musculotendon curve based on the equations from De Groote et al. (2016).

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the whole biomechanics module is moved to `sympy/physics/biomechanics`.

#### Other comments

I have specifically left the release notes entry empty. These will be added in the PR that moves the whole biomechanics module to `sympy/physics/biomechanics`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
