### PR TITLE
Validate arguments to DMP

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1189,7 +1189,7 @@ def dup_zz_i_factor(f, K0):
         # Extract content
         fac_denom, fac_num = dup_clear_denoms(fac, K1)
         fac_num_ZZ_I = dup_convert(fac_num, K1, K0)
-        content, fac_prim = dmp_ground_primitive(fac_num_ZZ_I, 0, K1)
+        content, fac_prim = dmp_ground_primitive(fac_num_ZZ_I, 0, K0)
 
         coeff = (coeff * content ** i) // fac_denom ** i
         new_factors.append((fac_prim, i))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1222,7 +1222,7 @@ def dmp_zz_i_factor(f, u, K0):
         # Extract content
         fac_denom, fac_num = dmp_clear_denoms(fac, u, K1)
         fac_num_ZZ_I = dmp_convert(fac_num, u, K1, K0)
-        content, fac_prim = dmp_ground_primitive(fac_num_ZZ_I, u, K1)
+        content, fac_prim = dmp_ground_primitive(fac_num_ZZ_I, u, K0)
 
         coeff = (coeff * content ** i) // fac_denom ** i
         new_factors.append((fac_prim, i))

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -167,7 +167,8 @@ class DMP(CantSympify):
     def new(cls, rep, dom, lev, ring):
         # It would be too slow to call _validate_args always at runtime.
         # Ideally this checking would be handled by a static type checker.
-        cls._validate_args(rep, dom, lev, ring)
+        #
+        # cls._validate_args(rep, dom, lev, ring)
 
         obj = super().__new__(cls)
         obj.rep = rep

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1,7 +1,5 @@
 """OO layer for several polynomial representations. """
 
-from sympy.external.gmpy import GROUND_TYPES
-
 from sympy.core.numbers import oo
 from sympy.core.sympify import CantSympify
 from sympy.polys.polyerrors import CoercionFailed, NotReversible, NotInvertible

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -143,7 +143,7 @@ def init_normal_DMP(rep, lev, dom):
     return DMP(dmp_normal(rep, lev, dom), dom, lev)
 
 
-class DMP(PicklableWithSlots, CantSympify):
+class DMP(CantSympify):
     """Dense Multivariate Polynomials over `K`. """
 
     __slots__ = ('rep', 'lev', 'dom', 'ring')
@@ -159,6 +159,9 @@ class DMP(PicklableWithSlots, CantSympify):
             rep, lev = dmp_validate(rep)
 
         return cls.new(rep, dom, lev, ring)
+
+    def __getnewargs__(self):
+        return self.rep, self.dom, self.lev, self.ring
 
     @classmethod
     def new(cls, rep, dom, lev, ring):

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -11,19 +11,19 @@ from sympy.testing.pytest import raises
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
 
 def test_DMP___init__():
-    f = DMP([[0], [], [0, 1, 2], [3]], ZZ)
+    f = DMP([[ZZ(0)], [], [ZZ(0), ZZ(1), ZZ(2)], [ZZ(3)]], ZZ)
 
     assert f.rep == [[1, 2], [3]]
     assert f.dom == ZZ
     assert f.lev == 1
 
-    f = DMP([[1, 2], [3]], ZZ, 1)
+    f = DMP([[ZZ(1), ZZ(2)], [ZZ(3)]], ZZ, 1)
 
     assert f.rep == [[1, 2], [3]]
     assert f.dom == ZZ
     assert f.lev == 1
 
-    f = DMP({(1, 1): 1, (0, 0): 2}, ZZ, 1)
+    f = DMP({(1, 1): ZZ(1), (0, 0): ZZ(2)}, ZZ, 1)
 
     assert f.rep == [[1, 0], [2]]
     assert f.dom == ZZ
@@ -45,11 +45,11 @@ def test_DMP___eq__():
 
 def test_DMP___bool__():
     assert bool(DMP([[]], ZZ)) is False
-    assert bool(DMP([[1]], ZZ)) is True
+    assert bool(DMP([[ZZ(1)]], ZZ)) is True
 
 
 def test_DMP_to_dict():
-    f = DMP([[3], [], [2], [], [8]], ZZ)
+    f = DMP([[ZZ(3)], [], [ZZ(2)], [], [ZZ(8)]], ZZ)
 
     assert f.to_dict() == \
         {(4, 0): 3, (2, 0): 2, (0, 0): 8}
