### PR TITLE
Miscellaneous improvements to Lark LaTeX parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -333,7 +333,7 @@ if __name__ == '__main__':
                   'test-examples/pydy-example-repo/*.py',
                   'test-examples/README.txt',
                   ],
-              'sympy.parsing.latex': ['*.txt', '*.g4', 'lark/*.lark'],
+              'sympy.parsing.latex': ['*.txt', '*.g4', 'lark/grammar/*.lark'],
               'sympy.plotting.tests': ['test_region_*.png'],
               'sympy': ['py.typed']
               },

--- a/sympy/parsing/latex/lark/grammar/greek_symbols.lark
+++ b/sympy/parsing/latex/lark/grammar/greek_symbols.lark
@@ -1,0 +1,28 @@
+// Greek symbols
+// TODO: Shouold we include the uppercase variants for the symbols where the uppercase variant doesn't have a separate meaning?
+ALPHA: "\\alpha"
+BETA: "\\beta"
+GAMMA: "\\gamma"
+DELTA: "\\delta" // TODO: Should this be included? Delta usually denotes other things.
+EPSILON: "\\epsilon" |  "\\varepsilon"
+ZETA: "\\zeta"
+ETA: "\\eta"
+THETA: "\\theta" | "\\vartheta"
+// TODO: Should I add iota to the list?
+KAPPA: "\\kappa"
+LAMBDA: "\\lambda" // TODO: What about the uppercase variant?
+MU: "\\mu"
+NU: "\\nu"
+XI: "\\xi"
+// TODO: Should there be a separate note for transforming \pi into sympy.pi?
+RHO: "\\rho" | "\\varrho"
+// TODO: What should we do about sigma?
+TAU: "\\tau"
+UPSILON: "\\upsilon"
+PHI: "\\phi" | "\\varphi"
+CHI: "\\chi"
+PSI: "\\psi"
+OMEGA: "\\omega"
+
+GREEK_SYMBOL: ALPHA | BETA | GAMMA | DELTA | EPSILON | ZETA | ETA | THETA | KAPPA
+    | LAMBDA | MU | NU | XI | RHO | TAU | UPSILON | PHI | CHI | PSI | OMEGA

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -123,7 +123,7 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 
 latex_string: _relation | _expression
 
-_oneletter_symbol: SYMBOL
+_one_letter_symbol: SYMBOL
     | BASIC_SUBSCRIPTED_SYMBOL
     | SYMBOL_WITH_GREEK_SUBSCRIPT
     | GREEK_SUBSCRIPTED_SYMBOL
@@ -131,7 +131,7 @@ _oneletter_symbol: SYMBOL
 multi_letter_symbol: CMD_MATHIT L_BRACE /[a-zA-Z]+(\s+[a-zA-Z]+)*/ R_BRACE
 number: /\d+(\.\d*)?/
 
-_atomic_expr: _oneletter_symbol
+_atomic_expr: _one_letter_symbol
     | multi_letter_symbol
     | number
     | CMD_INFTY
@@ -156,8 +156,8 @@ sub: _expression SUB _expression_mul
 mul: _expression_mul MUL_SYMBOL _expression_power
 div: _expression_mul DIV_SYMBOL _expression_power
 
-adjacent_expressions: (_oneletter_symbol | number) _expression_mul
-    | group_round_parentheses (group_round_parentheses | _oneletter_symbol)
+adjacent_expressions: (_one_letter_symbol | number) _expression_mul
+    | group_round_parentheses (group_round_parentheses | _one_letter_symbol)
     | _function _function
     | fraction _expression
 
