### PR TITLE
recognize Float as rational

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -5,7 +5,7 @@ Handlers for keys related to number theory: prime, even, odd, etc.
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Basic, Expr, Float, Mul, Pow, S
 from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NaN,
-    NegativeInfinity, NumberSymbol, Rational)
+    NegativeInfinity, NumberSymbol, Rational, int_valued)
 from sympy.functions import Abs, im, re
 from sympy.ntheory import isprime
 
@@ -125,7 +125,7 @@ def _EvenPredicate_number(expr, assumptions):
             raise TypeError
     except TypeError:
         return False
-    if isinstance(expr, (float, Float)):
+    if isinstance(expr, (float, Float)) and not int_valued(expr):
         return False
     return i % 2 == 0
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -100,8 +100,8 @@ def test_float_1():
     assert ask(Q.even(z)) is False
     assert ask(Q.odd(z)) is True
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is None
-    assert ask(Q.composite(z)) is None
+    assert ask(Q.prime(z)) is False
+    assert ask(Q.composite(z)) is False
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2310,10 +2310,10 @@ def test_issue_9636():
     assert ask(Q.integer(1.0)) is True
     assert ask(Q.prime(3.0)) is None
     assert ask(Q.composite(4.0)) is None
-    assert ask(Q.even(2.0)) is False
-    assert ask(Q.odd(2.0)) is False
     assert ask(Q.even(3.0)) is False
-    assert ask(Q.odd(3.0)) is False
+    assert ask(Q.odd(3.0)) is True
+    assert ask(Q.even(2.0)) is True
+    assert ask(Q.odd(2.0)) is False
 
 
 def test_autosimp_used_to_fail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -100,8 +100,8 @@ def test_float_1():
     assert ask(Q.even(z)) is False
     assert ask(Q.odd(z)) is True
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is False
-    assert ask(Q.composite(z)) is False
+    assert ask(Q.prime(z)) is None
+    assert ask(Q.composite(z)) is None
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
 
@@ -2310,10 +2310,10 @@ def test_issue_9636():
     assert ask(Q.integer(1.0)) is True
     assert ask(Q.prime(3.0)) is None
     assert ask(Q.composite(4.0)) is None
-    assert ask(Q.even(2.0)) is True
+    assert ask(Q.even(2.0)) is False
     assert ask(Q.odd(2.0)) is False
     assert ask(Q.even(3.0)) is False
-    assert ask(Q.odd(3.0)) is True
+    assert ask(Q.odd(3.0)) is False
 
 
 def test_autosimp_used_to_fail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -89,29 +89,29 @@ def test_int_12():
 def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
-    assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.integer(z)) is True
+    assert ask(Q.rational(z)) is True
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is None
+    assert ask(Q.irrational(z)) is False
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
     assert ask(Q.even(z)) is False
-    assert ask(Q.odd(z)) is False
+    assert ask(Q.odd(z)) is True
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is False
-    assert ask(Q.composite(z)) is False
+    assert ask(Q.prime(z)) is None
+    assert ask(Q.composite(z)) is None
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
 
     z = 7.2123
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.rational(z)) is True
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is None
+    assert ask(Q.irrational(z)) is False
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
@@ -124,7 +124,7 @@ def test_float_1():
     assert ask(Q.antihermitian(z)) is False
 
     # test for issue #12168
-    assert ask(Q.rational(math.pi)) is None
+    assert ask(Q.rational(math.pi)) is True
 
 
 def test_zero_0():
@@ -2307,11 +2307,13 @@ def test_check_old_assumption():
 
 
 def test_issue_9636():
-    assert ask(Q.integer(1.0)) is False
-    assert ask(Q.prime(3.0)) is False
-    assert ask(Q.composite(4.0)) is False
-    assert ask(Q.even(2.0)) is False
-    assert ask(Q.odd(3.0)) is False
+    assert ask(Q.integer(1.0)) is True
+    assert ask(Q.prime(3.0)) is None
+    assert ask(Q.composite(4.0)) is None
+    assert ask(Q.even(2.0)) is True
+    assert ask(Q.odd(2.0)) is False
+    assert ask(Q.even(3.0)) is False
+    assert ask(Q.odd(3.0)) is True
 
 
 def test_autosimp_used_to_fail():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -749,10 +749,9 @@ class Float(Number):
 
     _mpf_: tuple[int, int, int, int]
 
