### PR TITLE
Allowed for up to evalf triple integrals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -771,6 +771,7 @@ Joseph Dougherty <Github@JWDougherty.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
+Joshua Hwang <41476440+Joshua-Hwang@users.noreply.github.com>
 José Senart <jose.senart@gmail.com>
 João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1109,9 +1109,9 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
         max_real_term: tUnion[float, int] = MINUS_INF
         max_imag_term: tUnion[float, int] = MINUS_INF
 
-        def f(*args: 'Expr') -> tUnion[mpc, mpf]:
+        def f(*symbol_values: 'Expr') -> tUnion[mpc, mpf]:
             nonlocal max_real_term, max_imag_term
-            subs = {symbol: value for symbol, value in zip(integration_symbols, args)}
+            subs = dict(zip(integration_symbols, symbol_values))
             re, im, re_acc, im_acc = evalf(func, mp.prec, {'subs': subs})
 
             have_part[0] = re or have_part[0]

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1125,6 +1125,9 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
             return mpf(re or fzero)
 
         if options.get('quad') == 'osc':
+            if len(limits) > 1:
+                raise NotImplementedError
+
             A = Wild('A', exclude=[x])
             B = Wild('B', exclude=[x])
             D = Wild('D')

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1090,7 +1090,7 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
                     diff = xhigh - xlow
                     if diff.is_number:
                         xlow, xhigh = 0, diff
-            
+
             limits.append([
                 as_mpmath(xlow, prec + 15, options),
                 as_mpmath(xhigh, prec + 15, options)])

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -10,7 +10,7 @@ import math
 
 import mpmath.libmp as libmp
 from mpmath import (
-    make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc, workprec)
+    make_mpc, make_mpf, mpc, mpf, nsum, quadts, quadosc, workprec)
 from mpmath import inf as mpmath_inf
 from mpmath.libmp import (from_int, from_man_exp, from_rational, fhalf,
         fnan, finf, fninf, fnone, fone, fzero, mpf_abs, mpf_add,

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -516,12 +516,16 @@ def test_evalf_integral():
 
 
 def test_issue_21605_double_integral():
-    assert NS('Integral(x*y**2, (x, 0, 1), (y, 0, 1))', 10) == '0.1666666667'
+    assert NS('Integral(x*y**2, (x, 0, 1), (y, 0, 1))', 10, quadmaxdims=2) == '0.1666666667'
 
 
 @slow
 def test_issue_21605_triple_integral():
-    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10) == '0.04166666667'
+    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10, quadmaxdims=2) == '0.04166666667'
+
+
+def test_issue_21605_skip_evalf_triple_integral():
+    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10, quadmaxdims=1) == 'Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))'
 
 
 def test_issue_8821_highprec_from_str():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -35,7 +35,7 @@ from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
 from mpmath import inf, ninf, make_mpc
 from mpmath.libmp.libmpf import from_float, fzero
 from sympy.core.expr import unchanged
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, slow
 from sympy.abc import n, x, y
 
 
@@ -515,8 +515,12 @@ def test_evalf_integral():
     assert Integral(sin(x), (x, -pi, pi + eps)).n(2)._prec == 10
 
 
-def test_issue_21605_multi_dimension_integral():
+def test_issue_21605_double_integral():
     assert NS('Integral(x*y**2, (x, 0, 1), (y, 0, 1))', 10) == '0.1666666667'
+
+
+@slow
+def test_issue_21605_triple_integral():
     assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10) == '0.04166666667'
 
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -515,6 +515,11 @@ def test_evalf_integral():
     assert Integral(sin(x), (x, -pi, pi + eps)).n(2)._prec == 10
 
 
+def test_issue_21605_multi_dimension_integral():
+    assert NS('Integral(x*y**2, (x, 0, 1), (y, 0, 1))', 10) == '0.1666666667'
+    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10) == '0.04166666667'
+
+
 def test_issue_8821_highprec_from_str():
     s = str(pi.evalf(128))
     p = N(s)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -521,7 +521,7 @@ def test_issue_21605_double_integral():
 
 @slow
 def test_issue_21605_triple_integral():
-    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10, quadmaxdims=2) == '0.04166666667'
+    assert NS('Integral(x*y**2*z**3, (x, 0, 1), (y, 0, 1), (z, 0, 1))', 10, quadmaxdims=3) == '0.04166666667'
 
 
 def test_issue_21605_skip_evalf_triple_integral():

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2024,10 +2024,10 @@ class MatrixOperations(MatrixRequired):
     def doit(self, **hints):
         return self.applyfunc(lambda x: x.doit(**hints))
 
-    def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False):
+    def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False, quadmaxdims=1):
         """Apply evalf() to each element of self."""
         options = {'subs':subs, 'maxn':maxn, 'chop':chop, 'strict':strict,
-                'quad':quad, 'verbose':verbose}
+                'quad':quad, 'verbose':verbose, 'quadmaxdims':quadmaxdims}
         return self.applyfunc(lambda i: i.evalf(n, **options))
 
     def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -62,7 +62,7 @@ class BasisDependent(Expr):
     def __rtruediv__(self, other):
         return TypeError("Invalid divisor for division")
 
-    def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False):
+    def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False, quadmaxdims=1):
         """
         Implements the SymPy evalf routine for this quantity.
 
@@ -71,7 +71,7 @@ class BasisDependent(Expr):
 
         """
         options = {'subs':subs, 'maxn':maxn, 'chop':chop, 'strict':strict,
-                'quad':quad, 'verbose':verbose}
+                'quad':quad, 'verbose':verbose, 'quadmaxdims':quadmaxdims}
         vec = self.zero
         for k, v in self.components.items():
             vec += v.evalf(n, **options) * k


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #21605 


#### Brief description of what is fixed or changed
`mpmath` allows for evaluating up to triple integrals.

I've exposed this ability in `evalf`

#### Other comments
Testing the triple integral was quite slow. That's a result of how many dimensions we're working in.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `Integral` with up to three dimensions can be `evalf`d
<!-- END RELEASE NOTES -->
