### PR TITLE
Eq(i/2, 0.5) is no longer False

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1586,8 +1586,7 @@ def is_eq(lhs, rhs, assumptions=None):
             if _d.is_infinite:
                 rv = True
             elif _n.is_zero is False:
-                rv = _d.is_infinite
-                if rv is None:
+                if _d.is_infinite is None:
                     # if the condition that makes the denominator
                     # infinite does not make the original expression
                     # True then False can be returned

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import XFAIL, raises
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, unchanged
 from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (Float, I, Rational, nan, oo, pi, zoo)
@@ -1251,6 +1251,11 @@ def test_weak_strict():
     eq = Le(x, 1)
     assert eq.strict == Lt(x, 1)
     assert eq.weak == eq
+
+def test_issue_23731():
+    i = symbols('i', integer=True)
+    assert unchanged(Eq, i/2, 0.5)
+
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #23731 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * fix bug that lead to evaluation of Eq which should have remained unevaluated
<!-- END RELEASE NOTES -->
