### PR TITLE
Fix solve_univariate_inequality

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1593,6 +1593,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
+vitrun <vitrun@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -549,18 +549,20 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if v.is_extended_real is False:
                     return S.false
                 else:
-                    if v.is_comparable:
-                        return expr.func(v, 0)
+                    v2 = v.n(2)
+                    if v2.is_comparable:
+                        return expr.func(v2, 0)
                     # if v is not comparable it could mean that it is an
                     # expression that equals 0. Rather than include every
                     # simplification strategy to try show that v == 0, include
                     # here the specific simplification step needed to try prove
                     # that v == 0 for a case that was not yet handled
                     # ------ specific cases to try show v == 0
+                    v0 = v2
                     if v.has(log):  # log(b**a)/log(b) - a case
-                        v = expand_log(v)
+                        v0 = expand_log(v)
                     # ------ end of simplification help
-                    if v == 0:  # because something helped make it so
+                    if v0 == 0:  # because something helped make it so
                         return expr.func(0, 0)
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -551,7 +551,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 else:
                     if v.is_comparable:
                         return expr.func(v, 0)
-                     if v.equals(0):
+                    if v.equals(0):
                         return expr.func(0, 0) 
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -552,7 +552,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     if v.is_comparable:
                         return expr.func(v, 0)
                     if v.equals(0):
-                        return expr.func(0, 0) 
+                        return expr.func(0, 0)
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(
                         'relationship did not evaluate: %s' % r)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -549,8 +549,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if v.is_extended_real is False:
                     return S.false
                 else:
-                    v = v.n(2, chop=True)
-                    if v.is_comparable:
+                    if v.is_comparable or v.equals(0):
                         return expr.func(v, 0)
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -10,6 +10,7 @@ from sympy.core.symbol import Symbol, Dummy
 from sympy.sets.sets import Interval, FiniteSet, Union, Intersection
 from sympy.core.singleton import S
 from sympy.core.function import expand_mul, expand_log
+from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.complexes import im, Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -549,8 +549,10 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if v.is_extended_real is False:
                     return S.false
                 else:
-                    if v.is_comparable or v.equals(0):
+                    if v.is_comparable:
                         return expr.func(v, 0)
+                     if v.equals(0):
+                        return expr.func(0, 0) 
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(
                         'relationship did not evaluate: %s' % r)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -549,7 +549,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if v.is_extended_real is False:
                     return S.false
                 else:
-                    v = v.n(2)
+                    v = v.n(2, chop=True)
                     if v.is_comparable:
                         return expr.func(v, 0)
                     # not comparable or couldn't be evaluated

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -9,7 +9,7 @@ from sympy.core.relational import Relational, Lt, Ge, Eq
 from sympy.core.symbol import Symbol, Dummy
 from sympy.sets.sets import Interval, FiniteSet, Union, Intersection
 from sympy.core.singleton import S
-from sympy.core.function import expand_mul
+from sympy.core.function import expand_mul, expand_log
 from sympy.functions.elementary.complexes import im, Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
@@ -551,7 +551,16 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 else:
                     if v.is_comparable:
                         return expr.func(v, 0)
-                    if v.equals(0):
+                    # if v is not comparable it could mean that it is an
+                    # expression that equals 0. Rather than include every
+                    # simplification strategy to try show that v == 0, include
+                    # here the specific simplification step needed to try prove
+                    # that v == 0 for a case that was not yet handled
+                    # ------ specific cases to try show v == 0
+                    if v.has(log):  # log(b**a)/log(b) - a case
+                        v = expand_log(v)
+                    # ------ end of simplification help
+                    if v == 0:  # because something helped make it so
                         return expr.func(0, 0)
                     # not comparable or couldn't be evaluated
                     raise NotImplementedError(

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3144,7 +3144,7 @@ def _invert(eq, *symbols, **kwargs):
 
     >>> invert(sqrt(x + y) - 2)
     (4, x + y)
-    >>> invert(sqrt(x + y) - 2)
+    >>> invert(sqrt(x + y) + 2)
     (4, x + y)
 
     If the exponent is an Integer, setting ``integer_power`` to True

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -447,8 +447,8 @@ def test_issue_10671_12466():
 
 
 def test_issue_25697():
-    assert reduce_inequalities([log(x, 3) <= 2], x) == True
-    assert reduce_inequalities([log(x, 3) < 2], x) == False
+    assert reduce_inequalities([log(x, 3) <= 2], x) == (x <= 9) & (0 < x)
+    assert reduce_inequalities([log(x, 3) < 2], x) == (x < 9) & (0 < x)
 
 
 def test__solve_inequality():

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -447,8 +447,8 @@ def test_issue_10671_12466():
 
 
 def test_issue_25697():
-    assert reduce_inequalities([log(x, 3) <= 2], x) === True
-    assert reduce_inequalities([log(x, 3) < 2], x) === False
+    assert reduce_inequalities([log(x, 3) <= 2], x) == True
+    assert reduce_inequalities([log(x, 3) < 2], x) == False
 
 
 def test__solve_inequality():

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -446,6 +446,10 @@ def test_issue_10671_12466():
         Interval.Lopen(6, 7)
 
 
+def test_issue_25697():
+    assert reduce_inequalities([log(x, 3) <= 2], x) === True
+
+
 def test__solve_inequality():
     for op in (Gt, Lt, Le, Ge, Eq, Ne):
         assert _solve_inequality(op(x, 1), x).lhs == x

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -448,6 +448,7 @@ def test_issue_10671_12466():
 
 def test_issue_25697():
     assert reduce_inequalities([log(x, 3) <= 2], x) === True
+    assert reduce_inequalities([log(x, 3) < 2], x) === False
 
 
 def test__solve_inequality():

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -447,8 +447,8 @@ def test_issue_10671_12466():
 
 
 def test_issue_25697():
-    assert reduce_inequalities([log(x, 3) <= 2], x) == (x <= 9) & (0 < x)
-    assert reduce_inequalities([log(x, 3) < 2], x) == (x < 9) & (0 < x)
+    assert reduce_inequalities([log(x, 3) <= 2], x) == (x <= 9) & (S(0) < x)
+    assert reduce_inequalities([log(x, 3) < 2], x) == (x < 9) & (S(0) < x)
 
 
 def test__solve_inequality():


### PR DESCRIPTION
Improved Handling of Expressions Evaluating to Zero.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25697 

#### Brief Description of the Fix
This fix addresses the scenario where the variable `v` can be simplified to zero, such as in the case of `-2 + log(9)/log(3)`. To handle this situation, the code now utilizes `v.n(2, chop=True)` to ensure that `v` is evaluated as zero. 

#### Additional Comments
While this fix may not be considered the optimal solution, it effectively resolves the issue.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Improved Handling of Expressions Evaluating to Zero.
<!-- END RELEASE NOTES -->
