### PR TITLE
fix: remove deprecated string fallback in sympify

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1182,6 +1182,12 @@ See also {ref}`deprecated-poly-nonpoly-binary-operations` above.
 (deprecated-sympify-string-fallback)=
 ### The string fallback in `sympify()`
 
+UPDATE: The string fallback in `sympify` was deprecated in SymPy 1.6 and is now
+an error in SymPy 1.13 and later. Keeping this behaviour around even in
+deprecated form was too problematic so it is now removed entirely. In the cases
+where the string fallback would have been used a `SympifyError` will now be
+raised instead.
+
 The current behavior of {func}`~.sympify` is that `sympify(expr)` tries
 various methods to try to convert `expr` into a SymPy objects. If all these
 methods fail, it takes `str(expr)` and tries to parse it using

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,60 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
+(deprecated-sympify-string-fallback)=
+### The string fallback in `sympify()`
+
+The `sympify` function would previously convert an unrecognized object to a
+string and retry sympification. This was deprecated in SymPy 1.6 and was
+removed in SymPy 1.13.
+
+The behavior of {func}`~.sympify` is that `sympify(expr)` tries various methods
+to try to convert `expr` into a SymPy objects. Previously if all these methods
+would fail, it would take `str(expr)` and try to parse it using
+{func}`~.parse_expr`. This string fallback feature was deprecated in SymPy 1.6
+and was removed in SymPy 1.13.
+
+This behaviour was problematic for a few reasons:
+
+- It could affect performance in major ways. See for instance issues
+  [#18056](https://github.com/sympy/sympy/issues/18056) and
+  [#15416](https://github.com/sympy/sympy/issues/15416) where it caused up to
+  100x slowdowns. The issue is that SymPy functions automatically call
+  `sympify` on their arguments. Whenever a function is passed something that
+  `sympify` doesn't know how to convert to a SymPy object, for instance, a
+  Python function type, it passes the string to {func}`~.parse_expr`. This is
+  significantly slower than the direct conversions that happen by default.
+  This occurs specifically whenever `sympify()` is used in library code
+  instead of `_sympify()` (or equivalently `sympify(strict=True)`), but
+  presently this is done a lot. Using `strict=True` will at some point be the
+  default for all library code, but this is a [harder change to
+  make](https://github.com/sympy/sympy/issues/11003).
+
+- It can cause security issues, since strings are evaled, and objects can
+  return whatever string they want in their `__repr__`. See also
+  https://github.com/sympy/sympy/pull/12524.
+
+- It really wasn't very useful to begin with. Just because an object's string
+  form can be parsed into a SymPy expression doesn't mean it should be parsed
+  that way. This is usually correct for custom numeric types, but an object's
+  repr could be anything. For instance, if the string form of an object looks
+  like a valid Python identifier, it would parse as a `Symbol`.
+
+There are plenty of ways to make custom objects work inside of
+{func}`~.sympify`.
+
+- Firstly, if an object is intended to work alongside other SymPy expressions,
+  it should subclass from {class}`~.Basic` (or {class}`~.Expr`). If it does,
+  {func}`~.sympify` will just return it unchanged because it will already be a
+  valid SymPy object.
+
+- For objects that you control, you can add the `_sympy_` method. The [sympify
+  docstring](sympy.core.sympify.sympify) has an example of this.
+
+- For objects that you don't control, you can add a custom converter to the
+  `sympy.core.sympify.converter` dictionary. The {func}`~.sympify` docstring
+  also has an example of this.
+
 (dmp-rep)=
 ### Deprecate the DMP.rep attribute.
 
@@ -1178,65 +1232,6 @@ integral as an {class}`~.Expr` object, call the {meth}`.Poly.as_expr` method
 first.
 
 See also {ref}`deprecated-poly-nonpoly-binary-operations` above.
-
-(deprecated-sympify-string-fallback)=
-### The string fallback in `sympify()`
-
-UPDATE: The string fallback in `sympify` was deprecated in SymPy 1.6 and is now
-an error in SymPy 1.13 and later. Keeping this behaviour around even in
-deprecated form was too problematic so it is now removed entirely. In the cases
-where the string fallback would have been used a `SympifyError` will now be
-raised instead.
-
-The current behavior of {func}`~.sympify` is that `sympify(expr)` tries
-various methods to try to convert `expr` into a SymPy objects. If all these
-methods fail, it takes `str(expr)` and tries to parse it using
-{func}`~.parse_expr`. This string fallback feature is deprecated. It is
-problematic for a few reasons:
-
-- It can affect performance in major ways. See for instance issues
-  [#18056](https://github.com/sympy/sympy/issues/18056) and
-  [#15416](https://github.com/sympy/sympy/issues/15416) where it caused up to
-  100x slowdowns. The issue is that SymPy functions automatically call
-  `sympify` on their arguments. Whenever a function is passed something that
-  `sympify` doesn't know how to convert to a SymPy object, for instance, a
-  Python function type, it passes the string to {func}`~.parse_expr`. This is
-  significantly slower than the direct conversions that happen by default.
-  This occurs specifically whenever `sympify()` is used in library code
-  instead of `_sympify()` (or equivalently `sympify(strict=True)`), but
-  presently this is done a lot. Using `strict=True` will at some point be the
-  default for all library code, but this is a [harder change to
-  make](https://github.com/sympy/sympy/issues/11003).
-
-- It can cause security issues, since strings are evaled, and objects can
-  return whatever string they want in their `__repr__`. See also
-  https://github.com/sympy/sympy/pull/12524.
-
-- It really isn't very useful to begin with. Just because an object's string
-  form can be parsed into a SymPy expression doesn't mean it should be parsed
-  that way. This is usually correct for custom numeric types, but an object's
-  repr could be anything. For instance, if the string form of an object looks
-  like a valid Python identifier, it will parse as a `Symbol`.
-
-There are plenty of ways to make custom objects work inside of
-{func}`~.sympify`.
-
-- Firstly, if an object is intended to work alongside other SymPy expressions,
-  it should subclass from {class}`~.Basic` (or {class}`~.Expr`). If it does,
-  {func}`~.sympify` will just return it unchanged because it will already be a
-  valid SymPy object.
-
-- For objects that you control, you can add the `_sympy_` method. The [sympify
-  docstring](sympy.core.sympify.sympify) has an example of this.
-
-- For objects that you don't control, you can add a custom converter to the
-  `sympy.core.sympify.converter` dictionary. The {func}`~.sympify` docstring
-  also has an example of this.
-
-To silence this deprecation warning in all cases, you can pass `strict=True`
-to `sympify()`. However, note that this will also disable some other
-conversions such as conversion of strings (for converting strings to SymPy
-types, you can explicitly use {func}`~.parse_expr`).
 
 (deprecated-indefinite-integral-eq)=
 ### Creating an indefinite `Integral` with an `Eq` argument

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -457,26 +457,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             pass
 
     if not isinstance(a, str):
-        try:
-            a = str(a)
-        except Exception as exc:
-            raise SympifyError(a, exc)
-        sympy_deprecation_warning(
-            f"""
-The string fallback in sympify() is deprecated.
-
-To explicitly convert the string form of an object, use
-sympify(str(obj)). To add define sympify behavior on custom
-objects, use sympy.core.sympify.converter or define obj._sympy_
-(see the sympify() docstring).
-
-sympify() performed the string fallback resulting in the following string:
-
-{a!r}
-            """,
-            deprecated_since_version='1.6',
-            active_deprecations_target="deprecated-sympify-string-fallback",
-        )
+        raise SympifyError('cannot sympify object of type %r' % type(a))
 
     from sympy.parsing.sympy_parser import (parse_expr, TokenError,
                                             standard_transformations)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -9,7 +9,6 @@ from sympy.core.random import choice
 
 from .parameters import global_parameters
 
-from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
 
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -286,8 +286,7 @@ def test_sympify_raises():
         def __str__(self):
             return 'x'
 
-    with warns_deprecated_sympy():
-        assert sympify(A()) == Symbol('x')
+    raises(SympifyError, lambda: sympify(A()))
 
 
 def test__sympify():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -22,7 +22,7 @@ from sympy.core.sympify import (sympify, _sympify, SympifyError, kernS,
     CantSympify, converter)
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
-from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
+from sympy.testing.pytest import raises, XFAIL, skip
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -3,7 +3,7 @@ from sympy.core.sympify import SympifyError
 from sympy.functions import KroneckerDelta
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import FunctionMatrix, MatrixExpr, Identity
-from sympy.testing.pytest import raises, warns
+from sympy.testing.pytest import raises
 
 
 def test_funcmatrix_creation():

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -1,4 +1,5 @@
 from sympy.core import symbols, Lambda
+from sympy.core.sympify import SympifyError
 from sympy.functions import KroneckerDelta
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import FunctionMatrix, MatrixExpr, Identity
@@ -19,9 +20,7 @@ def test_funcmatrix_creation():
     raises(ValueError, lambda: FunctionMatrix(0, 2j, Lambda((i, j), 0)))
 
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda(i, 0)))
-    with warns(SymPyDeprecationWarning, test_stacklevel=False):
-        # This raises a deprecation warning from sympify()
-        raises(ValueError, lambda: FunctionMatrix(2, 2, lambda i, j: 0))
+    raises(SympifyError, lambda: FunctionMatrix(2, 2, lambda i, j: 0))
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda((i,), 0)))
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda((i, j, k), 0)))
     raises(ValueError, lambda: FunctionMatrix(2, 2, i+j))

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -4,7 +4,6 @@ from sympy.functions import KroneckerDelta
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import FunctionMatrix, MatrixExpr, Identity
 from sympy.testing.pytest import raises, warns
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 def test_funcmatrix_creation():

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -75,7 +75,5 @@ def test_arraycomprehensionmap():
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
     assert ArrayComprehensionMap(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
     raises(ValueError, lambda: ArrayComprehensionMap(i*j, (i, 1, 3), (j, 2, 4)))
-    # The use of a function here triggers a deprecation warning from sympify()
-    with warns(SymPyDeprecationWarning, test_stacklevel=False):
-        a = ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5))
-        raises(ValueError, lambda: a.doit())
+    a = ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5))
+    raises(ValueError, lambda: a.doit())

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -1,8 +1,7 @@
 from sympy.tensor.array.array_comprehension import ArrayComprehension, ArrayComprehensionMap
 from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.abc import i, j, k, l
