### PR TITLE
Explanation of a shared math framework for the DAEs produced by Newton-Euler's, Kane's, and Lagrange's Methods.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -170,6 +170,3 @@ $(BUILDDIR)/logo/*.png: $(SOURCEDIR)/logo/sympy.svg
 	$(PYTHON) ./generate_logos.py -d
 	@echo
 	@echo "Logo generated."
-
-autobuild:
-	sphinx-autobuild $(ALLSPHINXOPTS) $(SPHINXSAVEWARNINGS) $(SOURCEDIR) $(BUILDDIR)/html

--- a/doc/src/modules/physics/mechanics/api/system.rst
+++ b/doc/src/modules/physics/mechanics/api/system.rst
@@ -2,6 +2,9 @@
 SymbolicSystem (Docstrings)
 ===========================
 
+.. automodule:: sympy.physics.mechanics._system
+   :members:
+
 .. autoclass:: sympy.physics.mechanics._system.System
    :members:
 

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -49,7 +49,7 @@ Dynamical equations of motion
 
 Acceleration constraints
 
-If there are holonomic of nonholonomic constraints the dynamical differential
+If there are holonomic or nonholonomic constraints the dynamical differential
 equations must be augmented with the constraint forces. The holonomic
 constraints are twice differentiated with respect to time and the nonholonomic
 constraints are differentiated once.

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -10,10 +10,13 @@ Explanation
 - :math:`\mathrm{u} \in \mathbb{R}^n` : generalized speeds
 - :math:`\mathrm{u}_s \in \mathbb{R}^p` : independent generalized speeds
 - :math:`\mathrm{u}_r \in \mathbb{R}^m` : dependent generalized speeds
+- :math:`\mathrm{u}_a` : auxiliary generalized speeds
 - :math:`\mathrm{p}` : constants
-- :math:`\mathrm{r}` : time varying specified inputs
+- :math:`\mathrm{r}` : time varying specified inputs (can be kinematic
+  quantities, force quantities, or other)
 - :math:`\mathrm{\lambda}` : Lagrange multipliers (constraint forces)
 - :math:`\mathrm{y}` : time varying outputs
+- :math:`\mathrm{w}` : additional state variables
 
 Lagrange
 ========
@@ -135,6 +138,68 @@ Output equations
    \mathbf{f}_o(\bar{y}, \ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
    \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{\lambda},
    \mathrm{p}, t) = \mathbf{0}
