### PR TITLE
use inversion for single trig and Real domain

### DIFF
--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -168,10 +168,15 @@ def test_halfcircle():
     assert (0, -1) not in halfcircle
     assert (0, 0) in halfcircle
     assert halfcircle._contains((r, 0)) is None
-    # This one doesn't work:
-    #assert (r, 2*pi) not in halfcircle
-
     assert not halfcircle.is_iterable
+
+
+@XFAIL
+def test_halfcircle_fail():
+    r, th = symbols('r, theta', real=True)
+    L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
+    halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
+    assert (r, 2*pi) not in halfcircle
 
 
 def test_ImageSet_iterator_not_injective():

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -314,7 +314,7 @@ def _invert_real(f, g_ys, symbol):
                 if isinstance(trig, (sin, csc)):
                     F = asin if isinstance(trig, sin) else acsc
                     return (
-                        lambda a: 2*n*pi + F(a)),
+                        lambda a: 2*n*pi + F(a),
                         lambda a: 2*n*pi + pi - F(a))
                 if isinstance(trig, (cos, sec)):
                     F = acos if isinstance(trig, cos) else asec
@@ -3280,12 +3280,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         total_solvest_call = 0
         total_conditionst = 0
 
-        # sort equations to the one with the fewest potential
+        # sort equations so the one with the fewest potential
         # symbols appears first
         for index, eq in enumerate(eqs_in_better_order):
             newresult = []
             original_imageset = {}
-            # if imageset, expr is used to solve other symbol
+            # if imageset, expr is used to solve for other symbol
             imgset_yes = False
             result = _new_order_result(result, eq)
             for res in result:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1023,7 +1023,7 @@ def _solveset(f, symbol, domain, _check=False):
         return domain
 
     orig_f = f
-    linear_trig = False
+    invert_trig = False  # True if we will use inversion to solve
     if f.is_Mul:
         coeff, f = f.as_independent(symbol, as_Add=False)
         if coeff in {S.ComplexInfinity, S.NegativeInfinity, S.Infinity}:
@@ -1034,9 +1034,10 @@ def _solveset(f, symbol, domain, _check=False):
         if m not in {S.ComplexInfinity, S.Zero, S.Infinity,
                               S.NegativeInfinity}:
             f = a/m + h  # XXX condition `m != 0` should be added to soln
-        if a and a.is_number and a.is_real and isinstance(h, TrigonometricFunction) and domain.is_subset(S.Reals):
+        if isinstance(h, TrigonometricFunction) and (a and a.is_number
+                and a.is_real and domain.is_subset(S.Reals)):
             # solve this by inversion
-            linear_trig = True
+            invert_trig = True
 
     # assign the solvers to use
     solver = lambda f, x, domain=domain: _solveset(f, x, domain)
@@ -1057,7 +1058,7 @@ def _solveset(f, symbol, domain, _check=False):
         # wrong solutions we are using this technique only if both f and g are
         # finite for a finite input.
         result = Union(*[solver(m, symbol) for m in f.args])
