### PR TITLE
Use slices in `Sieve.primerange`

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -210,7 +210,6 @@ class Sieve:
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
         """
-
         if b is None:
             b = _as_int_ceiling(a)
             a = 2
@@ -220,15 +219,8 @@ class Sieve:
         if a >= b:
             return
         self.extend(b)
-        i = self.search(a)[1]
-        maxi = len(self._list) + 1
-        while i < maxi:
-            p = self._list[i - 1]
-            if p < b:
-                yield p
-                i += 1
-            else:
-                return
+        yield from self._list[bisect_left(self._list, a):
+                              bisect_left(self._list, b)]
 
     def totientrange(self, a, b):
         """Generate all totient numbers for the range [a, b).


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
