### PR TITLE
ensures lcm(f,0) = 0

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1639,7 +1639,7 @@ def dup_rr_lcm(f, g, K):
     x**3 - 2*x**2 - x + 2
 
     """
-    if not f and not g:
+    if not f or not g:
         return K.zero
 
     fc, f = dup_primitive(f, K)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2079,8 +2079,10 @@ def test_gcd():
     raises(TypeError, lambda: lcm(x))
 
     f = Poly(0, x)
-    g = Poly(0, x)
-    assert lcm(f, g) == 0
+    assert lcm(f, 0) == 0
+
+    f = Poly([1, 1], x)
+    assert lcm(f,0) == 0
 
 
 def test_gcd_numbers_vs_polys():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2083,10 +2083,12 @@ def test_gcd():
     assert lcm(f, g) == Poly(1, x)
 
     f = Poly(0, x)
-    assert lcm(f, 0) == 0
-
-    f = Poly([1, 1], x)
-    assert lcm(f,0) == 0
+    g = Poly([1, 1], x)
+    for i in (f, g):
+        assert lcm(i, 0) == 0
+        assert lcm(0, i) == 0
+        assert lcm(i, f) == 0
+        assert lcm(f, i) == 0
 
 
 def test_gcd_numbers_vs_polys():


### PR DESCRIPTION


#### References to other Issues or PRs
A more generalized fix for #25581 

#### Brief description of what is fixed or changed

ensures that lcm(f,0) = 0

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