-    elif not linear_trig and (_is_function_class_equation(TrigonometricFunction, f, symbol) or \
+    elif not invert_trig and (_is_function_class_equation(TrigonometricFunction, f, symbol) or \
             _is_function_class_equation(HyperbolicFunction, f, symbol)):
         result = _solve_trig(f, symbol, domain)
     elif isinstance(f, arg):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -375,7 +375,7 @@ def _invert_complex(f, g_ys, symbol):
 
     if isinstance(f, exp) or (f.is_Pow and f.base == S.Exp1):
         if isinstance(g_ys, ImageSet):
-            # can solve upto `(d*exp(exp(...(exp(a*x + b))...) + c)` format.
+            # can solve up to `(d*exp(exp(...(exp(a*x + b))...) + c)` format.
             # Further can be improved to `(d*exp(exp(...(exp(a*x**n + b*x**(n-1) + ... + f))...) + c)`.
             g_ys_expr = g_ys.lamda.expr
             g_ys_vars = g_ys.lamda.variables

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -58,6 +58,7 @@ from sympy.utilities.iterables import (numbered_symbols, has_dups,
                                        is_sequence, iterable)
 from sympy.calculus.util import periodicity, continuous_domain, function_range
 
+
 from types import GeneratorType
 
 
@@ -1033,7 +1034,7 @@ def _solveset(f, symbol, domain, _check=False):
         if m not in {S.ComplexInfinity, S.Zero, S.Infinity,
                               S.NegativeInfinity}:
             f = a/m + h  # XXX condition `m != 0` should be added to soln
-        if isinstance(h, TrigonometricFunction) and domain.is_subset(S.Reals):
+        if a and a.is_number and a.is_real and isinstance(h, TrigonometricFunction) and domain.is_subset(S.Reals):
             # solve this by inversion
             linear_trig = True
 
@@ -3287,7 +3288,6 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
             original_imageset = {}
             # if imageset, expr is used to solve for other symbol
             imgset_yes = False
-            result = _new_order_result(result, eq)
             for res in result:
                 got_symbol = set()  # symbols solved in one iteration
                 # find the imageset and use its expr.
@@ -3298,8 +3298,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         dummy_n = v.lamda.expr.atoms(Dummy).pop()
                         (base,) = v.base_sets
                         imgset_yes = (dummy_n, base)
-                    elif isinstance(v, FiniteSet):
-                        raise NotImplementedError('unhandled type: %s' % v)
+                    assert not isinstance(v, FiniteSet)  # if so, internal error
                 # update eq with everything that is known so far
                 eq2 = eq.subs(res).expand()
                 unsolved_syms = _unsolved_syms(eq2, sort=True)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -129,16 +129,24 @@ def test_invert_real():
     assert invert_real(Abs(x**31 + x + 1), y, x) == (lhs, base_values)
 
     assert dumeq(invert_real(sin(x), y, x),
-        (x, imageset(Lambda(n, n*pi + (-1)**n*asin(y)), S.Integers)))
+        (x, Union(
+            ImageSet(Lambda(n, 2*n*pi + asin(y)), S.Integers),
+            ImageSet(Lambda(n, pi*2*n + pi - asin(y)), S.Integers))))
 
     assert dumeq(invert_real(sin(exp(x)), y, x),
-        (x, imageset(Lambda(n, log((-1)**n*asin(y) + n*pi)), S.Integers)))
+        (x, Union(
+            ImageSet(Lambda(n, log(2*n*pi + asin(y))), S.Integers),
+            ImageSet(Lambda(n, log(pi*2*n + pi - asin(y))), S.Integers))))
 
     assert dumeq(invert_real(csc(x), y, x),
-        (x, imageset(Lambda(n, n*pi + (-1)**n*acsc(y)), S.Integers)))
+        (x, Union(
+            ImageSet(Lambda(n, 2*n*pi + acsc(y)), S.Integers),
+            ImageSet(Lambda(n, pi*2*n + pi - acsc(y)), S.Integers))))
 
     assert dumeq(invert_real(csc(exp(x)), y, x),
-        (x, imageset(Lambda(n, log((-1)**n*acsc(y) + n*pi)), S.Integers)))
+        (x, Union(
+            ImageSet(Lambda(n, log(2*n*pi + acsc(y))), S.Integers),
+            ImageSet(Lambda(n, log(pi*2*n + pi - acsc(y))), S.Integers))))
 
     assert dumeq(invert_real(cos(x), y, x),
         (x, Union(imageset(Lambda(n, 2*n*pi + acos(y)), S.Integers), \
@@ -347,6 +355,19 @@ def test_solve_invert():
 
     # issue 4504
     assert solveset_real(2**x - 10, x) == FiniteSet(1 + log(5)/log(2))
+
+
+def test_issue_25768():
+    assert dumeq(solveset_real(sin(x) - S.Half, x), Union(
+        ImageSet(Lambda(n, pi*2*n + pi/6), S.Integers),
+        ImageSet(Lambda(n, pi*2*n + pi*5/6), S.Integers)))
+    n1 = solveset_real(sin(x) - 0.5, x).n(5)
+    n2 = solveset_real(sin(x) - S.Half, x).n(5)
+    # help pass despite fp differences
+    eq = [i.replace(
+        lambda x:x.is_Float,
+        lambda x:Rational(x).limit_denominator(1000)) for i in (n1, n2)]
+    assert dumeq(*eq),(n1,n2)
 
 
 def test_errorinverses():
@@ -657,10 +678,11 @@ def test_solve_abs():
     for si in sol.subs(reps):
         assert not eqab.subs(x, si)
     assert dumeq(solveset(Eq(sin(Abs(x)), 1), x, domain=S.Reals), Union(
-        Intersection(Interval(0, oo),
-            ImageSet(Lambda(n, (-1)**n*pi/2 + n*pi), S.Integers)),
-        Intersection(Interval(-oo, 0),
-            ImageSet(Lambda(n, n*pi - (-1)**(-n)*pi/2), S.Integers))))
+        Intersection(Interval(0, oo), Union(
+        Intersection(ImageSet(Lambda(n, 2*n*pi + 3*pi/2), S.Integers),
+            Interval(-oo, 0)),
+        Intersection(ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers),
+            Interval(0, oo))))))
 
 
 def test_issue_9824():
