### PR TITLE
Removed unnecessary check in _laplace_expand

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -958,8 +958,6 @@ def _laplace_expand(f, t, s):
     expanded term.
     """
 
-    if f.is_Add:
-        return None
     r = expand(f, deep=False)
     if r.is_Add:
         return _laplace_transform(r, t, s, simplify=False)


### PR DESCRIPTION
#### References to other Issues or PRs
Part of #24561

#### Brief description of what is fixed or changed
This check has become unnecessary with #25693. It could cause unnecessary integrations. No known output changes, so no Release Notes.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
