### PR TITLE
biomechanics: Minor Fixes math rendering and added hyperlinks

### DIFF
--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -544,7 +544,7 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``FiberForceLengthPassiveDeGroote2016`` is
-    using the ``with_defaults`` constructor because this will automatically
+    using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber length. We'll
@@ -959,9 +959,9 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
 
     The function is defined by the equation:
 
-    $fl^M_{act} = c_0 \exp{-\frac{1}{2}\left(\frac{\tilde{l}^M - c_1}{\left(c_2 + c_3 \tilde{l}^M\right)}\right)^2}
-        + c_4 \exp{-\frac{1}{2}\left(\frac{\tilde{l}^M - c_5}{\left(c_6 + c_7 \tilde{l}^M\right)}\right)^2}
-        + c_8 \exp{-\frac{1}{2}\left(\frac{\tilde{l}^M - c_9}{\left(c_{10} + c_{11} \tilde{l}^M\right)}\right)^2}$
+    $f_{\text{act}}^M = c_0 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_1}{c_2 + c_3 \tilde{l}^M}\right)^2\right)
+    + c_4 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_5}{c_6 + c_7 \tilde{l}^M}\right)^2\right)
+    + c_8 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_9}{c_{10} + c_{11} \tilde{l}^M}\right)^2\right)$
 
     with constant values of $c0 = 0.814$, $c1 = 1.06$, $c2 = 0.162$,
     $c3 = 0.0633$, $c4 = 0.433$, $c5 = 0.717$, $c6 = -0.0299$, $c7 = 0.2$,
@@ -977,7 +977,7 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``FiberForceLengthActiveDeGroote2016`` is
-    using the ``with_defaults`` constructor because this will automatically
+    using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber length. We'll
@@ -1299,8 +1299,7 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
 
     The function is defined by the equation:
 
-    $fv^M = c_0 \log{\left(c_1 v_M_tilde + c_2\right)
-        + \sqrt{\left(c_1 v_M_tilde + c_2\right)^2 + 1}} + c_3
+    $fv^M = c_0 \log{\left(c_1 \tilde{v}_m + c_2\right) + \sqrt{\left(c_1 \tilde{v}_m + c_2\right)^2 + 1}} + c_3$
 
     with constant values of $c_0 = -0.318$, $c_1 = -8.149$, $c_2 = -0.374$, and
     $c_3 = 0.886$.

--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -959,7 +959,7 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
 
     The function is defined by the equation:
 
-    $f_{\text{act}}^M = c_0 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_1}{c_2 + c_3 \tilde{l}^M}\right)^2\right)
+    $fl_{\text{act}}^M = c_0 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_1}{c_2 + c_3 \tilde{l}^M}\right)^2\right)
     + c_4 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_5}{c_6 + c_7 \tilde{l}^M}\right)^2\right)
     + c_8 \exp\left(-\frac{1}{2}\left(\frac{\tilde{l}^M - c_9}{c_{10} + c_{11} \tilde{l}^M}\right)^2\right)$
 

--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -98,7 +98,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``TendonForceLengthDeGroote2016`` is using
-    the ``with_defaults`` constructor because this will automatically
+    the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon length. We'll create a
@@ -134,7 +134,7 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     33.93669377311689)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -329,7 +329,7 @@ class TendonForceLengthInverseDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``TendonForceLengthInverseDeGroote2016`` is
-    using the ``with_defaults`` constructor because this will automatically
+    using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon force-length, which is
@@ -353,7 +353,7 @@ class TendonForceLengthInverseDeGroote2016(CharacteristicCurveFunction):
     TendonForceLengthInverseDeGroote2016(fl_T, c0, c1, c2, c3)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -578,7 +578,7 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
     FiberForceLengthPassiveDeGroote2016(l_M/l_M_opt, 0.6, 4.0)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -768,7 +768,7 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
 
     The preferred way to instantiate
     ``FiberForceLengthPassiveInverseDeGroote2016`` is using the
-    ``with_defaults`` constructor because this will automatically populate the
+    :meth:`~.with_defaults` constructor because this will automatically populate the
     constants within the characteristic curve equation with the floating point
     values from the original publication. This constructor takes a single
     argument corresponding to the normalized passive muscle fiber length-force
@@ -791,7 +791,7 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
     FiberForceLengthPassiveInverseDeGroote2016(fl_M_pas, c0, c1)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -1015,7 +1015,7 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
     0.433, 0.717, -0.0299, 0.2, 0.1, 1.0, 0.354, 0.0)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -1314,7 +1314,7 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``FiberForceVelocityDeGroote2016`` is using
-    the ``with_defaults`` constructor because this will automatically populate
+    the :meth:`~.with_defaults` constructor because this will automatically populate
     the constants within the characteristic curve equation with the floating
     point values from the original publication. This constructor takes a single
     argument corresponding to normalized muscle fiber extension velocity. We'll
@@ -1348,7 +1348,7 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
     FiberForceVelocityDeGroote2016(v_M/v_M_max, -0.318, -8.149, -0.374, 0.886)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 
@@ -1548,7 +1548,7 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate ``FiberForceVelocityInverseDeGroote2016``
-    is using the ``with_defaults`` constructor because this will automatically
+    is using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber force-velocity
@@ -1571,7 +1571,7 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
     FiberForceVelocityInverseDeGroote2016(fv_M, c0, c1, c2, c3)
 
     To inspect the actual symbolic expression that this function represents,
