### PR TITLE
fix #25781: solving with two powers

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3216,9 +3216,12 @@ def _invert(eq, *symbols, **kwargs):
             if any(_ispow(i) for i in (ad, bd)):
                 a_base, a_exp = ad.as_base_exp()
                 b_base, b_exp = bd.as_base_exp()
-                if a_base == b_base:
-                    # a = -b
-                    lhs = powsimp(powdenest(ad/bd))
+                if a_base == b_base and a_exp.extract_additively(b_exp) is None:
+                    # a = -b and exponents do not have canceling terms/factors
+                    # e.g. if exponents were 3*x and x then the ratio would have
+                    # an exponent of 2*x: one of the roots would be lost
+                    rat = powsimp(powdenest(ad/bd))
+                    lhs = rat
                     rhs = -bi/ai
                 else:
                     rat = ad/bd

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3267,3 +3267,7 @@ def test_issue_21890():
 def test_issue_22628():
     assert nonlinsolve([h - 1, k - 1, f - 2, f - 4, -2*k], h, k, f) == S.EmptySet
     assert nonlinsolve([x**3 - 1, x + y, x**2 - 4], [x, y]) == S.EmptySet
+
+
+def test_issue_25781():
+    assert solve(sqrt(x/2) - x) == [0, S.Half]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * solution no longer dropped for equations involving `x**a = x**b` when `a` and `b` have term or factor in common
<!-- END RELEASE NOTES -->
