### PR TITLE
Improved two aspects of the biomechanics API

### DIFF
--- a/sympy/physics/_biomechanics/activation.py
+++ b/sympy/physics/_biomechanics/activation.py
@@ -51,7 +51,7 @@ class ActivationBase(ABC, _NamedMixin):
 
     @classmethod
     @abstractmethod
-    def with_default_constants(cls, name):
+    def with_defaults(cls, name):
         """Alternate constructor that provides recommended defaults for
         constants."""
         pass
@@ -288,7 +288,7 @@ class ZerothOrderActivation(ActivationBase):
         self._a = self._e
 
     @classmethod
-    def with_default_constants(cls, name):
+    def with_defaults(cls, name):
         """Alternate constructor that provides recommended defaults for
         constants.
 
@@ -533,7 +533,7 @@ class FirstOrderActivationDeGroote2016(ActivationBase):
         self.smoothing_rate = smoothing_rate
 
     @classmethod
-    def with_default_constants(cls, name):
+    def with_defaults(cls, name):
         """Alternate constructor that will use the published constants.
 
         Explanation

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -92,7 +92,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``TendonForceLengthDeGroote2016`` is using
-    the ``with_default_constants`` constructor because this will automatically
+    the ``with_defaults`` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon length. We'll create a
@@ -101,7 +101,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     >>> from sympy import Symbol
     >>> from sympy.physics._biomechanics import TendonForceLengthDeGroote2016
     >>> l_T_tilde = Symbol('l_T_tilde')
-    >>> fl_T = TendonForceLengthDeGroote2016.with_default_constants(l_T_tilde)
+    >>> fl_T = TendonForceLengthDeGroote2016.with_defaults(l_T_tilde)
     >>> fl_T
     TendonForceLengthDeGroote2016(l_T_tilde, 0.2, 0.995, 0.25,
     33.93669377311689)
@@ -122,7 +122,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
 
     >>> l_T, l_T_slack = symbols('l_T l_T_slack')
     >>> l_T_tilde = l_T/l_T_slack
-    >>> fl_T = TendonForceLengthDeGroote2016.with_default_constants(l_T_tilde)
+    >>> fl_T = TendonForceLengthDeGroote2016.with_defaults(l_T_tilde)
     >>> fl_T
     TendonForceLengthDeGroote2016(l_T/l_T_slack, 0.2, 0.995, 0.25,
     33.93669377311689)
@@ -153,7 +153,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, l_T_tilde):
+    def with_defaults(cls, l_T_tilde):
         r"""Recommended constructor that will use the published constants.
 
         Explanation
@@ -330,7 +330,7 @@ class TendonForceLengthInverseDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, fl_T):
+    def with_defaults(cls, fl_T):
         r"""Recommended constructor that will use the published constants.
 
         Explanation
@@ -503,7 +503,7 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, l_M_tilde):
+    def with_defaults(cls, l_M_tilde):
         r"""Recommended constructor that will use the published constants.
 
         Explanation
@@ -671,7 +671,7 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, fl_M_pas):
+    def with_defaults(cls, fl_M_pas):
         r"""Recommended constructor that will use the published constants.
 
         Explanation
@@ -839,7 +839,7 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, l_M_tilde):
+    def with_defaults(cls, l_M_tilde):
         r"""Recommended constructor that will use the published constants.
 
         Explanation
@@ -1109,7 +1109,7 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
     """
 
     @classmethod
