### PR TITLE
Fix Wigner small d-matrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -627,7 +627,6 @@ Gina <Dr-G@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
-gnrraphi <raphael.lehner@gmail.com>
 GolimarOurHero <metalera94@hotmail.com>
 Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
 Govind Sahai <gsiitbhu@gmail.com>
@@ -1520,6 +1519,7 @@ erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>
 faizan2700 <syedfaizan824@gmail.com>
 foice <foice.news@gmail.com>
+gnrraphi <raphael.lehner@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
 haru-44 <36563693+haru-44@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -627,6 +627,7 @@ Gina <Dr-G@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
+gnrraphi <raphael.lehner@gmail.com>
 GolimarOurHero <metalera94@hotmail.com>
 Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
 Govind Sahai <gsiitbhu@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1132,6 +1132,7 @@ Randy Heydon <randy.heydon@clockworklab.net>
 Ranjith Kumar <ranjith.dakshana2015@gmail.com>
 Raoul Bourquin <raoulb@bluewin.ch>
 Raoul Bourquin <raoulb@bluewin.ch> <raoulb@bluewin.chh>
+Raphael Lehner <raphael.lehner@gmail.com> gnrraphi <raphael.lehner@gmail.com>
 Raphael Michel <webmaster@raphaelmichel.de>
 Rashmi Shehana <rashmi.watagedara@syscolabs.com>
 Rastislav Rabatin <rastislav.rabatin@gmail.com>
@@ -1519,7 +1520,6 @@ erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>
 faizan2700 <syedfaizan824@gmail.com>
 foice <foice.news@gmail.com>
-gnrraphi <raphael.lehner@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
 haru-44 <36563693+haru-44@users.noreply.github.com>

--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -179,13 +179,20 @@ def test_dot_rota_grad_SH():
 
 def test_wigner_d():
     half = S(1)/2
-    alpha, beta, gamma = symbols("alpha, beta, gamma", real=True)
-    d = wigner_d_small(half, beta).subs({beta: pi/2})
-    d_ = Matrix([[1, 1], [-1, 1]])/sqrt(2)
-    assert d == d_
+    assert wigner_d_small(half, 0) == Matrix([[1, 0], [0, 1]])
+    assert wigner_d_small(half, pi/2) == Matrix([[1, 1], [-1, 1]])/sqrt(2)
+    assert wigner_d_small(half, pi) == Matrix([[0, 1], [-1, 0]])
 
+    alpha, beta, gamma = symbols("alpha, beta, gamma", real=True)
     D = wigner_d(half, alpha, beta, gamma)
     assert D[0, 0] == exp(I*alpha/2)*exp(I*gamma/2)*cos(beta/2)
     assert D[0, 1] == exp(I*alpha/2)*exp(-I*gamma/2)*sin(beta/2)
     assert D[1, 0] == -exp(-I*alpha/2)*exp(I*gamma/2)*sin(beta/2)
     assert D[1, 1] == exp(-I*alpha/2)*exp(-I*gamma/2)*cos(beta/2)
+
+    # Test Y_{n mi}(g*x)=\sum_{mj}D^n_{mi mj}*Y_{n mj}(x)
+    theta, phi = symbols("theta phi", real=True)
+    v = Matrix([Ynm(1, mj, theta, phi) for mj in range(1, -2, -1)])
+    w = wigner_d(1, -pi/2, pi/2, -pi/2)@v.subs({theta: pi/4, phi: pi})
+    w_ = v.subs({theta: pi/2, phi: pi/4})
+    assert w.expand(func=True).as_real_imag() == w_.expand(func=True).as_real_imag()

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -1084,8 +1084,8 @@ def wigner_d_small(J, beta):
         for j, Mj in enumerate(M):
 
             # We get the maximum and minimum value of sigma.
-            sigmamax = max([-Mi-Mj, J-Mj])
-            sigmamin = min([0, J-Mi])
+            sigmamax = min([J-Mi, J-Mj])
+            sigmamin = max([0, -Mi-Mj])
 
             dij = sqrt(factorial(J+Mi)*factorial(J-Mi) /
                        factorial(J+Mj)/factorial(J-Mj))


### PR DESCRIPTION
**Brief description of what is fixed or changed**

The current maximum and minimum values of sigma 
https://github.com/sympy/sympy/blob/69f98fb2b0d845e76874067a381dba37b577e8c5/sympy/physics/wigner.py#L1087-L1088
in the `wigner_d_small` function are incorrect. This discrepancy becomes evident when examining the arguments of the binomial coefficients, as shown in
https://github.com/sympy/sympy/blob/69f98fb2b0d845e76874067a381dba37b577e8c5/sympy/physics/wigner.py#L1093-L1094
A prime illustration of this issue is observed when evaluating the expression `wigner_d_small(2, 0)`.  This example highlights an error arising due to an erroneous inclusion of a term that leads to division by zero. In this pull request, I fixed the values of sigma, respectively .

**Release notes**

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * Fixed a bug with the `wigner_d_small` function.
<!-- END RELEASE NOTES -->