-    # A Float represents many real numbers,
-    # both rational and irrational.
-    is_rational = None
-    is_irrational = None
+    # A Float is a computationally efficient rational
+    is_rational = True
+    is_irrational = False
     is_number = True
 
     is_real = True
@@ -969,7 +968,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_ == fzero
+        return self._mpf_ == fzero or int_valued(self)
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -973,6 +973,17 @@ class Float(Number):
     def _eval_is_odd(self):
         return int_valued(self) and not bool(self._mpf_[2])
 
+    def _eval_is_prime(self):
+        from sympy.ntheory.primetest import isprime
+        if not int_valued(self):
+            return False
+        return isprime(int(self))
+
+    def _eval_is_composite(self):
+        if not int_valued(self) or self <= 1:
+            return False
+        return fuzzy_not(self.is_prime)
+
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):
             return False

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -660,7 +660,8 @@ class Float(Number):
     Notes
     =====
 
-    == Floats are rational approximations ==
+    Floats are rational
+    -------------------
 
     Floats represent all numbers as a rational with a denominator that
     is a power of 2: ``(-1)**s*m*2**e`` where ``s`` is 0 or 1, ``m`` is an
@@ -726,23 +727,24 @@ class Float(Number):
     combine under constraints of precision. This makes them
     computationally efficient but less exact than Rationals.
 
-    == Floats are rational...but not Rational ==
+    Floats are rational...but not Rational
+    --------------------------------------
 
     Integers, Rationals, and Floats are all SymPy Numbers. While all
     Numbers are rational, the attribute `is_Rational` is True only
     for Integers and Rational and the rational Float does not
     behave as a rational in all operations unless it is an integer,
-    so `is_rational` is None and `is_integer` is True. Other
-    lower-case attributes may also be true for integer Floats:
+    so `is_rational` is None and `is_integer` is True.
 
     >>> f1 = Float(1)
     >>> f1.is_rational, f1.is_Rational, f1.is_integer, f1.is_odd
-    (None, False, True, True)
+    (None, False, True, None)
     >>> r = Float(0.1)
     >>> r.is_integer, r.is_odd
     (False, False)
 
-    == SymPy Float from Python float ==
+    SymPy Float from Python float
+    -----------------------------
 
     Python floats follow the same sort of rules as the SymPy Float
     but only retain 15 decomal digits of precision. Trying to make
@@ -771,7 +773,8 @@ class Float(Number):
     >>> Rational(_)
     354177486215223391027/1180591620717411303424
 
-    == Changing Float precision ==
+    Changing Float precision
+    ------------------------
 
     During calculations, `evalf` changes the precision of numbers
     but this will not increase the accuracy of the inexact value.
@@ -800,7 +803,8 @@ class Float(Number):
     >>> show(t.evalf(2))
     307/2**10 at prec=10
 
-    == Instantiating from tuple ==
+    Instantiating from tuple
+    ------------------------
 
     Floats can be instantiated with an mpf tuple (s, m, e) to
     produce the number (-1)**s*m*2**e:
@@ -821,7 +825,8 @@ class Float(Number):
     precision. The mpf tuple and the precision are two separate quantities
     that Float tracks.
 
-    == Instantiating inf and nan ==
+    Instantiating inf and nan
+    -------------------------
 
     In SymPy, a Float is a number that can be computed with arbitrary
     precision. Although floating point 'inf' and 'nan' are not such

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -970,6 +970,9 @@ class Float(Number):
     def _eval_is_integer(self):
         return self._mpf_ == fzero or int_valued(self)
 
+    def _eval_is_odd(self):
+        return int_valued(self) and not bool(self._mpf_[2])
+
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):
             return False

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -668,7 +668,7 @@ class Float(Number):
     in the `_mpf_` attribute of the Float:
 
     >>> mpf = s, m, e, b = Float(26)._mpf_; mpf
-    (0, 13, 2, 4)
+    (0, 13, 1, 4)
     >>> (-1)**s*m*2**e
     26
 
