### PR TITLE
Noncommutative symbols in `fu`

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -443,7 +443,7 @@ def TR8(rv, first=True):
             return rv
 
         args = {cos: [], sin: [], None: []}
-        for a in ordered(Mul.make_args(rv)):
+        for a in Mul.make_args(rv):
             if a.func in (cos, sin):
                 args[type(a)].append(a.args[0])
             elif (a.is_Pow and a.exp.is_Integer and a.exp > 0 and \
@@ -1074,7 +1074,7 @@ def TR13(rv):
 
         # XXX handle products of powers? or let power-reducing handle it?
         args = {tan: [], cot: [], None: []}
-        for a in ordered(Mul.make_args(rv)):
+        for a in Mul.make_args(rv):
             if a.func in (tan, cot):
                 args[type(a)].append(a.args[0])
             else:

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -466,3 +466,15 @@ def test_as_f_sign_1():
     assert as_f_sign_1(2*x + 2) == (2, x, 1)
     assert as_f_sign_1(x*y - y) == (y, x, -1)
     assert as_f_sign_1(-x*y + y) == (-y, x, -1)
+
+
+def test_issue_25590():
+    A = Symbol('A', commutative=False)
+    B = Symbol('B', commutative=False)
+
+    assert TR8(2*cos(x)*sin(x)*B*A) == sin(2*x)*B*A
+    assert TR13(tan(2)*tan(3)*B*A) == (-tan(2)/tan(5) - tan(3)/tan(5) + 1)*B*A
+
+    # XXX The result may not be optimal than
+    # sin(2*x)*B*A + cos(x)**2 and may change in the future
+    assert (2*cos(x)*sin(x)*B*A + cos(x)**2).simplify() == sin(2*x)*B*A + cos(2*x)/2 + S.One/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/25590

#### Brief description of what is fixed or changed

I copied how it was done in `diofant`, but I also attempt to fix `TR13` which has suspicious `ordered` usage anyway.
TR13 is anyway another bug, but I am not able to provide an example to how to fail that in user example, from `simplify` or `trigsimp`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
  - Fixed an issue where noncommutative symbols with trigonometric functions would give incorrect simplification results. For example, `simplify(2*cos(x)*sin(x)*B*A + cos(x)**2)`
<!-- END RELEASE NOTES -->
