### PR TITLE
Added `evaluate` flag in LaTeX parser and made `evaluate=False` the default behavior

### DIFF
--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -65,7 +65,7 @@ class LarkLaTeXParser:
         self.transform_expr = transform
 
         if transformer is None:
-            self.transformer = TransformToSymPyExpr()
+            self.transformer = TransformToSymPyExpr(evaluate=False)
         else:
             self.transformer = transformer()
 

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -69,7 +69,7 @@ class LarkLaTeXParser:
         else:
             self.transformer = transformer()
 
-    def doparse(self, s: str):
+    def doparse(self, s: str, evaluate: bool):
         if self.print_debug_output:
             _lark.logger.setLevel(logging.DEBUG)
 
@@ -88,7 +88,7 @@ class LarkLaTeXParser:
             # print the `parse_tree` variable
             _lark.logger.debug(parse_tree.pretty())
 
-        sympy_expression = self.transformer.transform(parse_tree)
+        sympy_expression = self.transformer.transform_tree(parse_tree, evaluate)
 
         if self.print_debug_output:
             _lark.logger.debug("SymPy expression =", sympy_expression)
@@ -100,7 +100,7 @@ if _lark is not None:
     _lark_latex_parser = LarkLaTeXParser()
 
 
-def parse_latex_lark(s: str):
+def parse_latex_lark(s: str, evaluate=False):
     """
     Experimental LaTeX parser using Lark.
 
@@ -109,7 +109,7 @@ def parse_latex_lark(s: str):
     """
     if _lark is None:
         raise ImportError("Lark is probably not installed")
-    return _lark_latex_parser.doparse(s)
+    return _lark_latex_parser.doparse(s, evaluate=evaluate)
 
 
 def _pretty_print_lark_trees(tree, indent=0, show_expr=True):

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -69,7 +69,7 @@ class LarkLaTeXParser:
         else:
             self.transformer = transformer()
 
-    def doparse(self, s: str, evaluate: bool):
+    def doparse(self, s: str, evaluate: bool=False):
         if self.print_debug_output:
             _lark.logger.setLevel(logging.DEBUG)
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -7,7 +7,7 @@ from sympy.parsing.latex.errors import LaTeXParsingError
 lark = import_module("lark")
 
 if lark:
-    from lark import Transformer, Token, Tree  # type: ignore
+    from lark import Transformer, Token  # type: ignore
 else:
     class Transformer:  # type: ignore
         def transform(self, *args):

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -42,13 +42,14 @@ class TransformToSymPyExpr(Transformer):
 
         Note that the option must be set to ``True`` for the default parser to work.
     """
-    evaluate = None
+    def __init__(self, evaluate):
+        self.evaluate = evaluate
 
     SYMBOL = sympy.Symbol
     DIGIT = sympy.core.numbers.Integer
 
     def transform_tree(self, tree, evaluate):
-        TransformToSymPyExpr.evaluate = evaluate
+        self.evaluate = evaluate
 
         return super().transform(tree)
 
@@ -113,43 +114,43 @@ class TransformToSymPyExpr(Transformer):
         return tokens[1]
 
     def eq(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Eq(tokens[0], tokens[2])
         else:
             return sympy.Eq(tokens[0], tokens[2], evaluate=False)
 
     def ne(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Ne(tokens[0], tokens[2])
         else:
             return sympy.Ne(tokens[0], tokens[2], evaluate=False)
 
     def lt(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Lt(tokens[0], tokens[2])
         else:
             return sympy.Lt(tokens[0], tokens[2], evaluate=False)
 
     def lte(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Le(tokens[0], tokens[2])
         else:
             return sympy.Le(tokens[0], tokens[2], evaluate=False)
 
     def gt(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Gt(tokens[0], tokens[2])
         else:
             return sympy.Gt(tokens[0], tokens[2], evaluate=False)
 
     def gte(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Ge(tokens[0], tokens[2])
         else:
             return sympy.Ge(tokens[0], tokens[2], evaluate=False)
 
     def add(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Add(tokens[0], tokens[2])
         else:
             return sympy.Add(tokens[0], tokens[2], evaluate=False)
@@ -165,19 +166,19 @@ class TransformToSymPyExpr(Transformer):
             # which is not useful to anyone.
             return -tokens[1]
         elif len(tokens) == 3:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Add(tokens[0], -tokens[2])
             else:
                 return sympy.Add(tokens[0], sympy.Mul(-1, tokens[2], evaluate=False), evaluate=False)
 
     def mul(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Mul(tokens[0], tokens[2])
         else:
             return sympy.Mul(tokens[0], tokens[2], evaluate=False)
 
     def div(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
         else:
             return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1, evaluate=False), evaluate=False)
@@ -194,18 +195,18 @@ class TransformToSymPyExpr(Transformer):
             return tokens[0], tokens[1]
         elif isinstance(tokens[0], tuple):
             # then we have a derivative
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Derivative(tokens[1], tokens[0][1])
             else:
                 return sympy.Derivative(tokens[1], tokens[0][1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Mul(tokens[0], tokens[1])
             else:
                 return sympy.Mul(tokens[0], tokens[1], evaluate=False)
 
     def superscript(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Pow(tokens[0], tokens[2])
         else:
             return sympy.Pow(tokens[0], tokens[2], evaluate=False)
@@ -221,13 +222,13 @@ class TransformToSymPyExpr(Transformer):
         else:
             denominator = tokens[2]
 
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Mul(numerator, sympy.Pow(denominator, -1))
             else:
                 return sympy.Mul(numerator, sympy.Pow(denominator, -1, evaluate=False), evaluate=False)
 
     def binomial(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.binomial(tokens[1], tokens[2])
         else:
             return sympy.binomial(tokens[1], tokens[2], evaluate=False)
@@ -430,7 +431,7 @@ class TransformToSymPyExpr(Transformer):
         return tokens[1]
 
     def derivative(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Derivative(tokens[-1], tokens[5])
         else:
             return sympy.Derivative(tokens[-1], tokens[5], evaluate=False)
@@ -455,13 +456,13 @@ class TransformToSymPyExpr(Transformer):
         return sympy.Function(tokens[0])(*tokens[2])
 
     def min(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Min(*tokens[2])
         else:
             return sympy.Min(*tokens[2], evaluate=False)
 
     def max(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Max(*tokens[2])
         else:
             return sympy.Max(*tokens[2], evaluate=False)
@@ -479,37 +480,37 @@ class TransformToSymPyExpr(Transformer):
         return InnerProduct(Bra(tokens[1]), Ket(tokens[3]))
 
     def sin(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.sin(tokens[1])
         else:
             return sympy.sin(tokens[1], evaluate=False)
 
     def cos(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.cos(tokens[1])
         else:
             return sympy.cos(tokens[1], evaluate=False)
 
     def tan(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.tan(tokens[1])
         else:
             return sympy.tan(tokens[1], evaluate=False)
 
     def csc(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.csc(tokens[1])
         else:
             return sympy.csc(tokens[1], evaluate=False)
 
     def sec(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.sec(tokens[1])
         else:
             return sympy.sec(tokens[1], evaluate=False)
 
     def cot(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.cot(tokens[1])
         else:
             return sympy.cot(tokens[1], evaluate=False)
@@ -517,12 +518,12 @@ class TransformToSymPyExpr(Transformer):
     def sin_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.asin(tokens[-1])
             else:
                 return sympy.asin(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.sin(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.sin(tokens[-1]), exponent, evaluate=False)
@@ -530,12 +531,12 @@ class TransformToSymPyExpr(Transformer):
     def cos_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.acos(tokens[-1])
             else:
                 return sympy.acos(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.cos(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.cos(tokens[-1]), exponent, evaluate=False)
@@ -543,12 +544,12 @@ class TransformToSymPyExpr(Transformer):
     def tan_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.atan(tokens[-1])
             else:
                 return sympy.atan(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.tan(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.tan(tokens[-1]), exponent, evaluate=False)
@@ -556,12 +557,12 @@ class TransformToSymPyExpr(Transformer):
     def csc_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.acsc(tokens[-1])
             else:
                 return sympy.acsc(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.csc(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.csc(tokens[-1]), exponent, evaluate=False)
@@ -569,12 +570,12 @@ class TransformToSymPyExpr(Transformer):
     def sec_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.asec(tokens[-1])
             else:
                 return sympy.asec(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.sec(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.sec(tokens[-1]), exponent, evaluate=False)
@@ -582,114 +583,114 @@ class TransformToSymPyExpr(Transformer):
     def cot_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.acot(tokens[-1])
             else:
                 return sympy.acot(tokens[-1], evaluate=False)
         else:
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.Pow(sympy.cot(tokens[-1]), exponent)
             else:
                 return sympy.Pow(sympy.cot(tokens[-1]), exponent, evaluate=False)
 
     def arcsin(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.asin(tokens[1])
         else:
             return sympy.asin(tokens[1], evaluate=False)
 
     def arccos(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.acos(tokens[1])
         else:
             return sympy.acos(tokens[1], evaluate=False)
 
     def arctan(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.atan(tokens[1])
         else:
             return sympy.atan(tokens[1], evaluate=False)
 
     def arccsc(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.acsc(tokens[1])
         else:
             return sympy.acsc(tokens[1], evaluate=False)
 
     def arcsec(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.asec(tokens[1])
         else:
             return sympy.asec(tokens[1], evaluate=False)
 
     def arccot(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.acot(tokens[1])
         else:
             return sympy.acot(tokens[1], evaluate=False)
 
     def sinh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.sinh(tokens[1])
         else:
             return sympy.sinh(tokens[1], evaluate=False)
 
     def cosh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.cosh(tokens[1])
         else:
             return sympy.cosh(tokens[1], evaluate=False)
 
     def tanh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.tanh(tokens[1])
         else:
             return sympy.tanh(tokens[1], evaluate=False)
 
     def asinh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.asinh(tokens[1])
         else:
             return sympy.asinh(tokens[1], evaluate=False)
 
     def acosh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.acosh(tokens[1])
         else:
             return sympy.acosh(tokens[1], evaluate=False)
 
     def atanh(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.atanh(tokens[1])
         else:
             return sympy.atanh(tokens[1], evaluate=False)
 
     def abs(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.Abs(tokens[1])
         else:
             return sympy.Abs(tokens[1], evaluate=False)
 
     def floor(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.floor(tokens[1])
         else:
             return sympy.floor(tokens[1], evaluate=False)
 
     def ceil(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.ceiling(tokens[1])
         else:
             return sympy.ceiling(tokens[1], evaluate=False)
 
     def factorial(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.factorial(tokens[0])
         else:
             return sympy.factorial(tokens[0], evaluate=False)
 
     def conjugate(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.conjugate(tokens[1])
         else:
             return sympy.conjugate(tokens[1], evaluate=False)
@@ -697,19 +698,19 @@ class TransformToSymPyExpr(Transformer):
     def square_root(self, tokens):
         if len(tokens) == 2:
             # then there was no square bracket argument
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.sqrt(tokens[1])
             else:
                 return sympy.sqrt(tokens[1], evaluate=False)
         elif len(tokens) == 3:
             # then there _was_ a square bracket argument
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.root(tokens[2], tokens[1])
             else:
                 return sympy.root(tokens[2], tokens[1], evaluate=False)
 
     def exponential(self, tokens):
-        if TransformToSymPyExpr.evaluate:
+        if self.evaluate:
             return sympy.exp(tokens[1])
         else:
             return sympy.exp(tokens[1], evaluate=False)
@@ -719,12 +720,12 @@ class TransformToSymPyExpr(Transformer):
             # we don't need to check if there's an underscore or not because having one
             # in this case would be meaningless
             # TODO: ANTLR refers to ISO 80000-2:2019. should we keep base 10 or base 2?
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.log(tokens[1], 10)
             else:
                 return sympy.log(tokens[1], 10, evaluate=False)
         elif tokens[0].type == "FUNC_LN":
-            if TransformToSymPyExpr.evaluate:
+            if self.evaluate:
                 return sympy.log(tokens[1])
             else:
                 return sympy.log(tokens[1], evaluate=False)
@@ -732,13 +733,13 @@ class TransformToSymPyExpr(Transformer):
             # we check if a base was specified or not
             if "_" in tokens:
                 # then a base was specified
-                if TransformToSymPyExpr.evaluate:
+                if self.evaluate:
                     return sympy.log(tokens[3], tokens[2])
                 else:
                     return sympy.log(tokens[3], tokens[2], evaluate=False)
             else:
                 # a base was not specified
-                if TransformToSymPyExpr.evaluate:
+                if self.evaluate:
                     return sympy.log(tokens[1])
                 else:
                     return sympy.log(tokens[1], evaluate=False)

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -1,7 +1,5 @@
 import re
 
-from lark.visitors import _Leaf_T, _Return_T
-
 import sympy
 from sympy.external import import_module
 from sympy.parsing.latex.errors import LaTeXParsingError

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -1,5 +1,7 @@
 import re
 
+from lark.visitors import _Leaf_T, _Return_T
+
 import sympy
 from sympy.external import import_module
 from sympy.parsing.latex.errors import LaTeXParsingError
@@ -7,7 +9,7 @@ from sympy.parsing.latex.errors import LaTeXParsingError
 lark = import_module("lark")
 
 if lark:
-    from lark import Transformer, Token  # type: ignore
+    from lark import Transformer, Token, Tree  # type: ignore
 else:
     class Transformer:  # type: ignore
         def transform(self, *args):
@@ -42,9 +44,15 @@ class TransformToSymPyExpr(Transformer):
 
         Note that the option must be set to ``True`` for the default parser to work.
     """
