### PR TITLE
Added unimodular matrices S,T for smith_normal_form

### DIFF
--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -7,6 +7,7 @@ from .exceptions import DMDomainError, DMShapeError
 from sympy.ntheory.modular import symmetric_residue
 from sympy.polys.domains import QQ, ZZ
 
+from sympy import Matrix
 
 # TODO (future work):
 #  There are faster algorithms for Smith and Hermite normal forms, which
@@ -41,8 +42,6 @@ def smith_normal_form(m):
     '''
     Return the Smith Normal Form of a matrix `m` along with the unimodular matrices S and T.
     '''
-    from sympy import Matrix
-
     M = Matrix(m)
     S = Matrix.eye(M.rows)
     T = Matrix.eye(M.cols)
@@ -66,6 +65,7 @@ def smith_normal_form(m):
                 T.col_add(j, i, -q)
                 J.col_add(j, i, -q)
     return J, S, T
+
 
 def add_columns(m, i, j, a, b, c, d):
     # replace m[:, i] by a*m[:, i] + b*m[:, j]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #25759" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25759

#### Brief description of what is fixed or changed

Implemented the functionality to retrieve unimodular matrices S and T in the Smith normal form computation such that A = S * J * T, where A is the original matrix and J is the Smith normal form.

#### Other comments

The added feature ensures that users can now obtain the unimodular matrices associated with the Smith normal form, which was previously not available.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added functionality to obtain unimodular matrices associated with the Smith normal form in `polys.matrices.normalforms`.
<!-- END RELEASE NOTES -->