@@ -60,34 +60,34 @@ def test_DMP_to_dict():
 
 def test_DMP_properties():
     assert DMP([[]], ZZ).is_zero is True
-    assert DMP([[1]], ZZ).is_zero is False
+    assert DMP([[ZZ(1)]], ZZ).is_zero is False
 
-    assert DMP([[1]], ZZ).is_one is True
-    assert DMP([[2]], ZZ).is_one is False
+    assert DMP([[ZZ(1)]], ZZ).is_one is True
+    assert DMP([[ZZ(2)]], ZZ).is_one is False
 
-    assert DMP([[1]], ZZ).is_ground is True
-    assert DMP([[1], [2], [1]], ZZ).is_ground is False
+    assert DMP([[ZZ(1)]], ZZ).is_ground is True
+    assert DMP([[ZZ(1)], [ZZ(2)], [ZZ(1)]], ZZ).is_ground is False
 
-    assert DMP([[1], [2, 0], [1, 0]], ZZ).is_sqf is True
-    assert DMP([[1], [2, 0], [1, 0, 0]], ZZ).is_sqf is False
+    assert DMP([[ZZ(1)], [ZZ(2), ZZ(0)], [ZZ(1), ZZ(0)]], ZZ).is_sqf is True
+    assert DMP([[ZZ(1)], [ZZ(2), ZZ(0)], [ZZ(1), ZZ(0), ZZ(0)]], ZZ).is_sqf is False
 
-    assert DMP([[1, 2], [3]], ZZ).is_monic is True
-    assert DMP([[2, 2], [3]], ZZ).is_monic is False
+    assert DMP([[ZZ(1), ZZ(2)], [ZZ(3)]], ZZ).is_monic is True
+    assert DMP([[ZZ(2), ZZ(2)], [ZZ(3)]], ZZ).is_monic is False
 
-    assert DMP([[1, 2], [3]], ZZ).is_primitive is True
-    assert DMP([[2, 4], [6]], ZZ).is_primitive is False
+    assert DMP([[ZZ(1), ZZ(2)], [ZZ(3)]], ZZ).is_primitive is True
+    assert DMP([[ZZ(2), ZZ(4)], [ZZ(6)]], ZZ).is_primitive is False
 
 
 def test_DMP_arithmetics():
-    f = DMP([[2], [2, 0]], ZZ)
+    f = DMP([[ZZ(2)], [ZZ(2), ZZ(0)]], ZZ)
 
-    assert f.mul_ground(2) == DMP([[4], [4, 0]], ZZ)
-    assert f.quo_ground(2) == DMP([[1], [1, 0]], ZZ)
+    assert f.mul_ground(2) == DMP([[ZZ(4)], [ZZ(4), ZZ(0)]], ZZ)
+    assert f.quo_ground(2) == DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ)
 
     raises(ExactQuotientFailed, lambda: f.exquo_ground(3))
 
-    f = DMP([[-5]], ZZ)
-    g = DMP([[5]], ZZ)
+    f = DMP([[ZZ(-5)]], ZZ)
+    g = DMP([[ZZ(5)]], ZZ)
 
     assert f.abs() == g
     assert abs(f) == g
@@ -103,7 +103,7 @@ def test_DMP_arithmetics():
     assert f + 5 == h
     assert 5 + f == h
 
-    h = DMP([[-10]], ZZ)
+    h = DMP([[ZZ(-10)]], ZZ)
 
     assert f.sub(g) == h
     assert f - g == h
@@ -111,7 +111,7 @@ def test_DMP_arithmetics():
     assert f - 5 == h
     assert 5 - f == -h
 
-    h = DMP([[-25]], ZZ)
+    h = DMP([[ZZ(-25)]], ZZ)
 
     assert f.mul(g) == h
     assert f * g == h
@@ -119,7 +119,7 @@ def test_DMP_arithmetics():
     assert f * 5 == h
     assert 5 * f == h
 
-    h = DMP([[25]], ZZ)
+    h = DMP([[ZZ(25)]], ZZ)
 
     assert f.sqr() == h
     assert f.pow(2) == h
@@ -127,11 +127,11 @@ def test_DMP_arithmetics():
 
     raises(TypeError, lambda: f.pow('x'))
 
