### PR TITLE
avoid evaluating Eq with Float args

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -4,6 +4,7 @@ from .basic import Atom, Basic
 from .sorting import ordered
 from .evalf import EvalfMixin
 from .function import AppliedUndef
+from .numbers import int_valued
 from .singleton import S
 from .symbol import Dummy
 from .sympify import _sympify, SympifyError
@@ -625,8 +626,8 @@ class Equality(Relational):
             # args with rational/integer symbols to see if the
             # expression evaluates
             val = is_eq(
-                lhs if not lhs.is_Float else Dummy(rational=True),
-                rhs if not rhs.is_Float else Dummy(rational=True))
+                lhs if not lhs.is_Float else (Dummy(integer=True) if int_valued(lhs) else Dummy(rational=True)),
+                rhs if not rhs.is_Float else (Dummy(integer=True) if int_valued(rhs) else Dummy(rational=True)))
             if val is None:
                 return cls(lhs, rhs, evaluate=False)
             else:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -4,7 +4,6 @@ from .basic import Atom, Basic
 from .sorting import ordered
 from .evalf import EvalfMixin
 from .function import AppliedUndef
-from .numbers import int_valued, Float
 from .singleton import S
 from .symbol import Dummy
 from .sympify import _sympify, SympifyError
@@ -622,17 +621,12 @@ class Equality(Relational):
         rhs = _sympify(rhs)
         if evaluate:
             # while 1 != 1.0, Eq(1, 1.0) is True
-            # so for purpose of evaluation, replace Floats
-            # with rational/integer symbols to see if the
+            # so for purpose of evaluation, replace Float
+            # args with rational/integer symbols to see if the
             # expression evaluates
-            reps = {}
-            for f in lhs.atoms(Float)|rhs.atoms(Float):
-                if f not in reps:
-                    if 0 and int_valued(f):
-                        reps[f] = Dummy(integer=True)
-                    else:
-                        reps[f] = Dummy(rational=True)
-            val = is_eq(lhs.xreplace(reps), rhs.xreplace(reps))
+            val = is_eq(
+                lhs if not lhs.is_Float else Dummy(rational=True),
+                rhs if not rhs.is_Float else Dummy(rational=True))
             if val is None:
                 return cls(lhs, rhs, evaluate=False)
             else:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -625,9 +625,23 @@ class Equality(Relational):
             # so for purpose of evaluation, replace Float
             # args with rational/integer symbols to see if the
             # expression evaluates
-            val = is_eq(
-                lhs if not lhs.is_Float else (Dummy(integer=True) if int_valued(lhs) else Dummy(rational=True)),
-                rhs if not rhs.is_Float else (Dummy(integer=True) if int_valued(rhs) else Dummy(rational=True)))
+            if 0. in (lhs, rhs) or lhs.is_number and rhs.is_number:
+                val = is_eq(lhs, rhs)
+            elif lhs.is_Float:
+                if rhs.is_Float:
+                    val = is_eq(lhs, rhs)
+                else:
+                    val = is_eq(
+                        Dummy(integer=True) if int_valued(lhs)
+                        else Dummy(rational=True),
+                        rhs)
+            elif rhs.is_Float:
+                val = is_eq(
+                    lhs,
+                    Dummy(integer=True) if int_valued(rhs)
+                    else Dummy(rational=True))
+            else:
+                val = is_eq(lhs, rhs)
             if val is None:
                 return cls(lhs, rhs, evaluate=False)
             else:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import XFAIL, raises
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, unchanged
 from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (Float, I, Rational, nan, oo, pi, zoo)
@@ -1251,6 +1251,18 @@ def test_weak_strict():
     eq = Le(x, 1)
     assert eq.strict == Lt(x, 1)
     assert eq.weak == eq
+
+
+def test_issue_23731():
+    i = symbols('i', integer=True)
+    assert unchanged(Eq, i, 1.0)
+    assert unchanged(Eq, i/2, 0.5)
+    ni = symbols('ni', integer=False)
+    assert Eq(ni, 1.0) == Eq(ni, 1) == False
+    nr = symbols('nr', rational=False)
+    assert Eq(nr, .1) == False
+    assert unchanged(Eq, ni, .1)
+
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1644,7 +1644,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     >>> B = BernoulliProcess("B", p=0.7, success=1, failure=0)
     >>> B.state_space
     {0, 1}
-    >>> (B.p).round(2)
+    >>> B.p.round(2)
     0.70
     >>> B.success
     1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

alternative to #25856 and #25865
fixes #23731 

#### Brief description of what is fixed or changed


#### Other comments

This maintains all current assumptions for Float (rather than modifying the implications of what `is_rational` means) and handles the troubles with `Eq` and assumptions at the source. See also [google groups discusion](https://groups.google.com/g/sympy/c/RUYOxxwMgac/m/LmgtqH6VBAAJ)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * relational now treats Floats as integers or rationals when making symbolic comparisons so `Eq(Dummy(integer=1), 1.0)` is not False
<!-- END RELEASE NOTES -->
