### PR TITLE
[GSoC] Added support for Min, Max, Bra, and Ket

### DIFF
--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -80,6 +80,8 @@ CMD_DIV:   "\\div"
 CMD_FRAC:  "\\frac" | "\\dfrac" | "\\tfrac" | "\\nicefrac"
 CMD_BINOM: "\\binom" | "\\dbinom" | "\\tbinom"
 CMD_OVERLINE: "\\overline"
+CMD_LANGLE: "\\langle"
+CMD_RANGLE: "\\rangle"
 
 CMD_MATHIT: "\\mathit"
 
@@ -249,6 +251,10 @@ min: FUNC_MIN L_PAREN list_of_expressions R_PAREN
 
 max: FUNC_MAX L_PAREN list_of_expressions R_PAREN
 
+bra: CMD_LANGLE _expression BAR
+
+ket: BAR _expression CMD_RANGLE
+
 _function: function_applied
     | abs | floor | ceil
     | _trigonometric_function | _inverse_trigonometric_function
@@ -259,8 +265,8 @@ _function: function_applied
     | square_root
     | factorial
     | conjugate
-    | min
-    | max
+    | max | min
+    | bra | ket
 
 exponential: FUNC_EXP _expression
 

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -44,6 +44,8 @@ FUNC_EXP:  "\\exp"
 FUNC_LOG:  "\\log"
 FUNC_LN:   "\\ln"
 FUNC_LG:   "\\lg"
+FUNC_MIN: "\\min"
+FUNC_MAX: "\\max"
 
 // trigonometric functions
 FUNC_SIN:  "\\sin"
@@ -243,6 +245,10 @@ list_of_expressions: _expression ("," _expression)*
 
 function_applied: _oneletter_symbol L_PAREN list_of_expressions R_PAREN
 
+min: FUNC_MIN L_PAREN list_of_expressions R_PAREN
+
+max: FUNC_MAX L_PAREN list_of_expressions R_PAREN
+
 _function: function_applied
     | abs | floor | ceil
     | _trigonometric_function | _inverse_trigonometric_function
@@ -253,6 +259,8 @@ _function: function_applied
     | square_root
     | factorial
     | conjugate
+    | min
+    | max
 
 exponential: FUNC_EXP _expression
 

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -251,13 +251,13 @@ min: FUNC_MIN L_PAREN list_of_expressions R_PAREN
 
 max: FUNC_MAX L_PAREN list_of_expressions R_PAREN
 
-bra: CMD_LANGLE _atomic_expr BAR
+bra: CMD_LANGLE _expression BAR
 
-ket: BAR _atomic_expr CMD_RANGLE
+ket: BAR _expression CMD_RANGLE
 
-inner_product: CMD_LANGLE _atomic_expr BAR _atomic_expr CMD_RANGLE
+inner_product: CMD_LANGLE _expression BAR _expression CMD_RANGLE
 
-// outer_product: BAR _atomic_expr CMD_RANGLE CMD_LANGLE _atomic_expr BAR
+// outer_product: BAR _expression CMD_RANGLE CMD_LANGLE _expression BAR
 
 _function: function_applied
     | abs | floor | ceil

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -251,9 +251,13 @@ min: FUNC_MIN L_PAREN list_of_expressions R_PAREN
 
 max: FUNC_MAX L_PAREN list_of_expressions R_PAREN
 
-bra: CMD_LANGLE _expression BAR
+bra: CMD_LANGLE _atomic_expr BAR
 
-ket: BAR _expression CMD_RANGLE
+ket: BAR _atomic_expr CMD_RANGLE
+
+inner_product: CMD_LANGLE _atomic_expr BAR _atomic_expr CMD_RANGLE
+
+// outer_product: BAR _atomic_expr CMD_RANGLE CMD_LANGLE _atomic_expr BAR
 
 _function: function_applied
     | abs | floor | ceil
@@ -266,7 +270,7 @@ _function: function_applied
     | factorial
     | conjugate
     | max | min
-    | bra | ket
+    | bra | ket | inner_product
 
 exponential: FUNC_EXP _expression
 

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -307,6 +307,12 @@ class TransformToSymPyExpr(Transformer):
         from sympy.physics.quantum import Ket
         return Ket(tokens[1])
 
+    def inner_product(self, tokens):
+        # TODO: Change or update the below code (or remove this comment) when the issue #25551 is resolved
+        from sympy.physics.quantum import Bra, Ket, InnerProduct
+        return InnerProduct(Bra(tokens[1]), Ket(tokens[3]))
+
+
     def sin(self, tokens):
         return sympy.sin(tokens[1])
 

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -290,12 +290,22 @@ class TransformToSymPyExpr(Transformer):
 
     def function_applied(self, tokens):
         return sympy.Function(tokens[0])(*tokens[2])
-    
+
     def min(self, tokens):
         return sympy.Min(*tokens[2])
-    
+
     def max(self, tokens):
         return sympy.Max(*tokens[2])
+
+    def bra(self, tokens):
+        # TODO: Change or update the below code (or remove this comment) when the issue #25551 is resolved
+        from sympy.physics.quantum import Bra
+        return Bra(tokens[1])
+
+    def ket(self, tokens):
+        # TODO: Change or update the below code (or remove this comment) when the issue #25551 is resolved
+        from sympy.physics.quantum import Ket
+        return Ket(tokens[1])
 
     def sin(self, tokens):
         return sympy.sin(tokens[1])

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -290,6 +290,12 @@ class TransformToSymPyExpr(Transformer):
 
     def function_applied(self, tokens):
         return sympy.Function(tokens[0])(*tokens[2])
