### PR TITLE
Implemented inverse muscle fiber force-velocity characteristic curve in `sympy.physics._biomechanics`

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3402,6 +3402,12 @@ def test_sympy__physics___biomechanics__curve__FiberForceVelocityDeGroote2016():
     assert _test_args(FiberForceVelocityDeGroote2016(v_M_tilde, c0, c1, c2, c3))
 
 
+def test_sympy__physics___biomechanics__curve__FiberForceVelocityInverseDeGroote2016():
+    from sympy.physics._biomechanics import FiberForceVelocityInverseDeGroote2016
+    fv_M, c0, c1, c2, c3 = symbols('fv_M, c0, c1, c2, c3')
+    assert _test_args(FiberForceVelocityInverseDeGroote2016(fv_M, c0, c1, c2, c3))
+
+
 def test_sympy__physics__paulialgebra__Pauli():
     from sympy.physics.paulialgebra import Pauli
     assert _test_args(Pauli(1))

--- a/sympy/physics/_biomechanics/__init__.py
+++ b/sympy/physics/_biomechanics/__init__.py
@@ -16,6 +16,7 @@ from .curve import (
    FiberForceLengthPassiveDeGroote2016,
    FiberForceLengthPassiveInverseDeGroote2016,
    FiberForceVelocityDeGroote2016,
+   FiberForceVelocityInverseDeGroote2016,
    TendonForceLengthDeGroote2016,
    TendonForceLengthInverseDeGroote2016,
 )
