### PR TITLE
FIX: #25738 | Replaced set intersection (bitwise and) with set union (bitwise or)

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -222,6 +222,7 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     >>> reduce_rational_inequalities([[y + 2 > 0]], y)
     (-2 < y) & (y < oo)
     """
+
     exact = True
     eqs = []
     solution = S.Reals if exprs else S.EmptySet
@@ -261,7 +262,7 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
             if not (domain.is_ZZ or domain.is_QQ):
                 expr = numer/denom
                 expr = Relational(expr, 0, rel)
-                solution &= solve_univariate_inequality(expr, gen, relational=False)
+                solution |= solve_univariate_inequality(expr, gen, relational=False)
             else:
                 _eqs.append(((numer, denom), rel))
 
@@ -303,6 +304,7 @@ def reduce_abs_inequality(expr, rel, gen):
 
     reduce_abs_inequalities
     """
+
     if gen.is_extended_real is False:
          raise TypeError(filldedent('''
             Cannot solve inequalities with absolute values containing
@@ -375,6 +377,7 @@ def reduce_abs_inequalities(exprs, gen):
 
     reduce_abs_inequality
     """
+
     return And(*[ reduce_abs_inequality(expr, rel, gen)
         for expr, rel in exprs ])
 
@@ -882,13 +885,13 @@ def _solve_inequality(ie, s, linear=False):
 
 def _reduce_inequalities(inequalities, symbols):
     # helper for reduce_inequalities
-
     poly_part, abs_part = {}, {}
     other = []
 
     for inequality in inequalities:
 
         expr, rel = inequality.lhs, inequality.rel_op  # rhs is 0
+
 
         # check for gens using atoms which is more strict than free_symbols to
         # guard against EX domain which won't be handled by
@@ -918,6 +921,7 @@ def _reduce_inequalities(inequalities, symbols):
                 abs_part.setdefault(gen, []).append((expr, rel))
             else:
                 other.append(_solve_inequality(Relational(expr, 0, rel), gen))
+
 
     poly_reduced = [reduce_rational_inequalities([exprs], gen) for gen, exprs in poly_part.items()]
     abs_reduced = [reduce_abs_inequalities(exprs, gen) for gen, exprs in abs_part.items()]

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -892,7 +892,6 @@ def _reduce_inequalities(inequalities, symbols):
 
         expr, rel = inequality.lhs, inequality.rel_op  # rhs is 0
 
-
         # check for gens using atoms which is more strict than free_symbols to
         # guard against EX domain which won't be handled by
         # reduce_rational_inequalities
@@ -921,7 +920,6 @@ def _reduce_inequalities(inequalities, symbols):
                 abs_part.setdefault(gen, []).append((expr, rel))
             else:
                 other.append(_solve_inequality(Relational(expr, 0, rel), gen))
-
 
     poly_reduced = [reduce_rational_inequalities([exprs], gen) for gen, exprs in poly_part.items()]
     abs_reduced = [reduce_abs_inequalities(exprs, gen) for gen, exprs in abs_part.items()]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes: #25738


#### Brief description of what is fixed or changed
Simply changed the intersection (&) of solved univariate inequalities with the union (|) of solved univariate inequalities, so instead of returning an empty set, it gives the correct answer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * Fixed a bug related to Abs() while dealing with resolve_inequality.
<!-- END RELEASE NOTES -->
