### PR TITLE
Move GF(p) to_int method to domain rather than element

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -157,6 +157,80 @@ Now they should be imported from ``sympy.physics.mechanics``:
 >>> from sympy.physics.mechanics.loads import gravity
 ```
 
+
+modularinteger-to-int=
+### The ``ModularInteger.to_int()`` method
+
+SymPy's ``GF`` domains are for modular integers e.g. ``GF(n)`` is for the
+integers modulo ``n`` and can be used like:
+```py
+>>> from sympy import GF
+>>> K = GF(5)
+>>> a = K(7)
+>>> a
+SymmetricModularIntegerMod5(2)
+>>> print(a)
+2 mod 5
+```
+The elements of a modular integer domain have a ``to_int()`` method that is
+deprecated since SymPy 1.13:
+```py
+>>> a.to_int() # deprecated
+2
+```
+Instead the preferred way to achieve equivalent behavior is to use the method
+on the domain (added in SymPy 1.13) or just by calling ``int``:
+```py
+>>> K.to_int(a)
+2
+>>> int(a)
+2
+```
+These two ways of converting to an ``int`` are not equivalent. The domain
+``GF(p)`` can be defined with ``symmetric=True`` or ``symmetric=False``. This
+difference affects the behavior of the ``to_int`` method:
+```py
+>>> KS = GF(5, symmetric=True)
+>>> KU = GF(5, symmetric=False)
+>>> [KS.to_int(KS(n)) for n in range(10)]
+[0, 1, 2, -2, -1, 0, 1, 2, -2, -1]
+>>> [KU.to_int(KU(n)) for n in range(10)]
+[0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+>>> [int(KS(n)) for n in range(10)]
+[0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+>>> [int(KU(n)) for n in range(10)]
+[0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+```
+So if ``symmetric=True`` (which is the default) then the ``to_int`` method will
+sometimes return negative integers. If ``symmetric=False`` or if the ``int(a)``
+method is used the returned result is always a nonnegative integer. Note also
+that the behaviour of ``int(a)`` was changed in SymPy 1.13: in previous
+versions it was equivalent to ``a.to_int()``. To write code that behaves the
+same way in all SymPy versions you can:
+
+1. Use ``symmetric=False`` and use ``int(a)``.
+2. Define a function like
+    ```py
+    def to_int(K, a):
+        if hasattr(K, 'to_int'):
+            return K.to_int(a)
+        else:
+            return a.to_int()
+    ```
+
+The reason for this change is that it makes it possible to use python-flint's
+``nmod`` as an alternative (much faster) implementation for the elements of
+``GF(p)``. It is not possible to add a ``to_int`` method to python-flint's
+``nmod`` type or to capture the equivalent of ``symmetric=True/False`` by
+storing data in the ``nmod`` instance. Deprecating and removing the ``to_int``
+method and changing the behavior of the ``int`` method means that the element
+instances do not have any behavior that depends on whether the domain is
+considered to be "symmetric" or not. Instead the notion of "symmetric" is now
+purely a property of the domain object itself rather than of the elements and
+so the ``to_int`` method that depends on this must be a domain method rather
+than an element method.
+
+
 ## Version 1.12
 
 (managedproperties)=

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -168,24 +168,27 @@ integers modulo ``n`` and can be used like:
 >>> K = GF(5)
 >>> a = K(7)
 >>> a
-SymmetricModularIntegerMod5(2)
->>> print(a)
 2 mod 5
 ```
+
 The elements of a modular integer domain have a ``to_int()`` method that is
 deprecated since SymPy 1.13:
 ```py
->>> a.to_int() # deprecated
+>>> # this is deprecated:
+>>> a.to_int()  # doctest: +SKIP
 2
 ```
+
 Instead the preferred way to achieve equivalent behavior is to use the method
-on the domain (added in SymPy 1.13) or just by calling ``int``:
+on the domain (added in SymPy 1.13) or alternatively calling ``int`` might be
+better:
 ```py
 >>> K.to_int(a)
 2
 >>> int(a)
 2
 ```
+
 These two ways of converting to an ``int`` are not equivalent. The domain
 ``GF(p)`` can be defined with ``symmetric=True`` or ``symmetric=False``. This
 difference affects the behavior of the ``to_int`` method:
@@ -201,6 +204,7 @@ difference affects the behavior of the ``to_int`` method:
 >>> [int(KU(n)) for n in range(10)]
 [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
 ```
+
 So if ``symmetric=True`` (which is the default) then the ``to_int`` method will
 sometimes return negative integers. If ``symmetric=False`` or if the ``int(a)``
 method is used the returned result is always a nonnegative integer. Note also

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2384,7 +2384,7 @@ def lfsr_sequence(key, fill, n):
         s = s[1:k]
         x = sum([int(key[i]*s0[i]) for i in range(k)])
         s.append(F(x))
-    return L       # use [x.to_int() for x in L] for int version
+    return L       # use [int(x) for x in L] for int version
 
 
 def lfsr_autocorrelation(L, P, k):
@@ -2432,7 +2432,7 @@ def lfsr_autocorrelation(L, P, k):
     k = int(k)
     L0 = L[:P]     # slices makes a copy
     L1 = L0 + L0[:k]
-    L2 = [(-1)**(L1[i].to_int() + L1[i + k].to_int()) for i in range(P)]
+    L2 = [(-1)**(int(L1[i]) + int(L1[i + k])) for i in range(P)]
     tot = sum(L2)
     return Rational(tot, P)
 
@@ -2508,10 +2508,10 @@ def lfsr_connection_polynomial(s):
             r = min(L + 1, dC + 1)
             coeffsC = [C.subs(x, 0)] + [C.coeff(x**i)
                 for i in range(1, dC + 1)]
-            d = (s[N].to_int() + sum([coeffsC[i]*s[N - i].to_int()
+            d = (int(s[N]) + sum([coeffsC[i]*int(s[N - i])
                 for i in range(1, r)])) % p
         if L == 0:
-            d = s[N].to_int()*x**0
+            d = int(s[N])*x**0
         if d == 0:
             m += 1
             N += 1

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -125,6 +125,7 @@ class FiniteField(Field, SimpleDomain):
         self.one = self.dtype(1)
         self.dom = dom
         self.mod = mod
+        self.sym = symmetric
 
     def __str__(self):
         return 'GF(%s)' % self.mod
@@ -147,7 +148,7 @@ class FiniteField(Field, SimpleDomain):
 
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
-        return SymPyInteger(int(a))
+        return SymPyInteger(self.to_int(a))
 
     def from_sympy(self, a):
         """Convert SymPy's Integer to SymPy's ``Integer``. """
@@ -157,6 +158,13 @@ class FiniteField(Field, SimpleDomain):
             return self.dtype(self.dom.dtype(int(a)))
         else:
             raise CoercionFailed("expected an integer, got %s" % a)
+
+    def to_int(self, a):
+        """Convert ``val`` to a Python ``int`` object. """
+        aval = a.val
+        if self.sym and aval > self.mod // 2:
+            aval -= self.mod
+        return aval
 
     def from_FF(K1, a, K0=None):
         """Convert ``ModularInteger(int)`` to ``dtype``. """

--- a/sympy/polys/domains/gmpyintegerring.py
+++ b/sympy/polys/domains/gmpyintegerring.py
@@ -43,7 +43,7 @@ class GMPYIntegerRing(IntegerRing):
 
     def from_FF_python(K1, a, K0):
         """Convert ``ModularInteger(int)`` to GMPY's ``mpz``. """
-        return GMPYInteger(a.to_int())
+        return K0.to_int(a)
 
     def from_ZZ_python(K1, a, K0):
         """Convert Python's ``int`` to GMPY's ``mpz``. """
@@ -61,7 +61,7 @@ class GMPYIntegerRing(IntegerRing):
 
     def from_FF_gmpy(K1, a, K0):
         """Convert ``ModularInteger(mpz)`` to GMPY's ``mpz``. """
-        return a.to_int()
+        return K0.to_int(a)
 
     def from_ZZ_gmpy(K1, a, K0):
         """Convert GMPY's ``mpz`` to GMPY's ``mpz``. """

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -167,11 +167,11 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
 
     def from_FF(K1, a, K0):
         """Convert ``ModularInteger(int)`` to GMPY's ``mpz``. """
-        return MPZ(a.to_int())
+        return MPZ(K0.to_int(a))
 
     def from_FF_python(K1, a, K0):
         """Convert ``ModularInteger(int)`` to GMPY's ``mpz``. """
-        return MPZ(a.to_int())
+        return MPZ(K0.to_int(a))
 
     def from_ZZ(K1, a, K0):
         """Convert Python's ``int`` to GMPY's ``mpz``. """
@@ -193,7 +193,7 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
 
     def from_FF_gmpy(K1, a, K0):
         """Convert ``ModularInteger(mpz)`` to GMPY's ``mpz``. """
-        return a.to_int()
+        return MPZ(K0.to_int(a))
 
     def from_ZZ_gmpy(K1, a, K0):
         """Convert GMPY's ``mpz`` to GMPY's ``mpz``. """

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -38,16 +38,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         return "%s mod %s" % (self.val, self.mod)
 
     def __int__(self):
-        return int(self.to_int())
-
-    def to_int(self):
-        if self.sym:
-            if self.val <= self.mod // 2:
-                return self.val
-            else:
-                return self.val - self.mod
-        else:
-            return self.val
+        return int(self.val)
 
     def __pos__(self):
         return self

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -10,6 +10,7 @@ from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.domains.domainelement import DomainElement
 
 from sympy.utilities import public
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 @public
 class ModularInteger(PicklableWithSlots, DomainElement):
@@ -39,6 +40,25 @@ class ModularInteger(PicklableWithSlots, DomainElement):
 
     def __int__(self):
         return int(self.val)
+
+    def to_int(self):
+
+        sympy_deprecation_warning(
+            """ModularInteger.to_int() is deprecated.
+
+            Use int(a) or K = GF(p) and K.to_int(a) instead of a.to_int().
+            """,
+            deprecated_since_version="1.13",
+            active_deprecations_target="modularinteger-to-int",
+        )
+
+        if self.sym:
+            if self.val <= self.mod // 2:
+                return self.val
+            else:
+                return self.val - self.mod
+        else:
+            return self.val
 
     def __pos__(self):
         return self

--- a/sympy/polys/domains/pythonintegerring.py
+++ b/sympy/polys/domains/pythonintegerring.py
@@ -41,7 +41,7 @@ class PythonIntegerRing(IntegerRing):
 
     def from_FF_python(K1, a, K0):
         """Convert ``ModularInteger(int)`` to Python's ``int``. """
-        return a.to_int()
+        return K0.to_int(a)
 
     def from_ZZ_python(K1, a, K0):
         """Convert Python's ``int`` to Python's ``int``. """
@@ -59,7 +59,7 @@ class PythonIntegerRing(IntegerRing):
 
     def from_FF_gmpy(K1, a, K0):
         """Convert ``ModularInteger(mpz)`` to Python's ``int``. """
-        return PythonInteger(a.to_int())
+        return PythonInteger(K0.to_int(a))
 
     def from_ZZ_gmpy(K1, a, K0):
         """Convert GMPY's ``mpz`` to Python's ``int``. """


### PR DESCRIPTION
The to_int and __int__ methods of GF(p) are the only methods that depend on the symmetric property of the domain. Having this dependence at the element level rather than the domain level makes it not possible to swap out the implementing of GF(p) for a more efficient implementation that does not provide the to_int method or the symmetric property.

The only place that the to_int method was being used directly was in crypto. It is unclear if the crypto code actually needs the symmetric property because all of the tested examples use GF(2) for which it has no effect. The crypto code does not provide for the user to pass in a domain so there is no way to use K.to_int(a) instead of a.to_int() in order to preserve the existing behaviour.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * DEPRECATED: The `.to_int()` method of `GF(p)` elements is moved to the domain rather than being a method of the elements and element method is deprecated.  Previously you could do `K = GF(3); a = K(2); ai = a.to_int()`. Now `a.to_int()` is deprecated and it should be `ai = K.to_int(a)`. The purpose of this change is that limiting the behaviour that is expected directly from the elements of `GF(p)` makes it possible to swap in the more efficient implementation provided by python-flint's `nmod`. See the deprecation docs for more explanation.
   * BREAKING CHANGE: The `__int__` method of `GF(p)` elements is now changed so that `int(a)` always returns the value of `a` as an integer mod `p` rather than the symmetric version that sometimes returns negative numbers. Use `K.to_int(a)` for the symmetric version. The purpose of this change is that limiting the behaviour that is expected directly from the elements of `GF(p)` makes it possible to swap in the more efficient implementation provided by python-flint's `nmod`. See the deprecation docs for more explanation.
<!-- END RELEASE NOTES -->