### PR TITLE
Reject unordered sets in linear_eq_to_matrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -466,6 +466,7 @@ Colin B. Macdonald <cbm@m.fsf.org> <macdonald@maths.ox.ac.uk>
 Colin Marquardt <github@marquardt-home.de>
 Colleen Lee <colleenclee@gmail.com> <clee@coursera.org>
 Comer Duncan <comer.duncan@gmail.com>
+Congxu Yang <u7189828@anu.edu.au>
 Constantin Mateescu <costica1234@me.com>
 Costor <pcs2009@web.de>
 Craig A. Stoudt <craig.stoudt@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2605,6 +2605,11 @@ def linear_eq_to_matrix(equations, *symbols):
             are to be found.
             '''))
 
+    # Check if 'symbols' is a set and raise an error if it is
+    if isinstance(symbols[0], set):
+        raise TypeError(
+            "Unordered 'set' type is not supported as input for symbols.")
+
     if hasattr(symbols[0], '__iter__'):
         symbols = symbols[0]
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3277,7 +3277,6 @@ def test_issue_25423():
     x, y = symbols('x y')
     equations1 = []
     equations2 = [2 * x + 3 * y - 1]
-    nonlinear_equations = [x ** 2 + y ** 2 - 1, x - y]
     raises(TypeError, lambda: linear_eq_to_matrix(equations1, {x, y}))
     raises(TypeError, lambda: linear_eq_to_matrix(equations2, {x, y}))
-    raises(NonlinearError, lambda: linear_eq_to_matrix(nonlinear_equations, x, y))
+    raises(ValueError, lambda: linear_eq_to_matrix(set(equations2), (x, y)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1408,6 +1408,11 @@ def test_linear_eq_to_matrix():
     assert linear_eq_to_matrix(Eq(x + 2, 1), x) == (
         Matrix([[1]]), Matrix([[-1]]))
 
+    # issue 25423
+    raises(TypeError, lambda: linear_eq_to_matrix([], {x, y}))
+    raises(TypeError, lambda: linear_eq_to_matrix([x + y], {x, y}))
+    raises(ValueError, lambda: linear_eq_to_matrix({x + y}, (x, y)))
+
 
 def test_issue_16577():
     assert linear_eq_to_matrix(Eq(a*(2*x + 3*y) + 4*y, 5), x, y) == (
@@ -3271,12 +3276,3 @@ def test_issue_22628():
 
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
-
-
-def test_issue_25423():
-    x, y = symbols('x y')
-    equations1 = []
-    equations2 = [2 * x + 3 * y - 1]
-    raises(TypeError, lambda: linear_eq_to_matrix(equations1, {x, y}))
-    raises(TypeError, lambda: linear_eq_to_matrix(equations2, {x, y}))
-    raises(ValueError, lambda: linear_eq_to_matrix(set(equations2), (x, y)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3271,3 +3271,13 @@ def test_issue_22628():
 
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
+
+
+def test_issue_25423():
+    x, y = symbols('x y')
+    equations1 = []
+    equations2 = [2 * x + 3 * y - 1]
+    nonlinear_equations = [x ** 2 + y ** 2 - 1, x - y]
+    raises(TypeError, lambda: linear_eq_to_matrix(equations1, {x, y}))
+    raises(TypeError, lambda: linear_eq_to_matrix(equations2, {x, y}))
+    raises(NonlinearError, lambda: linear_eq_to_matrix(nonlinear_equations, x, y))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes https://github.com/sympy/sympy/pull/25812
This PR contains the squashed commit version of the previously closed #25812 . This new PR do not have commits which will unintentionally affect a large number of lines in the blame.

Fixes https://github.com/sympy/sympy/issues/25423
If a user relies on `sets` to pass symbols to `linear_eq_to_matrix`, they might receive results that appear inconsistent. Since the equations' coefficients matrix depends on the order of symbols, using an unordered set can lead to confusion. Different runs could potentially produce different matrices, even if the equations and symbols remain the same.

#### Brief description of what is fixed or changed

Previous implementations allowed unordered `sets` as inputs for `linear_eq_to_matrix`, leading to unpredictable outputs. With input validation in `solveset.py` , symbols are provided in a predictable sequence, enforcing consistent behavior.

New test cases implemented in `test_solveset.py`cover the scenarios where `sets` are passed to the function, ensuring proper error responses.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `linear_eq_to_matrix` now raises TypeError when passing unordered symbols
<!-- END RELEASE NOTES -->
