### PR TITLE
improve elementary trig solutions

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1144,15 +1144,15 @@ def solve(f, *symbols, **flags):
     # relationship between values
     targs = {t for fi in f for t in fi.atoms(TrigonometricFunction)}
     add, other = sift(targs, lambda x: x.args[0].is_Add, binary=True)
+    add, other = [[i for i in l if i.has_free(*symbols)] for l in (add, other)]
     trep = {}
-    for i in add:
-        a = i.args[0]
-        if len(a.args) == 2:
-            ind, dep = a.as_independent(*symbols)
-            if dep in symbols or -dep in symbols:
-                # don't let expansion expand wrt anything in ind
-                n = Dummy() if not ind.is_Number else ind
-                trep[i] = TR10(i.xreplace({ind: n})).xreplace({n: ind})
+    for t in add:
+        a = t.args[0]
+        ind, dep = a.as_independent(*symbols)
+        if dep in symbols or -dep in symbols:
+            # don't let expansion expand wrt anything in ind
+            n = Dummy() if not ind.is_Number else ind
+            trep[t] = TR10(t.func(dep + n)).xreplace({n: ind})
     if other and len(other) <= 2:
         base = gcd(*[i.args[0] for i in other]) if len(other) > 1 else other[0].args[0]
         for i in other:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -42,17 +42,18 @@ from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
     separatevars)
 from sympy.simplify.sqrtdenest import sqrt_depth
-from sympy.simplify.fu import TR1, TR2i
+from sympy.simplify.fu import TR1, TR2i, TR11
 from sympy.strategies.rl import rebuild
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, factor, Poly
-from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
+from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
+from sympy.polys.polytools import gcd
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent, debugf
 from sympy.utilities.iterables import (connected_components,
-    generate_bell, uniq, iterable, is_sequence, subsets, flatten)
+    generate_bell, uniq, iterable, is_sequence, subsets, flatten, sift)
 from sympy.utilities.decorator import conserve_mpmath_dps
 
 from mpmath import findroot
@@ -1135,6 +1136,29 @@ def solve(f, *symbols, **flags):
     for i, fi in enumerate(f):
         if _has_piecewise(fi):
             f[i] = piecewise_fold(fi)
+
+    # expand double angles; in general, expand_trig will allow
+    # more roots to be found but this is not a great solultion
+    # to not returning a parametric solution, otherwise
+    # many values can be returned that have a simple
+    # relationship between values
+    targs = {t for fi in f for t in fi.atoms(TrigonometricFunction)}
+    add, other = sift(targs, lambda x: x.args[0].is_Add, binary=True)
+    trep = {}
+    for i in add:
+        a = i.args[0]
+        if len(a.args) == 2:
+            ind, dep = a.as_independent(*symbols)
+            if dep in symbols or -dep in symbols:
+                # don't let expansion expand wrt anything in ind
+                n = Dummy() if not ind.is_Number else ind
+                trep[i] = i.xreplace({ind: n}).expand(trig=True
+                    ).xreplace({n: ind})
+    if other and len(other) <= 2:
+        base = gcd(*[i.args[0] for i in other]) if len(other) > 1 else other[0].args[0]
+        for i in other:
+            trep[i] = TR11(i, base)
+    f = [fi.xreplace(trep) for fi in f]
 
     #
     # try to get a solution

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -42,7 +42,7 @@ from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
     separatevars)
 from sympy.simplify.sqrtdenest import sqrt_depth
-from sympy.simplify.fu import TR1, TR2i, TR11
+from sympy.simplify.fu import TR1, TR2i, TR10, TR11
 from sympy.strategies.rl import rebuild
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
@@ -1152,8 +1152,7 @@ def solve(f, *symbols, **flags):
             if dep in symbols or -dep in symbols:
                 # don't let expansion expand wrt anything in ind
                 n = Dummy() if not ind.is_Number else ind
-                trep[i] = i.xreplace({ind: n}).expand(trig=True
-                    ).xreplace({n: ind})
+                trep[i] = TR10(i.xreplace({ind: n})).xreplace({n: ind})
     if other and len(other) <= 2:
         base = gcd(*[i.args[0] for i in other]) if len(other) > 1 else other[0].args[0]
         for i in other:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -638,6 +638,14 @@ def test_solve_transcendental():
     # issue 15325
     assert solve(y**(1/x) - z, x) == [log(y)/log(z)]
 