@@ -186,7 +186,7 @@ group_curly_parentheses_lim: L_BRACE _expression LIM_APPROACH_SYM (limit_dir_exp
 
 limit: FUNC_LIM UNDERSCORE group_curly_parentheses_lim _expression
 
-differential: DIFFERENTIAL_SYMBOL _oneletter_symbol
+differential: DIFFERENTIAL_SYMBOL _one_letter_symbol
 
 _derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE differential R_BRACE
 
@@ -194,9 +194,9 @@ derivative: _derivative_operator _expression
 
 _integral: normal_integral | integral_with_special_fraction
 
-normal_integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _oneletter_symbol
-    | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
-    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
+normal_integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _one_letter_symbol
+    | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? _expression? DIFFERENTIAL_SYMBOL _one_letter_symbol
+    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _one_letter_symbol
 
 group_curly_parentheses_int: L_BRACE _expression? differential R_BRACE
 
@@ -217,7 +217,7 @@ product: FUNC_PROD group_curly_parentheses_special _expression
 
 superscript: _expression_func CARET _expression_power
 
-ambiguous_sub: _oneletter_symbol number
+ambiguous_sub: _one_letter_symbol number
 
 fraction: _basic_fraction
     | _simple_fraction
@@ -243,7 +243,7 @@ _general_binomial: CMD_BINOM group_curly_parentheses group_curly_parentheses
 
 list_of_expressions: _expression ("," _expression)*
 
-function_applied: _oneletter_symbol L_PAREN list_of_expressions R_PAREN
+function_applied: _one_letter_symbol L_PAREN list_of_expressions R_PAREN
 
 min: FUNC_MIN L_PAREN list_of_expressions R_PAREN
 
@@ -273,7 +273,7 @@ exponential: FUNC_EXP _expression
 log: FUNC_LOG _expression
     | FUNC_LN _expression
     | FUNC_LG _expression
-    | FUNC_LOG UNDERSCORE (DIGIT | _oneletter_symbol) _expression
+    | FUNC_LOG UNDERSCORE (DIGIT | _one_letter_symbol) _expression
     | FUNC_LOG UNDERSCORE group_curly_parentheses _expression
 
 square_root: FUNC_SQRT group_curly_parentheses

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -104,38 +104,12 @@ GTE: "\\geq" | "\\ge" | "\\geqslant"
 DIV_SYMBOL: CMD_DIV | DIV
 MUL_SYMBOL: MUL | CMD_TIMES | CMD_CDOT
 
-// Greek symbols
-// TODO: Shouold we include the uppercase variants for the symbols where the uppercase variant doesn't have a separate meaning?
-ALPHA: "\\alpha"
-BETA: "\\beta"
-GAMMA: "\\gamma"
-DELTA: "\\delta" // TODO: Should this be included? Delta usually denotes other things.
-EPSILON: "\\epsilon" |  "\\varepsilon"
-ZETA: "\\zeta"
-ETA: "\\eta"
-THETA: "\\theta" | "\\vartheta"
-// TODO: Should I add iota to the list?
-KAPPA: "\\kappa"
-LAMBDA: "\\lambda" // TODO: What about the uppercase variant?
-MU: "\\mu"
-NU: "\\nu"
-XI: "\\xi"
-// TODO: Should there be a separate note for transforming \pi into sympy.pi?
-RHO: "\\rho" | "\\varrho"
-// TODO: What should we do about sigma?
-TAU: "\\tau"
-UPSILON: "\\upsilon"
-PHI: "\\phi" | "\\varphi"
-CHI: "\\chi"
-PSI: "\\psi"
-OMEGA: "\\omega"
+%import .greek_symbols.GREEK_SYMBOL
 
-GREEK_SYMBOL: ALPHA | BETA | GAMMA | DELTA | EPSILON | ZETA | ETA | THETA | KAPPA
-    | LAMBDA | MU | NU | XI | RHO | TAU | UPSILON | PHI | CHI | PSI | OMEGA
+DIFFERENTIAL_SYMBOL: "d" | "\\text{d}" | "\\mathrm{d}"
 
-DIFFERENTIAL: "d" | "\\text{d}" | "\\mathrm{d}"
-
-SYMBOL: /[a-zA-Z]/
+// disallow "d" as a variable name because we want to parse "d" as a differential symbol.
+SYMBOL: /[a-ce-zA-Z]/
 BASIC_SUBSCRIPTED_SYMBOL: /([a-zA-Z])_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]|[a-zA-Z]+)\})/
 SYMBOL_WITH_GREEK_SUBSCRIPT: /([a-zA-Z])_/ GREEK_SYMBOL | /([a-zA-Z])_/ L_BRACE GREEK_SYMBOL R_BRACE
 // best to define the variant with braces like that instead of shoving it all into one case like in
@@ -192,7 +166,7 @@ _expression_power: _expression_func | superscript
 
 _expression_mul: _expression_power
     | mul | div | adjacent_expressions
-    | integral// | derivative
+    | integral | derivative
     | summation | product
     | limit
 
@@ -206,9 +180,18 @@ group_curly_parentheses_lim: L_BRACE _expression LIM_APPROACH_SYM (limit_dir_exp
 
 limit: FUNC_LIM UNDERSCORE group_curly_parentheses_lim _expression
 
-integral: FUNC_INT _expression DIFFERENTIAL _oneletter_symbol
-    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL _oneletter_symbol
-    | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? _expression? DIFFERENTIAL _oneletter_symbol
+differential: DIFFERENTIAL_SYMBOL _oneletter_symbol
+
+_derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE differential R_BRACE
+
+derivative: _derivative_operator _expression
+
+//derivative: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE _expression
+//    | CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE
+
+integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _oneletter_symbol
+    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
+    | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
 
 group_curly_parentheses_special: UNDERSCORE L_BRACE _atomic_expr EQUAL _atomic_expr R_BRACE CARET _expression_core
     | CARET _expression_core UNDERSCORE L_BRACE _atomic_expr EQUAL _atomic_expr R_BRACE
@@ -226,9 +209,6 @@ ambiguous_sub: _oneletter_symbol number
 fraction: _basic_fraction
     | _simple_fraction
     | _general_fraction
-
-//derivative: CMD_FRAC L_BRACE DIFFERENTIAL R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE _expression
-//    | CMD_FRAC L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE
 
 _basic_fraction: CMD_FRAC DIGIT (DIGIT | SYMBOL | GREEK_SYMBOL)
 

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -107,11 +107,10 @@ MUL_SYMBOL: MUL | CMD_TIMES | CMD_CDOT
 %import .greek_symbols.GREEK_SYMBOL
 
 UPRIGHT_DIFFERENTIAL_SYMBOL: "\\text{d}" | "\\mathrm{d}"
-LOWERCASE_LETTER_D: "d"
-DIFFERENTIAL_SYMBOL: LOWERCASE_LETTER_D | UPRIGHT_DIFFERENTIAL_SYMBOL
+DIFFERENTIAL_SYMBOL: "d" | UPRIGHT_DIFFERENTIAL_SYMBOL
 
 // disallow "d" as a variable name because we want to parse "d" as a differential symbol.
-SYMBOL: /[a-ce-zA-Z]/
+SYMBOL: /[a-zA-Z]/
 BASIC_SUBSCRIPTED_SYMBOL: /([a-zA-Z])_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]|[a-zA-Z]+)\})/
 SYMBOL_WITH_GREEK_SUBSCRIPT: /([a-zA-Z])_/ GREEK_SYMBOL | /([a-zA-Z])_/ L_BRACE GREEK_SYMBOL R_BRACE
 // best to define the variant with braces like that instead of shoving it all into one case like in
