### PR TITLE
polys: use float('-inf') instead of -oo for degree(0)

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1,12 +1,15 @@
 """Basic tools for dense recursive polynomials in ``K[x]`` or ``K[X]``. """
 
 
-from sympy.core.numbers import oo
 from sympy.core import igcd
 from sympy.polys.monomials import monomial_min, monomial_div
 from sympy.polys.orderings import monomial_key
 
 import random
+
+
+ninf = float('-inf')
+
 
 def poly_LC(f, K):
     """
@@ -135,7 +138,7 @@ def dup_degree(f):
     """
     Return the leading degree of ``f`` in ``K[x]``.
 
-    Note that the degree of 0 is negative infinity (the SymPy object -oo).
+    Note that the degree of 0 is negative infinity (``float('-inf')``).
 
     Examples
     ========
@@ -150,7 +153,7 @@ def dup_degree(f):
 
     """
     if not f:
-        return -oo
+        return ninf
     return len(f) - 1
 
 
@@ -158,7 +161,7 @@ def dmp_degree(f, u):
     """
     Return the leading degree of ``f`` in ``x_0`` in ``K[X]``.
 
-    Note that the degree of 0 is negative infinity (the SymPy object -oo).
+    Note that the degree of 0 is negative infinity (``float('-inf')``).
 
     Examples
     ========
@@ -167,7 +170,7 @@ def dmp_degree(f, u):
     >>> from sympy.polys.densebasic import dmp_degree
 
     >>> dmp_degree([[[]]], 2)
-    -oo
+    -inf
 
     >>> f = ZZ.map([[2], [1, 2, 3]])
 
@@ -176,7 +179,7 @@ def dmp_degree(f, u):
 
     """
     if dmp_zero_p(f, u):
-        return -oo
+        return ninf
     else:
         return len(f) - 1
 
@@ -244,7 +247,7 @@ def dmp_degree_list(f, u):
     (1, 2)
 
     """
-    degs = [-oo]*(u + 1)
+    degs = [ninf]*(u + 1)
     _rec_degree_list(f, u, 0, degs)
     return tuple(degs)
 
@@ -685,7 +688,7 @@ def dmp_ground_nth(f, N, u, K):
             return K.zero
         else:
             d = dmp_degree(f, v)
-            if d == -oo:
+            if d == ninf:
                 d = -1
             f, v = f[d - n], v - 1
 
@@ -1091,7 +1094,7 @@ def dmp_to_dict(f, u, K=None, zero=False):
 
     n, v, result = dmp_degree(f, u), u - 1, {}
 
-    if n == -oo:
+    if n == ninf:
         n = -1
 
     for k in range(0, n + 1):

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -894,7 +894,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
         m = dmp_nest([K.one, -a], n, K)
         M = dmp_one(n, K)
 
-        for k in K.map(range(0, d)):
+        for k in range(0, d):
             if dmp_zero_p(c, u):
                 break
 
@@ -902,7 +902,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
             C = dmp_diff_eval_in(c, k + 1, a, n, u, K)
 
             if not dmp_zero_p(C, v):
-                C = dmp_quo_ground(C, K.factorial(k + 1), v, K)
+                C = dmp_quo_ground(C, K.factorial(K(k) + 1), v, K)
                 T = dmp_zz_diophantine(G, C, A, d, p, v, K)
 
                 for i, t in enumerate(T):
@@ -949,7 +949,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
         dj = dmp_degree_in(s, w, w)
 
-        for k in K.map(range(0, dj)):
+        for k in range(0, dj):
             if dmp_zero_p(c, w):
                 break
 
@@ -957,7 +957,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
             C = dmp_diff_eval_in(c, k + 1, a, w, w, K)
 
             if not dmp_zero_p(C, w - 1):
-                C = dmp_quo_ground(C, K.factorial(k + 1), w - 1, K)
+                C = dmp_quo_ground(C, K.factorial(K(k) + 1), w - 1, K)
                 T = dmp_zz_diophantine(G, C, I, d, p, w - 1, K)
 
                 for i, (h, t) in enumerate(zip(H, T)):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -19,6 +19,7 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy.polys.densebasic import (
+    ninf,
     dmp_validate,
     dup_normal, dmp_normal,
     dup_convert, dmp_convert,
@@ -1976,7 +1977,7 @@ class DUP_Flint(DMP):
         """Returns the leading degree of ``f`` in ``x_j``. """
         d = f._rep.degree()
         if d == -1:
-            d = -oo
+            d = ninf
         return d
 
     def degree_list(f):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1890,7 +1890,10 @@ class Poly(Basic):
         j = f._gen_to_level(gen)
 
         if hasattr(f.rep, 'degree'):
-            return f.rep.degree(j)
+            d = f.rep.degree(j)
+            if d < 0:
+                d = S.NegativeInfinity
+            return d
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'degree')
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -9,13 +9,12 @@ from types import GeneratorType
 
 from sympy.core.expr import Expr
 from sympy.core.intfunc import igcd