-    f = DMP([[1], [], [1, 0, 0]], ZZ)
-    g = DMP([[2], [-2, 0]], ZZ)
+    f = DMP([[ZZ(1)], [], [ZZ(1), ZZ(0), ZZ(0)]], ZZ)
+    g = DMP([[ZZ(2)], [ZZ(-2), ZZ(0)]], ZZ)
 
-    q = DMP([[2], [2, 0]], ZZ)
-    r = DMP([[8, 0, 0]], ZZ)
+    q = DMP([[ZZ(2)], [ZZ(2), ZZ(0)]], ZZ)
+    r = DMP([[ZZ(8), ZZ(0), ZZ(0)]], ZZ)
 
     assert f.pdiv(g) == (q, r)
     assert f.pquo(g) == q
@@ -139,11 +139,11 @@ def test_DMP_arithmetics():
 
     raises(ExactQuotientFailed, lambda: f.pexquo(g))
 
-    f = DMP([[1], [], [1, 0, 0]], ZZ)
-    g = DMP([[1], [-1, 0]], ZZ)
+    f = DMP([[ZZ(1)], [], [ZZ(1), ZZ(0), ZZ(0)]], ZZ)
+    g = DMP([[ZZ(1)], [ZZ(-1), ZZ(0)]], ZZ)
 
-    q = DMP([[1], [1, 0]], ZZ)
-    r = DMP([[2, 0, 0]], ZZ)
+    q = DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ)
+    r = DMP([[ZZ(2), ZZ(0), ZZ(0)]], ZZ)
 
     assert f.div(g) == (q, r)
     assert f.quo(g) == q
@@ -157,9 +157,9 @@ def test_DMP_arithmetics():
 
 
 def test_DMP_functionality():
-    f = DMP([[1], [2, 0], [1, 0, 0]], ZZ)
-    g = DMP([[1], [1, 0]], ZZ)
-    h = DMP([[1]], ZZ)
+    f = DMP([[ZZ(1)], [ZZ(2), ZZ(0)], [ZZ(1), ZZ(0), ZZ(0)]], ZZ)
+    g = DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ)
+    h = DMP([[ZZ(1)]], ZZ)
 
     assert f.degree() == 2
     assert f.degree_list() == (2, 2)
@@ -174,15 +174,15 @@ def test_DMP_functionality():
     assert f.max_norm() == 2
     assert f.l1_norm() == 4
 
-    u = DMP([[2], [2, 0]], ZZ)
+    u = DMP([[ZZ(2)], [ZZ(2), ZZ(0)]], ZZ)
 
     assert f.diff(m=1, j=0) == u
     assert f.diff(m=1, j=1) == u
 
     raises(TypeError, lambda: f.diff(m='x', j=0))
 
-    u = DMP([1, 2, 1], ZZ)
-    v = DMP([1, 2, 1], ZZ)
+    u = DMP([ZZ(1), ZZ(2), ZZ(1)], ZZ)
+    v = DMP([ZZ(1), ZZ(2), ZZ(1)], ZZ)
 
     assert f.eval(a=1, j=0) == u
     assert f.eval(a=1, j=1) == v
@@ -201,25 +201,25 @@ def test_DMP_functionality():
     assert (4*f).content() == ZZ(4)
     assert (4*f).primitive() == (ZZ(4), f)
 
-    f = DMP([[1], [2], [3], [4], [5], [6]], ZZ)
+    f = DMP([[ZZ(1)], [ZZ(2)], [ZZ(3)], [ZZ(4)], [ZZ(5)], [ZZ(6)]], ZZ)
 
-    assert f.trunc(3) == DMP([[1], [-1], [], [1], [-1], []], ZZ)
+    assert f.trunc(3) == DMP([[ZZ(1)], [ZZ(-1)], [], [ZZ(1)], [ZZ(-1)], []], ZZ)
 
     f = DMP(f_4, ZZ)
 
     assert f.sqf_part() == -f
     assert f.sqf_list() == (ZZ(-1), [(-f, 1)])
 
-    f = DMP([[-1], [], [], [5]], ZZ)
-    g = DMP([[3, 1], [], []], ZZ)
-    h = DMP([[45, 30, 5]], ZZ)
+    f = DMP([[ZZ(-1)], [], [], [ZZ(5)]], ZZ)
+    g = DMP([[ZZ(3), ZZ(1)], [], []], ZZ)
+    h = DMP([[ZZ(45), ZZ(30), ZZ(5)]], ZZ)
 