+
+Additional first order differential equations
+
+.. math::
+
+   \mathbf{f}_a(\dot{\mathbf{w}}, \mathbf{w}, \dot{\mathrm{q}}, \mathrm{q},
+   \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) = \mathbf{0}
+
+Kane
+====
+
+Holonomic constraints
+
+.. math::
+
+   \mathrm{f}_h(\mathrm{q}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0}
+   \in \mathbb{R}^M
+
+Kinematical differential equations
+
+.. math::
+
+   \mathbf{f}_k(\mathrm{u}, \dot{\mathrm{q}}, \mathrm{q}, \mathrm{r},
+   \mathrm{p}, t) = \mathbf{u} +
+   \mathbf{J}_{\mathbf{f}_k,\dot{\mathbf{q}}}\dot{\mathbf{q}} +
+   \mathbf{g}_k(\mathrm{q}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in
+   \mathbb{R}^n
+
+Nonholonomic constraints
+
+.. math::
+
+   \mathrm{f}_n(\mathrm{u}, \mathrm{q}, \dot{\mathrm{r}}, \mathrm{r},
+   \mathrm{p}, t) = \mathrm{J}_{\mathrm{f}_n, \mathrm{u}_s}
+   \mathrm{u}_s + \mathrm{J}_{\mathrm{f}_n, \mathrm{u}_r}
+   \mathrm{u}_r + \mathrm{g}_n(\mathrm{q}, \dot{\mathrm{r}}, \mathrm{r},
+   \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^m
+
+Dynamical equations of motion
+
+.. math::
+
+   \mathrm{f}_d(\dot{\mathrm{u}}, \mathrm{u}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) =
+   \mathrm{J}_{\mathrm{f}_d, \dot{\mathrm{u}}} \dot{\mathrm{u}} +
+   \mathrm{g}_d(\mathrm{u}, \mathrm{q}, \ddot{\mathrm{r}},
+   \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^p
+
+Output equations
+
+.. math::
+
+   \mathbf{f}_o(\bar{y}, \ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{\lambda},
+   \mathrm{p}, t) = \mathbf{0}
+
+Additional first order differential equations
+
+.. math::
+
+   \mathbf{f}_a(\dot{\mathbf{w}}, \mathbf{w}, \dot{\mathrm{q}}, \mathrm{q},
+   \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) = \mathbf{0}
 
 Notes
 =====

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -1,5 +1,72 @@
 """Implementation of system for book-keeping all objects defining a model.
 
+Explanation
+===========
+
+- :math:`t` : time
+- :math:`\mathrm{q} \in \mathbb{R}^N` : coordinates
+- :math:`\mathrm{q}_s \in \mathbb{R}^n` : independent coordinates
+- :math:`\mathrm{q}_r \in \mathbb{R}^M` : dependent coordinates
+- :math:`\mathrm{u} \in \mathbb{R}^n` : generalized speeds
+- :math:`\mathrm{u}_s \in \mathbb{R}^p` : independent generalized speeds
+- :math:`\mathrm{u}_r \in \mathbb{R}^m` : dependent generalized speeds
+- :math:`\mathrm{p}` : constants
+- :math:`\mathrm{r}` : time varying specified inputs
+- :math:`\mathrm{\lambda}` : Lagrange multipliers (constraint forces)
+- :math:`\mathrm{y}` : time varying outputs
+
+Lagrange
+========
+
+Holonomic constraints
+
+.. math::
+
+   \mathrm{f}_h(\mathrm{q}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^M
+
+Twice time differentiated holonomic constraints
+
+.. math::
+
+   \dot{\mathrm{f}}_h(\ddot{\mathrm{q}},\dot{\mathrm{q}},\mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
+
+   \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_n(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
+
+Nonholonomic constraints
+
+.. math::
+
+   \mathrm{f}_n(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+
+   \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}} \dot{\mathrm{q}} + \mathrm{g}_n(\mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+
+Dynamical equations of motion
+
+.. math::
+
+   \mathrm{f}_d(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+
+   \mathrm{J}_{\mathrm{f}_d, \ddot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_d(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+
+Acceleration constraints
+
+The holonomic constraints are twice differentiated with respect to time and the
+nonholonomic constraints are differentiated once.
+
+.. math::
+
+   \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_n(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
+
+   \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_{nd}(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+
+   \mathrm{f}_c(\ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \begin{bmatrix}\ddot{\mathrm{f}}_h \\ \dot{\mathrm{f}}_h\end{bmatrix}
+
+Output equations
+
+.. math::
+
+   \mathbf{f}_o(\bar{y}, \ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q}, \mathrm{r}, \mathrm{\lambda}, \mathrm{p}, t) = \mathbf{0}
+
 Notes
 =====
 

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -107,7 +107,7 @@ constraints are differentiated once.
    \in \mathbb{R}^{(m + M) \times N}
 
 Introducing Lagrange multipliers :math:`\mathbf{\lambda}` lets us write the
-constrained euquations of motion:
+constrained equations of motion:
 
 .. math::
 

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -139,7 +139,7 @@ Output equations
    \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{\lambda},
    \mathrm{p}, t) = \mathbf{0}
 
-Additional first order differential equations
+Additional first-order differential equations
 
 .. math::
 

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -1,4 +1,4 @@
-"""Implementation of system for book-keeping all objects defining a model.
+r"""Implementation of system for book-keeping all objects defining a model.
 
 Explanation
 ===========
@@ -22,50 +22,119 @@ Holonomic constraints
 
 .. math::
 
-   \mathrm{f}_h(\mathrm{q}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^M
-
-Twice time differentiated holonomic constraints
-
-.. math::
-
-   \dot{\mathrm{f}}_h(\ddot{\mathrm{q}},\dot{\mathrm{q}},\mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
-
-   \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_n(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
+   \mathrm{f}_h(\mathrm{q}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0}
+   \in \mathbb{R}^M
 
 Nonholonomic constraints
 
 .. math::
 
-   \mathrm{f}_n(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
-
-   \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}} \dot{\mathrm{q}} + \mathrm{g}_n(\mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+   \mathrm{f}_n(\dot{\mathrm{q}}, \mathrm{q}, \dot{\mathrm{r}}, \mathrm{r},
+   \mathrm{p}, t) = \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}}
+   \dot{\mathrm{q}} + \mathrm{g}_n(\mathrm{q}, \dot{\mathrm{r}}, \mathrm{r},
+   \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^m
 
 Dynamical equations of motion
 
 .. math::
 
-   \mathrm{f}_d(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
-
-   \mathrm{J}_{\mathrm{f}_d, \ddot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_d(\dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+   \mathrm{f}_d(\ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) =
+   \mathrm{J}_{\mathrm{f}_d, \ddot{\mathrm{q}}} \ddot{\mathrm{q}} +
+   \mathrm{g}_d(\dot{\mathrm{q}}, \mathrm{q}, \ddot{\mathrm{r}},
+   \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^n
 
 Acceleration constraints
 
-The holonomic constraints are twice differentiated with respect to time and the
-nonholonomic constraints are differentiated once.
+If there are holonomic of nonholonomic constraints the dynamical differential
+equations must be augmented with the constraint forces. The holonomic
+constraints are twice differentiated with respect to time and the nonholonomic
+constraints are differentiated once.
 
 .. math::
 
-   \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_n(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^M
+   \ddot{\mathrm{f}}_h(\ddot{\mathrm{q}},\dot{\mathrm{q}},\mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) =
+   \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \ddot{\mathrm{q}} +
+   \ddot{\mathrm{g}}_h(\dot{\mathrm{q}}, \mathrm{q}, \dot{\mathrm{r}},
+   \mathrm{r}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^M
 
-   \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}} \ddot{\mathrm{q}} + \mathrm{g}_{nd}(\dot{mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \mathrm{0} \in \mathbb{R}^m
+.. math::
 
-   \mathrm{f}_c(\ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q}, \mathrm{p}, \mathrm{r}, t) = \begin{bmatrix}\ddot{\mathrm{f}}_h \\ \dot{\mathrm{f}}_h\end{bmatrix}
+   \dot{\mathrm{f}}_n(\ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) =
+   \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}} \ddot{\mathrm{q}} +
+   \dot{\mathrm{g}}_n(\dot{\mathrm{q}}, \mathrm{q}, \dot{\mathrm{r}},
+   \mathrm{r}, \mathrm{r}, \mathrm{p}, t) = \mathrm{0} \in \mathbb{R}^m
+
+.. math::
+
+   \mathrm{f}_c(\ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{p}, t) =
+   \begin{bmatrix}
+     \ddot{\mathrm{f}}_h \\
+     \dot{\mathrm{f}}_n
+   \end{bmatrix}
+   =
+   \begin{bmatrix}
+     \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \\
+     \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}}
+   \end{bmatrix}
+   \ddot{\mathrm{q}}
+   +
+   \begin{bmatrix}
+     \ddot{\mathrm{g}}_h(\dot{\mathrm{q}}, \mathrm{q}, \dot{\mathrm{r}},
+     \mathrm{r}, \mathrm{r}, \mathrm{p}, t) \\
+     \dot{\mathrm{g}}_n(\dot{\mathrm{q}}, \mathrm{q}, \dot{\mathrm{r}},
+     \mathrm{r}, \mathrm{r}, \mathrm{p}, t)
+   \end{bmatrix}
+   =
+   \begin{bmatrix}
+     \mathrm{0} \\
+     \mathrm{0}
+   \end{bmatrix}
+
+.. math::
+
+   \mathrm{J}_{\mathrm{f}_c, \ddot{\mathrm{q}}} =
+   \begin{bmatrix}
+     \mathrm{J}_{\dot{\mathrm{f}}_h, \dot{\mathrm{q}}} \\
+     \mathrm{J}_{\mathrm{f}_n, \dot{\mathrm{q}}}
+   \end{bmatrix}
+   \in \mathbb{R}^{(m + M) \times N}
+
+Introducing Lagrange multipliers :math:`\mathbf{\lambda}` lets us write the
+constrained euquations of motion:
+
+.. math::
+
+   \begin{bmatrix}
+     \mathrm{J}_{\mathrm{f}_d, \ddot{\mathrm{q}}} &
+     \mathrm{J}_{\mathrm{f}_c, \ddot{\mathrm{q}}}^T \\
+     \mathrm{J}_{\mathrm{f}_c, \ddot{\mathrm{q}}} & \mathbf{0}
+   \end{bmatrix}
+   \begin{bmatrix}
+     \ddot{\mathbf{q}} \\
+     \mathbf{\lambda}
+   \end{bmatrix}
+   +
+   \begin{bmatrix}
+   \mathbf{g}_d \\
+   \mathbf{g}_c
+   \end{bmatrix}
+   =
+   \begin{bmatrix}
+     \mathrm{0} \\
+     \mathrm{0}
+   \end{bmatrix}
 
 Output equations
 
 .. math::
 
-   \mathbf{f}_o(\bar{y}, \ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q}, \mathrm{r}, \mathrm{\lambda}, \mathrm{p}, t) = \mathbf{0}
+   \mathbf{f}_o(\bar{y}, \ddot{\mathrm{q}}, \dot{\mathrm{q}}, \mathrm{q},
+   \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{\lambda},
+   \mathrm{p}, t) = \mathbf{0}
 
 Notes
 =====

--- a/sympy/physics/mechanics/_system.py
+++ b/sympy/physics/mechanics/_system.py
@@ -194,7 +194,7 @@ Output equations
    \ddot{\mathrm{r}}, \dot{\mathrm{r}}, \mathrm{r}, \mathrm{\lambda},
    \mathrm{p}, t) = \mathbf{0}
 
-Additional first order differential equations
+Additional first-order differential equations
 
 .. math::
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Old PR where I started to rework the explanation of Kane's equations: https://github.com/sympy/sympy/pull/11183

Making `System` public : https://github.com/sympy/sympy/pull/25560

Introduction of the `System` class and module: https://github.com/sympy/sympy/pull/24962

#### Brief description of what is fixed or changed

We developed `SymbolicSystem` in https://github.com/sympy/sympy/pull/11431 to be a container class for all the symbolic variables and equations produced by `KanesMethod` and `LagrangesMethod`. We have a general need to package the symbolic variables and equations of a multlbody system, regardless of derviation method, in a generic form so that downstream uses of the symbolics have all necessary descriptions of the variables and equations.

Recently a new `System` object was introduced (https://github.com/sympy/sympy/pull/24962) that has overlapping functionality as `SymbolicSystem`  with an intention of deprecating `SymbolicSystem`. It is important to note that there are probably no any downstream uses of `SymbolicSystem` (pydy was going to use it, but it never materialized).

We have not made `System` public yet (see https://github.com/sympy/sympy/pull/25560). I have reviewed that code but have a worry that we are not creating a "system" object that is generic enough for the equations of motion derived from any of the standard methods (I'm personally excluding Featherstone/Jain now, because I haven't studied that method to know what final form the equations are in). 

The purpose of this PR is to try to write down the mathematical forms of Newton-Euler, Lagrange, and Kane's equations in a shared notation, so that we can see what mathematical form can encompass all three equations. My preference is that we would settle on this before making `System` public so that we don't find ourselves in the situation of having to deprecate `System` in the future (as we are hoping to do with `SymbolicSystem`). I will hack on this, but feel free to help me sort out the notation and forms.

@TJStienstra @brocksam 

Checklist

- [ ] handle generic output equations
- [ ] handle adding addition differential equations (muslces, electric motor)
- [ ] handle the Lagrange multiplier form
- [ ] handle auxiliary equations form of Kanes

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