+    # issue 25685 (basic trig identies should give simple solutions)
+    for yi in [cos(2*x),sin(2*x),cos(x - pi/3)]:
+        sol = solve([cos(x) - S(3)/5, yi - y])
+        assert (sol[0][y] + sol[1][y]).is_Rational, (yi,sol)
+    # don't allow massive expansion
+    assert solve(cos(1000*x) - S.Half) == [pi/3000, pi/600]
+    assert solve(cos(x - 1000*y) - 1, x) == [2*atan(tan(500*y))]
+
 
 def test_solve_for_functions_derivatives():
     t = Symbol('t')
@@ -2246,20 +2254,12 @@ def test_issue_8828():
     assert p == q == r
 
 
-@slow
 def test_issue_2840_8155():
-    assert solve(sin(3*x) + sin(6*x)) == [
-        0, pi*Rational(-5, 3), pi*Rational(-4, 3), -pi, pi*Rational(-2, 3),
-        pi*Rational(-4, 9), -pi/3, pi*Rational(-2, 9), pi*Rational(2, 9),
-        pi/3, pi*Rational(4, 9), pi*Rational(2, 3), pi, pi*Rational(4, 3),
-        pi*Rational(14, 9), pi*Rational(5, 3), pi*Rational(16, 9), 2*pi,
-        -2*I*log(-(-1)**Rational(1, 9)), -2*I*log(-(-1)**Rational(2, 9)),
-        -2*I*log(-sin(pi/18) - I*cos(pi/18)),
-        -2*I*log(-sin(pi/18) + I*cos(pi/18)),
-        -2*I*log(sin(pi/18) - I*cos(pi/18)),
-        -2*I*log(sin(pi/18) + I*cos(pi/18))]
-    assert solve(2*sin(x) - 2*sin(2*x)) == [
-        0, pi*Rational(-5, 3), -pi, -pi/3, pi/3, pi, pi*Rational(5, 3)]
+    # with parameter-free solutions (i.e. no `n`), we want to avoid
+    # excessive periodic solutions
+    assert solve(sin(3*x) + sin(6*x)) == [0, -2*pi/9, 2*pi/9]
+    assert solve(sin(300*x) + sin(600*x)) == [0, -pi/450, pi/450]
+    assert solve(2*sin(x) - 2*sin(2*x)) == [0, -pi/3, pi/3]
 
 
 def test_issue_9567():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -645,6 +645,7 @@ def test_solve_transcendental():
     # don't allow massive expansion
     assert solve(cos(1000*x) - S.Half) == [pi/3000, pi/600]
     assert solve(cos(x - 1000*y) - 1, x) == [2*atan(tan(500*y))]
+    assert solve(cos(x + y + z) - 1, x) == [-2*atan(tan(y/2 + z/2))]
 
 
 def test_solve_for_functions_derivatives():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

close #25685

#### Brief description of what is fixed or changed

Solutions of systems of equation involving trig identities give simple solutions when the arguments of the trig functions are the same. This requires expanding functions that don't have simple arguments, e.g. `sin(2*x) -> 2*sin(x)*cos(x)`.

e.g. the following now give algebraic solutions for `y` instead of solutions involving trigonomentric functions:

master:
```python
>>> for yi in [cos(2*x),sin(2*x),cos(x - pi/3)]:
...  solve([cos(x)-S(3)/5,yi-y])[1]
...
[{x: -acos(3/5) + 2*pi, y: cos(2*acos(3/5))}, {x: acos(3/5), y: cos(2*acos(3/5))}]
[{x: -acos(3/5) + 2*pi, y: -24/25}, {x: acos(3/5), y: sin(2*acos(3/5))}]
[{x: -acos(3/5) + 2*pi, y: sin(-acos(3/5) + pi/6)}, {x: acos(3/5), y: sin(pi/6 + acos(3/5))}]```
```

after this PR:

```python
>>> for yi in [cos(2*x),sin(2*x),cos(x - pi/3)]:
...  solve([cos(x)-S(3)/5,yi-y])
...
[{x: -acos(3/5) + 2*pi, y: -7/25}, {x: acos(3/5), y: -7/25}]
[{x: -acos(3/5) + 2*pi, y: -24/25}, {x: acos(3/5), y: 24/25}]
[{x: -acos(3/5) + 2*pi, y: 3/10 - 2*sqrt(3)/5}, {x: acos(3/5), y: 3/10 + 2*sqrt(3)/5}]
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * improve recognition of sytems involving algebraic trigonometric relationships so algebraic solutions are returned
  * fewer periodic solutions are returned as solutions to equations like `cos(300*x) - cos(600*x)`
<!-- END RELEASE NOTES -->
