### PR TITLE
feat(polys): use python-flint's nmod for GF(p)

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -265,8 +265,30 @@ Now they should be imported from ``sympy.physics.mechanics``:
 >>> from sympy.physics.mechanics.loads import gravity
 ```
 
+(modularinteger-compare)=
+### Ordered comparisons like ``a < b`` with modular integers
 
-modularinteger-to-int=
+SymPy's ``GF`` domains represent modular integers. Previously it was possible
+to compare these with ordered comparisons like ``a < b``:
+```py
+>>> from sympy import GF
+>>> F5 = GF(5)
+>>> F5(2) < F5(3) # doctest: +SKIP
+True
+```
+This will now fail with ``TypeError`` when the ground types are set to
+``flint``. When the ground types are not ``flint`` these comparisons are now
+deprecated: they will still work but will give a deprecation warning when used.
+
+Ordered comparisons of modular integer or finite fields do not make sense
+because these are not ordered fields:
+```
+>>> e = F5(4)
+>>> e + 1 > e # doctest: +SKIP
+False
+```
+
+(modularinteger-to-int)=
 ### The ``ModularInteger.to_int()`` method
 
 SymPy's ``GF`` domains are for modular integers e.g. ``GF(n)`` is for the

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -301,18 +301,6 @@ def test_factorint():
     assert str(factorint(Dict(n))) == sans
 
 
-def test_factorint_flint_int_issue():
-    """
-    Because of a bug in flint, we are temporarily wrapping int in `factorint`.
-    When this fails, the int wrapper is no longer needed in factorint.
-
-    https://github.com/flintlib/python-flint/issues/92
-    https://github.com/sympy/sympy/pull/25749
-    """
-    if GROUND_TYPES == 'flint':
-        assert pow(2, 5, SYMPY_INTS[1](1000)) == 1
-
-
 def test_divisors_and_divisor_count():
     assert divisors(-1) == [1]
     assert divisors(0) == []

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -6,7 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial as fac
 from sympy.core.numbers import Integer, Rational
-from sympy.external.gmpy import gcd, GROUND_TYPES, SYMPY_INTS
+from sympy.external.gmpy import gcd
 
 from sympy.ntheory import (totient,
     factorint, primefactors, divisors, nextprime,

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -453,6 +453,10 @@ def dup_trunc(f, p, K):
                 g.append(c - p)
             else:
                 g.append(c)
+    elif K.is_FiniteField:
+        # XXX: python-flint's nmod does not support %
+        pi = int(p)
+        g = [ K(int(c) % pi) for c in f ]
     else:
         g = [ c % p for c in f ]
 

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -29,12 +29,8 @@ def _modular_int_factory(mod, dom, symmetric, self):
             raise ValueError('modulus must be an integer, got %s' % mod)
 
         # flint's nmod is only for moduli up to 2^64-1 (on a 64-bit machine)
-        try:
-            flint.nmod(0, mod)
-        except OverflowError:
-            pass
-        else:
-            return lambda val: flint.nmod(val, mod)
+        ctx = flint.fmpz_mod_ctx(mod)
+        return ctx
 
     # Use the Python implementation
     return ModularIntegerFactory(mod, dom, symmetric, self)

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -150,10 +150,28 @@ class ModularInteger(PicklableWithSlots, DomainElement):
     def _compare(self, other, op):
         val = self._get_val(other)
 
-        if val is not None:
-            return op(self.val, val % self.mod)
-        else:
+        if val is None:
             return NotImplemented
+
+        return op(self.val, val % self.mod)
+
+    def _compare_deprecated(self, other, op):
+        val = self._get_val(other)
+
+        if val is None:
+            return NotImplemented
+
+        sympy_deprecation_warning(
+            """Ordered comparisons with modular integers are deprecated.
+
+            Use e.g. int(a) < int(b) instead of a < b.
+            """,
+            deprecated_since_version="1.13",
+            active_deprecations_target="modularinteger-compare",
+            stacklevel=4,
+        )
+
+        return op(self.val, val % self.mod)
 
     def __eq__(self, other):
         return self._compare(other, operator.eq)
@@ -162,16 +180,16 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         return self._compare(other, operator.ne)
 
     def __lt__(self, other):
-        return self._compare(other, operator.lt)
+        return self._compare_deprecated(other, operator.lt)
 
     def __le__(self, other):
-        return self._compare(other, operator.le)
+        return self._compare_deprecated(other, operator.le)
 
     def __gt__(self, other):
-        return self._compare(other, operator.gt)
+        return self._compare_deprecated(other, operator.gt)
 
     def __ge__(self, other):
-        return self._compare(other, operator.ge)
+        return self._compare_deprecated(other, operator.ge)
 
     def __bool__(self):
         return bool(self.val)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -32,7 +32,7 @@ from sympy.polys.polyerrors import (
     NotInvertible,
     DomainError)
 
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 from itertools import product
 
@@ -955,6 +955,23 @@ def test_ModularInteger():
 
     raises(ValueError, lambda: FF(0))
     raises(ValueError, lambda: FF(2.1))
+
+    for n1 in range(5):
+        for n2 in range(5):
+            if GROUND_TYPES != 'flint':
+                with warns_deprecated_sympy():
+                    assert (F5(n1) < F5(n2)) is (n1 < n2)
+                with warns_deprecated_sympy():
+                    assert (F5(n1) <= F5(n2)) is (n1 <= n2)
+                with warns_deprecated_sympy():
+                    assert (F5(n1) > F5(n2)) is (n1 > n2)
+                with warns_deprecated_sympy():
+                    assert (F5(n1) >= F5(n2)) is (n1 >= n2)
+            else:
+                raises(TypeError, lambda: F5(n1) < F5(n2))
+                raises(TypeError, lambda: F5(n1) <= F5(n2))
+                raises(TypeError, lambda: F5(n1) > F5(n2))
+                raises(TypeError, lambda: F5(n1) >= F5(n2))
 
 def test_QQ_int():
     assert int(QQ(2**2000, 3**1250)) == 455431

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1,5 +1,7 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
+from sympy.external.gmpy import GROUND_TYPES
+
 from sympy.core.numbers import (AlgebraicNumber, E, Float, I, Integer,
     Rational, oo, pi, _illegal)
 from sympy.core.singleton import S
@@ -811,6 +813,7 @@ def test_PolynomialRing_from_FractionField():
     assert R.to_domain().from_FractionField(g, F.to_domain()) == X**2/4 + Y**2/4
     assert R.to_domain().from_FractionField(h, F.to_domain()) == X**2 + Y**2
 
+
 def test_FractionField_from_PolynomialRing():
     R, x,y = ring("x,y", QQ)
     F, X,Y = field("x,y", ZZ)
@@ -821,10 +824,12 @@ def test_FractionField_from_PolynomialRing():
     assert F.to_domain().from_PolynomialRing(f, R.to_domain()) == 3*X**2 + 5*Y**2
     assert F.to_domain().from_PolynomialRing(g, R.to_domain()) == (5*X**2 + 3*Y**2)/15
 
+
 def test_FF_of_type():
+    # XXX: of_type is not very useful here because in the case of ground types
+    # = flint all elements are of type nmod.
     assert FF(3).of_type(FF(3)(1)) is True
     assert FF(5).of_type(FF(5)(3)) is True
-    assert FF(5).of_type(FF(7)(3)) is False
 
 
 def test___eq__():
@@ -855,92 +860,81 @@ def test_ModularInteger():
     F3 = FF(3)
 
     a = F3(0)
-    assert isinstance(a, F3.dtype) and a == 0
+    assert F3.of_type(a) and a == 0
     a = F3(1)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)
-    assert isinstance(a, F3.dtype) and a == 2
+    assert F3.of_type(a) and a == 2
     a = F3(3)
-    assert isinstance(a, F3.dtype) and a == 0
+    assert F3.of_type(a) and a == 0
     a = F3(4)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = F3(F3(0))
-    assert isinstance(a, F3.dtype) and a == 0
+    assert F3.of_type(a) and a == 0
     a = F3(F3(1))
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(F3(2))
-    assert isinstance(a, F3.dtype) and a == 2
+    assert F3.of_type(a) and a == 2
     a = F3(F3(3))
-    assert isinstance(a, F3.dtype) and a == 0
+    assert F3.of_type(a) and a == 0
     a = F3(F3(4))
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = -F3(1)
-    assert isinstance(a, F3.dtype) and a == 2
+    assert F3.of_type(a) and a == 2
     a = -F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = 2 + F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2) + 2
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2) + F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2) + F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = 3 - F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(3) - 2
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(3) - F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(3) - F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = 2*F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)*2
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)*F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)*F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = 2/F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)/2
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)/F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)/F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
-
-    a = 1 % F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
-    a = F3(1) % 2
-    assert isinstance(a, F3.dtype) and a == 1
-    a = F3(1) % F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
-    a = F3(1) % F3(2)
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     a = F3(2)**0
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
     a = F3(2)**1
-    assert isinstance(a, F3.dtype) and a == 2
+    assert F3.of_type(a) and a == 2
     a = F3(2)**2
-    assert isinstance(a, F3.dtype) and a == 1
+    assert F3.of_type(a) and a == 1
 
     F7 = FF(7)
 
     a = F7(3)**100000000000
-    assert isinstance(a, F7.dtype) and a == 4
+    assert F7.of_type(a) and a == 4
     a = F7(3)**-100000000000
-    assert isinstance(a, F7.dtype) and a == 2
-    a = F7(3)**S(2)
-    assert isinstance(a, F7.dtype) and a == 2
+    assert F7.of_type(a) and a == 2
 
     assert bool(F3(3)) is False
     assert bool(F3(4)) is True
@@ -948,56 +942,18 @@ def test_ModularInteger():
     F5 = FF(5)
 
     a = F5(1)**(-1)
-    assert isinstance(a, F5.dtype) and a == 1
+    assert F5.of_type(a) and a == 1
     a = F5(2)**(-1)
-    assert isinstance(a, F5.dtype) and a == 3
+    assert F5.of_type(a) and a == 3
     a = F5(3)**(-1)
-    assert isinstance(a, F5.dtype) and a == 2
+    assert F5.of_type(a) and a == 2
     a = F5(4)**(-1)
-    assert isinstance(a, F5.dtype) and a == 4
+    assert F5.of_type(a) and a == 4
 
-    assert (F5(1) < F5(2)) is True
-    assert (F5(1) <= F5(2)) is True
-    assert (F5(1) > F5(2)) is False
-    assert (F5(1) >= F5(2)) is False
-
-    assert (F5(3) < F5(2)) is False
-    assert (F5(3) <= F5(2)) is False
-    assert (F5(3) > F5(2)) is True
-    assert (F5(3) >= F5(2)) is True
-
-    assert (F5(1) < F5(7)) is True
-    assert (F5(1) <= F5(7)) is True
-    assert (F5(1) > F5(7)) is False
-    assert (F5(1) >= F5(7)) is False
-
-    assert (F5(3) < F5(7)) is False
-    assert (F5(3) <= F5(7)) is False
-    assert (F5(3) > F5(7)) is True
-    assert (F5(3) >= F5(7)) is True
-
-    assert (F5(1) < 2) is True
-    assert (F5(1) <= 2) is True
-    assert (F5(1) > 2) is False
-    assert (F5(1) >= 2) is False
-
-    assert (F5(3) < 2) is False
-    assert (F5(3) <= 2) is False
-    assert (F5(3) > 2) is True
-    assert (F5(3) >= 2) is True
-
-    assert (F5(1) < 7) is True
-    assert (F5(1) <= 7) is True
-    assert (F5(1) > 7) is False
-    assert (F5(1) >= 7) is False
-
-    assert (F5(3) < 7) is False
-    assert (F5(3) <= 7) is False
-    assert (F5(3) > 7) is True
-    assert (F5(3) >= 7) is True
-
-    raises(NotInvertible, lambda: F5(0)**(-1))
-    raises(NotInvertible, lambda: F5(5)**(-1))
+    if GROUND_TYPES != 'flint':
+        # XXX: This gives a core dump with python-flint...
+        raises(NotInvertible, lambda: F5(0)**(-1))
+        raises(NotInvertible, lambda: F5(5)**(-1))
 
     raises(ValueError, lambda: FF(0))
     raises(ValueError, lambda: FF(2.1))

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -11,8 +11,6 @@ from sympy.functions.elementary.trigonometric import sin
 from sympy.polys.polytools import Poly
 from sympy.abc import x, y, z
 
-from sympy.external.gmpy import GROUND_TYPES
-
 from sympy.polys.domains import (ZZ, QQ, RR, CC, FF, GF, EX, EXRAW, ZZ_gmpy,
     ZZ_python, QQ_gmpy, QQ_python)
 from sympy.polys.domains.algebraicfield import AlgebraicField

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -14,8 +14,10 @@ import re
 
 if GROUND_TYPES == 'flint':
     import flint
+    flint_ZZ_n = (flint.nmod, flint.fmpz_mod)
 else:
     flint = None
+    flint_ZZ_n = ()
 
 
 _gens_order = {
@@ -167,7 +169,7 @@ def _sort_factors(factors, **args):
     # solution might be to add a sort key method to each domain.
     if flint is not None:
         def order_key(factor):
-            if isinstance(factor, flint.nmod):
+            if isinstance(factor, flint_ZZ_n):
                 return int(factor)
             elif isinstance(factor, list):
                 return [order_key(f) for f in factor]

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -1,5 +1,7 @@
 """Useful utilities for higher level polynomial classes. """
 
+from __future__ import annotations
+
 from sympy.external.gmpy import GROUND_TYPES
 
 from sympy.core import (S, Add, Mul, Pow, Eq, Expr,
@@ -10,6 +12,9 @@ from sympy.polys.polyerrors import PolynomialError, GeneratorsError
 from sympy.polys.polyoptions import build_options
 
 import re
+
+
+flint_ZZ_n: tuple[type, ...]
 
 
 if GROUND_TYPES == 'flint':


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Some changes are needed in python-flint before this can be used:
https://github.com/flintlib/python-flint/pull/78

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * The `GF(p)` domains will now use python-flint's nmod or `fmpz_mod` implementation with `GROUND_TYPES=flint`. This makes calculations with `GF(p)` significantly faster.
   * DEPRECATION: Ordered comparisons like `a < b` with elements of `GF(p)` are now deprecated. When the ground types are `flint` a comparison such as `a < b` will give TypeError but if the ground types are not `flint` then a deprecation warning will be emitted. Also elements of `GF(p)` do not have a `.val` attribute when the ground types are `flint`.
<!-- END RELEASE NOTES -->