### PR TITLE
Fixing cast of `n * (log(n) + log(log(n)))` in function `prime`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1554,6 +1554,7 @@ numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
+platypus <platypus.computerchip@gmail.com>
 prshnt19 <prashant.rawat216@gmail.com>
 rahuldan <rahul02013@gmail.com>
 ramvenkat98 <ramvenkat98@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -7,7 +7,6 @@ import re
 
 from .sympify import sympify, _sympify
 from .basic import Basic, Atom
-from .numbers import int_valued
 from .singleton import S
 from .evalf import EvalfMixin, pure_complex, DEFAULT_MAXPREC
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
@@ -4144,4 +4143,4 @@ from .power import Pow
 from .function import Function, _derivative_dispatch
 from .mod import Mod
 from .exprtools import factor_terms
-from .numbers import Float, Integer, Rational, _illegal
+from .numbers import Float, Integer, Rational, _illegal, int_valued

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3829,9 +3829,12 @@ class Expr(Basic, EvalfMixin):
                     'Expected a number but got %s:' % func_name(x))
         elif x in _illegal:
             return x
-        if x.is_extended_real is False:
+        if not (xr := x.is_extended_real):
             r, i = x.as_real_imag()
-            return r.round(n) + S.ImaginaryUnit*i.round(n)
+            if xr is False:
+                return r.round(n) + S.ImaginaryUnit*i.round(n)
+            if i.equals(0):
+                return r.round(n)
         if not x:
             return S.Zero if n is None else x
 
@@ -3901,6 +3904,11 @@ class Expr(Basic, EvalfMixin):
         # the 2nd digit from the left) we get 5700000000000000.
         #
         xf = x.n(dps + extra)*Pow(10, shift)
+        if xf._prec == 1:
+            # is x == 0?
+            if x.equals(0):
+                return Float(0)
+            raise ValueError('not computing with precision')
         xi = Integer(xf)
         # use the last digit to select the value of xi
         # nearest to x before rounding at the desired digit

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -319,6 +319,11 @@ class Expr(Basic, EvalfMixin):
                 return i
             if (self < i) is S.true:
                 return i - 1
+            ok = self.equals(i)
+            if ok is None:
+                raise TypeError('cannot compute int value accurately')
+            if ok:
+                return i
             # off by one
             return i - (1 if i > 0 else -1)
         return i

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -7,6 +7,7 @@ import re
 
 from .sympify import sympify, _sympify
 from .basic import Basic, Atom
+from .numbers import int_valued
 from .singleton import S
 from .evalf import EvalfMixin, pure_complex, DEFAULT_MAXPREC
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
@@ -303,18 +304,6 @@ class Expr(Basic, EvalfMixin):
         return floor(other / self), Mod(other, self)
 
     def __int__(self):
-        # Although we only need to round to the units position, we'll
-        # get one more digit so the extra testing below can be avoided
-        # unless the rounded value rounded to an integer, e.g. if an
-        # expression were equal to 1.9 and we rounded to the unit position
-        # we would get a 2 and would not know if this rounded up or not
-        # without doing a test (as done below). But if we keep an extra
-        # digit we know that 1.9 is not the same as 1 and there is no
-        # need for further testing: our int value is correct. If the value
-        # were 1.99, however, this would round to 2.0 and our int value is
-        # off by one. So...if our round value is the same as the int value
-        # (regardless of how much extra work we do to calculate extra decimal
-        # places) we need to test whether we are off by one.
         from .symbol import Dummy
         if not self.is_number:
             raise TypeError("Cannot convert symbols to int")
@@ -324,19 +313,13 @@ class Expr(Basic, EvalfMixin):
         if r in (S.NaN, S.Infinity, S.NegativeInfinity):
             raise TypeError("Cannot convert %s to int" % r)
         i = int(r)
