### PR TITLE
Speed up `totientrange`

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -252,16 +252,18 @@ class Sieve:
             self._tlist += _array('L', range(n, b))
             for i in range(1, n):
                 ti = self._tlist[i]
-                startindex = (n + i - 1) // i * i
-                for j in range(startindex, b, i):
-                    self._tlist[j] -= ti
+                if ti == i - 1:
+                    startindex = (n + i - 1) // i * i
+                    for j in range(startindex, b, i):
+                        self._tlist[j] -= self._tlist[j] // i
                 if i >= a:
                     yield ti
 
             for i in range(n, b):
                 ti = self._tlist[i]
-                for j in range(2 * i, b, i):
-                    self._tlist[j] -= ti
+                if ti == i:
+                    for j in range(i, b, i):
+                        self._tlist[j] -= self._tlist[j] // i
                 if i >= a:
                     yield ti
 


### PR DESCRIPTION
Compared to the mainline, this code runs at about the same speed in CPython 3.11.3 but is significantly faster in PyPy 7.3.12.

```
cpython_old: 24.7744 seconds
cpython_new: 24.2009 seconds
2.37% faster

pypy_old: 4.13073 seconds
pypy_new: 1.56451 seconds
164% faster
```

Benchmark code:
```python
import sympy
u = list(sympy.sieve.totientrange(10**7, 2 * 10**7))
``` 

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Speed up `totientrange`.
<!-- END RELEASE NOTES -->
