### PR TITLE
Add `gcdext` to `external`

### DIFF
--- a/sympy/core/intfunc.py
+++ b/sympy/core/intfunc.py
@@ -14,7 +14,8 @@ from functools import lru_cache
 
 from .sympify import sympify
 from .singleton import S
-from sympy.external.gmpy import gcd as number_gcd, lcm as number_lcm, sqrt, iroot, bit_scan1
+from sympy.external.gmpy import (gcd as number_gcd, lcm as number_lcm, sqrt,
+                                 iroot, bit_scan1, gcdext)
 from sympy.utilities.misc import as_int, filldedent
 
 
@@ -379,29 +380,8 @@ def igcdex(a, b):
     """
     if (not a) and (not b):
         return (0, 1, 0)
-
-    if not a:
-        return (0, b // abs(b), abs(b))
-    if not b:
-        return (a // abs(a), 0, abs(a))
-
-    if a < 0:
-        a, x_sign = -a, -1
-    else:
-        x_sign = 1
-
-    if b < 0:
-        b, y_sign = -b, -1
-    else:
-        y_sign = 1
-
-    x, y, r, s = 1, 0, 0, 1
-
-    while b:
-        (c, q) = (a % b, a // b)
-        (a, b, r, s, x, y) = (b, c, x - q * r, y - q * s, r, s)
-
-    return (x * x_sign, y * y_sign, a)
+    g, x, y = gcdext(a, b)
+    return x, y, g
 
 
 def mod_inverse(a, m):

--- a/sympy/core/intfunc.py
+++ b/sympy/core/intfunc.py
@@ -380,7 +380,7 @@ def igcdex(a, b):
     """
     if (not a) and (not b):
         return (0, 1, 0)
-    g, x, y = gcdext(a, b)
+    g, x, y = gcdext(int(a), int(b))
     return x, y, g
 
 

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -16,6 +16,7 @@ from .ntheory import (
     sqrtrem as python_sqrtrem,
     gcd as python_gcd,
     lcm as python_lcm,
+    gcdext as python_gcdext,
     is_square as python_is_square,
     invert as python_invert,
     legendre as python_legendre,
@@ -60,6 +61,7 @@ __all__ = [
     'sqrtrem',
     'gcd',
     'lcm',
+    'gcdext',
     'invert',
     'legendre',
     'jacobi',
@@ -162,6 +164,7 @@ if GROUND_TYPES == 'gmpy':
     sqrtrem = gmpy.isqrt_rem
     gcd = gmpy.gcd
     lcm = gmpy.lcm
+    gcdext = gmpy.gcdext
     invert = gmpy.invert
     legendre = gmpy.legendre
     jacobi = gmpy.jacobi
@@ -208,6 +211,7 @@ elif GROUND_TYPES == 'flint':
     def lcm(*args):
         return reduce(flint.fmpz.lcm, args, flint.fmpz(1))
 
+    gcdext = python_gcdext
     invert = python_invert
     legendre = python_legendre
 
@@ -245,6 +249,7 @@ elif GROUND_TYPES == 'python':
     sqrtrem = python_sqrtrem
     gcd = python_gcd
     lcm = python_lcm
+    gcdext = python_gcdext
     invert = python_invert
     legendre = python_legendre
     jacobi = python_jacobi

--- a/sympy/external/ntheory.py
+++ b/sympy/external/ntheory.py
@@ -116,6 +116,33 @@ else:
         return reduce(lambda x, y: x*y//math.gcd(x, y), args, 1)
 
 
+def _sign(n):
+    if n < 0:
+        return -1, -n
+    return 1, n
+
+
+def gcdext(a, b):
+    if not a or not b:
+        g = abs(a) or abs(b)
+        if not g:
+            return (0, 0, 0)
+        return (g, a // g, b // g)
+
+    x_sign, a = _sign(a)
+    y_sign, b = _sign(b)
+    x, r = 1, 0
+    y, s = 0, 1
+
+    while b:
+        q, c = divmod(a, b)
+        a, b = b, c
+        x, r = r, x - q*r
+        y, s = s, y - q*s
+
+    return (a, x * x_sign, y * y_sign)
+
+
 def is_square(x):
     """Return True if x is a square number."""
     if x < 0:

--- a/sympy/external/tests/test_ntheory.py
+++ b/sympy/external/tests/test_ntheory.py
@@ -1,5 +1,7 @@
+from itertools import permutations
+
 from sympy.external.ntheory import (bit_scan1, remove, bit_scan0, is_fermat_prp,
-                                    is_euler_prp, is_strong_prp)
+                                    is_euler_prp, is_strong_prp, gcdext)
 from sympy.testing.pytest import raises
 
 
@@ -38,6 +40,26 @@ def test_remove():
         for y in range(2, 1000):
             for z in [1, 17, 101, 1009]:
                 assert remove(z*f**y, f) == (z, y)
+
+
+def test_gcdext():
+    assert gcdext(0, 0) == (0, 0, 0)
+    assert gcdext(3, 0) == (3, 1, 0)
+    assert gcdext(0, 4) == (4, 0, 1)
+
+    for n in range(1, 10):
+        assert gcdext(n, 1) == gcdext(-n, 1) == (1, 0, 1)
+        assert gcdext(n, -1) == gcdext(-n, -1) == (1, 0, -1)
+        assert gcdext(n, n) == gcdext(-n, n) == (n, 0, 1)
+        assert gcdext(n, -n) == gcdext(-n, -n) == (n, 0, -1)
+
+    for n in range(2, 10):
+        assert gcdext(1, n) == gcdext(1, -n) == (1, 1, 0)
+        assert gcdext(-1, n) == gcdext(-1, -n) == (1, -1, 0)
+
+    for a, b in permutations([2**5, 3, 5, 7**2, 11], 2):
+        g, x, y = gcdext(a, b)
+        assert g == a*x + b*y == 1
 
 
 def test_is_fermat_prp():

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,7 +1,6 @@
 from math import prod
 
-from sympy.core.intfunc import igcdex
-from sympy.external.gmpy import gcd
+from sympy.external.gmpy import gcd, gcdext
 from sympy.ntheory.primetest import isprime
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt, gf_crt1, gf_crt2
@@ -237,7 +236,7 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         g = gcd(a, b, c)
         a, b, c = [i//g for i in [a, b, c]]
         if a != 1:
-            inv_a, _, g = igcdex(a, c)
+            g, inv_a, _ = gcdext(a, c)
             if g != 1:
                 return None
             b *= inv_a


### PR DESCRIPTION
The `gmpy2.gcdext` function is almost the same as `igcdex`. The `igcdex` implementation has been moved to `gcdext`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
