### PR TITLE
[GSOC 2.2.2] Update implementation to evaluate system response at given frequency.

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -818,7 +818,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         """
         return _roots(Poly(self.num, self.var), self.var)
 
-    def eval_frequency(self,other):
+    def eval_frequency(self, other):
         """
         Returns the system response at any point in the real or complex plane.
 
@@ -3223,7 +3223,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         """
         return [[element.zeros() for element in row] for row in self.doit().args[0]]
 
-    def eval_frequency(self,other):
+    def eval_frequency(self, other):
         """
         Evaluates each element of the ``TransferFunctionMatrix`` at a frequency.
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -818,6 +818,31 @@ class TransferFunction(SISOLinearTimeInvariant):
         """
         return _roots(Poly(self.num, self.var), self.var)
 
+    def eval_frequency(self,other):
+        """
+        Returns the system response at any point in the real or complex plane.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s, p, a
+        >>> from sympy.physics.control.lti import TransferFunction
+        >>> from sympy import I
+        >>> tf1 = TransferFunction(1, s**2 + 2*s + 1, s)
+        >>> omega = 0.1
+        >>> tf1.eval_frequency(I*omega)
+        1/(0.99 + 0.2*I)
+        >>> tf2 = TransferFunction(s**2, a*s + p, s)
+        >>> tf2.eval_frequency(2)
+        4/(2*a + p)
+        >>> tf2.eval_frequency(I*2)
+        -4/(2*I*a + p)
+        """
+        arg_num = self.num.subs(self.var, other)
+        arg_den = self.den.subs(self.var, other)
+        argnew = TransferFunction(arg_num, arg_den, self.var).to_expr()
+        return argnew.expand()
+
     def is_stable(self):
         """
         Returns True if the transfer function is asymptotically stable; else False.
@@ -3197,6 +3222,35 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
 
         """
         return [[element.zeros() for element in row] for row in self.doit().args[0]]
+
+    def eval_frequency(self,other):
+        """
+        Evaluates each element of the ``TransferFunctionMatrix`` at a frequency.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s
+        >>> from sympy.physics.control.lti import TransferFunction, TransferFunctionMatrix
+        >>> from sympy import I
+        >>> tf_1 = TransferFunction(3, (s + 1), s)
+        >>> tf_2 = TransferFunction(s + 6, (s + 1)*(s + 2), s)
+        >>> tf_3 = TransferFunction(s + 3, s**2 + 3*s + 2, s)
+        >>> tf_4 = TransferFunction(s**2 - 9*s + 20, s**2 + 5*s - 10, s)
+        >>> tfm_1 = TransferFunctionMatrix([[tf_1, tf_2], [tf_3, tf_4]])
+        >>> tfm_1
+        TransferFunctionMatrix(((TransferFunction(3, s + 1, s), TransferFunction(s + 6, (s + 1)*(s + 2), s)), (TransferFunction(s + 3, s**2 + 3*s + 2, s), TransferFunction(s**2 - 9*s + 20, s**2 + 5*s - 10, s))))
+        >>> tfm_1.eval_frequency(2)
+        Matrix([
+        [   1, 2/3],
+        [5/12, 3/2]])
+        >>> tfm_1.eval_frequency(I*2)
+        Matrix([
+        [   3/5 - 6*I/5,                -I],
+        [3/20 - 11*I/20, -101/74 + 23*I/74]])
+        """
+        mat = self._expr_mat.subs(self.var, other)
+        return mat.expand()
 
     def _flat(self):
         """Returns flattened list of args in TransferFunctionMatrix"""

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -3225,7 +3225,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
 
     def eval_frequency(self, other):
         """
-        Evaluates each element of the ``TransferFunctionMatrix`` at a frequency.
+        Evaluates system response of each transfer function in the ``TransferFunctionMatrix`` at any point in the real or complex plane.
 
         Examples
         ========

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -231,6 +231,12 @@ def test_TransferFunction_functions():
     assert SP4.subs({a0: -1, a1: -7}).evalf() == expect4
     assert expect4_.evalf() == expect4
 
+    # evaluate the transfer function at particular frequencies.
+    assert tf1.eval_frequency(wn) == wn**2/(wn**2 + 4*wn - 5) + 2*wn/(wn**2 + 4*wn - 5) - 3/(wn**2 + 4*wn - 5)
+    assert G1.eval_frequency(1 + I) == S(3)/25 + S(4)*I/25
+    assert G4.eval_frequency(S(5)/3) == \
+        a0*s**s/(a1*a2*s**(S(8)/3) + S(5)*a1*s/3 + 5*a2*b1*s**(S(8)/3)/3 + S(25)*b1*s/9) - 5*3**(S(1)/3)*5**(S(2)/3)*b0/(9*a1*a2*s**(S(8)/3) + 15*a1*s + 15*a2*b1*s**(S(8)/3) + 25*b1*s)
+
     # Low-frequency (or DC) gain.
     assert tf0.dc_gain() == 1
     assert tf1.dc_gain() == Rational(3, 5)
@@ -1180,6 +1186,9 @@ def test_TransferFunctionMatrix_functions():
     assert H_2.subs(k, 1) == TransferFunctionMatrix([[TransferFunction(a*p*s, s**2, s), TransferFunction(p*s, -a + s**2, s)]])
     assert H_2.subs(a, 0) == TransferFunctionMatrix([[TransferFunction(0, k*s**2, s), TransferFunction(p*s, k*s**2, s)]])
     assert H_2.subs({p: 1, k: 1, a: a0}) == TransferFunctionMatrix([[TransferFunction(a0*s, s**2, s), TransferFunction(s, -a0 + s**2, s)]])
+
+    # eval_frequency()
+    assert H_2.eval_frequency(S(1)/2 + I) == Matrix([[2*a*p/(5*k) - 4*I*a*p/(5*k), I*p/(-a*k - 3*k/4 + I*k) + p/(-2*a*k - 3*k/2 + 2*I*k)]])
 
     # transpose()
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25315 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added eval_frequency method to TransferFunction and TransferFunctionMatrix class.
<!-- END RELEASE NOTES -->
