### PR TITLE
[GSoC] Simplified Lark LaTeX parser testing framework

### DIFF
--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -25,8 +25,7 @@ from sympy.abc import x, y, z, a, b, c, t, k, n
 antlr4 = import_module("antlr4")
 
 # disable tests if antlr4-python3-runtime is not present
-if not antlr4:
-    disabled = True
+disabled = antlr4 is None
 
 theta = Symbol('theta')
 f = Function('f')

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -25,53 +25,20 @@ from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
 from sympy.abc import x, y, z, a, b, c, d, t, k, n
 
+from .test_latex import theta, f, _Add, _Mul, _Pow, _Sqrt, _Conjugate, _Abs, _factorial, _exp, _binomial
+
 lark = import_module("lark")
 
 # disable tests if lark is not present
-if not lark:
-    disabled = True
+disabled = lark is None
 
-theta = Symbol('theta')
-f = Function('f')
-
-
-# shorthand definitions
-def _Add(a, b):
-    return Add(a, b, evaluate=False)
-
-
-def _Mul(a, b):
-    return Mul(a, b, evaluate=False)
-
-
-def _Pow(a, b):
-    return Pow(a, b, evaluate=False)
-
-
-def _Sqrt(a):
-    return sqrt(a, evaluate=False)
-
-
-def _Conjugate(a):
-    return conjugate(a, evaluate=False)
-
-
-def _Abs(a):
-    return Abs(a, evaluate=False)
-
+# shorthand definitions that are only needed for the Lark LaTeX parser
 def _Min(*args):
     return Min(*args, evaluate=False)
 
+
 def _Max(*args):
     return Max(*args, evaluate=False)
-
-
-def _factorial(a):
-    return factorial(a, evaluate=False)
-
-
-def _exp(a):
-    return exp(a, evaluate=False)
 
 
 def _log(a, b=E):
@@ -79,10 +46,6 @@ def _log(a, b=E):
         return log(a, evaluate=False)
     else:
         return log(a, b, evaluate=False)
-
-
-def _binomial(n, k):
-    return binomial(n, k, evaluate=False)
 
 
 # These LaTeX strings should parse to the corresponding SymPy expression

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -587,8 +587,7 @@ def test_binomial_expressions():
     for latex_str, sympy_expr in EVALUATED_BINOMIAL_EXPRESSION_PAIRS:
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
-# sus expressions
-@XFAIL
+
 def test_miscellaneous_expressions():
     for latex_str, sympy_expr in MISCELLANEOUS_EXPRESSION_PAIRS:
         with evaluate(False):

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -4,11 +4,8 @@ from sympy.external import import_module
 
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
-from sympy.core.add import Add
 from sympy.core.function import Derivative, Function
-from sympy.core.mul import Mul
 from sympy.core.numbers import E, oo, Rational
-from sympy.core.parameters import evaluate
 from sympy.core.power import Pow
 from sympy.core.relational import GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality
 from sympy.core.symbol import Symbol

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -7,6 +7,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.function import Derivative, Function
 from sympy.core.numbers import E, oo, Rational
 from sympy.core.power import Pow
+from sympy.core.parameters import evaluate
 from sympy.core.relational import GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import binomial, factorial


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I simplified the testing framework in the tests for the Lark-based LaTeX parser. Previously, there was a lot of code duplication. I reduced code duplication greatly by reusing the shorthand definitions in `test_latex.py`, which also allowed me to cut down on the imports for `test_latex_lark.py`.

I also simplified the test disabling logic, and removed the `XFAIL` marker from a test that is now passing.

#### Other comments
cc @Upabjojr @sylee957 for review.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
