### PR TITLE
quick exit for expand_log(log(a*b**e)/log(b))

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2884,8 +2884,21 @@ def expand_log(expr, deep=True, force=False, factor=False):
 
     """
     from sympy.functions.elementary.exponential import log
+    from sympy.simplify.radsimp import fraction
     if factor is False:
-        def _handle(x):
+        def _handleMul(x):
+            # look for the simple case of expanded log(b**a)/log(b) -> a in args
+            n, d = fraction(x)
+            n = [i for i in n.atoms(log) if i.args[0].is_Integer]
+            d = [i for i in d.atoms(log) if i.args[0].is_Integer]
+            if len(n) == 1 and len(d) == 1:
+                n = n[0]
+                d = d[0]
+                from sympy import multiplicity
+                m = multiplicity(d.args[0], n.args[0])
+                if m:
+                    r = m + log(n.args[0]//d.args[0]**m)/d
+                    x = x.subs(n, d*r)
             x1 = expand_mul(expand_log(x, deep=deep, force=force, factor=True))
             if x1.count(log) <= x.count(log):
                 return x1
@@ -2894,7 +2907,7 @@ def expand_log(expr, deep=True, force=False, factor=False):
         expr = expr.replace(
         lambda x: x.is_Mul and all(any(isinstance(i, log) and i.args[0].is_Rational
         for i in Mul.make_args(j)) for j in x.as_numer_denom()),
-        _handle)
+        _handleMul)
 
     return sympify(expr).expand(deep=deep, log=True, mul=False,
         power_exp=False, power_base=False, multinomial=False,

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -4,12 +4,14 @@ from sympy.core.numbers import (I, Rational as R, pi)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
+from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.series.order import O
 from sympy.simplify.radsimp import expand_numer
-from sympy.core.function import expand, expand_multinomial, expand_power_base
+from sympy.core.function import (expand, expand_multinomial,
+    expand_power_base, expand_log)
 
 from sympy.testing.pytest import raises
 from sympy.core.random import verify_numerically
@@ -322,6 +324,10 @@ def test_expand_log():
     t = Symbol('t', positive=True)
     # after first expansion, -2*log(2) + log(4); then 0 after second
     assert expand(log(t**2) - log(t**2/4) - 2*log(2)) == 0
+    assert expand_log(log(7*6)/log(6)) == 1 + log(7)/log(6)
+    b = factorial(10)
+    assert expand_log(log(7*b**4)/log(b)
+        ) == 4 + log(7)/log(b)
 
 
 def test_issue_23952():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

master:
```python
>>> expand_log(log(2*10)/log(10))
log(20)/log(10)
>>> _.expand(log=True)
log(20)/log(10)
>>> expand(_, factor=True)
2*log(2)/(log(2) + log(5)) + log(5)/(log(2) + log(5))
```
now
```python
>>> (log(2*10)/log(10)).expand(log=True)
log(20)/log(10)
>>> expand_log(log(2*10)/log(10))
1 + log(2)/log(10)
```
#### Other comments
While factoring a single logs argument might be avoided because of the size of a number, when there is a ratio of logs, the lower arg gives a hint of what to check for in the upper. This would be easier to detect if log(a,b) did not auto evaluate to log(a)/log(b).

I don't really like that `expand(..., log=True)` does nothing. Maybe the action of this PR should be done if factor is false but log is true.

I would prefer to have `log(x, i)` remain unevaluated instead of rewriting to `log(x)/log(i)`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `expand_log` now detects the ratio `log(a)/log(b)` and will simplify if `a == c*b**m`
<!-- END RELEASE NOTES -->
