### PR TITLE
Improve warning message of Point.vel

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -1,6 +1,7 @@
 from .vector import Vector, _check_vector
 from .frame import _check_frame
 from warnings import warn
+from sympy.utilities.misc import filldedent
 
 __all__ = ['Point']
 
@@ -567,21 +568,23 @@ class Point:
                             self.set_vel(frame, self.pos_from(neighbor).dt(frame) + neighbor_velocity)
                             valid_neighbor_found = True
             if is_cyclic:
-                warn('Kinematic loops are defined among the positions of '
-                     'points. This is likely not desired and may cause errors '
-                     'in your calculations.')
+                warn(filldedent("""
+                Kinematic loops are defined among the positions of points. This
+                is likely not desired and may cause errors in your calculations.
+                """))
             if len(candidate_neighbor) > 1:
-                warn(f"Velocity of {self.name} automatically calculated based "
-                     f"on point {candidate_neighbor[0].name} but it is also "
-                     f"possible from points(s): {str(candidate_neighbor[1:])}. "
-                     f"Velocities from these points are not necessarily the "
-                     f"same. This may cause errors in your calculations.")
+                warn(filldedent(f"""
+                Velocity of {self.name} automatically calculated based on point
+                {candidate_neighbor[0].name} but it is also possible from
+                points(s): {str(candidate_neighbor[1:])}. Velocities from these
+                points are not necessarily the same. This may cause errors in
+                your calculations."""))
             if valid_neighbor_found:
                 return self._vel_dict[frame]
             else:
-                raise ValueError(
-                    f"Velocity of point {self.name} has not been defined in "
-                    f"RefernceFrame {frame.name}.")
+                raise ValueError(filldedent(f"""
+                Velocity of point {self.name} has not been defined in
+                ReferenceFrame {frame.name}."""))
 
         return self._vel_dict[frame]
 

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -571,18 +571,17 @@ class Point:
                      'points. This is likely not desired and may cause errors '
                      'in your calculations.')
             if len(candidate_neighbor) > 1:
-                warn('Velocity automatically calculated based on point ' +
-                     candidate_neighbor[0].name +
-                     ' but it is also possible from points(s):' +
-                     str(candidate_neighbor[1:]) +
-                     '. Velocities from these points are not necessarily the '
-                     'same. This may cause errors in your calculations.')
+                warn(f"Velocity of {self.name} automatically calculated based "
+                     f"on point {candidate_neighbor[0].name} but it is also "
+                     f"possible from points(s): {str(candidate_neighbor[1:])}. "
+                     f"Velocities from these points are not necessarily the "
+                     f"same. This may cause errors in your calculations.")
             if valid_neighbor_found:
                 return self._vel_dict[frame]
             else:
-                raise ValueError('Velocity of point ' + self.name +
-                                 ' has not been'
-                                 ' defined in ReferenceFrame ' + frame.name)
+                raise ValueError(
+                    f"Velocity of point {self.name} has not been defined in "
+                    f"RefernceFrame {frame.name}.")
 
         return self._vel_dict[frame]
 

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -280,8 +280,9 @@ def test_auto_vel_cyclic_warning_msg():
     with warnings.catch_warnings(record = True) as w: #The path is cyclic at P1, thus a warning is raised
         warnings.simplefilter("always")
         P2.vel(N)
+        msg = str(w[-1].message).replace("\n", " ")
         assert issubclass(w[-1].category, UserWarning)
-        assert 'Kinematic loops are defined among the positions of points. This is likely not desired and may cause errors in your calculations.' in str(w[-1].message)
+        assert 'Kinematic loops are defined among the positions of points. This is likely not desired and may cause errors in your calculations.' in msg
 
 def test_auto_vel_multiple_path_warning_msg():
     N = ReferenceFrame('N')
@@ -295,9 +296,11 @@ def test_auto_vel_multiple_path_warning_msg():
     with warnings.catch_warnings(record = True) as w: #There are two possible paths in this point tree, thus a warning is raised
         warnings.simplefilter("always")
         O.vel(N)
+        msg = str(w[-1].message).replace("\n", " ")
         assert issubclass(w[-1].category, UserWarning)
-        assert 'Velocity automatically calculated based on point' in str(w[-1].message)
-        assert 'Velocities from these points are not necessarily the same. This may cause errors in your calculations.' in str(w[-1].message)
+        assert 'Velocity' in msg
+        assert 'automatically calculated based on point' in msg
+        assert 'Velocities from these points are not necessarily the same. This may cause errors in your calculations.' in msg
 
 def test_auto_vel_derivative():
     q1, q2 = dynamicsymbols('q1:3')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR improves the warning message of `Point.vel`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Improve `Point.vel` warning message.
<!-- END RELEASE NOTES -->