-    r = DMP([675, 675, 225, 25], ZZ)
+    r = DMP([ZZ(675), ZZ(675), ZZ(225), ZZ(25)], ZZ)
 
     assert f.subresultants(g) == [f, g, h]
     assert f.resultant(g) == r
 
-    f = DMP([1, 3, 9, -13], ZZ)
+    f = DMP([ZZ(1), ZZ(3), ZZ(9), ZZ(-13)], ZZ)
 
     assert f.discriminant() == -11664
 
@@ -235,33 +235,33 @@ def test_DMP_functionality():
 
     assert f.invert(g) == s
 
-    f = DMP([[1], [2], [3]], QQ)
+    f = DMP([[QQ(1)], [QQ(2)], [QQ(3)]], QQ)
 
     raises(ValueError, lambda: f.half_gcdex(f))
     raises(ValueError, lambda: f.gcdex(f))
 
     raises(ValueError, lambda: f.invert(f))
 
-    f = DMP([1, 0, 20, 0, 150, 0, 500, 0, 625, -2, 0, -10, 9], ZZ)
-    g = DMP([1, 0, 0, -2, 9], ZZ)
-    h = DMP([1, 0, 5, 0], ZZ)
+    f = DMP([ZZ(1), ZZ(0), ZZ(20), ZZ(0), ZZ(150), ZZ(0), ZZ(500), ZZ(0), ZZ(625), ZZ(-2), ZZ(0), ZZ(-10), ZZ(9)], ZZ)
+    g = DMP([ZZ(1), ZZ(0), ZZ(0), ZZ(-2), ZZ(9)], ZZ)
+    h = DMP([ZZ(1), ZZ(0), ZZ(5), ZZ(0)], ZZ)
 
     assert g.compose(h) == f
     assert f.decompose() == [g, h]
 
-    f = DMP([[1], [2], [3]], QQ)
+    f = DMP([[QQ(1)], [QQ(2)], [QQ(3)]], QQ)
 
     raises(ValueError, lambda: f.decompose())
     raises(ValueError, lambda: f.sturm())
 
 
 def test_DMP_exclude():
-    f = [[[[[[[[[[[[[[[[[[[[[[[[[[1]], [[]]]]]]]]]]]]]]]]]]]]]]]]]]
+    f = [[[[[[[[[[[[[[[[[[[[[[[[[[ZZ(1)]], [[]]]]]]]]]]]]]]]]]]]]]]]]]]
     J = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
         18, 19, 20, 21, 22, 24, 25]
 
-    assert DMP(f, ZZ).exclude() == (J, DMP([1, 0], ZZ))
-    assert DMP([[1], [1, 0]], ZZ).exclude() == ([], DMP([[1], [1, 0]], ZZ))
+    assert DMP(f, ZZ).exclude() == (J, DMP([ZZ(1), ZZ(0)], ZZ))
+    assert DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ).exclude() == ([], DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ))
 
 
 def test_DMF__init__():
@@ -534,17 +534,3 @@ def test_ANP_unify():
     assert b.unify(a)[0] == QQ
     assert a.unify(a)[0] == QQ
     assert b.unify(b)[0] == ZZ
-
-
-def test___hash__():
-    # issue 5571
-    # Make sure int vs. long doesn't affect hashing with Python ground types
-    assert DMP([[1, 2], [3]], ZZ) == DMP([[int(1), int(2)], [int(3)]], ZZ)
-    assert hash(DMP([[1, 2], [3]], ZZ)) == hash(DMP([[int(1), int(2)], [int(3)]], ZZ))
-    assert DMF(
-        ([[1, 2], [3]], [[1]]), ZZ) == DMF(([[int(1), int(2)], [int(3)]], [[int(1)]]), ZZ)
-    assert hash(DMF(([[1, 2], [3]], [[1]]), ZZ)) == hash(DMF(([[int(1),
-                int(2)], [int(3)]], [[int(1)]]), ZZ))
-    assert ANP([1, 1], [1, 0, 1], ZZ) == ANP([int(1), int(1)], [int(1), int(0), int(1)], ZZ)
-    assert hash(
-        ANP([1, 1], [1, 0, 1], ZZ)) == hash(ANP([int(1), int(1)], [int(1), int(0), int(1)], ZZ))

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -242,7 +242,7 @@ def test_DMP_functionality():
 
     raises(ValueError, lambda: f.invert(f))
 
