### PR TITLE
Limit the version of flint available to 0.5.0 and above

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -119,7 +119,7 @@ if GROUND_TYPES in ('auto', 'gmpy', 'gmpy2'):
 elif GROUND_TYPES == 'flint':
 
     # Try to use python_flint
-    flint = import_module('flint')
+    flint = import_module('flint', min_module_version='0.5.0')
     gmpy = None
 
     if flint is None:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -963,7 +963,7 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
         for b, e in facs.items():
             if verbose:
                 print(factor_msg % (b, e))
-            factors[b] = exp*e
+            factors[b] = int(exp*e)
         if verbose:
             print(complete_msg)
         return True

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -963,8 +963,7 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
         for b, e in facs.items():
             if verbose:
                 print(factor_msg % (b, e))
-            # int() can be removed when https://github.com/flintlib/python-flint/issues/92 is resolved
-            factors[b] = int(exp*e)
+            factors[b] = exp*e
         if verbose:
             print(complete_msg)
         return True

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -15,11 +15,6 @@ from sympy.polys.domains.groundtypes import SymPyInteger
 
 if GROUND_TYPES == 'flint':
     import flint
-    # Don't use python-flint < 0.5.0 because nmod was missing some features in
-    # previous versions of python-flint and fmpz_mod was not yet added.
-    _major, _minor, *_ = flint.__version__.split('.')
-    if (int(_major), int(_minor)) < (0, 5):
-        flint = None
 else:
     flint = None
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25749
flintlib/python-flint#92

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* external
  * Limit the version of flint available to 0.5.0 and above
<!-- END RELEASE NOTES -->
