### PR TITLE
correct handling of imaginary parts in `solve_univariate_inequality`

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -800,10 +800,10 @@ def test_simplify_relational():
     assert Lt(x, 2).simplify() == Lt(x, 2)
     assert Lt(-x, 2).simplify() == Gt(x, -2)
 
-    # Test particulat branches of _eval_simplify
+    # Test particular branches of _eval_simplify
     m = exp(1) - exp_polar(1)
     assert simplify(m*x > 1) is S.false
-    # These two tests the same branch
+    # These two test the same branch
     assert simplify(m*x + 2*m*y > 1) is S.false
     assert simplify(m*x + y > 1 + y) is S.false
 

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -10,7 +10,7 @@ from sympy.core.symbol import Symbol, Dummy
 from sympy.sets.sets import Interval, FiniteSet, Union, Intersection
 from sympy.core.singleton import S
 from sympy.core.function import expand_mul
-from sympy.functions.elementary.complexes import im, Abs
+from sympy.functions.elementary.complexes import Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
@@ -592,11 +592,11 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             # If expr contains imaginary coefficients, only take real
             # values of x for which the imaginary part is 0
             make_real = S.Reals
-            if im(expanded_e) != S.Zero:
+            if (coeffI := expanded_e.coeff(S.ImaginaryUnit)) != S.Zero:
                 check = True
                 im_sol = FiniteSet()
                 try:
-                    a = solveset(im(expanded_e), gen, domain)
+                    a = solveset(coeffI, gen, domain)
                     if not isinstance(a, Interval):
                         for z in a:
                             if z not in singularities and valid(z) and z.is_extended_real:
@@ -665,7 +665,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             if valid(_pt(start, end)):
                 sol_sets.append(Interval.open(start, end))
 
-            if im(expanded_e) != S.Zero and check:
+            if coeffI != S.Zero and check:
                 rv = (make_real).intersect(_domain)
             else:
                 rv = Intersection(

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3144,7 +3144,7 @@ def _invert(eq, *symbols, **kwargs):
 
     >>> invert(sqrt(x + y) - 2)
     (4, x + y)
-    >>> invert(sqrt(x + y) - 2)
+    >>> invert(sqrt(x + y) + 2)  # note +2 instead of -2
     (4, x + y)
 
     If the exponent is an Integer, setting ``integer_power`` to True

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -485,3 +485,7 @@ def test__pt():
     assert _pt(x, oo) == _pt(oo, x) == x + 1
     assert _pt(x, -oo) == _pt(-oo, x) == x - 1
     raises(ValueError, lambda: _pt(Dummy('i', infinite=True), S.One))
+
+
+def test_issue_25697():
+    assert _solve_inequality(log(x, 3) <= 2, x) == (x <= 9) & (S.Zero < x)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -950,11 +950,12 @@ def test_M8():
 @XFAIL
 def test_M9():
     # x = symbols('x')
+    # solutions are 1/2*(1 +/- sqrt(9 + 8*I*pi*n)) for integer n
     raise NotImplementedError("solveset(exp(2-x**2)-exp(-x),x) has complex solutions.")
 
 
 def test_M10():
-    # TODO: Replace solve with solveset, as of now test fails for solveset
+    # TODO: Replace solve with solveset when it gives Lambert solution
     assert solve(exp(x) - x, x) == [-LambertW(-1)]
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #25697 

#### Brief description of what is fixed or changed

Some typos were fixed and the handling of expressions with imaginary components was improved.

Because `im`, rather than a literal coefficient of `I` was being used -- and tests are written with `I` -- the `im`-handling branch was capturing expressions that it was not intended to handle. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve_univariate_inequality` is less likely to get hung up on expressions because of inability to verify a solution
<!-- END RELEASE NOTES -->
