### PR TITLE
If `p` is special, `d` is now fixed

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -425,16 +425,13 @@ def _sqrt_mod_tonelli_shanks(a, p):
     Returns the square root in the case of ``p`` prime with ``p == 1 (mod 8)``
 
     Assume that the root exists.
-    Although ``p`` correctly returns the answer for any odd prime,
-    ``p != 1 (mod 8)``, there is no advantage to using this algorithm since
-    a more efficient algorithm exists.
 
     Parameters
     ==========
 
     a : int
     p : int
-        Odd prime number
+        prime number. should be ``p % 8 == 1``
 
     Returns
     =======
@@ -452,17 +449,24 @@ def _sqrt_mod_tonelli_shanks(a, p):
     References
     ==========
 
-    .. [1] R. Crandall and C. Pomerance "Prime Numbers", 2nd Ed., page 101
+    .. [1] Carl Pomerance, Richard Crandall, Prime Numbers: A Computational Perspective,
+           2nd Edition (2005), page 101, ISBN:978-0387252827
 
     """
     s = bit_scan1(p - 1)
     t = p >> s
     # find a non-quadratic residue
-    while 1:
-        d = randint(2, p - 1)
-        r = jacobi(d, p)
-        if r == -1:
-            break
+    if p % 12 == 5:
+        # Legendre symbol (3/p) == -1 if p % 12 in [5, 7]
+        d = 3
+    elif p % 5 in [2, 3]:
+        # Legendre symbol (5/p) == -1 if p % 5 in [2, 3]
+        d = 5
+    else:
+        while 1:
+            d = randint(6, p - 1)
+            if jacobi(d, p) == -1:
+                break
     #assert legendre_symbol(d, p) == -1
     A = pow(a, t, p)
     D = pow(d, t, p)


### PR DESCRIPTION
In `_sqrt_mod_tonelli_shanks`, `d` is only required to be a non-quadratic residue. In general, we randomly search for `d` such that the Legendre symbol $(d/p)$ is -1. In special cases, however, such guesswork is not necessary. In this case, we assume `p % 8 == 1`, so we fix the docstring.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
[Properties of the Legendre symbol](https://en.wikipedia.org/wiki/Legendre_symbol#Properties_of_the_Legendre_symbol)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