-from sympy.core.numbers import oo
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.sympify import CantSympify, sympify
 from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.compatibility import IPolys
 from sympy.polys.constructor import construct_domain
-from sympy.polys.densebasic import dmp_to_dict, dmp_from_dict
+from sympy.polys.densebasic import ninf, dmp_to_dict, dmp_from_dict
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.heuristicgcd import heugcd
@@ -1629,13 +1628,13 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         The leading degree in ``x`` or the main variable.
 
-        Note that the degree of 0 is negative infinity (the SymPy object -oo).
+        Note that the degree of 0 is negative infinity (``float('-inf')``)
 
         """
         i = f.ring.index(x)
 
         if not f:
-            return -oo
+            return ninf
         elif i < 0:
             return 0
         else:
@@ -1645,11 +1644,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         A tuple containing leading degrees in all variables.
 
-        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+        Note that the degree of 0 is negative infinity (``float('-inf')``)
 
         """
         if not f:
-            return (-oo,)*f.ring.ngens
+            return (ninf,)*f.ring.ngens
         else:
             return tuple(map(max, list(zip(*f.itermonoms()))))
 
@@ -1657,13 +1656,13 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         The tail degree in ``x`` or the main variable.
 
-        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+        Note that the degree of 0 is negative infinity (``float('-inf')``)
 
         """
         i = f.ring.index(x)
 
         if not f:
-            return -oo
+            return ninf
         elif i < 0:
             return 0
         else:
@@ -1673,11 +1672,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         A tuple containing tail degrees in all variables.
 
-        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+        Note that the degree of 0 is negative infinity (``float('-inf')``)
 
         """
         if not f:
-            return (-oo,)*f.ring.ngens
+            return (ninf,)*f.ring.ngens
         else:
             return tuple(map(min, list(zip(*f.itermonoms()))))
 

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -1,6 +1,7 @@
 """Tests for dense recursive polynomials' basic tools. """
 
 from sympy.polys.densebasic import (
+    ninf,
     dup_LC, dmp_LC,
     dup_TC, dmp_TC,
     dmp_ground_LC, dmp_ground_TC,
@@ -95,24 +96,25 @@ def test_dmp_true_LT():
 
 
 def test_dup_degree():
-    assert dup_degree([]) is -oo
+    assert ninf == float('-inf')
+    assert dup_degree([]) is ninf
     assert dup_degree([1]) == 0
     assert dup_degree([1, 0]) == 1
     assert dup_degree([1, 0, 0, 0, 1]) == 4
 
 
 def test_dmp_degree():
-    assert dmp_degree([[]], 1) is -oo
-    assert dmp_degree([[[]]], 2) is -oo
+    assert dmp_degree([[]], 1) is ninf
+    assert dmp_degree([[[]]], 2) is ninf
 
     assert dmp_degree([[1]], 1) == 0
     assert dmp_degree([[2], [1]], 1) == 1
 
 
 def test_dmp_degree_in():
-    assert dmp_degree_in([[[]]], 0, 2) is -oo
-    assert dmp_degree_in([[[]]], 1, 2) is -oo
-    assert dmp_degree_in([[[]]], 2, 2) is -oo
+    assert dmp_degree_in([[[]]], 0, 2) is ninf
+    assert dmp_degree_in([[[]]], 1, 2) is ninf
+    assert dmp_degree_in([[[]]], 2, 2) is ninf
 
     assert dmp_degree_in([[[1]]], 0, 2) == 0
     assert dmp_degree_in([[[1]]], 1, 2) == 0

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -5,6 +5,7 @@ from operator import add, mul
 
 from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement
 from sympy.polys.fields import field, FracField
+from sympy.polys.densebasic import ninf
 from sympy.polys.domains import ZZ, QQ, RR, FF, EX
 from sympy.polys.orderings import lex, grlex
 from sympy.polys.polyerrors import GeneratorsError, \
@@ -13,7 +14,7 @@ from sympy.polys.polyerrors import GeneratorsError, \
 from sympy.testing.pytest import raises
 from sympy.core import Symbol, symbols
 from sympy.core.singleton import S
-from sympy.core.numbers import (oo, pi)
+from sympy.core.numbers import pi
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 
@@ -316,28 +317,30 @@ def test_PolyElement_from_expr():
 def test_PolyElement_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).degree() is -oo
+    assert ninf == float('-inf')
+
+    assert R(0).degree() is ninf
     assert R(1).degree() == 0
     assert (x + 1).degree() == 1
     assert (2*y**3 + z).degree() == 0
     assert (x*y**3 + z).degree() == 1
     assert (x**5*y**3 + z).degree() == 5
 
