### PR TITLE
laplace_transform: support for Piecewise and SingularityFunction

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1006,7 +1006,7 @@ def _piecewise_to_heaviside(f, t):
     with Heaviside. It is not exact, but valid in the context of the Laplace
     transform.
     """
-    tr = symbols('tr', real=True)
+    tr = Dummy('tr', real=True)
     x = piecewise_exclusive(f.subs(t, tr))
     r = S.Zero
     for fn, cond in x.args:

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1016,7 +1016,7 @@ def _piecewise_to_heaviside(f, t):
         # has a clearly predictable output. However, if any of the conditions
         # is not relative to t, this function just returns the input argument.
         if isinstance(cond, Relational) and t in cond.args:
-            if isinstance(cond, Eq) or isinstance(cond, Ne):
+            if isinstance(cond, (Eq, Ne)):
                 # We do not cover this case; these would be single-point
                 # exceptions that do not play a role in Laplace practice,
                 # except if they contain Dirac impulses, and then we can

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -7,6 +7,7 @@ from sympy.core.function import Function, expand_mul
 from sympy.core import EulerGamma, Subs, Derivative, diff
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import I, oo, pi
+from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, symbols
 from sympy.simplify.simplify import simplify
@@ -344,6 +345,9 @@ def test_laplace_transform():
         Piecewise((1, And(t > 1, t < 3)), (2, True))]
     for x2 in x1:
         assert LT(x2, t, s)[0] == 2/s - exp(-s)/s + exp(-3*s)/s
+    assert (
+        LT(Piecewise((1, Eq(t, 1)), (2, True)), t, s)[0] ==
+        LaplaceTransform(Piecewise((1, Eq(t, 1)), (2, True)), t, s))
     # The following lines test whether _laplace_transform successfully
     # removes Heaviside(1) before processing espressions. It fails if
     # Heaviside(t) remains because then meijerg functions will appear.

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -16,6 +16,7 @@ from sympy.functions.elementary.hyperbolic import cosh, sinh, coth, asinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import atan, cos, sin
+from sympy.logic.boolalg import And
 from sympy.functions.special.gamma_functions import lowergamma, gamma
 from sympy.functions.special.delta_functions import DiracDelta, Heaviside
 from sympy.functions.special.singularity_functions import SingularityFunction
@@ -34,6 +35,7 @@ def test_laplace_transform():
     ILT = inverse_laplace_transform
     a, b, c, = symbols('a, b, c', positive=True)
     t, w, x = symbols('t, w, x')
+    tr = symbols('tr', real=True)
     f = Function('f')
     F = Function('F')
     g = Function('g')
@@ -336,6 +338,13 @@ def test_laplace_transform():
     x1 = Piecewise((0, x <= 0), (1, x <= 1), (0, True))
     X1 = LT(x1, t, s)[0]
     assert X1 == Piecewise((0, x <= 0), (1, x <= 1), (0, True))/s
+    x1 = [
+        Piecewise((1, And(t>1, t<=3)), (2, True)),
+        Piecewise((1, And(t>=1, t<=3)), (2, True)),
+        Piecewise((1, And(t>=1, t<3)), (2, True)),
+        Piecewise((1, And(t>1, t<3)), (2, True))]
+    for x2 in x1:
+        assert LT(x2, t, s)[0] == 2/s - exp(-s)/s + exp(-3*s)/s
     # The following lines test whether _laplace_transform successfully
     # removes Heaviside(1) before processing espressions. It fails if
     # Heaviside(t) remains because then meijerg functions will appear.

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -35,7 +35,6 @@ def test_laplace_transform():
     ILT = inverse_laplace_transform
     a, b, c, = symbols('a, b, c', positive=True)
     t, w, x = symbols('t, w, x')
-    tr = symbols('tr', real=True)
     f = Function('f')
     F = Function('F')
     g = Function('g')
@@ -339,10 +338,10 @@ def test_laplace_transform():
     X1 = LT(x1, t, s)[0]
     assert X1 == Piecewise((0, x <= 0), (1, x <= 1), (0, True))/s
     x1 = [
-        Piecewise((1, And(t>1, t<=3)), (2, True)),
-        Piecewise((1, And(t>=1, t<=3)), (2, True)),
-        Piecewise((1, And(t>=1, t<3)), (2, True)),
-        Piecewise((1, And(t>1, t<3)), (2, True))]
+        Piecewise((1, And(t > 1, t <= 3)), (2, True)),
+        Piecewise((1, And(t >= 1, t <= 3)), (2, True)),
+        Piecewise((1, And(t >= 1, t < 3)), (2, True)),
+        Piecewise((1, And(t > 1, t < 3)), (2, True))]
     for x2 in x1:
         assert LT(x2, t, s)[0] == 2/s - exp(-s)/s + exp(-3*s)/s
     # The following lines test whether _laplace_transform successfully

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -18,6 +18,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import atan, cos, sin
 from sympy.functions.special.gamma_functions import lowergamma, gamma
 from sympy.functions.special.delta_functions import DiracDelta, Heaviside
+from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import lerchphi
 from sympy.functions.special.error_functions import (
     fresnelc, fresnels, erf, erfc, Ei, Ci, expint, E1)
@@ -397,6 +398,11 @@ def test_laplace_transform():
     assert LT(f(t)*DiracDelta(b*t-a), t, s) == (f(a/b)*exp(-a*s/b)/b,
                                                 -oo, True)
     assert LT(f(t)*DiracDelta(b*t+a), t, s) == (0, -oo, True)
+    # SingularityFunction
+    assert LT(SingularityFunction(t, a, -1), t, s)[0] == exp(-a*s)
+    assert LT(SingularityFunction(t, a, 1), t, s)[0] == exp(-a*s)/s**2
+    assert LT(SingularityFunction(t, a, x), t, s)[0] == (
+        LaplaceTransform(SingularityFunction(t, a, x), t, s))
     # Collection of cases that cannot be fully evaluated and/or would catch
     # some common implementation errors
     assert (LT(DiracDelta(t**2), t, s, noconds=True) ==


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561

#### Brief description of what is fixed or changed
The Laplace transform can now parse (and more easily transform) the functions Piecewise and SingularityFunction.

It treats Piecewise with a re-write function called `_piecewise_to_heaviside`, which rewrites the Piecewise function as a sum containing `Heaviside` functions instead.

This is not strictly correct, as the values directly at the boundaries between the pieces are incorrect, but it works fine inside the Laplace transform because integrating over a single incorrect point does not change the integral's value. It would fail, though, if there was a `DiracDelta` on one of the boundaries, so the Laplace transform will not use `_piecewise_to_heaviside` if there is a `DiracDelta` inside.

`SingularityFunction` has its own method `.rewrite(Heaviside)` which rewrites it with `Heaviside` or `DiracDelta` if possible, depending on its arguments.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * The Laplace transform can now parse and directly transform the functions Piecewise and SingularityFunction.
<!-- END RELEASE NOTES -->
