### PR TITLE
Implemented `_NamedMixin` mixin class for adding error-checked `name` attribute to classes

### DIFF
--- a/sympy/physics/_biomechanics/_mixin.py
+++ b/sympy/physics/_biomechanics/_mixin.py
@@ -1,0 +1,52 @@
+"""Mixin classes for sharing functionality between unrelated classes.
+
+This module is named with a leading underscore to signify to users that it's
+"private" and only intended for internal use by the biomechanics module.
+
+"""
+
+
+__all__ = ['_NamedMixin']
+
+
+class _NamedMixin:
+    """Mixin class for adding `name` properties.
+
+    Valid names, as will typically be used by subclasses as a suffix when
+    naming automatically-instantiated symbol attributes, must be nonzero length
+    strings.
+
+    Attributes
+    ==========
+    name : str
+        The name identifier associated with the instance. Must be a string of
+        length at least 1.
+
+    """
+
+    @property
+    def name(self) -> str:
+        """The name associated with the class instance."""
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        if hasattr(self, '_name'):
+            msg = (
+                f'Can\'t set attribute `name` to {repr(name)} as it is '
+                f'immutable.'
+            )
+            raise AttributeError(msg)
+        if not isinstance(name, str):
+            msg = (
+                f'Name {repr(name)} passed to `name` was of type '
+                f'{type(name)}, must be {str}.'
+            )
+            raise TypeError(msg)
+        if name in {''}:
+            msg = (
+                f'Name {repr(name)} is invalid, must be a nonzero length '
+                f'{type(str)}.'
+            )
+            raise ValueError(msg)
+        self._name = name

--- a/sympy/physics/_biomechanics/tests/test_mixin.py
+++ b/sympy/physics/_biomechanics/tests/test_mixin.py
@@ -1,0 +1,48 @@
+"""Tests for the ``sympy.physics._biomechanics._mixin.py`` module."""
+
+import pytest
+
+from sympy.physics._biomechanics._mixin import _NamedMixin
+
+
+class TestNamedMixin:
+
+    @staticmethod
+    def test_subclass():
+
+        class Subclass(_NamedMixin):
+
+            def __init__(self, name):
+                self.name = name
+
+        instance = Subclass('name')
+        assert instance.name == 'name'
+
+    @pytest.fixture(autouse=True)
+    def _named_mixin_fixture(self):
+
+        class Subclass(_NamedMixin):
+
+            def __init__(self, name):
+                self.name = name
+
+        self.Subclass = Subclass
+
+    @pytest.mark.parametrize('name', ['a', 'name', 'long_name'])
+    def test_valid_name_argument(self, name):
+        instance = self.Subclass(name)
+        assert instance.name == name
+
+    @pytest.mark.parametrize('invalid_name', [0, 0.0, None, False])
+    def test_invalid_name_argument_not_str(self, invalid_name):
+        with pytest.raises(TypeError):
+            _ = self.Subclass(invalid_name)
+
+    def test_invalid_name_argument_zero_length_str(self):
+        with pytest.raises(ValueError):
+            _ = self.Subclass('')
+
+    def test_name_attribute_is_immutable(self):
+        instance = self.Subclass('name')
+        with pytest.raises(AttributeError):
+            instance.name = 'new_name'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

#### Brief description of what is fixed or changed

Introduces a mixin class, `_NamedMixin`, which can be used to add a `name` attribute to classes. This property comes with simple error checking and useful error messages when a user supplies an invalid name. These names are needed to help with the naming of automatically-created symbols while avoid name conflicts. Musculotendon and activation dynamics classes will use this mixin.

#### Other comments

The module and class are named with a leading underscore to signal that they are intended for internal use only and won't be part of the `sympy.physics.biomechanics` namespace. No release notes will be needed for this.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
