### PR TITLE
stats/joint_rv_types.py: Fixed broken link to reference 2 of Ewens Distribution

### DIFF
--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -633,7 +633,7 @@ def MultivariateEwens(syms, n, theta):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
-    .. [2] https://projecteuclid.org/journalArticle/Download?urlId=10.1214%2F15-STS529 
+    .. [2] https://projecteuclid.org/journalArticle/Download?urlId=10.1214%2F15-STS529
 
     """
     return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -634,7 +634,6 @@ def MultivariateEwens(syms, n, theta):
 
     .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
     .. [2] https://www.jstor.org/stable/24780825
- 
     """
     return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -633,8 +633,8 @@ def MultivariateEwens(syms, n, theta):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
-    .. [2] https://projecteuclid.org/journalArticle/Download?urlId=10.1214%2F15-STS529
-
+    .. [2] https://www.jstor.org/stable/24780825
+ 
     """
     return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -633,7 +633,7 @@ def MultivariateEwens(syms, n, theta):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
-    .. [2] https://www.researchgate.net/publication/280311472_The_Ubiquitous_Ewens_Sampling_Formula
+    .. [2] https://projecteuclid.org/journalArticle/Download?urlId=10.1214%2F15-STS529 
 
     """
     return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)


### PR DESCRIPTION
#### References to other Issues or PRs
#24140 

#### Brief description of what is fixed or changed
The link of Reference 2 of `sympy.stats.MultivariateEwens` has been fixed with a redirect link.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
