### PR TITLE
fix to ensure lcm(0,0) = 0 in  poly setting

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1639,6 +1639,9 @@ def dup_rr_lcm(f, g, K):
     x**3 - 2*x**2 - x + 2
 
     """
+    if not f and not g:
+        return K.zero
+
     fc, f = dup_primitive(f, K)
     gc, g = dup_primitive(g, K)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2078,6 +2078,10 @@ def test_gcd():
     raises(TypeError, lambda: gcd(x))
     raises(TypeError, lambda: lcm(x))
 
+    f = Poly(0, x)
+    g = Poly(0, x)
+    assert lcm(f, g) == 0
+
 
 def test_gcd_numbers_vs_polys():
     assert isinstance(gcd(3, 9), Integer)


### PR DESCRIPTION

#### References to other Issues or PRs
Fixes #25581 


#### Brief description of what is fixed or changed
`lcm(Poly([],x), Poly([],x)) ` should be 0, but currently throws a `ZeroDivisionError`. This PR will attempt to fix that. 


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
