### PR TITLE
ask inequality handling: Check for predicates implying real

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -432,16 +432,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
       ...
     ValueError: inconsistent assumptions Q.even(x) & Q.odd(x)
 
-    Notes
-    =====
-
-    Relations in assumptions are not implemented (yet), so the following
-    will not give a meaningful result.
-
-    >>> ask(Q.positive(x), x > 0)
-
-    It is however a work in progress.
-
     See Also
     ========
 


### PR DESCRIPTION
Previously ask could only handle inequalities that were specified to be real using the old assumptions. Now inequalities can be specified to be real using predicates as well.

Example:

```python
In [1]: from sympy import ask, Q

In [2]: from sympy.abc import x

In [3]: ask(Q.gt(x, 0), Q.gt(x, 1))  # used to return None

Out[3]: True

In [5]: ask(Q.gt(x, 0), ~Q.le(x, 1) & Q.real(x)) # used to return None

Out[5]: True

In [6]: ask(Q.gt(x, 0), ~Q.le(x, 1)) # continues to return None
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25750


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions 
  * Make `ask` handle inequalities when expressions are specified to be real with predicates. Previously variables had to be specified to be real using old assumptions only.

<!-- END RELEASE NOTES -->