-    def with_default_constants(cls, v_M_tilde):
+    def with_defaults(cls, v_M_tilde):
         r"""Recommended constructor that will use the published constants.
 
         Explanation

--- a/sympy/physics/_biomechanics/musculotendon.py
+++ b/sympy/physics/_biomechanics/musculotendon.py
@@ -204,7 +204,7 @@ class MusculotendonDeGroote2016(ForceActuator, _NamedMixin):
         self._force = -self._F_T
 
     @classmethod
-    def with_default_constants(
+    def with_defaults(
         cls,
         name,
         pathway,
@@ -355,10 +355,10 @@ class MusculotendonDeGroote2016(ForceActuator, _NamedMixin):
         self._l_M_tilde = self._l_M/self._l_M_opt
         self._v_M = self._v_MT*(self._l_MT - self._l_T_slack)/self._l_M
         self._v_M_tilde = self._v_M/self._v_M_max
-        self._fl_T = TendonForceLengthDeGroote2016.with_default_constants(self._l_T_tilde)
-        self._fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self._l_M_tilde)
-        self._fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self._l_M_tilde)
-        self._fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self._v_M_tilde)
+        self._fl_T = TendonForceLengthDeGroote2016.with_defaults(self._l_T_tilde)
+        self._fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self._l_M_tilde)
+        self._fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self._l_M_tilde)
+        self._fv_M = FiberForceVelocityDeGroote2016.with_defaults(self._v_M_tilde)
         self._F_M_tilde = self.a*self._fl_M_act*self._fv_M + self._fl_M_pas + self._beta*self._v_M_tilde
         self._F_T_tilde = self._F_M_tilde
         self._F_M = self._F_M_tilde*self._F_M_max
@@ -378,15 +378,15 @@ class MusculotendonDeGroote2016(ForceActuator, _NamedMixin):
         self._l_T = self._l_MT - sqrt(self._l_M**2 - (self._l_M_opt*sin(self._alpha_opt))**2)
         self._l_T_tilde = self._l_T/self._l_T_slack
         self._cos_alpha = (self._l_MT - self._l_T)/self._l_M
-        self._fl_T = TendonForceLengthDeGroote2016.with_default_constants(self._l_T_tilde)
-        self._fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self._l_M_tilde)
-        self._fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self._l_M_tilde)
+        self._fl_T = TendonForceLengthDeGroote2016.with_defaults(self._l_T_tilde)
+        self._fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self._l_M_tilde)
+        self._fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self._l_M_tilde)
         self._F_T_tilde = self._fl_T
         self._F_T = self._F_T_tilde*self._F_M_max
         self._F_M = self._F_T/self._cos_alpha
         self._F_M_tilde = self._F_M/self._F_M_max
         self._fv_M = (self._F_M_tilde - self._fl_M_pas)/(self.a*self._fl_M_act)
-        self._v_M_tilde = FiberForceVelocityDeGroote2016.with_default_constants(self._fv_M)
+        self._v_M_tilde = FiberForceVelocityDeGroote2016.with_defaults(self._fv_M)
         self._dl_M_tilde_dt = (self._v_M_max/self._l_M_opt)*self._v_M_tilde
 
         self._state_vars = Matrix([self._l_M_tilde])

--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -35,8 +35,8 @@ class TestZerothOrderActivation:
         instance = ZerothOrderActivation(self.name)
         assert isinstance(instance, ZerothOrderActivation)
 
-    def test_with_default_constants(self):
-        instance = ZerothOrderActivation.with_default_constants(self.name)
+    def test_with_defaults(self):
+        instance = ZerothOrderActivation.with_defaults(self.name)
         assert isinstance(instance, ZerothOrderActivation)
         assert instance == ZerothOrderActivation(self.name)
 
@@ -155,8 +155,8 @@ class TestFirstOrderActivationDeGroote2016:
         instance = FirstOrderActivationDeGroote2016(self.name)
         assert isinstance(instance, FirstOrderActivationDeGroote2016)
 
-    def test_with_default_constants(self):
-        instance = FirstOrderActivationDeGroote2016.with_default_constants(self.name)
+    def test_with_defaults(self):
+        instance = FirstOrderActivationDeGroote2016.with_defaults(self.name)
         assert isinstance(instance, FirstOrderActivationDeGroote2016)
         assert instance.tau_a == Float('0.015')
         assert instance.activation_time_constant == Float('0.015')

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -116,7 +116,7 @@ class TestTendonForceLengthDeGroote2016:
         fl_T = TendonForceLengthDeGroote2016(self.l_T_tilde, *self.constants).doit(evaluate=False)
         assert fl_T == self.c0*exp(self.c3*UnevaluatedExpr(self.l_T_tilde - self.c1)) - self.c2
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Float('0.2'),
             Float('0.995'),
@@ -124,7 +124,7 @@ class TestTendonForceLengthDeGroote2016:
             Float('33.93669377311689'),
         )
         fl_T_manual = TendonForceLengthDeGroote2016(self.l_T_tilde, *constants)
-        fl_T_constants = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T_constants = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         assert fl_T_manual == fl_T_constants
 
     def test_differentiate_wrt_l_T_tilde(self):
@@ -234,23 +234,23 @@ class TestTendonForceLengthDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         assert code_printer().doprint(fl_T) == expected
 
     def test_derivative_print_code(self):
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         dfl_T_dl_T_tilde = fl_T.diff(self.l_T_tilde)
         expected = '6.787338754623378*math.exp(33.93669377311689*(l_T_tilde - 0.995))'
         assert PythonCodePrinter().doprint(dfl_T_dl_T_tilde) == expected
 
     def test_lambdify(self):
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         fl_T_callable = lambdify(self.l_T_tilde, fl_T)
         assert fl_T_callable(1.0) == pytest.approx(-0.013014055039221595)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         fl_T_callable = lambdify(self.l_T_tilde, fl_T, 'numpy')
         l_T_tilde = numpy.array([0.95, 1.0, 1.01, 1.05])
         expected = numpy.array([
@@ -263,7 +263,7 @@ class TestTendonForceLengthDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(self.l_T_tilde)
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(self.l_T_tilde)
         fl_T_callable = jax.jit(lambdify(self.l_T_tilde, fl_T, 'jax'))
         l_T_tilde = jax.numpy.array([0.95, 1.0, 1.01, 1.05])
         expected = jax.numpy.array([
@@ -305,7 +305,7 @@ class TestTendonForceLengthInverseDeGroote2016:
         fl_T_inv = TendonForceLengthInverseDeGroote2016(self.fl_T, *self.constants).doit(evaluate=False)
         assert fl_T_inv == log(UnevaluatedExpr((self.fl_T + self.c2)/self.c0))/self.c3 + self.c1
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Float('0.2'),
             Float('0.995'),
@@ -313,7 +313,7 @@ class TestTendonForceLengthInverseDeGroote2016:
             Float('33.93669377311689'),
         )
         fl_T_inv_manual = TendonForceLengthInverseDeGroote2016(self.fl_T, *constants)
-        fl_T_inv_constants = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv_constants = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         assert fl_T_inv_manual == fl_T_inv_constants
 
     def test_differentiate_wrt_fl_T(self):
@@ -423,23 +423,23 @@ class TestTendonForceLengthInverseDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         assert code_printer().doprint(fl_T_inv) == expected
 
     def test_derivative_print_code(self):
-        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         dfl_T_inv_dfl_T = fl_T_inv.diff(self.fl_T)
         expected = '1/(33.93669377311689*fl_T + 8.484173443279222)'
         assert PythonCodePrinter().doprint(dfl_T_inv_dfl_T) == expected
 
     def test_lambdify(self):
-        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         fl_T_inv_callable = lambdify(self.fl_T, fl_T_inv)
         assert fl_T_inv_callable(0.0) == pytest.approx(1.0015752885)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         fl_T_inv_callable = lambdify(self.fl_T, fl_T_inv, 'numpy')
         fl_T = numpy.array([-0.2, -0.01, 0.0, 1.01, 1.02, 1.05])
         expected = numpy.array([
@@ -454,7 +454,7 @@ class TestTendonForceLengthInverseDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_default_constants(self.fl_T)
+        fl_T_inv = TendonForceLengthInverseDeGroote2016.with_defaults(self.fl_T)
         fl_T_inv_callable = jax.jit(lambdify(self.fl_T, fl_T_inv, 'jax'))
         fl_T = jax.numpy.array([-0.2, -0.01, 0.0, 1.01, 1.02, 1.05])
         expected = jax.numpy.array([
@@ -496,13 +496,13 @@ class TestFiberForceLengthPassiveDeGroote2016:
         fl_M_pas = FiberForceLengthPassiveDeGroote2016(self.l_M_tilde, *self.constants).doit(evaluate=False)
         assert fl_M_pas == (exp((self.c1*UnevaluatedExpr(self.l_M_tilde - 1))/self.c0) - 1)/(exp(self.c1) - 1)
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Rational(3, 5),
             Integer(4),
         )
         fl_M_pas_manual = FiberForceLengthPassiveDeGroote2016(self.l_M_tilde, *constants)
-        fl_M_pas_constants = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas_constants = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         assert fl_M_pas_manual == fl_M_pas_constants
 
     def test_differentiate_wrt_l_M_tilde(self):
@@ -608,23 +608,23 @@ class TestFiberForceLengthPassiveDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         assert code_printer().doprint(fl_M_pas) == expected
 
     def test_derivative_print_code(self):
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_pas_dl_M_tilde = fl_M_pas.diff(self.l_M_tilde)
         expected = '4*math.exp((20/3)*(l_M_tilde - 1))/(-3/5 + (3/5)*math.exp(4))'
         assert PythonCodePrinter().doprint(fl_M_pas_dl_M_tilde) == expected
 
     def test_lambdify(self):
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_pas_callable = lambdify(self.l_M_tilde, fl_M_pas)
         assert fl_M_pas_callable(1.0) == pytest.approx(0.0)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_pas_callable = lambdify(self.l_M_tilde, fl_M_pas, 'numpy')
         l_M_tilde = numpy.array([0.5, 0.8, 0.9, 1.0, 1.1, 1.2, 1.5])
         expected = numpy.array([
@@ -640,7 +640,7 @@ class TestFiberForceLengthPassiveDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_pas_callable = jax.jit(lambdify(self.l_M_tilde, fl_M_pas, 'jax'))
         l_M_tilde = jax.numpy.array([0.5, 0.8, 0.9, 1.0, 1.1, 1.2, 1.5])
         expected = jax.numpy.array([
@@ -683,13 +683,13 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *self.constants).doit(evaluate=False)
         assert fl_M_pas_inv == self.c0*log(UnevaluatedExpr(self.fl_M_pas*(exp(self.c1) - 1)) + 1)/self.c1 + 1
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Rational(3, 5),
             Integer(4),
         )
         fl_M_pas_inv_manual = FiberForceLengthPassiveInverseDeGroote2016(self.fl_M_pas, *constants)
-        fl_M_pas_inv_constants = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv_constants = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         assert fl_M_pas_inv_manual == fl_M_pas_inv_constants
 
     def test_differentiate_wrt_fl_T(self):
@@ -791,23 +791,23 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         assert code_printer().doprint(fl_M_pas_inv) == expected
 
     def test_derivative_print_code(self):
-        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         dfl_M_pas_inv_dfl_T = fl_M_pas_inv.diff(self.fl_M_pas)
         expected = '(-3/5 + (3/5)*math.exp(4))/(4*fl_M_pas*(-1 + math.exp(4)) + 4)'
         assert PythonCodePrinter().doprint(dfl_M_pas_inv_dfl_T) == expected
 
     def test_lambdify(self):
-        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         fl_M_pas_inv_callable = lambdify(self.fl_M_pas, fl_M_pas_inv)
         assert fl_M_pas_inv_callable(0.0) == pytest.approx(1.0)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         fl_M_pas_inv_callable = lambdify(self.fl_M_pas, fl_M_pas_inv, 'numpy')
         fl_M_pas = numpy.array([-0.01, 0.0, 0.01, 0.02, 0.05, 0.1])
         expected = numpy.array([
@@ -822,7 +822,7 @@ class TestFiberForceLengthPassiveInverseDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_default_constants(self.fl_M_pas)
+        fl_M_pas_inv = FiberForceLengthPassiveInverseDeGroote2016.with_defaults(self.fl_M_pas)
         fl_M_pas_inv_callable = jax.jit(lambdify(self.fl_M_pas, fl_M_pas_inv, 'jax'))
         fl_M_pas = jax.numpy.array([-0.01, 0.0, 0.01, 0.02, 0.05, 0.1])
         expected = jax.numpy.array([
@@ -888,7 +888,7 @@ class TestFiberForceLengthActiveDeGroote2016:
             + self.c8*exp(-((UnevaluatedExpr(self.l_M_tilde - self.c9)/(self.c10 + self.c11*self.l_M_tilde))**2)/2)
         )
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Float('0.814'),
             Float('1.06'),
@@ -904,7 +904,7 @@ class TestFiberForceLengthActiveDeGroote2016:
             Integer(0),
         )
         fl_M_act_manual = FiberForceLengthActiveDeGroote2016(self.l_M_tilde, *constants)
-        fl_M_act_constants = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act_constants = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         assert fl_M_act_manual == fl_M_act_constants
 
     def test_differentiate_wrt_l_M_tilde(self):
@@ -1206,11 +1206,11 @@ class TestFiberForceLengthActiveDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         assert code_printer().doprint(fl_M_act) == expected
 
     def test_derivative_print_code(self):
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_act_dl_M_tilde = fl_M_act.diff(self.l_M_tilde)
         expected = (
             '(0.79798269973507 - 0.79798269973507*l_M_tilde)'
@@ -1227,13 +1227,13 @@ class TestFiberForceLengthActiveDeGroote2016:
         assert PythonCodePrinter().doprint(fl_M_act_dl_M_tilde) == expected
 
     def test_lambdify(self):
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_act_callable = lambdify(self.l_M_tilde, fl_M_act)
         assert fl_M_act_callable(1.0) == pytest.approx(0.9941398866)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_act_callable = lambdify(self.l_M_tilde, fl_M_act, 'numpy')
         l_M_tilde = numpy.array([0.0, 0.5, 1.0, 1.5, 2.0])
         expected = numpy.array([
@@ -1247,7 +1247,7 @@ class TestFiberForceLengthActiveDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(self.l_M_tilde)
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(self.l_M_tilde)
         fl_M_act_callable = jax.jit(lambdify(self.l_M_tilde, fl_M_act, 'jax'))
         l_M_tilde = jax.numpy.array([0.0, 0.5, 1.0, 1.5, 2.0])
         expected = jax.numpy.array([
@@ -1298,7 +1298,7 @@ class TestFiberForceVelocityDeGroote2016:
         )
         assert fv_M == expected
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         constants = (
             Float('-0.318'),
             Float('-8.149'),
@@ -1306,7 +1306,7 @@ class TestFiberForceVelocityDeGroote2016:
             Float('0.886'),
         )
         fv_M_manual = FiberForceVelocityDeGroote2016(self.v_M_tilde, *constants)
-        fv_M_constants = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M_constants = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         assert fv_M_manual == fv_M_constants
 
     def test_differentiate_wrt_v_M_tilde(self):
@@ -1444,23 +1444,23 @@ class TestFiberForceVelocityDeGroote2016:
         ]
     )
     def test_print_code(self, code_printer, expected):
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         assert code_printer().doprint(fv_M) == expected
 
     def test_derivative_print_code(self):
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         dfv_M_dv_M_tilde = fv_M.diff(self.v_M_tilde)
         expected = '2.591382*(1 + (-8.149*v_M_tilde - 0.374)**2)**(-1/2)'
         assert PythonCodePrinter().doprint(dfv_M_dv_M_tilde) == expected
 
     def test_lambdify(self):
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         fv_M_callable = lambdify(self.v_M_tilde, fv_M)
         assert fv_M_callable(0.0) == pytest.approx(1.002320622548512)
 
     @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
     def test_lambdify_numpy(self):
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         fv_M_callable = lambdify(self.v_M_tilde, fv_M, 'numpy')
         v_M_tilde = numpy.array([-1.0, -0.5, 0.0, 0.5])
         expected = numpy.array([
@@ -1473,7 +1473,7 @@ class TestFiberForceVelocityDeGroote2016:
 
     @pytest.mark.skipif(jax is None, reason='JAX not installed')
     def test_lambdify_jax(self):
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(self.v_M_tilde)
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(self.v_M_tilde)
         fv_M_callable = jax.jit(lambdify(self.v_M_tilde, fv_M, 'jax'))
         v_M_tilde = jax.numpy.array([-1.0, -0.5, 0.0, 0.5])
         expected = jax.numpy.array([

--- a/sympy/physics/_biomechanics/tests/test_musculotendon.py
+++ b/sympy/physics/_biomechanics/tests/test_musculotendon.py
@@ -108,7 +108,7 @@ class TestMusculotendonDeGroote2016:
         self.alpha_opt = Symbol("alpha_opt")
         self.beta = Symbol("beta")
 
-    def test_with_default_constants(self):
+    def test_with_defaults(self):
         origin = Point("pO")
         insertion = Point("pI")
         insertion.set_pos(origin, dynamicsymbols("q")*ReferenceFrame("N").x)
@@ -120,7 +120,7 @@ class TestMusculotendonDeGroote2016:
         v_M_max = Integer(10)
         alpha_opt = Integer(0)
         beta = Rational(1, 10)
-        instance = MusculotendonDeGroote2016.with_default_constants(
+        instance = MusculotendonDeGroote2016.with_defaults(
             "name",
             pathway,
             activation,
@@ -535,16 +535,16 @@ class TestMusculotendonDeGroote2016FiberLengthExplicit:
         l_MT = self.pathway.length
         l_M = self.l_M_tilde*self.l_M_opt
         l_T = l_MT - sqrt(l_M**2 - (self.l_M_opt*sin(self.alpha_opt)) ** 2)
-        fl_T = TendonForceLengthDeGroote2016.with_default_constants(
+        fl_T = TendonForceLengthDeGroote2016.with_defaults(
             l_T/self.l_T_slack
         )
-        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_default_constants(
+        fl_M_pas = FiberForceLengthPassiveDeGroote2016.with_defaults(
             self.l_M_tilde
         )
-        fl_M_act = FiberForceLengthActiveDeGroote2016.with_default_constants(
+        fl_M_act = FiberForceLengthActiveDeGroote2016.with_defaults(
             self.l_M_tilde
         )
-        fv_M = FiberForceVelocityDeGroote2016.with_default_constants(
+        fv_M = FiberForceVelocityDeGroote2016.with_defaults(
             ((((fl_T*self.F_M_max)/((l_MT - l_T)/l_M))/self.F_M_max) - fl_M_pas)
             /(self.a*fl_M_act)
         )

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -254,7 +254,7 @@ class ForceActuator(ActuatorBase):
         [(pA, c*Derivative(q(t), t)*N.x), (pB, - c*Derivative(q(t), t)*N.x)]
 
         """
