### PR TITLE
ceiling/floor recognize int floats

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -7,7 +7,7 @@ from sympy.core import Add, S
 from sympy.core.evalf import get_integer_part, PrecisionExhausted
 from sympy.core.function import Function
 from sympy.core.logic import fuzzy_or
-from sympy.core.numbers import Integer
+from sympy.core.numbers import Integer, int_valued
 from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
@@ -42,11 +42,13 @@ class RoundFunction(Function):
         ipart = npart = spart = S.Zero
 
         # Extract integral (or complex integral) terms
-        terms = Add.make_args(arg)
-
-        for t in terms:
-            if t.is_integer or (t.is_imaginary and im(t).is_integer):
-                ipart += t
+        intof = lambda x: int(x) if int_valued(x) else (
+            x if x.is_integer else None)
+        for t in Add.make_args(arg):
+            if t.is_imaginary and (i := intof(im(t))) is not None:
+                ipart += i*S.ImaginaryUnit
+            elif (i := intof(t)) is not None:
+                ipart += i
             elif t.has(Symbol):
                 spart += t
             else:
@@ -494,9 +496,8 @@ class frac(Function):
                     return arg - floor(arg)
             return cls(arg, evaluate=False)
 
-        terms = Add.make_args(arg)
         real, imag = S.Zero, S.Zero
-        for t in terms:
+        for t in Add.make_args(arg):
             # Two checks are needed for complex arguments
             # see issue-7649 for details
             if t.is_imaginary or (S.ImaginaryUnit*t).is_real:

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -276,6 +276,8 @@ def test_ceiling():
     assert unchanged(ceiling, x + y)
 
     assert ceiling(x + 3) == ceiling(x) + 3
+    assert ceiling(x + 3.0) == ceiling(x) + 3
+    assert ceiling(x + 3.0*I) == ceiling(x) + 3*I
     assert ceiling(x + k) == ceiling(x) + k
 
     assert ceiling(y + 3) == ceiling(y) + 3

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -643,7 +643,7 @@ def test_C99CodePrinter():
 @XFAIL
 def test_C99CodePrinter__precision_f80():
     f80_printer = C99CodePrinter({"type_aliases": {real: float80}})
-    assert f80_printer.doprint(sin(x+Float('2.1'))) == 'sinl(x + 2.1L)'
+    assert f80_printer.doprint(sin(x + Float('2.1'))) == 'sinl(x + 2.1L)'
 
 
 def test_C99CodePrinter__precision():
@@ -699,8 +699,8 @@ def test_C99CodePrinter__precision():
         check(gamma(x), 'tgamma{s}(x)')
         check(loggamma(x), 'lgamma{s}(x)')
 
-        check(ceiling(x + 2.), "ceil{s}(x + 2.0{S})")
-        check(floor(x + 2.), "floor{s}(x + 2.0{S})")
+        check(ceiling(x + 2.), "ceil{s}(x) + 2")
+        check(floor(x + 2.), "floor{s}(x) + 2")
         check(fma(x, y, -z), 'fma{s}(x, y, -z)')
         check(Max(x, 8.0, x**4.0), 'fmax{s}(8.0{S}, fmax{s}(x, pow{s}(x, 4.0{S})))')
         check(Min(x, 2.0), 'fmin{s}(2.0{S}, x)')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * ceiling and floor recognize Float that are integers so `ceiling(x + 1.0) as 1 + ceiling(x)` as the exact symbolic answer
<!-- END RELEASE NOTES -->
