### PR TITLE
besselk: implement series expansion for non-integer order

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -698,17 +698,21 @@ class besselk(BesselBase):
         _, e = arg.as_coeff_exponent(x)
 
         if e.is_positive:
-            term_one = ((-1)**(nu -1)*log(z/2)*besseli(nu, z))
-            term_two = (z/2)**(-nu)*factorial(nu - 1)/2 if (nu).is_positive else S.Zero
-            term_three = (-1)**nu*(z/2)**nu/(2*factorial(nu))*(digamma(nu + 1) - S.EulerGamma)
-            arg = Add(*[term_one, term_two, term_three]).as_leading_term(x, logx=logx)
-            return arg
-        elif e.is_negative:
-            # Refer Abramowitz and Stegun 1965, p. 378 for more information on
-            # asymptotic approximation of besselk function.
-            return sqrt(pi)*exp(-z)/sqrt(2*z)
+            if nu.is_zero:
+                # Equation 9.6.8 of Abramowitz and Stegun (10th ed, 1972).
+                term = -log(z) - S.EulerGamma + log(2)
+            elif nu.is_nonzero:
+                # Equation 9.6.9 of Abramowitz and Stegun (10th ed, 1972).
+                term = gamma(Abs(nu))*(z/2)**(-Abs(nu))/2
+            else:
+                raise NotImplementedError(f"Cannot proceed without knowing if {nu} is zero or not.")
 
