### PR TITLE
diophantine output sign-canonical

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -111,6 +111,12 @@ class DiophantineSolutionSet(set):
     def add(self, solution):
         if len(solution) != len(self.symbols):
             raise ValueError("Solution should have a length of %s, not %s" % (len(self.symbols), len(solution)))
+        # make solution canonical wrt sign (i.e. no -x unless x is also present as an arg)
+        args = set(solution)
+        for i in range(len(solution)):
+            x = solution[i]
+            if not type(x) is int and (-x).is_Symbol and -x not in args:
+                solution = [_.subs(-x, x) for _ in solution]
         super().add(Tuple(*solution))
 
     def update(self, *solutions):
@@ -1322,7 +1328,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     >>> diophantine(x*(2*x + 3*y - z))
     {(0, n1, n2), (t_0, t_1, 2*t_0 + 3*t_1)}
     >>> diophantine(x**2 + 3*x*y + 4*x)
-    {(0, n1), (3*t_0 - 4, -t_0)}
+    {(0, n1), (-3*t_0 - 4, t_0)}
 
     See Also
     ========

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -96,7 +96,7 @@ def test_linear():
     assert diop_solve(2*x - 3*y - 5) == (3*t_0 - 5, 2*t_0 - 5)
     assert diop_solve(-2*x - 3*y - 5) == (3*t_0 + 5, -2*t_0 - 5)
     assert diop_solve(7*x + 5*y) == (5*t_0, -7*t_0)
-    assert diop_solve(2*x + 4*y) == (2*t_0, -t_0)
+    assert diop_solve(2*x + 4*y) == (-2*t_0, t_0)
     assert diop_solve(4*x + 6*y - 4) == (3*t_0 - 2, -2*t_0 + 2)
     assert diop_solve(4*x + 6*y - 3) == (None, None)
     assert diop_solve(0*x + 3*y - 4*z + 5) == (4*t_0 + 5, 3*t_0 + 5)
@@ -569,10 +569,10 @@ def test_diophantine():
            {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
 
     # issue 18122
-    assert check_solutions(x**2-y)
-    assert check_solutions(y**2-x)
-    assert diophantine((x**2-y), t) == {(t, t**2)}
-    assert diophantine((y**2-x), t) == {(t**2, -t)}
+    assert check_solutions(x**2 - y)
+    assert check_solutions(y**2 - x)
+    assert diophantine((x**2 - y), t) == {(t, t**2)}
+    assert diophantine((y**2 - x), t) == {(t**2, t)}
 
 
 def test_general_pythagorean():
@@ -769,8 +769,8 @@ def test_diopcoverage():
     eq = (2*x + y + 1)**2
     assert diop_solve(eq) == {(t_0, -2*t_0 - 1)}
     eq = 2*x**2 + 6*x*y + 12*x + 4*y**2 + 18*y + 18
-    assert diop_solve(eq) == {(t, -t - 3), (2*t - 3, -t)}
-    assert diop_quadratic(x + y**2 - 3) == {(-t**2 + 3, -t)}
+    assert diop_solve(eq) == {(t, -t - 3), (-2*t - 3, t)}
+    assert diop_quadratic(x + y**2 - 3) == {(-t**2 + 3, t)}
 
     assert diop_linear(x + y - 3) == (t_0, 3 - t_0)
 
@@ -1033,5 +1033,5 @@ def test_quadratic_parameter_passing():
     eq = -33*x*y + 3*y**2
     solution = BinaryQuadratic(eq).solve(parameters=[t, u])
     # test that parameters are passed all the way to the final solution
-    assert solution == {(t, 11*t), (-t, 22*t)}
+    assert solution == {(t, 11*t), (t, -22*t)}
     assert solution(0, 0) == {(0, 0)}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #25775

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * DiophantineSolutionSet now makes solution tuples canonical wrt sign
<!-- END RELEASE NOTES -->
