### PR TITLE
no negative outputs for lcm

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1650,11 +1650,9 @@ def dup_rr_lcm(f, g, K):
     h = dup_quo(dup_mul(f, g, K),
                 dup_gcd(f, g, K), K)
 
-    h = dup_mul_ground(h, c, K)
-
     u = K.canonical_unit(dup_LC(h, K))
 
-    return dup_mul_ground(h, u, K)
+    return dup_mul_ground(h, c*u, K)
 
 
 def dup_ff_lcm(f, g, K):

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1650,7 +1650,11 @@ def dup_rr_lcm(f, g, K):
     h = dup_quo(dup_mul(f, g, K),
                 dup_gcd(f, g, K), K)
 
-    return dup_mul_ground(h, c, K)
+    h = dup_mul_ground(h, c, K)
+
+    u = K.canonical_unit(dup_LC(h, K))
+
+    return dup_mul_ground(h, u, K)
 
 
 def dup_ff_lcm(f, g, K):

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2078,6 +2078,10 @@ def test_gcd():
     raises(TypeError, lambda: gcd(x))
     raises(TypeError, lambda: lcm(x))
 
+    f = Poly(-1, x)
+    g = Poly(1, x)
+    assert lcm(f, g) == Poly(1, x)
+
     f = Poly(0, x)
     g = Poly(0, x)
     assert lcm(f, g) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#25624


#### Brief description of what is fixed or changed
`lcm` by definition shouldn't return a negative number, but does in sympy. This PR aims to 
fix that (or discuss why not to). 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