@@ -126,7 +125,6 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 latex_string: _relation | _expression
 
 _one_letter_symbol: SYMBOL
-    | LOWERCASE_LETTER_D
     | BASIC_SUBSCRIPTED_SYMBOL
     | SYMBOL_WITH_GREEK_SUBSCRIPT
     | GREEK_SUBSCRIPTED_SYMBOL

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -106,7 +106,9 @@ MUL_SYMBOL: MUL | CMD_TIMES | CMD_CDOT
 
 %import .greek_symbols.GREEK_SYMBOL
 
-DIFFERENTIAL_SYMBOL: "d" | "\\text{d}" | "\\mathrm{d}"
+UPRIGHT_DIFFERENTIAL_SYMBOL: "\\text{d}" | "\\mathrm{d}"
+LOWERCASE_LETTER_D: "d"
+DIFFERENTIAL_SYMBOL: LOWERCASE_LETTER_D | UPRIGHT_DIFFERENTIAL_SYMBOL
 
 // disallow "d" as a variable name because we want to parse "d" as a differential symbol.
 SYMBOL: /[a-ce-zA-Z]/
@@ -124,6 +126,7 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 latex_string: _relation | _expression
 
 _one_letter_symbol: SYMBOL
+    | LOWERCASE_LETTER_D
     | BASIC_SUBSCRIPTED_SYMBOL
     | SYMBOL_WITH_GREEK_SUBSCRIPT
     | GREEK_SUBSCRIPTED_SYMBOL
@@ -141,6 +144,7 @@ group_square_brackets: L_BRACKET _expression R_BRACKET
 group_curly_parentheses: L_BRACE _expression R_BRACE
 
 _relation: eq | ne | lt | lte | gt | gte
+
 eq: _expression EQUAL _expression
 ne: _expression NOT_EQUAL _expression
 lt: _expression LT _expression
@@ -166,13 +170,12 @@ _expression_func: _expression_core
     | fraction
     | binomial
     | _function
-    | ambiguous_sub
 
 _expression_power: _expression_func | superscript
 
 _expression_mul: _expression_power
     | mul | div | adjacent_expressions
-    | _integral | derivative
+    | _integral// | derivative
     | summation | product
     | limit
 
@@ -188,9 +191,9 @@ limit: FUNC_LIM UNDERSCORE group_curly_parentheses_lim _expression
 
 differential: DIFFERENTIAL_SYMBOL _one_letter_symbol
 
-_derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE differential R_BRACE
+//_derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE differential R_BRACE
 
-derivative: _derivative_operator _expression
+//derivative: _derivative_operator _expression
 
 _integral: normal_integral | integral_with_special_fraction
 
@@ -216,8 +219,6 @@ product: FUNC_PROD group_curly_parentheses_special _expression
     | FUNC_PROD group_curly_parentheses_special _expression
 
 superscript: _expression_func CARET _expression_power
-
-ambiguous_sub: _one_letter_symbol number
 
 fraction: _basic_fraction
     | _simple_fraction

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -121,7 +121,7 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 
 //////////////////// grammar //////////////////////
 
-latex_string: relation | _expression
+latex_string: _relation | _expression
 
 _oneletter_symbol: SYMBOL
     | BASIC_SUBSCRIPTED_SYMBOL
@@ -140,7 +140,13 @@ group_round_parentheses: L_PAREN _expression R_PAREN
 group_square_brackets: L_BRACKET _expression R_BRACKET
 group_curly_parentheses: L_BRACE _expression R_BRACE
 
-relation: _expression (EQUAL | NOT_EQUAL | LT | LTE | GT | GTE) _expression
+_relation: eq | ne | lt | lte | gt | gte
+eq: _expression EQUAL _expression
+ne: _expression NOT_EQUAL _expression
+lt: _expression LT _expression
+lte: _expression LTE _expression
+gt: _expression GT _expression
+gte: _expression GTE _expression
 
 _expression_core: _atomic_expr | group_curly_parentheses
 
@@ -185,9 +191,6 @@ differential: DIFFERENTIAL_SYMBOL _oneletter_symbol
 _derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE differential R_BRACE
 
 derivative: _derivative_operator _expression
-
-//derivative: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE _expression
-//    | CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL_SYMBOL _oneletter_symbol R_BRACE
 
 integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _oneletter_symbol
     | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -172,7 +172,7 @@ _expression_power: _expression_func | superscript
 
 _expression_mul: _expression_power
     | mul | div | adjacent_expressions
-    | integral | derivative
+    | _integral | derivative
     | summation | product
     | limit
 
@@ -192,9 +192,19 @@ _derivative_operator: CMD_FRAC L_BRACE DIFFERENTIAL_SYMBOL R_BRACE L_BRACE diffe
 
 derivative: _derivative_operator _expression
 
-integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _oneletter_symbol
-    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
+_integral: normal_integral | integral_with_special_fraction
+
+normal_integral: FUNC_INT _expression DIFFERENTIAL_SYMBOL _oneletter_symbol
     | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