+    evaluate = None
 
     SYMBOL = sympy.Symbol
     DIGIT = sympy.core.numbers.Integer
+
+    def transform_tree(self, tree, evaluate):
+        TransformToSymPyExpr.evaluate = evaluate
+
+        return super().transform(tree)
 
     def CMD_INFTY(self, tokens):
         return sympy.oo
@@ -107,37 +115,70 @@ class TransformToSymPyExpr(Transformer):
         return tokens[1]
 
     def eq(self, tokens):
-        return sympy.Eq(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Eq(tokens[0], tokens[2])
+        else:
+            return sympy.Eq(tokens[0], tokens[2], evaluate=False)
 
     def ne(self, tokens):
-        return sympy.Ne(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Ne(tokens[0], tokens[2])
+        else:
+            return sympy.Ne(tokens[0], tokens[2], evaluate=False)
 
     def lt(self, tokens):
-        return sympy.Lt(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Lt(tokens[0], tokens[2])
+        else:
+            return sympy.Lt(tokens[0], tokens[2], evaluate=False)
 
     def lte(self, tokens):
-        return sympy.Le(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Le(tokens[0], tokens[2])
+        else:
+            return sympy.Le(tokens[0], tokens[2], evaluate=False)
 
     def gt(self, tokens):
-        return sympy.Gt(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Gt(tokens[0], tokens[2])
+        else:
+            return sympy.Gt(tokens[0], tokens[2], evaluate=False)
 
     def gte(self, tokens):
-        return sympy.Ge(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Ge(tokens[0], tokens[2])
+        else:
+            return sympy.Ge(tokens[0], tokens[2], evaluate=False)
 
     def add(self, tokens):
-        return sympy.Add(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Add(tokens[0], tokens[2])
+        else:
+            return sympy.Add(tokens[0], tokens[2], evaluate=False)
 
     def sub(self, tokens):
         if len(tokens) == 2:
-            return -tokens[1]
+            if TransformToSymPyExpr.evaluate:
+                return -tokens[1]
+            else:
+                return sympy.Mul(-1, tokens[1], evaluate=False)
         elif len(tokens) == 3:
-            return sympy.Add(tokens[0], -tokens[2])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Add(tokens[0], -tokens[2])
+            else:
+                return sympy.Add(tokens[0], sympy.Mul(-1, tokens[2], evaluate=False), evaluate=False)
 
     def mul(self, tokens):
-        return sympy.Mul(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Mul(tokens[0], tokens[2])
+        else:
+            return sympy.Mul(tokens[0], tokens[2], evaluate=False)
 
     def div(self, tokens):
-        return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1))
+        else:
+            return sympy.Mul(tokens[0], sympy.Pow(tokens[2], -1, evaluate=False), evaluate=False)
 
     def adjacent_expressions(self, tokens):
         # Most of the time, if two expressions are next to each other, it means implicit multiplication,
@@ -156,7 +197,10 @@ class TransformToSymPyExpr(Transformer):
             return sympy.Mul(tokens[0], tokens[1])
 
     def superscript(self, tokens):
-        return sympy.Pow(tokens[0], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Pow(tokens[0], tokens[2])
+        else:
+            return sympy.Pow(tokens[0], tokens[2], evaluate=False)
 
     def fraction(self, tokens):
         numerator = tokens[1]
@@ -168,10 +212,17 @@ class TransformToSymPyExpr(Transformer):
             return "derivative", variable
         else:
             denominator = tokens[2]
-            return sympy.Mul(numerator, sympy.Pow(denominator, -1))
+
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Mul(numerator, sympy.Pow(denominator, -1))
+            else:
+                return sympy.Mul(numerator, sympy.Pow(denominator, -1, evaluate=False), evaluate=False)
 
     def binomial(self, tokens):
-        return sympy.binomial(tokens[1], tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.binomial(tokens[1], tokens[2])
+        else:
+            return sympy.binomial(tokens[1], tokens[2], evaluate=False)
 
     def normal_integral(self, tokens):
         underscore_index = None
@@ -235,10 +286,16 @@ class TransformToSymPyExpr(Transformer):
 
             # we can assume that either both the lower and upper bounds are given, or
             # neither of them are
-            return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound))
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound))
+            else:
+                return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound), evaluate=False)
         else:
             # we have an indefinite integral
-            return sympy.Integral(integrand, differential_variable)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Integral(integrand, differential_variable)
+            else:
+                return sympy.Integral(integrand, differential_variable, evaluate=False)
 
     def group_curly_parentheses_int(self, tokens):
         # return signature is a tuple consisting of the expression in the numerator, along with the variable of
@@ -253,7 +310,7 @@ class TransformToSymPyExpr(Transformer):
         numerator, variable = tokens[1]
         denominator = tokens[2]
 
-        # We pass the integrand, along with information about the variable of integration, upw
+        # We pass the integrand, along with information about the variable of integration, up
         return sympy.Mul(numerator, sympy.Pow(denominator, -1)), variable
 
     def integral_with_special_fraction(self, tokens):
@@ -290,10 +347,16 @@ class TransformToSymPyExpr(Transformer):
 
             # we can assume that either both the lower and upper bounds are given, or
             # neither of them are
-            return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound))
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound))
+            else:
+                return sympy.Integral(integrand, (differential_variable, lower_bound, upper_bound), evaluate=False)
         else:
             # we have an indefinite integral