-    we can call the ``doit`` method on an instance. We'll use the keyword
+    we can call the :meth:`~.doit` method on an instance. We'll use the keyword
     argument ``evaluate=False`` as this will keep the expression in its
     canonical form and won't simplify any constants.
 

--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -333,7 +333,7 @@ class TendonForceLengthInverseDeGroote2016(CharacteristicCurveFunction):
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon force-length, which is
-    equal to the tendon force. We'll create a :class:`~.Symbol`` called ``fl_T`` to
+    equal to the tendon force. We'll create a :class:`~.Symbol` called ``fl_T`` to
     represent this.
 
     >>> from sympy import Symbol

--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -97,12 +97,12 @@ class TendonForceLengthDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``TendonForceLengthDeGroote2016`` is using
+    The preferred way to instantiate :class:`TendonForceLengthDeGroote2016` is using
     the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon length. We'll create a
-    ``Symbol`` called ``l_T_tilde`` to represent this.
+    :class:`~.Symbol` called ``l_T_tilde`` to represent this.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.biomechanics import TendonForceLengthDeGroote2016
@@ -328,12 +328,12 @@ class TendonForceLengthInverseDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``TendonForceLengthInverseDeGroote2016`` is
+    The preferred way to instantiate :class:`TendonForceLengthInverseDeGroote2016` is
     using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized tendon force-length, which is
-    equal to the tendon force. We'll create a ``Symbol`` called ``fl_T`` to
+    equal to the tendon force. We'll create a :class:`~.Symbol`` called ``fl_T`` to
     represent this.
 
     >>> from sympy import Symbol
@@ -543,12 +543,12 @@ class FiberForceLengthPassiveDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``FiberForceLengthPassiveDeGroote2016`` is
+    The preferred way to instantiate :class:`FiberForceLengthPassiveDeGroote2016` is
     using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber length. We'll
-    create a ``Symbol`` called ``l_M_tilde`` to represent this.
+    create a :class:`~.Symbol` called ``l_M_tilde`` to represent this.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.biomechanics import FiberForceLengthPassiveDeGroote2016
@@ -767,12 +767,12 @@ class FiberForceLengthPassiveInverseDeGroote2016(CharacteristicCurveFunction):
     ========
 
     The preferred way to instantiate
-    ``FiberForceLengthPassiveInverseDeGroote2016`` is using the
+    :class:`FiberForceLengthPassiveInverseDeGroote2016` is using the
     :meth:`~.with_defaults` constructor because this will automatically populate the
     constants within the characteristic curve equation with the floating point
     values from the original publication. This constructor takes a single
     argument corresponding to the normalized passive muscle fiber length-force
-    component of the muscle fiber force. We'll create a ``Symbol`` called
+    component of the muscle fiber force. We'll create a :class:`~.Symbol` called
     ``fl_M_pas`` to represent this.
 
     >>> from sympy import Symbol
@@ -976,12 +976,12 @@ class FiberForceLengthActiveDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``FiberForceLengthActiveDeGroote2016`` is
+    The preferred way to instantiate :class:`FiberForceLengthActiveDeGroote2016` is
     using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber length. We'll
-    create a ``Symbol`` called ``l_M_tilde`` to represent this.
+    create a :class:`~.Symbol` called ``l_M_tilde`` to represent this.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.biomechanics import FiberForceLengthActiveDeGroote2016
@@ -1313,12 +1313,12 @@ class FiberForceVelocityDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``FiberForceVelocityDeGroote2016`` is using
+    The preferred way to instantiate :class:`FiberForceVelocityDeGroote2016` is using
     the :meth:`~.with_defaults` constructor because this will automatically populate
     the constants within the characteristic curve equation with the floating
     point values from the original publication. This constructor takes a single
     argument corresponding to normalized muscle fiber extension velocity. We'll
-    create a ``Symbol`` called ``v_M_tilde`` to represent this.
+    create a :class:`~.Symbol` called ``v_M_tilde`` to represent this.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.biomechanics import FiberForceVelocityDeGroote2016
@@ -1547,12 +1547,12 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
     Examples
     ========
 
-    The preferred way to instantiate ``FiberForceVelocityInverseDeGroote2016``
+    The preferred way to instantiate :class:`FiberForceVelocityInverseDeGroote2016`
     is using the :meth:`~.with_defaults` constructor because this will automatically
     populate the constants within the characteristic curve equation with the
     floating point values from the original publication. This constructor takes
     a single argument corresponding to normalized muscle fiber force-velocity
-    component of the muscle fiber force. We'll create a ``Symbol`` called
+    component of the muscle fiber force. We'll create a :class:`~.Symbol` called
     ``fv_M`` to represent this.
 
     >>> from sympy import Symbol


### PR DESCRIPTION
Fixes #25785
Fixed math rendering of:
- FiberForceLengthActiveDeGroote2016
- FiberForceLengthPassiveDeGroote2016 
Also added sphinx referencing for with_defaults in:
- FiberForceLengthActiveDeGroote2016
- FiberForceLengthPassiveDeGroote2016

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25785 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
