### PR TITLE
correct quaternion docstring for intrinsic/extrinsic

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1223,8 +1223,8 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
-Saicharan <saicharanhahaha@gmail.com>
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
+Saicharan <saicharanhahaha@gmail.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1223,7 +1223,8 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
-Saicharan <saicharanhahaha@gmail.com> <62512681+saicharan2804@users.noreply.github.com>
+Saicharan <saicharanhahaha@gmail.com>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1224,6 +1224,7 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1224,8 +1224,7 @@ Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
-Saicharan <62512681+saicharan2804@users.noreply.github.com>
-Saicharan <saicharanhahaha@gmail.com>
+Saicharan <saicharanhahaha@gmail.com> <62512681+saicharan2804@users.noreply.github.com>
 Saikat Das <saikatdchhe@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -383,9 +383,9 @@ class Quaternion(Expr):
             The Euler angles (in radians).
         seq : string of length 3
             Represents the sequence of rotations.
-            For intrinsic rotations, seq must be all lowercase and its elements
+            For extrinsic rotations, seq must be all lowercase and its elements
             must be from the set ``{'x', 'y', 'z'}``
-            For extrinsic rotations, seq must be all uppercase and its elements
+            For intrinsic rotations, seq must be all uppercase and its elements
             must be from the set ``{'X', 'Y', 'Z'}``
 
         Returns
@@ -448,9 +448,9 @@ class Quaternion(Expr):
 
         seq : string of length 3
             Represents the sequence of rotations.
-            For intrinsic rotations, seq must be all lowercase and its elements
+            For extrinsic rotations, seq must be all lowercase and its elements
             must be from the set ``{'x', 'y', 'z'}``
-            For extrinsic rotations, seq must be all uppercase and its elements
+            For intrinsic rotations, seq must be all uppercase and its elements
             must be from the set ``{'X', 'Y', 'Z'}``
 
         angle_addition : bool


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #25848

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
