### PR TITLE
allow rhs in rref

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -176,12 +176,10 @@ class MatrixReductions(MatrixDeterminant):
     def rank(self, iszerofunc=_iszero, simplify=False):
         return _rank(self, iszerofunc=iszerofunc, simplify=simplify)
 
-    def rref_rhs(self, rhs, iszerofunc=_iszero, simplify=False, pivots=True,
-        normalize_last=True):
+    def rref_rhs(self, rhs):
         """Return reduced row-echelon form of matrix, matrix showing
-        rhs after reduction steps, and indices of pivot vars. All
-        parameters other than ``rhs`` have the same semantics as in
-        ``rref``.
+        rhs after reduction steps. ``rhs`` must have the same number
+        of rows as ``self``.
 
         Examples
         ========
@@ -193,12 +191,10 @@ class MatrixReductions(MatrixDeterminant):
         [1, 0],
         [0, 1]]), Matrix([
         [ -r1 + r2],
-        [2*r1 - r2]]), (0, 1))
+        [2*r1 - r2]]))
         """
-        r, p = _rref(self.hstack(self, self.eye(self.rows), rhs),
-            iszerofunc=iszerofunc, simplify=simplify,
-            pivots=pivots, normalize_last=normalize_last)
-        return r[:, :self.cols], r[:, -rhs.cols:], p[:self.cols]
+        r, _ = _rref(self.hstack(self, self.eye(self.rows), rhs))
+        return r[:, :self.cols], r[:, -rhs.cols:]
 
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True,
             normalize_last=True):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -176,13 +176,32 @@ class MatrixReductions(MatrixDeterminant):
     def rank(self, iszerofunc=_iszero, simplify=False):
         return _rank(self, iszerofunc=iszerofunc, simplify=simplify)
 
+    def rref_rhs(self, rhs, iszerofunc=_iszero, simplify=False, pivots=True,
+        normalize_last=True):
+        """Return reduced row-echelon form of matrix, matrix showing
+        rhs after reduction steps, and indices of pivot vars. All
+        parameters other than ``rhs`` have the same semantics as in
+        ``rref``.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix, symbols
+        >>> r1, r2 = symbols('r1 r2')
+        >>> Matrix([[1, 1], [2, 1]]).rref_rhs(Matrix([r1, r2]))
+        (Matrix([
+        [1, 0],
+        [0, 1]]), Matrix([
+        [ -r1 + r2],
+        [2*r1 - r2]]), (0, 1))
+        """
+        r, p = _rref(self.hstack(self, self.eye(self.rows), rhs),
+            iszerofunc=iszerofunc, simplify=simplify,
+            pivots=pivots, normalize_last=normalize_last)
+        return r[:, :self.cols], r[:, -rhs.cols:], p[:self.cols]
+
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True,
-            normalize_last=True, rhs=None):
-        if rhs is not None:
-            r, p = _rref(self.hstack(self, self.eye(self.rows), rhs),
-                iszerofunc=iszerofunc, simplify=simplify,
-                pivots=pivots, normalize_last=normalize_last)
-            return r[:, :self.cols], r[:, -rhs.cols:], p[:self.cols]
+            normalize_last=True):
         return _rref(self, iszerofunc=iszerofunc, simplify=simplify,
             pivots=pivots, normalize_last=normalize_last)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -177,7 +177,12 @@ class MatrixReductions(MatrixDeterminant):
         return _rank(self, iszerofunc=iszerofunc, simplify=simplify)
 
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True,
-            normalize_last=True):
+            normalize_last=True, rhs=None):
+        if rhs is not None:
+            r, p = _rref(self.hstack(self, self.eye(self.rows), rhs),
+                iszerofunc=iszerofunc, simplify=simplify,
+                pivots=pivots, normalize_last=normalize_last)
+            return r[:, :self.cols], r[:, -rhs.cols:], p[:self.cols]
         return _rref(self, iszerofunc=iszerofunc, simplify=simplify,
             pivots=pivots, normalize_last=normalize_last)
 

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -293,10 +293,9 @@ def _rref_dm(dM):
 
 
 def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
