### PR TITLE
gruntz: fixes for limit evaluation of type (1+u(x))^v(x)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -342,6 +342,7 @@ Arie Bovenberg <a.c.bovenberg@gmail.com>
 Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
 Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
 Arihant Parsoya <parsoyaarihant@gmail.com>
+Arnab Nandi <arnabnandi2002@gmail.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
 Arpit Goyal <agmps18@gmail.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -276,7 +276,8 @@ def mrv(e, x):
             return SubsSet(), b1
         if e1.has(x):
             base_lim = limitinf(b1, x)
-            if base_lim is S.One:
+            exp_lim = limitinf(e1, x)
+            if base_lim is S.One and exp_lim is S.Infinity:
                 return mrv(exp(e1 * (b1 - 1)), x)
             return mrv(exp(e1 * log(b1)), x)
         else:

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -474,3 +474,6 @@ def test_issue_6682():
 def test_issue_7096():
     from sympy.functions import sign
     assert gruntz(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
+
+def test_issue_24210():
+    assert gruntz(exp(x)/((1+1/x)**(x**2)),x,+oo) == sqrt(E)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #24210 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added the extra conditon for exp to be tending to infinity for correct representation of the indeterminate form 1^(oo) 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.



* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * added extra condition for exp to be infinity in  `mrv`

<!-- END RELEASE NOTES -->
