### PR TITLE
Add `remove` to `external`

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -10,6 +10,7 @@ from .pythonmpq import PythonMPQ
 from .ntheory import (
     bit_scan1 as python_bit_scan1,
     bit_scan0 as python_bit_scan0,
+    remove as python_remove,
     factorial as python_factorial,
     sqrt as python_sqrt,
     sqrtrem as python_sqrtrem,
@@ -52,6 +53,7 @@ __all__ = [
 
     'bit_scan1',
     'bit_scan0',
+    'remove',
     'factorial',
     'sqrt',
     'is_square',
@@ -153,6 +155,7 @@ if GROUND_TYPES == 'gmpy':
 
     bit_scan1 = gmpy.bit_scan1
     bit_scan0 = gmpy.bit_scan0
+    remove = gmpy.remove
     factorial = gmpy.fac
     sqrt = gmpy.isqrt
     is_square = gmpy.is_square
@@ -185,6 +188,7 @@ elif GROUND_TYPES == 'flint':
 
     bit_scan1 = python_bit_scan1
     bit_scan0 = python_bit_scan0
+    remove = python_remove
     factorial = python_factorial
 
     def sqrt(x):
@@ -234,6 +238,7 @@ elif GROUND_TYPES == 'python':
 
     bit_scan1 = python_bit_scan1
     bit_scan0 = python_bit_scan0
+    remove = python_remove
     factorial = python_factorial
     sqrt = python_sqrt
     is_square = python_is_square

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -50,6 +50,34 @@ def bit_scan0(x, n=0):
     return bit_scan1(x + (1 << n), n)
 
 
+def remove(x, f):
+    if f < 2:
+        raise ValueError("factor must be > 1")
+    if x == 0:
+        return 0, 0
+    if f == 2:
+        b = bit_scan1(x)
+        return x >> b, b
+    m = 0
+    y, rem = divmod(x, f)
+    while not rem:
+        x = y
+        m += 1
+        if m > 5:
+            pow_list = [f**2]
+            while pow_list:
+                _f = pow_list[-1]
+                y, rem = divmod(x, _f)
+                if not rem:
+                    m += 1 << len(pow_list)
+                    x = y
+                    pow_list.append(_f**2)
+                else:
+                    pow_list.pop()
+        y, rem = divmod(x, f)
+    return x, m
+
+
 def factorial(x):
     """Return x!."""
     return int(mlib.ifac(int(x)))

--- a/sympy/external/tests/test_ntheory.py
+++ b/sympy/external/tests/test_ntheory.py
@@ -1,4 +1,4 @@
-from sympy.external.ntheory import (bit_scan1, bit_scan0, is_fermat_prp,
+from sympy.external.ntheory import (bit_scan1, remove, bit_scan0, is_fermat_prp,
                                     is_euler_prp, is_strong_prp)
 from sympy.testing.pytest import raises
 
@@ -29,6 +29,15 @@ def test_bit_scan0():
     assert bit_scan0(0) == 0
     assert bit_scan0(1) == 1
     assert bit_scan0(-2) == 0
+
+
+def test_remove():
+    raises(ValueError, lambda: remove(1, 1))
+    assert remove(0, 3) == (0, 0)
+    for f in range(2, 10):
+        for y in range(2, 1000):
+            for z in [1, 17, 101, 1009]:
+                assert remove(z*f**y, f) == (z, y)
 
 
 def test_is_fermat_prp():

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from sympy.core.function import Function
 from sympy.core.singleton import S
-from sympy.external.gmpy import gcd, lcm, invert, sqrt, legendre, jacobi, kronecker, bit_scan1
+from sympy.external.gmpy import (gcd, lcm, invert, sqrt, legendre, jacobi,
+                                 kronecker, bit_scan1, remove)
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
 from .primetest import isprime
-from .factor_ import factorint, multiplicity, _perfect_power
+from .factor_ import factorint, _perfect_power
 from .modular import crt
 from sympy.utilities.misc import as_int
 from sympy.utilities.iterables import iproduct
@@ -674,10 +675,10 @@ def _sqrt_mod1(a, p, n):
         # case gcd(a, p**k) = p**n
         return range(0, pn, p**((n + 1) // 2))
     # case gcd(a, p**k) = p**r, r < n
-    r = multiplicity(p, a)
+    a, r = remove(a, p)
     if r % 2 == 1:
         return None
-    res = _sqrt_mod_prime_power(a // p**r, p, n - r)
+    res = _sqrt_mod_prime_power(a, p, n - r)
     if res is None:
         return None
     m = r // 2
@@ -769,8 +770,8 @@ def is_quad_residue(a, p):
             a_ = a % px**ex
             if a_ == 0:
                 continue
-            r = multiplicity(px, a_)
-            if r % 2 or jacobi(a_ // px**r, px) != 1:
+            a_, r = remove(a_, px)
+            if r % 2 or jacobi(a_, px) != 1:
                 return False
     return True
 
@@ -822,10 +823,9 @@ def _is_nthpow_residue_bign_prime_power(a, n, p, k):
         a %= pow(p, k)
         if not a:
             return True
-        mu = multiplicity(p, a)
+        a, mu = remove(a, p)
         if mu % n:
             return False
-        a //= pow(p, mu)
         k -= mu
     if p != 2:
         f = p**(k - 1)*(p - 1) # f = totient(p**k)


### PR DESCRIPTION
The `gmpy2.remove` function is almost the same as `multiplicity`. The `multiplicity` implementation has been moved to `remove`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
