### PR TITLE
Removes Symengine backend from sympy.physics.vector/mechanics/_biomechanics.

### DIFF
--- a/sympy/physics/_biomechanics/tests/test_activation.py
+++ b/sympy/physics/_biomechanics/tests/test_activation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sympy.core.backend import Symbol
+from sympy import Symbol
 from sympy.core.numbers import Float, Integer, Rational
 from sympy.functions.elementary.hyperbolic import tanh
 from sympy.matrices import Matrix

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -11,8 +11,8 @@ changes.
 
 from functools import wraps
 
-from sympy.core.backend import Basic
-from sympy.core.backend import ImmutableMatrix as Matrix
+from sympy import Basic
+from sympy import ImmutableMatrix as Matrix
 from sympy.core.containers import OrderedSet
 from sympy.physics.mechanics.actuator import ActuatorBase
 from sympy.physics.mechanics.body_base import BodyBase

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from sympy.core.backend import S, sympify
+from sympy import S, sympify
 from sympy.physics.mechanics import (
     PathwayBase,
     PinJoint,

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import Symbol
+from sympy import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame, Dyadic
 from sympy.physics.mechanics import RigidBody, Particle, Inertia
 from sympy.physics.mechanics.body_base import BodyBase

--- a/sympy/physics/mechanics/body_base.py
+++ b/sympy/physics/mechanics/body_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from sympy.core.backend import Symbol, sympify
+from sympy import Symbol, sympify
 from sympy.physics.vector import Point
 
 __all__ = ['BodyBase']

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -7,8 +7,8 @@ from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.simplify.simplify import simplify
-from sympy.core.backend import (Matrix, Mul, Derivative, sin, cos, tan,
-                                AppliedUndef, S)
+from sympy import Matrix, Mul, Derivative, sin, cos, tan, S
+from sympy.core.function import AppliedUndef
 from sympy.physics.mechanics.inertia import (inertia as _inertia,
     inertia_of_point_mass as _inertia_of_point_mass)
 from sympy.utilities.exceptions import sympy_deprecation_warning

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import sympify
+from sympy import sympify
 from sympy.physics.vector import Point, Dyadic, ReferenceFrame
 from collections import namedtuple
 

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -2,7 +2,8 @@
 
 from abc import ABC, abstractmethod
 
-from sympy.core.backend import pi, AppliedUndef, Derivative, Matrix
+from sympy import pi, Derivative, Matrix
+from sympy.core.function import AppliedUndef
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.functions import _validate_coordinates
 from sympy.physics.vector import (Vector, dynamicsymbols, cross, Point,

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -2,7 +2,7 @@ from sympy.physics.mechanics import (Body, Lagrangian, KanesMethod, LagrangesMet
                                     RigidBody, Particle)
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.method import _Methods
-from sympy.core.backend import Matrix
+from sympy import Matrix
 
 __all__ = ['JointsMethod']
 

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import zeros, Matrix, diff, eye
+from sympy import zeros, Matrix, diff, eye
 from sympy.core.sorting import default_sort_key
 from sympy.physics.vector import (ReferenceFrame, dynamicsymbols,
                                   partial_velocity)

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import diff, zeros, Matrix, eye, sympify
+from sympy import diff, zeros, Matrix, eye, sympify
 from sympy.core.sorting import default_sort_key
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
 from sympy.physics.mechanics.method import _Methods

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -1,6 +1,6 @@
 __all__ = ['Linearizer']
 
-from sympy.core.backend import Matrix, eye, zeros
+from sympy import Matrix, eye, zeros
 from sympy.core.symbol import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import S
+from sympy import S
 from sympy.physics.vector import cross, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.inertia import inertia_of_point_mass

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import Symbol, S
+from sympy import Symbol, S
 from sympy.physics.vector import ReferenceFrame, Dyadic, Point, dot
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.inertia import inertia_of_point_mass, Inertia

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import eye, zeros, Matrix
+from sympy import eye, zeros, Matrix
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import find_dynamicsymbols
 

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -2,9 +2,8 @@
 
 import pytest
 
-from sympy.core.backend import (
+from sympy import (
     S,
-    USE_SYMENGINE,
     Matrix,
     Symbol,
     SympifyError,
@@ -28,10 +27,7 @@ from sympy.physics.mechanics import (
     dynamicsymbols,
 )
 
-if USE_SYMENGINE:
-    from sympy.core.backend import Basic as ExprType
-else:
-    from sympy.core.expr import Expr as ExprType
+from sympy.core.expr import Expr as ExprType
 
 target = RigidBody('target')
 reaction = RigidBody('reaction')
@@ -336,14 +332,6 @@ class TestLinearDamper:
         assert isinstance(damper.pathway, LinearPathway)
         assert damper.pathway == self.pathway
 
-    @pytest.mark.skipif(
-        USE_SYMENGINE,
-        reason=(
-            'SymEngine give equivalent expression that does not compare equal;'
-            'SymPy puts the sqrt(q(t)**2) term in the numerator, while '
-            'SymEngine puts it in the denominator'
-        )
-    )
     def test_valid_constructor_force(self):
         self.pB.set_pos(self.pA, self.q*self.N.x)
         damper = LinearDamper(self.damping, self.pathway)

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,5 +1,5 @@
-from sympy.core.backend import (Symbol, symbols, sin, cos, Matrix, zeros,
-                                _simplify_matrix)
+from sympy import (Symbol, symbols, sin, cos, Matrix, zeros,
+                                simplify)
 from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols, Dyadic
 from sympy.physics.mechanics import inertia, Body
 from sympy.testing.pytest import raises
@@ -306,7 +306,7 @@ def test_parallel_axis():
     # Reference frame from which the parallel axis is viewed should not matter
     A = ReferenceFrame('A')
     A.orient_axis(N, N.z, 1)
-    assert _simplify_matrix(
+    assert simplify(
         (R.parallel_axis(p, A) - Ip_expected).to_matrix(A)) == zeros(3, 3)
     # Test Particle
     o = Point('o')

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import sin, cos, tan, pi, symbols, Matrix, S, Function
+from sympy import sin, cos, tan, pi, symbols, Matrix, S, Function
 from sympy.physics.mechanics import (Particle, Point, ReferenceFrame,
                                      RigidBody)
 from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,

--- a/sympy/physics/mechanics/tests/test_inertia.py
+++ b/sympy/physics/mechanics/tests/test_inertia.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import symbols
+from sympy import symbols
 from sympy.testing.pytest import raises
 from sympy.physics.mechanics import (inertia, inertia_of_point_mass,
                                      Inertia, ReferenceFrame, Point)

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -3,7 +3,7 @@ from sympy.core.numbers import pi
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
-from sympy.core.backend import Matrix, _simplify_matrix, eye, zeros
+from sympy import Matrix, simplify, eye, zeros
 from sympy.core.symbol import symbols
 from sympy.physics.mechanics import (
     dynamicsymbols, RigidBody, Particle, JointsMethod, PinJoint, PrismaticJoint,
@@ -249,7 +249,7 @@ def test_pin_joint_double_pendulum():
                                [sin(q1), cos(q1), 0], [0, 0, 1]])
     assert A.dcm(B) == Matrix([[cos(q2), -sin(q2), 0],
                                [sin(q2), cos(q2), 0], [0, 0, 1]])
-    assert _simplify_matrix(N.dcm(B)) == Matrix([[cos(q1 + q2), -sin(q1 + q2), 0],
+    assert simplify(N.dcm(B)) == Matrix([[cos(q1 + q2), -sin(q1 + q2), 0],
                                                  [sin(q1 + q2), cos(q1 + q2), 0],
                                                  [0, 0, 1]])
 
@@ -333,7 +333,7 @@ def test_pin_joint_interframe():
     Pint.orient_body_fixed(N, (pi / 4, pi, pi / 3), 'xyz')
     PinJoint('J', P, C, q, u, parent_point=N.x, child_point=-C.y,
              parent_interframe=Pint, joint_axis=Pint.x)
-    assert _simplify_matrix(N.dcm(A)) - Matrix([
+    assert simplify(N.dcm(A)) - Matrix([
         [-1 / 2, sqrt(3) * cos(q) / 2, -sqrt(3) * sin(q) / 2],
         [sqrt(6) / 4, sqrt(2) * (2 * sin(q) + cos(q)) / 4,
          sqrt(2) * (-sin(q) + 2 * cos(q)) / 4],
@@ -350,7 +350,7 @@ def test_pin_joint_interframe():
     Cint.orient_body_fixed(A, (2 * pi / 3, -pi, pi / 2), 'xyz')
     PinJoint('J', P, C, q, u, parent_point=-N.z, child_point=C.x,
              child_interframe=Cint, joint_axis=P.x + P.z)
-    assert _simplify_matrix(N.dcm(A)) == Matrix([
+    assert simplify(N.dcm(A)) == Matrix([
         [-sqrt(2) * sin(q) / 2,
          -sqrt(3) * (cos(q) - 1) / 4 - cos(q) / 4 - S(1) / 4,
          sqrt(3) * (cos(q) + 1) / 4 - cos(q) / 4 + S(1) / 4],
@@ -373,7 +373,7 @@ def test_pin_joint_interframe():
     PinJoint('J', P, C, q, u, parent_point=N.x - N.y, child_point=-C.z,
              parent_interframe=Pint, child_interframe=Cint,
              joint_axis=Pint.x + Pint.z)
-    assert _simplify_matrix(N.dcm(A)) == Matrix([
+    assert simplify(N.dcm(A)) == Matrix([
         [cos(q), (sqrt(2) + sqrt(6)) * -sin(q) / 4,
          (-sqrt(2) + sqrt(6)) * sin(q) / 4],
         [-sqrt(2) * sin(q) / 2,
@@ -508,7 +508,7 @@ def test_pin_joint_arbitrary_axis():
              child_interframe=A.x + A.y)
     assert expand_mul(N.x.angle_between(A.x + A.y)) == 0  # Axis are aligned
     assert (A.x + A.y).express(N).simplify() == sqrt(2)*N.x
-    assert _simplify_matrix(A.dcm(N)) == Matrix([
+    assert simplify(A.dcm(N)) == Matrix([
         [sqrt(2)/2, -sqrt(2)*cos(q)/2, -sqrt(2)*sin(q)/2],
         [sqrt(2)/2, sqrt(2)*cos(q)/2, sqrt(2)*sin(q)/2],
         [0, -sin(q), cos(q)]])
@@ -532,7 +532,7 @@ def test_pin_joint_arbitrary_axis():
              child_interframe=A.x + A.y - A.z)
     assert expand_mul(N.x.angle_between(A.x + A.y - A.z)) == 0  # Axis aligned
     assert (A.x + A.y - A.z).express(N).simplify() == sqrt(3)*N.x
-    assert _simplify_matrix(A.dcm(N)) == Matrix([
+    assert simplify(A.dcm(N)) == Matrix([
         [sqrt(3)/3, -sqrt(6)*sin(q + pi/4)/3,
          sqrt(6)*cos(q + pi/4)/3],
         [sqrt(3)/3, sqrt(6)*cos(q + pi/12)/3,
@@ -565,7 +565,7 @@ def test_pin_joint_arbitrary_axis():
     assert ((A.x-A.y+A.z).express(N).simplify() ==
             (-4*cos(q)/3 - S(1)/3)*N.x + (S(1)/3 - 4*sin(q + pi/6)/3)*N.y +
             (4*cos(q + pi/3)/3 - S(1)/3)*N.z)
-    assert _simplify_matrix(A.dcm(N)) == Matrix([
+    assert simplify(A.dcm(N)) == Matrix([
         [S(1)/3 - 2*cos(q)/3, -2*sin(q + pi/6)/3 - S(1)/3,
          2*cos(q + pi/3)/3 + S(1)/3],
         [2*cos(q + pi/3)/3 + S(1)/3, 2*cos(q)/3 - S(1)/3,
@@ -802,7 +802,7 @@ def test_prismatic_joint_arbitrary_axis():
                    child_interframe=A.x + A.y - A.z)
     assert N.x.angle_between(A.x + A.y - A.z).simplify() == 0 #Axis are aligned
     assert ((A.x + A.y - A.z).express(N) - sqrt(3)*N.x).simplify() == 0
-    assert _simplify_matrix(A.dcm(N)) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
+    assert simplify(A.dcm(N)) == Matrix([[sqrt(3)/3, -sqrt(3)/3, sqrt(3)/3],
                                                  [sqrt(3)/3, sqrt(3)/6 + S(1)/2, S(1)/2 - sqrt(3)/6],
                                                  [-sqrt(3)/3, S(1)/2 - sqrt(3)/6, sqrt(3)/6 + S(1)/2]])
     assert C.masscenter.pos_from(P.masscenter) == (q + 1)*N.x - A.x
@@ -822,7 +822,7 @@ def test_prismatic_joint_arbitrary_axis():
     # 0 angle means that the axis are aligned
     assert (N.x-N.y+N.z).angle_between(A.x+A.y-A.z).simplify() == 0
     assert ((A.x+A.y-A.z).express(N) - (N.x - N.y + N.z)).simplify() == 0
-    assert _simplify_matrix(A.dcm(N)) == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
+    assert simplify(A.dcm(N)) == Matrix([[-S(1)/3, -S(2)/3, S(2)/3],
                                                  [S(2)/3, S(1)/3, S(2)/3],
                                                  [-S(2)/3, S(2)/3, S(1)/3]])
     assert (C.masscenter.pos_from(P.masscenter) - (
@@ -967,7 +967,7 @@ def test_planar_joint_advanced():
          sqrt(3) * (1 - cos(q0)) / 4],
         [-sin(q0) / 2, sqrt(3) * (1 - cos(q0)) / 4, cos(q0) / 4 + 3 / 4]])
     # N.dcm(A) == N_R_A did not work
-    assert _simplify_matrix(N.dcm(A) - N_R_A) == zeros(3)
+    assert simplify(N.dcm(A) - N_R_A) == zeros(3)
 
 
 def test_spherical_joint():
@@ -1059,9 +1059,9 @@ def test_spherical_joint_orient_body():
                        rot_type='body', rot_order=123)
     assert S._rot_type.upper() == 'BODY'
     assert S._rot_order == 123
-    assert _simplify_matrix(N.dcm(A) - N_R_A) == zeros(3)
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - N_w_A) == zeros(3, 1)
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
+    assert simplify(N.dcm(A) - N_R_A) == zeros(3)
+    assert simplify(A.ang_vel_in(N).to_matrix(A) - N_w_A) == zeros(3, 1)
+    assert simplify(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
     # Test change of amounts
     N, A, P, C, Pint, Cint = _generate_body(True)
     S = SphericalJoint('S', P, C, coordinates=[q0, q1, q2], speeds=[u0, u1, u2],
@@ -1072,10 +1072,10 @@ def test_spherical_joint_orient_body():
         {q0: q1, q1: q0, q2: q2, u0: u1, u1: u0, u2: u2})
     assert S._rot_type.upper() == 'BODY'
     assert S._rot_order == 123
-    assert _simplify_matrix(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - switch_order(N_w_A)
+    assert simplify(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
+    assert simplify(A.ang_vel_in(N).to_matrix(A) - switch_order(N_w_A)
                             ) == zeros(3, 1)
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
+    assert simplify(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
     # Test different rot_order
     N, A, P, C, Pint, Cint = _generate_body(True)
     S = SphericalJoint('S', P, C, coordinates=[q0, q1, q2], speeds=[u0, u1, u2],
@@ -1084,16 +1084,16 @@ def test_spherical_joint_orient_body():
                        rot_type='BodY', rot_order='yxz')
     assert S._rot_type.upper() == 'BODY'
     assert S._rot_order == 'yxz'
-    assert _simplify_matrix(N.dcm(A) - Matrix([
+    assert simplify(N.dcm(A) - Matrix([
         [-sin(q0) * cos(q1), sin(q0) * sin(q1) * cos(q2) - sin(q2) * cos(q0),
          sin(q0) * sin(q1) * sin(q2) + cos(q0) * cos(q2)],
         [-sin(q1), -cos(q1) * cos(q2), -sin(q2) * cos(q1)],
         [cos(q0) * cos(q1), -sin(q0) * sin(q2) - sin(q1) * cos(q0) * cos(q2),
          sin(q0) * cos(q2) - sin(q1) * sin(q2) * cos(q0)]])) == zeros(3)
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - Matrix([
+    assert simplify(A.ang_vel_in(N).to_matrix(A) - Matrix([
         [u0 * sin(q1) - u2], [u0 * cos(q1) * cos(q2) - u1 * sin(q2)],
         [u0 * sin(q2) * cos(q1) + u1 * cos(q2)]])) == zeros(3, 1)
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == Matrix([
+    assert simplify(C.masscenter.vel(N).to_matrix(A)) == Matrix([
         [-sqrt(2) * (u0 * sin(q2 + pi / 4) * cos(q1) + u1 * cos(q2 + pi / 4))],
         [u0 * sin(q1) - u2], [u0 * sin(q1) - u2]])
 
@@ -1120,9 +1120,9 @@ def test_spherical_joint_orient_space():
                        rot_type='space', rot_order=123)
     assert S._rot_type.upper() == 'SPACE'
     assert S._rot_order == 123
-    assert _simplify_matrix(N.dcm(A) - N_R_A) == zeros(3)
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A)) == N_w_A
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
+    assert simplify(N.dcm(A) - N_R_A) == zeros(3)
+    assert simplify(A.ang_vel_in(N).to_matrix(A)) == N_w_A
+    assert simplify(C.masscenter.vel(N).to_matrix(A)) == N_v_Co
     # Test change of amounts
     switch_order = lambda expr: expr.xreplace(
         {q0: q1, q1: q0, q2: q2, u0: u1, u1: u0, u2: u2})
@@ -1133,9 +1133,9 @@ def test_spherical_joint_orient_space():
                        rot_type='SPACE', amounts=(q1, q0, q2), rot_order=123)
     assert S._rot_type.upper() == 'SPACE'
     assert S._rot_order == 123
-    assert _simplify_matrix(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A)) == switch_order(N_w_A)
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
+    assert simplify(N.dcm(A) - switch_order(N_R_A)) == zeros(3)
+    assert simplify(A.ang_vel_in(N).to_matrix(A)) == switch_order(N_w_A)
+    assert simplify(C.masscenter.vel(N).to_matrix(A)) == switch_order(N_v_Co)
     # Test different rot_order
     N, A, P, C, Pint, Cint = _generate_body(True)
     S = SphericalJoint('S', P, C, coordinates=[q0, q1, q2], speeds=[u0, u1, u2],
@@ -1144,16 +1144,16 @@ def test_spherical_joint_orient_space():
                        rot_type='SPaCe', rot_order='zxy')
     assert S._rot_type.upper() == 'SPACE'
     assert S._rot_order == 'zxy'
-    assert _simplify_matrix(N.dcm(A) - Matrix([
+    assert simplify(N.dcm(A) - Matrix([
         [-sin(q2) * cos(q1), -sin(q0) * cos(q2) + sin(q1) * sin(q2) * cos(q0),
          sin(q0) * sin(q1) * sin(q2) + cos(q0) * cos(q2)],
         [-sin(q1), -cos(q0) * cos(q1), -sin(q0) * cos(q1)],
         [cos(q1) * cos(q2), -sin(q0) * sin(q2) - sin(q1) * cos(q0) * cos(q2),
          -sin(q0) * sin(q1) * cos(q2) + sin(q2) * cos(q0)]]))
-    assert _simplify_matrix(A.ang_vel_in(N).to_matrix(A) - Matrix([
+    assert simplify(A.ang_vel_in(N).to_matrix(A) - Matrix([
         [-u0 + u2 * sin(q1)], [-u1 * sin(q0) + u2 * cos(q0) * cos(q1)],
         [u1 * cos(q0) + u2 * sin(q0) * cos(q1)]])) == zeros(3, 1)
-    assert _simplify_matrix(C.masscenter.vel(N).to_matrix(A) - Matrix([
+    assert simplify(C.masscenter.vel(N).to_matrix(A) - Matrix([
         [u1 * cos(q0) + u2 * sin(q0) * cos(q1)],
         [u1 * cos(q0) + u2 * sin(q0) * cos(q1)],
         [u0 + u1 * sin(q0) - u2 * sin(q1) -

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -8,7 +8,7 @@ from sympy.physics.mechanics import (
     PrismaticJoint, LagrangesMethod, inertia)
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
 from sympy.testing.pytest import raises
-from sympy.core.backend import zeros
+from sympy import zeros
 from sympy.utilities.lambdify import lambdify
 from sympy.solvers.solvers import solve
 

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,12 +1,11 @@
 from sympy import solve
-from sympy.core.backend import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
+from sympy import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
                                 zeros, eye)
 from sympy.simplify.simplify import simplify
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
                                      dot, find_dynamicsymbols)
 from sympy.testing.pytest import raises
-from sympy.core.backend import USE_SYMENGINE
 
 
 def test_invalid_coordinates():
@@ -454,11 +453,7 @@ def test_implicit_kinematics():
           explicit_kinematics = False # implicit kinematics
         )
     except Exception as e:
-        # symengine struggles with these kinematic equations
-        if USE_SYMENGINE and 'Matrix is rank deficient' in str(e):
-            return
-        else:
-            raise e
+        raise e
 
     # mass and inertia dyadic relative to CM
     M_B = symbols('M_B')

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import cos, Matrix, sin, zeros, tan, pi, symbols
+from sympy import cos, Matrix, sin, zeros, tan, pi, symbols
 from sympy.simplify.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.solvers.solvers import solve

--- a/sympy/physics/mechanics/tests/test_kane4.py
+++ b/sympy/physics/mechanics/tests/test_kane4.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import (cos, sin, Matrix, symbols)
+from sympy import (cos, sin, Matrix, symbols)
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                         KanesMethod, Particle)
 

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -2,7 +2,6 @@ from sympy import (zeros, Matrix, symbols, lambdify, sqrt, pi,
                                 simplify)
 from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
-from sympy.testing.pytest import skip
 
 
 def _create_rolling_disc():

--- a/sympy/physics/mechanics/tests/test_kane5.py
+++ b/sympy/physics/mechanics/tests/test_kane5.py
@@ -1,5 +1,5 @@
-from sympy.core.backend import (zeros, Matrix, symbols, lambdify, sqrt, pi,
-                                _simplify_matrix, USE_SYMENGINE)
+from sympy import (zeros, Matrix, symbols, lambdify, sqrt, pi,
+                                simplify)
 from sympy.physics.mechanics import (dynamicsymbols, cross, inertia, RigidBody,
                                      ReferenceFrame, KanesMethod)
 from sympy.testing.pytest import skip
@@ -91,8 +91,6 @@ def _verify_rolling_disc_numerically(kane, all_zero=False):
 
 
 def test_kane_rolling_disc_lu():
-    if USE_SYMENGINE:
-        skip('symengine does not support lambdify with dynamicsymbols.')
     props = _create_rolling_disc()
     kane = KanesMethod(props['frame'], props['q_ind'], props['u_ind'],
                        props['kdes'], u_dependent=props['u_dep'],
@@ -104,15 +102,13 @@ def test_kane_rolling_disc_lu():
 
 
 def test_kane_rolling_disc_kdes_callable():
-    if USE_SYMENGINE:
-        skip('symengine does not support lambdify with dynamicsymbols.')
     props = _create_rolling_disc()
     kane = KanesMethod(
         props['frame'], props['q_ind'], props['u_ind'], props['kdes'],
         u_dependent=props['u_dep'], velocity_constraints=props['fnh'],
         bodies=props['bodies'], forcelist=props['loads'],
         explicit_kinematics=False,
-        kd_eqs_solver=lambda A, b: _simplify_matrix(A.LUsolve(b)))
+        kd_eqs_solver=lambda A, b: simplify(A.LUsolve(b)))
     q, u, p = dynamicsymbols('q1:6'), dynamicsymbols('u1:6'), symbols('g r m')
     qd = dynamicsymbols('q1:6', 1)
     eval_kdes = lambdify((q, qd, u, p), tuple(kane.kindiffdict().items()))

--- a/sympy/physics/mechanics/tests/test_lagrange2.py
+++ b/sympy/physics/mechanics/tests/test_lagrange2.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import symbols
+from sympy import symbols
 from sympy.physics.mechanics import dynamicsymbols
 from sympy.physics.mechanics import ReferenceFrame, Point, Particle
 from sympy.physics.mechanics import LagrangesMethod, Lagrangian

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,5 +1,5 @@
-from sympy.core.backend import (symbols, Matrix, cos, sin, atan, sqrt,
-    Rational, _simplify_matrix, USE_SYMENGINE)
+from sympy import (symbols, Matrix, cos, sin, atan, sqrt,
+    Rational, simplify)
 from sympy.core.sympify import sympify
 from sympy.simplify.simplify import simplify
 from sympy.solvers.solvers import solve
@@ -132,13 +132,12 @@ def test_linearize_rolling_disc_kane():
     assert sympify(A.subs(upright_nominal).subs(q3d, 1/sqrt(3))).eigenvals() == {0: 8}
 
     # Check whether alternative solvers work
-    if not USE_SYMENGINE:
-        # symengine doesn't support method='GJ'
-        linearizer = KM.to_linearizer(linear_solver='GJ')
-        A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op],
-                                    A_and_B=True, simplify=True)
-        assert A.subs(upright_nominal) == A_sol
-        assert B.subs(upright_nominal) == B_sol
+    # symengine doesn't support method='GJ'
+    linearizer = KM.to_linearizer(linear_solver='GJ')
+    A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op],
+                                A_and_B=True, simplify=True)
+    assert A.subs(upright_nominal) == A_sol
+    assert B.subs(upright_nominal) == B_sol
 
 def test_linearize_pendulum_kane_minimal():
     q1 = dynamicsymbols('q1')                     # angle of pendulum
@@ -242,13 +241,12 @@ def test_linearize_pendulum_kane_nonminimal():
     assert B == Matrix([])
 
 
-    if not USE_SYMENGINE:
-        # symengine doesn't support method='GJ'
-        A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True,
-                                    simplify=True, linear_solver='GJ')
+    # symengine doesn't support method='GJ'
+    A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True,
+                                simplify=True, linear_solver='GJ')
 
-        assert A.expand() == Matrix([[0, 1], [-9.8/L, 0]])
-        assert B == Matrix([])
+    assert A.expand() == Matrix([[0, 1], [-9.8/L, 0]])
+    assert B == Matrix([])
 
     A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op],
                                  A_and_B=True,
@@ -287,17 +285,14 @@ def test_linearize_pendulum_lagrange_minimal():
     # Linearize
     A, B, inp_vec = LM.linearize([q1], [q1d], A_and_B=True)
 
-    assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
+    assert simplify(A) == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
     assert B == Matrix([])
 
     # Check an alternative solver
-    if not USE_SYMENGINE:
-        # symengine doesn't support method='GJ'
-        A, B, inp_vec = LM.linearize([q1], [q1d], A_and_B=True,
-                                     linear_solver='GJ')
+    A, B, inp_vec = LM.linearize([q1], [q1d], A_and_B=True, linear_solver='GJ')
 
-        assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
-        assert B == Matrix([])
+    assert simplify(A) == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
+    assert B == Matrix([])
 
 
 def test_linearize_pendulum_lagrange_nonminimal():
@@ -330,14 +325,14 @@ def test_linearize_pendulum_lagrange_nonminimal():
     # Perform the Linearization
     A, B, inp_vec = LM.linearize([q2], [q2d], [q1], [q1d],
             op_point=op_point, A_and_B=True)
-    assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8/L, 0]])
+    assert simplify(A) == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])
 
     # Check if passing a function to linear_solver works
     A, B, inp_vec = LM.linearize([q2], [q2d], [q1], [q1d], op_point=op_point,
                                  A_and_B=True, linear_solver=lambda A, b:
                                  A.LUsolve(b))
-    assert _simplify_matrix(A) == Matrix([[0, 1], [-9.8/L, 0]])
+    assert simplify(A) == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])
 
 def test_linearize_rolling_disc_lagrange():

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,5 +1,4 @@
-from sympy import (symbols, Matrix, cos, sin, atan, sqrt,
-    Rational, simplify)
+from sympy import symbols, Matrix, cos, sin, atan, sqrt, Rational
 from sympy.core.sympify import sympify
 from sympy.simplify.simplify import simplify
 from sympy.solvers.solvers import solve

--- a/sympy/physics/mechanics/tests/test_loads.py
+++ b/sympy/physics/mechanics/tests/test_loads.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from sympy.core.backend import symbols
+from sympy import symbols
 from sympy.physics.mechanics import (RigidBody, Particle, ReferenceFrame, Point,
                                      outer, dynamicsymbols, Force, Torque)
 from sympy.physics.mechanics.loads import gravity, _parse_load

--- a/sympy/physics/mechanics/tests/test_models.py
+++ b/sympy/physics/mechanics/tests/test_models.py
@@ -1,5 +1,5 @@
 import sympy.physics.mechanics.models as models
-from sympy.core.backend import (cos, sin, Matrix, symbols, zeros)
+from sympy import (cos, sin, Matrix, symbols, zeros)
 from sympy.simplify.simplify import simplify
 from sympy.physics.mechanics import (dynamicsymbols)
 

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import symbols
+from sympy import symbols
 from sympy.physics.mechanics import Point, Particle, ReferenceFrame, inertia
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.testing.pytest import raises, warns_deprecated_sympy

--- a/sympy/physics/mechanics/tests/test_pathway.py
+++ b/sympy/physics/mechanics/tests/test_pathway.py
@@ -2,10 +2,9 @@
 
 import pytest
 
-from sympy.core.backend import (
+from sympy import (
     Rational,
     Symbol,
-    USE_SYMENGINE,
     cos,
     pi,
     sin,
@@ -132,14 +131,6 @@ class TestLinearPathway:
         expected = 2*sqrt(self.q1**2)
         assert self.pathway.length == expected
 
-    @pytest.mark.skipif(
-        USE_SYMENGINE,
-        reason=(
-            'SymEngine give equivalent expression that does not compare equal;'
-            'SymPy puts the sqrt(q(t)**2) term in the numerator, while '
-            'SymEngine puts it in the denominator'
-        )
-    )
     def test_2D_pathway_extension_velocity(self):
         self.pB.set_pos(self.pA, 2*self.q1*self.N.x)
         expected = 2*sqrt(self.q1**2)*self.q1d/self.q1
@@ -589,7 +580,6 @@ class TestWrappingPathway:
         ]
         assert pathway.to_loads(self.F) == expected
 
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'pA_vec, pB_vec, pA_vec_expected, pB_vec_expected, pO_vec_expected',
         (
@@ -662,7 +652,6 @@ class TestWrappingPathway:
         ]
         assert _simplify_loads(pathway.to_loads(self.F)) == expected
 
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_length(self):
         q = dynamicsymbols('q')
         pA_pos = self.r*self.N.x
@@ -672,7 +661,6 @@ class TestWrappingPathway:
         expected = self.r*sqrt(q**2)
         assert simplify(self.pathway.length - expected) == 0
 
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_extension_velocity(self):
         q = dynamicsymbols('q')
         qd = dynamicsymbols('q', 1)
@@ -683,7 +671,6 @@ class TestWrappingPathway:
         expected = self.r*(sqrt(q**2)/q)*qd
         assert simplify(self.pathway.extension_velocity - expected) == 0
 
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     def test_2D_pathway_on_cylinder_to_loads(self):
         q = dynamicsymbols('q')
         pA_pos = self.r*self.N.x

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,7 +1,7 @@
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
 from sympy.physics.mechanics import dynamicsymbols, outer, inertia, Inertia
 from sympy.physics.mechanics import inertia_of_point_mass
-from sympy.core.backend import expand, zeros, _simplify_matrix, symbols
+from sympy import expand, zeros, simplify, symbols
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
@@ -170,7 +170,7 @@ def test_parallel_axis():
     # Reference frame from which the parallel axis is viewed should not matter
     A = ReferenceFrame('A')
     A.orient_axis(N, N.z, 1)
-    assert _simplify_matrix(
+    assert simplify(
         (R.parallel_axis(p, A) - Ip_expected).to_matrix(A)) == zeros(3, 3)
 
 

--- a/sympy/physics/mechanics/tests/test_system.py
+++ b/sympy/physics/mechanics/tests/test_system.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import symbols, Matrix, atan, zeros
+from sympy import symbols, Matrix, atan, zeros
 from sympy.simplify.simplify import simplify
 from sympy.physics.mechanics import (dynamicsymbols, Particle, Point,
                                      ReferenceFrame, SymbolicSystem)

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -1,7 +1,6 @@
 import pytest
 
-from sympy import (
-    ImmutableMatrix, simplify, cos, eye, sin, symbols, sympify, zeros)
+from sympy import ImmutableMatrix, cos, eye, sin, symbols, sympify, zeros
 from sympy.physics.mechanics import (
     Force, KanesMethod, LagrangesMethod, Particle, PinJoint, Point,
     PrismaticJoint, ReferenceFrame, RigidBody, Torque, TorqueActuator,

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -1,7 +1,7 @@
 import pytest
 
-from sympy.core.backend import (
-    ImmutableMatrix, _simplify_matrix, cos, eye, sin, symbols, sympify, zeros)
+from sympy import (
+    ImmutableMatrix, simplify, cos, eye, sin, symbols, sympify, zeros)
 from sympy.physics.mechanics import (
     Force, KanesMethod, LagrangesMethod, Particle, PinJoint, Point,
     PrismaticJoint, ReferenceFrame, RigidBody, Torque, TorqueActuator,
@@ -611,10 +611,10 @@ class TestSystemExamples:
         system.validate_system()
         system.form_eoms()
         assert isinstance(system.eom_method, KanesMethod)
-        assert (_simplify_matrix(system.mass_matrix - ImmutableMatrix(
+        assert (simplify(system.mass_matrix - ImmutableMatrix(
             [[mp + mc, mp * l * cos(qp)], [mp * l * cos(qp), mp * l ** 2]]))
                 == zeros(2, 2))
-        assert (_simplify_matrix(system.forcing - ImmutableMatrix([
+        assert (simplify(system.forcing - ImmutableMatrix([
             [mp * l * up ** 2 * sin(qp) + F],
             [-mp * g * l * sin(qp) + k * qp]])) == zeros(2, 1))
 
@@ -649,10 +649,10 @@ class TestSystemExamples:
               cos(qp) - l * F * cos(qp)], [l * up ** 2 * sin(qp)]])
         Mm = (Mk.row_join(zeros(2, 2))).col_join(zeros(2, 2).row_join(Md))
         gm = gk.col_join(gd)
-        assert _simplify_matrix(system.mass_matrix - Md) == zeros(2, 2)
-        assert _simplify_matrix(system.forcing - gd) == zeros(2, 1)
-        assert _simplify_matrix(system.mass_matrix_full - Mm) == zeros(4, 4)
-        assert _simplify_matrix(system.forcing_full - gm) == zeros(4, 1)
+        assert simplify(system.mass_matrix - Md) == zeros(2, 2)
+        assert simplify(system.forcing - gd) == zeros(2, 1)
+        assert simplify(system.mass_matrix_full - Mm) == zeros(4, 4)
+        assert simplify(system.forcing_full - gm) == zeros(4, 1)
 
     def test_cart_pendulum_lagrange(self):
         # Lagrange version of test_cart_pendulus_kanes
@@ -683,10 +683,10 @@ class TestSystemExamples:
         system.add_actuators(TorqueActuator(k * qp, cart.z, bob_frame, cart))
         system.validate_system(LagrangesMethod)
         system.form_eoms(LagrangesMethod)
-        assert (_simplify_matrix(system.mass_matrix - ImmutableMatrix(
+        assert (simplify(system.mass_matrix - ImmutableMatrix(
             [[mp + mc, mp * l * cos(qp)], [mp * l * cos(qp), mp * l ** 2]]))
                 == zeros(2, 2))
-        assert (_simplify_matrix(system.forcing - ImmutableMatrix([
+        assert (simplify(system.forcing - ImmutableMatrix([
             [mp * l * qpd ** 2 * sin(qp) + F], [-mp * g * l * sin(qp) + k * qp]]
         )) == zeros(2, 1))
 
@@ -720,7 +720,7 @@ class TestSystemExamples:
         Mm = (eye(2).row_join(zeros(2, 3))).col_join(zeros(3, 2).row_join(
             Md.col_join(ImmutableMatrix([l * cos(qp), 1, 0]).T)))
         gm = ImmutableMatrix([qpd, qcd] + gd[:] + [l * sin(qp) * qpd ** 2])
-        assert _simplify_matrix(system.mass_matrix - Md) == zeros(2, 3)
-        assert _simplify_matrix(system.forcing - gd) == zeros(2, 1)
-        assert _simplify_matrix(system.mass_matrix_full - Mm) == zeros(5, 5)
-        assert _simplify_matrix(system.forcing_full - gm) == zeros(5, 1)
+        assert simplify(system.mass_matrix - Md) == zeros(2, 3)
+        assert simplify(system.forcing - gd) == zeros(2, 1)
+        assert simplify(system.mass_matrix_full - Mm) == zeros(5, 5)
+        assert simplify(system.forcing_full - gm) == zeros(5, 1)

--- a/sympy/physics/mechanics/tests/test_wrapping_geometry.py
+++ b/sympy/physics/mechanics/tests/test_wrapping_geometry.py
@@ -2,12 +2,11 @@
 
 import pytest
 
-from sympy.core.backend import (
+from sympy import (
     Integer,
     Rational,
     S,
     Symbol,
-    USE_SYMENGINE,
     acos,
     cos,
     pi,
@@ -89,7 +88,6 @@ class TestWrappingSphere:
         assert simplify(Eq(sphere.geodesic_length(p1, p2), expected))
 
     @staticmethod
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'position_1, position_2, vector_1, vector_2',
         [
@@ -266,7 +264,6 @@ class TestWrappingCylinder:
         assert simplify(Eq(cylinder.geodesic_length(p1, p2), expected))
 
     @staticmethod
-    @pytest.mark.skipif(USE_SYMENGINE, reason='SymEngine does not simplify')
     @pytest.mark.parametrize(
         'axis, position_1, position_2, vector_1, vector_2',
         [

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from sympy.core.backend import Integer, acos, pi, sqrt, sympify, tan
+from sympy import Integer, acos, pi, sqrt, sympify, tan
 from sympy.core.relational import Eq
 from sympy.functions.elementary.trigonometric import atan2
 from sympy.polys.polytools import cancel

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
+from sympy import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.evalf import EvalfMixin
 from sympy.printing.defaults import Printable
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import (diff, expand, sin, cos, sympify, eye, zeros,
+from sympy import (diff, expand, sin, cos, sympify, eye, zeros,
                                 ImmutableMatrix as Matrix, MatrixBase)
 from sympy.core.symbol import Symbol
 from sympy.simplify.trigsimp import trigsimp

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -1,6 +1,6 @@
 from functools import reduce
 
-from sympy.core.backend import (sympify, diff, sin, cos, Matrix, symbols,
+from sympy import (sympify, diff, sin, cos, Matrix, symbols,
                                 Function, S, Symbol)
 from sympy.integrals.integrals import integrate
 from sympy.simplify.trigsimp import trigsimp

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,5 @@
-from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros, acos,
-                                ImmutableMatrix as Matrix, _simplify_matrix)
+from sympy import (S, sympify, expand, sqrt, Add, zeros, acos,
+                                ImmutableMatrix as Matrix, simplify)
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -655,7 +655,7 @@ class Vector(Printable, EvalfMixin):
         """Returns a simplified Vector."""
         d = {}
         for v in self.args:
-            d[v[1]] = _simplify_matrix(v[0])
+            d[v[1]] = simplify(v[0])
         return Vector(d)
 
     def subs(self, *args, **kwargs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25401


#### Brief description of what is fixed or changed

Symengine was added as a backend for sympy.physics.mechanics and related packages and modules to improve performance. Instead it created a maintenance burden because the developers of these SymPy packages do not develop Symengine and many additions improvements to the SymPy packages require duplicating functionality in Symengine. This PR removes support for the Symengine backend in a backwards compatible fashion. If a user was using this, results will not change but their code execution may become slower.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * Symengine backend support removed.
* physics.mechanics
  * Symengine backend support removed.
* physics.biomechanics
  * Symengine backend support removed.
  
<!-- END RELEASE NOTES -->