-        normalize_last=True, rhs=None):  # handle rhs in rref
+        normalize_last=True):
     """Return reduced row-echelon form of matrix and indices
-    of pivot vars. If ``rhs`` is included it will be returned
-    as the 2nd element of the tuple, before the pivots.
+    of pivot vars.
 
     Parameters
     ==========
@@ -333,7 +332,7 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     Examples
     ========
 
-    >>> from sympy import Matrix, symbols
+    >>> from sympy import Matrix
     >>> from sympy.abc import x
     >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
     >>> m.rref()
@@ -365,14 +364,6 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     [1, 0, -0.301369863013699, 0],
     [0, 1, -0.712328767123288, 0],
     [0, 0,         0,          0]]), (0, 1))
-
-    >>> r1, r2 = symbols('r1 r2')
-    >>> Matrix([[1, 1], [2, 1]]).rref(rhs=Matrix([r1, r2]))
-    (Matrix([
-    [1, 0],
-    [0, 1]]), Matrix([
-    [ -r1 + r2],
-    [2*r1 - r2]]), (0, 1))
 
     Notes
     =====

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -366,12 +366,13 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     [0, 1, -0.712328767123288, 0],
     [0, 0,         0,          0]]), (0, 1))
 
-    >>> Matrix([[1, 1], [2, 1]]).rref(rhs=Matrix(symbols('r1 r2')))
+    >>> r1, r2 = symbols('r1 r2')
+    >>> Matrix([[1, 1], [2, 1]]).rref(rhs=Matrix([r1, r2]))
     (Matrix([
     [1, 0],
-    [0, 1]]), (0, 1), Matrix([
+    [0, 1]]), Matrix([
     [ -r1 + r2],
-    [2*r1 - r2]]))
+    [2*r1 - r2]]), (0, 1))
 
     Notes
     =====

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -293,8 +293,10 @@ def _rref_dm(dM):
 
 
 def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
-        normalize_last=True):
-    """Return reduced row-echelon form of matrix and indices of pivot vars.
+        normalize_last=True, rhs=None):  # handle rhs in rref
+    """Return reduced row-echelon form of matrix and indices
+    of pivot vars. If ``rhs`` is included it will be returned
+    as the 2nd element of the tuple, before the pivots.
 
     Parameters
     ==========
@@ -320,10 +322,18 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
         each pivot is normalized to be `1` before row operations are
         used to zero above and below the pivot.
 
+    rhs : Matrix
+        If ``rhs`` is passed it must have the same number of rows as ``M``.
+        Reduction steps will not take place in this matrix, but
+        the elements will be included in the reduction steps. If a single
+        column matrix of symbols is passed, the expressions in each
+        row at the end of the reduction will indicate how rows were
+        combined to perform the reduction.
+
     Examples
     ========
 
-    >>> from sympy import Matrix
+    >>> from sympy import Matrix, symbols
     >>> from sympy.abc import x
     >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
     >>> m.rref()
@@ -341,7 +351,7 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     ``iszerofunc`` can correct rounding errors in matrices with float
     values. In the following example, calling ``rref()`` leads to
     floating point errors, incorrectly row reducing the matrix.
-    ``iszerofunc= lambda x: abs(x)<1e-9`` sets sufficiently small numbers
+    ``iszerofunc= lambda x: abs(x) < 1e-9`` sets sufficiently small numbers
     to zero, avoiding this error.
 
     >>> m = Matrix([[0.9, -0.1, -0.2, 0], [-0.8, 0.9, -0.4, 0], [-0.1, -0.8, 0.6, 0]])
@@ -356,13 +366,20 @@ def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
     [0, 1, -0.712328767123288, 0],
     [0, 0,         0,          0]]), (0, 1))
 
+    >>> Matrix([[1, 1], [2, 1]]).rref(rhs=Matrix(symbols('r1 r2')))
+    (Matrix([
+    [1, 0],
+    [0, 1]]), (0, 1), Matrix([
+    [ -r1 + r2],
+    [2*r1 - r2]]))
+
     Notes
     =====
 
     The default value of ``normalize_last=True`` can provide significant
     speedup to row reduction, especially on matrices with symbols.  However,
     if you depend on the form row reduction algorithm leaves entries
-    of the matrix, set ``noramlize_last=False``
+    of the matrix, set ``normalize_last=False``
     """
     # Try to use DomainMatrix for ZZ or QQ
     dM = _to_DM_ZZ_QQ(M)

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -282,8 +282,8 @@ def test_rref():
 
     a, b, c, d = symbols('a b c d')
     A = Matrix([[0, 0], [0, 0], [1, 2], [3, 4]])
-    rhs = Matrix([a, b, c, d])
-    assert A.rref(rhs=rhs) == (Matrix([
+    B = Matrix([a, b, c, d])
+    assert A.rref_rhs(B) == (Matrix([
     [1, 0],
     [0, 1],
     [0, 0],

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -280,6 +280,8 @@ def test_rref():
                 0, 1, 1/(sqrt(x) + x + 1)]):
         assert simplify(i - j).is_zero
 
+
+def test_rref_rhs():
     a, b, c, d = symbols('a b c d')
     A = Matrix([[0, 0], [0, 0], [1, 2], [3, 4]])
     B = Matrix([a, b, c, d])
@@ -291,7 +293,7 @@ def test_rref():
     [   -2*c + d],
     [3*c/2 - d/2],
     [          a],
-    [          b]]), (0, 1))
+    [          b]]))
 
 
 def test_issue_17827():

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -10,6 +10,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.simplify.simplify import simplify
 from sympy.abc import x
 
+
 class ReductionsOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixReductions):
     pass
 
@@ -278,6 +279,20 @@ def test_rref():
             [1, 0, sqrt(x)*(-x + 1)/(-x**Rational(5, 2) + x),
                 0, 1, 1/(sqrt(x) + x + 1)]):
         assert simplify(i - j).is_zero
+
+    a, b, c, d = symbols('a b c d')
+    A = Matrix([[0, 0], [0, 0], [1, 2], [3, 4]])
+    rhs = Matrix([a, b, c, d])
+    assert A.rref(rhs=rhs) == (Matrix([
+    [1, 0],
+    [0, 1],
+    [0, 0],
+    [0, 0]]), Matrix([
+    [   -2*c + d],
+    [3*c/2 - d/2],
+    [          a],
+    [          b]]), (0, 1))
+
 
 def test_issue_17827():
     C = Matrix([


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#25661 related

#### Brief description of what is fixed or changed


#### Other comments

see issue page and the questions I raise there

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * `A.rref_rhs(b)` will return rref of A and resulting form of b without reducing b; pivots are returned as 3rd arg
<!-- END RELEASE NOTES -->
