### PR TITLE
Changed from Fermat pseudoprime to Euler pseudoprime

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -657,8 +657,9 @@ def isprime(n):
         return False
     if n < 2809:
         return True
-    if n < 31417:
-        return pow(2, n, n) == 2 and n not in [7957, 8321, 13747, 18721, 19951, 23377]
+    if n < 65077:
+        # There are only five Euler pseudoprimes with a least prime factor greater than 47
+        return pow(2, n >> 1, n) in [1, n - 1] and n not in [8321, 31621, 42799, 49141, 49981]
 
     # bisection search on the sieve if the sieve is large enough
     from sympy.ntheory.generate import sieve as s


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
Verification Code
```python
from sympy.ntheory import isprime, factorint

for n in range(2809, 65077, 2):
    if isprime(n) or min(factorint(n).keys()) <= 47:
        continue
    if pow(2, n >> 1, n) in [1, n - 1]:
        print(n)
8321
31621
42799
49141
49981
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
