### PR TITLE
Implemented first-order activation dynamics in `sympy.physics._biomechanics`

### DIFF
--- a/sympy/physics/_biomechanics/__init__.py
+++ b/sympy/physics/_biomechanics/__init__.py
@@ -8,6 +8,7 @@ musculoskeletal models involding musculotendons and activation dynamics.
 
 from .activation import (
    ActivationBase,
+   FirstOrderActivationDeGroote2016,
    ZerothOrderActivation,
 )
 from .curve import (
@@ -31,5 +32,6 @@ __all__ = [
 
    # Activation dynamics classes
    'ActivationBase',
+   'FirstOrderActivationDeGroote2016',
    'ZerothOrderActivation',
 ]

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -237,6 +237,14 @@ class ActivationBase(ABC, _NamedMixin):
         """
         pass
 
+    def __eq__(self, other):
+        """Equality check for activation dynamics."""
+        if type(self) != type(other):
+            return False
+        if self.name != other.name:
+            return False
+        return True
+
     def __repr__(self):
         """Default representation of activation dynamics."""
         return f'{self.__class__.__name__}({self.name!r})'

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -625,3 +625,38 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return self._tau_d
+
+    @property
+    def smoothing_rate(self):
+        """Smoothing constant for the hyperbolic tangent term.
+
+        Explanation
+        ===========
+
+        The alias ``b`` can also be used to access the same attribute.
+
+        """
+        return self._b
+
+    @smoothing_rate.setter
+    def smoothing_rate(self, b):
+        if hasattr(self, '_b'):
+            msg = (
+                f'Can\'t set attribute `smoothing_rate` to {b!r} as it is '
+                f'immutable and already has value {self._b!r}.'
+            )
+            raise AttributeError(msg)
+        self._b = Symbol(f'b_{self.name}') if b is None else b
+
+    @property
+    def b(self):
+        """Smoothing constant for the hyperbolic tangent term.
+
+        Explanation
+        ===========
+
+        The alias ``smoothing_rate`` can also be used to access the same
+        attribute.
+
+        """
+        return self._b

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -495,3 +495,35 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
            engineering, 44(10), (2016) pp. 2922-2936
 
     """
+
+    def __init__(self,
+        name,
+        activation_time_constant=None,
+        deactivation_time_constant=None,
+        smoothing_rate=None,
+    ):
+        """Initializer for ``FirstOrderActivationDeGroote2016``.
+
+        Parameters
+        ==========
+        activation time constant : Symbol | Number | None
+            The value of the activation time constant governing the delay
+            between excitation and activation when excitation exceeds
+            activation.
+        deactivation time constant : Symbol | Number | None
+            The value of the deactivation time constant governing the delay
+            between excitation and activation when activation exceeds
+            excitation.
+        smoothing_rate : Symbol | Number | None
+            The slope of the hyperbolic tangent function used to smooth between
+            the switching of the equations where excitation exceed activation
+            and where activation exceeds excitation. The recommended value to
+            use is ``10``, but values between ``0.1`` and ``100`` can be used.
+
+        """
+        super().__init__(name)
+
+        # Symbols
+        self.activation_time_constant = activation_time_constant
+        self.deactivation_time_constant = deactivation_time_constant
+        self.smoothing_rate = smoothing_rate

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -807,3 +807,12 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
         if self_attrs == other_attrs:
             return True
         return False
+
+    def __repr__(self):
+        """Representation of ``FirstOrderActivationDeGroote2016``."""
+        return (
+            f'{self.__class__.__name__}({self.name!r}, '
+            f'activation_time_constant={self.tau_a!r}, '
+            f'deactivation_time_constant={self.tau_d!r}, '
+            f'smoothing_rate={self.b!r})'
+        )

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -553,3 +553,39 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
         tau_d = Float('0.060')
         b = Integer(10)
         return cls(name, tau_a, tau_d, b)
+
+    @property
+    def activation_time_constant(self):
+        """Delay constant for activation.
+
+        Explanation
+        ===========
+
+        The alias ```tau_a`` can also be used to access the same attribute.
+
+        """
+        return self._tau_a
+
+    @activation_time_constant.setter
+    def activation_time_constant(self, tau_a):
+        if hasattr(self, '_tau_a'):
+            msg = (
+                f'Can\'t set attribute `activation_time_constant` to '
+                f'{repr(tau_a)} as it is immutable and already has value '
+                f'{self._tau_a}.'
+            )
+            raise AttributeError(msg)
+        self._tau_a = Symbol(f'tau_a_{self.name}') if tau_a is None else tau_a
+
+    @property
+    def tau_a(self):
+        """Delay constant for activation.
+
+        Explanation
+        ===========
+
+        The alias ``activation_time_constant`` can also be used to access the
+        same attribute.
+
+        """
+        return self._tau_a

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -11,7 +11,11 @@ level, can be modeled by the models present in this module.
 """
 
 from abc import ABC, abstractmethod
+from functools import cached_property
 
+from sympy.core.symbol import Symbol
+from sympy.core.numbers import Float, Integer, Rational
+from sympy.functions.elementary.hyperbolic import tanh
 from sympy.matrices import Matrix
 from sympy.matrices.dense import zeros
 from sympy.physics._biomechanics._mixin import _NamedMixin
@@ -527,3 +531,25 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
         self.activation_time_constant = activation_time_constant
         self.deactivation_time_constant = deactivation_time_constant
         self.smoothing_rate = smoothing_rate
+
+    @classmethod
+    def with_default_constants(cls, name):
+        """Alternate constructor that will use the published constants.
+
+        Explanation
+        ===========
+
+        Returns an instance of ``FirstOrderActivationDeGroote2016`` using the
+        three constant values specified in the original publication.
+
+        These have the values:
+
+        $tau_a = 0.015$
+        $tau_d = 0.060$
+        $b = 10$
+
+        """
+        tau_a = Float('0.015')
+        tau_d = Float('0.060')
+        b = Integer(10)
+        return cls(name, tau_a, tau_d, b)

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -445,7 +445,7 @@ class ZerothOrderActivation(ActivationBase):
         return zeros(0, 1)
 
     def rhs(self):
-        """
+        """Ordered column matrix of equations for the solution of ``M x' = F``.
 
         Explanation
         ===========

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -660,3 +660,8 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return self._b
+
+    @property
+    def order(self):
+        """Order of the (differential) equation governing activation."""
+        return 1

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -45,6 +45,13 @@ class ActivationBase(ABC, _NamedMixin):
         self._e = dynamicsymbols(f"e_{name}")
         self._a = dynamicsymbols(f"a_{name}")
 
+    @classmethod
+    @abstractmethod
+    def with_default_constants(cls, name):
+        """Alternate constructor that provides recommended defaults for
+        constants."""
+        pass
+
     @property
     def excitation(self):
         """Dynamic symbol representing excitation.
@@ -267,6 +274,22 @@ class ZerothOrderActivation(ActivationBase):
         # Zeroth-order activation dynamics has activation equal excitation so
         # overwrite the symbol for activation with the excitation symbol.
         self._a = self._e
+
+    @classmethod
+    def with_default_constants(cls, name):
+        """Alternate constructor that provides recommended defaults for
+        constants.
+
+        Explanation
+        ===========
+
+        As this concrete class doesn't implement any constants associated with
+        its dynamics, this ``classmethod`` simply creates a standard instance
+        of ``ZerothOrderActivation``. An implementation is provided to ensure
+        a consistent interface between all ``ActivationBase`` concrete classes.
+
+        """
+        return cls(name)
 
     @property
     def order(self):

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -20,6 +20,7 @@ from sympy.physics.mechanics import dynamicsymbols
 
 __all__ = [
     'ActivationBase',
+    'FirstOrderActivationDeGroote2016',
     'ZerothOrderActivation',
 ]
 
@@ -429,3 +430,7 @@ class ZerothOrderActivation(ActivationBase):
 
         """
         return zeros(0, 1)
+
+
+class FirstOrderActivationDeGroote2016(ActivationBase):
+    pass

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -464,4 +464,34 @@ class ZerothOrderActivation(ActivationBase):
 
 
 class FirstOrderActivationDeGroote2016(ActivationBase):
-    pass
+    r"""First-order activation dynamics based on De Groote et al., 2016 [1].
+
+    Explanation
+    ===========
+
+    Gives the first-order activation dynamics equation for the rate of change
+    of activation with respect to time as a function of excitation and
+    activation.
+
+    The function is defined by the equation:
+
+    $\frac{da}{dt} = \left(\frac{\frac{1}{2} + a0}{\tau_a \left(\frac{1}{2}
+        + \frac{3a}{2}\right)} + \frac{\left(\frac{1}{2}
+        + \frac{3a}{2}\right) \left(\frac{1}{2} - a0\right)}{\tau_d}\right)
+        \left(e - a\right)$
+
+    where
+
+    $a0 = \frac{\tanh{\left(b \left(e - a\right) \right)}}{2}$
+
+    with constant values of $tau_a = 0.015$, $tau_d = 0.060$, and $b = 10$.
+
+    References
+    ==========
+
+    .. [1] De Groote, F., Kinney, A. L., Rao, A. V., & Fregly, B. J., Evaluation
+           of direct collocation optimal control problem formulations for
+           solving the muscle redundancy problem, Annals of biomedical
+           engineering, 44(10), (2016) pp. 2922-2936
+
+    """

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -589,3 +589,39 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return self._tau_a
+
+    @property
+    def deactivation_time_constant(self):
+        """Delay constant for deactivation.
+
+        Explanation
+        ===========
+
+        The alias ``tau_d`` can also be used to access the same attribute.
+
+        """
+        return self._tau_d
+
+    @deactivation_time_constant.setter
+    def deactivation_time_constant(self, tau_d):
+        if hasattr(self, '_tau_d'):
+            msg = (
+                f'Can\'t set attribute `deactivation_time_constant` to '
+                f'{repr(tau_d)} as it is immutable and already has value '
+                f'{self._tau_d}.'
+            )
+            raise AttributeError(msg)
+        self._tau_d = Symbol(f'tau_d_{self.name}') if tau_d is None else tau_d
+
+    @property
+    def tau_d(self):
+        """Delay constant for deactivation.
+
+        Explanation
+        ===========
+
+        The alias ``deactivation_time_constant`` can also be used to access the
+        same attribute.
+
+        """
+        return self._tau_d

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -59,7 +59,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `e` can also be used to access the same attribute.
+        The alias ``e`` can also be used to access the same attribute.
 
         """
         return self._e
@@ -71,7 +71,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `excitation` can also be used to access the same attribute.
+        The alias ``excitation`` can also be used to access the same attribute.
 
         """
         return self._e
@@ -83,7 +83,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `a` can also be used to access the same attribute.
+        The alias ``a`` can also be used to access the same attribute.
 
         """
         return self._a
@@ -95,7 +95,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `activation` can also be used to access the same attribute.
+        The alias ``activation`` can also be used to access the same attribute.
 
         """
         return self._a
@@ -115,7 +115,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `x` can also be used to access the same attribute.
+        The alias ``x`` can also be used to access the same attribute.
 
         """
         pass
@@ -129,7 +129,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `state_vars` can also be used to access the same attribute.
+        The alias ``state_vars`` can also be used to access the same attribute.
 
         """
         pass
@@ -143,7 +143,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `r` can also be used to access the same attribute.
+        The alias ``r`` can also be used to access the same attribute.
 
         """
         pass
@@ -157,7 +157,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `input_vars` can also be used to access the same attribute.
+        The alias ``input_vars`` can also be used to access the same attribute.
 
         """
         pass
@@ -171,7 +171,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `p` can also be used to access the same attribute.
+        The alias ``p`` can also be used to access the same attribute.
 
         """
         pass
@@ -185,7 +185,7 @@ class ActivationBase(ABC, _NamedMixin):
         Explanation
         ===========
 
-        The alias `constants` can also be used to access the same attribute.
+        The alias ``constants`` can also be used to access the same attribute.
 
         """
         pass
@@ -316,7 +316,7 @@ class ZerothOrderActivation(ActivationBase):
         activation, this class has no associated state variables and so this
         property return an empty column ``Matrix`` with shape (0, 1).
 
-        The alias `x` can also be used to access the same attribute.
+        The alias ``x`` can also be used to access the same attribute.
 
         """
         return zeros(0, 1)
@@ -333,7 +333,7 @@ class ZerothOrderActivation(ActivationBase):
         activation, this class has no associated state variables and so this
         property return an empty column ``Matrix`` with shape (0, 1).
 
-        The alias `state_vars` can also be used to access the same attribute.
+        The alias ``state_vars`` can also be used to access the same attribute.
 
         """
         return zeros(0, 1)
@@ -350,7 +350,7 @@ class ZerothOrderActivation(ActivationBase):
         this property returns a column ``Matrix`` with one entry, ``e``, and
         shape (1, 1).
 
-        The alias `r` can also be used to access the same attribute.
+        The alias ``r`` can also be used to access the same attribute.
 
         """
         return Matrix([self._e])
@@ -367,7 +367,7 @@ class ZerothOrderActivation(ActivationBase):
         this property returns a column ``Matrix`` with one entry, ``e``, and
         shape (1, 1).
 
-        The alias `input_vars` can also be used to access the same attribute.
+        The alias ``input_vars`` can also be used to access the same attribute.
 
         """
         return Matrix([self._e])
@@ -384,7 +384,7 @@ class ZerothOrderActivation(ActivationBase):
         activation, this class has no associated constants and so this property
         return an empty column ``Matrix`` with shape (0, 1).
 
-        The alias `p` can also be used to access the same attribute.
+        The alias ``p`` can also be used to access the same attribute.
 
         """
         return zeros(0, 1)
@@ -401,7 +401,7 @@ class ZerothOrderActivation(ActivationBase):
         activation, this class has no associated constants and so this property
         return an empty column ``Matrix`` with shape (0, 1).
 
-        The alias `constants` can also be used to access the same attribute.
+        The alias ``constants`` can also be used to access the same attribute.
 
         """
         return zeros(0, 1)

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -797,3 +797,13 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
         a3 = a1 * (HALF - a0) / self._tau_d
         activation_dynamics_equation = (a2 + a3) * (self._e - self._a)
         return activation_dynamics_equation
+
+    def __eq__(self, other):
+        """Equality check for ``FirstOrderActivationDeGroote2016``."""
+        if type(self) != type(other):
+            return False
+        self_attrs = (self.name, self.tau_a, self.tau_d, self.b)
+        other_attrs = (other.name, other.tau_a, other.tau_d, other.b)
+        if self_attrs == other_attrs:
+            return True
+        return False

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -691,3 +691,29 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return Matrix([self._a])
+
+    @property
+    def input_vars(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        The alias ``r`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._e])
+
+    @property
+    def r(self):
+        """Ordered column matrix of functions of time that represent the input
+        variables.
+
+        Explanation
+        ===========
+
+        The alias ``input_vars`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._e])

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -665,3 +665,29 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
     def order(self):
         """Order of the (differential) equation governing activation."""
         return 1
+
+    @property
+    def state_vars(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        The alias ``x`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._a])
+
+    @property
+    def x(self):
+        """Ordered column matrix of functions of time that represent the state
+        variables.
+
+        Explanation
+        ===========
+
+        The alias ``state_vars`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._a])

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -717,3 +717,29 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return Matrix([self._e])
+
+    @property
+    def constants(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        The alias ``p`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._tau_a, self._tau_d, self._b])
+
+    @property
+    def p(self):
+        """Ordered column matrix of non-time varying symbols present in ``M``
+        and ``F``.
+
+        Explanation
+        ===========
+
+        The alias ``constants`` can also be used to access the same attribute.
+
+        """
+        return Matrix([self._tau_a, self._tau_d, self._b])

--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -743,3 +743,57 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
 
         """
         return Matrix([self._tau_a, self._tau_d, self._b])