-from sympy.testing.pytest import raises, warns
-from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.testing.pytest import raises
 from sympy.matrices import Matrix
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Remove the string fallback that was deprecated in gh-19006 (SymPy 1.6).

#### Brief description of what is fixed or changed

The string fallback has been deprecated for some time but this PR removes it so that in the case that the string fallback would have been used a SympifyError is raised instead.

Currently on master we have:
```
>>> from sympy import sympify
>>> sympify(open)
<stdin>:1: SymPyDeprecationWarning: 

The string fallback in sympify() is deprecated.

To explicitly convert the string form of an object, use
sympify(str(obj)). To add define sympify behavior on custom
objects, use sympy.core.sympify.converter or define obj._sympy_
(see the sympify() docstring).

sympify() performed the string fallback resulting in the following string:

'<built-in function open>'

See https://docs.sympy.org/latest/explanation/active-deprecations.html#deprecated-sympify-string-fallback
for details.

This has been deprecated since SymPy version 1.6. It
will be removed in a future version of SymPy.

ValueError: Error from parse_expr with transformed code: "<Symbol ('built' )-in Symbol ('function' )open >"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/oscar/current/active/sympy/sympy/core/sympify.py", line 495, in sympify
    expr = parse_expr(a, local_dict=locals, transformations=transformations, evaluate=evaluate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oscar/current/active/sympy/sympy/parsing/sympy_parser.py", line 1090, in parse_expr
    raise e from ValueError(f"Error from parse_expr with transformed code: {code!r}")
  File "/home/oscar/current/active/sympy/sympy/parsing/sympy_parser.py", line 1081, in parse_expr
    rv = eval_expr(code, local_dict, global_dict)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oscar/current/active/sympy/sympy/parsing/sympy_parser.py", line 909, in eval_expr
    expr = eval(
           ^^^^^
  File "<string>", line 1
    <Symbol ('built' )-in Symbol ('function' )open >
    ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oscar/current/active/sympy/sympy/core/sympify.py", line 497, in sympify
    raise SympifyError('could not parse %r' % a, exc)
sympy.core.sympify.SympifyError: Sympify of expression 'could not parse '<built-in function open>'' failed, because of exception being raised:
SyntaxError: invalid syntax (<string>, line 1)
```
With this PR we have:
```
>>> from sympy import sympify
>>> sympify(open)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oscar/current/active/sympy/sympy/core/sympify.py", line 460, in sympify
    raise SympifyError('cannot sympify object of type %r' % type(a))
sympy.core.sympify.SympifyError: SympifyError: "cannot sympify object of type <class 'builtin_function_or_method'>"
```
There are other situations where parsing the string succeeds and just leads to most-likely incorrect behaviour further along albeit with a warning. With the change here those would all just be an error.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * BREAKING CHANGE: The `sympify` function previously would fall back to converting an object to a string with `str(obj)` and then parsing that string with `parse_expr`. This behaviour was already deprecated and had been giving a SymPyDeprecationWarning since SymPy 1.6. As of SymPy 1.13 this string parsing fallback is now removed and in the situations where it might have previously been used SympifyError will be raised instead. Keeping this behaviour even in deprecated form is problematic because it leads to warnings in situations that should just give TypeError so the behaviour is now fully removed.
<!-- END RELEASE NOTES -->