### PR TITLE
Add \dfrac in powers.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1034,6 +1034,7 @@ Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Ohlomonchick <64347118+Ohlomonchick@users.noreply.github.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>
@@ -1224,7 +1225,6 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
-Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1035,6 +1035,7 @@ Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Ohlomonchick <64347118+Ohlomonchick@users.noreply.github.com>
+Ohlomonchick <proskurin.dima16@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1225,6 +1225,7 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
                             'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec',
                             'csc', 'cot', 'coth', 're', 'im', 'frac', 'root',
-                            'arg',
+                            'arg', 'dfrac',
                             ]
 
 tex_greek_dictionary = {
@@ -166,6 +166,7 @@ class LatexPrinter(Printer):
         "min": None,
         "max": None,
         "diff_operator": "d",
+        "use_dfrac_powers": False
     }
 
     def __init__(self, settings=None):
@@ -666,6 +667,13 @@ class LatexPrinter(Printer):
                     base = self.parenthesize_super(base)
                 if expr.base.is_Function:
                     return self._print(expr.base, exp="%s/%s" % (p, q))
+                return r"%s^{%s/%s}" % (base, p, q)
+            elif self._settings['use_dfrac_powers'] and q != 1:
+                base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+                if expr.base.is_Symbol:
+                    base = self.parenthesize_super(base)
+                if expr.base.is_Function:
+                    return self._print(expr.base, exp=r"\dfrac{%s}{%s}" % (p, q))
                 return r"%s^{%s/%s}" % (base, p, q)
             elif expr.exp.is_negative and expr.base.is_commutative:
                 # special case for 1^(-x), issue 9216
@@ -3036,6 +3044,8 @@ def latex(expr, **settings):
     diff_operator: string, optional
         String to use for differential operator. Default is ``'d'``, to print in italic
         form. ``'rd'``, ``'td'`` are shortcuts for ``\mathrm{d}`` and ``\text{d}``.
+    use_dfrac_powers : boolean, optional
+        Emit ``^{\dfrac{p}{q}}`` instead of ``^{\frac{p}{q}}`` for fractional powers.
 
     Notes
     =====
@@ -3100,6 +3110,8 @@ def latex(expr, **settings):
     \frac{\int r\, dr}{2 \pi}
     >>> print(latex(Integral(r, r)/2/pi, long_frac_ratio=0))
     \frac{1}{2 \pi} \int r\, dr
+    >>> print(latex((2*tau)**Rational(7,2), use_dfrac_powers=True))
+    8 \sqrt{2} \tau^{\dfrac{7}{2}}
 
     Multiplication options:
 


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
"use_dfrac_powers" option added to LatexPrinter


#### Other comments
Function \dfrac in latex restrics deminishing of power expressions. People use it a lot in math papers.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added a new optional boolean parameter `"use_dfrac_powers"` to `LatexPrinter.settings`.
<!-- END RELEASE NOTES -->
