### PR TITLE
Allow some customizability in the Lark LaTeX parser

### DIFF
--- a/sympy/parsing/latex/lark/__init__.py
+++ b/sympy/parsing/latex/lark/__init__.py
@@ -1,1 +1,2 @@
-from .latex_parser import parse_latex_lark # noqa
+from .latex_parser import parse_latex_lark, LarkLatexParser # noqa
+from .transformer import TransformToSymPyExpr # noqa

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -9,17 +9,15 @@ _lark = import_module("lark")
 
 
 class LarkLatexParser:
-    def __init__(self, logger=False, print_debug_output=False, transform=True, extends=None, overrides=None):
-        grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
+    def __init__(self, logger=False, print_debug_output=False, transform=True, grammar_file=None):
+        if grammar_file is None:
+            grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
 
-        with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
-            latex_grammar = f.read()
-
-        if extends is not None:
-            latex_grammar += "\n" + extends
-
-        if overrides is not None:
-            latex_grammar += "\n" + overrides
+            with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
+                latex_grammar = f.read()
+        else:
+            with open(grammar_file, encoding="utf-8") as f:
+                latex_grammar = f.read()
 
         self.parser = _lark.Lark(
             latex_grammar,

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -9,11 +9,17 @@ _lark = import_module("lark")
 
 
 class LarkLatexParser:
-    def __init__(self, logger=False, print_debug_output=False, transform=True):
+    def __init__(self, logger=False, print_debug_output=False, transform=True, extends=None, overrides=None):
         grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
 
         with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
             latex_grammar = f.read()
+
+        if extends is not None:
+            latex_grammar += "\n" + extends
+
+        if overrides is not None:
+            latex_grammar += "\n" + overrides
 
         self.parser = _lark.Lark(
             latex_grammar,

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -11,7 +11,7 @@ _lark = import_module("lark")
 class LarkLatexParser:
     def __init__(self, logger=False, print_debug_output=False, transform=True, grammar_file=None, transformer=None):
         grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
-        
+
         if grammar_file is None:
             with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
                 latex_grammar = f.read()

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -9,10 +9,10 @@ _lark = import_module("lark")
 
 
 class LarkLatexParser:
-    def __init__(self, logger=False, print_debug_output=False, transform=True, grammar_file=None):
+    def __init__(self, logger=False, print_debug_output=False, transform=True, grammar_file=None, transformer=None):
+        grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
+        
         if grammar_file is None:
-            grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
-
             with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
                 latex_grammar = f.read()
         else:
@@ -35,7 +35,10 @@ class LarkLatexParser:
         self.print_debug_output = print_debug_output
         self.transform_expr = transform
 
-        self.transformer = TransformToSymPyExpr()
+        if transformer is None:
+            self.transformer = TransformToSymPyExpr()
+        else:
+            self.transformer = transformer()
 
     def doparse(self, s: str):
         if self.logger:

--- a/sympy/parsing/tests/test_custom_latex.py
+++ b/sympy/parsing/tests/test_custom_latex.py
@@ -36,6 +36,8 @@ def init_custom_parser(modification, transformer=None):
     return parser
 
 def test_custom1():
+    # Removes the parser's ability to understand \cdot and \div.
+
     parser = init_custom_parser(modification1)
 
     with raises(lark.exceptions.UnexpectedCharacters):
@@ -51,6 +53,8 @@ class CustomTransformer(TransformToSymPyExpr):
             return sympy.core.numbers.Integer(tokens[0])
 
 def test_custom2():
+    # Makes the parser parse commas as the decimal separator instead of dots
+
     parser = init_custom_parser(modification2, CustomTransformer)
 
     with raises(lark.exceptions.UnexpectedCharacters):

--- a/sympy/parsing/tests/test_custom_latex.py
+++ b/sympy/parsing/tests/test_custom_latex.py
@@ -25,19 +25,19 @@ modification2 = r"""
 def init_custom_parser(modification, transformer=None):
     with open(grammar_file, encoding="utf-8") as f:
         latex_grammar = f.read()
-    
+
     latex_grammar += modification
-    
+
     with tempfile.NamedTemporaryFile() as f:
         f.write(bytes(latex_grammar, encoding="utf8"))
-        
+
         parser = LarkLatexParser(grammar_file=f.name, transformer=transformer)
-    
+
     return parser
 
 def test_custom1():
     parser = init_custom_parser(modification1)
-    
+
     with raises(lark.exceptions.UnexpectedCharacters):
         parser.doparse(r"a \cdot b")
         parser.doparse(r"x \div y")
@@ -52,15 +52,14 @@ class CustomTransformer(TransformToSymPyExpr):
 
 def test_custom2():
     parser = init_custom_parser(modification2, CustomTransformer)
-    
+
     with raises(lark.exceptions.UnexpectedCharacters):
         # Asserting that the default parser cannot parse numbers which have commas as
         # the decimal separator
         parse_latex_lark("100,1")
         parse_latex_lark("0,009")
-    
+
     parser.doparse("100,1")
     parser.doparse("0,009")
     parser.doparse("2,71828")
     parser.doparse("3,14159")
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
As discussed in a meet with @Upabjojr, I added some hooks to the `LarkLaTeXParser` class to allow the user to add some `%extends` and `%override` lines to the grammar to customize its behavior.

#### Other comments
cc @Upabjojr for review.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * The Lark-based parser now allows customizability by allowing the user to specify their own LaTeX grammar file.
<!-- END RELEASE NOTES -->
