### PR TITLE
When `generator=True`, always return generator

### DIFF
--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -311,6 +311,7 @@ def test_divisors_and_divisor_count():
     assert divisors(10) == [1, 2, 5, 10]
     assert divisors(100) == [1, 2, 4, 5, 10, 20, 25, 50, 100]
     assert divisors(101) == [1, 101]
+    assert type(divisors(2, generator=True)) is not list
 
     assert divisor_count(0) == 0
     assert divisor_count(-1) == 1
@@ -332,6 +333,7 @@ def test_proper_divisors_and_proper_divisor_count():
     assert proper_divisors(10) == [1, 2, 5]
     assert proper_divisors(100) == [1, 2, 4, 5, 10, 20, 25, 50]
     assert proper_divisors(1000000007) == [1]
+    assert type(proper_divisors(2, generator=True)) is not list
 
     assert proper_divisor_count(0) == 0
     assert proper_divisor_count(-1) == 0
@@ -351,6 +353,7 @@ def test_udivisors_and_udivisor_count():
     assert udivisors(100) == [1, 4, 25, 100]
     assert udivisors(101) == [1, 101]
     assert udivisors(1000) == [1, 8, 125, 1000]
+    assert type(udivisors(2, generator=True)) is not list
 
     assert udivisor_count(0) == 0
     assert udivisor_count(-1) == 1
@@ -497,7 +500,7 @@ def test_antidivisors():
     assert sorted(x for x in antidivisors(3*5*7, 1)) == \
         [2, 6, 10, 11, 14, 19, 30, 42, 70]
     assert antidivisors(1) == []
-
+    assert type(antidivisort(2, generator=True)) is not list
 
 def test_antidivisor_count():
     assert antidivisor_count(0) == 0

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -500,7 +500,7 @@ def test_antidivisors():
     assert sorted(x for x in antidivisors(3*5*7, 1)) == \
         [2, 6, 10, 11, 14, 19, 30, 42, 70]
     assert antidivisors(1) == []
-    assert type(antidivisort(2, generator=True)) is not list
+    assert type(antidivisors(2, generator=True)) is not list
 
 def test_antidivisor_count():
     assert antidivisor_count(0) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The `divisors` may not return a generator even if `generator=True` is specified.

```python
from sympy.ntheory.factor_ import divisors
divisors(5, generator=True)
[1, 5]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
