### PR TITLE
Use expr.func to reconstruct Basic instances

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -561,6 +561,7 @@ Fabian Ball <fabian.ball@kit.edu>
 Fabian Froehlich <fabian@schaluck.com> FFroehlich <fabian@schaluck.com>
 Fabian Pedregosa <fabian@fseoane.net>
 Fabian Pedregosa <fabian@fseoane.net> <fabian@debian.(none)>
+Fabio Luporini <fabio@devitocodes.com>
 Faisal Anees <faisal.iiit@gmail.com>
 Faisal Riyaz <faisalriyaz011@gmail.com>
 Fawaz Alazemi <Mba7eth@gmail.com>

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -74,9 +74,9 @@ def together(expr, deep=False, fraction=True):
                 else:
                     exp = expr.exp
 
-                return expr.__class__(base, exp)
+                return expr.func(base, exp)
             else:
-                return expr.__class__(*[ _together(arg) for arg in expr.args ])
+                return expr.func(*[ _together(arg) for arg in expr.args ])
         elif iterable(expr):
             return expr.__class__([ _together(ex) for ex in expr ])
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #25496 

#### Brief description of what is fixed or changed

Reconstruct Basics objects using the canonical `expr.func(...)`.
This preserves the integrity of subtypes that have overridden `.func`. 

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->