-        return super(besselk, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
+            return term.as_leading_term(x, logx=logx)
+        elif e.is_negative:
+            # Equation 9.7.2 of Abramowitz and Stegun (10th ed, 1972).
+            return sqrt(pi)*exp(-arg)/sqrt(2*arg)
+        else:
+            return self.func(nu, arg)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         # Refer https://functions.wolfram.com/Bessel-TypeFunctions/BesselK/06/01/04/01/02/0008/

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -10,7 +10,7 @@ from sympy.core.numbers import Rational, pi, I
 from sympy.core.power import Pow
 from sympy.core.symbol import Dummy, uniquely_named_symbol, Wild
 from sympy.core.sympify import sympify
-from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
 from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.exponential import exp, log
@@ -715,51 +715,71 @@ class besselk(BesselBase):
             return self.func(nu, arg)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        # Refer https://functions.wolfram.com/Bessel-TypeFunctions/BesselK/06/01/04/01/02/0008/
-        # for more information on nseries expansion of besselk function.
         from sympy.series.order import Order
         nu, z = self.args
 
-        # In case of powers less than 1, number of terms need to be computed
-        # separately to avoid repeated callings of _eval_nseries with wrong n
         try:
             _, exp = z.leadterm(x)
         except (ValueError, NotImplementedError):
             return self
 
-        if exp.is_positive and nu.is_integer:
-            newn = ceiling(n/exp)
-            bn = besseli(nu, z)
-            a = ((-1)**(nu - 1)*log(z/2)*bn)._eval_nseries(x, n, logx, cdir)
-
-            b, c = [], []
-            o = Order(x**n, x)
+        # In case of powers less than 1, number of terms need to be computed
+        # separately to avoid repeated callings of _eval_nseries with wrong n
+        if exp.is_positive:
             r = (z/2)._eval_nseries(x, n, logx, cdir).removeO()
             if r is S.Zero:
-                return o
-            t = (_mexpand(r**2) + o).removeO()
+                return Order(z**(-nu) + z**nu, x)
 
-            if nu > S.Zero:
-                term = r**(-nu)*factorial(nu - 1)/2
-                b.append(term)
-                for k in range(1, nu):
-                    denom = (k - nu)*k
-                    if denom == S.Zero:
-                        term *= t/k
-                    else:
-                        term *= t/denom
-                    term = (_mexpand(term) + o).removeO()
+            o = Order(x**n, x)
+            if nu.is_integer:
+                # Reference: https://functions.wolfram.com/Bessel-TypeFunctions/BesselK/06/01/04/01/02/0008/ (only for integer order)
+                newn = ceiling(n/exp)
+                bn = besseli(nu, z)
+                a = ((-1)**(nu - 1)*log(z/2)*bn)._eval_nseries(x, n, logx, cdir)
+
+                b, c = [], []
+                t = _mexpand(r**2)
+
+                if nu > S.Zero:
+                    term = r**(-nu)*factorial(nu - 1)/2
                     b.append(term)
+                    for k in range(1, nu):
+                        term *= t/((k - nu)*k)
+                        term = (_mexpand(term) + o).removeO()
+                        b.append(term)
 
-            p = r**nu*(-1)**nu/(2*factorial(nu))
-            term = p*(digamma(nu + 1) - S.EulerGamma)
-            c.append(term)
-            for k in range(1, (newn + 1)//2):
-                p *= t/(k*(k + nu))
-                p = (_mexpand(p) + o).removeO()
-                term = p*(digamma(k + nu + 1) + digamma(k + 1))
+                p = r**nu*(-1)**nu/(2*factorial(nu))
+                term = p*(digamma(nu + 1) - S.EulerGamma)
                 c.append(term)
-            return a + Add(*b) + Add(*c) # Order term comes from a
+                for k in range(1, (newn + 1)//2):
+                    p *= t/(k*(k + nu))
+                    p = (_mexpand(p) + o).removeO()
+                    term = p*(digamma(k + nu + 1) + digamma(k + 1))
+                    c.append(term)
+                return a + Add(*b) + Add(*c) + o
+            elif nu.is_noninteger:
+                # Reference: https://functions.wolfram.com/Bessel-TypeFunctions/BesselK/06/01/04/01/01/0003/
+                # (only for non-integer order).
+                # While the expression in the reference above seems correct
+                # for non-real order as well, it would need some manipulation
+                # (not implemented) to be written as a power series in x with
+                # real exponents [e.g. Dunster 1990. "Bessel functions
+                # of purely imaginary order, with an application to second-order
+                # linear differential equations having a large parameter".
+                # SIAM J. Math. Anal. Vol 21, No. 4, pp 995-1018.].
+                newn_a = ceiling((n+nu)/exp)
+                newn_b = ceiling((n-nu)/exp)
+
+                a, b = [], []
+                for k in range((newn_a+1)//2):
+                    term = gamma(nu)*r**(2*k-nu)/(2*RisingFactorial(1-nu, k)*factorial(k))
+                    a.append(_mexpand(term))
+                for k in range((newn_b+1)//2):
+                    term = gamma(-nu)*r**(2*k+nu)/(2*RisingFactorial(nu+1, k)*factorial(k))
+                    b.append(_mexpand(term))
+                return Add(*a) + Add(*b) + o
+            else:
+                raise NotImplementedError("besselk expansion is only implemented for real order")
 
         return super(besselk, self)._eval_nseries(x, n, logx, cdir)
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -169,6 +169,7 @@ def test_besselk_series():
         S.EulerGamma/16) + O(x**4*log(x))
     assert besselk(2, x).series(x, n=4) == 2/x**2 - S(1)/2 + x**2*(-log(x)/8 - \
         S.EulerGamma/8 + log(2)/8 + S(3)/32) + O(x**4*log(x))
+    assert besselk(2, x).series(x, n=1) == 2/x**2 - S(1)/2 + O(x) #edge case for series truncation
     assert besselk(0, x**(1.1)).series(x, n=4) == log(2) - S.EulerGamma - \
         1.1*log(x) + x**2.2*(-0.275*log(x) - S.EulerGamma/4 + \
         log(2)/4 + S(1)/4) + O(x**4*log(x))
@@ -183,6 +184,9 @@ def test_besselk_series():
         sqrt(x)*(log(x)/2 - S(1)/2 + S.EulerGamma) + x**(S(3)/2)*(log(x)/4 - S(5)/8 + \
         S.EulerGamma/2) + x**(S(5)/2)*(log(x)/24 - S(5)/36 + S.EulerGamma/12) + O(x**3*log(x))
     assert besselk(-2, sin(x)).series(x, n=4) == besselk(2, sin(x)).series(x, n=4)
+    assert besselk(2, x**2).series(x, n=2) == 2/x**4 - S(1)/2 + O(x**2) #edge case for series truncation
+    assert besselk(2, x**2).series(x, n=6) == 2/x**4 - S(1)/2 + x**4*(-log(x)/4 - S.EulerGamma/8 + log(2)/8 + S(3)/32) + O(x**6*log(x))
+    assert (x**2*besselk(2, x)).series(x, n=2) == 2 + O(x**2)
 
     #test for aseries
     assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(sqrt(1/x) + (1/x)**(S(3)/2)/8 - \

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -195,6 +195,20 @@ def test_besselk_series():
             3*I*(-1/x)**(S(5)/2)/128 + 15*I*(-1/x)**(S(7)/2)/1024 + O((-1/x)**(S(9)/2), (x, -oo)))*exp(-x)/2
 
 
+def test_besselk_frac_order_series():
+    assert besselk(S(5)/3, x).series(x, n=2) == 2**(S(2)/3)*gamma(S(5)/3)/x**(S(5)/3) - \
+        3*gamma(S(5)/3)*x**(S(1)/3)/(4*2**(S(1)/3)) + \
+            gamma(-S(5)/3)*x**(S(5)/3)/(4*2**(S(2)/3)) + O(x**2)
+    assert besselk(S(1)/2, x).series(x, n=2) == sqrt(pi/2)/sqrt(x) - \
+        sqrt(pi*x/2) + x**(S(3)/2)*sqrt(pi/2)/2 + O(x**2)
+    assert besselk(S(1)/2, sqrt(x)).series(x, n=2) == sqrt(pi/2)/x**(S(1)/4) - \
+        sqrt(pi/2)*x**(S(1)/4) + sqrt(pi/2)*x**(S(3)/4)/2 - \
+            sqrt(pi/2)*x**(S(5)/4)/6 + sqrt(pi/2)*x**(S(7)/4)/24 + O(x**2)
+    assert besselk(S(1)/2, x**2).series(x, n=2) == sqrt(pi/2)/x \
+        - sqrt(pi/2)*x + O(x**2)
+    assert besselk(-S(1)/2, x).series(x) == besselk(S(1)/2, x).series(x)
+    assert besselk(-S(7)/6, x).series(x) == besselk(S(7)/6, x).series(x)
+
 
 def test_diff():
     assert besselj(n, z).diff(z) == besselj(n - 1, z)/2 - besselj(n + 1, z)/2

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -69,6 +69,17 @@ def test_besselk_leading_term():
     assert besselk(0, x).as_leading_term(x) == -log(x) - S.EulerGamma + log(2)
     assert besselk(1, sin(x)).as_leading_term(x) == 1/x
     assert besselk(1, 2*sqrt(x)).as_leading_term(x) == 1/(2*sqrt(x))
+    assert besselk(S(5)/3, x).as_leading_term(x) == 2**(S(2)/3)*gamma(S(5)/3)/x**(S(5)/3)
+    assert besselk(S(2)/3, x).as_leading_term(x) == besselk(-S(2)/3, x).as_leading_term(x)
+    assert besselk(1,cos(x)).as_leading_term(x) == besselk(1,1)
+    assert besselk(3,1/x).as_leading_term(x) == sqrt(pi)*exp(-(1/x))/sqrt(2/x)
+    assert besselk(3,1/sin(x)).as_leading_term(x) == sqrt(pi)*exp(-(1/x))/sqrt(2/x)
+
+    nz = Symbol("nz", nonzero=True)
+    assert besselk(nz, x).as_leading_term(x).subs({nz:S(5)/7}) == besselk(S(5)/7, x).series(x).as_leading_term(x)
+    assert besselk(nz, x).as_leading_term(x).subs({nz:S(-15)/7}) == besselk(S(-15)/7, x).series(x).as_leading_term(x)
+    assert besselk(nz, x).as_leading_term(x).subs({nz:3}) == besselk(3, x).series(x).as_leading_term(x)
+    assert besselk(nz, x).as_leading_term(x).subs({nz:-2}) == besselk(-2, x).series(x).as_leading_term(x)
 
 
 def test_besselj_series():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Series expansion for besselk (usually denoted as $K_\nu$) about the origin.
(<https://functions.wolfram.com/Bessel-TypeFunctions/BesselK/06/01/04/01/01/0003/>). Earlier, it was implemented only for integer orders.

This PR also fixes `besselk._eval_as_leading_term` for negative non-integer orders.

#### Other comments
I have also fixed a bug in the series expansion for integer orders (it was sometimes returning the wrong `Order` object), and added tests.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Implemented besselk series expansion for non-integer order
  * besselk: fixed calculation of leading term for non-integer negative orders
<!-- END RELEASE NOTES -->
