### PR TITLE
Make Float.is_integer always return None

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -89,8 +89,8 @@ def test_int_12():
 def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
-    assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.integer(z))
+    assert ask(Q.rational(z))
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
     assert ask(Q.irrational(z)) is None

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -969,6 +969,8 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
+        if not int_valued(self):
+            return False
         return None
 
     def _eval_is_negative(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -969,9 +969,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        if not int_valued(self):
-            return False
-        return True
+        return int_valued(self)
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -969,7 +969,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_ == fzero
+        return None
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -971,7 +971,7 @@ class Float(Number):
     def _eval_is_integer(self):
         if not int_valued(self):
             return False
-        return None
+        return True
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -173,7 +173,7 @@ class Pow(Expr):
             # cancellation might occur as in (x - 1)/(1 - x) -> -1. If
             # we returned Piecewise((-1, Ne(x, 1))) for such cases then
             # we could do this...but we don't
-            elif (e.is_Symbol and e.is_integer or e.is_Integer
+            elif (e.is_Symbol and e.is_integer and not e.is_Float or e.is_Integer
                     ) and (b.is_number and b.is_Mul or b.is_Number
                     ) and b.could_extract_minus_sign():
                 if e.is_even:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -504,9 +504,9 @@ def test_Float():
     # rationality properties
     # if the integer test fails then the use of intlike
     # should be removed from gamma_functions.py
-    assert Float(1).is_integer is False
-    assert Float(1).is_rational is None
-    assert Float(1).is_irrational is None
+    assert Float(1).is_integer
+    assert Float(1).is_rational
+    assert Float(1).is_irrational is False
     assert sqrt(2).n(15).is_rational is None
     assert sqrt(2).n(15).is_irrational is None
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -45,7 +45,7 @@ class RoundFunction(Function):
         terms = Add.make_args(arg)
 
         for t in terms:
-            if t.is_integer or (t.is_imaginary and im(t).is_integer):
+            if t.is_integer and not t.is_Float or (t.is_imaginary and im(t).is_integer):
                 ipart += t
             elif t.has(Symbol):
                 spart += t


### PR DESCRIPTION
This is a fix for #23731. Mostly just trying to see what consequences this change has. It fixes some wrong results, for example:

```py
>>> k = Symbol('k', integer=True)
>>> Eq(k/2, 0.5)
False
```

(now it is correctly unevaluated).

But I don't know yet if this breaks things.

Another possibility would be to return True if the Float is an integer that is exactly represented, False if it has a nonzero fractional part, and None if it is larger in magnitude than 2**prec.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Make Float.is_integer give True when the factional part is nonzero. Previously Float.is_integer was always False except for 0.0. This fixes several bugs such as `Eq` incorrectly evaluating to False when one side is a float.
<!-- END RELEASE NOTES -->
