### PR TITLE
Fix mpelement.to_rational when gmpy2 is installed

### DIFF
--- a/sympy/polys/domains/mpelements.py
+++ b/sympy/polys/domains/mpelements.py
@@ -125,6 +125,11 @@ class MPContext(PythonMPContext):
     def to_rational(ctx, s, limit=True):
         p, q = to_rational(s._mpf_)
 
+        # Needed for GROUND_TYPES=flint if gmpy2 is installed because mpmath's
+        # to_rational() function returns a gmpy2.mpz instance and if MPQ is
+        # flint.fmpq then MPQ(p, q) will fail.
+        p = int(p)
+
         if not limit or q <= ctx.max_denom:
             return p, q
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Various polys tests fail if both gmpy2 and python-flint are installed and if `SYMPY_GROUND_TYPES=flint` is set.

Probably there should be CI testing for the case that gmpy2 and python-flint are both installed because they often don't mix well:
https://github.com/flintlib/python-flint/issues/56

The problems arise from mixing with mpmath because mpmath will use gmpy2 types if gmpy2 is installed. Often the difference between `int` and `gmpy2.mpz` can go unnoticed but when `GROUND_TYPES=flint` we have `MPQ=flint.fmpq` and that fails when given `gmpy2.mpz`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