-    f = DMP([ZZ(1), ZZ(0), ZZ(20), ZZ(0), ZZ(150), ZZ(0), ZZ(500), ZZ(0), ZZ(625), ZZ(-2), ZZ(0), ZZ(-10), ZZ(9)], ZZ)
+    f = DMP(ZZ.map([1, 0, 20, 0, 150, 0, 500, 0, 625, -2, 0, -10, 9]), ZZ)
     g = DMP([ZZ(1), ZZ(0), ZZ(0), ZZ(-2), ZZ(9)], ZZ)
     h = DMP([ZZ(1), ZZ(0), ZZ(5), ZZ(0)], ZZ)
 
@@ -261,7 +261,8 @@ def test_DMP_exclude():
         18, 19, 20, 21, 22, 24, 25]
 
     assert DMP(f, ZZ).exclude() == (J, DMP([ZZ(1), ZZ(0)], ZZ))
-    assert DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ).exclude() == ([], DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ))
+    assert DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ).exclude() ==\
+            ([], DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ))
 
 
 def test_DMF__init__():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -467,40 +467,66 @@ def test_Poly__unify():
     assert Poly(x, x, modulus=3)._unify(Poly(y, y, modulus=5))[2:] == (
         DMP([[F5(1)], []], F5), DMP([[F5(1), F5(0)]], F5))
 
