### PR TITLE
Fix incorrect type information for `attachments` parameter to `LinearPathway`

### DIFF
--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -167,6 +167,9 @@ class LinearPathway(PathwayBase):
 
     attachments : tuple[Point, Point]
         Pair of ``Point`` objects between which the linear pathway spans.
+        Constructor expects two points to be passed, e.g.
+        ``LinearPathway(Point('pA'), Point('pB'))``. More or fewer points will
+        cause an error to be thrown.
 
     """
 
@@ -176,8 +179,11 @@ class LinearPathway(PathwayBase):
         Parameters
         ==========
 
-        attachments : tuple[Point, Point]
+        attachments : Point
             Pair of ``Point`` objects between which the linear pathway spans.
+            Constructor expects two points to be passed, e.g.
+            ``LinearPathway(Point('pA'), Point('pB'))``. More or fewer points
+            will cause an error to be thrown.
 
         """
         super().__init__(*attachments)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240.

#### Brief description of what is fixed or changed

Makes a minor edit to the docstring of the new `LinearPathway` class introduced in #24914.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
