### PR TITLE
Update _eval_simplify for Xor

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -490,25 +490,7 @@ class BooleanFunction(Application, Boolean):
 
     @classmethod
     def binary_check_and_simplify(self, *args):
-        from sympy.core.relational import Relational, Eq, Ne
-        args = [as_Boolean(i) for i in args]
-        bin_syms = set().union(*[i.binary_symbols for i in args])
-        rel = set().union(*[i.atoms(Relational) for i in args])
-        reps = {}
-        for x in bin_syms:
-            for r in rel:
-                if x in bin_syms and x in r.free_symbols:
-                    if isinstance(r, (Eq, Ne)):
-                        if not (
-                                true in r.args or
-                                false in r.args):
-                            reps[r] = false
-                    else:
-                        raise TypeError(filldedent('''
-                            Incompatible use of binary symbol `%s` as a
-                            real variable in `%s`
-                            ''' % (x, r)))
-        return [i.subs(reps) for i in args]
+        return [as_Boolean(i) for i in args]
 
     def to_nnf(self, simplify=True):
         return self._to_nnf(*self.args, simplify=simplify)
@@ -680,7 +662,7 @@ class And(LatticeOp, BooleanFunction):
                     if (e.lhs != x or x in e.rhs.free_symbols) and x not in reps:
                         try:
                             m, b = linear_coeffs(
-                                e.rewrite(Add, evaluate=False), x)
+                                Add(e.lhs, -e.rhs, evaluate=False), x)
                             enew = e.func(x, -b/m)
                             if measure(enew) <= ratio*measure(e):
                                 e = enew
@@ -1012,7 +994,7 @@ class Xor(BooleanFunction):
             for j in range(i + 1, len(rel)):
                 rj, cj = rel[j][:2]
                 if cj == nc:
-                    odd = ~odd
+                    odd = not odd
                     break
                 elif cj == c:
                     break
@@ -1062,14 +1044,15 @@ class Xor(BooleanFunction):
                      for x in _get_even_parity_terms(len(a))])
 
     def _eval_simplify(self, **kwargs):
-        rv = super()._eval_simplify(**kwargs)
-        if not isinstance(rv, Xor) and type(rv) != BooleanTrue:
-            # The second condition simplifies for a case of an arbitrary symbol
-            # (a ^ ~a)
-            # As standard simplify uses simplify_logic which writes things as
-            # And and Or, we only simplify the partial expressions before using
-            # patterns
-            return self.func(*[a.simplify(**kwargs) for a in self.args])
+        # as standard simplify uses simplify_logic which writes things as
+        # And and Or, we only simplify the partial expressions before using
+        # patterns
+        rv = self.func(*[a.simplify(**kwargs) for a in self.args])
+        if type(super()._eval_simplify(**kwargs)) == BooleanTrue:
+            # this block fixes simplify in case of (x ^ ~x)
+            return super()._eval_simplify(**kwargs)
+        if not isinstance(rv, Xor):  # This shouldn't really happen here
+            return rv
         patterns = _simplify_patterns_xor()
         return _apply_patternbased_simplification(rv, patterns,
                                                   kwargs['measure'], None)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25827


#### Brief description of what is fixed or changed
The behaviour of `_eval_simplify` for Xor has been changed to simplify to `BooleanTrue` in case of (a ^ ~a).


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
