### PR TITLE
Correct the `QRdocumentation` docs for more easier matrix augmentation

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1474,11 +1474,11 @@ def _QRdecomposition(M):
     decomposition, you should augment $Q$ with an another orthogonal
     column.
 
-    You are able to append an arbitrary standard basis that are linearly
-    independent to every other columns and you can run the Gram-Schmidt
+    You are able to append an identity matrix,
+    and you can run the Gram-Schmidt
     process to make them augmented as orthogonal basis.
 
-    >>> Q_aug = Q.row_join(Matrix([0, 0, 1]))
+    >>> Q_aug = Q.row_join(Matrix.eye(3))
     >>> Q_aug = Q_aug.QRdecomposition()[0]
     >>> Q_aug
     Matrix([


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed



This is just a documentation correction.

I corrected the example from `Q.row_join(Matrix([0, 0, 1]))` to `Q.row_join(Matrix.eye(3))`
because the assumption that `Matrix([0, 0, 1])` is linearly independent to other columns is not true for an arbitrary matrix,
and it is not easy to discover a vector that is linearly independent to all other known vectors, 
without calculation, and this can just be misleading.
However, hstacking or vstacking identity matrix always guranatees to make the matrix full rank, so I would suggest that example instead.

This is one example that jumps in mind when discussing https://github.com/sympy/sympy/issues/25661

I now think that it is nontrivial to implement the square option from https://github.com/sympy/sympy/issues/19017, so this can be done as user option (adding an identity matrix seems like a huge redudancy)
however, it is more likely to be done after moving some parts of QRdecomposition with Domainmatrix, which can still speed things up for some matrix workarounds like this.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
