### PR TITLE
Added `is_fermat_pseudoprime` etc

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -135,7 +135,11 @@ Ntheory Functions Reference
 
 .. module:: sympy.ntheory.primetest
 
+.. autofunction:: is_fermat_pseudoprime
+
 .. autofunction:: is_euler_pseudoprime
+
+.. autofunction:: is_euler_jacobi_pseudoprime
 
 .. autofunction:: is_square
 

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -21,6 +21,9 @@ from .ntheory import (
     jacobi as python_jacobi,
     kronecker as python_kronecker,
     iroot as python_iroot,
+    is_fermat_prp as python_is_fermat_prp,
+    is_euler_prp as python_is_euler_prp,
+    is_strong_prp as python_is_strong_prp,
 )
 
 
@@ -60,6 +63,9 @@ __all__ = [
     'jacobi',
     'kronecker',
     'iroot',
+    'is_fermat_prp',
+    'is_euler_prp',
+    'is_strong_prp',
 ]
 
 
@@ -165,6 +171,10 @@ if GROUND_TYPES == 'gmpy':
             return gmpy.iroot(x, n)
         return python_iroot(x, n)
 
+    is_fermat_prp = gmpy.is_fermat_prp
+    is_euler_prp = gmpy.is_euler_prp
+    is_strong_prp = gmpy.is_strong_prp
+
 elif GROUND_TYPES == 'flint':
 
     HAS_GMPY = 0
@@ -210,6 +220,10 @@ elif GROUND_TYPES == 'flint':
             return y, y**n == x
         return python_iroot(x, n)
 
+    is_fermat_prp = python_is_fermat_prp
+    is_euler_prp = python_is_euler_prp
+    is_strong_prp = python_is_strong_prp
+
 elif GROUND_TYPES == 'python':
 
     HAS_GMPY = 0
@@ -231,6 +245,9 @@ elif GROUND_TYPES == 'python':
     jacobi = python_jacobi
     kronecker = python_kronecker
     iroot = python_iroot
+    is_fermat_prp = python_is_fermat_prp
+    is_euler_prp = python_is_euler_prp
+    is_strong_prp = python_is_strong_prp
 
 else:
     assert False

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -237,3 +237,58 @@ def iroot(y, n):
         x -= 1
         t = x**n
     return x, t == y
+
+
+def is_fermat_prp(n, a):
+    if a < 2:
+        raise ValueError("is_fermat_prp() requires 'a' greater than or equal to 2")
+    if n < 1:
+        raise ValueError("is_fermat_prp() requires 'n' be greater than 0")
+    if n == 1:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    a %= n
+    if gcd(n, a) != 1:
+        raise ValueError("is_fermat_prp() requires gcd(n,a) == 1")
+    return pow(a, n - 1, n) == 1
+
+
+def is_euler_prp(n, a):
+    if a < 2:
+        raise ValueError("is_euler_prp() requires 'a' greater than or equal to 2")
+    if n < 1:
+        raise ValueError("is_euler_prp() requires 'n' be greater than 0")
+    if n == 1:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    a %= n
+    if gcd(n, a) != 1:
+        raise ValueError("is_euler_prp() requires gcd(n,a) == 1")
+    return pow(a, n >> 1, n) == jacobi(a, n) % n
+
+
+def is_strong_prp(n, a):
+    if a < 2:
+        raise ValueError("is_strong_prp() requires 'a' greater than or equal to 2")
+    if n < 1:
+        raise ValueError("is_strong_prp() requires 'n' be greater than 0")
+    if n == 1:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    a %= n
+    if gcd(n, a) != 1:
+        raise ValueError("is_strong_prp() requires gcd(n,a) == 1")
+    s = bit_scan1(n - 1)
+    a = pow(a, n >> s, n)
+    if a == 1 or a == n - 1:
+        return True
+    for _ in range(s - 1):
+        a = pow(a, 2, n)
+        if a == n - 1:
+            return True
+        if a == 1:
+            return False
+    return False

--- a/sympy/external/tests/test_ntheory.py
+++ b/sympy/external/tests/test_ntheory.py
@@ -1,4 +1,6 @@
-from sympy.external.ntheory import bit_scan1, bit_scan0
+from sympy.external.ntheory import (bit_scan1, bit_scan0, is_fermat_prp,
+                                    is_euler_prp, is_strong_prp)
+from sympy.testing.pytest import raises
 
 
 def test_bit_scan1():