+    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? _expression? DIFFERENTIAL_SYMBOL _oneletter_symbol
+
+group_curly_parentheses_int: L_BRACE _expression? differential R_BRACE
+
+special_fraction: CMD_FRAC group_curly_parentheses_int group_curly_parentheses
+
+integral_with_special_fraction: FUNC_INT special_fraction
+    | FUNC_INT (CARET _expression_core UNDERSCORE _expression_core)? special_fraction
+    | FUNC_INT (UNDERSCORE _expression_core CARET _expression_core)? special_fraction
 
 group_curly_parentheses_special: UNDERSCORE L_BRACE _atomic_expr EQUAL _atomic_expr R_BRACE CARET _expression_core
     | CARET _expression_core UNDERSCORE L_BRACE _atomic_expr EQUAL _atomic_expr R_BRACE

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -147,18 +147,18 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 
 //////////////////// grammar //////////////////////
 
-latex_string: relation | _expression
+?start: relation | _expression
 
 _oneletter_symbol: SYMBOL
     | BASIC_SUBSCRIPTED_SYMBOL
     | SYMBOL_WITH_GREEK_SUBSCRIPT
     | GREEK_SUBSCRIPTED_SYMBOL
     | GREEK_SYMBOL
-multiletter_symbol: CMD_MATHIT L_BRACE /[a-zA-Z]+(\s+[a-zA-Z]+)*/ R_BRACE
+multi_letter_symbol: CMD_MATHIT L_BRACE /[a-zA-Z]+(\s+[a-zA-Z]+)*/ R_BRACE
 number: /\d+(\.\d*)?/
 
 _atomic_expr: _oneletter_symbol
-    | multiletter_symbol
+    | multi_letter_symbol
     | number
     | CMD_INFTY
 
@@ -190,7 +190,11 @@ _expression_func: _expression_core
 
 _expression_power: _expression_func | superscript
 
-_expression_mul: _expression_power | mul | div | integral | summation | product | limit | derivative
+_expression_mul: _expression_power
+    | mul | div | adjacent_expressions
+    | integral// | derivative
+    | summation | product
+    | limit
 
 _expression: _expression_mul | add | sub
 
@@ -223,8 +227,8 @@ fraction: _basic_fraction
     | _simple_fraction
     | _general_fraction
 
-derivative: CMD_FRAC L_BRACE DIFFERENTIAL R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE _expression
-    |  CMD_FRAC L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE
+//derivative: CMD_FRAC L_BRACE DIFFERENTIAL R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE _expression
+//    | CMD_FRAC L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE
 
 _basic_fraction: CMD_FRAC DIGIT (DIGIT | SYMBOL | GREEK_SYMBOL)
 

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -156,12 +156,11 @@ _oneletter_symbol: SYMBOL
     | GREEK_SYMBOL
 multiletter_symbol: CMD_MATHIT L_BRACE /[a-zA-Z]+(\s+[a-zA-Z]+)*/ R_BRACE
 number: /\d+(\.\d*)?/
-infinity: CMD_INFTY
 
 _atomic_expr: _oneletter_symbol
     | multiletter_symbol
     | number
