### PR TITLE
Remove `_num, _den` and `_var` setter for `TransferFunction`

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -620,11 +620,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 
         if (((isinstance(num, Expr) and num.has(Symbol)) or num.is_number) and
             ((isinstance(den, Expr) and den.has(Symbol)) or den.is_number)):
-            obj = super(TransferFunction, cls).__new__(cls, num, den, var)
-            obj._num = num
-            obj._den = den
-            obj._var = var
-            return obj
+            return super(TransferFunction, cls).__new__(cls, num, den, var)
 
         else:
             raise TypeError("Unsupported type for numerator or denominator of TransferFunction.")
@@ -831,7 +827,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         (p - 3)*(p + 5)
 
         """
-        return self._num
+        return self.args[0]
 
     @property
     def den(self):
@@ -851,7 +847,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         4
 
         """
-        return self._den
+        return self.args[1]
 
     @property
     def var(self):
@@ -872,7 +868,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         s
 
         """
-        return self._var
+        return self.args[2]
 
     def _eval_subs(self, old, new):
         arg_num = self.num.subs(old, new)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I'd like to touch the StateSpace later.
However, for the `StateSpace`, `_A, _B, _C, _D` should be replaced with more verbose names `state_matrix, output_matrix, ...` which may or may not liked by everyone.
I wonder if `A, B, C, D` can be made as short-hand attributes or not. The names like `A, B, C, D` are semantically clear if they are also mathematical notations.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
