### PR TITLE
allow alternate Parabola instantiation

### DIFF
--- a/sympy/geometry/parabola.py
+++ b/sympy/geometry/parabola.py
@@ -5,7 +5,7 @@ Contains
 
 """
 
-from sympy.core import S, sympify
+from sympy.core import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import _symbol, symbols, Dummy
 from sympy.geometry.entity import GeometryEntity, GeometrySet
@@ -56,7 +56,7 @@ class Parabola(GeometrySet):
     Examples
     ========
 
-    >>> from sympy import Parabola, Point, Line, Eq
+    >>> from sympy import Parabola, Point, Line, pi
     >>> p1 = Parabola(Point(0, 0), Line(Point(5, 8), Point(7, 8)))
     >>> p1.focus
     Point2D(0, 0)
@@ -470,4 +470,4 @@ class Parabola(GeometrySet):
 
     def is_similar(self, other):
         # all parbolas are self similar
-        return is_instance(other, Parabola)
+        return isinstance(other, Parabola)

--- a/sympy/geometry/parabola.py
+++ b/sympy/geometry/parabola.py
@@ -20,8 +20,8 @@ from sympy.solvers.solvers import solve
 class Parabola(GeometrySet):
     """A parabolic GeometryEntity.
 
-    A parabola is declared with a point, that is called 'focus', and
-    a line, that is called 'directrix'.
+    A parabola is declared with a point (the 'focus') and
+    a line (the 'directrix') or a quadratic equation in ``x`` or ``y``.
     Only vertical or horizontal parabolas are currently supported.
 
     Parameters
@@ -30,11 +30,9 @@ class Parabola(GeometrySet):
     focus : Point
         Default value is Point(0, 0)
     directrix : Line
-    apq : tuple containing ``a``, ``p``, ``q`` for ``a*(x - p)*(x - q)``
-    ahk : tuple containing ``a``, ``h``, ``k`` for ``a*(x - h)**2 + k``
-    abc : tuple containing ``a``, ``b``, ``c`` for ``a*x**2 + b*x + c``
-    eq : an expression in terms of ``x`` and ``y`` that contains
-        either ``x**2`` or ``y**2``
+    eq : Equality or Expr
+        An expression in terms of ``x`` and ``y`` that contains
+        either ``x**2`` or ``y**2``, but not both, and no ``x*y`` term.
 
     Attributes
     ==========
@@ -52,6 +50,7 @@ class Parabola(GeometrySet):
     ValueError
         When `focus` is not a two dimensional point.
         When `focus` is a point of directrix.
+        When more than one variable has name `x` or `y` in `eq` or `eq` is not the equation of a vertical or horizontal parabola.
     NotImplementedError
         When `directrix` is neither horizontal nor vertical.
 

--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -146,10 +146,10 @@ def test_parabola_intersection():
 def test_Parabola_alt_instantiation():
     ans = -x**2 - 3*x/2 + y/2 - S(5)/2
     eq = 2*x**2 + 3*x + 5
-    assert Parabola(eq=eq).equation(x, y).expand() == ans
-    assert Parabola(eq=eq.subs(x, y)).equation(y, x).expand() == ans  # reversed x and y
-    raises(ValueError, lambda: Parabola(eq=x*y + y**2))
-    raises(ValueError, lambda: Parabola(eq=x*y + y**2))
-    raises(ValueError, lambda: Parabola(eq=x**2 + y**2))
-    raises(ValueError, lambda: Parabola(eq=x**2 + Dummy('x')**2))
-    raises(ValueError, lambda: Parabola(eq=2))
+    assert Parabola(eq).equation(x, y).expand() == ans
+    assert Parabola(eq.subs(x, y)).equation(y, x).expand() == ans  # reversed x and y
+    raises(ValueError, lambda: Parabola(x*y + y**2))
+    raises(ValueError, lambda: Parabola(x*y + y**2))
+    raises(ValueError, lambda: Parabola(x**2 + y**2))
+    raises(ValueError, lambda: Parabola(x**2 + Dummy('x')**2))
+    raises(ValueError, lambda: Parabola(2))

--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -1,4 +1,4 @@
-from sympy.core.numbers import (Rational, oo)
+from sympy.core.numbers import (pi, Rational, oo)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Dummy
 from sympy.functions.elementary.complexes import sign
@@ -143,11 +143,16 @@ def test_parabola_intersection():
     raises(TypeError, lambda: parabola1.intersection(2))
 
 
+def test_is_similar():
+    assert not Parabola().is_similar(Line((0, 0), slope=1)
+    assert Parabola().is_similar(abc=(1,2,3))
+
+
 def test_Parabola_alt_instantiation():
     ans = -x**2 - 3*x/2 + y/2 - S(5)/2
     eq = 2*x**2 + 3*x + 5
-    assert Parabola(eq).equation(x, y).expand() == ans
-    assert Parabola(eq.subs(x, y)).equation(y, x).expand() == ans  # reversed x and y
+    assert Parabola(abc=(2, 3, 5)).equation(x, y).expand() == ans
+    assert Parabola(abc=(2, 3, 5)).rotate(-pi/2).equation(y, x).expand() == ans  # reversed x and y
     raises(ValueError, lambda: Parabola(x*y + y**2))
     raises(ValueError, lambda: Parabola(x*y + y**2))
     raises(ValueError, lambda: Parabola(x**2 + y**2))

--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -144,7 +144,7 @@ def test_parabola_intersection():
 
 
 def test_is_similar():
-    assert not Parabola().is_similar(Line((0, 0), slope=1)
+    assert not Parabola().is_similar(Line((0, 0), slope=1))
     assert Parabola().is_similar(abc=(1,2,3))
 
 

--- a/sympy/geometry/tests/test_parabola.py
+++ b/sympy/geometry/tests/test_parabola.py
@@ -1,6 +1,6 @@
 from sympy.core.numbers import (Rational, oo)
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.core.symbol import symbols, Dummy
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry.ellipse import (Circle, Ellipse)
@@ -141,3 +141,15 @@ def test_parabola_intersection():
            Point2D(4*sqrt(17)/3, Rational(59, 9))]
     # parabola with unsupported type
     raises(TypeError, lambda: parabola1.intersection(2))
+
+
+def test_Parabola_alt_instantiation():
+    ans = -x**2 - 3*x/2 + y/2 - S(5)/2
+    eq = 2*x**2 + 3*x + 5
+    assert Parabola(eq=eq).equation(x, y).expand() == ans
+    assert Parabola(eq=eq.subs(x, y)).equation(y, x).expand() == ans  # reversed x and y
+    raises(ValueError, lambda: Parabola(eq=x*y + y**2))
+    raises(ValueError, lambda: Parabola(eq=x*y + y**2))
+    raises(ValueError, lambda: Parabola(eq=x**2 + y**2))
+    raises(ValueError, lambda: Parabola(eq=x**2 + Dummy('x')**2))
+    raises(ValueError, lambda: Parabola(eq=2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Parabola can be instantiated from an expression in terms of x and/or y
<!-- END RELEASE NOTES -->
