### PR TITLE
Fix `is_euler_pseudoprime`

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -13,11 +13,8 @@ from sympy.utilities.misc import as_int
 
 
 def is_euler_pseudoprime(n, a):
-    """Returns True if n is prime or an Euler pseudoprime to base a, else False.
-
-    Euler Pseudoprime : In arithmetic, an odd composite integer n is called an
-    euler pseudoprime to base a, if a and n are coprime and satisfy the modular
-    arithmetic congruence relation :
+    """Returns True if ``n`` is prime or is an odd composite integer that
+    is coprime to ``a`` and satisfy the modular arithmetic congruence relation:
 
     a ^ (n-1)/2 = + 1(mod n) or
     a ^ (n-1)/2 = - 1(mod n)
@@ -37,7 +34,7 @@ def is_euler_pseudoprime(n, a):
     =======
 
     bool : If ``n`` is prime, it always returns ``True``.
-           The composite number that returns ``True`` is called Euler pseudoprime.
+           The composite number that returns ``True`` is called an Euler pseudoprime.
 
     Examples
     ========

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -6,12 +6,14 @@ Primality testing
 from itertools import count
 
 from sympy.core.sympify import sympify
-from sympy.external.gmpy import gmpy as _gmpy, jacobi, is_square as gmpy_is_square, bit_scan1
+from sympy.external.gmpy import (gmpy as _gmpy, gcd, jacobi,
+                                 is_square as gmpy_is_square,
+                                 bit_scan1)
 from sympy.utilities.misc import as_int
 
 
-def is_euler_pseudoprime(n, b):
-    """Returns True if n is prime or an Euler pseudoprime to base b, else False.
+def is_euler_pseudoprime(n, a):
+    """Returns True if n is prime or an Euler pseudoprime to base a, else False.
 
     Euler Pseudoprime : In arithmetic, an odd composite integer n is called an
     euler pseudoprime to base a, if a and n are coprime and satisfy the modular
@@ -22,35 +24,49 @@ def is_euler_pseudoprime(n, b):
 
     (where mod refers to the modulo operation).
 
+    Parameters
+    ==========
+
+    n : Integer
+        ``n`` is a positive integer
+    a : Integer
+        ``a`` is an integer greater than 1.
+        ``a`` and ``n`` should be relatively prime.
+
+    Returns
+    =======
+
+    bool : If ``n`` is prime, it always returns ``True``.
+           The composite number that returns ``True`` is called Euler pseudoprime.
+
     Examples
     ========
 
     >>> from sympy.ntheory.primetest import is_euler_pseudoprime
-    >>> is_euler_pseudoprime(2, 5)
-    True
+    >>> from sympy.ntheory.factor_ import isprime
+    >>> for n in range(1, 1000):
+    ...     if is_euler_pseudoprime(n, 2) and not isprime(n):
+    ...         print(n)
+    341
+    561
 
     References
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Euler_pseudoprime
     """
-
-    if not mr(n, [b]):
+    n, a = as_int(n), as_int(a)
+    if a < 2:
+        raise ValueError("a should be an integer greater than 1")
+    if n < 1:
+        raise ValueError("n should be an integer greater than 0")
+    if n == 1:
         return False
-
-    n = as_int(n)
-    r = n - 1
-    c = pow(b, r >> bit_scan1(r), n)
-
-    if c == 1:
-        return True
-
-    while True:
-        if c == n - 1:
-            return True
-        c = pow(c, 2, n)
-        if c == 1:
-            return False
+    if n % 2 == 0:
+        return n == 2
+    if gcd(n, a) != 1:
+        raise ValueError("The two numbers should be relatively prime")
+    return pow(a, (n - 1) // 2, n) in [1, n - 1]
 
 
 def is_square(n, prep=True):

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -13,11 +13,11 @@ from sympy.utilities.misc import as_int
 
 
 def is_euler_pseudoprime(n, a):
-    """Returns True if ``n`` is prime or is an odd composite integer that
+    r"""Returns True if ``n`` is prime or is an odd composite integer that
     is coprime to ``a`` and satisfy the modular arithmetic congruence relation:
 
-    a ^ (n-1)/2 = + 1(mod n) or
-    a ^ (n-1)/2 = - 1(mod n)
+    .. math ::
+        a^{(n-1)/2} \equiv \pm 1 \pmod{n}
 
     (where mod refers to the modulo operation).
 
@@ -25,9 +25,9 @@ def is_euler_pseudoprime(n, a):
     ==========
 
     n : Integer
-        ``n`` is a positive integer
+        ``n`` is a positive integer.
     a : Integer
-        ``a`` is an integer greater than 1.
+        ``a`` is a positive integer.
         ``a`` and ``n`` should be relatively prime.
 
     Returns
@@ -53,8 +53,8 @@ def is_euler_pseudoprime(n, a):
     .. [1] https://en.wikipedia.org/wiki/Euler_pseudoprime
     """
     n, a = as_int(n), as_int(a)