+
+    @property
+    def M(self):
+        """Ordered square matrix of coefficients on the LHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The square matrix that forms part of the LHS of the linear system of
+        ordinary differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        return Matrix([Integer(1)])
+
+    @property
+    def F(self):
+        """Ordered column matrix of equations on the RHS of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The column matrix that forms the RHS of the linear system of ordinary
+        differential equations governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        return Matrix([self._da_eqn])
+
+    def rhs(self):
+        """Ordered column matrix of equations for the solution of ``M x' = F``.
+
+        Explanation
+        ===========
+
+        The solution to the linear system of ordinary differential equations
+        governing the activation dynamics:
+
+        ``M(x, r, t, p) x' = F(x, r, t, p)``.
+
+        """
+        return Matrix([self._da_eqn])
+
+    @cached_property
+    def _da_eqn(self):
+        HALF = Rational(1, 2)
+        a0 = HALF * tanh(self._b * (self._e - self._a))
+        a1 = (HALF + Rational(3, 2) * self._a)
+        a2 = (HALF + a0) / (self._tau_a * a1)
+        a3 = a1 * (HALF - a0) / self._tau_d
+        activation_dynamics_equation = (a2 + a3) * (self._e - self._a)
+        return activation_dynamics_equation

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -30,6 +30,11 @@ class TestZerothOrderActivation:
         instance = ZerothOrderActivation(self.name)
         assert isinstance(instance, ZerothOrderActivation)
 