-        if not i:
-            return 0
-        # off-by-one check
-        if i == r and not (self - i).equals(0):
-            isign = 1 if i > 0 else -1
-            x = Dummy()
-            # in the following (self - i).evalf(2) will not always work while
-            # (self - r).evalf(2) and the use of subs does; if the test that
-            # was added when this comment was added passes, it might be safe
-            # to simply use sign to compute this rather than doing this by hand:
-            diff_sign = 1 if (self - x).evalf(2, subs={x: i}) > 0 else -1
-            if diff_sign != isign:
-                i -= isign
+        if int_valued(r):
+            # non-integer self should pass one of these tests
+            if self > i is S.true:
+                return i
+            if self < i is S.true:
+                return i - 1
+            # is it safe to assume that self == i?
         return i
 
     def __float__(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -311,24 +311,16 @@ class Expr(Basic, EvalfMixin):
         if r in (S.NaN, S.Infinity, S.NegativeInfinity):
             raise TypeError("Cannot convert %s to int" % r)
         i = int(r)
+        if not i:
+            return i
         if int_valued(r):
             # non-integer self should pass one of these tests
             if (self > i) is S.true:
                 return i
             if (self < i) is S.true:
                 return i - 1
-            # off-by-one check since i might be smaller than self
-            if not (self - i).equals(0):
-                from .symbol import Dummy
-                isign = 1 if i > 0 else -1
-                x = Dummy()
-                # in the following (self - i).evalf(2) will not always work while
-                # (self - r).evalf(2) and the use of subs does; if the test that
-                # was added when this comment was added passes, it might be safe
-                # to simply use sign to compute this rather than doing this by hand:
-                diff_sign = 1 if (self - x).evalf(2, subs={x: i}) > 0 else -1
-                if diff_sign != isign:
-                    i -= isign
+            # off by one
+            return i - (1 if i > 0 else -1)
         return i
 
     def __float__(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -317,7 +317,18 @@ class Expr(Basic, EvalfMixin):
                 return i
             if (self < i) is S.true:
                 return i - 1
-            # is it safe to assume that self == i?
+            # off-by-one check since i might be smaller than self
+            if not (self - i).equals(0):
+                from .symbol import Dummy
+                isign = 1 if i > 0 else -1
+                x = Dummy()
+                # in the following (self - i).evalf(2) will not always work while
+                # (self - r).evalf(2) and the use of subs does; if the test that
+                # was added when this comment was added passes, it might be safe
+                # to simply use sign to compute this rather than doing this by hand:
+                diff_sign = 1 if (self - x).evalf(2, subs={x: i}) > 0 else -1
+                if diff_sign != isign:
+                    i -= isign
         return i
 
     def __float__(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -313,9 +313,9 @@ class Expr(Basic, EvalfMixin):
         i = int(r)
         if int_valued(r):
             # non-integer self should pass one of these tests
-            if self > i is S.true:
+            if (self > i) is S.true:
                 return i
-            if self < i is S.true:
+            if (self < i) is S.true:
                 return i - 1
             # is it safe to assume that self == i?
         return i

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -303,7 +303,6 @@ class Expr(Basic, EvalfMixin):
         return floor(other / self), Mod(other, self)
 
     def __int__(self):
-        from .symbol import Dummy
         if not self.is_number:
             raise TypeError("Cannot convert symbols to int")
         r = self.round(2)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3904,7 +3904,7 @@ class Expr(Basic, EvalfMixin):
         # the 2nd digit from the left) we get 5700000000000000.
         #
         xf = x.n(dps + extra)*Pow(10, shift)
-        if xf._prec == 1:
+        if xf.is_Number and xf._prec == 1:  # case where xf.is_Add will raise below
             # is x == 0?
             if x.equals(0):
                 return Float(0)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2084,6 +2084,15 @@ def test_round():
         assert type(round(fi)) is int
         assert S(fi).round().is_Integer
 
+        # issue 25698
+        one = cos(2)**2 + sin(2)**2
+        eq = exp(one*I*pi)
+        qr, qi = eq.as_real_imag()
+        assert qi.round(2) == 0.0
+        assert eq.round(2) == -1.0
+        n = 6000002
+        assert int(n*(log(n) + log(log(n)))) == 110130079
+
 
 def test_held_expression_UnevaluatedExpr():
     x = symbols("x")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2092,6 +2092,10 @@ def test_round():
         assert eq.round(2) == -1.0
         n = 6000002
         assert int(n*(log(n) + log(log(n)))) == 110130079
+        eq = one - 1/S(10**120)
+        assert S.true not in (eq > 1, eq < 1)
+        assert int(eq) == 0
+        assert int(-eq) == 0
 
 
 def test_held_expression_UnevaluatedExpr():

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -438,7 +438,7 @@ def prime(nth):
     from sympy.functions.elementary.exponential import log
     from sympy.functions.special.error_functions import li
     a = 2 # Lower bound for binary search
-    b = int(float(n*(log(n) + log(log(n))))) # Upper bound for the search.
+    b = int((n*(log(n) + log(log(n)))).n()) # Upper bound for the search.
 
     while a < b:
         mid = (a + b) >> 1

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -438,7 +438,7 @@ def prime(nth):
     from sympy.functions.elementary.exponential import log
     from sympy.functions.special.error_functions import li
     a = 2 # Lower bound for binary search
-    b = int((n*(log(n) + log(log(n)))).n()) # Upper bound for the search.
+    b = n*int(log(n) + log(log(n))) # Upper bound for the search.
 
     while a < b:
         mid = (a + b) >> 1

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -438,7 +438,9 @@ def prime(nth):
     from sympy.functions.elementary.exponential import log
     from sympy.functions.special.error_functions import li
     a = 2 # Lower bound for binary search
-    b = n*int(log(n) + log(log(n))) # Upper bound for the search.
+    # leave n inside int since int(i*r) != i*int(r) is not a valid property
+    # e.g. int(2*.5) != 2*int(.5)
+    b = int(n*(log(n) + log(log(n)))) # Upper bound for the search.
 
     while a < b:
         mid = (a + b) >> 1

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -438,7 +438,7 @@ def prime(nth):
     from sympy.functions.elementary.exponential import log
     from sympy.functions.special.error_functions import li
     a = 2 # Lower bound for binary search
-    b = int(n*(log(n) + log(log(n)))) # Upper bound for the search.
+    b = int(float(n*(log(n) + log(log(n))))) # Upper bound for the search.
 
     while a < b:
         mid = (a + b) >> 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25698 

#### Brief description of what is fixed or changed

Evaluates `n * (log(n) + log(log(n)))` to a numerical value then cast to integer, reducing lag in certain values of `n`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
