### PR TITLE
Add 'sign' to experimental_lambdify.Lambdifier.numpy_functions_same

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -684,6 +684,7 @@ Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
 Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
 Itay4 <31018228+Itay4@users.noreply.github.com>
 Ivan Petuhov <ivan@ostrovok.ru>
+Ivan Petukhov <satels@gmail.com>
 Ivan Tkachenko <me@ratijas.tk> ivan tkachenko <ratijas@users.noreply.github.com>
 Ivan Tkachenko <me@ratijas.tk> ratijas <ratijas@users.noreply.github.com>
 JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -298,7 +298,7 @@ class Lambdifier:
     # Functions that are the same in numpy
     numpy_functions_same = [
         'sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'exp', 'log',
-        'sqrt', 'floor', 'conjugate',
+        'sqrt', 'floor', 'conjugate', 'sign',
     ]
 
     # Functions with different names in numpy


### PR DESCRIPTION
#### What is fixed

```python
import numpy
from sympy.plotting.experimental_lambdify import experimental_lambdify, sign, sin
from sympy.abc import x

f = experimental_lambdify(x, x-sign(sin(x)), numpy)

arr = numpy.array([1, 2, 3, 4, 5])

f(arr)

# ImportError: cannot import name 'sign' from 'sympy.plotting.experimental_lambdify'

```


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* plotting
  * Add 'sign' sympy-to-numpy same function
<!-- END RELEASE NOTES -->