@@ -27,3 +29,84 @@ def test_bit_scan0():
     assert bit_scan0(0) == 0
     assert bit_scan0(1) == 1
     assert bit_scan0(-2) == 0
+
+
+def test_is_fermat_prp():
+    # invalid input
+    raises(ValueError, lambda: is_fermat_prp(0, 10))
+    raises(ValueError, lambda: is_fermat_prp(5, 1))
+
+    # n = 1
+    assert not is_fermat_prp(1, 3)
+
+    # n is prime
+    assert is_fermat_prp(2, 4)
+    assert is_fermat_prp(3, 2)
+    assert is_fermat_prp(11, 3)
+    assert is_fermat_prp(2**31-1, 5)
+
+    # A001567
+    pseudorpime = [341, 561, 645, 1105, 1387, 1729, 1905, 2047,
+                   2465, 2701, 2821, 3277, 4033, 4369, 4371, 4681]
+    for n in pseudorpime:
+        assert is_fermat_prp(n, 2)
+
+    # A020136
+    pseudorpime = [15, 85, 91, 341, 435, 451, 561, 645, 703, 1105,
+                   1247, 1271, 1387, 1581, 1695, 1729, 1891, 1905]
+    for n in pseudorpime:
+        assert is_fermat_prp(n, 4)
+
+
+def test_is_euler_prp():
+    # invalid input
+    raises(ValueError, lambda: is_euler_prp(0, 10))
+    raises(ValueError, lambda: is_euler_prp(5, 1))
+
+    # n = 1
+    assert not is_euler_prp(1, 3)
+
+    # n is prime
+    assert is_euler_prp(2, 4)
+    assert is_euler_prp(3, 2)
+    assert is_euler_prp(11, 3)
+    assert is_euler_prp(2**31-1, 5)
+
+    # A047713
+    pseudorpime = [561, 1105, 1729, 1905, 2047, 2465, 3277, 4033,
+                   4681, 6601, 8321, 8481, 10585, 12801, 15841]
+    for n in pseudorpime:
+        assert is_euler_prp(n, 2)
+
+    # A048950
+    pseudorpime = [121, 703, 1729, 1891, 2821, 3281, 7381, 8401,
+                   8911, 10585, 12403, 15457, 15841, 16531, 18721]
+    for n in pseudorpime:
+        assert is_euler_prp(n, 3)
+
+
+def test_is_strong_prp():
+    # invalid input
+    raises(ValueError, lambda: is_strong_prp(0, 10))
+    raises(ValueError, lambda: is_strong_prp(5, 1))
+
+    # n = 1
+    assert not is_strong_prp(1, 3)
+
+    # n is prime
+    assert is_strong_prp(2, 4)
+    assert is_strong_prp(3, 2)
+    assert is_strong_prp(11, 3)
+    assert is_strong_prp(2**31-1, 5)
+
+    # A001262
+    pseudorpime = [2047, 3277, 4033, 4681, 8321, 15841, 29341,
+                   42799, 49141, 52633, 65281, 74665, 80581]
+    for n in pseudorpime:
+        assert is_strong_prp(n, 2)
+
+    # A020229
+    pseudorpime = [121, 703, 1891, 3281, 8401, 8911, 10585, 12403,
+                   16531, 18721, 19345, 23521, 31621, 44287, 47197]
+    for n in pseudorpime:
+        assert is_strong_prp(n, 3)

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -8,8 +8,55 @@ from itertools import count
 from sympy.core.sympify import sympify
 from sympy.external.gmpy import (gmpy as _gmpy, gcd, jacobi,
                                  is_square as gmpy_is_square,
-                                 bit_scan1)
+                                 bit_scan1, is_fermat_prp, is_euler_prp)
 from sympy.utilities.misc import as_int
+
+
+def is_fermat_pseudoprime(n, a):
+    r"""Returns True if ``n`` is prime or is an odd composite integer that
+    is coprime to ``a`` and satisfy the modular arithmetic congruence relation:
+
+    .. math ::
+        a^{n-1} \equiv 1 \pmod{n}
+
+    (where mod refers to the modulo operation).
+
+    Parameters
+    ==========
+
+    n : Integer
+        ``n`` is a positive integer.
+    a : Integer
+        ``a`` is a positive integer.
+        ``a`` and ``n`` should be relatively prime.
+
+    Returns
+    =======
+
+    bool : If ``n`` is prime, it always returns ``True``.
+           The composite number that returns ``True`` is called an Fermat pseudoprime.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.primetest import is_fermat_pseudoprime
+    >>> from sympy.ntheory.factor_ import isprime
+    >>> for n in range(1, 1000):
+    ...     if is_fermat_pseudoprime(n, 2) and not isprime(n):
+    ...         print(n)
+    341
+    561
+    645
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Fermat_pseudoprime
+    """
+    n, a = as_int(n), as_int(a)
+    if a == 1:
+        return n == 2 or bool(n % 2)
+    return is_fermat_prp(n, a)
 
 
 def is_euler_pseudoprime(n, a):