-        return self.pathway.compute_loads(self.force)
+        return self.pathway.to_loads(self.force)
 
     def __repr__(self):
         """Representation of a ``ForceActuator``."""

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -67,7 +67,7 @@ class PathwayBase(ABC):
         pass
 
     @abstractmethod
-    def compute_loads(self, force):
+    def to_loads(self, force):
         """Loads required by the equations of motion method classes.
 
         Explanation
@@ -198,7 +198,7 @@ class LinearPathway(PathwayBase):
         """Exact analytical expression for the pathway's extension velocity."""
         return _point_pair_extension_velocity(*self.attachments)
 
-    def compute_loads(self, force):
+    def to_loads(self, force):
         """Loads required by the equations of motion method classes.
 
         Explanation
@@ -233,11 +233,11 @@ class LinearPathway(PathwayBase):
         Now create a symbol ``F`` to describe the magnitude of the (expansile)
         force that will be produced along the pathway. The list of loads that
         ``KanesMethod`` requires can be produced by calling the pathway's
-        ``compute_loads`` method with ``F`` passed as the only argument.
+        ``to_loads`` method with ``F`` passed as the only argument.
 
         >>> from sympy import symbols
         >>> F = symbols('F')
-        >>> linear_pathway.compute_loads(F)
+        >>> linear_pathway.to_loads(F)
         [(pA, - F*q(t)/sqrt(q(t)**2)*N.x), (pB, F*q(t)/sqrt(q(t)**2)*N.x)]
 
         Parameters
@@ -386,7 +386,7 @@ class ObstacleSetPathway(PathwayBase):
             extension_velocity += _point_pair_extension_velocity(*attachment_pair)
         return extension_velocity
 
-    def compute_loads(self, force):
+    def to_loads(self, force):
         """Loads required by the equations of motion method classes.
 
         Explanation