+    def test_with_default_constants(self):
+        instance = ZerothOrderActivation.with_default_constants(self.name)
+        assert isinstance(instance, ZerothOrderActivation)
+        assert instance == ZerothOrderActivation(self.name)
+
     def test_name_attribute(self):
         assert hasattr(self.instance, 'name')
         assert self.instance.name == self.name

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -2,14 +2,19 @@
 
 import pytest
 
+from sympy.core.backend import Symbol
+from sympy.core.numbers import Float, Integer, Rational
+from sympy.functions.elementary.hyperbolic import tanh
 from sympy.matrices import Matrix
 from sympy.matrices.dense import zeros
 from sympy.physics.mechanics import dynamicsymbols
 from sympy.physics._biomechanics import (
     ActivationBase,
+    FirstOrderActivationDeGroote2016,
     ZerothOrderActivation,
 )
 from sympy.physics._biomechanics._mixin import _NamedMixin
+from sympy.simplify.simplify import simplify
 
 
 class TestZerothOrderActivation:
@@ -119,4 +124,225 @@ class TestZerothOrderActivation:
 
     def test_repr(self):
         expected = 'ZerothOrderActivation(\'name\')'
+        assert repr(self.instance) == expected
+
+
+class TestFirstOrderActivationDeGroote2016:
+
+    @staticmethod
+    def test_class():
+        assert issubclass(FirstOrderActivationDeGroote2016, ActivationBase)
+        assert issubclass(FirstOrderActivationDeGroote2016, _NamedMixin)
+        assert FirstOrderActivationDeGroote2016.__name__ == 'FirstOrderActivationDeGroote2016'
+
+    @pytest.fixture(autouse=True)
+    def _first_order_activation_de_groote_2016_fixture(self):
+        self.name = 'name'
+        self.e = dynamicsymbols('e_name')
+        self.a = dynamicsymbols('a_name')
+        self.tau_a = Symbol('tau_a')
+        self.tau_d = Symbol('tau_d')
+        self.b = Symbol('b')
+        self.instance = FirstOrderActivationDeGroote2016(
+            self.name,
+            self.tau_a,
+            self.tau_d,
+            self.b,
+        )
+
+    def test_instance(self):
+        instance = FirstOrderActivationDeGroote2016(self.name)
+        assert isinstance(instance, FirstOrderActivationDeGroote2016)
+
+    def test_with_default_constants(self):
+        instance = FirstOrderActivationDeGroote2016.with_default_constants(self.name)
+        assert isinstance(instance, FirstOrderActivationDeGroote2016)
+        assert instance.tau_a == Float('0.015')
+        assert instance.activation_time_constant == Float('0.015')
+        assert instance.tau_d == Float('0.060')
+        assert instance.deactivation_time_constant == Float('0.060')
+        assert instance.b == Integer(10)
+        assert instance.smoothing_rate == Integer(10)
+
+    def test_name(self):
+        assert hasattr(self.instance, 'name')
+        assert self.instance.name == self.name
+
+    def test_order(self):
+        assert hasattr(self.instance, 'order')
+        assert self.instance.order == 1
+
+    def test_excitation(self):
+        assert hasattr(self.instance, 'e')
+        assert hasattr(self.instance, 'excitation')
+        e_expected = dynamicsymbols('e_name')
+        assert self.instance.e == e_expected
+        assert self.instance.excitation == e_expected
+        assert self.instance.e is self.instance.excitation
+
+    def test_excitation_is_immutable(self):
+        with pytest.raises(AttributeError):
+            self.instance.e = None
+        with pytest.raises(AttributeError):
+            self.instance.excitation = None
+
+    def test_activation(self):
+        assert hasattr(self.instance, 'a')
+        assert hasattr(self.instance, 'activation')
+        a_expected = dynamicsymbols('a_name')
+        assert self.instance.a == a_expected
+        assert self.instance.activation == a_expected
+
+    def test_activation_is_immutable(self):
+        with pytest.raises(AttributeError):
+            self.instance.a = None
+        with pytest.raises(AttributeError):
+            self.instance.activation = None
+
+    @pytest.mark.parametrize(
+        'tau_a, expected',
+        [
+            (None, Symbol('tau_a_name')),
+            (Symbol('tau_a'), Symbol('tau_a')),
+            (Float('0.015'), Float('0.015')),
+        ]
+    )
+    def test_activation_time_constant(self, tau_a, expected):
+        instance = FirstOrderActivationDeGroote2016(
+            'name', activation_time_constant=tau_a,
+        )
+        assert instance.tau_a == expected
+        assert instance.activation_time_constant == expected
+        assert instance.tau_a is instance.activation_time_constant
+
+    def test_activation_time_constant_is_immutable(self):
+        with pytest.raises(AttributeError):
+            self.instance.tau_a = None
+        with pytest.raises(AttributeError):
+            self.instance.activation_time_constant = None
+
+    @pytest.mark.parametrize(
+        'tau_d, expected',
+        [
+            (None, Symbol('tau_d_name')),
+            (Symbol('tau_d'), Symbol('tau_d')),
+            (Float('0.060'), Float('0.060')),
+        ]
+    )
+    def test_deactivation_time_constant(self, tau_d, expected):
+        instance = FirstOrderActivationDeGroote2016(
+            'name', deactivation_time_constant=tau_d,
+        )
+        assert instance.tau_d == expected
+        assert instance.deactivation_time_constant == expected
+        assert instance.tau_d is instance.deactivation_time_constant
+
+    def test_deactivation_time_constant_is_immutable(self):
+        with pytest.raises(AttributeError):
+            self.instance.tau_d = None
+        with pytest.raises(AttributeError):
+            self.instance.deactivation_time_constant = None
+
+    @pytest.mark.parametrize(
+        'b, expected',
+        [
+            (None, Symbol('b_name')),
+            (Symbol('b'), Symbol('b')),
+            (Integer('10'), Integer('10')),
+        ]
+    )
+    def test_smoothing_rate(self, b, expected):
+        instance = FirstOrderActivationDeGroote2016(
+            'name', smoothing_rate=b,
+        )
+        assert instance.b == expected
+        assert instance.smoothing_rate == expected
+        assert instance.b is instance.smoothing_rate
+
+    def test_smoothing_rate_is_immutable(self):
+        with pytest.raises(AttributeError):
+            self.instance.b = None
+        with pytest.raises(AttributeError):
+            self.instance.smoothing_rate = None
+
+    def test_state_vars(self):
+        assert hasattr(self.instance, 'x')
+        assert hasattr(self.instance, 'state_vars')
+        assert self.instance.x == self.instance.state_vars
+        x_expected = Matrix([self.a])
+        assert self.instance.x == x_expected
+        assert self.instance.state_vars == x_expected
+        assert isinstance(self.instance.x, Matrix)
+        assert isinstance(self.instance.state_vars, Matrix)
+        assert self.instance.x.shape == (1, 1)
+        assert self.instance.state_vars.shape == (1, 1)
+
+    def test_input_vars(self):
+        assert hasattr(self.instance, 'r')
+        assert hasattr(self.instance, 'input_vars')
+        assert self.instance.r == self.instance.input_vars
+        r_expected = Matrix([self.e])
+        assert self.instance.r == r_expected
+        assert self.instance.input_vars == r_expected
+        assert isinstance(self.instance.r, Matrix)
+        assert isinstance(self.instance.input_vars, Matrix)
+        assert self.instance.r.shape == (1, 1)
+        assert self.instance.input_vars.shape == (1, 1)
+
+    def test_constants(self):
+        assert hasattr(self.instance, 'p')
+        assert hasattr(self.instance, 'constants')
+        assert self.instance.p == self.instance.constants
+        p_expected = Matrix([self.tau_a, self.tau_d, self.b])
+        assert self.instance.p == p_expected
+        assert self.instance.constants == p_expected
+        assert isinstance(self.instance.p, Matrix)
+        assert isinstance(self.instance.constants, Matrix)
+        assert self.instance.p.shape == (3, 1)
+        assert self.instance.constants.shape == (3, 1)
+
+    def test_M(self):
+        assert hasattr(self.instance, 'M')
+        M_expected = Matrix([1])
+        assert self.instance.M == M_expected
+        assert isinstance(self.instance.M, Matrix)
+        assert self.instance.M.shape == (1, 1)
+
+    def test_F(self):
+        assert hasattr(self.instance, 'F')
+        da_expr = (
+            ((1/(self.tau_a*(Rational(1, 2) + Rational(3, 2)*self.a)))
+            *(Rational(1, 2) + Rational(1, 2)*tanh(self.b*(self.e - self.a)))
+            + ((Rational(1, 2) + Rational(3, 2)*self.a)/self.tau_d)
+            *(Rational(1, 2) - Rational(1, 2)*tanh(self.b*(self.e - self.a))))
+            *(self.e - self.a)
+        )
+        F_expected = Matrix([da_expr])
+        assert self.instance.F == F_expected
+        assert isinstance(self.instance.F, Matrix)
+        assert self.instance.F.shape == (1, 1)
+
+    def test_rhs(self):
+        assert hasattr(self.instance, 'rhs')
+        da_expr = (
+            ((1/(self.tau_a*(Rational(1, 2) + Rational(3, 2)*self.a)))
+            *(Rational(1, 2) + Rational(1, 2)*tanh(self.b*(self.e - self.a)))
+            + ((Rational(1, 2) + Rational(3, 2)*self.a)/self.tau_d)
+            *(Rational(1, 2) - Rational(1, 2)*tanh(self.b*(self.e - self.a))))
+            *(self.e - self.a)
+        )
+        rhs_expected = Matrix([da_expr])
+        rhs = self.instance.rhs()
+        assert rhs == rhs_expected
+        assert isinstance(rhs, Matrix)
+        assert rhs.shape == (1, 1)
+        assert simplify(self.instance.M.solve(self.instance.F) - rhs) == zeros(1)
+
+    def test_repr(self):
+        expected = (
+            'FirstOrderActivationDeGroote2016(\'name\', '
+            'activation_time_constant=tau_a, '
+            'deactivation_time_constant=tau_d, '
+            'smoothing_rate=b)'
+        )
         assert repr(self.instance) == expected

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -35,15 +35,15 @@ class TestZerothOrderActivation:
         assert isinstance(instance, ZerothOrderActivation)
         assert instance == ZerothOrderActivation(self.name)
 
