### PR TITLE
Support generic for `Basic`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -118,6 +118,7 @@ class Basic(Printable):
         # property methods. This method will only be called for subclasses of
         # Basic but not for Basic itself so we call
         # _prepare_class_assumptions(Basic) below the class definition.
+        super().__init_subclass__()
         _prepare_class_assumptions(cls)
 
     # To be overridden with True in the appropriate subclasses

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -2,6 +2,7 @@
 of Basic or Atom."""
 
 import collections
+from typing import TypeVar, Generic
 
 from sympy.assumptions.ask import Q
 from sympy.core.basic import (Basic, Atom, as_Basic,
@@ -22,6 +23,7 @@ b1 = Basic()
 b2 = Basic(b1)
 b3 = Basic(b2)
 b21 = Basic(b2, b1)
+T = TypeVar('T')
 
 
 def test__aresame():
@@ -317,3 +319,18 @@ class MySubclass(Basic, metaclass=MyMeta):
         exec(code)
 
     assert myclasses == ['executed']
+
+
+def test_generic():
+    # https://github.com/sympy/sympy/issues/25399
+    class A(Symbol, Generic[T]):
+        pass
+
+    class B(A[T]):
+        pass
+
+    class C(Basic, Generic[T]):
+        args: tuple[T]
+
+    class D(C[Symbol]):
+        pass

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -1,6 +1,5 @@
 """This tests sympy/core/basic.py with (ideally) no reference to subclasses
 of Basic or Atom."""
-
 import collections
 from typing import TypeVar, Generic
 
@@ -327,10 +326,4 @@ def test_generic():
         pass
 
     class B(A[T]):
-        pass
-
-    class C(Basic, Generic[T]):
-        args: tuple[T]
-
-    class D(C[Symbol]):
         pass


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25399

#### Brief description of what is fixed or changed



#### Other comments

It may also not be obvious whether `super().__init_subclass__` should be put at the before or after,
so I'm picking to put before the `_prepare_class_assumptions(cls)` line

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed issue of `Basic` not subclassable with `Generic` by multiple inheritance.
<!-- END RELEASE NOTES -->
