### PR TITLE
Fixed a bug about vector cross product

### DIFF
--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -551,7 +551,7 @@ def cross(vect1, vect2):
             n2 = vect2.args[0]
             if n1 == n2:
                 return Vector.zero
-            n3 = ({0,1,2}.difference({n1, n2})).pop()
+            n3 = ({S(0),S(1),S(2)}.difference({n1, n2})).pop()
             sign = 1 if ((n1 + 1) % 3 == n2) else -1
             return sign*vect1._sys.base_vectors()[n3]
         from .functions import express


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* vector
  * Fixed a result error during the cross product operation when two of the three basis vectors were known but no third party could be obtained. Modified the condition of how to find the remaining basis vectors in two of the known three basis vectors.
<!-- END RELEASE NOTES -->