@@ -68,6 +115,51 @@ def is_euler_pseudoprime(n, a):
     return pow(a, (n - 1) // 2, n) in [1, n - 1]
 
 
+def is_euler_jacobi_pseudoprime(n, a):
+    r"""Returns True if ``n`` is prime or is an odd composite integer that
+    is coprime to ``a`` and satisfy the modular arithmetic congruence relation:
+
+    .. math ::
+        a^{(n-1)/2} \equiv \left(\frac{a}{n}\right) \pmod{n}
+
+    (where mod refers to the modulo operation).
+
+    Parameters
+    ==========
+
+    n : Integer
+        ``n`` is a positive integer.
+    a : Integer
+        ``a`` is a positive integer.
+        ``a`` and ``n`` should be relatively prime.
+
+    Returns
+    =======
+
+    bool : If ``n`` is prime, it always returns ``True``.
+           The composite number that returns ``True`` is called an Euler-Jacobi pseudoprime.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.primetest import is_euler_jacobi_pseudoprime
+    >>> from sympy.ntheory.factor_ import isprime
+    >>> for n in range(1, 1000):
+    ...     if is_euler_jacobi_pseudoprime(n, 2) and not isprime(n):
+    ...         print(n)
+    561
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Euler%E2%80%93Jacobi_pseudoprime
+    """
+    n, a = as_int(n), as_int(a)
+    if a == 1:
+        return n == 2 or bool(n % 2)
+    return is_euler_prp(n, a)
+
+
 def is_square(n, prep=True):
     """Return True if n == a * a for some integer a, else False.
     If n is suspected of *not* being a square then this is a
@@ -110,14 +202,13 @@ def _test(n, base, s, t):
     b = pow(base, t, n)
     if b == 1 or b == n - 1:
         return True
-    else:
-        for j in range(1, s):
-            b = pow(b, 2, n)
-            if b == n - 1:
-                return True
-            # see I. Niven et al. "An Introduction to Theory of Numbers", page 78
-            if b == 1:
-                return False
+    for _ in range(s - 1):
+        b = pow(b, 2, n)
+        if b == n - 1:
+            return True
+        # see I. Niven et al. "An Introduction to Theory of Numbers", page 78
+        if b == 1:
+            return False
     return False
 
 

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -4,10 +4,16 @@ from sympy.ntheory.generate import Sieve, sieve
 from sympy.ntheory.primetest import (mr, _lucas_sequence, _lucas_selfridge_params, _lucas_extrastrong_params,
                                      is_lucas_prp, is_square,
                                      is_strong_lucas_prp, is_extra_strong_lucas_prp, isprime, is_euler_pseudoprime,
-                                     is_gaussian_prime)
+                                     is_gaussian_prime, is_fermat_pseudoprime, is_euler_jacobi_pseudoprime)
 
 from sympy.testing.pytest import slow, raises
 from sympy.core.numbers import I
+
+
+def test_is_fermat_pseudoprime():
+    assert is_fermat_pseudoprime(5, 1)
+    assert is_fermat_pseudoprime(9, 1)
+
 
 def test_euler_pseudoprimes():
     assert is_euler_pseudoprime(13, 1)
@@ -41,6 +47,11 @@ def test_euler_pseudoprimes():
             if gcd(a, p) != 1:
                 continue
             assert is_euler_pseudoprime(p, a)
+
+
+def test_is_euler_jacobi_pseudoprime():
+    assert is_euler_jacobi_pseudoprime(11, 1)
+    assert is_euler_jacobi_pseudoprime(15, 1)
 
 
 def test_lucas_sequence():


### PR DESCRIPTION
Add `is_fermat_prp`, `is_euler_prp`, and `is_strong_prp` as `external` functions.
Add `is_fermat_pseudoprime` and `is_euler_jacobi_pseudoprime` functions for `ntheory`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Add `is_fermat_pseudoprime` and `is_euler_jacobi_pseudoprime` functions
<!-- END RELEASE NOTES -->
