### PR TITLE
Implemented zeroth-order activation dynamics in `sympy.physics._biomechanics`

### DIFF
--- a/sympy/physics/_biomechanics/__init__.py
+++ b/sympy/physics/_biomechanics/__init__.py
@@ -6,6 +6,10 @@ musculoskeletal models involding musculotendons and activation dynamics.
 
 """
 
+from .activation import (
+   ActivationBase,
+   ZerothOrderActivation,
+)
 from .characteristic import (
    FiberForceLengthActiveDeGroote2016,
    FiberForceLengthPassiveDeGroote2016,
@@ -22,4 +26,8 @@ __all__ = [
    'FiberForceLengthPassiveInverseDeGroote2016',
    'TendonForceLengthDeGroote2016',
    'TendonForceLengthInverseDeGroote2016',
+
+   # Activation dynamics classes
+   'ActivationBase',
+   'ZerothOrderActivation',
 ]

--- a/sympy/physics/_biomechanics/_mixin.py
+++ b/sympy/physics/_biomechanics/_mixin.py
@@ -18,6 +18,7 @@ class _NamedMixin:
 
     Attributes
     ==========
+
     name : str
         The name identifier associated with the instance. Must be a string of
         length at least 1.

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -3,10 +3,11 @@
 Musculotendon models are able to produce active force when they are activated,
 which is when a chemical process has taken place within the muscle fibers
 causing them to voluntarily contract. Biologically this chemical process (the
-diffusion of $Ca^{2+}$ ions) is not the input in the system, electrical signals
-from the nervous system are. These are termed excitations. Activation dynamics,
-which relates the normalized excitation level to the normalized activation
-level, can be modeled by the models present in this module.
+diffusion of :math:`\textrm{Ca}^{2+}` ions) is not the input in the system,
+electrical signals from the nervous system are. These are termed excitations.
+Activation dynamics, which relates the normalized excitation level to the
+normalized activation level, can be modeled by the models present in this
+module.
 
 """
 

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -1,0 +1,219 @@
+"""Activation dynamics for musclotendon models."""
+
+from abc import ABC, abstractmethod
+
+from sympy.physics._biomechanics._mixin import _NamedMixin
+from sympy.physics.mechanics import dynamicsymbols
+
+
+__all__ = ['ActivationBase']
+
+
+class ActivationBase(ABC, _NamedMixin):
+    """Abstract base class for all activation dynamics classes to inherit from.
+
+    Notes
+    =====
+
+    Instances of this class cannot be directly instantiated by users. However,
+    it can be used to created custom activation dynamics types through
+    subclassing.
+
+    """
+
+    def __init__(self, name):
+        """Initializer for ``ActivationBase``."""
+        self.name = str(name)
+
+        # Symbols
+        self._e = dynamicsymbols(f"e_{name}")
+        self._a = dynamicsymbols(f"a_{name}")
+
+    @property
+    def excitation(self):
+        """Dynamic symbol representing excitation.
+
+        Explanation
+        ===========
+
+        The alias `e` can also be used to access the same attribute.
+
+        """
+        return self._e
+
+    @property
+    def e(self):
+        """Dynamic symbol representing excitation.
+
+        Explanation
+        ===========
+
+        The alias `excitation` can also be used to access the same attribute.
+
+        """
+        return self._e
+
+    @property
+    def activation(self):
+        """Dynamic symbol representing activation.
+
+        Explanation
+        ===========
+
+        The alias `a` can also be used to access the same attribute.
+
+        """
+        return self._a
+
+    @property
+    def a(self):
+        """Dynamic symbol representing activation.
+
+        Explanation
+        ===========
+
+        The alias `activation` can also be used to access the same attribute.
+
+        """
+        return self._a
+
+    @property
+    @abstractmethod
+    def order(self):
+        """Order of the (differential) equation governing activation."""
+        pass
+
+    @property
+    @abstractmethod
+    def state_vars(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        The alias `x` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def x(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        The alias `state_vars` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def input_vars(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        The alias `r` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def r(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        The alias `input_vars` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def constants(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        The alias `p` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def p(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        The alias `constants` can also be used to access the same attribute.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def M(self):
+        """Ordered square matrix of coefficients on the LHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The square matrix that forms part of the LHS of the linear system of
+        ordinary differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def F(self):
+        """Ordered column matrix of equations on the RHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The column matrix that forms the RHS of the linear system of ordinary
+        differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        pass
+
+    @abstractmethod
+    def rhs(self):
+        """
+
+        Explanation
+        ===========
+
+        The solution to the linear system of ordinary differential equations
+        governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        pass
+
+    def __repr__(self):
+        """Default representation of activation dynamics."""
+        return f'{self.__class__.__name__}({self.name!r})'

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -2,11 +2,16 @@
 
 from abc import ABC, abstractmethod
 
+from sympy.matrices import Matrix
+from sympy.matrices.dense import zeros
 from sympy.physics._biomechanics._mixin import _NamedMixin
 from sympy.physics.mechanics import dynamicsymbols
 
 
-__all__ = ['ActivationBase']
+__all__ = [
+    'ActivationBase',
+    'ZerothOrderActivation',
+]
 
 
 class ActivationBase(ABC, _NamedMixin):
@@ -217,3 +222,200 @@ class ActivationBase(ABC, _NamedMixin):
     def __repr__(self):
         """Default representation of activation dynamics."""
         return f'{self.__class__.__name__}({self.name!r})'
+
+
+class ZerothOrderActivation(ActivationBase):
+    """Simple zeroth-order activation dynamics mapping excitation to
+    activation.
+
+    Explanation
+    ===========
+
+    Zeroth-order activation dynamics are useful in instances where you want to
+    reduce the complexity of your musculotendon dynamics as they simple map
+    exictation to activation. As a result, no additional state equations are
+    introduced to your system. They also remove a potential source of delay
+    between the input and dynamics of your system as no (ordinary) differential
+    equations are involed.
+
+    """
+
+    def __init__(self, name):
+        """Initializer for ``ZerothOrderActivation``.
+
+        Parameters
+        ==========
+
+        name : str
+            The name identifier associated with the instance. Must be a string
+            of length at least 1.
+
+        """
+        super().__init__(name)
+
+        # Zeroth-order activation dynamics has activation equal excitation so
+        # overwrite the symbol for activation with the excitation symbol.
+        self._a = self._e
+
+    @property
+    def order(self):
+        """Order of the (differential) equation governing activation."""
+        return 0
+
+    @property
+    def state_vars(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        As zeroth-order activation dynamics simply maps excitation to
+        activation, this class has no associated state variables and so this
+        property return an empty column ``Matrix`` with shape (0, 1).
+
+        The alias `x` can also be used to access the same attribute.
+
+        """
+        return zeros(0, 1)
+
+    @property
+    def x(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        As zeroth-order activation dynamics simply maps excitation to
+        activation, this class has no associated state variables and so this
+        property return an empty column ``Matrix`` with shape (0, 1).
+
+        The alias `state_vars` can also be used to access the same attribute.
+
+        """
+        return zeros(0, 1)
+
+    @property
+    def input_vars(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        Excitation is the only input in zeroth-order activation dynamics and so
+        this property returns a column ``Matrix`` with one entry, ``e``, and
+        shape (1, 1).
+
+        The alias `r` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._e])
+
+    @property
+    def r(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        Excitation is the only input in zeroth-order activation dynamics and so
+        this property returns a column ``Matrix`` with one entry, ``e``, and
+        shape (1, 1).
+
+        The alias `input_vars` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._e])
+
+    @property
+    def constants(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        As zeroth-order activation dynamics simply maps excitation to
+        activation, this class has no associated constants and so this property
+        return an empty column ``Matrix`` with shape (0, 1).
+
+        The alias `p` can also be used to access the same attribute.
+
+        """
+        return zeros(0, 1)
+
+    @property
+    def p(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        As zeroth-order activation dynamics simply maps excitation to
+        activation, this class has no associated constants and so this property
+        return an empty column ``Matrix`` with shape (0, 1).
+
+        The alias `constants` can also be used to access the same attribute.
+
+        """
+        return zeros(0, 1)
+
+    @property
+    def M(self):
+        """Ordered square matrix of coefficients on the LHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The square matrix that forms part of the LHS of the linear system of
+        ordinary differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        As zeroth-order activation dynamics have no state variables, this
+        linear system has dimension 0 and therefore ``M`` is an empty square
+        ``Matrix`` with shape (0, 0).
+
+        """
+        return Matrix([])
+
+    @property
+    def F(self):
+        """Ordered column matrix of equations on the RHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The column matrix that forms the RHS of the linear system of ordinary
+        differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        As zeroth-order activation dynamics have no state variables, this
+        linear system has dimension 0 and therefore ``F`` is an empty column
+        ``Matrix`` with shape (0, 1).
+
+        """
+        return zeros(0, 1)
+
+    def rhs(self):
+        """
+
+        Explanation
+        ===========
+
+        The solution to the linear system of ordinary differential equations
+        governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        As zeroth-order activation dynamics have no state variables, this
+        linear has dimension 0 and therefore this method returns an empty
+        column ``Matrix`` with shape (0, 1).
+
+        """
+        return zeros(0, 1)

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -1,4 +1,14 @@
-"""Activation dynamics for musclotendon models."""
+"""Activation dynamics for musclotendon models.
+
+Musculotendon models are able to produce active force when they are activated,
+which is when a chemical process has taken place within the muscle fibers
+causing them to voluntarily contract. Biologically this chemical process (the
+diffusion of $Ca^{2+}$ ions) is not the input in the system, electrical signals
+from the nervous system are. These are termed excitations. Activation dynamics,
+which relates the normalized excitation level to the normalized activation
+level, can be modeled by the models present in this module.
+
+"""
 
 from abc import ABC, abstractmethod
 

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -23,7 +23,7 @@ class TestZerothOrderActivation:
     @pytest.fixture(autouse=True)
     def _zeroth_order_activation_fixture(self):
         self.name = 'name'
-        self.e = dynamicsymbols(f'e_name')
+        self.e = dynamicsymbols('e_name')
         self.instance = ZerothOrderActivation(self.name)
 
     def test_instance(self):

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -1,0 +1,117 @@
+"""Tests for the ``sympy.physics._biomechanics.activation.py`` module."""
+
+import pytest
+
+from sympy.matrices import Matrix
+from sympy.matrices.dense import zeros
+from sympy.physics.mechanics import dynamicsymbols
+from sympy.physics._biomechanics import (
+    ActivationBase,
+    ZerothOrderActivation,
+)
+from sympy.physics._biomechanics._mixin import _NamedMixin
+
+
+class TestZerothOrderActivation:
+
+    @staticmethod
+    def test_class():
+        assert issubclass(ZerothOrderActivation, ActivationBase)
+        assert issubclass(ZerothOrderActivation, _NamedMixin)
+        assert ZerothOrderActivation.__name__ == 'ZerothOrderActivation'
+
+    @pytest.fixture(autouse=True)
+    def _zeroth_order_activation_fixture(self):
+        self.name = 'name'
+        self.e = dynamicsymbols(f'e_name')
+        self.instance = ZerothOrderActivation(self.name)
+
+    def test_instance(self):
+        instance = ZerothOrderActivation(self.name)
+        assert isinstance(instance, ZerothOrderActivation)
+
+    def test_name_attribute(self):
+        assert hasattr(self.instance, 'name')
+        assert self.instance.name == self.name
+
+    def test_order_attribute(self):
+        assert hasattr(self.instance, 'order')
+        assert self.instance.order == 0
+
+    def test_excitation_attribute(self):
+        assert hasattr(self.instance, 'e')
+        assert hasattr(self.instance, 'excitation')
+        e_expected = dynamicsymbols('e_name')
+        assert self.instance.e == e_expected
+        assert self.instance.excitation == e_expected
+        assert self.instance.e is self.instance.excitation
+
+    def test_activation_attribute(self):
+        assert hasattr(self.instance, 'a')
+        assert hasattr(self.instance, 'activation')
+        a_expected = dynamicsymbols('e_name')
+        assert self.instance.a == a_expected
+        assert self.instance.activation == a_expected
+        assert self.instance.a is self.instance.activation is self.instance.e
+
+    def test_state_vars_attribute(self):
+        assert hasattr(self.instance, 'x')
+        assert hasattr(self.instance, 'state_vars')
+        assert self.instance.x == self.instance.state_vars
+        x_expected = zeros(0, 1)
+        assert self.instance.x == x_expected
+        assert self.instance.state_vars == x_expected
+        assert isinstance(self.instance.x, Matrix)
+        assert isinstance(self.instance.state_vars, Matrix)
+        assert self.instance.x.shape == (0, 1)
+        assert self.instance.state_vars.shape == (0, 1)
+
+    def test_input_vars_attribute(self):
+        assert hasattr(self.instance, 'r')
+        assert hasattr(self.instance, 'input_vars')
+        assert self.instance.r == self.instance.input_vars
+        r_expected = Matrix([self.e])
+        assert self.instance.r == r_expected
+        assert self.instance.input_vars == r_expected
+        assert isinstance(self.instance.r, Matrix)
+        assert isinstance(self.instance.input_vars, Matrix)
+        assert self.instance.r.shape == (1, 1)
+        assert self.instance.input_vars.shape == (1, 1)
+
+    def test_constants_attribute(self):
+        assert hasattr(self.instance, 'p')
+        assert hasattr(self.instance, 'constants')
+        assert self.instance.p == self.instance.constants
+        p_expected = zeros(0, 1)
+        assert self.instance.p == p_expected
+        assert self.instance.constants == p_expected
+        assert isinstance(self.instance.p, Matrix)
+        assert isinstance(self.instance.constants, Matrix)
+        assert self.instance.p.shape == (0, 1)
+        assert self.instance.constants.shape == (0, 1)
+
+    def test_M_attribute(self):
+        assert hasattr(self.instance, 'M')
+        M_expected = Matrix([])
+        assert self.instance.M == M_expected
+        assert isinstance(self.instance.M, Matrix)
+        assert self.instance.M.shape == (0, 0)
+
+    def test_F_attribute(self):
+        assert hasattr(self.instance, 'F')
+        F_expected = zeros(0, 1)
+        assert self.instance.F == F_expected
+        assert isinstance(self.instance.F, Matrix)
+        assert self.instance.F.shape == (0, 1)
+
+    def test_rhs(self):
+        assert hasattr(self.instance, 'rhs')
+        rhs_expected = zeros(0, 1)
+        rhs = self.instance.rhs()
+        assert rhs == rhs_expected
+        assert isinstance(rhs, Matrix)
+        assert rhs.shape == (0, 1)
+
+    def test_repr(self):
+        expected = 'ZerothOrderActivation(\'name\')'
+        assert repr(self.instance) == expected


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

#### Brief description of what is fixed or changed

Adds activation dynamics for biomechanics. Introduces a new base class, `ActivationBase`, for different concrete activation classes to subclass, with a defined interface (abstract methods for expected properties and methods to be implemented by subclasses). Also add a concrete class `ZerothOrderActivation`, which is the simplest form of activation dynamics simply mapping excitation to activation. An implementation of first-order activation dynamics will follow in another PR shortly.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->