-    assert R(0).degree(x) is -oo
+    assert R(0).degree(x) is ninf
     assert R(1).degree(x) == 0
     assert (x + 1).degree(x) == 1
     assert (2*y**3 + z).degree(x) == 0
     assert (x*y**3 + z).degree(x) == 1
     assert (7*x**5*y**3 + z).degree(x) == 5
 
-    assert R(0).degree(y) is -oo
+    assert R(0).degree(y) is ninf
     assert R(1).degree(y) == 0
     assert (x + 1).degree(y) == 0
     assert (2*y**3 + z).degree(y) == 3
     assert (x*y**3 + z).degree(y) == 3
     assert (7*x**5*y**3 + z).degree(y) == 3
 
-    assert R(0).degree(z) is -oo
+    assert R(0).degree(z) is ninf
     assert R(1).degree(z) == 0
     assert (x + 1).degree(z) == 0
     assert (2*y**3 + z).degree(z) == 1
@@ -345,34 +348,34 @@ def test_PolyElement_degree():
     assert (7*x**5*y**3 + z).degree(z) == 1
 
     R, = ring("", ZZ)
-    assert R(0).degree() is -oo
+    assert R(0).degree() is ninf
     assert R(1).degree() == 0
 
 def test_PolyElement_tail_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).tail_degree() is -oo
+    assert R(0).tail_degree() is ninf
     assert R(1).tail_degree() == 0
     assert (x + 1).tail_degree() == 0
     assert (2*y**3 + x**3*z).tail_degree() == 0
     assert (x*y**3 + x**3*z).tail_degree() == 1
     assert (x**5*y**3 + x**3*z).tail_degree() == 3
 
-    assert R(0).tail_degree(x) is -oo
+    assert R(0).tail_degree(x) is ninf
     assert R(1).tail_degree(x) == 0
     assert (x + 1).tail_degree(x) == 0
     assert (2*y**3 + x**3*z).tail_degree(x) == 0
     assert (x*y**3 + x**3*z).tail_degree(x) == 1
     assert (7*x**5*y**3 + x**3*z).tail_degree(x) == 3
 
-    assert R(0).tail_degree(y) is -oo
+    assert R(0).tail_degree(y) is ninf
     assert R(1).tail_degree(y) == 0
     assert (x + 1).tail_degree(y) == 0
     assert (2*y**3 + x**3*z).tail_degree(y) == 0
     assert (x*y**3 + x**3*z).tail_degree(y) == 0
     assert (7*x**5*y**3 + x**3*z).tail_degree(y) == 0
 
-    assert R(0).tail_degree(z) is -oo
+    assert R(0).tail_degree(z) is ninf
     assert R(1).tail_degree(z) == 0
     assert (x + 1).tail_degree(z) == 0
     assert (2*y**3 + x**3*z).tail_degree(z) == 0
@@ -380,20 +383,20 @@ def test_PolyElement_tail_degree():
     assert (7*x**5*y**3 + x**3*z).tail_degree(z) == 0
 
     R, = ring("", ZZ)
-    assert R(0).tail_degree() is -oo
+    assert R(0).tail_degree() is ninf
     assert R(1).tail_degree() == 0
 
 def test_PolyElement_degrees():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).degrees() == (-oo, -oo, -oo)
+    assert R(0).degrees() == (ninf, ninf, ninf)
     assert R(1).degrees() == (0, 0, 0)
     assert (x**2*y + x**3*z**2).degrees() == (3, 1, 2)
 
 def test_PolyElement_tail_degrees():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).tail_degrees() == (-oo, -oo, -oo)
+    assert R(0).tail_degrees() == (ninf, ninf, ninf)
     assert R(1).tail_degrees() == (0, 0, 0)
     assert (x**2*y + x**3*z**2).tail_degrees() == (2, 0, 0)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Changes it so that within the internal poly code SymPy's symbolic negative infinity (`-oo`) is not used for the degree of zero. This makes various operations faster because symbolic comparisons are avoided in the internals of performance sensitive algorithms.

SymPy defines the degree of 0 as `-oo`:
```python
In [4]: degree(x**2)
Out[4]: 2

In [5]: degree(x)
Out[5]: 1

In [6]: degree(1)
Out[6]: 0

In [7]: degree(0)
Out[7]: -∞
```
In general I am not convinced that this is useful but particularly in the case of the polys code this means that symbolic expressions are being used in low-level algorithms which should be avoided. Low-level functions like `dup_degree` should not return the high-level `-oo` type. The most common thing that is done with the output from `dup_degree` is to test if it is less than zero or to compare two degrees:
https://github.com/sympy/sympy/blob/5cc71ab22cdbe4d332bbe0a17191603288d97e2b/sympy/polys/euclidtools.py#L817-L820

