### PR TITLE
Refactoring of `is_quad_residue`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -732,8 +732,37 @@ def is_quad_residue(a, p):
     Returns True if ``a`` (mod ``p``) is in the set of squares mod ``p``,
     i.e a % p in set([i**2 % p for i in range(p)]).
 
+    Parameters
+    ==========
+
+    a : integer
+    p : positive integer
+
+    Returns
+    =======
+
+    bool : If True, ``x**2 == a (mod p)`` has solution.
+
+    Raises
+    ======
+
+    ValueError
+        If ``a``, ``p`` is not integer.
+        If ``p`` is not positive.
+
     Examples
     ========
+
+    >>> from sympy.ntheory import is_quad_residue
+    >>> is_quad_residue(21, 100)
+    True
+
+    Indeed, ``pow(39, 2, 100)`` would be 21.
+
+    >>> is_quad_residue(21, 120)
+    False
+
+    That is, for any integer ``x``, ``pow(x, 2, 120)`` is not 21.
 
     If ``p`` is an odd
     prime, an iterative method is used to make the determination:
@@ -747,25 +776,46 @@ def is_quad_residue(a, p):
     See Also
     ========
 
-    legendre_symbol, jacobi_symbol
+    legendre_symbol, jacobi_symbol, sqrt_mod
     """
     a, p = as_int(a), as_int(p)
     if p < 1:
         raise ValueError('p must be > 0')
-    if a >= p or a < 0:
-        a = a % p
+    a %= p
     if a < 2 or p < 3:
         return True
-    if not isprime(p):
-        if p % 2 and jacobi(a, p) == -1:
-            return False
-        r = sqrt_mod(a, p)
-        if r is None:
-            return False
-        else:
+    # Since we want to compute the Jacobi symbol,
+    # we separate p into the odd part and the rest.
+    t = trailing(p)
+    if t:
+        # The existence of a solution to a power of 2 is determined
+        # using the logic of `p==2` in `_sqrt_mod_prime_power` and `_sqrt_mod1`.
+        a_ = a % (1 << t)
+        if a_:
+            r = trailing(a_)
+            if r % 2 or (a_ >> r) & 6:
+                return False
+        p >>= t
+        a %= p
+        if a < 2 or p < 3:
             return True
-
-    return pow(a, (p - 1) // 2, p) == 1
+    # If Jacobi symbol is -1 or p is prime, can be determined by Jacobi symbol only
+    j = jacobi(a, p)
+    if j == -1 or isprime(p):
+        return j == 1
+    # Checks if `x**2 = a (mod p)` has a solution
+    for px, ex in factorint(p).items():
+        if a % px:
+            if jacobi(a, px) != 1:
+                return False
+        else:
+            a_ = a % px**ex
+            if a_ == 0:
+                continue
+            r = multiplicity(px, a_)
+            if r % 2 or jacobi(a_ // px**r, px) != 1:
+                return False
+    return True
 
 
 def is_nthpow_residue(a, n, m):


### PR DESCRIPTION
We separate p into the odd part and the rest. This makes it faster than simply finding the square root and checking if a solution exists.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