-    def test_name_attribute(self):
+    def test_name(self):
         assert hasattr(self.instance, 'name')
         assert self.instance.name == self.name
 
-    def test_order_attribute(self):
+    def test_order(self):
         assert hasattr(self.instance, 'order')
         assert self.instance.order == 0
 
-    def test_excitation_attribute(self):
+    def test_excitation(self):
         assert hasattr(self.instance, 'e')
         assert hasattr(self.instance, 'excitation')
         e_expected = dynamicsymbols('e_name')
@@ -51,7 +51,7 @@ class TestZerothOrderActivation:
         assert self.instance.excitation == e_expected
         assert self.instance.e is self.instance.excitation
 
-    def test_activation_attribute(self):
+    def test_activation(self):
         assert hasattr(self.instance, 'a')
         assert hasattr(self.instance, 'activation')
         a_expected = dynamicsymbols('e_name')
@@ -59,7 +59,7 @@ class TestZerothOrderActivation:
         assert self.instance.activation == a_expected
         assert self.instance.a is self.instance.activation is self.instance.e
 
-    def test_state_vars_attribute(self):
+    def test_state_vars(self):
         assert hasattr(self.instance, 'x')
         assert hasattr(self.instance, 'state_vars')
         assert self.instance.x == self.instance.state_vars
