### PR TITLE
Float(n) != Rational(n)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2113,18 +2113,21 @@ def _aresame(a, b):
     Examples
     ========
 
-    In SymPy (as in Python) two numbers compare the same if they
-    have the same underlying base-2 representation even though
-    they may not be the same type:
+    In SymPy (unlike Python) two numbers do not compare the same if they are
+    not of the same type. In particular an Integer or Rational will always
+    compare unequal with a Float. Also Floats of differing precision will
+    compare unequal.
 
     >>> from sympy import S
     >>> 2.0 == S(2)
-    True
+    False
     >>> 0.5 == S.Half
-    True
+    False
 
-    This routine was written to provide a query for such cases that
-    would give false when the types do not match:
+    Before SymPy 1.7 the two comparisons above would have given True rather
+    than False. This routine was written to provide a query that could
+    distinguish those cases but is no longer needed after the changes to Float
+    comparison introduced in SymPy 1.7. Its usage is
 
     >>> from sympy.core.basic import _aresame
     >>> _aresame(S(2.0), S(2))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -14,8 +14,7 @@ from .expr import Expr, AtomicExpr
 from .evalf import pure_complex
 from .cache import cacheit, clear_cache
 from .decorators import _sympifyit
-from .intfunc import (num_digits, igcd, ilcm, mod_inverse,
-    integer_nthroot, integer_log)
+from .intfunc import num_digits, igcd, ilcm, mod_inverse, integer_nthroot
 from .logic import fuzzy_not
 from .kind import NumberKind
 from sympy.external.gmpy import SYMPY_INTS, gmpy, flint

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1600,8 +1600,6 @@ class Rational(Number):
             # a Rational is always in reduced form so will never be 2/4
             # so we can just check equivalence of args
             return self.p == other.p and self.q == other.q
-        if other.is_Float:
-            return False
         return False
 
     def __ne__(self, other):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1043,7 +1043,7 @@ class Float(Number):
                          precision=self._prec)
         if isinstance(other, Float) and global_parameters.evaluate:
             r = self/other
-            if r == r.round(0):
+            if int_valued(r):
                 return Float(0, precision=max(self._prec, other._prec))
         if isinstance(other, Number) and global_parameters.evaluate:
             rhs, prec = other._as_mpf_op(self._prec)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4166,7 +4166,7 @@ def equal_valued(x, y):
     However an individual Float compares equal to a Rational:
 
     >>> Rational(1, 2) == Float(0.5)
-    True
+    False
 
     In a future version of SymPy this might change so that Rational and Float
     compare unequal. This function provides the behavior currently expected of

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1044,7 +1044,7 @@ class Float(Number):
                          precision=self._prec)
         if isinstance(other, Float) and global_parameters.evaluate:
             r = self/other
-            if r == int(r):
+            if r == r.round(0):
                 return Float(0, precision=max(self._prec, other._prec))
         if isinstance(other, Number) and global_parameters.evaluate:
             rhs, prec = other._as_mpf_op(self._prec)
@@ -1101,37 +1101,22 @@ class Float(Number):
         return int(mlib.to_int(self._mpf_))  # uses round_fast = round_down
 
     def __eq__(self, other):
-        from sympy.logic.boolalg import Boolean
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            return NotImplemented
-        if isinstance(other, Boolean):
-            return False
-        if other.is_NumberSymbol:
-            if other.is_irrational:
-                return False
-            return other.__eq__(self)
-        if other.is_Float:
-            # comparison is exact
-            # so Float(.1, 3) != Float(.1, 33)
-            return self._mpf_ == other._mpf_
-        if other.is_Rational:
-            return other.__eq__(self)
-        if other.is_Number:
-            # numbers should compare at the same precision;
-            # all _as_mpf_val routines should be sure to abide
-            # by the request to change the prec if necessary; if
-            # they don't, the equality test will fail since it compares
-            # the mpf tuples
-            ompf = other._as_mpf_val(self._prec)
-            return bool(mlib.mpf_eq(self._mpf_, ompf))
-        if not self:
-            return not other
-        return False    # Float != non-Number
+        if isinstance(other, float):
+            other = Float(other)
+        return Basic.__eq__(self, other)
 
     def __ne__(self, other):
-        return not self == other
+        eq = self.__eq__(other)
+        if eq is NotImplemented:
+            return eq
+        else:
+            return not eq
+
+    def __hash__(self):
+        float_val = float(self)
+        if not math.isinf(float_val):
+            return hash(float_val)
+        return Basic.__hash__(self)
 
     def _Frel(self, other, op):
         try:
@@ -1193,9 +1178,6 @@ class Float(Number):
         if rv is None:
             return Expr.__le__(self, other)
         return rv
