### PR TITLE
Fix some warnings in the optional dependency tests

### DIFF
--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -147,7 +147,7 @@ class AesaraPrinter(Printer):
         if key in self.cache:
             return self.cache[key]
 
-        value = aet.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
+        value = aet.tensor(name=name, dtype=dtype, shape=broadcastable)
         self.cache[key] = value
         return value
 

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -24,7 +24,7 @@ aesaralogger.setLevel(logging.WARNING)
 if aesara:
     import numpy as np
     aet = aesara.tensor
-    from aesara.scalar.basic import Scalar
+    from aesara.scalar.basic import ScalarType
     from aesara.graph.basic import Variable
     from aesara.tensor.var import TensorVariable
     from aesara.tensor.elemwise import Elemwise, DimShuffle
@@ -95,7 +95,7 @@ def aesara_simplify(fgraph):
     """
     mode = aesara.compile.get_default_mode().excluding("fusion")
     fgraph = fgraph.clone()
-    mode.optimizer.optimize(fgraph)
+    mode.optimizer.rewrite(fgraph)
     return fgraph
 
 
@@ -421,7 +421,7 @@ def test_MatrixSlice():
     Y = X[1:2:3, 4:5:6]
     Yt = aesara_code_(Y, cache=cache)
 
-    s = Scalar('int64')
+    s = ScalarType('int64')
     assert tuple(Yt.owner.op.idx_list) == (slice(s, s, s), slice(s, s, s))
     assert Yt.owner.inputs[0] == aesara_code_(X, cache=cache)
     # == doesn't work in Aesara like it does in SymPy. You have to use

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -534,8 +534,8 @@ def test_python_div_zero_issue_11306():
     p = Piecewise((1 / x, y < -1), (x, y < 1), (1 / x, True))
     f = lambdify([x, y], p, modules='numpy')
     numpy.seterr(divide='ignore')
-    assert float(f(numpy.array([0]),numpy.array([0.5]))) == 0
-    assert str(float(f(numpy.array([0]),numpy.array([1])))) == 'inf'
+    assert float(f(numpy.array([0]).squeeze(), numpy.array([0.5]).squeeze())) == 0
+    assert str(float(f(numpy.array([0]).squeeze(), numpy.array([1]).squeeze()))) == 'inf'
     numpy.seterr(divide='warn')
 
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1412,7 +1412,7 @@ def test_issue_20070():
         skip("numba not installed")
 
     f = lambdify(x, sin(x), 'numpy')
-    assert numba.jit(f)(1)==0.8414709848078965
+    assert numba.jit(f, nopython=True)(1)==0.8414709848078965
 
 
 def test_fresnel_integrals_scipy():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -533,10 +533,9 @@ def test_python_div_zero_issue_11306():
         skip("numpy not installed.")
     p = Piecewise((1 / x, y < -1), (x, y < 1), (1 / x, True))
     f = lambdify([x, y], p, modules='numpy')
-    numpy.seterr(divide='ignore')
-    assert float(f(numpy.array([0]).squeeze(), numpy.array([0.5]).squeeze())) == 0
-    assert str(float(f(numpy.array([0]).squeeze(), numpy.array([1]).squeeze()))) == 'inf'
-    numpy.seterr(divide='warn')
+    with numpy.errstate(divide='ignore'):
+        assert float(f(numpy.array(0), numpy.array(0.5))) == 0
+        assert float(f(numpy.array(0), numpy.array(1))) == float('inf')
 
 
 def test_issue9474():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I noticed that there are some warnings emitted when the optional dependency tests are run. This PR fixes as many of those warnings as possible.

In particular, I addressed a warning emitted by Numba (which was being emitted due to their `.jit()` function's behavior changing slightly), and a couple of warnings emitted by the `aesara` testing code.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
