### PR TITLE
fix(polys): don't unify characteristics

### DIFF
--- a/sympy/polys/agca/extensions.py
+++ b/sympy/polys/agca/extensions.py
@@ -303,6 +303,13 @@ class MonogenicFiniteExtension(Domain):
 
     __repr__ = __str__
 
+    @property
+    def has_CharacteristicZero(self):
+        return self.domain.has_CharacteristicZero
+
+    def characteristic(self):
+        return self.domain.characteristic()
+
     def convert(self, f, base=None):
         rep = self.ring.convert(f, base)
         return ExtElem(rep % self.mod, self)

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from sympy.core.numbers import AlgebraicNumber
 from sympy.core import Basic, sympify
-from sympy.core.sorting import default_sort_key, ordered
+from sympy.core.sorting import ordered
 from sympy.external.gmpy import GROUND_TYPES
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.orderings import lex

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -673,6 +673,39 @@ class Domain:
 
         return K0.unify(K1)
 
+    def unify_composite(K0, K1):
+        """Unify two domains where at least one is composite."""
+        K0_ground = K0.dom if K0.is_Composite else K0
+        K1_ground = K1.dom if K1.is_Composite else K1
+
+        K0_symbols = K0.symbols if K0.is_Composite else ()
+        K1_symbols = K1.symbols if K1.is_Composite else ()
+
+        domain = K0_ground.unify(K1_ground)
+        symbols = _unify_gens(K0_symbols, K1_symbols)
+        order = K0.order if K0.is_Composite else K1.order
+
+        # E.g. ZZ[x].unify(QQ.frac_field(x)) -> ZZ.frac_field(x)
+        if ((K0.is_FractionField and K1.is_PolynomialRing or
+             K1.is_FractionField and K0.is_PolynomialRing) and
+             (not K0_ground.is_Field or not K1_ground.is_Field) and domain.is_Field
+             and domain.has_assoc_Ring):
+            domain = domain.get_ring()
+
+        if K0.is_Composite and (not K1.is_Composite or K0.is_FractionField or K1.is_PolynomialRing):
+            cls = K0.__class__
+        else:
+            cls = K1.__class__
+
+        # Here cls might be PolynomialRing, FractionField, GlobalPolynomialRing
+        # (dense/old Polynomialring) or dense/old FractionField.
+
+        from sympy.polys.domains.old_polynomialring import GlobalPolynomialRing
+        if cls == GlobalPolynomialRing:
+            return cls(domain, symbols)
+
+        return cls(domain, symbols, order)
+
     def unify(K0, K1, symbols=None):
         """
         Construct a minimal domain that contains elements of ``K0`` and ``K1``.
@@ -695,6 +728,19 @@ class Domain:
 
         if K0 == K1:
             return K0
+
+        if not (K0.has_CharacteristicZero and K1.has_CharacteristicZero):
+            # Reject unification of domains with different characteristics.
+            if K0.characteristic() != K1.characteristic():
+                raise UnificationFailed("Cannot unify %s with %s" % (K0, K1))
+
+            # We do not get here if K0 == K1. The two domains have the same
+            # characteristic but are unequal so at least one is composite and
+            # we are unifying something like GF(3).unify(GF(3)[x]).
+            return K0.unify_composite(K1)
+
+        # From here we know both domains have characteristic zero and it can be
+        # acceptable to fall back on EX.
 
         if K0.is_EXRAW:
             return K0
@@ -722,32 +768,7 @@ class Domain:
                 return K0.set_domain(K1)
 
         if K0.is_Composite or K1.is_Composite:
-            K0_ground = K0.dom if K0.is_Composite else K0
-            K1_ground = K1.dom if K1.is_Composite else K1
-
-            K0_symbols = K0.symbols if K0.is_Composite else ()
-            K1_symbols = K1.symbols if K1.is_Composite else ()
-
-            domain = K0_ground.unify(K1_ground)
-            symbols = _unify_gens(K0_symbols, K1_symbols)
-            order = K0.order if K0.is_Composite else K1.order
-
-            if ((K0.is_FractionField and K1.is_PolynomialRing or
-                 K1.is_FractionField and K0.is_PolynomialRing) and
-                 (not K0_ground.is_Field or not K1_ground.is_Field) and domain.is_Field
-                 and domain.has_assoc_Ring):
-                domain = domain.get_ring()
-
-            if K0.is_Composite and (not K1.is_Composite or K0.is_FractionField or K1.is_PolynomialRing):
-                cls = K0.__class__
-            else:
-                cls = K1.__class__
-
-            from sympy.polys.domains.old_polynomialring import GlobalPolynomialRing
-            if cls == GlobalPolynomialRing:
-                return cls(domain, symbols)
-
-            return cls(domain, symbols, order)
+            return K0.unify_composite(K1)
 
         def mkinexact(cls, K0, K1):
             prec = max(K0.precision, K1.precision)
@@ -808,9 +829,6 @@ class Domain:
             return K0
         if K1.is_IntegerRing:
             return K1
-
-        if K0.is_FiniteField and K1.is_FiniteField:
-            return K0.__class__(max(K0.mod, K1.mod, key=default_sort_key))
 
         from sympy.polys.domains import EX
         return EX

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -68,6 +68,13 @@ class FractionField(Field, CompositeDomain):
             (self.dtype.field, self.domain, self.symbols) ==\
             (other.dtype.field, other.domain, other.symbols)
 
+    @property
+    def has_CharacteristicZero(self):
+        return self.domain.has_CharacteristicZero
+
+    def characteristic(self):
+        return self.domain.characteristic()
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return a.as_expr()

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -251,13 +251,6 @@ class GaussianDomain():
     has_assoc_Ring = True
     has_assoc_Field = True
 
-    @property
-    def has_CharacteristicZero(self):
-        return True
-
-    def characteristic(self):
-        return 0
-
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         conv = self.dom.to_sympy
@@ -456,6 +449,13 @@ class GaussianIntegerRing(GaussianDomain, Ring):
         """Compute hash code of ``self``. """
         return hash('ZZ_I')
 
+    @property
+    def has_CharacteristicZero(self):
+        return True
+
+    def characteristic(self):
+        return 0
+
     def get_ring(self):
         """Returns a ring associated with ``self``. """
         return self
@@ -637,6 +637,13 @@ class GaussianRationalField(GaussianDomain, Field):
     def __hash__(self):
         """Compute hash code of ``self``. """
         return hash('QQ_I')
+
+    @property
+    def has_CharacteristicZero(self):
+        return True
+
+    def characteristic(self):
+        return 0
 
     def get_ring(self):
         """Returns a ring associated with ``self``. """

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -251,6 +251,13 @@ class GaussianDomain():
     has_assoc_Ring = True
     has_assoc_Field = True
 
+    @property
+    def has_CharacteristicZero(self):
+        return True
+
+    def characteristic(self):
+        return 0
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         conv = self.dom.to_sympy

--- a/sympy/polys/domains/old_fractionfield.py
+++ b/sympy/polys/domains/old_fractionfield.py
@@ -46,6 +46,13 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
         return isinstance(other, FractionField) and \
             self.dtype == other.dtype and self.dom == other.dom and self.gens == other.gens
 
+    @property
+    def has_CharacteristicZero(self):
+        return self.dom.has_CharacteristicZero
+
+    def characteristic(self):
+        return self.dom.characteristic()
+
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return (basic_from_dict(a.numer().to_sympy_dict(), *self.gens) /

--- a/sympy/polys/domains/old_polynomialring.py
+++ b/sympy/polys/domains/old_polynomialring.py
@@ -66,6 +66,13 @@ class PolynomialRingBase(Ring, CharacteristicZero, CompositeDomain):
             self.dtype == other.dtype and self.dom == other.dom and \
             self.gens == other.gens and self.order == other.order
 
+    @property
+    def has_CharacteristicZero(self):
+        return self.dom.has_CharacteristicZero
+
+    def characteristic(self):
+        return self.dom.characteristic()
+
     def from_ZZ(K1, a, K0):
         """Convert a Python ``int`` object to ``dtype``. """
         return K1(K1.dom.convert(a, K0))

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -67,6 +67,13 @@ class PolynomialRing(Ring, CompositeDomain):
             (self.dtype.ring, self.domain, self.symbols) == \
             (other.dtype.ring, other.domain, other.symbols)
 
+    @property
+    def has_CharacteristicZero(self):
+        return self.domain.has_CharacteristicZero
+
+    def characteristic(self):
+        return self.domain.characteristic()
+
     def is_unit(self, a):
         """Returns ``True`` if ``a`` is a unit of ``self``"""
         if not a.is_ground:

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -45,16 +45,16 @@ def test_Domain_unify():
     F3 = GF(3)
 
     assert unify(F3, F3) == F3
-    assert unify(F3, ZZ) == ZZ
-    assert unify(F3, QQ) == QQ
-    assert unify(F3, ALG) == ALG
-    assert unify(F3, RR) == RR
-    assert unify(F3, CC) == CC
-    assert unify(F3, ZZ[x]) == ZZ[x]
-    assert unify(F3, ZZ.frac_field(x)) == ZZ.frac_field(x)
-    assert unify(F3, EX) == EX
+    raises(UnificationFailed, lambda: unify(F3, ZZ))
+    raises(UnificationFailed, lambda: unify(F3, QQ))
+    raises(UnificationFailed, lambda: unify(F3, ALG))
+    raises(UnificationFailed, lambda: unify(F3, RR))
+    raises(UnificationFailed, lambda: unify(F3, CC))
+    raises(UnificationFailed, lambda: unify(F3, ZZ[x]))
+    raises(UnificationFailed, lambda: unify(F3, ZZ.frac_field(x)))
+    raises(UnificationFailed, lambda: unify(F3, EX))
 
-    assert unify(ZZ, F3) == ZZ
+    raises(UnificationFailed, lambda: unify(ZZ, F3))
     assert unify(ZZ, ZZ) == ZZ
     assert unify(ZZ, QQ) == QQ
     assert unify(ZZ, ALG) == ALG
@@ -64,7 +64,7 @@ def test_Domain_unify():
     assert unify(ZZ, ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ, EX) == EX
 
-    assert unify(QQ, F3) == QQ
+    raises(UnificationFailed, lambda: unify(QQ, F3))
     assert unify(QQ, ZZ) == QQ
     assert unify(QQ, QQ) == QQ
     assert unify(QQ, ALG) == ALG
@@ -74,7 +74,7 @@ def test_Domain_unify():
     assert unify(QQ, ZZ.frac_field(x)) == QQ.frac_field(x)
     assert unify(QQ, EX) == EX
 
-    assert unify(ZZ_I, F3) == ZZ_I
+    raises(UnificationFailed, lambda: unify(ZZ_I, F3))
     assert unify(ZZ_I, ZZ) == ZZ_I
     assert unify(ZZ_I, ZZ_I) == ZZ_I
     assert unify(ZZ_I, QQ) == QQ_I
@@ -87,7 +87,7 @@ def test_Domain_unify():
     assert unify(ZZ_I, ZZ_I.frac_field(x)) == ZZ_I.frac_field(x)
     assert unify(ZZ_I, EX) == EX
 
-    assert unify(QQ_I, F3) == QQ_I
+    raises(UnificationFailed, lambda: unify(QQ_I, F3))
     assert unify(QQ_I, ZZ) == QQ_I
     assert unify(QQ_I, ZZ_I) == QQ_I
     assert unify(QQ_I, QQ) == QQ_I
@@ -104,7 +104,7 @@ def test_Domain_unify():
     assert unify(QQ_I, QQ_I.frac_field(x)) == QQ_I.frac_field(x)
     assert unify(QQ_I, EX) == EX
 
-    assert unify(RR, F3) == RR
+    raises(UnificationFailed, lambda: unify(RR, F3))
     assert unify(RR, ZZ) == RR
     assert unify(RR, QQ) == RR
     assert unify(RR, ALG) == RR
@@ -115,7 +115,7 @@ def test_Domain_unify():
     assert unify(RR, EX) == EX
     assert RR[x].unify(ZZ.frac_field(y)) == RR.frac_field(x, y)
 
-    assert unify(CC, F3) == CC
+    raises(UnificationFailed, lambda: unify(CC, F3))
     assert unify(CC, ZZ) == CC
     assert unify(CC, QQ) == CC
     assert unify(CC, ALG) == CC
@@ -125,7 +125,7 @@ def test_Domain_unify():
     assert unify(CC, ZZ.frac_field(x)) == CC.frac_field(x)
     assert unify(CC, EX) == EX
 
-    assert unify(ZZ[x], F3) == ZZ[x]
+    raises(UnificationFailed, lambda: unify(ZZ[x], F3))
     assert unify(ZZ[x], ZZ) == ZZ[x]
     assert unify(ZZ[x], QQ) == QQ[x]
     assert unify(ZZ[x], ALG) == ALG[x]
@@ -135,7 +135,7 @@ def test_Domain_unify():
     assert unify(ZZ[x], ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ[x], EX) == EX
 
-    assert unify(ZZ.frac_field(x), F3) == ZZ.frac_field(x)
+    raises(UnificationFailed, lambda: unify(ZZ.frac_field(x), F3))
     assert unify(ZZ.frac_field(x), ZZ) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), QQ) == QQ.frac_field(x)
     assert unify(ZZ.frac_field(x), ALG) == ALG.frac_field(x)
@@ -145,7 +145,7 @@ def test_Domain_unify():
     assert unify(ZZ.frac_field(x), ZZ.frac_field(x)) == ZZ.frac_field(x)
     assert unify(ZZ.frac_field(x), EX) == EX
 
-    assert unify(EX, F3) == EX
+    raises(UnificationFailed, lambda: unify(EX, F3))
     assert unify(EX, ZZ) == EX
     assert unify(EX, QQ) == EX
     assert unify(EX, ALG) == EX

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -43,16 +43,24 @@ def unify(K0, K1):
 
 def test_Domain_unify():
     F3 = GF(3)
+    F5 = GF(5)
 
     assert unify(F3, F3) == F3
     raises(UnificationFailed, lambda: unify(F3, ZZ))
     raises(UnificationFailed, lambda: unify(F3, QQ))
+    raises(UnificationFailed, lambda: unify(F3, ZZ_I))
+    raises(UnificationFailed, lambda: unify(F3, QQ_I))
     raises(UnificationFailed, lambda: unify(F3, ALG))
     raises(UnificationFailed, lambda: unify(F3, RR))
     raises(UnificationFailed, lambda: unify(F3, CC))
     raises(UnificationFailed, lambda: unify(F3, ZZ[x]))
     raises(UnificationFailed, lambda: unify(F3, ZZ.frac_field(x)))
     raises(UnificationFailed, lambda: unify(F3, EX))
+
+    assert unify(F5, F5) == F5
+    raises(UnificationFailed, lambda: unify(F5, F3))
+    raises(UnificationFailed, lambda: unify(F5, F3[x]))
+    raises(UnificationFailed, lambda: unify(F5, F3.frac_field(x)))
 
     raises(UnificationFailed, lambda: unify(ZZ, F3))
     assert unify(ZZ, ZZ) == ZZ
@@ -559,6 +567,8 @@ def test_Domain_get_exact():
     assert ZZ.get_exact() == ZZ
     assert QQ.get_exact() == QQ
     assert RR.get_exact() == QQ
+    # XXX: This should also be like RR:
+    # assert CC.get_exact() == QQ_I
     assert ALG.get_exact() == ALG
     assert ZZ[x].get_exact() == ZZ[x]
     assert QQ[x].get_exact() == QQ[x]
@@ -568,6 +578,17 @@ def test_Domain_get_exact():
     assert QQ.frac_field(x).get_exact() == QQ.frac_field(x)
     assert ZZ.frac_field(x, y).get_exact() == ZZ.frac_field(x, y)
     assert QQ.frac_field(x, y).get_exact() == QQ.frac_field(x, y)
+
+
+def test_Domain_characteristic():
+    for F, c in [(FF(3), 3), (FF(5), 5), (FF(7), 7)]:
+        for R in F, F[x], F.frac_field(x), F.old_poly_ring(x), F.old_frac_field(x):
+            assert F.has_CharacteristicZero is False
+            assert F.characteristic() == c
+    for D in ZZ, QQ, ZZ_I, QQ_I, ALG:
+        for R in D, D[x], D.frac_field(x), D.old_poly_ring(x), D.old_frac_field(x):
+            assert D.has_CharacteristicZero is True
+            assert D.characteristic() == 0
 
 
 def test_Domain_is_unit():

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -583,12 +583,12 @@ def test_Domain_get_exact():
 def test_Domain_characteristic():
     for F, c in [(FF(3), 3), (FF(5), 5), (FF(7), 7)]:
         for R in F, F[x], F.frac_field(x), F.old_poly_ring(x), F.old_frac_field(x):
-            assert F.has_CharacteristicZero is False
-            assert F.characteristic() == c
+            assert R.has_CharacteristicZero is False
+            assert R.characteristic() == c
     for D in ZZ, QQ, ZZ_I, QQ_I, ALG:
         for R in D, D[x], D.frac_field(x), D.old_poly_ring(x), D.old_frac_field(x):
-            assert D.has_CharacteristicZero is True
-            assert D.characteristic() == 0
+            assert R.has_CharacteristicZero is True
+            assert R.characteristic() == 0
 
 
 def test_Domain_is_unit():

--- a/sympy/polys/numberfields/primes.py
+++ b/sympy/polys/numberfields/primes.py
@@ -396,7 +396,7 @@ def _compute_test_factor(p, gens, ZK):
     # predicts that such an element must exist, so nullspace should
     # be non-trivial.
     x = B.nullspace()[0, :].transpose()
-    beta = ZK.parent(ZK.matrix * x, denom=ZK.denom)
+    beta = ZK.parent(ZK.matrix * x.convert_to(ZZ), denom=ZK.denom)
     return beta
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -71,6 +71,9 @@ def _polifyit(func):
         g = _sympify(g)
         if isinstance(g, Poly):
             return func(f, g)
+        elif isinstance(g, Integer):
+            g = f.from_expr(g, *f.gens, domain=f.domain)
+            return func(f, g)
         elif isinstance(g, Expr):
             try:
                 g = f.from_expr(g, *f.gens)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -460,7 +460,6 @@ def test_Poly__unify():
     raises(UnificationFailed, lambda: Poly(x)._unify(y))
 
     F3 = FF(3)
-    F5 = FF(5)
 
     assert Poly(x, x, modulus=3)._unify(Poly(y, y, modulus=3))[2:] == (
         DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -464,13 +464,10 @@ def test_Poly__unify():
 
     assert Poly(x, x, modulus=3)._unify(Poly(y, y, modulus=3))[2:] == (
         DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))
-    assert Poly(x, x, modulus=3)._unify(Poly(y, y, modulus=5))[2:] == (
-        DMP([[F5(1)], []], F5), DMP([[F5(1), F5(0)]], F5))
+    raises(UnificationFailed, lambda: Poly(x, x, modulus=3)._unify(Poly(y, y, modulus=5)))
 
-    assert Poly(y, x, y)._unify(Poly(x, x, modulus=3))[2:] ==\
-        (DMP([[F3(1), F3(0)]], F3), DMP([[F3(1)], []], F3))
-    assert Poly(x, x, modulus=3)._unify(Poly(y, x, y))[2:] ==\
-        (DMP([[F3(1)], []], F3), DMP([[F3(1), F3(0)]], F3))
+    raises(UnificationFailed, lambda: Poly(y, x, y)._unify(Poly(x, x, modulus=3)))
+    raises(UnificationFailed, lambda: Poly(x, x, modulus=3)._unify(Poly(y, x, y)))
 
     assert Poly(x + 1, x)._unify(Poly(x + 2, x))[2:] ==\
         (DMP([ZZ(1), ZZ(1)], ZZ), DMP([ZZ(1), ZZ(2)], ZZ))

--- a/sympy/simplify/tests/test_ratsimp.py
+++ b/sympy/simplify/tests/test_ratsimp.py
@@ -74,5 +74,5 @@ def test_ratsimpmodprime():
         y/2
 
     a = (x**5 + 2*x**4 + 2*x**3 + 2*x**2 + x + 2/x + x**(-2))
-    assert ratsimpmodprime(a, [x + 1], domain=GF(2)) == 1
-    assert ratsimpmodprime(a, [x + 1], domain=GF(3)) == -1
+    # assert ratsimpmodprime(a, [x + 1], domain=GF(2)) == 1
+    # assert ratsimpmodprime(a, [x + 1], domain=GF(3)) == -1

--- a/sympy/simplify/tests/test_ratsimp.py
+++ b/sympy/simplify/tests/test_ratsimp.py
@@ -2,7 +2,6 @@ from sympy.core.numbers import (Rational, pi)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.error_functions import erf
-from sympy.polys.domains.finitefield import GF
 from sympy.simplify.ratsimp import (ratsimp, ratsimpmodprime)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e

--- a/sympy/simplify/tests/test_ratsimp.py
+++ b/sympy/simplify/tests/test_ratsimp.py
@@ -2,6 +2,7 @@ from sympy.core.numbers import (Rational, pi)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.error_functions import erf
+from sympy.polys.domains import GF
 from sympy.simplify.ratsimp import (ratsimp, ratsimpmodprime)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e
@@ -73,5 +74,5 @@ def test_ratsimpmodprime():
         y/2
 
     a = (x**5 + 2*x**4 + 2*x**3 + 2*x**2 + x + 2/x + x**(-2))
-    # assert ratsimpmodprime(a, [x + 1], domain=GF(2)) == 1
-    # assert ratsimpmodprime(a, [x + 1], domain=GF(3)) == -1
+    assert ratsimpmodprime(a, [x + 1], domain=GF(2)) == 1
+    assert ratsimpmodprime(a, [x + 1], domain=GF(3)) == -1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #25653 by disallowing any unification of domains with different characteristic.

#### Brief description of what is fixed or changed

Previously:
```python
>>> GF(3).unify(ZZ)
ZZ
```
With the PR:
```python
>>> GF(3).unify(ZZ)
...
UnificationFailed: Cannot unify GF(3) with ZZ 
```

Also adds more consistent handling of `.has_CharacteristicZero` and `.characteristic()` for different domains.

#### Other comments

There was one place in the code

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * BREAKING CHANGE: Unification of domains like `GF(p)` with `ZZ` or other domains would previously result in `ZZ` (or any other domain). This now results in a UnificationFailed error. Previously unification like e.g. `GF(2).unify(GF(3))` would unify to the large characteristic but this now results in UnificationFailed.
<!-- END RELEASE NOTES -->