@@ -432,11 +432,11 @@ class ObstacleSetPathway(PathwayBase):
         Now create a symbol ``F`` to describe the magnitude of the (expansile)
         force that will be produced along the pathway. The list of loads that
         ``KanesMethod`` requires can be produced by calling the pathway's
-        ``compute_loads`` method with ``F`` passed as the only argument.
+        ``to_loads`` method with ``F`` passed as the only argument.
 
         >>> from sympy import Symbol
         >>> F = Symbol('F')
-        >>> obstacle_set_pathway.compute_loads(F)
+        >>> obstacle_set_pathway.to_loads(F)
         [(pA, sqrt(2)*F/2*A.x + sqrt(2)*F/2*A.y),
          (pB, - sqrt(2)*F/2*A.x - sqrt(2)*F/2*A.y),
          (pB, - F/sqrt(2*cos(q(t)) + 2)*A.y - F/sqrt(2*cos(q(t)) + 2)*B.y),
@@ -583,7 +583,7 @@ class WrappingPathway(PathwayBase):
         """Exact analytical expression for the pathway's extension velocity."""
         return self.length.diff(dynamicsymbols._t)
 
-    def compute_loads(self, force):
+    def to_loads(self, force):
         """Loads required by the equations of motion method classes.
 
         Explanation
@@ -634,10 +634,10 @@ class WrappingPathway(PathwayBase):
         Now create a symbol ``F`` to describe the magnitude of the (expansile)
         force that will be produced along the pathway. The list of loads that
         ``KanesMethod`` requires can be produced by calling the pathway's
-        ``compute_loads`` method with ``F`` passed as the only argument.
+        ``to_loads`` method with ``F`` passed as the only argument.
 
         >>> F = symbols('F')
-        >>> loads = pathway.compute_loads(F)
+        >>> loads = pathway.to_loads(F)
         >>> [load.__class__(load.location, load.vector.simplify()) for load in loads]
         [(pA, F*N.y), (pB, F*sin(q(t))*N.x - F*cos(q(t))*N.y),
          (pO, - F*sin(q(t))*N.x + F*(cos(q(t)) - 1)*N.y)]

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -119,13 +119,13 @@ class TestLinearPathway:
         self.pB.set_pos(self.pA, 2*self.N.x)
         assert self.pathway.extension_velocity == 0
 
-    def test_static_pathway_compute_loads(self):
+    def test_static_pathway_to_loads(self):
         self.pB.set_pos(self.pA, 2*self.N.x)
         expected = [
             (self.pA, - self.F*self.N.x),
             (self.pB, self.F*self.N.x),
         ]
-        assert self.pathway.compute_loads(self.F) == expected
+        assert self.pathway.to_loads(self.F) == expected
 
     def test_2D_pathway_length(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
@@ -145,13 +145,13 @@ class TestLinearPathway:
         expected = 2*sqrt(self.q1**2)*self.q1d/self.q1
         assert self.pathway.extension_velocity == expected
 
-    def test_2D_pathway_compute_loads(self):
+    def test_2D_pathway_to_loads(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = [
             (self.pA, - self.F*(self.q1 / sqrt(self.q1**2))*self.N.x),
             (self.pB, self.F*(self.q1 / sqrt(self.q1**2))*self.N.x),
         ]
-        assert self.pathway.compute_loads(self.F) == expected
+        assert self.pathway.to_loads(self.F) == expected
 
     def test_3D_pathway_length(self):
         self.pB.set_pos(
@@ -174,7 +174,7 @@ class TestLinearPathway:
         )
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
-    def test_3D_pathway_compute_loads(self):
+    def test_3D_pathway_to_loads(self):
         self.pB.set_pos(
             self.pA,
             self.q1*self.N.x - self.q2*self.N.y + 2*self.q3*self.N.z,
@@ -194,7 +194,7 @@ class TestLinearPathway:
             (self.pA, pO_force),
             (self.pB, pI_force),
         ]
-        assert self.pathway.compute_loads(self.F) == expected
+        assert self.pathway.to_loads(self.F) == expected
 
 
 class TestObstacleSetPathway:
@@ -300,7 +300,7 @@ class TestObstacleSetPathway:
         pathway = ObstacleSetPathway(self.pO, self.pA, self.pB, self.pI)
         assert pathway.extension_velocity == 0
 
-    def test_static_pathway_compute_loads(self):
+    def test_static_pathway_to_loads(self):
         self.pA.set_pos(self.pO, self.N.x)
         self.pB.set_pos(self.pO, self.N.y)
         self.pI.set_pos(self.pO, self.N.z)
@@ -313,7 +313,7 @@ class TestObstacleSetPathway:
             Force(self.pB, self.F * sqrt(2) / 2 * (self.N.y - self.N.z)),
             Force(self.pI, self.F * sqrt(2) / 2 * (self.N.z - self.N.y)),
         ]
-        assert pathway.compute_loads(self.F) == expected
+        assert pathway.to_loads(self.F) == expected
 
     def test_2D_pathway_length(self):
         self.pA.set_pos(self.pO, -(self.N.x + self.N.y))
@@ -339,7 +339,7 @@ class TestObstacleSetPathway:
         expected = - (sqrt(2) * sin(self.q) * self.qd) / (2 * sqrt(cos(self.q) + 1))
         assert (pathway.extension_velocity - expected).simplify() == 0
 
-    def test_2D_pathway_compute_loads(self):
+    def test_2D_pathway_to_loads(self):
         self.pA.set_pos(self.pO, -(self.N.x + self.N.y))
         self.pB.set_pos(
             self.pO, cos(self.q) * self.N.x - (sin(self.q) + 1) * self.N.y
@@ -362,7 +362,7 @@ class TestObstacleSetPathway:
             Force(self.pB, self.F * pB_pI_force_vec),
             Force(self.pI, -self.F * pB_pI_force_vec),
         ]
-        assert _simplify_loads(pathway.compute_loads(self.F)) == expected
+        assert _simplify_loads(pathway.to_loads(self.F)) == expected
 
 
 class TestWrappingPathway:
@@ -559,7 +559,7 @@ class TestWrappingPathway:
             ),
         )
     )
-    def test_static_pathway_on_sphere_compute_loads(
+    def test_static_pathway_on_sphere_to_loads(
         self,
         pA_vec,
         pB_vec,
@@ -587,7 +587,7 @@ class TestWrappingPathway:
             Force(self.pB, self.F*(self.r**3/sqrt(self.r**6))*pB_vec_expected),
             Force(self.pO, self.F*(self.r**3/sqrt(self.r**6))*pO_vec_expected),
         ]
-        assert pathway.compute_loads(self.F) == expected
+        assert pathway.to_loads(self.F) == expected
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
@@ -635,7 +635,7 @@ class TestWrappingPathway:
             ),
         )
     )
-    def test_static_pathway_on_cylinder_compute_loads(
+    def test_static_pathway_on_cylinder_to_loads(
         self,
         pA_vec,
         pB_vec,
@@ -660,7 +660,7 @@ class TestWrappingPathway:
             Force(self.pB, pB_force_expected),
             Force(self.pO, pO_force_expected),
         ]
-        assert _simplify_loads(pathway.compute_loads(self.F)) == expected
+        assert _simplify_loads(pathway.to_loads(self.F)) == expected
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_length(self):
@@ -684,7 +684,7 @@ class TestWrappingPathway:
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
     @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
-    def test_2D_pathway_on_cylinder_compute_loads(self):
+    def test_2D_pathway_on_cylinder_to_loads(self):
         q = dynamicsymbols('q')
         pA_pos = self.r*self.N.x
         pB_pos = self.r*(cos(q)*self.N.x + sin(q)*self.N.y)
@@ -700,5 +700,5 @@ class TestWrappingPathway:
             Force(self.pO, pO_force),
         ]
 
-        loads = _simplify_loads(self.pathway.compute_loads(self.F))
+        loads = _simplify_loads(self.pathway.to_loads(self.F))
         assert loads == expected


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

As per the discussion in https://github.com/sympy/sympy/pull/25525, we made two slight changes to the API:

`with_default_constants() -> with_defaults()`

`compute_loads() -> to_loads()`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
