### PR TITLE
test: remove warnings when running test_pickling

### DIFF
--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -4,7 +4,7 @@ import pickle
 
 from sympy.physics.units import meter
 
-from sympy.testing.pytest import XFAIL, raises
+from sympy.testing.pytest import XFAIL, raises, ignore_warnings
 
 from sympy.core.basic import Atom, Basic
 from sympy.core.singleton import SingletonRegistry
@@ -30,17 +30,20 @@ from sympy.core.symbol import symbols
 from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
-excluded_attrs = {
+
+not_equal_attrs = {
     '_assumptions',  # This is a local cache that isn't automatically filled on creation
     '_mhash',   # Cached after __hash__ is called but set to None after creation
+}
+
+
+deprecated_attrs = {
     'is_EmptySet',  # Deprecated from SymPy 1.5. This can be removed when is_EmptySet is removed.
     'expr_free_symbols',  # Deprecated from SymPy 1.9. This can be removed when exr_free_symbols is removed.
-    '_mat', # Deprecated from SymPy 1.9. This can be removed when Matrix._mat is removed
-    '_smat', # Deprecated from SymPy 1.9. This can be removed when SparseMatrix._smat is removed
-    }
+}
 
 
-def check(a, exclude=[], check_attr=True):
+def check(a, exclude=[], check_attr=True, deprecated=()):
     """ Check that pickling and copying round-trips.
     """
     # Pickling with protocols 0 and 1 is disabled for Basic instances:
@@ -75,14 +78,19 @@ def check(a, exclude=[], check_attr=True):
 
         def c(a, b, d):
             for i in d:
-                if i in excluded_attrs:
+                if i in not_equal_attrs:
+                    if hasattr(a, i):
+                        assert hasattr(b, i), i
+                elif i in deprecated_attrs or i in deprecated:
+                    with ignore_warnings(SymPyDeprecationWarning):
+                        assert getattr(a, i) == getattr(b, i), i
+                elif not hasattr(a, i):
                     continue
-                if not hasattr(a, i):
-                    continue
-                attr = getattr(a, i)
-                if not hasattr(attr, "__call__"):
-                    assert hasattr(b, i), i
-                    assert getattr(b, i) == attr, "%s != %s, protocol: %s" % (getattr(b, i), attr, protocol)
+                else:
+                    attr = getattr(a, i)
+                    if not hasattr(attr, "__call__"):
+                        assert hasattr(b, i), i
+                        assert getattr(b, i) == attr, "%s != %s, protocol: %s" % (getattr(b, i), attr, protocol)
 
         c(a, b, d1)
         c(b, a, d2)
@@ -275,7 +283,7 @@ from sympy.matrices import Matrix, SparseMatrix
 
 def test_matrices():
     for c in (Matrix, Matrix([1, 2, 3]), SparseMatrix, SparseMatrix([[1, 2], [3, 4]])):
-        check(c)
+        check(c, deprecated=['_smat', '_mat'])
 
 #================== ntheory =====================
 from sympy.ntheory.generate import Sieve
@@ -373,7 +381,7 @@ def test_pickling_polys_polyclasses():
     from sympy.polys.polyclasses import DMP, DMF, ANP
 
     for c in (DMP, DMP([[ZZ(1)], [ZZ(2)], [ZZ(3)]], ZZ)):
-        check(c)
+        check(c, deprecated=['rep'])
     for c in (DMF, DMF(([ZZ(1), ZZ(2)], [ZZ(1), ZZ(3)]), ZZ)):
         check(c)
     for c in (ANP, ANP([QQ(1), QQ(2)], [QQ(1), QQ(2), QQ(3)], QQ)):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Remove some warnings from test_pickling after gh-25722 was merged
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