-    | infinity
+    | CMD_INFTY
 
 group_round_parentheses: L_PAREN _expression R_PAREN
 group_square_brackets: L_BRACKET _expression R_BRACKET

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -147,7 +147,7 @@ GREEK_SUBSCRIPTED_SYMBOL: GREEK_SYMBOL /_(([A-Za-z0-9]|[a-zA-Z]+)|\{([A-Za-z0-9]
 
 //////////////////// grammar //////////////////////
 
-?start: relation | _expression
+latex_string: relation | _expression
 
 _oneletter_symbol: SYMBOL
     | BASIC_SUBSCRIPTED_SYMBOL

--- a/sympy/parsing/latex/lark/latex.lark
+++ b/sympy/parsing/latex/lark/latex.lark
@@ -175,10 +175,9 @@ add: _expression ADD _expression_mul
 sub: _expression SUB _expression_mul
     | SUB _expression_mul
 mul: _expression_mul MUL_SYMBOL _expression_power
-    | _implicit_multiplication
 div: _expression_mul DIV_SYMBOL _expression_power
 
-_implicit_multiplication: (_oneletter_symbol | number) _expression_mul
+adjacent_expressions: (_oneletter_symbol | number) _expression_mul
     | group_round_parentheses (group_round_parentheses | _oneletter_symbol)
     | _function _function
     | fraction _expression
@@ -192,7 +191,7 @@ _expression_func: _expression_core
 
 _expression_power: _expression_func | superscript
 
-_expression_mul: _expression_power | mul | div | integral | summation | product | limit
+_expression_mul: _expression_power | mul | div | integral | summation | product | limit | derivative
 
 _expression: _expression_mul | add | sub
 
@@ -225,6 +224,9 @@ fraction: _basic_fraction
     | _simple_fraction
     | _general_fraction
 
+derivative: CMD_FRAC L_BRACE DIFFERENTIAL R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE _expression
+    |  CMD_FRAC L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE L_BRACE DIFFERENTIAL _oneletter_symbol R_BRACE
+
 _basic_fraction: CMD_FRAC DIGIT (DIGIT | SYMBOL | GREEK_SYMBOL)
 
 _simple_fraction: CMD_FRAC DIGIT group_curly_parentheses
@@ -256,8 +258,6 @@ bra: CMD_LANGLE _expression BAR
 ket: BAR _expression CMD_RANGLE
 
 inner_product: CMD_LANGLE _expression BAR _expression CMD_RANGLE
-
-// outer_product: BAR _expression CMD_RANGLE CMD_LANGLE _expression BAR
 
 _function: function_applied
     | abs | floor | ceil

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -13,7 +13,7 @@ class LarkLatexParser:
             latex_grammar = f.read()
 
         self.parser = _lark.Lark(
-            latex_grammar, parser="earley", start="latex_string",
+            latex_grammar, parser="earley",
             lexer="auto",
             ambiguity="explicit",
             debug=True,
@@ -23,7 +23,7 @@ class LarkLatexParser:
 
         self.logger = logger
         self.print_debug_output = print_debug_output
-        self.transform = transform
+        self.transform_expr = transform
 
         self.transformer = TransformToSymPyExpr()
 
@@ -33,7 +33,7 @@ class LarkLatexParser:
 
         parse_tree = self.parser.parse(s)
 
-        if not self.transform:
+        if not self.transform_expr:
             # exit early and return the parse tree
             _lark.logger.debug("expression =", s)
             _lark.logger.debug(parse_tree)

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -9,7 +9,6 @@ _lark = import_module("lark")
 
 class LarkLatexParser:
     def __init__(self, logger=False, print_debug_output=False, transform=True):
-
         with open(os.path.join(os.path.dirname(__file__), "latex.lark"), encoding="utf-8") as f:
             latex_grammar = f.read()
 
@@ -26,7 +25,7 @@ class LarkLatexParser:
         self.print_debug_output = print_debug_output
         self.transform = transform
 
-        self.transform_to_sympy_expr = TransformToSymPyExpr()
+        self.transformer = TransformToSymPyExpr()
 
     def doparse(self, s: str):
         if self.logger:
@@ -47,7 +46,7 @@ class LarkLatexParser:
             # print the `parse_tree` variable
             _lark.logger.debug(parse_tree.pretty())
 
-        sympy_expression = self.transform_to_sympy_expr.transform(parse_tree)
+        sympy_expression = self.transformer.transform(parse_tree)
 
         if self.print_debug_output:
             _lark.logger.debug("SymPy expression =", sympy_expression)

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -13,7 +13,7 @@ class LarkLatexParser:
             latex_grammar = f.read()
 
         self.parser = _lark.Lark(
-            latex_grammar, parser="earley",
+            latex_grammar, parser="earley", start="latex_string",
             lexer="auto",
             ambiguity="explicit",
             debug=True,
@@ -23,7 +23,7 @@ class LarkLatexParser:
 
         self.logger = logger
         self.print_debug_output = print_debug_output
-        self.transform_expr = transform
+        self.transform = transform
 
         self.transformer = TransformToSymPyExpr()
 
@@ -33,7 +33,7 @@ class LarkLatexParser:
 
         parse_tree = self.parser.parse(s)
 
-        if not self.transform_expr:
+        if not self.transform:
             # exit early and return the parse tree
             _lark.logger.debug("expression =", s)
             _lark.logger.debug(parse_tree)

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 from sympy.external import import_module
-from .transformer import TransformToSymPyExpr
+from sympy.parsing.latex.lark.transformer import TransformToSymPyExpr
 
 _lark = import_module("lark")
 
@@ -69,14 +69,6 @@ def parse_latex_lark(s: str):
     if _lark is None:
         raise ImportError("Lark is probably not installed")
     return _lark_latex_parser.doparse(s)
-
-
-def pr_ltx(s: str):
-    LarkLatexParser(print_debug_output=True, transform=False).doparse(s)
-
-
-def trfm_ltx(s: str):
-    LarkLatexParser(print_debug_output=True).doparse(s)
 
 
 def _pretty_print_lark_trees(tree, indent=0, show_expr=True):

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -10,16 +10,22 @@ _lark = import_module("lark")
 
 class LarkLatexParser:
     def __init__(self, logger=False, print_debug_output=False, transform=True):
-        self.parser = _lark.Lark.open("latex.lark",
-                                      rel_to=os.path.join(os.path.dirname(__file__), "grammar/"),
-                                      parser="earley",
-                                      start="latex_string",
-                                      lexer="auto",
-                                      ambiguity="explicit",
-                                      debug=True,
-                                      propagate_positions=False,
-                                      maybe_placeholders=False,
-                                      keep_all_tokens=True)
+        grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
+
+        with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
+            latex_grammar = f.read()
+
+        self.parser = _lark.Lark(
+            latex_grammar,
+            source_path=grammar_dir_path,
+            parser="earley",
+            start="latex_string",
+            lexer="auto",
+            ambiguity="explicit",
+            debug=True,
+            propagate_positions=False,
+            maybe_placeholders=False,
+            keep_all_tokens=True)
 
         self.logger = logger
         self.print_debug_output = print_debug_output

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -7,19 +7,19 @@ from sympy.parsing.latex.lark.transformer import TransformToSymPyExpr
 
 _lark = import_module("lark")
 
+
 class LarkLatexParser:
     def __init__(self, logger=False, print_debug_output=False, transform=True):
-        with open(os.path.join(os.path.dirname(__file__), "latex.lark"), encoding="utf-8") as f:
-            latex_grammar = f.read()
-
-        self.parser = _lark.Lark(
-            latex_grammar, parser="earley", start="latex_string",
-            lexer="auto",
-            ambiguity="explicit",
-            debug=True,
-            propagate_positions=False,
-            maybe_placeholders=False,
-            keep_all_tokens=True)
+        self.parser = _lark.Lark.open("latex.lark",
+                                      rel_to=os.path.join(os.path.dirname(__file__), "grammar/"),
+                                      parser="earley",
+                                      start="latex_string",
+                                      lexer="auto",
+                                      ambiguity="explicit",
+                                      debug=True,
+                                      propagate_positions=False,
+                                      maybe_placeholders=False,
+                                      keep_all_tokens=True)
 
         self.logger = logger
         self.print_debug_output = print_debug_output

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -23,7 +23,7 @@ class LarkLatexParser:
 
         self.logger = logger
         self.print_debug_output = print_debug_output
-        self.transform = transform
+        self.transform_expr = transform
 
         self.transformer = TransformToSymPyExpr()
 
@@ -33,7 +33,7 @@ class LarkLatexParser:
 
         parse_tree = self.parser.parse(s)
 
-        if not self.transform:
+        if not self.transform_expr:
             # exit early and return the parse tree
             _lark.logger.debug("expression =", s)
             _lark.logger.debug(parse_tree)

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -167,16 +167,24 @@ class TransformToSymPyExpr(Transformer):
             raise LaTeXParsingError() # TODO: fill out descriptive error message
 
         # check if any expression was given or not. If it wasn't, then set the integrand to 1.
-        if underscore_index is not None and underscore_index == differential_variable_index - 2:
+        if underscore_index is not None and underscore_index == differential_variable_index - 3:
+            # The Token at differential_variable_index - 2 should be the integrand. However, if going one more step
+            # backwards after that gives us the underscore, then that means that there _was_ no integrand.
+            # Example: \int^7_0 dx
             integrand = 1
-        elif caret_index is not None and caret_index == differential_variable_index - 2:
+        elif caret_index is not None and caret_index == differential_variable_index - 3:
+            # The Token at differential_variable_index - 2 should be the integrand. However, if going one more step
+            # backwards after that gives us the caret, then that means that there _was_ no integrand.
+            # Example: \int_0^7 dx
             integrand = 1
-        elif differential_variable_index == 1:
+        elif differential_variable_index == 2:
             # this means we have something like \int dx, because the \int symbol will always be
             # at index 0 in `tokens`
             integrand = 1
         else:
-            integrand = tokens[differential_variable_index - 1]
+            # The Token at differential_variable_index - 1 is the differential symbol itself, so we need to go one
+            # more step before that.
+            integrand = tokens[differential_variable_index - 2]
 
         if lower_bound is not None:
             # we have an definite integral

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -110,6 +110,10 @@ class TransformToSymPyExpr(Transformer):
 
     def mul(self, tokens):
         if len(tokens) == 2:
+            from sympy.physics.quantum import Bra, Ket
+            if isinstance(tokens[0], Ket) and isinstance(tokens[1], Bra):
+                from sympy.physics.quantum import OuterProduct
+                return OuterProduct(tokens[0], tokens[1])
             return sympy.Mul(tokens[0], tokens[1])
         elif len(tokens) == 3:
             return sympy.Mul(tokens[0], tokens[2])

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -82,22 +82,23 @@ class TransformToSymPyExpr(Transformer):
     def group_curly_parentheses(self, tokens):
         return tokens[1]
 
-    def relation(self, tokens):
-        relation_type = tokens[1].type
-        if relation_type == "EQUAL":
-            return sympy.Eq(tokens[0], tokens[2])
-        elif relation_type == "NOT_EQUAL":
-            return sympy.Ne(tokens[0], tokens[2])
-        elif relation_type == "LT":
-            return sympy.Lt(tokens[0], tokens[2])
-        elif relation_type == "LTE":
-            return sympy.Le(tokens[0], tokens[2])
-        elif relation_type == "GT":
-            return sympy.Gt(tokens[0], tokens[2])
-        elif relation_type == "GTE":
-            return sympy.Ge(tokens[0], tokens[2])
-        else:
-            raise LaTeXParsingError() # TODO: Fill descriptive error message.
+    def eq(self, tokens):
+        return sympy.Eq(tokens[0], tokens[2])
+
+    def ne(self, tokens):
+        return sympy.Ne(tokens[0], tokens[2])
+
+    def lt(self, tokens):
+        return sympy.Lt(tokens[0], tokens[2])
+
+    def lte(self, tokens):
+        return sympy.Le(tokens[0], tokens[2])
+
+    def gt(self, tokens):
+        return sympy.Gt(tokens[0], tokens[2])
+
+    def gte(self, tokens):
+        return sympy.Ge(tokens[0], tokens[2])
 
     def add(self, tokens):
         return sympy.Add(tokens[0], tokens[2])

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -22,6 +22,9 @@ class TransformToSymPyExpr(Transformer):
     SYMBOL = sympy.Symbol
     DIGIT = sympy.core.numbers.Integer
 
+    def CMD_INFTY(self, tokens):
+        return sympy.oo
+
     def GREEK_SYMBOL(self, tokens):
         # we omit the first character because it is a backslash. Also, if the variable name has "var" in it,
         # like "varphi" or "varepsilon", we remove that too
@@ -70,8 +73,8 @@ class TransformToSymPyExpr(Transformer):
     def latex_string(self, tokens):
         return tokens[0]
 
-    def infinity(self, tokens):
-        return sympy.oo
+    # def infinity(self, tokens):
+    #     return sympy.oo
 
     def group_round_parentheses(self, tokens):
         return tokens[1]

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -260,6 +260,12 @@ class TransformToSymPyExpr(Transformer):
 
         return sympy.Limit(tokens[-1], limit_variable, destination, direction)
 
+    def differential(self, tokens):
+        return tokens[1]
+
+    def derivative(self, tokens):
+        return sympy.Derivative(tokens[-1], tokens[5])
+
     def list_of_expressions(self, tokens):
         if len(tokens) == 1:
             # we return it verbatim because the function_applied node expects

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -61,7 +61,7 @@ class TransformToSymPyExpr(Transformer):
 
             return sympy.Symbol("%s_{%s}" % (symbol, greek_letter))
 
-    def multiletter_symbol(self, tokens):
+    def multi_letter_symbol(self, tokens):
         return sympy.Symbol(tokens[2])
 
     def number(self, tokens):
@@ -69,12 +69,6 @@ class TransformToSymPyExpr(Transformer):
             return sympy.core.numbers.Float(tokens[0])
         else:
             return sympy.core.numbers.Integer(tokens[0])
-
-    def latex_string(self, tokens):
-        return tokens[0]
-
-    # def infinity(self, tokens):
-    #     return sympy.oo
 
     def group_round_parentheses(self, tokens):
         return tokens[1]

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -70,6 +70,9 @@ class TransformToSymPyExpr(Transformer):
         else:
             return sympy.core.numbers.Integer(tokens[0])
 
+    def latex_string(self, tokens):
+        return tokens[0]
+
     def group_round_parentheses(self, tokens):
         return tokens[1]
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -247,8 +247,6 @@ class TransformToSymPyExpr(Transformer):
 
         integrand, differential_variable = tokens[-1]
 
-        print(f"{integrand=}")
-
         if lower_bound is not None:
             # then we have a definite integral
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -26,9 +26,6 @@ class TransformToSymPyExpr(Transformer):
     def CMD_INFTY(self, tokens):
         return sympy.oo
 
-    def LOWERCASE_LETTER_D(self, tokens):
-        return sympy.Symbol("d")
-
     def GREEK_SYMBOL(self, tokens):
         # we omit the first character because it is a backslash. Also, if the variable name has "var" in it,
         # like "varphi" or "varepsilon", we remove that too

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -217,7 +217,7 @@ EVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
 DERIVATIVE_EXPRESSION_PAIRS = [
     (r"\frac{d}{dx} x", Derivative(x, x)),
     (r"\frac{d}{dt} x", Derivative(x, t)),
-    (r"\frac{d}{dx} [ \tan x ]", Derivative(tan(x), x)),
+    (r"\frac{d}{dx} ( \tan x )", Derivative(tan(x), x)),
     (r"\frac{d f(x)}{dx}", Derivative(f(x), x)),
     (r"\frac{d\theta(x)}{dx}", Derivative(Function('theta')(x), x))
 ]
@@ -495,12 +495,19 @@ def test_integral_expressions():
             continue
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
-# feature yet to be added
-@XFAIL
+
 def test_derivative_expressions():
-    for latex_str, sympy_expr in DERIVATIVE_EXPRESSION_PAIRS:
+    expected_failures = {3, 4}
+    for i, (latex_str, sympy_expr) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for i, (latex_str, sympy_expr) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_trigonometric_expressions():

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -21,7 +21,7 @@ from sympy.series.limits import Limit
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
-from sympy.abc import x, y, z, a, b, c, d, t, k, n
+from sympy.abc import x, y, z, a, b, c, t, k, n
 
 from .test_latex import theta, f, _Add, _Mul, _Pow, _Sqrt, _Conjugate, _Abs, _factorial, _exp, _binomial
 
@@ -351,9 +351,9 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{x + y}", _Conjugate(_Add(x, y))),
     (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
     (r"\min(a, b)", _Min(a, b)),
-    (r"\min(a, b, c - d, xy)", _Min(a, b, c - d, x * y)),
+    (r"\min(a, b, c - x, xy)", _Min(a, b, c - x, x * y)),
     (r"\max(a, b)", _Max(a, b)),
-    (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y)),
+    (r"\max(a, b, c - x, xy)", _Max(a, b, c - x, x * y)),
     # physics things don't have an `evaluate=False` variant
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
@@ -385,9 +385,9 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{x + y}", conjugate(x + y)),
     (r"\overline{x} + \overline{y}", conjugate(x) + conjugate(y)),
     (r"\min(a, b)", Min(a, b)),
-    (r"\min(a, b, c - d, xy)", Min(a, b, c - d, x * y)),
+    (r"\min(a, b, c - x, xy)", Min(a, b, c - x, x * y)),
     (r"\max(a, b)", Max(a, b)),
-    (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y)),
+    (r"\max(a, b, c - x, xy)", Max(a, b, c - x, x * y)),
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
     (r"\langle x | y \rangle", InnerProduct(Bra('x'), Ket('y'))),

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -21,7 +21,7 @@ from sympy.series.limits import Limit
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
-from sympy.abc import x, y, z, a, b, c, t, k, n
+from sympy.abc import x, y, z, a, b, c, d, t, k, n
 
 from .test_latex import theta, f, _Add, _Mul, _Pow, _Sqrt, _Conjugate, _Abs, _factorial, _exp, _binomial
 
@@ -347,9 +347,9 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{x + y}", _Conjugate(_Add(x, y))),
     (r"\overline{x} + \overline{y}", _Conjugate(x) + _Conjugate(y)),
     (r"\min(a, b)", _Min(a, b)),
-    (r"\min(a, b, c - x, xy)", _Min(a, b, c - x, x * y)),
+    (r"\min(a, b, c - d, xy)", _Min(a, b, c - d, x * y)),
     (r"\max(a, b)", _Max(a, b)),
-    (r"\max(a, b, c - x, xy)", _Max(a, b, c - x, x * y)),
+    (r"\max(a, b, c - d, xy)", _Max(a, b, c - d, x * y)),
     # physics things don't have an `evaluate=False` variant
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
@@ -381,9 +381,9 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\overline{x + y}", conjugate(x + y)),
     (r"\overline{x} + \overline{y}", conjugate(x) + conjugate(y)),
     (r"\min(a, b)", Min(a, b)),
-    (r"\min(a, b, c - x, xy)", Min(a, b, c - x, x * y)),
+    (r"\min(a, b, c - d, xy)", Min(a, b, c - d, x * y)),
     (r"\max(a, b)", Max(a, b)),
-    (r"\max(a, b, c - x, xy)", Max(a, b, c - x, x * y)),
+    (r"\max(a, b, c - d, xy)", Max(a, b, c - d, x * y)),
     (r"\langle x |", Bra('x')),
     (r"| x \rangle", Ket('x')),
     (r"\langle x | y \rangle", InnerProduct(Bra('x'), Ket('y'))),

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -178,13 +178,11 @@ UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int^{b}_{a} x dx", Integral(_Mul(1, x), (x, a, b))),
     (r"\int_{f(a)}^{f(b)} f(z) dz", Integral(f(z), (z, f(a), f(b)))),
     (r"\int a + b + c dx", Integral(_Mul(1, _Add(_Add(a, b), c)), x)),
-    (r"\int \frac{dz}{z}", Integral(Pow(z, -1), z)),
-    (r"\int \frac{3 dz}{z}", Integral(3 * Pow(z, -1), z)),
+    (r"\int \frac{dz}{z}", Integral(_Mul(1, _Mul(1, Pow(z, -1))), z)),
+    (r"\int \frac{3 dz}{z}", Integral(_Mul(1, _Mul(3, _Pow(z, -1))), z)),
     (r"\int \frac{1}{x} dx", Integral(_Mul(1, _Mul(1, Pow(x, -1))), x)),
     (r"\int \frac{1}{a} + \frac{1}{b} dx",
      Integral(_Mul(1, _Add(_Mul(1, _Pow(a, -1)), _Mul(1, Pow(b, -1)))), x)),
-    (r"\int \frac{3 \cdot d\theta}{\theta}",
-     Integral(3 * _Pow(theta, -1), theta)),
     (r"\int \frac{1}{x} + 1 dx", Integral(_Mul(1, _Add(_Mul(1, _Pow(x, -1)), 1)), x))
 ]
 
@@ -209,8 +207,6 @@ EVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int \frac{3 dz}{z}", Integral(3 * Pow(z, -1), z)),
     (r"\int \frac{1}{x} dx", Integral(1 / x, x)),
     (r"\int \frac{1}{a} + \frac{1}{b} dx", Integral(1 / a + 1 / b, x)),
-    (r"\int \frac{3 \cdot d\theta}{\theta}",
-     Integral(3 * _Pow(theta, -1), theta)),
     (r"\int \frac{1}{x} + 1 dx", Integral(1 / x + 1, x))
 ]
 
@@ -483,12 +479,12 @@ def test_power_expressions():
 
 
 def test_integral_expressions():
-    expected_failures = {14, 16, 17, 20}
+    expected_failures = {14}
     for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
         with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+            assert parse_latex_lark(latex_str) == sympy_expr, i
 
     for i, (latex_str, sympy_expr) in enumerate(EVALUATED_INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses [#25622 (comment)](https://github.com/sympy/sympy/pull/25622#discussion_r1314247676), among other things.

#### Brief description of what is fixed or changed

I did a lot of miscellaneous refactoring and stuff in this PR. Here's a list of changes:
* Added support for Outer Products, just like how Inner Products for Bra and Ket are supported
* Renamed the `_implicit_multipilcation` node to a more aptly named node `adjacent_expressions` and also unfolded the node. This change made the `mul` node's Transformer logic much simpler.
* Renamed `multiletter_symbol` to `multi_letter_symbol` to make the underscore usage more consistent
* Removed the unnecessary rule for the `CMD_INFTY` terminal
* Changed some variable names in the `LarkLaTeXParser` class to more aptly named ones.
* Added support for derivatives. Things like `\frac{\mathrm{d}}{\mathrm{d}x} \sin x` work.
* Slightly modified the logic for the `integral` node in the transformer, and added comments explaining how it works.
* Refactored the Greek Symbol stuff out into its own `.lark` file.

#### Other comments
cc @sylee957 and @Upabjojr for review.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * The Lark-based LaTeX parser now supports parsing derivative-related expressions.
<!-- END RELEASE NOTES -->