@@ -28,6 +29,7 @@ __all__ = [
    'FiberForceLengthPassiveDeGroote2016',
    'FiberForceLengthPassiveInverseDeGroote2016',
    'FiberForceVelocityDeGroote2016',
+   'FiberForceVelocityInverseDeGroote2016',
    'TendonForceLengthDeGroote2016',
    'TendonForceLengthInverseDeGroote2016',
 

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1292,3 +1292,34 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
            engineering, 44(10), (2016) pp. 2922-2936
 
     """
+
+    @classmethod
+    def with_defaults(cls, fv_M):
+        r"""Recommended constructor that will use the published constants.
+
+        Explanation
+        ===========
+
+        Returns a new instance of the inverse muscle fiber force-velocity
+        function using the four constant values specified in the original
+        publication.
+
+        These have the values:
+
+        $c_0 = -0.318$
+        $c_1 = -8.149$
+        $c_2 = -0.374$
+        $c_3 = 0.886$
+
+        Parameters
+        ==========
+
+        fv_M : Any (sympifiable)
+            Normalized muscle fiber extension velocity.
+
+        """
+        c0=Float('-0.318')
+        c1=Float('-8.149')
+        c2=Float('-0.374')
+        c3=Float('0.886')
+        return cls(fv_M, c0, c1, c2, c3)

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1232,6 +1232,18 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
 
         raise ArgumentIndexError(self, argindex)
 
+    def inverse(self, argindex=1):
+        """Inverse function.
+
+        Parameters
+        ==========
+
+        argindex : int
+            Value to start indexing the arguments at. Default is ``1``.
+
+        """
+        return FiberForceVelocityInverseDeGroote2016
+
     def _latex(self, printer):
         """Print a LaTeX representation of the function defining the curve.
 

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -656,7 +656,7 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
 
     with constant values of $c_0 = 0.6$ and $c_1 = 4.0$. This function is the
     exact analytical inverse of the related tendon force-length curve
-    ``fl_M_pas_de_groote_2016``.
+    ``FiberForceLengthPassiveDeGroote2016``.
 
     While it is possible to change the constant values, these were carefully
     selected in the original publication to give the characteristic curve

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1245,4 +1245,35 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
 
 
 class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
-    pass
+    r"""Inverse muscle fiber force-velocity curve based on De Groote et al.,
+    2016 [1].
+
+    Explanation
+    ===========
+
+    Gives the normalized muscle fiber velocity that produces a specific
+    normalized muscle fiber force.
+
+    The function is defined by the equation:
+
+    ${fv^M}^{-1} = \frac{\sinh{\frac{fv^M - c_3}{c_0}} - c_2}{c_1}$
+
+    with constant values of $c_0 = -0.318$, $c_1 = -8.149$, $c_2 = -0.374$, and
+    $c_3 = 0.886$. This function is the exact analytical inverse of the related
+    muscle fiber force-velocity curve ``FiberForceVelocityDeGroote2016``.
+
+    While it is possible to change the constant values, these were carefully
+    selected in the original publication to give the characteristic curve
+    specific and required properties. For example, the function produces a
+    normalized muscle fiber force of 1 when the muscle fibers are contracting
+    isometrically (they have an extension rate of 0).
+
+    References
+    ==========
+
+    .. [1] De Groote, F., Kinney, A. L., Rao, A. V., & Fregly, B. J., Evaluation
+           of direct collocation optimal control problem formulations for
+           solving the muscle redundancy problem, Annals of biomedical
+           engineering, 44(10), (2016) pp. 2922-2936
+
+    """

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1323,3 +1323,33 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
         c2=Float('-0.374')
         c3=Float('0.886')
         return cls(fv_M, c0, c1, c2, c3)
+
+    @classmethod
+    def eval(cls, fv_M, c0, c1, c2, c3):
+        """Evaluation of basic inputs.
+
+        Parameters
+        ==========
+
+        fv_M : Any (sympifiable)
+            Normalized muscle fiber force as a function of muscle fiber
+            extension velocity.
+        c0 : Any (sympifiable)
+            The first constant in the characteristic equation. The published
+            value is ``-0.318``.
+        c1 : Any (sympifiable)
+            The second constant in the characteristic equation. The published
+            value is ``-8.149``.
+        c2 : Any (sympifiable)
+            The third constant in the characteristic equation. The published
+            value is ``-0.374``.
+        c3 : Any (sympifiable)
+            The fourth constant in the characteristic equation. The published
+            value is ``0.886``.
+
+        """
+        pass
+
+    def _eval_evalf(self, prec):
+        """Evaluate the expression numerically using ``evalf``."""
+        return self.doit(deep=False, evaluate=False)._eval_evalf(prec)

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -4,7 +4,7 @@ from sympy.core.expr import UnevaluatedExpr
 from sympy.core.function import ArgumentIndexError, Function
 from sympy.core.numbers import Float, Integer, Rational
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.hyperbolic import sinh
+from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.printing.precedence import PRECEDENCE
 
@@ -1386,3 +1386,29 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
             return (sinh((fv_M - c3)/c0) - c2)/c1
 
         return (sinh(UnevaluatedExpr(fv_M - c3)/c0) - c2)/c1
+
+    def fdiff(self, argindex=1):
+        """Derivative of the function with respect to a single argument.
+
+        Parameters
+        ==========
+
+        argindex : int
+            The index of the function's arguments with respect to which the
+            derivative should be taken. Argument indexes start at ``1``.
+            Default is ``1``.
+
+        """
+        fv_M, c0, c1, c2, c3 = self.args
+        if argindex == 1:
+            return cosh((fv_M - c3)/c0)/(c0*c1)
+        elif argindex == 2:
+            return (c3 - fv_M)*cosh((fv_M - c3)/c0)/(c0**2*c1)
+        elif argindex == 3:
+            return (c2 - sinh((fv_M - c3)/c0))/c1**2
+        elif argindex == 4:
+            return -1/c1
+        elif argindex == 5:
+            return -cosh((fv_M - c3)/c0)/(c0*c1)
+
+        raise ArgumentIndexError(self, argindex)

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1412,3 +1412,15 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
             return -cosh((fv_M - c3)/c0)/(c0*c1)
 
         raise ArgumentIndexError(self, argindex)
+
+    def inverse(self, argindex=1):
+        """Inverse function.
+
+        Parameters
+        ==========
+
+        argindex : int
+            Value to start indexing the arguments at. Default is ``1``.
+
+        """
+        return FiberForceVelocityDeGroote2016

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1090,8 +1090,8 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
 
     The function is defined by the equation:
 
-    $fv^M = c_0 \log{\left(c1 v_M_tilde + c2\right)
-        + \sqrt{\left(c1 v_M_tilde + c2\right)^2 + 1}} + c3
+    $fv^M = c_0 \log{\left(c_1 v_M_tilde + c_2\right)
+        + \sqrt{\left(c_1 v_M_tilde + c_2\right)^2 + 1}} + c_3
 
     with constant values of $c_0 = -0.318$, $c_1 = -8.149$, $c_2 = -0.374$, and
     $c_3 = 0.886$.

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -647,6 +647,9 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
     Explanation
     ===========
 
+    Gives the normalized muscle fiber length that produces a specific normalized
+    passive muscle fiber force.
+
     The function is defined by the equation:
 
     ${fl^M_{pas}}^{-1} = \frac{c_0 \log{\left(\exp{c_1} - 1\right)fl^M_pas + 1}}{c_1} + 1$

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -4,6 +4,7 @@ from sympy.core.expr import UnevaluatedExpr
 from sympy.core.function import ArgumentIndexError, Function
 from sympy.core.numbers import Float, Integer, Rational
 from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.hyperbolic import sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.printing.precedence import PRECEDENCE
 
@@ -1353,3 +1354,35 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
     def _eval_evalf(self, prec):
         """Evaluate the expression numerically using ``evalf``."""
         return self.doit(deep=False, evaluate=False)._eval_evalf(prec)
+
+    def doit(self, deep=True, evaluate=True, **hints):
+        """Evaluate the expression defining the function.
+
+        Parameters
+        ==========
+
+        deep : bool
+            Whether ``doit`` should be recursively called. Default is ``True``.
+        evaluate : bool.
+            Whether the SymPy expression should be evaluated as it is
+            constructed. If ``False``, then no constant folding will be
+            conducted which will leave the expression in a more numerically-
+            stable for values of ``fv_M`` that correspond to a sensible
+            operating range for a musculotendon. Default is ``True``.
+        **kwargs : dict[str, Any]
+            Additional keyword argument pairs to be recursively passed to
+            ``doit``.
+
+        """
+        fv_M, *constants = self.args
+        if deep:
+            hints['evaluate'] = evaluate
+            fv_M = fv_M.doit(deep=deep, **hints)
+            c0, c1, c2, c3 = [c.doit(deep=deep, **hints) for c in constants]
+        else:
+            c0, c1, c2, c3 = constants
+
+        if evaluate:
+            return (sinh((fv_M - c3)/c0) - c2)/c1
+
+        return (sinh(UnevaluatedExpr(fv_M - c3)/c0) - c2)/c1

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1284,6 +1284,47 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
     normalized muscle fiber force of 1 when the muscle fibers are contracting
     isometrically (they have an extension rate of 0).
 
+    Examples
+    ========
+
+    The preferred way to instantiate ``FiberForceVelocityInverseDeGroote2016``
+    is using the ``with_defaults`` constructor because this will automatically
+    populate the constants within the characteristic curve equation with the
+    floating point values from the original publication. This constructor takes
+    a single argument corresponding to normalized muscle fiber force-velocity
+    component of the muscle fiber force. We'll create a ``Symbol`` called
+    ``fv_M`` to represent this.
+
+    >>> from sympy import Symbol
+    >>> from sympy.physics._biomechanics import FiberForceVelocityInverseDeGroote2016
+    >>> fv_M = Symbol('fv_M')
+    >>> v_M_tilde = FiberForceVelocityInverseDeGroote2016.with_defaults(fv_M)
+    >>> v_M_tilde
+    FiberForceVelocityInverseDeGroote2016(fv_M, -0.318, -8.149, -0.374, 0.886)
+
+    It's also possible to populate the four constants with your own values too.
+
+    >>> from sympy import symbols
+    >>> c0, c1, c2, c3 = symbols('c0 c1 c2 c3')
+    >>> v_M_tilde = FiberForceVelocityInverseDeGroote2016(fv_M, c0, c1, c2, c3)
+    >>> v_M_tilde
+    FiberForceVelocityInverseDeGroote2016(fv_M, c0, c1, c2, c3)
+
+    To inspect the actual symbolic expression that this function represents,
+    we can call the ``doit`` method on an instance. We'll use the keyword
+    argument ``evaluate=False`` as this will keep the expression in its
+    canonical form and won't simplify any constants.
+
+    >>> v_M_tilde.doit(evaluate=False)
+    (-c2 + sinh((-c3 + fv_M)/c0))/c1
+
+    The function can also be differentiated. We'll differentiate with respect
+    to fv_M using the ``diff`` method on an instance with the single positional
+    argument ``fv_M``.
+
+    >>> v_M_tilde.diff(fv_M)
+    cosh((-c3 + fv_M)/c0)/(c0*c1)
+
     References
     ==========
 

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -1424,3 +1424,17 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
 
         """
         return FiberForceVelocityDeGroote2016
+
+    def _latex(self, printer):
+        """Print a LaTeX representation of the function defining the curve.
+
+        Parameters
+        ==========
+
+        printer : Printer
+            The printer to be used to print the LaTeX string representation.
+
+        """
+        fv_M = self.args[0]
+        _fv_M = printer._print(fv_M)
+        return r'\left( \operatorname{fv}^M \right)^{-1} \left( %s \right)' % _fv_M

--- a/sympy/physics/_biomechanics/curve.py
+++ b/sympy/physics/_biomechanics/curve.py
@@ -13,6 +13,7 @@ __all__ = [
     'FiberForceLengthPassiveDeGroote2016',
     'FiberForceLengthPassiveInverseDeGroote2016',
     'FiberForceVelocityDeGroote2016',
+    'FiberForceVelocityInverseDeGroote2016',
     'TendonForceLengthDeGroote2016',
     'TendonForceLengthInverseDeGroote2016',
 ]
@@ -1241,3 +1242,7 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
         v_M_tilde = self.args[0]
         _v_M_tilde = printer._print(v_M_tilde)
         return r'\operatorname{fv}^M \left( %s \right)' % _v_M_tilde
+
+
+class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
+    pass

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1570,3 +1570,98 @@ class TestFiberForceVelocityInverseDeGroote2016:
         fv_M = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
         expected = r'\frac{- c_{2} + \sinh{\left(\frac{- c_{3} + fv_{M}}{c_{0}} \right)}}{c_{1}}'
         assert LatexPrinter().doprint(fv_M.doit()) == expected
+
+    @pytest.mark.parametrize(
+        'code_printer, expected',
+        [
+            (
+                C89CodePrinter,
+                '(-0.12271444348999878*(0.374 - sinh(3.1446540880503142*(fv_M '
+                '- 0.88600000000000001))))',
+            ),
+            (
+                C99CodePrinter,
+                '(-0.12271444348999878*(0.374 - sinh(3.1446540880503142*(fv_M '
+                '- 0.88600000000000001))))',
+            ),
+            (
+                C11CodePrinter,
+                '(-0.12271444348999878*(0.374 - sinh(3.1446540880503142*(fv_M '
+                '- 0.88600000000000001))))',
+            ),
+            (
+                CXX98CodePrinter,
+                '(-0.12271444348999878*(0.374 - sinh(3.1446540880503142*(fv_M '
+                '- 0.88600000000000001))))',
+            ),
+            (
+                CXX11CodePrinter,
+                '(-0.12271444348999878*(0.374 - std::sinh(3.1446540880503142'
+                '*(fv_M - 0.88600000000000001))))',
+            ),
+            (
+                CXX17CodePrinter,
+                '(-0.12271444348999878*(0.374 - std::sinh(3.1446540880503142'
+                '*(fv_M - 0.88600000000000001))))',
+            ),
+            (
+                FCodePrinter,
+                '      (-0.122714443489999d0*(0.374d0 - sinh(3.1446540880503142d0*(fv_M -\n'
+                '     @ 0.886d0))))',
+            ),
+            (
+                OctaveCodePrinter,
+                '(-0.122714443489999*(0.374 - sinh(3.14465408805031*(fv_M '
+                '- 0.886))))',
+            ),
+            (
+                PythonCodePrinter,
+                '(-0.122714443489999*(0.374 - math.sinh(3.14465408805031*(fv_M '
+                '- 0.886))))',
+            ),
+            (
+                NumPyPrinter,
+                '(-0.122714443489999*(0.374 - numpy.sinh(3.14465408805031'
+                '*(fv_M - 0.886))))',
+            ),
+            (
+                SciPyPrinter,
+                '(-0.122714443489999*(0.374 - numpy.sinh(3.14465408805031'
+                '*(fv_M - 0.886))))',
+            ),
+            (
+                CuPyPrinter,
+                '(-0.122714443489999*(0.374 - cupy.sinh(3.14465408805031*(fv_M '
+                '- 0.886))))',
+            ),
+            (
+                JaxPrinter,
+                '(-0.122714443489999*(0.374 - jax.numpy.sinh(3.14465408805031'
+                '*(fv_M - 0.886))))',
+            ),
+            (
+                MpmathPrinter,
+                '(-mpmath.mpf((0, 8842507551592581, -56, 53))*(mpmath.mpf((0, '
+                '3368692521273131, -53, 52)) - mpmath.sinh(mpmath.mpf((0, '
+                '7081131489576251, -51, 53))*(fv_M + mpmath.mpf((1, '
+                '7980378539700519, -53, 53))))))',
+            ),
+            (
+                LambdaPrinter,
+                '(-0.122714443489999*(0.374 - math.sinh(3.14465408805031*(fv_M '
+                '- 0.886))))',
+            ),
+        ]
+    )
+    def test_print_code(self, code_printer, expected):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        assert code_printer().doprint(fv_M_inv) == expected
+
+    def test_derivative_print_code(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        dfv_M_inv_dfv_M = fv_M_inv.diff(self.fv_M)
+        expected = (
+            '0.385894476383644*math.cosh(3.14465408805031*fv_M '
+            '- 2.78616352201258)'
+        )
+        assert PythonCodePrinter().doprint(dfv_M_inv_dfv_M) == expected

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1348,6 +1348,10 @@ class TestFiberForceVelocityDeGroote2016:
         expected = Integer(1)
         assert fv_M.diff(self.c3) == expected
 
+    def test_inverse(self):
+        fv_M = FiberForceVelocityDeGroote2016(self.v_M_tilde, *self.constants)
+        assert fv_M.inverse() is FiberForceVelocityInverseDeGroote2016
+
     def test_function_print_latex(self):
         fv_M = FiberForceVelocityDeGroote2016(self.v_M_tilde, *self.constants)
         expected = r'\operatorname{fv}^M \left( v_{M tilde} \right)'
@@ -1552,3 +1556,7 @@ class TestFiberForceVelocityInverseDeGroote2016:
         fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
         expected = -cosh((self.fv_M - self.c3)/self.c0)/(self.c0*self.c1)
         assert fv_M_inv.diff(self.c3) == expected
+
+    def test_inverse(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        assert fv_M_inv.inverse() is FiberForceVelocityDeGroote2016

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1496,3 +1496,9 @@ class TestFiberForceVelocityInverseDeGroote2016:
         self.c2 = Symbol('c_2')
         self.c3 = Symbol('c_3')
         self.constants = (self.c0, self.c1, self.c2, self.c3)
+
+    @staticmethod
+    def test_class():
+        assert issubclass(FiberForceVelocityInverseDeGroote2016, Function)
+        assert issubclass(FiberForceVelocityInverseDeGroote2016, CharacteristicCurveFunction)
+        assert FiberForceVelocityInverseDeGroote2016.__name__ == 'FiberForceVelocityInverseDeGroote2016'

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1560,3 +1560,13 @@ class TestFiberForceVelocityInverseDeGroote2016:
     def test_inverse(self):
         fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
         assert fv_M_inv.inverse() is FiberForceVelocityDeGroote2016
+
+    def test_function_print_latex(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = r'\left( \operatorname{fv}^M \right)^{-1} \left( fv_{M} \right)'
+        assert LatexPrinter().doprint(fv_M_inv) == expected
+
+    def test_expression_print_latex(self):
+        fv_M = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = r'\frac{- c_{2} + \sinh{\left(\frac{- c_{3} + fv_{M}}{c_{0}} \right)}}{c_{1}}'
+        assert LatexPrinter().doprint(fv_M.doit()) == expected

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1516,3 +1516,14 @@ class TestFiberForceVelocityInverseDeGroote2016:
     def test_doit_evaluate_false(self):
         fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants).doit(evaluate=False)
         assert fv_M_inv == (sinh((self.fv_M - self.c3)/self.c0) - self.c2)/self.c1
+
+    def test_with_defaults(self):
+        constants = (
+            Float('-0.318'),
+            Float('-8.149'),
+            Float('-0.374'),
+            Float('0.886'),
+        )
+        fv_M_inv_manual = FiberForceVelocityInverseDeGroote2016(self.fv_M, *constants)
+        fv_M_inv_constants = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        assert fv_M_inv_manual == fv_M_inv_constants

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1502,3 +1502,8 @@ class TestFiberForceVelocityInverseDeGroote2016:
         assert issubclass(FiberForceVelocityInverseDeGroote2016, Function)
         assert issubclass(FiberForceVelocityInverseDeGroote2016, CharacteristicCurveFunction)
         assert FiberForceVelocityInverseDeGroote2016.__name__ == 'FiberForceVelocityInverseDeGroote2016'
+
+    def test_instance(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        assert isinstance(fv_M_inv, FiberForceVelocityInverseDeGroote2016)
+        assert str(fv_M_inv) == 'FiberForceVelocityInverseDeGroote2016(fv_M, c_0, c_1, c_2, c_3)'

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1519,7 +1519,7 @@ class TestFiberForceVelocityInverseDeGroote2016:
 
     def test_doit_evaluate_false(self):
         fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants).doit(evaluate=False)
-        assert fv_M_inv == (sinh((self.fv_M - self.c3)/self.c0) - self.c2)/self.c1
+        assert fv_M_inv == (sinh(UnevaluatedExpr(self.fv_M - self.c3)/self.c0) - self.c2)/self.c1
 
     def test_with_defaults(self):
         constants = (

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -8,6 +8,7 @@ from sympy.core.numbers import Float, Integer, Rational
 from sympy.core.symbol import Symbol, symbols
 from sympy.external.importtools import import_module
 from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.hyperbolic import sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.physics._biomechanics.curve import (
     CharacteristicCurveFunction,
@@ -1507,3 +1508,11 @@ class TestFiberForceVelocityInverseDeGroote2016:
         fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
         assert isinstance(fv_M_inv, FiberForceVelocityInverseDeGroote2016)
         assert str(fv_M_inv) == 'FiberForceVelocityInverseDeGroote2016(fv_M, c_0, c_1, c_2, c_3)'
+
+    def test_doit(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants).doit()
+        assert fv_M_inv == (sinh((self.fv_M - self.c3)/self.c0) - self.c2)/self.c1
+
+    def test_doit_evaluate_false(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants).doit(evaluate=False)
+        assert fv_M_inv == (sinh((self.fv_M - self.c3)/self.c0) - self.c2)/self.c1

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -15,6 +15,7 @@ from sympy.physics._biomechanics.curve import (
     FiberForceLengthPassiveDeGroote2016,
     FiberForceLengthPassiveInverseDeGroote2016,
     FiberForceVelocityDeGroote2016,
+    FiberForceVelocityInverseDeGroote2016,
     TendonForceLengthDeGroote2016,
     TendonForceLengthInverseDeGroote2016,
 )
@@ -1483,3 +1484,15 @@ class TestFiberForceVelocityDeGroote2016:
             1.5850003903,
         ])
         numpy.testing.assert_allclose(fv_M_callable(v_M_tilde), expected)
+
+
+class TestFiberForceVelocityInverseDeGroote2016:
+
+    @pytest.fixture(autouse=True)
+    def _tendon_force_length_inverse_arguments_fixture(self):
+        self.fv_M = Symbol('fv_M')
+        self.c0 = Symbol('c_0')
+        self.c1 = Symbol('c_1')
+        self.c2 = Symbol('c_2')
+        self.c3 = Symbol('c_3')
+        self.constants = (self.c0, self.c1, self.c2, self.c3)

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -8,7 +8,7 @@ from sympy.core.numbers import Float, Integer, Rational
 from sympy.core.symbol import Symbol, symbols
 from sympy.external.importtools import import_module
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.hyperbolic import sinh
+from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.physics._biomechanics.curve import (
     CharacteristicCurveFunction,
@@ -1527,3 +1527,28 @@ class TestFiberForceVelocityInverseDeGroote2016:
         fv_M_inv_manual = FiberForceVelocityInverseDeGroote2016(self.fv_M, *constants)
         fv_M_inv_constants = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
         assert fv_M_inv_manual == fv_M_inv_constants
+
+    def test_differentiate_wrt_fv_M(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = cosh((self.fv_M - self.c3)/self.c0)/(self.c0*self.c1)
+        assert fv_M_inv.diff(self.fv_M) == expected
+
+    def test_differentiate_wrt_c0(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = (self.c3 - self.fv_M)*cosh((self.fv_M - self.c3)/self.c0)/(self.c0**2*self.c1)
+        assert fv_M_inv.diff(self.c0) == expected
+
+    def test_differentiate_wrt_c1(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = (self.c2 - sinh((self.fv_M - self.c3)/self.c0))/self.c1**2
+        assert fv_M_inv.diff(self.c1) == expected
+
+    def test_differentiate_wrt_c2(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = -1/self.c1
+        assert fv_M_inv.diff(self.c2) == expected
+
+    def test_differentiate_wrt_c3(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016(self.fv_M, *self.constants)
+        expected = -cosh((self.fv_M - self.c3)/self.c0)/(self.c0*self.c1)
+        assert fv_M_inv.diff(self.c3) == expected

--- a/sympy/physics/_biomechanics/tests/test_curve.py
+++ b/sympy/physics/_biomechanics/tests/test_curve.py
@@ -1665,3 +1665,36 @@ class TestFiberForceVelocityInverseDeGroote2016:
             '- 2.78616352201258)'
         )
         assert PythonCodePrinter().doprint(dfv_M_inv_dfv_M) == expected
+
+    def test_lambdify(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        fv_M_inv_callable = lambdify(self.fv_M, fv_M_inv)
+        assert fv_M_inv_callable(1.0) == pytest.approx(-0.0009548832444487479)
+
+    @pytest.mark.skipif(numpy is None, reason='NumPy not installed')
+    def test_lambdify_numpy(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        fv_M_inv_callable = lambdify(self.fv_M, fv_M_inv, 'numpy')
+        fv_M = numpy.array([0.8, 0.9, 1.0, 1.1, 1.2])
+        expected = numpy.array([
+            -0.0794881459,
+            -0.0404909338,
+            -0.0009548832,
+            0.043061991,
+            0.0959484397,
+        ])
+        numpy.testing.assert_allclose(fv_M_inv_callable(fv_M), expected)
+
+    @pytest.mark.skipif(jax is None, reason='JAX not installed')
+    def test_lambdify_jax(self):
+        fv_M_inv = FiberForceVelocityInverseDeGroote2016.with_defaults(self.fv_M)
+        fv_M_inv_callable = jax.jit(lambdify(self.fv_M, fv_M_inv, 'jax'))
+        fv_M = jax.numpy.array([0.8, 0.9, 1.0, 1.1, 1.2])
+        expected = jax.numpy.array([
+            -0.0794881459,
+            -0.0404909338,
+            -0.0009548832,
+            0.043061991,
+            0.0959484397,
+        ])
+        numpy.testing.assert_allclose(fv_M_inv_callable(fv_M), expected)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Forms part of the CZI biomechanics work program described in https://github.com/sympy/sympy/issues/24240. Follows directly on from #25441, #25509, #25516, #25519, #25530, and #25539.
 
#### Brief description of what is fixed or changed

This PR adds the inverse muscle fibre force-velocity characteristic musculotendon curve based on the equations from De Groote et al. (2016).

I have not added any documentation beyond docstrings, nor have I added the docstrings to the online documentation yet. For the reasoning above this would likely need significant rewriting after any API changes. Documentation will be contributed in a future PR when the whole biomechanics module is moved to `sympy/physics/biomechanics`.

#### Other comments

I have specifically left the release notes entry empty. These will be added in the PR that moves the whole biomechanics module to `sympy/physics/biomechanics`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