-            return sympy.Integral(integrand, differential_variable)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Integral(integrand, differential_variable)
+            else:
+                return sympy.Integral(integrand, differential_variable, evaluate=False)
 
     def group_curly_parentheses_special(self, tokens):
         underscore_index = tokens.index("_")
@@ -331,10 +394,16 @@ class TransformToSymPyExpr(Transformer):
         return index_variable, lower_limit, upper_limit
 
     def summation(self, tokens):
-        return sympy.Sum(tokens[2], tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Sum(tokens[2], tokens[1])
+        else:
+            return sympy.Sum(tokens[2], tokens[1], evaluate=False)
 
     def product(self, tokens):
-        return sympy.Product(tokens[2], tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Product(tokens[2], tokens[1])
+        else:
+            return sympy.Product(tokens[2], tokens[1], evaluate=False)
 
     def limit_dir_expr(self, tokens):
         caret_index = tokens.index("^")
@@ -371,7 +440,10 @@ class TransformToSymPyExpr(Transformer):
         return tokens[1]
 
     def derivative(self, tokens):
-        return sympy.Derivative(tokens[-1], tokens[5])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Derivative(tokens[-1], tokens[5])
+        else:
+            return sympy.Derivative(tokens[-1], tokens[5], evaluate=False)
 
     def list_of_expressions(self, tokens):
         if len(tokens) == 1:
@@ -393,10 +465,16 @@ class TransformToSymPyExpr(Transformer):
         return sympy.Function(tokens[0])(*tokens[2])
 
     def min(self, tokens):
-        return sympy.Min(*tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Min(*tokens[2])
+        else:
+            return sympy.Min(*tokens[2], evaluate=False)
 
     def max(self, tokens):
-        return sympy.Max(*tokens[2])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Max(*tokens[2])
+        else:
+            return sympy.Max(*tokens[2], evaluate=False)
 
     def bra(self, tokens):
         from sympy.physics.quantum import Bra
@@ -411,143 +489,269 @@ class TransformToSymPyExpr(Transformer):
         return InnerProduct(Bra(tokens[1]), Ket(tokens[3]))
 
     def sin(self, tokens):
-        return sympy.sin(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.sin(tokens[1])
+        else:
+            return sympy.sin(tokens[1], evaluate=False)
 
     def cos(self, tokens):
-        return sympy.cos(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.cos(tokens[1])
+        else:
+            return sympy.cos(tokens[1], evaluate=False)
 
     def tan(self, tokens):
-        return sympy.tan(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.tan(tokens[1])
+        else:
+            return sympy.tan(tokens[1], evaluate=False)
 
     def csc(self, tokens):
-        return sympy.csc(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.csc(tokens[1])
+        else:
+            return sympy.csc(tokens[1], evaluate=False)
 
     def sec(self, tokens):
-        return sympy.sec(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.sec(tokens[1])
+        else:
+            return sympy.sec(tokens[1], evaluate=False)
 
     def cot(self, tokens):
-        return sympy.cot(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.cot(tokens[1])
+        else:
+            return sympy.cot(tokens[1], evaluate=False)
 
     def sin_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.asin(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.asin(tokens[-1])
+            else:
+                return sympy.asin(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.sin(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.sin(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.sin(tokens[-1]), exponent, evaluate=False)
 
     def cos_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acos(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.acos(tokens[-1])
+            else:
+                return sympy.acos(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.cos(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.cos(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.cos(tokens[-1]), exponent, evaluate=False)
 
     def tan_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.atan(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.atan(tokens[-1])
+            else:
+                return sympy.atan(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.tan(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.tan(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.tan(tokens[-1]), exponent, evaluate=False)
 
     def csc_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acsc(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.acsc(tokens[-1])
+            else:
+                return sympy.acsc(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.csc(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.csc(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.csc(tokens[-1]), exponent, evaluate=False)
 
     def sec_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.asec(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.asec(tokens[-1])
+            else:
+                return sympy.asec(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.sec(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.sec(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.sec(tokens[-1]), exponent, evaluate=False)
 
     def cot_power(self, tokens):
         exponent = tokens[2]
         if exponent == -1:
-            return sympy.acot(tokens[-1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.acot(tokens[-1])
+            else:
+                return sympy.acot(tokens[-1], evaluate=False)
         else:
-            return sympy.Pow(sympy.cot(tokens[-1]), exponent)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.Pow(sympy.cot(tokens[-1]), exponent)
+            else:
+                return sympy.Pow(sympy.cot(tokens[-1]), exponent, evaluate=False)
 
     def arcsin(self, tokens):
-        return sympy.asin(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.asin(tokens[1])
+        else:
+            return sympy.asin(tokens[1], evaluate=False)
 
     def arccos(self, tokens):
-        return sympy.acos(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.acos(tokens[1])
+        else:
+            return sympy.acos(tokens[1], evaluate=False)
 
     def arctan(self, tokens):
-        return sympy.atan(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.atan(tokens[1])
+        else:
+            return sympy.atan(tokens[1], evaluate=False)
 
     def arccsc(self, tokens):
-        return sympy.acsc(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.acsc(tokens[1])
+        else:
+            return sympy.acsc(tokens[1], evaluate=False)
 
     def arcsec(self, tokens):
-        return sympy.asec(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.asec(tokens[1])
+        else:
+            return sympy.asec(tokens[1], evaluate=False)
 
     def arccot(self, tokens):
-        return sympy.acot(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.acot(tokens[1])
+        else:
+            return sympy.acot(tokens[1], evaluate=False)
 
     def sinh(self, tokens):
-        return sympy.sinh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.sinh(tokens[1])
+        else:
+            return sympy.sinh(tokens[1], evaluate=False)
 
     def cosh(self, tokens):
-        return sympy.cosh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.cosh(tokens[1])
+        else:
+            return sympy.cosh(tokens[1], evaluate=False)
 
     def tanh(self, tokens):
-        return sympy.tanh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.tanh(tokens[1])
+        else:
+            return sympy.tanh(tokens[1], evaluate=False)
 
     def asinh(self, tokens):
-        return sympy.asinh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.asinh(tokens[1])
+        else:
+            return sympy.asinh(tokens[1], evaluate=False)
 
     def acosh(self, tokens):
-        return sympy.acosh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.acosh(tokens[1])
+        else:
+            return sympy.acosh(tokens[1], evaluate=False)
 
     def atanh(self, tokens):
-        return sympy.atanh(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.atanh(tokens[1])
+        else:
+            return sympy.atanh(tokens[1], evaluate=False)
 
     def abs(self, tokens):
-        return sympy.Abs(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.Abs(tokens[1])
+        else:
+            return sympy.Abs(tokens[1], evaluate=False)
 
     def floor(self, tokens):
-        return sympy.floor(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.floor(tokens[1])
+        else:
+            return sympy.floor(tokens[1], evaluate=False)
 
     def ceil(self, tokens):
-        return sympy.ceiling(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.ceiling(tokens[1])
+        else:
+            return sympy.ceiling(tokens[1], evaluate=False)
 
     def factorial(self, tokens):
-        return sympy.factorial(tokens[0])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.factorial(tokens[0])
+        else:
+            return sympy.factorial(tokens[0], evaluate=False)
 
     def conjugate(self, tokens):
-        return sympy.conjugate(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.conjugate(tokens[1])
+        else:
+            return sympy.conjugate(tokens[1], evaluate=False)
 
     def square_root(self, tokens):
         if len(tokens) == 2:
             # then there was no square bracket argument
-            return sympy.sqrt(tokens[1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.sqrt(tokens[1])
+            else:
+                return sympy.sqrt(tokens[1], evaluate=False)
         elif len(tokens) == 3:
             # then there _was_ a square bracket argument
-            return sympy.root(tokens[2], tokens[1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.root(tokens[2], tokens[1])
+            else:
+                return sympy.root(tokens[2], tokens[1], evaluate=False)
 
     def exponential(self, tokens):
-        return sympy.exp(tokens[1])
+        if TransformToSymPyExpr.evaluate:
+            return sympy.exp(tokens[1])
+        else:
+            return sympy.exp(tokens[1], evaluate=False)
 
     def log(self, tokens):
         if tokens[0].type == "FUNC_LG":
             # we don't need to check if there's an underscore or not because having one
             # in this case would be meaningless
             # TODO: ANTLR refers to ISO 80000-2:2019. should we keep base 10 or base 2?
-            return sympy.log(tokens[1], 10)
+            if TransformToSymPyExpr.evaluate:
+                return sympy.log(tokens[1], 10)
+            else:
+                return sympy.log(tokens[1], 10, evaluate=False)
         elif tokens[0].type == "FUNC_LN":
-            return sympy.log(tokens[1])
+            if TransformToSymPyExpr.evaluate:
+                return sympy.log(tokens[1])
+            else:
+                return sympy.log(tokens[1], evaluate=False)
         elif tokens[0].type == "FUNC_LOG":
             # we check if a base was specified or not
             if "_" in tokens:
                 # then a base was specified
-                return sympy.log(tokens[3], tokens[2])
+                if TransformToSymPyExpr.evaluate:
+                    return sympy.log(tokens[3], tokens[2])
+                else:
+                    return sympy.log(tokens[3], tokens[2], evaluate=False)
             else:
                 # a base was not specified
-                return sympy.log(tokens[1])
+                if TransformToSymPyExpr.evaluate:
+                    return sympy.log(tokens[1])
+                else:
+                    return sympy.log(tokens[1], evaluate=False)
 
     def _extract_differential_symbol(self, s: str):
         differential_symbols = {"d", r"\text{d}", r"\mathrm{d}"}

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -7,7 +7,6 @@ from sympy.concrete.summations import Sum
 from sympy.core.function import Derivative, Function
 from sympy.core.numbers import E, oo, Rational
 from sympy.core.power import Pow
-from sympy.core.parameters import evaluate
 from sympy.core.relational import GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Unequality
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import binomial, factorial

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -588,7 +588,7 @@ def test_product_expressions():
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
         # Testing evaluate=True
         assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
-        
+
 
 @XFAIL
 def test_applied_function_expressions():

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -73,7 +73,7 @@ UNEVALUATED_SIMPLE_EXPRESSION_PAIRS = [
     (r"0*1", _Mul(0, 1)),
     (r"x", x),
     (r"2x", 2 * x),
-    (r"3x - 1", _Add(_Mul(3, x), -1)),
+    (r"3x - 1", _Add(_Mul(3, x), _Mul(-1, 1))),
     (r"-c", -c),
     (r"\infty", oo),
     (r"a \cdot b", a * b),
@@ -87,7 +87,10 @@ UNEVALUATED_SIMPLE_EXPRESSION_PAIRS = [
 ]
 
 EVALUATED_SIMPLE_EXPRESSION_PAIRS = [
-    (r"(-7.13)(1.5)", -10.695),
+    (r"0", 0),
+    (r"1", 1),
+    (r"-3.14", -3.14),
+    (r"(-7.13)(1.5)", -7.13 * 1.5),
     (r"1+1", 2),
     (r"0+1", 1),
     (r"1*2", 2),
@@ -162,28 +165,28 @@ EVALUATED_POWER_EXPRESSION_PAIRS = [
 ]
 
 UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
-    (r"\int x dx", Integral(_Mul(1, x), x)),
-    (r"\int x \, dx", Integral(_Mul(1, x), x)),
-    (r"\int x d\theta", Integral(_Mul(1, x), theta)),
-    (r"\int (x^2 - y)dx", Integral(_Mul(1, x ** 2 - y), x)),
-    (r"\int x + a dx", Integral(_Mul(1, _Add(x, a)), x)),
-    (r"\int da", Integral(_Mul(1, 1), a)),
-    (r"\int_0^7 dx", Integral(_Mul(1, 1), (x, 0, 7))),
-    (r"\int\limits_{0}^{1} x dx", Integral(_Mul(1, x), (x, 0, 1))),
-    (r"\int_a^b x dx", Integral(_Mul(1, x), (x, a, b))),
-    (r"\int^b_a x dx", Integral(_Mul(1, x), (x, a, b))),
-    (r"\int_{a}^b x dx", Integral(_Mul(1, x), (x, a, b))),
-    (r"\int^{b}_a x dx", Integral(_Mul(1, x), (x, a, b))),
-    (r"\int_{a}^{b} x dx", Integral(_Mul(1, x), (x, a, b))),
-    (r"\int^{b}_{a} x dx", Integral(_Mul(1, x), (x, a, b))),
+    (r"\int x dx", Integral(x, x)),
+    (r"\int x \, dx", Integral(x, x)),
+    (r"\int x d\theta", Integral(x, theta)),
+    (r"\int (x^2 - y)dx", Integral(x ** 2 - y, x)),
+    (r"\int x + a dx", Integral(_Add(x, a), x)),
+    (r"\int da", Integral(1, a)),
+    (r"\int_0^7 dx", Integral(1, (x, 0, 7))),
+    (r"\int\limits_{0}^{1} x dx", Integral(x, (x, 0, 1))),
+    (r"\int_a^b x dx", Integral(x, (x, a, b))),
+    (r"\int^b_a x dx", Integral(x, (x, a, b))),
+    (r"\int_{a}^b x dx", Integral(x, (x, a, b))),
+    (r"\int^{b}_a x dx", Integral(x, (x, a, b))),
+    (r"\int_{a}^{b} x dx", Integral(x, (x, a, b))),
+    (r"\int^{b}_{a} x dx", Integral(x, (x, a, b))),
     (r"\int_{f(a)}^{f(b)} f(z) dz", Integral(f(z), (z, f(a), f(b)))),
-    (r"\int a + b + c dx", Integral(_Mul(1, _Add(_Add(a, b), c)), x)),
-    (r"\int \frac{dz}{z}", Integral(_Mul(1, _Mul(1, Pow(z, -1))), z)),
-    (r"\int \frac{3 dz}{z}", Integral(_Mul(1, _Mul(3, _Pow(z, -1))), z)),
-    (r"\int \frac{1}{x} dx", Integral(_Mul(1, _Mul(1, Pow(x, -1))), x)),
+    (r"\int a + b + c dx", Integral(_Add(_Add(a, b), c), x)),
+    (r"\int \frac{dz}{z}", Integral(Pow(z, -1), z)),
+    (r"\int \frac{3 dz}{z}", Integral(_Mul(3, _Pow(z, -1)), z)),
+    (r"\int \frac{1}{x} dx", Integral(_Mul(1, Pow(x, -1)), x)),
     (r"\int \frac{1}{a} + \frac{1}{b} dx",
-     Integral(_Mul(1, _Add(_Mul(1, _Pow(a, -1)), _Mul(1, Pow(b, -1)))), x)),
-    (r"\int \frac{1}{x} + 1 dx", Integral(_Mul(1, _Add(_Mul(1, _Pow(x, -1)), 1)), x))
+     Integral(_Add(_Mul(1, _Pow(a, -1)), _Mul(1, Pow(b, -1))), x)),
+    (r"\int \frac{1}{x} + 1 dx", Integral(_Add(_Mul(1, _Pow(x, -1)), 1), x))
 ]
 
 EVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
@@ -218,7 +221,7 @@ DERIVATIVE_EXPRESSION_PAIRS = [
     (r"\frac{d\theta(x)}{dx}", Derivative(Function('theta')(x), x))
 ]
 
-TRIGONOMETRIC_EXPRESSION_PAIRS = [
+UNEVALUATED_TRIGONOMETRIC_EXPRESSION_PAIRS = [
     (r"\sin \theta", sin(theta)),
     (r"\sin(\theta)", sin(theta)),
     (r"\sin^{-1} a", asin(a)),
@@ -227,6 +230,17 @@ TRIGONOMETRIC_EXPRESSION_PAIRS = [
     (r"\sin(\cos \theta)", sin(cos(theta))),
     (r"(\csc x)(\sec y)", csc(x) * sec(y)),
     (r"\frac{\sin{x}}2", _Mul(sin(x), _Pow(2, -1)))
+]
+
+EVALUATED_TRIGONOMETRIC_EXPRESSION_PAIRS = [
+    (r"\sin \theta", sin(theta)),
+    (r"\sin(\theta)", sin(theta)),
+    (r"\sin^{-1} a", asin(a)),
+    (r"\sin a \cos b", sin(a) * cos(b)),
+    (r"\sin \cos \theta", sin(cos(theta))),
+    (r"\sin(\cos \theta)", sin(cos(theta))),
+    (r"(\csc x)(\sec y)", csc(x) * sec(y)),
+    (r"\frac{\sin{x}}2", sin(x) / 2)
 ]
 
 UNEVALUATED_LIMIT_EXPRESSION_PAIRS = [
@@ -249,9 +263,7 @@ EVALUATED_LIMIT_EXPRESSION_PAIRS = [
 UNEVALUATED_SQRT_EXPRESSION_PAIRS = [
     (r"\sqrt{x}", sqrt(x)),
     (r"\sqrt{x + b}", sqrt(_Add(x, b))),
-    (r"\sqrt[3]{\sin x}", _Pow(sin(x), _Pow(3, -1))),
-    # the above test needed to be handled differently than the ones below because root
-    # acts differently if its second argument is a number
+    (r"\sqrt[3]{\sin x}", root(sin(x), 3)),
     (r"\sqrt[y]{\sin x}", root(sin(x), y)),
     (r"\sqrt[\theta]{\sin x}", root(sin(x), theta)),
     (r"\sqrt{\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1))))
@@ -287,13 +299,13 @@ EVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
 ]
 
 UNEVALUATED_SUM_EXPRESSION_PAIRS = [
-    (r"\sum_{k = 1}^{3} c", Sum(_Mul(1, c), (k, 1, 3))),
-    (r"\sum_{k = 1}^3 c", Sum(_Mul(1, c), (k, 1, 3))),
-    (r"\sum^{3}_{k = 1} c", Sum(_Mul(1, c), (k, 1, 3))),
-    (r"\sum^3_{k = 1} c", Sum(_Mul(1, c), (k, 1, 3))),
-    (r"\sum_{k = 1}^{10} k^2", Sum(_Mul(1, k ** 2), (k, 1, 10))),
+    (r"\sum_{k = 1}^{3} c", Sum(c, (k, 1, 3))),
+    (r"\sum_{k = 1}^3 c", Sum(c, (k, 1, 3))),
+    (r"\sum^{3}_{k = 1} c", Sum(c, (k, 1, 3))),
+    (r"\sum^3_{k = 1} c", Sum(c, (k, 1, 3))),
+    (r"\sum_{k = 1}^{10} k^2", Sum(k ** 2, (k, 1, 10))),
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}",
-     Sum(_Mul(1, _Mul(1, _Pow(_factorial(n), -1))), (n, 0, oo)))
+     Sum(_Mul(1, _Pow(_factorial(n), -1)), (n, 0, oo)))
 ]
 
 EVALUATED_SUM_EXPRESSION_PAIRS = [
@@ -305,7 +317,7 @@ EVALUATED_SUM_EXPRESSION_PAIRS = [
     (r"\sum_{n = 0}^{\infty} \frac{1}{n!}", Sum(1 / factorial(n), (n, 0, oo)))
 ]
 
-UNEVALUATED_PRODUCT_EXPRESSION_PAIRS = [
+PRODUCT_EXPRESSION_PAIRS = [
     (r"\prod_{a = b}^{c} x", Product(x, (a, b, c))),
     (r"\prod_{a = b}^c x", Product(x, (a, b, c))),
     (r"\prod^{c}_{a = b} x", Product(x, (a, b, c))),
@@ -432,8 +444,10 @@ def test_symbol_expressions():
     for i, (latex_str, sympy_expr) in enumerate(SYMBOL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_simple_expressions():
@@ -441,41 +455,46 @@ def test_simple_expressions():
     for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_SIMPLE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for i, (latex_str, sympy_expr) in enumerate(EVALUATED_SIMPLE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_fraction_expressions():
     for latex_str, sympy_expr in UNEVALUATED_FRACTION_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_FRACTION_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_relation_expressions():
     for latex_str, sympy_expr in RELATION_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 def test_power_expressions():
     expected_failures = {3}
     for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_POWER_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for i, (latex_str, sympy_expr) in enumerate(EVALUATED_POWER_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_integral_expressions():
@@ -483,13 +502,14 @@ def test_integral_expressions():
     for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, i
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for i, (latex_str, sympy_expr) in enumerate(EVALUATED_INTEGRAL_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_derivative_expressions():
@@ -497,99 +517,117 @@ def test_derivative_expressions():
     for i, (latex_str, sympy_expr) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for i, (latex_str, sympy_expr) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_trigonometric_expressions():
     expected_failures = {3}
-    for i, (latex_str, sympy_expr) in enumerate(TRIGONOMETRIC_EXPRESSION_PAIRS):
+    for i, (latex_str, sympy_expr) in enumerate(UNEVALUATED_TRIGONOMETRIC_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for i, (latex_str, sympy_expr) in enumerate(EVALUATED_TRIGONOMETRIC_EXPRESSION_PAIRS):
+        if i in expected_failures:
+            continue
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_limit_expressions():
     for latex_str, sympy_expr in UNEVALUATED_LIMIT_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+    for latex_str, sympy_expr in EVALUATED_LIMIT_EXPRESSION_PAIRS:
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_square_root_expressions():
     for latex_str, sympy_expr in UNEVALUATED_SQRT_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_SQRT_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_factorial_expressions():
     for latex_str, sympy_expr in UNEVALUATED_FACTORIAL_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_FACTORIAL_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_sum_expressions():
     for latex_str, sympy_expr in UNEVALUATED_SUM_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_SUM_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_product_expressions():
-    for latex_str, sympy_expr in UNEVALUATED_PRODUCT_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+    for latex_str, sympy_expr in PRODUCT_EXPRESSION_PAIRS:
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
+        
 
 @XFAIL
 def test_applied_function_expressions():
     expected_failures = {0, 3, 4}  # 0 is ambiguous, and the others require not-yet-added features
-    # not sure why 1, and 2 are failing
     for i, (latex_str, sympy_expr) in enumerate(APPLIED_FUNCTION_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_common_function_expressions():
     for latex_str, sympy_expr in UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 # unhandled bug causing these to fail
 @XFAIL
 def test_spacing():
     for latex_str, sympy_expr in SPACING_RELATED_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_binomial_expressions():
     for latex_str, sympy_expr in UNEVALUATED_BINOMIAL_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
     for latex_str, sympy_expr in EVALUATED_BINOMIAL_EXPRESSION_PAIRS:
-        assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=True
+        assert parse_latex_lark(latex_str, evaluate=True) == sympy_expr, latex_str
 
 
 def test_miscellaneous_expressions():
     for latex_str, sympy_expr in MISCELLANEOUS_EXPRESSION_PAIRS:
-        with evaluate(False):
-            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+        # Testing evaluate=False
+        assert parse_latex_lark(latex_str) == sympy_expr, latex_str


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Address the comments in #25790.


#### Brief description of what is fixed or changed
I added a `evaluate` parameter to `parse_latex_lark` which controls whether or not the SymPy expressions are evaluated. The default behavior is set to `False` to maintain backwards compatibility with the ANTLR-based parser. However, using `evaluate=True` brings back the old behavior of the Lark-based parser.

#### Other comments
It was pointed out in [#25626 (comment)](https://github.com/sympy/sympy/pull/25626#discussion_r1315230783) that the tests for `evaluate=False` have a lot of random multiplications by 1. While making this change, I noticed that many tests were failing because those extra multiplications aren't present anymore, so I had to remove a lot of them.

I've intentionally not made any changes to the docs and to `parse_latex`. I'll do that in #25790 once this is merged.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * The Lark-based LaTeX parser now supports the `evaluate` flag, which allows the user to control whether or not expressions are evaluated. The default behavior is to use `evaluate=False`.
<!-- END RELEASE NOTES -->
