### PR TITLE
Added error messages to the Lark LaTeX parser

### DIFF
--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -158,15 +158,15 @@ class TransformToSymPyExpr(Transformer):
 
         differential_symbol = tokens[differential_symbol_index + 1]
 
-        # we can't simply do something like `if (lower_bound and not upper_bound) ...`
-        # because this would evaluate to `True` if the `lower_bound` is 0
+        # we can't simply do something like `if (lower_bound and not upper_bound) ...` because this would
+        # evaluate to `True` if the `lower_bound` is 0 and upper bound is non-zero
         if lower_bound is not None and upper_bound is None:
             # then one was given and the other wasn't
-            raise LaTeXParsingError("Lower bound for the integral was found, but upper bound was not bound.")
+            raise LaTeXParsingError("Lower bound for the integral was found, but upper bound was not found.")
 
         if upper_bound is not None and lower_bound is None:
             # then one was given and the other wasn't
-            raise LaTeXParsingError("Upper bound for the integral was found, but lower bound was not bound.")
+            raise LaTeXParsingError("Upper bound for the integral was found, but lower bound was not found.")
 
         # check if any expression was given or not. If it wasn't, then set the integrand to 1.
         if underscore_index is not None and underscore_index == differential_symbol_index - 2:
@@ -181,10 +181,9 @@ class TransformToSymPyExpr(Transformer):
             integrand = tokens[differential_symbol_index - 1]
 
         if lower_bound is not None:
-            # we have an definite integral
+            # we have a definite integral
 
-            # we can assume that either both the lower and upper bounds are given, or
-            # neither of them are
+            # we can assume that either both the lower and upper bounds are given, or neither of them are
             return sympy.Integral(integrand, (differential_symbol, lower_bound, upper_bound))
         else:
             # we have an indefinite integral

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -7,11 +7,12 @@ from sympy.parsing.latex.errors import LaTeXParsingError
 lark = import_module("lark")
 
 if lark:
-    from lark import Transformer, Token # type: ignore
+    from lark import Transformer, Token  # type: ignore
 else:
     class Transformer:  # type: ignore
         def transform(self, *args):
             pass
+
 
     class Token:  # type: ignore
         pass
@@ -97,7 +98,7 @@ class TransformToSymPyExpr(Transformer):
         elif relation_type == "GTE":
             return sympy.Ge(tokens[0], tokens[2])
         else:
-            raise LaTeXParsingError() # TODO: Fill descriptive error message.
+            raise LaTeXParsingError()  # TODO: Fill descriptive error message.
 
     def add(self, tokens):
         return sympy.Add(tokens[0], tokens[2])
@@ -110,6 +111,7 @@ class TransformToSymPyExpr(Transformer):
 
     def mul(self, tokens):
         if len(tokens) == 2:
+            # if left tokken is a ket and right one is a bra, then return outer product. Else, return normal multiplication.
             return sympy.Mul(tokens[0], tokens[1])
         elif len(tokens) == 3:
             return sympy.Mul(tokens[0], tokens[2])
@@ -152,8 +154,8 @@ class TransformToSymPyExpr(Transformer):
             differential_symbol_index = tokens.index(r"\mathrm{d}")
         else:
             # differential symbol was not found
-            raise LaTeXParsingError("Differential symbol was not found in the expression." \
-                "Valid differential symbols are \"d\", \"\\text{d}, and \"\\mathrm{d}\".")
+            raise LaTeXParsingError("Differential symbol was not found in the expression."
+                                    "Valid differential symbols are \"d\", \"\\text{d}, and \"\\mathrm{d}\".")
 
         differential_symbol = tokens[differential_symbol_index + 1]
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -98,7 +98,7 @@ class TransformToSymPyExpr(Transformer):
         elif relation_type == "GTE":
             return sympy.Ge(tokens[0], tokens[2])
         else:
-            raise LaTeXParsingError()  # TODO: Fill descriptive error message.
+            raise LaTeXParsingError("An unsupported relational symbol was found.")
 
     def add(self, tokens):
         return sympy.Add(tokens[0], tokens[2])
@@ -111,7 +111,6 @@ class TransformToSymPyExpr(Transformer):
 
     def mul(self, tokens):
         if len(tokens) == 2:
-            # if left tokken is a ket and right one is a bra, then return outer product. Else, return normal multiplication.
             return sympy.Mul(tokens[0], tokens[1])
         elif len(tokens) == 3:
             return sympy.Mul(tokens[0], tokens[2])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

When writing the LaTeX parser, I had left most of the error messages as TODOs. In this PR, I filled out all the error messages with helpful strings.

#### Other comments

cc @sylee957 and @Upabjojr for review.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
