### PR TITLE
Fast `_perfect_power` implemented

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -988,7 +988,7 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
         for b, e in facs.items():
             if verbose:
                 print(factor_msg % (b, e))
-            factors[b] = int(exp*e)
+            factors[b] = int(exp*e)  # int() can be removed when https://github.com/flintlib/python-flint/issues/92 is resolved
         raise StopIteration
 
     if isprime(n):

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -346,6 +346,160 @@ def multiplicity_in_factorial(p, n):
     return min((n + k - sum(digits(n, k)))//(k - 1)//v for v, k in f.items())
 
 
+def _perfect_power(n, k=2):
+    """ Return ``(b, e)`` such that ``n == b**e`` if ``n`` is a unique
+    perfect power with ``e > 1``, else ``False`` (e.g. 1 is not a perfect power).
+
+    Explanation
+    ===========
+
+    ``perfect_power`` exists, but this function is a low-function,
+    fast version for internal use.
+
+    Parameters
+    ==========
+
+    n : int
+        Positive integer
+    k : int
+        Assume that n has no factor less than k.
+        i.e., all(n % p for p in range(2, k)) is True
+
+    Examples
+    ========
+    >>> from sympy.ntheory.factor_ import _perfect_power
+    >>> _perfect_power(16)
+    (2, 4)
+    >>> _perfect_power(17)
+    False
+
+    """
+    if n <= 3:
+        return False
+
+    factors = {}
+    g = 0
+    multi = 1
+
+    def done(n, factors, g, multi):
+        g = gcd(g, multi)
+        if g == 1:
+            return False
+        factors[n] = multi
+        return math.prod(p**(e//g) for p, e in factors.items()), g
+
+    # If n is small, only trial factoring is faster
+    if n <= 1_000_000:
+        n, next_p = _factorint_small(factors, n, 1_000, 1_000)
+        if factors:
+            g = gcd(*factors.values())
+            if g == 1:
+                return False
+        if next_p:
+            k = max(k, next_p)
+        else:
+            if n > 1:
+                return False
+            return math.prod(p**(e//g) for p, e in factors.items()), g
+
+    # divide by 2
+    if k < 3:
+        g = bit_scan1(n)
+        if g:
+            if g == 1:
+                return False
+            n >>= g
+            factors[2] = g
+            if n == 1:
+                return 2, g
+            else:
+                # If `m**g`, then we have found perfect power.
+                # Otherwise, there is no possibility of perfect power, especially if `g` is prime.
+                m, _exact = iroot(n, g)
+                if _exact:
+                    return 2*m, g
+                elif isprime(g):
+                    return False
+        k = 3
+
+    # square number?
+    while n & 7 == 1: # n % 8 == 1:
+        m, _exact = iroot(n, 2)
+        if _exact:
+            n = m
+            multi <<= 1
+        else:
+            break
+    if n < k**3:
+        return done(n, factors, g, multi)
+
+    # trial factoring
+    # Since the maximum value an exponent can take is `log_k(n)`,
+    # the number of exponents to be checked can be reduced by performing a trial factoring.
+    # The value of `tf_max` needs more consideration.
+    tf_max = n.bit_length()//27 + 24
+    if k < tf_max:
+        for p in primerange(k, tf_max):
+            t = multiplicity(p, n)
+            if t:
+                n //= p**t
+                t *= multi
+                _g = gcd(g, t)
+                if _g == 1:
+                    return False
+                factors[p] = t
+                if n == 1:
+                    return math.prod(p**(e//_g)
+                                        for p, e in factors.items()), _g
+                elif g == 0 or _g < g: # If g is updated
+                    g = _g
+                    m, _exact = iroot(n, g)
+                    if _exact:
+                        return m**multi * math.prod(p**(e//g)
+                                    for p, e in factors.items()), g
+                    elif isprime(g):
+                        return False
+        k = tf_max
+    if n < k**3:
+        return done(n, factors, g, multi)
+
+    # check iroot
+    if g:
+        # If g is non-zero, the exponent is a divisor of g.
+        # 2 can be omitted since it has already been checked.
+        prime_iter = sorted(factorint(g >> bit_scan1(g)).keys())
+    else:
+        # The maximum possible value of the exponent is `log_k(n)`.
+        # To compensate for the presence of computational error, 2 is added.
+        prime_iter = primerange(3, int(math.log(n, k)) + 2)
+    logn = math.log2(n)
+    threshold = logn / 40 # Threshold for direct calculation
+    for p in prime_iter:
+        if threshold < p:
+            # If p is large, find the power root p directly without `iroot`.
+            while True:
+                b = pow(2, logn / p)
+                rb = int(b + 0.5)
+                if abs(rb - b) < 0.01 and rb**p == n:
+                    n = rb
+                    multi *= p
+                    logn = math.log2(n)
+                else:
+                    break
+        else:
+            while True:
+                m, _exact = iroot(n, p)
+                if _exact:
+                    n = m
+                    multi *= p
+                    logn = math.log2(n)
+                else:
+                    break
+        if n < k**(p + 2):
+            break
+    return done(n, factors, g, multi)
+
+
 def perfect_power(n, candidates=None, big=True, factor=True):
     """
     Return ``(b, e)`` such that ``n`` == ``b**e`` if ``n`` is a unique
@@ -439,6 +593,9 @@ def perfect_power(n, candidates=None, big=True, factor=True):
             if e % 2:
                 return -b, e
         return False
+
+    if candidates is None and big:
+        return _perfect_power(n)
 
     if n <= 3:
         # no unique exponent for 0, 1
@@ -824,7 +981,7 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
 
     # since we've already been factoring there is no need to do
     # simultaneous factoring with the power check
-    p = perfect_power(n, factor=False)
+    p = _perfect_power(n)
     if p is not False:
         base, exp = p
         if limitp1:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -359,7 +359,7 @@ def _perfect_power(n, k=2):
     ==========
 
     n : int
-        Positive integer
+        assume that n is a nonnegative integer
     k : int
         Assume that n has no factor less than k.
         i.e., all(n % p for p in range(2, k)) is True

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -353,8 +353,7 @@ def _perfect_power(n, k=2):
     Explanation
     ===========
 
-    ``perfect_power`` exists, but this function is a low-function,
-    fast version for internal use.
+    This is a low-level helper for ``perfect_power``, for internal use.
 
     Parameters
     ==========

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -347,7 +347,7 @@ def multiplicity_in_factorial(p, n):
 
 
 def _perfect_power(n, k=2):
-    """ Return ``(b, e)`` such that ``n == b**e`` if ``n`` is a unique
+    """ Return integers ``(b, e)`` such that ``n == b**e`` if ``n`` is a unique
     perfect power with ``e > 1``, else ``False`` (e.g. 1 is not a perfect power).
 
     Explanation

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -386,21 +386,17 @@ def _perfect_power(n, k=2):
         if g == 1:
             return False
         factors[n] = multi
-        return int(math.prod(p**(e//g) for p, e in factors.items())), int(g)
+        return math.prod(p**(e//g) for p, e in factors.items()), g
 
     # If n is small, only trial factoring is faster
     if n <= 1_000_000:
-        n, next_p = _factorint_small(factors, n, 1_000, 1_000)
-        if factors:
-            g = gcd(*factors.values())
-            if g == 1:
-                return False
-        if next_p:
-            k = max(k, next_p)
-        else:
-            if n > 1:
-                return False
-            return int(math.prod(p**(e//g) for p, e in factors.items())), int(g)
+        n = _factorint_small(factors, n, 1_000, 1_000)[0]
+        if n > 1:
+            return False
+        g = gcd(*factors.values())
+        if g == 1:
+            return False
+        return math.prod(p**(e//g) for p, e in factors.items()), g
 
     # divide by 2
     if k < 3:
@@ -411,13 +407,13 @@ def _perfect_power(n, k=2):
             n >>= g
             factors[2] = g
             if n == 1:
-                return 2, int(g)
+                return 2, g
             else:
                 # If `m**g`, then we have found perfect power.
                 # Otherwise, there is no possibility of perfect power, especially if `g` is prime.
                 m, _exact = iroot(n, g)
                 if _exact:
-                    return int(2*m), int(g)
+                    return 2*m, g
                 elif isprime(g):
                     return False
         k = 3
@@ -449,14 +445,14 @@ def _perfect_power(n, k=2):
                     return False
                 factors[p] = t
                 if n == 1:
-                    return int(math.prod(p**(e//_g)
-                                        for p, e in factors.items())), int(_g)
+                    return math.prod(p**(e//_g)
+                                        for p, e in factors.items()), _g
                 elif g == 0 or _g < g: # If g is updated
                     g = _g
-                    m, _exact = iroot(n, g)
+                    m, _exact = iroot(n**multi, g)
                     if _exact:
-                        return int(m**multi * math.prod(p**(e//g)
-                                    for p, e in factors.items())), int(g)
+                        return m * math.prod(p**(e//g)
+                                            for p, e in factors.items()), g
                     elif isprime(g):
                         return False
         k = tf_max
@@ -993,7 +989,7 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
         for b, e in facs.items():
             if verbose:
                 print(factor_msg % (b, e))
-            factors[b] = exp*e
+            factors[b] = int(exp*e)
         raise StopIteration
 
     if isprime(n):

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -449,14 +449,14 @@ def _perfect_power(n, k=2):
                     return False
                 factors[p] = t
                 if n == 1:
-                    return math.prod(p**(e//_g)
-                                        for p, e in factors.items()), _g
+                    return int(math.prod(p**(e//_g)
+                                        for p, e in factors.items())), int(_g)
                 elif g == 0 or _g < g: # If g is updated
                     g = _g
                     m, _exact = iroot(n, g)
                     if _exact:
-                        return m**multi * math.prod(p**(e//g)
-                                    for p, e in factors.items()), g
+                        return int(m**multi * math.prod(p**(e//g)
+                                    for p, e in factors.items())), int(g)
                     elif isprime(g):
                         return False
         k = tf_max

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -386,7 +386,7 @@ def _perfect_power(n, k=2):
         if g == 1:
             return False
         factors[n] = multi
-        return math.prod(p**(e//g) for p, e in factors.items()), g
+        return int(math.prod(p**(e//g) for p, e in factors.items())), int(g)
 
     # If n is small, only trial factoring is faster
     if n <= 1_000_000:
@@ -400,7 +400,7 @@ def _perfect_power(n, k=2):
         else:
             if n > 1:
                 return False
-            return math.prod(p**(e//g) for p, e in factors.items()), g
+            return int(math.prod(p**(e//g) for p, e in factors.items())), int(g)
 
     # divide by 2
     if k < 3:
@@ -411,13 +411,13 @@ def _perfect_power(n, k=2):
             n >>= g
             factors[2] = g
             if n == 1:
-                return 2, g
+                return 2, int(g)
             else:
                 # If `m**g`, then we have found perfect power.
                 # Otherwise, there is no possibility of perfect power, especially if `g` is prime.
                 m, _exact = iroot(n, g)
                 if _exact:
-                    return 2*m, g
+                    return int(2*m), int(g)
                 elif isprime(g):
                     return False
         k = 3

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -7,7 +7,7 @@ from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
 from .primetest import isprime
-from .factor_ import factorint, multiplicity, perfect_power
+from .factor_ import factorint, multiplicity, _perfect_power
 from .modular import crt
 from sympy.utilities.misc import as_int
 from sympy.utilities.iterables import iproduct
@@ -308,7 +308,7 @@ def primitive_root(p, smallest=True):
     if isprime(q):
         e = 1
     else:
-        m = perfect_power(q)
+        m = _perfect_power(q, 3)
         if not m:
             return None
         q, e = m
@@ -408,7 +408,7 @@ def is_primitive_root(a, p):
         group_order = q - 1
         factors = factorint(q - 1).keys()
     else:
-        m = perfect_power(q)
+        m = _perfect_power(q, 3)
         if not m:
             return False
         q, e = m

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -6,7 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial as fac
 from sympy.core.numbers import Integer, Rational
-from sympy.external.gmpy import gcd
+from sympy.external.gmpy import gcd, GROUND_TYPES, SYMPY_INTS
 
 from sympy.ntheory import (totient,
     factorint, primefactors, divisors, nextprime,
@@ -299,6 +299,18 @@ def test_factorint():
     n = {4: 2, 12: 3}
     assert str(factorint(n)) == sans
     assert str(factorint(Dict(n))) == sans
+
+
+def test_factorint_flint_int_issue():
+    """
+    Because of a bug in flint, we are temporarily wrapping int in `factorint`.
+    When this fails, the int wrapper is no longer needed in factorint.
+
+    https://github.com/flintlib/python-flint/issues/92
+    https://github.com/sympy/sympy/pull/25749
+    """
+    if GROUND_TYPES == 'flint':
+        assert pow(2, 5, SYMPY_INTS[1](1000)) == 1
 
 
 def test_divisors_and_divisor_count():

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -16,7 +16,7 @@ from sympy.ntheory.factor_ import (smoothness, smoothness_p, proper_divisors,
     antidivisors, antidivisor_count, core, udivisors, udivisor_sigma,
     udivisor_count, proper_divisor_count, primenu, primeomega,
     mersenne_prime_exponent, is_perfect, is_mersenne_prime, is_abundant,
-    is_deficient, is_amicable, dra, drm)
+    is_deficient, is_amicable, dra, drm, _perfect_power)
 
 from sympy.testing.pytest import raises, slow
 
@@ -94,6 +94,25 @@ def test_multiplicity_in_factorial():
     n = fac(1000)
     for i in (2, 4, 6, 12, 30, 36, 48, 60, 72, 96):
         assert multiplicity(i, n) == multiplicity_in_factorial(i, 1000)
+
+
+def test_private_perfect_power():
+    assert _perfect_power(0) is False
+    assert _perfect_power(1) is False
+    assert _perfect_power(2) is False
+    assert _perfect_power(3) is False
+    for x in [2, 3, 5, 6, 7, 12, 15, 105, 100003]:
+        for y in range(2, 100):
+            assert _perfect_power(x**y) == (x, y)
+            if x != 2:
+                assert _perfect_power(x**y, k=3) == (x, y)
+            if x == 100003:
+                assert _perfect_power(x**y, k=100003) == (x, y)
+            assert _perfect_power(11*x**y) == False
+            # Catalan's conjecture
+            if x**y not in [8, 9]:
+                assert _perfect_power(x**y + 1) == False
+                assert _perfect_power(x**y - 1) == False
 
 
 def test_perfect_power():

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -6,6 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial as fac
 from sympy.core.numbers import Integer, Rational
+from sympy.external.gmpy import gcd
 
 from sympy.ntheory import (totient,
     factorint, primefactors, divisors, nextprime,
@@ -108,11 +109,18 @@ def test_private_perfect_power():
                 assert _perfect_power(x**y, k=3) == (x, y)
             if x == 100003:
                 assert _perfect_power(x**y, k=100003) == (x, y)
-            assert _perfect_power(11*x**y) == False
+            assert _perfect_power(101*x**y) == False
             # Catalan's conjecture
             if x**y not in [8, 9]:
                 assert _perfect_power(x**y + 1) == False
                 assert _perfect_power(x**y - 1) == False
+    for x in range(1, 10):
+        for y in range(1, 10):
+            g = gcd(x, y)
+            if g == 1:
+                assert _perfect_power(5**x * 101**y) == False
+            else:
+                assert _perfect_power(5**x * 101**y) == (5**(x//g) * 101**(y//g), g)
 
 
 def test_perfect_power():


### PR DESCRIPTION
`perfect_power` is slow(see #25138). So we implemented `_perfect_power` which has less functionality. The arguments `candidates`, `big`, and `factor` of `perfect_power` are absent. This speeds up the calculation of perfect power. Use `_perfect_power` when `candidates is None and big is True`. Otherwise, the previous logic is used.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25138
#25342

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
