### PR TITLE
Piecewiese functions use fewer integrations

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1191,11 +1191,11 @@ def _laplace_transform(fn, t_, s_, *, simplify):
     for ff in terms_t:
         k, ft = ff.as_independent(t_, as_Add=False)
         if ft.has(SingularityFunction):
-            _terms = Add.make_args(ft.rewrite(Heaviside))
+            _terms = Add.make_args(k*ft.rewrite(Heaviside))
             for _term in _terms:
                 terms.append(_term.as_independent(t_, as_Add=False))
         elif ft.func == Piecewise and not ft.has(DiracDelta(t_)):
-            _terms = Add.make_args(_piecewise_to_heaviside(ft, t_))
+            _terms = Add.make_args(k*_piecewise_to_heaviside(ft, t_))
             for _term in _terms:
                 terms.append(_term.as_independent(t_, as_Add=False))
         else:

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -1191,13 +1191,15 @@ def _laplace_transform(fn, t_, s_, *, simplify):
     for ff in terms_t:
         k, ft = ff.as_independent(t_, as_Add=False)
         if ft.has(SingularityFunction):
-            _terms = Add.make_args(k*ft.rewrite(Heaviside))
+            _terms = Add.make_args(ft.rewrite(Heaviside))
             for _term in _terms:
-                terms.append(_term.as_independent(t_, as_Add=False))
+                k1, f1 = _term.as_independent(t_, as_Add=False)
+                terms.append((k*k1, f1))
         elif ft.func == Piecewise and not ft.has(DiracDelta(t_)):
-            _terms = Add.make_args(k*_piecewise_to_heaviside(ft, t_))
+            _terms = Add.make_args(_piecewise_to_heaviside(ft, t_))
             for _term in _terms:
-                terms.append(_term.as_independent(t_, as_Add=False))
+                k1, f1 = _term.as_independent(t_, as_Add=False)
+                terms.append((k*k1, f1))
         else:
             terms.append((k, ft))
 

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -332,9 +332,10 @@ def test_laplace_transform():
         2*(t - 1)*Heaviside(t - 1)).simplify() == 0
     x1 = Piecewise((exp(t), t <= 0), (1, t <= 1), (exp(-(t)), True))
     X1 = LT(x1, t, s)[0]
-    assert X1 == exp(-s - 1)/(s + 1) + 1/s - exp(-s)/s
+    assert X1 == exp(-1)*exp(-s)/(s + 1) + 1/s - exp(-s)/s
     y1 = ILT(X1, s, t)
-    assert y1 == Heaviside(t) - Heaviside(t - 1) + exp(-t)*Heaviside(t - 1)
+    assert y1 == (
+        exp(-1)*exp(1 - t)*Heaviside(t - 1) + Heaviside(t) - Heaviside(t - 1))
     x1 = Piecewise((0, x <= 0), (1, x <= 1), (0, True))
     X1 = LT(x1, t, s)[0]
     assert X1 == Piecewise((0, x <= 0), (1, x <= 1), (0, True))/s
@@ -344,7 +345,7 @@ def test_laplace_transform():
         Piecewise((1, And(t >= 1, t < 3)), (2, True)),
         Piecewise((1, And(t > 1, t < 3)), (2, True))]
     for x2 in x1:
-        assert LT(x2, t, s)[0] == 2/s - exp(-s)/s + exp(-3*s)/s
+        assert LT(x2, t, s)[0].expand() == 2/s - exp(-s)/s + exp(-3*s)/s
     assert (
         LT(Piecewise((1, Eq(t, 1)), (2, True)), t, s)[0] ==
         LaplaceTransform(Piecewise((1, Eq(t, 1)), (2, True)), t, s))

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -340,12 +340,12 @@ def test_laplace_transform():
     X1 = LT(x1, t, s)[0]
     assert X1 == Piecewise((0, x <= 0), (1, x <= 1), (0, True))/s
     x1 = [
-        Piecewise((1, And(t > 1, t <= 3)), (2, True)),
-        Piecewise((1, And(t >= 1, t <= 3)), (2, True)),
-        Piecewise((1, And(t >= 1, t < 3)), (2, True)),
-        Piecewise((1, And(t > 1, t < 3)), (2, True))]
+        a*Piecewise((1, And(t > 1, t <= 3)), (2, True)),
+        a*Piecewise((1, And(t >= 1, t <= 3)), (2, True)),
+        a*Piecewise((1, And(t >= 1, t < 3)), (2, True)),
+        a*Piecewise((1, And(t > 1, t < 3)), (2, True))]
     for x2 in x1:
-        assert LT(x2, t, s)[0].expand() == 2/s - exp(-s)/s + exp(-3*s)/s
+        assert LT(x2, t, s)[0].expand() == 2*a/s - a*exp(-s)/s + a*exp(-3*s)/s
     assert (
         LT(Piecewise((1, Eq(t, 1)), (2, True)), t, s)[0] ==
         LaplaceTransform(Piecewise((1, Eq(t, 1)), (2, True)), t, s))


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561

#### Brief description of what is fixed or changed
_laplace_transform now has a separate block for rewrites. Before this PR, when a re-write
of a Piecewise function gave a sum of expressions, integration would be used. Now we
split the re-write's sum of expressions into individual terms such that Laplace rules can
trigger.

This changes the output format of the Laplace transform of Piecewise functions, but
since that was not yet implemented in SymPy 1.12, there is no need for release notes.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