-    assert Poly(y, x, y)._unify(Poly(x, x, modulus=3))[2:] == (DMP([[F3(1), F3(0)]], F3), DMP([[F3(1)], []], F3))
-    assert Poly(x, x, modulus=3)._unify(Poly(y, x, y))[2:] == (DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))
+    assert Poly(y, x, y)._unify(Poly(x, x, modulus=3))[2:] ==\
+        (DMP([[F3(1), F3(0)]], F3), DMP([[F3(1)], []], F3))
+    assert Poly(x, x, modulus=3)._unify(Poly(y, x, y))[2:] ==\
+        (DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x))[2:] == (DMP([ZZ(1), ZZ(1)], ZZ), DMP([ZZ(1), ZZ(2)], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([ZZ(1), ZZ(1)], ZZ), DMP([ZZ(1), ZZ(2)], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] ==\
+        (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x))[2:] ==\
+        (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, y, x))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
-    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x))[2:] ==\
+        (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, y, x))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
-    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] ==\
+        (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
     assert Poly(x**2 + I, x, domain=ZZ_I).unify(Poly(x**2 + sqrt(2), x, extension=True)) == \
             (Poly(x**2 + I, x, domain='QQ<sqrt(2) + I>'), Poly(x**2 + sqrt(2), x, domain='QQ<sqrt(2) + I>'))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -186,13 +186,13 @@ def test_Poly_from_poly():
 
     assert Poly.from_poly(f) == f
     assert Poly.from_poly(f, domain=K).rep == DMP([K(1), K(1)], K)
-    assert Poly.from_poly(f, domain=ZZ).rep == DMP([1, 7], ZZ)
-    assert Poly.from_poly(f, domain=QQ).rep == DMP([1, 7], QQ)
+    assert Poly.from_poly(f, domain=ZZ).rep == DMP([ZZ(1), ZZ(7)], ZZ)
+    assert Poly.from_poly(f, domain=QQ).rep == DMP([QQ(1), QQ(7)], QQ)
 
     assert Poly.from_poly(f, gens=x) == f
     assert Poly.from_poly(f, gens=x, domain=K).rep == DMP([K(1), K(1)], K)
-    assert Poly.from_poly(f, gens=x, domain=ZZ).rep == DMP([1, 7], ZZ)
-    assert Poly.from_poly(f, gens=x, domain=QQ).rep == DMP([1, 7], QQ)
+    assert Poly.from_poly(f, gens=x, domain=ZZ).rep == DMP([ZZ(1), ZZ(7)], ZZ)
+    assert Poly.from_poly(f, gens=x, domain=QQ).rep == DMP([QQ(1), QQ(7)], QQ)
 
     assert Poly.from_poly(f, gens=y) == Poly(x + 7, y, domain='ZZ[x]')
     raises(CoercionFailed, lambda: Poly.from_poly(f, gens=y, domain=K))
@@ -210,12 +210,12 @@ def test_Poly_from_poly():
     K = FF(2)
 
     assert Poly.from_poly(g) == g
-    assert Poly.from_poly(g, domain=ZZ).rep == DMP([1, -1], ZZ)
+    assert Poly.from_poly(g, domain=ZZ).rep == DMP([ZZ(1), ZZ(-1)], ZZ)
     raises(CoercionFailed, lambda: Poly.from_poly(g, domain=QQ))
     assert Poly.from_poly(g, domain=K).rep == DMP([K(1), K(0)], K)
 
     assert Poly.from_poly(g, gens=x) == g
-    assert Poly.from_poly(g, gens=x, domain=ZZ).rep == DMP([1, -1], ZZ)
+    assert Poly.from_poly(g, gens=x, domain=ZZ).rep == DMP([ZZ(1), ZZ(-1)], ZZ)
     raises(CoercionFailed, lambda: Poly.from_poly(g, gens=x, domain=QQ))
     assert Poly.from_poly(g, gens=x, domain=K).rep == DMP([K(1), K(0)], K)
 
@@ -284,20 +284,20 @@ def test_Poly_from_expr():
     assert Poly.from_expr(x + y, domain=F3).rep == DMP([[F3(1)], [F3(1), F3(0)]], F3)
     assert Poly.from_expr(x + y, x, y, domain=F3).rep == DMP([[F3(1)], [F3(1), F3(0)]], F3)
 
-    assert Poly.from_expr(x + 5).rep == DMP([1, 5], ZZ)
-    assert Poly.from_expr(y + 5).rep == DMP([1, 5], ZZ)
+    assert Poly.from_expr(x + 5).rep == DMP([ZZ(1), ZZ(5)], ZZ)
+    assert Poly.from_expr(y + 5).rep == DMP([ZZ(1), ZZ(5)], ZZ)
 
-    assert Poly.from_expr(x + 5, x).rep == DMP([1, 5], ZZ)
-    assert Poly.from_expr(y + 5, y).rep == DMP([1, 5], ZZ)
+    assert Poly.from_expr(x + 5, x).rep == DMP([ZZ(1), ZZ(5)], ZZ)
+    assert Poly.from_expr(y + 5, y).rep == DMP([ZZ(1), ZZ(5)], ZZ)
 
-    assert Poly.from_expr(x + 5, domain=ZZ).rep == DMP([1, 5], ZZ)
-    assert Poly.from_expr(y + 5, domain=ZZ).rep == DMP([1, 5], ZZ)
+    assert Poly.from_expr(x + 5, domain=ZZ).rep == DMP([ZZ(1), ZZ(5)], ZZ)
+    assert Poly.from_expr(y + 5, domain=ZZ).rep == DMP([ZZ(1), ZZ(5)], ZZ)
 
-    assert Poly.from_expr(x + 5, x, domain=ZZ).rep == DMP([1, 5], ZZ)
-    assert Poly.from_expr(y + 5, y, domain=ZZ).rep == DMP([1, 5], ZZ)
+    assert Poly.from_expr(x + 5, x, domain=ZZ).rep == DMP([ZZ(1), ZZ(5)], ZZ)
+    assert Poly.from_expr(y + 5, y, domain=ZZ).rep == DMP([ZZ(1), ZZ(5)], ZZ)
 
-    assert Poly.from_expr(x + 5, x, y, domain=ZZ).rep == DMP([[1], [5]], ZZ)
-    assert Poly.from_expr(y + 5, x, y, domain=ZZ).rep == DMP([[1, 5]], ZZ)
+    assert Poly.from_expr(x + 5, x, y, domain=ZZ).rep == DMP([[ZZ(1)], [ZZ(5)]], ZZ)
+    assert Poly.from_expr(y + 5, x, y, domain=ZZ).rep == DMP([[ZZ(1), ZZ(5)]], ZZ)
 
 
 def test_poly_from_domain_element():
@@ -312,14 +312,14 @@ def test_poly_from_domain_element():
     assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
 
     dom = ZZ.old_poly_ring(x)
-    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    assert Poly(dom([ZZ(1), ZZ(1)]), y, domain=dom).rep == DMP([dom([ZZ(1), ZZ(1)])], dom)
     dom = dom.get_field()
-    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    assert Poly(dom([ZZ(1), ZZ(1)]), y, domain=dom).rep == DMP([dom([ZZ(1), ZZ(1)])], dom)
 
     dom = QQ.old_poly_ring(x)
-    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    assert Poly(dom([QQ(1), QQ(1)]), y, domain=dom).rep == DMP([dom([QQ(1), QQ(1)])], dom)
     dom = dom.get_field()
-    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    assert Poly(dom([QQ(1), QQ(1)]), y, domain=dom).rep == DMP([dom([QQ(1), QQ(1)])], dom)
 
     dom = QQ.algebraic_field(I)
     assert Poly(dom([1, 1]), x, domain=dom).rep == DMP([dom([1, 1])], dom)
@@ -470,37 +470,37 @@ def test_Poly__unify():
     assert Poly(y, x, y)._unify(Poly(x, x, modulus=3))[2:] == (DMP([[F3(1), F3(0)]], F3), DMP([[F3(1)], []], F3))
     assert Poly(x, x, modulus=3)._unify(Poly(y, x, y))[2:] == (DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x))[2:] == (DMP([1, 1], ZZ), DMP([1, 2], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([1, 1], QQ), DMP([1, 2], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([1, 1], QQ), DMP([1, 2], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x))[2:] == (DMP([ZZ(1), ZZ(1)], ZZ), DMP([ZZ(1), ZZ(2)], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([QQ(1), QQ(1)], QQ), DMP([QQ(1), QQ(2)], QQ))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[1], [1]], ZZ), DMP([[1], [2]], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x))[2:] == (DMP([[1], [1]], ZZ), DMP([[1], [2]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y))[2:] == (DMP([[1], [1]], ZZ), DMP([[1], [2]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x))[2:] == (DMP([[1, 1]], ZZ), DMP([[1, 2]], ZZ))
-    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
-    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, x)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x))[2:] == (DMP([[1, 1]], ZZ), DMP([[1, 2]], ZZ))
-    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x))[2:] == (DMP([[1], [1]], ZZ), DMP([[1], [2]], ZZ))
-    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
-    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[1], [1]], QQ), DMP([[1], [2]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x))[2:] == (DMP([[ZZ(1)], [ZZ(1)]], ZZ), DMP([[ZZ(1)], [ZZ(2)]], ZZ))
+    assert Poly(x + 1, x, y, domain='QQ')._unify(Poly(x + 2, y, x))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
+    assert Poly(x + 1, x, y)._unify(Poly(x + 2, y, x, domain='QQ'))[2:] == (DMP([[QQ(1)], [QQ(1)]], QQ), DMP([[QQ(1)], [QQ(2)]], QQ))
 
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[1, 1]], ZZ), DMP([[1, 2]], ZZ))
-    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
-    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[1, 1]], QQ), DMP([[1, 2]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y))[2:] == (DMP([[ZZ(1), ZZ(1)]], ZZ), DMP([[ZZ(1), ZZ(2)]], ZZ))
+    assert Poly(x + 1, y, x, domain='QQ')._unify(Poly(x + 2, x, y))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
+    assert Poly(x + 1, y, x)._unify(Poly(x + 2, x, y, domain='QQ'))[2:] == (DMP([[QQ(1), QQ(1)]], QQ), DMP([[QQ(1), QQ(2)]], QQ))
 
     assert Poly(x**2 + I, x, domain=ZZ_I).unify(Poly(x**2 + sqrt(2), x, extension=True)) == \
             (Poly(x**2 + I, x, domain='QQ<sqrt(2) + I>'), Poly(x**2 + sqrt(2), x, domain='QQ<sqrt(2) + I>'))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Validates the arguments to DMP.

Some tests are fixed to pass domain elements instead of int.

A redundant test function `test___hash__` was removed. This was for testing int vs long which might have been relevant in Python 2 but is not needed any more.

A bug in factor for `ZZ_I` was fixed. I am not sure if this bug would ever lead to incorrect results but an incorrect domain argument was being passed to `dmp_ground_primitive` meaning that `dup_zz_i_factor` was returning results over `QQ_I` rather than `ZZ_I`.

#### Other comments

The validation code is slow and should not be used at runtime. I will remove it in a subsequent commit after verifying that all tests have passed with the validation. This is a good example of the sort of thing that should really be handled by a static type checker because runtime type checks are too slow.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
