### PR TITLE
Neg mul parenthesis fix 25026

### DIFF
--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -120,6 +120,8 @@ def precedence(item):
 
     This is the precedence for StrPrinter.
     """
+    from sympy.core import sympify
+    item = sympify(item)
     if hasattr(item, "precedence"):
         return item.precedence
     if not isinstance(item, type):
@@ -129,7 +131,11 @@ def precedence(item):
                 return PRECEDENCE_FUNCTIONS[n](item)
             elif n in PRECEDENCE_VALUES:
                 return PRECEDENCE_VALUES[n]
+    # Check if it's a negative number, and add parentheses
+    if item.is_number and item < 0:
+        return PRECEDENCE["Add"]
     return PRECEDENCE["Atom"]
+    
 
 
 PRECEDENCE_TRADITIONAL = PRECEDENCE.copy()

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -130,7 +130,7 @@ def precedence(item):
             elif n in PRECEDENCE_VALUES:
                 return PRECEDENCE_VALUES[n]
     # Check if it's a negative number, and add parentheses
-    if isinstance(item, (int, float, complex)) and item < 0:
+    if item.is_Number and item < 0:
         return PRECEDENCE["Add"]
     return PRECEDENCE["Atom"]
 

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -120,8 +120,8 @@ def precedence(item):
 
     This is the precedence for StrPrinter.
     """
-    from sympy.core import sympify
-    item = sympify(item)
+    
+    
     if hasattr(item, "precedence"):
         return item.precedence
     if not isinstance(item, type):
@@ -132,7 +132,7 @@ def precedence(item):
             elif n in PRECEDENCE_VALUES:
                 return PRECEDENCE_VALUES[n]
     # Check if it's a negative number, and add parentheses
-    if item.is_number and item < 0:
+    if isinstance(item, (int, float, complex)) and item < 0:
         return PRECEDENCE["Add"]
     return PRECEDENCE["Atom"]
     

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -133,7 +133,6 @@ def precedence(item):
     if isinstance(item, (int, float, complex)) and item < 0:
         return PRECEDENCE["Add"]
     return PRECEDENCE["Atom"]
-    
 
 
 PRECEDENCE_TRADITIONAL = PRECEDENCE.copy()

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -120,8 +120,6 @@ def precedence(item):
 
     This is the precedence for StrPrinter.
     """
-    
-    
     if hasattr(item, "precedence"):
         return item.precedence
     if not isinstance(item, type):

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1155,17 +1155,21 @@ def test_diffgeom():
     b = BaseScalarField(rect, 0)
     assert str(b) == "x"
 
+
 def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=True) == '1.00000000000000'
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=True) == '[1.00000000000000, 2.00000000000000]'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'
 
+
 def test_Predicate():
     assert sstr(Q.even) == 'Q.even'
 
+
 def test_AppliedPredicate():
     assert sstr(Q.even(x)) == 'Q.even(x)'
+
 
 def test_printing_str_array_expressions():
     assert sstr(ArraySymbol("A", (2, 3, 4))) == "A"
@@ -1173,3 +1177,14 @@ def test_printing_str_array_expressions():
     M = MatrixSymbol("M", 3, 3)
     N = MatrixSymbol("N", 3, 3)
     assert sstr(ArrayElement(M*N, [x, 0])) == "(M*N)[x, 0]"
+
+
+def test_issue_25026():
+    class F(Function):
+        precedence = 45
+        def _sympystr(self, printer):
+            return f"{printer._print(self.args[0])} F {printer._print(self.args[1])}"
+
+    eq = 2*F(x, y)
+    assert str(eq) == '2*(x F y)'
+    assert str(-eq) == '-2*(x F y)'


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #25026 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #25026" -->

#### Brief description of what is fixed or changed

This pull request addresses the issue #25026 by fixing the printing of multiplication by negative numbers when a custom (infix) function is involved. The changes to the `precedence.py` file ensure that parentheses are correctly added around negative numbers in expressions involving the custom function with lower precedence.

#### Other comments

I've tested these changes locally and verified that they resolve the issue as expected. Additionally, the code modifications do not affect other functionality in the precedence handling.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
