### PR TITLE
Adds test for `plot3d` for functions involving `Min`/`Max`

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, lo
 from sympy.functions.elementary.miscellaneous import (real_root, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.miscellaneous import Min
 from sympy.functions.special.hyper import meijerg
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import And
@@ -26,7 +27,6 @@ from sympy.plotting.series import (
 from sympy.testing.pytest import skip, warns, raises, warns_deprecated_sympy
 from sympy.utilities import lambdify as lambdify_
 from sympy.utilities.exceptions import ignore_warnings
-
 
 unset_show()
 
@@ -1239,6 +1239,16 @@ def test_plot3d_plot_contour_arguments():
     assert p[0].ranges[0][1:] == (-5, 3)
     assert p[0].ranges[1][1:] == (-2, 1)
     assert p[0].get_label(False) == "test"
+    assert p[0].rendering_kw == {}
+
+    # test issue 25818
+    # single expression, custom range, min/max functions
+    p = plot3d(Min(x, y), (x, 0, 10), (y, 0, 10))
+    assert isinstance(p[0], SurfaceOver2DRangeSeries)
+    assert p[0].expr == Min(x, y)
+    assert p[0].ranges[0] == (x, 0, 10)
+    assert p[0].ranges[1] == (y, 0, 10)
+    assert p[0].get_label(False) == "Min(x, y)"
     assert p[0].rendering_kw == {}
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25818

#### Brief description of what is fixed or changed

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