@@ -685,6 +685,7 @@ class Float(Number):
     by passing it to Rational (see also discusion below on SymPy Float
     and Python float):
 
+    >>> from sympy import Rational
     >>> Rational(Float(1/8))
     1/8
     >>> Rational(Float(1/10, 1))  # the 1 digit approximation
@@ -697,7 +698,7 @@ class Float(Number):
     Consider the 2 digit approximations for 1/10 and 1/3:
 
     >>> a, b = Float(1/10, 2), Float(1/3, 2); (a, b)
-    (0.10, 0.33)
+    (0.1, 0.33)
 
     The underlying rational approximations are
 
@@ -729,15 +730,17 @@ class Float(Number):
 
     Integers, Rationals, and Floats are all SymPy Numbers. While all
     Numbers are rational, the attribute `is_Rational` is True only
-    for Integers and Rational. Other lower-case attributes may
-    also be true for Floats:
+    for Integers and Rational and the rational Float does not
+    behave as a rational in all operations unless it is an integer,
+    so `is_rational` is None and `is_integer` is True. Other
+    lower-case attributes may also be true for integer Floats:
 
     >>> f1 = Float(1)
-    >>> f1.is_Rational, f1.is_rational, f1.is_integer, f1.is_odd
-    (False, True, True, True)
+    >>> f1.is_rational, f1.is_Rational, f1.is_integer, f1.is_odd
+    (None, False, True, True)
     >>> r = Float(0.1)
-    >>> r.is_rational, r.is_integer, r.is_odd
-    (True, False, False)
+    >>> r.is_integer, r.is_odd
+    (False, False)
 
     == SymPy Float from Python float ==
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -836,8 +836,12 @@ class Float(Number):
 
     _mpf_: tuple[int, int, int, int]
 
-    # A Float is a computationally efficient rational
-    is_rational = True
+    # A Float is a computationally efficient rational but does
+    # not behaves as such in all computations. Integers --
+    # as well all fractions with denominators that are powers
+    # of 2 -- are exact, but currently only the integer
+    # is tracked after instantiation.
+    is_rational = None
     is_irrational = False
     is_number = True
 
@@ -1056,20 +1060,6 @@ class Float(Number):
 
     def _eval_is_integer(self):
         return self._mpf_ == fzero or int_valued(self)
-
-    def _eval_is_odd(self):
-        return int_valued(self) and not bool(self._mpf_[2])
-
-    def _eval_is_prime(self):
-        from sympy.ntheory.primetest import isprime
-        if not int_valued(self):
-            return False
-        return isprime(int(self))
-
-    def _eval_is_composite(self):
-        if not int_valued(self) or self <= 1:
-            return False
-        return fuzzy_not(self.is_prime)
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -419,7 +419,7 @@ def test_Mul_is_integer():
     assert (o/e).is_integer is False
     assert (o/i2).is_integer is False
     assert Mul(k, 1/k, evaluate=False).is_integer is None
-    assert Mul(2., S.Half, evaluate=False).is_integer
+    assert Mul(2., S.Half, evaluate=False).is_integer is None
     assert (2*sqrt(k)).is_integer is None
     assert (2*k**n).is_integer is None
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -419,7 +419,7 @@ def test_Mul_is_integer():
     assert (o/e).is_integer is False
     assert (o/i2).is_integer is False
     assert Mul(k, 1/k, evaluate=False).is_integer is None
-    assert Mul(2., S.Half, evaluate=False).is_integer is None
+    assert Mul(2., S.Half, evaluate=False).is_integer
     assert (2*sqrt(k)).is_integer is None
     assert (2*k**n).is_integer is None
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -504,11 +504,11 @@ def test_Float():
     # rationality properties
     # if the integer test fails then the use of intlike
     # should be removed from gamma_functions.py
-    assert Float(1).is_integer is False
-    assert Float(1).is_rational is None
-    assert Float(1).is_irrational is None
-    assert sqrt(2).n(15).is_rational is None
-    assert sqrt(2).n(15).is_irrational is None
+    assert Float(1).is_integer is True
+    assert Float(1).is_rational is True
+    assert Float(1).is_irrational is False
+    assert sqrt(2).n(15).is_rational is True
+    assert sqrt(2).n(15).is_irrational is False
 
     # do not automatically evalf
     def teq(a):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -505,9 +505,9 @@ def test_Float():
     # if the integer test fails then the use of intlike
     # should be removed from gamma_functions.py
     assert Float(1).is_integer is True
