### PR TITLE
Added abbreviations to "liter" unit quantities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1507,6 +1507,7 @@ andreo <andrey.torba@gmail.com>
 anutosh491 <andersonbhat491@gmail.com> Anutosh Bhat <87052487+anutosh491@users.noreply.github.com>
 anutosh491 <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.noreply.github.com>
 arooshiverma <av22@iitbbs.ac.in>
+atharvParlikar <atharvparlikar@gmail.com>
 bluebrook <perl4logic@gmail.com>
 carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>

--- a/sympy/physics/units/definitions/unit_definitions.py
+++ b/sympy/physics/units/definitions/unit_definitions.py
@@ -173,15 +173,15 @@ angstrom.set_global_relative_scale_factor(Rational(1, 10**10), meter)
 
 ha = hectare = Quantity("hectare", abbrev="ha")
 
-l = L = liter = liters = Quantity("liter")
+l = L = liter = liters = Quantity("liter", abbrev="l")
 
-dl = dL = deciliter = deciliters = Quantity("deciliter")
+dl = dL = deciliter = deciliters = Quantity("deciliter", abbrev="dl")
 dl.set_global_relative_scale_factor(Rational(1, 10), liter)
 
-cl = cL = centiliter = centiliters = Quantity("centiliter")
+cl = cL = centiliter = centiliters = Quantity("centiliter", abbrev="cl")
 cl.set_global_relative_scale_factor(Rational(1, 100), liter)
 
-ml = mL = milliliter = milliliters = Quantity("milliliter")
+ml = mL = milliliter = milliliters = Quantity("milliliter", abbrev="ml")
 ml.set_global_relative_scale_factor(Rational(1, 1000), liter)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25710 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
