### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1514,6 +1515,7 @@ elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>
 faizan2700 <syedfaizan824@gmail.com>
+fazledyn-or <ataf@openrefactory.com>
 foice <foice.news@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,7 +185,6 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
-
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1084,14 +1084,13 @@ def laplace_initial_conds(f, t, fdict, /):
     s**3*Y(s) - 2*s**2 - 4*s - 8
     """
     for y, ic in fdict.items():
-        if len(ic) >= 0:
-            for k in range(len(ic)):
-                if k == 0:
-                    f = f.replace(y(0), ic[0])
-                elif k == 1:
-                    f = f.replace(Subs(Derivative(y(t), t), t, 0), ic[1])
-                else:
-                    f = f.replace(Subs(Derivative(y(t), (t, k)), t, 0), ic[k])
+        for k in range(len(ic)):
+            if k == 0:
+                f = f.replace(y(0), ic[0])
+            elif k == 1:
+                f = f.replace(Subs(Derivative(y(t), t), t, 0), ic[1])
+            else:
+                f = f.replace(Subs(Derivative(y(t), (t, k)), t, 0), ic[k])
     return f
 
 


### PR DESCRIPTION
In file: `laplace.py`, the comparison of Collection length creates a logical short circuit. iCR suggested that the Collection length comparison should be done without creating a logical short circuit.

Details:
The `fdict` variable in the file is a Python dictionary that maps key to list of items. Now, the list can be either empty or have items in it. As a result, the `len(ic)` will always have a non-negative value. Which is why the `if len(ic) >= 0` check is unnecessary.


### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