@@ -71,7 +71,7 @@ class TestZerothOrderActivation:
         assert self.instance.x.shape == (0, 1)
         assert self.instance.state_vars.shape == (0, 1)
 
-    def test_input_vars_attribute(self):
+    def test_input_vars(self):
         assert hasattr(self.instance, 'r')
         assert hasattr(self.instance, 'input_vars')
         assert self.instance.r == self.instance.input_vars
@@ -83,7 +83,7 @@ class TestZerothOrderActivation:
         assert self.instance.r.shape == (1, 1)
         assert self.instance.input_vars.shape == (1, 1)
 
-    def test_constants_attribute(self):
+    def test_constants(self):
         assert hasattr(self.instance, 'p')
         assert hasattr(self.instance, 'constants')
         assert self.instance.p == self.instance.constants
@@ -95,14 +95,14 @@ class TestZerothOrderActivation:
         assert self.instance.p.shape == (0, 1)
         assert self.instance.constants.shape == (0, 1)
 
-    def test_M_attribute(self):
+    def test_M(self):
         assert hasattr(self.instance, 'M')
         M_expected = Matrix([])
         assert self.instance.M == M_expected
         assert isinstance(self.instance.M, Matrix)
         assert self.instance.M.shape == (0, 0)
 
-    def test_F_attribute(self):
+    def test_F(self):
         assert hasattr(self.instance, 'F')
         F_expected = zeros(0, 1)
         assert self.instance.F == F_expected


### PR DESCRIPTION
**_This PR follows directly on from #25548 and should not be merged until #25548 has been merged._**

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240. Follows directly on from #25548.

#### Brief description of what is fixed or changed

Introduces a new concrete subclass of `ActivationBase`, `FirstOrderActivationDeGroote2016`, which implements first-order activation dynamics based on De Groote et al., 2016.

Adds activation dynamics for biomechanics. Introduces a new base class, `ActivationBase`, for different concrete activation classes to subclass, with a defined interface (abstract methods for expected properties and methods to be implemented by subclasses). Also add a concrete class `ZerothOrderActivation`, which is the simplest form of activation dynamics simply mapping excitation to activation. An implementation of first-order activation dynamics will follow in another PR shortly.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->