### PR TITLE
When `flint` is specified, the function of flint is used

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -173,6 +173,8 @@ elif GROUND_TYPES == 'flint':
         return flint.fmpz(x).isqrt()
 
     def is_square(x):
+        if x < 0:
+            return False
         return flint.fmpz(x).sqrtrem()[1] == 0
 
     def sqrtrem(x):

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -1,5 +1,6 @@
 import os
 from ctypes import c_long, sizeof
+from functools import reduce
 from typing import Tuple as tTuple, Type
 
 from sympy.external import import_module
@@ -44,37 +45,16 @@ __all__ = [
     # MPZ is either gmpy.mpz or int.
     'MPZ',
 
-    # Either the gmpy or the mpmath function
     'factorial',
-
-    # isqrt from gmpy or mpmath
     'sqrt',
-
-    # is_square from gmpy or mpmath
     'is_square',
-
-    # sqrtrem from gmpy or mpmath
     'sqrtrem',
-
-    # gcd from gmpy or math
     'gcd',
-
-    # lcm from gmpy or math
     'lcm',
-
-    # invert from gmpy or pow
     'invert',
-
-    # legendre from gmpy or sympy
     'legendre',
-
-    # jacobi from gmpy or sympy
     'jacobi',
-
-    # kronecker from gmpy or sympy
     'kronecker',
-
-    # iroot from gmpy or sympy
     'iroot',
 ]
 
@@ -188,14 +168,30 @@ elif GROUND_TYPES == 'flint':
     MPQ = flint.fmpq # type: ignore
 
     factorial = python_factorial
-    sqrt = python_sqrt
-    is_square = python_is_square
-    sqrtrem = python_sqrtrem
-    gcd = python_gcd
-    lcm = python_lcm
+
+    def sqrt(x):
+        return flint.fmpz(x).isqrt()
+
+    def is_square(x):
+        return flint.fmpz(x).sqrtrem()[1] == 0
+
+    def sqrtrem(x):
+        return flint.fmpz(x).sqrtrem()
+
+    def gcd(*args):
+        return reduce(flint.fmpz.gcd, args, flint.fmpz(0))
+
+    def lcm(*args):
+        return reduce(flint.fmpz.lcm, args, flint.fmpz(1))
+
     invert = python_invert
     legendre = python_legendre
-    jacobi = python_jacobi
+
+    def jacobi(x, y):
+        if y <= 0 or not y % 2:
+            raise ValueError("y should be an odd positive integer")
+        return flint.fmpz(x).jacobi(y)
+
     kronecker = python_kronecker
 
     def iroot(x, n):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25504

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