-
-    def __hash__(self):
-        return super().__hash__()
 
     def epsilon_eq(self, other, epsilon="1e-15"):
         return abs(self - other) < Float(epsilon)
@@ -1620,30 +1602,7 @@ class Rational(Number):
             # so we can just check equivalence of args
             return self.p == other.p and self.q == other.q
         if other.is_Float:
-            # all Floats have a denominator that is a power of 2
-            # so if self doesn't, it can't be equal to other
-            if self.q & (self.q - 1):
-                return False
-            s, m, t = other._mpf_[:3]
-            if s:
-                m = -m
-            if not t:
-                # other is an odd integer
-                if not self.is_Integer or self.is_even:
-                    return False
-                return m == self.p
-
-            if t > 0:
-                # other is an even integer
-                if not self.is_Integer:
-                    return False
-                # does m*2**t == self.p
-                return self.p and not self.p % m and \
-                    integer_log(self.p//m, 2) == (t, True)
-            # does non-integer s*m/2**-t = p/q?
-            if self.is_Integer:
-                return False
-            return m == self.p and integer_log(self.q, 2) == (-t, True)
+            return False
         return False
 
     def __ne__(self, other):

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -8,7 +8,7 @@ from sympy.core.basic import (Basic, Atom, as_Basic,
     _atomic, _aresame)
 from sympy.core.containers import Tuple
 from sympy.core.function import Function, Lambda
-from sympy.core.numbers import I, pi
+from sympy.core.numbers import I, pi, Float
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Symbol, Dummy
 from sympy.concrete.summations import Sum
@@ -27,7 +27,11 @@ T = TypeVar('T')
 
 def test__aresame():
     assert not _aresame(Basic(Tuple()), Basic())
-    assert not _aresame(Basic(S(2)), Basic(S(2.)))
+    for i, j in [(S(2), S(2.)), (1., Float(1))]:
+        for do in range(2):
+            assert not _aresame(Basic(i), Basic(j))
+            assert not _aresame(i, j)
+            i, j = j, i
 
 
 def test_structure():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2015,6 +2015,11 @@ def test_round():
     assert a.round(26) == Float('3.000000000000000000000000000', '')
     assert a.round(27) == Float('2.999999999999999999999999999', '')
     assert a.round(30) == Float('2.999999999999999999999999999', '')
+    #assert a.round(10) == Float('3.0000000000', '')
+    #assert a.round(25) == Float('3.0000000000000000000000000', '')
+    #assert a.round(26) == Float('3.00000000000000000000000000', '')
+    #assert a.round(27) == Float('2.999999999999999999999999999', '')
+    #assert a.round(30) == Float('2.999999999999999999999999999', '')
 
     # XXX: Should round set the precision of the result?
     #      The previous version of the tests above is this but they only pass

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -190,10 +190,6 @@ def test_divmod():
     assert divmod(S(-3), S(2)) == (-2, 1)
     assert divmod(S(-3), 2) == (-2, 1)
 
-    assert divmod(S(4), S(-3.1)) == Tuple(-2, -2.2)
-    # divmod(4, -2.1) gives an inaccurate result for the remainder
-    # assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
-    assert divmod(S(-8), S(-2.5) ) == Tuple(3, -0.5)
 
     assert divmod(oo, 1) == (S.NaN, S.NaN)
     assert divmod(S.NaN, 1) == (S.NaN, S.NaN)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -190,6 +190,11 @@ def test_divmod():
     assert divmod(S(-3), S(2)) == (-2, 1)
     assert divmod(S(-3), 2) == (-2, 1)
 
+    assert divmod(S(4), S(-3.1)) == Tuple(-2, -2.2)
+    # divmod(4, -2.1) gives an inaccurate result for the remainder
+    # assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
+    assert divmod(S(-8), S(-2.5) ) == Tuple(3, -0.5)
+
     assert divmod(oo, 1) == (S.NaN, S.NaN)
     assert divmod(S.NaN, 1) == (S.NaN, S.NaN)
     assert divmod(1, S.NaN) == (S.NaN, S.NaN)
@@ -455,7 +460,9 @@ def test_Float():
         return (-t < a - b < t)
 
     zeros = (0, S.Zero, 0., Float(0))
-    for i, j in permutations(zeros, 2):
+    for i, j in permutations(zeros[:-1], 2):
+        assert i == j
+    for i, j in permutations(zeros[-2:], 2):
         assert i == j
     for z in zeros:
         assert z in zeros
@@ -529,8 +536,10 @@ def test_Float():
 
     # inexact floats (repeating binary = denom not multiple of 2)
     # cannot have precision greater than 15
-    assert Float(.125, 22) == .125
-    assert Float(2.0, 22) == 2
+    assert Float(.125, 22)._prec == 76
+    assert Float(2.0, 22)._prec == 76
+    #assert Float(.125, 22) == .125
+    #assert Float(2.0, 22) == 2
     assert float(Float('.12500000000000001', '')) == .125
     raises(ValueError, lambda: Float(.12500000000000001, ''))
 
@@ -1385,7 +1394,9 @@ def test_abs1():
 
 
 def test_accept_int():
-    assert Float(4) == 4
+    assert not Float(4) == 4
+    assert Float(4) != 4
+    assert Float(4) == 4.0
 
 
 def test_dont_accept_str():
@@ -1851,8 +1862,8 @@ def test_bool_eq():
 
 
 def test_Float_eq():
-    # all .5 values are the same
-    assert Float(.5, 10) == Float(.5, 11) == Float(.5, 1)
+    # Floats with different precision should not compare equal
+    assert Float(.5, 10) != Float(.5, 11) != Float(.5, 1)
     # but floats that aren't exact in base-2 still
     # don't compare the same because they have different
     # underlying mpf values
@@ -1868,23 +1879,27 @@ def test_Float_eq():
     assert Rational(11, 10) != Float('1.1')
     # coverage
     assert not Float(3) == 2
+    assert not Float(3) == Float(2)
+    assert not Float(3) == 3
     assert not Float(2**2) == S.Half
-    assert Float(2**2) == 4
+    assert Float(2**2) == 4.0
     assert not Float(2**-2) == 1
-    assert Float(2**-1) == S.Half
+    assert Float(2**-1) == 0.5
     assert not Float(2*3) == 3
-    assert not Float(2*3) == S.Half
-    assert Float(2*3) == 6
+    assert not Float(2*3) == 0.5
+    assert Float(2*3) == 6.0
+    assert not Float(2*3) == 6
     assert not Float(2*3) == 8
-    assert Float(.75) == Rational(3, 4)
+    assert not Float(.75) == Rational(3, 4)
+    assert Float(.75) == 0.75
     assert Float(5/18) == 5/18
     # 4473
     assert Float(2.) != 3
-    assert Float((0,1,-3)) == S.One/8
+    assert not Float((0,1,-3)) == S.One/8
+    assert Float((0,1,-3)) == 1/8
     assert Float((0,1,-3)) != S.One/9
     # 16196
-    assert 2 == Float(2)  # as per Python
-    # but in a computation...
+    assert not 2 == Float(2)  # unlike Python
     assert t**2 != t**2.0
 
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -190,7 +190,6 @@ def test_divmod():
     assert divmod(S(-3), S(2)) == (-2, 1)
     assert divmod(S(-3), 2) == (-2, 1)
 
-
     assert divmod(oo, 1) == (S.NaN, S.NaN)
     assert divmod(S.NaN, 1) == (S.NaN, S.NaN)
     assert divmod(1, S.NaN) == (S.NaN, S.NaN)
@@ -534,7 +533,8 @@ def test_Float():
     # cannot have precision greater than 15
     assert Float(.125, 22)._prec == 76
     assert Float(2.0, 22)._prec == 76
-    #assert Float(.125, 22) == .125
+    # only default prec is equal, even for exactly representable float
+    assert Float(.125, 22) != .125
     #assert Float(2.0, 22) == 2
     assert float(Float('.12500000000000001', '')) == .125
     raises(ValueError, lambda: Float(.12500000000000001, ''))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -36,6 +36,7 @@ z = symbols('z', nonzero=True)
 def test_piecewise1():
 
     # Test canonicalization
+    assert Piecewise((x, x < 1.)).has(1.0)  # doesn't get changed to x < 1
     assert unchanged(Piecewise, ExprCondPair(x, x < 1), ExprCondPair(0, True))
     assert Piecewise((x, x < 1), (0, True)) == Piecewise(ExprCondPair(x, x < 1),
                                                          ExprCondPair(0, True))

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1965,7 +1965,7 @@ class HolonomicFunction:
             sol = S.Zero
             for j, i in enumerate(nonzeroterms):
 
-                if i < 0 or int(i) != i:
+                if i < 0 or not (int(i) == i or i.round(0) == i):
                     continue
 
                 i = int(i)

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -4,9 +4,8 @@ various operations on them.
 """
 
 from sympy.core import Add, Mul, Pow
-from sympy.core.numbers import int_valued
 from sympy.core.numbers import (NaN, Infinity, NegativeInfinity, Float, I, pi,
-        equal_valued)
+        equal_valued, int_valued)
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
@@ -1965,7 +1964,7 @@ class HolonomicFunction:
             sol = S.Zero
             for j, i in enumerate(nonzeroterms):
 
-                if i < 0 or not (int(i) == i or i.round(0) == i):
+                if i < 0 or not int_valued(i):
                     continue
 
                 i = int(i)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2074,37 +2074,32 @@ def test_mul_pow_derivative():
     assert integrate(x**3*Derivative(f(x), (x, 4))) == \
            x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) + 6*x*Derivative(f(x), x) - 6*f(x)
 
+
 def test_issue_20782():
-    x_d = symbols('x_d')
+    fun1 = Piecewise((0, x < 0.0), (1, True))
+    fun2 = -Piecewise((0, x < 1.0), (1, True))
+    fun_sum = fun1 + fun2
+    L = (x, -float('Inf'), 1)
 
-    fun1 = lambda x : -Piecewise((0, x < 0.0), (1, True))
-    fun2 = lambda x : Piecewise((0, x < 1.0), (1, True))
-    fun_sum = lambda x : +Piecewise((0, x < 0.0), (1, True)) \
-                        -Piecewise((0, x < 1.0), (1, True))
+    assert integrate(fun1, L) == 1
+    assert integrate(fun2, L) == 0
+    assert integrate(-fun1, L) == -1
+    assert integrate(-fun2, L) == 0.
+    assert integrate(fun_sum, L) == 1.
+    assert integrate(-fun_sum, L) == -1.
 
-    fun_sum_neg = lambda x : -Piecewise((0, x < 0.0), (1, True)) \
-                            +Piecewise((0, x < 1.0), (1, True))
-
-    assert integrate(-fun1(x_d), (x_d, -float('Inf'), 1)) == 1
-    assert integrate(-fun2(x_d), (x_d, -float('Inf'), 1)) == 0
-    assert integrate(fun1(x_d), (x_d, -float('Inf'), 1)) == -1
-    assert integrate(fun2(x_d), (x_d, -float('Inf'), 1)) == 0
-    assert integrate(fun_sum(x_d), (x_d, -float('Inf'), 1)) == 1
-    assert integrate(-fun_sum(x_d), (x_d, -float('Inf'), 1)) == -1
-    assert integrate(fun_sum_neg(x_d), (x_d, -float('Inf'), 1)) == -1
-    assert integrate(-fun_sum_neg(x_d), (x_d, -float('Inf'), 1)) == 1
-
-    f = Piecewise((0, x < 0.0), (1, True)) - Piecewise((0, x < 1.0), (1, True))
-    assert integrate(f, (x, -oo, 1)) == 1
-    assert integrate(-f, (x, -oo, 1)) == -1
 
 def test_issue_20781():
-    x_d = Symbol('x_d')
-    fun_sum = lambda x, a1, a2: Piecewise((0, x<a1),(1, x>=a1)) + Piecewise((0, x<a2),(1, x>=a2))
+    P = lambda a: Piecewise((0, x < a), (1, x >= a))
+    f = lambda a: P(int(a)) + P(float(a))
+    L = (x, -float('Inf'), x)
+    f1 = integrate(f(1), L)
+    assert f1 == 2*x - Min(1.0, x) - Min(x, Max(1.0, 1, evaluate=False))
+    # XXX is_zero is True for S(0) and Float(0) and this is baked into
+    # the code more deeply than the issue of Float(0) != S(0)
+    assert integrate(f(0), (x, -float('Inf'), x)
+        ) == 2*x - 2*Min(0, x)
 
-    assert integrate(fun_sum((x_d), 0, 0.0), (x_d, -float('Inf'), x)) == 2*x - 2*Min(0, x)
-    assert integrate(fun_sum((x_d), 0.0, 0), (x_d, -float('Inf'), x)) == 2*x - 2*Min(0, x)
-    assert integrate(fun_sum((x_d), 1.0, 1), (x_d, -float('Inf'), x)) == 2*x - 2*Min(1, x)
 
 @slow
 def test_issue_19427():

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -15,6 +15,7 @@ from sympy.core.basic import Atom
 from sympy.core.decorators import call_highest_priority
 from sympy.core.kind import Kind, NumberKind
 from sympy.core.logic import fuzzy_and, FuzzyBool
+from sympy.core.numbers import Integer
 from sympy.core.mod import Mod
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
@@ -2848,6 +2849,8 @@ class MatrixArithmetic(MatrixRequired):
             return a._eval_pow_by_recursion(exp)
 
         elif method is None and exp.is_Number and exp % 1 == 0:
+            if exp.is_Float:
+                exp = Integer(exp)
             # Decide heuristically which method to apply
             if a.rows == 2 and exp > 100000:
                 return jordan_pow(exp)

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -505,13 +505,13 @@ class BlockMatrix(MatrixExpr):
             [[A, B],
              [C, D]] = self.blocks.tolist()
             try:
-                A = A**0.5
+                A = A**S.Half
                 AI = A.I
             except NonInvertibleMatrixError:
                 raise NonInvertibleMatrixError('Block LU decomposition cannot be calculated when\
                     "A" is singular')
             Z = ZeroMatrix(*B.shape)
-            Q = self.schur()**0.5
+            Q = self.schur()**S.Half
             L = BlockMatrix([[A, Z], [C*AI, Q]])
             U = BlockMatrix([[A, AI*B],[Z.T, Q]])
             return L, U

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -616,10 +616,10 @@ def isprime(n):
     >>> near_int == int(near_int)
     False
     >>> n = Float(near_int, 10)  # truncated by precision
-    >>> n == n.round(0)
+    >>> n % 1 == 0
     True
     >>> n = Float(near_int, 20)
-    >>> n == n.round(0)
+    >>> n % 1 == 0
     False
 
     See Also

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -616,10 +616,10 @@ def isprime(n):
     >>> near_int == int(near_int)
     False
     >>> n = Float(near_int, 10)  # truncated by precision
-    >>> n == int(n)
+    >>> n == n.round(0)
     True
     >>> n = Float(near_int, 20)
-    >>> n == int(n)
+    >>> n == n.round(0)
     False
 
     See Also

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -186,8 +186,10 @@ def test_aux_dep():
 
     assert Matrix(Fr_c).expand() == fr.expand()
     assert Matrix(Fr_star_c.subs(kdd)).expand() == frstar.expand()
-    assert (simplify(Matrix(Fr_star_steady).expand()) ==
-            simplify(frstar_steady.expand()))
+    # These Matrices have some Integer(0) and some Float(0). Running under
+    # SymEngine gives different types of zero.
+    assert (simplify(Matrix(Fr_star_steady).expand()).xreplace({0:0.0}) ==
+            simplify(frstar_steady.expand()).xreplace({0:0.0}))
 
     syms_in_forcing = find_dynamicsymbols(kane.forcing)
     for qdi in qd:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -257,7 +257,7 @@ def test_frac():
     raises(ValueError, lambda: limit(frac(x), x, 0, '+-'))
     assert limit(frac(-2*x + 1), x, 0, "+") == 1
     assert limit(frac(-2*x + 1), x, 0, "-") == 0
-    assert limit(frac(x + S.Half), x, 0, "+-") == 1/2
+    assert limit(frac(x + S.Half), x, 0, "+-") == S(1)/2
     assert limit(frac(1/x), x, 0) == AccumBounds(0, 1)
 
 
@@ -421,10 +421,10 @@ def test_issue_4547():
 
 def test_issue_5164():
     assert limit(x**0.5, x, oo) == oo**0.5 is oo
-    assert limit(x**0.5, x, 16) == S(16)**0.5
+    assert limit(x**0.5, x, 16) == 4 # Should this be a float?
     assert limit(x**0.5, x, 0) == 0
     assert limit(x**(-0.5), x, oo) == 0
-    assert limit(x**(-0.5), x, 4) == S(4)**(-0.5)
+    assert limit(x**(-0.5), x, 4) == S.Half # Should this be a float?
 
 
 def test_issue_5383():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -233,10 +233,11 @@ def test_issue_12791():
     expr = (-beta**2*varphi*sin(theta) + beta**2*cos(theta) + \
         beta*varphi*sin(theta) - beta*cos(theta) - beta + 1)/(beta*cos(theta) - 1)**2
 
-    sol = 0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta)\
-        - 1.0)**2 + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)\
-        + 0.25*cos(2*theta) + 1.25)/(0.5*cos(theta) - 1.0)**3\
-        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2 + O((beta - S.Half)**2, (beta, S.Half))
+    sol = (0.5/(0.5*cos(theta) - 1.0)**2 - 0.25*cos(theta)/(0.5*cos(theta) - 1.0)**2
+        + (beta - 0.5)*(-0.25*varphi*sin(2*theta) - 1.5*cos(theta)
+        + 0.25*cos(2*theta) + 1.25)/((0.5*cos(theta) - 1.0)**2*(0.5*cos(theta) - 1.0))
+        + 0.25*varphi*sin(theta)/(0.5*cos(theta) - 1.0)**2
+        + O((beta - S.Half)**2, (beta, S.Half)))
 
     assert expr.series(beta, 0.5, 2).trigsimp() == sol
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -1,3 +1,4 @@
+from sympy.core.basic import _aresame
 from sympy.core.function import Lambda, expand_complex
 from sympy.core.mul import Mul
 from sympy.core.numbers import ilcm, Float
@@ -436,7 +437,7 @@ def _(a, b):
             left_open = a.left_open
         else:
             start = a.start
-            if a.start != b.start:
+            if not _aresame(a.start, b.start):
                 # For example Integer(2) != Float(2)
                 # Prefer the Float boundary because Floats should be
                 # contagious in calculations.
@@ -445,7 +446,7 @@ def _(a, b):
                 elif a.start.has(Float) and not b.start.has(Float):
                     start = a.start
                 else:
-                    #this is to ensure that if Eq(a.start,b.start) but
+                    #this is to ensure that if Eq(a.start, b.start) but
                     #type(a.start) != type(b.start) the order of a and b
                     #does not matter for the result
                     start = list(ordered([a,b]))[0].start
@@ -458,11 +459,9 @@ def _(a, b):
             end = b.end
             right_open = b.right_open
         else:
+            # see above for logic with start
             end = a.end
-            if a.end != b.end:
-                # For example Integer(2) != Float(2)
-                # Prefer the Float boundary because Floats should be
-                # contagious in calculations.
+            if not _aresame(a.end, b.end):
                 if b.end.has(Float) and not a.end.has(Float):
                     end = b.end
                 elif a.end.has(Float) and not b.end.has(Float):

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -1,6 +1,6 @@
 from sympy.core.function import Lambda, expand_complex
 from sympy.core.mul import Mul
-from sympy.core.intfunc import ilcm
+from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
@@ -435,10 +435,20 @@ def _(a, b):
             start = a.start
             left_open = a.left_open
         else:
-            #this is to ensure that if Eq(a.start,b.start) but
-            #type(a.start) != type(b.start) the order of a and b
-            #does not matter for the result
-            start = list(ordered([a,b]))[0].start
+            start = a.start
+            if a.start != b.start:
+                # For example Integer(2) != Float(2)
+                # Prefer the Float boundary because Floats should be
+                # contagious in calculations.
+                if b.start.has(Float) and not a.start.has(Float):
+                    start = b.start
+                elif a.start.has(Float) and not b.start.has(Float):
+                    start = a.start
+                else:
+                    #this is to ensure that if Eq(a.start,b.start) but
+                    #type(a.start) != type(b.start) the order of a and b
+                    #does not matter for the result
+                    start = list(ordered([a,b]))[0].start
             left_open = a.left_open or b.left_open
 
         if a.end < b.end:
@@ -448,7 +458,17 @@ def _(a, b):
             end = b.end
             right_open = b.right_open
         else:
-            end = list(ordered([a,b]))[0].end
+            end = a.end
+            if a.end != b.end:
+                # For example Integer(2) != Float(2)
+                # Prefer the Float boundary because Floats should be
+                # contagious in calculations.
+                if b.end.has(Float) and not a.end.has(Float):
+                    end = b.end
+                elif a.end.has(Float) and not b.end.has(Float):
+                    end = a.end
+                else:
+                    end = list(ordered([a,b]))[0].end
             right_open = a.right_open or b.right_open
 
         if end - start == 0 and (left_open or right_open):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -501,6 +501,12 @@ def test_intersect1():
     assert Union(Interval(0, 1), Interval(2, 3)).intersection(Interval(1, 2)) == \
         Union(Interval(1, 1), Interval(2, 2))
 
+    # canonical boundary selected
+    a = sqrt(2*sqrt(6) + 5)
+    b = sqrt(2) + sqrt(3)
+    assert Interval(a, 4).intersection(Interval(b, 5)) == Interval(b, 4)
+    assert Interval(1, a).intersection(Interval(0, b)) == Interval(1, b)
+
 
 def test_intersection_interval_float():
     # intersection of Intervals with mixed Rational/Float boundaries should

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -24,6 +24,7 @@ from sympy.core.expr import unchanged
 from sympy.core.relational import Eq, Ne, Le, Lt, LessThan
 from sympy.logic import And, Or, Xor
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+from sympy.utilities.iterables import cartes
 
 from sympy.abc import x, y, z, m, n
 
@@ -499,6 +500,34 @@ def test_intersect1():
 
     assert Union(Interval(0, 1), Interval(2, 3)).intersection(Interval(1, 2)) == \
         Union(Interval(1, 1), Interval(2, 2))
+
+
+def test_intersection_interval_float():
+    # intersection of Intervals with mixed Rational/Float boundaries should
+    # lead to Float boundaries in all cases regardless of which Interval is
+    # open or closed.
+    typs = [
+        (Interval, Interval, Interval),
+        (Interval, Interval.open, Interval.open),
+        (Interval, Interval.Lopen, Interval.Lopen),
+        (Interval, Interval.Ropen, Interval.Ropen),
+        (Interval.open, Interval.open, Interval.open),
+        (Interval.open, Interval.Lopen, Interval.open),
+        (Interval.open, Interval.Ropen, Interval.open),
+        (Interval.Lopen, Interval.Lopen, Interval.Lopen),
+        (Interval.Lopen, Interval.Ropen, Interval.open),
+        (Interval.Ropen, Interval.Ropen, Interval.Ropen),
+    ]
+
+    as_float = lambda a1, a2: a2 if isinstance(a2, float) else a1
+
+    for t1, t2, t3 in typs:
+        for t1i, t2i in [(t1, t2), (t2, t1)]:
+            for a1, a2, b1, b2 in cartes([2, 2.0], [2, 2.0], [3, 3.0], [3, 3.0]):
+                I1 = t1(a1, b1)
+                I2 = t2(a2, b2)
+                I3 = t3(as_float(a1, a2), as_float(b1, b2))
+                assert I1.intersect(I2) == I3
 
 
 def test_intersection():

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -560,6 +560,6 @@ def as_int(n, strict=True):
             result = int(n)
         except TypeError:
             raise ValueError('%s is not an integer' % (n,))
-        if n != result:
+        if not (n == result or n == n.round(0)):
             raise ValueError('%s is not an integer' % (n,))
         return result

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -560,6 +560,6 @@ def as_int(n, strict=True):
             result = int(n)
         except TypeError:
             raise ValueError('%s is not an integer' % (n,))
-        if not (n == result or n == n.round(0)):
+        if n - result:
             raise ValueError('%s is not an integer' % (n,))
         return result


### PR DESCRIPTION
continuation of #20033 
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows #16924
Fixes #19915 
Fixes #19976 
Fixes #11707
(Probably other issues)

#### Brief description of what is fixed or changed

Previously @smichr's work in #16924 made it so that expressions containing Float would compare unequal to expressions containing Rationals e.g.:
```julia
In [1]: e1 = x**2

In [2]: e2 = x**2.0

In [3]: e1
Out[3]: 
 2
x 

In [4]: e2
Out[4]: 
 2.0
x   

In [5]: e1 == e2
Out[5]: False
```
However #16924 left the behaviour unchanged for individual Number comparisons e.g.:
```julia
In [6]: Float(2.0) == Integer(2)
Out[6]: True
```
This PR extends that change to apply to individual Number so with the PR we have:
```julia
In [1]: Float(2.0) == Integer(2)
Out[1]: False
```
Moreover a Float will only compare equal to another Float if they have the same precision:
```julia
In [3]: Float(2.0, 5) == Float(2.0, 6)
Out[3]: False

In [4]: Float(2.0, 5) == Float(2.0, 5)
Out[4]: True
```
Only a `Float` created with default precision will compare equal to a Python `float`:
```julia
In [5]: Float(2.0, 5) == 2.0
Out[5]: False

In [6]: Float(2.0) == 2.0
Out[6]: True
``` 
The hash function for Float is changed to return the same as `float.__hash__` if the Float can be represented as a float (e.g. if the exponent is not too large/small):
```julia
In [7]: hash(2.3)
Out[7]: 691752902764107778

In [8]: hash(Float(2.3))
Out[8]: 691752902764107778
```

On master expressions involving Float compare equal but with distinct hashes:
```julia
In [1]: e1 = x**Float(5, 10)

In [2]: e2 = x**Float(5, 20)

In [3]: e1
Out[3]: 
 5.0
x   

In [4]: e2
Out[4]: 
 5.0
x   

In [5]: e1 == e2
Out[5]: True

In [6]: hash(e1)
Out[6]: 1397520323187279713

In [7]: hash(e2)
Out[7]: 7223358913859886252
```
With this PR we get
```julia
In [5]: e1 == e2
Out[5]: False

In [6]: hash(e1)
Out[6]: 5346466018815759790

In [7]: hash(e2)
Out[7]: 5346466018815759790
```
It is not necessary that the hash functions be equal in this example. That's just a consequence of ensuring that they are equal between Float and float. The important thing is that the expressions compare unequal. In that situation there are no constraints on whether the hashes should be equal or not.

This fixes #11707 by ensuring that Floats respect the hash invariant:
```
a == b   -->   hash(a) == hash(b)
```
This also ensures that comparisons using `==` with Floats respect structural equality. Expressions that differ in use of Float/Rational are not structurally equal and the same goes for Floats with differing precision. In this PR those will no longer compare equal.

### cps comments
To ignore differences in precision (or to compare numbers in an arbitrary way in an expression) the `is_same` method can be used with a custom function for comparing numbers:
```python
>>> from sympy.core.numbers import equal_valued
>>> e1.is_same(e2)
False
>>> e1.is_same(e2, equal_valued)
True
```
The `equal_valued` function is strict in terms of checking that the internal base-2 representation of the number is the same while ignoring the precision. This means that floats with a decimal portion that is not representable as a fraction with a denominator that is a power of 2 will not compare the same.
```python
>>> equal_valued(Float(.5), Float(.5, 20))
True
>>> equal_valued(Float(.1), Float(.1, 20))
False
```
There are other options for testing such numbers (and any function that can do so can be passed to `is_same`), see, for example [this description and comparison to similar functions](https://docs.pytest.org/en/latest/reference/reference.html#pytest-approx)
```python
>>> from sympy import root
>>> import math
>>> root(x,10).is_same(x**Float(.1), equal_valued)
False
>>> root(x,10).is_same(x**Float(.1), math.isclose)
True
```
#### Other comments

This is not yet finished. In particular after making various changes to fix tests I have found that there seems to be a need for some sort of `equalf` function that would compare expressions while ignoring the distinction between Float/Rational or Floats of differing precision.

We could have a function `equalf` so that e.g.:
```
>>> equalf(Float(2.0), 2)
True
>>> equalf(S.Half, 0.5)
True
>>> equalf(x**2.0, x**2)
True
```
#### UPDATE: this can be done by passing the desired number-comparing function like `equal_valued` to `is_same`.

There probably also needs to be a function for determining whether or not a Float/Rational represents an integer value. Currently around the codebase we have many cases that do `int(a) == a` which fails in this PR. Instead I have replaced those with `a.round(0) == a` since `a.round(0)` returns a `Float`. With `equalf` you could do `equalf(a, int(a))` but that could be problematic if `a` has a large exponent.

#### UPDATE: this can be done the same way we test for odd or even numbers: to check for fraction on `n` use `n % 1` but there is a faster test added to numbers.py named `int_valued` that returns True when passed a number that has no decimal part.

Clearly this change is not backwards compatible. I expect that many users will find this more confusing than the current situation but I think it will help with sympy's internal consistency and will reduce bugs in future. For example the bug in #19976 is fixed here:
```julia
In [16]: (2.0*x).replace(lambda e: e.is_Float, Integer)
Out[16]: 2⋅x
```
On master that gives `2.0*x`. I have fixed many other bugs that were ultimately caused by Float comparisons in the past.

One particular point of confusion is that in this PR sympy's Float/Integer no longer behave analogously to Python's float/int:
```julia
In [11]: a, b = 2, 2.0

In [12]: a == b
Out[12]: True

In [13]: S(a) == S(b)
Out[13]: False
```
This also breaks transitivity of `==` although I don't think that's actually a problem any of Python's core data structures in the way that breaking the hash invariant is:
```julia
In [14]: Integer(1) == 1 == 1.0 == Float(1.0) != Integer(1)
Out[14]: True
```

I'm putting this up to discuss whether this is wanted and consider whether it is worth a significant break in backwards compatibility.

### cps
It is past-due to have this change added since it is hard to defend how `sqrt(x) != x**.5` while `S.Half == .5` and `x == x`.

There are semantic issues to consider now, namely: what type of comparison should be used for internal simplification
```python

>>> for f in (Eq, equal_valued, Basic.__eq__):
...    print(f(S(1), S(1.)), f(S.Half, S(.5)), f(Rational(1,10), Float(.1)))
...
True True True
True True False
False False False

>>> Min(1, 1.0)
1.0
>>> Max(1, 1.0)
1

>>> And(x<1,x<1.)
(x < 1.0) & (x < 1)
```
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * BREAKING CHANGE: Float and Integer/Rational no longer compare equal with `a == b`. From now on `Float(2.0) != Integer(2)`. Previously expressions involving `Float` would compare unequal e.g. `x*2.0 != x*2` but an individual `Float` would compare equal to an `Integer`. In SymPy 1.7 a `Float` will always compare unequal to an `Integer` even if they have the same "value". Use `sympy.numbers.int_valued(number)` to test if a number is a concrete number with no decimal part.
    * BREAKING CHANGE: Floats with different prevision no longer compare equal with `a == b`. From now on `Float(2.0, 10) != Float(2.0, 5)`. Previously expressions involving `Float` with different precision would compare equal although they would have different hashes. Now expressions compared with `a == b` involving Floats respect structural equality since Floats of differing precision are not interchangeable.
    * The hash function for Floats and expressions involving Float now respects the hash invariant that if `a == b` then `hash(a) == hash(b)`. This ensures that it is possible to use such expressions in a guaranteed deterministic way in Python's core `set` and `dict` data structures. It is however not recommended to mix up sympy `Basic` objects with non-sympy number types such as core Python's `float` or `int` in the same `set/dict`.
    * It is now possible to replace `Float` with `Integer` in an expression using the `Basic.replace` method.
    * Basic.is_same(a, b) returns True only if all classes are exactly the same; has option to test numbers with custom rule
<!-- END RELEASE NOTES -->