@@ -848,10 +870,8 @@ def test_solve_trig():
               imageset(Lambda(n, 2*n*pi + pi/3), S.Integers)))
 
     assert dumeq(solveset(sin(y + a) - sin(y), a, domain=S.Reals),
-        Union(ImageSet(Lambda(n, 2*n*pi), S.Integers),
-        Intersection(ImageSet(Lambda(n, -I*(I*(
-        2*n*pi + arg(-exp(-2*I*y))) +
-        2*im(y))), S.Integers), S.Reals)))
+        Union(ImageSet(Lambda(n, 2*n*pi - y + asin(sin(y))), S.Integers),
+        ImageSet(Lambda(n, 2*n*pi - y - asin(sin(y)) + pi), S.Integers)))
 
     assert dumeq(solveset_real(sin(2*x)*cos(x) + cos(2*x)*sin(x)-1, x),
         ImageSet(Lambda(n, n*pi*Rational(2, 3) + pi/6), S.Integers))
@@ -1272,12 +1292,13 @@ def test__solveset_multi():
             [Interval(0, pi), Interval(-1, 1)]) == FiniteSet((0, 1), (pi, -1))
     assert _solveset_multi([r*cos(theta)-1, r*sin(theta)], [r, theta],
             [Interval(0, 1), Interval(0, pi)]) == FiniteSet((1, 0))
-    #assert _solveset_multi([r*cos(theta)-r, r*sin(theta)], [r, theta],
-    #        [Interval(0, 1), Interval(0, pi)]) == ?
-    assert dumeq(_solveset_multi([r*cos(theta)-r, r*sin(theta)], [r, theta],
-            [Interval(0, 1), Interval(0, pi)]), Union(
-            ImageSet(Lambda(((r,),), (r, 0)), ImageSet(Lambda(r, (r,)), Interval(0, 1))),
-            ImageSet(Lambda(((theta,),), (0, theta)), ImageSet(Lambda(theta, (theta,)), Interval(0, pi)))))
+    assert _solveset_multi([r*cos(theta)-r, r*sin(theta)], [r, theta],
+           [Interval(0, 1), Interval(0, pi)]) == Union(
+           {(0, pi)},
+           ImageSet(Lambda(((r,),), (r, 0)),
+           ImageSet(Lambda(r, (r,)), Interval(0, 1))),
+           ImageSet(Lambda(((theta,),), (0, theta)),
+           ImageSet(Lambda(theta, (theta,)), Interval(0, pi))))
 
 
 def test_conditionset():
@@ -1583,6 +1604,7 @@ def test_solve_decomposition():
     assert solve_decomposition(f6, x, S.Reals) == S.EmptySet
     assert solve_decomposition(f7, x, S.Reals) == S.EmptySet
     assert solve_decomposition(x, x, Interval(1, 2)) == S.EmptySet
