### PR TITLE
Remove setting `_a, _b, _c, _d` attribute directly in quaternion

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -113,15 +113,10 @@ class Quaternion(Expr):
 
         if any(i.is_commutative is False for i in [a, b, c, d]):
             raise ValueError("arguments have to be commutative")
-        else:
-            obj = Expr.__new__(cls, a, b, c, d)
-            obj._a = a
-            obj._b = b
-            obj._c = c
-            obj._d = d
-            obj._real_field = real_field
-            obj.set_norm(norm)
-            return obj
+        obj = super().__new__(cls, a, b, c, d)
+        obj._real_field = real_field
+        obj.set_norm(norm)
+        return obj
 
     def set_norm(self, norm):
         """Sets norm of an already instantiated quaternion.
@@ -161,19 +156,19 @@ class Quaternion(Expr):
 
     @property
     def a(self):
-        return self._a
+        return self.args[0]
 
     @property
     def b(self):
-        return self._b
+        return self.args[1]
 
     @property
     def c(self):
-        return self._c
+        return self.args[2]
 
     @property
     def d(self):
-        return self._d
+        return self.args[3]
 
     @property
     def real_field(self):
@@ -688,7 +683,7 @@ class Quaternion(Expr):
         return self.pow(p)
 
     def __neg__(self):
-        return Quaternion(-self._a, -self._b, -self._c, -self.d)
+        return Quaternion(-self.a, -self.b, -self.c, -self.d)
 
     def __truediv__(self, other):
         return self * sympify(other)**-1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/25512

#### Brief description of what is fixed or changed

This is some following up the best practices that you shouldn't set the extraneous attributes directly in SymPy objects.
This is commonly used as escape hatches for cacheing, or for people who find difficulty programming with immutable objects, however, this shouldn't be difficult to fix, and I'm trying to get rid of them for easy cases as much as possible, to let people not misguided about them.

I'd also like to remove `real_field` and `norm` as object attributes, use `@cacheit` but I'd like to watch over the issue
https://github.com/sympy/sympy/issues/24943 first before that.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
