### PR TITLE
Fixing a bug in Inverse Quantum Fourier Transform (IQFT) in pyshics.quantum module, file qft.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -959,6 +959,7 @@ Mihail Tarigradschi <m.tarigradschi@gmail.com>
 Mihir Wadwekar <m.mihirw@gmail.com>
 Mike Boyle <boyle@astro.cornell.edu>
 Mikel Rouco <mikel.mrm@gmail.com>
+Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>

--- a/sympy/physics/quantum/qft.py
+++ b/sympy/physics/quantum/qft.py
@@ -27,6 +27,8 @@ from sympy.physics.quantum.gate import (
     Gate, HadamardGate, SwapGate, OneQubitGate, CGate, PhaseGate, TGate, ZGate
 )
 
+from sympy.functions.elementary.complexes import sign
+
 __all__ = [
     'QFT',
     'IQFT',
@@ -85,7 +87,7 @@ class RkGate(OneQubitGate):
 
     def get_target_matrix(self, format='sympy'):
         if format == 'sympy':
-            return Matrix([[1, 0], [0, exp(Integer(2)*pi*I/(Integer(2)**self.k))]])
+            return Matrix([[1, 0], [0, exp(sign(self.k)*Integer(2)*pi*I/(Integer(2)**abs(self.k)))]])
         raise NotImplementedError(
             'Invalid format for the R_k gate: %r' % format)
 

--- a/sympy/physics/quantum/tests/test_qft.py
+++ b/sympy/physics/quantum/tests/test_qft.py
@@ -11,6 +11,8 @@ from sympy.physics.quantum.qubit import Qubit
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.represent import represent
 
+from sympy.functions.elementary.complexes import sign
+
 
 def test_RkGate():
     x = Symbol('x')
@@ -21,7 +23,7 @@ def test_RkGate():
     assert RkGate(3, 3) == TGate(3)
 
     assert represent(
-        RkGate(0, x), nqubits=1) == Matrix([[1, 0], [0, exp(2*I*pi/2**x)]])
+        RkGate(0, x), nqubits=1) == Matrix([[1, 0], [0, exp(sign(x)*2*pi*I/(2**abs(x)))]])
 
 
 def test_quantum_fourier():


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in RkGate function of qft.py which coused wrong result of inverse quantum Fourier transformation with a decomposition
<!-- END RELEASE NOTES -->

Hi!

I guess there is a mistake in sympy.physics.quantum.iqft.

if I run this code

```
reg = Qubit('001')
res1 = qapply(QFT(0,3).decompose()*reg)
res = qapply(IQFT(0,3).decompose()*res1)
res.evalf()
```
returns something like:
`0.25*|001> + 0.603553390593274*I*|001> + 0.603553390593274*|011> - 0.25*I*|011> + 0.25*|101> - 0.103553390593274*I*|101> - 0.103553390593274*|111> - 0.25*I*|111>`

But it is wrong. The direct and reverse Fourier transform should return the same result: `|001>`

It happens because of the mistake in RkGate():
Command `qapply(RkGate(0,-4)*Qubit('1')) ` returns `|1>` rather than `exp(-I*pi/8)*|1>`.

Problem's in line 88 of qft.py.
I propose to change `return Matrix([[1, 0], [0, exp(Integer(2)*pi*I/(Integer(2)**self.k))]])` into 
`return Matrix([[1, 0], [0, exp(sign(self.k)*Integer(2)*pi*I/(Integer(2)**abs(self.k)))]])` 
and add line `from sympy.functions.elementary.complexes import sign` above.

This change helps to get correct results:
`print(qapply(RkGate(0,-4)*Qubit('1')))` is `exp(-I*pi/8)*|1>
`


