### PR TITLE
expint/polylog: unicode print subscripts in more cases

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Bharath M R <catchmrbharath@gmail.com>
 Bhaskar Gupta <guptabhanu1999@gmail.com>
 Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in> BhaskarJoshi-01 <bhaskar.joshi@research.iiit.ac.in>
 Bhautik Mavani <mavanibhautik@gmail.com>
+Bhavik Sachdev <b.sachdev1904@gmail.com>
 Bhavya Srivastava <bhavya17037@iiitd.ac.in>
 Bilal Ahmed <b.ahmed0918@gmail.com>
 Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -393,7 +393,7 @@ Bharath M R <catchmrbharath@gmail.com>
 Bhaskar Gupta <guptabhanu1999@gmail.com>
 Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in> BhaskarJoshi-01 <bhaskar.joshi@research.iiit.ac.in>
 Bhautik Mavani <mavanibhautik@gmail.com>
-Bhavik Sachdev <b.sachdev1904@gmail.com>
+Bhavik Sachdev <b.sachdev1904@gmail.com> Bhavik Sachdev <69461338+bsach64@users.noreply.github.com>
 Bhavya Srivastava <bhavya17037@iiitd.ac.in>
 Bilal Ahmed <b.ahmed0918@gmail.com>
 Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1664,7 +1664,7 @@ class PrettyPrinter(Printer):
         return self.emptyPrinter(expr)
 
     def _print_polylog(self, e):
-        if _opportunistic_subscripter(e) and self._use_unicode:
+        if _opportunistic_subscripter(self._print(e.args[0])) and self._use_unicode:
             return self._print_Function(Function('Li_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)
 
@@ -1811,7 +1811,7 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_expint(self, e):
-        if _opportunistic_subscripter(e) and self._use_unicode:
+        if _opportunistic_subscripter(self._print(e.args[0])) and self._use_unicode:
             return self._print_Function(Function('E_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -20,7 +20,7 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import hobj, vobj, xobj, \
     xsym, pretty_symbol, pretty_atom, pretty_use_unicode, greek_unicode, U, \
-    pretty_try_use_unicode,  annotated, _opportunistic_subscripter
+    pretty_try_use_unicode, annotated, is_subscriptable_in_unicode
 
 # rename for usage from outside
 pprint_use_unicode = pretty_use_unicode
@@ -1664,8 +1664,9 @@ class PrettyPrinter(Printer):
         return self.emptyPrinter(expr)
 
     def _print_polylog(self, e):
-        if _opportunistic_subscripter(self._print(e.args[0])) and self._use_unicode:
-            return self._print_Function(Function('Li_%s' % e.args[0])(e.args[1]))
+        subscript = self._print(e.args[0])
+        if self._use_unicode and is_subscriptable_in_unicode(subscript):
+            return self._print_Function(Function('Li_%s' % subscript)(e.args[1]))
         return self._print_Function(e)
 
     def _print_lerchphi(self, e):
@@ -1811,8 +1812,9 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_expint(self, e):
-        if _opportunistic_subscripter(self._print(e.args[0])) and self._use_unicode:
-            return self._print_Function(Function('E_%s' % e.args[0])(e.args[1]))
+        subscript = self._print(e.args[0])
+        if self._use_unicode and is_subscriptable_in_unicode(subscript):
+            return self._print_Function(Function('E_%s' % subscript)(e.args[1]))
         return self._print_Function(e)
 
     def _print_Chi(self, e):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -20,7 +20,7 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import hobj, vobj, xobj, \
     xsym, pretty_symbol, pretty_atom, pretty_use_unicode, greek_unicode, U, \
-    pretty_try_use_unicode,  annotated
+    pretty_try_use_unicode,  annotated, _opportunistic_subscripter
 
 # rename for usage from outside
 pprint_use_unicode = pretty_use_unicode
@@ -1664,7 +1664,7 @@ class PrettyPrinter(Printer):
         return self.emptyPrinter(expr)
 
     def _print_polylog(self, e):
-        if e.args[0].is_Integer and self._use_unicode:
+        if _opportunistic_subscripter(e) and self._use_unicode:
             return self._print_Function(Function('Li_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)
 
@@ -1811,7 +1811,7 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_expint(self, e):
-        if e.args[0].is_Integer and self._use_unicode:
+        if _opportunistic_subscripter(e) and self._use_unicode:
             return self._print_Function(Function('E_%s' % e.args[0])(e.args[1]))
         return self._print_Function(e)
 

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -642,5 +642,24 @@ def line_width(line):
     """
     return len(line.translate(_remove_combining))
 
-def _opportunistic_subscripter(subscript):
+
+def is_subscriptable_in_unicode(subscript):
+    """
+    Checks whether a string is subscriptable in unicode or not.
+
+    Parameters
+    ==========
+
+    subscript: the string which needs to be checked
+
+    Examples
+    ========
+
+    >>> from sympy.printing.pretty.pretty_symbology import is_subscriptable_in_unicode
+    >>> is_subscriptable_in_unicode('abc')
+    False
+    >>> is_subscriptable_in_unicode('123')
+    True
+
+    """
     return all(character in sub for character in subscript)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -642,5 +642,5 @@ def line_width(line):
     """
     return len(line.translate(_remove_combining))
 
-def _opportunistic_subscripter(e):
-    return all(character in sub for character in str(e.args[0]))
+def _opportunistic_subscripter(subscript):
+    return all(character in sub for character in subscript)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -641,3 +641,6 @@ def line_width(line):
     separate symbols and thus should not be counted
     """
     return len(line.translate(_remove_combining))
+
+def _opportunistic_subscripter(e):
+    return all(character in sub for character in str(e.args[0]))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7507,7 +7507,8 @@ def test_print_polylog():
     assert upretty(polylog(2, 3)) == uresult
 
 
-def test_issue_25312():
+# Issue #25312
+def test_print_expint_polylog_symbolic_order():
     s, z = symbols("s, z")
     uresult = 'Liₛ(z)'
     aresult = 'polylog(s, z)'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7507,8 +7507,7 @@ def test_print_polylog():
     assert upretty(polylog(2, 3)) == uresult
 
 
-# Issue #25312
-def test_print_expint_polylog_symbolic_order():
+def test_issue_25312():
     s, z = symbols("s, z")
     uresult = 'Liₛ(z)'
     aresult = 'polylog(s, z)'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -80,7 +80,6 @@ from sympy.testing.pytest import raises, _both_exp_pow, warns_deprecated_sympy
 
 from sympy.vector import CoordSys3D, Gradient, Curl, Divergence, Dot, Cross, Laplacian
 
-from sympy.testing.pytest import XFAIL
 
 
 import sympy as sym
@@ -7508,7 +7507,7 @@ def test_print_polylog():
     assert upretty(polylog(2, 3)) == uresult
 
 
-@XFAIL  # Issue #25312
+# Issue #25312
 def test_print_expint_polylog_symbolic_order():
     s, z = symbols("s, z")
     uresult = 'Liₛ(z)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
changed _print_expint and _print_polylog to help pretty print. 
Added _opportunistic_subscripter function for the same
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25312 


#### Brief description of what is fixed or changed
Earlier printing expint & polylog functions with two symbols such as expint(s, z) did not subscript but now does as Eₛ(z)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug with printing of expint and polylog.
<!-- END RELEASE NOTES -->