-    assert Float(1).is_rational is True
+    assert Float(1).is_rational is None
     assert Float(1).is_irrational is False
-    assert sqrt(2).n(15).is_rational is True
+    assert sqrt(2).n(15).is_rational is None
     assert sqrt(2).n(15).is_irrational is False
 
     # do not automatically evalf

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -321,10 +321,7 @@ def test_issue_6100_12942_4473():
     assert (x**1.0)**2.0 != x**2
     b = Expr()
     assert Pow(b, 1.0, evaluate=False) != b
-    # if the following gets distributed as a Mul (x**1.0*y**1.0 then
-    # __eq__ methods could be added to Symbol and Pow to detect the
-    # power-of-1.0 case.
-    assert ((x*y)**1.0).func is Pow
+    assert ((x*y)**1.0).func is Mul
 
 
 def test_issue_6208():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1259,7 +1259,6 @@ def test_issue_23731():
     assert unchanged(Eq, i/2, 0.5)
     ni = symbols('ni', integer=False)
     assert Eq(ni, 1.0) == Eq(ni, 1) == False
-    nr = symbols('nr', rational=False)
     assert unchanged(Eq, ni, .1)
 
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import XFAIL, raises
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, unchanged
 from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (Float, I, Rational, nan, oo, pi, zoo)
@@ -1251,6 +1251,18 @@ def test_weak_strict():
     eq = Le(x, 1)
     assert eq.strict == Lt(x, 1)
     assert eq.weak == eq
+
+
+def test_issue_23731():
+    i = symbols('i', integer=True)
+    assert unchanged(Eq, i, 1.0)
+    assert unchanged(Eq, i/2, 0.5)
+    ni = symbols('ni', integer=False)
+    assert Eq(ni, 1.0) == Eq(ni, 1) == False
+    nr = symbols('nr', rational=False)
+    assert Eq(nr, .1) == False
+    assert unchanged(Eq, ni, .1)
+
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1260,8 +1260,13 @@ def test_issue_23731():
     ni = symbols('ni', integer=False)
     assert Eq(ni, 1.0) == Eq(ni, 1) == False
     nr = symbols('nr', rational=False)
-    assert Eq(nr, .1) == False
     assert unchanged(Eq, ni, .1)
+
+
+@XFAIL
+def test_issue_23731b():
+    nr = symbols('nr', rational=False)
+    assert Eq(nr, .1) == False
 
 
 def test_rewrite_Add():

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -548,7 +548,7 @@ class bernoulli(Function):
             return cls(n)
         elif n.is_zero:
             return S.One
-        elif n.is_integer is False or n.is_nonnegative is False:
+        elif n.is_Float or n.is_integer is False or n.is_nonnegative is False:
             if x is not None and x.is_Integer and x.is_nonpositive:
                 return S.NaN
             return

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -7,7 +7,7 @@ from sympy.core import Add, S
 from sympy.core.evalf import get_integer_part, PrecisionExhausted
 from sympy.core.function import Function
 from sympy.core.logic import fuzzy_or
-from sympy.core.numbers import Integer
+from sympy.core.numbers import Integer, int_valued
 from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
@@ -42,10 +42,9 @@ class RoundFunction(Function):
         ipart = npart = spart = S.Zero
 
         # Extract integral (or complex integral) terms
-        terms = Add.make_args(arg)
-
-        for t in terms:
-            if t.is_integer or (t.is_imaginary and im(t).is_integer):
+        intlike = lambda x: x.is_integer or int_valued(x)
+        for t in Add.make_args(arg):
+            if intlike(t) or t.is_imaginary and intlike(im(t)):
                 ipart += t
             elif t.has(Symbol):
                 spart += t
@@ -494,9 +493,8 @@ class frac(Function):
                     return arg - floor(arg)
             return cls(arg, evaluate=False)
 
-        terms = Add.make_args(arg)
         real, imag = S.Zero, S.Zero
