### PR TITLE
limit evaluation during ordering (alternate)

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1163,7 +1163,7 @@ class Expr(Basic, EvalfMixin):
 
             _term, ncpart = term.args_cnc()
 
-            cpart = {}
+            cpart = defaultdict(lambda: S.Zero)
 
             # collect all Rational coefficients in coeff
             coeff = S.One
@@ -1173,7 +1173,7 @@ class Expr(Basic, EvalfMixin):
                     coeff *= factor
                     continue
                 base, exp = decompose_power(factor)
-                cpart[base] = exp
+                cpart[base] += exp
                 gens.add(base)
 
             coeff = coeff, S.Zero  # XXX legacy format

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1167,17 +1167,18 @@ class Expr(Basic, EvalfMixin):
 
             # keep track of coefficient of number that are
             # either Number or Number + I*Number
-            coeff = S.One
+            coeff = complex(S.One)
 
             for factor in _term:
                 if (ri := pure_complex(factor, or_real=True)) is not None:
-                    coeff *= factor
+                    coeff *= complex(factor)
                     continue
                 base, exp = decompose_power(factor)
                 cpart[base] = exp
                 gens.add(base)
 
-            terms.append((term, (coeff.as_real_imag(), cpart, tuple(ncpart))))
+            coeff = coeff.real, coeff.imag
+            terms.append((term, (coeff, cpart, tuple(ncpart))))
 
         gens = sorted(gens, key=default_sort_key)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1168,20 +1168,16 @@ class Expr(Basic, EvalfMixin):
             # keep track of coefficient of number that are
             # either Number or Number + I*Number
             coeff = S.One
-            def _coeff(c, d):
-                a, b = coeff
-                coeff[0] = a*c - d*b
-                coeff[1] = a*d + b*c
 
             for factor in _term:
                 if (ri := pure_complex(factor, or_real=True)) is not None:
-                    _coeff(*ri)
+                    coeff *= factor
                     continue
                 base, exp = decompose_power(factor)
                 cpart[base] = exp
                 gens.add(base)
 
-            terms.append((term, (tuple(coeff), cpart, tuple(ncpart))))
+            terms.append((term, (coeff.as_real_imag(), cpart, tuple(ncpart))))
 
         gens = sorted(gens, key=default_sort_key)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1165,19 +1165,18 @@ class Expr(Basic, EvalfMixin):
 
             cpart = {}
 
-            # keep track of coefficient of number that are
-            # either Number or Number + I*Number
-            coeff = complex(S.One)
+            # collect all Rational coefficients in coeff
+            coeff = S.One
 
             for factor in _term:
-                if (ri := pure_complex(factor, or_real=True)) is not None:
-                    coeff *= complex(factor)
+                if factor.is_Number:
+                    coeff *= factor
                     continue
                 base, exp = decompose_power(factor)
                 cpart[base] = exp
                 gens.add(base)
 
-            coeff = coeff.real, coeff.imag
+            coeff = coeff, S.Zero  # XXX legacy format
             terms.append((term, (coeff, cpart, tuple(ncpart))))
 
         gens = sorted(gens, key=default_sort_key)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2282,3 +2282,7 @@ def test_format():
     assert '{:+3.0f}'.format(S(3)) == ' +3'
     assert '{:23.20f}'.format(pi) == ' 3.14159265358979323846'
     assert '{:50.48f}'.format(exp(sin(1))) == '2.319776824715853173956590377503266813254904772376'
+
+
+def test_issue_24045():
+    assert powsimp(exp(a)/((c*a - c*b)*(Float(1.0)*c*a - Float(1.0)*c*b)))  # doesn't raise

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1759,6 +1759,14 @@ def test_as_ordered_factors():
 
 def test_as_ordered_terms():
 
+    # the unevaluated should sort to the same place regardless
+    # or order of exponents
+    m1 = (x**2 + Mul(x, x**3, evaluate=False)).as_ordered_terms()
+    m2 = (x**2 + Mul(x**3, x, evaluate=False)).as_ordered_terms()
+    print(m1,m2)
+    assert [i for i in range(2) if x**3 in m1[i].args
+        ] == [i for i in range(2) if x**3 in m2[i].args]
+
     assert x.as_ordered_terms() == [x]
     assert (sin(x)**2*cos(x) + sin(x)*cos(x)**2 + 1).as_ordered_terms() \
         == [sin(x)**2*cos(x), sin(x)*cos(x)**2, 1]
@@ -2282,7 +2290,3 @@ def test_format():
     assert '{:+3.0f}'.format(S(3)) == ' +3'
     assert '{:23.20f}'.format(pi) == ' 3.14159265358979323846'
     assert '{:50.48f}'.format(exp(sin(1))) == '2.319776824715853173956590377503266813254904772376'
-
-
-def test_issue_24045():
-    assert powsimp(exp(a)/((c*a - c*b)*(Float(1.0)*c*a - Float(1.0)*c*b)))  # doesn't raise

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -346,7 +346,14 @@ class Printer:
         elif order == 'none':
             return list(expr.args)
         else:
-            return expr.as_ordered_terms(order=order)
+            terms = expr.as_ordered_terms(order=order)
+            # put real numbers first
+            front = []
+            for i in range(len(terms) - 1, -1, -1):
+                if terms[i].is_Number:
+                    front.append(terms[i])
+                    terms.pop(i)
+            return front + terms
 
 
 class _PrintFunction:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

I am interested to see if the failures are different here than on #25726. This is much simpler in terms of ordering terms because not even assumptions are used on the coefficient, now.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
