### PR TITLE
Fix Rational parsing in Mathematica parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -706,6 +706,7 @@ James Goppert <james.goppert@gmail.com>
 James Harrop <ebc121@gmail.com>
 James Pearson <xiong.chiamiov@gmail.com>
 James Taylor <user234683@tutanota.com>
+James Whitehead <whiteheadj@gmail.com> jcwhitehead <whiteheadj@gmail.com>
 Jan Kruse <janckruse@t-online.de>
 Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -5,7 +5,7 @@ from itertools import product
 from typing import Any, Callable
 
 import sympy
-from sympy import Mul, Add, Pow, log, exp, sqrt, cos, sin, tan, asin, acos, acot, asec, acsc, sinh, cosh, tanh, asinh, \
+from sympy import Mul, Add, Pow, Rational, log, exp, sqrt, cos, sin, tan, asin, acos, acot, asec, acsc, sinh, cosh, tanh, asinh, \
     acosh, atanh, acoth, asech, acsch, expand, im, flatten, polylog, cancel, expand_trig, sign, simplify, \
     UnevaluatedExpr, S, atan, atan2, Mod, Max, Min, rf, Ei, Si, Ci, airyai, airyaiprime, airybi, primepi, prime, \
     isprime, cot, sec, csc, csch, sech, coth, Function, I, pi, Tuple, GreaterThan, StrictGreaterThan, StrictLessThan, \
@@ -131,6 +131,7 @@ class MathematicaParser:
     # left: Mathematica, right: SymPy
     CORRESPONDENCES = {
         'Sqrt[x]': 'sqrt(x)',
+        'Rational[x,y]': 'Rational(x,y)',
         'Exp[x]': 'exp(x)',
         'Log[x]': 'log(x)',
         'Log[x,y]': 'log(y,x)',
@@ -975,6 +976,7 @@ class MathematicaParser:
         "Times": Mul,
         "Plus": Add,
         "Power": Pow,
+        "Rational": lambda *a: Rational(*a),
         "Log": lambda *a: log(*reversed(a)),
         "Log2": lambda x: log(x, 2),
         "Log10": lambda x: log(x, 10),

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -976,7 +976,7 @@ class MathematicaParser:
         "Times": Mul,
         "Plus": Add,
         "Power": Pow,
-        "Rational": lambda *a: Rational(*a),
+        "Rational": Rational,
         "Log": lambda *a: log(*reversed(a)),
         "Log2": lambda x: log(x, 2),
         "Log10": lambda x: log(x, 10),

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -67,7 +67,8 @@ def test_mathematica():
         'LogIntegral[4]': ' li(4)',
         'PrimePi[7]': 'primepi(7)',
         'Prime[5]': 'prime(5)',
-        'PrimeQ[5]': 'isprime(5)'
+        'PrimeQ[5]': 'isprime(5)',
+        'Rational[2,19]': 'Rational(2,19)',    # test case for issue 25716
         }
 
     for e in d:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25716

#### Brief description of what is fixed or changed
The Mathematica parser at present creates an `AppliedUndef` function with the same name and syntax as the built-in sympy `Rational` type, but none of the properties. This is because the conversion is not defined in the parser.

This PR adds the relevant conversion and a simple test to the test cases.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug in the Mathematica parser parsing rational objects Rational[p,q].
<!-- END RELEASE NOTES -->