-        for t in terms:
+        for t in Add.make_args(arg):
             # Two checks are needed for complex arguments
             # see issue-7649 for details
             if t.is_imaginary or (S.ImaginaryUnit*t).is_real:

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -276,6 +276,8 @@ def test_ceiling():
     assert unchanged(ceiling, x + y)
 
     assert ceiling(x + 3) == ceiling(x) + 3
+    assert ceiling(x + 3.0) == ceiling(x) + 3.0
+    assert ceiling(x + 3.0*I) == ceiling(x) + 3.0*I
     assert ceiling(x + k) == ceiling(x) + k
 
     assert ceiling(y + 3) == ceiling(y) + 3

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -235,7 +235,7 @@ class MatrixExpr(Expr):
     @classmethod
     def _check_dim(cls, dim):
         """Helper function to check invalid matrix dimensions"""
-        ok = check_assumptions(dim, integer=True, nonnegative=True)
+        ok = not dim.is_Float and check_assumptions(dim, integer=True, nonnegative=True)
         if ok is False:
             raise ValueError(
                 "The dimension specification {} should be "

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -489,7 +489,7 @@ def _minpoly_exp(ex, x):
     """
     c, a = ex.args[0].as_coeff_Mul()
     if a == I*pi:
-        if c.is_rational:
+        if c.is_rational and not c.is_Float:
             q = sympify(c.q)
             if c.p == 1 or c.p == -1:
                 if q == 3:

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -342,7 +342,7 @@ class RustCodePrinter(CodePrinter):
             return self._print_not_supported(expr)
 
     def _print_Pow(self, expr):
-        if expr.base.is_integer and not expr.exp.is_integer:
+        if expr.base.is_integer and not expr.base.is_Float and not expr.exp.is_integer:
             expr = type(expr)(Float(expr.base), expr.exp)
             return self._print(expr)
         return self._print_Function(expr)

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -658,7 +658,7 @@ def test_C99CodePrinter__precision():
 
     for printer, suffix in zip([f32_printer, f64_printer, f80_printer], ['f', '', 'l']):
         def check(expr, ref):
-            assert printer.doprint(expr) == ref.format(s=suffix, S=suffix.upper())
+            assert printer.doprint(expr) == ref.format(s=suffix, S=suffix.upper()),printer.doprint(expr)
         check(Abs(n), 'abs(n)')
         check(Abs(x + 2.0), 'fabs{s}(x + 2.0{S})')
         check(sin(x + 4.0)**cos(x - 2.0), 'pow{s}(sin{s}(x + 4.0{S}), cos{s}(x - 2.0{S}))')
@@ -699,8 +699,8 @@ def test_C99CodePrinter__precision():
         check(gamma(x), 'tgamma{s}(x)')
         check(loggamma(x), 'lgamma{s}(x)')
 
-        check(ceiling(x + 2.), "ceil{s}(x + 2.0{S})")
-        check(floor(x + 2.), "floor{s}(x + 2.0{S})")
+        check(ceiling(x + 2.), "ceil{s}(x) + 2.0{S}")
+        check(floor(x + 2.), "floor{s}(x) + 2.0{S}")
         check(fma(x, y, -z), 'fma{s}(x, y, -z)')
         check(Max(x, 8.0, x**4.0), 'fmax{s}(8.0{S}, fmax{s}(x, pow{s}(x, 4.0{S})))')
         check(Min(x, 2.0), 'fmin{s}(2.0{S}, x)')

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -114,7 +114,7 @@ def test_ImageSet():
     harmonics = ImageSet(Lambda(x, 1/x), S.Naturals)
     assert Rational(1, 5) in harmonics
     assert Rational(.25) in harmonics
-    assert 0.25 not in harmonics
+    assert 0.25 in harmonics
     assert Rational(.3) not in harmonics
     assert (1, 2) not in harmonics
 
@@ -1255,7 +1255,7 @@ def test_issue_18050():
         ) == ImageSet(Lambda(x, 3*x + 2 + 5*I), S.Integers)
 
 
-def test_Rationals():
+def test_Rationals_set():
     assert S.Integers.is_subset(S.Rationals)
     assert S.Naturals.is_subset(S.Rationals)
     assert S.Naturals0.is_subset(S.Rationals)
@@ -1268,7 +1268,7 @@ def test_Rationals():
         Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
-    assert S.Rationals.contains(0.5) == Contains(0.5, S.Rationals, evaluate=False)
+    assert S.Rationals.contains(0.5)
     assert 2 in S.Rationals
     r = symbols('r', rational=True)
     assert r in S.Rationals

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1644,7 +1644,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     >>> B = BernoulliProcess("B", p=0.7, success=1, failure=0)
     >>> B.state_space
     {0, 1}
-    >>> (B.p).round(2)
+    >>> B.p.round(2)
     0.70
     >>> B.success
     1

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -265,7 +265,7 @@ def get_default_datatype(expr, complex_allowed=None):
         final_dtype = "complex"
     else:
         final_dtype = "float"
-    if expr.is_integer:
+    if expr.is_integer and not expr.is_Float:
         return default_datatypes["int"]
     elif expr.is_real:
         return default_datatypes["float"]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

alternative to #25856 and #25864
fixes #23731 

#### Brief description of what is fixed or changed

That Float may be an approximation of an irrational number (or repeating binary fraction) does not make it any less a Rational number (though it is much more granular than the Rational representation used in SymPy). A Float is a computationally efficient representation of a number in a rational form.

The attributes have been updated accordingly.
```python
>>> Float(1).is_odd == Float(1).is_rational == Float(1).is_integer == True
True
>>> Float(3).is_prime
True
```

There was a long discussion of whether `Float` should be classified as `rational` [here](https://groups.google.com/g/sympy/c/RUYOxxwMgac/m/4-1JXtny32EJ). One major concern was that float/Float objects do not behave as Rationals in operations, e.g.
```python
>>> Float(1/3)+Float(1/10)-Float(1/10)-Float(1/3)
5.55111512312578e-17
>>> _.is_rational
True
>>> Float(1/3)+Float(1/10) - (Float(1/10)+Float(1/3))
0
>>> _.is_rational
True
```
Allowing a object to be classified as rational, however, does not imply how it behaves in computation *in particular* only in *general*. In general `rational +/- rational` is `rational`. Anyone using SymPy would be expected to write code to take the appropriate action for a given value type. The user is also expected to understand the difference between an exact result derived from a Float-free expression and a result from an expression containing Floats. The user is also expected to understand that associative properties do not apply to Float-rationals like they do to Rational-rationals (as shown above).

* It was the assumption system that was running into problems when being used to evaluate expressions like `Eq(Dummy(integer=True)/2, 0.5)`; this formerly failed because the lhs was rational and the rhs was not. Yet, SymPy recognizes that `Eq(S.Half, 0.5) -> True`. So, in fact, SymPy is treating 0.5 as a rational in this context. So the changes in this PR are aligned with that idea. The only alternative that I see to this is to make `Eq(S.Half, 0.5)` return False.

* `solve(x**.4 - 4)` still gives `[32.0]` because it takes action based on the exponent being Float instead of rational. So this is an example of something that did not "break" with this change. If, however, the code had made a decision based on the exponent being rational, it might have given a different result.

There are more than 600 uses of `is_integer` and about 200 uses of `is_rational` in the SymPy codebase.  Although no test currently fails there could be untested cases where a Float instead of a symbolic rational/integer will slip through into a codepath that was meant only for the symbolic (not Numeric) argument.

#### Other comments


Summary of things with assumptions:

```
Number (always is_rational)
* Integer is_Integer == is_Rational == is_integer == is_rational
* Rational (n/d) is_Rational == is_rational == True, collapses to Integer if d == 1
* Float (m/2**e) is_Integer == is_Rational == False, is_rational == True, is_integer if e==0, never collapses to Rational

Symbol is_integer per assumptions

NumberSymbol
* I is_imagary
* pi is_irrational
* Exp1 is_irrational
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Float is now treated like Rational in terms of assumptions, so `Eq(Dummy('x', integer=True), 1.0)` is not False
  * `e.is_integer` used to be true for Integer and symbolic integers; it is now true for Float if `e%1==0`.
<!-- END RELEASE NOTES -->