-    if a < 2:
-        raise ValueError("a should be an integer greater than 1")
+    if a < 1:
+        raise ValueError("a should be an integer greater than 0")
     if n < 1:
         raise ValueError("n should be an integer greater than 0")
     if n == 1:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -59,6 +59,8 @@ def is_euler_pseudoprime(n, a):
         raise ValueError("n should be an integer greater than 0")
     if n == 1:
         return False
+    if a == 1:
+        return n == 2 or bool(n % 2)  # (prime or odd composite)
     if n % 2 == 0:
         return n == 2
     if gcd(n, a) != 1:

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -10,13 +10,15 @@ from sympy.testing.pytest import slow, raises
 from sympy.core.numbers import I
 
 def test_euler_pseudoprimes():
+    assert is_euler_pseudoprime(13, 1)
+    assert is_euler_pseudoprime(15, 1)
     assert is_euler_pseudoprime(17, 6)
     assert is_euler_pseudoprime(101, 7)
     assert is_euler_pseudoprime(1009, 10)
     assert is_euler_pseudoprime(11287, 41)
 
     raises(ValueError, lambda: is_euler_pseudoprime(0, 4))
-    raises(ValueError, lambda: is_euler_pseudoprime(3, 1))
+    raises(ValueError, lambda: is_euler_pseudoprime(3, 0))
     raises(ValueError, lambda: is_euler_pseudoprime(15, 6))
 
     # A006970

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -1,30 +1,44 @@
+from math import gcd
+
 from sympy.ntheory.generate import Sieve, sieve
 from sympy.ntheory.primetest import (mr, _lucas_sequence, _lucas_selfridge_params, _lucas_extrastrong_params,
                                      is_lucas_prp, is_square,
                                      is_strong_lucas_prp, is_extra_strong_lucas_prp, isprime, is_euler_pseudoprime,
                                      is_gaussian_prime)
 
-from sympy.testing.pytest import slow
+from sympy.testing.pytest import slow, raises
 from sympy.core.numbers import I
 
 def test_euler_pseudoprimes():
-    assert is_euler_pseudoprime(9, 1) == True
-    assert is_euler_pseudoprime(341, 2) == False
-    assert is_euler_pseudoprime(121, 3) == True
-    assert is_euler_pseudoprime(341, 4) == True
-    assert is_euler_pseudoprime(217, 5) == False
-    assert is_euler_pseudoprime(185, 6) == False
-    assert is_euler_pseudoprime(55, 111) == True
-    assert is_euler_pseudoprime(115, 114) == True
-    assert is_euler_pseudoprime(49, 117) == True
-    assert is_euler_pseudoprime(85, 84) == True
-    assert is_euler_pseudoprime(87, 88) == True
-    assert is_euler_pseudoprime(49, 128) == True
-    assert is_euler_pseudoprime(39, 77) == True
-    assert is_euler_pseudoprime(9881, 30) == True
-    assert is_euler_pseudoprime(8841, 29) == False
-    assert is_euler_pseudoprime(8421, 29) == False
-    assert is_euler_pseudoprime(9997, 19) == True
+    assert is_euler_pseudoprime(17, 6)
+    assert is_euler_pseudoprime(101, 7)
+    assert is_euler_pseudoprime(1009, 10)
+    assert is_euler_pseudoprime(11287, 41)
+
+    raises(ValueError, lambda: is_euler_pseudoprime(0, 4))
+    raises(ValueError, lambda: is_euler_pseudoprime(3, 1))
+    raises(ValueError, lambda: is_euler_pseudoprime(15, 6))
+
+    # A006970
+    euler_prp = [341, 561, 1105, 1729, 1905, 2047, 2465, 3277,
+                 4033, 4681, 5461, 6601, 8321, 8481, 10261, 10585]
+    for p in euler_prp:
+        assert is_euler_pseudoprime(p, 2)
+
+    # A048950
+    euler_prp = [121, 703, 1729, 1891, 2821, 3281, 7381, 8401, 8911, 10585,
+                 12403, 15457, 15841, 16531, 18721, 19345, 23521, 24661, 28009]
+    for p in euler_prp:
+        assert is_euler_pseudoprime(p, 3)
+
+    # A033181
+    absolute_euler_prp = [1729, 2465, 15841, 41041, 46657, 75361,
+                          162401, 172081, 399001, 449065, 488881]
+    for p in absolute_euler_prp:
+        for a in range(2, p):
+            if gcd(a, p) != 1:
+                continue
+            assert is_euler_pseudoprime(p, a)
 
 
 def test_lucas_sequence():


### PR DESCRIPTION
There are several things called Euler pseudoprime. However, the current implementation is different from the docstring description and wikipedia. So we modified the implementation to be in line with the docstring definition.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * The behavior of `is_euler_pseudoprime` has changed. Composite numbers that used to return `False` may now also return `True`.
<!-- END RELEASE NOTES -->