The problem then is this:
```python
In [8]: sinf = -oo

In [9]: ninf = float('-inf')

In [10]: %timeit sinf < 0
32.5 µs ± 141 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [11]: %timeit ninf < 0
43.1 ns ± 0.928 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
In other words it is 1000x slower to use `-oo` in an inequality comparison than it is to use `float('inf')`.

I have known for some time that this was making various things slow because often when I interrupt a slow operation I will find that it is in the middle of the code that evaluates the inequality `-oo < 0`. I wanted to have a clear example of something that was made slow by this though.

This PR changes it so that all the low level routines like `dup_degree` use `float('-inf')` rather than `-oo` but still the high-level interfaces like `Poly(0, x).degree()` and `degree(0)` will return `-oo`.

An example of what this speeds up is factorisation over ZZ_I or QQ_I. These are timings with master:
```python
In [1]: a, b, c, d, e, f, g, h = symbols('a:h')

In [2]: eq2 = (a*b*d*g*(b*(I*d*e + f) + d*e)*(I*a*d*g + 1)*(a*c*d*(a*d*g - I) + a*d*h*(a*d*(c + g) - I))
   ...: + a*b*d*h*(b*(I*d*e + f) + d*e)*(a*d*g - I)*(a*d*(c + g) - I) - b*(a*d*g - I)*(I*a*d*g + 1)*(I*b*
   ...: d*e + d*e)*(a*c*d*(a*d*g - I) + a*d*h*(a*d*(c + g) - I)))

In [3]: eq2
Out[3]: 
a⋅b⋅d⋅g⋅(b⋅(ⅈ⋅d⋅e + f) + d⋅e)⋅(ⅈ⋅a⋅d⋅g + 1)⋅(a⋅c⋅d⋅(a⋅d⋅g - ⅈ) + a⋅d⋅h⋅(a⋅d⋅(c + g) - ⅈ)) + a⋅b⋅d⋅h⋅(b⋅ ↪

↪ (ⅈ⋅d⋅e + f) + d⋅e)⋅(a⋅d⋅g - ⅈ)⋅(a⋅d⋅(c + g) - ⅈ) - b⋅(a⋅d⋅g - ⅈ)⋅(ⅈ⋅a⋅d⋅g + 1)⋅(ⅈ⋅b⋅d⋅e + d⋅e)⋅(a⋅c⋅d ↪

↪ ⋅(a⋅d⋅g - ⅈ) + a⋅d⋅h⋅(a⋅d⋅(c + g) - ⅈ))

In [4]: %time eq2.factor()
CPU times: user 19 s, sys: 88.8 ms, total: 19.1 s
Wall time: 19.1 s
Out[4]: 
                   2                                                                        
ⅈ⋅a⋅b⋅d⋅(a⋅d⋅g - ⅈ) ⋅(a⋅b⋅c⋅d⋅f⋅g + a⋅b⋅c⋅d⋅f⋅h + a⋅b⋅d⋅f⋅g⋅h - b⋅c⋅d⋅e - ⅈ⋅b⋅f⋅h + ⅈ⋅c⋅d⋅e)
```
With the PR that is:
```python
In [4]: %time eq2.factor()
CPU times: user 4.41 s, sys: 20.7 ms, total: 4.43 s
Wall time: 4.43 s
Out[4]: 
                   2                                                                        
ⅈ⋅a⋅b⋅d⋅(a⋅d⋅g - ⅈ) ⋅(a⋅b⋅c⋅d⋅f⋅g + a⋅b⋅c⋅d⋅f⋅h + a⋅b⋅d⋅f⋅g⋅h - b⋅c⋅d⋅e - ⅈ⋅b⋅f⋅h + ⅈ⋅c⋅d⋅e)
```
So this high-level operation is made 4x faster by the change.

#### Other comments

An alternative convention for the degree of 0 is just -1 which is what python-flint uses:
```python
In [8]: import flint

In [9]: x = flint.fmpz_poly([0, 1])

In [10]: (x**2).degree()
Out[10]: 2

In [11]: (x**1).degree()
Out[11]: 1

In [12]: (x**0).degree()
Out[12]: 0

In [13]: (0*x**0).degree()
Out[13]: -1
```
I'm not sure that returning `-oo` for the degree is ever really useful. The advantage of returning `-1` would be that at least we know that it is always an int. Possibly returning `float('-inf')` is more backwards compatible.

Previously `-1` was used but that was changed in 424bab8 in gh-2436

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The low-level polynomial implementations such as the polynomial domains and types like DMP now return `float('-inf')` rather than SymPy's symbolic `-oo` for `degree(0)`. This is because using `-oo` was making many operations slow e.g. this change made factorisation over the `ZZ_I` or `QQ_I` domains 4x faster for one case.
<!-- END RELEASE NOTES -->