### PR TITLE
Fixed typo in the simple_mmlctop.xsl file

### DIFF
--- a/sympy/utilities/mathml/data/simple_mmlctop.xsl
+++ b/sympy/utilities/mathml/data/simple_mmlctop.xsl
@@ -261,7 +261,7 @@ CONSTANT and SYMBOL ELEMENTS
     </xsl:when>
     <xsl:when test="($SEM_SW=$SEM_XREF or $SEM_SW=$SEM_XREF_EXT) and @id">
       <xsl:choose>
-        <xsl:when test="self::sematics">
+        <xsl:when test="self::semantics">
           <xsl:copy>
             <xsl:copy-of select="@*"/>
             <xsl:attribute name="xref">


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24466

#### Brief description of what is fixed or changed
Fixed typo in the `simple_mmlctop.xsl` file.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