+    
+    def min(self, tokens):
+        return sympy.Min(*tokens[2])
+    
+    def max(self, tokens):
+        return sympy.Max(*tokens[2])
 
     def sin(self, tokens):
         return sympy.sin(tokens[1])

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -392,7 +392,9 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\min(a, b)", _Min(a, b)),
     (r"\min(a, b, c - d, xy)", _Min(a, b, c - d, x * y)),
     (r"\max(a, b)", _Max(a, b)),
-    (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y))
+    (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y)),
+    (r"\langle x |", Bra('x')),
+    (r"| x \rangle", Ket('x')) # physics things don't have an `evaluate=False` variant
 ]
 
 EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
@@ -422,7 +424,9 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\min(a, b)", Min(a, b)),
     (r"\min(a, b, c - d, xy)", Min(a, b, c - d, x * y)),
     (r"\max(a, b)", Max(a, b)),
-    (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y))
+    (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y)),
+    (r"\langle x |", Bra('x')),
+    (r"| x \rangle", Ket('x'))
 ]
 
 SPACING_RELATED_EXPRESSION_PAIRS = [
@@ -460,8 +464,6 @@ MISCELLANEOUS_EXPRESSION_PAIRS = [
     (r"\left(x + y\right) z", _Mul(_Add(x, y), z)),
     (r"\left( x + y\right ) z", _Mul(_Add(x, y), z)),
     (r"\left(  x + y\right ) z", _Mul(_Add(x, y), z)),
-    (r"\langle x |", Bra('x')),
-    (r"| x \rangle", Ket('x')),
 ]
 
 

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -16,14 +16,14 @@ from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.integers import ceiling, floor
-from sympy.functions.elementary.miscellaneous import root, sqrt
+from sympy.functions.elementary.miscellaneous import root, sqrt, Min, Max
 from sympy.functions.elementary.trigonometric import asin, cos, csc, sec, sin, tan
 from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum.state import Bra, Ket
-from sympy.abc import x, y, z, a, b, c, t, k, n
+from sympy.abc import x, y, z, a, b, c, d, t, k, n
 
 lark = import_module("lark")
 
@@ -58,6 +58,12 @@ def _Conjugate(a):
 
 def _Abs(a):
     return Abs(a, evaluate=False)
+
+def _Min(*args):
+    return Min(*args, evaluate=False)
+
+def _Max(*args):
+    return Max(*args, evaluate=False)
 
 
 def _factorial(a):
@@ -382,7 +388,11 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{z}", _Conjugate(z)),
     (r"\overline{\overline{z}}", _Conjugate(_Conjugate(z))),
     (r"\overline{x + y}", _Conjugate(_Add(x, y))),
-    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y))
+    (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
+    (r"\min(a, b)", _Min(a, b)),
+    (r"\min(a, b, c - d, xy)", _Min(a, b, c - d, x * y)),
+    (r"\max(a, b)", _Max(a, b)),
+    (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y))
 ]
 
 EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
@@ -408,7 +418,11 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{z}", conjugate(z)),
     (r"\overline{\overline{z}}", conjugate(conjugate(z))),
     (r"\overline{x + y}", conjugate(x + y)),
-    (r"\overline{x} + \overline{y}", conjugate(x) + conjugate(y))
+    (r"\overline{x} + \overline{y}", conjugate(x) + conjugate(y)),
+    (r"\min(a, b)", Min(a, b)),
+    (r"\min(a, b, c - d, xy)", Min(a, b, c - d, x * y)),
+    (r"\max(a, b)", Max(a, b)),
+    (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y))
 ]
 
 SPACING_RELATED_EXPRESSION_PAIRS = [

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -22,7 +22,7 @@ from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
-from sympy.physics.quantum.state import Bra, Ket
+from sympy.physics.quantum import Bra, Ket, InnerProduct
 from sympy.abc import x, y, z, a, b, c, d, t, k, n
 
 lark = import_module("lark")
@@ -393,8 +393,10 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\min(a, b, c - d, xy)", _Min(a, b, c - d, x * y)),
     (r"\max(a, b)", _Max(a, b)),
     (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y)),
+    # physics things don't have an `evaluate=False` variant
     (r"\langle x |", Bra('x')),
-    (r"| x \rangle", Ket('x')) # physics things don't have an `evaluate=False` variant
+    (r"| x \rangle", Ket('x')),
+    (r"\langle x | y \rangle", InnerProduct(Bra('x'), Ket('y'))),
 ]
 
 EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
@@ -426,7 +428,8 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\max(a, b)", Max(a, b)),
     (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y)),
     (r"\langle x |", Bra('x')),
-    (r"| x \rangle", Ket('x'))
+    (r"| x \rangle", Ket('x')),
+    (r"\langle x | y \rangle", InnerProduct(Bra('x'), Ket('y'))),
 ]
 
 SPACING_RELATED_EXPRESSION_PAIRS = [


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses #19127 for the Lark-based LaTeX parser.

#### Brief description of what is fixed or changed
I added support for Min and Max in the Lark-based LaTeX parser. I also took this opportunity to add support for Bra and Ket notation.

#### Other comments
cc @sylee957 and @Upabjojr for review.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * The Lark-based parser now supports Min, Max, and Bra and Ket.
<!-- END RELEASE NOTES -->
