### PR TITLE
Fixed the piecewise simplify when boolean conditions are included

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1189,6 +1189,8 @@ def piecewise_simplify_arguments(expr, **kwargs):
                 elif incl_b:
                     if b.is_infinite:
                         c = (x > a)
+                    elif a in covered:
+                        c = (x <= b)
                     else:
                         c = And(a < x, x <= b)
                 else:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1172,25 +1172,29 @@ def piecewise_simplify_arguments(expr, **kwargs):
                 cset = iv - covered
                 if not cset:
                     continue
+                a = cset.inf
+                incl_a = include(c, x, a)
                 if incl_a and incl_b:
                     if a.is_infinite and b.is_infinite:
                         c = S.true
                     elif b.is_infinite:
-                        c = (x >= a)
-                    elif a in covered or a.is_infinite:
+                        c = (x > a) if a in covered else (x >= a)
+                    elif a.is_infinite:
                         c = (x <= b)
+                    elif a in covered:
+                        c = And(a < x, x <= b)
                     else:
                         c = And(a <= x, x <= b)
                 elif incl_a:
-                    if a in covered or a.is_infinite:
+                    if a.is_infinite:
                         c = (x < b)
+                    elif a in covered:
+                        c = And(a < x, x < b)
                     else:
                         c = And(a <= x, x < b)
                 elif incl_b:
                     if b.is_infinite:
                         c = (x > a)
-                    elif a in covered:
-                        c = (x <= b)
                     else:
                         c = And(a < x, x <= b)
                 else:

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -26,7 +26,7 @@ from sympy.printing import srepr
 from sympy.sets.contains import Contains
 from sympy.sets.sets import Interval
 from sympy.solvers.solvers import solve
-from sympy.testing.pytest import raises, slow, XFAIL
+from sympy.testing.pytest import raises, slow
 from sympy.utilities.lambdify import lambdify
 
 a, b, c, d, x, y = symbols('a:d, x, y')

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -548,6 +548,13 @@ def test_piecewise_simplify():
     assert Piecewise((log(x), (x <= 5) & (x > 3)), (x, True)
         ).simplify() == Piecewise((log(x), (x <= 5) & (x > 3)), (x, True))
 
+    assert Piecewise((1, (x >= 1) & (x < 3)), (2, (x > 2) & (x < 4))
+        ).simplify() == Piecewise((1, (x >= 1) & (x < 3)), (
+        2, (x >= 3) & (x < 4)), (nan, True))
+    assert Piecewise((1, (x >= 1) & (x <= 3)), (2, (x > 2) & (x < 4))
+        ).simplify() == Piecewise((1, (x >= 1) & (x <= 3)), (
+        2, (x > 3) & (x < 4)), (nan, True))
+
 
 def test_piecewise_solve():
     abs2 = Piecewise((-x, x <= 0), (x, x > 0))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -534,13 +534,8 @@ def test_piecewise_simplify():
         ).simplify() == Piecewise((1, (x >= 2) & (x < oo)), (nan, True))
     assert Piecewise((1, x < 2), (2, (x > 1) & (x < 3)), (3, True)
         ). simplify() == Piecewise((1, x < 2), (2, x < 3), (3, True))
-
-    # See test_piecewise_simplify_xfail_redundant_inequality below
-    #
-    # assert Piecewise((1, x < 2), (2, (x <= 3) & (x > 1)), (3, True)
-    #     ).simplify() == Piecewise((1, x < 2), (2, x <= 3), (3, True))
-    #
-
+    assert Piecewise((1, x < 2), (2, (x <= 3) & (x > 1)), (3, True)
+        ).simplify() == Piecewise((1, x < 2), (2, x <= 3), (3, True))
     assert Piecewise((1, x < 2), (2, (x > 2) & (x < 3)), (3, True)
         ).simplify() == Piecewise((1, x < 2), (2, (x > 2) & (x < 3)),
         (3, True))
@@ -552,14 +547,6 @@ def test_piecewise_simplify():
     # https://github.com/sympy/sympy/issues/25603
     assert Piecewise((log(x), (x <= 5) & (x > 3)), (x, True)
         ).simplify() == Piecewise((log(x), (x <= 5) & (x > 3)), (x, True))
-
-
-@XFAIL
-def test_piecewise_simplify_xfail_redundant_inequality():
-    # Uncomment this case in test_piecewise_simplify() when it is fixed.
-    # See https://github.com/sympy/sympy/pull/25605
-    assert Piecewise((1, x < 2), (2, (x <= 3) & (x > 1)), (3, True)
-        ).simplify() == Piecewise((1, x < 2), (2, x <= 3), (3, True))
 
 
 def test_piecewise_solve():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -524,8 +524,8 @@ def test_piecewise_simplify():
 
     # coverage
     nan = Undefined
-    covered = Piecewise((1, x > 3), (2, x < 2), (3, x > 1))
-    assert covered.simplify().args  == covered.args
+    assert Piecewise((1, x > 3), (2, x < 2), (3, x > 1)).simplify(
+        )  == Piecewise((1, x > 3), (2, x < 2), (3, True))
     assert Piecewise((1, x < 2), (2, x < 1), (3, True)).simplify(
         ) == Piecewise((1, x < 2), (3, True))
     assert Piecewise((1, x > 2)).simplify() == Piecewise((1, x > 2),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves the #25603 by #25615 

#### Brief description of what is fixed or changed
Fixed the conditions in piecewise when boolean is included. So now the preceding conditions are checked if covered already or not. 

#### Other comments
@smichr 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