+
 
 # nonlinsolve testcases
 def test_nonlinsolve_basic():
@@ -2239,6 +2261,9 @@ def test_issue_17906():
     assert solveset(7**(x**2 - 80) - 49**x, x) == FiniteSet(-8, 10)
 
 
+@XFAIL
+# solveset does not handle the case when the solution is a set
+# instead of ImageSet at line 3302 at this time
 def test_issue_17933():
     eq1 = x*sin(45) - y*cos(q)
     eq2 = x*cos(45) - y*sin(q)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -870,8 +870,8 @@ def test_solve_trig():
               imageset(Lambda(n, 2*n*pi + pi/3), S.Integers)))
 
     assert dumeq(solveset(sin(y + a) - sin(y), a, domain=S.Reals),
-        Union(ImageSet(Lambda(n, 2*n*pi - y + asin(sin(y))), S.Integers),
-        ImageSet(Lambda(n, 2*n*pi - y - asin(sin(y)) + pi), S.Integers)))
+        Union(ImageSet(Lambda(n, 2*n*pi), S.Integers),
+        Intersection(ImageSet(Lambda(n, -I*(I*(2*n*pi + arg(-exp(-2*I*y))) + 2*im(y))), S.Integers), S.Reals)))
 
     assert dumeq(solveset_real(sin(2*x)*cos(x) + cos(2*x)*sin(x)-1, x),
         ImageSet(Lambda(n, n*pi*Rational(2, 3) + pi/6), S.Integers))
@@ -1294,7 +1294,6 @@ def test__solveset_multi():
             [Interval(0, 1), Interval(0, pi)]) == FiniteSet((1, 0))
     assert _solveset_multi([r*cos(theta)-r, r*sin(theta)], [r, theta],
            [Interval(0, 1), Interval(0, pi)]) == Union(
-           {(0, pi)},
            ImageSet(Lambda(((r,),), (r, 0)),
            ImageSet(Lambda(r, (r,)), Interval(0, 1))),
            ImageSet(Lambda(((theta,),), (0, theta)),
@@ -2261,15 +2260,11 @@ def test_issue_17906():
     assert solveset(7**(x**2 - 80) - 49**x, x) == FiniteSet(-8, 10)
 
 
-@XFAIL
-# solveset does not handle the case when the solution is a set
-# instead of ImageSet at line 3302 at this time
 def test_issue_17933():
     eq1 = x*sin(45) - y*cos(q)
     eq2 = x*cos(45) - y*sin(q)
     eq3 = 9*x*sin(45)/10 + y*cos(q)
     eq4 = 9*x*cos(45)/10 + y*sin(z) - z
-
     assert nonlinsolve([eq1, eq2, eq3, eq4], x, y, z, q) ==\
         FiniteSet((0, 0, 0, q))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #25768

#### Brief description of what is fixed or changed

Now detect when a single trig function is present that can be inverted in the real domain.

Also modified how branches of `sin` solutions were returned so they would intersect well with Intervals (see modified docstrings): use two branches instead of one with `(-1)**n` factor.

#### Other comments

There are no solvers implemented for an equation like the following:
```
>>> (-1)**x+x*pi  # using x instead of n that might appear in a periodic solution
(-1)**x + pi*x
>>> solve(_-y,x)
Traceback (most recent call last):
...
NotImplementedError: multiple generators [x, (-1)**x]
No algorithms are implemented to solve equation (-1)**x + pi*x - y
```
But if there were a `rewrite(Piecewise)` for this then
```
>>> Piecewise((1+pi*x,Eq(x%2,0)),(pi*x,True))
Piecewise((pi*x + 1, Eq(Mod(x, 2), 0)), (pi*x, True))
>>> solve(_-y,x)
[Piecewise((y/pi, Ne(Mod(y/pi, 2), 0)), (nan, True)), Piecewise(((y - 1)/pi, Eq(Mod((y - 1)/pi, 2), 0)), (nan, True))]
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
